### PR TITLE
fixes #1178 - Changed MarathonSchedulerActor to use a Set[PathId] for ap...

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -173,7 +173,7 @@ class MarathonScheduler @Inject() (
             case None       => log.warn(s"Couldn't post event for ${status.getTaskId}")
           }
 
-          schedulerActor ! ScaleApp(appId, force = false)
+          schedulerActor ! ScaleApp(appId)
         }
 
       case TASK_RUNNING if !maybeTask.exists(_.hasStartedAt) => // staged, not running

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -102,10 +102,7 @@ class MarathonSchedulerService @Inject() (
   }
 
   def cancelDeployment(id: String): Unit =
-    schedulerActor ! CancelDeployment(
-      id,
-      new DeploymentCanceledException("The upgrade has been cancelled")
-    )
+    schedulerActor ! CancelDeployment(id)
 
   def listApps(): Iterable[AppDefinition] =
     Await.result(appRepository.apps(), config.zkTimeoutDuration)

--- a/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
@@ -54,7 +54,7 @@ class MarathonExceptionMapper extends ExceptionMapper[Exception] {
     case e: AppLockedException =>
       Map(
         "message" -> e.getMessage,
-        "deployments" -> e.deploymentIds.map(Identifiable(_))
+        "deployments" -> e.deploymentIds.map(Identifiable)
       )
     case e: JsonParseException =>
       Map("message" -> e.getOriginalMessage)

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -152,7 +152,7 @@ class DeploymentActorTest
         case (step, num) => managerProbe.expectMsg(5.seconds, DeploymentStepInfo(plan, step, num + 1))
       }
 
-      managerProbe.expectMsg(5.seconds, DeploymentFinished(plan.id))
+      managerProbe.expectMsg(5.seconds, DeploymentFinished(plan))
 
       verify(scheduler).startApp(driver, app3.copy(instances = 0))
       verify(driver, times(1)).killTask(TaskID(task1_2.getId))
@@ -229,7 +229,7 @@ class DeploymentActorTest
         )
       )
 
-      receiverProbe.expectMsg(Finished)
+      receiverProbe.expectMsg(DeploymentFinished(plan))
 
       verify(driver).killTask(TaskID(task1_1.getId))
       verify(driver).killTask(TaskID(task1_2.getId))
@@ -274,7 +274,7 @@ class DeploymentActorTest
         )
       )
 
-      receiverProbe.expectMsg(Finished)
+      receiverProbe.expectMsg(DeploymentFinished(plan))
     }
     finally {
       system.shutdown()


### PR DESCRIPTION
...p locks instead of Semaphores

  The reason for this change is that previously we blocked on the
  semaphores inside of futures. There are several problems with this
  approach.

  - Prone to deadlocks
  - unnecessarily blocks threads
  - breaks actor encapsulation by closing over the semaphores
  - not necessarily fair if multiple forced commands arrive before
    the original command has been cancelled

  Because this is a very drastic change and caused lots of changes in
  the other deployment related classes, this should be thoroughly reviewed
  before merging.