### PR TITLE
Update service-discovery-load-balancing.md

### DIFF
--- a/docs/docs/service-discovery-load-balancing.md
+++ b/docs/docs/service-discovery-load-balancing.md
@@ -48,7 +48,7 @@ $ ./bin/haproxy-marathon-bridge install_haproxy_system localhost:8080
 ```
 
 - The list of Marathons to ping is stored one per line in
-  `/etc/haproxy_marathon_bridge/marathons`
+  `/etc/haproxy-marathon-bridge/marathons`
 - The script is installed as `/usr/local/bin/haproxy-marathon-bridge`
 - The cronjob is installed as `/etc/cron.d/haproxy-marathon-bridge`
   and run as root.


### PR DESCRIPTION
reference to /etc/haproxy_marathon_bridge/marathons is wrong, should be dashes, i.e. /etc/haproxy-marathon-bridge/marathons