### PR TITLE
WIP: Reconcile lost staged tasks

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.Semaphore
 import akka.actor._
 import akka.event.EventStream
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.apache.mesos.Protos.TaskInfo
+import org.apache.mesos.Protos.{ TaskState, TaskID, TaskStatus, TaskInfo }
 import org.apache.mesos.SchedulerDriver
 import org.slf4j.LoggerFactory
 
@@ -407,6 +407,11 @@ class SchedulerActions(
         val knownTaskStatuses = appIds.flatMap { appId =>
           taskTracker.get(appId).collect {
             case task if task.hasStatus => task.getStatus
+            case task => // staged tasks, which have no status yet
+              TaskStatus.newBuilder
+                .setState(TaskState.TASK_STAGING)
+                .setTaskId(TaskID.newBuilder.setValue(task.getId))
+                .build()
           }
         }
 


### PR DESCRIPTION
Staged tasks which are lost (e.g. due to lost TASK_KILLED or TASK_LOST status
updates during staging, e.g. in case of Marathon crashes or other leader
re-eleactions), were never reconciled because there are in the TaskTracker,
but without status.

This patch adds those to the reconciliation process such that Mesos can
answer with a TASK_LOST status update.

Fixes #1047