### PR TITLE
fixes #1274 - improved performance of AppResource.index and related inte...

### DIFF
--- a/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
@@ -120,6 +120,9 @@ class HealthCheckActor(
   def receive: Receive = {
     case GetTaskHealth(taskId) => sender() ! taskHealth.get(taskId)
 
+    case GetAppHealth =>
+      sender() ! AppHealth(taskHealth.values.toSeq)
+
     case Tick =>
       purgeStatusOfDoneTasks()
       dispatchJobs()
@@ -173,4 +176,7 @@ object HealthCheckActor {
   // self-sent every healthCheck.intervalSeconds
   case object Tick
   case class GetTaskHealth(taskId: String)
+  case object GetAppHealth
+
+  case class AppHealth(health: Seq[Health])
 }

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
@@ -58,6 +58,11 @@ trait HealthCheckManager {
   def status(appId: PathId, taskId: String): Future[Seq[Option[Health]]]
 
   /**
+    * Returns the health status of all tasks of the supplied app.
+    */
+  def statuses(appId: PathId): Future[Map[String, Seq[Health]]]
+
+  /**
     * Returns the health status counter for the supplied app.
     */
   def healthCounts(

--- a/src/main/scala/mesosphere/marathon/health/HealthCounts.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCounts.scala
@@ -1,6 +1,28 @@
 package mesosphere.marathon.health
 
+object HealthCounts {
+  def newBuilder: HealthCounts.Builder = new Builder
+
+  class Builder {
+    private[this] var healthy = 0
+    private[this] var unknown = 0
+    private[this] var unhealthy = 0
+
+    def incHealthy(): Unit = healthy += 1
+    def incUnknown(): Unit = unknown += 1
+    def incUnhealthy(): Unit = unhealthy += 1
+    def result(): HealthCounts = HealthCounts(healthy, unknown, unhealthy)
+  }
+}
+
 case class HealthCounts(
-  healthy: Int,
-  unknown: Int,
-  unhealthy: Int)
+    healthy: Int,
+    unknown: Int,
+    unhealthy: Int) {
+  def +(that: HealthCounts): HealthCounts =
+    HealthCounts(
+      this.healthy + that.healthy,
+      this.unknown + that.unknown,
+      this.unhealthy + that.unhealthy
+    )
+}


### PR DESCRIPTION
...rnal methods

At 1000 tasks on a 2 vCPU GCE instance Marathon currently takes more than 10 seconds to respond

```
λ time curl -XGET http://10.144.146.199:8080/v2/apps
{"apps":[{"id":"/pyserv2","cmd":"python -m SimpleHTTPServer $PORT0","args":null,"user":null,"env":{},"instances":1000,"cpus":0.001,"mem":2.0,"disk":0.0,"executor":"","constraints":[],"uris":[],"storeUrls":[],"ports":[32768],"requirePorts":false,"backoffSeconds":1,"backoffFactor":1.15,"maxLaunchDelaySeconds":3600,"container":null,"healthChecks":[{"path":"/","protocol":"HTTP","portIndex":0,"gracePeriodSeconds":300,"intervalSeconds":60,"timeoutSeconds":20,"maxConsecutiveFailures":3}],"dependencies":[],"upgradeStrategy":{"minimumHealthCapacity":1.0,"maximumOverCapacity":1.0},"labels":{},"version":"2015-03-06T11:38:15.372Z","tasksStaged":0,"tasksRunning":1000,"tasksHealthy":1000,"tasksUnhealthy":0,"deployments":[]}]}
real	0m12.081s
user	0m0.004s
sys	0m0.004s
```

With this patch on the same cluster it takes less than 100ms:

```
λ time curl localhost:8080/v2/apps
{"apps":[{"id":"/frufoo","cmd":"python -m SimpleHTTPServer $PORT0","args":null,"user":null,"env":{},"instances":1000,"cpus":0.001,"mem":1.0,"disk":0.0,"executor":"","constraints":[],"uris":[],"storeUrls":[],"ports":[32767],"requirePorts":false,"backoffSeconds":1,"backoffFactor":1.15,"maxLaunchDelaySeconds":3600,"container":null,"healthChecks":[{"path":"/","protocol":"HTTP","portIndex":0,"gracePeriodSeconds":300,"intervalSeconds":60,"timeoutSeconds":20,"maxConsecutiveFailures":3,"ignoreHttp1xx":false}],"dependencies":[],"upgradeStrategy":{"minimumHealthCapacity":1.0,"maximumOverCapacity":1.0},"labels":{},"version":"2015-03-09T22:58:37.112Z","tasksStaged":0,"tasksRunning":1001,"tasksHealthy":966,"tasksUnhealthy":0,"deployments":[{"id":"e9345382-c0fb-400c-afb5-74bcf8587a5d"}]}]}
real	0m0.085s
user	0m0.000s
sys	0m0.008s
```