### PR TITLE
Fixes #1215, serialize calculation of DeploymentPlans

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -92,12 +92,8 @@ class MarathonSchedulerService @Inject() (
 
   def deploy(plan: DeploymentPlan, force: Boolean = false): Future[Unit] = {
     log.info(s"Deploy plan:$plan with force:$force")
-    val promise = Promise[AnyRef]()
-    val receiver = system.actorOf(Props(classOf[PromiseActor], promise))
-
-    schedulerActor.tell(Deploy(plan, force), receiver)
-
-    promise.future.map {
+    val future: Future[Any] = PromiseActor.askWithoutTimeout(system, schedulerActor, Deploy(plan, force))
+    future.map {
       case DeploymentStarted(_) => ()
       case CommandFailed(_, t)  => throw t
     }

--- a/src/main/scala/mesosphere/util/PromiseActor.scala
+++ b/src/main/scala/mesosphere/util/PromiseActor.scala
@@ -1,15 +1,16 @@
 package mesosphere.util
 
-import akka.actor.Actor
+import akka.actor._
 import scala.concurrent.Promise
-import akka.actor.Status
+import scala.concurrent.Future
 
 /**
   * This actor waits for a response, similar to the ask pattern,
   * but without a timeout. This is needed for upgrade tasks where the
   * execution time can not be predicted, e.g. long running upgrade tasks.
   *
-  * @param promise
+  * @param promise the promise that is fulfilled when this actor receives its first
+  *                 and only message
   */
 class PromiseActor(promise: Promise[Any]) extends Actor {
   def receive: Receive = {
@@ -20,5 +21,22 @@ class PromiseActor(promise: Promise[Any]) extends Actor {
         case _                 => promise.success(x)
       }
       context.stop(self)
+  }
+}
+
+object PromiseActor {
+  /**
+    * Sends the given message to the given actorRef and waits indefinitely for the response. The response
+    * must be of the given type T or a [[Status.Failure]].
+    *
+    * @param actorRefFactory the factory for creating the internally used actor
+    * @param actorRef references the actor to send the message to
+    * @param message the message to be send to the actor
+    */
+  def askWithoutTimeout[T](actorRefFactory: ActorRefFactory, actorRef: ActorRef, message: Any): Future[T] = {
+    val promise = Promise[T]()
+    val promiseActor = actorRefFactory.actorOf(Props(classOf[PromiseActor], promise))
+    actorRef.tell(message, promiseActor)
+    promise.future
   }
 }

--- a/src/main/scala/mesosphere/util/SerializeExecutionActor.scala
+++ b/src/main/scala/mesosphere/util/SerializeExecutionActor.scala
@@ -1,0 +1,90 @@
+package mesosphere.util
+
+import javax.annotation.PreDestroy
+
+import akka.actor.{ Actor, ActorRefFactory, PoisonPill, Props, Status }
+import akka.pattern.pipe
+import org.apache.log4j.Logger
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+/**
+  * Allows the sequential execution of methods which return [[Future]]s.
+  * The execution of a [[Future]] waits for the prior Future to complete (not only the
+  * method returning the Future).
+  *
+  * {{{
+  * scala> import mesosphere.util.SerializeExecution
+  * scala> val serializeExecution = SerializeExecution(someActorRef, "serialize")
+  * scala> def myFutureReturningFunc: Future[Int] = Future.successful(1)
+  * scala> val result: Future[Int] = serializeExecution(myFutureReturningFunc)
+  * }}}
+  */
+object SerializeExecution {
+  private val log = Logger.getLogger(getClass.getName)
+
+  def apply[T](actorRefFactory: ActorRefFactory, actorName: String): SerializeExecution = {
+    new SerializeExecution(actorRefFactory, actorName)
+  }
+}
+
+class SerializeExecution private (actorRefFactory: ActorRefFactory, actorName: String) {
+  import SerializeExecution.log
+
+  private[this] val serializeExecutionActorProps = Props[SerializeExecutionActor]()
+  private[this] val serializeExecutionActorRef = actorRefFactory.actorOf(serializeExecutionActorProps, actorName)
+
+  def apply[T](block: => Future[T]): Future[T] = {
+    PromiseActor.askWithoutTimeout(
+      actorRefFactory, serializeExecutionActorRef, SerializeExecutionActor.Execute(() => block))
+  }
+
+  @PreDestroy
+  def close(): Unit = {
+    log.debug(s"stopping $serializeExecutionActorRef")
+    serializeExecutionActorRef ! PoisonPill
+  }
+}
+
+/**
+  * Accepts messages containing functions returning [[Future]]s.
+  * It starts the execution of a function after the [[Future]]s generated
+  * by prior functions have been completed.
+  */
+private[util] class SerializeExecutionActor extends Actor {
+
+  import SerializeExecutionActor.{ log, Execute }
+
+  private[this] var currentFuture: Future[Unit] = Future.successful(())
+
+  override def receive: Receive = {
+    case Execute(func) =>
+      val replyTo = sender()
+      log.debug(s"$self: Receiving Execute from $replyTo")
+      import context.dispatcher
+      currentFuture = currentFuture flatMap { _ =>
+        log.debug(s"$self: Executing func from $replyTo")
+        val nextFuture: Future[_] = try {
+          func()
+        }
+        catch {
+          case NonFatal(e) => Future.successful(Status.Failure(e))
+        }
+
+        pipe(nextFuture) to replyTo
+
+        // Ignore all errors. Otherwise further `map` calls
+        // have no effect. All non-fatal errors are already
+        // returned to the sender by the above pipeTo.
+        nextFuture recover { case NonFatal(_) => () } map { _ =>
+          log.debug(s"$self: Finished executing func from $replyTo")
+        }
+      }
+  }
+}
+
+private[util] object SerializeExecutionActor {
+  private val log = Logger.getLogger(getClass.getName)
+  case class Execute[T](func: () => Future[T])
+}

--- a/src/test/scala/mesosphere/util/PromiseActorTest.scala
+++ b/src/test/scala/mesosphere/util/PromiseActorTest.scala
@@ -1,10 +1,10 @@
 package mesosphere.util
 
-import akka.testkit.{ TestActorRef, TestKit }
+import akka.testkit.{ TestProbe, TestActorRef, TestKit }
 import akka.actor.{ Status, Props, ActorSystem }
 import mesosphere.marathon.MarathonSpec
 import org.scalatest.{ Matchers, BeforeAndAfterAll }
-import scala.concurrent.{ Await, Promise }
+import scala.concurrent.{ Future, Await, Promise }
 import scala.concurrent.duration._
 
 class PromiseActorTest
@@ -27,6 +27,15 @@ class PromiseActorTest
     Await.result(promise.future, 2.seconds) should equal('Test)
   }
 
+  test("Success with askWithoutTimeout") {
+    val probe = TestProbe()
+    val future: Future[Symbol] = PromiseActor.askWithoutTimeout(system, probe.ref, 'Question)
+    probe.expectMsg('Question)
+    probe.reply('Answer)
+
+    Await.result(future, 2.seconds) should equal('Answer)
+  }
+
   test("Status.Success") {
     val promise = Promise[Any]()
     val ref = TestActorRef(Props(classOf[PromiseActor], promise))
@@ -34,6 +43,15 @@ class PromiseActorTest
     ref ! Status.Success('Test)
 
     Await.result(promise.future, 2.seconds) should equal('Test)
+  }
+
+  test("State.Success with askWithoutTimeout") {
+    val probe = TestProbe()
+    val future: Future[Symbol] = PromiseActor.askWithoutTimeout(system, probe.ref, 'Question)
+    probe.expectMsg('Question)
+    probe.reply(Status.Success('Answer))
+
+    Await.result(future, 2.seconds) should equal('Answer)
   }
 
   test("Status.Failure") {
@@ -47,4 +65,16 @@ class PromiseActorTest
       Await.result(promise.future, 2.seconds)
     }.getMessage should be("test")
   }
+
+  test("State.Failure with askWithoutTimeout") {
+    val probe = TestProbe()
+    val future: Future[Symbol] = PromiseActor.askWithoutTimeout(system, probe.ref, 'Question)
+    probe.expectMsg('Question)
+    probe.reply(Status.Failure(new IllegalStateException("error")))
+
+    intercept[IllegalStateException] {
+      Await.result(future, 2.seconds)
+    }.getMessage should be("error")
+  }
+
 }

--- a/src/test/scala/mesosphere/util/SerializeExecutionTest.scala
+++ b/src/test/scala/mesosphere/util/SerializeExecutionTest.scala
@@ -1,0 +1,62 @@
+package mesosphere.util
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import mesosphere.marathon.MarathonSpec
+import org.scalatest.Matchers
+import scala.concurrent.{ Future, Await }
+import scala.concurrent.duration._
+
+class SerializeExecutionTest extends TestKit(ActorSystem("system")) with MarathonSpec with Matchers {
+  test("submit successful futures") {
+    val serialize = SerializeExecution(system, "serialize1")
+    try {
+      val future1: Future[Int] = serialize(Future.successful(1))
+      val result1 = Await.result(future1, 3.seconds)
+      result1 should be(1)
+      val future2: Future[Int] = serialize(Future.successful(2))
+      val result2 = Await.result(future2, 3.seconds)
+      result2 should be(2)
+      val future3: Future[Int] = serialize(Future.successful(3))
+      val result3 = Await.result(future3, 3.seconds)
+      result3 should be(3)
+    }
+    finally {
+      serialize.close()
+    }
+  }
+
+  test("submit successful futures after a failure") {
+    val serialize = SerializeExecution(system, "serialize1")
+    try {
+      val future1: Future[Int] = serialize(Future.failed(new IllegalStateException()))
+      a[IllegalStateException] should be thrownBy Await.result(future1, 3.seconds)
+      val future2: Future[Int] = serialize(Future.successful(2))
+      val result2 = Await.result(future2, 3.seconds)
+      result2 should be(2)
+      val future3: Future[Int] = serialize(Future.successful(3))
+      val result3 = Await.result(future3, 3.seconds)
+      result3 should be(3)
+    }
+    finally {
+      serialize.close()
+    }
+  }
+
+  test("submit successful futures after a failure to return future") {
+    val serialize = SerializeExecution(system, "serialize1")
+    try {
+      val future1: Future[Int] = serialize(throw new IllegalStateException())
+      a[IllegalStateException] should be thrownBy Await.result(future1, 3.seconds)
+      val future2: Future[Int] = serialize(Future.successful(2))
+      val result2 = Await.result(future2, 3.seconds)
+      result2 should be(2)
+      val future3: Future[Int] = serialize(Future.successful(3))
+      val result3 = Await.result(future3, 3.seconds)
+      result3 should be(3)
+    }
+    finally {
+      serialize.close()
+    }
+  }
+}


### PR DESCRIPTION
in GroupManager.update.

The GroupManager.update method was not designed to be called concurrently.
It was wrapped in a synchronized block which was ineffective since most of
the computation happened asynchronously in Futures.

This patch introduces a SerializeExecution helper which can be used to
substitute such incorrect usages of synchronized.