### PR TITLE
made tasks endpoint return dates as valid date strings again

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -70,8 +70,8 @@ trait Formats
       "id" -> task.getId,
       "host" -> (if (task.hasHost) task.getHost else JsNull),
       "ports" -> task.getPortsList.asScala,
-      "startedAt" -> (if (task.getStartedAt != 0) JsNumber(task.getStartedAt) else JsNull),
-      "stagedAt" -> (if (task.getStagedAt != 0) task.getStagedAt else JsNull),
+      "startedAt" -> (if (task.getStartedAt != 0) Timestamp(task.getStartedAt) else JsNull),
+      "stagedAt" -> (if (task.getStagedAt != 0) Timestamp(task.getStagedAt) else JsNull),
       "version" -> task.getVersion
     )
   }


### PR DESCRIPTION
With the transition to play-json, the format of the `startedAt` and `stagedAt` has accidentally been changed to a number instead of a date string in the json.
