### PR TITLE
Updated AppUpdate to allow version to be posted.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/AppUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppUpdate.scala
@@ -67,10 +67,10 @@ case class AppUpdate(
 
     version: Option[Timestamp] = None) {
 
-  require(version.isEmpty || onlyVersionSet, "The 'version' field may not be combined with other fields.")
+  require(version.isEmpty || onlyVersionOrIdSet, "The 'version' field may only be combined with the 'id' field.")
 
-  private def onlyVersionSet: Boolean = productIterator forall {
-    case x @ Some(_) => x == version
+  protected[api] def onlyVersionOrIdSet: Boolean = productIterator forall {
+    case x @ Some(_) => x == version || x == id
     case _           => true
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppUpdateTest.scala
@@ -6,6 +6,7 @@ import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.state.Container._
 import mesosphere.marathon.state.{ Container, PathId, Timestamp, UpgradeStrategy }
+import mesosphere.marathon.state.PathId._
 import org.apache.mesos.{ Protos => mesos }
 
 import scala.collection.immutable.Seq
@@ -122,7 +123,11 @@ class AppUpdateTest extends MarathonSpec {
 
   }
 
-  test("'version' field has to be exclusive") {
+  test("'version' field can only be combined with 'id'") {
+    assert(AppUpdate(version = Some(Timestamp.now())).onlyVersionOrIdSet)
+
+    assert(AppUpdate(id = Some("foo".toPath), version = Some(Timestamp.now())).onlyVersionOrIdSet)
+
     intercept[Exception] {
       AppUpdate(cmd = Some("foo"), version = Some(Timestamp.now()))
     }


### PR DESCRIPTION
- Edited tests accordingly.
- Fixes #977.

After the patch:

```http
PUT /v2/apps/http HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Content-Length: 39
Content-Type: application/json; charset=utf-8
Host: mesos.vm:8080
User-Agent: HTTPie/0.8.0

{
    "version": "2015-01-11T04:55:23.968Z"
}
```

```http
HTTP/1.1 200 OK
Content-Type: application/json
Server: Jetty(8.y.z-SNAPSHOT)
Transfer-Encoding: chunked

{
    "deploymentId": "2940faf0-150f-45c5-b244-5412cdf1cb3b", 
    "version": "2015-01-11T04:55:23.968Z"
}
```