### PR TITLE
Fix #851 - Allow apps to replace groups without apps

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/BeanValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/BeanValidation.scala
@@ -12,7 +12,7 @@ import org.hibernate.validator.internal.engine.path.PathImpl
   * Bean validation helper trait.
   * TODO: we should not use bean validation any longer.
   */
-trait BeanValidation {
+object BeanValidation {
 
   val validator = Validation.buildDefaultValidatorFactory().getValidator
 

--- a/src/main/scala/mesosphere/marathon/api/ModelValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/ModelValidation.scala
@@ -10,10 +10,12 @@ import scala.util.{ Failure, Success, Try }
 import mesosphere.marathon.api.v2.{ AppUpdate, GroupUpdate }
 import mesosphere.marathon.state._
 
+import BeanValidation._
+
 /**
   * Specific validation helper for specific model classes.
   */
-trait ModelValidation extends BeanValidation {
+object ModelValidation {
 
   def checkGroup(
     group: Group,

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -8,7 +8,7 @@ import javax.ws.rs.core.{ MediaType, Response }
 import com.codahale.metrics.annotation.Timed
 
 import mesosphere.marathon.{ ConflictingChangeException, MarathonConf }
-import mesosphere.marathon.api.{ ModelValidation, RestResource }
+import mesosphere.marathon.api.{ BeanValidation, ModelValidation, RestResource }
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ Group, GroupManager, PathId, Timestamp }
@@ -20,7 +20,7 @@ import play.api.libs.json.Json
 @Produces(Array(MediaType.APPLICATION_JSON))
 class GroupsResource @Inject() (
     groupManager: GroupManager,
-    val config: MarathonConf) extends RestResource with ModelValidation {
+    val config: MarathonConf) extends RestResource {
 
   val ListApps = """^((?:.+/)|)apps$""".r
   val ListRootApps = """^apps$""".r
@@ -86,7 +86,7 @@ class GroupsResource @Inject() (
   def createWithPath(@PathParam("id") id: String,
                      update: GroupUpdate,
                      @DefaultValue("false")@QueryParam("force") force: Boolean): Response = {
-    requireValid(checkGroupUpdate(update, needsId = true))
+    BeanValidation.requireValid(ModelValidation.checkGroupUpdate(update, needsId = true))
     val effectivePath = update.id.map(_.canonicalPath(id.toRootPath)).getOrElse(id.toRootPath)
     val current = result(groupManager.root(withLatestApps = false)).findGroup(_.id == effectivePath)
     if (current.isDefined)
@@ -118,7 +118,7 @@ class GroupsResource @Inject() (
              update: GroupUpdate,
              @DefaultValue("false")@QueryParam("force") force: Boolean,
              @DefaultValue("false")@QueryParam("dryRun") dryRun: Boolean): Response = {
-    requireValid(checkGroupUpdate(update, needsId = false))
+    BeanValidation.requireValid(ModelValidation.checkGroupUpdate(update, needsId = false))
     if (dryRun) {
       val planFuture = groupManager.group(id.toRootPath).map { maybeOldGroup =>
         val oldGroup = maybeOldGroup.getOrElse(Group.empty)

--- a/src/main/scala/mesosphere/marathon/api/v2/SchemaResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/SchemaResource.scala
@@ -5,14 +5,14 @@ import javax.ws.rs._
 import javax.ws.rs.core.{ MediaType }
 import mesosphere.marathon.MarathonConf
 import com.codahale.metrics.annotation.Timed
-import mesosphere.marathon.api.{ ModelValidation, RestResource }
+import mesosphere.marathon.api.RestResource
 import java.io.InputStream
 
 @Path("v2/schemas")
 @Consumes(Array(MediaType.APPLICATION_JSON))
 @Produces(Array(MediaType.APPLICATION_JSON))
 class SchemaResource @Inject() (
-    val config: MarathonConf) extends RestResource with ModelValidation {
+    val config: MarathonConf) extends RestResource {
 
   @GET
   @Timed

--- a/src/main/scala/mesosphere/marathon/state/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupManager.scala
@@ -6,7 +6,7 @@ import javax.inject.{ Inject, Named }
 
 import akka.event.EventStream
 import com.google.inject.Singleton
-import mesosphere.marathon.api.ModelValidation
+import mesosphere.marathon.api.{ BeanValidation, ModelValidation }
 import mesosphere.marathon.event.{ EventModule, GroupChangeFailed, GroupChangeSuccess }
 import mesosphere.marathon.io.PathFun
 import mesosphere.marathon.io.storage.StorageProvider
@@ -33,7 +33,7 @@ class GroupManager @Singleton @Inject() (
     groupRepo: GroupRepository,
     storage: StorageProvider,
     config: MarathonConf,
-    @Named(EventModule.busName) eventBus: EventStream) extends ModelValidation with PathFun {
+    @Named(EventModule.busName) eventBus: EventStream) extends PathFun {
 
   private[this] val log = Logger.getLogger(getClass.getName)
   private[this] val zkName = "root"
@@ -133,7 +133,7 @@ class GroupManager @Singleton @Inject() (
     val deployment = for {
       from <- rootGroup //ignore the state of the scheduler
       (to, resolve) <- resolveStoreUrls(assignDynamicAppPort(from, change(from)))
-      _ = requireValid(checkGroup(to))
+      _ = BeanValidation.requireValid(ModelValidation.checkGroup(to))
       plan <- deploy(from, to, resolve)
       _ <- groupRepo.store(zkName, to)
     } yield plan

--- a/src/test/scala/mesosphere/marathon/api/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/ModelValidationTest.scala
@@ -19,10 +19,9 @@ class ModelValidationTest
     with OptionValues {
 
   test("A group update should pass validation") {
-    val mv = new ModelValidation {}
     val update = GroupUpdate(id = Some("/a/b/c".toPath))
 
-    val violations = mv.checkGroupUpdate(update, true)
+    val violations = ModelValidation.checkGroupUpdate(update, true)
     violations should have size (0)
   }
 
@@ -61,8 +60,6 @@ class ModelValidationTest
 
     validations should not be Nil
   }
-
-  private object ModelValidation extends ModelValidation
 
   private def createServicePortApp(id: PathId, servicePort: Int) = {
     AppDefinition(

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -20,7 +20,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
-class AppDefinitionTest extends MarathonSpec with Matchers with ModelValidation {
+class AppDefinitionTest extends MarathonSpec with Matchers {
 
   test("ToProto") {
     val app1 = AppDefinition(
@@ -125,7 +125,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers with ModelValidation 
     val validator = Validation.buildDefaultValidatorFactory().getValidator
 
     def shouldViolate(app: AppDefinition, path: String, template: String) = {
-      val violations = checkAppConstraints(app, PathId.empty)
+      val violations = ModelValidation.checkAppConstraints(app, PathId.empty)
       assert(
         violations.exists { v =>
           v.getPropertyPath.toString == path && v.getMessageTemplate == template
@@ -135,7 +135,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers with ModelValidation 
     }
 
     def shouldNotViolate(app: AppDefinition, path: String, template: String) = {
-      val violations = checkAppConstraints(app, PathId.empty)
+      val violations = ModelValidation.checkAppConstraints(app, PathId.empty)
       assert(
         !violations.exists { v =>
           v.getPropertyPath.toString == path && v.getMessageTemplate == template

--- a/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
@@ -2,15 +2,13 @@ package mesosphere.marathon.state
 
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.Protos
-import mesosphere.marathon.api.ModelValidation
-import javax.validation.Validation
 import org.scalatest.Matchers
 import org.apache.mesos.{ Protos => mesos }
 
 import scala.collection.immutable.Seq
 import scala.collection.JavaConverters._
 
-class ContainerTest extends MarathonSpec with Matchers with ModelValidation {
+class ContainerTest extends MarathonSpec with Matchers {
 
   class Fixture {
     lazy val volumes = Seq(

--- a/src/test/scala/mesosphere/marathon/state/TaskFailureTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TaskFailureTest.scala
@@ -1,13 +1,12 @@
 package mesosphere.marathon.state
 
-import mesosphere.marathon.api.ModelValidation
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.Protos
 import mesosphere.marathon.state.PathId._
 import org.scalatest.Matchers
 import org.apache.mesos.{ Protos => mesos }
 
-class TaskFailureTest extends MarathonSpec with Matchers with ModelValidation {
+class TaskFailureTest extends MarathonSpec with Matchers {
 
   class Fixture {
     lazy val taskFailure = TaskFailure(


### PR DESCRIPTION
Since groups are created implicitly by creating apps with nested paths
and not visible yet in the GUI, we allow replacing groups without any apps
by app definitions.