### PR TITLE
Catch exceptions during election correctly and offer leadership again

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -28,6 +28,7 @@ import org.apache.mesos.Protos.FrameworkID
 import scala.collection.immutable.Seq
 import scala.concurrent.duration.{ MILLISECONDS, _ }
 import scala.concurrent.{ TimeoutException, Await, Future, Promise }
+import scala.util.control.NonFatal
 import scala.util.{ Failure, Success }
 
 /**
@@ -263,7 +264,7 @@ class MarathonSchedulerService @Inject() (
       resetOfferLeadershipBackOff
     }
     catch {
-      case e: scala.Exception =>
+      case NonFatal(e) => // catch Scala and Java exceptions
         log.error(s"Failed to take over leadership: $e")
 
         increaseOfferLeadershipBackOff()


### PR DESCRIPTION
The previous patch did not fix the problem of a
java.util.concurrent.TimeoutException exception thrown by the Mesos libs during
migration because this exception is not of type mesosphere.marathon.Exception.

When changing the type in the catch clause to scala.Exception the catch works,
but because the driver is not running yet, no offerLeadership is called.

This patch calls the abdication command and offerLeadership explicitly if the
driver is not yet running.

Moreover, a offerLeadership backoff mechanism is implemented because otherwise
very fast repeated election can happen when a host is bad.

Finally, a test case is added for the java.util.concurrent.TimeoutException
case in Migration.migrate.

Fixes #1043