### PR TITLE
relay all mesos status updates

### DIFF
--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -41,7 +41,7 @@ class TaskTracker @Inject()(state: State) {
     stagedTasks(task.getId) = task
   }
 
-  def running(appName: String, taskId: TaskID) {
+  def running(appName: String, taskId: TaskID) = {
     stagedTasks.remove(taskId.getValue) match {
       case Some(task) => {
         get(appName) += task
@@ -115,7 +115,7 @@ class TaskTracker @Inject()(state: State) {
     state.fetch(prefix + appName).get()
   }
 
-  def store(appName: String) {
+  def store(appName: String) = {
     val oldVar = fetchVariable(appName)
     val bytes = new ByteArrayOutputStream()
     val output = new ObjectOutputStream(bytes)


### PR DESCRIPTION
We've been using an older version of Marathon which correctly relays all Mesos status updates associated with a Marathon task through the event bus. I upgraded us to the current version and these updates weren't being sent due to Mesos tasks failing to be matched up with Marathon tasks. It looks like the issue was it was comparing to a task object instead of a task ID string (https://github.com/mesosphere/marathon/pull/35/files#L0L87).

In addition, it seems that only `TASK_KILLED` events are being relayed due to the order of execution in `statusUpdate()`, so I reorganized it a little bit. (https://github.com/mesosphere/marathon/pull/35/files#L0R86)

It also appeared that we were possibly querying for tasks before they finished being stored in the datastore, so I surfaced the Future that `state.store()` returns through TaskTracker's `store()` and `running()` methods. This allows `running()` to fully resolve before attempting to send the Mesos status update notification.

I think this is an okay way to do it and it makes everything work again locally, but let me know if you guys have a better way. Thanks!

@guenter @florianleibert
