### PR TITLE
Log "No matching offer ..." at level DEBUG

### DIFF
--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -34,7 +34,7 @@ class TaskBuilder(app: AppDefinition,
         build(offer, cpu, mem, disk, ranges)
 
       case _ =>
-        log.info(
+        log.debug(
           s"No matching offer for ${app.id} (need cpus=${app.cpus}, mem=${app.mem}, " +
             s"disk=${app.disk}, ports=${app.hostPorts()}) : " + offer
         )


### PR DESCRIPTION
Logging at INFO in a production environment can be rather verbose. Since "No matching offer ..." messages are actually protocol diagnostics it would be better to log these at the DEBUG level.