### PR TITLE
Marathon Plugin Architecture

### DIFF
--- a/interface/src/main/scala/mesosphere/marathon/plugin/Plugin.scala
+++ b/interface/src/main/scala/mesosphere/marathon/plugin/Plugin.scala
@@ -1,6 +1,9 @@
 package mesosphere.marathon.plugin
 
-trait Plugin {
-
-}
+/**
+  * Marker trait for all service provider plugins.
+  *
+  * TODO: add documentation for creating a service provider plugin.
+  */
+trait Plugin
 

--- a/interface/src/main/scala/mesosphere/marathon/plugin/Plugin.scala
+++ b/interface/src/main/scala/mesosphere/marathon/plugin/Plugin.scala
@@ -1,0 +1,6 @@
+package mesosphere.marathon.plugin
+
+trait Plugin {
+
+}
+

--- a/interface/src/main/scala/mesosphere/marathon/plugin/event/EventListener.scala
+++ b/interface/src/main/scala/mesosphere/marathon/plugin/event/EventListener.scala
@@ -1,0 +1,9 @@
+package mesosphere.marathon.plugin.event
+
+import mesosphere.marathon.plugin.Plugin
+
+trait EventListener extends Plugin {
+
+  def handleEvent(o: Object): Unit
+
+}

--- a/interface/src/main/scala/mesosphere/marathon/plugin/event/EventListener.scala
+++ b/interface/src/main/scala/mesosphere/marathon/plugin/event/EventListener.scala
@@ -2,8 +2,27 @@ package mesosphere.marathon.plugin.event
 
 import mesosphere.marathon.plugin.Plugin
 
