### PR TITLE
DO NOT MERGE: Enable marathon to start applications, if marathon is started the first time

### DIFF
--- a/src/main/scala/mesosphere/marathon/ApplicationOnInitStarterActor.scala
+++ b/src/main/scala/mesosphere/marathon/ApplicationOnInitStarterActor.scala
@@ -1,0 +1,71 @@
+package mesosphere.marathon
+
+import java.io.File
+import javax.inject.{ Named, Inject }
+
+import akka.actor.{ Props, ActorSystem, Actor }
+import akka.event.EventStream
+import mesosphere.marathon.api.{ ModelValidation, BeanValidation }
+import mesosphere.marathon.event.{ EventModule, ElectedAsLeader }
+import mesosphere.marathon.io.IO
+import mesosphere.marathon.state.{ GroupManager, PathId, AppDefinition }
+import org.apache.log4j.Logger
+import play.api.libs.json.Json
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+import mesosphere.marathon.api.v2.json.Formats._
+
+class ApplicationOnInitStarter @Inject() (
+    system: ActorSystem,
+    groupManager: GroupManager,
+    config: MarathonConf,
+    @Named(EventModule.busName) eventStream: EventStream) {
+  config.initialAppsDirectory.get.map { dir =>
+    system.actorOf(Props(classOf[ApplicationOnInitStarterActor], groupManager, eventStream, new File(dir)))
+  }
+}
+
+/**
+  * This actor waits until the instance gets elected as leader.
+  * It checks for the
+  */
+class ApplicationOnInitStarterActor(
+    groupManager: GroupManager,
+    eventStream: EventStream,
+    dir: File) extends Actor with IO {
+
+  implicit val ec = mesosphere.util.ThreadPoolContext.context
+  private[this] val log = Logger.getLogger(getClass.getName)
+
+  override def preStart(): Unit = eventStream.subscribe(self, classOf[ElectedAsLeader])
+
+  /**
+    * Read all applications from the install directory and start the application.
+    */
+  def installApplications(): Future[Seq[Boolean]] = {
+    val futures = listFiles(dir, """.*json$""".r).map { file =>
+      try {
+        log.info(s"Start application from install directory: $file")
+        val app = Json.parse(readFile(file)).as[AppDefinition]
+        BeanValidation.requireValid(ModelValidation.checkAppConstraints(app, PathId.empty))
+        groupManager.updateApp(app.id, _ => app).map(_ => true)
+      }
+      catch {
+        case NonFatal(ex) =>
+          log.warn(s"Could not import application json from $file", ex)
+          Future.successful(false)
+      }
+    }
+    Future.sequence(futures.toList)
+  }
+
+  override def receive: Receive = {
+    case ElectedAsLeader(_, _) =>
+      //install initial applications only, if there is no application defined
+      groupManager
+        .root(withLatestApps = false)
+        .filter(_.transitiveApps.isEmpty)
+        .foreach(_ => installApplications())
+  }
+}

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -119,4 +119,9 @@ trait MarathonConf extends ScallopConf with ZookeeperConf {
     descr = "Mesos Authentication Secret",
     noshort = true
   )
+
+  lazy val initialAppsDirectory = opt[String]("initial_app_install_dir",
+    descr = "The directory with application definitions that should get installed during first start up.",
+    noshort = true
+  )
 }

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -51,10 +51,9 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     bind(classOf[TaskTracker]).in(Scopes.SINGLETON)
     bind(classOf[TaskQueue]).in(Scopes.SINGLETON)
     bind(classOf[MetricRegistry]).asEagerSingleton()
-
     bind(classOf[GroupManager]).in(Scopes.SINGLETON)
-
     bind(classOf[HealthCheckManager]).to(classOf[MarathonHealthCheckManager]).asEagerSingleton()
