### PR TITLE
Complete rewrite of deployment plan calculation.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -219,7 +219,7 @@ trait DeploymentFormats {
     (__ \ "id").write[String] ~
     (__ \ "original").write[Group] ~
     (__ \ "target").write[Group] ~
-    (__ \ "steps").write[List[DeploymentStep]] ~
+    (__ \ "steps").write[Seq[DeploymentStep]] ~
     (__ \ "version").write[Timestamp]
   )(unlift(DeploymentPlan.unapply))
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -81,12 +81,9 @@ class DeploymentActor(
       eventBus.publish(DeploymentStatus(plan, step))
 
       val futures = step.actions.map {
-        case StartApplication(app, scaleTo) => startApp(app, scaleTo)
-        case ScaleApplication(app, scaleTo) => scaleApp(app, scaleTo)
-        case StopApplication(app)           => stopApp(app)
-        case KillAllOldTasksOf(app) =>
-          val runningTasks = taskTracker.get(app.id).toSeq
-          killTasks(app.id, runningTasks.filterNot(_.getVersion == app.version.toString))
+        case StartApplication(app, scaleTo)                  => startApp(app, scaleTo)
+        case ScaleApplication(app, scaleTo)                  => scaleApp(app, scaleTo)
+        case StopApplication(app)                            => stopApp(app)
         case RestartApplication(app, scaleOldTo, scaleNewTo) => restartApp(app, scaleOldTo, scaleNewTo)
         case ResolveArtifacts(app, urls)                     => resolveArtifacts(app, urls)
       }

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -108,6 +108,13 @@ class DeploymentActorTest
 
     when(scheduler.startApp(driver, app3)).thenAnswer(new Answer[Future[Unit]] {
       def answer(invocation: InvocationOnMock): Future[Unit] = {
+        // system.eventStream.publish(MesosStatusUpdateEvent("", "task3_1", "TASK_RUNNING", "", app3.id, "", Nil, app3.version.toString))
+        Future.successful(())
+      }
+    })
+
+    when(scheduler.scale(driver, app3)).thenAnswer(new Answer[Future[Unit]] {
+      def answer(invocation: InvocationOnMock): Future[Unit] = {
         system.eventStream.publish(MesosStatusUpdateEvent("", "task3_1", "TASK_RUNNING", "", app3.id, "", Nil, app3.version.toString))
         Future.successful(())
       }
@@ -144,7 +151,7 @@ class DeploymentActorTest
 
       managerProbe.expectMsg(5.seconds, DeploymentFinished(plan.id))
 
-      verify(scheduler).startApp(driver, app3)
+      verify(scheduler).startApp(driver, app3.copy(instances = 0))
       verify(driver, times(1)).killTask(TaskID(task1_2.getId))
       verify(scheduler).stopApp(driver, app4)
     }

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
@@ -9,13 +9,51 @@ import scala.collection.immutable.Seq
 
 class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen {
 
+  protected def actionsOf(plan: DeploymentPlan): Seq[DeploymentAction] =
+    plan.steps.flatMap(_.actions)
+
+  test("partition a group's apps into concurrently deployable subsets") {
+    Given("a group of four apps with some simple dependencies")
+    val aId = "/test/database/a".toPath
+    val bId = "/test/service/b".toPath
+    val cId = "/c".toPath
+    val dId = "/d".toPath
+
+    val a = AppDefinition(aId, version = Timestamp(0))
+    val b = AppDefinition(bId, dependencies = Set(aId), version = Timestamp(0))
+    val c = AppDefinition(cId, dependencies = Set(aId), version = Timestamp(0))
+    val d = AppDefinition(dId, dependencies = Set(bId), version = Timestamp(0))
+
+    val group = Group(
+      id = "/test".toPath,
+      apps = Set(c, d),
+      groups = Set(
+        Group("/test/database".toPath, Set(a)),
+        Group("/test/service".toPath, Set(b))
+      )
+    )
+
+    When("the group's apps are grouped by the longest outbound path")
+    val partitionedApps = DeploymentPlan.appsGroupedByLongestPath(group)
+
+    Then("three equivalence classes should be computed")
+    partitionedApps should have size (3)
+
+    partitionedApps.keySet should contain (1)
+    partitionedApps.keySet should contain (2)
+    partitionedApps.keySet should contain (3)
+
+    partitionedApps(2) should have size (2)
+  }
+
   test("start from empty group") {
     val app = AppDefinition("/app".toPath, instances = 2)
     val from = Group("/group".toPath, Set.empty)
     val to = Group("/group".toPath, Set(app))
     val plan = DeploymentPlan(from, to)
 
-    plan.steps(0).actions.toSet should be(Set(StartApplication(app, app.instances)))
+    actionsOf(plan) should contain (StartApplication(app, 0))
+    actionsOf(plan) should contain (ScaleApplication(app, app.instances))
   }
 
   test("start from running group") {
@@ -42,9 +80,9 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen {
     val to = Group("/group".toPath, update)
     val plan = DeploymentPlan(from, to)
 
-    plan.affectedApplicationIds should be (Set("/app".toPath, "/app2".toPath, "/app3".toPath, "/app4".toPath))
-    plan.isAffectedBy(plan) should be (right = true)
-    plan.isAffectedBy(DeploymentPlan(from, from)) should be(right = false)
+    plan.affectedApplicationIds should equal (Set("/app".toPath, "/app2".toPath, "/app3".toPath, "/app4".toPath))
+    plan.isAffectedBy(plan) should equal (right = true)
+    plan.isAffectedBy(DeploymentPlan(from, from)) should equal (right = false)
   }
 
   test("when updating a group with dependencies, the correct order is computed") {
@@ -53,30 +91,35 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen {
     val mongoId = "/test/database/mongo".toPath
     val serviceId = "/test/service/srv1".toPath
     val strategy = UpgradeStrategy(0.75)
-    val mongo = AppDefinition(mongoId, Some("mng1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
-      AppDefinition(mongoId, Some("mng2"), instances = 8, upgradeStrategy = strategy)
-    val service = AppDefinition(serviceId, Some("srv1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
-      AppDefinition(serviceId, Some("srv2"), dependencies = Set(mongoId), instances = 10, upgradeStrategy = strategy)
-    val from: Group = Group("/test".toPath, groups = Set(
-      Group("/test/database".toPath, Set(mongo._1)),
-      Group("/test/service".toPath, Set(service._1))
-    ))
 
-    When("the deployment plan is computed")
-    val to: Group = Group("/test".toPath, groups = Set(
+    val mongo: (AppDefinition, AppDefinition) =
+      AppDefinition(mongoId, Some("mng1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
+        AppDefinition(mongoId, Some("mng2"), instances = 8, upgradeStrategy = strategy)
+
+    val service: (AppDefinition, AppDefinition) =
+      AppDefinition(serviceId, Some("srv1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
+        AppDefinition(serviceId, Some("srv2"), dependencies = Set(mongoId), instances = 10, upgradeStrategy = strategy)
+
+    val from = Group(
+      id = "/test".toPath,
+      groups = Set(
+        Group("/test/database".toPath, Set(mongo._1)),
+        Group("/test/service".toPath, Set(service._1))
+      )
+    )
+
+    val to = Group("/test".toPath, groups = Set(
       Group("/test/database".toPath, Set(mongo._2)),
       Group("/test/service".toPath, Set(service._2))
     ))
+
+    When("the deployment plan is computed")
     val plan = DeploymentPlan(from, to)
 
     Then("the deployment steps are correct")
-    plan.steps should have size 6
-    plan.steps(0).actions.toSet should be(Set(RestartApplication(mongo._2, 3, 6)))
-    plan.steps(1).actions.toSet should be(Set(RestartApplication(service._2, 3, 8)))
-    plan.steps(2).actions.toSet should be(Set(KillAllOldTasksOf(service._2)))
-    plan.steps(3).actions.toSet should be(Set(KillAllOldTasksOf(mongo._2)))
-    plan.steps(4).actions.toSet should be(Set(ScaleApplication(mongo._2, 8)))
-    plan.steps(5).actions.toSet should be(Set(ScaleApplication(service._2, 10)))
+    plan.steps should have size 2
+    plan.steps(0).actions.toSet should equal (Set(RestartApplication(mongo._2, 3, 8)))
+    plan.steps(1).actions.toSet should equal (Set(RestartApplication(service._2, 3, 10)))
   }
 
   test("when updating a group without dependencies, a random order of updates is used") {
@@ -84,27 +127,32 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen {
     val mongoId = "/test/database/mongo".toPath
     val serviceId = "/test/service/srv1".toPath
     val strategy = UpgradeStrategy(0.75)
-    val mongo = AppDefinition(mongoId, Some("mng1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
-      AppDefinition(mongoId, Some("mng2"), instances = 8, upgradeStrategy = strategy)
-    val service = AppDefinition(serviceId, Some("srv1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
-      AppDefinition(serviceId, Some("srv2"), instances = 10, upgradeStrategy = strategy)
+
+    val mongo =
+      AppDefinition(mongoId, Some("mng1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
+        AppDefinition(mongoId, Some("mng2"), instances = 8, upgradeStrategy = strategy)
+
+    val service =
+      AppDefinition(serviceId, Some("srv1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
+        AppDefinition(serviceId, Some("srv2"), instances = 10, upgradeStrategy = strategy)
+
     val from: Group = Group("/test".toPath, groups = Set(
       Group("/test/database".toPath, Set(mongo._1)),
       Group("/test/service".toPath, Set(service._1))
     ))
 
-    When("the deployment plan is computed")
     val to: Group = Group("/test".toPath, groups = Set(
       Group("/test/database".toPath, Set(mongo._2)),
       Group("/test/service".toPath, Set(service._2))
     ))
+
+    When("the deployment plan is computed")
     val plan = DeploymentPlan(from, to)
 
     Then("the deployment steps are correct")
-    plan.steps should have size 3
-    plan.steps(0).actions.toSet should be(Set(RestartApplication(mongo._2, 3, 6), RestartApplication(service._2, 3, 8)))
-    plan.steps(1).actions.toSet should be(Set(KillAllOldTasksOf(mongo._2), KillAllOldTasksOf(service._2)))
-    plan.steps(2).actions.toSet should be(Set(ScaleApplication(mongo._2, 8), ScaleApplication(service._2, 10)))
+    plan.steps should have size 2
+    plan.steps(0).actions.toSet should equal (Set(RestartApplication(mongo._2, 3, 8)))
+    plan.steps(1).actions.toSet should equal (Set(RestartApplication(service._2, 3, 10)))
   }
 
   test("when updating a group with dependent and independent applications, the correct order is computed") {
@@ -113,56 +161,75 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen {
     val serviceId = "/test/service/srv1".toPath
     val appId = "/test/independent/app".toPath
     val strategy = UpgradeStrategy(0.75)
-    val mongo = AppDefinition(mongoId, Some("mng1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
-      AppDefinition(mongoId, Some("mng2"), instances = 8, upgradeStrategy = strategy)
-    val service = AppDefinition(serviceId, Some("srv1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
-      AppDefinition(serviceId, Some("srv2"), dependencies = Set(mongoId), instances = 10, upgradeStrategy = strategy)
-    val independent = AppDefinition(appId, Some("app1"), instances = 1, version = Timestamp(0), upgradeStrategy = strategy) ->
-      AppDefinition(appId, Some("app2"), instances = 3, upgradeStrategy = strategy)
-    val toStop = AppDefinition("/test/service/toStop".toPath, instances = 1, dependencies = Set(mongoId)) -> None
-    val toStart = None -> AppDefinition("/test/service/toStart".toPath, instances = 1, dependencies = Set(serviceId))
+
+    val mongo =
+      AppDefinition(mongoId, Some("mng1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
+        AppDefinition(mongoId, Some("mng2"), instances = 8, upgradeStrategy = strategy)
+
+    val service =
+      AppDefinition(serviceId, Some("srv1"), instances = 4, version = Timestamp(0), upgradeStrategy = strategy) ->
+        AppDefinition(serviceId, Some("srv2"), dependencies = Set(mongoId), instances = 10, upgradeStrategy = strategy)
+
+    val independent =
+      AppDefinition(appId, Some("app1"), instances = 1, version = Timestamp(0), upgradeStrategy = strategy) ->
+        AppDefinition(appId, Some("app2"), instances = 3, upgradeStrategy = strategy)
+
+    val toStop = AppDefinition("/test/service/toStop".toPath, instances = 1, dependencies = Set(mongoId))
+    val toStart = AppDefinition("/test/service/toStart".toPath, instances = 2, dependencies = Set(serviceId))
+
     val from: Group = Group("/test".toPath, groups = Set(
       Group("/test/database".toPath, Set(mongo._1)),
-      Group("/test/service".toPath, Set(service._1, toStop._1)),
+      Group("/test/service".toPath, Set(service._1, toStop)),
       Group("/test/independent".toPath, Set(independent._1))
     ))
 
-    When("the deployment plan is computed")
     val to: Group = Group("/test".toPath, groups = Set(
       Group("/test/database".toPath, Set(mongo._2)),
-      Group("/test/service".toPath, Set(service._2, toStart._2)),
+      Group("/test/service".toPath, Set(service._2, toStart)),
       Group("/test/independent".toPath, Set(independent._2))
     ))
+
+    When("the deployment plan is computed")
     val plan = DeploymentPlan(from, to)
 
     Then("the deployment contains steps for dependent and independent applications")
-    plan.steps should have size 11
-    plan.steps(0).actions.toSet should be(Set(RestartApplication(independent._2, 1, 3)))
-    plan.steps(1).actions.toSet should be(Set(KillAllOldTasksOf(independent._2)))
-    plan.steps(2).actions.toSet should be(Set(ScaleApplication(independent._2, 3)))
-    plan.steps(3).actions.toSet should be(Set(RestartApplication(mongo._2, 3, 6)))
-    plan.steps(4).actions.toSet should be(Set(RestartApplication(service._2, 3, 8)))
-    plan.steps(5).actions.toSet should be(Set(StartApplication(toStart._2, 1)))
-    plan.steps(6).actions.toSet should be(Set(KillAllOldTasksOf(service._2)))
-    plan.steps(7).actions.toSet should be(Set(KillAllOldTasksOf(mongo._2)))
-    plan.steps(8).actions.toSet should be(Set(ScaleApplication(mongo._2, 8)))
-    plan.steps(9).actions.toSet should be(Set(ScaleApplication(service._2, 10)))
-    plan.steps(10).actions.toSet should be(Set(StopApplication(toStop._1)))
+    plan.steps should have size (6)
+
+    actionsOf(plan) should have size (6)
+
+    plan.steps(0).actions.toSet should equal (Set(StopApplication(toStop)))
+    plan.steps(1).actions.toSet should equal (Set(StartApplication(toStart, 0)))
+    plan.steps(2).actions.toSet should equal (Set(RestartApplication(mongo._2, 3, 8)))
+    plan.steps(3).actions.toSet should equal (Set(RestartApplication(independent._2, 1, 3)))
+    plan.steps(4).actions.toSet should equal (Set(RestartApplication(service._2, 3, 10)))
+    plan.steps(5).actions.toSet should equal (Set(ScaleApplication(toStart, 2)))
+
+    /*
+    plan.steps(0).actions.toSet should equal (Set(RestartApplication(independent._2, 1, 3)))
+    plan.steps(1).actions.toSet should equal (Set(KillAllOldTasksOf(independent._2)))
+    plan.steps(2).actions.toSet should equal (Set(ScaleApplication(independent._2, 3)))
+    plan.steps(3).actions.toSet should equal (Set(RestartApplication(mongo._2, 3, 6)))
+    plan.steps(4).actions.toSet should equal (Set(RestartApplication(service._2, 3, 8)))
+    plan.steps(6).actions.toSet should equal (Set(KillAllOldTasksOf(service._2)))
+    plan.steps(7).actions.toSet should equal (Set(KillAllOldTasksOf(mongo._2)))
+    plan.steps(8).actions.toSet should equal (Set(ScaleApplication(mongo._2, 8)))
+    plan.steps(9).actions.toSet should equal (Set(ScaleApplication(service._2, 10)))
+  */
   }
 
   test("when the only action is to stop an application") {
-    Given("application updates with command and scale changes")
+    Given("application updates with only the removal of an app")
     val strategy = UpgradeStrategy(0.75)
     val app = AppDefinition("/test/independent/app".toPath, Some("app2"), instances = 3, upgradeStrategy = strategy) -> None
     val from: Group = Group("/test".toPath, groups = Set(
       Group("/test/independent".toPath, Set(app._1))
     ))
+    val to: Group = Group("/test".toPath)
 
     When("the deployment plan is computed")
-    val to: Group = Group("/test".toPath)
     val plan = DeploymentPlan(from, to)
 
-    Then("the deployment contains steps for dependent and independent applications")
+    Then("the deployment contains one step consisting of one stop action")
     plan.steps should have size 1
     plan.steps(0).actions.toSet should be(Set(StopApplication(app._1)))
   }


### PR DESCRIPTION
Simplified calculation of deployment plans.
- Plans now have less steps, and each step has less actions, in general.
- Group.dependencyGraph() now includes independent (e.g. disconnected) vertices.
- Removes the `KillAllOldTasksOf` deployment action, as it is no longer used.
- Removes now-unused Group.dependencyList() method.
- Updated tests.
- Fixes #807.
