### PR TITLE
Better handling of invalid requests

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v1/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/v1/MarathonExceptionMapper.scala
@@ -6,6 +6,9 @@ import scala.concurrent.TimeoutException
 import mesosphere.marathon.{BadRequestException, UnknownAppException}
 import java.util.logging.{Level, Logger}
 import com.sun.jersey.api.NotFoundException
+import com.fasterxml.jackson.core.JsonParseException
+import javax.ws.rs.WebApplicationException
+import javax.ws.rs.core.Response.Status
 
 /**
  * @author Tobi Knaup
@@ -17,19 +20,40 @@ class MarathonExceptionMapper extends ExceptionMapper[Exception] {
   private[this] val log = Logger.getLogger(getClass.getName)
 
   def toResponse(exception: Exception): Response = {
-    log.log(Level.WARNING, "", exception)
-    val statusCode = exception match {
-      case e: IllegalArgumentException => 422 // Unprocessable entity
-      case e: TimeoutException => 504 // Gateway timeout
-      case e: UnknownAppException => 404 // Not found
-      case e: NotFoundException => 404 // Not found
-      case e: BadRequestException => 400 // Bad Request
-      case _ => 500 // Internal server error
+    // WebApplicationException are things like invalid requests etc, no need to log a stack trace
+    if (!exception.isInstanceOf[WebApplicationException]) {
+      log.log(Level.WARNING, "", exception)
     }
-    val entity = exception match {
-      case e: NotFoundException => Map("message" -> s"URI not found: ${e.getNotFoundUri.getRawPath}")
-      case _ => Map("message" -> exception.getMessage)
-    }
-    Response.status(statusCode).`type`(MediaType.APPLICATION_JSON).entity(entity).build
+
+    Response
+      .status(statusCode(exception))
+      .entity(entity(exception))
+      .`type`(MediaType.APPLICATION_JSON)
+      .build
+  }
+
+  private def statusCode(exception: Exception): Int = exception match {
+    case e: IllegalArgumentException => 422 // Unprocessable entity
+    case e: TimeoutException => 504 // Gateway timeout
+    case e: UnknownAppException => 404 // Not found
+    case e: BadRequestException => 400 // Bad Request
+    case e: JsonParseException => 400 // Bad Request
+    case e: WebApplicationException => e.getResponse.getStatus
+    case _ => 500 // Internal server error
+  }
+
+  private def entity(exception: Exception): Any = exception match {
+    case e: NotFoundException =>
+      Map("message" -> s"URI not found: ${e.getNotFoundUri.getRawPath}")
+    case e: JsonParseException =>
+      Map("message" -> e.getOriginalMessage)
+    case e: WebApplicationException =>
+      if (e.getResponse.getEntity != null) {
+        Map("message" -> e.getResponse.getEntity)
+      } else {
+        Map("message" -> Status.fromStatusCode(e.getResponse.getStatus).getReasonPhrase)
+      }
+    case _ =>
+      Map("message" -> exception.getMessage)
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -19,6 +19,7 @@ import javax.ws.rs.core.Response.Status
  */
 
 @Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
 class AppTasksResource @Inject()(service: MarathonSchedulerService,
                                  taskTracker: TaskTracker) {
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon.api.Responses
 
 
 @Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
 class AppVersionsResource(service: MarathonSchedulerService) {
 
   val log = Logger.getLogger(getClass.getName)

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -27,6 +27,7 @@ import mesosphere.marathon.api.Responses
 
 @Path("v2/apps")
 @Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
 class AppsResource @Inject()(
     @Named(EventModule.busName) eventBus: Option[EventBus],
     service: MarathonSchedulerService,

--- a/src/main/scala/mesosphere/marathon/api/v2/EventSubscriptionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/EventSubscriptionsResource.scala
@@ -14,6 +14,7 @@ import mesosphere.marathon.BadRequestException
 
 @Path("v2/eventSubscriptions")
 @Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
 class EventSubscriptionsResource {
   // TODO(everpeace) this should be configurable option?
   val timeout = HttpEventModule.timeout.duration


### PR DESCRIPTION
Return more meaningful errors when receiving invalid requests

Invalid content type:

```
$ curl -i  localhost:8080/v2/apps --data-binary garbage
HTTP/1.1 415 Unsupported Media Type
Content-Type: application/json
Transfer-Encoding: chunked
Server: Jetty(8.1.11.v20130520)

{"message":"Unsupported Media Type"}
```

Invalid JSON:

```
$ curl -i -H 'Content-Type: application/json' localhost:8080/v2/apps --data-binary garbage
HTTP/1.1 400 Bad Request
Content-Type: application/json
Transfer-Encoding: chunked
Server: Jetty(8.1.11.v20130520)

{"message":"Unrecognized token 'garbage': was expecting ('true', 'false' or 'null')"}
```
