### PR TITLE
Fixes #1446 - Disallow empty strings for app.cmd

### DIFF
--- a/src/main/resources/mesosphere/marathon/api/v2/AppDefinition.json
+++ b/src/main/resources/mesosphere/marathon/api/v2/AppDefinition.json
@@ -43,7 +43,8 @@
             "type": "integer"
         },
         "cmd": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "constraints": {},
         "container": {

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -349,7 +349,7 @@ trait AppDefinitionFormats {
 
     (
       (__ \ "id").read[PathId].filterNot(_.isRoot) ~
-      (__ \ "cmd").readNullable[String] ~
+      (__ \ "cmd").readNullable[String](Reads.minLength(1)) ~
       (__ \ "args").readNullable[Seq[String]] ~
       (__ \ "user").readNullable[String] ~
       (__ \ "env").readNullable[Map[String, String]].withDefault(DefaultEnv) ~
@@ -442,7 +442,7 @@ trait AppDefinitionFormats {
 
     (
       (__ \ "id").readNullable[PathId].filterNot(_.exists(_.isRoot)) ~
-      (__ \ "cmd").readNullable[String] ~
+      (__ \ "cmd").readNullable[String](Reads.minLength(1)) ~
       (__ \ "args").readNullable[Seq[String]] ~
       (__ \ "user").readNullable[String] ~
       (__ \ "env").readNullable[Map[String, String]] ~

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -158,7 +158,7 @@ case class AppDefinition(
       else None
 
     val argsOption =
-      if (commandOption.isEmpty)
+      if (commandOption.isEmpty && proto.getCmd.getArgumentsCount != 0)
         Some(proto.getCmd.getArgumentsList.asScala.to[Seq])
       else None
 

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -136,6 +136,14 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     validateJsonSchema(app2, false) // no id
   }
 
+  test("Validation: empty cmd should fail") {
+    val app1 = AppDefinition(
+      id = "play".toPath,
+      cmd = Some("")
+    )
+    validateJsonSchema(app1, valid = false)
+  }
+
   test("Validation") {
     val validator = Validation.buildDefaultValidatorFactory().getValidator
 


### PR DESCRIPTION
Also treat no app.args as None instead of Some(Seq.empty)