### PR TITLE
Add support for Docker container ports within HAProxy bridge

### DIFF
--- a/bin/haproxy-marathon-bridge
+++ b/bin/haproxy-marathon-bridge
@@ -3,12 +3,18 @@ set -o errexit -o nounset -o pipefail
 function -h {
 cat <<USAGE
  USAGE: $name <marathon host:port>+
+        $name docker <marathon host:port>+
         $name install_haproxy_system <marathon host:port>+
 
   Generates a new configuration file for HAProxy from the specified Marathon
   servers, replaces the file in /etc/haproxy and restarts the service.
 
-  In the second form, installs the script itself, HAProxy and a cronjob that
+  In the second form, this script functions the same as stated above but it
+  is specifically intended for Docker, where it replaces the receiving port
+  in HAProxy with the container port that was specified when the containers
+  were created in Marathon.
+
+  In the third form, installs the script itself, HAProxy and a cronjob that
   once a minute pings one of the Marathon servers specified and refreshes
   HAProxy if anything has changed. The list of Marathons to ping is stored,
   one per line, in:
@@ -94,8 +100,13 @@ function config {
   apps "$@"
 }
 
+function docker {
+  header
+  apps_docker "$@"
+}
+
 function header {
-cat <<\EOF
+cat <<EOF
 global
   daemon
   log 127.0.0.1 local0
@@ -125,6 +136,35 @@ function apps {
     set -- $txt
     local app_name="$1"
     local app_port="$2"
+    shift 2
+
+    if [ "${app_port//[0-9]*}" = "" ]
+    then
+      cat <<EOF
+
+listen $app_name-$app_port
+  bind 0.0.0.0:$app_port
+  mode tcp
+  option tcplog
+  balance leastconn
+EOF
+      while [[ $# -ne 0 ]]
+      do
+        out "  server ${app_name}-$# $1 check"
+        shift
+      done
+    fi
+  done
+}
+
+function apps_docker {
+  local mesos_host="${1%/}"
+
+  (until curl -sSfLk -m 10 -H 'Accept: text/plain' "${mesos_host}"/v2/tasks; do [ $# -lt 2 ] && return 1 || shift; done) | while read -r txt
+  do
+    set -- $txt
+    local app_name="$1"
+    local app_port="$(curl -sSfLk -m 10 $mesos_host/v2/apps | grep -o \"containerPort\"\:[0-9]* | grep -o [0-9]*)"
     shift 2
 
     if [ "${app_port//[0-9]*}" = "" ]


### PR DESCRIPTION
I had an issue regarding Docker containers and HAProxy. I wanted to proxy the specified container port to multiple containers with random port assignments. For instance; 192.168.1.1:80 > 192.168.1.2:32000 && 192.168.1.3:32001

This commit adds a new function to the HAProxy-marathon-bridge shell script which is basically a copy of the apps function; however this retrieves the so called containerPort and sets it in the HAProxy configuration. This allows HAProxy to be used to directly map to running containers that are started within Marathon.