### PR TITLE
add Dockerfile for Docker Trusted Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ RUN apt-get update && apt-get install --assume-yes maven3
 RUN curl http://downloads.mesosphere.io/master/ubuntu/12.04/mesos_0.14.2_amd64.deb > mesos.deb && dpkg --install mesos.deb && rm mesos.deb
 
 ## MARATHON ##
-ADD . /etc/marathon
-RUN cd /etc/marathon && mvn3 package
+ADD . /opt/marathon
+RUN cd /opt/marathon && mvn3 package
 
 EXPOSE 8080
+WORKDIR /opt/marathon
 CMD ["--help"]
-ENTRYPOINT ["/etc/marathon/bin/start"]
+ENTRYPOINT ["/opt/marathon/bin/start"]


### PR DESCRIPTION
This is mostly there. It needs a couple things, yet, namely:
- [x] Who's the `MAINTAINER`?
- [x] I'm able to run this, and everything appears to be fine, but Mesos never says it's registered. I'm running it like so: `docker run -d -p 8080:8080 mesosphere/marathon --master zk://192.168.1.104:2181/mesos --zk_hosts 192.168.1.104:2181 --hostname 192.168.1.104:8080` (where `192.168.1.104` is the IP of the parent Vagrant host, which is also running Mesos and zookeeper)
- [x] install to `/opt` instead of `/etc`

(this PR in reference to #76)
