### PR TITLE
Implement upgradeStrategy.maximumOverCapacity in the TaskReplaceActor

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -147,7 +147,8 @@ The full JSON format of an application resource is as follows:
     ],
     "dependencies": ["/product/db/mongo", "/product/db", "../../db"],
     "upgradeStrategy": {
-        "minimumHealthCapacity": 0.5
+        "minimumHealthCapacity": 0.5,
+        "maximumOverCapacity": 0.2
     },
     "version": "2014-03-01T23:29:30.158Z"
 }
@@ -258,13 +259,49 @@ values. Each port value is exposed to the instance via environment variables
 via the task resource.
 
 ##### upgradeStrategy
+
 During an upgrade all instances of an application get replaced by a new version.
-The `minimumHealthCapacity` defines the minimum number of healthy nodes, that do not sacrifice overall application purpose.
-It is a number between `0` and `1` which is multiplied with the instance count.
-The default `minimumHealthCapacity` is `1`, which means no old instance can be stopped, before all new instances are deployed.
-A value of `0.5` means that an upgrade can be deployed side by side, by taking half of the instances down in the first step,
-deploy half of the new version and then take the other half down and deploy the rest.
-A value of `0` means take all instances down immediately and replace with the new application.
+The upgradeStrategy controls how Marathon stops old versions and launches
+new versions. It consists of two values:
+
+* `minimumHealthCapacity` (Optional. Default: 1.0) - a number between `0`and `1`
+that is multiplied with the instance count. This is the minimum number of healthy
+nodes that do not sacrifice overall application purpose. Marathon will make sure,
+during the upgrade process, that at any point of time this number of healthy
+instances are up.
+* `maximumOverCapacity` (Optional. Default: 1.0) - a number between `0` and
+`1` which is multiplied with the instance count. This is the maximum number of
+additional instances launched at any point of time during the upgrade process.
+
+The default `minimumHealthCapacity` is `1`, which means no old instance can be
+stopped before another healthy new version is deployed.
+A value of `0.5` means that during an upgrade half of the old version instances
+are stopped first to make space for the new version.
+A value of `0` means take all instances down immediately and replace with the
+new application.
+
+The default `maximumOverCapacity` is `1`, which means that all old and new
+instances can co-exist during the upgrade process.
+A value of `0.1` means that during the upgrade process 10% more capacity than
+usual may be used for old and new instances.
+A value of `0.0` means that even during the upgrade process no more capacity may
+be used for the new instances than usual. Only when an old version is stopped,
+a new instance can be deployed.
+
+If `minimumHealthCapacity` is `1` and `maximumOverCapacity` is `0`, at least
+one additional new instance is launched in the beginning of the upgrade process.
+When it is healthy, one of the old instances is stopped. After it is stopped,
+another new instance is started, and so on.
+
+A combination of `minimumHealthCapacity` equal to `0.9` and
+`maximumOverCapacity` equal to `0` results in a rolling update, replacing
+10% of the instances at a time, keeping at least 90% of the app online at any
+point of time during the upgrade.
+
+A combination of `minimumHealthCapacity` equal to `1.0` and
+`maximumOverCapacity` equal to `0.1` results in a rolling update, replacing
+10% of the instances at a time and keeping at least 100% of the app online at
+any point of time during the upgrade with 10% of additional capacity.
 
 ##### Example
 
@@ -313,7 +350,8 @@ User-Agent: HTTPie/0.8.0
         0
     ],
     "upgradeStrategy": {
-        "minimumHealthCapacity": 0.5
+        "minimumHealthCapacity": 0.5,
+        "minimumOverCapacity": 0.5
     }
 }
 {% endhighlight json %}
@@ -372,7 +410,8 @@ Transfer-Encoding: chunked
     "requirePorts": false,
     "storeUrls": [],
     "upgradeStrategy": {
-        "minimumHealthCapacity": 0.5
+        "minimumHealthCapacity": 0.5,
+        "minimumOverCapacity": 0.5
     },
     "uris": [],
     "user": null,
