### PR TITLE
Simplify and cleanup start actors

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
@@ -21,8 +21,6 @@ class AppStartActor(
 
   val nrToStart: Int = scaleTo
 
-  def withHealthChecks: Boolean = app.healthChecks.nonEmpty
-
   def initializeStart(): Unit = {
     scheduler.startApp(driver, app.copy(instances = scaleTo))
   }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -133,7 +133,6 @@ class DeploymentActor(
           eventBus,
           app,
           scaleTo,
-          app.healthChecks.nonEmpty,
           promise
         )
       )

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -17,7 +17,6 @@ trait StartingBehavior { this: Actor with ActorLogging =>
   def eventBus: EventStream
   def scaleTo: Int
   def nrToStart: Int
-  def withHealthChecks: Boolean
   def taskQueue: TaskQueue
   def driver: SchedulerDriver
   def scheduler: SchedulerActions
@@ -28,6 +27,7 @@ trait StartingBehavior { this: Actor with ActorLogging =>
   var atLeastOnceHealthyTasks = Set.empty[String]
   var startedRunningTasks = Set.empty[String]
   val AppId = app.id
+  val withHealthChecks: Boolean = app.healthChecks.nonEmpty
 
   def initializeStart(): Unit
 
@@ -62,29 +62,32 @@ trait StartingBehavior { this: Actor with ActorLogging =>
   final def checkForRunning: Receive = {
     case MesosStatusUpdateEvent(_, taskId, "TASK_RUNNING", _, app.`id`, _, _, Version, _, _) if !startedRunningTasks(taskId) => // scalastyle:off line.size.limit
       startedRunningTasks += taskId
-      log.info(s"Started $taskId")
+      log.info(s"New task $taskId now running during app ${app.id.toString} scaling, " +
+        s"${nrToStart - startedRunningTasks.size} more to go")
       checkFinished()
   }
 
   def commonBehavior: Receive = {
-    case MesosStatusUpdateEvent(_, taskId, "TASK_ERROR" | "TASK_FAILED" | "TASK_LOST" | "TASK_KILLED", _, app.`id`, _, _, Version, _, _) => // scalastyle:off line.size.limit
-      log.warning(s"Failed to start $taskId for app ${app.id}. Rescheduling.")
+    case MesosStatusUpdateEvent(_, taskId, StartErrorState(_), _, app.`id`, _, _, Version, _, _) => // scalastyle:off line.size.limit
+      log.warning(s"New task $taskId failed during app ${app.id.toString} scaling, queueing another task")
       startedRunningTasks -= taskId
       taskQueue.add(app)
 
     case Sync =>
       val actualSize = taskQueue.count(app.id) + taskTracker.count(app.id)
-      if (actualSize < scaleTo) {
-        taskQueue.add(app, scaleTo - actualSize)
+      val tasksToStartNow = Math.max(scaleTo - actualSize, 0)
+      if (tasksToStartNow > 0) {
+        log.info(s"Reconciling tasks during app ${app.id.toString} scaling: queuing ${tasksToStartNow} new tasks")
+        taskQueue.add(app, tasksToStartNow)
       }
       context.system.scheduler.scheduleOnce(5.seconds, self, Sync)
   }
 
   def checkFinished(): Unit = {
-    if (withHealthChecks && atLeastOnceHealthyTasks.size == nrToStart) {
-      success()
-    }
-    else if (startedRunningTasks.size == nrToStart) {
+    val started =
+      if (withHealthChecks) atLeastOnceHealthyTasks.size
+      else startedRunningTasks.size
+    if (started == nrToStart) {
       success()
     }
   }
@@ -94,4 +97,11 @@ trait StartingBehavior { this: Actor with ActorLogging =>
 
 object StartingBehavior {
   case object Sync
+}
+
+private object StartErrorState {
+  def unapply(state: String): Option[String] = state match {
+    case "TASK_ERROR" | "TASK_FAILED" | "TASK_KILLED" | "TASK_LOST" => Some(state)
+    case _ => None
+  }
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -83,12 +83,12 @@ class TaskReplaceActor(
   }
 
   def commonBehavior: PartialFunction[Any, Unit] = {
-    case MesosStatusUpdateEvent(slaveId, taskId, ErrorState(_), _, `appId`, _, _, `version`, _, _) if !oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
+    case MesosStatusUpdateEvent(slaveId, taskId, ReplaceErrorState(_), _, `appId`, _, _, `version`, _, _) if !oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
       log.error(s"New task $taskId failed on slave $slaveId during app ${app.id.toString} restart")
       healthy -= taskId
       taskQueue.add(app)
 
-    case MesosStatusUpdateEvent(slaveId, taskId, ErrorState(_), _, `appId`, _, _, _, _, _) if oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
+    case MesosStatusUpdateEvent(slaveId, taskId, ReplaceErrorState(_), _, `appId`, _, _, _, _, _) if oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
       log.error(s"Old task $taskId failed on slave $slaveId during app ${app.id.toString} restart")
       oldTaskIds -= taskId
       conciliateNewTasks()
@@ -135,9 +135,10 @@ class TaskReplaceActor(
       .build()
 }
 
-private object ErrorState {
+private object ReplaceErrorState {
   def unapply(state: String): Option[String] = state match {
     case "TASK_ERROR" | "TASK_FAILED" | "TASK_KILLED" | "TASK_LOST" => Some(state)
     case _ => None
   }
 }
+

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -17,7 +17,6 @@ class TaskStartActor(
     val eventBus: EventStream,
     val app: AppDefinition,
     val scaleTo: Int,
-    val withHealthChecks: Boolean,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
   val nrToStart: Int = scaleTo - taskQueue.count(app.id) - taskTracker.count(app.id)

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -5,6 +5,7 @@ import akka.testkit.{ TestActorRef, TestKit }
 import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.event.{ HealthStatusChanged, MesosStatusUpdateEvent }
 import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId._
@@ -49,7 +50,6 @@ class TaskStartActorTest
       system.eventStream,
       app,
       app.instances,
-      false,
       promise))
 
     watch(ref)
@@ -84,7 +84,6 @@ class TaskStartActorTest
       system.eventStream,
       app,
       app.instances,
-      false,
       promise))
 
     watch(ref)
@@ -123,7 +122,6 @@ class TaskStartActorTest
       system.eventStream,
       app,
       app.instances,
-      false,
       promise))
 
     watch(ref)
@@ -156,7 +154,6 @@ class TaskStartActorTest
       system.eventStream,
       app,
       app.instances,
-      false,
       promise))
 
     watch(ref)
@@ -173,7 +170,11 @@ class TaskStartActorTest
     val registry = new MetricRegistry
     val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
-    val app = AppDefinition("/myApp".toPath, instances = 5)
+    val app = AppDefinition(
+      "/myApp".toPath,
+      instances = 5,
+      healthChecks = Set(HealthCheck())
+    )
 
     val ref = TestActorRef(Props(
       classOf[TaskStartActor],
@@ -184,7 +185,6 @@ class TaskStartActorTest
       system.eventStream,
       app,
       app.instances,
-      true,
       promise))
 
     watch(ref)
@@ -206,7 +206,11 @@ class TaskStartActorTest
     val registry = new MetricRegistry
     val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
-    val app = AppDefinition("/myApp".toPath, instances = 0)
+    val app = AppDefinition(
+      "/myApp".toPath,
+      instances = 0,
+      healthChecks = Set(HealthCheck())
+    )
 
     val ref = TestActorRef(Props(
       classOf[TaskStartActor],
@@ -217,7 +221,6 @@ class TaskStartActorTest
       system.eventStream,
       app,
       app.instances,
-      true,
       promise))
 
     watch(ref)
@@ -245,7 +248,6 @@ class TaskStartActorTest
       system.eventStream,
       app,
       app.instances,
-      false,
       promise))
 
     watch(ref)
