### PR TITLE
fixes #1256 - Moved endpoint to generate deployment previews from /v2/de...

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,10 +8,10 @@ healthy nor unhealthy as long as e.g. "100 - continue" is returned.
 
 ## Changes from 0.8.0 to 0.8.1
 
-#### New endpoint `/v2/deployments/generate`
+#### New option `dryRun` on endpoint `PUT /v2/groups/{id}`
 
-When posting a group definition to this endpoint, it will
-return the deployment steps Marathon would execute to deploy
+When sending a group definition to this endpoint with `dryRun=true`,
+it will return the deployment steps Marathon would execute to deploy
 this group.
 
 #### New endpoint DELETE `/v2/tasks`

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -31,7 +31,6 @@ title: REST API
 * [Deployments](#deployments) <span class="label label-default">v0.7.0</span>
   * [GET /v2/deployments](#get-/v2/deployments): List running deployments
   * [DELETE /v2/deployments/{deploymentId}](#delete-/v2/deployments/{deploymentid}): Cancel the deployment with `deploymentId`
-  * [POST /v2/deployments/generate](#post-/v2/deployments/generate): Generate deployment steps for a group without executing them
 * [Event Subscriptions](#event-subscriptions)
   * [POST /v2/eventSubscriptions](#post-/v2/eventsubscriptions): Register a callback URL as an event subscriber
   * [GET /v2/eventSubscriptions](#get-/v2/eventsubscriptions): List all event subscriber callback URLs
@@ -1711,6 +1710,87 @@ Transfer-Encoding: chunked
 }
 {% endhighlight %}
 
+### Example
+
+Deployment dry run.
+
+Get a preview of the deployment steps Marathon would run for a given group update.
+
+**Request:**
+
+{% highlight http %}
+PUT /v2/groups/product?dryRun=true HTTP/1.1
+Accept: */*
+Accept-Encoding: gzip, deflate
+Content-Type: application/json
+Host: mesos.vm:8080
+User-Agent: HTTPie/0.8.0
+
+{
+    "id": "product",
+    "groups": [{
+        "id": "service",
+        "groups": [{
+            "id": "us-east",
+            "apps": [
+                {
+                    "id": "app1",
+                    "cmd": "someExecutable"
+                },
+                {
+                    "id": "app2",
+                    "cmd": "someOtherExecutable"
+                }
+            ]
+        }],
+        "dependencies": ["/product/database", "../backend"]
+    }],
+    "version": "2014-03-01T23:29:30.158Z"
+}
+{% endhighlight %}
+
+**Response:**
+
+{% highlight http %}
+HTTP/1.1 200 OK
+Content-Type: application/json
+Server: Jetty(8.y.z-SNAPSHOT)
+Transfer-Encoding: chunked
+
+{
+    "steps" : [
+        {
+            "actions" : [
+                {
+                    "app" : "app1",
+                    "type" : "StartApplication"
+                },
+                {
+                    "app" : "app2",
+                    "type" : "StartApplication"
+                }
+            ]
+        },
+        {
+            "actions" : [
+                {
+                    "type" : "ScaleApplication",
+                    "app" : "app1"
+                }
+            ]
+        },
+        {
+            "actions" : [
+                {
+                    "app" : "app2",
+                    "type" : "ScaleApplication"
+                }
+            ]
+        }
+    ]
+}
+{% endhighlight %}
+
 #### DELETE `/v2/groups/{groupId}`
 
 Destroy a group. All data about that group and all associated applications will be deleted.
@@ -2054,85 +2134,6 @@ HTTP/1.1 202 Accepted
 Content-Length: 0
 Content-Type: application/json
 Server: Jetty(8.y.z-SNAPSHOT)
-{% endhighlight %}
-
-#### POST /v2/deployments/generate
-
-Generates deployment steps for a given group without executing them.
-
-**Request:**
-
-{% highlight http %}
-POST /v2/deployments/generate HTTP/1.1
-Accept: */*
-Accept-Encoding: gzip, deflate
-Content-Type: application/json
-Host: mesos.vm:8080
-User-Agent: HTTPie/0.8.0
-
-{
-    "id": "product",
-    "groups": [{
-        "id": "service",
-        "groups": [{
-            "id": "us-east",
-            "apps": [
-                {
-                    "id": "app1",
-                    "cmd": "someExecutable"
-                },
-                {
-                    "id": "app2",
-                    "cmd": "someOtherExecutable"
-                }
-            ]
-        }],
-        "dependencies": ["/product/database", "../backend"]
-    }],
-    "version": "2014-03-01T23:29:30.158Z"
-}
-{% endhighlight %}
-
-**Response:**
-
-{% highlight http %}
-HTTP/1.1 200 OK
-Content-Type: application/json
-Server: Jetty(8.y.z-SNAPSHOT)
-Transfer-Encoding: chunked
-
-{
-    "steps" : [
-        {
-            "actions" : [
-                {
-                    "app" : "app1",
-                    "type" : "StartApplication"
-                },
-                {
-                    "app" : "app2",
-                    "type" : "StartApplication"
-                }
-            ]
-        },
-        {
-            "actions" : [
-                {
-                    "type" : "ScaleApplication",
-                    "app" : "app1"
-                }
-            ]
-        },
-        {
-            "actions" : [
-                {
-                    "app" : "app2",
-                    "type" : "ScaleApplication"
-                }
-            ]
-        }
-    ]
-}
 {% endhighlight %}
 
 ### Event Subscriptions

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckWorkerActor.scala
@@ -88,7 +88,8 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
       else if (check.ignoreHttp1xx && (toIgnoreResponses contains response.status.intValue)) {
         log.debug(s"Ignoring health check HTTP response ${response.status.intValue} for task ${task.getId}")
         None
-      } else {
+      }
+      else {
         Some(Unhealthy(task.getId, task.getVersion, response.status.toString()))
       }
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -1,0 +1,48 @@
+package mesosphere.marathon.api.v2
+
+import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.state.{ AppDefinition, GroupManager }
+import mesosphere.marathon.{ MarathonConf, MarathonSpec }
+import org.mockito.Mockito.when
+import org.scalatest.Matchers
+import play.api.libs.json.{ JsObject, Json }
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class GroupsResourceTest extends MarathonSpec with Matchers {
+  var config: MarathonConf = _
+  var groupManager: GroupManager = _
+  var groupsResource: GroupsResource = _
+
+  before {
+    config = mock[MarathonConf]
+    groupManager = mock[GroupManager]
+
+    when(config.zkTimeoutDuration).thenReturn(5.seconds)
+
+    groupsResource = new GroupsResource(groupManager, config)
+  }
+
+  test("dry run update") {
+
+    val app = AppDefinition(id = "/test/app".toRootPath, cmd = Some("test cmd"))
+    val update = GroupUpdate(id = Some("/test".toRootPath), apps = Some(Set(app)))
+
+    when(groupManager.group(update.groupId)).thenReturn(Future.successful(None))
+
+    val result = groupsResource.update("/test", update, force = false, dryRun = true)
+    val json = Json.parse(result.getEntity.toString)
+
+    val steps = (json \ "steps").as[Seq[JsObject]]
+    assert(steps.size == 2)
+
+    val firstStep = (steps.head \ "actions").as[Seq[JsObject]].head
+    assert((firstStep \ "type").as[String] == "StartApplication")
+    assert((firstStep \ "app").as[String] == "/test/app")
+
+    val secondStep = (steps.last \ "actions").as[Seq[JsObject]].head
+    assert((secondStep \ "type").as[String] == "ScaleApplication")
+    assert((secondStep \ "app").as[String] == "/test/app")
+  }
+}


### PR DESCRIPTION
...ployments to /v2/groups

This call expects a GroupUpdate as entity, so it belongs to the groups
endpoint.

**NOTE:** This needs to be cherrypicked into the 0.8.1 branch!