### PR TITLE
Use step timing for cursor blink to save CPU rendering

### DIFF
--- a/src/main/resources/assets/css/marathon.css
+++ b/src/main/resources/assets/css/marathon.css
@@ -20,13 +20,13 @@
 }
 
 @-webkit-keyframes blink {
-  0% { opacity:0.8; }
+  0% { opacity: 1; }
   50% { opacity: 0; }
   100% { opacity: 1; }
 }
 
 @keyframes blink {
-  0% { opacity:0.8; }
+  0% { opacity: 1; }
   50% { opacity: 0; }
   100% { opacity: 1; }
 }
@@ -242,13 +242,15 @@ h1 {
   font-size: 74px;
   font-weight: normal;
 
-  -webkit-animation-duration: 1s;
+  -webkit-animation-duration: 1.2s;
   -webkit-animation-iteration-count: infinite;
   -webkit-animation-name: blink;
+  -webkit-animation-timing-function: steps(1, start);
 
-  animation-duration: 1s;
+  animation-duration: 1.2s;
   animation-iteration-count: infinite;
   animation-name: blink;
+  animation-timing-function: steps(1, start);
 }
 
 .system-select {


### PR DESCRIPTION
The blinking cursor used the default timing function for its transition,
which caused Chrome 29 on OS X to take 100% when the Marathon tab was in
the background. The default timing function eased between 0- and 1
opacity, which ate CPU to composite on each step of the animation.

Switching to a step function means there are only two steps: opacity 0
and opacity 1. The composite time required is a tiny fraction of before
with a Chrome background tab taking <2% CPU, possibly due only to normal
activity and not the animation.

This also more closely mimics a real terminal; cursors typically blink
instead of fade.

This StackOverflow question pointed me in the right direction:
http://stackoverflow.com/a/13293044/368697
