### PR TITLE
Fixes #1520 - Satisfy port resources from any of the offered ranges

### DIFF
--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -17,8 +17,6 @@ case class AppLockedException(deploymentIds: Seq[String] = Nil)
       "View details at '/v2/deployments/<DEPLOYMENT_ID>'."
   )
 
-case class PortResourceException(msg: String) extends Exception(msg)
-
 class PortRangeExhaustedException(
   val minPort: Int,
   val maxPort: Int) extends Exception(s"All ports in the range $minPort-$maxPort are already in use")

--- a/src/test/scala/mesosphere/marathon/tasks/PortWithRoleCreatePortsResourcesTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortWithRoleCreatePortsResourcesTest.scala
@@ -1,0 +1,60 @@
+package mesosphere.marathon.tasks
+
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.tasks.PortsMatcher.PortWithRole
+import mesosphere.mesos.protos.{ Resource, RangesResource, Range }
+import scala.collection.immutable.Seq
+
+class PortWithRoleCreatePortsResourcesTest extends MarathonSpec {
+  test("create no ranges resource for empty port seq") {
+    val result = PortWithRole.createPortsResources(Seq.empty[PortWithRole])
+    assert(result.isEmpty)
+  }
+
+  test("create ranges resource for single port preserving role") {
+    val result = PortWithRole.createPortsResources(Seq(PortWithRole("*", 2)))
+    assert(result == Seq(RangesResource(Resource.PORTS, Seq(Range(2, 2)), role = "*")))
+    val result2 = PortWithRole.createPortsResources(Seq(PortWithRole("marathon", 3)))
+    assert(result2 == Seq(RangesResource(Resource.PORTS, Seq(Range(3, 3)), role = "marathon")))
+  }
+
+  test("one ranges resource for multiple ports of the same role") {
+    val result = PortWithRole.createPortsResources(Seq(PortWithRole("*", 2), PortWithRole("*", 10)))
+    assert(result == Seq(RangesResource(Resource.PORTS, Seq(Range(2, 2), Range(10, 10)), role = "*")))
+  }
+
+  test("one ranges resource for consecutive multiple ports of the same role") {
+    val result = PortWithRole.createPortsResources(Seq(
+      PortWithRole("*", 2), PortWithRole("*", 10),
+      PortWithRole("marathon", 11),
+      PortWithRole("*", 12)
+    ))
+    assert(result == Seq(
+      RangesResource(Resource.PORTS, Seq(Range(2, 2), Range(10, 10)), role = "*"),
+      RangesResource(Resource.PORTS, Seq(Range(11, 11)), role = "marathon"),
+      RangesResource(Resource.PORTS, Seq(Range(12, 12)), role = "*")
+    ))
+  }
+
+  test("combined consecutive ports of same role into one range") {
+    val result = PortWithRole.createPortsResources(Seq(
+      PortWithRole("*", 2), PortWithRole("*", 3)
+    ))
+    assert(result == Seq(
+      RangesResource(Resource.PORTS, Seq(Range(2, 3)), role = "*")
+    ))
+  }
+
+  test("complex example") {
+    val result = PortWithRole.createPortsResources(Seq(
+      PortWithRole("*", 2), PortWithRole("*", 3), PortWithRole("*", 10),
+      PortWithRole("marathon", 11),
+      PortWithRole("*", 12)
+    ))
+    assert(result == Seq(
+      RangesResource(Resource.PORTS, Seq(Range(2, 3), Range(10, 10)), role = "*"),
+      RangesResource(Resource.PORTS, Seq(Range(11, 11)), role = "marathon"),
+      RangesResource(Resource.PORTS, Seq(Range(12, 12)), role = "*")
+    ))
+  }
+}

