### PR TITLE
Log "No matching offer ..." at level WARN

### DIFF
--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -34,7 +34,7 @@ class TaskBuilder(app: AppDefinition,
         build(offer, cpu, mem, disk, ranges)
 
       case _ =>
-        log.info(
+        log.warn(
           s"No matching offer for ${app.id} (need cpus=${app.cpus}, mem=${app.mem}, " +
             s"disk=${app.disk}, ports=${app.hostPorts()}) : " + offer
         )


### PR DESCRIPTION
Logging at INFO in a production environment can be rather verbose, but it is important to capture "No matching offer ..." messages, since it can indicate issues with an application configuration, or other issue with the cluster. This change moves the "No matching offer ..." log message from the INFO level to the WARN level to make it more visible.