### PR TITLE
Bump minor version => 0.8.0-SNAPSHOT.

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.7-SNAPSHOT"
+version in ThisBuild := "0.8.0-SNAPSHOT"


### PR DESCRIPTION
#1003 introduced a backwards-incompatible API change, so the next release version should indicate this.  By rights according to [semver](http://semver.org) we should be incrementing the major version, but at least this jives with our versioning pattern to date.