@@ -277,7 +279,6 @@ class TaskStartActorTest
       system.eventStream,
       app,
       app.instances,
-      false,
       promise))
 
     watch(ref)
@@ -325,7 +326,6 @@ class TaskStartActorTest
       system.eventStream,
       app,
       app.instances,
-      false,
       promise))
 
     watch(ref)

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -15,7 +15,7 @@ import org.apache.mesos.SchedulerDriver
 import org.apache.mesos.state.InMemoryState
 import org.mockito.Mockito.{ times, spy, verify, when }
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{ BeforeAndAfterAll, FunSuiteLike, Matchers }
+import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, FunSuiteLike, Matchers }
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Promise }
@@ -25,7 +25,23 @@ class TaskStartActorTest
     with FunSuiteLike
     with Matchers
     with MockitoSugar
+    with BeforeAndAfter
     with BeforeAndAfterAll {
+
+  var driver: SchedulerDriver = _
+  var scheduler: SchedulerActions = _
+  var taskQueue: TaskQueue = _
+  var taskTracker: TaskTracker = _
+  var registry: MetricRegistry = _
+
+  before {
+    driver = mock[SchedulerDriver]
+    scheduler = mock[SchedulerActions]
+    taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], new MetricRegistry)
+    taskQueue = spy(new TaskQueue)
+    registry = new MetricRegistry
+    taskTracker = spy(new TaskTracker(new InMemoryState, mock[MarathonConf], registry))
+  }
 
   override protected def afterAll(): Unit = {
     super.afterAll()
@@ -33,11 +49,6 @@ class TaskStartActorTest
   }
 
   test("Start success") {
-    val driver = mock[SchedulerDriver]
-    val scheduler = mock[SchedulerActions]
-    val taskQueue = new TaskQueue
-    val registry = new MetricRegistry
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Unit]()
     val app = AppDefinition("/myApp".toPath, instances = 5)
 
