### PR TITLE
Added a timestamp property to the MarathonEvent object

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -13,14 +13,13 @@ import scala.concurrent.{Future, ExecutionContext}
 import com.google.common.collect.Lists
 import javax.inject.{Named, Inject}
 import com.google.common.eventbus.EventBus
-import mesosphere.marathon.event.{FrameworkMessageEvent, EventModule}
+import mesosphere.marathon.event._
 import mesosphere.marathon.tasks.{TaskTracker, TaskQueue, TaskIDUtil, MarathonTasks}
 import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.mesos.util.FrameworkIdUtil
 import mesosphere.mesos.protos
 import mesosphere.util.RateLimiters
-import mesosphere.marathon.event.MesosStatusUpdateEvent
 import mesosphere.marathon.health.HealthCheckManager
 import scala.util.{Success, Failure}
 import org.apache.log4j.Logger
@@ -175,7 +174,7 @@ class MarathonScheduler @Inject()(
 
   def frameworkMessage(driver: SchedulerDriver, executor: ExecutorID, slave: SlaveID, message: Array[Byte]) {
     log.info("Received framework message %s %s %s ".format(executor, slave, message))
-    eventBus.foreach(_.post(FrameworkMessageEvent(executor.getValue, slave.getValue, message)))
+    eventBus.foreach(_.post(MesosFrameworkMessageEvent(executor.getValue, slave.getValue, message)))
   }
 
   def disconnected(driver: SchedulerDriver) {

--- a/src/main/scala/mesosphere/marathon/event/http/SubscribersKeeperActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/SubscribersKeeperActor.scala
@@ -17,7 +17,7 @@ class SubscribersKeeperActor(val store: MarathonStore[EventSubscribers]) extends
 
   override def receive = {
 
-    case event @ Subscribe(_, callbackUrl, _) =>
+    case event @ Subscribe(_, callbackUrl, _, _) =>
       val addResult: Future[Option[EventSubscribers]] = add(callbackUrl)
 
       val subscription: Future[MarathonSubscriptionEvent] =
@@ -29,7 +29,7 @@ class SubscribersKeeperActor(val store: MarathonStore[EventSubscribers]) extends
 
       subscription pipeTo sender
 
-    case event @ Unsubscribe(_, callbackUrl, _) =>
+    case event @ Unsubscribe(_, callbackUrl, _, _) =>
       val removeResult: Future[Option[EventSubscribers]] = remove(callbackUrl)
 
       val subscription: Future[MarathonSubscriptionEvent] =


### PR DESCRIPTION
We needed a way to get the date/time when events were generated. Thus, I added a dataTimeString property to the MarathonEvent object. This property is populated with the current date/time (UTC timezone) with ISO8601 formatting. Renamed FrameworkMessageEvent to MesosFrameworkMessageEvent to make it clear that this object is for the scheduler.

EDIT: The property is called `timestamp`
