### PR TITLE
[README]

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ If you want to inspect the contents of the Docker:
 * [Python client](https://github.com/thefactory/marathon-python), developed at [The Factory](http://www.thefactory.com)
 * [Python client](https://github.com/Wizcorp/marathon-client.py), developed at [Wizcorp](http://www.wizcorp.jp)
 * [Go client](https://github.com/jbdalido/gomarathon) by Jean-Baptiste Dalido
+* [Go client](https://github.com/gambol99/go-marathon) by Rohith Jayawardene
 * [Node client](https://github.com/silas/node-mesos) by Silas Sewell
 * [Clojure client](https://github.com/codemomentum/marathonclj) by Halit Olali
 


### PR DESCRIPTION
- adding a link to a additional Marathon go client