### PR TITLE
Feature/cors headers

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -28,6 +28,7 @@ The following options can influence how Marathon works:
     `"file:///var/log/store"`. For details, see the
     [artifact store]({{ site.baseurl }}/docs/artifact-store.html) docs.
 * `--access_control_allow_origin` (Optional. Default: None):
+    Comma separated list of allowed originating domains for HTTP requests.
     The origin(s) to allow in Marathon. Not set by default.
     Examples: `"*"`, or `"http://localhost:8888, http://domain.com"`.
 * `--checkpoint` (Optional. Default: true): Enable checkpointing of tasks.

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -27,6 +27,9 @@ The following options can influence how Marathon works:
     Examples: `"hdfs://localhost:54310/path/to/store"`,
     `"file:///var/log/store"`. For details, see the
     [artifact store]({{ site.baseurl }}/docs/artifact-store.html) docs.
+* `--access_control_allow_origin` (Optional. Default: None):
+    The origin(s) to allow in Marathon. Not set by default.
+    Examples: `"*"`, or `"http://localhost:8888, http://domain.com"`.
 * `--checkpoint` (Optional. Default: true): Enable checkpointing of tasks.
     Requires checkpointing enabled on slaves. Allows tasks to continue running
     during mesos-slave restarts and Marathon scheduler failover.  See the
@@ -82,8 +85,8 @@ The following options can influence how Marathon works:
     authentication
 * `--mesos_authentication_secret_file` (Optional.): The path to the Mesos secret
     file containing the authentication secret
-* `--marathon_store_timeout` (Optional. Default: 2000 (2 seconds)): Maximum time 
-    in milliseconds, to wait for persistent storage operations to complete. 
+* `--marathon_store_timeout` (Optional. Default: 2000 (2 seconds)): Maximum time
+    in milliseconds, to wait for persistent storage operations to complete.
 
 ### Optional Flags Inherited from [Chaos](https://github.com/mesosphere/chaos)
 

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -50,6 +50,11 @@ trait MarathonConf extends ScallopConf with ZookeeperConf {
     noshort = true,
     default = None)
 
