### PR TITLE
App endpoints should block.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -8,7 +8,7 @@ import mesosphere.mesos.TaskBuilder
 import mesosphere.marathon.api.v1.AppDefinition
 import mesosphere.marathon.state.MarathonStore
 import scala.util.{Failure, Success}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Await}
 import com.google.common.collect.Lists
 import javax.inject.{Named, Inject}
 import com.google.common.eventbus.EventBus
@@ -162,25 +162,29 @@ class MarathonScheduler @Inject()(
 
   // TODO move stuff below out of the scheduler
 
-  def startApp(driver: SchedulerDriver, app: AppDefinition) {
-    store.fetch(app.id).onComplete {
-      case Success(option) => if (option.isEmpty) {
-        store.store(app.id, app)
-        log.info("Starting app " + app.id)
-        taskTracker.startUp(app.id)
-        rateLimiters.setPermits(app.id, app.taskRateLimit)
-        scale(driver, app)
-      } else {
+  def startApp(driver: SchedulerDriver, app: AppDefinition): Option[AppDefinition] = {
+    Await.result(store.fetch(app.id), store.defaultWait) match {
+      case None =>
+        Await.result(store.store(app.id, app), store.defaultWait) match {
+          case Some(_) =>
+            log.info("Starting app " + app.id)
+            taskTracker.startUp(app.id)
+            rateLimiters.setPermits(app.id, app.taskRateLimit)
+            scale(driver, app)
+            Some(app)
+          case None =>
+            log.warning("Error starting app %s: couldn't store state".format(app.id))
+            None
+        }
+      case Some(someApp) =>
         log.warning("Already started app " + app.id)
-      }
-      case Failure(t) =>
-        log.log(Level.WARNING, "Failed to start app %s".format(app.id), t)
+        None
     }
   }
 
-  def stopApp(driver: SchedulerDriver, app: AppDefinition) {
-    store.expunge(app.id).onComplete {
-      case Success(_) =>
+  def stopApp(driver: SchedulerDriver, app: AppDefinition): Option[AppDefinition] = {
+    Await.result(store.expunge(app.id), store.defaultWait) match {
+      case Some(success) =>
         log.info("Stopping app " + app.id)
         val tasks = taskTracker.get(app.id)
 
@@ -190,9 +194,16 @@ class MarathonScheduler @Inject()(
         }
         taskQueue.purge(app)
         taskTracker.shutDown(app.id)
+        if (success) {
+          Some(app)
+        } else {
+          log.warning("Error stopping app %s: couldn't expunge state.  Attempted to stop app anyway.".format(app.id))
+          None
+        }
         // TODO after all tasks have been killed we should remove the app from taskTracker
-      case Failure(t) =>
-        log.warning("Error stopping app %s: %s".format(app.id, t.getMessage))
+      case None =>
+        log.warning("Error stopping app %s: couldn't expunge state".format(app.id))
+        None
     }
   }
 
@@ -202,8 +213,12 @@ class MarathonScheduler @Inject()(
         appOption match {
           case Some(storedApp) => {
             storedApp.instances = app.instances
-            store.store(app.id, storedApp)
-            scale(driver, storedApp)
+            store.store(app.id, storedApp).onComplete {
+              case Success(_) =>
+                scale(driver, storedApp)
+              case Failure(t) =>
+                log.warning("Error scaling app %s: %s".format(app.id, t.getMessage))
+            }
           }
           case None =>
             log.warning("Service unknown: %s".format(app.id))

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -64,7 +64,7 @@ class MarathonSchedulerService @Inject()(
 
   val driver = new MesosSchedulerDriver(scheduler, frameworkInfo.build, config.mesosMaster())
 
-  def startApp(app: AppDefinition) {
+  def startApp(app: AppDefinition): Option[AppDefinition] = {
     // Backwards compatibility
     if (app.ports == Nil) {
       val port = newAppPort(app)
@@ -75,7 +75,7 @@ class MarathonSchedulerService @Inject()(
     scheduler.startApp(driver, app)
   }
 
-  def stopApp(app: AppDefinition) {
+  def stopApp(app: AppDefinition): Option[AppDefinition] = {
     scheduler.stopApp(driver, app)
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v1/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v1/AppsResource.scala
@@ -33,8 +33,12 @@ class AppsResource @Inject()(
   @Timed
   def start(@Context req: HttpServletRequest, @Valid app: AppDefinition): Response = {
     maybePostEvent(req, app)
-    service.startApp(app)
-    Response.noContent.build
+    service.startApp(app) match {
+      case Some(_) =>
+        Response.noContent.build
+      case _ =>
+        Response.serverError.build
+    }
   }
 
   @POST
@@ -42,8 +46,12 @@ class AppsResource @Inject()(
   @Timed
   def stop(@Context req: HttpServletRequest, app: AppDefinition): Response = {
     maybePostEvent(req, app)
-    service.stopApp(app)
-    Response.noContent.build
+    service.stopApp(app) match {
+      case Some(_) =>
+        Response.noContent.build
+      case _ =>
+        Response.serverError.build
+    }
   }
 
   @POST

--- a/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
+++ b/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
@@ -37,14 +37,14 @@ class MarathonStore[S <: MarathonState[_]](state: State,
     }
   }
 
-  def expunge(key: String): Future[Boolean] = {
+  def expunge(key: String): Future[Option[Boolean]] = {
     state.fetch(prefix + key) flatMap {
       case Some(variable) =>
         state.expunge(variable) map {
-          case Some(b) => b
-          case None => false
+          case Some(b) => Some(Boolean.unbox(b))
+          case None => None
         }
-      case None => false
+      case None => None
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/state/PersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/state/PersistenceStore.scala
@@ -12,7 +12,7 @@ trait PersistenceStore[T] {
 
   def store(key: String, value: T): Future[Option[T]]
 
-  def expunge(key: String): Future[Boolean]
+  def expunge(key: String): Future[Option[Boolean]]
 
   def names(): Future[Iterator[String]]
 


### PR DESCRIPTION
For the start/stop app endpoints, it makes sense to block while awaiting
a result.  The previous behaviour was to always return success, which is
confusing.  To make matters worse, Marathon would start tasks before the
app state is stored, resulting in phantom tasks.

@andykram @guenter @florianleibert 

This has been tested in our staging cluster.
