### PR TITLE
exec java for interop with supervisors

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -52,4 +52,4 @@ fi
 
 # Start Marathon
 marathon_jar=$(find "$FRAMEWORK_HOME"/target -name 'marathon-assembly-*.jar' | sort | tail -1)
-java "${java_args[@]}" -jar "$marathon_jar" "${app_args[@]}"
+exec java "${java_args[@]}" -jar "$marathon_jar" "${app_args[@]}"


### PR DESCRIPTION
We use runit to supervise marathon.  For those who wish to use bin/start
to launch marathon from a supervisor, it's necessary / beneficial for
the start script to exec the jvm, so that the supervisor is managing the
java process directly as a child (as opposed to bash->java).