--- a/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
@@ -1,0 +1,61 @@
+package mesosphere.marathon.tasks
+
+import java.util
+
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.tasks.PortsMatcher.{ PortRange, PortWithRole }
+import scala.collection.immutable.Seq
+import org.apache.mesos.Protos
+
+import scala.util.Random
+
+class PortWithRoleRandomPortsFromRangesTest extends MarathonSpec {
+
+  private[this] def portRange(role: String, begin: Long, end: Long): PortRange = {
+    val range = Protos.Value.Range.newBuilder().setBegin(begin).setEnd(end).build()
+    PortRange(role, range)
+  }
+
+  private[this] def withRandomSeeds(input: Seq[PortRange], expectedOutput: Iterable[PortWithRole]): Unit = {
+    for (seed <- 1 to 10) {
+      withClue(s"seed = $seed") {
+        val rand = new Random(new util.Random(seed.toLong))
+
+        assert(PortWithRole.randomPortsFromRanges(rand)(input).to[Set] == expectedOutput.to[Set])
+      }
+    }
+
+  }
+
+  test("works for empty seq") {
+    assert(PortWithRole.randomPortsFromRanges()(Seq.empty).to[Seq] == Seq.empty)
+  }
+
+  test("works for one element range") {
+    assert(
+      PortWithRole.randomPortsFromRanges()(Seq(portRange("role", 10, 10))).to[Seq] == Seq(PortWithRole("role", 10)))
+  }
+
+  test("works for one range with four ports") {
+    withRandomSeeds(
+      input = Seq(
+        portRange("role", 10, 13)
+      ),
+      expectedOutput = (10 to 13).map(PortWithRole("role", _))
+    )
+  }
+
+  test("works for multiple ranges") {
+    withRandomSeeds(
+      input = Seq(
+        portRange("role", 10, 13),
+        portRange("marathon", 14, 20),
+        portRange("role", 21, 30)
+      ),
+      expectedOutput =
+        (10 to 13).map(PortWithRole("role", _)) ++
+          (14 to 20).map(PortWithRole("marathon", _)) ++
+          (21 to 30).map(PortWithRole("role", _))
+    )
+  }
+}

