### PR TITLE
User specified env variables overwrite automatic port variables (#905)

### DIFF
--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -207,9 +207,9 @@ object TaskBuilder {
     val containerPorts = for (pms <- app.portMappings) yield pms.map(_.containerPort)
     val declaredPorts = containerPorts.getOrElse(app.ports)
     val envMap: Map[String, String] =
-      app.env ++
-        taskContextEnv(app, taskId) ++
-        portsEnv(declaredPorts, ports) ++ host.map("HOST" -> _)
+      taskContextEnv(app, taskId) ++
+        portsEnv(declaredPorts, ports) ++ host.map("HOST" -> _) ++
+        app.env
 
     val builder = CommandInfo.newBuilder()
       .setEnvironment(environment(envMap))


### PR DESCRIPTION
The user can overwrite any automatic variable with explicit definitions
of these variables.

That's also a sane behavior if we add any automatic variables in
the future (even though we should probably prefix them with MARATHON_).