### PR TITLE
Fix minimumHealthCapacity in TaskReplaceActor and add test case

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -32,9 +32,11 @@ class TaskReplaceActor(
     eventBus.subscribe(self, classOf[HealthStatusChanged])
 
     val minHealthy = (toKill.size.toDouble * app.upgradeStrategy.minimumHealthCapacity).ceil.toInt
-    val nrToKill = math.min(0, toKill.size - minHealthy)
+    val nrToKillImmediately = math.max(0, toKill.size - minHealthy)
+    log.info(s"For minimumHealthCapacity ${app.upgradeStrategy.minimumHealthCapacity} leave " +
+      s"${minHealthy} tasks running, killing ${nrToKillImmediately} tasks immediately")
 
-    for (_ <- 0 until nrToKill) {
+    for (_ <- 0 until nrToKillImmediately) {
       val taskId = Protos.TaskID.newBuilder
         .setValue(toKill.dequeue())
         .build()


### PR DESCRIPTION
Due to a logic error the TaskReplaceActor always behaved like
minimumHealthCapacity=1. This patch fixes the bug and extends the
existing test cases to cover the immediate killing of tasks above
minimumHealthCapacity.

Fixes #973.