### PR TITLE
Add link to marathonctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ We heartily welcome external contributions to Marathon's documentation. Document
 
 ## Marathon Clients
 
+* [marathonctl](https://github.com/shoenig/marathonctl) A handy CLI tool for controlling Marathon
 * [Ruby gem and command line client](https://rubygems.org/gems/marathon-api)
 
     Running Chronos with the Ruby Marathon Client:


### PR DESCRIPTION
marathonctl exposes the entire Marathon REST API to the command line. It is
useful for manipulating development environments and as a means for controlling Marathon without requiring access to the WebUI. 