### PR TITLE
haproxy-marathon-bridge EL7/systemd support

### DIFF
--- a/bin/haproxy-marathon-bridge
+++ b/bin/haproxy-marathon-bridge
@@ -46,7 +46,9 @@ function refresh_system_haproxy {
     msg "Found changes. Sending reload request to HAProxy..."
     cat /tmp/"$conf_file" > /etc/haproxy/"$conf_file"
     if [[ -f /etc/init/haproxy.conf ]]
-    then reload haproxy ## In case it switches to Upstart
+    then reload haproxy ## Upstart
+    elif [[ -f /usr/lib/systemd/system/haproxy.service ]]
+    then systemctl reload haproxy ## systemd
     else /etc/init.d/haproxy reload
     fi
   fi


### PR DESCRIPTION
- Added support for haproxy reload via systemd (tested on CentOS 7).
- Replaced deprecated timeout options with their equivalent updated names. E.g clitimeout -> timeout client
