### PR TITLE
Change link to new Constraints Marathon Documentation page on error message in GUI

### DIFF
--- a/src/main/resources/assets/js/models/App.js
+++ b/src/main/resources/assets/js/models/App.js
@@ -312,7 +312,7 @@ var App = Backbone.Model.extend({
           VALID_CONSTRAINTS.map(function (c) {
             return "`" + c + "`";
           }).join(", ") +
-          ". See https://github.com/mesosphere/marathon/wiki/Constraints."
+          ". See https://mesosphere.github.io/marathon/docs/constraints.html."
         )
       );
     }


### PR DESCRIPTION
Actual page https://github.com/mesosphere/marathon/wiki/Constraints does not
exist.
Changed to: https://mesosphere.github.io/marathon/docs/constraints.html.