### PR TITLE
Fixed problems in haproxy-marathon-bridge script.

### DIFF
--- a/bin/haproxy-marathon-bridge
+++ b/bin/haproxy-marathon-bridge
@@ -123,11 +123,16 @@ function apps {
   (until curl -sSfLk -m 10 -H 'Accept: text/plain' "${1%/}"/v2/tasks; do [ $# -lt 2 ] && return 1 || shift; done) | while read -r txt
   do
     set -- $txt
+    if [ $# -lt 2 ]; then
+      shift $#
+      continue
+    fi
+
     local app_name="$1"
     local app_port="$2"
     shift 2
 
-    if [ "${app_port//[0-9]*}" = "" ]
+    if [ ! -z "${app_port##*[!0-9]*}" ]
     then
       cat <<EOF
 


### PR DESCRIPTION
- Fixed "unbound local variable" for services which have neither servicePort nor active tasks. Previosuly any service without servicePort/tasks would terminate the script so that no other services were configured either.
- Fixed problem with IP-address being used as port in HAproxy for services without a servicePort. Fix skips services for which Marathon doesn't return a servicePort. Previously it would generate odd entries like

```
listen myproduct_myapp-10.1.2.3
  bind 0.0.0.0:10.1.2.3
  mode tcp
  option tcplog
  balance leastconn
```

Example output from Marathon in my case would look something like

```
core@ip-10-1-2-3 ~ $ curl -sSfLk -m 10 -H 'Accept: text/plain' http://10.1.2.3:8080/v2/tasks
myproduct_myapp1
myproduct_myapp2          10.1.2.3 10.1.2.4
myproduct_myapp3  4040    10.1.2.3:31006
```

Where _myproduct_myapp1_ would cause a script exit with "unbound local variable" and _myproduct_myapp2_ would get a the IP-address as the HAproxy port.
