### PR TITLE
Added new task search, scale endpoints.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -194,12 +194,16 @@ class MarathonScheduler @Inject()(
     }
   }
 
-  def scaleApp(driver: SchedulerDriver, app: AppDefinition): Future[_] = {
+  def scaleApp(driver: SchedulerDriver,
+               app: AppDefinition,
+               applyNow: Boolean): Future[_] = {
     store.fetch(app.id).flatMap {
       case Some(storedApp) => {
         storedApp.instances = app.instances
         store.store(app.id, storedApp).map { _ =>
-          scale(driver, storedApp)
+          if (applyNow) {
+            scale(driver, storedApp)
+          }
         }
       }
       case None => throw new UnknownAppException(app.id)

--- a/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
@@ -91,7 +91,8 @@ class LeaderProxyFilter @Inject()
               proxyOutputStream.close
           }
 
-          response.setStatus(proxy.getResponseCode())
+          val status = proxy.getResponseCode
+          response.setStatus(status)
 
           val fields = proxy.getHeaderFields
           // getHeaderNames() and getHeaders() are known to return null, see:

--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -46,6 +46,10 @@ class TaskTracker @Inject()(state: State) {
     get(appName).size
   }
 
+  def contains(appName: String) = {
+    apps.contains(appName)
+  }
+
   def take(appName: String, n: Int) = {
     get(appName).take(n)
   }
@@ -172,11 +176,15 @@ class TaskTracker @Inject()(state: State) {
     results
   }
 
-  def serialize(appName: String, tasks: Set[MarathonTask], sink: ObjectOutputStream) {
-    val app = MarathonApp.newBuilder
+  def getProto(appName: String, tasks: Set[MarathonTask]): MarathonApp = {
+    MarathonApp.newBuilder
       .setName(appName)
       .addAllTasks(tasks.toList.asJava)
       .build
+  }
+
+  def serialize(appName: String, tasks: Set[MarathonTask], sink: ObjectOutputStream) {
+    val app = getProto(appName, tasks)
 
     val size = app.getSerializedSize
     sink.writeInt(size)


### PR DESCRIPTION
Now you can scale apps by killing individual tasks.  You can use the
'/v1/tasks/app/appId' to list tasks for an app, and then scale
apps by killing individual tasks with a POST to
'/v1/tasks/scale?appId=id&host=host'.

@florianleibert @guenter
