### PR TITLE
687 expose recent scheduling decisions

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -94,6 +94,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     storage: StorageProvider,
     @Named(EventModule.busName) eventBus: EventStream,
     taskFailureRepository: TaskFailureRepository,
+    taskOffersDeclinedRepository: TaskOffersDeclinedRepository,
     config: MarathonConf): ActorRef = {
     val supervision = OneForOneStrategy() {
       case NonFatal(_) => Restart
@@ -113,6 +114,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
         storage,
         eventBus,
         taskFailureRepository,
+        taskOffersDeclinedRepository,
         config).withRouter(RoundRobinPool(nrOfInstances = 1, supervisorStrategy = supervision)),
       "MarathonScheduler")
   }
@@ -159,6 +161,15 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
       ),
       conf.zooKeeperMaxVersions.get
     )
+  }
+
+  @Provides
+  @Singleton
+  def provideTaskOffersDeclinedRepository(
+    state: State,
+    conf: MarathonConf,
+    registry: MetricRegistry): TaskOffersDeclinedRepository = {
+    new TaskOffersDeclinedRepository()
   }
 
   @Provides

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.Semaphore
 import akka.actor._
 import akka.event.EventStream
 import com.fasterxml.jackson.databind.ObjectMapper
+import mesosphere.mesos.TaskBuilder.BuildResult
 import org.apache.mesos.Protos.{ TaskState, TaskID, TaskStatus, TaskInfo }
 import org.apache.mesos.SchedulerDriver
 import org.slf4j.LoggerFactory
@@ -40,6 +41,7 @@ class MarathonSchedulerActor(
     storage: StorageProvider,
     eventBus: EventStream,
     taskFailureRepository: TaskFailureRepository,
+    taskOffersDeclinedRepository: TaskOffersDeclinedRepository,
     config: MarathonConf) extends Actor with ActorLogging with Stash {
   import context.dispatcher
 
@@ -79,7 +81,7 @@ class MarathonSchedulerActor(
     )
 
     historyActor = context.actorOf(
-      Props(classOf[HistoryActor], eventBus, taskFailureRepository), "HistoryActor")
+      Props(classOf[HistoryActor], eventBus, taskFailureRepository, taskOffersDeclinedRepository), "HistoryActor")
   }
 
   def receive: Receive = suspended