+  lazy val accessControlAllowOrigin = opt[String]("access_control_allow_origin",
+    descr = "The origin(s) to allow in marathon. Not set by default",
+    noshort = true,
+    default = None)
+
   def executor: Executor = Executor.dispatch(defaultExecutor())
 
   lazy val mesosRole = opt[String]("mesos_role",

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -51,7 +51,9 @@ trait MarathonConf extends ScallopConf with ZookeeperConf {
     default = None)
 
   lazy val accessControlAllowOrigin = opt[String]("access_control_allow_origin",
-    descr = "The origin(s) to allow in marathon. Not set by default",
+    descr = "The origin(s) to allow in marathon. Not set by default. " +
+      "Example values are \"*\", or " +
+      "\"http://localhost:8888, http://domain.com\"",
     noshort = true,
     default = None)
 

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -51,7 +51,7 @@ trait MarathonConf extends ScallopConf with ZookeeperConf {
     default = None)
 
   lazy val accessControlAllowOrigin = opt[String]("access_control_allow_origin",
-    descr = "The origin(s) to allow in marathon. Not set by default. " +
+    descr = "The origin(s) to allow in Marathon. Not set by default. " +
       "Example values are \"*\", or " +
       "\"http://localhost:8888, http://domain.com\"",
     noshort = true,

--- a/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
@@ -1,11 +1,13 @@
 package mesosphere.marathon.api
 
+import javax.inject.{ Inject }
 import javax.servlet._
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
+import mesosphere.marathon.{ MarathonConf }
 
 import scala.collection.JavaConverters._
 
-class CORSFilter @Inject() (config: MarathonConfig) extends Filter {
+class CORSFilter @Inject() (config: MarathonConf) extends Filter {
   override def init(filterConfig: FilterConfig): Unit = {}
 
   override def doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain): Unit = {

--- a/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
@@ -5,13 +5,13 @@ import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 
 import scala.collection.JavaConverters._
 
-class CORSFilter extends Filter {
+class CORSFilter @Inject() (config: MarathonConfig) extends Filter {
   override def init(filterConfig: FilterConfig): Unit = {}
 
   override def doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain): Unit = {
 
     response match {
-      case httpResponse: HttpServletResponse =>
+      case httpResponse: HttpServletResponse if config.accessControlAllowOrigin.isSupplied =>
         val httpRequest = request.asInstanceOf[HttpServletRequest]
         val static = ("Accept,Content-Type,Referer,Origin,Connection,Cache-Control,Access-Control-Request-Headers," +
           "Pragma,Access-Control-Request-Method,Accept-Language,Accept-Encoding,User-Agent,Host,Accept-Language," +
@@ -21,7 +21,7 @@ class CORSFilter extends Filter {
           .flatMap(_.split(","))
           .filter(hd => staticSet.contains(hd.toLowerCase))
 
-        httpResponse.setHeader("Access-Control-Allow-Origin", "*")
+        httpResponse.setHeader("Access-Control-Allow-Origin", config.accessControlAllowOrigin())
         httpResponse.setHeader("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
         httpResponse.setHeader("Access-Control-Max-Age", "86400")
         httpResponse.setHeader("Access-Control-Allow-Headers", (static ++ control).toList.distinct.mkString(", "))

--- a/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
@@ -8,6 +8,11 @@ import mesosphere.marathon.{ MarathonConf }
 import scala.collection.JavaConverters._
 
 class CORSFilter @Inject() (config: MarathonConf) extends Filter {
+  // Map access_control_allow_origin flag into separate headers
+  lazy val origins: Seq[String] = config.accessControlAllowOrigin()
+    .split(",")
+    .map(_.trim)
+
   override def init(filterConfig: FilterConfig): Unit = {}
 
   override def doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain): Unit = {
@@ -15,11 +20,6 @@ class CORSFilter @Inject() (config: MarathonConf) extends Filter {
     response match {
       case httpResponse: HttpServletResponse if config.accessControlAllowOrigin.isSupplied =>
         val httpRequest = request.asInstanceOf[HttpServletRequest]
-
-        // Map access_control_allow_origin flag into separate headers
-        val origins: Seq[String] = config.accessControlAllowOrigin()
-          .split(",")
-          .map(_.trim)
 
         origins.foreach { origin =>
           httpResponse.setHeader("Access-Control-Allow-Origin", origin)

--- a/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
@@ -8,24 +8,25 @@ import mesosphere.marathon.{ MarathonConf }
 import scala.collection.JavaConverters._
 
 class CORSFilter @Inject() (config: MarathonConf) extends Filter {
-  if (config.accessControlAllowOrigin.isSupplied) {
-    // Map access_control_allow_origin flag into separate headers
-    lazy val origins: Option[Seq[String]] =
-      config.accessControlAllowOrigin.get.map { configValue =>
-        configValue.split(",").map(_.trim)
-      }
-  }
+
+  // Map access_control_allow_origin flag into separate headers
+  lazy val maybeOrigins: Option[Seq[String]] =
+    config.accessControlAllowOrigin.get.map { configValue =>
+      configValue.split(",").map(_.trim)
+    }
 
   override def init(filterConfig: FilterConfig): Unit = {}
 
   override def doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain): Unit = {
 
     response match {
-      case httpResponse: HttpServletResponse if origins.isDefined =>
+      case httpResponse: HttpServletResponse if maybeOrigins.isDefined =>
         val httpRequest = request.asInstanceOf[HttpServletRequest]
 
-        origins.foreach { origin =>
-          httpResponse.setHeader("Access-Control-Allow-Origin", origin)
+        maybeOrigins.foreach { origins =>
+          origins.foreach { origin =>
+            httpResponse.setHeader("Access-Control-Allow-Origin", origin)
+          }
         }
 
         // Add all headers from request as accepted headers

--- a/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
@@ -1,0 +1,36 @@
+package mesosphere.marathon.api
+
+import javax.servlet._
+import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
+
+import scala.collection.JavaConverters._
+
+class CORSFilter extends Filter {
+  override def init(filterConfig: FilterConfig): Unit = {}
+
+  override def doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain): Unit = {
+
+    response match {
+      case httpResponse: HttpServletResponse =>
+        val httpRequest = request.asInstanceOf[HttpServletRequest]
+        val static = ("Accept,Content-Type,Referer,Origin,Connection,Cache-Control,Access-Control-Request-Headers," +
+          "Pragma,Access-Control-Request-Method,Accept-Language,Accept-Encoding,User-Agent,Host,Accept-Language," +
+          "Accept-Encoding,Content-Length,Origin,X-DevTools-Emulate-Network-Conditions-Client-Id").split(",")
+        val staticSet = static.map(_.toLowerCase).toSet
+        val control = httpRequest.getHeaders("Access-Control-Request-Headers").asScala
+          .flatMap(_.split(","))
+          .filter(hd => staticSet.contains(hd.toLowerCase))
+
+        //TODO: Michael wanted to have this one specific, but it should be "*"
+        httpResponse.setHeader("Access-Control-Allow-Origin", "*")
+        httpResponse.setHeader("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+        httpResponse.setHeader("Access-Control-Max-Age", "86400")
+        httpResponse.setHeader("Access-Control-Allow-Headers", (static ++ control).toList.distinct.mkString(", "))
+      case _ => // ignore other responses
+
+    }
+    chain.doFilter(request, response)
+  }
+
+  override def destroy(): Unit = {}
+}

--- a/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
@@ -21,7 +21,6 @@ class CORSFilter extends Filter {
           .flatMap(_.split(","))
           .filter(hd => staticSet.contains(hd.toLowerCase))
 
-        //TODO: Michael wanted to have this one specific, but it should be "*"
         httpResponse.setHeader("Access-Control-Allow-Origin", "*")
         httpResponse.setHeader("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
         httpResponse.setHeader("Access-Control-Max-Age", "86400")

--- a/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
@@ -35,6 +35,9 @@ class MarathonRestModule extends RestModule {
     bind(classOf[LeaderProxyFilter]).asEagerSingleton()
     filter("/*").through(classOf[LeaderProxyFilter])
 
+    bind(classOf[CORSFilter]).asEagerSingleton()
+    filter("/*").through(classOf[CORSFilter])
+
     bind(classOf[CacheDisablingFilter]).asEagerSingleton()
     filter("/*").through(classOf[CacheDisablingFilter])
   }


### PR DESCRIPTION
Added CORS headers with the help @drexin to allow

We need to add a flag `--access_control_allow_origin` to set the value of the header on marathon to, say  "*". @drexin how do we add a new flag and read the flag to configure the filter to make this an optional filter, that is disabled by default?