### PR TITLE
Fixes #1541, #1540 - LeaderProxyFilter, do not proxy to self, timeouts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -63,6 +63,26 @@ on task launch.
 If you rely on disk limits, you also need to configure Mesos appropriately. This includes configuring the correct
 isolator and enabling disk quotas enforcement with `--enforce_container_disk_quota`.
 
+#### Improved proxying to current leader
+
+One of the Marathon instances is always elected as a leader and is the only instance processing your requests.
+For convenience, Marathon has long proxied all requests to non-leaders to the current leader so that
+you do not have to lookup the current leader yourself or are annoyed by redirects.
+
+This proxying has now been improved and gained additional configuration parameters:
+
+* `--leader_proxy_connection_timeout` (Optional. Default: 5000):
+    Maximum time, in milliseconds, for connecting to the
+    current Marathon leader from this Marathon instance.
+* `--leader_proxy_read_timeout` (Optional. Default: 10000):
+    Maximum time, in milliseconds, for reading from the
+    current Marathon leader.
+
+These bugs are now obsolete:
+
+- #1540 A marathon instance should never proxy to itself
+- #1541 Proxying Marathon requests should use timeouts
+
 #### Relative URL paths in the UI
 
 The UI now uses relative URL paths making it easier to run Marathon behind a reverse proxy.

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -60,6 +60,12 @@ The core functionality flags can be also set by environment variable `MARATHON_O
 * `--webui_url` (Optional. Default: None): The url of the Marathon web ui. It
     is passed to Mesos to be used in links back to the Marathon UI. If not set,
     the url to the leading instance will be sent to Mesos.
+* <span class="label label-default">v0.9.0</span> `--leader_proxy_connection_timeout` (Optional. Default: 5000):
+    Maximum time, in milliseconds, for connecting to the
+    current Marathon leader from this Marathon instance.
+* <span class="label label-default">v0.9.0</span> `--leader_proxy_read_timeout` (Optional. Default: 10000):
+    Maximum time, in milliseconds, for reading from the
+    current Marathon leader.
 * `--local_port_max` (Optional. Default: 20000): Max port number to use when dynamically assigning globally unique
     service ports to apps. If you assign your service port statically in your app definition, it does
     not have to be in this range.

--- a/src/main/scala/mesosphere/marathon/LeaderProxyConf.scala
+++ b/src/main/scala/mesosphere/marathon/LeaderProxyConf.scala
@@ -1,0 +1,18 @@
+package mesosphere.marathon
+
+import org.rogach.scallop.ScallopConf
+
+/**
+  * Configuration for proxying to the current leader.
+  */
+trait LeaderProxyConf extends ScallopConf {
+  lazy val leaderProxyConnectionTimeout = opt[Int]("leader_proxy_connection_timeout",
+    descr = "Maximum time, in milliseconds, to wait for connecting to the current Marathon leader from " +
+      "another Marathon instance.",
+    default = Some(5000)) // 5 seconds
+
+  lazy val leaderProxyReadTimeout = opt[Int]("leader_proxy_read_timeout",
+    descr = "Maximum time, in milliseconds, for reading from the current Marathon leader.",
+    default = Some(10000)) // 10 seconds
+
+}

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -6,7 +6,7 @@ import scala.sys.SystemProperties
 
 import mesosphere.marathon.io.storage.StorageProvider
 
-trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMatcherConfig {
+trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMatcherConfig with LeaderProxyConf {
 
   lazy val mesosMaster = opt[String]("master",
     descr = "The URL of the Mesos master",

--- a/src/main/scala/mesosphere/marathon/MarathonLeaderInfo.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonLeaderInfo.scala
@@ -1,0 +1,33 @@
+package mesosphere.marathon
+
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.{ Named, Inject }
+
+import com.codahale.metrics.MetricRegistry
+import com.twitter.common.zookeeper.Candidate
+import mesosphere.marathon.api.LeaderInfo
+import mesosphere.util.TimerUtils
+import mesosphere.util.TimerUtils.ScalaTimer
+
+class MarathonLeaderInfo @Inject() (
+    @Named(ModuleNames.NAMED_CANDIDATE) candidate: Option[Candidate],
+    @Named(ModuleNames.NAMED_LEADER_ATOMIC_BOOLEAN) leader: AtomicBoolean,
+    metrics: MarathonLeaderInfoMetrics) extends LeaderInfo {
+
+  /** Query whether we are the current leader. This should be cheap. */
+  override def elected: Boolean = leader.get()
+
+  override def currentLeaderHostPort(): Option[String] = metrics.getLeaderDataTimer {
+    candidate.flatMap { c =>
+      Option(c.getLeaderData.orNull()).map { data =>
+        new String(data, "UTF-8")
+      }
+    }
+  }
+}
+
+class MarathonLeaderInfoMetrics @Inject() (metrics: MetricRegistry) {
+  val getLeaderDataTimer: ScalaTimer =
+    TimerUtils.timer(metrics, getClass, "current-leader-host-port")
+}
+

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
@@ -73,7 +73,7 @@ object MarathonSchedulerDriver {
         new MesosSchedulerDriver(newScheduler, frameworkInfo, config.mesosMaster())
     }
 
-    log.debug("Finished creating new driver")
+    log.debug("Finished creating new driver", newDriver)
 
     newDriver
   }

--- a/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
+++ b/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
@@ -41,9 +41,9 @@ trait ZookeeperConf extends ScallopConf {
   conflicts(zooKeeperPath, List(zooKeeperUrl))
   conflicts(zooKeeperUrl, List(zooKeeperHostString, zooKeeperPath))
 
-  def zooKeeperStatePath(): String = "%s/state".format(zkPath)
-  def zooKeeperLeaderPath(): String = "%s/leader".format(zkPath)
-  def zooKeeperServerSetPath(): String = "%s/apps".format(zkPath)
+  def zooKeeperStatePath: String = "%s/state".format(zkPath)
+  def zooKeeperLeaderPath: String = "%s/leader".format(zkPath)
+  def zooKeeperServerSetPath: String = "%s/apps".format(zkPath)
 
   def zooKeeperHostAddresses: Seq[InetSocketAddress] =
     for (s <- zkHosts.split(",")) yield {

--- a/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
@@ -1,137 +1,293 @@
 package mesosphere.marathon.api
 
-import scala.collection.JavaConverters._
-import com.google.inject.Inject
-import java.net.{ HttpURLConnection, URL }
-import java.io.{ OutputStream, InputStream }
-import java.util.concurrent.atomic.AtomicBoolean
+import java.io.{ IOException, InputStream, OutputStream }
+import java.net.{ UnknownServiceException, ConnectException, HttpURLConnection, URL }
 import javax.inject.Named
 import javax.servlet._
-import javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
-import mesosphere.marathon.{ MarathonSchedulerService, ModuleNames }
+import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
+
+import com.google.inject.Inject
+import mesosphere.chaos.http.HttpConf
+import mesosphere.marathon.io.IO
+import mesosphere.marathon.{ LeaderProxyConf, ModuleNames }
+import org.apache.http.HttpStatus
 import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.util.Try
+import scala.util.control.NonFatal
+
+/**
+  * Info about leadership.
+  */
+trait LeaderInfo {
+  /** Query whether we are elected as the current leader. This should be cheap. */
+  def elected: Boolean
+
+  /**
+    * Query the host/port of the current leader if any. This might involve network round trips
+    * and should be called sparingly.
+    *
+    * @return `Some(`<em>host</em>:</em>port</em>`)`, e.g. my.local.domain:8080 or `None` if
+    *        the leader is currently unknown
+    */
+  def currentLeaderHostPort(): Option[String]
+}
 
 /**
   * Servlet filter that proxies requests to the leader if we are not the leader.
-  *
-  * @param schedulerService
-  * @param leader
   */
-class LeaderProxyFilter @Inject() (schedulerService: MarathonSchedulerService,
-                                   @Named(ModuleNames.NAMED_LEADER_ATOMIC_BOOLEAN) leader: AtomicBoolean)
+class LeaderProxyFilter @Inject() (httpConf: HttpConf,
+                                   leaderInfo: LeaderInfo,
+                                   @Named(ModuleNames.NAMED_HOST_PORT) myHostPort: String,
+                                   forwarder: RequestForwarder)
     extends Filter {
 
-  val log = Logger.getLogger(getClass.getName)
+  import LeaderProxyFilter._
 
   def init(filterConfig: FilterConfig): Unit = {}
 
-  def copy(input: InputStream, output: OutputStream): Unit = {
-    val bytes = new Array[Byte](1024)
-    Iterator
-      .continually(input.read(bytes))
-      .takeWhile(_ != -1)
-      .foreach(read => output.write(bytes, 0, read))
-  }
+  private[this] val scheme = if (httpConf.disableHttp()) "https" else "http"
 
-  def buildUrl(leaderData: String, request: HttpServletRequest): URL = {
-    // TODO handle https
+  private[this] def buildUrl(leaderData: String, request: HttpServletRequest): URL = {
     if (request.getQueryString != null) {
-      new URL("http://%s%s?%s".format(leaderData, request.getRequestURI, request.getQueryString))
+      new URL(s"$scheme://$leaderData${request.getRequestURI}?${request.getQueryString}")
     }
     else {
-      new URL("http://%s%s".format(leaderData, request.getRequestURI))
+      new URL(s"$scheme://$leaderData${request.getRequestURI}")
     }
   }
 
-  def doFilter(rawRequest: ServletRequest,
-               rawResponse: ServletResponse,
-               chain: FilterChain) {
+  @tailrec
+  final def doFilter(rawRequest: ServletRequest,
+                     rawResponse: ServletResponse,
+                     chain: FilterChain) {
 
-    if (rawRequest.isInstanceOf[HttpServletRequest]) {
-      val request = rawRequest.asInstanceOf[HttpServletRequest]
-      val response = rawResponse.asInstanceOf[HttpServletResponse]
+    def waitForConsistentLeadership(response: HttpServletResponse): Boolean = {
+      var retries = 10
 
-      // Proxying occurs if we aren't in the leadership position and we know about the other leader (to proxy to).
-      if (schedulerService.isLeader || schedulerService.getLeader.isEmpty) {
-        chain.doFilter(request, response)
-      }
-      else {
-        try {
-          val leaderData = schedulerService.getLeader
+      do {
+        val weAreLeader = leaderInfo.elected
+        val currentLeaderData = leaderInfo.currentLeaderHostPort()
 
-          log.info(s"Proxying request to leader at ${leaderData.get}")
+        if (weAreLeader || currentLeaderData.exists(_ != myHostPort)) {
+          log.info("Leadership info is consistent again!")
+          return true
+        }
 
-          val method = request.getMethod
+        if (retries >= 0) {
+          log.info(s"Waiting for consistent leadership state. Are we leader?: $weAreLeader, leader: $currentLeaderData")
+          sleep()
+        }
+        else {
+          log.error(
+            s"inconsistent leadership state, refusing request for ourselves at $myHostPort. " +
+              s"Are we leader?: $weAreLeader, leader: $currentLeaderData")
+        }
 
-          val proxy =
-            buildUrl(leaderData.get, request)
-              .openConnection().asInstanceOf[HttpURLConnection]
+        retries -= 1
+      } while (retries >= 0)
 
-          // getHeaderNames() and getHeaders() are known to return null, see:
-          //http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getHeaders(java.lang.String)
-          val names = Option(request.getHeaderNames).map(_.asScala).getOrElse(Nil)
+      false
+    }
 
-          for (name <- names) {
-            val values = request.getHeaders(name)
-            if (values != null) {
-              proxy.setRequestProperty(name, values.asScala.mkString(","))
-            }
+    (rawRequest, rawResponse) match {
+      case (request: HttpServletRequest, response: HttpServletResponse) =>
+        lazy val leaderDataOpt = leaderInfo.currentLeaderHostPort()
+
+        if (leaderInfo.elected) {
+          chain.doFilter(request, response)
+        }
+        else if (leaderDataOpt.forall(_ == myHostPort)) { // either not leader or ourselves
+          log.info(
+            s"Do not proxy to myself. Waiting for consistent leadership state. " +
+              s"Are we leader?: false, leader: $leaderDataOpt")
+          if (waitForConsistentLeadership(response)) {
+            doFilter(rawRequest, rawResponse, chain)
           }
-
-          proxy.setRequestMethod(method)
-
-          method match {
-            case "GET" | "HEAD" | "DELETE" =>
-              proxy.setDoOutput(false)
-            case _ =>
-              proxy.setDoOutput(true)
-              if (!names.exists(_.toLowerCase == "content-type"))
-                proxy.setRequestProperty("Content-Type", "application/json")
-
-              val proxyOutputStream = proxy.getOutputStream
-              copy(request.getInputStream, proxyOutputStream)
-              proxyOutputStream.close
+          else {
+            response.sendError(HttpStatus.SC_SERVICE_UNAVAILABLE, ERROR_STATUS_NO_CURRENT_LEADER)
           }
-
-          val status = proxy.getResponseCode
-          response.setStatus(status)
-
-          val responseOutputStream = response.getOutputStream
-
+        }
+        else {
           try {
-            val fields = proxy.getHeaderFields
-            // getHeaderNames() and getHeaders() are known to return null
-            if (fields != null) {
-              for ((name, values) <- fields.asScala) {
-                if (name != null && values != null) {
-                  for (value <- values.asScala) {
-                    response.setHeader(name, value)
-                  }
-                }
-              }
-            }
-            copy(proxy.getInputStream, response.getOutputStream)
-            proxy.getInputStream.close()
+            val url: URL = buildUrl(leaderDataOpt.get, request)
+            forwarder.forward(url, request, response)
           }
           catch {
-            case e: Exception =>
-              copy(proxy.getErrorStream, response.getOutputStream)
-              proxy.getErrorStream().close()
+            case NonFatal(e) =>
+              throw new RuntimeException("while proxying", e)
           }
-          finally {
-            responseOutputStream.close()
-          }
-
         }
-        catch {
-          case e: Exception =>
-            log.warn("Exception while proxying", e)
-        }
-      }
+      case _ =>
+        throw new IllegalArgumentException(s"expected http request/response but got $rawRequest/$rawResponse")
     }
+  }
+
+  protected def sleep(): Unit = {
+    Thread.sleep(250)
   }
 
   def destroy() {
     //NO-OP
   }
+}
+
+object LeaderProxyFilter {
+  private val log = Logger.getLogger(getClass.getName)
+  val ERROR_STATUS_NO_CURRENT_LEADER: String = "Could not determine the current leader"
+}
+
+/**
+  * Forwards a HttpServletRequest to an URL.
+  */
+trait RequestForwarder {
+  def forward(url: URL, request: HttpServletRequest, response: HttpServletResponse): Unit
+}
+
+class JavaUrlConnectionRequestForwarder @Inject() (
+  leaderProxyConf: LeaderProxyConf, @Named(ModuleNames.NAMED_HOST_PORT) myHostPort: String)
+    extends RequestForwarder {
+
+  import JavaUrlConnectionRequestForwarder._
+
+  private[this] val viaValue: String = s"1.1 $myHostPort"
+
+  override def forward(url: URL, request: HttpServletRequest, response: HttpServletResponse): Unit = {
+
+    def hasProxyLoop: Boolean = {
+      val viaOpt = Option(request.getHeaders(HEADER_VIA)).map(_.asScala.toVector)
+      viaOpt.exists(_.contains(viaValue))
+    }
+
+    def copyRequestHeadersToConnection(leaderConnection: HttpURLConnection, request: HttpServletRequest): Unit = {
+      // getHeaderNames() and getHeaders() are known to return null, see:
+      //http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getHeaders(java.lang.String)
+      val names = Option(request.getHeaderNames).map(_.asScala).getOrElse(Nil)
+      for {
+        name <- names
+        // Reverse proxies commonly filter these headers: connection, host.
+        //
+        // The connection header is removed since it may make sense to persist the connection
+        // for further requests even if this single client will stop using it.
+        //
+        // The host header is used to choose the correct virtual host and should be set to the hostname
+        // of the URL for HTTP 1.1. Thus we do not preserve it, even though Marathon does not care.
+        if !name.equalsIgnoreCase("host") && !name.equalsIgnoreCase("connection")
+        headerValues <- Option(request.getHeaders(name))
+        headerValue <- headerValues.asScala
+      } {
+        log.debug(s"addRequestProperty $name: $headerValue")
+        leaderConnection.addRequestProperty(name, headerValue)
+      }
+
+      leaderConnection.addRequestProperty(HEADER_VIA, viaValue)
+    }
+
+    def copyRequestBodyToConnection(leaderConnection: HttpURLConnection, request: HttpServletRequest): Unit = {
+      request.getMethod match {
+        case "GET" | "HEAD" | "DELETE" =>
+          leaderConnection.setDoOutput(false)
+        case _ =>
+          leaderConnection.setDoOutput(true)
+
+          IO.using(request.getInputStream) { requestInput =>
+            IO.using(leaderConnection.getOutputStream) { proxyOutputStream =>
+              copy(request.getInputStream, proxyOutputStream)
+            }
+          }
+      }
+    }
+
+    def copyRequestToConnection(leaderConnection: HttpURLConnection, request: HttpServletRequest): Unit = {
+      leaderConnection.setRequestMethod(request.getMethod)
+      copyRequestHeadersToConnection(leaderConnection, request)
+      copyRequestBodyToConnection(leaderConnection, request)
+    }
+
+    def copyConnectionResponse(leaderConnection: HttpURLConnection, response: HttpServletResponse): Unit = {
+      val status = leaderConnection.getResponseCode
+      response.setStatus(status)
+
+      val fields = leaderConnection.getHeaderFields
+      // getHeaderNames() and getHeaders() are known to return null
+      if (fields != null) {
+        for ((name, values) <- fields.asScala) {
+          if (name != null && values != null) {
+            for (value <- values.asScala) {
+              response.addHeader(name, value)
+            }
+          }
+        }
+      }
+
+      IO.using(response.getOutputStream) { output =>
+        try {
+          IO.using(leaderConnection.getInputStream) { connectionInput => copy(connectionInput, output) }
+        }
+        catch {
+          case e: IOException =>
+            log.debug("got exception response, this is maybe an error code", e)
+            IO.using(leaderConnection.getErrorStream) { connectionError => copy(connectionError, output) }
+        }
+      }
+    }
+
+    log.info(s"Proxying request to ${request.getMethod} $url from $myHostPort")
+
+    try {
+      if (hasProxyLoop) {
+        log.error("Prevent proxy cycle, rejecting request")
+        response.sendError(HttpStatus.SC_BAD_GATEWAY, ERROR_STATUS_LOOP)
+      }
+      else {
+        val leaderConnection: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
+        try {
+          leaderConnection.setConnectTimeout(leaderProxyConf.leaderProxyConnectionTimeout())
+          leaderConnection.setReadTimeout(leaderProxyConf.leaderProxyReadTimeout())
+
+          copyRequestToConnection(leaderConnection, request)
+          copyConnectionResponse(leaderConnection, response)
+        }
+        catch {
+          case connException: ConnectException =>
+            response.sendError(HttpStatus.SC_BAD_GATEWAY, ERROR_STATUS_CONNECTION_REFUSED)
+        }
+        finally {
+          Try(leaderConnection.getInputStream.close())
+          Try(leaderConnection.getErrorStream.close())
+        }
+      }
+    }
+    finally {
+      Try(request.getInputStream.close())
+      Try(response.getOutputStream.close())
+    }
+
+  }
+
+  def copy(nullableIn: InputStream, nullableOut: OutputStream): Unit = {
+    try {
+      for {
+        in <- Option(nullableIn)
+        out <- Option(nullableOut)
+      } IO.transfer(in, out, close = false)
+    }
+    catch {
+      case e: UnknownServiceException =>
+        log.warn("unexpected unknown service exception", e)
+    }
+  }
+}
+
+object JavaUrlConnectionRequestForwarder {
+  private val log = LoggerFactory.getLogger(getClass)
+
+  /** Header for proxy loop detection. Simply "Via" is ignored by the URL connection.*/
+  val HEADER_VIA: String = "X-Marathon-Via"
+  val ERROR_STATUS_LOOP: String = "Detected proxying loop."
+  val ERROR_STATUS_CONNECTION_REFUSED: String = "Connection to leader refused."
+
 }

--- a/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
@@ -32,6 +32,7 @@ class MarathonRestModule extends RestModule {
     bind(classOf[v2.SchemaResource]).in(Scopes.SINGLETON)
 
     // This filter will redirect to the master if running in HA mode.
+    bind(classOf[RequestForwarder]).to(classOf[JavaUrlConnectionRequestForwarder]).in(Scopes.SINGLETON)
     bind(classOf[LeaderProxyFilter]).asEagerSingleton()
     filter("/*").through(classOf[LeaderProxyFilter])
 

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -5,11 +5,12 @@ import javax.ws.rs.{ GET, DELETE, Path, Produces }
 
 import com.google.inject.Inject
 import mesosphere.chaos.http.HttpConf
-import mesosphere.marathon.api.RestResource
+import mesosphere.marathon.api.{ LeaderInfo, RestResource }
 import mesosphere.marathon.{ MarathonSchedulerService, MarathonConf }
 
 @Path("v2/leader")
 class LeaderResource @Inject() (
+  leaderInfo: LeaderInfo,
   schedulerService: MarathonSchedulerService,
   val config: MarathonConf with HttpConf)
     extends RestResource {
@@ -17,7 +18,7 @@ class LeaderResource @Inject() (
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
   def index(): Response = {
-    schedulerService.getLeader match {
+    leaderInfo.currentLeaderHostPort() match {
       case None => notFound("There is no leader")
       case Some(leader) =>
         ok(Map("leader" -> leader))
@@ -27,7 +28,7 @@ class LeaderResource @Inject() (
   @DELETE
   @Produces(Array(MediaType.APPLICATION_JSON))
   def delete(): Response = {
-    schedulerService.isLeader match {
+    leaderInfo.elected match {
       case false => notFound("There is no leader")
       case true =>
         schedulerService.abdicateLeadership()

--- a/src/main/scala/mesosphere/marathon/io/CancelableDownload.scala
+++ b/src/main/scala/mesosphere/marathon/io/CancelableDownload.scala
@@ -17,7 +17,7 @@ import mesosphere.util.ThreadPoolContext.context
   * @param provider the storage provider
   * @param path the path inside the storage, to store the content of the url stream.
   */
-final class CancelableDownload(val url: URL, val provider: StorageProvider, val path: String) extends IO with Logging {
+final class CancelableDownload(val url: URL, val provider: StorageProvider, val path: String) extends Logging {
 
   val tempItem = provider.item(path + UUID.randomUUID().toString)
   var canceled = false
@@ -25,8 +25,8 @@ final class CancelableDownload(val url: URL, val provider: StorageProvider, val 
 
   lazy val get: Future[CancelableDownload] = Future {
     log.info(s"Download started from $url to path $path")
-    using(url.openStream()) { in =>
-      tempItem.store { out => transfer(in, out, close = false, !canceled) }
+    IO.using(url.openStream()) { in =>
+      tempItem.store { out => IO.transfer(in, out, close = false, !canceled) }
     }
     if (!canceled) {
       log.info(s"Download finished from $url to path $path")

--- a/src/main/scala/mesosphere/marathon/io/PathFun.scala
+++ b/src/main/scala/mesosphere/marathon/io/PathFun.scala
@@ -10,7 +10,7 @@ import org.apache.commons.io.FilenameUtils.getName
 
 import mesosphere.util.ThreadPoolContext.context
 
-trait PathFun extends IO {
+trait PathFun {
 
   private[this] def md = MessageDigest.getInstance("SHA-1")
 
@@ -27,7 +27,7 @@ trait PathFun extends IO {
     val eTag: Option[String] = header.get("ETag")
       .flatMap(_.filterNot(_.startsWith("W/")).headOption)
       .map(_.replaceAll("[^A-z0-9\\-]", ""))
-    val contentPart = eTag.getOrElse(mdSum(url.openStream()))
+    val contentPart = eTag.getOrElse(IO.mdSum(url.openStream()))
     s"$contentPart/${fileName(url)}"
   }
 

--- a/src/main/scala/mesosphere/marathon/io/storage/FileStorageProvider.scala
+++ b/src/main/scala/mesosphere/marathon/io/storage/FileStorageProvider.scala
@@ -2,6 +2,8 @@ package mesosphere.marathon.io.storage
 
 import java.io._
 
+import mesosphere.marathon.io.IO
+
 /**
   * The local file system implementation.
   *
@@ -11,14 +13,14 @@ import java.io._
 case class FileStorageItem(file: File, basePath: File, path: String, baseUrl: String) extends StorageItem {
 
   def store(fn: OutputStream => Unit): FileStorageItem = {
-    createDirectory(file.getParentFile)
-    using(new FileOutputStream(file)) { fn }
+    IO.createDirectory(file.getParentFile)
+    IO.using(new FileOutputStream(file)) { fn }
     this
   }
 
   def moveTo(path: String): FileStorageItem = {
     val to = new File(basePath, path)
-    moveFile(file, to)
+    IO.moveFile(file, to)
     cleanUpDir(file.getParentFile)
     FileStorageItem(to, basePath, path, url)
   }

--- a/src/main/scala/mesosphere/marathon/io/storage/HDFSStorageProvider.scala
+++ b/src/main/scala/mesosphere/marathon/io/storage/HDFSStorageProvider.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.io.storage
 import java.io.{ InputStream, OutputStream }
 import java.net.URI
 
+import mesosphere.marathon.io.IO
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{ FileSystem, Path }
 
@@ -15,7 +16,7 @@ import org.apache.hadoop.fs.{ FileSystem, Path }
 case class HDFSStorageItem(fs: FileSystem, fsPath: Path, base: String, path: String) extends StorageItem {
 
   def store(fn: (OutputStream) => Unit): StorageItem = {
-    using(fs.create(fsPath, true)) { fn }
+    IO.using(fs.create(fsPath, true)) { fn }
     this
   }
 

--- a/src/main/scala/mesosphere/marathon/io/storage/Storage.scala
+++ b/src/main/scala/mesosphere/marathon/io/storage/Storage.scala
@@ -13,7 +13,7 @@ import mesosphere.marathon.io.IO
   * The storage item is an entry in the storage, which is identified by a path.
   * The path is the unique identifier.
   */
-trait StorageItem extends IO {
+trait StorageItem {
 
   /**
     * The provider independent path of the item.
@@ -66,8 +66,8 @@ trait StorageItem extends IO {
     * Store this item with given file input.
     */
   def store(from: File): StorageItem = {
-    using(new FileInputStream(from)) { in =>
-      store(out => transfer(in, out))
+    IO.using(new FileInputStream(from)) { in =>
+      store(out => IO.transfer(in, out))
     }
   }
 
@@ -75,8 +75,8 @@ trait StorageItem extends IO {
     * Store this item with given item input.
     */
   def store(from: StorageItem): StorageItem = {
-    using(from.inputStream()) { in =>
-      store(out => transfer(in, out))
+    IO.using(from.inputStream()) { in =>
+      store(out => IO.transfer(in, out))
     }
   }
 
@@ -84,7 +84,7 @@ trait StorageItem extends IO {
     * Store this item with given input stream.
     */
   def store(in: InputStream): StorageItem = {
-    store(out => transfer(in, out))
+    store(out => IO.transfer(in, out))
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/upgrade/ResolveArtifactsActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/ResolveArtifactsActor.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon.upgrade
 
 import java.net.URL
-import scala.concurrent.Promise
 
 import akka.actor.Actor
 import akka.actor.Status.Failure
@@ -9,9 +8,11 @@ import akka.pattern.pipe
 
 import mesosphere.marathon.ResolveArtifactsCanceledException
 import mesosphere.marathon.io.storage.StorageProvider
-import mesosphere.marathon.io.{ CancelableDownload, IO, PathFun }
+import mesosphere.marathon.io.{ CancelableDownload, PathFun }
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.util.Logging
+
+import scala.concurrent.Promise
 
 class ResolveArtifactsActor(
   app: AppDefinition,
@@ -19,7 +20,6 @@ class ResolveArtifactsActor(
   promise: Promise[Boolean],
   storage: StorageProvider)
     extends Actor
-    with IO
     with PathFun
     with Logging {
 

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -1,14 +1,13 @@
 package mesosphere.marathon
 
-import java.util.{ TimerTask, Timer }
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.{ Timer, TimerTask }
 
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.testkit.{ TestKit, TestProbe }
-import com.google.inject.Provider
 import com.twitter.common.base.ExceptionalCommand
-import com.twitter.common.zookeeper.{ Group, Candidate }
 import com.twitter.common.zookeeper.Group.JoinException
+import com.twitter.common.zookeeper.{ Candidate, Group }
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.health.HealthCheckManager
@@ -16,16 +15,15 @@ import mesosphere.marathon.state.{ AppRepository, Migration }
 import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.mesos.util.FrameworkIdUtil
 import mesosphere.util.BackToTheFuture.Timeout
-import org.apache.mesos.SchedulerDriver
-import org.apache.mesos.{ Protos => mesos }
 import org.apache.mesos.state.InMemoryState
+import org.apache.mesos.{ Protos => mesos, SchedulerDriver }
 import org.mockito.Matchers.{ any, eq => mockEq }
 import org.mockito.Mockito
 import org.mockito.Mockito.{ times, verify, when }
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.rogach.scallop.ScallopOption
-import org.scalatest.{ Matchers, BeforeAndAfterAll }
+import org.scalatest.{ BeforeAndAfterAll, Matchers }
 
 import scala.concurrent.duration._
 
@@ -254,6 +252,6 @@ class MarathonSchedulerServiceTest
     schedulerService.onElected(mock[ExceptionalCommand[Group.JoinException]])
 
     awaitAssert { verify(candidate.get).offerLeadership(schedulerService) }
-    assert(schedulerService.isLeader == false)
+    assert(leader.get() == false)
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/LeaderProxyFilterTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/LeaderProxyFilterTest.scala
@@ -1,0 +1,191 @@
+package mesosphere.marathon.api
+
+import java.net.URL
+import javax.servlet.FilterChain
+import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
+
+import mesosphere.chaos.http.HttpConf
+import mesosphere.marathon.MarathonSpec
+import org.apache.http.HttpStatus
+import org.mockito.Mockito._
+import org.rogach.scallop.ScallopConf
+
+class LeaderProxyFilterTest extends MarathonSpec {
+
+  def httpConf(args: String*): HttpConf = {
+    val conf = new ScallopConf(args) with HttpConf {
+      // scallop will trigger sys exit
+      override protected def onError(e: Throwable): Unit = throw e
+    }
+    conf.afterInit()
+    conf
+  }
+
+  var leaderInfo: LeaderInfo = _
+  var forwarder: RequestForwarder = _
+  var filter: LeaderProxyFilter = _
+  var request: HttpServletRequest = _
+  var response: HttpServletResponse = _
+  var chain: FilterChain = _
+
+  def init(conf: HttpConf = httpConf()) {
+    leaderInfo = mock[LeaderInfo]("leaderInfo")
+    forwarder = mock[RequestForwarder]("forwarder")
+    filter = new LeaderProxyFilter(conf, leaderInfo, "host:10000", forwarder) {
+      override def sleep() = {}
+    }
+    request = mock[HttpServletRequest]("request")
+    response = mock[HttpServletResponse]("response")
+    chain = mock[FilterChain]("chain")
+  }
+
+  after {
+    verifyNoMoreInteractions(leaderInfo, forwarder, request, response, chain)
+    leaderInfo = null
+    forwarder = null
+    filter = null
+    request = null
+    response = null
+    chain = null
+  }
+
+  test("we are leader") {
+    // When we are leader
+    init()
+    when(leaderInfo.elected).thenReturn(true)
+
+    // And doFilter is called
+    filter.doFilter(request, response, chain)
+
+    // we pass that request down the chain
+    verify(leaderInfo, times(1)).elected
+    verify(chain, times(1)).doFilter(request, response)
+  }
+
+  test("try to wait for leadership info then give up") {
+    // When we are leader but there are not other options
+    init()
+    when(leaderInfo.elected).thenReturn(false)
+    when(leaderInfo.currentLeaderHostPort()).thenReturn(None)
+
+    // And doFilter is called
+    filter.doFilter(request, response, chain)
+
+    // we pass that request down the chain
+    verify(leaderInfo, times(12)).elected
+    verify(leaderInfo, times(12)).currentLeaderHostPort()
+    verify(response, times(1))
+      .sendError(HttpStatus.SC_SERVICE_UNAVAILABLE, LeaderProxyFilter.ERROR_STATUS_NO_CURRENT_LEADER)
+  }
+
+  test("forward to leader without query string") {
+    // When someone else is leader
+    init()
+    when(leaderInfo.elected).thenReturn(false)
+    when(leaderInfo.currentLeaderHostPort()).thenReturn(Some("otherhost:9999"))
+    when(request.getRequestURI).thenReturn("/test")
+    when(request.getQueryString).thenReturn(null)
+
+    // And doFilter is called
+    filter.doFilter(request, response, chain)
+
+    // we pass that request down the chain
+    verify(leaderInfo, times(1)).elected
+    verify(leaderInfo, times(1)).currentLeaderHostPort()
+    verify(request, atLeastOnce()).getRequestURI
+    verify(request, atLeastOnce()).getQueryString
+    verify(forwarder, times(1)).forward(new URL("http://otherhost:9999/test"), request, response)
+  }
+
+  test("forward to leader with query string") {
+    // When someone else is leader
+    init()
+    when(leaderInfo.elected).thenReturn(false)
+    when(leaderInfo.currentLeaderHostPort()).thenReturn(Some("otherhost:9999"))
+    when(request.getRequestURI).thenReturn("/test")
+    when(request.getQueryString).thenReturn("argument=blieh")
+
+    // And doFilter is called
+    filter.doFilter(request, response, chain)
+
+    // we pass that request down the chain
+    verify(leaderInfo, times(1)).elected
+    verify(leaderInfo, times(1)).currentLeaderHostPort()
+    verify(request, atLeastOnce()).getRequestURI
+    verify(request, atLeastOnce()).getQueryString
+    verify(forwarder, times(1)).forward(new URL("http://otherhost:9999/test?argument=blieh"), request, response)
+  }
+
+  test("use https if http is disabled") {
+    // When someone else is leader
+    init(conf = httpConf("--disable_http"))
+    when(leaderInfo.elected).thenReturn(false)
+    when(leaderInfo.currentLeaderHostPort()).thenReturn(Some("otherhost:9999"))
+    when(request.getRequestURI).thenReturn("/test")
+    when(request.getQueryString).thenReturn(null)
+
+    // And doFilter is called
+    filter.doFilter(request, response, chain)
+
+    // we pass that request down the chain
+    verify(leaderInfo, times(1)).elected
+    verify(leaderInfo, times(1)).currentLeaderHostPort()
+    verify(request, atLeastOnce()).getRequestURI
+    verify(request, atLeastOnce()).getQueryString
+    verify(forwarder, times(1)).forward(new URL("https://otherhost:9999/test"), request, response)
+  }
+
+  test("successfully wait for consistent leadership info, then someone else is the leader") {
+    // When we have inconsistent leadership info
+    init()
+    when(leaderInfo.elected).thenReturn(false)
+    when(leaderInfo.currentLeaderHostPort()).thenReturn(Some("host:10000"), Some("host:10000"), Some("otherhost:9999"))
+    when(request.getRequestURI).thenReturn("/test")
+    when(request.getQueryString).thenReturn(null)
+
+    // And doFilter is called
+    filter.doFilter(request, response, chain)
+
+    // we pass that request down the chain
+    verify(leaderInfo, times(4)).elected
+    verify(leaderInfo, times(4)).currentLeaderHostPort()
+    verify(forwarder, times(1)).forward(new URL("http://otherhost:9999/test"), request, response)
+    verify(request, atLeastOnce()).getRequestURI
+    verify(request, atLeastOnce()).getQueryString
+  }
+
+  test("successfully wait for consistent leadership info, then we are leader") {
+    // When we have inconsistent leadership info
+    init()
+    when(leaderInfo.elected).thenReturn(false, false, true)
+    when(leaderInfo.currentLeaderHostPort()).thenReturn(Some("host:10000"))
+    when(request.getRequestURI).thenReturn("/test")
+    when(request.getQueryString).thenReturn(null)
+
+    // And doFilter is called
+    filter.doFilter(request, response, chain)
+
+    // we pass that request down the chain
+    verify(leaderInfo, times(4)).elected
+    verify(leaderInfo, times(3)).currentLeaderHostPort()
+    verify(chain, times(1)).doFilter(request, response)
+  }
+
+  test("give up waiting for consistent leadership info") {
+    // When we have inconsistent leadership info
+    init()
+    when(leaderInfo.elected).thenReturn(false)
+    when(leaderInfo.currentLeaderHostPort()).thenReturn(Some("host:10000"))
+    when(request.getRequestURI).thenReturn("/test")
+    when(request.getQueryString).thenReturn(null)
+
+    // And doFilter is called
+    filter.doFilter(request, response, chain)
+
+    // we pass that request down the chain
+    verify(leaderInfo, times(12)).elected
+    verify(leaderInfo, times(12)).currentLeaderHostPort()
+    verify(response, times(1))
+      .sendError(HttpStatus.SC_SERVICE_UNAVAILABLE, LeaderProxyFilter.ERROR_STATUS_NO_CURRENT_LEADER)
+  }
+}

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -37,6 +37,22 @@ class AppDeployIntegrationTest
     waitForTasks(app.id, 1) //make sure, the app has really started
   }
 
+  test("create a simple app without health checks via secondary (proxying)") {
+    if (!config.useExternalSetup) {
+      Given("a new app")
+      val app = appProxy(testBasePath / "app", "v1", instances = 1, withHealth = false)
+
+      When("The app is deployed")
+      val result = marathonProxy.createApp(app)
+
+      Then("The app is created")
+      result.code should be (201) //Created
+      extractDeploymentIds(result) should have size 1
+      waitForEvent("deployment_success")
+      waitForTasks(app.id, 1) //make sure, the app has really started
+    }
+  }
+
   test("create a simple app with http health checks") {
     Given("a new app")
     val app = appProxy(testBasePath / "http-app", "v1", instances = 1, withHealth = false).

--- a/src/test/scala/mesosphere/marathon/integration/ForwardToLeaderIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ForwardToLeaderIntegrationTest.scala
@@ -1,0 +1,95 @@
+package mesosphere.marathon.integration
+
+import akka.actor.ActorSystem
+import mesosphere.marathon.integration.setup.{ AppMockFacade, ForwarderService, IntegrationFunSuite, ProcessKeeper }
+import org.apache.commons.httpclient.HttpStatus
+import org.scalatest.BeforeAndAfter
+
+/**
+  * Tests forwarding requests.
+  */
+class ForwardToLeaderIntegrationTest extends IntegrationFunSuite with BeforeAndAfter {
+  // ports to bind to
+  private[this] val ports = 10000 to 20000
+
+  implicit var actorSystem: ActorSystem = _
+
+  before {
+    actorSystem = ActorSystem()
+  }
+
+  after {
+    actorSystem.shutdown()
+    actorSystem.awaitTermination()
+    ProcessKeeper.shutdown()
+  }
+
+  test("direct ping") {
+    ProcessKeeper.startService(ForwarderService.createHelloApp(ports.head))
+    val appFacade = new AppMockFacade()
+    val result = appFacade.ping("localhost", port = ports.head)
+    assert(result.originalResponse.status.intValue == 200)
+    assert(result.entityString == "pong\n")
+  }
+
+  test("forwarding ping") {
+    // We cannot start two service in one process because of static variables in GuiceFilter
+    ForwarderService.startHelloAppProcess(ports.head)
+    ProcessKeeper.startService(ForwarderService.createForwarder(port = ports(1), forwardToPort = ports.head))
+    val appFacade = new AppMockFacade()
+    val result = appFacade.ping("localhost", port = ports(1))
+    assert(result.originalResponse.status.intValue == 200)
+    assert(result.entityString == "pong\n")
+  }
+
+  test("direct 404") {
+    ProcessKeeper.startService(ForwarderService.createHelloApp(ports.head))
+    val appFacade = new AppMockFacade()
+    val result = appFacade.custom("/notfound")("localhost", port = ports.head)
+    assert(result.originalResponse.status.intValue == 404)
+  }
+
+  test("forwarding 404") {
+    // We cannot start two service in one process because of static variables in GuiceFilter
+    ForwarderService.startHelloAppProcess(ports.head)
+    ProcessKeeper.startService(ForwarderService.createForwarder(port = ports(1), forwardToPort = ports.head))
+    val appFacade = new AppMockFacade()
+    val result = appFacade.custom("/notfound")("localhost", port = ports(1))
+    assert(result.originalResponse.status.intValue == 404)
+  }
+
+  test("direct internal server error") {
+    ProcessKeeper.startService(ForwarderService.createHelloApp(ports.head))
+    val appFacade = new AppMockFacade()
+    val result = appFacade.custom("/hello/crash")("localhost", port = ports.head)
+    assert(result.originalResponse.status.intValue == 500)
+    assert(result.entityString == "Error")
+  }
+
+  test("forwarding internal server error") {
+    // We cannot start two service in one process because of static variables in GuiceFilter
+    ForwarderService.startHelloAppProcess(ports.head)
+    ProcessKeeper.startService(ForwarderService.createForwarder(port = ports(1), forwardToPort = ports.head))
+    val appFacade = new AppMockFacade()
+    val result = appFacade.custom("/hello/crash")("localhost", port = ports(1))
+    assert(result.originalResponse.status.intValue == 500)
+    assert(result.entityString == "Error")
+  }
+
+  test("forwarding connection failed") {
+    ProcessKeeper.startService(ForwarderService.createForwarder(port = ports(1), forwardToPort = ports.head))
+    val appFacade = new AppMockFacade()
+    val result = appFacade.ping("localhost", port = ports(1))
+    assert(result.originalResponse.status.intValue == HttpStatus.SC_BAD_GATEWAY)
+  }
+
+  test("forwarding loop") {
+    // We cannot start two service in one process because of static variables in GuiceFilter
+    ForwarderService.startForwarderProcess(ports.head, forwardToPort = ports(1))
+    ProcessKeeper.startService(ForwarderService.createForwarder(port = ports(1), forwardToPort = ports.head))
+    val appFacade = new AppMockFacade()
+    val result = appFacade.ping("localhost", port = ports(1))
+    assert(result.originalResponse.status.intValue == HttpStatus.SC_BAD_GATEWAY)
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/integration/setup/AppMockFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/AppMockFacade.scala
@@ -25,9 +25,11 @@ class AppMockFacade(waitTime: Duration = 30.seconds)(implicit system: ActorSyste
   }
 
   val pipeline = sendReceive
-  def ping(host: String, port: Int): RestResult[String] = {
+  def ping(host: String, port: Int): RestResult[String] = custom("/ping")(host, port)
+
+  def custom(uri: String)(host: String, port: Int): RestResult[String] = {
     retry() {
-      RestResult.await(pipeline(Get(s"http://$host:$port/ping")), waitTime).map(_.entity.asString)
+      RestResult.await(pipeline(Get(s"http://$host:$port$uri")), waitTime).map(_.entity.asString)
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
@@ -1,0 +1,118 @@
+package mesosphere.marathon.integration.setup
+
+import javax.inject.{ Inject, Named }
+import javax.ws.rs.core.Response
+import javax.ws.rs.{ GET, Path }
+
+import com.google.common.util.concurrent.Service
+import com.google.inject._
+import mesosphere.chaos.http.{ HttpConf, HttpModule, HttpService, RestModule }
+import mesosphere.chaos.metrics.MetricsModule
+import mesosphere.marathon.api._
+import mesosphere.marathon.{ LeaderProxyConf, ModuleNames }
+import org.rogach.scallop.ScallopConf
+import org.slf4j.LoggerFactory
+
+object ForwarderService {
+  private val log = LoggerFactory.getLogger(getClass)
+  val className = {
+    val withDollar = getClass.getName
+    withDollar.substring(0, withDollar.length - 1)
+  }
+
+  @Path("hello")
+  class PingResource @Inject() () {
+    @GET
+    def index(): Response = {
+      Response.ok().entity("Hi").build()
+    }
+
+    @GET
+    @Path("/crash")
+    def crash(): Response = {
+      Response.serverError().entity("Error").build()
+    }
+  }
+
+  class LeaderInfoModule(elected: Boolean, leaderHostPort: Option[String]) extends AbstractModule {
+    log.info(s"Leader configuration: elected=$elected leaderHostPort=$leaderHostPort")
+
+    override def configure(): Unit = {
+      val electedAlias = elected
+      val leaderInfo = new LeaderInfo {
+        override def elected: Boolean = electedAlias
+        override def currentLeaderHostPort(): Option[String] = leaderHostPort
+      }
+
+      bind(classOf[LeaderInfo]).toInstance(leaderInfo)
+    }
+  }
+
+  class ForwarderAppModule(myHostPort: String, httpConf: HttpConf, leaderProxyConf: LeaderProxyConf) extends RestModule {
+    @Named(ModuleNames.NAMED_HOST_PORT)
+    @Provides
+    @Singleton
+    def provideHostPort(httpConf: HttpConf): String = myHostPort
+
+    override def configureServlets(): Unit = {
+      super.configureServlets()
+
+      bind(classOf[HttpConf]).toInstance(httpConf)
+      bind(classOf[LeaderProxyConf]).toInstance(leaderProxyConf)
+      bind(classOf[PingResource]).in(Scopes.SINGLETON)
+      bind(classOf[RequestForwarder]).to(classOf[JavaUrlConnectionRequestForwarder]).asEagerSingleton()
+      bind(classOf[LeaderProxyFilter]).asEagerSingleton()
+      filter("/*").through(classOf[LeaderProxyFilter])
+    }
+  }
+
+  def main(args: Array[String]) {
+    val service = args(0) match {
+      case "helloApp" =>
+        createHelloApp(port = args(1).toInt)
+      case "forwarder" =>
+        createForwarder(port = args(1).toInt, forwardToPort = args(2).toInt)
+    }
+    service.startAsync().awaitRunning()
+    service.awaitTerminated()
+  }
+
+  def startHelloAppProcess(port: Int): Unit = {
+    ProcessKeeper.startJavaProcess(
+      s"app_$port",
+      arguments = List(ForwarderService.className, "helloApp", port.toString),
+      upWhen = _.contains("Started SelectChannelConnector"))
+  }
+
+  def startForwarderProcess(port: Int, forwardToPort: Int): Unit = {
+    ProcessKeeper.startJavaProcess(
+      s"forwarder_$port",
+      arguments = List(ForwarderService.className, "forwarder", port.toString, forwardToPort.toString),
+      upWhen = _.contains("Started SelectChannelConnector"))
+  }
+
+  def createHelloApp(port: Int): Service = {
+    log.info(s"Start hello app at $port")
+    startImpl(port, new LeaderInfoModule(elected = true, leaderHostPort = None))
+  }
+
+  def createForwarder(port: Int, forwardToPort: Int): Service = {
+    log.info(s"Start forwarder on port $port, forwarding to $forwardToPort")
+    startImpl(port, new LeaderInfoModule(elected = false, leaderHostPort = Some(s"localhost:$forwardToPort")))
+  }
+
+  private def startImpl(port: Int, leaderModule: Module, assetPath: String = "/tmp"): Service = {
+    val conf = new ScallopConf(Array(
+      "--http_port", port.toString,
+      "--assets_path", assetPath)) with HttpConf with LeaderProxyConf
+    conf.afterInit()
+    val injector = Guice.createInjector(
+      new MetricsModule, new HttpModule(conf),
+      new ForwarderAppModule(myHostPort = s"localhost:$port", conf, conf),
+      leaderModule
+    )
+    val http = injector.getInstance(classOf[HttpService])
+    http
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -46,6 +46,11 @@ trait SingleMarathonIntegrationTest
   val testBasePath: PathId = PathId("/marathonintegrationtest")
   override lazy val marathon: MarathonFacade = new MarathonFacade(config.marathonUrl, testBasePath)
 
+  lazy val marathonProxy = {
+    startMarathon(config.marathonPort + 1, "--master", config.master, "--event_subscriber", "http_callback")
+    new MarathonFacade(config.copy(marathonPort = config.marathonPort + 1).marathonUrl, testBasePath)
+  }
+
   implicit class PathIdTestHelper(path: String) {
     def toRootTestPath: PathId = testBasePath.append(path).canonicalPath()
     def toTestPath: PathId = testBasePath.append(path)


### PR DESCRIPTION
also:

* prevent excessive calling of MarathonSchedulerService.getLeaderData
  since that results in synchronous Zookeeper calls (now we call
  it once per request instead of four times)
* provide a metric for getLeaderData
* wait for consistent leadership data if necessary