### PR TITLE
fixes #663 - Fix scaling of apps with health checks

### DIFF
--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -138,13 +138,13 @@ class TaskTracker @Inject() (state: State, config: MarathonConf) {
     }
   }
 
+  def stagedTasks = apps.values.flatMap(_.tasks.values.filter(_.getStartedAt == 0))
+
   def checkStagedTasks: Iterable[MarathonTask] = {
     // stagedAt is set when the task is created by the scheduler
     val now = System.currentTimeMillis
     val expires = now - Main.conf.taskLaunchTimeout()
-    val toKill = apps.values.map { app =>
-      app.tasks.values.filter(t => Option(t.getStartedAt).isEmpty && t.getStagedAt < expires)
-    }.flatten
+    val toKill = stagedTasks.filter(_.getStagedAt < expires)
 
     toKill.foreach(t => {
       log.warn(s"Task '${t.getId}' was staged ${(now - t.getStagedAt) / 1000}s ago and has not yet started")

--- a/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.upgrade
 import akka.actor._
 import akka.event.EventStream
 import mesosphere.marathon.state.AppDefinition
-import mesosphere.marathon.tasks.TaskQueue
+import mesosphere.marathon.tasks.{ TaskTracker, TaskQueue }
 import mesosphere.marathon.{ AppStartCanceledException, SchedulerActions }
 import org.apache.mesos.SchedulerDriver
 
@@ -13,6 +13,7 @@ class AppStartActor(
     val driver: SchedulerDriver,
     val scheduler: SchedulerActions,
     val taskQueue: TaskQueue,
+    val taskTracker: TaskTracker,
     val eventBus: EventStream,
     val app: AppDefinition,
     scaleTo: Int,

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -98,7 +98,7 @@ class DeploymentActor(
 
   def startApp(app: AppDefinition, scaleTo: Int): Future[Unit] = {
     val promise = Promise[Unit]()
-    context.actorOf(Props(classOf[AppStartActor], driver, scheduler, taskQueue, eventBus, app, scaleTo, promise))
+    context.actorOf(Props(classOf[AppStartActor], driver, scheduler, taskQueue, taskTracker, eventBus, app, scaleTo, promise))
     storeAndThen(app, promise.future)
   }
 
@@ -109,7 +109,7 @@ class DeploymentActor(
     }
     else if (scaleTo > runningTasks.size) {
       val promise = Promise[Unit]()
-      context.actorOf(Props(classOf[TaskStartActor], driver, scheduler, taskQueue, eventBus, app, scaleTo - runningTasks.size, app.healthChecks.nonEmpty, promise))
+      context.actorOf(Props(classOf[TaskStartActor], driver, scheduler, taskQueue, taskTracker, eventBus, app, scaleTo - runningTasks.size, app.healthChecks.nonEmpty, promise))
       promise.future.map(_ => ())
     }
     else {
@@ -141,7 +141,7 @@ class DeploymentActor(
     val runningNew = runningTasks.filter(_.getVersion == app.version.toString)
     val nrToStart = scaleNewTo - runningNew.size
 
-    context.actorOf(Props(classOf[TaskStartActor], driver, scheduler, taskQueue, eventBus, app, nrToStart, app.healthChecks.nonEmpty, startPromise))
+    context.actorOf(Props(classOf[TaskStartActor], driver, scheduler, taskQueue, taskTracker, eventBus, app, nrToStart, app.healthChecks.nonEmpty, startPromise))
 
     context.actorOf(Props(classOf[TaskKillActor], driver, app.id, taskTracker, eventBus, tasksToKill.toSet, stopPromise))
 

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.upgrade
 import akka.actor.{ Actor, ActorLogging }
 import akka.event.EventStream
 import mesosphere.marathon.state.AppDefinition
-import mesosphere.marathon.tasks.TaskQueue
+import mesosphere.marathon.tasks.{ TaskTracker, TaskQueue }
 import mesosphere.marathon.{ SchedulerActions, TaskUpgradeCanceledException }
 import org.apache.mesos.SchedulerDriver
 
@@ -13,6 +13,7 @@ class TaskStartActor(
     val driver: SchedulerDriver,
     val scheduler: SchedulerActions,
     val taskQueue: TaskQueue,
+    val taskTracker: TaskTracker,
     val eventBus: EventStream,
     val app: AppDefinition,
     nrToStart: Int,

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -2,8 +2,9 @@ package mesosphere.marathon.upgrade
 
 import akka.testkit.{ TestActorRef, TestKit }
 import akka.actor.{ Props, ActorSystem }
-import mesosphere.marathon.tasks.TaskQueue
-import mesosphere.marathon.{ AppStartCanceledException, SchedulerActions, MarathonSpec }
+import mesosphere.marathon.tasks.{ TaskTracker, TaskQueue }
+import mesosphere.marathon.{ MarathonConf, AppStartCanceledException, SchedulerActions, MarathonSpec }
+import org.apache.mesos.state.InMemoryState
 import org.scalatest.{ BeforeAndAfterAll, Matchers }
 import org.scalatest.mock.MockitoSugar
 import org.apache.mesos.SchedulerDriver
@@ -24,11 +25,13 @@ class AppStartActorTest
   var driver: SchedulerDriver = _
   var scheduler: SchedulerActions = _
   var taskQueue: TaskQueue = _
+  var taskTracker: TaskTracker = _
 
   before {
     driver = mock[SchedulerDriver]
     scheduler = mock[SchedulerActions]
     taskQueue = new TaskQueue
+    taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
   }
 
   test("Without Health Checks") {
@@ -40,6 +43,7 @@ class AppStartActorTest
         driver,
         scheduler,
         taskQueue,
+        taskTracker,
         system.eventStream,
         app,
         2,
@@ -66,6 +70,7 @@ class AppStartActorTest
         driver,
         scheduler,
         taskQueue,
+        taskTracker,
         system.eventStream,
         app,
         2,
@@ -92,6 +97,7 @@ class AppStartActorTest
         driver,
         scheduler,
         taskQueue,
+        taskTracker,
         system.eventStream,
         app,
         2,
@@ -120,6 +126,7 @@ class AppStartActorTest
         driver,
         scheduler,
         taskQueue,
+        taskTracker,
         system.eventStream,
         app,
         0,
@@ -143,6 +150,7 @@ class AppStartActorTest
         driver,
         scheduler,
         taskQueue,
+        taskTracker,
         system.eventStream,
         app,
         0,

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -2,12 +2,13 @@ package mesosphere.marathon.upgrade
 
 import akka.actor.{ ActorSystem, Props }
 import akka.testkit.{ TestActorRef, TestKit }
-import mesosphere.marathon.{ SchedulerActions, TaskUpgradeCanceledException }
+import mesosphere.marathon.{ MarathonConf, SchedulerActions, TaskUpgradeCanceledException }
 import mesosphere.marathon.event.{ HealthStatusChanged, MesosStatusUpdateEvent }
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.tasks.TaskQueue
+import mesosphere.marathon.tasks.{ TaskTracker, TaskQueue }
 import org.apache.mesos.SchedulerDriver
+import org.apache.mesos.state.InMemoryState
 import org.mockito.Mockito.{ spy, times, verify }
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfterAll, FunSuiteLike, Matchers }
@@ -31,6 +32,7 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = new TaskQueue
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
     val promise = Promise[Unit]()
     val app = AppDefinition("myApp".toPath, instances = 5)
 
@@ -39,6 +41,7 @@ class TaskStartActorTest
       driver,
       scheduler,
       taskQueue,
+      taskTracker,
       system.eventStream,
       app,
       app.instances,
@@ -61,6 +64,7 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = new TaskQueue
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
     val promise = Promise[Boolean]()
     val app = AppDefinition("myApp".toPath, instances = 0)
 
@@ -69,6 +73,7 @@ class TaskStartActorTest
       driver,
       scheduler,
       taskQueue,
+      taskTracker,
       system.eventStream,
       app,
       app.instances,
@@ -86,6 +91,7 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = new TaskQueue
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
     val promise = Promise[Boolean]()
     val app = AppDefinition("myApp".toPath, instances = 5)
 
@@ -94,6 +100,7 @@ class TaskStartActorTest
       driver,
       scheduler,
       taskQueue,
+      taskTracker,
       system.eventStream,
       app,
       app.instances,
@@ -116,6 +123,7 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = new TaskQueue
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
     val promise = Promise[Boolean]()
     val app = AppDefinition("myApp".toPath, instances = 0)
 
@@ -124,6 +132,7 @@ class TaskStartActorTest
       driver,
       scheduler,
       taskQueue,
+      taskTracker,
       system.eventStream,
       app,
       app.instances,
@@ -141,6 +150,7 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = new TaskQueue
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
     val promise = Promise[Boolean]()
     val app = AppDefinition("myApp".toPath, instances = 5)
 
@@ -149,6 +159,7 @@ class TaskStartActorTest
       driver,
       scheduler,
       taskQueue,
+      taskTracker,
       system.eventStream,
       app,
       app.instances,
@@ -170,6 +181,7 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = spy(new TaskQueue)
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
     val promise = Promise[Unit]()
     val app = AppDefinition("myApp".toPath, instances = 1)
 
@@ -178,6 +190,7 @@ class TaskStartActorTest
       driver,
       scheduler,
       taskQueue,
+      taskTracker,
       system.eventStream,
       app,
       app.instances,


### PR DESCRIPTION
The problem was, that the syncing in the `StartingBehavior` simply called scale app, while the app def had not been stored. Therefore it scaled down to the original value again.
