### PR TITLE
Tweak the Dockerfile to allow for caching of sbt downloaded dependencies between builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,13 @@ RUN apt-get install -y \
 RUN curl -SsL -O http://dl.bintray.com/sbt/debian/sbt-0.13.5.deb && \
     dpkg -i sbt-0.13.5.deb
 
-COPY . /marathon
 WORKDIR /marathon
+COPY ./project /marathon/project
+COPY ./version.sbt /marathon/version.sbt
+
+RUN sbt update
+
+COPY . /marathon
 
 RUN sbt assembly
 


### PR DESCRIPTION
I've been making some other changes to Marathon and using Docker to create the builds is pretty slow without this change.  Previously every `docker build -t marathon-tip .` would take 10-15 minutes just to download sbt dependencies.  This now downloads and caches those dependencies unless a change is made to the version.sbt or project/ of the project.  This gets builds down to a couple minutes.