### PR TITLE
Fixes #1053 add support for querying multiple labels of applications

### DIFF
--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -17,6 +17,8 @@ case class AppLockedException(deploymentIds: Seq[String] = Nil)
       "View details at '/v2/deployments/<DEPLOYMENT_ID>'."
   )
 
+case class InvalidQueryException(msg: String) extends Exception(msg)
+
 case class PortResourceException(msg: String) extends Exception(msg)
 
 class PortRangeExhaustedException(

--- a/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.{
   AppLockedException,
   BadRequestException,
   ConflictingChangeException,
+  InvalidQueryException,
   UnknownAppException
 }
 import mesosphere.marathon.state.Identifiable
@@ -44,6 +45,7 @@ class MarathonExceptionMapper extends ExceptionMapper[Exception] {
     case e: BadRequestException        => 400 // Bad Request
     case e: JsonParseException         => 400 // Bad Request
     case e: JsResultException          => 400 // Bad Request
+    case e: InvalidQueryException      => 400 // Bad Request
     case e: WebApplicationException    => e.getResponse.getStatus
     case _                             => 500 // Internal server error
   }
@@ -60,6 +62,8 @@ class MarathonExceptionMapper extends ExceptionMapper[Exception] {
       Map("message" -> e.getOriginalMessage)
     case e: JsResultException =>
       Map("message" -> s"Invalid JSON: ${e.getMessage}")
+    case e: InvalidQueryException =>
+      Map("message" -> s"Invalid Query: ${e.getMessage}")
     case e: WebApplicationException =>
       if (e.getResponse.getEntity != null) {
         Map("message" -> e.getResponse.getEntity)

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -17,7 +17,7 @@ import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.marathon.upgrade.{ DeploymentStep, RestartApplication, DeploymentPlan }
-import mesosphere.marathon.{ ConflictingChangeException, MarathonConf, MarathonSchedulerService }
+import mesosphere.marathon.{ ConflictingChangeException, InvalidQueryException, MarathonConf, MarathonSchedulerService }
 import mesosphere.marathon.api.v2.json.Formats._
 import play.api.libs.json.{ Writes, JsObject, Json }
 
@@ -46,8 +46,14 @@ class AppsResource @Inject() (
   @Timed
   def index(@QueryParam("cmd") cmd: String,
             @QueryParam("id") id: String,
-            @QueryParam("embed") embed: String): String = {
-    val apps = if (cmd != null || id != null) search(cmd, id) else service.listApps()
+            @QueryParam("embed") embed: String,
+            @QueryParam("labels") labels: String): String = {
+    val apps = if (cmd != null || id != null || labels != null) {
+      search(cmd, id, Option(labels))
+    }
+    else {
+      service.listApps()
+    }
     val runningDeployments = result(service.listRunningDeployments()).map(r => r._1)
     val mapped = embed match {
       case EmbedTasks =>
@@ -300,10 +306,37 @@ class AppsResource @Inject() (
   private def maybePostEvent(req: HttpServletRequest, app: AppDefinition) =
     eventBus.publish(ApiPostEvent(req.getRemoteAddr, req.getRequestURI, app))
 
-  private def search(cmd: String, id: String): Iterable[AppDefinition] = {
+  type LabelMatcher = (Map[String, String]) => Boolean
+
+  private def labelMatcher(labels: String): LabelMatcher = {
+    if (labels.indexOf(",,") != -1)
+      throw new InvalidQueryException(labels)
+
+    val pairs = for (pair <- labels.split(",")) yield pair.split("=")
+    val queryLabels = pairs.collect {
+      case Array(x, y, _*) => (x, y)
+    }.toMap
+
+    def matcher(appLabels: Map[String, String]): Boolean = {
+      val matches = for ((k, v) <- queryLabels) yield {
+        if (appLabels.contains(k) && appLabels(k) == v) {
+          true
+        }
+        else {
+          false
+        }
+      }
+      matches.size > 0 && !matches.exists(_ == false)
+    }
+    matcher
+  }
+
+  private def search(cmd: String, id: String, labels: Option[String]): Iterable[AppDefinition] = {
     /* Returns true iff `a` is a prefix of `b`, case-insensitively */
     def isPrefix(a: String, b: String): Boolean =
       b.toLowerCase contains a.toLowerCase
+
+    val matcher = labelMatcher(labels.getOrElse(""))
 
     service.listApps().filter { app =>
       val appMatchesCmd =
@@ -315,7 +348,9 @@ class AppsResource @Inject() (
         id != null &&
           id.nonEmpty && isPrefix(id, app.id.toString)
 
-      appMatchesCmd || appMatchesId
+      val appMatchesLabelQuery = matcher(app.labels)
+
+      appMatchesCmd || appMatchesId || appMatchesLabelQuery
     }
   }
 }


### PR DESCRIPTION
This adds support for querying multiple tags against exact values.  If multiple tags are supplied, they are AND'ed together and only apps matching all supplied tags exactly are returned.  This may be further extended (fuzzy matching, support for richer query semantics, etc...) by changing the matching function returned by the labelMatcher method.

This has only undergone rudimentary manual testing, and should definitely be further verified before merging.

This is loosely based on [the kubernetes labels query language](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/labels.md#api).

Examples:
single query - keys and their values are delimited by a url escaped equals sign (%3D):
```bash
curl '$MARATHON_HOST:8080/v2/apps?labels=PACKAGE_VERSION%3D1.2.3'
{"apps":[{"id":"/zero-instance-app","cmd":"sleep 1000","args":null,"user":null,"env":{},"instances":0,"cpus":0.1,"mem":16.0,"disk":0.0,"executor":"","constraints":[],"uris":[],"storeUrls":[],"ports":[10000],"requirePorts":false,"backoffSeconds":1,"backoffFactor":1.15,"maxLaunchDelaySeconds":3600,"container":null,"healthChecks":[],"dependencies":[],"upgradeStrategy":{"minimumHealthCapacity":1.0,"maximumOverCapacity":1.0},"labels":{"PACKAGE_ID":"zero-instance-app","PACKAGE_VERSION":"1.2.3"},"version":"2015-04-03T21:29:21.324Z","tasksStaged":0,"tasksRunning":0,"tasksHealthy":0,"tasksUnhealthy":0,"deployments":[]}]}%
```

multiple queries are separated by a comma:
```bash
curl 'localhost:8080/v2/apps?labels=PACKAGE_VERSION%3D1.2.1,some_tag%3Dsome_value'
{"apps":[{"id":"/app-1","cmd":"sleep 1000","args":null,"user":null,"env":{},"instances":0,"cpus":0.1,"mem":16.0,"disk":0.0,"executor":"","constraints":[],"uris":[],"storeUrls":[],"ports":[10002],"requirePorts":false,"backoffSeconds":1,"backoffFactor":1.15,"maxLaunchDelaySeconds":3600,"container":null,"healthChecks":[],"dependencies":[],"upgradeStrategy":{"minimumHealthCapacity":1.0,"maximumOverCapacity":1.0},"labels":{"PACKAGE_ID":"zero-instance-app","PACKAGE_VERSION":"1.2.1","some_tag":"some_value","another_tag":"another_value"},"version":"2015-04-04T14:57:12.644Z","tasksStaged":0,"tasksRunning":0,"tasksHealthy":0,"tasksUnhealthy":0,"deployments":[]},{"id":"/app-2","cmd":"sleep 1000","args":null,"user":null,"env":{},"instances":0,"cpus":0.1,"mem":16.0,"disk":0.0,"executor":"","constraints":[],"uris":[],"storeUrls":[],"ports":[10003],"requirePorts":false,"backoffSeconds":1,"backoffFactor":1.15,"maxLaunchDelaySeconds":3600,"container":null,"healthChecks":[],"dependencies":[],"upgradeStrategy":{"minimumHealthCapacity":1.0,"maximumOverCapacity":1.0},"labels":{"PACKAGE_ID":"zero-instance-app","PACKAGE_VERSION":"1.2.1","some_tag":"some_value","another_tag":"unusual_value"},"version":"2015-04-04T14:57:53.251Z","tasksStaged":0,"tasksRunning":0,"tasksHealthy":0,"tasksUnhealthy":0,"deployments":[]}]}%
```