### PR TITLE
added ConcurrentSet and use it in TaskTracker

### DIFF
--- a/src/main/scala/mesosphere/util/ConcurrentSet.scala
+++ b/src/main/scala/mesosphere/util/ConcurrentSet.scala
@@ -1,0 +1,48 @@
+package mesosphere.util
+
+import scala.collection.concurrent.TrieMap
+import scala.collection.generic.{ CanBuildFrom, GenericSetTemplate, MutableSetFactory }
+import scala.collection.mutable
+
+final class ConcurrentSet[A](elems: A*)
+    extends mutable.Set[A]
+    with GenericSetTemplate[A, ConcurrentSet]
+    with mutable.SetLike[A, ConcurrentSet[A]]
+    with mutable.FlatHashTable[A]
+    with Serializable {
+  import ConcurrentSet._
+
+  private[this] val underlying = TrieMap[A, AnyRef](elems.map(_ -> Dummy): _*)
+
+  override def +=(elem: A) = {
+    underlying.putIfAbsent(elem, Dummy)
+    this
+  }
+
+  override def -=(elem: A) = {
+    underlying.remove(elem)
+    this
+  }
+
+  override def contains(elem: A) = underlying.contains(elem)
+  override def iterator = underlying.keysIterator
+  override def companion = ConcurrentSet
+}
+
+object ConcurrentSet extends MutableSetFactory[ConcurrentSet] {
+  private[ConcurrentSet] val Dummy = new AnyRef
+
+  override def apply[A](elems: A*) = new ConcurrentSet[A](elems: _*)
+
+  override def empty[A]: ConcurrentSet[A] = new ConcurrentSet[A]
+
+  override def newBuilder[A]: mutable.Builder[A, ConcurrentSet[A]] = new mutable.SetBuilder[A, ConcurrentSet[A]](new ConcurrentSet[A]())
+
+  implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, ConcurrentSet[A]] = setCanBuildFrom[A]
+
+  override def setCanBuildFrom[A] = new CanBuildFrom[ConcurrentSet[_], A, ConcurrentSet[A]] {
+    override def apply(from: ConcurrentSet[_]): mutable.Builder[A, ConcurrentSet[A]] = newBuilder[A]
+
+    override def apply(): mutable.Builder[A, ConcurrentSet[A]] = newBuilder[A]
+  }
+}

--- a/src/test/scala/mesosphere/util/ConcurrentSetTest.scala
+++ b/src/test/scala/mesosphere/util/ConcurrentSetTest.scala
@@ -1,0 +1,65 @@
+package mesosphere.util
+
+import java.util.concurrent.Executors
+
+import org.scalatest.{ WordSpecLike, Matchers }
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future, ExecutionContext }
+
+class ConcurrentSetTest extends WordSpecLike with Matchers {
+
+  implicit val ec = ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
+
+  "A ConcurrentSet" should {
+    "contain all values" in {
+      val set = ConcurrentSet[Int]()
+
+      val futures = for (i <- 0 until 10) yield Future {
+        val start = i * 100000
+        val end = start + 100000
+        for (i <- start until end) set.add(i)
+      }
+
+      Await.ready(Future.sequence(futures), Duration.Inf)
+
+      set.size should be(1000000)
+      (0 until 1000000).forall(set) should be(true)
+    }
+
+    "contain no duplicate values" in {
+      val set = ConcurrentSet[Int]()
+
+      val futures = for (i <- 0 until 10) yield Future {
+        for (i <- 0 until 100000) set.add(i)
+      }
+
+      Await.ready(Future.sequence(futures), Duration.Inf)
+
+      set.size should be(100000)
+      (0 until 100000).forall(set) should be(true)
+    }
+
+    "contain all added and none of the removed values" in {
+      val set = ConcurrentSet[Int]((0 until 500000): _*)
+
+      val addFutures = for (i <- 5 until 10) yield Future {
+        val start = i * 100000
+        val end = start + 100000
+        for (i <- start until end) set.add(i)
+      }
+
+      val removeFutures = for (i <- 0 until 5) yield Future {
+        val start = i * 100000
+        val end = start + 100000
+        for (i <- start until end) set.remove(i)
+      }
+
+      Await.ready(Future.sequence(addFutures ++ removeFutures), Duration.Inf)
+
+      set.size should be(500000)
+      (500000 until 1000000).forall(set) should be(true)
+      (0 until 500000).exists(set) should be(false)
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a `ConcurrentSet` implementation based on `scala.collection.concurrent.TrieMap` and uses it as task storage in `TaskTracker`.
