### PR TITLE
Add coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ jdk:
   - openjdk6
 scala:
   - 2.11.5
-script: sbt doc test
+script: sbt clean coverage doc test
+after_success:
+  - sbt coverageReport coveralls
 notifications:
   slack:
     secure: apUObVUa/OhaTEvoYw3oM1ZTTT0LtYolofJYqnWiBOusc6qgMlK2rfk5kod7vDn33cSKwGhFcyVrrFCn2qxuvYUWCpK4Yo6Hj7KIjoqMi9yHLHXAAWIfAFNMlCdaUGjlHLWn757rBkbuQUDVH8HmB6Vc3J3sybTbiFmMDP1cEVo=

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,9 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 resolvers += "Era7 maven releases" at "http://releases.era7.com.s3.amazonaws.com"
 
 addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.10.1")
+
+resolvers += Classpaths.sbtPluginReleases
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")


### PR DESCRIPTION
I was about to try and fix a bug myself when I noticed this project lacks test coverage reporting. Fixes #817 

There is an exception in the log (see [scoverage/sbt-coveralls#28]), but coveralls report should work once you enable the service by logging in to coveralls.io.