### PR TITLE
Update mesosphere-dnsconfig call in marathon-framework startup wrapper

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -36,7 +36,7 @@ function element_in {
 
 function load_options_and_log {
   # Call mesosphere-dnsconf if present on the system to generate config files.
-  [ -x /usr/bin/mesosphere-dnsconfig ] && mesosphere-dnsconfig mesos && mesosphere-dnsconfig marathon
+  [ -x /usr/bin/mesosphere-dnsconfig ] && mesosphere-dnsconfig -write -service=marathon
 
   # Load Marathon options from Mesos and Marathon conf files that are present.
   # Launch main program with Syslog enabled.

--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -35,7 +35,7 @@ function element_in {
 }
 
 function load_options_and_log {
-  # Call mesosphere-dnsconf if present on the system to generate config files.
+  # Call mesosphere-dnsconfig if present on the system to generate config files.
   [ -x /usr/bin/mesosphere-dnsconfig ] && mesosphere-dnsconfig -write -service=marathon
 
   # Load Marathon options from Mesos and Marathon conf files that are present.


### PR DESCRIPTION
mesosphere-dnsconfig is now configured using flags. This PR reflects this change in cli args.