### PR TITLE
Minor refactoring for framework authentication

### DIFF
--- a/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
@@ -1,0 +1,42 @@
+package mesosphere.marathon
+
+import org.rogach.scallop.ScallopConf
+import scala.util.Try
+
+class MarathonConfTest extends MarathonSpec {
+
+  private[this] val principal = "foo"
+  private[this] val secretFile = "/bar/baz"
+
+  test("MesosAuthenticationIsOptional") {
+    val conf = makeConfig(
+      "--master", "127.0.0.1:5050"
+    )
+    assert(conf.mesosAuthenticationPrincipal.isEmpty)
+    assert(conf.mesosAuthenticationSecretFile.isEmpty)
+  }
+
+  test("MesosAuthenticationPrincipal") {
+    val conf = makeConfig(
+      "--master", "127.0.0.1:5050",
+      "--mesos_authentication_principal", principal
+    )
+    assert(conf.mesosAuthenticationPrincipal.isDefined)
+    assert(conf.mesosAuthenticationPrincipal.get == Some(principal))
+    assert(conf.mesosAuthenticationSecretFile.isEmpty)
+  }
+
+  test("MesosAuthenticationSecretFile") {
+    val conf = makeConfig(
+      "--master", "127.0.0.1:5050",
+      "--mesos_authentication_principal", principal,
+      "--mesos_authentication_secret_file", secretFile
+    )
+    assert(conf.mesosAuthenticationPrincipal.isDefined)
+    assert(conf.mesosAuthenticationPrincipal.get == Some(principal))
+    assert(conf.mesosAuthenticationSecretFile.isDefined)
+    assert(conf.mesosAuthenticationSecretFile.get == Some(secretFile))
+  }
+
+}
+


### PR DESCRIPTION
- Adds unit tests for the config parser.
- Less side effects in MarathonSchedulerDriver.
- Better exception msg if secret can't be read.
- Naming cleanup in MarathonSchedulerDriver.
