### PR TITLE
Relax the default health check parameters. Fixes #1050

### DIFF
--- a/docs/docs/health-checks.md
+++ b/docs/docs/health-checks.md
@@ -22,9 +22,9 @@ health checks consecutively, that task is killed.
   "path": "/api/health",
   "portIndex": 0,
   "protocol": "HTTP",
-  "gracePeriodSeconds": 30,
-  "intervalSeconds": 30,
-  "timeoutSeconds": 30,
+  "gracePeriodSeconds": 300,
+  "intervalSeconds": 60,
+  "timeoutSeconds": 20,
   "maxConsecutiveFailures": 3
 }
 ```
@@ -35,9 +35,9 @@ OR
 {
   "portIndex": 0,
   "protocol": "TCP",
-  "gracePeriodSeconds": 30,
-  "intervalSeconds": 30,
-  "timeoutSeconds": 30,
+  "gracePeriodSeconds": 300,
+  "intervalSeconds": 60,
+  "timeoutSeconds": 20,
   "maxConsecutiveFailures": 0
 }
 ```
@@ -48,19 +48,19 @@ OR
 {
   "protocol": "COMMAND",
   "command": { "value": "curl -f -X GET http://$HOST:$PORT0/health" },
-  "gracePeriodSeconds": 30,
-  "intervalSeconds": 30,
-  "timeoutSeconds": 30,
+  "gracePeriodSeconds": 300,
+  "intervalSeconds": 60,
+  "timeoutSeconds": 20,
   "maxConsecutiveFailures": 3
 }
 ```
 
 #### Health check options
 
-* `gracePeriodSeconds` (Optional. Default: 15): Health check failures are
+* `gracePeriodSeconds` (Optional. Default: 300): Health check failures are
   ignored within this number of seconds or until the task becomes healthy for
   the first time.
-* `intervalSeconds` (Optional. Default: 10): Number of seconds to wait between
+* `intervalSeconds` (Optional. Default: 60): Number of seconds to wait between
   health checks.
 * `maxConsecutiveFailures`(Optional. Default: 3) : Number of consecutive health
   check failures after which the unhealthy task should be killed. If this value

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -77,7 +77,7 @@ trait MarathonConf extends ScallopConf with ZookeeperConf {
 
   lazy val frameworkName = opt[String]("framework_name",
     descr = "Framework name to register with Mesos.",
-    default = Some(s"marathon-${BuildInfo.version}"))
+    default = Some("marathon"))
 
   lazy val artifactStore = opt[String]("artifact_store",
     descr = "URL to the artifact store. " +

--- a/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
@@ -111,8 +111,9 @@ object HealthCheck {
   val DefaultProtocol = Protocol.HTTP
   val DefaultPortIndex = 0
   val DefaultCommand = None
-  val DefaultGracePeriod = 15.seconds
-  val DefaultInterval = 10.seconds
+  // Dockers can take a long time to download, so default to a fairly long wait.
+  val DefaultGracePeriod = 5.minutes
+  val DefaultInterval = 1.minute
   val DefaultTimeout = 20.seconds
   val DefaultMaxConsecutiveFailures = 3
 }

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -124,8 +124,8 @@ class HealthCheckTest extends MarathonSpec {
           "protocol": "COMMAND",
           "portIndex": 0,
           "command": { "value": "echo healthy" },
-          "gracePeriodSeconds": 15,
-          "intervalSeconds": 10,
+          "gracePeriodSeconds": 300,
+          "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 3
         }
@@ -146,8 +146,8 @@ class HealthCheckTest extends MarathonSpec {
           "protocol": "COMMAND",
           "portIndex": 0,
           "command": { "value": "echo healthy" },
-          "gracePeriodSeconds": 15,
-          "intervalSeconds": 10,
+          "gracePeriodSeconds": 300,
+          "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 3
         }


### PR DESCRIPTION
- Fixes #1050
- Changes default framework name to "marathon" (no version number), to let DNS discovery systems generate nicer hostnames