### PR TITLE
Set crossScalaVersion to scalaVersion

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -71,6 +71,7 @@ object MarathonBuild extends Build {
   lazy val baseSettings = Defaults.defaultSettings ++ buildInfoSettings ++ Seq (
     organization := "mesosphere",
     scalaVersion := "2.11.5",
+    crossScalaVersions := Seq(scalaVersion.value),
     scalacOptions in Compile ++= Seq(
       "-encoding", "UTF-8",
       "-target:jvm-1.6",


### PR DESCRIPTION
to skip setting it manually in every release build.

I already put that on the release-8.2 branch.