### PR TITLE
Add marathon-client.py to the list of clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ as it did before being deprecated. Details on the V1 API can be found in the
 * [Scala client](https://github.com/guidewire/marathon-client), developed at Guidewire
 * [Java client](https://github.com/mohitsoni/marathon-client) by Mohit Soni
 * [Python client](https://github.com/thefactory/marathon-python), developed at [The Factory](http://www.thefactory.com)
+* [Python client](https://github.com/Wizcorp/marathon-client.py), developed at [Wizcorp](http://www.wizcorp.jp)
 
 ## Companies using Marathon
 


### PR DESCRIPTION
Unlike https://github.com/thefactory/marathon-python, it's a direct port https://github.com/mesosphere/marathon_client to python.

You can use it from the command line and the API is similar to the API of the ruby gem.
