### PR TITLE
Update instructions not to reference a blog post.

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -21,9 +21,7 @@ An easy way to try out Marathon locally is using the [playa-mesos](https://githu
 #### Install Mesos
 
 One easy way is via your system's package manager.
-Current builds for major Linux distributions and Mac OS X are available
-from on the Mesosphere [downloads page](http://mesosphere.com/downloads/)
-or from Mesosphere's [repositories](http://mesosphere.com/2014/07/17/mesosphere-package-repositories/).
+Current builds and instructions on how to set up repositories for major Linux distributions and Mac OS X are available on the Mesosphere [downloads page](http://mesosphere.com/downloads/).
 
 If building from source, see the
 Mesos [Getting Started](http://mesos.apache.org/gettingstarted/) page or the


### PR DESCRIPTION
Just point people to mesosphere.com/downloads since that's less likely to go out of date. (The blog post, on the other hand, will never be retroactively updated.)