+/**
+  * Base trait for all events.
+  * TODO: add a more specific event hierarchy.
+  */
+trait Event {
+  /**
+    * The type of event
+    */
+  val eventType: String
+
+  /**
+    * The timestamp of the event
+    */
+  val timestamp: String
+}
+
+/**
+  * An event listener plugin
+  */
 trait EventListener extends Plugin {
 
-  def handleEvent(o: Object): Unit
+  def handleEvent(event: Event): Unit
 
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -18,6 +18,7 @@ object MarathonBuild extends Build {
     id = "marathon",
     base = file("."),
     settings = baseSettings ++
+               buildInfoSettings ++
                asmSettings ++
                releaseSettings ++
                publishSettings ++
@@ -27,6 +28,9 @@ object MarathonBuild extends Build {
                graphSettings ++
       Seq(
         libraryDependencies ++= Dependencies.root,
+        sourceGenerators in Compile <+= buildInfo,
+        buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion),
+        buildInfoPackage := "mesosphere.marathon",
         parallelExecution in Test := false,
         fork in Test := true
       )
@@ -55,7 +59,7 @@ object MarathonBuild extends Build {
 
   lazy val IntegrationTest = config("integration") extend Test
 
-  lazy val baseSettings = Defaults.defaultSettings ++ buildInfoSettings ++ Seq (
+  lazy val baseSettings = Defaults.defaultSettings ++ Seq (
     organization := "mesosphere",
     scalaVersion := "2.11.5",
     scalacOptions in Compile ++= Seq(
@@ -78,10 +82,6 @@ object MarathonBuild extends Build {
       "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
       "Spray Maven Repository"    at "http://repo.spray.io/"
     ),
-    sourceGenerators in Compile <+= buildInfo,
-    fork in Test := true,
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion),
-    buildInfoPackage := "mesosphere.marathon",
     testScalaStyle := {
       org.scalastyle.sbt.PluginKeys.scalastyle.toTask("").value
     },

--- a/project/build.scala
+++ b/project/build.scala
@@ -13,6 +13,7 @@ import sbtbuildinfo.Plugin._
 import spray.revolver.RevolverPlugin.Revolver.{settings => revolverSettings}
 
 object MarathonBuild extends Build {
+
   lazy val root = Project(
     id = "marathon",
     base = file("."),
@@ -34,6 +35,21 @@ object MarathonBuild extends Build {
     .settings(inConfig(IntegrationTest)(Defaults.testTasks): _*)
     .settings(testOptions in Test := Seq(Tests.Argument("-l", "integration")))
     .settings(testOptions in IntegrationTest := Seq(Tests.Argument("-n", "integration")))
+    .dependsOn(marathonInterface)
+
+  lazy val marathonInterface = Project(
+    id = "marathon-interface",
+    base = file("interface"),
+    settings = baseSettings ++
+      asmSettings ++
+      publishSettings ++
+      formatSettings ++
+      styleSettings ++
+      graphSettings ++
+      Seq(
+        libraryDependencies ++= Dependencies.interface
+      )
+  )
 
   lazy val testScalaStyle = taskKey[Unit]("testScalaStyle")
 
@@ -125,6 +141,8 @@ object MarathonBuild extends Build {
 
 object Dependencies {
   import Dependency._
+
+  val interface = Seq.empty[ModuleID]
 
   val root = Seq(
     // runtime

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -1,19 +1,19 @@
 package mesosphere.marathon
 
-import mesosphere.chaos.App
-import org.rogach.scallop.ScallopConf
-import mesosphere.chaos.http.{ HttpService, HttpModule, HttpConf }
+import com.google.inject.AbstractModule
+import com.twitter.common.quantity.{ Amount, Time }
+import com.twitter.common.zookeeper.ZooKeeperClient
+import mesosphere.chaos.{ App, AppConfiguration }
+import mesosphere.chaos.http.{ HttpConf, HttpModule, HttpService }
 import mesosphere.chaos.metrics.MetricsModule
 import mesosphere.marathon.api.MarathonRestModule
-import mesosphere.chaos.AppConfiguration
-import mesosphere.marathon.event.{ EventModule, EventConfiguration }
-import mesosphere.marathon.event.http.{ HttpEventModule, HttpEventConfiguration }
-import com.google.inject.AbstractModule
-import com.twitter.common.quantity.{ Time, Amount }
-import com.twitter.common.zookeeper.ZooKeeperClient
-import scala.collection.JavaConverters._
-import java.util.Properties
+import mesosphere.marathon.event.http.{ HttpEventConfiguration, HttpEventModule }
+import mesosphere.marathon.event.{ EventConfiguration, EventModule }
+import mesosphere.marathon.plugin.{ PluginModule, PluginConfiguration }
 import org.apache.log4j.Logger
+import org.rogach.scallop.ScallopConf
+
+import scala.collection.JavaConverters._
 
 object Main extends App {
   val log = Logger.getLogger(getClass.getName)
@@ -57,7 +57,8 @@ object Main extends App {
       new MetricsModule,
       new MarathonModule(conf, conf, zk),
       new MarathonRestModule,
-      new EventModule(conf)
+      new EventModule(conf),
+      new PluginModule(conf)
     ) ++ getEventsModule
   }
 
@@ -80,6 +81,7 @@ object Main extends App {
     with AppConfiguration
     with EventConfiguration
     with HttpEventConfiguration
+    with PluginConfiguration
 
   lazy val conf = new AllConf
 

--- a/src/main/scala/mesosphere/marathon/event/EventDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/event/EventDelegate.scala
@@ -1,0 +1,17 @@
+package mesosphere.marathon.event
+
+import akka.actor.{ Actor, ActorLogging }
+import akka.event.EventStream
+import mesosphere.marathon.plugin.event.EventListener
+
+/**
+  * Actor, that delegates to all given event listener
+  */
+class EventDelegate(stream: EventStream, listener: Seq[EventListener]) extends Actor with ActorLogging {
+
+  override def preStart(): Unit = if (listener.nonEmpty) stream.subscribe(self, classOf[MarathonEvent])
+
+  override def receive: Receive = {
+    case event: MarathonEvent => listener.foreach(_.handleEvent(event))
+  }
+}

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.event
 
 import mesosphere.marathon.health.HealthCheck
+import mesosphere.marathon.plugin.event.Event
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep }
 import org.rogach.scallop.ScallopConf
 import com.google.inject.{ Inject, Singleton, Provides, AbstractModule }
@@ -40,7 +41,7 @@ object EventModule {
   final val busName = "events"
 }
 
-sealed trait MarathonEvent {
+sealed trait MarathonEvent extends Event {
   val eventType: String
   val timestamp: String
 }

--- a/src/main/scala/mesosphere/marathon/io/IO.scala
+++ b/src/main/scala/mesosphere/marathon/io/IO.scala
@@ -2,14 +2,20 @@ package mesosphere.marathon.io
 
 import java.io._
 import java.math.BigInteger
-import java.security.{ MessageDigest, DigestInputStream }
-import scala.annotation.tailrec
+import java.security.{ DigestInputStream, MessageDigest }
 
 import com.google.common.io.ByteStreams
+
+import scala.annotation.tailrec
+import scala.util.matching.Regex
 
 trait IO {
 
   private val BufferSize = 8192
+
+  protected def listFiles(inDir: File, regex: Regex): Array[File] = {
+    inDir.listFiles().filter(f => regex.pattern.matcher(f.getName).matches)
+  }
 
   protected def moveFile(from: File, to: File): File = {
     if (to.exists()) delete(to)

--- a/src/main/scala/mesosphere/marathon/plugin/PluginManager.scala
+++ b/src/main/scala/mesosphere/marathon/plugin/PluginManager.scala
@@ -37,7 +37,9 @@ class PluginManager(val urls: Seq[URL]) {
   private[this] def load[T <: Plugin](implicit ct: ClassTag[T]): PluginReference[T] = {
     val serviceLoader = ServiceLoader.load(ct.runtimeClass.asInstanceOf[Class[T]], classLoader)
     val instances = serviceLoader.iterator().asScala.toSeq
-    log.info(s"""Load plugin ${ct.runtimeClass.getName} from this locations: ${urls.mkString(", ")}. Found ${instances.size} instances.""")
+    log.info(
+      s"""Load plugin ${ct.runtimeClass.getName} from this locations: ${urls.mkString(", ")}.
+         |Found ${instances.size} instances.""".stripMargin)
     PluginReference(ct, serviceLoader, instances)
   }
 
@@ -66,7 +68,7 @@ class PluginManager(val urls: Seq[URL]) {
     if (p.nonEmpty) fn(p)
   }
 
-  def installedPlugins = plugins
+  def installedPlugins: Seq[PluginReference[_]] = plugins
 }
 
 object PluginManager extends IO {

--- a/src/main/scala/mesosphere/marathon/plugin/PluginManager.scala
+++ b/src/main/scala/mesosphere/marathon/plugin/PluginManager.scala
@@ -1,0 +1,59 @@
+package mesosphere.marathon.plugin
+
+import java.io.File
+import java.net.URLClassLoader
+import java.util.ServiceLoader
+
+import mesosphere.marathon.io.IO
+import mesosphere.marathon.plugin.event.EventListener
+
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+
+case class PluginReference[T](classTag: ClassTag[T], serviceLoader: ServiceLoader[T], instances: Seq[T])
+
+class PluginManager(dir: File) extends IO {
+
+  val jars = listFiles(dir, ".*jar$".r)
+  val classLoader = new URLClassLoader(listFiles(dir, ".*jar$".r).map(_.toURI.toURL), this.getClass.getClassLoader)
+
+  private[this] var plugins = List.empty[PluginReference[_]]
+
+  private[this] def load[T <: Plugin](implicit sc: ClassTag[T]): PluginReference[T] = synchronized {
+    val serviceLoader = ServiceLoader.load(sc.runtimeClass.asInstanceOf[Class[T]], classLoader)
+    val instances = serviceLoader.iterator().asScala.toSeq
+    val plugin = PluginReference(sc, serviceLoader, instances)
+    plugins ::= plugin
+    plugin
+  }
+
+  def instances[T <: Plugin](implicit sc: ClassTag[T]): Seq[T] = synchronized {
+    plugins
+      .find(_.classTag == sc)
+      .map(_.asInstanceOf[PluginReference[T]])
+      .getOrElse(load)
+      .instances
+  }
+
+  def instance[T <: Plugin](implicit sc: ClassTag[T]): Option[T] = instances[T].headOption
+
+  def installedPlugins = plugins
+}
+
+object PluginManager {
+
+  def main(args: Array[String]) {
+    val manager = new PluginManager(new File("/Users/matthias/"))
+    println(">>> " + manager.jars.mkString(", "))
+    manager.instance[EventListener].foreach { listener =>
+      listener.handleEvent("Test a")
+      listener.handleEvent("Test b")
+      listener.handleEvent("Test c")
+    }
+    manager.instance[EventListener].foreach { listener =>
+      listener.handleEvent("Test a")
+      listener.handleEvent("Test b")
+      listener.handleEvent("Test c")
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/plugin/PluginModule.scala
+++ b/src/main/scala/mesosphere/marathon/plugin/PluginModule.scala
@@ -27,7 +27,9 @@ class PluginModule(conf: PluginConfiguration) extends AbstractModule {
 
   @Provides
   @Named(PluginModule.PluginEventDelegate)
-  def provideEventDelegate(system: ActorSystem, pluginManager: PluginManager, @Named(EventModule.busName) stream: EventStream): ActorRef = {
+  def provideEventDelegate(system: ActorSystem,
+                           pluginManager: PluginManager,
+                           @Named(EventModule.busName) stream: EventStream): ActorRef = {
     val listener = pluginManager.providers[EventListener]
     system.actorOf(Props(new EventDelegate(stream, listener)))
   }

--- a/src/main/scala/mesosphere/marathon/plugin/PluginModule.scala
+++ b/src/main/scala/mesosphere/marathon/plugin/PluginModule.scala
@@ -1,0 +1,42 @@
+package mesosphere.marathon.plugin
+
+import javax.inject.Inject
+
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.event.EventStream
+import com.google.inject.name.Named
+import com.google.inject.{ AbstractModule, Provides }
+import mesosphere.marathon.event.{ EventDelegate, EventModule }
+import mesosphere.marathon.plugin.event.EventListener
+import org.rogach.scallop.ScallopConf
+
+trait PluginConfiguration extends ScallopConf {
+  lazy val pluginDir = opt[String]("plugin-dir",
+    descr = "Path to the local directory with plugin jars.",
+    required = false,
+    noshort = true)
+}
+
+class PluginModule(conf: PluginConfiguration) extends AbstractModule {
+
+  override def configure(): Unit = conf.pluginDir.foreach { dir =>
+    val pluginManager = PluginManager(dir)
+    bind(classOf[PluginManager]).toInstance(pluginManager)
+    bind(classOf[EagerDependency]).asEagerSingleton()
+  }
+
+  @Provides
+  @Named(PluginModule.PluginEventDelegate)
+  def provideEventDelegate(system: ActorSystem, pluginManager: PluginManager, @Named(EventModule.busName) stream: EventStream): ActorRef = {
+    val listener = pluginManager.providers[EventListener]
+    system.actorOf(Props(new EventDelegate(stream, listener)))
+  }
+
+}
+
+object PluginModule {
+  final val PluginEventDelegate = "EventDelegate"
+}
+
+//TODO: is there a better way of eager
+private class EagerDependency @Inject() (@Named(PluginModule.PluginEventDelegate) ref: ActorRef)

--- a/src/main/scala/mesosphere/marathon/plugin/PluginModule.scala
+++ b/src/main/scala/mesosphere/marathon/plugin/PluginModule.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.plugin.event.EventListener
 import org.rogach.scallop.ScallopConf
 
 trait PluginConfiguration extends ScallopConf {
-  lazy val pluginDir = opt[String]("plugin-dir",
+  lazy val pluginDir = opt[String]("plugin_dir",
     descr = "Path to the local directory with plugin jars.",
     required = false,
     noshort = true)
@@ -19,10 +19,15 @@ trait PluginConfiguration extends ScallopConf {
 
 class PluginModule(conf: PluginConfiguration) extends AbstractModule {
 
-  override def configure(): Unit = conf.pluginDir.foreach { dir =>
-    val pluginManager = PluginManager(dir)
-    bind(classOf[PluginManager]).toInstance(pluginManager)
-    bind(classOf[EagerDependency]).asEagerSingleton()
+  override def configure(): Unit = {
+    conf.pluginDir.map { dir =>
+      val pluginManager = PluginManager(dir)
+      bind(classOf[PluginManager]).toInstance(pluginManager)
+      bind(classOf[EagerDependency]).asEagerSingleton()
+    }.get.getOrElse {
+      //fallback, if no plugin directory was defined
+      bind(classOf[PluginManager]).toInstance(new PluginManager(Seq.empty))
+    }
   }
 
   @Provides


### PR DESCRIPTION
__DO NOT MERGE: it is meant as proposal__

## General idea
- identify functionality, where a service provider can be plugged in (extended or overridden)
- define a service provider interface for this functionality
- allow loading and using of service providers for the defined interface(s)

## marathon interface
Since the service provider needs some types to depend on, a separat sbt module has been created.
The marathon-interface is the library, a plugin depends on. With respect to marathon this should be the
only dependency (everything else is not considered as interface).

## event handling
The example extension of this proposal is to hook into the marathon event bus.
There are certain ideas to handle events, that should not be implemented in marathon directly (send events to a message queue etc.)

## example
See https://github.com/aquamatthias/marathon-test-plugin for an example plugin.

## implementation notes
The approach is based on the java service loader: https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html

@drexin @kolloch Feedback appreciated