### PR TITLE
Override Timestamp hashCode for consistent hashing

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -15,6 +15,10 @@ case class Timestamp(dateTime: DateTime) extends Ordered[Timestamp] {
     case _               => false
   }
 
+  /** hashCode must be computed on the UTC timestamp in order to uphold
+    * the equals/hashCode contract, 
+    * compare java.org.joda.time.base.AbstractInstant.hashCode
+    */
   override def hashCode: Int = time.hashCode
 
   def compare(that: Timestamp): Int = this.time compareTo that.time

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -15,6 +15,8 @@ case class Timestamp(dateTime: DateTime) extends Ordered[Timestamp] {
     case _               => false
   }
 
+  override def hashCode: Int = time.hashCode
+
   def compare(that: Timestamp): Int = this.time compareTo that.time
 
   override def toString: String = time.toString

--- a/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.state
 
 import mesosphere.marathon.MarathonSpec
+import org.joda.time.{ DateTime, DateTimeZone }
 
 class TimestampTest extends MarathonSpec {
 
@@ -8,5 +9,13 @@ class TimestampTest extends MarathonSpec {
     val t1 = Timestamp(1024)
     val t2 = Timestamp(2048)
     assert(t1.compare(t2) < 0)
+  }
+
+  test("Independent of timezone") {
+    val t1 = Timestamp(1024)
+    val t2 = Timestamp(new DateTime(1024).toDateTime(DateTimeZone.forOffsetHours(2)))
+
+    assert(t1 == t2)
+    assert(t1.hashCode == t2.hashCode)
   }
 }


### PR DESCRIPTION
Timestamp's hashCode was based on the parameter dateTime which might have
a timezone != UTC. The consequence:

  val t = Timestamp.now
  t.hashCode != Timestamp(t.toString).hashCode

This patch overrides hashCode to use the UTC normalized time variable of the
Timestamp case class.

This probably fixes #1082