### PR TITLE
Include task_launch_timeout in kill log message

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -87,7 +87,8 @@ class MarathonScheduler @Inject() (
     val toKill = taskTracker.checkStagedTasks
 
     if (toKill.nonEmpty) {
-      log.warn(s"There are ${toKill.size} tasks stuck in staging which will be killed")
+      log.warn(s"There are ${toKill.size} tasks stuck in staging for more " +
+        s"than ${config.taskLaunchTimeout()}ms which will be killed")
       log.info(s"About to kill these tasks: $toKill")
       for (task <- toKill)
         driver.killTask(protos.TaskID(task.getId))


### PR DESCRIPTION
Adds the task launch timeout to the log message before tasks get killed. This helps with debugging if it was accidentally set too low.