@@ -65,11 +76,6 @@ class TaskStartActorTest
   }
 
   test("Start success with tasks in taskQueue") {
-    val driver = mock[SchedulerDriver]
-    val scheduler = mock[SchedulerActions]
-    val taskQueue = new TaskQueue
-    val registry = new MetricRegistry
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Unit]()
     val app = AppDefinition("/myApp".toPath, instances = 5)
 
@@ -99,11 +105,6 @@ class TaskStartActorTest
   }
 
   test("Start success with existing task") {
-    val driver = mock[SchedulerDriver]
-    val scheduler = mock[SchedulerActions]
-    val taskQueue = new TaskQueue
-    val registry = new MetricRegistry
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Unit]()
     val app = AppDefinition("/myApp".toPath, instances = 5)
 
@@ -137,11 +138,6 @@ class TaskStartActorTest
   }
 
   test("Start success with no instances to start") {
-    val driver = mock[SchedulerDriver]
-    val scheduler = mock[SchedulerActions]
-    val taskQueue = new TaskQueue
-    val registry = new MetricRegistry
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
     val app = AppDefinition("/myApp".toPath, instances = 0)
 
@@ -164,11 +160,6 @@ class TaskStartActorTest
   }
 
   test("Start with health checks") {
-    val driver = mock[SchedulerDriver]
-    val scheduler = mock[SchedulerActions]
-    val taskQueue = new TaskQueue
-    val registry = new MetricRegistry
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
     val app = AppDefinition(
       "/myApp".toPath,
@@ -200,11 +191,6 @@ class TaskStartActorTest
   }
 
   test("Start with health checks with no instances to start") {
-    val driver = mock[SchedulerDriver]
-    val scheduler = mock[SchedulerActions]
-    val taskQueue = new TaskQueue
-    val registry = new MetricRegistry
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
     val app = AppDefinition(
       "/myApp".toPath,
@@ -231,11 +217,6 @@ class TaskStartActorTest
   }
 
   test("Cancelled") {
-    val driver = mock[SchedulerDriver]
-    val scheduler = mock[SchedulerActions]
-    val taskQueue = new TaskQueue
-    val registry = new MetricRegistry
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Boolean]()
     val app = AppDefinition("/myApp".toPath, instances = 5)
 
@@ -262,11 +243,6 @@ class TaskStartActorTest
   }
 
   test("Task fails to start") {
-    val driver = mock[SchedulerDriver]
-    val scheduler = mock[SchedulerActions]
-    val taskQueue = spy(new TaskQueue)
-    val registry = new MetricRegistry
-    val taskTracker = new TaskTracker(new InMemoryState, mock[MarathonConf], registry)
     val promise = Promise[Unit]()
     val app = AppDefinition("/myApp".toPath, instances = 1)
 
@@ -302,11 +278,6 @@ class TaskStartActorTest
   }
 
   test("Start success with dying existing task, reschedules, but finishes early") {
-    val driver = mock[SchedulerDriver]
-    val scheduler = mock[SchedulerActions]
-    val taskQueue = new TaskQueue
-    val registry = new MetricRegistry
-    val taskTracker = spy(new TaskTracker(new InMemoryState, mock[MarathonConf], registry))
     val promise = Promise[Unit]()
     val app = AppDefinition("/myApp".toPath, instances = 5)
 


### PR DESCRIPTION
- remove withHealthChecks parameter from start actors. This is not used in the code.
- add proper, useful log messages to the StartingBehaviour in order to follow what the actors actually do
- factor out long, duplicated boilerplate code in TaskStartActorTest
- make StartingBehaviour more similar to TaskReplaceActor