### PR TITLE
Start health checks of all running app versions after leader change

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -419,7 +419,7 @@ class SchedulerActions(
     for {
       apps <- appRepository.apps()
       app <- apps
-    } healthCheckManager.reconcileWith(app)
+    } healthCheckManager.reconcileWith(app.id)
 
   private def newTask(app: AppDefinition,
                       offer: Offer): Option[(TaskInfo, Seq[Long])] = {
@@ -505,15 +505,14 @@ class SchedulerActions(
       case Some(currentVersion) =>
         val updatedApp = appUpdate(currentVersion)
 
-        healthCheckManager.reconcileWith(updatedApp)
         taskQueue.purge(id)
         taskQueue.rateLimiter.resetDelay(id)
 
         appRepository.store(updatedApp).map { _ =>
           update(driver, updatedApp, appUpdate)
+          healthCheckManager.reconcileWith(id)
           updatedApp
         }
-
       case _ => throw new UnknownAppException(id)
     }
   }

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -273,8 +273,8 @@ class MarathonSchedulerService @Inject() (
     leader.set(true)
     runDriver(abdicateOption)
 
-    // Create health checks for any existing apps
-    listApps foreach healthCheckManager.reconcileWith
+    // Create health checks for any existing app and each running version of that
+    schedulerActor ! ReconcileHealthChecks
   }
 
   def abdicateLeadership(): Unit = {

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
@@ -44,7 +44,7 @@ trait HealthCheckManager {
   /**
     * Reconciles active health checks with those defined by the supplied app.
     */
-  def reconcileWith(appId: PathId): Unit
+  def reconcileWith(appId: PathId): Future[Unit]
 
   /**
     * Notifies this health check manager of health information received

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
@@ -44,7 +44,7 @@ trait HealthCheckManager {
   /**
     * Reconciles active health checks with those defined by the supplied app.
     */
-  def reconcileWith(app: AppDefinition): Unit
+  def reconcileWith(appId: PathId): Unit
 
   /**
     * Notifies this health check manager of health information received

--- a/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.ConfigFactory
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.state.Timestamp
+import mesosphere.marathon.state.{ Timestamp, AppRepository }
 import mesosphere.marathon.state.PathId.StringPathId
 import mesosphere.marathon.tasks.{ TaskIdUtil, TaskTracker }
 import mesosphere.util.Logging
@@ -22,6 +22,7 @@ class MarathonHealthCheckManagerTest extends MarathonSpec with Logging {
 
   var hcManager: MarathonHealthCheckManager = _
   var taskTracker: TaskTracker = _
+  var appRepository: AppRepository = _
 
   implicit var system: ActorSystem = _
 
@@ -40,7 +41,8 @@ class MarathonHealthCheckManagerTest extends MarathonSpec with Logging {
     hcManager = new MarathonHealthCheckManager(
       system,
       mock[EventStream],
-      taskTracker
+      taskTracker,
+      appRepository
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
@@ -5,15 +5,17 @@ import akka.event.EventStream
 import akka.testkit.EventFilter
 import com.codahale.metrics.MetricRegistry
 import com.typesafe.config.ConfigFactory
-import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.{ MarathonConf, MarathonSpec }
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.state.{ Timestamp, AppRepository }
+import mesosphere.marathon.state.{ AppDefinition, AppRepository, MarathonStore, PathId, Timestamp }
 import mesosphere.marathon.state.PathId.StringPathId
 import mesosphere.marathon.tasks.{ TaskIdUtil, TaskTracker }
 import mesosphere.util.Logging
 import org.apache.mesos.state.InMemoryState
 import org.apache.mesos.{ Protos => mesos }
+import org.mockito.Mockito._
+import org.rogach.scallop.ScallopConf
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -36,7 +38,13 @@ class MarathonHealthCheckManagerTest extends MarathonSpec with Logging {
       )
     )
 
+    val config = new ScallopConf(Seq("--master", "foo")) with MarathonConf
+    config.afterInit()
     taskTracker = new TaskTracker(new InMemoryState, defaultConfig(), registry)
+    appRepository = new AppRepository(
+      new MarathonStore[AppDefinition](config, new InMemoryState, registry, () => AppDefinition()),
+      None,
+      registry)
 
     hcManager = new MarathonHealthCheckManager(
       system,
@@ -103,7 +111,88 @@ class MarathonHealthCheckManagerTest extends MarathonSpec with Logging {
     assert(health3.lastFailure.isDefined)
     assert(health3.lastSuccess.isDefined)
     assert(health3.lastSuccess > health3.lastFailure)
-
   }
 
+  test("reconcileWith") {
+    val appId = "test".toRootPath
+    def taskStatus(task: MarathonTask, state: mesos.TaskState = mesos.TaskState.TASK_RUNNING) =
+      mesos.TaskStatus.newBuilder
+        .setTaskId(mesos.TaskID.newBuilder()
+          .setValue(task.getId)
+          .build)
+        .setState(mesos.TaskState.TASK_RUNNING)
+        .setHealthy(false)
+        .build
+    val healthChecks = List(0, 1, 2).map { i =>
+      (0 until i).map { j => HealthCheck(protocol = Protocol.COMMAND, gracePeriod = (i * 3 + j).seconds) }.toSet
+    }
+    val versions = List(0: Long, 1, 2).map { Timestamp(_) }.toArray
+    val tasks = List(0, 1, 2).map { i =>
+      MarathonTask.newBuilder
+        .setId(TaskIdUtil.newTaskId(appId).getValue)
+        .setVersion(versions(i).toString)
+        .build
+    }
+    def startTask(appId: PathId, task: MarathonTask, version: Timestamp, healthChecks: Set[HealthCheck]) = {
+      Await.result(appRepository.store(AppDefinition(
+        id = appId,
+        version = version,
+        healthChecks = healthChecks
+      )), 2.second)
+      taskTracker.created(appId, task)
+      Await.result(taskTracker.running(appId, taskStatus(task)), 2.second)
+    }
+    def startTask_i(i: Int): MarathonTask = startTask(appId, tasks(i), versions(i), healthChecks(i))
+    def stopTask(appId: PathId, task: MarathonTask) =
+      Await.result(taskTracker.terminated(appId, taskStatus(task, mesos.TaskState.TASK_FAILED)), 2.second)
+
+    // one other task of another app
+    val otherAppId = "other".toRootPath
+    val otherTask = MarathonTask.newBuilder
+      .setId(TaskIdUtil.newTaskId(appId).getValue)
+      .setVersion(Timestamp(0).toString)
+      .build
+    val otherHealthChecks = Set(HealthCheck(protocol = Protocol.COMMAND, gracePeriod = 0.seconds))
+    startTask(otherAppId, otherTask, Timestamp(42), otherHealthChecks)
+    hcManager.addAllFor(Await.result(appRepository.currentVersion(otherAppId), 2.second).get)
+    assert(hcManager.list(otherAppId) == otherHealthChecks)
+
+    // start task 0 without running health check
+    startTask_i(0)
+    assert(hcManager.list(appId) == Set())
+
+    // reconcileWith doesn't do anything b/c task 0 has no health checks
+    hcManager.reconcileWith(appId)
+    assert(hcManager.list(appId) == Set())
+
+    // reconcileWith starts health checks of task 1
+    assert(hcManager.list(appId) == Set())
+    startTask_i(1)
+    Await.result(hcManager.reconcileWith(appId), 2.second)
+    assert(hcManager.list(appId) == healthChecks(1))
+
+    // reconcileWith leaves health check running
+    Await.result(hcManager.reconcileWith(appId), 2.second)
+    assert(hcManager.list(appId) == healthChecks(1))
+
+    // reconcileWith starts health checks of task 2 and leaves those of task 1 running
+    startTask_i(2)
+    Await.result(hcManager.reconcileWith(appId), 2.second)
+    assert(hcManager.list(appId) == healthChecks(1) ++ healthChecks(2))
+
+    // reconcileWith stops health checks which are not current and which are without tasks
+    stopTask(appId, tasks(1))
+    assert(hcManager.list(appId) == healthChecks(1) ++ healthChecks(2))
+    Await.result(hcManager.reconcileWith(appId), 2.second)
+    assert(hcManager.list(appId) == healthChecks(2))
+
+    // reconcileWith leaves current version health checks running after termination
+    stopTask(appId, tasks(2))
+    assert(hcManager.list(appId) == healthChecks(2))
+    Await.result(hcManager.reconcileWith(appId), 2.second)
+    assert(hcManager.list(appId) == healthChecks(2))
+
+    // other task was not touched
+    assert(hcManager.list(otherAppId) == otherHealthChecks)
+  }
 }


### PR DESCRIPTION
Before only the current version's health checks were started on leader change,
leading to missing health checks when, e.g. after scaling, when old app versions
were still running.

Fixes #912