### PR TITLE
Fixes #1497 - Do not query app versions in MarathonHealthCheckManager

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/state/Migration.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.StorageVersions._
 import mesosphere.marathon.tasks.TaskTracker
-import mesosphere.marathon.tasks.TaskTracker.{InternalApp, App}
+import mesosphere.marathon.tasks.TaskTracker.{ InternalApp, App }
 import mesosphere.marathon.{ BuildInfo, MarathonConf, StorageException }
 import mesosphere.util.BackToTheFuture.futureToFutureOption
 import mesosphere.util.ThreadPoolContext.context


### PR DESCRIPTION
.statuses(appId: PathId)

and make MarathonHealthCheckManager data structures more efficient