### PR TITLE
allow for disabling output to syslog with USE_SYSLOG=0

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -95,9 +95,11 @@ function run_jar {
 }
 
 function logged {
-  local token="$1[$$]" ; shift
-  exec 1> >(exec logger -p user.info   -t "$token")
-  exec 2> >(exec logger -p user.notice -t "$token")
+  if [[ "${USE_SYSLOG:-1}" == "1" ]]; then
+    local token="$1[$$]" ; shift
+    exec 1> >(exec logger -p user.info   -t "$token")
+    exec 2> >(exec logger -p user.notice -t "$token")
+  fi
   "$@"
 }
 


### PR DESCRIPTION
This makes marathon wrapper script more compatible with supervisor and systemd, or anyone else who doesn't want all of their application logs sent to syslog.

Basically the same change as: https://github.com/mesosphere/mesos-deb-packaging/pull/35