### PR TITLE
Improve Docker documentation

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -46,7 +46,7 @@ layout: default
       </li>
       <li>
         <a href="{{ site.baseurl }}/docs/native-docker.html">
-          Docker
+          Docker Containers
         </a>
       </li>
       <li>

--- a/docs/docs/native-docker.md
+++ b/docs/docs/native-docker.md
@@ -1,29 +1,30 @@
 ---
-title: Native Docker Containers with Mesos and Marathon
+title: Running Docker Containers on Marathon
 ---
 
-# Native Docker Containers with Mesos and Marathon
+# Running Docker Containers on Marathon
 
 This document describes how to run [Docker](https://docker.com/) containers using
-the native Docker support added in version `0.20.0` (released August 2014).
+the native Docker support added in Apache Mesos version 0.20.0
+(released August 2014).
 
-## Resources
+### Prerequisites
 
-- [Mesos Docker Containerizer](http://mesos.apache.org/documentation/latest/docker-containerizer)
-
-## Prerequisites
-
-- Mesos `0.20.0` or better
-- Docker `1.0.0` or above installed on each Mesos slave
+- Mesos version 0.20.0 or later
+- Docker version 1.0.0 or later installed on each Mesos slave
 - Start all `mesos-slave` instances with the flag
   `--containerizers=docker,mesos`.
-    - The order is significant!
+    - _**The order of the containerizers is significant!**_
     - Mesosphere packages read config from well-known paths, so it's possible
       to specify this by doing
 
         ```bash
         $ echo 'docker,mesos' > /etc/mesos-slave/containerizers
         ```
+
+### Resources
+
+- [Mesos Docker Containerizer](http://mesos.apache.org/documentation/latest/docker-containerizer)
 
 ## Overview
 
@@ -63,21 +64,17 @@ For convenience, the mount point of the mesos sandbox is available in the
 environment as `$MESOS_SANDBOX`.  The `$HOME` environment variable is set
 by default to the same value as `$MESOS_SANDBOX`.
 
-## Using a private Docker Repository
+### Using a private Docker Repository
 
 To supply credentials to pull from a private repository, add a `.dockercfg` to
 the `uris` field of your app.
 
-## Advanced Usage
+### Advanced Usage
 
-At a lower level, the semantics have changed slightly for the `TaskInfo`
-protobuf message in Mesos.
-
-As of `0.7.0` Marathon supports an `args` field in the app JSON.  It is
-invalid to supply both `cmd` and `args` for the same app.  This change mirrors
-API and semantics changes in the Mesos `CommandInfo` protobuf message starting
-with version `0.20.0`.  The behavior of `cmd` is as in previous releases (the
-value is wrapped by Mesos via `/bin/sh -c '${app.cmd}`).
+As of version 0.7.0, Marathon supports an `args` field in the app JSON.  It is
+invalid to supply both `cmd` and `args` for the same app.  The behavior of `cmd`
+is as in previous releases (the value is wrapped by Mesos via
+`/bin/sh -c '${app.cmd}`).
 
 This new (`"args"`) mode of specifying a command allows for safe usage of
 containerizer features like custom Docker `ENTRYPOINT`s.  For example, given
@@ -91,7 +88,9 @@ CMD ["inky"]
 ENTRYPOINT ["echo"]
 ```
 
-Supplying the following trivial app definition will execute `echo hello`
+Supplying the following app definition will download the public
+["mesosphere/inky" Docker container](https://registry.hub.docker.com/u/mesosphere/inky/)
+and execute `echo hello`:
 
 ```json
 {


### PR DESCRIPTION
- Add “Containers” in nav for more details
- Shrink headers from `<h2>` to `<h3>` where appropriate for better
  segmentation (all headers had the same weight previously)
- Remove some Mesos implementation details that are not relevant to a
  user like protobuf changes
