### PR TITLE
Fix syntax error in docs (missing endhighlight).

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -2036,6 +2036,7 @@ HTTP/1.1 200 OK
 Content-Length: 0
 Content-Type: application/json
 Server: Jetty(8.y.z-SNAPSHOT)
+{% endhighlight %}
 
 ### Deployments
 


### PR DESCRIPTION
The REST API reference page won't build on the docs site without this closing tag.