### PR TITLE
POST /v2/apps now results in 409 if there is a service ports conflict.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/ModelValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/ModelValidation.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.api
 import java.lang.{ Double => JDouble }
 import java.net.{ HttpURLConnection, URL }
 import javax.validation.ConstraintViolation
+import mesosphere.marathon.MarathonSchedulerService
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success, Try }
 
@@ -147,7 +148,7 @@ trait ModelValidation extends BeanValidation {
     parent: PathId = PathId.empty): Iterable[ConstraintViolation[AppDefinition]] =
     apps.zipWithIndex.flatMap {
       case (app, pos) =>
-        checkApp(app, parent, s"$path[$pos].")
+        checkAppConstraints(app, parent, s"$path[$pos].")
     }
 
   def checkUpdate(
@@ -183,7 +184,8 @@ trait ModelValidation extends BeanValidation {
     )
   }
 
-  def checkApp(app: AppDefinition, parent: PathId, path: String = ""): Iterable[ConstraintViolation[AppDefinition]] =
+  def checkAppConstraints(app: AppDefinition, parent: PathId,
+                          path: String = ""): Iterable[ConstraintViolation[AppDefinition]] =
     validate(app,
       idErrors(app, parent, app.id, path + "id"),
       checkPath(app, parent, app.id, path + "id"),
@@ -255,4 +257,34 @@ trait ModelValidation extends BeanValidation {
       else if (upgradeStrategy.maximumOverCapacity > 1) Some("is greater than 1")
       else None
     }.map { violation(t, upgradeStrategy, path + ".maximumOverCapacity", _) })
+
+  /**
+    * Returns a non-empty list of validation messages if the given app definition
+    * will conflict with existing apps.
+    */
+  def checkAppConflicts(app: AppDefinition, baseId: PathId, service: MarathonSchedulerService): Seq[String] = {
+    app.containerServicePorts().toSeq.flatMap { servicePorts =>
+      checkServicePortConflicts(baseId, servicePorts, service)
+    }
+  }
+
+  /**
+    * Returns a non-empty list of validations messages if the given app definition has service ports
+    * that will conflict with service ports in other applications.
+    *
+    * Does not compare the app definition's service ports with the same deployed app's service ports, as app updates
+    * may simply restate the existing service ports.
+    */
+  private def checkServicePortConflicts(baseId: PathId, requestedServicePorts: Seq[Int],
+                                        service: MarathonSchedulerService): Seq[String] = {
+
+    for {
+      existingApp <- service.listApps().toList
+      if existingApp.id != baseId // in case of an update, do not compare the app against itself
+      existingServicePort <- existingApp.portMappings().toList.flatten.map(_.servicePort)
+      if existingServicePort != 0 // ignore zero ports, which will be chosen at random
+      if requestedServicePorts contains existingServicePort
+    } yield s"Requested service port $existingServicePort conflicts with a service port in app ${existingApp.id}"
+  }
+
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -17,7 +17,7 @@ import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.marathon.upgrade.{ DeploymentStep, RestartApplication, DeploymentPlan }
-import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService }
+import mesosphere.marathon.{ ConflictingChangeException, MarathonConf, MarathonSchedulerService }
 import mesosphere.marathon.api.v2.json.Formats._
 import play.api.libs.json.{ Writes, JsObject, Json }
 
