### PR TITLE
Allow arbitrary JVM options to be passed to marathon

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -41,6 +41,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [ -n ${JVM_OPTS+x} ]
+then
+  for arg in ${JVM_OPTS[@]}
+  do
+    addJava "$arg"
+  done
+fi
+
 # Start Marathon
 marathon_jar=$(find "$FRAMEWORK_HOME"/target -name 'marathon-assembly-*.jar' | sort | tail -1)
 java "${java_args[@]}" -jar "$marathon_jar" "${app_args[@]}"


### PR DESCRIPTION
The current start script only passes -D options as a command line parameter
to the JVM. This makes it impossible to use e.g. -agentlib or -agentpath or
the various -X options.

This change allows using an environment variable (JVM_OPTS) to contain these
options and have them passed directly to the JVM.

E.g. to start marathon with a tuned garbage collector and memory setting:

JVM_OPTS="-Xmx128m -XX:+UseConcMarkSweepGC -XX:+ExplicitGCInvokesConcurrent -XX:+AggressiveOpts -XX:+HeapDumpOnOutOfMemoryError" ./bin/start <marathon options>
