### PR TITLE
Ignore health checks with HTTP response 100 to 199

### DIFF
--- a/changelogs/changelog_0.8.0-0.8.1.md
+++ b/changelogs/changelog_0.8.0-0.8.1.md
@@ -28,3 +28,9 @@ it still return a `201 - Created` if the resource didn't exist.
 
 In 0.8.0 the queueing behavior has changed and the output of this endpoint
 did not contain the delay field anymore. In 0.8.1 we re-added this field.
+
+#### New health check option `ignoreHttp1xx`
+
+When set to true, the health check for the given app will ignore HTTP
+response codes 100 to 199, in contrast to considering it as unhealthy. With this unbounded task startup times can be handled: the tasks are neither
+healthy nor unhealthy as long as e.g. "100 - continue" is returned.

--- a/docs/docs/health-checks.md
+++ b/docs/docs/health-checks.md
@@ -12,8 +12,8 @@ Health checks may be specified per application to be run against that applicatio
 
 A health check is considered passing if (1) its HTTP response code is between
 200 and 399, inclusive, and (2) its response is received within the
-`timeoutSeconds` period. If a task fails more than `maxConseutiveFailures`
-health checks consecutively, that task is killed.
+`timeoutSeconds` period. If a task fails more than `maxConseutiveFailures` health
+checks consecutively, that task is killed.
 
 ##### Example usage
 
@@ -25,7 +25,8 @@ health checks consecutively, that task is killed.
   "gracePeriodSeconds": 300,
   "intervalSeconds": 60,
   "timeoutSeconds": 20,
