### PR TITLE
HolidayCheck added as one of Marathon users

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Marathon is managing applications on more than 100,000 nodes at these companies,
 * [The Factory](https://github.com/thefactory/)
 * [Guidewire](http://www.guidewire.com/)
 * [Groupon](http://www.groupon.com/)
+* [HolidayCheck](http://www.holidaycheck.com/)
 * [Human API](https://humanapi.co/)
 * [ING](http://www.ing.com/)
 * [iQIYI](http://www.iqiyi.com/)


### PR DESCRIPTION
Some proof that Marathon is used at HolidayCheck:
* https://speakerdeck.com/c089/docker-at-holidaycheck-docker-meetup-munich
* http://www.meetup.com/Docker-Munich/events/220433670/