### PR TITLE
Metrics for concrete subtypes of EntityRepository.

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/AppRepository.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppRepository.scala
@@ -1,12 +1,14 @@
 package mesosphere.marathon.state
 
+import com.codahale.metrics.MetricRegistry
 import mesosphere.util.ThreadPoolContext.context
 import scala.concurrent.Future
 
 class AppRepository(
   val store: PersistenceStore[AppDefinition],
-  val maxVersions: Option[Int] = None)
-    extends EntityRepository[AppDefinition] {
+  val maxVersions: Option[Int] = None,
+  val registry: MetricRegistry)
+    extends EntityRepository[AppDefinition] with StateMetrics {
 
   def allPathIds(): Future[Iterable[PathId]] = allIds().map(_.map(PathId.fromSafePath))
 

--- a/src/main/scala/mesosphere/marathon/state/DeploymentRepository.scala
+++ b/src/main/scala/mesosphere/marathon/state/DeploymentRepository.scala
@@ -1,14 +1,16 @@
 package mesosphere.marathon.state
 
 import mesosphere.marathon.upgrade.DeploymentPlan
-
+import com.codahale.metrics.MetricRegistry
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
 class DeploymentRepository(
   val store: PersistenceStore[DeploymentPlan],
-  val maxVersions: Option[Int] = None)
-    extends EntityRepository[DeploymentPlan] {
+  val maxVersions: Option[Int] = None,
+  val registry: MetricRegistry)
+    extends EntityRepository[DeploymentPlan] with StateMetrics {
+
   import mesosphere.util.ThreadPoolContext.context
 
   def store(plan: DeploymentPlan): Future[DeploymentPlan] =

--- a/src/main/scala/mesosphere/marathon/state/GroupRepository.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupRepository.scala
@@ -1,11 +1,13 @@
 package mesosphere.marathon.state
 
+import com.codahale.metrics.MetricRegistry
 import scala.concurrent.Future
 
 class GroupRepository(
   val store: PersistenceStore[Group],
   appRepo: AppRepository,
-  val maxVersions: Option[Int] = None)
+  val maxVersions: Option[Int] = None,
+  val registry: MetricRegistry)
     extends EntityRepository[Group] {
 
   import mesosphere.util.ThreadPoolContext.context

--- a/src/main/scala/mesosphere/marathon/state/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/state/Migration.scala
@@ -12,6 +12,7 @@ import mesosphere.marathon.{ BuildInfo, MarathonConf, StorageException }
 import mesosphere.util.BackToTheFuture.futureToFutureOption
 import mesosphere.util.ThreadPoolContext.context
 import mesosphere.util.{ BackToTheFuture, Logging }
+import com.codahale.metrics.MetricRegistry
 import org.apache.mesos.state.{ State, Variable }
 
 import scala.collection.JavaConverters._
@@ -24,6 +25,7 @@ class Migration @Inject() (
   appRepo: AppRepository,
   groupRepo: GroupRepository,
   config: MarathonConf,
+  registry: MetricRegistry,
   implicit val timeout: BackToTheFuture.Timeout = BackToTheFuture.Implicits.defaultTimeout)
     extends Logging {
 
@@ -101,7 +103,7 @@ class Migration @Inject() (
   }
 
   private def changeTasks(fn: InternalApp => InternalApp): Future[Any] = {
-    val taskTracker = new TaskTracker(state, config)
+    val taskTracker = new TaskTracker(state, config, registry)
     def fetchApp(appId: PathId): Option[InternalApp] = {
       val bytes = state.fetch("tasks:" + appId.safePath).get().value
       if (bytes.length > 0) {

--- a/src/main/scala/mesosphere/marathon/state/StateMetrics.scala
+++ b/src/main/scala/mesosphere/marathon/state/StateMetrics.scala
@@ -1,0 +1,34 @@
+package mesosphere.marathon.state
+
+import com.codahale.metrics.{ Histogram, Meter, MetricRegistry }
+import com.codahale.metrics.MetricRegistry.name
+
+trait StateMetrics {
+
+  // metrics!
+  protected def registry: MetricRegistry
+
+  private[this] val readRequests: Meter = registry.meter(name(getClass, "read-requests"))
+  private[this] val readRequestErrors: Meter = registry.meter(name(getClass, "read-request-errors"))
+  private[this] val readRequestTime: Histogram = registry.histogram(name(getClass, "read-request-time"))
+
+  private[this] val writeRequests: Meter = registry.meter(name(getClass, "write-requests"))
+  private[this] val writeRequestErrors: Meter = registry.meter(name(getClass, "write-request-errors"))
+  private[this] val writeRequestTime: Histogram = registry.histogram(name(getClass, "write-request-time"))
+
+  protected[this] def timed[T](hist: Histogram, invocations: Meter, errors: Meter)(f: => T): T = {
+    invocations.mark()
+    try {
+      val t0 = System.nanoTime()
+      val result = f
+      val t1 = System.nanoTime()
+      hist.update((t1 - t0) / 1000000)
+      result
+    }
+    catch { case t: Throwable => errors.mark(); throw t }
+  }
+
+  protected[this] def timedRead[T](f: => T): T = timed(readRequestTime, readRequests, readRequestErrors)(f)
+  protected[this] def timedWrite[T](f: => T): T = timed(writeRequestTime, writeRequests, writeRequestErrors)(f)
+
+}

--- a/src/test/scala/mesosphere/marathon/state/AppRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppRepositoryTest.scala
@@ -19,7 +19,8 @@ class AppRepositoryTest extends MarathonSpec {
 
     when(store.fetch(s"testApp:$timestamp")).thenReturn(future)
 
-    val repo = new AppRepository(store)
+    val registry = new com.codahale.metrics.MetricRegistry
+    val repo = new AppRepository(store, None, registry)
     val res = repo.app(path, timestamp)
 
     assert(Some(appDef) == Await.result(res, 5.seconds), "Should return the correct AppDefinition")
@@ -36,7 +37,8 @@ class AppRepositoryTest extends MarathonSpec {
     when(store.store(versionedKey, appDef)).thenReturn(future)
     when(store.store("testApp", appDef)).thenReturn(future)
 
-    val repo = new AppRepository(store)
+    val registry = new com.codahale.metrics.MetricRegistry
+    val repo = new AppRepository(store, None, registry)
     val res = repo.store(appDef)
 
     assert(appDef == Await.result(res, 5.seconds), "Should return the correct AppDefinition")
@@ -50,7 +52,8 @@ class AppRepositoryTest extends MarathonSpec {
 
     when(store.names()).thenReturn(future)
 
-    val repo = new AppRepository(store)
+    val registry = new com.codahale.metrics.MetricRegistry
+    val repo = new AppRepository(store, None, registry)
     val res = repo.allIds()
 
     assert(Seq("app1", "app2") == Await.result(res, 5.seconds), "Should return only unversioned names")
@@ -71,7 +74,8 @@ class AppRepositoryTest extends MarathonSpec {
     when(store.fetch(appDef1.id.toString)).thenReturn(Future.successful(Some(appDef1)))
     when(store.fetch(appDef2.id.toString)).thenReturn(Future.successful(Some(appDef2)))
 
-    val repo = new AppRepository(store)
+    val registry = new com.codahale.metrics.MetricRegistry
+    val repo = new AppRepository(store, None, registry)
     val res = repo.apps()
 
     assert(Seq(appDef1, appDef2) == Await.result(res, 5.seconds), "Should return only current versions")
@@ -93,7 +97,8 @@ class AppRepositoryTest extends MarathonSpec {
 
     when(store.names()).thenReturn(future)
 
-    val repo = new AppRepository(store)
+    val registry = new com.codahale.metrics.MetricRegistry
+    val repo = new AppRepository(store, None, registry)
     val res = repo.listVersions(appDef1.id)
 
     val expected = Seq(appDef1.version, version1.version, version2.version, version3.version)
@@ -115,7 +120,8 @@ class AppRepositoryTest extends MarathonSpec {
     when(store.names()).thenReturn(future)
     when(store.expunge(any())).thenReturn(Future.successful(true))
 
-    val repo = new AppRepository(store)
+    val registry = new com.codahale.metrics.MetricRegistry
+    val repo = new AppRepository(store, None, registry)
     val res = Await.result(repo.expunge(appDef1.id), 5.seconds).toSeq
 
     assert(res.size == 5, "Should expunge all versions")

--- a/src/test/scala/mesosphere/marathon/state/GroupRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupRepositoryTest.scala
@@ -20,7 +20,8 @@ class GroupRepositoryTest extends MarathonSpec with Matchers {
     when(store.store(versionedKey, group)).thenReturn(future)
     when(store.store("root", group)).thenReturn(future)
 
-    val repo = new GroupRepository(store, appRepo)
+    val registry = new com.codahale.metrics.MetricRegistry
+    val repo = new GroupRepository(store, appRepo, None, registry)
     val res = repo.store("root", group)
 
     assert(group == Await.result(res, 5 seconds), "Should return the correct Group")

--- a/src/test/scala/mesosphere/marathon/state/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MigrationTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.state
 
 import mesosphere.marathon.MarathonConf
+import com.codahale.metrics.MetricRegistry
 import org.apache.mesos.state.State
 import org.scalatest.{ Matchers, FunSuite }
 import org.scalatest.mock.MockitoSugar
@@ -24,6 +25,6 @@ class MigrationTest extends FunSuite with MockitoSugar with Matchers {
     val appRepo = mock[AppRepository]
     val groupRepo = mock[GroupRepository]
     val config = mock[MarathonConf]
-    new Migration(state, appRepo, groupRepo, config)
+    new Migration(state, appRepo, groupRepo, config, new MetricRegistry)
   }
 }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskTrackerTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskTrackerTest.scala
@@ -28,11 +28,11 @@ class TaskTrackerTest extends MarathonSpec {
   var state: State = null
   val config = mock[MarathonConf]
   val taskIdUtil = new TaskIdUtil
+  val registry = new MetricRegistry
 
   before {
-    val metricRegistry = new MetricRegistry
     state = spy(new InMemoryState)
-    taskTracker = new TaskTracker(state, config)
+    taskTracker = new TaskTracker(state, config, registry)
   }
 
   def makeSampleTask(id: String) = {

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.upgrade
 
 import akka.testkit.{ TestActorRef, TestKit }
 import akka.actor.{ Props, ActorSystem }
+import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.tasks.{ TaskTracker, TaskQueue }
 import mesosphere.marathon.{ MarathonConf, AppStartCanceledException, SchedulerActions, MarathonSpec }
 import org.apache.mesos.state.InMemoryState
@@ -31,7 +32,7 @@ class AppStartActorTest
     driver = mock[SchedulerDriver]
     scheduler = mock[SchedulerActions]
     taskQueue = new TaskQueue
-    taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
+    taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], new MetricRegistry)
   }
 
   test("Without Health Checks") {

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
@@ -6,6 +6,7 @@ import akka.pattern.ask
 import akka.testkit.TestActor.{ AutoPilot, NoAutoPilot }
 import akka.testkit.{ TestActorRef, TestKit, TestProbe }
 import akka.util.Timeout
+import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, AppRepository, Group, MarathonStore }
@@ -38,6 +39,7 @@ class DeploymentManagerTest
   var eventBus: EventStream = _
   var taskQueue: TaskQueue = _
   var config: MarathonConf = _
+  var registry: MetricRegistry = _
   var taskTracker: TaskTracker = _
   var scheduler: SchedulerActions = _
   var appRepo: AppRepository = _
@@ -48,10 +50,15 @@ class DeploymentManagerTest
     eventBus = mock[EventStream]
     taskQueue = mock[TaskQueue]
     config = mock[MarathonConf]
-    taskTracker = new TaskTracker(new InMemoryState, config)
+    registry = new com.codahale.metrics.MetricRegistry
+    taskTracker = new TaskTracker(new InMemoryState, config, registry)
     scheduler = mock[SchedulerActions]
     storage = mock[StorageProvider]
-    appRepo = new AppRepository(new MarathonStore[AppDefinition](new InMemoryState, () => AppDefinition()))
+    appRepo = new AppRepository(
+      new MarathonStore[AppDefinition](new InMemoryState, () => AppDefinition()),
+      None,
+      registry
+    )
   }
 
   test("deploy") {

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.upgrade
 
 import akka.actor.{ ActorSystem, Props }
 import akka.testkit.{ TestActorRef, TestKit }
+import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.{ MarathonConf, SchedulerActions, TaskUpgradeCanceledException }
 import mesosphere.marathon.event.{ HealthStatusChanged, MesosStatusUpdateEvent }
 import mesosphere.marathon.state.AppDefinition
@@ -32,7 +33,8 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = new TaskQueue
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
+    val registry = new MetricRegistry
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Unit]()
     val app = AppDefinition("myApp".toPath, instances = 5)
 
@@ -64,7 +66,8 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = new TaskQueue
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
+    val registry = new MetricRegistry
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
     val app = AppDefinition("myApp".toPath, instances = 0)
 
@@ -91,7 +94,8 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = new TaskQueue
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
+    val registry = new MetricRegistry
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
     val app = AppDefinition("myApp".toPath, instances = 5)
 
@@ -123,7 +127,8 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = new TaskQueue
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
+    val registry = new MetricRegistry
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
     val app = AppDefinition("myApp".toPath, instances = 0)
 
@@ -150,7 +155,8 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = new TaskQueue
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
+    val registry = new MetricRegistry
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
     val app = AppDefinition("myApp".toPath, instances = 5)
 
@@ -181,7 +187,8 @@ class TaskStartActorTest
     val driver = mock[SchedulerDriver]
     val scheduler = mock[SchedulerActions]
     val taskQueue = spy(new TaskQueue)
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf])
+    val registry = new MetricRegistry
+    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Unit]()
     val app = AppDefinition("myApp".toPath, instances = 1)
 


### PR DESCRIPTION
- Added a StateMetrics trait.
- Instrumented read/write ops in TaskTracker,
  AppRepository, DeploymentRepository,
  GroupRepository.
- Metrics are available at the /metrics endpoint.
- Fixes #703 
