### PR TITLE
#234 Fix unsafe generation of task listing

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.api
 
 import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.marathon.api.v1.AppDefinition
+import scala.collection.JavaConverters._
 
 object EndpointsHelper {
 
@@ -30,7 +31,8 @@ object EndpointsHelper {
         for ((port, i) <- app.ports.zipWithIndex) {
           sb.append(s"$cleanId$delimiter$port$delimiter")
           for (task <- tasks) {
-            sb.append(s"${task.getHost}:${task.getPorts(i)}$delimiter")
+            val ports = task.getPortsList.asScala.lift
+            sb.append(s"${task.getHost}:${ports(i).getOrElse(0)}$delimiter")
           }
           sb.append("\n")
         }

--- a/src/main/scala/mesosphere/marathon/api/v1/EndpointsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v1/EndpointsResource.scala
@@ -6,10 +6,9 @@ import javax.inject.Inject
 import mesosphere.marathon.MarathonSchedulerService
 import mesosphere.marathon.tasks.TaskTracker
 import com.codahale.metrics.annotation.Timed
-import mesosphere.marathon.state.{MarathonStore, AppRepository}
-import scala.concurrent.Await
 import javax.ws.rs.core.Response.Status
 import mesosphere.marathon.api.Responses
+import scala.collection.JavaConverters._
 
 /**
  * @author Tobi Knaup
@@ -19,8 +18,6 @@ import mesosphere.marathon.api.Responses
 class EndpointsResource @Inject()(
     schedulerService: MarathonSchedulerService,
     taskTracker: TaskTracker) {
-
-  import scala.concurrent.ExecutionContext.Implicits.global
 
   @GET
   @Produces(Array(MediaType.TEXT_PLAIN))
@@ -84,7 +81,8 @@ class EndpointsResource @Inject()(
         for ((port, i) <- app.ports.zipWithIndex) {
           sb.append(s"${cleanId}_$port $port ")
           for (task <- tasks) {
-            sb.append(s"${task.getHost}:${task.getPorts(i)} ")
+            val ports = task.getPortsList.asScala.lift
+            sb.append(s"${task.getHost}:${ports(i).getOrElse(0)} ")
           }
           sb.append("\n")
         }


### PR DESCRIPTION
This PR fixes an unsafe retrieval of ports in the `EndpointsHelper` and `v1.EndpointsResource` classes. If a running task had fewer ports than the `AppDefinition` it threw an `IndexOutOfBoundsException`. Now it defaults to port 0.

Fixes #234 