@@ -2120,7 +2159,8 @@ Transfer-Encoding: chunked
                 "requirePorts": false,
                 "storeUrls": [],
                 "upgradeStrategy": {
-                    "minimumHealthCapacity": 1.0
+                    "minimumHealthCapacity": 1.0,
+                    "maximumOverCapacity": 1.0
                 },
                 "uris": [
                     "http://downloads.mesosphere.com/misc/toggle.tgz"

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -9876,7 +9876,7 @@ public final class Protos {
        *
        * <pre>
        * Allowing arbitrary parameters to be passed to docker CLI.
-       * Note that anything passed to this field is not guranteed
+       * Note that anything passed to this field is not guaranteed
        * to be supported moving forward, as we might move away from
        * the docker CLI.
        * </pre>
@@ -9888,7 +9888,7 @@ public final class Protos {
        *
        * <pre>
        * Allowing arbitrary parameters to be passed to docker CLI.
-       * Note that anything passed to this field is not guranteed
+       * Note that anything passed to this field is not guaranteed
        * to be supported moving forward, as we might move away from
        * the docker CLI.
        * </pre>
@@ -9899,7 +9899,7 @@ public final class Protos {
        *
        * <pre>
        * Allowing arbitrary parameters to be passed to docker CLI.
-       * Note that anything passed to this field is not guranteed
+       * Note that anything passed to this field is not guaranteed
        * to be supported moving forward, as we might move away from
        * the docker CLI.
        * </pre>
@@ -9910,7 +9910,7 @@ public final class Protos {
        *
        * <pre>
        * Allowing arbitrary parameters to be passed to docker CLI.
-       * Note that anything passed to this field is not guranteed
+       * Note that anything passed to this field is not guaranteed
        * to be supported moving forward, as we might move away from
        * the docker CLI.
        * </pre>
@@ -9922,7 +9922,7 @@ public final class Protos {
        *
        * <pre>
        * Allowing arbitrary parameters to be passed to docker CLI.
-       * Note that anything passed to this field is not guranteed
+       * Note that anything passed to this field is not guaranteed
        * to be supported moving forward, as we might move away from
        * the docker CLI.
        * </pre>
@@ -10913,7 +10913,7 @@ public final class Protos {
        *
        * <pre>
        * Allowing arbitrary parameters to be passed to docker CLI.
-       * Note that anything passed to this field is not guranteed
+       * Note that anything passed to this field is not guaranteed
        * to be supported moving forward, as we might move away from
        * the docker CLI.
        * </pre>
@@ -10926,7 +10926,7 @@ public final class Protos {
        *
        * <pre>
        * Allowing arbitrary parameters to be passed to docker CLI.
-       * Note that anything passed to this field is not guranteed
+       * Note that anything passed to this field is not guaranteed
        * to be supported moving forward, as we might move away from
        * the docker CLI.
        * </pre>
@@ -10940,7 +10940,7 @@ public final class Protos {
        *
        * <pre>
        * Allowing arbitrary parameters to be passed to docker CLI.
-       * Note that anything passed to this field is not guranteed
+       * Note that anything passed to this field is not guaranteed
        * to be supported moving forward, as we might move away from
        * the docker CLI.
        * </pre>
@@ -10953,7 +10953,7 @@ public final class Protos {
        *
        * <pre>
        * Allowing arbitrary parameters to be passed to docker CLI.
-       * Note that anything passed to this field is not guranteed
+       * Note that anything passed to this field is not guaranteed
        * to be supported moving forward, as we might move away from
        * the docker CLI.
        * </pre>
@@ -10966,7 +10966,7 @@ public final class Protos {
        *
        * <pre>
        * Allowing arbitrary parameters to be passed to docker CLI.
-       * Note that anything passed to this field is not guranteed
+       * Note that anything passed to this field is not guaranteed
        * to be supported moving forward, as we might move away from
        * the docker CLI.
        * </pre>
@@ -11772,7 +11772,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11789,7 +11789,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11806,7 +11806,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11823,7 +11823,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11847,7 +11847,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11868,7 +11868,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11891,7 +11891,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11915,7 +11915,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11936,7 +11936,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11957,7 +11957,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11978,7 +11978,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -11998,7 +11998,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -12018,7 +12018,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -12032,7 +12032,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -12049,7 +12049,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -12067,7 +12067,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -12081,7 +12081,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -12096,7 +12096,7 @@ public final class Protos {
          *
          * <pre>
          * Allowing arbitrary parameters to be passed to docker CLI.
-         * Note that anything passed to this field is not guranteed
+         * Note that anything passed to this field is not guaranteed
          * to be supported moving forward, as we might move away from
          * the docker CLI.
          * </pre>
@@ -14041,6 +14041,16 @@ public final class Protos {
      * <code>required double minimumHealthCapacity = 1;</code>
      */
     double getMinimumHealthCapacity();
+
+    // required double maximumOverCapacity = 2 [default = 1];
+    /**
+     * <code>required double maximumOverCapacity = 2 [default = 1];</code>
+     */
+    boolean hasMaximumOverCapacity();
+    /**
+     * <code>required double maximumOverCapacity = 2 [default = 1];</code>
+     */
+    double getMaximumOverCapacity();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.UpgradeStrategyDefinition}
@@ -14096,6 +14106,11 @@ public final class Protos {
             case 9: {
               bitField0_ |= 0x00000001;
               minimumHealthCapacity_ = input.readDouble();
+              break;
+            }
+            case 17: {
+              bitField0_ |= 0x00000002;
+              maximumOverCapacity_ = input.readDouble();
               break;
             }
           }
@@ -14154,8 +14169,25 @@ public final class Protos {
       return minimumHealthCapacity_;
     }
 
+    // required double maximumOverCapacity = 2 [default = 1];
+    public static final int MAXIMUMOVERCAPACITY_FIELD_NUMBER = 2;
+    private double maximumOverCapacity_;
+    /**
+     * <code>required double maximumOverCapacity = 2 [default = 1];</code>
+     */
+    public boolean hasMaximumOverCapacity() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>required double maximumOverCapacity = 2 [default = 1];</code>
+     */
+    public double getMaximumOverCapacity() {
+      return maximumOverCapacity_;
+    }
+
     private void initFields() {
       minimumHealthCapacity_ = 0D;
+      maximumOverCapacity_ = 1D;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -14163,6 +14195,10 @@ public final class Protos {
       if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasMinimumHealthCapacity()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasMaximumOverCapacity()) {
         memoizedIsInitialized = 0;
         return false;
       }
@@ -14176,6 +14212,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeDouble(1, minimumHealthCapacity_);
       }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeDouble(2, maximumOverCapacity_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -14188,6 +14227,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
           .computeDoubleSize(1, minimumHealthCapacity_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeDoubleSize(2, maximumOverCapacity_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -14307,6 +14350,8 @@ public final class Protos {
         super.clear();
         minimumHealthCapacity_ = 0D;
         bitField0_ = (bitField0_ & ~0x00000001);
+        maximumOverCapacity_ = 1D;
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -14339,6 +14384,10 @@ public final class Protos {
           to_bitField0_ |= 0x00000001;
         }
         result.minimumHealthCapacity_ = minimumHealthCapacity_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.maximumOverCapacity_ = maximumOverCapacity_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -14358,12 +14407,19 @@ public final class Protos {
         if (other.hasMinimumHealthCapacity()) {
           setMinimumHealthCapacity(other.getMinimumHealthCapacity());
         }
+        if (other.hasMaximumOverCapacity()) {
+          setMaximumOverCapacity(other.getMaximumOverCapacity());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
 
       public final boolean isInitialized() {
         if (!hasMinimumHealthCapacity()) {
+          
+          return false;
+        }
+        if (!hasMaximumOverCapacity()) {
           
           return false;
         }
@@ -14418,6 +14474,39 @@ public final class Protos {
       public Builder clearMinimumHealthCapacity() {
         bitField0_ = (bitField0_ & ~0x00000001);
         minimumHealthCapacity_ = 0D;
+        onChanged();
+        return this;
+      }
+
+      // required double maximumOverCapacity = 2 [default = 1];
+      private double maximumOverCapacity_ = 1D;
+      /**
+       * <code>required double maximumOverCapacity = 2 [default = 1];</code>
+       */
+      public boolean hasMaximumOverCapacity() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required double maximumOverCapacity = 2 [default = 1];</code>
+       */
+      public double getMaximumOverCapacity() {
+        return maximumOverCapacity_;
+      }
+      /**
+       * <code>required double maximumOverCapacity = 2 [default = 1];</code>
+       */
+      public Builder setMaximumOverCapacity(double value) {
+        bitField0_ |= 0x00000002;
+        maximumOverCapacity_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required double maximumOverCapacity = 2 [default = 1];</code>
+       */
+      public Builder clearMaximumOverCapacity() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        maximumOverCapacity_ = 1D;
         onChanged();
         return this;
       }
@@ -18633,22 +18722,23 @@ public final class Protos {
       "\001(\t\022\027\n\014service_port\030d \001(\r:\0010\")\n\020EventSub" +
       "scribers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016Stora" +
       "geVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022" +
-      "\r\n\005patch\030\003 \002(\r\":\n\031UpgradeStrategyDefinit" +
-      "ion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\"\260\001\n\017G" +
-      "roupDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 " +
-      "\002(\t\0224\n\004apps\030\003 \003(\0132&.mesosphere.marathon.",
-      "ServiceDefinition\0224\n\006groups\030\004 \003(\0132$.meso" +
-      "sphere.marathon.GroupDefinition\022\024\n\014depen" +
-      "dencies\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefiniti" +
-      "on\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010origi" +
-      "nal\030\004 \002(\0132$.mesosphere.marathon.GroupDef" +
-      "inition\0224\n\006target\030\005 \002(\0132$.mesosphere.mar" +
-      "athon.GroupDefinition\"\245\001\n\013TaskFailure\022\016\n" +
-      "\006app_id\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.T" +
-      "askID\022\037\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021" +
-      "\n\007message\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007ver",
-      "sion\030\006 \002(\t\022\021\n\ttimestamp\030\007 \002(\tB\035\n\023mesosph" +
-      "ere.marathonB\006Protos"
+      "\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefinit" +
+      "ion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023ma" +
+      "ximumOverCapacity\030\002 \002(\001:\0011\"\260\001\n\017GroupDefi" +
+      "nition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004a",
+      "pps\030\003 \003(\0132&.mesosphere.marathon.ServiceD" +
+      "efinition\0224\n\006groups\030\004 \003(\0132$.mesosphere.m" +
+      "arathon.GroupDefinition\022\024\n\014dependencies\030" +
+      "\005 \003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002id" +
+      "\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002(" +
+      "\0132$.mesosphere.marathon.GroupDefinition\022" +
+      "4\n\006target\030\005 \002(\0132$.mesosphere.marathon.Gr" +
+      "oupDefinition\"\245\001\n\013TaskFailure\022\016\n\006app_id\030" +
+      "\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037\n" +
+      "\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007messag",
+      "e\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 \002" +
+      "(\t\022\021\n\ttimestamp\030\007 \002(\tB\035\n\023mesosphere.mara" +
+      "thonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -18726,7 +18816,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor,
-              new java.lang.String[] { "MinimumHealthCapacity", });
+              new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", });
           internal_static_mesosphere_marathon_GroupDefinition_descriptor =
             getDescriptor().getMessageTypes().get(10);
           internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -133,6 +133,7 @@ message StorageVersion {
 
 message UpgradeStrategyDefinition {
   required double minimumHealthCapacity = 1;
+  required double maximumOverCapacity = 2 [default = 1.0];;
 }
 
 message GroupDefinition {

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -295,8 +295,15 @@ trait AppDefinitionFormats {
 
   implicit lazy val IdentifiableWrites = Json.writes[Identifiable]
 
-  implicit lazy val UpgradeStrategyFormat: Format[UpgradeStrategy] = Json.format[UpgradeStrategy]
-
+  implicit lazy val UpgradeStrategyWrites = Json.writes[UpgradeStrategy]
+  implicit lazy val UpgradeStrategyReads: Reads[UpgradeStrategy] = {
+    import mesosphere.marathon.state.AppDefinition._
+    (
+      (__ \ "minimumHealthCapacity").readNullable[JDouble].withDefault(DefaultUpgradeStrategy.minimumHealthCapacity) ~
+      (__ \ "maximumOverCapacity").readNullable[JDouble].withDefault(DefaultUpgradeStrategy.maximumOverCapacity)
+    )(UpgradeStrategy(_, _))
+  }
+  
   implicit lazy val ConstraintFormat: Format[Constraint] = Format(
     Reads.of[Seq[String]].map { seq =>
       val builder = Constraint

--- a/src/main/scala/mesosphere/marathon/state/UpgradeStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/state/UpgradeStrategy.scala
@@ -2,14 +2,18 @@ package mesosphere.marathon.state
 
 import mesosphere.marathon.Protos._
 
-case class UpgradeStrategy(minimumHealthCapacity: Double) {
+case class UpgradeStrategy(minimumHealthCapacity: Double, maximumOverCapacity: Double = 1.0) {
   def toProto: UpgradeStrategyDefinition = UpgradeStrategyDefinition.newBuilder
     .setMinimumHealthCapacity(minimumHealthCapacity)
+    .setMaximumOverCapacity(maximumOverCapacity)
     .build
 }
 
 object UpgradeStrategy {
   def empty: UpgradeStrategy = UpgradeStrategy(1)
   def fromProto(upgradeStrategy: UpgradeStrategyDefinition): UpgradeStrategy =
-    UpgradeStrategy(upgradeStrategy.getMinimumHealthCapacity)
+    UpgradeStrategy(
+      upgradeStrategy.getMinimumHealthCapacity,
+      upgradeStrategy.getMaximumOverCapacity
+    )
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -24,8 +24,10 @@ class TaskReplaceActor(
   val appId = app.id
   val version = app.version.toString
   var healthy = Set.empty[String]
-  var taskIds = tasksToKill.map(_.getId)
-  val toKill = taskIds.to[mutable.Queue]
+  var newTasksStarted: Int = 0
+  var oldTaskIds = tasksToKill.map(_.getId)
+  val toKill = oldTaskIds.to[mutable.Queue]
+  var maxCapacity = (app.instances * (1 + app.upgradeStrategy.maximumOverCapacity)).toInt
 
   override def preStart(): Unit = {
     eventBus.subscribe(self, classOf[MesosStatusUpdateEvent])
@@ -33,8 +35,13 @@ class TaskReplaceActor(
 
     val minHealthy = (toKill.size.toDouble * app.upgradeStrategy.minimumHealthCapacity).ceil.toInt
     val nrToKillImmediately = math.max(0, toKill.size - minHealthy)
+
+    // make sure at least one task can be started to get the ball rolling
+    if (nrToKillImmediately == 0 && maxCapacity == app.instances)
+      maxCapacity += 1
+
     log.info(s"For minimumHealthCapacity ${app.upgradeStrategy.minimumHealthCapacity} leave " +
-      s"${minHealthy} tasks running, killing ${nrToKillImmediately} tasks immediately")
+      s"${minHealthy} tasks running, maximum capacity ${maxCapacity}, killing ${nrToKillImmediately} tasks immediately")
 
     for (_ <- 0 until nrToKillImmediately) {
       val taskId = Protos.TaskID.newBuilder
@@ -44,7 +51,7 @@ class TaskReplaceActor(
       driver.killTask(taskId)
     }
 
-    taskQueue.add(app, app.instances)
+    conciliateNewTasks()
   }
 
   override def postStop(): Unit = {
@@ -76,13 +83,27 @@ class TaskReplaceActor(
   }
 
   def commonBehavior: PartialFunction[Any, Unit] = {
-    case MesosStatusUpdateEvent(slaveId, taskId, ErrorState(_), _, `appId`, _, _, `version`, _, _) if !taskIds(taskId) => // scalastyle:ignore line.size.limit
+    case MesosStatusUpdateEvent(slaveId, taskId, ErrorState(_), _, `appId`, _, _, `version`, _, _) if !oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
       val msg = s"Task $taskId failed on slave $slaveId"
       log.error(msg)
       healthy -= taskId
       taskQueue.add(app)
 
+    case MesosStatusUpdateEvent(slaveId, taskId, ErrorState(_), _, `appId`, _, _, _, _, _) if oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
+      oldTaskIds -= taskId
+      conciliateNewTasks()
+
     case x => log.debug(s"Received $x")
+  }
+
+  def conciliateNewTasks(): Unit = {
+    val leftCapacity = math.max(0, maxCapacity - oldTaskIds.size - newTasksStarted)
+    val tasksNotStartedYet = math.max(0, app.instances - newTasksStarted)
+    val tasksToStartNow = math.min(tasksNotStartedYet, leftCapacity)
+    if (tasksToStartNow > 0) {
+      taskQueue.add(app, tasksToStartNow)
+      newTasksStarted += tasksToStartNow
+    }
   }
 
   def handleNewHealthyTask(taskId: String): Unit = {

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -442,7 +442,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers with ModelValidation 
         "dependencies": ["/product/db/mongo", "/product/db", "../../db"],
         "upgradeStrategy": {
             "minimumHealthCapacity": 0.5,
-            "maximumUpgradeCapacity": 1.5
+            "maximumOverCapacity": 0.5
         },
         "version": "2014-03-01T23:29:30.158Z"
     }"""

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -441,7 +441,8 @@ class AppDefinitionTest extends MarathonSpec with Matchers with ModelValidation 
         ],
         "dependencies": ["/product/db/mongo", "/product/db", "../../db"],
         "upgradeStrategy": {
-            "minimumHealthCapacity": 0.5
+            "minimumHealthCapacity": 0.5,
+            "maximumUpgradeCapacity": 1.5
         },
         "version": "2014-03-01T23:29:30.158Z"
     }"""

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -172,6 +172,211 @@ class TaskReplaceActorTest
     expectTerminated(ref)
   }
 
+  test("Replace with rolling upgrade without over-capacity") {
+    val app = AppDefinition(
+      id = "myApp".toPath,
+      instances = 3,
+      healthChecks = Set(HealthCheck()),
+      upgradeStrategy = UpgradeStrategy(0.5, 0.0)
+    )
+
+    val driver = mock[SchedulerDriver]
+    val taskA = MarathonTask.newBuilder().setId("taskA_id").build()
+    val taskB = MarathonTask.newBuilder().setId("taskB_id").build()
+    val taskC = MarathonTask.newBuilder().setId("taskC_id").build()
+    val queue = mock[TaskQueue]
+    val tracker = mock[TaskTracker]
+
+    var oldTaskCount = 3
+
+    when(tracker.get(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
+      override def answer(invocation: InvocationOnMock): Status = {
+        oldTaskCount -= 1
+        Status.DRIVER_RUNNING
+      }
+    })
+
+    val promise = Promise[Unit]()
+
+    val ref = TestActorRef(
+      new TaskReplaceActor(
+        driver,
+        queue,
+        tracker,
+        system.eventStream,
+        app,
+        promise))
+
+    watch(ref)
+
+    // only one task is queued directly
+    val queueOrder = org.mockito.Mockito.inOrder(queue);
+    eventually { queueOrder.verify(queue).add(_: AppDefinition, 1) }
+
+    // ceiling(minimumHealthCapacity * 3) = 2 are left running
+    assert(oldTaskCount == 2)
+
+    // first new task becomes healthy and another old task is killed
+    ref ! HealthStatusChanged(app.id, s"task_0", app.version.toString, alive = true)
+    eventually { oldTaskCount should be(1) }
+    eventually { queueOrder.verify(queue).add(_: AppDefinition, 1) }
+
+    // second new task becomes healthy and the last old task is killed
+    ref ! HealthStatusChanged(app.id, s"task_1", app.version.toString, alive = true)
+    eventually { oldTaskCount should be(0) }
+    eventually { queueOrder.verify(queue).add(_: AppDefinition, 1) }
+
+    // third new task becomes healthy
+    ref ! HealthStatusChanged(app.id, s"task_2", app.version.toString, alive = true)
+    oldTaskCount should be(0)
+
+    Await.result(promise.future, 5.seconds)
+
+    // all old tasks are killed
+    verify(driver).killTask(TaskID.newBuilder().setValue(taskA.getId).build())
+    verify(driver).killTask(TaskID.newBuilder().setValue(taskB.getId).build())
+    verify(driver).killTask(TaskID.newBuilder().setValue(taskC.getId).build())
+
+    expectTerminated(ref)
+  }
+
+  test("Replace with rolling upgrade with minimal over-capacity") {
+    val app = AppDefinition(
+      id = "myApp".toPath,
+      instances = 3,
+      healthChecks = Set(HealthCheck()),
+      upgradeStrategy = UpgradeStrategy(1.0, 0.0) // 1 task over-capacity is ok
+    )
+
+    val driver = mock[SchedulerDriver]
+    val taskA = MarathonTask.newBuilder().setId("taskA_id").build()
+    val taskB = MarathonTask.newBuilder().setId("taskB_id").build()
+    val taskC = MarathonTask.newBuilder().setId("taskC_id").build()
+    val queue = mock[TaskQueue]
+    val tracker = mock[TaskTracker]
+
+    var oldTaskCount = 3
+
+    when(tracker.get(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
+      override def answer(invocation: InvocationOnMock): Status = {
+        oldTaskCount -= 1
+        Status.DRIVER_RUNNING
+      }
+    })
+
+    val promise = Promise[Unit]()
+
+    val ref = TestActorRef(
+      new TaskReplaceActor(
+        driver,
+        queue,
+        tracker,
+        system.eventStream,
+        app,
+        promise))
+
+    watch(ref)
+
+    // only one task is queued directly, all old still running
+    val queueOrder = org.mockito.Mockito.inOrder(queue);
+    eventually { queueOrder.verify(queue).add(_: AppDefinition, 1) }
+    assert(oldTaskCount == 3)
+
+    // first new task becomes healthy and another old task is killed
+    ref ! HealthStatusChanged(app.id, s"task_0", app.version.toString, alive = true)
+    eventually { oldTaskCount should be(2) }
+    eventually { queueOrder.verify(queue).add(_: AppDefinition, 1) }
+
+    // second new task becomes healthy and another old task is killed
+    ref ! HealthStatusChanged(app.id, s"task_1", app.version.toString, alive = true)
+    eventually { oldTaskCount should be(1) }
+    eventually { queueOrder.verify(queue).add(_: AppDefinition, 1) }
+
+    // third new task becomes healthy and last old task is killed
+    ref ! HealthStatusChanged(app.id, s"task_2", app.version.toString, alive = true)
+    eventually { oldTaskCount should be(0) }
+    queueOrder.verify(queue, never()).add(_: AppDefinition, 1)
+
+    Await.result(promise.future, 5.seconds)
+
+    // all old tasks are killed
+    verify(driver).killTask(TaskID.newBuilder().setValue(taskA.getId).build())
+    verify(driver).killTask(TaskID.newBuilder().setValue(taskB.getId).build())
+    verify(driver).killTask(TaskID.newBuilder().setValue(taskC.getId).build())
+
+    expectTerminated(ref)
+  }
+
+  test("Replace with rolling upgrade with 2/3 over-capacity") {
+    val app = AppDefinition(
+      id = "myApp".toPath,
+      instances = 3,
+      healthChecks = Set(HealthCheck()),
+      upgradeStrategy = UpgradeStrategy(1.0, 0.7)
+    )
+
+    val driver = mock[SchedulerDriver]
+    val taskA = MarathonTask.newBuilder().setId("taskA_id").build()
+    val taskB = MarathonTask.newBuilder().setId("taskB_id").build()
+    val taskC = MarathonTask.newBuilder().setId("taskC_id").build()
+    val queue = mock[TaskQueue]
+    val tracker = mock[TaskTracker]
+
+    var oldTaskCount = 3
+
+    when(tracker.get(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
+      override def answer(invocation: InvocationOnMock): Status = {
+        oldTaskCount -= 1
+        Status.DRIVER_RUNNING
+      }
+    })
+
+    val promise = Promise[Unit]()
+
+    val ref = TestActorRef(
+      new TaskReplaceActor(
+        driver,
+        queue,
+        tracker,
+        system.eventStream,
+        app,
+        promise))
+
+    watch(ref)
+
+    // two tasks are queued directly, all old still running
+    val queueOrder = org.mockito.Mockito.inOrder(queue);
+    eventually { queueOrder.verify(queue).add(_: AppDefinition, 2) }
+    assert(oldTaskCount == 3)
+
+    // first new task becomes healthy and another old task is killed
+    ref ! HealthStatusChanged(app.id, s"task_0", app.version.toString, alive = true)
+    eventually { oldTaskCount should be(2) }
+    eventually { queueOrder.verify(queue).add(_: AppDefinition, 1) }
+
+    // second new task becomes healthy and another old task is killed
+    ref ! HealthStatusChanged(app.id, s"task_1", app.version.toString, alive = true)
+    eventually { oldTaskCount should be(1) }
+    queueOrder.verify(queue, never()).add(_: AppDefinition, 1)
+
+    // third new task becomes healthy and last old task is killed
+    ref ! HealthStatusChanged(app.id, s"task_2", app.version.toString, alive = true)
+    eventually { oldTaskCount should be(0) }
+    queueOrder.verify(queue, never()).add(_: AppDefinition, 1)
+
+    Await.result(promise.future, 5.seconds)
+
+    // all old tasks are killed
+    verify(driver).killTask(TaskID.newBuilder().setValue(taskA.getId).build())
+    verify(driver).killTask(TaskID.newBuilder().setValue(taskB.getId).build())
+    verify(driver).killTask(TaskID.newBuilder().setValue(taskC.getId).build())
+
+    expectTerminated(ref)
+  }
+
   test("Cancelled") {
     val app = AppDefinition(id = "myApp".toPath, instances = 2)
     val driver = mock[SchedulerDriver]


### PR DESCRIPTION
From the documentation:

> `maximumOverCapacity` (Optional. Default: 1.0) - a number between `0` and
> `1` which is multiplied with the instance count. This is the maximum number of
> additional instances launched at any point of time during the upgrade process.

> The default `maximumOverCapacity` is `1`, which means that all old and new
> instances can co-exist during the upgrade process.
> A value of `0.1` means that during the upgrade process 10% more capacity than
> usual may be used for old and new instances.
> A value of `0.0` means that even during the upgrade process no more capacity may
> be used for the new instances than usual. Only when an old version is stopped,
> a new instance can be deployed.

This allows to deploy rolling upgrades.

Fixes #689.