### PR TITLE
Fix Integration tests with mesos 0.22.1

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/setup/IntegrationTestConfig.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/IntegrationTestConfig.scala
@@ -104,7 +104,7 @@ object IntegrationTestConfig {
 
     val zkHost = string("zkHost", unusedForExternalSetup("localhost"))
     val zkPort = int("zkPort", 2183)
-    val master = string("master", unusedForExternalSetup("local"))
+    val master = string("master", unusedForExternalSetup("127.0.0.1:5050"))
     val mesosLib = string("mesosLib", unusedForExternalSetup(defaultMesosLibConfig))
     val httpPort = int("httpPort", 11211 + (math.random * 100).toInt)
     val marathonHost = string("marathonHost", "localhost")


### PR DESCRIPTION
Since mesos version 0.22.1 --master local will launch a new local mesos without checking, 
if there is already a running one. 
Changed it to an http connection string.

@kolloch please review