-  "maxConsecutiveFailures": 3
+  "maxConsecutiveFailures": 3,
+  "ignoreHttp1xx": false,
 }
 ```
 
@@ -76,6 +77,9 @@ OR
   performed. One of "HTTP" or "TCP".
 * `timeoutSeconds` (Optional. Default: 20): Number of seconds after which a
   health check is considered a failure regardless of the response.
+* `ignoreHttp1xx` (Optional. Default: false): Ignore HTTP informational status
+codes 100 to 199. If the HTTP health check returns one of these, the result is
+discarded and the health status of the task remains unchanged.
 
 #### Health Lifecycle
 

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -995,6 +995,16 @@ public final class Protos {
      * <code>optional .mesos.CommandInfo command = 8;</code>
      */
     org.apache.mesos.Protos.CommandInfoOrBuilder getCommandOrBuilder();
+
+    // optional bool ignoreHttp1xx = 9 [default = false];
+    /**
+     * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+     */
+    boolean hasIgnoreHttp1Xx();
+    /**
+     * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+     */
+    boolean getIgnoreHttp1Xx();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
@@ -1099,6 +1109,11 @@ public final class Protos {
                 command_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000080;
+              break;
+            }
+            case 72: {
+              bitField0_ |= 0x00000100;
+              ignoreHttp1Xx_ = input.readBool();
               break;
             }
           }
@@ -1405,6 +1420,22 @@ public final class Protos {
       return command_;
     }
 
+    // optional bool ignoreHttp1xx = 9 [default = false];
+    public static final int IGNOREHTTP1XX_FIELD_NUMBER = 9;
+    private boolean ignoreHttp1Xx_;
+    /**
+     * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+     */
+    public boolean hasIgnoreHttp1Xx() {
+      return ((bitField0_ & 0x00000100) == 0x00000100);
+    }
+    /**
+     * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+     */
+    public boolean getIgnoreHttp1Xx() {
+      return ignoreHttp1Xx_;
+    }
+
     private void initFields() {
       protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
       portIndex_ = 0;
@@ -1414,6 +1445,7 @@ public final class Protos {
       path_ = "/";
       maxConsecutiveFailures_ = 3;
       command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
+      ignoreHttp1Xx_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1465,6 +1497,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         output.writeMessage(8, command_);
       }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        output.writeBool(9, ignoreHttp1Xx_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -1505,6 +1540,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(8, command_);
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(9, ignoreHttp1Xx_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1643,6 +1682,8 @@ public final class Protos {
           commandBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000080);
+        ignoreHttp1Xx_ = false;
+        bitField0_ = (bitField0_ & ~0x00000100);
         return this;
       }
 
@@ -1707,6 +1748,10 @@ public final class Protos {
         } else {
           result.command_ = commandBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
+          to_bitField0_ |= 0x00000100;
+        }
+        result.ignoreHttp1Xx_ = ignoreHttp1Xx_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1748,6 +1793,9 @@ public final class Protos {
         }
         if (other.hasCommand()) {
           mergeCommand(other.getCommand());
+        }
+        if (other.hasIgnoreHttp1Xx()) {
+          setIgnoreHttp1Xx(other.getIgnoreHttp1Xx());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -2206,6 +2254,39 @@ public final class Protos {
         return commandBuilder_;
       }
 
+      // optional bool ignoreHttp1xx = 9 [default = false];
+      private boolean ignoreHttp1Xx_ ;
+      /**
+       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+       */
+      public boolean hasIgnoreHttp1Xx() {
+        return ((bitField0_ & 0x00000100) == 0x00000100);
+      }
+      /**
+       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+       */
+      public boolean getIgnoreHttp1Xx() {
+        return ignoreHttp1Xx_;
+      }
+      /**
+       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+       */
+      public Builder setIgnoreHttp1Xx(boolean value) {
+        bitField0_ |= 0x00000100;
+        ignoreHttp1Xx_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+       */
+      public Builder clearIgnoreHttp1Xx() {
+        bitField0_ = (bitField0_ & ~0x00000100);
+        ignoreHttp1Xx_ = false;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:mesosphere.marathon.HealthCheckDefinition)
     }
 
@@ -2565,10 +2646,18 @@ public final class Protos {
     // optional int64 maxLaunchDelay = 21 [default = 3600000];
     /**
      * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
+     *
+     * <pre>
+     * stored as Millis
+     * </pre>
      */
     boolean hasMaxLaunchDelay();
     /**
      * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
+     *
+     * <pre>
+     * stored as Millis
+     * </pre>
      */
     long getMaxLaunchDelay();
   }
@@ -3438,12 +3527,20 @@ public final class Protos {
     private long maxLaunchDelay_;
     /**
      * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
+     *
+     * <pre>
+     * stored as Millis
+     * </pre>
      */
     public boolean hasMaxLaunchDelay() {
       return ((bitField0_ & 0x00001000) == 0x00001000);
     }
     /**
      * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
+     *
+     * <pre>
+     * stored as Millis
+     * </pre>
      */
     public long getMaxLaunchDelay() {
       return maxLaunchDelay_;
@@ -6528,18 +6625,30 @@ public final class Protos {
       private long maxLaunchDelay_ = 3600000L;
       /**
        * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
+       *
+       * <pre>
+       * stored as Millis
+       * </pre>
        */
       public boolean hasMaxLaunchDelay() {
         return ((bitField0_ & 0x00080000) == 0x00080000);
       }
       /**
        * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
+       *
+       * <pre>
+       * stored as Millis
+       * </pre>
        */
       public long getMaxLaunchDelay() {
         return maxLaunchDelay_;
       }
       /**
        * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
+       *
+       * <pre>
+       * stored as Millis
+       * </pre>
        */
       public Builder setMaxLaunchDelay(long value) {
         bitField0_ |= 0x00080000;
@@ -6549,6 +6658,10 @@ public final class Protos {
       }
       /**
        * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
+       *
+       * <pre>
+       * stored as Millis
+       * </pre>
        */
       public Builder clearMaxLaunchDelay() {
         bitField0_ = (bitField0_ & ~0x00080000);
@@ -19118,7 +19231,7 @@ public final class Protos {
       "\030\001 \002(\t\022:\n\010operator\030\002 \002(\0162(.mesosphere.ma" +
       "rathon.Constraint.Operator\022\r\n\005value\030\003 \001(" +
       "\t\"G\n\010Operator\022\n\n\006UNIQUE\020\000\022\010\n\004LIKE\020\001\022\013\n\007C" +
-      "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\"\322\002\n\025H" +
+      "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\"\360\002\n\025H" +
       "ealthCheckDefinition\022E\n\010protocol\030\001 \002(\01623" +
       ".mesosphere.marathon.HealthCheckDefiniti" +
       "on.Protocol\022\024\n\tportIndex\030\002 \002(\r:\0010\022\036\n\022gra" +
@@ -19126,67 +19239,68 @@ public final class Protos {
       "onds\030\004 \001(\r:\00210\022\032\n\016timeoutSeconds\030\005 \001(\r:\002" +
       "20\022\017\n\004path\030\006 \001(\t:\001/\022!\n\026maxConsecutiveFai" +
       "lures\030\007 \001(\r:\0013\022#\n\007command\030\010 \001(\0132\022.mesos." +
-      "CommandInfo\"*\n\010Protocol\022\010\n\004HTTP\020\000\022\007\n\003TCP" +
-      "\020\001\022\013\n\007COMMAND\020\002\"\330\005\n\021ServiceDefinition\022\n\n" +
-      "\002id\030\001 \002(\t\022\037\n\003cmd\030\002 \002(\0132\022.mesos.CommandIn" +
-      "fo\022\021\n\tinstances\030\003 \002(\r\022\"\n\tresources\030\004 \003(\013" +
-      "2\017.mesos.Resource\022\023\n\013description\030\005 \001(\t\022\r" +
-      "\n\005ports\030\006 \003(\r\0224\n\013constraints\030\007 \003(\0132\037.mes" +
-      "osphere.marathon.Constraint\022\022\n\010executor\030",
-      "\010 \002(\t:\000\022>\n\022OBSOLETE_container\030\n \001(\0132\".me" +
-      "sosphere.marathon.ContainerInfo\022)\n\007versi" +
-      "on\030\013 \001(\t:\0301970-01-01T00:00:00.000Z\022@\n\014he" +
-      "althChecks\030\014 \003(\0132*.mesosphere.marathon.H" +
-      "ealthCheckDefinition\022\025\n\007backoff\030\r \001(\003:\0041" +
-      "000\022\033\n\rbackoffFactor\030\016 \001(\001:\0041.15\022G\n\017upgr" +
-      "adeStrategy\030\017 \001(\0132..mesosphere.marathon." +
-      "UpgradeStrategyDefinition\022\024\n\014dependencie" +
-      "s\030\020 \003(\t\022\021\n\tstoreUrls\030\021 \003(\t\022\034\n\rrequire_po" +
-      "rts\030\022 \001(\010:\005false\022=\n\tcontainer\030\023 \001(\0132*.me",
-      "sosphere.marathon.ExtendedContainerInfo\022" +
-      " \n\006labels\030\024 \003(\0132\020.mesos.Parameter\022\037\n\016max" +
-      "LaunchDelay\030\025 \001(\003:\0073600000\"\200\002\n\014MarathonT" +
-      "ask\022\n\n\002id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003" +
-      " \003(\r\022$\n\nattributes\030\004 \003(\0132\020.mesos.Attribu" +
-      "te\022\021\n\tstaged_at\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(" +
-      "\003\022,\n\021OBSOLETE_statuses\030\007 \003(\0132\021.mesos.Tas" +
-      "kStatus\022)\n\007version\030\010 \001(\t:\0301970-01-01T00:" +
-      "00:00.000Z\022!\n\006status\030\t \001(\0132\021.mesos.TaskS" +
-      "tatus\"M\n\013MarathonApp\022\014\n\004name\030\001 \001(\t\0220\n\005ta",
-      "sks\030\002 \003(\0132!.mesosphere.marathon.Marathon" +
-      "Task\"1\n\rContainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017" +
-      "\n\007options\030\002 \003(\014\"\205\004\n\025ExtendedContainerInf" +
-      "o\022\'\n\004type\030\001 \002(\0162\031.mesos.ContainerInfo.Ty" +
-      "pe\022\036\n\007volumes\030\002 \003(\0132\r.mesos.Volume\022E\n\006do" +
-      "cker\030\003 \001(\01325.mesosphere.marathon.Extende" +
-      "dContainerInfo.DockerInfo\032\333\002\n\nDockerInfo" +
-      "\022\r\n\005image\030\001 \002(\t\022>\n\007network\030\002 \001(\0162\'.mesos" +
-      ".ContainerInfo.DockerInfo.Network:\004HOST\022" +
-      "X\n\rport_mappings\030\003 \003(\0132A.mesosphere.mara",
-      "thon.ExtendedContainerInfo.DockerInfo.Po" +
-      "rtMapping\022\031\n\nprivileged\030\004 \001(\010:\005false\022$\n\n" +
-      "parameters\030\005 \003(\0132\020.mesos.Parameter\032c\n\013Po" +
-      "rtMapping\022\021\n\thost_port\030\001 \002(\r\022\026\n\016containe" +
-      "r_port\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\027\n\014servic" +
-      "e_port\030d \001(\r:\0010\")\n\020EventSubscribers\022\025\n\rc" +
-      "allback_urls\030\001 \003(\t\"=\n\016StorageVersion\022\r\n\005" +
-      "major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(" +
-      "\r\"Z\n\031UpgradeStrategyDefinition\022\035\n\025minimu" +
-      "mHealthCapacity\030\001 \002(\001\022\036\n\023maximumOverCapa",
-      "city\030\002 \001(\001:\0011\"\260\001\n\017GroupDefinition\022\n\n\002id\030" +
-      "\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.m" +
-      "esosphere.marathon.ServiceDefinition\0224\n\006" +
-      "groups\030\004 \003(\0132$.mesosphere.marathon.Group" +
-      "Definition\022\024\n\014dependencies\030\005 \003(\t\"\245\001\n\030Dep" +
-      "loymentPlanDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007ver" +
-      "sion\030\002 \002(\t\0226\n\010original\030\004 \002(\0132$.mesospher" +
-      "e.marathon.GroupDefinition\0224\n\006target\030\005 \002" +
+      "CommandInfo\022\034\n\rignoreHttp1xx\030\t \001(\010:\005fals" +
+      "e\"*\n\010Protocol\022\010\n\004HTTP\020\000\022\007\n\003TCP\020\001\022\013\n\007COMM" +
+      "AND\020\002\"\330\005\n\021ServiceDefinition\022\n\n\002id\030\001 \002(\t\022" +
+      "\037\n\003cmd\030\002 \002(\0132\022.mesos.CommandInfo\022\021\n\tinst" +
+      "ances\030\003 \002(\r\022\"\n\tresources\030\004 \003(\0132\017.mesos.R" +
+      "esource\022\023\n\013description\030\005 \001(\t\022\r\n\005ports\030\006 " +
+      "\003(\r\0224\n\013constraints\030\007 \003(\0132\037.mesosphere.ma",
+      "rathon.Constraint\022\022\n\010executor\030\010 \002(\t:\000\022>\n" +
+      "\022OBSOLETE_container\030\n \001(\0132\".mesosphere.m" +
+      "arathon.ContainerInfo\022)\n\007version\030\013 \001(\t:\030" +
+      "1970-01-01T00:00:00.000Z\022@\n\014healthChecks" +
+      "\030\014 \003(\0132*.mesosphere.marathon.HealthCheck" +
+      "Definition\022\025\n\007backoff\030\r \001(\003:\0041000\022\033\n\rbac" +
+      "koffFactor\030\016 \001(\001:\0041.15\022G\n\017upgradeStrateg" +
+      "y\030\017 \001(\0132..mesosphere.marathon.UpgradeStr" +
+      "ategyDefinition\022\024\n\014dependencies\030\020 \003(\t\022\021\n" +
+      "\tstoreUrls\030\021 \003(\t\022\034\n\rrequire_ports\030\022 \001(\010:",
+      "\005false\022=\n\tcontainer\030\023 \001(\0132*.mesosphere.m" +
+      "arathon.ExtendedContainerInfo\022 \n\006labels\030" +
+      "\024 \003(\0132\020.mesos.Parameter\022\037\n\016maxLaunchDela" +
+      "y\030\025 \001(\003:\0073600000\"\200\002\n\014MarathonTask\022\n\n\002id\030" +
+      "\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022$\n\nat" +
+      "tributes\030\004 \003(\0132\020.mesos.Attribute\022\021\n\tstag" +
+      "ed_at\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003\022,\n\021OBSOL" +
+      "ETE_statuses\030\007 \003(\0132\021.mesos.TaskStatus\022)\n" +
+      "\007version\030\010 \001(\t:\0301970-01-01T00:00:00.000Z" +
+      "\022!\n\006status\030\t \001(\0132\021.mesos.TaskStatus\"M\n\013M",
+      "arathonApp\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132" +
+      "!.mesosphere.marathon.MarathonTask\"1\n\rCo" +
+      "ntainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007options\030" +
+      "\002 \003(\014\"\205\004\n\025ExtendedContainerInfo\022\'\n\004type\030" +
+      "\001 \002(\0162\031.mesos.ContainerInfo.Type\022\036\n\007volu" +
+      "mes\030\002 \003(\0132\r.mesos.Volume\022E\n\006docker\030\003 \001(\013" +
+      "25.mesosphere.marathon.ExtendedContainer" +
+      "Info.DockerInfo\032\333\002\n\nDockerInfo\022\r\n\005image\030" +
+      "\001 \002(\t\022>\n\007network\030\002 \001(\0162\'.mesos.Container" +
+      "Info.DockerInfo.Network:\004HOST\022X\n\rport_ma",
+      "ppings\030\003 \003(\0132A.mesosphere.marathon.Exten" +
+      "dedContainerInfo.DockerInfo.PortMapping\022" +
+      "\031\n\nprivileged\030\004 \001(\010:\005false\022$\n\nparameters" +
+      "\030\005 \003(\0132\020.mesos.Parameter\032c\n\013PortMapping\022" +
+      "\021\n\thost_port\030\001 \002(\r\022\026\n\016container_port\030\002 \002" +
+      "(\r\022\020\n\010protocol\030\003 \001(\t\022\027\n\014service_port\030d \001" +
+      "(\r:\0010\")\n\020EventSubscribers\022\025\n\rcallback_ur" +
+      "ls\030\001 \003(\t\"=\n\016StorageVersion\022\r\n\005major\030\001 \002(" +
+      "\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z\n\031Upgra" +
+      "deStrategyDefinition\022\035\n\025minimumHealthCap",
+      "acity\030\001 \002(\001\022\036\n\023maximumOverCapacity\030\002 \001(\001" +
+      ":\0011\"\260\001\n\017GroupDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007v" +
+      "ersion\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.mesosphere." +
+      "marathon.ServiceDefinition\0224\n\006groups\030\004 \003" +
       "(\0132$.mesosphere.marathon.GroupDefinition" +
-      "\"\245\001\n\013TaskFailure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task",
-      "_id\030\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003 \002(\0162" +
-      "\020.mesos.TaskState\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004" +
-      "host\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\ttimesta" +
-      "mp\030\007 \002(\tB\035\n\023mesosphere.marathonB\006Protos"
+      "\022\024\n\014dependencies\030\005 \003(\t\"\245\001\n\030DeploymentPla" +
+      "nDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t" +
+      "\0226\n\010original\030\004 \002(\0132$.mesosphere.marathon" +
+      ".GroupDefinition\0224\n\006target\030\005 \002(\0132$.mesos" +
+      "phere.marathon.GroupDefinition\"\245\001\n\013TaskF",
+      "ailure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132" +
+      "\r.mesos.TaskID\022\037\n\005state\030\003 \002(\0162\020.mesos.Ta" +
+      "skState\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t" +
+      ":\000\022\017\n\007version\030\006 \002(\t\022\021\n\ttimestamp\030\007 \002(\tB\035" +
+      "\n\023mesosphere.marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -19204,7 +19318,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
-              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", });
+              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", });
           internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
             getDescriptor().getMessageTypes().get(2);
           internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -41,6 +41,7 @@ message HealthCheckDefinition {
   optional string path = 6 [default = "/"]; // used for HTTP only
   optional uint32 maxConsecutiveFailures = 7 [default = 3];
   optional mesos.CommandInfo command = 8;
+  optional bool ignoreHttp1xx = 9 [default = false];
 }
 
 message ServiceDefinition {

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -297,7 +297,8 @@ trait HealthCheckFormats {
       (__ \ "gracePeriodSeconds").formatNullable[Long].withDefault(DefaultGracePeriod.toSeconds).asSeconds ~
       (__ \ "intervalSeconds").formatNullable[Long].withDefault(DefaultInterval.toSeconds).asSeconds ~
       (__ \ "timeoutSeconds").formatNullable[Long].withDefault(DefaultTimeout.toSeconds).asSeconds ~
-      (__ \ "maxConsecutiveFailures").formatNullable[Integer].withDefault(DefaultMaxConsecutiveFailures)
+      (__ \ "maxConsecutiveFailures").formatNullable[Integer].withDefault(DefaultMaxConsecutiveFailures) ~
+      (__ \ "ignoreHttp1xx").formatNullable[Boolean].withDefault(DefaultIgnoreHttp1xx)
     )(HealthCheck.apply, unlift(HealthCheck.unapply))
   }
 }

--- a/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
@@ -30,7 +30,9 @@ case class HealthCheck(
 
   @FieldJsonProperty("timeoutSeconds") timeout: FiniteDuration = HealthCheck.DefaultTimeout,
 
-  maxConsecutiveFailures: JInt = HealthCheck.DefaultMaxConsecutiveFailures)
+  maxConsecutiveFailures: JInt = HealthCheck.DefaultMaxConsecutiveFailures,
+
+  ignoreHttp1xx: Boolean = HealthCheck.DefaultIgnoreHttp1xx)
     extends MarathonState[Protos.HealthCheckDefinition, HealthCheck] {
 
   def toProto: Protos.HealthCheckDefinition = {
@@ -41,6 +43,7 @@ case class HealthCheck(
       .setIntervalSeconds(this.interval.toSeconds.toInt)
       .setTimeoutSeconds(this.timeout.toSeconds.toInt)
       .setMaxConsecutiveFailures(this.maxConsecutiveFailures)
+      .setIgnoreHttp1Xx(this.ignoreHttp1xx)
 
     command foreach { c => builder.setCommand(c.toProto) }
 
@@ -61,7 +64,8 @@ case class HealthCheck(
       gracePeriod = proto.getGracePeriodSeconds.seconds,
       timeout = proto.getTimeoutSeconds.seconds,
       interval = proto.getIntervalSeconds.seconds,
-      maxConsecutiveFailures = proto.getMaxConsecutiveFailures
+      maxConsecutiveFailures = proto.getMaxConsecutiveFailures,
+      ignoreHttp1xx = proto.getIgnoreHttp1Xx
     )
 
   def mergeFromProto(bytes: Array[Byte]): HealthCheck =
@@ -116,4 +120,5 @@ object HealthCheck {
   val DefaultInterval = 1.minute
   val DefaultTimeout = 20.seconds
   val DefaultMaxConsecutiveFailures = 3
+  val DefaultIgnoreHttp1xx = false
 }


### PR DESCRIPTION
To support apps which have a variable startup time, having only healthy and
unhealthy as results of health checks is not enough. This patch introduces
a third behaviour for the HTTP response codes 100 to 199: health checks with
these response codes are ignored.

Fixes #1126