### PR TITLE
fixes #1278 - Improves response time of /v2/tasks and /v2/apps/{appId}/t...

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -33,8 +33,9 @@ class AppTasksResource @Inject() (service: MarathonSchedulerService,
 
     def tasks(appIds: Set[PathId]): Set[EnrichedTask] = for {
       id <- appIds
+      health = result(healthCheckManager.statuses(id))
       task <- taskTracker.get(id)
-    } yield EnrichedTask(id, task, result(healthCheckManager.status(id, task.getId)))
+    } yield EnrichedTask(id, task, health.getOrElse(task.getId, Nil).map(Some(_)))
 
     val matchingApps = appId match {
       case GroupTasks(gid) =>


### PR DESCRIPTION
...asks ans adds `limit` and `offset` parameters.

The tests have been executed on a GCE 2 vCPU instance with 1,000 running tasks.

`/v2/tasks`

**Before:**

```
time curl -H "Accept: application/json" localhost:8080/v2/tasks >> /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  234k    0  234k    0     0  34984      0 --:--:--  0:00:06 --:--:-- 62134

real	0m6.880s
user	0m0.004s
sys	0m0.004s
```

**After:**

```
time curl -H "Accept: application/json" localhost:8080/v2/tasks >> /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  234k    0  234k    0     0   847k      0 --:--:-- --:--:-- --:--:--  847k

real	0m0.283s
user	0m0.020s
sys	0m0.152s
```

`/v2/apps/{appId}/tasks`

**Before:**

```
time curl -H "Accept: application/json" localhost:8080/v2/apps/foo/tasks >> /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  212k    0  212k    0     0  23290      0 --:--:--  0:00:09 --:--:-- 65303

real	0m9.342s
user	0m0.000s
sys	0m0.008s
```

**After:**

```
time curl -H "Accept: application/json" localhost:8080/v2/apps/foo/tasks >> /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  212k    0  212k    0     0  1388k      0 --:--:-- --:--:-- --:--:-- 1397k

real	0m0.159s
user	0m0.012s
sys	0m0.048s
```