### PR TITLE
Reduced the initial task reconciliation delay to 15s.

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -51,10 +51,10 @@ The following options can influence how Marathon works:
 * `--mesos_user` (Optional. Default: current user): Mesos user for
     this framework. _Note: Default is determined by
     [`SystemProperties.get("user.name")`](http://www.scala-lang.org/api/current/index.html#scala.sys.SystemProperties@get\(key:String\):Option[String])._
-* `--reconciliation_initial_delay` (Optional. Default: 30000 (30 seconds)): The
+* `--reconciliation_initial_delay` (Optional. Default: 15000 (15 seconds)): The
     delay, in milliseconds, before Marathon begins to periodically perform task
     reconciliation operations.
-* `--reconciliation_interval` (Optional. Default: 30000 (30 seconds)): The
+* `--reconciliation_interval` (Optional. Default: 300000 (5 minutes)): The
     period, in milliseconds, between task reconciliation operations.
 * `--task_launch_timeout` (Optional. Default: 60000 (60 seconds)): Time,
     in milliseconds, to wait for a task to enter the TASK_RUNNING state before

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -59,7 +59,7 @@ trait MarathonConf extends ScallopConf with ZookeeperConf {
   lazy val reconciliationInitialDelay = opt[Long]("reconciliation_initial_delay",
     descr = "This is the length of time, in milliseconds, before Marathon " +
       "begins to periodically perform task reconciliation operations",
-    default = Some(300000L)) // 300 seconds (5 minutes)
+    default = Some(15000L)) // 15 seconds
 
   lazy val reconciliationInterval = opt[Long]("reconciliation_interval",
     descr = "This is the length of time, in milliseconds, between task " +


### PR DESCRIPTION
Primarily, to more quickly learn the health status of tasks with command health checks.  See #916, #917, and #923.

Health status for tasks with command checks was added to the TaskStatus messages sent in response to task reconciliation in Mesos review [#29556](https://reviews.apache.org/r/29556).