### PR TITLE
Change link to Developing Marathon Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ options, see [the Marathon docs](https://mesosphere.github.io/marathon/docs/).
 
 ## Developing Marathon
 
-The [Marathon Project Docs](https://mesosphere.github.io/marathon/docs/contributing.html)
+The [Marathon Wiki Page](https://github.com/mesosphere/marathon/wiki/Developing-Marathon-in-a-Preconfigured-VM)
 contains documentation on simplifying local development and testing of Marathon
-including how to run a Mesos environment inside a preconfigured virtual machine
-and a list of recipes for launching applications that test specific Marathon
+including how to run a Mesos environment inside a preconfigured virtual machine running on Vagrant and a list of recipes for launching applications that test specific Marathon
 features.
 
 ### Running the development Docker


### PR DESCRIPTION
Change link to wiki page, which describe how to run Marathon on develop mode.
Actual page https://mesosphere.github.io/marathon/docs/contributing.html only describe contributor guidelines.
Changed to: https://github.com/mesosphere/marathon/wiki/Developing-Marathon-in-a-Preconfigured-VM