### PR TITLE
Ignore `MARATHON_APP_*` when converting env vars to option values in start scripts.

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -65,7 +65,7 @@ function load_options_and_log {
       cmd+=( --master "$(cat /etc/mesos/zk)" )
     fi
   fi
-  for env_op in `env |grep ^MARATHON_ | sed -e 's/MARATHON_//' -e 's/=/ /'| awk '{printf("%s%s ", "--", tolower($1)); for(i=2;i<=NF;i++){printf("%s ", $i)}}'| sed -e 's/ $//'`; do
+  for env_op in `env | grep ^MARATHON_ | sed -e '/^MARATHON_APP/d' -e 's/MARATHON_//' -e 's/=/ /'| awk '{printf("%s%s ", "--", tolower($1)); for(i=2;i<=NF;i++){printf("%s ", $i)}}'| sed -e 's/ $//'`; do
     cmd+=( "$env_op" )
   done
   echo "${cmd[@]}"

--- a/bin/start
+++ b/bin/start
@@ -34,7 +34,7 @@ require_arg() {
   fi
 }
 
-for env_op in `env |grep ^MARATHON_ | sed -e 's/MARATHON_//' -e 's/=/ /'| awk '{printf("%s%s ", "--", tolower($1)); for(i=2;i<=NF;i++){printf("%s ", $i)}}'| sed -e 's/ $//'`; do
+for env_op in `env | grep ^MARATHON_ | sed -e '/^MARATHON_APP/d' -e 's/MARATHON_//' -e 's/=/ /' | awk '{printf("%s%s ", "--", tolower($1)); for(i=2;i<=NF;i++){printf("%s ", $i)}}'| sed -e 's/ $//'`; do
   addApplication "$env_op"
 done
 


### PR DESCRIPTION
This is a quick and temporal fix for #1143.
