### PR TITLE
GroupManager: the plan should be stored after the deployment is accepted

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupManager.scala
@@ -120,8 +120,8 @@ class GroupManager @Singleton @Inject() (
       from <- rootGroup //ignore the state of the scheduler
       (to, resolve) <- resolveStoreUrls(assignDynamicAppPort(from, change(from)))
       _ = requireValid(checkGroup(to))
-      _ <- groupRepo.store(zkName, to)
       plan <- deploy(from, to, resolve)
+      _ <- groupRepo.store(zkName, to)
     } yield plan
 
     deployment.onComplete {


### PR DESCRIPTION
The new group state was stored before the deployment was triggered.
In case of a failing deployment (e.g. app is locked) this leads to the wrong state being persisted.
This change will persist the changed group only, if the deployment is accepted by the scheduler.
