### PR TITLE
Add /v2/leader API endpoint which abdicates leadership on DELETE

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -39,6 +39,7 @@ title: REST API
   * [GET /v2/queue](#get-/v2/queue): List content of the staging queue.
 * [Server Info](#server-info) <span class="label label-default">v0.7.0</span>
   * [GET /v2/info](#get-/v2/info): Get info about the Marathon Instance
+  * [DELETE /v2/leader](#delete-/v2/leader): Start a new leadership election
 * [Miscellaneous](#miscellaneous)
   * [GET /ping](#get-/ping)
   * [GET /logging](#get-/logging)
@@ -2202,6 +2203,35 @@ Server: Jetty(8.y.z-SNAPSHOT)
         "zk_state": "/marathon",
         "zk_timeout": 10
     }
+}
+{% endhighlight %}
+
+#### DELETE `/v2/leader`
+
+<span class="label label-default">v0.7.7</span>
+
+Abdictate the current leadership and start a new leadership election.
+
+**Request:**
+
+{% highlight http %}
+DELETE /v2/leader HTTP/1.1
+Accept: application/json
+Accept-Encoding: gzip, deflate, compress
+Host: localhost:8080
+User-Agent: HTTPie/0.7.2
+{% endhighlight %}
+
+**Response:**
+
+{% highlight http %}
+HTTP/1.1 200 OK
+Content-Length: 872
+Content-Type: application/json
+Server: Jetty(8.y.z-SNAPSHOT)
+
+{
+    "message": "Leadership abdicted"
 }
 {% endhighlight %}
 

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -39,6 +39,7 @@ title: REST API
   * [GET /v2/queue](#get-/v2/queue): List content of the staging queue.
 * [Server Info](#server-info) <span class="label label-default">v0.7.0</span>
   * [GET /v2/info](#get-/v2/info): Get info about the Marathon Instance
+  * [GET /v2/leader](#get-/v2/leader): Get the current leader
   * [DELETE /v2/leader](#delete-/v2/leader): Start a new leadership election
 * [Miscellaneous](#miscellaneous)
   * [GET /ping](#get-/ping)
@@ -2203,6 +2204,33 @@ Server: Jetty(8.y.z-SNAPSHOT)
         "zk_state": "/marathon",
         "zk_timeout": 10
     }
+}
+{% endhighlight %}
+
+#### GET `/v2/leader`
+
+Return the current leader or a 404 error if no leader exists.
+
+**Request:**
+
+{% highlight http %}
+GET /v2/leader HTTP/1.1
+Accept: application/json
+Accept-Encoding: gzip, deflate, compress
+Host: localhost:8080
+User-Agent: HTTPie/0.7.2
+{% endhighlight %}
+
+**Response:**
+
+{% highlight http %}
+HTTP/1.1 200 OK
+Content-Length: 872
+Content-Type: application/json
+Server: Jetty(8.y.z-SNAPSHOT)
+
+{
+    "leader": "127.0.0.1:8080"
 }
 {% endhighlight %}
 

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -40,7 +40,7 @@ title: REST API
 * [Server Info](#server-info) <span class="label label-default">v0.7.0</span>
   * [GET /v2/info](#get-/v2/info): Get info about the Marathon Instance
   * [GET /v2/leader](#get-/v2/leader): Get the current leader
-  * [DELETE /v2/leader](#delete-/v2/leader): Start a new leadership election
+  * [DELETE /v2/leader](#delete-/v2/leader): Causes the current leader to abdicate, triggering a new election
 * [Miscellaneous](#miscellaneous)
   * [GET /ping](#get-/ping)
   * [GET /logging](#get-/logging)
@@ -2209,7 +2209,8 @@ Server: Jetty(8.y.z-SNAPSHOT)
 
 #### GET `/v2/leader`
 
-Return the current leader or a 404 error if no leader exists.
+Returns the current leader.
+If no leader exists, Marathon will respond with a 404 error.
 
 **Request:**
 
@@ -2238,7 +2239,8 @@ Server: Jetty(8.y.z-SNAPSHOT)
 
 <span class="label label-default">v0.7.7</span>
 
-Abdictate the current leadership and start a new leadership election.
+Causes the current leader to abdicate, triggering a new election.
+If no leader exists, Marathon will respond with a 404 error.
 
 **Request:**
 

--- a/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
@@ -26,6 +26,7 @@ class MarathonRestModule extends RestModule {
     bind(classOf[v2.QueueResource]).in(Scopes.SINGLETON)
     bind(classOf[v2.GroupsResource]).in(Scopes.SINGLETON)
     bind(classOf[v2.InfoResource]).in(Scopes.SINGLETON)
+    bind(classOf[v2.LeaderResource]).in(Scopes.SINGLETON)
     bind(classOf[v2.DeploymentsResource]).in(Scopes.SINGLETON)
     bind(classOf[v2.ArtifactsResource]).in(Scopes.SINGLETON)
 

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -18,7 +18,7 @@ class LeaderResource @Inject() (
   @Produces(Array(MediaType.APPLICATION_JSON))
   def index(): Response = {
     schedulerService.getLeader match {
-      case None => notFound(s"There is no leader")
+      case None => notFound("There is no leader")
       case Some(leader) => 
         ok(Map("leader" -> leader))
     }
@@ -28,7 +28,7 @@ class LeaderResource @Inject() (
   @Produces(Array(MediaType.APPLICATION_JSON))
   def delete(): Response = {
     schedulerService.isLeader match {
-      case false => notFound(s"Marathon instance '${config.hostname}' is not a leader")
+      case false => notFound("There is no leader")
       case true => 
         schedulerService.abdicateLeadership()
         ok(Map("message" -> "Leadership abdicted"))

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -1,0 +1,27 @@
+package mesosphere.marathon.api.v2
+
+import javax.ws.rs.core.{ MediaType, Response }
+import javax.ws.rs.{ GET, DELETE, Path, Produces }
+
+import com.google.inject.Inject
+import mesosphere.chaos.http.HttpConf
+import mesosphere.marathon.api.RestResource
+import mesosphere.marathon.{ MarathonSchedulerService, MarathonConf }
+
+@Path("v2/leader")
+class LeaderResource @Inject() (
+    schedulerService: MarathonSchedulerService,
+    val config: MarathonConf with HttpConf)
+    extends RestResource {
+
+  @DELETE
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  def delete(): Response = {
+    schedulerService.isLeader match {
+      case false => notFound(s"Marathon instance '${config.hostname}' is not a leader")
+      case true => 
+        schedulerService.abdicateLeadership()
+        ok(Map("message" -> "Leadership abdicted"))
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -14,6 +14,16 @@ class LeaderResource @Inject() (
     val config: MarathonConf with HttpConf)
     extends RestResource {
 
+  @GET
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  def index(): Response = {
+    schedulerService.getLeader match {
+      case None => notFound(s"There is no leader")
+      case Some(leader) => 
+        ok(Map("leader" -> leader))
+    }
+  }
+
   @DELETE
   @Produces(Array(MediaType.APPLICATION_JSON))
   def delete(): Response = {


### PR DESCRIPTION
During testing of failover scenarios one has to force a leadership change.
This API endpoint allows to force the current leader to abdictate its
leadership and start a new leadership election.