### PR TITLE
Validate ports for uniqueness

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v1/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/api/v1/AppDefinition.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.{ContainerInfo, Protos}
 import mesosphere.marathon.state.{MarathonState, Timestamp, Timestamped}
 import mesosphere.marathon.Protos.{MarathonTask, Constraint}
 import mesosphere.marathon.tasks.TaskTracker
-import mesosphere.marathon.api.FieldConstraints._
+import mesosphere.marathon.api.validation.FieldConstraints._
 import com.fasterxml.jackson.annotation.{
   JsonIgnore,
   JsonIgnoreProperties,
@@ -42,6 +42,7 @@ case class AppDefinition(
 
   uris: Seq[String] = Seq(),
 
+  @FieldUniqueElements
   ports: Seq[Int] = Seq(0),
 
   /**

--- a/src/main/scala/mesosphere/marathon/api/v2/AppUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppUpdate.scala
@@ -4,7 +4,10 @@ import mesosphere.marathon.ContainerInfo
 import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.api.v1.AppDefinition
 import mesosphere.marathon.Protos.Constraint
-import mesosphere.marathon.api.FieldConstraints.FieldJsonDeserialize
+import mesosphere.marathon.api.validation.FieldConstraints.{
+  FieldJsonDeserialize,
+  FieldUniqueElements
+}
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 
@@ -28,6 +31,9 @@ case class AppUpdate(
   mem: Option[Double] = None,
 
   uris: Option[Seq[String]] = None,
+
+  @FieldUniqueElements
+  ports: Option[Seq[Int]] = None,
 
   constraints: Option[Set[Constraint]] = None,
 
@@ -58,6 +64,7 @@ case class AppUpdate(
     for (v <- cpus) updated = updated.copy(cpus = v)
     for (v <- mem) updated = updated.copy(mem = v)
     for (v <- uris) updated = updated.copy(uris = v)
+    for (v <- ports) updated = updated.copy(ports = v)
     for (v <- constraints) updated = updated.copy(constraints = v)
     for (v <- executor) updated = updated.copy(executor = v)
 
@@ -78,6 +85,7 @@ object AppUpdate {
       cpus = Option(app.cpus),
       mem = Option(app.mem),
       uris = Option(app.uris),
+      ports = Option(app.ports),
       constraints = Option(app.constraints),
       executor = Option(app.executor),
       container = app.container

--- a/src/main/scala/mesosphere/marathon/api/validation/FieldConstraints.scala
+++ b/src/main/scala/mesosphere/marathon/api/validation/FieldConstraints.scala
@@ -1,4 +1,4 @@
-package mesosphere.marathon.api
+package mesosphere.marathon.api.validation
 
 import org.hibernate.validator.constraints.NotEmpty
 import com.fasterxml.jackson.annotation.{
@@ -15,6 +15,7 @@ import scala.annotation.meta.field
  * associated with Scala class constructor arguments.
  */
 object FieldConstraints {
+  type FieldUniqueElements = UniqueElements @field
   type FieldNotEmpty = NotEmpty @field
   type FieldPattern = Pattern @field
   type FieldJsonInclude = JsonInclude @field

--- a/src/main/scala/mesosphere/marathon/api/validation/UniqueElements.java
+++ b/src/main/scala/mesosphere/marathon/api/validation/UniqueElements.java
@@ -1,0 +1,26 @@
+package mesosphere.marathon.api.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({
+	ElementType.METHOD,
+	ElementType.FIELD,
+	ElementType.ANNOTATION_TYPE,
+	ElementType.CONSTRUCTOR,
+	ElementType.PARAMETER
+})
+@Documented
+@Constraint(validatedBy = UniqueElementsValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniqueElements {
+	String message() default "Elements must be unique";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/scala/mesosphere/marathon/api/validation/UniqueElementsValidator.scala
+++ b/src/main/scala/mesosphere/marathon/api/validation/UniqueElementsValidator.scala
@@ -1,0 +1,22 @@
+package mesosphere.marathon.api.validation
+
+import javax.validation.{ConstraintValidator, ConstraintValidatorContext}
+
+/**
+ * This validator accepts objects of type Iterable[_] where all of the
+ * elements are unique, and Option[Iterable[_]] where the wrapped collection's
+ * elements are unique.
+ */
+class UniqueElementsValidator
+  extends ConstraintValidator[UniqueElements, Any] {
+
+  def initialize(annotation: UniqueElements): Unit = {}
+
+  def isValid(obj: Any, context: ConstraintValidatorContext): Boolean =
+    obj match {
+      case opt: Option[_] => opt.forall { isValid(_, context) }
+      case it: Iterable[_] => it.size == it.toSeq.distinct.size
+      case _ => false
+    }
+
+}

--- a/src/main/scala/mesosphere/marathon/event/http/EventSubscribers.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/EventSubscribers.scala
@@ -4,7 +4,7 @@ import mesosphere.marathon.state.MarathonState
 import mesosphere.marathon.Protos
 import collection.JavaConversions._
 
-import mesosphere.marathon.api.FieldConstraints.FieldJsonProperty
+import mesosphere.marathon.api.validation.FieldConstraints.FieldJsonProperty
 
 case class EventSubscribers(
   @FieldJsonProperty("callbackUrls")

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.state
 
-import mesosphere.marathon.api.FieldConstraints.FieldJsonValue
+import mesosphere.marathon.api.validation.FieldConstraints.FieldJsonValue
 import org.joda.time.{DateTime, DateTimeZone}
 import scala.math.Ordered
 

--- a/src/test/scala/mesosphere/marathon/api/v1/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v1/AppDefinitionTest.scala
@@ -67,8 +67,12 @@ class AppDefinitionTest {
       assertion(violations.exists(v =>
         v.getPropertyPath.toString == path && v.getMessageTemplate == template))
     }
-    def shouldViolate(app: AppDefinition, path: String, template: String) = should(assertTrue, app, path, template)
-    def shouldNotViolate(app: AppDefinition, path: String, template: String) = should(assertFalse, app, path, template)
+
+    def shouldViolate(app: AppDefinition, path: String, template: String) =
+      should(assertTrue, app, path, template)
+
+    def shouldNotViolate(app: AppDefinition, path: String, template: String) =
+      should(assertFalse, app, path, template)
 
     val app = AppDefinition(id = "a b")
     shouldViolate(app, "id", "{javax.validation.constraints.Pattern.message}")
@@ -90,6 +94,13 @@ class AppDefinitionTest {
       "instances",
       "{javax.validation.constraints.Min.message}"
     )
+
+    shouldViolate(
+      AppDefinition(id = "test", instances = -3, ports = Seq(9000, 8080, 9000)),
+      "ports",
+      "Elements must be unique"
+    )
+
   }
 
   @Test

--- a/src/test/scala/mesosphere/marathon/api/v2/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppUpdateTest.scala
@@ -1,0 +1,36 @@
+package mesosphere.marathon.api.v2
+
+import org.junit.Test
+import org.junit.Assert._
+import javax.validation.Validation
+import scala.collection.JavaConverters._
+
+class AppUpdateTest {
+
+  @Test
+  def testValidation() {
+    val validator = Validation.buildDefaultValidatorFactory().getValidator
+
+    def should(assertion: (Boolean) => Unit, update: AppUpdate, path: String, template: String) = {
+      val violations = validator.validate(update).asScala
+      assertion(violations.exists(v =>
+        v.getPropertyPath.toString == path && v.getMessageTemplate == template))
+    }
+
+    def shouldViolate(update: AppUpdate, path: String, template: String) =
+      should(assertTrue, update, path, template)
+
+    def shouldNotViolate(update: AppUpdate, path: String, template: String) =
+      should(assertFalse, update, path, template)
+
+    val update = AppUpdate()
+
+    shouldViolate(
+      update.copy(ports = Some(Seq(9000, 8080, 9000))),
+      "ports",
+      "Elements must be unique"
+    )
+
+  }
+
+}


### PR DESCRIPTION
Adds a custom JSON validator to check Iterable[_] and Option[Iterable[_]] for unique elements.

Fixes #183.

@solidsnack 