@@ -87,7 +87,9 @@ class AppsResource @Inject() (
 
   private def create(req: HttpServletRequest, app: AppDefinition, force: Boolean): Response = {
     val baseId = app.id.canonicalPath()
-    requireValid(checkApp(app, baseId.parent))
+    requireValid(checkAppConstraints(app, baseId.parent))
+    val conflicts = checkAppConflicts(app, baseId, service)
+    if (conflicts.nonEmpty) throw new ConflictingChangeException(conflicts.mkString(","))
     maybePostEvent(req, app)
     val managed = app.copy(id = baseId, dependencies = app.dependencies.map(_.canonicalPath(baseId)))
     result(groupManager.updateApp(baseId, _ => managed, managed.version, force))

--- a/src/test/scala/mesosphere/marathon/api/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/ModelValidationTest.scala
@@ -1,16 +1,22 @@
 package mesosphere.marathon.api
 
-import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.api.v2.GroupUpdate
+import mesosphere.marathon.state.Container.Docker.PortMapping
+import mesosphere.marathon.state.Container._
 import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.state._
+import mesosphere.marathon.{ MarathonSchedulerService, MarathonSpec }
+import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network
+import org.mockito.Mockito.when
+import org.scalatest.{ BeforeAndAfterAll, Matchers, OptionValues }
 
-import java.net.{ ServerSocket, InetAddress }
-import org.scalatest.{ BeforeAndAfterAll, Matchers }
+import scala.collection.immutable.Seq
 
 class ModelValidationTest
     extends MarathonSpec
     with Matchers
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with OptionValues {
 
   test("A group update should pass validation") {
     val mv = new ModelValidation {}
@@ -20,4 +26,54 @@ class ModelValidationTest
     violations should have size (0)
   }
 
+  test("Model validation should catch new apps that conflict with service ports in existing apps") {
+
+    val existingApp = createServicePortApp("/app1".toPath, 3200)
+    val service = mock[MarathonSchedulerService]
+    when(service.listApps()).thenReturn(List(existingApp))
+
+    val conflictingApp = createServicePortApp("/app2".toPath, 3200)
+    val validations = ModelValidation.checkAppConflicts(conflictingApp, conflictingApp.id, service)
+
+    validations should not be Nil
+  }
+
+  test("Model validation should allow new apps that do not conflict with service ports in existing apps") {
+
+    val existingApp = createServicePortApp("/app1".toPath, 3200)
+    val service = mock[MarathonSchedulerService]
+    when(service.listApps()).thenReturn(List(existingApp))
+
+    val conflictingApp = createServicePortApp("/app2".toPath, 3201)
+    val validations = ModelValidation.checkAppConflicts(conflictingApp, conflictingApp.id, service)
+
+    validations should be(Nil)
+  }
+
+  test("Model validation should check for application conflicts") {
+
+    val existingApp = createServicePortApp("/app1".toPath, 3200)
+    val service = mock[MarathonSchedulerService]
+    when(service.listApps()).thenReturn(List(existingApp))
+
+    val conflictingApp = existingApp.copy(id = "/app2".toPath)
+    val validations = ModelValidation.checkAppConflicts(conflictingApp, conflictingApp.id, service)
+
+    validations should not be Nil
+  }
+
+  private object ModelValidation extends ModelValidation
+
+  private def createServicePortApp(id: PathId, servicePort: Int) = {
+    AppDefinition(
+      id,
+      container = Some(Container(
+        docker = Some(Docker(
+          image = "demothing",
+          network = Some(Network.BRIDGE),
+          portMappings = Some(Seq(PortMapping(2000, servicePort = servicePort)))
+        ))
+      ))
+    )
+  }
 }

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -125,7 +125,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers with ModelValidation 
     val validator = Validation.buildDefaultValidatorFactory().getValidator
 
     def shouldViolate(app: AppDefinition, path: String, template: String) = {
-      val violations = checkApp(app, PathId.empty)
+      val violations = checkAppConstraints(app, PathId.empty)
       assert(
         violations.exists { v =>
           v.getPropertyPath.toString == path && v.getMessageTemplate.toString == template
@@ -135,7 +135,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers with ModelValidation 
     }
 
     def shouldNotViolate(app: AppDefinition, path: String, template: String) = {
-      val violations = checkApp(app, PathId.empty)
+      val violations = checkAppConstraints(app, PathId.empty)
       assert(
         !violations.exists { v =>
           v.getPropertyPath.toString == path && v.getMessageTemplate == template


### PR DESCRIPTION
If a port has been claimed as a service port by some app, the next app that tries to claim it will by rejected with a 409 Conflict response.

Added ModelValidation.checkAppConflicts() which checks for any conflicts that a new or updated app may have with existing apps. Renamed ModelValidation.checkApp() to ModelValidation.checkAppConstraints() to differentiate it from the new ModelValidation.checkAppConflicts().

Tested this manually, as there appears to be no existing support for integration tests of the endpoints. Running the marathon app in vagrant, creating a new app with a new service port worked via httpie. However, creating a new app with an existing service port returned a 409 status code with the response message "Requested service port 3000 conflicts with a service port in app /demo".

https://github.com/mesosphere/marathon/issues/1002

