### PR TITLE
Fixes #660 - Revert only changes of selected deployment on rollback

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -31,7 +31,7 @@ title: REST API
   * [POST /v2/tasks/delete](#post-/v2/tasks/delete): Kill given list of tasks
 * [Deployments](#deployments) <span class="label label-default">v0.7.0</span>
   * [GET /v2/deployments](#get-/v2/deployments): List running deployments
-  * [DELETE /v2/deployments/{deploymentId}](#delete-/v2/deployments/{deploymentid}): Cancel the deployment with `deploymentId`
+  * [DELETE /v2/deployments/{deploymentId}](#delete-/v2/deployments/{deploymentid}): Revert or cancel the deployment with `deploymentId`
 * [Event Subscriptions](#event-subscriptions)
   * [POST /v2/eventSubscriptions](#post-/v2/eventsubscriptions): Register a callback URL as an event subscriber
   * [GET /v2/eventSubscriptions](#get-/v2/eventsubscriptions): List all event subscriber callback URLs
@@ -2109,8 +2109,9 @@ Transfer-Encoding: chunked
       <td><code>boolean</code></td>
       <td>
         If set to <code>false</code> (the default) then the deployment is
-        canceled and a new deployment is created to restore the previous
-        configuration.  If set to <code>true</code>, then the deployment
+        canceled and a new deployment is created to revert the changes of this
+        deployment. Without concurrent deployments, this restores the configuration before this
+        deployment. If set to <code>true</code>, then the deployment
         is still canceled but no rollback deployment is created.
         Default: <code>false</code>.</td>
     </tr>
@@ -2119,7 +2120,8 @@ Transfer-Encoding: chunked
 
 ##### Example
 
-Cancel the deployment with `deploymentId`
+Revert the deployment with `deploymentId` by creating a new deployment which reverses
+all changes.
 
 **Request:**
 

--- a/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
@@ -44,7 +44,7 @@ class DeploymentsResource @Inject() (
           // create a new deployment to return to the previous state
           deploymentResult(result(groupManager.update(
             plan.original.id,
-            _ => plan.original,
+            plan.revert,
             force = true
           )))
       }

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -240,6 +240,8 @@ case class AppDefinition(
       runningDeployments, taskFailure, this
     )
 
+  def withNormalizedVersion: AppDefinition = copy(version = Timestamp(0))
+
   def isOnlyScaleChange(to: AppDefinition): Boolean =
     !isUpgrade(to) && (instances != to.instances)
 

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -77,6 +77,7 @@ case class Group(
     fn(this.copy(groups = in(groups.toList).toSet, version = timestamp))
   }
 
+  /** Removes the group with the given gid if it exists */
   def remove(gid: PathId, timestamp: Timestamp = Timestamp.now()): Group = {
     copy(groups = groups.filter(_.id != gid).map(_.remove(gid, timestamp)), version = timestamp)
   }
@@ -96,6 +97,11 @@ case class Group(
     )
   }
 
+  /**
+    * Remove the app with the given id if it is a direct child of this group.
+    *
+    * Use together with [[update]].
+    */
   def removeApplication(appId: PathId): Group = copy(apps = apps.filter(_.id != appId))
 
   def makeGroup(gid: PathId): Group = {
@@ -169,6 +175,15 @@ case class Group(
   /** @return true if and only if this group directly or indirectly contains app definitions. */
   @JsonIgnore
   def containsApps: Boolean = apps.nonEmpty || groups.exists(_.containsApps)
+
+  @JsonIgnore
+  def containsAppsOrGroups: Boolean = apps.nonEmpty || groups.nonEmpty
+
+  @JsonIgnore
+  def withNormalizedVersion: Group = copy(version = Timestamp(0))
+
+  @JsonIgnore
+  def withoutChildren: Group = copy(apps = Set.empty, groups = Set.empty)
 }
 
 object Group {

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.state
 
 import scala.language.implicitConversions
 
-case class PathId(path: List[String], absolute: Boolean = true) {
+case class PathId(path: List[String], absolute: Boolean = true) extends Ordered[PathId] {
 
   def root: String = path.headOption.getOrElse("")
 
@@ -57,6 +57,12 @@ case class PathId(path: List[String], absolute: Boolean = true) {
 
   override def toString: String = toString("/")
   private def toString(delimiter: String): String = path.mkString(if (absolute) delimiter else "", delimiter, "")
+
+  override def compare(that: PathId): Int = {
+    import Ordering.Implicits._
+    val seqOrder = implicitly(Ordering[List[String]])
+    seqOrder.compare(canonicalPath().path, that.canonicalPath().path)
+  }
 }
 
 object PathId {

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlanReverter.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlanReverter.scala
@@ -1,0 +1,182 @@
+package mesosphere.marathon.upgrade
+
+import mesosphere.marathon.state.{ Timestamp, AppDefinition, PathId, Group }
+import org.slf4j.LoggerFactory
+
+import scala.collection.immutable.Seq
+
+/**
+  * Contains the logic to revert deployments by calculating the changes
+  * of the deployment and applying the reverse on the given group.
+  */
+private[upgrade] object DeploymentPlanReverter {
+  private[this] val log = LoggerFactory.getLogger(getClass)
+
+  /**
+    * Reverts this plan by applying the reverse changes to the given Group.
+    *
+    * If they were no concurrent deployments and the passed group is equal to
+    * the target group, this method should result in the original group
+    * except for version/timestamp changes.
+    *
+    * If there were concurrent changes, this method tries to revert the changes
+    * of this deployment only without affecting the other deployments.
+    */
+  def revert(original: Group, target: Group, newVersion: Timestamp = Timestamp.now()): Group => Group = {
+
+    def changesOnIds[T](originalSet: Set[T], targetSet: Set[T])(id: T => PathId): Seq[(Option[T], Option[T])] = {
+      def mapById(entities: Set[T]): Map[PathId, T] =
+        entities.map { entity => id(entity) -> entity }.toMap
+
+      val originalById = mapById(originalSet)
+      val targetById = mapById(targetSet)
+
+      val ids = originalById.keys ++ targetById.keys
+
+      ids
+        .iterator
+        .map { id => originalById.get(id) -> targetById.get(id) }
+        .to[Seq]
+    }
+
+    /* a sequence of tuples with the old and the new group definition (also for unchanged groups) */
+    val groupChanges: Seq[(Option[Group], Option[Group])] =
+      changesOnIds(original.transitiveGroups, target.transitiveGroups)(_.id)
+
+    /* a sequence of tuples with the old and the new app definition */
+    val appChanges: Seq[(Option[AppDefinition], Option[AppDefinition])] = {
+      changesOnIds(original.transitiveApps, target.transitiveApps)(_.id)
+        .filter { case (oldOpt, newOpt) => oldOpt != newOpt }
+    }
+
+    // We need to revert app changes first so that apps have already been deleted when we check
+    // a group is empty and can be removed.
+    (revertAppChanges(newVersion, appChanges) _).andThen(revertGroupChanges(newVersion, groupChanges))
+  }
+
+  /**
+    * Reverts any group additions, changes, removals.
+    *
+    * It is more difficult than reverting any app definition changes
+    * because groups are not locked by deployments and concurrent changes are allowed.
+    */
+  private[this] def revertGroupChanges(
+    version: Timestamp, groupChanges: Seq[(Option[Group], Option[Group])])(
+      group: Group): Group = {
+
+    def revertGroupRemoval(oldGroup: Group)(existingGroup: Group): Group = {
+      log.debug("re-adding group {} with dependencies {}", Seq(oldGroup.id, oldGroup.dependencies): _*)
+      if ((oldGroup.dependencies -- existingGroup.dependencies).nonEmpty) {
+        existingGroup.copy(dependencies = existingGroup.dependencies ++ oldGroup.dependencies)
+      }
+      else {
+        existingGroup
+      }
+    }
+
+    def revertDependencyChanges(oldGroup: Group, newGroup: Group)(group: Group): Group = {
+      val removedDependencies = oldGroup.dependencies -- newGroup.dependencies
+      val addedDependencies = newGroup.dependencies -- oldGroup.dependencies
+
+      if (removedDependencies.nonEmpty || addedDependencies.nonEmpty) {
+        if (log.isDebugEnabled)
+          log.debug(
+            s"revert dependency changes in group ${oldGroup.id}, " +
+              s"readding removed {${removedDependencies.mkString(", ")}}, " +
+              s"removing added {${addedDependencies.mkString(", ")}}")
+
+        group.copy(dependencies = group.dependencies ++ removedDependencies -- addedDependencies)
+      }
+      else {
+        // common case, unchanged
+        group
+      }
+    }
+
+    def revertGroupAddition(result: Group, newGroup: Group): Group = {
+      // We know that all group removals for groups inside of this group have been
+      // performed before. If there are no conflicts with other deployments, we could
+      // just remove the group. Unfortunately, another deployment could have
+      // added a new sub group or sub app definition. In this case, we should not remove
+      // this group.
+
+      def normalized(group: Group): Group = group.withNormalizedVersion.withoutChildren
+      def isGroupUnchanged(group: Group): Boolean =
+        !group.containsAppsOrGroups && normalized(group) == normalized(newGroup)
+
+      result.group(newGroup.id) match {
+        case Some(unchanged) if isGroupUnchanged(unchanged) =>
+
+          log.debug("remove unchanged group {}", unchanged.id)
+          result.remove(unchanged.id, version)
+        case _ if newGroup.dependencies.nonEmpty =>
+          // group dependencies have changed
+          if (log.isDebugEnabled)
+            log.debug(s"group ${newGroup.id} has changed. " +
+              s"Removed added dependencies ${newGroup.dependencies.mkString(", ")}")
+          result.update(
+            newGroup.id,
+            group => group.copy(dependencies = group.dependencies -- newGroup.dependencies),
+            version)
+        case _ =>
+          // still contains apps/groups, so we keep it
+          result
+      }
+    }
+
+    // sort groups so that inner groups are processed first
+    val sortedGroupChanges = groupChanges.sortWith {
+      case (change1, change2) =>
+        // both groups are supposed to have the same path id (if there are any)
+        def pathId(change: (Option[Group], Option[Group])): PathId = {
+          Seq(change._1, change._2).flatten.map(_.id).headOption.getOrElse(PathId.empty)
+        }
+
+        pathId(change1) > pathId(change2)
+    }
+
+    sortedGroupChanges.foldLeft(group) {
+      case (result, groupUpdate) =>
+        groupUpdate match {
+          case (Some(oldGroup), None) =>
+            result.update(oldGroup.id, revertGroupRemoval(oldGroup), version)
+
+          case (Some(oldGroup), Some(newGroup)) =>
+            result.update(oldGroup.id, revertDependencyChanges(oldGroup, newGroup), version)
+
+          case (None, Some(newGroup)) =>
+            revertGroupAddition(result, newGroup)
+
+          case (None, None) =>
+            log.warn("processing unexpected NOOP in group changes")
+            result
+        }
+    }
+  }
+
+  /**
+    * Reverts app additions, changes and removals.
+    *
+    * The logic is quite simple because during a deployment apps are locked which
+    * prevents any concurrent changes.
+    */
+  private[this] def revertAppChanges(
+    version: Timestamp, changes: Seq[(Option[AppDefinition], Option[AppDefinition])])(
+      g: Group): Group = {
+
+    changes.foldLeft(g) {
+      case (result, appUpdate) =>
+        appUpdate match {
+          case (Some(oldApp), _) => //removal or change
+            log.debug("revert to old app definition {}", oldApp.id)
+            result.updateApp(oldApp.id, _ => oldApp, version)
+          case (None, Some(newApp)) =>
+            log.debug("remove app definition {}", newApp.id)
+            result.update(newApp.id.parent, _.removeApplication(newApp.id), version)
+          case (None, None) =>
+            log.warn("processing unexpected NOOP in app changes")
+            result
+        }
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
@@ -3,6 +3,8 @@ package mesosphere.marathon.state
 import mesosphere.marathon.state.PathId._
 import org.scalatest.{ FunSpec, GivenWhenThen, Matchers }
 
+import scala.collection.SortedSet
+
 class PathIdTest extends FunSpec with GivenWhenThen with Matchers {
 
   describe("A PathId") {
@@ -117,5 +119,27 @@ class PathIdTest extends FunSpec with GivenWhenThen with Matchers {
   it("handles root paths") {
     PathId("/").isRoot shouldBe true
     PathId("").isRoot shouldBe true
+  }
+
+  describe("An ordered PathID collection") {
+    val a = PathId("/a")
+    val aa = a / "a"
+    val ab = a / "b"
+    val ac = a / "c"
+    val b = PathId("/b")
+    val c = PathId("/c")
+
+    it("can be sorted if all paths are on the same level") {
+      SortedSet(a, b, a).toSeq should equal(Seq(a, b))
+    }
+
+    it("can be sorted if with paths on different levels") {
+      SortedSet(a, b, aa, a).toSeq should equal(Seq(a, aa, b))
+    }
+
+    it("can be sorted if it was reversed") {
+      SortedSet(c, b, a).toSeq should equal(Seq(a, b, c))
+      SortedSet(ac, ab, aa).toSeq should equal(Seq(aa, ab, ac))
+    }
   }
 }

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanRevertTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanRevertTest.scala
@@ -1,0 +1,575 @@
+package mesosphere.marathon.upgrade
+
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.state._
+import org.scalatest.{ GivenWhenThen, Matchers }
+import mesosphere.marathon.state.PathId._
+
+import scala.collection.SortedSet
+
+class DeploymentPlanRevertTest extends MarathonSpec with Matchers with GivenWhenThen {
+  private def normalizeVersions(group: Group): Group = {
+    group.withNormalizedVersion.copy(
+      apps = group.apps.map(_.withNormalizedVersion),
+      groups = group.groups.map(normalizeVersions)
+    )
+  }
+
+  /**
+    * An assert equals which provides better feedback about what's different for groups.
+    */
+  private def assertEqualsExceptVersion(expectedOrig: Group, actualOrig: Group): Unit = {
+    val expected: Group = normalizeVersions(expectedOrig)
+    val actual: Group = normalizeVersions(actualOrig)
+
+    if (expected != actual) {
+      val actualGroupIds = actual.transitiveGroups.map(_.id)
+      val expectedGroupIds = expected.transitiveGroups.map(_.id)
+
+      val unexpectedGroupIds = actualGroupIds -- expectedGroupIds
+      val missingGroupIds = expectedGroupIds -- actualGroupIds
+
+      withClue(s"unexpected groups $unexpectedGroupIds, missing groups $missingGroupIds: ") {
+        actualGroupIds should equal(expectedGroupIds)
+      }
+
+      for (groupId <- expectedGroupIds) {
+        withClue(s"for group id $groupId") {
+          actual.group(groupId).map(_.withoutChildren) should equal(expected.group(groupId).map(_.withoutChildren))
+        }
+      }
+
+      val actualAppIds = actual.transitiveApps.map(_.id)
+      val expectedAppIds = expected.transitiveApps.map(_.id)
+
+      val unexpectedAppIds = actualAppIds -- expectedAppIds
+      val missingAppIds = expectedAppIds -- actualAppIds
+
+      withClue(s"unexpected apps $unexpectedAppIds, missing apps $missingAppIds: ") {
+        actualAppIds should equal(expectedAppIds)
+      }
+
+      for (appId <- expectedAppIds) {
+        withClue(s"for app id $appId") {
+          actual.app(appId) should equal(expected.app(appId))
+        }
+      }
+
+      // just in case we missed differences
+      actual should equal(expected)
+    }
+  }
+
+  test("Revert app addition") {
+    Given("an unrelated group")
+    val unrelatedGroup = {
+      val id = "unrelated".toRootPath
+      Group(
+        id,
+        apps = Set(
+          AppDefinition(id / "app1"),
+          AppDefinition(id / "app2")
+        )
+      )
+    }
+
+    val original = Group(
+      PathId.empty,
+      groups = Set(unrelatedGroup)
+    )
+
+    When("we add an unrelated app and try to revert that without concurrent changes")
+    val target = original.updateApp("test".toPath, _ => AppDefinition("test".toPath), Timestamp.now())
+    val plan = DeploymentPlan(original, target)
+    val revertToOriginal = plan.revert(target)
+
+    Then("we get back the original definitions")
+    assertEqualsExceptVersion(original, actualOrig = revertToOriginal)
+  }
+
+  test("Revert app removal") {
+    Given("an existing group with apps")
+    val changeme = {
+      val id = "changeme".toRootPath
+      Group(
+        id,
+        apps = Set(
+          AppDefinition(id / "app1"),
+          AppDefinition(id / "app2")
+        )
+      )
+    }
+
+    val original = Group(
+      PathId.empty,
+      groups = Set(changeme)
+    )
+
+    When("we remove an app and try to revert that without concurrent changes")
+    val appId = "/changeme/app1".toRootPath
+    val target = original.update(appId.parent, _.removeApplication(appId), Timestamp.now())
+    target.app(appId) should be('empty)
+    val plan = DeploymentPlan(original, target)
+    val revertToOriginal = plan.revert(target)
+
+    Then("we get back the original definitions")
+    assertEqualsExceptVersion(original, actualOrig = revertToOriginal)
+  }
+
+  test("Revert group addition") {
+    Given("an unrelated group")
+    val unrelatedGroup = {
+      val id = "unrelated".toRootPath
+      Group(
+        id,
+        apps = Set(
+          AppDefinition(id / "app1"),
+          AppDefinition(id / "app2")
+        )
+      )
+    }
+
+    val original = Group(
+      PathId.empty,
+      groups = Set(unrelatedGroup)
+    )
+
+    When("we add a group and try to revert that without concurrent changes")
+    val target = original.update("test".toPath, _ => Group("supergroup".toRootPath), Timestamp.now())
+    val plan = DeploymentPlan(original, target)
+    val revertToOriginal = plan.revert(target)
+
+    Then("we get back the original definitions")
+    assertEqualsExceptVersion(original, actualOrig = revertToOriginal)
+  }
+
+  test("Revert removing a group without apps") {
+    Given("a group")
+    val changeme = {
+      val id = "changeme".toRootPath
+      Group(
+        id,
+        apps = Set()
+      )
+    }
+
+    val original = Group(
+      PathId.empty,
+      groups = Set(changeme)
+    )
+
+    When("we remove the group and try to revert that without concurrent changes")
+    val target = original.remove("changeme".toRootPath)
+    val plan = DeploymentPlan(original, target)
+    val revertToOriginal = plan.revert(target)
+
+    Then("we get back the original definitions")
+    assertEqualsExceptVersion(original, actualOrig = revertToOriginal)
+  }
+
+  test("Revert removing a group with apps") {
+    Given("a group")
+    val changeme = {
+      val id = "changeme".toRootPath
+      Group(
+        id,
+        apps = Set(
+          AppDefinition(id / "app1"),
+          AppDefinition(id / "app2")
+        )
+      )
+    }
+
+    val original = Group(
+      PathId.empty,
+      groups = Set(changeme)
+    )
+
+    When("we remove the group and try to revert that without concurrent changes")
+    val target = original.remove("changeme".toRootPath)
+    val plan = DeploymentPlan(original, target)
+    val revertToOriginal = plan.revert(target)
+
+    Then("we get back the original definitions")
+    assertEqualsExceptVersion(original, actualOrig = revertToOriginal)
+  }
+
+  test("Revert group dependency changes") {
+    Given("an existing group with apps")
+    val existingGroup = {
+      val id = "changeme".toRootPath
+      Group(
+        id,
+        dependencies = Set(
+          "othergroup1".toRootPath,
+          "othergroup2".toRootPath
+        ),
+        apps = Set(
+          AppDefinition(id / "app1"),
+          AppDefinition(id / "app2")
+        )
+      )
+    }
+
+    val original = Group(
+      PathId.empty,
+      groups = Set(
+        Group("othergroup1".toRootPath),
+        Group("othergroup2".toRootPath),
+        Group("othergroup3".toRootPath),
+        existingGroup
+      )
+    )
+
+    When("we change the dependencies to the existing group")
+    val target = original.update(
+      existingGroup.id,
+      _.copy(dependencies = Set(
+        "othergroup2".toRootPath,
+        "othergroup3".toRootPath
+      )),
+      Timestamp.now())
+    val plan = DeploymentPlan(original, target)
+    val revertToOriginal = plan.revert(target)
+
+    Then("we get back the original definitions")
+    assertEqualsExceptVersion(original, actualOrig = revertToOriginal)
+  }
+
+  val existingGroup = {
+    val id = "changeme".toRootPath
+    Group(
+      id,
+      dependencies = Set(
+        "othergroup1".toRootPath,
+        "othergroup2".toRootPath
+      ),
+      apps = Set(
+        AppDefinition(id / "app1"),
+        AppDefinition(id / "app2")
+      )
+    )
+  }
+
+  val original = Group(
+    PathId.empty,
+    groups = Set(
+      Group("othergroup1".toRootPath),
+      Group("othergroup2".toRootPath),
+      Group("othergroup3".toRootPath),
+      existingGroup
+    )
+  )
+
+  testWithConcurrentChange(original)(
+    removeApp("/changeme/app1"),
+    // unrelated app changes
+    addApp("/changeme/app3"),
+    addApp("/other/app4"),
+    removeApp("/changeme/app2")
+  ) {
+      Group(
+        PathId.empty,
+        groups = Set(
+          Group("othergroup1".toRootPath),
+          Group("othergroup2".toRootPath),
+          Group("othergroup3".toRootPath),
+          {
+            val id = "other".toRootPath
+            Group(
+              id,
+              apps = Set(AppDefinition(id / "app4")) // app4 was added
+            )
+          },
+          {
+            val id = "changeme".toRootPath
+            Group(
+              id,
+              dependencies = Set(
+                "othergroup1".toRootPath,
+                "othergroup2".toRootPath
+              ),
+              apps = Set(
+                AppDefinition(id / "app1"), // app1 was kept
+                // app2 was removed
+                AppDefinition(id / "app3") // app3 was added
+              )
+            )
+          }
+        )
+      )
+    }
+
+  testWithConcurrentChange(original)(
+    changeGroupDependencies("/withdeps", add = Seq("/a", "/b", "/c")),
+    // cannot delete /withdeps in revert
+    addGroup("/withdeps/some")
+  ) {
+      // expected outcome after revert of first deployment
+      Group(
+        PathId.empty,
+        groups = Set(
+          Group("othergroup1".toRootPath),
+          Group("othergroup2".toRootPath),
+          Group("othergroup3".toRootPath),
+          {
+            val id = "withdeps".toRootPath // withdeps still exists because of the subgroup
+            Group(
+              id,
+              groups = Set(Group(id / "some")),
+              dependencies = Set() // dependencies were introduce with first deployment, should be gone now
+            )
+          },
+          {
+            val id = "changeme".toRootPath
+            Group(
+              id,
+              dependencies = Set(
+                "othergroup1".toRootPath,
+                "othergroup2".toRootPath
+              ),
+              apps = Set(
+                AppDefinition(id / "app1"),
+                AppDefinition(id / "app2")
+              )
+            )
+          }
+        )
+      )
+    }
+
+  testWithConcurrentChange(original)(
+    changeGroupDependencies("/changeme", remove = Seq("/othergroup1"), add = Seq("/othergroup3")),
+    // "conflicting" dependency changes
+    changeGroupDependencies("/changeme", remove = Seq("/othergroup2"), add = Seq("/othergroup4"))
+  ) {
+      // expected outcome after revert of first deployment
+      Group(
+        PathId.empty,
+        groups = Set(
+          Group("othergroup1".toRootPath),
+          Group("othergroup2".toRootPath),
+          Group("othergroup3".toRootPath),
+          {
+            val id = "changeme".toRootPath
+            Group(
+              id,
+              dependencies = Set(
+                // othergroup2 was removed and othergroup4 added
+                "othergroup1".toRootPath,
+                "othergroup4".toRootPath
+              ),
+              apps = Set(
+                AppDefinition(id / "app1"),
+                AppDefinition(id / "app2")
+              )
+            )
+          }
+        )
+      )
+    }
+
+  testWithConcurrentChange(original)(
+    removeGroup("/othergroup3"),
+    // unrelated dependency changes
+    changeGroupDependencies("/changeme", remove = Seq("/othergroup2"), add = Seq("/othergroup4"))
+  ) {
+      // expected outcome after revert of first deployment
+      Group(
+        PathId.empty,
+        groups = Set(
+          Group("othergroup1".toRootPath),
+          Group("othergroup2".toRootPath),
+          Group("othergroup3".toRootPath),
+          {
+            val id = "changeme".toRootPath
+            Group(
+              id,
+              dependencies = Set(
+                // othergroup2 was removed and othergroup4 added
+                "othergroup1".toRootPath,
+                "othergroup4".toRootPath
+              ),
+              apps = Set(
+                AppDefinition(id / "app1"),
+                AppDefinition(id / "app2")
+              )
+            )
+          }
+        )
+      )
+    }
+
+  testWithConcurrentChange(
+    original,
+    addGroup("/changeme/some")
+  )(
+      // revert first
+      addGroup("/changeme/some/a"),
+      // concurrent deployments
+      addGroup("/changeme/some/b")
+    ) {
+        // expected outcome after revert
+        Group(
+          PathId.empty,
+          groups = Set(
+            Group("othergroup1".toRootPath),
+            Group("othergroup2".toRootPath),
+            Group("othergroup3".toRootPath),
+            {
+              val id = "changeme".toRootPath
+              Group(
+                id,
+                dependencies = Set(
+                  "othergroup1".toRootPath,
+                  "othergroup2".toRootPath
+                ),
+                apps = Set(
+                  AppDefinition(id / "app1"),
+                  AppDefinition(id / "app2")
+                ),
+                groups = Set(
+                  Group(
+                    id / "some",
+                    groups = Set(
+                      Group(id / "some" / "b")
+                    )
+                  )
+                )
+              )
+            }
+          )
+        )
+      }
+
+  testWithConcurrentChange(
+    original
+  )(
+      // revert first
+      addApp("/changeme/some/a"),
+      // concurrent deployments
+      addApp("/changeme/some/b/a"),
+      addApp("/changeme/some/b/b"),
+      addApp("/changeme/some/b/c")
+    ) {
+        // expected outcome after revert
+        Group(
+          PathId.empty,
+          groups = Set(
+            Group("othergroup1".toRootPath),
+            Group("othergroup2".toRootPath),
+            Group("othergroup3".toRootPath),
+            {
+              val id = "changeme".toRootPath
+              Group(
+                id,
+                dependencies = Set(
+                  "othergroup1".toRootPath,
+                  "othergroup2".toRootPath
+                ),
+                apps = Set(
+                  AppDefinition(id / "app1"),
+                  AppDefinition(id / "app2")
+                ),
+                groups = Set(
+                  Group(
+                    id / "some",
+                    groups = Set(
+                      Group(
+                        id / "some" / "b",
+                        apps = Set(
+                          AppDefinition(id / "some" / "b" / "a"),
+                          AppDefinition(id / "some" / "b" / "b"),
+                          AppDefinition(id / "some" / "b" / "c")
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            }
+          )
+        )
+      }
+
+  case class Deployment(name: String, change: Group => Group)
+
+  private[this] def testWithConcurrentChange(originalBeforeChanges: Group, changesBeforeTest: Deployment*)(deployments: Deployment*)(expectedReverted: Group): Unit = {
+    val firstDeployment = deployments.head
+
+    def performDeployments(orig: Group, deployments: Seq[Deployment]): Group = {
+      deployments.foldLeft(orig) {
+        case (last: Group, deployment: Deployment) =>
+          deployment.change(last)
+      }
+    }
+
+    test(s"Reverting ${firstDeployment.name} after deploying ${deployments.tail.map(_.name).mkString(", ")}") {
+      Given("an existing group with apps")
+      val original = performDeployments(originalBeforeChanges, changesBeforeTest)
+
+      When(s"performing a series of deployments (${deployments.map(_.name).mkString(", ")})")
+
+      val targetWithAllDeployments = performDeployments(original, deployments)
+
+      When(s"reverting the first one while we reset the versions before that")
+      val newVersion = Timestamp(1)
+      val deploymentReverterForFirst = DeploymentPlanReverter.revert(
+        normalizeVersions(original),
+        normalizeVersions(firstDeployment.change(original)),
+        newVersion)
+      val reverted = deploymentReverterForFirst(normalizeVersions(targetWithAllDeployments))
+
+      Then("The result should only contain items with the prior or the new version")
+      for (app <- reverted.transitiveApps) {
+        withClue(s"version for app ${app.id} ") {
+          app.version.toDateTime.getMillis should be <= (1L)
+        }
+      }
+
+      for (group <- reverted.transitiveGroups) {
+        withClue(s"version for group ${group.id} ") {
+          group.version.toDateTime.getMillis should be <= (1L)
+        }
+      }
+
+      Then("the result should be the same as if we had only applied all the other deployments")
+      val targetWithoutFirstDeployment = performDeployments(original, deployments.tail)
+      withClue("while comparing reverted with targetWithoutFirstDeployment: ") {
+        assertEqualsExceptVersion(targetWithoutFirstDeployment, reverted)
+      }
+
+      Then("we should have the expected groups and apps")
+      withClue("while comparing reverted with expected: ") {
+        assertEqualsExceptVersion(expectedReverted, reverted)
+      }
+    }
+  }
+
+  private[this] def removeApp(appIdString: String) = {
+    val appId = appIdString.toRootPath
+    val parent = appId.parent
+    Deployment(s"remove app '$appId'", _.update(parent, _.removeApplication(appId), Timestamp.now()))
+  }
+  private[this] def addApp(appId: String) = Deployment(s"add app '$appId'", _.updateApp(appId.toRootPath, _ => AppDefinition(appId.toRootPath), Timestamp.now()))
+  private[this] def addGroup(groupId: String) = Deployment(s"add group '$groupId'", _.makeGroup(groupId.toRootPath))
+  private[this] def removeGroup(groupId: String) = Deployment(s"remove group '$groupId'", _.remove(groupId.toRootPath))
+
+  private[this] def changeGroupDependencies(groupId: String, add: Seq[String] = Seq.empty, remove: Seq[String] = Seq.empty) = {
+    val addedIds = add.map(_.toRootPath)
+    val removedIds = remove.map(_.toRootPath)
+
+    def setDependencies(group: Group): Group = group.copy(dependencies = group.dependencies ++ addedIds -- removedIds)
+
+    val name = if (removedIds.isEmpty)
+      s"group '$groupId' add deps {${addedIds.mkString(", ")}}"
+    else if (addedIds.isEmpty)
+      s"group '$groupId' remove deps {${removedIds.mkString(", ")}}"
+    else
+      s"group '$groupId' change deps -{${removedIds.mkString(", ")}} +{${addedIds.mkString(", ")}}"
+
+    Deployment(
+      name,
+      _.update(groupId.toRootPath, setDependencies, Timestamp.now()))
+  }
+}


### PR DESCRIPTION
Also introduces an ordering of PathIds.

I considered extracting the revert logic into a separate class DeploymentPlanRevert with the origin, target fields copied. I'd like to hear feedback of the reviewer about that idea.
