### PR TITLE
Set ulimit-n to correct value for 4096 maxconn.

### DIFF
--- a/bin/haproxy_cfg
+++ b/bin/haproxy_cfg
@@ -21,6 +21,7 @@ global
   log 127.0.0.1 local0
   log 127.0.0.1 local1 notice
   maxconn 4096
+  ulimit-n 8203
 
 defaults
   log         global


### PR DESCRIPTION
[Haproxy documentation](http://www.haproxy.org/download/1.3/doc/haproxy-en.txt) suggests that you should set `ulimit-n` using global keyword to (2 \* maxconn + nbproxies + nbservers + 1).

Otherwise when I run haproxy in docker with the generated config I get

```
[WARNING] 209/130738 (19) : [haproxy.main()] Cannot raise FD limit to 8203.
[WARNING] 209/130738 (19) : [haproxy.main()] FD limit (1024) too low for maxconn=4096/maxsock=8203. Please raise 'ulimit-n' to 8203 or more to avoid any trouble.
```
