### PR TITLE
Add "id" search for feature parity with V1 API

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -135,18 +135,16 @@ class AppsResource @Inject()(
     }
   }
 
-  private def search(cmd: String, id: String) = {
-    service.listApps().filter {
-      x =>
-        var valid = true
-        if (cmd != null && !cmd.isEmpty && !x.cmd.toLowerCase.contains(cmd.toLowerCase)) {
-          valid = false
-        }
-        if (id != null && !id.isEmpty && !x.id.toLowerCase.contains(id.toLowerCase)) {
-          valid = false
-        }
-        // Maybe add some other query parameters?
-        valid
+  private def search(cmd: String, id: String): Iterable[AppDefinition] = {
+    /** Returns true iff `a` is a prefix of `b`, case-insensitively */
+    def isPrefix(a: String, b: String): Boolean =
+      b.toLowerCase contains a.toLowerCase
+
+    service.listApps().filterNot { app =>
+      val appMatchesCmd = cmd != null && cmd.nonEmpty && isPrefix(cmd, app.cmd)
+      val appMatchesId = id != null && id.nonEmpty && isPrefix(id, app.id)
+
+      appMatchesCmd || appMatchesId
     }
   }
 }


### PR DESCRIPTION
The V1 API "search" endpoint allows searching both on "cmd" and on "id".
V2 already supports "cmd", and so this adds "id" to make V2 on par with
V1's functionality.

Example:

```
curl -H "Accept: application/json" localhost:8080/v2/apps?id=hadoop_
```