--- a/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
@@ -12,8 +12,7 @@ import scala.util.Random
 class PortWithRoleRandomPortsFromRangesTest extends MarathonSpec {
 
   private[this] def portRange(role: String, begin: Long, end: Long): PortRange = {
-    val range = Protos.Value.Range.newBuilder().setBegin(begin).setEnd(end).build()
-    PortRange(role, range)
+    PortRange(role, Range.inclusive(begin.toInt, end.toInt))
   }
 
   private[this] def withRandomSeeds(input: Seq[PortRange], expectedOutput: Iterable[PortWithRole]): Unit = {

--- a/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
@@ -1,15 +1,20 @@
 package mesosphere.marathon.tasks
 
 import java.util
+import java.util.concurrent.TimeUnit
 
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.tasks.PortsMatcher.{ PortRange, PortWithRole }
+import org.slf4j.LoggerFactory
 import scala.collection.immutable.Seq
 import org.apache.mesos.Protos
 
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Random
 
 class PortWithRoleRandomPortsFromRangesTest extends MarathonSpec {
+
+  private[this] val log = LoggerFactory.getLogger(getClass)
 
   private[this] def portRange(role: String, begin: Long, end: Long): PortRange = {
     PortRange(role, Range.inclusive(begin.toInt, end.toInt))
@@ -20,19 +25,19 @@ class PortWithRoleRandomPortsFromRangesTest extends MarathonSpec {
       withClue(s"seed = $seed") {
         val rand = new Random(new util.Random(seed.toLong))
 
-        assert(PortWithRole.randomPortsFromRanges(rand)(input).to[Set] == expectedOutput.to[Set])
+        assert(PortWithRole.lazyRandomPortsFromRanges(rand)(input).to[Set] == expectedOutput.to[Set])
       }
     }
 
   }
 
   test("works for empty seq") {
-    assert(PortWithRole.randomPortsFromRanges()(Seq.empty).to[Seq] == Seq.empty)
+    assert(PortWithRole.lazyRandomPortsFromRanges()(Seq.empty).to[Seq] == Seq.empty)
   }
 
   test("works for one element range") {
     assert(
-      PortWithRole.randomPortsFromRanges()(Seq(portRange("role", 10, 10))).to[Seq] == Seq(PortWithRole("role", 10)))
+      PortWithRole.lazyRandomPortsFromRanges()(Seq(portRange("role", 10, 10))).to[Seq] == Seq(PortWithRole("role", 10)))
   }
 
   test("works for one range with four ports") {
@@ -57,4 +62,31 @@ class PortWithRoleRandomPortsFromRangesTest extends MarathonSpec {
           (21 to 30).map(PortWithRole("role", _))
     )
   }
+
+  test("is lazy with one range") {
+    // otherwise this will be really really slow
+    val start = System.nanoTime()
+
+    val ports = PortWithRole.lazyRandomPortsFromRanges()(Seq(portRange("role", 1, Integer.MAX_VALUE)))
+    ports.take(3)
+
+    val duration = FiniteDuration(System.nanoTime() - start, TimeUnit.NANOSECONDS)
+    log.info(s"duration = ${duration.toMillis}ms")
+    assert(duration.toMillis < 500)
+  }
+
+  test("is lazy with multiple ranges") {
+    // otherwise this will be really really slow
+    val start = System.nanoTime()
+
+    val ports = PortWithRole.lazyRandomPortsFromRanges()(
+      (0 to 500).map { _ => portRange("role", 1, Integer.MAX_VALUE) }
+    )
+    ports.take(3)
+
+    val duration = FiniteDuration(System.nanoTime() - start, TimeUnit.NANOSECONDS)
+    log.info(s"duration = ${duration.toMillis}ms")
+    assert(duration.toMillis < 500)
+  }
+
 }

--- a/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
@@ -1,5 +1,7 @@
 package mesosphere.marathon.tasks
 
+import java.util
+
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state.{ Container, AppDefinition }
@@ -8,6 +10,7 @@ import mesosphere.mesos.protos._
 import org.apache.mesos.Protos.Offer
 
 import scala.collection.immutable.Seq
+import scala.util.Random
 
 class PortsMatcherTest extends MarathonSpec {
 
@@ -27,7 +30,7 @@ class PortsMatcherTest extends MarathonSpec {
     val app = AppDefinition(ports = Seq(80, 81, 82, 83, 84))
     val portsResource = RangesResource(
       Resource.PORTS,
-      Seq(protos.Range(30000, 30003), protos.Range(31000, 31009))
+      Seq(protos.Range(30000, 30003), protos.Range(31000, 31000))
     )
     val offer = Offer.newBuilder
       .setId(OfferID("1"))
@@ -43,12 +46,11 @@ class PortsMatcherTest extends MarathonSpec {
     assert(matcher.portRanges.get.map(_.role) == Seq("*"))
   }
 
-  test("get ports from multiple ranges, preserving role") {
-    val app = AppDefinition(ports = Seq(80, 81, 82, 83, 84))
+  test("get ports from multiple ranges, requirePorts") {
+    val app = AppDefinition(ports = Seq(80, 81, 82, 83, 100), requirePorts = true)
     val portsResource = RangesResource(
       Resource.PORTS,
-      Seq(protos.Range(30000, 30003), protos.Range(31000, 31009)),
-      role = "marathon"
+      Seq(protos.Range(80, 83), protos.Range(100, 100))
     )
     val offer = Offer.newBuilder
       .setId(OfferID("1"))
@@ -57,11 +59,37 @@ class PortsMatcherTest extends MarathonSpec {
       .setHostname("localhost")
       .addResources(portsResource)
       .build
+    val matcher = new PortsMatcher(app, offer, acceptedResourceRoles = Set("*"))
+
+    assert(matcher.matches)
+    assert(matcher.ports == Seq(80, 81, 82, 83, 100))
+    assert(matcher.portRanges.get.map(_.role) == Seq("*"))
+  }
+
+  test("get ports from multiple resources, preserving role") {
+    val app = AppDefinition(ports = Seq(80, 81, 82, 83, 84))
+    val portsResource = RangesResource(
+      Resource.PORTS,
+      Seq(protos.Range(30000, 30003))
+    )
+    val portsResource2 = RangesResource(
+      Resource.PORTS,
+      Seq(protos.Range(31000, 31000)),
+      "marathon"
+    )
+    val offer = Offer.newBuilder
+      .setId(OfferID("1"))
+      .setFrameworkId(FrameworkID("marathon"))
+      .setSlaveId(SlaveID("slave0"))
+      .setHostname("localhost")
+      .addResources(portsResource)
+      .addResources(portsResource2)
+      .build
     val matcher = new PortsMatcher(app, offer, acceptedResourceRoles = Set("*", "marathon"))
 
     assert(matcher.matches)
     assert(5 == matcher.ports.size)
-    assert(matcher.portRanges.get.map(_.role) == Seq("marathon"))
+    assert(matcher.portRanges.get.map(_.role).to[Set] == Set("*", "marathon"))
   }
 
   test("get ports from multiple ranges, ignore ranges with unwanted roles") {
@@ -151,11 +179,38 @@ class PortsMatcherTest extends MarathonSpec {
       )
     ))
 
-    val offer = makeBasicOffer(beginPort = 31000, endPort = 32000).build
+    val offer = makeBasicOffer(beginPort = 31000, endPort = 31000).build
     val matcher = new PortsMatcher(app, offer)
 
     assert(matcher.matches)
     assert(Some(Seq(RangesResource("ports", Seq(protos.Range(31000, 31000)), "*"))) == matcher.portRanges)
+  }
+
+  test("randomly satisfy dynamic mapped port from container") {
+    val app = AppDefinition(container = Some(
+      Container(
+        docker = Some(new Docker(
+          portMappings = Some(Seq(
+            new Docker.PortMapping(containerPort = 1, hostPort = 0)
+          ))
+        ))
+      )
+    ))
+
+    val offer = makeBasicOffer(beginPort = 31000, endPort = 32000).build
+    val rand = new Random(new util.Random(0))
+    val matcher = new PortsMatcher(app, offer, random = rand)
+
+    assert(matcher.matches)
+    val firstPort = matcher.ports.head
+
+    val differentMatch = (1 to 1000).find { seed =>
+      val rand = new Random(new util.Random(0))
+      val matcher = new PortsMatcher(app, offer, random = rand)
+      matcher.ports.head != firstPort
+    }
+
+    assert(differentMatch.isDefined)
   }
 
   test("fail if fixed mapped port from container cannot be satisfied") {
@@ -193,7 +248,7 @@ class PortsMatcherTest extends MarathonSpec {
     assert(Some(Seq(RangesResource("ports", Seq(protos.Range(31200, 31200)), "*"))) == matcher.portRanges)
   }
 
-  test("do not satisfy fixed mapped port from container with resource offfer of incorrect role") {
+  test("do not satisfy fixed mapped port from container with resource offer of incorrect role") {
     val app = AppDefinition(container = Some(
       Container(
         docker = Some(new Docker(
@@ -228,7 +283,7 @@ class PortsMatcherTest extends MarathonSpec {
       )
     ))
 
-    val offer = makeBasicOffer(beginPort = 31000, endPort = 32000).build
+    val offer = makeBasicOffer(beginPort = 31000, endPort = 31001).build
     val matcher = new PortsMatcher(app, offer)
 
     assert(matcher.matches)

--- a/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
@@ -204,13 +204,21 @@ class PortsMatcherTest extends MarathonSpec {
     assert(matcher.matches)
     val firstPort = matcher.ports.head
 
-    val differentMatch = (1 to 1000).find { seed =>
+    val differentMatchWithSameSeed = (1 to 10).find { _ =>
       val rand = new Random(new util.Random(0))
       val matcher = new PortsMatcher(app, offer, random = rand)
       matcher.ports.head != firstPort
     }
 
-    assert(differentMatch.isDefined)
+    assert(differentMatchWithSameSeed.isEmpty)
+
+    val differentMatchWithDifferentSeed = (1 to 1000).find { seed =>
+      val rand = new Random(new util.Random(seed.toLong))
+      val matcher = new PortsMatcher(app, offer, random = rand)
+      matcher.ports.head != firstPort
+    }
+
+    assert(differentMatchWithDifferentSeed.isDefined)
   }
 
   test("fail if fixed mapped port from container cannot be satisfied") {

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -344,7 +344,9 @@ class TaskBuilderTest extends MarathonSpec {
   }
 
   test("PortMappingsWithZeroContainerPort") {
-    val offer = makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = "*")
+    val offer = makeBasicOfferWithRole(
+      cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31000, role = "*"
+    )
       .addResources(ScalarResource("cpus", 1, "*"))
       .addResources(ScalarResource("mem", 128, "*"))
       .addResources(ScalarResource("disk", 1000, "*"))


### PR DESCRIPTION
We now also
* always log a reason if we cannot match all ports
* use randomized hosts ports for container port mappings
* make ResourceUtil work with the consumption of multiple roles with
  the same name and role