### PR TITLE
Burst Browser Cache for Static Assets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <scala.version>2.10.3</scala.version>
 
         <!-- runtime deps versions -->
-        <chaos.version>0.5.0</chaos.version>
+        <chaos.version>0.5.2</chaos.version>
         <mesos.version>0.14.2</mesos.version>
         <protobuf.version>2.4.1</protobuf.version>
         <akka.version>2.2.3</akka.version>

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -25,7 +25,10 @@ object Main extends App {
 
   def modules() = {
     Seq(
-      new HttpModule(conf),
+      new HttpModule(conf) {
+        // burst browser cache for assets
+        protected override val resourceCacheControlHeader = Some("max-age=0, must-revalidate")
+      },
       new MetricsModule,
       new MarathonModule(conf),
       new MarathonRestModule,


### PR DESCRIPTION
Required a new minor version of Chaos which allows downstream projects (incl. this one) to override a value to set the cache control header for resources.

Here's an example of the new cache-control header in action:

```
GET /js/dist/main.js HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, compress
Host: localhost:8080
User-Agent: HTTPie/0.7.2

HTTP/1.1 200 OK
Cache-Control: max-age=0, must-revalidate
Content-Length: 224098
Content-Type: application/x-javascript
Last-Modified: Wed, 29 Jan 2014 16:00:30 GMT
Server: Jetty(8.y.z-SNAPSHOT)
```
