### PR TITLE
Replace global ExecutionContext by a cached thread pool context

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.mesos.util.FrameworkIdUtil
 import mesosphere.mesos.protos
-import mesosphere.util.RateLimiters
+import mesosphere.util.{ThreadPoolContext, RateLimiters}
 import mesosphere.marathon.health.HealthCheckManager
 import scala.util.{Success, Failure}
 import org.apache.log4j.Logger
@@ -56,8 +56,7 @@ class MarathonScheduler @Inject()(
 
   private val log = Logger.getLogger(getClass.getName)
 
-  // TODO use a thread pool here
-  import ExecutionContext.Implicits.global
+  import ThreadPoolContext.context
   import mesosphere.mesos.protos.Implicits._
 
   /**

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -23,6 +23,7 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.health.HealthCheckManager
 import scala.concurrent.duration._
 import java.util.concurrent.CountDownLatch
+import mesosphere.util.ThreadPoolContext
 
 /**
  * Wrapper class for the scheduler
@@ -39,8 +40,7 @@ class MarathonSchedulerService @Inject()(
     scheduler: MarathonScheduler)
   extends AbstractExecutionThreadService with Leader {
 
-  // TODO use a thread pool here
-  import ExecutionContext.Implicits.global
+  import ThreadPoolContext.context
 
   val latch = new CountDownLatch(1)
 

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
@@ -9,7 +9,7 @@ import akka.util.Timeout
 import javax.inject.{Named, Inject, Singleton}
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
+import mesosphere.util.ThreadPoolContext.context
 import com.google.common.eventbus.EventBus
 import mesosphere.marathon.event.{RemoveHealthCheck, AddHealthCheck, EventModule}
 import org.apache.mesos.MesosSchedulerDriver

--- a/src/main/scala/mesosphere/marathon/state/AppRepository.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppRepository.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.state
 import mesosphere.marathon.api.v1.AppDefinition
 
 import scala.concurrent.duration.{Duration, SECONDS}
-import scala.concurrent.ExecutionContext.Implicits.global
+import mesosphere.util.ThreadPoolContext.context
 import scala.concurrent.Future
 
 
@@ -11,7 +11,7 @@ class AppRepository(store: PersistenceStore[AppDefinition]) {
 
   protected val ID_DELIMITER = ":"
 
-  val defaultWait = store match { 
+  val defaultWait = store match {
     case m: MarathonStore[_] => m.defaultWait
     case _ => Duration(3, SECONDS)
   }
@@ -53,7 +53,7 @@ class AppRepository(store: PersistenceStore[AppDefinition]) {
    * Returns the current version for all apps.
    */
   def apps(): Future[Iterable[AppDefinition]] =
-    appIds().flatMap { names => 
+    appIds().flatMap { names =>
       Future.sequence(names.map { name =>
       	currentVersion(name)
       }).map { _.flatten }

--- a/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
+++ b/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
@@ -28,7 +28,7 @@ class MarathonStore[S <: MarathonState[_, S]](state: State,
       )
   }
 
-  import ExecutionContext.Implicits.global
+  import mesosphere.util.ThreadPoolContext.context
   import mesosphere.util.BackToTheFuture.futureToFutureOption
 
   def fetch(key: String): Future[Option[S]] = {

--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.Protos._
 import mesosphere.marathon.Main
 import java.io._
 import scala.Some
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import org.apache.log4j.Logger
 
 /**
@@ -19,7 +19,7 @@ import org.apache.log4j.Logger
 class TaskTracker @Inject()(state: State) {
 
   import TaskTracker.App
-  import ExecutionContext.Implicits.global
+  import mesosphere.util.ThreadPoolContext.context
   import mesosphere.util.BackToTheFuture.futureToFuture
 
   private[this] val log = Logger.getLogger(getClass.getName)

--- a/src/main/scala/mesosphere/util/ThreadPoolContext.scala
+++ b/src/main/scala/mesosphere/util/ThreadPoolContext.scala
@@ -1,0 +1,15 @@
+package mesosphere.util
+
+import scala.concurrent.ExecutionContext
+import java.util.concurrent.Executors
+
+object ThreadPoolContext {
+
+  /**
+   * This execution context is backed by a cached thread pool.
+   * Use this context instead of the global execution context,
+   * if you do blocking IO operations.
+   */
+  implicit lazy val context = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+
+}

--- a/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
@@ -171,7 +171,7 @@ class MarathonStoreTest extends MarathonSpec {
   }
 
   test("ConcurrentModifications") {
-    import scala.concurrent.ExecutionContext.Implicits.global
+    import mesosphere.util.ThreadPoolContext.context
     val state = new InMemoryState
 
     val store = new MarathonStore[AppDefinition](state, () => AppDefinition())


### PR DESCRIPTION
The default global execution context should not be used, if blocking IO operations have to be performed .
This PR introduces an ExecutionContext backed by a CachedThreadPool and replaces all occurrences of the global execution context.
