### PR TITLE
Add a label to the memory field to clarify that it is MB and not GB

### DIFF
--- a/src/main/resources/assets/css/marathon.css
+++ b/src/main/resources/assets/css/marathon.css
@@ -157,7 +157,7 @@ h1 {
 }
 
 .input-row label {
-  width: 133px;
+  width: 170px;
   font-weight: 300;
   font-family: 'lato';
   text-transform: uppercase;

--- a/src/main/resources/assets/index.html
+++ b/src/main/resources/assets/index.html
@@ -40,7 +40,7 @@
           <input id='cmd-field' name='cmd' tabindex='2'>
         </div>
         <div class='input-row'>
-          <label for='mem-field'>Memory</label>
+          <label for='mem-field'>Memory (MB)</label>
           <input id='mem-field' name='mem' value='{{mem}}' tabindex='3'>
         </div>
         <div class='input-row'>


### PR DESCRIPTION
I'm just getting started with Marathon today and was confused by this screen for awhile. I'm pretty sure now that it's MB, but it would be very nice to make that obvious in the UI.
