### PR TITLE
Adds hists for MarathonStore read-data-size, write-data-size.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -145,12 +145,16 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
 
   @Provides
   @Singleton
-  def provideTaskFailureRepository(state: State, conf: MarathonConf): TaskFailureRepository = {
+  def provideTaskFailureRepository(
+    state: State,
+    conf: MarathonConf,
+    registry: MetricRegistry): TaskFailureRepository = {
     import mesosphere.marathon.state.PathId
     import org.apache.mesos.{ Protos => mesos }
     new TaskFailureRepository(
       new MarathonStore[TaskFailure](
         state,
+        registry,
         () => TaskFailure(
           PathId.empty,
           mesos.TaskID.newBuilder().setValue("").build,
@@ -168,7 +172,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     conf: MarathonConf,
     registry: MetricRegistry): AppRepository =
     new AppRepository(
-      new MarathonStore[AppDefinition](state, () => AppDefinition.apply()),
+      new MarathonStore[AppDefinition](state, registry, () => AppDefinition.apply()),
       maxVersions = conf.zooKeeperMaxVersions.get,
       registry
     )
@@ -181,7 +185,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     conf: MarathonConf,
     registry: MetricRegistry): GroupRepository =
     new GroupRepository(
-      new MarathonStore[Group](state, () => Group.empty, "group:"),
+      new MarathonStore[Group](state, registry, () => Group.empty, "group:"),
       appRepository, conf.zooKeeperMaxVersions.get,
       registry
     )
@@ -193,7 +197,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     conf: MarathonConf,
     registry: MetricRegistry): DeploymentRepository =
     new DeploymentRepository(
-      new MarathonStore[DeploymentPlan](state, () => DeploymentPlan.empty, "deployment:"),
+      new MarathonStore[DeploymentPlan](state, registry, () => DeploymentPlan.empty, "deployment:"),
       conf.zooKeeperMaxVersions.get,
       registry
     )

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventModule.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventModule.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.event.http
 
 import scala.language.postfixOps
+import com.codahale.metrics.MetricRegistry
 import com.google.inject.{ Scopes, Singleton, Provides, AbstractModule }
 import akka.actor.{ Props, ActorRef, ActorSystem }
 import akka.pattern.ask
@@ -65,8 +66,8 @@ class HttpEventModule extends AbstractModule {
 
   @Provides
   @Singleton
-  def provideCallbackUrlsStore(state: State): MarathonStore[EventSubscribers] =
-    new MarathonStore[EventSubscribers](state, () => new EventSubscribers(Set.empty[String]), "events:")
+  def provideCallbackUrlsStore(state: State, registry: MetricRegistry): MarathonStore[EventSubscribers] =
+    new MarathonStore[EventSubscribers](state, registry, () => new EventSubscribers(Set.empty[String]), "events:")
 }
 
 object HttpEventModule {

--- a/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.{ ExecutionException, Future => JFuture }
 
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.{ MarathonSpec, StorageException }
+import com.codahale.metrics.MetricRegistry
 import org.apache.mesos.state.{ InMemoryState, State, Variable }
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -20,6 +21,7 @@ class MarathonStoreTest extends MarathonSpec {
     val future = mock[JFuture[Variable]]
     val variable = mock[Variable]
     val appDef = AppDefinition(id = "testApp".toPath, args = Some(Seq("arg")))
+    val registry = new MetricRegistry
 
     when(variable.value()).thenReturn(appDef.toProtoByteArray)
     when(future.get(anyLong, any[TimeUnit])).thenReturn(variable)
@@ -27,7 +29,7 @@ class MarathonStoreTest extends MarathonSpec {
     when(state.fetch("__internal__:app:storage:version")).thenReturn(currentVersionFuture)
     when(state.store(currentVersionVariable)).thenReturn(currentVersionFuture)
 
-    val store = new MarathonStore[AppDefinition](state, () => AppDefinition())
+    val store = new MarathonStore[AppDefinition](state, registry, () => AppDefinition())
     val res = store.fetch("testApp")
 
     verify(state).fetch("app:testApp")
@@ -37,13 +39,14 @@ class MarathonStoreTest extends MarathonSpec {
   test("FetchFail") {
     val state = mock[State]
     val future = mock[JFuture[Variable]]
+    val registry = new MetricRegistry
 
     when(future.get(anyLong, any[TimeUnit])).thenReturn(null)
     when(state.fetch("app:testApp")).thenReturn(future)
     when(state.fetch("__internal__:app:storage:version")).thenReturn(currentVersionFuture)
     when(state.store(currentVersionVariable)).thenReturn(currentVersionFuture)
 
-    val store = new MarathonStore[AppDefinition](state, () => AppDefinition())
+    val store = new MarathonStore[AppDefinition](state, registry, () => AppDefinition())
     val res = store.fetch("testApp")
 
     verify(state).fetch("app:testApp")
@@ -58,6 +61,7 @@ class MarathonStoreTest extends MarathonSpec {
     val future = mock[JFuture[Variable]]
     val variable = mock[Variable]
     val appDef = AppDefinition(id = "testApp".toPath, args = Some(Seq("arg")))
+    val registry = new MetricRegistry
 
     val newAppDef = appDef.copy(id = "newTestApp".toPath)
     val newVariable = mock[Variable]
@@ -73,7 +77,7 @@ class MarathonStoreTest extends MarathonSpec {
     when(state.fetch("__internal__:app:storage:version")).thenReturn(currentVersionFuture)
     when(state.store(currentVersionVariable)).thenReturn(currentVersionFuture)
 
-    val store = new MarathonStore[AppDefinition](state, () => AppDefinition())
+    val store = new MarathonStore[AppDefinition](state, registry, () => AppDefinition())
     val res = store.modify("testApp") { _ =>
       newAppDef
     }
@@ -88,6 +92,7 @@ class MarathonStoreTest extends MarathonSpec {
     val future = mock[JFuture[Variable]]
     val variable = mock[Variable]
     val appDef = AppDefinition(id = "testApp".toPath, args = Some(Seq("arg")))
+    val registry = new MetricRegistry
 
     val newAppDef = appDef.copy(id = "newTestApp".toPath)
     val newVariable = mock[Variable]
@@ -103,7 +108,7 @@ class MarathonStoreTest extends MarathonSpec {
     when(state.fetch("__internal__:app:storage:version")).thenReturn(currentVersionFuture)
     when(state.store(currentVersionVariable)).thenReturn(currentVersionFuture)
 
-    val store = new MarathonStore[AppDefinition](state, () => AppDefinition())
+    val store = new MarathonStore[AppDefinition](state, registry, () => AppDefinition())
     val res = store.modify("testApp") { _ =>
       newAppDef
     }
@@ -118,6 +123,7 @@ class MarathonStoreTest extends MarathonSpec {
     val future = mock[JFuture[Variable]]
     val variable = mock[Variable]
     val resultFuture = mock[JFuture[JBoolean]]
+    val registry = new MetricRegistry
 
     when(future.get(anyLong, any[TimeUnit])).thenReturn(variable)
     when(state.fetch("app:testApp")).thenReturn(future)
@@ -126,7 +132,7 @@ class MarathonStoreTest extends MarathonSpec {
     when(state.fetch("__internal__:app:storage:version")).thenReturn(currentVersionFuture)
     when(state.store(currentVersionVariable)).thenReturn(currentVersionFuture)
 
-    val store = new MarathonStore[AppDefinition](state, () => AppDefinition())
+    val store = new MarathonStore[AppDefinition](state, registry, () => AppDefinition())
 
     val res = store.expunge("testApp")
 
@@ -140,6 +146,7 @@ class MarathonStoreTest extends MarathonSpec {
     val future = mock[JFuture[Variable]]
     val variable = mock[Variable]
     val resultFuture = mock[JFuture[JBoolean]]
+    val registry = new MetricRegistry
 
     when(future.get(anyLong, any[TimeUnit])).thenReturn(variable)
     when(state.fetch("app:testApp")).thenReturn(future)
@@ -148,7 +155,7 @@ class MarathonStoreTest extends MarathonSpec {
     when(state.fetch("__internal__:app:storage:version")).thenReturn(currentVersionFuture)
     when(state.store(currentVersionVariable)).thenReturn(currentVersionFuture)
 
-    val store = new MarathonStore[AppDefinition](state, () => AppDefinition())
+    val store = new MarathonStore[AppDefinition](state, registry, () => AppDefinition())
 
     val res = store.expunge("testApp")
 
@@ -159,6 +166,7 @@ class MarathonStoreTest extends MarathonSpec {
 
   test("Names") {
     val state = new InMemoryState
+    val registry = new MetricRegistry
 
     def populate(key: String, value: Array[Byte]) = {
       val variable = state.fetch(key).get().mutate(value)
@@ -170,7 +178,7 @@ class MarathonStoreTest extends MarathonSpec {
     populate("no_match", Array())
     populate("__internal__:app:storage:version", StorageVersions.current.toByteArray)
 
-    val store = new MarathonStore[AppDefinition](state, () => AppDefinition())
+    val store = new MarathonStore[AppDefinition](state, registry, () => AppDefinition())
     val res = store.names()
 
     assert(Set("foo", "bar") == Await.result(res, 5.seconds).toSet, "Should return all application keys")
@@ -178,11 +186,13 @@ class MarathonStoreTest extends MarathonSpec {
 
   test("NamesFail") {
     val state = mock[State]
+    val registry = new MetricRegistry
+
     when(state.names()).thenThrow(classOf[ExecutionException])
     when(state.fetch("__internal__:app:storage:version")).thenReturn(currentVersionFuture)
     when(state.store(currentVersionVariable)).thenReturn(currentVersionFuture)
 
-    val store = new MarathonStore[AppDefinition](state, () => AppDefinition())
+    val store = new MarathonStore[AppDefinition](state, registry, () => AppDefinition())
     val res = store.names()
 
     assert(Await.result(res, 5.seconds).isEmpty, "Should return empty iterator")
@@ -191,10 +201,12 @@ class MarathonStoreTest extends MarathonSpec {
   test("ConcurrentModifications") {
     import mesosphere.util.ThreadPoolContext.context
     val state = new InMemoryState
+    val registry = new MetricRegistry
     val variable = state.fetch("__internal__:app:storage:version").get().mutate(StorageVersions.current.toByteArray)
+
     state.store(variable)
 
-    val store = new MarathonStore[AppDefinition](state, () => AppDefinition())
+    val store = new MarathonStore[AppDefinition](state, registry, () => AppDefinition())
 
     Await.ready(store.store("foo", AppDefinition(id = "foo".toPath, instances = 0)), 2.seconds)
 

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
@@ -55,7 +55,7 @@ class DeploymentManagerTest
     scheduler = mock[SchedulerActions]
     storage = mock[StorageProvider]
     appRepo = new AppRepository(
-      new MarathonStore[AppDefinition](new InMemoryState, () => AppDefinition()),
+      new MarathonStore[AppDefinition](new InMemoryState, registry, () => AppDefinition()),
       None,
       registry
     )


### PR DESCRIPTION
State-related performance metrics are now the following:

```
"mesosphere.marathon.state.AppRepository.read-request-time"
"mesosphere.marathon.state.AppRepository.write-request-time"
"mesosphere.marathon.state.DeploymentRepository.read-request-time"
"mesosphere.marathon.state.DeploymentRepository.write-request-time"
"mesosphere.marathon.state.GroupRepository.read-request-time"
"mesosphere.marathon.state.GroupRepository.write-request-time"
"mesosphere.marathon.state.MarathonStore.AppDefinition.read-data-size"
"mesosphere.marathon.state.MarathonStore.AppDefinition.write-data-size"
"mesosphere.marathon.state.MarathonStore.DeploymentPlan.read-data-size"
"mesosphere.marathon.state.MarathonStore.DeploymentPlan.write-data-size"
"mesosphere.marathon.state.MarathonStore.EventSubscribers.read-data-size"
"mesosphere.marathon.state.MarathonStore.EventSubscribers.write-data-size"
"mesosphere.marathon.state.MarathonStore.Group.read-data-size"
"mesosphere.marathon.state.MarathonStore.Group.write-data-size"
"mesosphere.marathon.state.MarathonStore.TaskFailure.read-data-size"
"mesosphere.marathon.state.MarathonStore.TaskFailure.write-data-size"
"mesosphere.marathon.tasks.TaskTracker.read-request-time"
"mesosphere.marathon.tasks.TaskTracker.write-request-time"
"mesosphere.marathon.state.AppRepository.read-request-errors"
"mesosphere.marathon.state.AppRepository.read-requests"
"mesosphere.marathon.state.AppRepository.write-request-errors"
"mesosphere.marathon.state.AppRepository.write-requests"
"mesosphere.marathon.state.DeploymentRepository.read-request-errors"
"mesosphere.marathon.state.DeploymentRepository.read-requests"
"mesosphere.marathon.state.DeploymentRepository.write-request-errors"
"mesosphere.marathon.state.DeploymentRepository.write-requests"
"mesosphere.marathon.state.GroupRepository.read-request-errors"
"mesosphere.marathon.state.GroupRepository.read-requests"
"mesosphere.marathon.state.GroupRepository.write-request-errors"
"mesosphere.marathon.state.GroupRepository.write-requests"
"mesosphere.marathon.tasks.TaskTracker.read-request-errors"
"mesosphere.marathon.tasks.TaskTracker.read-requests"
"mesosphere.marathon.tasks.TaskTracker.write-request-errors"
"mesosphere.marathon.tasks.TaskTracker.write-requests"
```
