### PR TITLE
Added a framework message event and support for publishing these events ...

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -15,7 +15,7 @@ import scala.concurrent.{Future, ExecutionContext}
 import com.google.common.collect.Lists
 import javax.inject.{Named, Inject}
 import com.google.common.eventbus.EventBus
-import mesosphere.marathon.event.{EventModule, MesosStatusUpdateEvent}
+import mesosphere.marathon.event.{FrameworkMessageEvent, EventModule, MesosStatusUpdateEvent}
 import mesosphere.marathon.tasks.{TaskTracker, TaskQueue, TaskIDUtil, MarathonTasks}
 import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.Protos.MarathonTask
@@ -169,6 +169,7 @@ class MarathonScheduler @Inject()(
 
   def frameworkMessage(driver: SchedulerDriver, executor: ExecutorID, slave: SlaveID, message: Array[Byte]) {
     log.info("Received framework message %s %s %s ".format(executor, slave, message))
+    eventBus.map(bus => bus.post(FrameworkMessageEvent(executor.getValue, slave.getValue, message)))
   }
 
   def disconnected(driver: SchedulerDriver) {


### PR DESCRIPTION
I added a framework message event and post these events to the event bus. This pull request is for issue #228.

I followed the pattern for existing events and and for the framework message class parameters I just used what is provided as part of the framework message (i.e. the executor ID, the slave ID and the message). Here's the case class:

``` scala
case class FrameworkMessageEvent(
   executorID: String,
   slaveID: String,
   message: Array[Byte],
   eventType: String = "framework_message_event")
  extends MarathonEvent
```

For my own testing and inspecting events I created a simple HTTP endpoint application based on the [Play Framework](http://www.playframework.com/) which can be used to receive and log POSTed JSON data. Here's the application: https://github.com/marc-barry/HTTP-JSON-Validator.

Just run the Play! application and configure Marathon to post messages to the endpoint:

```
/bin/start --master zk://localhost:2181/mesos  --zk_hosts localhost:2181 --event_subscriber http_callback --http_endpoints http://localhost:9000/validate
```

The `http_enpoints` command line argument is just the endpoint of the Play! application which accepts and validates JSON.
