### PR TITLE
TaskStartActor tests, fixes and simplifications

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -476,7 +476,7 @@ class SchedulerActions(
       if (targetCount > currentCount) {
         log.info(s"Need to scale ${app.id} from $currentCount up to $targetCount instances")
 
-        val queuedCount = taskQueue.count(app)
+        val queuedCount = taskQueue.count(app.id)
         val toQueue = targetCount - (currentCount + queuedCount)
 
         if (toQueue > 0) {

--- a/src/main/scala/mesosphere/marathon/tasks/TaskQueue.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskQueue.scala
@@ -68,16 +68,15 @@ class TaskQueue {
     queuedTask.count.addAndGet(count)
   }
 
-  // TODO: should only return the count for the same version
   /**
     * Number of tasks in the queue for the given app
     *
-    * @param app The app
+    * @param appId The app id
     * @return count
     */
-  def count(app: AppDefinition): Int = apps.values.foldLeft(0) {
-    case (count, task) if task.app.id == app.id => count + task.count.get()
-    case (count, _)                             => count
+  def count(appId: PathId): Int = apps.values.foldLeft(0) {
+    case (count, task) if task.app.id == appId => count + task.count.get()
+    case (count, _)                            => count
   }
 
   def purge(appId: PathId): Unit = {

--- a/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
@@ -16,10 +16,9 @@ class AppStartActor(
     val taskTracker: TaskTracker,
     val eventBus: EventStream,
     val app: AppDefinition,
-    scaleTo: Int,
+    val scaleTo: Int,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
-  val expectedSize: Int = scaleTo
   val nrToStart: Int = scaleTo
 
   def withHealthChecks: Boolean = app.healthChecks.nonEmpty

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -15,7 +15,7 @@ trait StartingBehavior { this: Actor with ActorLogging =>
   import mesosphere.marathon.upgrade.StartingBehavior._
 
   def eventBus: EventStream
-  def expectedSize: Int
+  def scaleTo: Int
   def nrToStart: Int
   def withHealthChecks: Boolean
   def taskQueue: TaskQueue
@@ -74,9 +74,8 @@ trait StartingBehavior { this: Actor with ActorLogging =>
 
     case Sync =>
       val actualSize = taskQueue.count(app.id) + taskTracker.count(app.id)
-
-      if (actualSize < expectedSize) {
-        taskQueue.add(app, expectedSize - actualSize)
+      if (actualSize < scaleTo) {
+        taskQueue.add(app, scaleTo - actualSize)
       }
       context.system.scheduler.scheduleOnce(5.seconds, self, Sync)
   }

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -73,7 +73,7 @@ trait StartingBehavior { this: Actor with ActorLogging =>
       taskQueue.add(app)
 
     case Sync =>
-      val actualSize = taskQueue.count(app) + taskTracker.count(app.id)
+      val actualSize = taskQueue.count(app.id) + taskTracker.count(app.id)
 
       if (actualSize < expectedSize) {
         taskQueue.add(app, expectedSize - actualSize)

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -16,11 +16,10 @@ class TaskStartActor(
     val taskTracker: TaskTracker,
     val eventBus: EventStream,
     val app: AppDefinition,
-    scaleTo: Int,
+    val scaleTo: Int,
     val withHealthChecks: Boolean,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
-  val expectedSize: Int = scaleTo
   val nrToStart: Int = scaleTo - taskTracker.count(app.id)
 
   override def initializeStart(): Unit = {

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -20,7 +20,7 @@ class TaskStartActor(
     val withHealthChecks: Boolean,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
-  val nrToStart: Int = scaleTo - taskTracker.count(app.id)
+  val nrToStart: Int = scaleTo - taskQueue.count(app.id) - taskTracker.count(app.id)
 
   override def initializeStart(): Unit = {
     taskQueue.add(app, nrToStart)

--- a/src/test/scala/mesosphere/marathon/tasks/TaskQueueTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskQueueTest.scala
@@ -48,9 +48,9 @@ class TaskQueueTest extends MarathonSpec {
   test("poll") {
     queue.add(app1, 3)
 
-    assert(queue.count(app1) == 3)
+    assert(queue.count(app1.id) == 3)
     assert(queue.poll().map(_.app) == Some(app1))
-    assert(queue.count(app1) == 2)
+    assert(queue.count(app1.id) == 2)
   }
 
   test("pollMatching") {

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -197,7 +197,7 @@ class DeploymentActorTest
 
     val taskIDs = Iterator.from(3)
 
-    when(queue.count(appNew)).thenAnswer(new Answer[Int] {
+    when(queue.count(appNew.id)).thenAnswer(new Answer[Int] {
       override def answer(p1: InvocationOnMock): Int = appNew.instances
     })
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -36,7 +36,7 @@ class TaskStartActorTest
     val registry = new MetricRegistry
     val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Unit]()
-    val app = AppDefinition("myApp".toPath, instances = 5)
+    val app = AppDefinition("/myApp".toPath, instances = 5)
 
     val ref = TestActorRef(Props(
       classOf[TaskStartActor],
@@ -69,7 +69,7 @@ class TaskStartActorTest
     val registry = new MetricRegistry
     val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Unit]()
-    val app = AppDefinition("myApp".toPath, instances = 5)
+    val app = AppDefinition("/myApp".toPath, instances = 5)
 
     taskQueue.add(app)
 
@@ -104,7 +104,7 @@ class TaskStartActorTest
     val registry = new MetricRegistry
     val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
-    val app = AppDefinition("myApp".toPath, instances = 0)
+    val app = AppDefinition("/myApp".toPath, instances = 0)
 
     val ref = TestActorRef(Props(
       classOf[TaskStartActor],
@@ -132,7 +132,7 @@ class TaskStartActorTest
     val registry = new MetricRegistry
     val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
-    val app = AppDefinition("myApp".toPath, instances = 5)
+    val app = AppDefinition("/myApp".toPath, instances = 5)
 
     val ref = TestActorRef(Props(
       classOf[TaskStartActor],
@@ -165,7 +165,7 @@ class TaskStartActorTest
     val registry = new MetricRegistry
     val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
-    val app = AppDefinition("myApp".toPath, instances = 0)
+    val app = AppDefinition("/myApp".toPath, instances = 0)
 
     val ref = TestActorRef(Props(
       classOf[TaskStartActor],
@@ -193,7 +193,7 @@ class TaskStartActorTest
     val registry = new MetricRegistry
     val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
-    val app = AppDefinition("myApp".toPath, instances = 5)
+    val app = AppDefinition("/myApp".toPath, instances = 5)
 
     val ref = system.actorOf(Props(
       classOf[TaskStartActor],
@@ -225,7 +225,7 @@ class TaskStartActorTest
     val registry = new MetricRegistry
     val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Unit]()
-    val app = AppDefinition("myApp".toPath, instances = 1)
+    val app = AppDefinition("/myApp".toPath, instances = 1)
 
     val ref = TestActorRef(Props(
       classOf[TaskStartActor],

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -52,9 +52,9 @@ class TaskStartActorTest
 
     watch(ref)
 
-    awaitCond(taskQueue.count(app) == 5, 3.seconds)
+    awaitCond(taskQueue.count(app.id) == 5, 3.seconds)
 
-    for (i <- 0 until taskQueue.count(app))
+    for (i <- 0 until taskQueue.count(app.id))
       system.eventStream.publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
 
     Await.result(promise.future, 3.seconds) should be(())
@@ -113,9 +113,9 @@ class TaskStartActorTest
 
     watch(ref)
 
-    awaitCond(taskQueue.count(app) == 5, 3.seconds)
+    awaitCond(taskQueue.count(app.id) == 5, 3.seconds)
 
-    for (i <- 0 until taskQueue.count(app))
+    for (i <- 0 until taskQueue.count(app.id))
       system.eventStream.publish(HealthStatusChanged(app.id, s"task_$i", app.version.toString, alive = true))
 
     Await.result(promise.future, 3.seconds) should be(())
@@ -206,17 +206,17 @@ class TaskStartActorTest
 
     watch(ref)
 
-    awaitCond(taskQueue.count(app) == 1, 3.seconds)
+    awaitCond(taskQueue.count(app.id) == 1, 3.seconds)
 
     taskQueue.purge(app.id)
 
     system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_FAILED", "", app.id, "", Nil, app.version.toString))
 
-    awaitCond(taskQueue.count(app) == 1, 3.seconds)
+    awaitCond(taskQueue.count(app.id) == 1, 3.seconds)
 
     verify(taskQueue, times(2)).add(app, 1)
 
-    for (i <- 0 until taskQueue.count(app))
+    for (i <- 0 until taskQueue.count(app.id))
       system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
 
     Await.result(promise.future, 3.seconds) should be(())

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker }
 import mesosphere.marathon.{ MarathonConf, SchedulerActions, TaskUpgradeCanceledException }
 import org.apache.mesos.SchedulerDriver
 import org.apache.mesos.state.InMemoryState
-import org.mockito.Mockito.{ times, spy, verify }
+import org.mockito.Mockito.{ times, spy, verify, when }
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfterAll, FunSuiteLike, Matchers }
 
@@ -295,6 +295,63 @@ class TaskStartActorTest
     for (i <- 0 until taskQueue.count(app.id))
       system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
 
+    Await.result(promise.future, 3.seconds) should be(())
+
+    expectTerminated(ref)
+  }
+
+  test("Start success with dying existing task, reschedules, but finishes early") {
+    val driver = mock[SchedulerDriver]
+    val scheduler = mock[SchedulerActions]
+    val taskQueue = new TaskQueue
+    val registry = new MetricRegistry
+    val taskTracker = spy(new TaskTracker(new InMemoryState, mock[MarathonConf], registry))
+    val promise = Promise[Unit]()
+    val app = AppDefinition("/myApp".toPath, instances = 5)
+
+    val taskId = TaskIdUtil.newTaskId(app.id)
+    val task = MarathonTask.newBuilder
+      .setId(taskId.getValue)
+      .setVersion(Timestamp(1024).toString)
+      .build
+    taskTracker.created(app.id, task)
+
+    val ref = TestActorRef(Props(
+      classOf[TaskStartActor],
+      driver,
+      scheduler,
+      taskQueue,
+      taskTracker,
+      system.eventStream,
+      app,
+      app.instances,
+      false,
+      promise))
+
+    watch(ref)
+
+    // wait for initial sync
+    awaitCond(taskQueue.count(app.id) == 4, 3.seconds)
+
+    // let existing task die
+    // doesn't work because it needs Zookeeper: taskTracker.terminated(app.id, taskStatus)
+    // we mock instead
+    when(taskTracker.count(app.id)).thenReturn(0)
+    system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_ERROR", "", app.id, "", Nil, task.getVersion))
+
+    // sync will reschedule task
+    ref ! StartingBehavior.Sync
+    awaitCond(taskQueue.count(app.id) == 5, 3.seconds)
+
+    // launch 4 of the tasks
+    when(taskTracker.count(app.id)).thenReturn(4)
+    List(0, 1, 2, 3) foreach { i =>
+      taskQueue.poll
+      system.eventStream.publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
+    }
+    assert(taskQueue.count(app.id) == 1)
+
+    // it finished early
     Await.result(promise.future, 3.seconds) should be(())
 
     expectTerminated(ref)


### PR DESCRIPTION
This pull request follows up on #913, adding more tests for

- scaling when a task exists already
- scaling when taskQueue contains a task (e.g. after reconciliation which reschedules a dead task)
- scaling with a dying, previously existing task

and adding some simplifications

- use of scaleTo directly in StartingBehavior instead of expectedSize
- speaking name for actual semantics of StartingBehavior's variables.

Replaces #931, extends #913.