### PR TITLE
Automatically upload marathon assets to s3 with shasum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ after_success:
   - bin/build-distribution
   # Prepend a marathon version dir to the tarball elements (requires GNU tar)
   - |
-    tar -czv -f "$ARTIFACT" --transform "s,,marathon_$PROJECT_VERSION/," \
+    tar -czv -f "$ARTIFACT" --transform "s,,marathon-$PROJECT_VERSION/," \
       Dockerfile README.md REST.md LICENSE bin examples docs \
       target/marathon-*-jar-with-dependencies.jar
   - shasum --binary --algorithm 256 "$ARTIFACT" > "$ARTIFACT".sha256


### PR DESCRIPTION
This is based on [Travis CI's support of artifact uploads](http://blog.travis-ci.com/2012-12-18-travis-artifacts/). For every successful build, it will upload target/marathon-runnable.jar to our downloads.mesosphere.io s3 bucket with the following path:

`marathon/$TRAVIS_BRANCH/marathon-runnable_$PROJECT_VERSION.jar`
- TRAVIS_BRANCH is the github branch name
- PROJECT_VERSION is the version string extracted from pom.xml

Please let me know what you guys think ( @guenter @ssorallen @solidsnack ) In particular, what do you think about the artifact naming... are there any other assets we want to upload?

Thanks!
