### PR TITLE
fixes #1186 - Improve message for an unknown version

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -32,6 +32,7 @@ class AppVersionsResource(service: MarathonSchedulerService, val config: Maratho
   def show(@PathParam("appId") appId: String,
            @PathParam("version") version: String): Response = {
     val id = appId.toRootPath
-    service.getApp(id, Timestamp(version)).map(ok(_)) getOrElse unknownApp(id)
+    val timestamp = Timestamp(version)
+    service.getApp(id, timestamp).map(ok(_)) getOrElse unknownApp(id, Option(timestamp))
   }
 }


### PR DESCRIPTION
Tests:
curl http://localhost:8080/v2/apps/zero-instance-app/versions
{"versions":["2015-02-11T21:45:53.389Z","2015-02-11T21:45:44.041Z"]}

curl http://localhost:8080/v2/apps/zero-instance-app/versions/2015-02-11T21:45:44.041Z
{"id":"/zero-instance-app","version":"2015-02-11T21:45:44.041Z", ...}

curl http://localhost:8080/v2/apps/zero-instance-app/versions/2010-02-11T21:45:44.041Z
{"message":"App '/zero-instance-app' does not exist in version 2010-02-11T21:45:44.041Z"}