### PR TITLE
#222 Show apps with empty ports in endpoint api

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -19,12 +19,21 @@ object EndpointsHelper {
     for (app <- apps) {
       val cleanId = app.id.replaceAll("\\s+", "_")
       val tasks = taskTracker.get(app.id)
-      for ((port, i) <- app.ports.zipWithIndex) {
-        sb.append(s"$cleanId$delimiter$port$delimiter")
-        for (task <- tasks) {
-          sb.append(s"${task.getHost}:${task.getPorts(i)}$delimiter")
+
+      if (app.ports.isEmpty) {
+        sb.append(s"${cleanId}$delimiter $delimiter")
+        tasks.foreach { task =>
+          sb.append(s"${task.getHost} ")
         }
-        sb.append("\n")
+        sb.append(s"\n")
+      } else {
+        for ((port, i) <- app.ports.zipWithIndex) {
+          sb.append(s"$cleanId$delimiter$port$delimiter")
+          for (task <- tasks) {
+            sb.append(s"${task.getHost}:${task.getPorts(i)}$delimiter")
+          }
+          sb.append("\n")
+        }
       }
     }
     sb.toString()

--- a/src/main/scala/mesosphere/marathon/api/v1/EndpointsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v1/EndpointsResource.scala
@@ -75,12 +75,21 @@ class EndpointsResource @Inject()(
     for (app <- apps) {
       val cleanId = app.id.replaceAll("\\s+", "_")
       val tasks = taskTracker.get(app.id)
-      for ((port, i) <- app.ports.zipWithIndex) {
-        sb.append(s"${cleanId}_$port $port ")
-        for (task <- tasks) {
-          sb.append(s"${task.getHost}:${task.getPorts(i)} ")
+
+      if (app.ports.isEmpty) {
+        sb.append(s"${cleanId}   ")
+        tasks.foreach { task =>
+          sb.append(s"${task.getHost} ")
         }
-        sb.append("\n")
+        sb.append(s"\n")
+      } else {
+        for ((port, i) <- app.ports.zipWithIndex) {
+          sb.append(s"${cleanId}_$port $port ")
+          for (task <- tasks) {
+            sb.append(s"${task.getHost}:${task.getPorts(i)} ")
+          }
+          sb.append("\n")
+        }
       }
     }
     sb.toString()


### PR DESCRIPTION
This PR fixes the /v1/endpoints and /v2/tasks endpoints when using `text/plain`. In earlier versions tasks that did not have ports assigned would not show up in the list.
