### PR TITLE
#203 Add PATCH support for updating app instances

### DIFF
--- a/REST.md
+++ b/REST.md
@@ -11,7 +11,9 @@
   * [GET /v2/apps/{appId}](#get-v2appsappid): List the app `appId`
   * [GET /v2/apps/{appId}/versions](#get-v2appsappidversions): List the versions of the application with id `appId`.
   * [GET /v2/apps/{appId}/versions/{version}](#get-v2appsappidversionsversion): List the configuration of the application with id `appId` at version `version`.
-  * [PUT /v2/apps/{appId}](#put-v2appsappid): Change config of the app
+  * [PATCH /v2/apps/{appId}](#put-v2appsappid): Replace config of the app
+    `appId`
+  * [PATCH /v2/apps/{appId}](#put-v2appsappid): Change config of the app
     `appId`
   * [DELETE /v2/apps/{appId}](#delete-v2appsappid): Destroy app `appId`
   * [GET /v2/apps/{appId}/tasks](#get-v2appsappidtasks): List running tasks
@@ -415,11 +417,17 @@ Transfer-Encoding: chunked
 }
 ```
 
+#203 Add PATCH support for updating app instances
+
 #### PUT `/v2/apps/{appId}`
 
-Change parameters of a running application.  The new application parameters
-apply only to subsequently created tasks, and currently running tasks are
-__not__ pre-emptively restarted.
+Change parameters of a running application. The new application
+parameters
+apply only to subsequently created tasks, and currently running tasks
+are
+__not__ pre-emptively restarted. If no application with the given id
+exists,
+it will be created.
 
 ##### Example
 
@@ -427,6 +435,55 @@ __not__ pre-emptively restarted.
 
 ```
 PUT /v2/apps/myApp HTTP/1.1
+Accept: application/json
+Accept-Encoding: gzip, deflate, compress
+Content-Length: 126
+Content-Type: application/json; charset=utf-8
+Host: localhost:8080
+User-Agent: HTTPie/0.7.2
+
+{
+    "cmd": "sleep 55",
+    "constraints": [
+        [
+            "hostname",
+            "UNIQUE",
+            ""
+        ]
+    ],
+    "cpus": "0.3",
+    "instances": "2",
+    "mem": "9",
+    "ports": [
+        9000
+    ]
+}
+```
+
+**Response:**
+
+```
+HTTP/1.1 204 No Content
+Content-Type: application/json
+Server: Jetty(8.y.z-SNAPSHOT)
+
+
+```
+
+#### PATCH `/v2/apps/{appId}`
+
+Change parameters of a running application.  The new application
+parameters
+apply only to subsequently created tasks, and currently running tasks
+are
+__not__ pre-emptively restarted.
+
+##### Example
+
+**Request:**
+
+```
+PATCH /v2/apps/myApp HTTP/1.1
 Accept: application/json
 Accept-Encoding: gzip, deflate, compress
 Content-Length: 126
@@ -462,7 +519,6 @@ Server: Jetty(8.y.z-SNAPSHOT)
 
 ```
 
-
 ##### Example (version rollback)
 
 If the `version` key is supplied in the JSON body, the rest of the object is ignored.  If the supplied version is known, then the app is updated (a new version is created) with those parameters.  Otherwise, if the supplied version is not known Marathon responds with a 404.
@@ -470,7 +526,7 @@ If the `version` key is supplied in the JSON body, the rest of the object is ign
 **Request:**
 
 ```
-PUT /v2/apps/myApp HTTP/1.1
+PATCH /v2/apps/myApp HTTP/1.1
 Accept: application/json
 Accept-Encoding: gzip, deflate, compress
 Content-Length: 39

--- a/src/main/java/mesosphere/marathon/api/PATCH.java
+++ b/src/main/java/mesosphere/marathon/api/PATCH.java
@@ -1,0 +1,13 @@
+package mesosphere.marathon.api;
+
+import javax.ws.rs.HttpMethod;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@HttpMethod("PATCH")
+public @interface PATCH {
+}

--- a/src/main/scala/mesosphere/marathon/ContainerInfo.scala
+++ b/src/main/scala/mesosphere/marathon/ContainerInfo.scala
@@ -4,7 +4,7 @@ import com.google.protobuf.ByteString
 import scala.collection.JavaConverters._
 
 
-case class ContainerInfo(image: String = "", options: Seq[String] = Seq()) {
+class ContainerInfo protected (val image: String, val options: Seq[String]) {
   def toProto: Protos.ContainerInfo =
     Protos.ContainerInfo.newBuilder()
       .setImage(ByteString.copyFromUtf8(image))
@@ -12,9 +12,18 @@ case class ContainerInfo(image: String = "", options: Seq[String] = Seq()) {
       .build()
 }
 
+case object EmptyContainerInfo extends ContainerInfo("", Nil)
+
 object ContainerInfo {
   def apply(proto: Protos.ContainerInfo): ContainerInfo = ContainerInfo(
     proto.getImage.toStringUtf8,
     proto.getOptionsList.asScala.map(_.toStringUtf8).toSeq
   )
+
+  def apply(image: String = "", options: Seq[String] = Nil) = {
+    if (image.isEmpty && options.isEmpty)
+      EmptyContainerInfo
+    else
+      new ContainerInfo(image, options)
+  }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppUpdate.scala
@@ -4,14 +4,10 @@ import mesosphere.marathon.ContainerInfo
 import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.api.v1.AppDefinition
 import mesosphere.marathon.Protos.Constraint
-import mesosphere.marathon.api.validation.FieldConstraints.{
-  FieldJsonDeserialize,
-  FieldPortsArray
-}
+import mesosphere.marathon.api.validation.FieldConstraints.FieldPortsArray
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import scala.collection.mutable
 import java.lang.{Integer => JInt, Double => JDouble}
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 
 // TODO: Accept a task restart strategy as a constructor parameter here, to be
 //       used in MarathonScheduler.
@@ -59,7 +55,7 @@ case class AppUpdate(
     for (v <- constraints) updated = updated.copy(constraints = v)
     for (v <- executor) updated = updated.copy(executor = v)
 
-    updated.copy(container = this.container, version = Timestamp.now)
+    updated.copy(container = this.container.orElse(app.container), version = Timestamp.now)
   }
 
 }


### PR DESCRIPTION
This PR adds support for PATCH to update app instances. The PATCH method behaves exactly as the PUT used to behave in earlier version except that it will retain the original container if no new container is defined by the update. The PUT method now stops the running app with the given ID and replaces it with the new `AppDefinition`. If no app with the given id exists, the app will be created.

Fixes #221 
Fixes #203 
