### PR TITLE
Set a default value for zk_max_versions, if this parameter is omitted.

### DIFF
--- a/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
+++ b/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
@@ -32,7 +32,8 @@ trait ZookeeperConf extends ScallopConf {
   )
 
   lazy val zooKeeperMaxVersions = opt[Int]("zk_max_versions",
-    descr = "Limit the number of versions, stored for one entity."
+    descr = "Limit the number of versions, stored for one entity.",
+    default = Some(25)
   )
 
   //do not allow mixing of hostState and url


### PR DESCRIPTION
Fixes #1521 

@drexin please review