### PR TITLE
don't accept empty string or / as app id

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/ModelValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/ModelValidation.scala
@@ -213,6 +213,10 @@ trait ModelValidation extends BeanValidation {
   }
 
   def idErrors[T: ClassTag](t: T, base: PathId, id: PathId, path: String): Iterable[ConstraintViolation[T]] = {
+    if (id == PathId.empty) {
+      return List(violation(t, id, path, "the empty path can't be used as id"))
+    }
+
     val p = "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$".r
     val valid = id.path.forall(p.pattern.matcher(_).matches())
     val errors =

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -95,7 +95,7 @@ trait Formats
   }
 
   implicit lazy val PathIdFormat: Format[PathId] = Format(
-    Reads.of[String].map(PathId(_)),
+    Reads.of[String](Reads.minLength[String](1)).map(PathId(_)).filterNot(_.isRoot),
     Writes[PathId] { id => JsString(id.toString) }
   )
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -96,5 +96,15 @@ class AppDefinitionFormatsTest
     r1.upgradeStrategy should equal (DefaultUpgradeStrategy)
   }
 
+  test("FromJSON should fail for empty id") {
+    val json = Json.parse( """ { "id": "" }""")
+    a [JsResultException] shouldBe thrownBy { json.as[AppDefinition] }
+  }
+
+  test("FromJSON should fail when using / as an id") {
+    val json = Json.parse( """ { "id": "/" }""")
+    a [JsResultException] shouldBe thrownBy { json.as[AppDefinition] }
+  }
+
 }
 

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -154,6 +154,8 @@ class AppDefinitionTest extends MarathonSpec with Matchers with ModelValidation 
     shouldViolate(app.copy(id = "uppercaseLettersNoGood".toRootPath), "id", idError)
     shouldNotViolate(app.copy(id = "ab".toRootPath), "id", idError)
 
+    shouldViolate(app.copy(id = "".toRootPath), "id", "the empty path can't be used as id")
+
     shouldViolate(
       AppDefinition(id = "test".toPath, instances = -3, ports = Seq(9000, 8080, 9000)),
       "ports",

--- a/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
@@ -113,4 +113,9 @@ class PathIdTest extends FunSpec with GivenWhenThen with Matchers {
       host3 should be("")
     }
   }
+
+  it("handles root paths") {
+    PathId("/").isRoot shouldBe true
+    PathId("").isRoot shouldBe true
+  }
 }


### PR DESCRIPTION
Currently, the marathon API allows to create apps with `"id": ""`. Not only do I think that doesn't make sense, it also caused issues with mesos: It will create tasks with an empty name which are not removed from mesos when deleting the app.