### PR TITLE
Switch to scalatest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,8 @@
         <twitter-commons.version>0.0.52</twitter-commons.version>
 
         <!-- test deps versions -->
-        <junit.version>4.11</junit.version>
         <mockito.version>1.9.5</mockito.version>
-        <scalatest.version>1.9.2</scalatest.version>
+        <scalatest.version>2.1.5</scalatest.version>
     </properties>
 
     <distributionManagement>
@@ -144,11 +143,6 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.10</artifactId>
             <version>${scalatest.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -260,6 +254,25 @@
                         <jvmArg>-Xmx2G</jvmArg>
                     </jvmArgs>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+                <version>1.0-RC2</version>
+                <configuration>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                    <junitxml>.</junitxml>
+                    <filereports>WDF TestSuite.txt</filereports>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <resources>

--- a/src/test/scala/mesosphere/marathon/MarathonSpec.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSpec.scala
@@ -1,0 +1,13 @@
+package mesosphere.marathon
+
+import org.scalatest.{FunSuite, BeforeAndAfter}
+import org.scalatest.mock.MockitoSugar
+
+/**
+ * @author Tobi Knaup
+ */
+
+abstract class MarathonSpec extends FunSuite
+  with BeforeAndAfter with MockitoSugar with MarathonTestHelper {
+
+}

--- a/src/test/scala/mesosphere/marathon/TaskTrackerTest.scala
+++ b/src/test/scala/mesosphere/marathon/TaskTrackerTest.scala
@@ -1,19 +1,14 @@
 package mesosphere.marathon
 
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mock.MockitoSugar
-import org.junit.Test
 import org.apache.mesos.state.InMemoryState
 import mesosphere.marathon.Protos.MarathonTask
 import org.apache.mesos.Protos.{TaskID, TaskStatus, TaskState}
 import java.io.{ByteArrayInputStream, ObjectInputStream, ByteArrayOutputStream, ObjectOutputStream}
-
-import org.junit.Assert._
 import mesosphere.marathon.tasks.{TaskTracker, TaskIDUtil}
 import com.google.common.collect.Lists
 import mesosphere.mesos.protos.TextAttribute
 
-class TaskTrackerTest extends AssertionsForJUnit with MockitoSugar {
+class TaskTrackerTest extends MarathonSpec {
 
   import mesosphere.mesos.protos.Implicits._
 
@@ -39,14 +34,13 @@ class TaskTrackerTest extends AssertionsForJUnit with MockitoSugar {
       .build
   }
 
-  @Test
-  def testStartingPersistsTasks() {
+  test("StartingPersistsTasks") {
     def shouldContainTask(tasks: Iterable[MarathonTask], task: MarathonTask) {
-      assertTrue(
-        s"Should contain task ${task.getId}",
+      assert(
         tasks.exists(t => t.getId == task.getId
           && t.getHost == task.getHost
-          && t.getPortsList == task.getPortsList)
+          && t.getPortsList == task.getPortsList),
+        s"Should contain task ${task.getId}"
       )
     }
 
@@ -77,14 +71,13 @@ class TaskTrackerTest extends AssertionsForJUnit with MockitoSugar {
     shouldContainTask(results, task3)
   }
 
-  @Test
-  def testStoreFetchTasks() {
+  test("StoreFetchTasks") {
     def shouldContainTask(tasks: Iterable[MarathonTask], task: MarathonTask) {
-      assertTrue(
-        s"Should contain task ${task.getId}",
+      assert(
         tasks.exists(t => t.getId == task.getId
           && t.getHost == task.getHost
-          && t.getPortsList == task.getPortsList)
+          && t.getPortsList == task.getPortsList),
+        s"Should contain task ${task.getId}"
       )
     }
 
@@ -116,8 +109,7 @@ class TaskTrackerTest extends AssertionsForJUnit with MockitoSugar {
     shouldContainTask(results, task3)
   }
 
-  @Test
-  def testSerDe() {
+  test("SerDe") {
     val state = new InMemoryState
     val taskTracker = new TaskTracker(state)
 
@@ -137,7 +129,7 @@ class TaskTrackerTest extends AssertionsForJUnit with MockitoSugar {
 
       val ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
       taskTracker.deserialize("app1", ois)
-      assertTrue("Tasks are not properly serialized", taskTracker.count("app1") == 3)
+      assert(taskTracker.count("app1") == 3, "Tasks are not properly serialized")
     }
 
     taskTracker.running("app1", makeTaskStatus("task1"))
@@ -152,7 +144,7 @@ class TaskTrackerTest extends AssertionsForJUnit with MockitoSugar {
 
       val ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
       taskTracker.deserialize("app1", ois)
-      assertTrue("Tasks are not properly serialized", taskTracker.count("app1") == 3)
+      assert(taskTracker.count("app1") == 3, "Tasks are not properly serialized")
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/ZookeeperConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/ZookeeperConfTest.scala
@@ -1,46 +1,40 @@
 package mesosphere.marathon
 
 import org.rogach.scallop.ScallopConf
-import org.junit.Test
-import org.junit.Assert._
 import scala.util.Try
 
-class ZookeeperConfTest {
+class ZookeeperConfTest extends MarathonSpec {
 
-  @Test
-  def emptyConfigurationGivesDefaultValues() {
+  test("emptyConfigurationGivesDefaultValues") {
     val opts = conf()
-    assertFalse(opts.zooKeeperHostString.isEmpty)
-    assertFalse(opts.zooKeeperPath.isEmpty)
-    assertFalse(opts.zooKeeperTimeout.isEmpty)
+    assert(opts.zooKeeperHostString.isDefined)
+    assert(opts.zooKeeperPath.isDefined)
+    assert(opts.zooKeeperTimeout.isDefined)
   }
 
-  @Test
-  def hostStateParameterGetParsed() {
+  test("hostStateParameterGetParsed") {
     val host = "host1:123"
     val timeout = 123
     val state = "/test"
     val opts = conf("--zk_hosts", host, "--zk_timeout", timeout.toString, "--zk_state", state )
 
-    assertTrue(opts.zooKeeperHostString() == host)
-    assertTrue(opts.zooKeeperTimeout() == timeout)
-    assertTrue(opts.zooKeeperPath() == state)
-    assertEquals(opts.zkURL, s"zk://$host$state")
+    assert(opts.zooKeeperHostString() == host)
+    assert(opts.zooKeeperTimeout() == timeout)
+    assert(opts.zooKeeperPath() == state)
+    assert(opts.zkURL == s"zk://$host$state")
   }
 
-  @Test
-  def urlParameterGetParsed() {
+  test("urlParameterGetParsed") {
     val url = "zk://host1:123,host2,host3:312/path"
     val opts = conf("--zk", url)
-    assertEquals(opts.zkURL, url)
-    assertEquals(opts.zkHosts, "host1:123,host2,host3:312")
-    assertEquals(opts.zkPath, "/path")
+    assert(opts.zkURL == url)
+    assert(opts.zkHosts == "host1:123,host2,host3:312")
+    assert(opts.zkPath == "/path")
   }
 
-  @Test
-  def wrongURLIsNotParsed() {
-    assertFalse("No port number",  Try(conf("--zk", "zk://host1:foo/path")).isSuccess)
-    assertFalse("No path", Try(conf("--zk", "zk://host1")).isSuccess)
+  test("wrongURLIsNotParsed") {
+    assert(Try(conf("--zk", "zk://host1:foo/path")).isFailure, "No port number")
+    assert(Try(conf("--zk", "zk://host1")).isFailure, "No path")
   }
 
   def conf(args:String *) = {

--- a/src/test/scala/mesosphere/marathon/api/v1/json/ConstraintTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v1/json/ConstraintTest.scala
@@ -1,27 +1,25 @@
 package mesosphere.marathon.api.v1.json
 
-import org.junit.Test
-import org.junit.Assert._
 import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.api.v2.json.MarathonModule
+import mesosphere.marathon.MarathonSpec
 
 
 /**
  * @author Tobi Knaup
  */
-class ConstraintTest {
+class ConstraintTest extends MarathonSpec {
 
-  @Test
-  def testDeserialize() {
+  test("Deserialize") {
     val mapper = new ObjectMapper
     mapper.registerModule(new MarathonModule)
 
     def shouldMatch(json: String, field: String, operator: Constraint.Operator, value: String = "") {
       val constraint = mapper.readValue(json, classOf[Constraint])
-      assertEquals(field, constraint.getField)
-      assertEquals(operator, constraint.getOperator)
-      assertEquals(value, constraint.getValue)
+      assert(field == constraint.getField)
+      assert(operator == constraint.getOperator)
+      assert(value == constraint.getValue)
     }
 
     shouldMatch("""["hostname","UNIQUE"]""", "hostname", Constraint.Operator.UNIQUE)
@@ -29,14 +27,13 @@ class ConstraintTest {
     shouldMatch("""["jdk","LIKE","7"]""", "jdk", Constraint.Operator.LIKE, "7")
   }
 
-  @Test
-  def testSerialize() {
+  test("Serialize") {
     val mapper = new ObjectMapper
     mapper.registerModule(new MarathonModule)
 
     def shouldMatch(expected: String, constraint: Constraint) {
       val actual = mapper.writeValueAsString(constraint)
-      assertEquals(expected, actual)
+      assert(expected == actual)
     }
 
     shouldMatch("""["hostname","UNIQUE"]""", Constraint.newBuilder.setField("hostname")

--- a/src/test/scala/mesosphere/marathon/api/v2/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppUpdateTest.scala
@@ -1,27 +1,25 @@
 package mesosphere.marathon.api.v2
 
-import org.junit.Test
-import org.junit.Assert._
 import javax.validation.Validation
 import scala.collection.JavaConverters._
+import mesosphere.marathon.MarathonSpec
 
-class AppUpdateTest {
+class AppUpdateTest extends MarathonSpec {
 
-  @Test
-  def testValidation() {
+  test("Validation") {
     val validator = Validation.buildDefaultValidatorFactory().getValidator
 
-    def should(assertion: (Boolean) => Unit, update: AppUpdate, path: String, template: String) = {
+    def shouldViolate(update: AppUpdate, path: String, template: String) = {
       val violations = validator.validate(update).asScala
-      assertion(violations.exists(v =>
+      assert(violations.exists(v =>
         v.getPropertyPath.toString == path && v.getMessageTemplate == template))
     }
 
-    def shouldViolate(update: AppUpdate, path: String, template: String) =
-      should(assertTrue, update, path, template)
-
-    def shouldNotViolate(update: AppUpdate, path: String, template: String) =
-      should(assertFalse, update, path, template)
+    def shouldNotViolate(update: AppUpdate, path: String, template: String) = {
+      val violations = validator.validate(update).asScala
+      assert(!violations.exists(v =>
+        v.getPropertyPath.toString == path && v.getMessageTemplate == template))
+    }
 
     val update = AppUpdate()
 

--- a/src/test/scala/mesosphere/marathon/event/http/EventSubscribersTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/http/EventSubscribersTest.scala
@@ -1,45 +1,39 @@
 package mesosphere.marathon.event.http
 
-import org.junit.Test
-import org.junit.Assert._
-import mesosphere.marathon.Protos
+import mesosphere.marathon.{MarathonSpec, Protos}
 
-class EventSubscribersTest {
+class EventSubscribersTest extends MarathonSpec {
 
-  @Test
-  def testToProtoEmpty() {
+  test("ToProtoEmpty") {
     val v = new EventSubscribers
     val proto = v.toProto
 
-    assertEquals(proto.getCallbackUrlsCount, 0)
-    assertEquals(proto.getCallbackUrlsList.size(), 0)
+    assert(proto.getCallbackUrlsCount == 0)
+    assert(proto.getCallbackUrlsList.size() == 0)
   }
 
-  @Test
-  def testToProtoNotEmpty() {
+  test("ToProtoNotEmpty") {
     val v = new EventSubscribers(Set("http://localhost:9090/callback"))
     val proto = v.toProto
 
-    assertEquals(proto.getCallbackUrlsCount, 1)
-    assertEquals(proto.getCallbackUrlsList.size(), 1)
-    assertEquals(proto.getCallbackUrls(0), "http://localhost:9090/callback")
+    assert(proto.getCallbackUrlsCount == 1)
+    assert(proto.getCallbackUrlsList.size() == 1)
+    assert(proto.getCallbackUrls(0) == "http://localhost:9090/callback")
   }
 
-  @Test
-  def mergeFromProtoEmpty() {
+  test("mergeFromProtoEmpty") {
     val proto = Protos.EventSubscribers.newBuilder().build()
     val subscribers = EventSubscribers()
     val mergeResult = subscribers.mergeFromProto(proto)
 
-    assertEquals(mergeResult.urls, Set.empty[String])
+    assert(mergeResult.urls == Set.empty[String])
   }
 
-  @Test
-  def mergeFromProtoNotEmpty() {
+  test("mergeFromProtoNotEmpty") {
     val proto = Protos.EventSubscribers.newBuilder().addCallbackUrls("http://localhost:9090/callback").build()
     val subscribers = EventSubscribers()
     val mergeResult = subscribers.mergeFromProto(proto)
 
-    assertEquals(mergeResult.urls, Set("http://localhost:9090/callback"))
+    assert(mergeResult.urls == Set("http://localhost:9090/callback"))
   }
 }

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -1,21 +1,13 @@
 package mesosphere.marathon.health
 
-import mesosphere.marathon.Protos
+import mesosphere.marathon.{MarathonSpec, Protos}
 import Protos.HealthCheckDefinition.Protocol
-
-import org.junit.Test
-import org.junit.Assert._
-
 import scala.concurrent.duration.FiniteDuration
-import scala.collection.JavaConverters._
-
 import java.util.concurrent.TimeUnit.SECONDS
-import javax.validation.Validation
 
-class HealthCheckTest {
+class HealthCheckTest extends MarathonSpec {
 
-  @Test
-  def testToProto() {
+  test("ToProto") {
     val healthCheck = HealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTP,
@@ -26,15 +18,14 @@ class HealthCheckTest {
 
     val proto = healthCheck.toProto
 
-    assertEquals("/health", proto.getPath)
-    assertEquals(Protocol.HTTP, proto.getProtocol)
-    assertEquals(0, proto.getPortIndex)
-    assertEquals(10, proto.getInitialDelaySeconds)
-    assertEquals(60, proto.getIntervalSeconds)
+    assert("/health" == proto.getPath)
+    assert(Protocol.HTTP == proto.getProtocol)
+    assert(0 == proto.getPortIndex)
+    assert(10 == proto.getInitialDelaySeconds)
+    assert(60 == proto.getIntervalSeconds)
   }
 
-  @Test
-  def testToProtoTcp() {
+  test("ToProtoTcp") {
     val healthCheck = HealthCheck(
       protocol = Protocol.TCP,
       portIndex = 1,
@@ -44,14 +35,13 @@ class HealthCheckTest {
 
     val proto = healthCheck.toProto
 
-    assertEquals(Protocol.TCP, proto.getProtocol)
-    assertEquals(1, proto.getPortIndex)
-    assertEquals(7, proto.getInitialDelaySeconds)
-    assertEquals(35, proto.getIntervalSeconds)
+    assert(Protocol.TCP == proto.getProtocol)
+    assert(1 == proto.getPortIndex)
+    assert(7 == proto.getInitialDelaySeconds)
+    assert(35 == proto.getIntervalSeconds)
   }
 
-  @Test
-  def testMergeFromProto() {
+  test("MergeFromProto") {
     val proto = Protos.HealthCheckDefinition.newBuilder
       .setPath("/health")
       .setProtocol(Protocol.HTTP)
@@ -72,11 +62,10 @@ class HealthCheckTest {
       timeout = FiniteDuration(10, SECONDS)
     )
 
-    assertEquals(mergeResult, expectedResult)
+    assert(mergeResult == expectedResult)
   }
 
-  @Test
-  def testMergeFromProtoTcp() {
+  test("MergeFromProtoTcp") {
     val proto = Protos.HealthCheckDefinition.newBuilder
       .setProtocol(Protocol.TCP)
       .setPortIndex(1)
@@ -96,11 +85,10 @@ class HealthCheckTest {
       timeout = FiniteDuration(10, SECONDS)
     )
 
-    assertEquals(mergeResult, expectedResult)
+    assert(mergeResult == expectedResult)
   }
 
-  @Test
-  def testSerializationRoundtrip() {
+  test("SerializationRoundtrip") {
     import com.fasterxml.jackson.databind.ObjectMapper
     import com.fasterxml.jackson.module.scala.DefaultScalaModule
     import mesosphere.marathon.api.v2.json.MarathonModule
@@ -113,7 +101,7 @@ class HealthCheckTest {
     val json = mapper.writeValueAsString(original)
     val readResult = mapper.readValue(json, classOf[HealthCheck])
 
-    assertEquals(readResult, original)
+    assert(readResult == original)
   }
 
 }

--- a/src/test/scala/mesosphere/marathon/state/AppRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppRepositoryTest.scala
@@ -1,19 +1,15 @@
 package mesosphere.marathon.state
 
-import org.junit.Test
-import org.junit.Assert._
 import mesosphere.marathon.api.v1.AppDefinition
 import org.mockito.Mockito._
 import org.mockito.Matchers._
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mock.MockitoSugar
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration._
 import org.joda.time.DateTime
+import mesosphere.marathon.MarathonSpec
 
-class AppRepositoryTest extends AssertionsForJUnit with MockitoSugar {
-  @Test
-  def testApp() {
+class AppRepositoryTest extends MarathonSpec {
+  test("App") {
     val store = mock[MarathonStore[AppDefinition]]
     val timestamp = new Timestamp(DateTime.now())
     val appDef = AppDefinition(id = "testApp", version = timestamp)
@@ -24,12 +20,11 @@ class AppRepositoryTest extends AssertionsForJUnit with MockitoSugar {
     val repo = new AppRepository(store)
     val res = repo.app("testApp", timestamp)
 
-    assertEquals("Should return the correct AppDefinition", Some(appDef), Await.result(res, 5 seconds))
+    assert(Some(appDef) == Await.result(res, 5 seconds), "Should return the correct AppDefinition")
     verify(store).fetch(s"testApp:${timestamp}")
   }
 
-  @Test
-  def testStore() {
+  test("Store") {
     val store = mock[MarathonStore[AppDefinition]]
     val appDef = AppDefinition(id = "testApp")
     val future = Future.successful(Some(appDef))
@@ -41,13 +36,12 @@ class AppRepositoryTest extends AssertionsForJUnit with MockitoSugar {
     val repo = new AppRepository(store)
     val res = repo.store(appDef)
 
-    assertEquals("Should return the correct AppDefinition", Some(appDef), Await.result(res, 5 seconds))
+    assert(Some(appDef) == Await.result(res, 5 seconds), "Should return the correct AppDefinition")
     verify(store).store(versionedKey, appDef)
     verify(store).store(s"testApp", appDef)
   }
 
-  @Test
-  def testAppIds() {
+  test("AppIds") {
     val store = mock[MarathonStore[AppDefinition]]
     val future = Future.successful(Seq("app1", "app2", "app1:version", "app2:version").iterator)
 
@@ -56,12 +50,11 @@ class AppRepositoryTest extends AssertionsForJUnit with MockitoSugar {
     val repo = new AppRepository(store)
     val res = repo.appIds()
 
-    assertEquals("Should return only unversioned names", Seq("app1", "app2"), Await.result(res, 5 seconds))
+    assert(Seq("app1", "app2") == Await.result(res, 5 seconds), "Should return only unversioned names")
     verify(store).names()
   }
 
-  @Test
-  def testApps() {
+  test("Apps") {
     val store = mock[MarathonStore[AppDefinition]]
     val appDef1 = AppDefinition("app1")
     val appDef2 = AppDefinition("app2")
@@ -78,14 +71,13 @@ class AppRepositoryTest extends AssertionsForJUnit with MockitoSugar {
     val repo = new AppRepository(store)
     val res = repo.apps()
 
-    assertEquals("Should return only current versions", Seq(appDef1, appDef2), Await.result(res, 5 seconds))
+    assert(Seq(appDef1, appDef2) == Await.result(res, 5 seconds), "Should return only current versions")
     verify(store).names()
     verify(store).fetch(appDef1.id)
     verify(store).fetch(appDef2.id)
   }
 
-  @Test
-  def testListVersions() {
+  test("ListVersions") {
     val store = mock[MarathonStore[AppDefinition]]
     val appDef1 = AppDefinition("app1")
     val version1 = appDef1.copy(version = Timestamp(appDef1.version.dateTime.minusDays(1)))
@@ -102,12 +94,11 @@ class AppRepositoryTest extends AssertionsForJUnit with MockitoSugar {
     val res = repo.listVersions(appDef1.id)
 
     val expected = Seq(appDef1.version, version1.version, version2.version, version3.version)
-    assertEquals("Should return all versions of given app", expected, Await.result(res, 5 seconds))
+    assert(expected == Await.result(res, 5 seconds), "Should return all versions of given app")
     verify(store).names()
   }
 
-  @Test
-  def testExpunge() {
+  test("Expunge") {
     val store = mock[MarathonStore[AppDefinition]]
     val appDef1 = AppDefinition("app1")
     val version1 = appDef1.copy(version = Timestamp(appDef1.version.dateTime.minusDays(1)))
@@ -124,8 +115,8 @@ class AppRepositoryTest extends AssertionsForJUnit with MockitoSugar {
     val repo = new AppRepository(store)
     val res = Await.result(repo.expunge(appDef1.id), 5 seconds).toSeq
 
-    assertTrue("Should expunge all versions", res.size == 5)
-    assertTrue("Should succeed", res.forall(identity))
+    assert(res.size == 5, "Should expunge all versions")
+    assert(res.forall(identity), "Should succeed")
 
     verify(store).names()
     verify(store).expunge("app1")

--- a/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
@@ -1,15 +1,12 @@
 package mesosphere.marathon.state
 
-import org.junit.Test
-import org.junit.Assert._
+import mesosphere.marathon.MarathonSpec
 
-class TimestampTest {
+class TimestampTest extends MarathonSpec {
 
-  @Test
-  def testOrdering() {
+  test("Ordering") {
     val t1 = Timestamp(1024)
     val t2 = Timestamp(2048)
-    assertTrue(t1.compare(t2) < 0)
+    assert(t1.compare(t2) < 0)
   }
-
 }

--- a/src/test/scala/mesosphere/marathon/state/TimestampedTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TimestampedTest.scala
@@ -1,22 +1,18 @@
 package mesosphere.marathon.state
 
-import org.junit.Test
-import org.junit.Assert._
+import mesosphere.marathon.MarathonSpec
 
-class TimestampedTest {
+class TimestampedTest extends MarathonSpec {
 
   class A(val version: Timestamp = Timestamp.now) extends Timestamped
 
-  @Test
-  def testOrdering() {
-
+  test("Ordering") {
     val a1 = new A(Timestamp(1393989019980L))
     val a2 = new A(Timestamp(1393989019981L))
     val a3 = new A(Timestamp(1393989019982L))
 
     implicit val orderingOnA = Timestamped.timestampOrdering[A]
 
-    assertEquals(Seq(a2, a3, a1).sorted, Seq(a1, a2, a3))
+    assert(Seq(a2, a3, a1).sorted == Seq(a1, a2, a3))
   }
-
 }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskQueueTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskQueueTest.scala
@@ -1,13 +1,10 @@
 package mesosphere.marathon.tasks
 
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mock.MockitoSugar
-import org.junit.Test
 import mesosphere.marathon.api.v1.AppDefinition
 import mesosphere.marathon.Protos.Constraint
-import org.junit.Assert._
+import mesosphere.marathon.MarathonSpec
 
-class TaskQueueTest extends AssertionsForJUnit with MockitoSugar {
+class TaskQueueTest extends MarathonSpec {
   val app1 = AppDefinition(id = "app1", constraints = Set.empty)
   val app2 = AppDefinition(id = "app2", constraints = Set(buildConstraint("hostname", "UNIQUE"), buildConstraint("rack_id", "CLUSTER", "rack-1")))
   val app3 = AppDefinition(id = "app3", constraints = Set(buildConstraint("hostname", "UNIQUE")))
@@ -20,21 +17,19 @@ class TaskQueueTest extends AssertionsForJUnit with MockitoSugar {
       .build()
   }
 
-  @Test
-  def testPriority() {
+  test("Priority") {
     val queue = new TaskQueue
 
     queue.add(app1)
     queue.add(app2)
     queue.add(app3)
 
-    assertEquals(s"Should return $app2", app2, queue.poll())
-    assertEquals(s"Should return $app3", app3, queue.poll())
-    assertEquals(s"Should return $app1", app1, queue.poll())
+    assert(app2 == queue.poll(), s"Should return $app2")
+    assert(app3 == queue.poll(), s"Should return $app3")
+    assert(app1 == queue.poll(), s"Should return $app1")
   }
 
-  @Test
-  def testRemoveAll() {
+  test("RemoveAll") {
     val queue = new TaskQueue
 
     queue.add(app1)
@@ -43,24 +38,22 @@ class TaskQueueTest extends AssertionsForJUnit with MockitoSugar {
 
     val res = queue.removeAll()
 
-    assertEquals(s"Should return all elements in correct order.", Vector(app2, app3, app1), res)
-    assertTrue("TaskQueue should be empty.", queue.queue.isEmpty)
+    assert(Vector(app2, app3, app1) == res, s"Should return all elements in correct order.")
+    assert(queue.queue.isEmpty, "TaskQueue should be empty.")
   }
 
-  @Test
-  def testAddAll() {
+  test("AddAll") {
     val queue = new TaskQueue
 
     queue.addAll(Seq(app1, app2, app3))
 
-    assertTrue("Queue should contain 3 elements.", queue.queue.size() == 3)
-    assertTrue(s"Queue should contain $app1.", queue.queue.contains(app1))
-    assertTrue(s"Queue should contain $app2.", queue.queue.contains(app2))
-    assertTrue(s"Queue should contain $app3.", queue.queue.contains(app3))
+    assert(queue.queue.size() == 3, "Queue should contain 3 elements.")
+    assert(queue.queue.contains(app1), s"Queue should contain $app1.")
+    assert(queue.queue.contains(app2), s"Queue should contain $app2.")
+    assert(queue.queue.contains(app3), s"Queue should contain $app3.")
 
     val res = queue.removeAll()
 
-    assertEquals(s"Should return all elements in correct order.", Vector(app2, app3, app1), res)
+    assert(Vector(app2, app3, app1) == res, s"Should return all elements in correct order.")
   }
-
 }

--- a/src/test/scala/mesosphere/util/RateLimitersTest.scala
+++ b/src/test/scala/mesosphere/util/RateLimitersTest.scala
@@ -1,25 +1,23 @@
 package mesosphere.util
 
-import org.junit.Test
-import org.junit.Assert._
+import mesosphere.marathon.MarathonSpec
 
 
-class RateLimitersTest {
-  @Test
-  def testTryAcquire() {
+class RateLimitersTest extends MarathonSpec {
+  test("TryAcquire") {
     val rl = new RateLimiters()
     // Uses default rate limiter which allows 1 per second,
     // so 2nd call should fail
-    assertTrue(rl.tryAcquire("foo"))
-    assertFalse(rl.tryAcquire("foo"))
+    assert(rl.tryAcquire("foo"))
+    assert(!rl.tryAcquire("foo"))
     Thread.sleep(1000)
-    assertTrue(rl.tryAcquire("foo"))
+    assert(rl.tryAcquire("foo"))
 
     // Should take the new setting
     rl.setPermits("foo", 100.0)
-    assertTrue(rl.tryAcquire("foo"))
-    assertFalse(rl.tryAcquire("foo"))
+    assert(rl.tryAcquire("foo"))
+    assert(!rl.tryAcquire("foo"))
     Thread.sleep(10)
-    assertTrue(rl.tryAcquire("foo"))
+    assert(rl.tryAcquire("foo"))
   }
 }


### PR DESCRIPTION
Using JUnit was sometimes awkward because there are no Scala-ish matchers.
Scalatest is mature enough now to use it here.