@@ -447,7 +449,7 @@ class SchedulerActions(
     } healthCheckManager.reconcileWith(app.id)
 
   private def newTask(app: AppDefinition,
-                      offer: Offer): Option[(TaskInfo, Seq[Long])] = {
+                      offer: Offer): BuildResult = {
     // TODO this should return a MarathonTask
     val builder = new TaskBuilder(
       app,
@@ -457,10 +459,10 @@ class SchedulerActions(
       mapper
     )
 
-    builder.buildIfMatches(offer) map {
-      case (task, ports) =>
-        val taskBuilder = task.toBuilder
-        taskBuilder.build -> ports
+    builder.buildIfMatches(offer) match {
+      case TaskBuilder.BuildSuccess(task, ports) =>
+        TaskBuilder.BuildSuccess(task.toBuilder.build, ports)
+      case declined: TaskBuilder.BuildDeclined => declined
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -231,7 +231,7 @@ trait DeploymentFormats {
 
 trait EventFormats {
   import Formats._
-
+  implicit lazy val TaskOfferDeclinedEventWrites: Writes[TaskOfferDeclinedEvent] = Json.writes[TaskOfferDeclinedEvent]
   implicit lazy val AppTerminatedEventWrites: Writes[AppTerminatedEvent] = Json.writes[AppTerminatedEvent]
   implicit lazy val ApiPostEventWrites: Writes[ApiPostEvent] = Json.writes[ApiPostEvent]
   implicit lazy val SubscribeWrites: Writes[Subscribe] = Json.writes[Subscribe]

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -203,3 +203,9 @@ case class MesosFrameworkMessageEvent(
   message: Array[Byte],
   eventType: String = "framework_message_event",
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
+
+case class TaskOfferDeclinedEvent(
+  appId: PathId,
+  message: Array[Byte],
+  eventType: String = "app_failed_to_start_event",
+  timestamp: String = Timestamp.now().toString) extends MarathonEvent

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventActor.scala
@@ -54,6 +54,7 @@ class HttpEventActor(val subscribersKeeper: ActorRef) extends Actor with ActorLo
   }
 
   def eventToJson(event: MarathonEvent): JsValue = event match {
+    case event: TaskOfferDeclinedEvent     => Json.toJson(event)
     case event: AppTerminatedEvent         => Json.toJson(event)
     case event: ApiPostEvent               => Json.toJson(event)
     case event: Subscribe                  => Json.toJson(event)

--- a/src/main/scala/mesosphere/marathon/state/TaskOfferDeclinedRepository.scala
+++ b/src/main/scala/mesosphere/marathon/state/TaskOfferDeclinedRepository.scala
@@ -1,0 +1,19 @@
+package mesosphere.marathon.state
+
+import mesosphere.marathon.event.TaskOfferDeclinedEvent
+
+import scala.collection.mutable
+
+class TaskOffersDeclinedRepository() {
+
+  protected[this] val tasksDeclined = mutable.Map[PathId, TaskOfferDeclinedEvent]()
+
+  def store(id: PathId, value: TaskOfferDeclinedEvent): Unit =
+    synchronized { tasksDeclined(id) = value }
+
+  def expunge(id: PathId): Unit =
+    synchronized { tasksDeclined -= id }
+
+  def current(id: PathId): Option[TaskOfferDeclinedEvent] = tasksDeclined.get(id)
+
+}

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -45,6 +45,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
   var taskIdUtil: TaskIdUtil = _
   var storage: StorageProvider = _
   var taskFailureEventRepository: TaskFailureRepository = _
+  var taskOffersDeclinedRepository: TaskOffersDeclinedRepository = _
 
   implicit val defaultTimeout: Timeout = 5.seconds
 
@@ -60,6 +61,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     taskIdUtil = new TaskIdUtil
     storage = mock[StorageProvider]
     taskFailureEventRepository = mock[TaskFailureRepository]
+    taskOffersDeclinedRepository = mock[TaskOffersDeclinedRepository]
 
     when(deploymentRepo.store(any())).thenAnswer(new Answer[Future[DeploymentPlan]] {
       override def answer(p1: InvocationOnMock): Future[DeploymentPlan] = {
@@ -88,6 +90,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
       storage,
       system.eventStream,
       taskFailureEventRepository,
+      taskOffersDeclinedRepository,
       mock[MarathonConf]
     ))
   }
@@ -350,6 +353,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
       storage,
       system.eventStream,
       taskFailureEventRepository,
+      taskOffersDeclinedRepository,
       mock[MarathonConf]
     ))
 

--- a/src/test/scala/mesosphere/marathon/event/HistoryActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/HistoryActorTest.scala
@@ -4,7 +4,7 @@ import akka.actor.{ ActorRef, ActorSystem, Props }
 import akka.testkit.{ ImplicitSender, TestActorRef, TestKit }
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{ TaskFailure, TaskFailureRepository, Timestamp }
+import mesosphere.marathon.state.{ TaskFailure, TaskFailureRepository, TaskOffersDeclinedRepository, Timestamp }
 import org.apache.mesos.Protos.TaskState
 import org.mockito.Matchers.any
 import org.mockito.Mockito._
@@ -22,11 +22,13 @@ class HistoryActorTest
 
   var historyActor: ActorRef = _
   var failureRepo: TaskFailureRepository = _
+  var declinedRepo: TaskOffersDeclinedRepository = _
 
   before {
     failureRepo = mock[TaskFailureRepository]
+    declinedRepo = mock[TaskOffersDeclinedRepository]
     historyActor = TestActorRef(Props(
-      new HistoryActor(system.eventStream, failureRepo)
+      new HistoryActor(system.eventStream, failureRepo, declinedRepo)
     ))
   }
 

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
@@ -4,7 +4,7 @@ import akka.actor.{ ActorSystem, Props }
 import akka.testkit.{ TestProbe, TestActorRef, TestKit }
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.event.{ HistoryActor, AppTerminatedEvent, MesosStatusUpdateEvent }
-import mesosphere.marathon.state.{ TaskFailure, TaskFailureRepository, AppDefinition, PathId }
+import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.marathon.upgrade.StoppingBehavior.SynchronizeTasks
 import mesosphere.marathon.{ MarathonSpec, SchedulerActions, TaskUpgradeCanceledException }
@@ -27,12 +27,14 @@ class AppStopActorTest
   var scheduler: SchedulerActions = _
   var taskTracker: TaskTracker = _
   var taskFailureRepository: TaskFailureRepository = _
+  var declinedRepository: TaskOffersDeclinedRepository = _
 
   before {
     driver = mock[SchedulerDriver]
     scheduler = mock[SchedulerActions]
     taskTracker = mock[TaskTracker]
     taskFailureRepository = mock[TaskFailureRepository]
+    declinedRepository = mock[TaskOffersDeclinedRepository]
   }
 
   test("Stop App") {
@@ -59,7 +61,8 @@ class AppStopActorTest
       Props(
         new HistoryActor(
           system.eventStream,
-          taskFailureRepository
+          taskFailureRepository,
+          declinedRepository
         )
       )
     )


### PR DESCRIPTION
This creates a kv-store for data about declined offers for apps. If an
app’s resource requirements cannot be supplied by the current system,
there should eventually be some notification back to the executor.

Note: Manually adding event types to a bucket style method isn’t fun.