### PR TITLE
Let Mesos generate the framework ID and keep track of it in state.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -15,6 +15,7 @@ import com.google.inject.name.Names
 import mesosphere.marathon.state.MarathonStore
 import mesosphere.marathon.api.v1.AppDefinition
 import mesosphere.marathon.tasks.TaskTracker
+import mesosphere.mesos.util.FrameworkIdUtil
 
 /**
  * @author Tobi Knaup
@@ -94,5 +95,11 @@ class MarathonModule(conf: MarathonConfiguration) extends AbstractModule {
   @Singleton
   def provideMarathonStore(state: State): MarathonStore[AppDefinition] = {
     new MarathonStore[AppDefinition](state, () => new AppDefinition)
+  }
+
+  @Provides
+  @Singleton
+  def provideFrameworkIdUtil(state: State): FrameworkIdUtil = {
+    new FrameworkIdUtil(state)
   }
 }

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -16,6 +16,7 @@ import mesosphere.marathon.event.{EventModule, MesosStatusUpdateEvent}
 import mesosphere.marathon.tasks.{TaskTracker, TaskQueue, TaskIDUtil, MarathonTasks}
 import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.mesos.util.FrameworkIdUtil
 
 
 /**
@@ -26,7 +27,8 @@ class MarathonScheduler @Inject()(
     @Named("restMapper") mapper: ObjectMapper,
     store: MarathonStore[AppDefinition],
     taskTracker: TaskTracker,
-    taskQueue: TaskQueue)
+    taskQueue: TaskQueue,
+    frameworkIdUtil: FrameworkIdUtil)
   extends Scheduler {
 
   val log = Logger.getLogger(getClass.getName)
@@ -36,6 +38,7 @@ class MarathonScheduler @Inject()(
 
   def registered(driver: SchedulerDriver, frameworkId: FrameworkID, master: MasterInfo) {
     log.info("Registered as %s to master '%s'".format(frameworkId.getValue, master.getId))
+    frameworkIdUtil.store(frameworkId)
   }
 
   def reregistered(driver: SchedulerDriver, master: MasterInfo) {

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.marathon.{PathExecutor, CommandExecutor, Executor, Main}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.protobuf.ByteString
-import org.apache.mesos.Protos
+import scala.util.Random
 
 
 /**
@@ -208,12 +208,12 @@ object TaskBuilder {
       return Some(Seq())
     }
 
-    val ranges = util.Random.shuffle(resource.getRanges.getRangeList.asScala)
+    val ranges = Random.shuffle(resource.getRanges.getRangeList.asScala)
     for (range <- ranges) {
       // TODO use multiple ranges if one is not enough
       if (range.getEnd - range.getBegin + 1 >= numPorts) {
         val maxOffset = (range.getEnd - range.getBegin - numPorts + 2).toInt
-        val firstPort = range.getBegin.toInt + util.Random.nextInt(maxOffset)
+        val firstPort = range.getBegin.toInt + Random.nextInt(maxOffset)
         return Some(Seq((firstPort, firstPort + numPorts - 1, resource.getRole)))
       }
     }

--- a/src/main/scala/mesosphere/mesos/util/FrameworkIdUtil.scala
+++ b/src/main/scala/mesosphere/mesos/util/FrameworkIdUtil.scala
@@ -1,0 +1,61 @@
+package mesosphere.mesos.util
+
+import org.apache.mesos.state.State
+import mesosphere.util.BackToTheFuture
+import org.apache.mesos.Protos.FrameworkID
+import com.google.protobuf.InvalidProtocolBufferException
+import java.util.logging.{Level, Logger}
+import scala.util.{Failure, Success}
+import scala.concurrent.{Future, Await, ExecutionContext}
+import scala.concurrent.duration.Duration
+
+/**
+ * Utility class for keeping track of a framework ID in Mesos state.
+ *
+ * @param state State implementation
+ * @param key The key to store the framework ID under
+ */
+
+class FrameworkIdUtil(val state: State, val key: String = "frameworkId") {
+
+  val defaultWait = Duration(2, "seconds")
+  private val log = Logger.getLogger(getClass.getName)
+
+  import BackToTheFuture.FutureToFutureOption
+  import ExecutionContext.Implicits.global
+
+  def fetch(wait: Duration = defaultWait): Option[FrameworkID] = {
+    val f: Future[Option[FrameworkID]] = state.fetch(key).map {
+      case Some(variable) if variable.value().length > 0 => {
+        try {
+          val frameworkId = FrameworkID.parseFrom(variable.value())
+          Some(frameworkId)
+        } catch {
+          case e: InvalidProtocolBufferException => {
+            log.warning("Failed to parse framework ID")
+            None
+          }
+        }
+      }
+      case _ => None
+    }
+    Await.result(f, wait)
+  }
+
+  def store(frameworkId: FrameworkID) {
+    state.fetch(key).map {
+      case Some(oldVariable) => {
+        val newVariable = oldVariable.mutate(frameworkId.toByteArray)
+        state.store(newVariable).onComplete {
+          case Success(_) => {
+            log.info(s"Stored framework ID ${frameworkId.getValue}")
+          }
+          case Failure(t) => {
+            log.log(Level.WARNING, "Failed to store framework ID", t)
+          }
+        }
+      }
+      case _ => log.warning("Fetch framework ID returned nothing")
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -16,6 +16,7 @@ import org.apache.mesos.Protos.{TaskID, TaskInfo}
 import org.mockito.ArgumentCaptor
 import mesosphere.marathon.Protos.MarathonTask
 import scala.collection.JavaConverters._
+import mesosphere.mesos.util.FrameworkIdUtil
 
 /**
  * @author Tobi Knaup
@@ -27,14 +28,16 @@ class MarathonSchedulerTest extends AssertionsForJUnit
   var tracker: TaskTracker = null
   var queue: TaskQueue = null
   var scheduler: MarathonScheduler = null
+  var frameworkIdUtil: FrameworkIdUtil = null
 
   @Before
   def setupScheduler() = {
     store = mock[MarathonStore[AppDefinition]]
     tracker = mock[TaskTracker]
     queue = mock[TaskQueue]
+    frameworkIdUtil = mock[FrameworkIdUtil]
     scheduler = new MarathonScheduler(
-      None, new ObjectMapper, store, tracker, queue)
+      None, new ObjectMapper, store, tracker, queue, frameworkIdUtil)
   }
 
   @Test


### PR DESCRIPTION
Frameworks are not supposed to generate their own framework ID. Let Mesos assign it instead, and store it in state so we can pick it up again after getting disconnected.
