### PR TITLE
Convey port selection, environment variables, etc. to PathExecutor insta...

### DIFF
--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -79,7 +79,7 @@ class TaskBuilder (app: AppDefinition,
           mapper.writeValue(binary, app)
           val info = ExecutorInfo.newBuilder()
             .setExecutorId(ExecutorID.newBuilder().setValue(executorId))
-            .setCommand(CommandInfo.newBuilder().setValue(cmd))
+            .setCommand(TaskBuilder.commandInfo(app, ports).toBuilder.setValue(cmd).build)
           builder.setExecutor(info)
           builder.setData(ByteString.copyFrom(binary.toByteArray))
         }


### PR DESCRIPTION
Convey port selection, environment variables, etc. to PathExecutor instances

Information provided such as ports, environment variables, and uris for CommandExecutor isn't provided for PathExecutors. This unifies the information available to both.
