### PR TITLE
Allow user and password in Zookeeper URL

### DIFF
--- a/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
+++ b/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
@@ -7,9 +7,10 @@ import scala.concurrent.duration._
 
 trait ZookeeperConf extends ScallopConf {
 
+  private val userAndPass = """[^/@]+"""
   private val hostAndPort = """[A-z0-9-.]+(?::\d+)?"""
   private val zkNode = """[^/]+"""
-  private val zkURLPattern = s"""^zk://($hostAndPort(?:,$hostAndPort)*)(/$zkNode(?:/$zkNode)*)$$""".r
+  private val zkURLPattern = s"""^zk://(?:$userAndPass@)?($hostAndPort(?:,$hostAndPort)*)(/$zkNode(?:/$zkNode)*)$$""".r
 
   @Deprecated
   lazy val zooKeeperHostString = opt[String]("zk_hosts",

--- a/src/test/scala/mesosphere/marathon/ZookeeperConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/ZookeeperConfTest.scala
@@ -32,6 +32,14 @@ class ZookeeperConfTest extends MarathonSpec {
     assert(opts.zkPath == "/path")
   }
 
+  test("urlParameterWithAuthGetParsed") {
+    val url = "zk://user1:pass1@host1:123,host2,host3:312/path"
+    val opts = conf("--zk", url)
+    assert(opts.zkURL == url)
+    assert(opts.zkHosts == "host1:123,host2,host3:312")
+    assert(opts.zkPath == "/path")
+  }
+
   test("wrongURLIsNotParsed") {
     assert(Try(conf("--zk", "zk://host1:foo/path")).isFailure, "No port number")
     assert(Try(conf("--zk", "zk://host1")).isFailure, "No path")


### PR DESCRIPTION
This allow us to use a Zookeeper URL like: zk://user1:pass1@host1:123,host2,host3:312/path
