### PR TITLE
Don't create unknown tasks with incomplete data in TaskTracker.running

### DIFF
--- a/src/test/scala/mesosphere/marathon/tasks/TaskTrackerTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskTrackerTest.scala
@@ -14,6 +14,7 @@ import org.apache.mesos.Protos.{ TaskID, TaskState, TaskStatus }
 import org.apache.mesos.state.{ InMemoryState, State }
 import org.mockito.Mockito.{ reset, spy, times, verify }
 import org.mockito.Matchers.any
+import org.scalatest.concurrent.ScalaFutures
 
 import scala.collection.JavaConverters._
 import scala.collection._
@@ -57,14 +58,14 @@ class TaskTrackerTest extends MarathonSpec {
       .build
   }
 
-  def shouldContainTask(tasks: Iterable[MarathonTask], task: MarathonTask) {
-    assert(
-      tasks.exists(t => t.getId == task.getId
-        && t.getHost == task.getHost
-        && t.getPortsList == task.getPortsList),
-      s"Should contain task ${task.getId}"
-    )
-  }
+  def containsTask(tasks: Iterable[MarathonTask], task: MarathonTask) =
+    tasks.exists(t => t.getId == task.getId
+      && t.getHost == task.getHost
+      && t.getPortsList == task.getPortsList)
+  def shouldContainTask(tasks: Iterable[MarathonTask], task: MarathonTask) =
+    assert(containsTask(tasks, task), s"Should contain task ${task.getId}")
+  def shouldNotContainTask(tasks: Iterable[MarathonTask], task: MarathonTask) =
+    assert(!containsTask(tasks, task), s"Should not contain task ${task.getId}")
 
   def shouldHaveTaskStatus(task: MarathonTask, taskStatus: TaskStatus) {
     assert(
@@ -176,6 +177,20 @@ class TaskTrackerTest extends MarathonSpec {
 
     // Empty option means this message was discarded since there was no matching task
     assert(taskOption.isEmpty, "Task was able to be updated and was not removed")
+  }
+
+  test("UnknownTasks") {
+    val sampleTask = makeSampleTask(TEST_TASK_ID)
+    val sampleTaskKey = taskTracker.getKey(TEST_APP_NAME, TEST_TASK_ID)
+
+    // don't call taskTracker.created, but directly running
+    val runningTaskStatus: TaskStatus = makeTaskStatus(TEST_TASK_ID, TaskState.TASK_RUNNING)
+    val res = taskTracker.running(TEST_APP_NAME, runningTaskStatus)
+    ScalaFutures.whenReady(res.failed) { e =>
+      assert(e.getMessage == s"No staged task for ID $TEST_TASK_ID, ignoring")
+    }
+    shouldNotContainTask(taskTracker.get(TEST_APP_NAME), sampleTask)
+    stateShouldNotContainKey(state, sampleTaskKey)
   }
 
   test("MultipleApps") {


### PR DESCRIPTION
When a task is not known by the TaskTracker when TaskTracker.running is
called by the scheduler, before this patch an incomplete task was stored
in the TaskTracker, recognizable from the 1970 beginning of epoch date.

This somehow happens sometimes after reconciation, wenn Mesos sends
status updates of task not in the task store after some leader change.

The actual bug is that those tasks are missing in the task store. An
unproven theory is that health checks run by non-leaders are remove
tasks from the store although after leader defeat all health checks must
be stopped. But this is not true right now, compare #356.

Workaround for #896.