### PR TITLE
Check args when deciding whether to use default zk

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -47,11 +47,11 @@ function load_options_and_log {
   # Default zk and master option
   if [[ -s /etc/mesos/zk ]]
   then
-    if [[ "${cmd[@]}" != *'--zk'* ]]
+    if [[ "${cmd[@]} $@" != *'--zk'* ]]
     then
       cmd+=( --zk "$(cut -d / -f 1-3 /etc/mesos/zk)/marathon" )
     fi
-    if [[ "${cmd[@]}" != *'--master'* ]]
+    if [[ "${cmd[@]} $@" != *'--master'* ]]
     then
       cmd+=( --master "$(cat /etc/mesos/zk)" )
     fi


### PR DESCRIPTION
Without this patch, on Ubuntu 12.04:

```
vagrant@ubuntu:~$ dpkg -s marathon
Package: marathon
Status: install ok installed
Priority: extra
Section: default
Installed-Size: 67414
Maintainer: Mesosphere Package Builder <support@mesosphere.io>
Architecture: amd64
Version: 0.7.5-1.0
Depends: java7-runtime-headless | java6-runtime-headless
Conffiles:
 /etc/init.d/marathon 227ab567c0af60136b75a1c921f9e386
 /etc/init/marathon.conf 5487f23d524da9ef9a81e03f1403a07b
Description: Cluster-wide init and control system for services running on Apache Mesos
License: Apache-2.0
Vendor: Mesosphere, Inc.
Homepage: https://github.com/mesosphere/marathon
vagrant@ubuntu:~$ which marathon
/usr/local/bin/marathon
vagrant@ubuntu:~$ cat /etc/mesos/zk
zk://foo:2181/mesos
vagrant@ubuntu:~$ ls /etc/marathon
ls: cannot access /etc/marathon: No such file or directory
vagrant@ubuntu:~$ marathon --master=zk://bar:2181/mesos --zk=zk://bar:2181/marathon &
[1] 26154
vagrant@ubuntu:~$ ps aux | grep marathon
vagrant  26154  118 10.6 1406844 53532 pts/2   Sl   23:29   0:02 java -Xmx512m -Djava.library.path=/usr/local/lib -Djava.util.logging.SimpleFormatter.format=%2$s%5$s%6$s%n -cp /usr/local/bin/marathon mesosphere.marathon.Main --zk zk://foo:2181/marathon --master zk://foo:2181/mesos --master zk://bar:2181/mesos --zk zk://bar:2181/marathon
vagrant  26176  0.0  0.1   9616   932 pts/2    R+   23:29   0:00 grep --color=auto marathon
vagrant@ubuntu:~$ 
```

Because `/etc/mesos/zk` is present and I'm configuring Marathon with command line arguments rather than config files, the `--zk` and `--master` args have been passed twice, once based on the contents of `/etc/mesos/zk` and once from the args passed to `marathon`.

With this patch, only the `--zk` and `--master` arguments passed to `marathon` will be used.
