### PR TITLE
Fixes #1545 - Make it easy to run integration tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,23 @@
 # docker related files
 .dockerignore
-Dockerfile
+Dockerfile*
 
 # source repository history
 .git
 
+# unneeded
+.travis.yml
+
+# tool configuration
+.idea
+*.iml
+.classpath
+.settings
+.Rproj.user
+.reviewboardrc
+
 # build directories
+docker-volumes
 target
 */target
 */*/target

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+bin/run-tests-config.sh
 .idea
 *.iml
+docker-volumes
 target
 .reviewboardrc
 dependency-reduced-pom.xml

--- a/Dockerfile.build-base
+++ b/Dockerfile.build-base
@@ -4,7 +4,6 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \
     default-jdk \
-    scala \
     curl
 
 RUN curl -SsL -O http://dl.bintray.com/sbt/debian/sbt-0.13.5.deb && \
@@ -12,10 +11,3 @@ RUN curl -SsL -O http://dl.bintray.com/sbt/debian/sbt-0.13.5.deb && \
 
 COPY . /marathon
 WORKDIR /marathon
-
-RUN sbt -Dsbt.log.format=false assembly && \
-    mv $(find target -name 'marathon-assembly-*.jar' | sort | tail -1) ./ && \
-    rm -rf target/* ~/.sbt ~/.ivy2 && \
-    mv marathon-assembly-*.jar target
-
-ENTRYPOINT ["./bin/start"]

--- a/bin/run-tests-config-template.sh
+++ b/bin/run-tests-config-template.sh
@@ -1,0 +1,32 @@
+#
+# Configuration tempalte for run-tests.sh
+#
+# Copy to run-tests-config.sh and adjust to your needs.
+#
+
+
+# Where do you want to put your persistent build data by default?
+# Per default all other build directories will get stored sub directories of this.
+# If you adjust them all, you do not need this setting
+#BUILD_VOLUME_DIR="$PROJECT_DIR/docker-volumes"
+
+# Where do you want to store you SBT config/cache?
+# You can configure your ~/.sbt here but be aware of permission issues
+# since the build is running as root inside of the container.
+SBT_DIR="$HOME/.sbt"
+# Where do you want to store your IVY2 config/cache?
+# You can configure your ~/.ivy2 here but be aware of permission issues
+# since the build is running as root inside of the container.
+IVY2_DIR="$HOME/.ivy2"
+# Where do you want to store build artifacts?
+#TARGET_DIRS="..."
+# Do you want to clean the target directories before the build?
+# Not deleting them results in faster incremental builds but incremental builds might not be reproducible.
+CLEANUP_TARGET_DIRS="${CLEANUP_TARGET_DIRS-false}"
+# Do you want to remove all generated images/containers on exit?
+CLEANUP_CONTAINERS_ON_EXIT="${CLEANUP_CONTAINERS-false}"
+# Do you want to NOT use the docker cache?
+NO_DOCKER_CACHE="${NO_DOCKER_CACHE-false}"
+
+# A parameter for the AppScalingTest
+export MARATHON_MAX_TASKS_PER_OFFER="${MARATHON_MAX_TASKS_PER_OFFER-1}"

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+#
+# Run all tests including integration tests via docker.
+#
+# The script places some files into target/docker-build-volumes.
+# If you keep it around between builds your can greatly speed up resolving artifacts
+# but on the other hand you do not test if all artifacts are still resolvable.
+#
+# You can configure this script by copying run-tests-config-template.sh to run-tests-config.sh
+# and adjusting it to your needs.
+#
+# Usage:
+#  ./run-tests.sh $0 [<unique build id>]
+#
+#  The build id is used as part of the docker image version/container names.
+#
+
+
+# be verbose and print all commands, better for debugging
+# set -x
+
+PROJECT_DIR=`dirname $0`/..
+PROJECT_DIR=$(cd "$PROJECT_DIR"; pwd)
+
+if [ -r "$PROJECT_DIR/bin/run-tests-config.sh" ]; then
+    . "$PROJECT_DIR/bin/run-tests-config.sh"
+fi
+
+function fatal {
+    echo "======== FATAL ERROR ===================================================================================" >&2
+    echo "$*" >&2
+    echo "========================================================================================================" >&2
+    exit 2
+}
+
+BUILD_ID=${1-test}
+
+# We preserve some files across builds if the target directory is not deleted in between.
+# Especially the ivy cache can speed up builds substantially.
+BUILD_VOLUME_DIR="${BUILD_VOLUME_DIR-$PROJECT_DIR/docker-volumes}"
+SBT_DIR="${SBT_DIR-$BUILD_VOLUME_DIR/sbt}"
+IVY2_DIR="${IVY2_DIR-$BUILD_VOLUME_DIR/ivy2}"
+TARGET_DIRS="${TARGET_DIRS-$BUILD_VOLUME_DIR/targets}"
+CLEANUP_TARGET_DIRS="${CLEANUP_TARGET_DIRS-true}"
+CLEANUP_CONTAINERS_ON_EXIT="${CLEANUP_CONTAINERS-true}"
+export MARATHON_MAX_TASKS_PER_OFFER="${MARATHON_MAX_TASKS_PER_OFFER-1}"
+NO_DOCKER_CACHE="${NO_DOCKER_CACHE-true}"
+
+cat <<HERE
+BUILD_ID $BUILD_ID
+PROJECT_DIR $PROJECT_DIR
+
+Current configuration
+=====================
+
+Change this by copying run-tests-config-template.sh to run-tests-config.sh and adjusting it to your needs.
+
+Directories:
+
+    BUILD_VOLUME_DIR = "$BUILD_VOLUME_DIR"
+                       (the directory containing the persistent state of the build by default)
+    SBT_DIR          = "$SBT_DIR"
+                       (your sbt config directory)
+    IVY2_DIR         = "$IVY2_DIR"
+                       (your ivy2 configuration and test)
+    TARGET_DIRS      = "$TARGET_DIRS"
+                       (the directory containing your build results)
+
+Docker caching:
+
+    NO_DOCKER_CACHE = "NO_DOCKER_CACHE" allowed: true or false default: true
+                       (whether to use the docker cache when building the base image)
+
+Cleanup:
+
+    CLEANUP_TARGET_DIRS         = "$CLEANUP_TARGET_DIRS" allowed: true or false default: true
+                                  (whether to clean the build target dirs before building)
+    CLEANUP_CONTAINERS_ON_EXIT  = "$CLEANUP_CONTAINERS_ON_EXIT" allowed: true or false default: true
+                                  (whether to clean/remove container images and containers on exit)
+
+Test parameters:
+
+    MARATHON_MAX_TASKS_PER_OFFER = "$MARATHON_MAX_TASKS_PER_OFFER"
+                                   (see --max_tasks_per_offer)
+
+Building
+========
+
+Started: $(date)
+HERE
+
+mkdir -p "$BUILD_VOLUME_DIR" "$TARGET_DIRS" || fatal "Couldn't created '$BUILD_VOLUME_DIR' '$TARGET_DIRS'" >&2
+
+if [ "$CLEANUP_TARGET_DIRS" = "true" ]; then
+    rm -rf "$TARGET_DIRS" || fatal "Couldn't clean '$TARGET_DIRS'"
+fi
+
+# Cleanup left-over containers
+function cleanup {
+    echo Cleaning up volumes
+    docker rmi marathon-buildbase:$BUILD_ID 2>/dev/null
+    docker rm -v marathon-itests-$BUILD_ID 2>/dev/null
+}
+
+cleanup
+
+if [ "$CLEANUP_CONTAINERS_ON_EXIT" = "true" ]; then
+    trap cleanup EXIT
+fi
+
+if ! docker build --rm=$NO_DOCKER_CACHE --no-cache=$NO_DOCKER_CACHE -t marathon-buildbase:$BUILD_ID \
+    -f "$PROJECT_DIR/Dockerfile.build-base" "$PROJECT_DIR"; then
+    fatal "Build for the buildbase failed" >&2
+fi
+
+docker run \
+    --rm=$CLEANUP_CONTAINERS_ON_EXIT \
+    --name marathon-itests-$BUILD_ID \
+    -e MARATHON_MAX_TASKS_PER_OFFER=$MARATHON_MAX_TASKS_PER_OFFER \
+    -v "$SBT_DIR:/root/.sbt" \
+    -v "$IVY2_DIR:/root/.ivy2" \
+    -v "$TARGET_DIRS/main:/marathon/target" \
+    -v "$TARGET_DIRS/project:/marathon/project/target" \
+    -v "$TARGET_DIRS/mesos-simulation:/marathon/mesos-simulation/target" \
+    -i \
+    marathon-buildbase:$BUILD_ID \
+    bash -c '
+    sbt -Dsbt.log.format=false test:compile &&\
+    sbt -Dsbt.log.format=false test integration:test &&\
+    sbt -Dsbt.log.format=false "project mesosSimulation" integration:test "test:runMain mesosphere.mesos.scale.DisplayAppScalingResults"' \
+    || fatal "build/tests failed"

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -19,7 +19,8 @@ _TODO_: Do we need a CLA?
 
 ## Submitting Changes to Marathon
 
-- A GitHub pull request is the preferred way of submitting patch sets.
+- A GitHub pull request is the preferred way of submitting patch sets. Please rebase your
+  pull requests on top of the current master and squash your changes to a single commit.
 
 - Any changes in the public API or behavior must be reflected in the project
   documentation.
@@ -28,6 +29,8 @@ _TODO_: Do we need a CLA?
 
 - If the change is a bugfix, then the added tests must fail without the patch
   as a safeguard against future regressions.
+
+- Run all tests via the supplied `./bin/run-tests.sh` script (requires docker).
 
 ## Source Files
 

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
@@ -35,7 +35,12 @@ class SingleAppScalingTest
 
   override def startMarathon(port: Int, args: String*): Unit = {
     val cwd = new File(".")
-    ProcessKeeper.startMarathon(cwd, env, List("--http_port", port.toString, "--zk", config.zk, "--enable_metrics") ++ args.toList,
+
+    val maxTasksPerOffer = Option(System.getenv("MARATHON_MAX_TASKS_PER_OFFER")).getOrElse("1")
+
+    ProcessKeeper.startMarathon(cwd, env,
+      List("--http_port", port.toString, "--zk", config.zk, "--enable_metrics",
+        "--max_tasks_per_offer", maxTasksPerOffer) ++ args.toList,
       mainClass = "mesosphere.mesos.simulation.SimulateMesosMain")
   }
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -47,12 +47,32 @@ object MarathonBuild extends Build {
       integrationTestSettings
     ).dependsOn(root % "compile->compile; test->test").configs(IntegrationTest)
 
+  lazy val withFormatting = System.getProperty("sbt.log.format", "true").toBoolean
+
+  /**
+   * Determine scala test runner output. `-e` for reporting on standard error.
+   *
+   * W - without color
+   * D - show all durations
+   * S - show short stack traces
+   * F - show full stack traces
+   * U - unformatted mode
+   * I - show reminder of failed and canceled tests without stack traces
+   * T - show reminder of failed and canceled tests with short stack traces
+   * G - show reminder of failed and canceled tests with full stack traces
+   * K - exclude TestCanceled events from reminder
+   *
+   * http://scalatest.org/user_guide/using_the_runner
+   */
+  lazy val formattingTestArg = Tests.Argument(if (withFormatting) "-eDST" else "-eWUDST")
+
   lazy val integrationTestSettings = inConfig(IntegrationTest)(Defaults.testTasks) ++
     Seq(
-      testOptions in Test := Seq(Tests.Argument("-l", "integration")),
-      testOptions in IntegrationTest := Seq(Tests.Argument("-n", "integration")))
+      testOptions in IntegrationTest := Seq(formattingTestArg, Tests.Argument("-n", "integration"))
+    )
 
   lazy val testSettings = Seq(
+    testOptions in Test := Seq(formattingTestArg, Tests.Argument("-l", "integration")),
     parallelExecution in Test := false,
     fork in Test := true
   )


### PR DESCRIPTION
via a script and docker.

Adjust test settings:

* to be sensitive to whether sbt formatting is enabled
* to include durations
* to print stack traces in error summary

Make scaling test slightly more agressive.