### PR TITLE
Add elected info attribute

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -69,6 +69,7 @@ class InfoResource @Inject() (
       Map(
         "name" -> BuildInfo.name,
         "version" -> BuildInfo.version,
+        "elected" -> schedulerService.isLeader,
         "leader" -> schedulerService.getLeader,
         "frameworkId" -> schedulerService.frameworkId.map(_.getValue),
         "marathon_config" -> marathonConfigValues,


### PR DESCRIPTION
# What's This Do?

In monitoring Marathon I'd like to know if the appropriate number of leaders are elected. Therefore I need a way to determine if a host is a leader without relying on the comparison of hostnames in the `leader` attribute.

This PR adds an `elected` attribute to the `/v2/info` resource so that I can modify the Datadog plugin for Marathon to tell me the count of overall leaders! This follows the convention used in Mesos wherein the `/master/stats.json` has an 'elected' value of 1 or 0.
# Thanks

I appreciate you taking the time to look at this. If I can do anything to help a merge, let me know!
