### PR TITLE
Fixed $PORTS enviroment variable.

### DIFF
--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -206,6 +206,7 @@ object TaskBuilder {
     })
 
     env += ("PORT" -> ports.head.toString)
+    env += ("PORTS" -> ports.mkString(","))
     env
   }
 }


### PR DESCRIPTION
The $PORTS enviromnment variable should be a command separated list of
ports.  Even though we export $PORT${N} as well, this is a nice
convenience option.
