### PR TITLE
Add WebSocket and HTTP SSE support to stream Marathon events directly.

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -32,6 +32,8 @@ title: REST API
 * [Deployments](#deployments) <span class="label label-default">v0.7.0</span>
   * [GET /v2/deployments](#get-/v2/deployments): List running deployments
   * [DELETE /v2/deployments/{deploymentId}](#delete-/v2/deployments/{deploymentid}): Revert or cancel the deployment with `deploymentId`
+* [Event Stream](#event-stream)
+  * [GET /v2/events](#get-/v2/events): Attach to the event stream
 * [Event Subscriptions](#event-subscriptions)
   * [POST /v2/eventSubscriptions](#post-/v2/eventsubscriptions): Register a callback URL as an event subscriber
   * [GET /v2/eventSubscriptions](#get-/v2/eventsubscriptions): List all event subscriber callback URLs
@@ -2208,6 +2210,52 @@ Content-Length: 0
 Content-Type: application/json
 Server: Jetty(8.y.z-SNAPSHOT)
 {% endhighlight %}
+
+
+### Event Stream
+
+#### GET `/v2/events`
+
+<span class="label label-default">v0.9.0</span>
+
+Attach to the marathon event stream.
+
+To use this endpoint, the client has to accept the text/event-stream content type.
+Please note: a request to this endpoint will not be closed by the server.
+If an event happens on the server side, this event will be propagated to the client immediately.
+See [Server Sent Events](http://www.w3schools.com/html/html5_serversentevents.asp) for a more detailed explanation.
+
+**Request:**
+
+```
+GET /v2/events HTTP/1.1
+Accept: text/event-stream
+Accept-Encoding: gzip, deflate
+Host: localhost:8080
+User-Agent: HTTPie/0.8.0
+```
+
+**Response:**
+
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache, no-store, must-revalidate
+Connection: close
+Content-Type: text/event-stream;charset=UTF-8
+Expires: 0
+Pragma: no-cache
+Server: Jetty(8.1.15.v20140411)
+
+```
+
+If an event happens on the server side, it is sent as plain json prepended with the mandatory `data:` field.
+
+**Response:**
+```
+data: {"remoteAddress":"96.23.11.158","eventType":"event_stream_attached","timestamp":"2015-04-28T12:14:57.812Z"}
+
+data: {"groupId":"/","version":"2015-04-28T12:24:12.098Z","eventType":"group_change_success","timestamp":"2015-04-28T12:24:12.224Z"}
+```
 
 ### Event Subscriptions
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -164,6 +164,7 @@ object Dependencies {
     jodaConvert % "compile",
     jerseyServlet % "compile",
     jerseyMultiPart % "compile",
+    jettyEventSource % "compile",
     uuidGenerator % "compile",
     jGraphT % "compile",
     hadoopHdfs % "compile",
@@ -190,6 +191,7 @@ object Dependency {
     val Spray = "1.3.2"
     val TwitterCommons = "0.0.76"
     val Jersey = "1.18.1"
+    val JettyEventSource = "1.0.0"
     val JodaTime = "2.3"
     val JodaConvert = "1.6"
     val UUIDGenerator = "3.1.3"
@@ -216,6 +218,7 @@ object Dependency {
   val mesosUtils = "mesosphere" %% "mesos-utils" % V.MesosUtils
   val jacksonCaseClass = "mesosphere" %% "jackson-case-class-module" % V.JacksonCCM
   val jerseyServlet =  "com.sun.jersey" % "jersey-servlet" % V.Jersey
+  val jettyEventSource = "org.eclipse.jetty" % "jetty-eventsource-servlet" % V.JettyEventSource
   val jerseyMultiPart =  "com.sun.jersey.contribs" % "jersey-multipart" % V.Jersey
   val jodaTime = "joda-time" % "joda-time" % V.JodaTime
   val jodaConvert = "org.joda" % "joda-convert" % V.JodaConvert

--- a/src/main/resources/mesosphere/marathon/api/v2/EventResource_get.md
+++ b/src/main/resources/mesosphere/marathon/api/v2/EventResource_get.md
@@ -1,0 +1,46 @@
+## GET `/v2/events`
+
+Attach to the marathon event stream.
+
+### Server Sent Events
+
+To use this endpoint, the client has to accept the text/event-stream content type.
+Please note: a request to this endpoint will not be closed by the server.
+If an event happens on the server side, this event will be propagated to the client immediately.
+See [Server Sent Events](http://www.w3schools.com/html/html5_serversentevents.asp) for a more detailed explanation.
+
+**Request:**
+
+```
+GET /v2/events HTTP/1.1
+Accept: text/event-stream
+Accept-Encoding: gzip, deflate
+Host: localhost:8080
+User-Agent: HTTPie/0.8.0
+```
+
+**Response:**
+
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache, no-store, must-revalidate
+Connection: close
+Content-Type: text/event-stream;charset=UTF-8
+Expires: 0
+Pragma: no-cache
+Server: Jetty(8.1.15.v20140411)
+
+```
+
+If an event happens on the server side, it is sent as plain json prepended with the mandatory `data:` field.
+
+**Response:**
+```
+data: {"remoteAddress":"96.23.11.158","eventType":"event_stream_attached","timestamp":"2015-04-28T12:14:57.812Z"}
+
+data: {"groupId":"/","version":"2015-04-28T12:24:12.098Z","eventType":"group_change_success","timestamp":"2015-04-28T12:24:12.224Z"}
+```
+
+
+
+

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -58,6 +58,13 @@ trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMat
     noshort = true,
     default = None)
 
+  lazy val eventStreamMaxOutstandingMessages = opt[Int]("event_stream_max_outstanding_messages",
+    descr = "The event stream buffers events, that are not already consumed by clients. " +
+      "This number defines the number of events that get buffered on the server side, before messages are dropped.",
+    noshort = true,
+    default = Some(50)
+  )
+
   def executor: Executor = Executor.dispatch(defaultExecutor())
 
   lazy val mesosRole = opt[String]("mesos_role",

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -82,7 +82,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
   @Singleton
   def provideHttpEventStreamActor(system: ActorSystem,
                                   @Named(EventModule.busName) eventBus: EventStream): ActorRef = {
-    val outstanding = 50 //yet another command line parameter??
+    val outstanding = conf.eventStreamMaxOutstandingMessages.get.getOrElse(50)
     system.actorOf(Props(classOf[HttpEventStreamActor], eventBus, outstanding), "HttpEventStream")
   }
 

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -16,6 +16,7 @@ import com.twitter.common.base.Supplier
 import com.twitter.common.zookeeper.{ Candidate, CandidateImpl, Group => ZGroup, ZooKeeperClient }
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.event.EventModule
+import mesosphere.marathon.event.http.HttpEventStreamActor
 import mesosphere.marathon.health.{ HealthCheckManager, MarathonHealthCheckManager }
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state._
@@ -34,6 +35,7 @@ object ModuleNames {
   final val NAMED_LEADER_ATOMIC_BOOLEAN = "LEADER_ATOMIC_BOOLEAN"
   final val NAMED_SERVER_SET_PATH = "SERVER_SET_PATH"
   final val NAMED_SERIALIZE_GROUP_UPDATES = "SERIALIZE_GROUP_UPDATES"
+  final val NAMED_HTTP_EVENT_STREAM = "HTTP_EVENT_STREAM"
 }
 
 class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
@@ -73,6 +75,15 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
       .annotatedWith(Names.named(ModuleNames.NAMED_LEADER_ATOMIC_BOOLEAN))
       .toInstance(leader)
 
+  }
+
+  @Named(ModuleNames.NAMED_HTTP_EVENT_STREAM)
+  @Provides
+  @Singleton
+  def provideHttpEventStreamActor(system: ActorSystem,
+                                  @Named(EventModule.busName) eventBus: EventStream): ActorRef = {
+    val outstanding = 50 //yet another command line parameter??
+    system.actorOf(Props(classOf[HttpEventStreamActor], eventBus, outstanding), "HttpEventStream")
   }
 
   @Provides

--- a/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
@@ -1,10 +1,11 @@
 package mesosphere.marathon.api
 
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.google.inject.Scopes
 import mesosphere.chaos.http.RestModule
 import mesosphere.jackson.CaseClassModule
 import mesosphere.marathon.api.v2.json.MarathonModule
-import com.google.inject.Scopes
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import mesosphere.marathon.event.http.HttpEventStreamServlet
 
 class MarathonRestModule extends RestModule {
 
@@ -14,7 +15,6 @@ class MarathonRestModule extends RestModule {
   )
 
   protected override def configureServlets() {
-    super.configureServlets()
 
     // Map some exceptions to HTTP responses
     bind(classOf[MarathonExceptionMapper]).asEagerSingleton()
@@ -40,6 +40,10 @@ class MarathonRestModule extends RestModule {
 
     bind(classOf[CacheDisablingFilter]).asEagerSingleton()
     filter("/*").through(classOf[CacheDisablingFilter])
-  }
 
+    bind(classOf[HttpEventStreamServlet]).asEagerSingleton()
+    serve("/v2/events").`with`(classOf[HttpEventStreamServlet])
+
+    super.configureServlets()
+  }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -250,6 +250,8 @@ trait EventFormats {
   implicit lazy val ApiPostEventWrites: Writes[ApiPostEvent] = Json.writes[ApiPostEvent]
   implicit lazy val SubscribeWrites: Writes[Subscribe] = Json.writes[Subscribe]
   implicit lazy val UnsubscribeWrites: Writes[Unsubscribe] = Json.writes[Unsubscribe]
+  implicit lazy val EventStreamAttachedWrites: Writes[EventStreamAttached] = Json.writes[EventStreamAttached]
+  implicit lazy val EventStreamDetachedWrites: Writes[EventStreamDetached] = Json.writes[EventStreamDetached]
   implicit lazy val AddHealthCheckWrites: Writes[AddHealthCheck] = Json.writes[AddHealthCheck]
   implicit lazy val RemoveHealthCheckWrites: Writes[RemoveHealthCheck] = Json.writes[RemoveHealthCheck]
   implicit lazy val FailedHealthCheckWrites: Writes[FailedHealthCheck] = Json.writes[FailedHealthCheck]
@@ -270,6 +272,31 @@ trait EventFormats {
     Json.writes[SchedulerRegisteredEvent]
   implicit lazy val SchedulerReregisteredEventWritesWrites: Writes[SchedulerReregisteredEvent] =
     Json.writes[SchedulerReregisteredEvent]
+
+  def eventToJson(event: MarathonEvent): JsValue = event match {
+    case event: AppTerminatedEvent         => Json.toJson(event)
+    case event: ApiPostEvent               => Json.toJson(event)
+    case event: Subscribe                  => Json.toJson(event)
+    case event: Unsubscribe                => Json.toJson(event)
+    case event: EventStreamAttached        => Json.toJson(event)
+    case event: EventStreamDetached        => Json.toJson(event)
+    case event: AddHealthCheck             => Json.toJson(event)
+    case event: RemoveHealthCheck          => Json.toJson(event)
+    case event: FailedHealthCheck          => Json.toJson(event)
+    case event: HealthStatusChanged        => Json.toJson(event)
+    case event: GroupChangeSuccess         => Json.toJson(event)
+    case event: GroupChangeFailed          => Json.toJson(event)
+    case event: DeploymentSuccess          => Json.toJson(event)
+    case event: DeploymentFailed           => Json.toJson(event)
+    case event: DeploymentStatus           => Json.toJson(event)
+    case event: DeploymentStepSuccess      => Json.toJson(event)
+    case event: DeploymentStepFailure      => Json.toJson(event)
+    case event: MesosStatusUpdateEvent     => Json.toJson(event)
+    case event: MesosFrameworkMessageEvent => Json.toJson(event)
+    case event: SchedulerDisconnectedEvent => Json.toJson(event)
+    case event: SchedulerRegisteredEvent   => Json.toJson(event)
+    case event: SchedulerReregisteredEvent => Json.toJson(event)
+  }
 }
 
 trait HealthCheckFormats {

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -77,10 +77,7 @@ final case class SchedulerDisconnectedEvent(
 
 // event subscriptions
 
-sealed trait MarathonSubscriptionEvent extends MarathonEvent {
-  def clientIp: String
-  def callbackUrl: String
-}
+sealed trait MarathonSubscriptionEvent extends MarathonEvent
 
 case class Subscribe(
   clientIp: String,
@@ -95,6 +92,16 @@ case class Unsubscribe(
   eventType: String = "unsubscribe_event",
   timestamp: String = Timestamp.now().toString)
     extends MarathonSubscriptionEvent
+
+case class EventStreamAttached(
+  remoteAddress: String,
+  eventType: String = "event_stream_attached",
+  timestamp: String = Timestamp.now().toString) extends MarathonSubscriptionEvent
+
+case class EventStreamDetached(
+  remoteAddress: String,
+  eventType: String = "event_stream_detached",
+  timestamp: String = Timestamp.now().toString) extends MarathonSubscriptionEvent
 
 // health checks
 

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventActor.scala
@@ -51,28 +51,5 @@ class HttpEventActor(val subscribersKeeper: ActorRef) extends Actor with ActorLo
         log.warning(s"Failed to post $event to $urlString", t)
     }
   }
-
-  def eventToJson(event: MarathonEvent): JsValue = event match {
-    case event: AppTerminatedEvent         => Json.toJson(event)
-    case event: ApiPostEvent               => Json.toJson(event)
-    case event: Subscribe                  => Json.toJson(event)
-    case event: Unsubscribe                => Json.toJson(event)
-    case event: AddHealthCheck             => Json.toJson(event)
-    case event: RemoveHealthCheck          => Json.toJson(event)
-    case event: FailedHealthCheck          => Json.toJson(event)
-    case event: HealthStatusChanged        => Json.toJson(event)
-    case event: GroupChangeSuccess         => Json.toJson(event)
-    case event: GroupChangeFailed          => Json.toJson(event)
-    case event: DeploymentSuccess          => Json.toJson(event)
-    case event: DeploymentFailed           => Json.toJson(event)
-    case event: DeploymentStatus           => Json.toJson(event)
-    case event: DeploymentStepSuccess      => Json.toJson(event)
-    case event: DeploymentStepFailure      => Json.toJson(event)
-    case event: MesosStatusUpdateEvent     => Json.toJson(event)
-    case event: MesosFrameworkMessageEvent => Json.toJson(event)
-    case event: SchedulerDisconnectedEvent => Json.toJson(event)
-    case event: SchedulerRegisteredEvent   => Json.toJson(event)
-    case event: SchedulerReregisteredEvent => Json.toJson(event)
-  }
 }
 

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
@@ -1,0 +1,73 @@
+package mesosphere.marathon.event.http
+
+import akka.actor._
+import akka.event.EventStream
+import mesosphere.marathon.event.http.HttpEventStreamActor._
+import org.apache.log4j.Logger
+import play.api.libs.json.Json
+
+/**
+  * A HttpEventStreamHandle is a reference to the underlying client http stream.
+  */
+trait HttpEventStreamHandle {
+  def id: String
+  def remoteAddress: String
+  def sendMessage(message: String): Unit
+  def close(): Unit
+}
+
+/**
+  * This actor handles subscriptions from event stream handler.
+  * It subscribes to the event stream and pushes all marathon events to all listener.
+  * @param eventStream the marathon event stream
+  */
+class HttpEventStreamActor(eventStream: EventStream, maxOutstandingMessages: Int) extends Actor {
+  //map from handle to actor
+  private[http] var clients = Map.empty[HttpEventStreamHandle, ActorRef]
+  private[this] val log = Logger.getLogger(getClass)
+
+  override def receive: Receive = {
+    case HttpEventStreamConnectionOpen(handle)           => addHandler(handle)
+    case HttpEventStreamConnectionClosed(handle)         => removeHandler(handle)
+    case HttpEventStreamIncomingMessage(handle, message) => sendReply(handle, message)
+    case Terminated(actor)                               => removeActor(actor)
+  }
+
+  def addHandler(handle: HttpEventStreamHandle): Unit = {
+    log.info(s"Add EventStream Handle as event listener: $handle. Current nr of listeners: ${clients.size}")
+    val actor = context.actorOf(Props(
+      classOf[HttpEventStreamHandleActor],
+      handle,
+      eventStream,
+      maxOutstandingMessages), handle.id)
+    context.watch(actor)
+    clients += handle -> actor
+  }
+
+  def removeHandler(handle: HttpEventStreamHandle): Unit = {
+    clients.get(handle).foreach { actor =>
+      context.unwatch(actor)
+      context.stop(actor)
+      clients -= handle
+      log.info(s"Removed EventStream Handle as event listener: $handle. Current nr of listeners: ${clients.size}")
+    }
+  }
+
+  def removeActor(actor: ActorRef): Unit = {
+    clients.find(_._2 == actor).foreach {
+      case (handle, ref) =>
+        log.error(s"Actor terminated unexpectedly: $handle")
+        clients -= handle
+    }
+  }
+
+  def sendReply(handle: HttpEventStreamHandle, message: String): Unit = {
+    handle.sendMessage(Json.stringify(Json.obj("received" -> message)))
+  }
+}
+
+object HttpEventStreamActor {
+  case class HttpEventStreamConnectionOpen(handler: HttpEventStreamHandle)
+  case class HttpEventStreamConnectionClosed(handle: HttpEventStreamHandle)
+  case class HttpEventStreamIncomingMessage(handle: HttpEventStreamHandle, message: String)
+}

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
@@ -27,10 +27,9 @@ class HttpEventStreamActor(eventStream: EventStream, maxOutstandingMessages: Int
   private[this] val log = Logger.getLogger(getClass)
 
   override def receive: Receive = {
-    case HttpEventStreamConnectionOpen(handle)           => addHandler(handle)
-    case HttpEventStreamConnectionClosed(handle)         => removeHandler(handle)
-    case HttpEventStreamIncomingMessage(handle, message) => sendReply(handle, message)
-    case Terminated(actor)                               => removeActor(actor)
+    case HttpEventStreamConnectionOpen(handle)   => addHandler(handle)
+    case HttpEventStreamConnectionClosed(handle) => removeHandler(handle)
+    case Terminated(actor)                       => removeActor(actor)
   }
 
   def addHandler(handle: HttpEventStreamHandle): Unit = {
@@ -60,14 +59,9 @@ class HttpEventStreamActor(eventStream: EventStream, maxOutstandingMessages: Int
         clients -= handle
     }
   }
-
-  def sendReply(handle: HttpEventStreamHandle, message: String): Unit = {
-    handle.sendMessage(Json.stringify(Json.obj("received" -> message)))
-  }
 }
 
 object HttpEventStreamActor {
   case class HttpEventStreamConnectionOpen(handler: HttpEventStreamHandle)
   case class HttpEventStreamConnectionClosed(handle: HttpEventStreamHandle)
-  case class HttpEventStreamIncomingMessage(handle: HttpEventStreamHandle, message: String)
 }

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamHandleActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamHandleActor.scala
@@ -1,0 +1,84 @@
+package mesosphere.marathon.event.http
+
+import java.io.EOFException
+
+import akka.actor.{ Actor, Status }
+import akka.event.EventStream
+import akka.pattern.pipe
+import mesosphere.marathon.api.v2.json.Formats._
+import mesosphere.marathon.event.http.HttpEventStreamHandleActor.WorkDone
+import mesosphere.marathon.event.{ EventStreamAttached, EventStreamDetached, MarathonEvent }
+import mesosphere.util.ThreadPoolContext
+import org.apache.log4j.Logger
+import play.api.libs.json.Json
+
+import scala.concurrent.Future
+import scala.util.Try
+
+class HttpEventStreamHandleActor(
+    handle: HttpEventStreamHandle,
+    stream: EventStream,
+    maxOutStanding: Int) extends Actor {
+
+  private[this] val log = Logger.getLogger(getClass.getName)
+  private[http] var outstanding = 0 //the number of unhandled outstanding send event futures
+
+  override def preStart(): Unit = {
+    stream.subscribe(self, classOf[MarathonEvent])
+    stream.publish(EventStreamAttached(handle.remoteAddress))
+  }
+
+  override def postStop(): Unit = {
+    log.info(s"Stop actor $handle")
+    stream.unsubscribe(self)
+    stream.publish(EventStreamDetached(handle.remoteAddress))
+    Try(handle.close()) //ignore, if this fails
+  }
+
+  def handleException(ex: Throwable): Unit = ex match {
+    case eof: EOFException =>
+      log.info(s"Received EOF from stream handle $handle. Ignore subsequent events.")
+      //We know the connection is dead, but it is not finalized from the container.
+      //Do not act any longer on any event.
+      context.become(Actor.emptyBehavior)
+    case _ =>
+      log.warn(s"Could not send message to $handle", ex)
+  }
+
+  override def receive: Receive = sendEvents
+
+  def sendEvents: Receive = {
+    case event: MarathonEvent if outstanding < maxOutStanding =>
+      implicit val ec = ThreadPoolContext.context
+      Future {
+        handle.sendMessage(Json.stringify(eventToJson(event)))
+        WorkDone
+      } pipeTo self
+      outstanding += 1
+    case event: MarathonEvent =>
+      log.warn(s"Ignore event $event for handle $handle (slow consumer)")
+      context.become(dropEvents)
+    case Status.Failure(ex) =>
+      outstanding -= 1
+      handleException(ex)
+    case WorkDone =>
+      outstanding -= 1
+  }
+
+  def dropEvents: Receive = {
+    case event: MarathonEvent =>
+      log.warn(s"Ignore event $event for handle $handle (slow consumer)")
+    case Status.Failure(ex) =>
+      outstanding -= 1
+      handleException(ex)
+      if (outstanding < maxOutStanding) context.become(sendEvents)
+    case WorkDone =>
+      outstanding -= 1
+      if (outstanding < maxOutStanding) context.become(sendEvents)
+  }
+}
+
+object HttpEventStreamHandleActor {
+  object WorkDone
+}
+

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamServlet.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamServlet.scala
@@ -1,0 +1,54 @@
+package mesosphere.marathon.event.http
+
+import java.util.UUID
+import javax.inject.{ Inject, Named }
+import javax.servlet.http.HttpServletRequest
+
+import akka.actor.ActorRef
+import mesosphere.marathon.ModuleNames
+import mesosphere.marathon.event.http.HttpEventStreamActor._
+import org.eclipse.jetty.servlets.EventSource.Emitter
+import org.eclipse.jetty.servlets.{ EventSource, EventSourceServlet }
+
+import scala.concurrent.blocking
+
+/**
+  * The Stream handle implementation for SSE.
+  * @param request the initial http request.
+  * @param emitter the emitter to emit data
+  */
+class HttpEventSSEHandle(request: HttpServletRequest, emitter: Emitter) extends HttpEventStreamHandle {
+
+  lazy val id: String = UUID.randomUUID().toString
+
+  override def remoteAddress: String = request.getRemoteAddr
+
+  override def close(): Unit = emitter.close()
+
+  override def sendMessage(message: String): Unit = blocking(emitter.data(message))
+
+  override def toString: String = s"HttpEventSSEHandle($id on $remoteAddress)"
+}
+
+/**
+  * Handle a server side event client stream by delegating events to the stream actor.
+  */
+class HttpEventStreamServlet @Inject() (@Named(ModuleNames.NAMED_HTTP_EVENT_STREAM) streamActor: ActorRef)
+    extends EventSourceServlet {
+
+  override def newEventSource(request: HttpServletRequest): EventSource = new EventSource {
+    @volatile private var handler: Option[HttpEventSSEHandle] = None
+
+    override def onOpen(emitter: Emitter): Unit = {
+      val handle = new HttpEventSSEHandle(request, emitter)
+      this.handler = Some(handle)
+      streamActor ! HttpEventStreamConnectionOpen(handle)
+    }
+
+    override def onClose(): Unit = {
+      handler.foreach(streamActor ! HttpEventStreamConnectionClosed(_))
+      handler = None
+    }
+  }
+}
+

--- a/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
+++ b/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
@@ -128,7 +128,7 @@ class MarathonStore[S <: MarathonState[_, S]](
         // the native mesos code returns an ExecutionException without cause. Therefore, we cannot robustly
         // differentiate between exceptions which are "normal" and exceptions which indicate real errors
         // and we have to log them all.
-        log.warn(s"error while calling $getClass.names() for prefix $prefix", e)
+        log.warn(s"exception while calling $getClass.names() for prefix $prefix", e)
         Iterator.empty
     }
   }

--- a/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamActorTest.scala
@@ -4,11 +4,10 @@ import akka.actor.{ ActorSystem, Props }
 import akka.event.EventStream
 import akka.testkit._
 import mesosphere.marathon.MarathonSpec
-import mesosphere.marathon.event.http.HttpEventStreamActor.{ HttpEventStreamConnectionClosed, HttpEventStreamConnectionOpen, HttpEventStreamIncomingMessage }
-import org.mockito.Mockito.{ when => call, verify }
+import mesosphere.marathon.event.http.HttpEventStreamActor.{ HttpEventStreamConnectionClosed, HttpEventStreamConnectionOpen }
+import org.mockito.Mockito.{ when => call }
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
-import play.api.libs.json.Json
 
 class HttpEventStreamActorTest extends TestKit(ActorSystem())
     with MarathonSpec with Matchers with GivenWhenThen with MockitoSugar with ImplicitSender with BeforeAndAfter {
@@ -38,21 +37,6 @@ class HttpEventStreamActorTest extends TestKit(ActorSystem())
 
     Then("The actor is unsubscribed from the event stream")
     streamActor.underlyingActor.clients should have size 0
-  }
-
-  test("An incoming message will be replied") {
-    Given("A registered handler")
-    val handle = mock[HttpEventStreamHandle]
-    call(handle.id).thenReturn("1")
-    streamActor ! HttpEventStreamConnectionOpen(handle)
-    streamActor.underlyingActor.clients should have size 1
-    val message = "Hello"
-
-    When("An incoming message is send")
-    streamActor ! HttpEventStreamIncomingMessage(handle, message)
-
-    Then("A response is send to the handle")
-    verify(handle).sendMessage(Json.stringify(Json.obj("received" -> message)))
   }
 
   var streamActor: TestActorRef[HttpEventStreamActor] = _

--- a/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamActorTest.scala
@@ -1,0 +1,67 @@
+package mesosphere.marathon.event.http
+
+import akka.actor.{ ActorSystem, Props }
+import akka.event.EventStream
+import akka.testkit._
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.event.http.HttpEventStreamActor.{ HttpEventStreamConnectionClosed, HttpEventStreamConnectionOpen, HttpEventStreamIncomingMessage }
+import org.mockito.Mockito.{ when => call, verify }
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
+import play.api.libs.json.Json
+
+class HttpEventStreamActorTest extends TestKit(ActorSystem())
+    with MarathonSpec with Matchers with GivenWhenThen with MockitoSugar with ImplicitSender with BeforeAndAfter {
+
+  test("Register Handler") {
+    Given("A handler that wants to connect")
+    val handle = mock[HttpEventStreamHandle]
+    call(handle.id).thenReturn("1")
+
+    When("A connection open message is sent to the stream actor")
+    streamActor ! HttpEventStreamConnectionOpen(handle)
+
+    Then("An actor is created and subscribed to the event stream")
+    streamActor.underlyingActor.clients should have size 1
+    streamActor.underlyingActor.clients.get(handle) should be ('nonEmpty)
+  }
+
+  test("Unregister an already registered Handler") {
+    Given("A registered handler")
+    val handle = mock[HttpEventStreamHandle]
+    call(handle.id).thenReturn("1")
+    streamActor ! HttpEventStreamConnectionOpen(handle)
+    streamActor.underlyingActor.clients should have size 1
+
+    When("A connection closed message is sent to the stream actor")
+    streamActor ! HttpEventStreamConnectionClosed(handle)
+
+    Then("The actor is unsubscribed from the event stream")
+    streamActor.underlyingActor.clients should have size 0
+  }
+
+  test("An incoming message will be replied") {
+    Given("A registered handler")
+    val handle = mock[HttpEventStreamHandle]
+    call(handle.id).thenReturn("1")
+    streamActor ! HttpEventStreamConnectionOpen(handle)
+    streamActor.underlyingActor.clients should have size 1
+    val message = "Hello"
+
+    When("An incoming message is send")
+    streamActor ! HttpEventStreamIncomingMessage(handle, message)
+
+    Then("A response is send to the handle")
+    verify(handle).sendMessage(Json.stringify(Json.obj("received" -> message)))
+  }
+
+  var streamActor: TestActorRef[HttpEventStreamActor] = _
+  var stream: EventStream = _
+
+  before {
+    stream = mock[EventStream]
+    streamActor = TestActorRef(Props(
+      new HttpEventStreamActor(stream, 1)
+    ))
+  }
+}

--- a/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamHandleActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamHandleActorTest.scala
@@ -1,0 +1,91 @@
+package mesosphere.marathon.event.http
+
+import java.io.{ IOException, EOFException }
+import java.util.concurrent.CountDownLatch
+
+import akka.actor.{ Actor, ActorSystem, Props }
+import akka.event.EventStream
+import akka.testkit.{ ImplicitSender, TestActorRef, TestKit }
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.event.EventStreamAttached
+import org.mockito.Matchers.any
+import org.mockito.Mockito.{ times, verify, when => call }
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
+
+class HttpEventStreamHandleActorTest extends TestKit(ActorSystem())
+    with MarathonSpec with Matchers with GivenWhenThen with MockitoSugar with ImplicitSender with BeforeAndAfter {
+
+  test("A message send to the handle actor will be transferred to the stream handle") {
+    Given("A handler that will postpone sending until latch is hit")
+    val latch = new CountDownLatch(1)
+    call(handle.sendMessage(any[String])).thenAnswer(new Answer[Unit] {
+      override def answer(invocation: InvocationOnMock): Unit = latch.await()
+    })
+
+    When("The event is send to the actor, the outstanding messages is 1")
+    handleActor ! EventStreamAttached("remote")
+    awaitCond(handleActor.underlyingActor.outstanding == 1)
+
+    Then("We need to wait for the future to succeed")
+    latch.countDown()
+    awaitCond(handleActor.underlyingActor.outstanding == 0)
+    verify(handle, times(1)).sendMessage(any[String])
+  }
+
+  test("If the consumer is slow and maxOutstanding limit is reached, messages get dropped") {
+    Given("A handler that will postpone the sending")
+    val latch = new CountDownLatch(1)
+    call(handle.sendMessage(any[String])).thenAnswer(new Answer[Unit] {
+      override def answer(invocation: InvocationOnMock): Unit = latch.await()
+    })
+
+    When("More than the max size of outstanding events is send to the actor")
+    handleActor ! EventStreamAttached("remote")
+    handleActor ! EventStreamAttached("remote")
+    handleActor ! EventStreamAttached("remote")
+    handleActor ! EventStreamAttached("remote")
+
+    Then("Only one message is send to the handler")
+    latch.countDown()
+    awaitCond(handleActor.underlyingActor.outstanding == 0)
+    verify(handle, times(1)).sendMessage(any[String])
+  }
+
+  test("If the handler throws an EOF exception, the actor stops acting") {
+    Given("A handler that will postpone the sending")
+    val latch = new CountDownLatch(1)
+    call(handle.sendMessage(any[String])).thenAnswer(new Answer[Unit] {
+      override def answer(invocation: InvocationOnMock): Unit = {
+        val ex = latch.getCount == 0
+        latch.await()
+        if (ex) throw new EOFException()
+      }
+    })
+
+    When("An event is send to actor")
+    handleActor ! EventStreamAttached("remote")
+    awaitCond(handleActor.underlyingActor.outstanding == 1)
+
+    Then("The actor does not understand any messages")
+    latch.countDown()
+    awaitCond(handleActor.underlyingActor.outstanding == 0)
+    handleActor ! EventStreamAttached("remote")
+    handleActor ! EventStreamAttached("remote")
+    awaitCond(handleActor.underlyingActor.outstanding == 0)
+  }
+
+  var handleActor: TestActorRef[HttpEventStreamHandleActor] = _
+  var stream: EventStream = _
+  var handle: HttpEventStreamHandle = _
+
+  before {
+    handle = mock[HttpEventStreamHandle]
+    stream = mock[EventStream]
+    handleActor = TestActorRef(Props(
+      new HttpEventStreamHandleActor(handle, stream, 1)
+    ))
+  }
+}

--- a/src/test/scala/mesosphere/marathon/integration/MarathonCommandLineHelpTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MarathonCommandLineHelpTest.scala
@@ -19,8 +19,7 @@ class MarathonCommandLineHelpTest
     val cwd = new File(".")
     val process = ProcessKeeper.startMarathon(
       cwd, env = Map.empty, arguments = List("--help"),
-      startupLine = "--help                                      Show help message")
+      startupLine = "Show help message")
     assert(process.exitValue() == 0)
   }
-
 }


### PR DESCRIPTION
Add /v2/events endpoint with content negotiation to handle different clients.

@drexin Please Review