### PR TITLE
Fixes #1365 - Always export service ports in app.ports field

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -60,10 +60,10 @@ The core functionality flags can be also set by environment variable `MARATHON_O
 * `--webui_url` (Optional. Default: None): The url of the Marathon web ui. It
     is passed to Mesos to be used in links back to the Marathon UI. If not set,
     the url to the leading instance will be sent to Mesos.
-* `--local_port_max` (Optional. Default: 20000): Max port number to use when
-    assigning ports to apps.
-* `--local_port_min` (Optional. Default: 10000): Min port number to use when
-    assigning ports to apps.
+* `--local_port_max` (Optional. Default: 20000): Max port number to use when assigning globally unique service ports
+    to apps.
+* `--local_port_min` (Optional. Default: 10000): Min port number to use when assigning globally unique service ports
+    to apps.
 * <span class="label label-default">v0.8.2</span> `--max_tasks_per_offer` (Optional. Default: 1): Launch at most this
     number of tasks per Mesos offer. Usually,
     there is one offer per cycle and slave. You can speed up launching tasks by increasing this number.

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -30,11 +30,11 @@ trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMat
     noshort = true, default = Some(true))
 
   lazy val localPortMin = opt[Int]("local_port_min",
-    descr = "Min port number to use when assigning ports to apps",
+    descr = "Min port number to use when assigning globally unique service ports to apps",
     default = Some(10000))
 
   lazy val localPortMax = opt[Int]("local_port_max",
-    descr = "Max port number to use when assigning ports to apps",
+    descr = "Max port number to use when assigning globally unique service ports to apps",
     default = Some(20000))
 
   lazy val defaultExecutor = opt[String]("executor",

--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -21,7 +21,7 @@ object EndpointsHelper {
       val cleanId = app.id.safePath.replaceAll("\\s+", "_")
       val tasks = taskTracker.get(app.id)
 
-      val servicePorts = app.servicePorts()
+      val servicePorts = app.servicePorts
 
       if (servicePorts.isEmpty) {
         sb.append(s"${cleanId}$delimiter $delimiter")

--- a/src/main/scala/mesosphere/marathon/api/ModelValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/ModelValidation.scala
@@ -268,7 +268,7 @@ object ModelValidation {
     * will conflict with existing apps.
     */
   def checkAppConflicts(app: AppDefinition, baseId: PathId, service: MarathonSchedulerService): Seq[String] = {
-    app.containerServicePorts().toSeq.flatMap { servicePorts =>
+    app.containerServicePorts.toSeq.flatMap { servicePorts =>
       checkServicePortConflicts(baseId, servicePorts, service)
     }
   }
@@ -286,7 +286,7 @@ object ModelValidation {
     for {
       existingApp <- service.listApps().toList
       if existingApp.id != baseId // in case of an update, do not compare the app against itself
-      existingServicePort <- existingApp.portMappings().toList.flatten.map(_.servicePort)
+      existingServicePort <- existingApp.portMappings.toList.flatten.map(_.servicePort)
       if existingServicePort != 0 // ignore zero ports, which will be chosen at random
       if requestedServicePorts contains existingServicePort
     } yield s"Requested service port $existingServicePort conflicts with a service port in app ${existingApp.id}"

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -47,7 +47,7 @@ class TasksResource @Inject() (
     val appIds = taskTracker.list.keySet
 
     val appToPorts = appIds.map { appId =>
-      appId -> service.getApp(appId).map(_.servicePorts()).getOrElse(Nil)
+      appId -> service.getApp(appId).map(_.servicePorts).getOrElse(Nil)
     }.toMap
 
     val health = appIds.flatMap { appId =>

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -402,39 +402,35 @@ trait AppDefinitionFormats {
     }
 
     Writes[AppDefinition] { app =>
-      try {
-        Json.obj(
-          "id" -> app.id.toString,
-          "cmd" -> app.cmd,
-          "args" -> app.args,
-          "user" -> app.user,
-          "env" -> app.env,
-          "instances" -> app.instances,
-          "cpus" -> app.cpus,
-          "mem" -> app.mem,
-          "disk" -> app.disk,
-          "executor" -> app.executor,
-          "constraints" -> app.constraints,
-          "uris" -> app.uris,
-          "storeUrls" -> app.storeUrls,
-          "ports" -> app.ports,
-          "requirePorts" -> app.requirePorts,
-          "backoffSeconds" -> app.backoff,
-          "backoffFactor" -> app.backoffFactor,
-          "maxLaunchDelaySeconds" -> app.maxLaunchDelay,
-          "container" -> app.container,
-          "healthChecks" -> app.healthChecks,
-          "dependencies" -> app.dependencies,
-          "upgradeStrategy" -> app.upgradeStrategy,
-          "labels" -> app.labels,
-          "acceptedResourceRoles" -> app.acceptedResourceRoles,
-          "version" -> app.version
-        )
-      }
-      catch {
-        case NonFatal(e) =>
-          throw e
-      }
+      Json.obj(
+        "id" -> app.id.toString,
+        "cmd" -> app.cmd,
+        "args" -> app.args,
+        "user" -> app.user,
+        "env" -> app.env,
+        "instances" -> app.instances,
+        "cpus" -> app.cpus,
+        "mem" -> app.mem,
+        "disk" -> app.disk,
+        "executor" -> app.executor,
+        "constraints" -> app.constraints,
+        "uris" -> app.uris,
+        "storeUrls" -> app.storeUrls,
+        // the ports field was written incorrectly in old code if a container was specified
+        // it should contain the service ports
+        "ports" -> app.servicePorts,
+        "requirePorts" -> app.requirePorts,
+        "backoffSeconds" -> app.backoff,
+        "backoffFactor" -> app.backoffFactor,
+        "maxLaunchDelaySeconds" -> app.maxLaunchDelay,
+        "container" -> app.container,
+        "healthChecks" -> app.healthChecks,
+        "dependencies" -> app.dependencies,
+        "upgradeStrategy" -> app.upgradeStrategy,
+        "labels" -> app.labels,
+        "acceptedResourceRoles" -> app.acceptedResourceRoles,
+        "version" -> app.version
+      )
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.state
 
 import java.lang.{ Double => JDouble, Integer => JInt }
 
-import com.fasterxml.jackson.annotation.{ JsonIgnoreProperties, JsonProperty }
+import com.fasterxml.jackson.annotation.{ JsonIgnore, JsonIgnoreProperties, JsonProperty }
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.api.v2.json.EnrichedTask
 import mesosphere.marathon.api.validation.FieldConstraints._
@@ -208,7 +208,8 @@ case class AppDefinition(
     )
   }
 
-  def portMappings(): Option[Seq[PortMapping]] =
+  @JsonIgnore
+  def portMappings: Option[Seq[PortMapping]] =
     for {
       c <- container
       d <- c.docker
@@ -216,19 +217,24 @@ case class AppDefinition(
       pms <- d.portMappings
     } yield pms
 
-  def containerHostPorts(): Option[Seq[Int]] =
+  @JsonIgnore
+  def containerHostPorts: Option[Seq[Int]] =
     for (pms <- portMappings) yield pms.map(_.hostPort.toInt)
 
-  def containerServicePorts(): Option[Seq[Int]] =
+  @JsonIgnore
+  def containerServicePorts: Option[Seq[Int]] =
     for (pms <- portMappings) yield pms.map(_.servicePort.toInt)
 
-  def hostPorts(): Seq[Int] =
+  @JsonIgnore
+  def hostPorts: Seq[Int] =
     containerHostPorts.getOrElse(ports.map(_.toInt))
 
-  def servicePorts(): Seq[Int] =
+  @JsonIgnore
+  def servicePorts: Seq[Int] =
     containerServicePorts.getOrElse(ports.map(_.toInt))
 
-  def hasDynamicPort(): Boolean = servicePorts.contains(0)
+  @JsonIgnore
+  def hasDynamicPort: Boolean = servicePorts.contains(0)
 
   def mergeFromProto(bytes: Array[Byte]): AppDefinition = {
     val proto = Protos.ServiceDefinition.parseFrom(bytes)

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -45,7 +45,7 @@ class TaskBuilder(app: AppDefinition,
         case _ =>
           log.debug(
             s"No matching offer for ${app.id} (need cpus=${app.cpus}, mem=${app.mem}, " +
-              s"disk=${app.disk}, ports=${app.hostPorts()}) : " + offer
+              s"disk=${app.disk}, ports=${app.hostPorts}) : " + offer
           )
           None
       }
@@ -169,7 +169,7 @@ class TaskBuilder(app: AppDefinition,
 object TaskBuilder {
 
   def commandInfo(app: AppDefinition, taskId: Option[TaskID], host: Option[String], ports: Seq[Long]): CommandInfo = {
-    val containerPorts = for (pms <- app.portMappings()) yield pms.map(_.containerPort)
+    val containerPorts = for (pms <- app.portMappings) yield pms.map(_.containerPort)
     val declaredPorts = containerPorts.getOrElse(app.ports)
     val envMap: Map[String, String] =
       taskContextEnv(app, taskId) ++

--- a/src/test/scala/mesosphere/marathon/state/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupManagerTest.scala
@@ -34,12 +34,12 @@ class GroupManagerTest extends TestKit(ActorSystem("System")) with MockitoSugar 
       AppDefinition("/app2".toPath, ports = Seq(1, 2, 3)),
       AppDefinition("/app2".toPath, ports = Seq(0, 2, 0))
     ))
-    val update = manager(10, 20).assignDynamicAppPort(Group.empty, group)
+    val update = manager(10, 20).assignDynamicServicePorts(Group.empty, group)
     update.transitiveApps.filter(_.hasDynamicPort) should be('empty)
     update.transitiveApps.flatMap(_.ports.filter(x => x >= 10 && x <= 20)) should have size 5
   }
 
-  test("Assign dynamic app ports specified in the container") {
+  test("Assign dynamic service ports specified in the container") {
     import Container.Docker
     import Docker.PortMapping
     import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network
@@ -57,9 +57,32 @@ class GroupManagerTest extends TestKit(ActorSystem("System")) with MockitoSugar 
     val group = Group(PathId.empty, Set(
       AppDefinition("/app1".toPath, ports = Seq(), container = Some(container))
     ))
-    val update = manager(10, 20).assignDynamicAppPort(Group.empty, group)
+    val update = manager(minServicePort = 10, maxServicePort = 20).assignDynamicServicePorts(Group.empty, group)
     update.transitiveApps.filter(_.hasDynamicPort) should be ('empty)
     update.transitiveApps.flatMap(_.ports.filter(x => x >= 10 && x <= 20)) should have size 2
+  }
+
+  // Regression test for #1365
+  test("Export non-dynamic service ports specified in the container to the ports field") {
+    import Container.Docker
+    import Docker.PortMapping
+    import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network
+    val container = Container(
+      docker = Some(Docker(
+        image = "busybox",
+        network = Some(Network.BRIDGE),
+        portMappings = Some(Seq(
+          PortMapping(containerPort = 8080, hostPort = 0, servicePort = 80, protocol = "tcp"),
+          PortMapping (containerPort = 9000, hostPort = 10555, servicePort = 81, protocol = "udp")
+        ))
+      ))
+    )
+    val group = Group(PathId.empty, Set(
+      AppDefinition("/app1".toPath, container = Some(container))
+    ))
+    val update = manager(minServicePort = 90, maxServicePort = 900).assignDynamicServicePorts(Group.empty, group)
+    update.transitiveApps.filter(_.hasDynamicPort) should be ('empty)
+    update.transitiveApps.flatMap(_.ports) should equal (Set(80, 81).map(Integer.valueOf))
   }
 
   test("Already taken ports will not be used") {
@@ -67,7 +90,7 @@ class GroupManagerTest extends TestKit(ActorSystem("System")) with MockitoSugar 
       AppDefinition("/app1".toPath, ports = Seq(0, 0, 0)),
       AppDefinition("/app2".toPath, ports = Seq(0, 2, 0))
     ))
-    val update = manager(10, 20).assignDynamicAppPort(Group.empty, group)
+    val update = manager(10, 20).assignDynamicServicePorts(Group.empty, group)
     update.transitiveApps.filter(_.hasDynamicPort) should be('empty)
     update.transitiveApps.flatMap(_.ports.filter(x => x >= 10 && x <= 20)) should have size 5
   }
@@ -78,7 +101,7 @@ class GroupManagerTest extends TestKit(ActorSystem("System")) with MockitoSugar 
       AppDefinition("/app2".toPath, ports = Seq(0, 0, 0))
     ))
     val ex = intercept[PortRangeExhaustedException] {
-      manager(10, 15).assignDynamicAppPort(Group.empty, group)
+      manager(10, 15).assignDynamicServicePorts(Group.empty, group)
     }
     ex.minPort should be(10)
     ex.maxPort should be(15)
@@ -100,7 +123,7 @@ class GroupManagerTest extends TestKit(ActorSystem("System")) with MockitoSugar 
       )
     ))
 
-    val result = manager(10, 15).assignDynamicAppPort(Group.empty, group)
+    val result = manager(10, 15).assignDynamicServicePorts(Group.empty, group)
     result.apps.size should be(1)
     val app = result.apps.head
     app.container should be (Some(container))
@@ -127,8 +150,10 @@ class GroupManagerTest extends TestKit(ActorSystem("System")) with MockitoSugar 
     verify(groupRepo, times(0)).store(any(), any())
   }
 
-  def manager(from: Int, to: Int) = {
-    val config = new ScallopConf(Seq("--master", "foo", "--local_port_min", from.toString, "--local_port_max", to.toString)) with MarathonConf
+  def manager(minServicePort: Int, maxServicePort: Int) = {
+    val config = new ScallopConf(Seq(
+      "--master", "foo",
+      "--local_port_min", minServicePort.toString, "--local_port_max", maxServicePort.toString)) with MarathonConf
     config.afterInit()
     val scheduler = mock[MarathonSchedulerService]
     val taskTracker = mock[TaskTracker]


### PR DESCRIPTION
...even if there are no dynamic app ports to assign.

Also:

* cleanup some methods without side effects that had a () call convention.
* improve documentation about --local_port_min and --local_port_max