### PR TITLE
Fixes #1507 - Ignore all NonFatal exceptions in MarathonStore.names()

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/state/Migration.scala
@@ -67,7 +67,7 @@ class Migration @Inject() (
 
     result.onComplete {
       case Success(version) => log.info(s"Migration successfully applied for version ${version.str}")
-      case Failure(ex)      => log.error(s"Migration failed! $ex")
+      case Failure(ex)      => log.error("Migration failed!", ex)
     }
 
     Await.result(result, Duration.Inf)


### PR DESCRIPTION
Otherwise, our store migration code fails. This is also triggered when
Marathon is started without any prior Zookeeper state.