+    bind(classOf[ApplicationOnInitStarter]).asEagerSingleton()
 
     bind(classOf[String])
       .annotatedWith(Names.named(ModuleNames.NAMED_SERVER_SET_PATH))

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -243,6 +243,8 @@ trait DeploymentFormats {
 trait EventFormats {
   import Formats._
 
+  implicit lazy val ElectedAsLeaderWrites: Writes[ElectedAsLeader] = Json.writes[ElectedAsLeader]
+  implicit lazy val DefeatedAsLeaderWrites: Writes[DefeatedAsLeader] = Json.writes[DefeatedAsLeader]
   implicit lazy val AppTerminatedEventWrites: Writes[AppTerminatedEvent] = Json.writes[AppTerminatedEvent]
   implicit lazy val ApiPostEventWrites: Writes[ApiPostEvent] = Json.writes[ApiPostEvent]
   implicit lazy val SubscribeWrites: Writes[Subscribe] = Json.writes[Subscribe]

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -75,6 +75,15 @@ final case class SchedulerDisconnectedEvent(
   timestamp: String = Timestamp.now().toString)
     extends MarathonSchedulerEvent
 
+// leader message
+final case class ElectedAsLeader(
+  eventType: String = "elected_as_leader",
+  timestamp: String = Timestamp.now().toString) extends MarathonEvent
+
+final case class DefeatedAsLeader(
+  eventType: String = "defeated_as_leader",
+  timestamp: String = Timestamp.now().toString) extends MarathonEvent
+
 // event subscriptions
 
 sealed trait MarathonSubscriptionEvent extends MarathonEvent {
@@ -203,3 +212,4 @@ case class MesosFrameworkMessageEvent(
   message: Array[Byte],
   eventType: String = "framework_message_event",
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
+

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventActor.scala
@@ -73,6 +73,8 @@ class HttpEventActor(val subscribersKeeper: ActorRef) extends Actor with ActorLo
     case event: SchedulerDisconnectedEvent => Json.toJson(event)
     case event: SchedulerRegisteredEvent   => Json.toJson(event)
     case event: SchedulerReregisteredEvent => Json.toJson(event)
+    case event: ElectedAsLeader            => Json.toJson(event)
+    case event: DefeatedAsLeader           => Json.toJson(event)
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/io/IO.scala
+++ b/src/main/scala/mesosphere/marathon/io/IO.scala
@@ -7,9 +7,25 @@ import scala.annotation.tailrec
 
 import com.google.common.io.ByteStreams
 
+import scala.util.matching.Regex
+
 trait IO {
 
   private val BufferSize = 8192
+
+  protected def listFiles(inDir: File, regex: Regex): Array[File] = {
+    val files = Option(inDir.listFiles()).getOrElse(Array.empty)
+    files.filter(f => regex.pattern.matcher(f.getName).matches)
+  }
+
+  protected def readFile(file: File): Array[Byte] = {
+    using(new FileInputStream(file)) { in =>
+      using(new ByteArrayOutputStream(file.length().toInt)) { out =>
+        transfer(in, out)
+        out.toByteArray
+      }
+    }
+  }
 
   protected def moveFile(from: File, to: File): File = {
     if (to.exists()) delete(to)

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -4,6 +4,7 @@ import java.util.{ TimerTask, Timer }
 import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.actor.{ ActorRef, ActorSystem }
+import akka.event.EventStream
 import akka.testkit.{ TestKit, TestProbe }
 import com.twitter.common.base.ExceptionalCommand
 import com.twitter.common.zookeeper.{ Group, Candidate }
@@ -76,6 +77,7 @@ class MarathonSchedulerServiceTest
   var scheduler: MarathonScheduler = _
   var migration: Migration = _
   var schedulerActor: ActorRef = _
+  var eventStream: EventStream = _
 
   before {
     probe = TestProbe()
@@ -89,6 +91,7 @@ class MarathonSchedulerServiceTest
     taskTracker = mock[TaskTracker]
     scheduler = mock[MarathonScheduler]
     migration = mock[Migration]
+    eventStream = mock[EventStream]
     schedulerActor = probe.ref
   }
 
@@ -98,6 +101,7 @@ class MarathonSchedulerServiceTest
     when(frameworkIdUtil.fetch(any(), any())).thenReturn(None)
 
     val schedulerService = new MarathonSchedulerService(
+      eventStream,
       healthCheckManager,
       candidate,
       config,
@@ -129,6 +133,7 @@ class MarathonSchedulerServiceTest
     when(frameworkIdUtil.fetch(any(), any())).thenReturn(None)
 
     val schedulerService = new MarathonSchedulerService(
+      eventStream,
       healthCheckManager,
       candidate,
       config,
@@ -160,6 +165,7 @@ class MarathonSchedulerServiceTest
     when(frameworkIdUtil.fetch(any(), any())).thenReturn(None)
 
     val schedulerService = new MarathonSchedulerService(
+      eventStream,
       healthCheckManager,
       candidate,
       config,
@@ -197,6 +203,7 @@ class MarathonSchedulerServiceTest
     frameworkIdUtil = new FrameworkIdUtil(new InMemoryState)
 
     val schedulerService = new MarathonSchedulerService(
+      eventStream,
       healthCheckManager,
       candidate,
       config,
@@ -230,6 +237,7 @@ class MarathonSchedulerServiceTest
     candidate = Some(mock[Candidate])
 
     val schedulerService = new MarathonSchedulerService(
+      eventStream,
       healthCheckManager,
       candidate,
       config,


### PR DESCRIPTION
@ConnorDoyle 
This is the proposal for letting marathon start applications during first run.
On the command line define --initial_app_install_dir <dir to apps>
If a marathon instance got elected as leader, it will check, if there is an application defined, and if not it will add all applications found in the directory (*.json).
The idea is to prevent reinstalling applications, that were already changed or removed.

In a discussion with Dario and Lukas we came to the point that this functionality should not be part of marathon, but handled elsewhere. As long as there is no consensus, I will leave that PR open.
