### PR TITLE
Fixes #1391 - Provide a simplistic simulation of mesos for scale testing

### DIFF
--- a/mesos-simulation/README.md
+++ b/mesos-simulation/README.md
@@ -1,0 +1,30 @@
+This module provides a simplistic Mesos simulation which can be used for Marathon scale tests.
+
+# Run Marathon in Simulation Mode
+
+The marathon with the simulated Mesos can be started from the command line like this:
+
+```bash
+sbt -Djava.library.path=<...include the directories of your native mesos libraries...> \
+    "project mesosSimulation" "run --master zk://localhost:2181/mesos --zk zk://localhost:2181/marathon"
+```
+
+Of course, you can adjust your configuration. You need to provide the master configuration but no Mesos master or slave
+has to be running.
+
+# Run Automated Scaling Test
+
+Run scaling tests:
+
+```bash
+sbt "project mesosSimulation" "integration:testOnly **ScalingTest"
+```
+
+Show results:
+
+```bash
+sbt "project mesosSimulation" "test:run"
+```
+
+The simulation is currently not configurable outside the code. If you want to adjust the number
+of offers sent every offer cycle, you can change `mesosphere.mesos.simulation.DriverActor.numberOfOffersPerCycle`.

--- a/mesos-simulation/src/main/resources/mesos-simulation.conf
+++ b/mesos-simulation/src/main/resources/mesos-simulation.conf
@@ -1,0 +1,15 @@
+#
+# Configure the Akka Actor System for the Mesos Simulation
+#
+
+akka {
+  loglevel = DEBUG
+
+  debug {
+    # enable function of LoggingReceive, which is to log any received message at
+    # DEBUG level
+    receive = on
+    # enable DEBUG logging of actor lifecycle changes
+    lifecycle = on
+  }
+}

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/DriverActor.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/DriverActor.scala
@@ -1,0 +1,116 @@
+package mesosphere.mesos.simulation
+
+import akka.actor.{ Actor, ActorRef, Cancellable, Props }
+import akka.event.LoggingReceive
+import mesosphere.mesos.simulation.DriverActor.{ KillTask, LaunchTasks }
+import org.apache.mesos.Protos._
+import org.apache.mesos.SchedulerDriver
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConversions._
+import scala.concurrent.duration._
+
+object DriverActor {
+  case class DeclineOffer(offerId: OfferID)
+
+  /**
+    * Corresponds to the following method in [[org.apache.mesos.MesosSchedulerDriver]]:
+    *
+    * `override def launchTasks(offerIds: util.Collection[OfferID], tasks: util.Collection[TaskInfo]): Status`
+    */
+  case class LaunchTasks(offerIds: Seq[OfferID], tasks: Seq[TaskInfo])
+
+  /**
+    * Corresponds to the following method in [[org.apache.mesos.MesosSchedulerDriver]]:
+    *
+    * `override def killTask(taskId: TaskID): Status`
+    */
+  case class KillTask(taskId: TaskID)
+
+  /**
+    * Corresponds to the following method in [[org.apache.mesos.MesosSchedulerDriver]]:
+    *
+    * `override def reconcileTasks(statuses: util.Collection[TaskStatus]): Status`
+    */
+  case class ReconcileTask(taskStatus: Seq[TaskStatus])
+}
+
+class DriverActor(schedulerProps: Props) extends Actor {
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private[this] val numberOfOffersPerCycle: Int = 10
+
+  private[this] var periodicOffers: Option[Cancellable] = None
+  private[this] var scheduler: ActorRef = _
+
+  override def preStart(): Unit = {
+    super.preStart()
+    scheduler = context.actorOf(schedulerProps, "scheduler")
+    def resource(name: String, value: Double): Resource = {
+      Resource.newBuilder()
+        .setName(name)
+        .setType(Value.Type.SCALAR)
+        .setScalar(Value.Scalar.newBuilder().setValue(value))
+        .build()
+    }
+
+    val offer: Offer = Offer.newBuilder()
+      .setId(OfferID.newBuilder().setValue("thisisnotandid"))
+      .setFrameworkId(FrameworkID.newBuilder().setValue("notanidframework"))
+      .setSlaveId(SlaveID.newBuilder().setValue("notanidslave"))
+      .setHostname("hostname")
+      .addAllResources(Seq(
+        resource("cpus", 100),
+        resource("mem", 500000),
+        resource("disk", 1000000000),
+        Resource.newBuilder()
+          .setName("ports")
+          .setType(Value.Type.RANGES)
+          .setRanges(
+            Value.Ranges
+              .newBuilder()
+              .addRange(Value.Range.newBuilder().setBegin(10000).setEnd(20000)))
+          .build()
+      ))
+      .build()
+
+    val offers = SchedulerActor.ResourceOffers((1 to numberOfOffersPerCycle).map(_ => offer))
+
+    import context.dispatcher
+    periodicOffers = Some(
+      context.system.scheduler.schedule(1.second, 1.seconds, scheduler, offers)
+    )
+  }
+
+  override def postStop(): Unit = {
+    periodicOffers.foreach(_.cancel())
+    periodicOffers = None
+    super.postStop()
+  }
+
+  override def receive: Receive = LoggingReceive {
+    case driver: SchedulerDriver =>
+      log.debug(s"pass on driver to scheduler $scheduler")
+      scheduler ! driver
+
+    case LaunchTasks(offers, tasks) =>
+      log.debug(s"launch tasks $offers, $tasks")
+      tasks.foreach { taskInfo: TaskInfo =>
+        scheduler ! TaskStatus.newBuilder()
+          .setSource(TaskStatus.Source.SOURCE_EXECUTOR)
+          .setTaskId(taskInfo.getTaskId)
+          .setState(TaskState.TASK_RUNNING)
+          .build()
+      }
+
+    case KillTask(taskId) =>
+      log.debug(s"kill tasks $taskId")
+      scheduler ! TaskStatus.newBuilder()
+        .setSource(TaskStatus.Source.SOURCE_EXECUTOR)
+        .setTaskId(taskId)
+        .setState(TaskState.TASK_KILLED)
+        .build()
+
+    case _ =>
+  }
+}

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SchedulerActor.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SchedulerActor.scala
@@ -1,0 +1,51 @@
+package mesosphere.mesos.simulation
+
+import akka.actor.{ Actor, Stash }
+import akka.event.LoggingReceive
+import org.apache.mesos.Protos.{ FrameworkID, MasterInfo, Offer, TaskStatus }
+import org.apache.mesos.{ Scheduler, SchedulerDriver }
+import org.slf4j.LoggerFactory
+
+object SchedulerActor {
+  private val log = LoggerFactory.getLogger(getClass)
+
+  case class Registered(
+    frameworkId: FrameworkID,
+    master: MasterInfo)
+
+  case class ResourceOffers(offers: Seq[Offer])
+}
+
+class SchedulerActor(scheduler: Scheduler) extends Actor with Stash {
+  import SchedulerActor._
+
+  var driverOpt: Option[SchedulerDriver] = None
+
+  def receive: Receive = waitForDriver
+
+  def waitForDriver: Receive = LoggingReceive.withLabel("waitForDriver") {
+    case driver: SchedulerDriver =>
+      log.info("received driver")
+      driverOpt = Some(driver)
+      context.become(handleCmds(driver))
+      unstashAll()
+
+    case _ => stash()
+  }
+
+  def handleCmds(driver: SchedulerDriver): Receive = LoggingReceive.withLabel("handleCmds") {
+    case Registered(frameworkId, masterInfo) =>
+      scheduler.registered(driver, frameworkId, masterInfo)
+
+    case ResourceOffers(offers) =>
+      import scala.collection.JavaConversions._
+      scheduler.resourceOffers(driver, offers)
+
+    case status: TaskStatus =>
+      scheduler.statusUpdate(driver, status)
+  }
+
+  override def postStop(): Unit = {
+    driverOpt.foreach { driver => scheduler.disconnected(driver) }
+  }
+}

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulateMesosMain.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulateMesosMain.scala
@@ -1,0 +1,24 @@
+package mesosphere.mesos.simulation
+
+import com.google.inject._
+import com.google.inject.util.Modules
+import mesosphere.marathon._
+
+/**
+  * Start marathon with a simulated mesos driver.
+  */
+object SimulateMesosMain extends MarathonApp {
+  private[this] def simulatedDriverModule: Module = {
+    new AbstractModule {
+      override def configure(): Unit = {
+        bind(classOf[SchedulerDriverFactory]).to(classOf[SimulatedSchedulerDriverFactory]).in(Scopes.SINGLETON)
+      }
+    }
+  }
+
+  override def modules(): Seq[Module] = {
+    Seq(Modules.`override`(super.modules(): _*).`with`(simulatedDriverModule))
+  }
+
+  runDefault()
+}

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
@@ -1,0 +1,112 @@
+package mesosphere.mesos.simulation
+
+import java.util
+
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.apache.mesos.Protos._
+import org.apache.mesos.SchedulerDriver
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConversions._
+
+/**
+  * The facade to the mesos simulation.
+  *
+  * It starts/stops a new actor system for the simulation when the corresponding life-cycle methods of the
+  * [[SchedulerDriver]] interface are called.
+  *
+  * The implemented commands of the driver interface are forwarded as messages to the [[DriverActor]].
+  * Unimplemented methods throw [[NotImplementedError]]s.
+  */
+class SimulatedDriver(driverProps: Props) extends SchedulerDriver {
+
+  private[this] val log = LoggerFactory.getLogger(getClass)
+
+  private[this] def driverCmd(cmd: AnyRef): Status = {
+    driverActorRefOpt match {
+      case Some(driverActor) =>
+        log.debug(s"send driver cmd $cmd")
+        driverActor ! cmd
+      case None =>
+        log.debug("no driver actor configured")
+    }
+    status
+  }
+
+  override def declineOffer(offerId: OfferID): Status =
+    driverCmd(DriverActor.DeclineOffer(offerId))
+
+  override def launchTasks(offerIds: util.Collection[OfferID], tasks: util.Collection[TaskInfo]): Status =
+    driverCmd(DriverActor.LaunchTasks(offerIds.toSeq, tasks.toSeq))
+
+  override def killTask(taskId: TaskID): Status = driverCmd(DriverActor.KillTask(taskId))
+  override def reconcileTasks(statuses: util.Collection[TaskStatus]): Status = {
+    driverCmd(DriverActor.ReconcileTask(statuses.toSeq))
+  }
+
+  override def declineOffer(offerId: OfferID, filters: Filters): Status = Status.DRIVER_RUNNING
+
+  override def launchTasks(offerIds: util.Collection[OfferID], tasks: util.Collection[TaskInfo],
+                           filters: Filters): Status = ???
+  override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo], filters: Filters): Status = ???
+  override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo]): Status = ???
+  override def requestResources(requests: util.Collection[Request]): Status = ???
+  override def sendFrameworkMessage(executorId: ExecutorID, slaveId: SlaveID, data: Array[Byte]): Status = ???
+  override def reviveOffers(): Status = ???
+  override def acknowledgeStatusUpdate(status: TaskStatus): Status = ???
+  // Mesos 0.23.x
+  //  override def acceptOffers(
+  //    o: util.Collection[OfferID], ops: util.Collection[Offer.Operation], filters: Filters): Status = ???
+
+  // life cycle
+
+  @volatile
+  var system: Option[ActorSystem] = None
+  @volatile
+  var driverActorRefOpt: Option[ActorRef] = None
+
+  private def status: Status = system match {
+    case None    => Status.DRIVER_STOPPED
+    case Some(_) => Status.DRIVER_RUNNING
+  }
+
+  override def start(): Status = {
+    log.info("Starting simulated Mesos")
+    val config: Config = ConfigFactory.load(getClass.getClassLoader, "mesos-simulation.conf")
+    val sys: ActorSystem = ActorSystem("mesos-simulation", config)
+    system = Some(sys)
+    driverActorRefOpt = Some(sys.actorOf(driverProps, "driver"))
+    driverCmd(this)
+
+    Status.DRIVER_RUNNING
+  }
+
+  override def stop(failover: Boolean): Status = stop()
+  override def stop(): Status = abort()
+  override def abort(): Status = {
+    system match {
+      case None => Status.DRIVER_NOT_STARTED
+      case Some(sys) =>
+        sys.shutdown()
+        Status.DRIVER_ABORTED
+    }
+  }
+
+  override def run(): Status = {
+    start()
+    join()
+  }
+
+  override def join(): Status = {
+    system match {
+      case None => Status.DRIVER_NOT_STARTED
+      case Some(sys) =>
+        sys.awaitTermination()
+        driverActorRefOpt = None
+        system = None
+        log.info("Stopped simulated Mesos")
+        Status.DRIVER_STOPPED
+    }
+  }
+}

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriverWiring.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriverWiring.scala
@@ -1,0 +1,19 @@
+package mesosphere.mesos.simulation
+
+import akka.actor.Props
+import org.apache.mesos.{ Scheduler, SchedulerDriver }
+
+private class SimulatedDriverWiring(scheduler: Scheduler) {
+  private lazy val schedulerActorProps = Props(new SchedulerActor(scheduler))
+  private lazy val driverActorProps = Props(new DriverActor(schedulerActorProps))
+  lazy val driver = new SimulatedDriver(driverActorProps)
+}
+
+/**
+  * A factory for a simulated [[SchedulerDriver]].
+  */
+object SimulatedDriverWiring {
+  def createDriver(scheduler: Scheduler): SchedulerDriver = {
+    new SimulatedDriverWiring(scheduler).driver
+  }
+}

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedSchedulerDriverFactory.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedSchedulerDriverFactory.scala
@@ -1,0 +1,18 @@
+package mesosphere.mesos.simulation
+
+import javax.inject.Inject
+
+import mesosphere.marathon.{ MarathonScheduler, MarathonSchedulerDriverHolder, SchedulerDriverFactory }
+import org.apache.mesos.SchedulerDriver
+
+class SimulatedSchedulerDriverFactory @Inject() (
+  holder: MarathonSchedulerDriverHolder,
+  newScheduler: MarathonScheduler)
+    extends SchedulerDriverFactory {
+
+  override def createDriver(): SchedulerDriver = {
+    val driver = SimulatedDriverWiring.createDriver(newScheduler)
+    holder.driver = Some(driver)
+    driver
+  }
+}

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/DisplayAppScalingResults.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/DisplayAppScalingResults.scala
@@ -1,0 +1,126 @@
+package mesosphere.mesos.scale
+
+import play.api.libs.json.JsObject
+import play.api.libs.json.Reads._
+
+/**
+  * Displays the saved data of [[SingleAppScalingTest]] in a human readable way.
+  */
+object DisplayAppScalingResults {
+
+  def displayAppInfoScaling(fileName: String): Unit = {
+    val appInfos: Seq[JsObject] = ScalingTestResultFiles.readJson[Seq[JsObject]](fileName)
+
+    val header = IndexedSeq("relative time (ms)", "staged", "running", "newRunning/s", "instances")
+    var lastTimestamp: Long = 0
+    var lastRunning: Long = 0
+    val rows = appInfos.map { jsObject: JsObject =>
+      val relativeTimestamp = (jsObject \ ScalingTestResultFiles.relativeTimestampMs).as[Long]
+      val staged = (jsObject \ "tasksStaged").as[Long]
+      val running = (jsObject \ "tasksRunning").as[Long]
+      val newRunningPerSecond = 1000.0 * (running - lastRunning) / (relativeTimestamp - lastTimestamp)
+      lastTimestamp = relativeTimestamp
+      lastRunning = running
+      val instances = (jsObject \ "instances").as[Long]
+
+      IndexedSeq(relativeTimestamp, staged, running, newRunningPerSecond.round, instances)
+    }
+
+    import DisplayHelpers.right
+    DisplayHelpers.printTable(Seq(right, right, right, right, right), DisplayHelpers.withUnderline(header) ++ rows)
+  }
+
+  def displayMetrics(fileName: String): Unit = {
+    val allMetrics: Seq[JsObject] = ScalingTestResultFiles.readJson[Seq[JsObject]](fileName)
+
+    def subMetric(name: String): Map[String, JsObject] = {
+      (allMetrics.last \ name).as[JsObject].value.map {
+        case (name, value) => name -> value.as[JsObject]
+      }.toMap
+    }
+
+    displayMeters(subMetric("meters"))
+
+    println()
+
+    displayHistograms(subMetric("histograms"))
+
+    println()
+
+    displayTimers(subMetric("timers"))
+  }
+
+  def shortenName(name: String): String = {
+    name.replaceAll("mesosphere\\.marathon", "marathon").replaceAll("org\\.eclipse\\.jetty\\.servlet", "servlet")
+  }
+
+  def displayMeters(meters: Map[String, JsObject]): Unit = {
+    val header = IndexedSeq("meter", "count", "m15_rate", "m5_rate", "m1_rate", "mean_rate", "units")
+    val rows: Seq[IndexedSeq[Any]] = meters.map {
+      case (meter: String, jsObject: JsObject) =>
+        def d(fieldName: String): Any =
+          (jsObject \ fieldName).asOpt[Double].map(_.round).getOrElse("-")
+
+        val units: String = (jsObject \ "units").asOpt[String].getOrElse("-")
+        IndexedSeq[Any](
+          shortenName(meter),
+          d("count"), d("m15_rate"), d("m5_rate"), d("m1_rate"), d("mean_rate"), units)
+    }.toSeq
+
+    val sortedRows = rows.sortBy(-_(1).asInstanceOf[Long])
+
+    import DisplayHelpers.{ left, right }
+    DisplayHelpers.printTable(
+      Seq(left, right, right, right, right, right, left),
+      DisplayHelpers.withUnderline(header) ++ sortedRows)
+  }
+
+  def displayHistograms(histograms: Map[String, JsObject]): Unit = {
+    val header = IndexedSeq("histogram", "count", "mean", "min", "p50", "p75", "p95", "p98", "p99", "p999", "max", "stddev")
+    val rows: Seq[IndexedSeq[Any]] = histograms.map {
+      case (histogram: String, jsObject: JsObject) =>
+        def d(fieldName: String): Any =
+          (jsObject \ fieldName).asOpt[Double].map(_.round).getOrElse("-")
+
+        IndexedSeq[Any](
+          shortenName(histogram),
+          d("count"), d("mean"),
+          d("min"), d("p50"), d("p75"), d("p95"), d("p98"), d("p99"), d("p999"), d("max"), d("stddev"))
+    }.toSeq
+
+    val sortedRows = rows.sortBy(-_(1).asInstanceOf[Long])
+
+    import DisplayHelpers.{ left, right }
+    DisplayHelpers.printTable(
+      Seq(left, right, right, right, right, right, right, right, right, right, right, right),
+      DisplayHelpers.withUnderline(header) ++ sortedRows)
+  }
+
+  def displayTimers(timers: Map[String, JsObject]): Unit = {
+    val header = IndexedSeq("timer", "count", "mean", "min", "p50", "p75", "p95", "p98", "p99", "p999", "max", "stddev")
+    val rows: Seq[IndexedSeq[Any]] = timers.map {
+      case (timer: String, jsObject: JsObject) =>
+        def d(fieldName: String): Any =
+          (jsObject \ fieldName).asOpt[Double].map(_.round).getOrElse("-")
+
+        IndexedSeq[Any](
+          shortenName(timer),
+          d("count"), d("mean"),
+          d("min"), d("p50"), d("p75"), d("p95"), d("p98"), d("p99"), d("p999"), d("max"), d("stddev"))
+    }.toSeq
+
+    val sortedRows = rows.sortBy(-_(1).asInstanceOf[Long])
+
+    import DisplayHelpers.{ left, right }
+    DisplayHelpers.printTable(
+      Seq(left, right, right, right, right, right, right, right, right, right, right, right),
+      DisplayHelpers.withUnderline(header) ++ sortedRows)
+  }
+
+  def main(args: Array[String]): Unit = {
+    println()
+    displayMetrics(SingleAppScalingTest.metricsFile)
+    println()
+    displayAppInfoScaling(SingleAppScalingTest.appInfosFile)
+  }
+}

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/DisplayHelpers.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/DisplayHelpers.scala
@@ -1,0 +1,46 @@
+package mesosphere.mesos.scale
+
+object DisplayHelpers {
+  /** Formatting function. The first parameter is the input string and the second parameter the desired length. */
+  type ColumnFormat = ((String, Int) => String)
+
+  /** Left align field. */
+  def left(str: String, length: Int) = {
+    if (str.length > length)
+      str.substring(length - 3) + "..."
+    else
+      str + (" " * (length - str.length))
+  }
+
+  def right(str: String, length: Int) = {
+    if (str.length > length)
+      "..." + str.substring(length - 3)
+    else
+      (" " * (length - str.length)) + str
+  }
+
+  def printTable(columnFormats: Seq[ColumnFormat], rowsWithAny: Seq[IndexedSeq[Any]]): Unit = {
+    val rows = rowsWithAny.map(_.map(_.toString))
+
+    val columns = columnFormats.size
+
+    val maxColumnLengths: IndexedSeq[Int] = for {
+      column <- 0 until columns
+    } yield rows.iterator.map(_(column).length).max
+
+    for (row <- rows) {
+      val formatted = columnFormats.zipWithIndex.zip(row).map {
+        case ((format, index), value) => format(value, maxColumnLengths(index))
+      }
+
+      println(formatted.mkString(" "))
+    }
+  }
+
+  def withUnderline(header: IndexedSeq[String]): Seq[IndexedSeq[String]] = {
+    IndexedSeq(
+      header,
+      header.map { str => "-" * str.length }
+    )
+  }
+}

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/ScalingTestResultFiles.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/ScalingTestResultFiles.scala
@@ -1,0 +1,27 @@
+package mesosphere.mesos.scale
+
+import java.io.File
+
+import org.apache.commons.io.FileUtils
+import play.api.libs.json._
+
+object ScalingTestResultFiles {
+  val resultDir: File = new File("./target")
+  def jsonFile(name: String): File = new File(resultDir, s"scaleTest-$name.json")
+
+  def writeJson[T](name: String, json: T)(implicit writes: Writes[T]): Unit = {
+    FileUtils.write(jsonFile(name), Json.prettyPrint(Json.toJson(json)))
+  }
+
+  def readJson[T](name: String)(implicit reads: Reads[T]): T = {
+    val fileString = FileUtils.readFileToString(jsonFile(name))
+    val fileJson = Json.parse(fileString)
+    Json.fromJson(fileJson).get
+  }
+
+  val relativeTimestampMs: String = "relativeTimestampMs"
+
+  def addTimestamp(startTime: Long)(value: JsValue): JsObject = {
+    value.transform(__.json.update((__ \ relativeTimestampMs).json.put(JsNumber(System.currentTimeMillis() - startTime)))).get
+  }
+}

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
@@ -1,0 +1,134 @@
+package mesosphere.mesos.scale
+
+import java.io.File
+
+import mesosphere.marathon.api.v2.AppUpdate
+import mesosphere.marathon.integration.setup._
+import mesosphere.marathon.state.{ AppDefinition, PathId }
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
+import org.slf4j.LoggerFactory
+import play.api.libs.json._
+
+import scala.concurrent.duration._
+
+object SingleAppScalingTest {
+  val metricsFile = "scaleUp20s-metrics"
+  val appInfosFile = "scaleUp20s-appInfos"
+}
+
+class SingleAppScalingTest
+    extends IntegrationFunSuite
+    with SingleMarathonIntegrationTest
+    with Matchers
+    with BeforeAndAfter
+    with GivenWhenThen {
+
+  private[this] val log = LoggerFactory.getLogger(getClass)
+
+  //clean up state before running the test case
+  before(cleanUp())
+
+  def extractDeploymentIds(app: RestResult[AppDefinition]): Seq[String] = {
+    for (deployment <- (app.entityJson \ "deployments").as[JsArray].value)
+      yield (deployment \ "id").as[String]
+  }
+
+  override def startMarathon(port: Int, args: String*): Unit = {
+    val cwd = new File(".")
+    ProcessKeeper.startMarathon(cwd, env, List("--http_port", port.toString, "--zk", config.zk) ++ args.toList,
+      mainClass = "mesosphere.mesos.simulation.SimulateMesosMain")
+  }
+
+  private[this] def createStopApp(instances: Int): Unit = {
+    Given("a new app")
+    val appIdPath: PathId = testBasePath / "/test/app"
+    val app = appProxy(appIdPath, "v1", instances = instances, withHealth = false)
+
+    When("the app gets posted")
+    val createdApp: RestResult[AppDefinition] = marathon.createApp(app)
+    createdApp.code should be(201) // created
+    val deploymentIds: Seq[String] = extractDeploymentIds(createdApp)
+    deploymentIds.length should be(1)
+    val deploymentId = deploymentIds.head
+
+    Then("the deployment should finish eventually")
+    waitForDeploymentId(deploymentId)
+
+    When("deleting the app")
+    val deleteResult: RestResult[ITDeploymentResult] = marathon.deleteApp(appIdPath, force = true)
+
+    Then("the delete should finish eventually")
+    waitForChange(deleteResult)
+  }
+
+  test("create/stop app with 1 instance (does it work?)") {
+    createStopApp(1)
+  }
+
+  test("create/stop app with 100 instances (warm up)") {
+    createStopApp(100)
+  }
+
+  test("application scaling") {
+    // This test has a lot of logging output. Thus all log statements are prefixed with XXX
+    // for better grepability.
+
+    val appIdPath = testBasePath / "/test/app"
+    val appWithManyInstances = appProxy(appIdPath, "v1", instances = 100000, withHealth = false)
+    val response = marathon.createApp(appWithManyInstances)
+    log.info(s"XXX ${response.originalResponse.status}: ${response.originalResponse.entity}")
+
+    val startTime = System.currentTimeMillis()
+    var metrics = Seq.newBuilder[JsValue]
+    var appInfos = Seq.newBuilder[JsValue]
+
+    for (i <- 1 to 20) {
+      Thread.sleep(startTime + i * 1000 - System.currentTimeMillis())
+      //      val currentApp = marathon.app(appIdPath)
+      val appJson =
+        (marathon.listAppsInBaseGroup.entityJson \ "apps")
+          .as[Seq[JsObject]]
+          .filter { appJson => (appJson \ "id").as[String] == appIdPath.toString }
+          .head
+
+      val instances = (appJson \ "instances").as[Int]
+      val tasksRunning = (appJson \ "tasksRunning").as[Int]
+      val tasksStaged = (appJson \ "tasksStaged").as[Int]
+
+      log.info(s"XXX (starting) Current instance count: staged $tasksStaged, running $tasksRunning / $instances")
+
+      appInfos += ScalingTestResultFiles.addTimestamp(startTime)(appJson)
+      metrics += ScalingTestResultFiles.addTimestamp(startTime)(marathon.metrics().entityJson)
+    }
+
+    ScalingTestResultFiles.writeJson(SingleAppScalingTest.appInfosFile, appInfos.result())
+    ScalingTestResultFiles.writeJson(SingleAppScalingTest.metricsFile, metrics.result())
+
+    log.info("XXX suspend")
+    val result = marathon.updateApp(appWithManyInstances.id, AppUpdate(instances = Some(0)), force = true).originalResponse
+    log.info(s"XXX ${result.status}: ${result.entity}")
+
+    WaitTestSupport.waitFor("app suspension", 10.seconds) {
+      val currentApp = marathon.app(appIdPath)
+
+      val instances = (currentApp.entityJson \ "app" \ "instances").as[Int]
+      val tasksRunning = (currentApp.entityJson \ "app" \ "tasksRunning").as[Int]
+      val tasksStaged = (currentApp.entityJson \ "app" \ "tasksStaged").as[Int]
+
+      log.info(s"XXX (suspend) Current instance count: staged $tasksStaged, running $tasksRunning / $instances")
+
+      if (instances == 0) {
+        Some(())
+      }
+      else {
+        // slow down
+        Thread.sleep(1000)
+        None
+      }
+    }
+
+    log.info("XXX deleting")
+    val deleteResult: RestResult[ITDeploymentResult] = marathon.deleteApp(appWithManyInstances.id, force = true)
+    waitForChange(deleteResult)
+  }
+}

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -1,22 +1,21 @@
 package mesosphere.marathon
 
