### PR TITLE
Reconcile health checks after a task is launched

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -133,6 +133,8 @@ class MarathonScheduler @Inject() (
 
             taskTracker.created(qt.app.id, marathonTask)
             driver.launchTasks(Seq(offer.getId).asJava, taskInfos.asJava)
+
+            healthCheckManager.reconcileWith(qt.app)
         }
 
         // put unscheduled tasks back in the queue

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -339,12 +339,10 @@ class SchedulerActions(
     currentAppVersion(app.id).flatMap { appOption =>
       require(appOption.isEmpty, s"Already started app '${app.id}'")
 
-      val persistenceResult = appRepository.store(app).map { _ =>
+      appRepository.store(app).map { _ =>
         log.info(s"Starting app ${app.id}")
         scale(driver, app)
       }
-
-      persistenceResult.map { _ => healthCheckManager.reconcileWith(app) }
     }
   }
 
@@ -485,6 +483,7 @@ class SchedulerActions(
         for (task <- toKill) {
           driver.killTask(protos.TaskID(task.getId))
         }
+        healthCheckManager.reconcileWith(app)
       }
       else {
         log.info(s"Already running ${app.instances} instances of ${app.id}. Not scaling.")


### PR DESCRIPTION
During scale up new tasks are started with a new appVersion. Because each health
check only checks the tasks of exactly one appVersion, the health checks before
the scaling ignore the new tasks.

New health checks are started by the HealthCheckManager on "reconcileWith" which
before this patch was called only after app creation and on leader change. This
patch adds another call after a task is launched and after scale down.

Note, that it would not be enough to call reconcileWith after
MarathonSchedulerActor.scale on scale up because new tasks are launched
asynchronously and reconcileWith would not see new tasks yet.

Fixes #901.
