### PR TITLE
Use our execution context and the configured ZK timeout everywhere.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <chaos.version>0.5.6</chaos.version>
         <jackson-ccm.version>0.1.0</jackson-ccm.version>
         <mesos.version>0.18.2</mesos.version>
-        <mesos-utils.version>0.18.2-1</mesos-utils.version>
+        <mesos-utils.version>${mesos.version}-2</mesos-utils.version>
         <akka.version>2.2.4</akka.version>
         <spray.version>1.2.1</spray.version>
         <json4s.version>3.2.5</json4s.version>

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -84,7 +84,7 @@ object Main extends App {
   //TOOD(FL): Make Events optional / wire up.
   lazy val conf = new ScallopConf(args)
     with HttpConf with MarathonConf with AppConfiguration
-      with EventConfiguration with HttpEventConfiguration with ZookeeperConf
+      with EventConfiguration with HttpEventConfiguration
 
   run(
     classOf[HttpService],

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -8,7 +8,7 @@ import scala.sys.SystemProperties
  * @author Tobi Knaup
  */
 
-trait MarathonConf extends ScallopConf {
+trait MarathonConf extends ScallopConf with ZookeeperConf {
 
   lazy val mesosMaster = opt[String]("master",
     descr = "The URL of the Mesos master",

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -27,7 +27,7 @@ object ModuleNames {
   final val NAMED_SERVER_SET_PATH = "SERVER_SET_PATH"
 }
 
-class MarathonModule(conf: MarathonConf with ZookeeperConf, zk: ZooKeeperClient)
+class MarathonModule(conf: MarathonConf, zk: ZooKeeperClient)
   extends AbstractModule {
 
   val log = Logger.getLogger(getClass.getName)
@@ -60,7 +60,7 @@ class MarathonModule(conf: MarathonConf with ZookeeperConf, zk: ZooKeeperClient)
   def provideMesosState(): State = {
     new ZooKeeperState(
       conf.zkHosts,
-      conf.zooKeeperTimeout.get.get,
+      conf.zkTimeoutDuration.toMillis,
       TimeUnit.MILLISECONDS,
       conf.zooKeeperStatePath
     )

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -9,7 +9,7 @@ import mesosphere.mesos.TaskBuilder
 import mesosphere.marathon.api.v1.AppDefinition
 import mesosphere.marathon.api.v2.AppUpdate
 import mesosphere.marathon.state.AppRepository
-import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.Future
 import com.google.common.collect.Lists
 import javax.inject.{Named, Inject}
 import com.google.common.eventbus.EventBus
@@ -51,13 +51,16 @@ class MarathonScheduler @Inject()(
   taskTracker: TaskTracker,
   taskQueue: TaskQueue,
   frameworkIdUtil: FrameworkIdUtil,
-  rateLimiters: RateLimiters
+  rateLimiters: RateLimiters,
+  config: MarathonConf
 ) extends Scheduler {
 
   private val log = Logger.getLogger(getClass.getName)
 
   import ThreadPoolContext.context
   import mesosphere.mesos.protos.Implicits._
+
+  implicit val zkTimeout = config.zkFutureTimeout
 
   /**
    * Returns a future containing the optional most recent version

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon
 
-import org.apache.mesos.Protos.{TaskID, FrameworkInfo}
-import org.apache.mesos.MesosSchedulerDriver
+import org.apache.mesos.Protos.TaskID
 import org.apache.log4j.Logger
 import mesosphere.marathon.api.v1.AppDefinition
 import mesosphere.marathon.api.v2.AppUpdate
@@ -9,8 +8,8 @@ import mesosphere.marathon.state.{AppRepository, Timestamp}
 import com.google.common.util.concurrent.AbstractExecutionThreadService
 import javax.inject.{Named, Inject}
 import java.util.{TimerTask, Timer}
-import scala.concurrent.{Future, ExecutionContext, Await}
-import scala.concurrent.duration.{Duration, MILLISECONDS}
+import scala.concurrent.{Future, Await}
+import scala.concurrent.duration.MILLISECONDS
 import java.util.concurrent.atomic.AtomicBoolean
 import com.twitter.common.base.ExceptionalCommand
 import com.twitter.common.zookeeper.Group.JoinException
@@ -23,7 +22,7 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.health.HealthCheckManager
 import scala.concurrent.duration._
 import java.util.concurrent.CountDownLatch
-import mesosphere.util.ThreadPoolContext
+import mesosphere.util.{BackToTheFuture, ThreadPoolContext}
 
 /**
  * Wrapper class for the scheduler
@@ -42,6 +41,8 @@ class MarathonSchedulerService @Inject()(
 
   import ThreadPoolContext.context
 
+  implicit val zkTimeout = config.zkFutureTimeout
+
   val latch = new CountDownLatch(1)
 
   // Time to wait before trying to reconcile app tasks after driver starts
@@ -56,7 +57,7 @@ class MarathonSchedulerService @Inject()(
 
   val log = Logger.getLogger(getClass.getName)
 
-  val frameworkId = frameworkIdUtil.fetch()
+  val frameworkId = frameworkIdUtil.fetch
   frameworkId match {
     case Some(id) =>
       log.info(s"Setting framework ID to ${id.getValue}")
@@ -68,10 +69,6 @@ class MarathonSchedulerService @Inject()(
   // be reused (i.e. once stopped they can't be started again. Thus,
   // we have to allocate a new driver before each run or after each stop.
   var driver = MarathonSchedulerDriver.newDriver(config, scheduler, frameworkId)
-
-  def defaultWait = {
-    appRepository.defaultWait
-  }
 
   def startApp(app: AppDefinition): Future[_] = {
     // Backwards compatibility
@@ -96,17 +93,17 @@ class MarathonSchedulerService @Inject()(
     }
 
   def listApps(): Iterable[AppDefinition] =
-    Await.result(appRepository.apps, defaultWait)
+    Await.result(appRepository.apps, config.zkTimeoutDuration)
 
   def listAppVersions(appName: String): Iterable[Timestamp] =
-    Await.result(appRepository.listVersions(appName), defaultWait)
+    Await.result(appRepository.listVersions(appName), config.zkTimeoutDuration)
 
   def getApp(appName: String): Option[AppDefinition] = {
-    Await.result(appRepository.currentVersion(appName), defaultWait)
+    Await.result(appRepository.currentVersion(appName), config.zkTimeoutDuration)
   }
 
   def getApp(appName: String, version: Timestamp) : Option[AppDefinition] = {
-    Await.result(appRepository.app(appName, version), defaultWait)
+    Await.result(appRepository.app(appName, version), config.zkTimeoutDuration)
   }
 
   def killTasks(
@@ -117,7 +114,7 @@ class MarathonSchedulerService @Inject()(
     if (scale) {
       getApp(appName) foreach { app =>
         val appUpdate = AppUpdate(instances = Some(app.instances - tasks.size))
-        Await.result(scheduler.updateApp(driver, appName, appUpdate), defaultWait)
+        Await.result(scheduler.updateApp(driver, appName, appUpdate), config.zkTimeoutDuration)
       }
     }
 

--- a/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
+++ b/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
@@ -2,6 +2,8 @@ package mesosphere.marathon
 
 import org.rogach.scallop.ScallopConf
 import java.net.InetSocketAddress
+import mesosphere.util.BackToTheFuture
+import scala.concurrent.duration._
 
 /**
  * @author Tobi Knaup
@@ -51,4 +53,6 @@ trait ZookeeperConf extends ScallopConf {
   def zkURL = zooKeeperUrl.get.getOrElse(s"zk://${zooKeeperHostString()}${zooKeeperPath()}")
   lazy val zkHosts = zkURL match { case zkURLPattern(server, _) => server }
   lazy val zkPath = zkURL match { case zkURLPattern(_, path) => path }
+  lazy val zkTimeoutDuration = Duration(zooKeeperTimeout(), MILLISECONDS)
+  lazy val zkFutureTimeout = BackToTheFuture.Timeout(zkTimeoutDuration)
 }

--- a/src/main/scala/mesosphere/marathon/api/v1/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v1/AppsResource.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.api.v1
 
-import mesosphere.marathon.MarathonSchedulerService
+import mesosphere.marathon.{MarathonConf, MarathonSchedulerService}
 import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.marathon.api.v2.AppUpdate
 import mesosphere.marathon.event.{EventModule, ApiPostEvent}
@@ -23,7 +23,8 @@ import mesosphere.marathon.api.Responses
 class AppsResource @Inject()(
     @Named(EventModule.busName) eventBus: Option[EventBus],
     service: MarathonSchedulerService,
-    taskTracker: TaskTracker) {
+    taskTracker: TaskTracker,
+    config: MarathonConf) {
 
   val log = Logger.getLogger(getClass.getName)
 
@@ -36,7 +37,7 @@ class AppsResource @Inject()(
   @Timed
   def start(@Context req: HttpServletRequest, @Valid app: AppDefinition): Response = {
     maybePostEvent(req, app)
-    Await.result(service.startApp(app), service.defaultWait)
+    Await.result(service.startApp(app), config.zkTimeoutDuration)
     Response.noContent.build
   }
 
@@ -45,7 +46,7 @@ class AppsResource @Inject()(
   @Timed
   def stop(@Context req: HttpServletRequest, app: AppDefinition): Response = {
     maybePostEvent(req, app)
-    Await.result(service.stopApp(app), service.defaultWait)
+    Await.result(service.stopApp(app), config.zkTimeoutDuration)
     Response.noContent.build
   }
 
@@ -55,7 +56,7 @@ class AppsResource @Inject()(
   def scale(@Context req: HttpServletRequest, @Valid app: AppDefinition): Response = {
     maybePostEvent(req, app)
     val appUpdate = AppUpdate(instances = Some(app.instances))
-    Await.result(service.updateApp(app.id, appUpdate), service.defaultWait)
+    Await.result(service.updateApp(app.id, appUpdate), config.zkTimeoutDuration)
     Response.noContent.build
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -6,10 +6,9 @@ import javax.ws.rs.core.{Response, Context, MediaType}
 import javax.inject.{Named, Inject}
 import mesosphere.marathon.event.EventModule
 import com.google.common.eventbus.EventBus
-import mesosphere.marathon.{MarathonSchedulerService, BadRequestException}
+import mesosphere.marathon.{MarathonConf, MarathonSchedulerService}
 import mesosphere.marathon.tasks.TaskTracker
 import com.codahale.metrics.annotation.Timed
-import com.sun.jersey.api.NotFoundException
 import javax.servlet.http.HttpServletRequest
 import javax.validation.Valid
 import mesosphere.marathon.api.v1.AppDefinition
@@ -17,7 +16,7 @@ import scala.concurrent.Await
 import mesosphere.marathon.event.ApiPostEvent
 import java.net.URI
 import mesosphere.marathon.health.HealthCheckManager
-import mesosphere.marathon.api.{PATCH, Responses}
+import mesosphere.marathon.api.Responses
 
 /**
  * @author Tobi Knaup
@@ -29,7 +28,8 @@ class AppsResource @Inject()(
     @Named(EventModule.busName) eventBus: Option[EventBus],
     service: MarathonSchedulerService,
     taskTracker: TaskTracker,
-    healthCheckManager: HealthCheckManager) {
+    healthCheckManager: HealthCheckManager,
+    config: MarathonConf) {
 
   @GET
   @Timed
@@ -50,7 +50,7 @@ class AppsResource @Inject()(
   @Produces(Array(MediaType.APPLICATION_JSON))
   def create(@Context req: HttpServletRequest, @Valid app: AppDefinition): Response = {
     maybePostEvent(req, app)
-    Await.result(service.startApp(app), service.defaultWait)
+    Await.result(service.startApp(app), config.zkTimeoutDuration)
     Response.created(new URI(s"${app.id}")).build
   }
 
@@ -78,7 +78,7 @@ class AppsResource @Inject()(
     service.getApp(id) match {
       case Some(app) =>
         maybePostEvent(req, updatedApp)
-        Await.result(service.updateApp(id, appUpdate), service.defaultWait)
+        Await.result(service.updateApp(id, appUpdate), config.zkTimeoutDuration)
         Response.noContent.build
 
       case None => create(req, updatedApp)
@@ -91,7 +91,7 @@ class AppsResource @Inject()(
   def delete(@Context req: HttpServletRequest, @PathParam("id") id: String): Response = {
     val app = AppDefinition(id = id)
     maybePostEvent(req, app)
-    Await.result(service.stopApp(app), service.defaultWait)
+    Await.result(service.stopApp(app), config.zkTimeoutDuration)
     Response.noContent.build
   }
 

--- a/src/main/scala/mesosphere/marathon/state/AppRepository.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppRepository.scala
@@ -11,10 +11,6 @@ class AppRepository(store: PersistenceStore[AppDefinition]) {
 
   protected val ID_DELIMITER = ":"
 
-  val defaultWait = store match {
-    case m: MarathonStore[_] => m.defaultWait
-    case _ => Duration(3, SECONDS)
-  }
 
   /**
    * Returns the most recently stored app with the supplied id.

--- a/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
+++ b/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
@@ -4,19 +4,25 @@ import com.google.protobuf.InvalidProtocolBufferException
 import org.apache.mesos.state.State
 import scala.collection.JavaConverters._
 import scala.concurrent._
-import scala.concurrent.duration.Duration
 import mesosphere.marathon.StorageException
 import com.google.common.cache.{CacheLoader, CacheBuilder}
 import java.util.concurrent.Semaphore
+import mesosphere.util.{ThreadPoolContext, BackToTheFuture}
 
 /**
  * @author Tobi Knaup
  */
 
-class MarathonStore[S <: MarathonState[_, S]](state: State,
-                       newState: () => S, prefix:String = "app:") extends PersistenceStore[S] {
+class MarathonStore[S <: MarathonState[_, S]](
+    state: State,
+    newState: () => S,
+    prefix: String = "app:",
+    implicit val timeout: BackToTheFuture.Timeout = BackToTheFuture.Implicits.defaultTimeout
+  ) extends PersistenceStore[S] {
 
-  val defaultWait = Duration(3, "seconds")
+  import ThreadPoolContext.context
+  import BackToTheFuture.futureToFutureOption
+
   private [this] val locks = {
     CacheBuilder
       .newBuilder()
@@ -27,9 +33,6 @@ class MarathonStore[S <: MarathonState[_, S]](state: State,
         }
       )
   }
-
-  import mesosphere.util.ThreadPoolContext.context
-  import mesosphere.util.BackToTheFuture.futureToFutureOption
 
   def fetch(key: String): Future[Option[S]] = {
     state.fetch(prefix + key) map {

--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -6,21 +6,24 @@ import org.apache.mesos.Protos.{TaskID, TaskStatus}
 import javax.inject.Inject
 import org.apache.mesos.state.{Variable, State}
 import mesosphere.marathon.Protos._
-import mesosphere.marathon.Main
+import mesosphere.marathon.{MarathonConf, Main}
 import java.io._
 import scala.Some
 import scala.concurrent.Future
 import org.apache.log4j.Logger
+import mesosphere.util.{ThreadPoolContext, BackToTheFuture}
 
 /**
  * @author Tobi Knaup
  */
 
-class TaskTracker @Inject()(state: State) {
+class TaskTracker @Inject()(state: State, config: MarathonConf) {
 
   import TaskTracker.App
-  import mesosphere.util.ThreadPoolContext.context
-  import mesosphere.util.BackToTheFuture.futureToFuture
+  import ThreadPoolContext.context
+  import BackToTheFuture.futureToFuture
+
+  implicit val timeout = config.zkFutureTimeout
 
   private[this] val log = Logger.getLogger(getClass.getName)
 

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -29,6 +29,7 @@ class MarathonSchedulerTest extends MarathonSpec {
   var scheduler: MarathonScheduler = null
   var frameworkIdUtil: FrameworkIdUtil = null
   var rateLimiters: RateLimiters = null
+  var config: MarathonConf = null
 
   before {
     repo = mock[AppRepository]
@@ -37,6 +38,7 @@ class MarathonSchedulerTest extends MarathonSpec {
     queue = mock[TaskQueue]
     frameworkIdUtil = mock[FrameworkIdUtil]
     rateLimiters = mock[RateLimiters]
+    config = mock[MarathonConf]
     scheduler = new MarathonScheduler(
       None,
       new ObjectMapper,
@@ -45,7 +47,8 @@ class MarathonSchedulerTest extends MarathonSpec {
       tracker,
       queue,
       frameworkIdUtil,
-      rateLimiters
+      rateLimiters,
+      config
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/TaskTrackerTest.scala
+++ b/src/test/scala/mesosphere/marathon/TaskTrackerTest.scala
@@ -12,6 +12,8 @@ class TaskTrackerTest extends MarathonSpec {
 
   import mesosphere.mesos.protos.Implicits._
 
+  val config = mock[MarathonConf]
+
   def makeSampleTask(id: String) = {
     makeTask(id, "host", 999)
   }
@@ -45,7 +47,7 @@ class TaskTrackerTest extends MarathonSpec {
     }
 
     val state = new InMemoryState
-    val taskTracker = new TaskTracker(state)
+    val taskTracker = new TaskTracker(state, config)
     val app = "foo"
     val taskId1 = TaskIDUtil.taskId(app, 1)
     val taskId2 = TaskIDUtil.taskId(app, 2)
@@ -82,7 +84,7 @@ class TaskTrackerTest extends MarathonSpec {
     }
 
     val state = new InMemoryState
-    val taskTracker1 = new TaskTracker(state)
+    val taskTracker1 = new TaskTracker(state, config)
     val app = "foo"
     val taskId1 = TaskIDUtil.taskId(app, 1)
     val taskId2 = TaskIDUtil.taskId(app, 2)
@@ -101,7 +103,7 @@ class TaskTrackerTest extends MarathonSpec {
     taskTracker1.starting(app, task3)
     taskTracker1.running(app, makeTaskStatus(taskId3))
 
-    val taskTracker2 = new TaskTracker(state)
+    val taskTracker2 = new TaskTracker(state, config)
     val results = taskTracker2.fetchApp(app).tasks
 
     shouldContainTask(results, task1)
@@ -111,7 +113,7 @@ class TaskTrackerTest extends MarathonSpec {
 
   test("SerDe") {
     val state = new InMemoryState
-    val taskTracker = new TaskTracker(state)
+    val taskTracker = new TaskTracker(state, config)
 
     val task1 = makeSampleTask("task1")
     val task2 = makeSampleTask("task2")


### PR DESCRIPTION
This uses `ThreadPoolContext.context`, and the timeout configured via `--zk_timeout` everywhere we talk to ZK.
