### PR TITLE
Return deployment with POST /v2/apps response.

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -403,6 +403,11 @@ Transfer-Encoding: chunked
     },
     "cpus": 0.25,
     "dependencies": [],
+    "deployments": [
+        {
+            "id": "f44fd4fc-4330-4600-a68b-99c7bd33014a"
+        }
+    ],
     "disk": 0.0,
     "env": {},
     "executor": "",


### PR DESCRIPTION
Plus minor related formatting for readability.

```http
POST /v2/apps HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Content-Length: 175
Content-Type: application/json; charset=utf-8
Host: localhost:8080
User-Agent: HTTPie/0.8.0

{
    "cmd": "sleep 1000", 
    "cpus": 0.5, 
    "id": "test-app", 
    "instances": 1000, 
    "labels": {
        "PACKAGE_ID": "test-app", 
        "PACKAGE_VERSION": "1.2.3"
    }, 
    "mem": 16
}
```

```http
HTTP/1.1 201 Created
Content-Type: application/json
Location: http://localhost:8080/v2/apps/test-app
Server: Jetty(8.y.z-SNAPSHOT)
Transfer-Encoding: chunked

{
    "args": null, 
    "backoffFactor": 1.15, 
    "backoffSeconds": 1, 
    "cmd": "sleep 1000", 
    "constraints": [], 
    "container": null, 
    "cpus": 0.5, 
    "dependencies": [], 
    "deployments": [
        {
            "id": "f44fd4fc-4330-4600-a68b-99c7bd33014a"
        }
    ], 
    "disk": 0.0, 
    "env": {}, 
    "executor": "", 
    "healthChecks": [], 
    "id": "/test-app", 
    "instances": 1000, 
    "labels": {
        "PACKAGE_ID": "test-app", 
        "PACKAGE_VERSION": "1.2.3"
    }, 
    "maxLaunchDelaySeconds": 3600, 
    "mem": 16.0, 
    "ports": [
        0
    ], 
    "requirePorts": false, 
    "storeUrls": [], 
    "tasks": [], 
    "tasksHealthy": 0, 
    "tasksRunning": 0, 
    "tasksStaged": 0, 
    "tasksUnhealthy": 0, 
    "upgradeStrategy": {
        "maximumOverCapacity": 1.0, 
        "minimumHealthCapacity": 1.0
    }, 
    "uris": [], 
    "user": null, 
    "version": "2015-02-13T23:12:48.826Z"
}
```

cc @jsancio 