### PR TITLE
Fix exception logging

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -257,7 +257,7 @@ class MarathonSchedulerActor(
           deploymentRepository.expunge(plan.id)
 
         case Failure(e) =>
-          log.error(s"Deployment of ${plan.target.id} failed", e)
+          log.error(e, s"Deployment of ${plan.target.id} failed")
           plan.affectedApplicationIds.foreach(appId => taskQueue.purge(appId))
           eventBus.publish(DeploymentFailed(plan.id))
           if (e.isInstanceOf[DeploymentCanceledException])


### PR DESCRIPTION
According to the akka logging documentation, `Throwable` should come
first in the parameters.

http://doc.akka.io/api/akka/2.0/akka/event/LoggingAdapter.html

Change-Id: I869f560801eb71374b61885c1645357728e7ee44
