### PR TITLE
Add deployment ids to app locked error message

### DIFF
--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -10,7 +10,8 @@ class UnknownAppException(id: PathId) extends Exception(s"App '$id' does not exi
 
 class BadRequestException(msg: String) extends Exception(msg)
 
-class AppLockedException extends Exception("App is locked by another operation")
+case class AppLockedException(deploymentIds: Seq[String] = Nil)
+  extends Exception("App is locked by another operation")
 
 class PortRangeExhaustedException(
   val minPort: Int,

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -43,7 +43,7 @@ class MarathonSchedulerActor(
   val appLocks = LockManager[PathId]()
   var scheduler: SchedulerActions = _
 
-  var upgradeManager: ActorRef = _
+  var deploymentManager: ActorRef = _
 
   override def preStart(): Unit = {
 
@@ -58,7 +58,7 @@ class MarathonSchedulerActor(
       self,
       config)
 
-    upgradeManager = context.actorOf(
+    deploymentManager = context.actorOf(
       Props(classOf[DeploymentManager], appRepository, taskTracker, taskQueue, scheduler, storage, eventBus), "UpgradeManager")
 
   }
@@ -94,7 +94,7 @@ class MarathonSchedulerActor(
       val origSender = sender
       val ids = plan.affectedApplicationIds
 
-      upgradeManager ! CancelConflictingDeployments(plan, new DeploymentCanceledException("The upgrade has been cancelled"))
+      deploymentManager ! CancelConflictingDeployments(plan, new DeploymentCanceledException("The upgrade has been cancelled"))
       locking(ids, origSender, cmd, blocking = true) {
         val res = deploy(driver, plan)
         origSender ! cmd.answer
@@ -123,7 +123,7 @@ class MarathonSchedulerActor(
       log.info(s"Conflicting deployments for deployment $id have been canceled")
 
     case msg @ RetrieveRunningDeployments =>
-      upgradeManager forward msg
+      deploymentManager forward msg
   }
 
   /**
@@ -159,7 +159,25 @@ class MarathonSchedulerActor(
       else {
         log.debug(s"Failed to acquire some of the locks for $appIds to perform cmd: $cmd")
         acquiredLocks.foreach(_.release())
-        origSender ! CommandFailed(cmd, new AppLockedException)
+
+        import akka.pattern.ask
+        import akka.util.Timeout
+        import scala.concurrent.duration._
+
+        deploymentManager.ask(RetrieveRunningDeployments)(Timeout(2.seconds))
+          .mapTo[RunningDeployments]
+          .foreach {
+            case RunningDeployments(plans) =>
+              val relatedDeploymentIds: Seq[String] = plans.collect {
+                case p if distinctIds(p).toSet.intersect(appIds).nonEmpty =>
+                  p.id
+              }
+
+              origSender ! CommandFailed(
+                cmd,
+                AppLockedException(relatedDeploymentIds)
+              )
+          }
       }
     }
   }
@@ -180,7 +198,7 @@ class MarathonSchedulerActor(
     val promise = Promise[Any]()
     val promiseActor = context.actorOf(Props(classOf[PromiseActor], promise))
     val msg = PerformDeployment(driver, plan)
-    upgradeManager.tell(msg, promiseActor)
+    deploymentManager.tell(msg, promiseActor)
 
     val res = promise.future.map(_ => ())
 

--- a/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
@@ -3,7 +3,11 @@ package mesosphere.marathon.api
 import javax.ws.rs.ext.{ Provider, ExceptionMapper }
 import javax.ws.rs.core.{ MediaType, Response }
 import scala.concurrent.TimeoutException
-import mesosphere.marathon.{ BadRequestException, UnknownAppException }
+import mesosphere.marathon.{
+  AppLockedException,
+  BadRequestException,
+  UnknownAppException
+}
 import com.sun.jersey.api.NotFoundException
 import com.fasterxml.jackson.core.JsonParseException
 import javax.ws.rs.WebApplicationException
@@ -32,6 +36,7 @@ class MarathonExceptionMapper extends ExceptionMapper[Exception] {
     case e: IllegalArgumentException => 422 // Unprocessable entity
     case e: TimeoutException         => 504 // Gateway timeout
     case e: UnknownAppException      => 404 // Not found
+    case e: AppLockedException       => 409 // Conflict
     case e: BadRequestException      => 400 // Bad Request
     case e: JsonParseException       => 400 // Bad Request
     case e: WebApplicationException  => e.getResponse.getStatus
@@ -41,6 +46,11 @@ class MarathonExceptionMapper extends ExceptionMapper[Exception] {
   private def entity(exception: Exception): Any = exception match {
     case e: NotFoundException =>
       Map("message" -> s"URI not found: ${e.getNotFoundUri.getRawPath}")
+    case e: AppLockedException =>
+      Map(
+        "message" -> e.getMessage,
+        "deployments" -> e.deploymentIds
+      )
     case e: JsonParseException =>
       Map("message" -> e.getOriginalMessage)
     case e: WebApplicationException =>


### PR DESCRIPTION
- Changes the response code from `500: Internal Server Error` to `409: Conflict`
- Fixes #450 

New output:

```
HTTP/1.1 409 Conflict
Content-Type: application/json
Server: Jetty(8.y.z-SNAPSHOT)
Transfer-Encoding: chunked
```

``` json
{
    "deployments": [
        "742dc1b0-d26d-4f75-95f0-808b8ea9eed2"
    ], 
    "message": "App is locked by another operation"
}
```
