### PR TITLE
--no-logger - do not propagate it to scala

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -75,8 +75,7 @@ function load_options_and_log {
 
   if [[ "${cmd[@]} $@" == *'--no-logger'* ]]
   then
-    params=$(echo "$@"|sed 's/--no-logger//g') 
-    "${cmd[@]}" ${params}
+    "${cmd[@]}" ${@//--no-logger/}
   else
     logged marathon "${cmd[@]}" "$@"
   fi

--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -75,7 +75,8 @@ function load_options_and_log {
 
   if [[ "${cmd[@]} $@" == *'--no-logger'* ]]
   then
-    "${cmd[@]}" "$@"
+    params=$(echo "$@"|sed 's/--no-logger//g') 
+    "${cmd[@]}" ${params}
   else
     logged marathon "${cmd[@]}" "$@"
   fi


### PR DESCRIPTION
Since this is parameter is related only to startup scripts,
it should not be propagated to scala.

Scala screams now "[scallop] Error: Unknown option"

Somehow "unknown option" worked with previous version,
now it is generate Error.