### PR TITLE
Slim docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM ubuntu:14.04
+FROM mesosphere/mesos:0.21.1-1.1.ubuntu1404
 
-RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
-    apt-get update
-
-RUN apt-get install -y \
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install --no-install-recommends -y \
     default-jdk \
-    mesos \
     scala \
     curl
 
@@ -16,6 +13,9 @@ RUN curl -SsL -O http://dl.bintray.com/sbt/debian/sbt-0.13.5.deb && \
 COPY . /marathon
 WORKDIR /marathon
 
-RUN sbt assembly
+RUN sbt assembly && \
+    mv $(find target -name 'marathon-assembly-*.jar' | sort | tail -1) ./ && \
+    rm -rf target/* ~/.sbt ~/.ivy2 && \
+    mv marathon-assembly-*.jar target
 
 ENTRYPOINT ["./bin/start"]


### PR DESCRIPTION
Using mesos image as base, removing caches and unneded files after sbt.

Image size is much smaller, 1.316gb vs 1.951gb for current image. Moreover, if you run marathon on the same node as mesos (which is common case), you get 1.172gb shared with mesos-master image. It makes 150mb on disk instead of 1951mb. Layer where marathon jar is built:

```
47f807a08209        23 seconds ago      /bin/sh -c sbt assembly &&     mv $(find targ   59.39 MB
```

And old one:

```
7fc8b0dc7d69        6 weeks ago         /bin/sh -c sbt assembly                         483.9 MB
```

However, ideal case would be (single `RUN` step):

1. Install jdk, scala, sbt
2. Build marathon jar
3. Remove jdk, scala, sbt
4. Install jre

This way image would only contain needed files to run marathon, not to build it. Disk and bandwidth savings compared to proposed version are not that big to do it now.

Bonus: mesos version is now more obvious.