### PR TITLE
Fix deployment stuck when scaling apps

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
@@ -19,7 +19,8 @@ class AppStartActor(
     scaleTo: Int,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
-  val expectedSize = scaleTo
+  val expectedSize: Int = scaleTo
+  val nrToStart: Int = scaleTo
 
   def withHealthChecks: Boolean = app.healthChecks.nonEmpty
 

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -130,7 +130,7 @@ class DeploymentActor(
           taskTracker,
           eventBus,
           app,
-          scaleTo - runningTasks.size,
+          scaleTo,
           app.healthChecks.nonEmpty,
           promise
         )

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -16,6 +16,7 @@ trait StartingBehavior { this: Actor with ActorLogging =>
 
   def eventBus: EventStream
   def expectedSize: Int
+  def nrToStart: Int
   def withHealthChecks: Boolean
   def taskQueue: TaskQueue
   def driver: SchedulerDriver
@@ -81,10 +82,10 @@ trait StartingBehavior { this: Actor with ActorLogging =>
   }
 
   def checkFinished(): Unit = {
-    if (withHealthChecks && healthyTasks.size == expectedSize) {
+    if (withHealthChecks && healthyTasks.size == nrToStart) {
       success()
     }
-    else if (runningTasks.size == expectedSize) {
+    else if (runningTasks.size == nrToStart) {
       success()
     }
   }

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -16,11 +16,12 @@ class TaskStartActor(
     val taskTracker: TaskTracker,
     val eventBus: EventStream,
     val app: AppDefinition,
-    nrToStart: Int,
+    scaleTo: Int,
     val withHealthChecks: Boolean,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
-  var running: Int = 0
+  val expectedSize: Int = scaleTo
+  val nrToStart: Int = scaleTo - taskTracker.count(app.id)
 
   override def initializeStart(): Unit = {
     for (_ <- 0 until nrToStart) taskQueue.add(app)
@@ -33,8 +34,6 @@ class TaskStartActor(
         new TaskUpgradeCanceledException(
           "The task upgrade has been cancelled"))
   }
-
-  override def expectedSize: Int = nrToStart
 
   override def success(): Unit = {
     log.info(s"Successfully started $nrToStart instances of ${app.id}")


### PR DESCRIPTION
When doing SYNC, Marathon should try to check if the count of current running tasks equals the count of tasks we want to scale to. In the original code, it instead tries to match the count of tasks added this time, which is less than the expected size, so that the current running task size never reaches the expected size.

This should fix #829.