### PR TITLE
Extend executor field to allow URLs.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v1/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/api/v1/AppDefinition.scala
@@ -25,7 +25,7 @@ class AppDefinition extends MarathonState[Protos.ServiceDefinition] {
   var instances: Int = 0
   var cpus: Double = 1.0
   var mem: Double = 128.0
-  @Pattern(regexp="(^//cmd$)|(^/[^/].*$)|")
+  @Pattern(regexp="(^//cmd$)|(^/[^/].*$)|(^[a-z][a-z0-9./+-]+://.+$)")
   var executor: String = ""
 
 

--- a/src/test/scala/mesosphere/marathon/api/v1/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v1/AppDefinitionTest.scala
@@ -78,6 +78,13 @@ class AppDefinitionTest {
     shouldViolate(app, "id", "must match \"^[A-Za-z0-9_.-]+$\"")
     app.id = "ab"
     shouldNotViolate(app, "id", "must match \"^[A-Za-z0-9_.-]+$\"")
+
+    app.executor = "//cmd"
+    shouldNotViolate(app, "executor", "must accept \"//cmd\"")
+    app.executor = "http://abc.123/example?url"
+    shouldNotViolate(app, "executor", "must accept URLs")
+    app.executor = "/a#/%$^/cube"
+    shouldNotViolate(app, "executor", "must accept absolute paths")
   }
 
   def getScalarResourceValue(proto: ServiceDefinition, name: String) = {


### PR DESCRIPTION
The validation of the scheme part of the URL is relatively permissive and a quick review of Wikipedia's big list of URL schemes suggest there aren't any, ancient or modern, that won't fit.
