### PR TITLE
Added abdication of leadership on disconnect from the Mesos master (plus other leadership defeats/elections rework)

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -25,6 +25,22 @@ import mesosphere.marathon.health.HealthCheckManager
 import scala.util.{Success, Failure}
 import org.apache.log4j.Logger
 
+
+trait SchedulerCallbacks {
+  def disconnected(): Unit
+}
+
+object MarathonScheduler {
+  private class MarathonSchedulerCallbacksImpl(serviceOption: Option[MarathonSchedulerService]) extends SchedulerCallbacks {
+    override def disconnected(): Unit = {
+      // Abdicate leadership when we become disconnected from the Mesos master.
+      serviceOption.foreach(_.abdicateLeadership())
+    }
+  }
+
+  val callbacks: SchedulerCallbacks = new MarathonSchedulerCallbacksImpl(Some(Main.injector.getInstance(classOf[MarathonSchedulerService])))
+}
+
 /**
  * @author Tobi Knaup
  */
@@ -53,16 +69,16 @@ class MarathonScheduler @Inject()(
     appId: String
   ): Future[Option[AppDefinition]] = appRepository.currentVersion(appId)
 
-  def registered(driver: SchedulerDriver, frameworkId: FrameworkID, master: MasterInfo) {
+  override def registered(driver: SchedulerDriver, frameworkId: FrameworkID, master: MasterInfo) {
     log.info("Registered as %s to master '%s'".format(frameworkId.getValue, master.getId))
     frameworkIdUtil.store(frameworkId)
   }
 
-  def reregistered(driver: SchedulerDriver, master: MasterInfo) {
+  override def reregistered(driver: SchedulerDriver, master: MasterInfo) {
     log.info("Re-registered to %s".format(master))
   }
 
-  def resourceOffers(driver: SchedulerDriver, offers: java.util.List[Offer]) {
+  override def resourceOffers(driver: SchedulerDriver, offers: java.util.List[Offer]) {
     // Check for any tasks which were started but never entered TASK_RUNNING
     // TODO resourceOffers() doesn't feel like the right place to run this
     val toKill = taskTracker.checkStagedTasks
@@ -119,11 +135,11 @@ class MarathonScheduler @Inject()(
     }
   }
 
-  def offerRescinded(driver: SchedulerDriver, offer: OfferID) {
+  override def offerRescinded(driver: SchedulerDriver, offer: OfferID) {
     log.info("Offer %s rescinded".format(offer))
   }
 
-  def statusUpdate(driver: SchedulerDriver, status: TaskStatus) {
+  override def statusUpdate(driver: SchedulerDriver, status: TaskStatus) {
     log.info("Received status update for task %s: %s (%s)"
       .format(status.getTaskId.getValue, status.getState, status.getMessage))
 
@@ -173,25 +189,27 @@ class MarathonScheduler @Inject()(
     }
   }
 
-  def frameworkMessage(driver: SchedulerDriver, executor: ExecutorID, slave: SlaveID, message: Array[Byte]) {
+  override def frameworkMessage(driver: SchedulerDriver, executor: ExecutorID, slave: SlaveID, message: Array[Byte]) {
     log.info("Received framework message %s %s %s ".format(executor, slave, message))
     eventBus.foreach(_.post(FrameworkMessageEvent(executor.getValue, slave.getValue, message)))
   }
 
-  def disconnected(driver: SchedulerDriver) {
+  override def disconnected(driver: SchedulerDriver) {
     log.warn("Disconnected")
-    suicide()
+
+    // Disconnection from the Mesos master has occurred. Thus, call the scheduler callbacks.
+    MarathonScheduler.callbacks.disconnected()
   }
 
-  def slaveLost(driver: SchedulerDriver, slave: SlaveID) {
+  override def slaveLost(driver: SchedulerDriver, slave: SlaveID) {
     log.info("Lost slave %s".format(slave))
   }
 
-  def executorLost(driver: SchedulerDriver, executor: ExecutorID, slave: SlaveID, p4: Int) {
+  override def executorLost(driver: SchedulerDriver, executor: ExecutorID, slave: SlaveID, p4: Int) {
     log.info("Lost executor %s %s %s ".format(executor, slave, p4))
   }
 
-  def error(driver: SchedulerDriver, message: String) {
+  override def error(driver: SchedulerDriver, message: String) {
     log.warn("Error: %s".format(message))
     suicide()
   }
@@ -367,7 +385,11 @@ class MarathonScheduler @Inject()(
     log.fatal("Committing suicide")
 
     // Asynchronously call sys.exit() to avoid deadlock due to the JVM shutdown hooks
-    Future(sys.exit(9))
+    Future(sys.exit(9)).map {
+      _ => log.info("Committed suicide")
+    }.recover {
+      case e => log.fatal("Exception while committing suicide: " + e.getMessage)
+    }
   }
 
   private def postEvent(status: TaskStatus, task: MarathonTask) {

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -22,6 +22,7 @@ import mesosphere.mesos.util.FrameworkIdUtil
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.health.HealthCheckManager
 import scala.concurrent.duration._
+import java.util.concurrent.CountDownLatch
 
 /**
  * Wrapper class for the scheduler
@@ -40,6 +41,8 @@ class MarathonSchedulerService @Inject()(
 
   // TODO use a thread pool here
   import ExecutionContext.Implicits.global
+
+  val latch = new CountDownLatch(1)
 
   // Time to wait before trying to reconcile app tasks after driver starts
   val reconciliationInitialDelay =
@@ -61,7 +64,6 @@ class MarathonSchedulerService @Inject()(
     .setUser(config.mesosUser())
     .setCheckpoint(config.checkpoint())
 
-
   // Set the framework ID
   frameworkIdUtil.fetch() match {
     case Some(id) => {
@@ -72,16 +74,17 @@ class MarathonSchedulerService @Inject()(
       log.info("No previous framework ID found")
     }
   }
+
   // Set the role, if provided.
   config.mesosRole.get.map(frameworkInfo.setRole)
 
-  val driver = new MesosSchedulerDriver(
+  // This is a little ugly as we are using a mutable variable. But drivers can't be reused (i.e. once stopped they can't
+  // be started again. Thus, we have to allocate a new driver before each run or after each stop.
+  var driver = new MesosSchedulerDriver(
     scheduler,
     frameworkInfo.build,
     config.mesosMaster()
   )
-
-  var abdicateCmd: Option[ExceptionalCommand[JoinException]] = None
 
   def defaultWait = {
     appRepository.defaultWait
@@ -143,106 +146,182 @@ class MarathonSchedulerService @Inject()(
     tasks
   }
 
-  /**
-   * Shutdown hook of guava service interface.
-   */
-  override def shutDown(): Unit = {
-    triggerShutdown()
-    super.shutDown()
-  }
-
   //Begin Service interface
-  def run() {
+
+  override def startUp(): Unit = {
     log.info("Starting up")
-    if (leader.get) {
-      runDriver()
-    } else {
-      offerLeadership()
-    }
+    super.startUp()
   }
 
-  // FIXME: remove dirty workaround as soon as the twitter code
-  //        has been changed to allow cancellation
-  override def triggerShutdown() {
+  override def run(): Unit = {
+    log.info("Beginning run")
 
-    def kill(): Unit = {
-      System.err.println("Finalization failed, killing JVM.")
-      Runtime.getRuntime.halt(1)
-    }
+    // The first thing we do is offer our leadership. If using Zookeeper for leadership election than we will wait to be
+    // elected. If we aren't (i.e. no HA) then we take over leadership run the driver immediately.
+    offerLeadership()
 
-    log.info("Shutting down")
+    // Block on the latch which will be countdown only when shutdown has been triggered. This is to prevent run()
+    // from exiting.
+    latch.await()
 
-    val f = Future {
-      abdicateCmd.map(_.execute)
-      stopDriver()
-      reconciliationTimer.cancel
-    }
-
-    try {
-      // TODO: How long should we wait? Should it be configurable?
-      Await.result(f, 5.seconds)
-    } catch {
-      case _: Throwable => kill()
-    }
+    log.info("Completed run")
   }
 
-  def runDriver() {
+  override def triggerShutdown(): Unit = {
+    log.info("Shutdown triggered")
+
+    leader.set(false)
+
+    stopDriver()
+
+    log.info("Cancelling reconciliation timer")
+    reconciliationTimer.cancel
+
+    log.info("Removing the blocking of run()")
+
+    // The countdown latch blocks run() from exiting. Counting down the latch removes the block.
+    latch.countDown()
+
+    super.triggerShutdown()
+  }
+
+  def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = {
     log.info("Running driver")
     scheduleTaskReconciliation
     listApps foreach healthCheckManager.reconcileWith
-    driver.run()
+
+    // The following block asynchronously runs the driver. Note that driver.run() blocks until the driver has been
+    // stopped (or aborted).
+    Future {
+      driver.run()
+    }.map {
+      _ => log.info("Driver stopped normally")
+    }.recover {
+      case e => log.error("Exception while running driver: " + e.getMessage)
+    }.onComplete {
+      _ => {
+        log.info("Driver future completed. Executing optional abdication command.")
+
+        // If there is an abdication command we need to execute it so that our leadership is given up. Note that executing
+        // the abdication command does a few things:
+        // - It causes onDefeated() to be executed (which is part of the Leader interface).
+        // - It removes us as a leadership candidate. We must offer out leadership candidacy if we ever want to become
+        //   the leader again in the future.
+        //
+        // If we don't have a abdication command we simply mark ourselves as not the leader
+        abdicateCmdOption.fold(leader.set(false))(_.execute)
+
+        // If we are shutting down than don't offer leadership. But if we aren't than the driver was stopped via external
+        // means. For example, our leadership could have been defeated or perhaps it was abdicated. Therfore, for these
+        // cases we offer our leadership again.
+        if (isRunning) {
+          offerLeadership()
+        }
+      }
+    }
   }
 
-  def stopDriver() {
+  def stopDriver(): Unit = {
     log.info("Stopping driver")
+
+    // Stopping the driver will cause the driver run() method to return.
     driver.stop(true) // failover = true
+
+    // We need to allocate a new driver as drivers can't be reused. Once they are in the stopped state they cannot be
+    // restarted. See the Mesos C++ source code for the MesosScheduleDriver.
+    driver = new MesosSchedulerDriver(
+      scheduler,
+      frameworkInfo.build,
+      config.mesosMaster()
+    )
   }
 
   def isLeader = {
-    leader.get() || getLeader.isEmpty
+    leader.get()
   }
 
   def getLeader: Option[String] = {
-    if (candidate.nonEmpty && candidate.get.getLeaderData.isPresent) {
-      return Some(new String(candidate.get.getLeaderData.get))
+    candidate.flatMap {
+      c =>
+        if (c.getLeaderData.isPresent)
+          Some(new String(c.getLeaderData.get))
+        else
+          None
     }
-    None
   }
   //End Service interface
 
   //Begin Leader interface, which is required for CandidateImpl.
-  def onDefeated() {
-    log.info("Defeated")
-    leader.set(false)
-    stopDriver()
+  override def onDefeated(): Unit = {
+    log.info("Defeated (Leader Interface)")
 
-    // Don't offer leadership if we're shutting down
-    if (isRunning) {
-      offerLeadership()
-    }
+    // Our leadership has been defeated and thus we call the defeatLeadership() method.
+    defeatLeadership()
   }
 
-  def onElected(abdicate: ExceptionalCommand[JoinException]) {
-    log.info("Elected")
-    abdicateCmd = Some(abdicate)
-    leader.set(true)
-    runDriver()
+  override def onElected(abdicateCmd: ExceptionalCommand[JoinException]): Unit = {
+    log.info("Elected (Leader Interface)")
+
+    // We have been elected. Thus, elect leadership with the abdication command.
+    electLeadership(Some(abdicateCmd))
   }
   //End Leader interface
 
+  private def defeatLeadership() {
+    log.info("Defeat leadership")
+
+    // Our leadership has been defeated. Thus, update leadership and stop the driver.
+    // Note that abdication command will be ran upon driver shutdown.
+    leader.set(false)
+
+    stopDriver()
+  }
+
+  private def electLeadership(abdicateOption: Option[ExceptionalCommand[JoinException]]) {
+    log.info("Elect leadership")
+
+    // We have been elected as leader. Thus, update leadership and run the driver.
+    leader.set(true)
+    runDriver(abdicateOption)
+  }
+
+  def abdicateLeadership() = {
+    log.info("Abdicating")
+
+    // To abdicate we defeat our leadership
+    defeatLeadership()
+  }
+
+  private def offerLeadership(): Unit = {
+    log.info("Offering leadership")
+
+    candidate.synchronized {
+      candidate.fold {
+        // In this case we aren't using Zookeeper for leadership election. Thus, we simply elect ourselves as leader.
+        log.info("Not using HA and therefore electing as leader by default")
+        electLeadership(None)
+      } {
+        c => {
+          // In this case we care using Zookeeper for leadership candidacy. Thus, offer our leadership.
+          log.info("Using HA and therefore offering leadership")
+          c.offerLeadership(this)
+        }
+      }
+    }
+  }
+
   private def scheduleTaskReconciliation {
     reconciliationTimer.schedule(
-      new TimerTask { def run() { scheduler.reconcileTasks(driver) }},
+      new TimerTask {
+        def run() {
+          if (isLeader) {
+            scheduler.reconcileTasks(driver)
+          } else log.info("Not leader therefore not reconciling tasks")
+        }
+      },
       reconciliationInitialDelay.toMillis,
       reconciliationFrequency.toMillis
     )
-  }
-
-  private def offerLeadership() {
-    if (candidate.nonEmpty) {
-      log.info("Offering leadership.")
-      candidate.get.offerLeadership(this)
-    }
   }
 
   private def newAppPort(app: AppDefinition): Integer = {

--- a/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
@@ -52,7 +52,8 @@ class LeaderProxyFilter @Inject()
       val request = rawRequest.asInstanceOf[HttpServletRequest]
       val response = rawResponse.asInstanceOf[HttpServletResponse]
 
-      if (schedulerService.isLeader) {
+      // Proxying occurs if we aren't in the leadership position and we know about the other leader (to proxy to).
+      if (schedulerService.isLeader || schedulerService.getLeader.isEmpty) {
         chain.doFilter(request, response)
       } else {
         try {


### PR DESCRIPTION
This PR includes quite a few things.
1. It includes the abdication of leadership on disconnect from the Mesos master. Thus, when the `Scheduler` calls `disconnected()` Marathon no longer commits suicide. Instead, it abdicates its leadership position. It is possible that this Marathon instance is re-elected which basically translates into "Wait until the master comes back." But under normal circumstances a different Marathon instance will be elected.
2. I reworked the `MarathonSchedulerService` class to properly handle leadership defeats and elections. 
   As I learnt that `MesosSchedulerDriver` objects cannot be "restarted". Once one calls `stop()` on the driver it cannot be started again via `join()`, `run()` or `start()`. Thus, I instantiate a new driver after every `stop()`. This insures that a new driver is ready and waiting to be started the instance of Marathon is elected.

I added comments in the code to help with understanding.

Note that I am using the term "leadership" loosely as Marathon can be elected as leader via Zookeeper or by default in the case of no HA. Basically, with my changes a single non-HA configuration will result in the Marathon instance assuming leadership from its internal perspective.
