### PR TITLE
Proposal: Change the MesosStatusUpdateEvent taskStatus parameter to a String

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -373,7 +373,7 @@ class MarathonScheduler @Inject()(
           MesosStatusUpdateEvent(
             status.getSlaveId.getValue,
             status.getTaskId.getValue,
-            status.getState.getNumber,
+            status.getState.name,
             TaskIDUtil.appID(status.getTaskId),
             task.getHost,
             task.getPortsList.asScala

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -62,7 +62,7 @@ case class ApiPostEvent(
 case class MesosStatusUpdateEvent(
   slaveId: String,
   taskId: String,
-  taskStatus: Int,
+  taskStatus: String,
   appId: String,
   host: String,
   ports: Iterable[Integer],


### PR DESCRIPTION
I want to propose that the `taskStatus` parameter of `MesosStatusUpdateEvent` be changed to a `String` instead of an `Int` and its value to be changed to something more meaningful (i.e. `TaskStatus.TaskState.name`).

Currently, the `taskStatus` parameter is an `Int` with its value from `getNumber` which comes from the `com.google.protobuf.ProtocolMessageEnum` interface. This results in JSON events like the following:

``` json
{
  "slaveId" : "20140428-140502-16842879-5050-4741-0",
  "taskId" : "app_11_0-1398700942222",
  "taskStatus" : 1,
  "appId" : "app_11",
  "host" : "vagrant.myshopify.io",
  "ports" : [ 31859 ],
  "eventType" : "status_update_event"
}
```

This change would make it look like this:

``` json
{
  "slaveId" : "20140428-140502-16842879-5050-4741-0",
  "taskId" : "app_11_0-1398700942222",
  "taskStatus" : "TASK_RUNNING",
  "appId" : "app_11",
  "host" : "vagrant.myshopify.io",
  "ports" : [ 31859 ],
  "eventType" : "status_update_event"
}
```

I think this provides a more meaningful set of task states such as TASK_STAGING, TASK_STARTING, TASK_RUNNING, TASK_FINISHED, TASK_FAILED, TASK_KILLED and TASK_LOST.
