### PR TITLE
fixes #1252 - Moved endpoint `DELETE /v2/tasks` to `POST /v2/tasks/delet...

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,11 +14,11 @@ When posting a group definition to this endpoint, it will
 return the deployment steps Marathon would execute to deploy
 this group.
 
-#### New endpoint DELETE `/v2/tasks`
+#### New endpoint POST `/v2/tasks/delete`
 
-Takes a JSON array of task ids and kills them. If `?scale=true`
-the tasks will not be restarted and the instances number will
-be adjusted.
+Takes a JSON object containing an array of task ids and kills them.
+If `?scale=true` the tasks will not be restarted and the `instances`
+field of the affected apps will be adjusted.
 
 #### POST `/v2/apps` rejects existing ids
 

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -28,6 +28,7 @@ title: REST API
   * [DELETE /v2/groups/{groupId}](#delete-/v2/groups/{groupid}): Destroy a group
 * [Tasks](#tasks)
   * [GET /v2/tasks](#get-/v2/tasks): List all running tasks
+  * [POST /v2/tasks/delete](#post-/v2/tasks/delete): Kill given list of tasks
 * [Deployments](#deployments) <span class="label label-default">v0.7.0</span>
   * [GET /v2/deployments](#get-/v2/deployments): List running deployments
   * [DELETE /v2/deployments/{deploymentId}](#delete-/v2/deployments/{deploymentid}): Cancel the deployment with `deploymentId`
@@ -1871,7 +1872,7 @@ my-app  19385 agouti.local:31336  agouti.local:31364  agouti.local:31382
 my-app2  11186 agouti.local:31337  agouti.local:31365  agouti.local:31383 
 {% endhighlight %}
 
-#### DELETE `/v2/tasks`
+#### POST `/v2/tasks/delete`
 
 Kill the given list of tasks and scale apps if requested.
 
@@ -1901,18 +1902,19 @@ Kill the given list of tasks and scale apps if requested.
 **Request:**
 
 {% highlight http %}
-DELETE /v2/tasks HTTP/1.1
+POST /v2/tasks/delete HTTP/1.1
 Accept: application/json
 Accept-Encoding: gzip, deflate
 Content-Type: application/json; charset=utf-8
 Host: mesos.vm:8080
 User-Agent: HTTPie/0.8.0
-
-[
-    "task.25ab260e-b5ec-11e4-a4f4-685b35c8a22e",
-    "task.5e7b39d4-b5f0-11e4-8021-685b35c8a22e",
-    "task.a21cb64a-b5eb-11e4-a4f4-685b35c8a22e"
-]
+{
+    "ids": [
+        "task.25ab260e-b5ec-11e4-a4f4-685b35c8a22e",
+        "task.5e7b39d4-b5f0-11e4-8021-685b35c8a22e",
+        "task.a21cb64a-b5eb-11e4-a4f4-685b35c8a22e"
+    ]
+}
 
 {% endhighlight %}
 

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -59,14 +59,15 @@ class TasksResource @Inject() (
     "\t"
   ))
 
-  @DELETE
+  @POST
   @Produces(Array(MediaType.APPLICATION_JSON))
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Timed
+  @Path("/delete")
   def killTasks(
     @QueryParam("scale")@DefaultValue("false") scale: Boolean,
     body: Array[Byte]): Response = {
-    val taskIds = Json.parse(body).as[Seq[String]]
+    val taskIds = (Json.parse(body) \ "ids").as[Seq[String]]
 
     val groupedTasks = taskIds.flatMap { taskId =>
       val appId = try {

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckWorkerActor.scala
@@ -88,7 +88,8 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
       else if (check.ignoreHttp1xx && (toIgnoreResponses contains response.status.intValue)) {
         log.debug(s"Ignoring health check HTTP response ${response.status.intValue} for task ${task.getId}")
         None
-      } else {
+      }
+      else {
         Some(Unhealthy(task.getId, task.getVersion, response.status.toString()))
       }
     }


### PR DESCRIPTION
...e`

DELETE should not contain a body, also this change makes the endpoint
more RESTy
.
**NOTE:** This needs to be cherrypicked into the 0.8.1 branch