### PR TITLE
- don't remove tasks from task tracker before receiving TASK_KILLED

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable
 import scala.concurrent.Promise
 
 class AppStopActor(
-    driver: SchedulerDriver,
+    val driver: SchedulerDriver,
     scheduler: SchedulerActions,
     val taskTracker: TaskTracker,
     val eventBus: EventStream,

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskKillActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskKillActor.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable
 import scala.concurrent.Promise
 
 class TaskKillActor(
-    driver: SchedulerDriver,
+    val driver: SchedulerDriver,
     val appId: PathId,
     val taskTracker: TaskTracker,
     val eventBus: EventStream,
@@ -24,11 +24,6 @@ class TaskKillActor(
     log.info(s"Killing ${tasksToKill.size} instances")
     for (task <- tasksToKill) {
       driver.killTask(taskId(task.getId))
-      val status = TaskStatus.newBuilder
-        .setTaskId(taskId(task.getId))
-        .setState(TaskState.TASK_KILLED)
-        .build
-      taskTracker.terminated(appId, status)
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
@@ -6,6 +6,7 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.event.MesosStatusUpdateEvent
 import mesosphere.marathon.state.{ AppDefinition, PathId }
 import mesosphere.marathon.tasks.TaskTracker
+import mesosphere.marathon.upgrade.StoppingBehavior.SynchronizeTasks
 import mesosphere.marathon.{ MarathonSpec, SchedulerActions, TaskUpgradeCanceledException }
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito._
@@ -125,7 +126,7 @@ class AppStopActorTest
       .thenReturn(tasks)
       .thenReturn(Set.empty[MarathonTask])
 
-    val ref = system.actorOf(
+    val ref = TestActorRef[AppStopActor](
       Props(
         classOf[AppStopActor],
         driver,
@@ -137,6 +138,10 @@ class AppStopActorTest
       )
     )
     watch(ref)
+
+    ref.underlyingActor.periodicalCheck.cancel()
+
+    ref ! SynchronizeTasks
 
     Await.result(promise.future, 10.seconds) should be(())
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.upgrade
 import akka.testkit.{ TestKit, TestActorRef }
 import akka.actor.{ Props, ActorSystem }
 import mesosphere.marathon.tasks.TaskTracker
+import mesosphere.marathon.upgrade.StoppingBehavior.SynchronizeTasks
 import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, Matchers, FunSuiteLike }
 import org.apache.mesos.SchedulerDriver
 import org.scalatest.mock.MockitoSugar
@@ -102,10 +103,42 @@ class TaskKillActorTest
     when(taskTracker.get(app.id))
       .thenReturn(Set.empty[MarathonTask])
 
-    val ref = system.actorOf(Props(classOf[TaskKillActor], driver, app.id, taskTracker, system.eventStream, tasks.toSet, promise))
+    val ref = TestActorRef[TaskKillActor](Props(classOf[TaskKillActor], driver, app.id, taskTracker, system.eventStream, tasks.toSet, promise))
     watch(ref)
 
-    Await.result(promise.future, 10.seconds) should be(())
+    ref.underlyingActor.periodicalCheck.cancel()
+
+    ref ! SynchronizeTasks
+
+    Await.result(promise.future, 5.seconds) should be(())
+
+    expectTerminated(ref)
+  }
+
+  test("Send kill again after synchronization with task tracker") {
+    val taskA = MarathonTask.newBuilder().setId("taskA_id").build()
+    val taskB = MarathonTask.newBuilder().setId("taskB_id").build()
+    val appId = PathId("/test")
+
+    val tasks = Set(taskA, taskB)
+    val promise = Promise[Unit]()
+
+    val ref = TestActorRef[TaskKillActor](Props(classOf[TaskKillActor], driver, appId, taskTracker, system.eventStream, tasks, promise))
+
+    when(taskTracker.get(appId)).thenReturn(Set(taskA, taskB))
+
+    watch(ref)
+
+    ref.underlyingActor.periodicalCheck.cancel()
+
+    ref ! SynchronizeTasks
+
+    system.eventStream.publish(MesosStatusUpdateEvent("", taskA.getId, "TASK_KILLED", PathId.empty, "", Nil, ""))
+    system.eventStream.publish(MesosStatusUpdateEvent("", taskB.getId, "TASK_KILLED", PathId.empty, "", Nil, ""))
+
+    Await.result(promise.future, 5.seconds) should be(())
+    verify(driver, times(2)).killTask(TaskID.newBuilder().setValue(taskA.getId).build())
+    verify(driver, times(2)).killTask(TaskID.newBuilder().setValue(taskB.getId).build())
 
     expectTerminated(ref)
   }


### PR DESCRIPTION
- resend kill command if TASK_KILLED does not arrive before timeout
