### PR TITLE
Lower case component names (wrap) are no longer supported in JSX

### DIFF
--- a/src/main/resources/assets/js/components/PagedContentComponent.jsx
+++ b/src/main/resources/assets/js/components/PagedContentComponent.jsx
@@ -23,7 +23,7 @@ define([
     },
 
     render: function() {
-      var wrap = React.DOM[this.props.element];
+      var Wrap = React.DOM[this.props.element];
 
       var children = this.props.children;
       var begin = this.props.currentPage * this.props.itemsPerPage;
@@ -35,9 +35,9 @@ define([
       });
 
       return (
-        <wrap className={this.props.className}>
+        <Wrap className={this.props.className}>
           {pageNodes}
-        </wrap>
+        </Wrap>
       );
     }
   });


### PR DESCRIPTION
I wasn't able to compile it so here it goes.
Fixes error when compiling jsx
```
Error while reading module components/PagedContentComponent:
Error: Lower case component names (wrap) are no longer supported in JSX: See http://fb.me/react-jsx-lower-case
```