### PR TITLE
Renamed some of the MarathonEvent case class parameters (*ID -> *Id)

### DIFF
--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -62,7 +62,7 @@ case class ApiPostEvent(
 case class MesosStatusUpdateEvent(
   taskId: String,
   taskStatus: Int,
-  appID: String,
+  appId: String,
   host: String,
   ports: Iterable[Integer],
   eventType: String = "status_update_event"
@@ -111,8 +111,8 @@ case class FailedHealthCheck(
 // framework messages
 
 case class FrameworkMessageEvent(
-   executorID: String,
-   slaveID: String,
+   executorId: String,
+   slaveId: String,
    message: Array[Byte],
    eventType: String = "framework_message_event")
 extends MarathonEvent


### PR DESCRIPTION
Renamed some of the case class parameters. When I introduced the `FrameworkMessageEvent` I accidentally used "ID" instead of "Id". Normally, this wouldn't be an issue. But since the case classes are directly serialized to JSON with property names the same as the case class parameters it makes sense to remain consistent.
