### PR TITLE
Scale app in /tasks/kill only if `scale` is true

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v1/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v1/TasksResource.scala
@@ -41,12 +41,14 @@ class TasksResource @Inject()(
         x.getHost == host || x.getId == id || host == "*"
     )
 
-    service.getApp(appId) match {
-      case Some(appDef) =>
-        appDef.instances = appDef.instances - toKill.size
+    if (scale) {
+      service.getApp(appId) match {
+        case Some(appDef) =>
+          appDef.instances = appDef.instances - toKill.size
 
-        Await.result(service.scaleApp(appDef, false), service.defaultWait)
-      case None =>
+          Await.result(service.scaleApp(appDef, false), service.defaultWait)
+        case None =>
+      }
     }
 
     toKill.map({task =>


### PR DESCRIPTION
The `scale` URL parameter was added to decide whether to scale the app,
but the variable was never referenced. This wraps app scaling so it is
only performed if `scale` is true.
