### PR TITLE
Always stop hc worker actor after sending results.

### DIFF
--- a/src/main/scala/mesosphere/marathon/health/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckWorkerActor.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.{
   TCP
 }
 
-import akka.actor.{ Actor, ActorLogging }
+import akka.actor.{ Actor, ActorLogging, PoisonPill }
 import akka.util.Timeout
 
 import spray.http._
@@ -31,19 +31,17 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
     case HealthCheckJob(task, check) =>
       val replyTo = sender() // avoids closing over the volatile sender ref
 
-      val replyWithHealth = doCheck(task, check)
-
-      replyWithHealth.onComplete {
-        case Success(result) => replyTo ! result
-        case Failure(t) =>
-          replyTo ! Unhealthy(
-            task.getId,
-            task.getVersion,
-            s"${t.getClass.getSimpleName}: ${t.getMessage}"
-          )
-
-          context stop self
-      }
+      doCheck(task, check)
+        .andThen {
+          case Success(result) => replyTo ! result
+          case Failure(t) =>
+            replyTo ! Unhealthy(
+              task.getId,
+              task.getVersion,
+              s"${t.getClass.getSimpleName}: ${t.getMessage}"
+            )
+        }
+        .onComplete { case _ => self ! PoisonPill }
   }
 
   def doCheck(task: MarathonTask, check: HealthCheck): Future[HealthResult] =

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.health
 import java.net.{ ServerSocket, InetAddress }
 
 import akka.actor.{ Props, ActorSystem }
-import akka.testkit.{ TestActorRef, TestKit }
+import akka.testkit.{ ImplicitSender, TestActorRef, TestKit }
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.{ Protos, MarathonSpec }
 import org.scalatest.{ BeforeAndAfterAll, Matchers }
@@ -13,33 +13,73 @@ import scala.concurrent.duration._
 
 class HealthCheckWorkerActorTest
     extends TestKit(ActorSystem("System"))
+    with ImplicitSender
     with MarathonSpec
     with Matchers
     with BeforeAndAfterAll {
 
   import mesosphere.util.ThreadPoolContext.context
+  import HealthCheckWorker._
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
 
   test("A TCP health check should correctly resolve the hostname") {
-    val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
-    val task = Protos.MarathonTask
-      .newBuilder
-      .setHost(InetAddress.getLocalHost.getCanonicalHostName)
-      .setId("test_id")
-      .build()
-
     val socket = new ServerSocket(0)
+    val socketPort: Int = socket.getLocalPort
 
     val res = Future {
       socket.accept().close()
     }
 
-    ref.underlyingActor.tcp(task, HealthCheck(protocol = Protocol.TCP), socket.getLocalPort)
+    val task = Protos.MarathonTask
+      .newBuilder
+      .setHost(InetAddress.getLocalHost.getCanonicalHostName)
+      .setId("test_id")
+      .addPorts(socketPort)
+      .build()
 
-    try {
-      Await.result(res, 1.seconds)
-    }
-    finally {
-      socket.close()
+    val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
+
+    ref ! HealthCheckJob(task, HealthCheck(protocol = Protocol.TCP))
+
+    try { Await.result(res, 1.seconds) }
+    finally { socket.close() }
+
+    expectMsgPF(1.seconds) {
+      case Healthy(taskId, _, _) => ()
     }
   }
+
+  test("A health check worker should shut itself down") {
+    val socket = new ServerSocket(0)
+    val socketPort: Int = socket.getLocalPort
+
+    val res = Future {
+      socket.accept().close()
+    }
+
+    val task = Protos.MarathonTask
+      .newBuilder
+      .setHost(InetAddress.getLocalHost.getCanonicalHostName)
+      .setId("test_id")
+      .addPorts(socketPort)
+      .build()
+
+    val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
+
+    ref ! HealthCheckJob(task, HealthCheck(protocol = Protocol.TCP))
+
+    try { Await.result(res, 1.seconds) }
+    finally { socket.close() }
+
+    expectMsgPF(1.seconds) {
+      case _: HealthResult => ()
+    }
+
+    watch(ref)
+    expectTerminated(ref)
+  }
+
 }


### PR DESCRIPTION
Fixes an actor leak in the health check subsystem.