### PR TITLE
Updates executor health checks description

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -114,8 +114,9 @@ See the detailed docs on
 ### Command (executor) health checks
 
 These health checks are executed on the slave where the task is running.
-To enable this feature, start Marathon with the `--executor_health_checks`
-flag.  Requires Mesos version `0.20.0` or later.
+To enable this feature for marathon versions prior to `0.7.4`, start 
+Marathon with the `--executor_health_checks` flag (not required/allowed 
+since `0.7.4`).  Requires Mesos version `0.20.0` or later.
 
 ```json
 {


### PR DESCRIPTION
The `--executor_health_checks` flag is no longer allowed as of `0.7.4` (but was required to enable executor health checks prior to that version). Discussed in issue #724 and merged in #727.