### PR TITLE
Fixes #1569 - Split http_endpoints parameter

### DIFF
--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventModule.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventModule.scala
@@ -19,10 +19,13 @@ import mesosphere.marathon.MarathonConf
 
 trait HttpEventConfiguration extends ScallopConf {
 
-  lazy val httpEventEndpoints = opt[List[String]]("http_endpoints",
-    descr = "The URLs of the event endpoints master",
+  lazy val httpEventEndpoints = opt[String]("http_endpoints",
+    descr = "The URLs of the event endpoints",
     required = false,
-    noshort = true)
+    noshort = true).map(parseHttpEventEndpoints)
+
+  private[this] def parseHttpEventEndpoints(str: String): List[String] =
+    str.split(',').map(_.trim).toList
 }
 
 class HttpEventModule(httpEventConfiguration: HttpEventConfiguration) extends AbstractModule {

--- a/src/test/scala/mesosphere/marathon/event/http/HttpEventModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/http/HttpEventModuleTest.scala
@@ -1,0 +1,39 @@
+package mesosphere.marathon.event.http
+
+import mesosphere.marathon.MarathonSpec
+import org.rogach.scallop.ScallopConf
+
+class HttpEventModuleTest extends MarathonSpec {
+  test("--http_endpoints accepts just one endpoint") {
+    val conf = makeHttpEventConfig(
+      "--http_endpoints", "http://127.0.0.1:8000"
+    )
+
+    assert(conf.httpEventEndpoints.get == Some(List("http://127.0.0.1:8000")))
+  }
+
+  test("--http_endpointss correctly splits multiple endpoints") {
+    val conf = makeHttpEventConfig(
+      "--http_endpoints", "http://127.0.0.1:8000,http://127.0.0.1:8001"
+    )
+
+    assert(conf.httpEventEndpoints.get == Some(List("http://127.0.0.1:8000", "http://127.0.0.1:8001")))
+  }
+
+  test("--http_endpoints trims endpoints") {
+    val conf = makeHttpEventConfig(
+      "--http_endpoints", "http://127.0.0.1:8000 , http://127.0.0.1:8001   "
+    )
+
+    assert(conf.httpEventEndpoints.get == Some(List("http://127.0.0.1:8000", "http://127.0.0.1:8001")))
+  }
+
+  def makeHttpEventConfig(args: String*): HttpEventConfiguration = {
+    val opts = new ScallopConf(args) with HttpEventConfiguration {
+      // scallop will trigger sys exit
+      override protected def onError(e: Throwable): Unit = throw e
+    }
+    opts.afterInit()
+    opts
+  }
+}


### PR DESCRIPTION
This change is inspired on code from MarathonConf. I'm still a scala newbie, so don't be afraid to bash me ;-).