### PR TITLE
Avoid health checks and deployment recovery if a marathon instance is not leader

### DIFF
--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -29,6 +29,8 @@ case class CanceledActionException(msg: String) extends Exception(msg)
 
 case class ConflictingChangeException(msg: String) extends Exception(msg)
 
+case class LostLeadershipException(msg: String) extends Exception(msg)
+
 /*
  * Task upgrade specific exceptions
  */

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -80,30 +80,42 @@ class MarathonSchedulerActor(
 
     historyActor = context.actorOf(
       Props(classOf[HistoryActor], eventBus, taskFailureRepository), "HistoryActor")
-
-    deploymentRepository.all() onComplete {
-      case Success(deployments) => self ! RecoveredDeployments(deployments)
-      case Failure(_)           => self ! RecoveredDeployments(Nil)
-    }
-
   }
 
-  def receive: Receive = recovering
+  def receive: Receive = suspended
 
-  def recovering: Receive = {
-    case RecoveredDeployments(deployments) =>
+  def suspended: Receive = {
+    case Start =>
+      log.info("Starting scheduler actor")
+      deploymentRepository.all() onComplete {
+        case Success(deployments) => self ! RecoverDeployments(deployments)
+        case Failure(_)           => self ! RecoverDeployments(Nil)
+      }
+      
+    case RecoverDeployments(deployments) =>
       deployments.foreach { plan =>
         log.info(s"Recovering deployment: $plan")
         deploy(Actor.noSender, Deploy(plan, force = false), plan, blocking = false)
       }
+
+      log.info("Scheduler actor ready")
       unstashAll()
-      context.become(ready)
+      context.become(started)
       self ! ReconcileHealthChecks
 
+    case Suspend => // ignore
+    
     case _ => stash()
   }
 
-  def ready: Receive = {
+  def started: Receive = {
+    case Suspend =>
+      log.info("Suspending scheduler actor")
+      healthCheckManager.removeAll()
+      context.become(suspended)
+
+    case Start => // ignore
+
     case ReconcileTasks =>
       scheduler.reconcileTasks(driver)
       sender ! ReconcileTasks.answer
@@ -268,7 +280,10 @@ class MarathonSchedulerActor(
 }
 
 object MarathonSchedulerActor {
-  case class RecoveredDeployments(deployments: Seq[DeploymentPlan])
+  case object Start
+  case object Suspend
+
+  case class RecoverDeployments(deployments: Seq[DeploymentPlan])
 
   sealed trait Command {
     def answer: Event

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -109,9 +109,10 @@ class MarathonSchedulerActor(
   }
 
   def started: Receive = {
-    case Suspend =>
+    case Suspend(t) =>
       log.info("Suspending scheduler actor")
       healthCheckManager.removeAll()
+      deploymentManager ! CancelAllDeployments(t)
       context.become(suspended)
 
     case Start => // ignore
@@ -281,7 +282,7 @@ class MarathonSchedulerActor(
 
 object MarathonSchedulerActor {
   case object Start
-  case object Suspend
+  case class Suspend(reason: Throwable)
 
   case class RecoverDeployments(deployments: Seq[DeploymentPlan])
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -256,13 +256,11 @@ class MarathonSchedulerService @Inject() (
   private def defeatLeadership(): Unit = {
     log.info("Defeat leadership")
 
+    schedulerActor ! Suspend
+
     // Our leadership has been defeated. Thus, update leadership and stop the driver.
     // Note that abdication command will be ran upon driver shutdown.
     leader.set(false)
-
-    // Stop all health checks
-    healthCheckManager.removeAll()
-
     stopDriver()
   }
 
@@ -273,8 +271,7 @@ class MarathonSchedulerService @Inject() (
     leader.set(true)
     runDriver(abdicateOption)
 
-    // Create health checks for any existing app and each running version of that
-    schedulerActor ! ReconcileHealthChecks
+    schedulerActor ! Start
   }
 
   def abdicateLeadership(): Unit = {

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -256,7 +256,7 @@ class MarathonSchedulerService @Inject() (
   private def defeatLeadership(): Unit = {
     log.info("Defeat leadership")
 
-    schedulerActor ! Suspend
+    schedulerActor ! Suspend(LostLeadershipException("Leadership was defeated"))
 
     // Our leadership has been defeated. Thus, update leadership and stop the driver.
     // Note that abdication command will be ran upon driver shutdown.


### PR DESCRIPTION
Deployment recoverment triggered health check conciliation. Moreover, deployment
recoverment was started when the scheduler actor was started (which is right
at the beginning of the maration startup). Deployment recoverment did NOT
wait for leadership election results. Hence, every newly started marathon instance
started health checks, even when some other instance was the leader.

This patch adds a start/suspend logic to the scheduler actor, triggered by
leadership election and defeat. The deployment recoverment now happens when
the scheduler actor goes into started state, hence no unexpected health check
reconciliation on marathon startup before leadership election.

Probably fixes #356.

In addition, running deployments are stopped on leadership defeat.