### PR TITLE
Add TaskRateLimit deprecation to migration doc

### DIFF
--- a/docs/docs/event-bus.md
+++ b/docs/docs/event-bus.md
@@ -33,17 +33,28 @@ Fired every time Marathon receives an API request that modifies an app (create, 
   "clientIp": "0:0:0:0:0:0:0:1",
   "uri": "/v1/apps/start",
   "appDefinition":{
-    "id": "sleep",
-    "cmd": "sleep 10",
-    "env": {},
-    "instances": 1,
-    "cpus": 1.0,
-    "mem": 10.0,
-    "executor": "",
-    "constraints": [],
-    "uris": [],
-    "ports": [14480],
-    "taskRateLimit": 1.0
+    "backoffFactor": 1.15, 
+    "backoffSeconds": 1, 
+    "cmd": "sleep 30", 
+    "constraints": [], 
+    "cpus": 0.25, 
+    "dependencies": [], 
+    "disk": 0.0, 
+    "env": {}, 
+    "executor": "", 
+    "healthChecks": [], 
+    "id": "/nested/app", 
+    "instances": 1, 
+    "mem": 16.0, 
+    "ports": [10001], 
+    "requirePorts": false, 
+    "storeUrls": [], 
+    "upgradeStrategy": {
+      "minimumHealthCapacity": 1.0
+    }, 
+    "uris": [], 
+    "user": null, 
+    "version": "2014-09-08T18:12:38.259Z"
   }
 }
 ```

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -1342,7 +1342,6 @@ User-Agent: HTTPie/0.8.0
             "ports": [
                 19970
             ], 
-            "taskRateLimit": 1.0, 
             "uris": []
         }
     ]

--- a/docs/docs/upgrade/06xto070.md
+++ b/docs/docs/upgrade/06xto070.md
@@ -18,6 +18,13 @@ the new Docker features Mesos 0.20.0 is required.
 The v1 API has been removed from Marathon. See [REST API]({{ site.baseurl }}/docs/rest-api.html) for up to
 date documentation of the REST API.
 
+## Task Rate Limit
+
+The `taskRateLimit` app parameter has been replaced with two new parameters
+that together control per-app exponential backoff.  The new parameters are
+`backoffSeconds` and  `backoffFactor`.  The backoff period (`backoffSeconds`)
+is multiplied by the factor for each consecutive failed task launch.
+
 ## HAProxy Bridge
 
 Make sure you're using the latest version of the script, as `/v1/endpoints`


### PR DESCRIPTION
- purge taskRateLimit from other example responses

Fixes #530
