### PR TITLE
fixes #1145 - Scale app after killing tasks without scaling

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -173,7 +173,7 @@ class MarathonScheduler @Inject() (
             case None       => log.warn(s"Couldn't post event for ${status.getTaskId}")
           }
 
-          schedulerActor ! ScaleApp(appId)
+          schedulerActor ! ScaleApp(appId, force = false)
         }
 
       case TASK_RUNNING if !maybeTask.exists(_.hasStartedAt) => // staged, not running


### PR DESCRIPTION
- added force parameter to ScaleApp message to prevent races between
  the finishing of KillTasks and the execution of ScaleApp