### PR TITLE
Added the slave ID to MesosStatusUpdateEvent.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -371,6 +371,7 @@ class MarathonScheduler @Inject()(
         log.info("Sending event notification.")
         bus.post(
           MesosStatusUpdateEvent(
+            status.getSlaveId.getValue,
             status.getTaskId.getValue,
             status.getState.getNumber,
             TaskIDUtil.appID(status.getTaskId),

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -60,6 +60,7 @@ case class ApiPostEvent(
 ) extends MarathonEvent
 
 case class MesosStatusUpdateEvent(
+  slaveId: String,
   taskId: String,
   taskStatus: Int,
   appId: String,


### PR DESCRIPTION
I added the slave ID to the `MesosStatusUpdateEvent` case class. As this information is useful for reconciling status update events against a particular slave in the Mesos cluster. I would also like to know which Executor the status update came from but I can't seem to find a way to get that data from the update event sent to the framework.
