### PR TITLE
Use grace period instead of initial delay

### DIFF
--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -898,15 +898,15 @@ public final class Protos {
      */
     int getPortIndex();
 
-    // optional uint32 initialDelaySeconds = 3 [default = 15];
+    // optional uint32 gracePeriodSeconds = 3 [default = 15];
     /**
-     * <code>optional uint32 initialDelaySeconds = 3 [default = 15];</code>
+     * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
      */
-    boolean hasInitialDelaySeconds();
+    boolean hasGracePeriodSeconds();
     /**
-     * <code>optional uint32 initialDelaySeconds = 3 [default = 15];</code>
+     * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
      */
-    int getInitialDelaySeconds();
+    int getGracePeriodSeconds();
 
     // optional uint32 intervalSeconds = 4 [default = 10];
     /**
@@ -1034,7 +1034,7 @@ public final class Protos {
             }
             case 24: {
               bitField0_ |= 0x00000004;
-              initialDelaySeconds_ = input.readUInt32();
+              gracePeriodSeconds_ = input.readUInt32();
               break;
             }
             case 32: {
@@ -1211,20 +1211,20 @@ public final class Protos {
       return portIndex_;
     }
 
-    // optional uint32 initialDelaySeconds = 3 [default = 15];
-    public static final int INITIALDELAYSECONDS_FIELD_NUMBER = 3;
-    private int initialDelaySeconds_;
+    // optional uint32 gracePeriodSeconds = 3 [default = 15];
+    public static final int GRACEPERIODSECONDS_FIELD_NUMBER = 3;
+    private int gracePeriodSeconds_;
     /**
-     * <code>optional uint32 initialDelaySeconds = 3 [default = 15];</code>
+     * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
      */
-    public boolean hasInitialDelaySeconds() {
+    public boolean hasGracePeriodSeconds() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional uint32 initialDelaySeconds = 3 [default = 15];</code>
+     * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
      */
-    public int getInitialDelaySeconds() {
-      return initialDelaySeconds_;
+    public int getGracePeriodSeconds() {
+      return gracePeriodSeconds_;
     }
 
     // optional uint32 intervalSeconds = 4 [default = 10];
@@ -1333,7 +1333,7 @@ public final class Protos {
     private void initFields() {
       protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
       portIndex_ = 0;
-      initialDelaySeconds_ = 15;
+      gracePeriodSeconds_ = 15;
       intervalSeconds_ = 10;
       timeoutSeconds_ = 20;
       path_ = "/";
@@ -1366,7 +1366,7 @@ public final class Protos {
         output.writeUInt32(2, portIndex_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeUInt32(3, initialDelaySeconds_);
+        output.writeUInt32(3, gracePeriodSeconds_);
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeUInt32(4, intervalSeconds_);
@@ -1399,7 +1399,7 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(3, initialDelaySeconds_);
+          .computeUInt32Size(3, gracePeriodSeconds_);
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
@@ -1537,7 +1537,7 @@ public final class Protos {
         bitField0_ = (bitField0_ & ~0x00000001);
         portIndex_ = 0;
         bitField0_ = (bitField0_ & ~0x00000002);
-        initialDelaySeconds_ = 15;
+        gracePeriodSeconds_ = 15;
         bitField0_ = (bitField0_ & ~0x00000004);
         intervalSeconds_ = 10;
         bitField0_ = (bitField0_ & ~0x00000008);
@@ -1586,7 +1586,7 @@ public final class Protos {
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
         }
-        result.initialDelaySeconds_ = initialDelaySeconds_;
+        result.gracePeriodSeconds_ = gracePeriodSeconds_;
         if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
           to_bitField0_ |= 0x00000008;
         }
@@ -1625,8 +1625,8 @@ public final class Protos {
         if (other.hasPortIndex()) {
           setPortIndex(other.getPortIndex());
         }
-        if (other.hasInitialDelaySeconds()) {
-          setInitialDelaySeconds(other.getInitialDelaySeconds());
+        if (other.hasGracePeriodSeconds()) {
+          setGracePeriodSeconds(other.getGracePeriodSeconds());
         }
         if (other.hasIntervalSeconds()) {
           setIntervalSeconds(other.getIntervalSeconds());
@@ -1746,35 +1746,35 @@ public final class Protos {
         return this;
       }
 
-      // optional uint32 initialDelaySeconds = 3 [default = 15];
-      private int initialDelaySeconds_ = 15;
+      // optional uint32 gracePeriodSeconds = 3 [default = 15];
+      private int gracePeriodSeconds_ = 15;
       /**
-       * <code>optional uint32 initialDelaySeconds = 3 [default = 15];</code>
+       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
        */
-      public boolean hasInitialDelaySeconds() {
+      public boolean hasGracePeriodSeconds() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
-       * <code>optional uint32 initialDelaySeconds = 3 [default = 15];</code>
+       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
        */
-      public int getInitialDelaySeconds() {
-        return initialDelaySeconds_;
+      public int getGracePeriodSeconds() {
+        return gracePeriodSeconds_;
       }
       /**
-       * <code>optional uint32 initialDelaySeconds = 3 [default = 15];</code>
+       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
        */
-      public Builder setInitialDelaySeconds(int value) {
+      public Builder setGracePeriodSeconds(int value) {
         bitField0_ |= 0x00000004;
-        initialDelaySeconds_ = value;
+        gracePeriodSeconds_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional uint32 initialDelaySeconds = 3 [default = 15];</code>
+       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
        */
-      public Builder clearInitialDelaySeconds() {
+      public Builder clearGracePeriodSeconds() {
         bitField0_ = (bitField0_ & ~0x00000004);
-        initialDelaySeconds_ = 15;
+        gracePeriodSeconds_ = 15;
         onChanged();
         return this;
       }
@@ -8657,35 +8657,35 @@ public final class Protos {
       "\022:\n\010operator\030\002 \002(\0162(.mesosphere.marathon" +
       ".Constraint.Operator\022\r\n\005value\030\003 \001(\t\";\n\010O" +
       "perator\022\n\n\006UNIQUE\020\000\022\010\n\004LIKE\020\001\022\013\n\007CLUSTER" +
-      "\020\002\022\014\n\010GROUP_BY\020\003\"\241\002\n\025HealthCheckDefiniti" +
+      "\020\002\022\014\n\010GROUP_BY\020\003\"\240\002\n\025HealthCheckDefiniti" +
       "on\022E\n\010protocol\030\001 \002(\01623.mesosphere.marath" +
       "on.HealthCheckDefinition.Protocol\022\024\n\tpor" +
-      "tIndex\030\002 \002(\r:\0010\022\037\n\023initialDelaySeconds\030\003" +
-      " \001(\r:\00215\022\033\n\017intervalSeconds\030\004 \001(\r:\00210\022\032\n",
-      "\016timeoutSeconds\030\005 \001(\r:\00220\022\017\n\004path\030\006 \001(\t:" +
-      "\001/\022!\n\026maxConsecutiveFailures\030\007 \001(\r:\0013\"\035\n" +
-      "\010Protocol\022\010\n\004HTTP\020\000\022\007\n\003TCP\020\001\"\243\003\n\021Service" +
-      "Definition\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030\002 \002(\0132\022.me" +
-      "sos.CommandInfo\022\021\n\tinstances\030\003 \002(\r\022\"\n\tre" +
-      "sources\030\004 \003(\0132\017.mesos.Resource\022\023\n\013descri" +
-      "ption\030\005 \001(\t\022\r\n\005ports\030\006 \003(\r\0224\n\013constraint" +
-      "s\030\007 \003(\0132\037.mesosphere.marathon.Constraint" +
-      "\022\022\n\010executor\030\010 \002(\t:\000\022\030\n\rtaskRateLimit\030\t " +
-      "\001(\001:\0011\0225\n\tcontainer\030\n \001(\0132\".mesosphere.m",
-      "arathon.ContainerInfo\022)\n\007version\030\013 \001(\t:\030" +
-      "1970-01-01T00:00:00.000Z\022@\n\014healthChecks" +
-      "\030\014 \003(\0132*.mesosphere.marathon.HealthCheck" +
-      "Definition\"\272\001\n\014MarathonTask\022\n\n\002id\030\001 \002(\t\022" +
-      "\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022$\n\nattribut" +
-      "es\030\004 \003(\0132\020.mesos.Attribute\022\021\n\tstaged_at\030" +
-      "\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003\022#\n\010statuses\030\007 " +
-      "\003(\0132\021.mesos.TaskStatus\022\017\n\007version\030\010 \001(\t\"" +
-      "M\n\013MarathonApp\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 " +
-      "\003(\0132!.mesosphere.marathon.MarathonTask\"1",
-      "\n\rContainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007opti" +
-      "ons\030\002 \003(\014\")\n\020EventSubscribers\022\025\n\rcallbac" +
-      "k_urls\030\001 \003(\tB\035\n\023mesosphere.marathonB\006Pro" +
-      "tos"
+      "tIndex\030\002 \002(\r:\0010\022\036\n\022gracePeriodSeconds\030\003 " +
+      "\001(\r:\00215\022\033\n\017intervalSeconds\030\004 \001(\r:\00210\022\032\n\016",
+      "timeoutSeconds\030\005 \001(\r:\00220\022\017\n\004path\030\006 \001(\t:\001" +
+      "/\022!\n\026maxConsecutiveFailures\030\007 \001(\r:\0013\"\035\n\010" +
+      "Protocol\022\010\n\004HTTP\020\000\022\007\n\003TCP\020\001\"\243\003\n\021ServiceD" +
+      "efinition\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030\002 \002(\0132\022.mes" +
+      "os.CommandInfo\022\021\n\tinstances\030\003 \002(\r\022\"\n\tres" +
+      "ources\030\004 \003(\0132\017.mesos.Resource\022\023\n\013descrip" +
+      "tion\030\005 \001(\t\022\r\n\005ports\030\006 \003(\r\0224\n\013constraints" +
+      "\030\007 \003(\0132\037.mesosphere.marathon.Constraint\022" +
+      "\022\n\010executor\030\010 \002(\t:\000\022\030\n\rtaskRateLimit\030\t \001" +
+      "(\001:\0011\0225\n\tcontainer\030\n \001(\0132\".mesosphere.ma",
+      "rathon.ContainerInfo\022)\n\007version\030\013 \001(\t:\0301" +
+      "970-01-01T00:00:00.000Z\022@\n\014healthChecks\030" +
+      "\014 \003(\0132*.mesosphere.marathon.HealthCheckD" +
+      "efinition\"\272\001\n\014MarathonTask\022\n\n\002id\030\001 \002(\t\022\014" +
+      "\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022$\n\nattribute" +
+      "s\030\004 \003(\0132\020.mesos.Attribute\022\021\n\tstaged_at\030\005" +
+      " \001(\003\022\022\n\nstarted_at\030\006 \001(\003\022#\n\010statuses\030\007 \003" +
+      "(\0132\021.mesos.TaskStatus\022\017\n\007version\030\010 \001(\t\"M" +
+      "\n\013MarathonApp\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003" +
+      "(\0132!.mesosphere.marathon.MarathonTask\"1\n",
+      "\rContainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007optio" +
+      "ns\030\002 \003(\014\")\n\020EventSubscribers\022\025\n\rcallback" +
+      "_urls\030\001 \003(\tB\035\n\023mesosphere.marathonB\006Prot" +
+      "os"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -8703,7 +8703,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
-              new java.lang.String[] { "Protocol", "PortIndex", "InitialDelaySeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", });
+              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", });
           internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
             getDescriptor().getMessageTypes().get(2);
           internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -32,7 +32,7 @@ message HealthCheckDefinition {
   }
   required Protocol protocol = 1;
   required uint32 portIndex = 2 [default = 0];
-  optional uint32 initialDelaySeconds = 3 [default = 15];
+  optional uint32 gracePeriodSeconds = 3 [default = 15];
   optional uint32 intervalSeconds = 4 [default = 10];
   optional uint32 timeoutSeconds = 5 [default = 20];
   optional string path = 6 [default = "/"]; // used for HTTP only

--- a/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
@@ -27,8 +27,8 @@ case class HealthCheck(
   @FieldNotEmpty
   portIndex: JInt = HealthCheck.DefaultPortIndex,
 
-  @FieldJsonProperty("initialDelaySeconds")
-  initialDelay: FiniteDuration = HealthCheck.DefaultInitialDelay,
+  @FieldJsonProperty("gracePeriodSeconds")
+  gracePeriod: FiniteDuration = HealthCheck.DefaultGracePeriod,
 
   @FieldJsonProperty("intervalSeconds")
   interval: FiniteDuration = HealthCheck.DefaultInterval,
@@ -45,7 +45,7 @@ case class HealthCheck(
     val builder = Protos.HealthCheckDefinition.newBuilder
       .setProtocol(this.protocol)
       .setPortIndex(this.portIndex)
-      .setInitialDelaySeconds(this.initialDelay.toSeconds.toInt)
+      .setGracePeriodSeconds(this.gracePeriod.toSeconds.toInt)
       .setIntervalSeconds(this.interval.toSeconds.toInt)
       .setTimeoutSeconds(this.timeout.toSeconds.toInt)
       .setMaxConsecutiveFailures(this.maxConsecutiveFailures)
@@ -60,7 +60,7 @@ case class HealthCheck(
       path = Option(proto.getPath),
       protocol = proto.getProtocol,
       portIndex = proto.getPortIndex,
-      initialDelay = FiniteDuration(proto.getInitialDelaySeconds, SECONDS),
+      gracePeriod = FiniteDuration(proto.getGracePeriodSeconds, SECONDS),
       timeout = FiniteDuration(proto.getTimeoutSeconds, SECONDS),
       interval = FiniteDuration(proto.getIntervalSeconds, SECONDS),
       maxConsecutiveFailures = proto.getMaxConsecutiveFailures
@@ -76,8 +76,8 @@ object HealthCheck {
   val DefaultPath                   = Some("/")
   val DefaultProtocol               = Protocol.HTTP
   val DefaultPortIndex              = 0
-  val DefaultInitialDelay           = FiniteDuration(15, SECONDS)
-  val DefaultInterval               = FiniteDuration(60, SECONDS)
-  val DefaultTimeout                = FiniteDuration(15, SECONDS)
+  val DefaultGracePeriod            = FiniteDuration(15, SECONDS)
+  val DefaultInterval               = FiniteDuration(10, SECONDS)
+  val DefaultTimeout                = FiniteDuration(20, SECONDS)
   val DefaultMaxConsecutiveFailures = 3
 }

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -12,7 +12,7 @@ class HealthCheckTest extends MarathonSpec {
       path = Some("/health"),
       protocol = Protocol.HTTP,
       portIndex = 0,
-      initialDelay = FiniteDuration(10, SECONDS),
+      gracePeriod = FiniteDuration(10, SECONDS),
       interval = FiniteDuration(60, SECONDS),
       maxConsecutiveFailures = 0
     )
@@ -22,7 +22,7 @@ class HealthCheckTest extends MarathonSpec {
     assert("/health" == proto.getPath)
     assert(Protocol.HTTP == proto.getProtocol)
     assert(0 == proto.getPortIndex)
-    assert(10 == proto.getInitialDelaySeconds)
+    assert(10 == proto.getGracePeriodSeconds)
     assert(60 == proto.getIntervalSeconds)
     assert(0 == proto.getMaxConsecutiveFailures)
   }
@@ -31,7 +31,7 @@ class HealthCheckTest extends MarathonSpec {
     val healthCheck = HealthCheck(
       protocol = Protocol.TCP,
       portIndex = 1,
-      initialDelay = FiniteDuration(7, SECONDS),
+      gracePeriod = FiniteDuration(7, SECONDS),
       interval = FiniteDuration(35, SECONDS),
       maxConsecutiveFailures = 10
     )
@@ -40,7 +40,7 @@ class HealthCheckTest extends MarathonSpec {
 
     assert(Protocol.TCP == proto.getProtocol)
     assert(1 == proto.getPortIndex)
-    assert(7 == proto.getInitialDelaySeconds)
+    assert(7 == proto.getGracePeriodSeconds)
     assert(35 == proto.getIntervalSeconds)
     assert(10 == proto.getMaxConsecutiveFailures)
   }
@@ -50,7 +50,7 @@ class HealthCheckTest extends MarathonSpec {
       .setPath("/health")
       .setProtocol(Protocol.HTTP)
       .setPortIndex(0)
-      .setInitialDelaySeconds(10)
+      .setGracePeriodSeconds(10)
       .setIntervalSeconds(60)
       .setTimeoutSeconds(10)
       .setMaxConsecutiveFailures(10)
@@ -62,7 +62,7 @@ class HealthCheckTest extends MarathonSpec {
       path = Some("/health"),
       protocol = Protocol.HTTP,
       portIndex = 0,
-      initialDelay = FiniteDuration(10, SECONDS),
+      gracePeriod = FiniteDuration(10, SECONDS),
       interval = FiniteDuration(60, SECONDS),
       timeout = FiniteDuration(10, SECONDS),
       maxConsecutiveFailures = 10
@@ -75,7 +75,7 @@ class HealthCheckTest extends MarathonSpec {
     val proto = Protos.HealthCheckDefinition.newBuilder
       .setProtocol(Protocol.TCP)
       .setPortIndex(1)
-      .setInitialDelaySeconds(7)
+      .setGracePeriodSeconds(7)
       .setIntervalSeconds(35)
       .setTimeoutSeconds(10)
       .setMaxConsecutiveFailures(10)
@@ -87,7 +87,7 @@ class HealthCheckTest extends MarathonSpec {
       path = Some("/"),
       protocol = Protocol.TCP,
       portIndex = 1,
-      initialDelay = FiniteDuration(7, SECONDS),
+      gracePeriod = FiniteDuration(7, SECONDS),
       interval = FiniteDuration(35, SECONDS),
       timeout = FiniteDuration(10, SECONDS),
       maxConsecutiveFailures = 10


### PR DESCRIPTION
This PR changes the initial delay (wait before scheduling the first health check) to a grace period. It starts running health checks immediately after receiving TASK_RUNNING from Mesos but ignores failures within the grace period. As soon as a health check passes for the first time maxConsecutiveFailures are enforced, even if the task is still within the grace period.
