### PR TITLE
add call to mesosphere-dnsconfig if installed

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -35,6 +35,9 @@ function element_in {
 }
 
 function load_options_and_log {
+  # Call mesosphere-dnsconf if present on the system to generate config files.
+  [ -x /usr/bin/mesosphere-dnsconfig ] && mesosphere-dnsconfig mesos && mesosphere-dnsconfig marathon
+
   # Load Marathon options from Mesos and Marathon conf files that are present.
   # Launch main program with Syslog enabled.
   local cmd=( run_jar )


### PR DESCRIPTION
Adds a nonintrusive patch that will call mesosphere-dnsconfig if mesosphere-dnsconfig is installed on the system.