### PR TITLE
Reduce padding and font-size to use more of the screen

### DIFF
--- a/src/main/resources/assets/css/marathon.css
+++ b/src/main/resources/assets/css/marathon.css
@@ -225,15 +225,6 @@ h1 {
   width: 600px;
 }
 
-.system-path {
-  padding-top: 10px;
-  font-family: 'arial', sans-serif;
-  font-weight: 300;
-  font-size: 86px;
-  position: relative;
-  top: 8px;
-}
-
 .system-caret {
   font-size: 74px;
   font-weight: normal;
@@ -343,7 +334,7 @@ h1 {
 }
 
 .content {
-  padding: 20px 50px;
+  padding: 20px 30px;
   opacity: 0;
 
   -webkit-animation-duration: 300ms;

--- a/src/main/resources/assets/index.html
+++ b/src/main/resources/assets/index.html
@@ -15,8 +15,7 @@
 
     <div class='fullscreen content'>
       <div class='system-input'>
-        <span class='system-folder'>Marathon</span>
-        <span class='system-path'>/</span>
+        <span class='system-folder'>Marathon /</span>
         <div id='terminal'>
           <input type='text' id='setter' />
           <span class='input' id='system-text'></span>


### PR DESCRIPTION
The slash in the system path was large, and the right/left padding of
the whole page used a lot of whitespace on smaller screens. Reducing the
font-size and the padding gives more space for Marathon tasks.

**Before:**
![screen shot 2013-10-17 at 1 43 03 pm](https://f.cloud.github.com/assets/29612/1355829/7c094966-376d-11e3-81f4-890bc960edeb.png)

**After:**
![screen shot 2013-10-17 at 1 43 31 pm](https://f.cloud.github.com/assets/29612/1355831/7fcfd402-376d-11e3-942e-c69073a23f25.png)
