### PR TITLE
Fixes #1583 - Only pass non-zero disk quota to Mesos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+## Changes from 0.8.2 to 0.9.0
+
+#### Recommended Mesos version is 0.22.1
+
+We tested this release against Mesos version 0.22.1. Thus this is the recommended
+Mesos version for this release.
+
+#### Disk resource limits are passed to Mesos
+
+If you specify a non-zero disk resource limit, this limit is now passed to Mesos
+on task launch.
+
+If you rely on disk limits, you also need to configure Mesos appropriately. This includes configuring the correct
+isolator and enabling disk quotas enforcement with `--enforce_container_disk_quota`.
+
 ## Changes from 0.8.1 to 0.8.2
 
 #### New health check option `ignoreHttp1xx`

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -78,8 +78,16 @@ class TaskBuilder(app: AppDefinition,
       .setSlaveId(offer.getSlaveId)
       .addResources(ScalarResource(Resource.CPUS, app.cpus, cpuRole))
       .addResources(ScalarResource(Resource.MEM, app.mem, memRole))
-      // this is not enforced in Mesos without specifically configuring the appropriate enforcer
-      .addResources(ScalarResource(Resource.DISK, app.disk, diskRole))
+
+    if (app.disk != 0) {
+      // This is only supported since Mesos 0.22.0 and will result in TASK_LOST messages in combination
+      // with older mesos versions. So if the user leaves this untouched, we will NOT pass it to
+      // Mesos. If the user chooses a value != 0, we assume that they rely on this value and we DO pass it to Mesos
+      // irrespective of the version.
+      //
+      // This is not enforced in Mesos without specifically configuring the appropriate enforcer.
+      builder.addResources(ScalarResource(Resource.DISK, app.disk, diskRole))
+    }
 
     if (labels.nonEmpty)
       builder.setLabels(Labels.newBuilder.addAllLabels(labels.asJava))


### PR DESCRIPTION
to stay compatible with older Mesos versions as long as
no disk limit has been specified.