### PR TITLE
add /usr/lib and /usr/lib64 to java.library.path

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -76,7 +76,7 @@ function run_jar {
   local log_format='%2$s%5$s%6$s%n' # Class name, message, exception
   ulimit -n 8192
   export PATH=/usr/local/bin:"$PATH"
-  local vm_opts=( -Djava.library.path=/usr/local/lib
+  local vm_opts=( -Djava.library.path=/usr/local/lib:/usr/lib:/usr/lib64
                   -Djava.util.logging.SimpleFormatter.format="$log_format" )
   for j_opt in ${JAVA_OPTS:-"-Xmx512m"}; do
     vm_opts+=( ${j_opt} )


### PR DESCRIPTION
Fixes problems in rpm/deb packages with installations where libmesos is not in /usr/local/lib