### PR TITLE
Allow groups with absolute paths to be POSTed.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/ModelValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/ModelValidation.scala
@@ -136,7 +136,7 @@ trait ModelValidation extends BeanValidation {
     child: PathId,
     path: String): Iterable[ConstraintViolation[T]] = {
     val isParent = child.canonicalPath(parent).parent == parent
-    if (!isParent)
+    if (parent != PathId.empty && !isParent)
       List(violation(t, child, path, s"identifier $child is not child of $parent. Hint: use relative paths."))
     else Nil
   }

--- a/src/test/scala/mesosphere/marathon/api/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/ModelValidationTest.scala
@@ -1,0 +1,23 @@
+package mesosphere.marathon.api
+
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.api.v2.GroupUpdate
+import mesosphere.marathon.state.PathId._
+
+import java.net.{ ServerSocket, InetAddress }
+import org.scalatest.{ BeforeAndAfterAll, Matchers }
+
+class ModelValidationTest
+    extends MarathonSpec
+    with Matchers
+    with BeforeAndAfterAll {
+
+  test("A group update should pass validation") {
+    val mv = new ModelValidation {}
+    val update = GroupUpdate(id = Some("/a/b/c".toPath))
+
+    val violations = mv.checkGroupUpdate(update, true)
+    violations should have size (0)
+  }
+
+}


### PR DESCRIPTION
- Adds first test for ModelValidation.
- Fixes #889.

After the change:

```http
POST /v2/groups HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Content-Length: 41
Content-Type: application/json; charset=utf-8
Host: localhost:8080
User-Agent: HTTPie/0.8.0

{
    "id": "/marathon/integration/test"
}
```

```http
HTTP/1.1 201 Created
Content-Type: application/json
Location: http://localhost:8080/v2/groups/marathon/integration/test
Server: Jetty(8.y.z-SNAPSHOT)
Transfer-Encoding: chunked

{
    "deploymentId": "491544b7-1fa5-46ca-b661-a541d4bfaf03", 
    "version": "2015-01-20T21:47:53.076Z"
}
```

Getting the groups collection is consistent:

```http
GET /v2/groups HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Host: localhost:8080
User-Agent: HTTPie/0.8.0
```

```http
HTTP/1.1 200 OK
Content-Type: application/json
Server: Jetty(8.y.z-SNAPSHOT)
Transfer-Encoding: chunked

{
    "apps": [], 
    "dependencies": [], 
    "groups": [
        {
            "apps": [], 
            "dependencies": [], 
            "groups": [], 
            "id": "/product", 
            "version": "2015-01-20T21:47:53.076Z"
        }, 
        {
            "apps": [], 
            "dependencies": [], 
            "groups": [
                {
                    "apps": [], 
                    "dependencies": [], 
                    "groups": [
                        {
                            "apps": [], 
                            "dependencies": [], 
                            "groups": [], 
                            "id": "/marathon/integration/test", 
                            "version": "2015-01-20T21:47:53.076Z"
                        }
                    ], 
                    "id": "/marathon/integration", 
                    "version": "2015-01-20T21:47:53.076Z"
                }
            ], 
            "id": "/marathon", 
            "version": "2015-01-20T21:47:53.076Z"
        }
    ], 
    "id": "/", 
    "version": "2015-01-20T21:47:53.076Z"
}
```