### PR TITLE
"marathon.proto" now imports "mesos.proto" again, not "mesos/mesos.proto"

### DIFF
--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -6,7 +6,7 @@ package mesosphere.marathon;
 option java_package = "mesosphere.marathon";
 option java_outer_classname = "Protos";
 
-import "mesos/mesos.proto";
+import "mesos.proto";
 
 message Constraint {
   required string field = 1;


### PR DESCRIPTION
Changed the "mesos.proto" import to point to "mesos.proto" in the current directory instead of in a "mesos" directory. Should make it easier to copy the file from the mesos project. Also now matches the instructions in "README.md".