### PR TITLE
Fix docs for constraints

### DIFF
--- a/docs/docs/constraints.md
+++ b/docs/docs/constraints.md
@@ -13,7 +13,7 @@ Constraints can be set via the REST API or the [Marathon gem](https://rubygems.o
 
 `hostname` field matches the slave hostnames, see `UNIQUE operator` for usage example.
 
-`hostname` field supports all operators except `CLUSTER`, since it's useless for hostnames.
+`hostname` field supports all operators except `GROUP_BY`.
 
 ### Attribute field
 


### PR DESCRIPTION
Sorry, I pushed the wrong doc last time. The constraint `hostname` doesn't support is `GROUP_BY`, not `CLUSTER`.

Personally I wonder why `GROUP_BY` `hostname` is not implemented, since it's really useful.
