### PR TITLE
Regognize all terminal states in StoppingBehavior

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
@@ -41,7 +41,7 @@ trait StoppingBehavior extends Actor with ActorLogging {
           "The operation has been cancelled"))
   }
 
-  val taskFinished = "^TASK_(FINISHED|LOST|KILLED)$".r
+  val taskFinished = "^TASK_(FAILED|FINISHED|LOST|KILLED)$".r
   def receive = {
     case MesosStatusUpdateEvent(_, taskId, taskFinished(_), _, _, _, _, _, _) if idsToKill(taskId) =>
       idsToKill.remove(taskId)


### PR DESCRIPTION
TASK_FAILED is a valid terminal task state.