-import mesosphere.chaos.App
-import org.rogach.scallop.ScallopConf
-import mesosphere.chaos.http.{ HttpService, HttpModule, HttpConf }
+import com.google.inject.Module
+import com.twitter.common.quantity.{ Amount, Time }
+import com.twitter.common.zookeeper.ZooKeeperClient
+import mesosphere.chaos.{ App, AppConfiguration }
+import mesosphere.chaos.http.{ HttpConf, HttpModule, HttpService }
 import mesosphere.chaos.metrics.MetricsModule
 import mesosphere.marathon.api.MarathonRestModule
-import mesosphere.chaos.AppConfiguration
-import mesosphere.marathon.event.{ EventModule, EventConfiguration }
-import mesosphere.marathon.event.http.{ HttpEventModule, HttpEventConfiguration }
-import com.google.inject.AbstractModule
-import com.twitter.common.quantity.{ Time, Amount }
-import com.twitter.common.zookeeper.ZooKeeperClient
-import scala.collection.JavaConverters._
+import mesosphere.marathon.event.http.{ HttpEventConfiguration, HttpEventModule }
+import mesosphere.marathon.event.{ EventConfiguration, EventModule }
 import org.apache.log4j.Logger
+import org.rogach.scallop.ScallopConf
 
-object Main extends App {
+import scala.collection.JavaConverters._
+
+class MarathonApp extends App {
   val log = Logger.getLogger(getClass.getName)
-  log.info(s"Starting Marathon ${BuildInfo.version}")
 
   lazy val zk: ZooKeeperClient = {
     require(
@@ -47,7 +46,7 @@ object Main extends App {
     client
   }
 
-  def modules(): Seq[AbstractModule] = {
+  def modules(): Seq[Module] = {
     Seq(
       new HttpModule(conf) {
         // burst browser cache for assets
@@ -61,12 +60,12 @@ object Main extends App {
     ) ++ getEventsModule
   }
 
-  def getEventsModule: Option[AbstractModule] = {
+  def getEventsModule: Option[Module] = {
     conf.eventSubscriber.get flatMap {
       case "http_callback" =>
         log.info("Using HttpCallbackEventSubscriber for event" +
           "notification")
-        Some(new HttpEventModule())
+        Some(new HttpEventModule(conf))
 
       case _ =>
         log.info("Event notification disabled.")
@@ -82,10 +81,17 @@ object Main extends App {
     with HttpEventConfiguration
     with DebugConf
 
-  lazy val conf = new AllConf
+  override lazy val conf = new AllConf
 
-  run(
-    classOf[HttpService],
-    classOf[MarathonSchedulerService]
-  )
+  def runDefault(): Unit = {
+    log.info(s"Starting Marathon ${BuildInfo.version}")
+    run(
+      classOf[HttpService],
+      classOf[MarathonSchedulerService]
+    )
+  }
+}
+
+object Main extends MarathonApp {
+  runDefault()
 }

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -3,13 +3,9 @@ package mesosphere.marathon
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Named
-import mesosphere.marathon.upgrade.DeploymentPlan
-import mesosphere.util.SerializeExecution
-
-import scala.util.control.NonFatal
 
 import akka.actor.SupervisorStrategy.Restart
-import akka.actor.{ ActorRefFactory, ActorRef, ActorSystem, OneForOneStrategy, Props }
+import akka.actor.{ ActorRef, ActorRefFactory, ActorSystem, OneForOneStrategy, Props }
 import akka.event.EventStream
 import akka.routing.RoundRobinPool
 import com.codahale.metrics.MetricRegistry
@@ -17,18 +13,22 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.inject._
 import com.google.inject.name.Names
 import com.twitter.common.base.Supplier
-import com.twitter.common.zookeeper.{ Candidate, CandidateImpl, ZooKeeperClient, Group => ZGroup }
-import org.apache.log4j.Logger
-import org.apache.mesos.state.{ State, ZooKeeperState }
-import org.apache.zookeeper.ZooDefs
-
+import com.twitter.common.zookeeper.{ Candidate, CandidateImpl, Group => ZGroup, ZooKeeperClient }
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.event.EventModule
 import mesosphere.marathon.health.{ HealthCheckManager, MarathonHealthCheckManager }
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker }
+import mesosphere.marathon.upgrade.DeploymentPlan
 import mesosphere.mesos.util.FrameworkIdUtil
+import mesosphere.util.SerializeExecution
+import org.apache.log4j.Logger
+import org.apache.mesos.SchedulerDriver
+import org.apache.mesos.state.{ State, ZooKeeperState }
+import org.apache.zookeeper.ZooDefs
+
+import scala.util.control.NonFatal
 
 object ModuleNames {
   final val NAMED_CANDIDATE = "CANDIDATE"
@@ -43,11 +43,18 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
   val log = Logger.getLogger(getClass.getName)
 
   def configure() {
+
     bind(classOf[MarathonConf]).toInstance(conf)
     bind(classOf[HttpConf]).toInstance(http)
     bind(classOf[ZooKeeperClient]).toInstance(zk)
-    bind(classOf[MarathonSchedulerService]).in(Scopes.SINGLETON)
+
+    // needs to be eager to break circular dependencies
+    bind(classOf[SchedulerCallbacks]).to(classOf[SchedulerCallbacksServiceAdapter]).asEagerSingleton()
+
+    bind(classOf[MarathonSchedulerDriverHolder]).in(Scopes.SINGLETON)
+    bind(classOf[SchedulerDriverFactory]).to(classOf[MesosSchedulerDriverFactory]).in(Scopes.SINGLETON)
     bind(classOf[MarathonScheduler]).in(Scopes.SINGLETON)
+    bind(classOf[MarathonSchedulerService]).in(Scopes.SINGLETON)
     bind(classOf[TaskTracker]).in(Scopes.SINGLETON)
     bind(classOf[TaskQueue]).in(Scopes.SINGLETON)
     bind(classOf[GroupManager]).in(Scopes.SINGLETON)
@@ -90,6 +97,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     taskTracker: TaskTracker,
     taskQueue: TaskQueue,
     frameworkIdUtil: FrameworkIdUtil,
+    driverHolder: MarathonSchedulerDriverHolder,
     taskIdUtil: TaskIdUtil,
     storage: StorageProvider,
     @Named(EventModule.busName) eventBus: EventStream,
@@ -109,6 +117,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
         taskTracker,
         taskQueue,
         frameworkIdUtil,
+        driverHolder,
         taskIdUtil,
         storage,
         eventBus,
@@ -121,16 +130,16 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
   @Provides
   @Singleton
   def provideCandidate(zk: ZooKeeperClient): Option[Candidate] = {
-    if (Main.conf.highlyAvailable()) {
+    if (conf.highlyAvailable()) {
       log.info("Registering in Zookeeper with hostname:"
-        + Main.conf.hostname())
+        + conf.hostname())
       val candidate = new CandidateImpl(new ZGroup(zk, ZooDefs.Ids.OPEN_ACL_UNSAFE,
-        Main.conf.zooKeeperLeaderPath),
+        conf.zooKeeperLeaderPath),
         new Supplier[Array[Byte]] {
           def get(): Array[Byte] = {
             //host:port
-            "%s:%d".format(Main.conf.hostname(),
-              Main.conf.httpPort()).getBytes
+            "%s:%d".format(conf.hostname(),
+              http.httpPort()).getBytes
           }
         })
       return Some(candidate)

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -38,6 +38,7 @@ class MarathonSchedulerActor(
     taskTracker: TaskTracker,
     taskQueue: TaskQueue,
     frameworkIdUtil: FrameworkIdUtil,
+    marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder,
     taskIdUtil: TaskIdUtil,
     storage: StorageProvider,
     eventBus: EventStream,
@@ -271,7 +272,7 @@ class MarathonSchedulerActor(
     withLockFor(Set(appId))(f)
 
   // there has to be a better way...
-  def driver: SchedulerDriver = MarathonSchedulerDriver.driver.get
+  def driver: SchedulerDriver = marathonSchedulerDriverHolder.driver.get
 
   def deploy(origSender: ActorRef, cmd: Deploy): Unit = {
     val plan = cmd.plan

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
@@ -1,24 +1,15 @@
 package mesosphere.marathon
 
-import mesosphere.chaos.http.HttpConf
-import org.apache.mesos.Protos.{ FrameworkID, FrameworkInfo, Credential }
-import org.apache.mesos.{ SchedulerDriver, MesosSchedulerDriver }
+import java.io.{ IOException, FileInputStream }
 
 import com.google.protobuf.ByteString
-import java.io.{ FileInputStream, IOException }
-
+import mesosphere.chaos.http.HttpConf
+import org.apache.mesos.Protos.{ Credential, FrameworkInfo, FrameworkID }
+import org.apache.mesos.{ MesosSchedulerDriver, SchedulerDriver }
 import org.slf4j.LoggerFactory
 
-/**
-  * Wrapper class for the scheduler
-  */
 object MarathonSchedulerDriver {
-
   private[this] val log = LoggerFactory.getLogger(getClass)
-
-  var driver: Option[SchedulerDriver] = None
-
-  var scheduler: Option[MarathonScheduler] = None
 
   def newDriver(config: MarathonConf,
                 httpConfig: HttpConf,
@@ -83,9 +74,6 @@ object MarathonSchedulerDriver {
     }
 
     log.debug("Finished creating new driver")
-
-    driver = Some(newDriver)
-    scheduler = Some(newScheduler)
 
     newDriver
   }

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriverHolder.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriverHolder.scala
@@ -1,0 +1,18 @@
+package mesosphere.marathon
+
+import org.apache.mesos.SchedulerDriver
+
+/**
+  * Holds the current instances of the driver and the scheduler.
+  *
+  * Usually, you would just wire in the driver directly. Unfortunately, the driver can change over the life
+  * time of the application. Whenever a process gains leadership, a new driver is created and has to be
+  * made available to the already wired dependencies.
+  *
+  * A better alternative would be to tear down all state/actors when loosing leadership and recreate/rewire
+  * everything when gaining leadership. This would require more code changes, though.
+  */
+class MarathonSchedulerDriverHolder {
+  @volatile
+  var driver: Option[SchedulerDriver] = None
+}

--- a/src/main/scala/mesosphere/marathon/SchedulerCallbacksServiceAdapter.scala
+++ b/src/main/scala/mesosphere/marathon/SchedulerCallbacksServiceAdapter.scala
@@ -1,0 +1,14 @@
+package mesosphere.marathon
+
+import com.google.inject.Inject
+
+/**
+  * Makes the [[MarathonSchedulerService]] service usable as [[SchedulerCallbacks]].
+  */
+class SchedulerCallbacksServiceAdapter @Inject() (
+    schedulerService: MarathonSchedulerService) extends SchedulerCallbacks {
+  override def disconnected(): Unit = {
+    // Abdicate leadership when we become disconnected from the Mesos master.
+    schedulerService.abdicateLeadership()
+  }
+}

--- a/src/main/scala/mesosphere/marathon/SchedulerDriverFactory.scala
+++ b/src/main/scala/mesosphere/marathon/SchedulerDriverFactory.scala
@@ -1,0 +1,33 @@
+package mesosphere.marathon
+
+import javax.inject.Inject
+
+import mesosphere.chaos.http.HttpConf
+import mesosphere.mesos.util.FrameworkIdUtil
+import org.apache.mesos.SchedulerDriver
+
+trait SchedulerDriverFactory {
+  def createDriver(): SchedulerDriver
+}
+
+class MesosSchedulerDriverFactory @Inject() (
+  holder: MarathonSchedulerDriverHolder,
+  config: MarathonConf,
+  httpConfig: HttpConf,
+  frameworkIdUtil: FrameworkIdUtil,
+  scheduler: MarathonScheduler)
+
+    extends SchedulerDriverFactory {
+
+  /**
+    * As a side effect, the corresponding driver is set in the [[MarathonSchedulerDriverHolder]].
+    */
+  override def createDriver(): SchedulerDriver = {
+    import mesosphere.util.ThreadPoolContext.context
+    implicit val zkTimeout = config.zkFutureTimeout
+    val frameworkId = frameworkIdUtil.fetch
+    val driver = MarathonSchedulerDriver.newDriver(config, httpConfig, scheduler, frameworkId)
+    holder.driver = Some(driver)
+    driver
+  }
+}

--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 import mesosphere.marathon.Protos._
 import mesosphere.marathon.state.{ PathId, StateMetrics, Timestamp }
-import mesosphere.marathon.{ Main, MarathonConf }
+import mesosphere.marathon.MarathonConf
 import com.codahale.metrics.MetricRegistry
 import org.apache.log4j.Logger
 import org.apache.mesos.Protos.TaskStatus
@@ -156,7 +156,7 @@ class TaskTracker @Inject() (
   def checkStagedTasks: Iterable[MarathonTask] = {
     // stagedAt is set when the task is created by the scheduler
     val now = System.currentTimeMillis
-    val expires = now - Main.conf.taskLaunchTimeout()
+    val expires = now - config.taskLaunchTimeout()
     val toKill = stagedTasks.filter(_.getStagedAt < expires)
 
     toKill.foreach(t => {

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -44,7 +44,7 @@ class TaskBuilder(app: AppDefinition,
 
   private def build(offer: Offer, cpuRole: String, memRole: String, diskRole: String, portsResource: RangesResource) = {
     val executor: Executor = if (app.executor == "") {
-      Main.conf.executor
+      config.executor
     }
     else {
       Executor.dispatch(app.executor)

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -44,6 +44,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
   var queue: TaskQueue = _
   var frameworkIdUtil: FrameworkIdUtil = _
   var driver: SchedulerDriver = _
+  var holder: MarathonSchedulerDriverHolder = _
   var taskIdUtil: TaskIdUtil = _
   var storage: StorageProvider = _
   var taskFailureEventRepository: TaskFailureRepository = _
@@ -52,7 +53,8 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
   before {
     driver = mock[SchedulerDriver]
-    MarathonSchedulerDriver.driver = Some(driver)
+    holder = new MarathonSchedulerDriverHolder
+    holder.driver = Some(driver)
     repo = mock[AppRepository]
     deploymentRepo = mock[DeploymentRepository]
     hcManager = mock[HealthCheckManager]
@@ -86,6 +88,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
       tracker,
       queue,
       frameworkIdUtil,
+      holder,
       taskIdUtil,
       storage,
       system.eventStream,
@@ -410,6 +413,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
       tracker,
       queue,
       frameworkIdUtil,
+      holder,
       taskIdUtil,
       storage,
       system.eventStream,
@@ -480,6 +484,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
         tracker,
         queue,
         frameworkIdUtil,
+        holder,
         taskIdUtil,
         storage,
         system.eventStream,

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.testkit.{ TestKit, TestProbe }
+import com.google.inject.Provider
 import com.twitter.common.base.ExceptionalCommand
 import com.twitter.common.zookeeper.{ Group, Candidate }
 import com.twitter.common.zookeeper.Group.JoinException
@@ -92,6 +93,12 @@ class MarathonSchedulerServiceTest
     schedulerActor = probe.ref
   }
 
+  def driverFactory[T](provide: => SchedulerDriver): SchedulerDriverFactory = {
+    new SchedulerDriverFactory {
+      override def createDriver(): SchedulerDriver = provide
+    }
+  }
+
   test("Start timer when elected") {
     val mockTimer = mock[Timer]
 
@@ -101,18 +108,16 @@ class MarathonSchedulerServiceTest
       healthCheckManager,
       candidate,
       config,
-      httpConfig,
       frameworkIdUtil,
       leader,
       appRepository,
       taskTracker,
-      scheduler,
+      driverFactory(mock[SchedulerDriver]),
       system,
       migration,
       schedulerActor
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
-      override def newDriver() = mock[SchedulerDriver]
     }
 
     schedulerService.timer = mockTimer
@@ -132,18 +137,16 @@ class MarathonSchedulerServiceTest
       healthCheckManager,
       candidate,
       config,
-      httpConfig,
       frameworkIdUtil,
       leader,
       appRepository,
       taskTracker,
-      scheduler,
+      driverFactory(mock[SchedulerDriver]),
       system,
       migration,
       schedulerActor
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
-      override def newDriver() = mock[SchedulerDriver]
     }
 
     schedulerService.timer = mockTimer
@@ -163,18 +166,16 @@ class MarathonSchedulerServiceTest
       healthCheckManager,
       candidate,
       config,
-      httpConfig,
       frameworkIdUtil,
       leader,
       appRepository,
       taskTracker,
-      scheduler,
+      driverFactory(mock[SchedulerDriver]),
       system,
       migration,
       schedulerActor
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
-      override def newDriver() = mock[SchedulerDriver]
       override def newTimer() = mockTimer
     }
 
@@ -200,18 +201,16 @@ class MarathonSchedulerServiceTest
       healthCheckManager,
       candidate,
       config,
-      httpConfig,
       frameworkIdUtil,
       leader,
       appRepository,
       taskTracker,
-      scheduler,
+      driverFactory(mock[SchedulerDriver]),
       system,
       migration,
       schedulerActor
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
-      override def newDriver() = mock[SchedulerDriver]
       override def newTimer() = mockTimer
     }
 
@@ -224,8 +223,6 @@ class MarathonSchedulerServiceTest
   }
 
   test("Abdicate leadership when migration fails and reoffer leadership") {
-    val mockTimer = mock[Timer]
-
     when(frameworkIdUtil.fetch(any(), any())).thenReturn(None)
     candidate = Some(mock[Candidate])
 
@@ -233,18 +230,16 @@ class MarathonSchedulerServiceTest
       healthCheckManager,
       candidate,
       config,
-      httpConfig,
       frameworkIdUtil,
       leader,
       appRepository,
       taskTracker,
-      scheduler,
+      driverFactory(mock[SchedulerDriver]),
       system,
       migration,
       schedulerActor
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
-      override def newDriver() = mock[SchedulerDriver]
     }
 
     // use an Answer object here because Mockito's thenThrow does only

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -60,7 +60,10 @@ class MarathonSchedulerTest extends TestKit(ActorSystem("System")) with Marathon
       frameworkIdUtil,
       taskIdUtil,
       mock[ActorSystem],
-      config
+      config,
+      new SchedulerCallbacks {
+        override def disconnected(): Unit = {}
+      }
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckActorTest.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.health
 import akka.actor.{ ActorSystem, Props }
 import akka.testkit._
 import mesosphere.marathon.health.HealthCheckActorTest.SameThreadExecutionContext
-import mesosphere.marathon.{ Protos, MarathonSpec }
+import mesosphere.marathon.{ MarathonScheduler, MarathonSchedulerDriverHolder, Protos, MarathonSpec }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.tasks.TaskTracker
 import org.mockito.Mockito.when
@@ -29,9 +29,10 @@ class HealthCheckActorTest extends TestKit(ActorSystem(name = "system", defaultE
 
     when(tracker.get(appId)).thenReturn(Set(task))
 
+    val holder: MarathonSchedulerDriverHolder = new MarathonSchedulerDriverHolder
     val actor = TestActorRef[HealthCheckActor](
       Props(
-        new HealthCheckActor(appId, taskVersion, HealthCheck(), tracker, system.eventStream) {
+        new HealthCheckActor(appId, taskVersion, holder, mock[MarathonScheduler], HealthCheck(), tracker, system.eventStream) {
           override val workerProps = Props {
             latch.countDown()
             new TestActors.EchoActor

--- a/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
@@ -5,7 +5,7 @@ import akka.event.EventStream
 import akka.testkit.EventFilter
 import com.codahale.metrics.MetricRegistry
 import com.typesafe.config.ConfigFactory
-import mesosphere.marathon.{ MarathonConf, MarathonSpec }
+import mesosphere.marathon.{ MarathonScheduler, MarathonSchedulerDriverHolder, MarathonConf, MarathonSpec }
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.state.{ AppDefinition, AppRepository, MarathonStore, PathId, Timestamp }
@@ -48,6 +48,8 @@ class MarathonHealthCheckManagerTest extends MarathonSpec with Logging {
 
     hcManager = new MarathonHealthCheckManager(
       system,
+      mock[MarathonScheduler],
+      new MarathonSchedulerDriverHolder,
       mock[EventStream],
       taskTracker,
       appRepository

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonCallbackTestSupport.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonCallbackTestSupport.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.integration.setup
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
+import scala.annotation.tailrec
 import scala.concurrent.duration.{ FiniteDuration, _ }
 
 /**
@@ -37,9 +38,10 @@ trait MarathonCallbackTestSupport extends ExternalMarathonIntegrationTest {
   }
 
   def waitForEventMatching(description: String, maxWait: FiniteDuration = 30.seconds)(fn: CallbackEvent => Boolean): CallbackEvent = {
+    @tailrec
     def nextEvent: Option[CallbackEvent] = if (events.isEmpty) None else {
       val event = events.poll()
-      if (fn(event)) Some(event) else None
+      if (fn(event)) Some(event) else nextEvent
     }
     WaitTestSupport.waitFor(description, maxWait)(nextEvent)
   }

--- a/src/test/scala/mesosphere/marathon/integration/setup/ProcessKeeper.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ProcessKeeper.scala
@@ -57,8 +57,8 @@ object ProcessKeeper {
       upWhen = _.toLowerCase.contains("registered with master"))
   }
 
-  def startMarathon(cwd: File, env: Map[String, String], arguments: List[String]): Process = {
-    val argsWithMain = "mesosphere.marathon.Main" :: arguments
+  def startMarathon(cwd: File, env: Map[String, String], arguments: List[String], mainClass: String = "mesosphere.marathon.Main"): Process = {
+    val argsWithMain = mainClass :: arguments
 
     val mesosWorkDir: String = "/tmp/marathon-itest-marathon"
     val mesosWorkDirFile: File = new File(mesosWorkDir)
@@ -85,7 +85,7 @@ object ProcessKeeper {
     val up = Promise[Boolean]()
     val logger = new ProcessLogger {
       def checkUp(out: String) = {
-        log.info(s"$name out: $out")
+        log.info(s"$name: $out")
         if (!up.isCompleted && upWhen(out)) up.success(true)
       }
       override def buffer[T](f: => T): T = f


### PR DESCRIPTION
Create a new sub module to separate simulation code from production code.
Also use a guice provider to instantiate the driver so that
we could substitute the provider to instatiate a simulated driver.
There were some global variable references that had to be removed for this to work.