### PR TITLE
Remove incorrect `cmd` validation from frontend

### DIFF
--- a/src/main/resources/assets/js/models/App.js
+++ b/src/main/resources/assets/js/models/App.js
@@ -230,20 +230,6 @@ define([
           new ValidationError("ports", "Ports must be a list of Numbers"));
       }
 
-      if (!_.isString(attrs.cmd) || attrs.cmd.length < 1) {
-        // If `cmd` string is empty, a `container` must be present otherwise the
-        // app will not be runnable.
-        if (attrs.container == null || !_.isString(attrs.container.image) ||
-            attrs.container.image.length < 1 ||
-            attrs.container.image.indexOf("docker") != 0) {
-          errors.push(
-            new ValidationError("cmd",
-              "Command must be a non-empty String if no container image is provided"
-            )
-          );
-        }
-      }
-
       if (!attrs.constraints.every(isValidConstraint)) {
         errors.push(new ValidationError("constraints",
           "Invalid constraints format or operator. Supported operators are " +


### PR DESCRIPTION
The dependency of `cmd` and `container` is not defined in the backend is
now incorrect in the frontend. Rather than re-implement validation here,
defer to the backend for complex inter-field dependencies.

The `container` format changed, will also prevented scaling and
suspending from the UI. This fixes scaling/suspending in the UI for apps
using the new container format.

Fixes #496.
