### PR TITLE
Adding Human API to list of companies using Marathon

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ If you want to inspect the contents of the Docker:
 * [The Factory](https://github.com/thefactory/)
 * [Guidewire](http://www.guidewire.com/)
 * [Groupon](http://www.groupon.com/)
+* [Human API](https://humanapi.co/)
 * [iQIYI](http://www.iqiyi.com/)
 * [Measurence](http://www.measurence.com/)
 * [OpenTable](http://www.opentable.com/)


### PR DESCRIPTION
Adding Human API (https://humanapi.co/) to list of companies using Marathon