### PR TITLE
Reduce pre-0.5 and post-0.5 taskIDs to one Regex

### DIFF
--- a/src/main/scala/mesosphere/marathon/tasks/TaskIDUtil.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskIDUtil.scala
@@ -10,8 +10,7 @@ import org.apache.mesos.Protos.TaskID
 
 class TaskIdUtil {
   val taskDelimiter = "."
-  val TaskId = """^(.+)\.(.+)$""".r
-  val OldTaskId = """^(.+)[_](.+)$""".r
+  val TaskIdRegex = """^(.+)[\._]([^_\.]+)$""".r
   val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
 
   def taskId(appId: PathId): String = {
@@ -20,10 +19,7 @@ class TaskIdUtil {
 
   def appId(taskId: TaskID): PathId = {
     taskId.getValue match {
-      //new task ids contain . as delimiter but _ for the safe path
-      case TaskId(appId, uuid)    => PathId.fromSafePath(appId)
-      //version 0.5 and below use _ as delimiter
-      case OldTaskId(appId, uuid) => PathId.fromSafePath(appId)
+      case TaskIdRegex(appId, uuid) => PathId.fromSafePath(appId)
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIDUtilTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIDUtilTest.scala
@@ -18,4 +18,14 @@ class TaskIDUtilTest extends FunSuite with Matchers {
     val taskId = TaskID.newBuilder().setValue("app_682ebe64-0771-11e4-b05d-e0f84720c54e").build
     taskIdUtil.appId(taskId) should equal("app".toRootPath)
   }
+
+  test("Old TaskIds can be converted even if they have dots in them") {
+    val taskId = TaskID.newBuilder().setValue("app.foo.bar_682ebe64-0771-11e4-b05d-e0f84720c54e").build
+    taskIdUtil.appId(taskId) should equal("app.foo.bar".toRootPath)
+  }
+
+  test("Old TaskIds can be converted even if they have underscores in them") {
+    val taskId = TaskID.newBuilder().setValue("app_foo_bar_0-12345678").build
+    taskIdUtil.appId(taskId) should equal("/app/foo/bar".toRootPath)
+  }
 }


### PR DESCRIPTION
- Added migration tests
- Fixes #671
