### PR TITLE
Cleanup to clear five compiler warnings.

### DIFF
--- a/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
+++ b/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
@@ -12,20 +12,20 @@ trait ZookeeperConf extends ScallopConf {
   private val zkURLPattern = s"""^zk://($hostAndPort(?:,$hostAndPort)*)(/$zkNode(?:/$zkNode)*)$$""".r
 
   @Deprecated
-  val zooKeeperHostString = opt[String]("zk_hosts",
+  lazy val zooKeeperHostString = opt[String]("zk_hosts",
     descr = "[DEPRECATED use zk] The list of ZooKeeper servers for storing state",
     default = Some("localhost:2181"))
 
   @Deprecated
-  val zooKeeperPath = opt[String]("zk_state",
+  lazy val zooKeeperPath = opt[String]("zk_state",
     descr = "[DEPRECATED use zk] Path in ZooKeeper for storing state",
     default = Some("/marathon"))
 
-  val zooKeeperTimeout = opt[Long]("zk_timeout",
+  lazy val zooKeeperTimeout = opt[Long]("zk_timeout",
     descr = "The timeout for ZooKeeper in milliseconds",
     default = Some(10000L))
 
-  val zooKeeperUrl = opt[String]("zk",
+  lazy val zooKeeperUrl = opt[String]("zk",
     descr = "ZooKeeper URL for storing state. Format: zk://host1:port1,host2:port2,.../path",
     validate = (in) => zkURLPattern.pattern.matcher(in).matches()
   )

--- a/src/main/scala/mesosphere/marathon/api/v2/EventSubscriptionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/EventSubscriptionsResource.scala
@@ -46,7 +46,7 @@ class EventSubscriptionsResource {
     Await.result(future, timeout)
   }
 
-  private def validateSubscriptionService = {
+  private def validateSubscriptionService() = {
     if (service eq null) throw new BadRequestException(
       "http event callback system is not running on this Marathon instance. " +
         "Please re-start this instance with \"--event_subscriber http_callback\"."


### PR DESCRIPTION
Fixes the following classes of warnings during the compile phase:
1. Delayed init likely to yield an uninitialized value:
   
   ```
   [warn] src/main/scala/mesosphere/marathon/Main.scala:24: Selecting value zooKeeperTimeout from trait ZookeeperConf, which extends scala.DelayedInit, is likely to yield an uninitialized value
   [warn]       conf.zooKeeperTimeout() < Integer.MAX_VALUE,
   [warn]            ^
   ```
2. Nullary methods with side-effects are discouraged:
   
   ```
   [warn] src/main/scala/mesosphere/marathon/api/v2/EventSubscriptionsResource.scala:49: side-effecting nullary methods are discouraged: suggest defining as `def validateSubscriptionService()` instead
   [warn]   private def validateSubscriptionService = {
   [warn]               ^
   ```
