### PR TITLE
Marathon Maven plugin from HolidayCheck added as a client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ We heartily welcome external contributions to Marathon's documentation. Document
             ./chronos/target/chronos-1.0-SNAPSHOT.jar" -c 1.0 -m 1024
 * [Scala client](https://github.com/guidewire/marathon-client), developed at Guidewire
 * [Java client](https://github.com/mohitsoni/marathon-client) by Mohit Soni
+* [Maven plugin](https://github.com/holidaycheck/marathon-maven-plugin), developed at [HolidayCheck](http://www.holidaycheck.com/)
 * [Python client](https://github.com/thefactory/marathon-python), developed at [The Factory](http://www.thefactory.com)
 * [Python client](https://github.com/Wizcorp/marathon-client.py), developed at [Wizcorp](http://www.wizcorp.jp)
 * [Go client](https://github.com/gambol99/go-marathon) by Rohith Jayawardene


### PR DESCRIPTION
The project https://github.com/holidaycheck/marathon-maven-plugin is a Maven plugin for interacting with Marathon via Java API library https://github.com/willroden/marathon-client
