### PR TITLE
Fix REST documentation bug for /v2/apps?cmd=

### DIFF
--- a/REST.md
+++ b/REST.md
@@ -228,7 +228,7 @@ Transfer-Encoding: chunked
 
 #### GET `/v2/apps?cmd={command}`
 
-List the application with id `app_id`.
+List the applications with cmd `command`.
 
 ##### Example
 


### PR DESCRIPTION
Found a minor typo with the new REST documentation. I believe this is an appropriate fix.
