### PR TITLE
Turn Timestamp into a normal case class and inherit equal and hashCode

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -6,27 +6,20 @@ import scala.math.Ordered
 /**
   * An ordered wrapper for UTC timestamps.
   */
-case class Timestamp(dateTime: DateTime) extends Ordered[Timestamp] {
+abstract case class Timestamp private (utcDateTime: DateTime) extends Ordered[Timestamp] {
+  def compare(that: Timestamp): Int = this.utcDateTime compareTo that.utcDateTime
 
-  val time = dateTime.toDateTime(DateTimeZone.UTC)
+  override def toString: String = utcDateTime.toString
 
-  override def equals(obj: Any): Boolean = obj match {
-    case that: Timestamp => this.time == that.time
-    case _               => false
-  }
-
-  /** hashCode must be computed on the UTC timestamp in order to uphold
-    * the equals/hashCode contract, 
-    * compare java.org.joda.time.base.AbstractInstant.hashCode
-    */
-  override def hashCode: Int = time.hashCode
-
-  def compare(that: Timestamp): Int = this.time compareTo that.time
-
-  override def toString: String = time.toString
+  def toDateTime: DateTime = utcDateTime
 }
 
 object Timestamp {
+  /**
+    * Returns a new Timestamp representing the instant that is the supplied
+    * dateTime converted to UTC.
+    */
+  def apply(dateTime: DateTime): Timestamp = new Timestamp(dateTime.toDateTime(DateTimeZone.UTC)) {}
 
   /**
     * Returns a new Timestamp representing the instant that is the supplied

--- a/src/test/scala/mesosphere/marathon/state/AppRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppRepositoryTest.scala
@@ -13,7 +13,7 @@ class AppRepositoryTest extends MarathonSpec {
   test("App") {
     val path = "testApp".toRootPath
     val store = mock[MarathonStore[AppDefinition]]
-    val timestamp = new Timestamp(DateTime.now())
+    val timestamp = Timestamp.now
     val appDef = AppDefinition(id = path, version = timestamp)
     val future = Future.successful(Some(appDef))
 
@@ -64,8 +64,8 @@ class AppRepositoryTest extends MarathonSpec {
     val store = mock[MarathonStore[AppDefinition]]
     val appDef1 = AppDefinition("app1".toPath)
     val appDef2 = AppDefinition("app2".toPath)
-    val appDef1Old = appDef1.copy(version = Timestamp(appDef1.version.dateTime.minusDays(1)))
-    val appDef2Old = appDef2.copy(version = Timestamp(appDef2.version.dateTime.minusDays(1)))
+    val appDef1Old = appDef1.copy(version = Timestamp(appDef1.version.toDateTime.minusDays(1)))
+    val appDef2Old = appDef2.copy(version = Timestamp(appDef2.version.toDateTime.minusDays(1)))
     val allApps = Seq(appDef1, appDef2, appDef1Old, appDef2Old)
 
     val future = Future.successful((Seq("app1", "app2") ++ allApps.map(x => s"${x.id}:${x.version}")).toIterator)
@@ -87,9 +87,9 @@ class AppRepositoryTest extends MarathonSpec {
   test("ListVersions") {
     val store = mock[MarathonStore[AppDefinition]]
     val appDef1 = AppDefinition("app1".toRootPath)
-    val version1 = appDef1.copy(version = Timestamp(appDef1.version.dateTime.minusDays(1)))
-    val version2 = appDef1.copy(version = Timestamp(appDef1.version.dateTime.minusDays(2)))
-    val version3 = appDef1.copy(version = Timestamp(appDef1.version.dateTime.minusDays(3)))
+    val version1 = appDef1.copy(version = Timestamp(appDef1.version.toDateTime.minusDays(1)))
+    val version2 = appDef1.copy(version = Timestamp(appDef1.version.toDateTime.minusDays(2)))
+    val version3 = appDef1.copy(version = Timestamp(appDef1.version.toDateTime.minusDays(3)))
     val appDef2 = AppDefinition("app2".toRootPath)
     val allApps = Seq(appDef1, version1, version2, version3, appDef2)
 
@@ -109,9 +109,9 @@ class AppRepositoryTest extends MarathonSpec {
   test("Expunge") {
     val store = mock[MarathonStore[AppDefinition]]
     val appDef1 = AppDefinition("app1".toRootPath)
-    val version1 = appDef1.copy(version = Timestamp(appDef1.version.dateTime.minusDays(1)))
-    val version2 = appDef1.copy(version = Timestamp(appDef1.version.dateTime.minusDays(2)))
-    val version3 = appDef1.copy(version = Timestamp(appDef1.version.dateTime.minusDays(3)))
+    val version1 = appDef1.copy(version = Timestamp(appDef1.version.toDateTime.minusDays(1)))
+    val version2 = appDef1.copy(version = Timestamp(appDef1.version.toDateTime.minusDays(2)))
+    val version3 = appDef1.copy(version = Timestamp(appDef1.version.toDateTime.minusDays(3)))
     val appDef2 = AppDefinition("app2".toRootPath)
     val allApps = Seq(appDef1, version1, version2, version3, appDef2)
 


### PR DESCRIPTION
Timestamp was a case class with overridden `equal` and `hashCode` methods which
used the UTC normalized dateTime instead of the parameter dataTime.

This patch removes the `time` value inside the case class. It enforces UTC
in the parameter `dateTime` by hiding the constructor and adding timezone
conversion to the companion object's `apply(dateTime: DateTime)`.

This solves the problem in #1218 in a more elegant way.