### PR TITLE
AWS Linux aware haproxy-marathon-bridge

### DIFF
--- a/bin/haproxy-marathon-bridge
+++ b/bin/haproxy-marathon-bridge
@@ -55,8 +55,16 @@ function refresh_system_haproxy {
 }
 
 function install_haproxy_system {
-  os=$(lsb_release -si)
-  if [[ $os == "CentOS" ]] || [[ $os == "RHEL" ]]
+
+  if hash lsb_release 2>/dev/null
+  then
+    os=$(lsb_release -si)
+  elif [ -e "/etc/system-release" ] && (grep -q "Amazon Linux AMI" "/etc/system-release")
+  then
+    os="AmazonAMI"
+  fi
+     
+  if [[ $os == "CentOS" ]] || [[ $os == "RHEL" ]] || [[ $os == "AmazonAMI" ]]
   then
     sudo yum install -y haproxy
     sudo chkconfig haproxy on


### PR DESCRIPTION
Check for AWS Linux.  If `lsb_release` does not exist check `/etc/system-release` to see if the OS is Amazon Linux.  If it is, set OS to `AmazonAMI`.

I chose not to install the `redhat-lsb` package on AWS because of the 59 dependencies.  Another solution could be to detect AWS Linux, install redhat-lsb and use the output from it.  The value if you do that is the same, `AmazonAMI`. 
