### PR TITLE
/v2/tasks response should include health info

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -4,31 +4,38 @@ import javax.ws.rs._
 import scala.Array
 import javax.ws.rs.core.MediaType
 import javax.inject.Inject
-import mesosphere.marathon.MarathonSchedulerService
-import mesosphere.marathon.tasks.TaskTracker
-import mesosphere.marathon.api.EndpointsHelper
+import mesosphere.marathon.api.{ EndpointsHelper, RestResource }
 import mesosphere.marathon.api.v2.json.EnrichedTask
+import mesosphere.marathon.health.{ Health, HealthCheckManager }
+import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService }
+import mesosphere.marathon.tasks.TaskTracker
 import org.apache.log4j.Logger
 import com.codahale.metrics.annotation.Timed
-import mesosphere.marathon.health.Health
 
 @Path("v2/tasks")
-class TasksResource @Inject() (service: MarathonSchedulerService,
-                               taskTracker: TaskTracker) {
+class TasksResource @Inject() (
+    service: MarathonSchedulerService,
+    healthCheckManager: HealthCheckManager,
+    taskTracker: TaskTracker,
+    val config: MarathonConf) extends RestResource {
 
   val log = Logger.getLogger(getClass.getName)
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
   @Timed
-  def indexJson() = {
-    val flatTasksList = taskTracker.list.flatMap {
+  def indexJson() = Map(
+    "tasks" -> taskTracker.list.flatMap {
       case (appId, setOfTasks) =>
-        setOfTasks.tasks.map(EnrichedTask(appId, _, Seq[Option[Health]]()))
+        setOfTasks.tasks.map { task =>
+          EnrichedTask(
+            appId,
+            task,
+            result(healthCheckManager.status(appId, task.getId))
+          )
+        }
     }
-
-    Map("tasks" -> flatTasksList)
-  }
+  )
 
   @GET
   @Produces(Array(MediaType.TEXT_PLAIN))


### PR DESCRIPTION
- Make `/v2/tasks` similar to `/v2/apps/{appId}/tasks`
- Fixes #443
