### PR TITLE
Remove task launch timeout.

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -78,10 +78,6 @@ The core functionality flags can be also set by environment variable `MARATHON_O
     application scaling operations.
 * `--scale_apps_interval` (Optional. Default: 300000 (5 minutes)): The period,
     in milliseconds, between application scaling operations.
-* `--task_launch_timeout` **DEPRECATED** (Optional. Default: 300000 (5 minutes)):
-    Time, in milliseconds, to wait for a task to enter the TASK_RUNNING state
-    before killing it. _Note: This is a temporary fix for MESOS-1922.
-    This option will be removed in a later release._
 * `--event_subscriber` (Optional. Default: None): Event subscriber module to
     enable. Currently the only valid value is `http_callback`.
 * `--http_endpoints` (Optional. Default: None): Pre-configured http callback

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -63,12 +63,6 @@ trait MarathonConf extends ScallopConf with ZookeeperConf {
     descr = "Mesos role for this framework",
     default = None)
 
-  lazy val taskLaunchTimeout = opt[Long]("task_launch_timeout",
-    descr = "(deprecated) Time, in milliseconds, to wait for a task to enter " +
-      "the TASK_RUNNING state before killing it. NOTE: this is a temporary " +
-      "fix for MESOS-1922. This option will be removed in a later release.",
-    default = Some(300000L)) // 300 seconds (5 minutes)
-
   lazy val reconciliationInitialDelay = opt[Long]("reconciliation_initial_delay",
     descr = "This is the length of time, in milliseconds, before Marathon " +
       "begins to periodically perform task reconciliation operations",

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -44,7 +44,6 @@ class MarathonScheduler @Inject() (
 
   private[this] val log = Logger.getLogger(getClass.getName)
 
-  import mesosphere.mesos.protos.Implicits._
   import mesosphere.util.ThreadPoolContext.context
 
   implicit val zkTimeout = config.zkFutureTimeout
@@ -66,18 +65,6 @@ class MarathonScheduler @Inject() (
   }
 
   override def resourceOffers(driver: SchedulerDriver, offers: java.util.List[Offer]): Unit = {
-    // Check for any tasks which were started but never entered TASK_RUNNING
-    // TODO resourceOffers() doesn't feel like the right place to run this
-    val toKill = taskTracker.checkStagedTasks
-
-    if (toKill.nonEmpty) {
-      log.warn(s"There are ${toKill.size} tasks stuck in staging for more " +
-        s"than ${config.taskLaunchTimeout()}ms which will be killed")
-      log.info(s"About to kill these tasks: $toKill")
-      for (task <- toKill)
-        driver.killTask(protos.TaskID(task.getId))
-    }
-
     // remove queued tasks with stale (non-current) app definition versions
     val appVersions: Map[PathId, Timestamp] =
       Await.result(appRepo.currentAppVersions(), config.zkTimeoutDuration)

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -27,7 +27,6 @@ class InfoResource @Inject() (
     "hostname" -> conf.hostname.get,
     "webui_url" -> conf.webuiUrl.get,
     "mesos_role" -> conf.mesosRole.get,
-    "task_launch_timeout" -> conf.taskLaunchTimeout.get,
     "reconciliation_initial_delay" -> conf.reconciliationInitialDelay.get,
     "reconciliation_interval" -> conf.reconciliationInterval.get,
     "marathon_store_timeout" -> conf.marathonStoreTimeout.get,

--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -151,20 +151,6 @@ class TaskTracker @Inject() (
     }
   }
 
-  def stagedTasks(): Iterable[MarathonTask] = apps.values.flatMap(_.tasks.values.filter(_.getStartedAt == 0))
-
-  def checkStagedTasks: Iterable[MarathonTask] = {
-    // stagedAt is set when the task is created by the scheduler
-    val now = System.currentTimeMillis
-    val expires = now - config.taskLaunchTimeout()
-    val toKill = stagedTasks.filter(_.getStagedAt < expires)
-
-    toKill.foreach(t => {
-      log.warn(s"Task '${t.getId}' was staged ${(now - t.getStagedAt) / 1000}s ago and has not yet started")
-    })
-    toKill
-  }
-
   def expungeOrphanedTasks(): Unit = {
     // Remove tasks that don't have any tasks associated with them. Expensive!
     log.info("Expunging orphaned tasks from store")

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -85,7 +85,6 @@ class MarathonSchedulerTest extends TestKit(ActorSystem("System")) with Marathon
 
     queue.add(app)
 
-    when(tracker.checkStagedTasks).thenReturn(Seq())
     when(repo.currentAppVersions())
       .thenReturn(Future.successful(Map(app.id -> app.version)))
 


### PR DESCRIPTION
The task launch timeout was added as a workaround for a problem with how
Mesos handles failed fetches. The workaround is no longer necessary in
Marathon as it's now correctly handled by Mesos.

cc @guenter @ConnorDoyle @drexin 