### PR TITLE
Modify representation of docker params

### DIFF
--- a/docs/docs/native-docker.md
+++ b/docs/docs/native-docker.md
@@ -224,11 +224,11 @@ the future, as Mesos may not always interact with Docker via the CLI.
         "docker": {
             "image": "mesosphere/inky"
             "privileged": true,
-            "parameters": {
-                "hostname": "a.corp.org",
-                "volumes-from": "another-container",
-                "lxc-conf": "..."
-            }
+            "parameters": [
+                { "key": "hostname", "value": "a.corp.org" },
+                { "key": "volumes-from", "value": "another-container" },
+                { "key": "lxc-conf", "value": "..." }
+            ]
         },
         "type": "DOCKER",
         "volumes": []

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -79,10 +79,10 @@ The full JSON format of an application resource is as follows:
                 }
             ],
             "privileged": false,
-            "parameters": {
-                "a-docker-option": "xxx",
-                "b-docker-option": "yyy"
-            }
+            "parameters": [
+                { "key": "a-docker-option", "value": "xxx" },
+                { "key": "b-docker-option", "value": "yyy" }
+            ]
         },
         "volumes": [
             {

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -115,6 +115,11 @@ trait Formats
 
   implicit lazy val CommandFormat: Format[Command] = Json.format[Command]
 
+  implicit lazy val ParameterFormat: Format[Parameter] = (
+    (__ \ "key").format[String] ~
+    (__ \ "value").format[String]
+  )(Parameter(_, _), unlift(Parameter.unapply))
+
   /*
  * Helpers
  */
@@ -164,7 +169,7 @@ trait ContainerFormats {
     (__ \ "network").formatNullable[Network] ~
     (__ \ "portMappings").formatNullable[Seq[Docker.PortMapping]] ~
     (__ \ "privileged").formatNullable[Boolean].withDefault(false) ~
-    (__ \ "parameters").formatNullable[Map[String, String]].withDefault(Map.empty)
+    (__ \ "parameters").formatNullable[Seq[Parameter]].withDefault(Seq.empty)
   )(Docker(_, _, _, _, _), unlift(Docker.unapply))
 
   implicit val ModeFormat: Format[mesos.Volume.Mode] =

--- a/src/main/scala/mesosphere/marathon/state/Container.scala
+++ b/src/main/scala/mesosphere/marathon/state/Container.scala
@@ -94,7 +94,7 @@ object Container {
       network: Option[mesos.ContainerInfo.DockerInfo.Network] = None,
       portMappings: Option[Seq[Docker.PortMapping]] = None,
       privileged: Boolean = false,
-      parameters: Map[String, String] = Map[String, String]()) {
+      parameters: Seq[Parameter] = Nil) {
 
     def toProto(): Protos.ExtendedContainerInfo.DockerInfo = {
       val builder = Protos.ExtendedContainerInfo.DockerInfo.newBuilder
@@ -109,7 +109,7 @@ object Container {
 
       builder.setPrivileged(privileged)
 
-      builder.addAllParameters(Docker.mapToParameters(parameters).asJava)
+      builder.addAllParameters(parameters.map(_.toProto).asJava)
 
       builder.build
     }
@@ -127,7 +127,7 @@ object Container {
 
       builder.setPrivileged(privileged)
 
-      builder.addAllParameters(Docker.mapToParameters(parameters).asJava)
+      builder.addAllParameters(parameters.map(_.toProto).asJava)
 
       builder.build
     }
@@ -150,22 +150,8 @@ object Container {
 
         privileged = proto.getPrivileged,
 
-        parameters = parametersToMap(proto.getParametersList.asScala.to[Seq])
+        parameters = proto.getParametersList.asScala.map(Parameter(_)).to[Seq]
       )
-
-    protected def mapToParameters(ps: Map[String, String]): Iterable[mesos.Parameter] =
-      ps.map {
-        case (key, value) =>
-          mesos.Parameter.newBuilder
-            .setKey(key)
-            .setValue(value)
-            .build
-      }
-
-    protected def parametersToMap(ps: Seq[mesos.Parameter]): Map[String, String] =
-      ps.map { parameter =>
-        parameter.getKey -> parameter.getValue
-      }.toMap
 
     /**
       * @param containerPort The container port to expose

--- a/src/main/scala/mesosphere/marathon/state/Parameter.scala
+++ b/src/main/scala/mesosphere/marathon/state/Parameter.scala
@@ -1,0 +1,23 @@
+package mesosphere.marathon.state
+
+import org.apache.mesos.{ Protos => mesos }
+
+case class Parameter(
+    key: String,
+    value: String) {
+
+  def toProto(): mesos.Parameter =
+    mesos.Parameter.newBuilder
+      .setKey(key)
+      .setValue(value)
+      .build
+}
+
+object Parameter {
+  def apply(proto: mesos.Parameter): Parameter =
+    Parameter(
+      proto.getKey,
+      proto.getValue
+    )
+}
+


### PR DESCRIPTION
Allow multiple values for the same option.
For example, users may need to pass `-e` (environment variable) many times.

- Fixes #970.