### PR TITLE
396 simplify version numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 .classpath
 .settings
 .Rproj.user
+start.sh

--- a/src/main/resources/assets/css/marathon.css
+++ b/src/main/resources/assets/css/marathon.css
@@ -517,6 +517,13 @@ fieldset[disabled] .btn-info.active {
    padding: 0 2px;
 }
 
+.badge.task {
+  position: relative;
+  top: 0px;
+  left: 0px;
+  margin-right: 10px;
+}
+
 .progress {
   height: 10px;
   border-radius: 3px;

--- a/src/main/resources/assets/css/marathon.css
+++ b/src/main/resources/assets/css/marathon.css
@@ -517,13 +517,6 @@ fieldset[disabled] .btn-info.active {
    padding: 0 2px;
 }
 
-.badge.task {
-  position: relative;
-  top: 0px;
-  left: 0px;
-  margin-right: 10px;
-}
-
 .progress {
   height: 10px;
   border-radius: 3px;

--- a/src/main/resources/assets/js/components/AppModalComponent.jsx
+++ b/src/main/resources/assets/js/components/AppModalComponent.jsx
@@ -178,7 +178,7 @@ define([
                 activeViewIndex={this.state.activeViewIndex}>
                 <TaskViewComponent
                   collection={model.tasks}
-                  appVersion={this.props.model.get('version')}
+                  currentAppVersion={model.get('version')}
                   fetchState={this.props.tasksFetchState}
                   fetchTasks={this.props.fetchTasks}
                   formatTaskHealthMessage={model.formatTaskHealthMessage}

--- a/src/main/resources/assets/js/components/AppModalComponent.jsx
+++ b/src/main/resources/assets/js/components/AppModalComponent.jsx
@@ -178,6 +178,7 @@ define([
                 activeViewIndex={this.state.activeViewIndex}>
                 <TaskViewComponent
                   collection={model.tasks}
+                  appVersion={this.props.model.get('version')}
                   fetchState={this.props.tasksFetchState}
                   fetchTasks={this.props.fetchTasks}
                   formatTaskHealthMessage={model.formatTaskHealthMessage}

--- a/src/main/resources/assets/js/components/TaskListComponent.jsx
+++ b/src/main/resources/assets/js/components/TaskListComponent.jsx
@@ -21,7 +21,8 @@ define([
       itemsPerPage: React.PropTypes.number.isRequired,
       hasHealth: React.PropTypes.bool,
       selectedTasks: React.PropTypes.object.isRequired,
-      tasks: React.PropTypes.object.isRequired
+      tasks: React.PropTypes.object.isRequired,
+      appVersion: React.PropTypes.object.isRequired
     },
 
     getResource: function() {
@@ -112,7 +113,8 @@ define([
                       onToggle={this.props.onTaskToggle}
                       onTaskDetailSelect={this.props.onTaskDetailSelect}
                       hasHealth={hasHealth}
-                      task={task} />
+                      task={task}
+                      appVersion={this.props.appVersion} />
                 );
               }, this)
             }

--- a/src/main/resources/assets/js/components/TaskListComponent.jsx
+++ b/src/main/resources/assets/js/components/TaskListComponent.jsx
@@ -22,7 +22,7 @@ define([
       hasHealth: React.PropTypes.bool,
       selectedTasks: React.PropTypes.object.isRequired,
       tasks: React.PropTypes.object.isRequired,
-      appVersion: React.PropTypes.object.isRequired
+      currentAppVersion: React.PropTypes.object.isRequired
     },
 
     getResource: function() {
@@ -114,7 +114,7 @@ define([
                       onTaskDetailSelect={this.props.onTaskDetailSelect}
                       hasHealth={hasHealth}
                       task={task}
-                      appVersion={this.props.appVersion} />
+                      currentAppVersion={this.props.currentAppVersion} />
                 );
               }, this)
             }

--- a/src/main/resources/assets/js/components/TaskListItemComponent.jsx
+++ b/src/main/resources/assets/js/components/TaskListItemComponent.jsx
@@ -55,10 +55,6 @@ define([
       currentAppVersion: React.PropTypes.object.isRequired
     },
 
-    getInitialState: function() {
-      return {versionShowTimestamp: false};
-    },
-
     handleClick: function(event) {
       // If the click happens on the checkbox, let the checkbox's onchange event
       // handler handle it and skip handling the event here.
@@ -76,16 +72,13 @@ define([
       this.props.onTaskDetailSelect(this.props.task);
     },
 
-    handleVersionClick: function(event) {
-      this.setState({versionShowTimestamp: !this.state.versionShowTimestamp});
-    },
-
     render: function() {
       var className = (this.props.isActive) ? "active" : "";
       var task = this.props.task;
       var hasHealth = !!this.props.hasHealth;
       var currentAppVersion = this.props.currentAppVersion;
-      var outdated = currentAppVersion && task.get("version") < currentAppVersion;
+      var outdated = currentAppVersion &&
+        task.get("version") < currentAppVersion;
 
       var taskHealth = task.getHealth();
       var healthClassSet = React.addons.classSet({
@@ -101,8 +94,7 @@ define([
 
       var versionClassSet = React.addons.classSet({
         "text-muted": !outdated,
-        "text-warning": outdated,
-        "clickable": true
+        "text-warning": outdated
       });
 
       var updatedAtNode;
@@ -136,11 +128,9 @@ define([
           <td className="text-right">
             <span
               title={task.get("version").toISOString()}
-              className={versionClassSet}
-              onClick={this.handleVersionClick}>{
-                this.state.versionShowTimestamp ?
-                  task.get("version").toISOString() :
-                  (outdated ? "Out-of-date" : "Current")}</span>
+              className={versionClassSet}>
+              {outdated ? "Out-of-date" : "Current"}
+            </span>
           </td>
           <td className="text-right">{updatedAtNode}</td>
           {

--- a/src/main/resources/assets/js/components/TaskListItemComponent.jsx
+++ b/src/main/resources/assets/js/components/TaskListItemComponent.jsx
@@ -55,6 +55,10 @@ define([
       currentAppVersion: React.PropTypes.object.isRequired
     },
 
+    getInitialState: function() {
+      return {versionShowTimestamp: false};
+    },
+
     handleClick: function(event) {
       // If the click happens on the checkbox, let the checkbox's onchange event
       // handler handle it and skip handling the event here.
@@ -70,6 +74,10 @@ define([
     handleTaskDetailSelect: function(event) {
       event.preventDefault();
       this.props.onTaskDetailSelect(this.props.task);
+    },
+
+    handleVersionClick: function(event) {
+      this.setState({versionShowTimestamp: !this.state.versionShowTimestamp});
     },
 
     render: function() {
@@ -93,7 +101,8 @@ define([
 
       var versionClassSet = React.addons.classSet({
         "text-muted": !outdated,
-        "text-warning": outdated
+        "text-warning": outdated,
+        "clickable": true
       });
 
       var updatedAtNode;
@@ -127,7 +136,11 @@ define([
           <td className="text-right">
             <span
               title={task.get("version").toISOString()}
-              className={versionClassSet}>{outdated ? "Out-of-date" : "Current"}</span>
+              className={versionClassSet}
+              onClick={this.handleVersionClick}>{
+                this.state.versionShowTimestamp ?
+                  task.get("version").toISOString() :
+                  (outdated ? "Out-of-date" : "Current")}</span>
           </td>
           <td className="text-right">{updatedAtNode}</td>
           {

--- a/src/main/resources/assets/js/components/TaskListItemComponent.jsx
+++ b/src/main/resources/assets/js/components/TaskListItemComponent.jsx
@@ -125,7 +125,9 @@ define([
             </span>
           </td>
           <td className="text-right">
-            <span title={task.get("version").toISOString()} className={versionClassSet}>{outdated ? "Out-of-date" : "Current"}</span>
+            <span
+              title={task.get("version").toISOString()}
+              className={versionClassSet}>{outdated ? "Out-of-date" : "Current"}</span>
           </td>
           <td className="text-right">{updatedAtNode}</td>
           {

--- a/src/main/resources/assets/js/components/TaskListItemComponent.jsx
+++ b/src/main/resources/assets/js/components/TaskListItemComponent.jsx
@@ -52,7 +52,7 @@ define([
       onToggle: React.PropTypes.func.isRequired,
       onTaskDetailSelect: React.PropTypes.func.isRequired,
       task: React.PropTypes.object.isRequired,
-      appVersion: React.PropTypes.object.isRequired
+      currentAppVersion: React.PropTypes.object.isRequired
     },
 
     handleClick: function(event) {
@@ -76,9 +76,8 @@ define([
       var className = (this.props.isActive) ? "active" : "";
       var task = this.props.task;
       var hasHealth = !!this.props.hasHealth;
-      var outdated = (this.props.appVersion.toISOString() && (task.get("version").toISOString() != this.props.appVersion.toISOString())) ?
-        <span className="badge task">out-of-date</span> :
-        null;
+      var currentAppVersion = this.props.currentAppVersion;
+      var outdated = currentAppVersion && task.get("version") < currentAppVersion;
 
       var taskHealth = task.getHealth();
       var healthClassSet = React.addons.classSet({
@@ -90,6 +89,11 @@ define([
 
       var statusClassSet = React.addons.classSet({
         "text-warning": task.isStaged()
+      });
+
+      var versionClassSet = React.addons.classSet({
+        "text-muted": !outdated,
+        "text-warning": outdated
       });
 
       var updatedAtNode;
@@ -121,10 +125,7 @@ define([
             </span>
           </td>
           <td className="text-right">
-            {outdated}
-            <time dateTime={task.get("version").toISOString()} title={task.get("version").toISOString()}>
-              {task.get("version").toLocaleString()}
-            </time>
+            <span title={task.get("version").toISOString()} className={versionClassSet}>{outdated ? "Out-of-date" : "Current"}</span>
           </td>
           <td className="text-right">{updatedAtNode}</td>
           {

--- a/src/main/resources/assets/js/components/TaskListItemComponent.jsx
+++ b/src/main/resources/assets/js/components/TaskListItemComponent.jsx
@@ -51,7 +51,8 @@ define([
       isActive: React.PropTypes.bool.isRequired,
       onToggle: React.PropTypes.func.isRequired,
       onTaskDetailSelect: React.PropTypes.func.isRequired,
-      task: React.PropTypes.object.isRequired
+      task: React.PropTypes.object.isRequired,
+      appVersion: React.PropTypes.object.isRequired
     },
 
     handleClick: function(event) {
@@ -75,6 +76,9 @@ define([
       var className = (this.props.isActive) ? "active" : "";
       var task = this.props.task;
       var hasHealth = !!this.props.hasHealth;
+      var outdated = (this.props.appVersion.toISOString() && (task.get("version").toISOString() != this.props.appVersion.toISOString())) ?
+        <span className="badge task">out-of-date</span> :
+        null;
 
       var taskHealth = task.getHealth();
       var healthClassSet = React.addons.classSet({
@@ -117,6 +121,7 @@ define([
             </span>
           </td>
           <td className="text-right">
+            {outdated}
             <time dateTime={task.get("version").toISOString()} title={task.get("version").toISOString()}>
               {task.get("version").toLocaleString()}
             </time>

--- a/src/main/resources/assets/js/components/TaskViewComponent.jsx
+++ b/src/main/resources/assets/js/components/TaskViewComponent.jsx
@@ -12,7 +12,7 @@ define([
 
     propTypes: {
       collection: React.PropTypes.object.isRequired,
-      appVersion: React.PropTypes.object.isRequired,
+      currentAppVersion: React.PropTypes.object.isRequired,
       fetchState: React.PropTypes.number.isRequired,
       fetchTasks: React.PropTypes.func.isRequired,
       formatTaskHealthMessage: React.PropTypes.func.isRequired,
@@ -158,7 +158,7 @@ define([
             itemsPerPage={itemsPerPage}
             selectedTasks={this.state.selectedTasks}
             tasks={this.props.collection}
-            appVersion={this.props.appVersion}
+            currentAppVersion={this.props.currentAppVersion}
             toggleAllTasks={this.toggleAllTasks} />
         </div>
       );

--- a/src/main/resources/assets/js/components/TaskViewComponent.jsx
+++ b/src/main/resources/assets/js/components/TaskViewComponent.jsx
@@ -11,8 +11,9 @@ define([
     displayName: "TaskViewComponent",
 
     propTypes: {
-      fetchState: React.PropTypes.number.isRequired,
       collection: React.PropTypes.object.isRequired,
+      appVersion: React.PropTypes.object.isRequired,
+      fetchState: React.PropTypes.number.isRequired,
       fetchTasks: React.PropTypes.func.isRequired,
       formatTaskHealthMessage: React.PropTypes.func.isRequired,
       hasHealth: React.PropTypes.bool,
@@ -157,6 +158,7 @@ define([
             itemsPerPage={itemsPerPage}
             selectedTasks={this.state.selectedTasks}
             tasks={this.props.collection}
+            appVersion={this.props.appVersion}
             toggleAllTasks={this.toggleAllTasks} />
         </div>
       );


### PR DESCRIPTION
Display 'Current'- or 'Out-of-date'-text instead of the timestamp in the version field of the task list for more readability.
According to #396 .
'Current' is displayed as .text-muted and 'Out-of-date' as .text-warning.