### PR TITLE
Allow leading slash in app names in UI

### DIFF
--- a/src/main/resources/assets/js/models/App.js
+++ b/src/main/resources/assets/js/models/App.js
@@ -13,7 +13,7 @@ define([
   var DEFAULT_HEALTH_MSG = "Unknown";
   var EDITABLE_ATTRIBUTES = ["cmd", "constraints", "container", "cpus", "env",
     "executor", "id", "instances", "mem", "disk", "ports", "uris"];
-  var VALID_ID_PATTERN = "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$";
+  var VALID_ID_PATTERN = "^/?(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$";
   var VALID_ID_REGEX = new RegExp(VALID_ID_PATTERN);
   var VALID_CONSTRAINTS = ["unique", "cluster", "group_by"];
 


### PR DESCRIPTION
If an app name does not start with a slash when posted to the API, the
API prepends a slash and returns that name. The UI expected app names to
start only with alphanumeric characters and so raised a validation error
when the API responded with the new name.

Let the app name regex start with an optional slash so the UI doesn’t
require it during creation but will allow it when the name is returned
from the API.

Fixes #445.
