### PR TITLE
Updated Scala version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
 jdk:
   - openjdk6
 scala:
-  - 2.10.2
+  - 2.11.2
 env:
   global:
     - ARTIFACTS_AWS_REGION=us-east-1


### PR DESCRIPTION
This should speed up the Travis builds (right now it has to re-compile the scalac interface for 2.11 during the compile phase).
