### PR TITLE
use joda-time for < java 7 compatability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,16 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.joda</groupId>
+            <artifactId>joda-convert</artifactId>
+            <version>1.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/scala/mesosphere/marathon/api/v2/json/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/MarathonModule.scala
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import java.text.SimpleDateFormat
 import java.util.{Date, TimeZone}
+import org.joda.time.format.{ISODateTimeFormat, DateTimeFormatter}
+import org.joda.time.{DateTimeZone, DateTime}
 
 /**
  * @author Tobi Knaup
@@ -85,10 +87,10 @@ class MarathonModule extends Module {
     }
   }
 
-  val isoDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mmX");
-  isoDateFormat setTimeZone TimeZone.getTimeZone("UTC")
+  val isoDateFormatter = ISODateTimeFormat.dateTime()
+  isoDateFormatter.withZone(DateTimeZone.UTC)
 
-  def timestampToUTC(timestamp: Long): String = isoDateFormat.format(new Date(timestamp))
+  def timestampToUTC(timestamp: Long): String = isoDateFormatter.print(new DateTime(timestamp))
 
   class MarathonTaskSerializer extends JsonSerializer[MarathonTask] {
     def serialize(task: MarathonTask, jgen: JsonGenerator, provider: SerializerProvider) {


### PR DESCRIPTION
This replaces SimpleDateFormat  due to Java 1.6's SimpleDateFormat implementation causing a runtime exception referenced in #153
