### PR TITLE
Allow requests with no ports. Addresses #138.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -75,11 +75,7 @@ class MarathonSchedulerService @Inject()(
   def startApp(app: AppDefinition): Future[_] = {
     // Backwards compatibility
     val oldPorts = app.ports
-    val newPorts = if (oldPorts == Nil) {
-      Seq(newAppPort(app))
-    } else {
-      oldPorts.map(port => if (port == 0) newAppPort(app) else port)
-    }
+    val newPorts = oldPorts.map(p => if (p == 0) newAppPort(app) else p)
 
     if (oldPorts != newPorts) {
       val asMsg = Seq(oldPorts, newPorts).map("[" + _.mkString(", ") + "]")

--- a/src/main/scala/mesosphere/marathon/api/v1/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/api/v1/AppDefinition.scala
@@ -32,7 +32,7 @@ class AppDefinition extends MarathonState[Protos.ServiceDefinition] {
   var constraints: Set[Constraint] = Set()
 
   var uris: Seq[String] = Seq()
-  var ports: Seq[Int] = Nil
+  var ports: Seq[Int] = Seq(0)
   // Number of new tasks this app may spawn per second in response to
   // terminated tasks. This prevents frequently failing apps from spamming
   // the cluster.


### PR DESCRIPTION
This preserves desired default behaviour of the web API -- requests that do not explicitly specify `ports` are allocated one port -- but now when an empty array is passed, no ports are allocated.
