### PR TITLE
Fixes #1625 - Close stream handle when the current instance loses

### DIFF
--- a/src/main/java/mesosphere/marathon/metrics/MetricPrefixes.scala
+++ b/src/main/java/mesosphere/marathon/metrics/MetricPrefixes.scala
@@ -1,0 +1,12 @@
+package mesosphere.marathon.metrics
+
+object MetricPrefixes {
+  /**
+   * Metrics relating to our API.
+   */
+  val API = "api"
+  /**
+   * Metrics relating to the application code.
+   */
+  val SERVICE = "service"
+}

--- a/src/main/java/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/java/mesosphere/marathon/metrics/Metrics.scala
@@ -1,8 +1,9 @@
 package mesosphere.marathon.metrics
 
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 
-import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.{Gauge, MetricRegistry}
 import com.google.inject.Inject
 import mesosphere.marathon.metrics.Metrics.{Histogram, Meter, Timer}
 import org.aopalliance.intercept.MethodInvocation
@@ -37,6 +38,11 @@ class Metrics @Inject() (val registry: MetricRegistry) {
 
   def histogram(name: String): Histogram = {
     new Histogram(registry.histogram(name))
+  }
+
+  def gauge[G <: Gauge[_]](name: String, gauge: G): G = {
+    registry.register(name, gauge)
+    gauge
   }
 
   def name(prefix: String, clazz: Class[_], method: String): String = {
@@ -88,5 +94,12 @@ object Metrics {
     def mark(n: Long): Unit = {
       meter.mark(n)
     }
+  }
+
+  class AtomicIntGauge extends Gauge[Int] {
+    private[this] val value_ = new AtomicInteger(0)
+
+    def setValue(l: Int): Unit = value_.set(l)
+    override def getValue: Int = value_.get()
   }
 }

--- a/src/main/scala/mesosphere/marathon/DebugConf.scala
+++ b/src/main/scala/mesosphere/marathon/DebugConf.scala
@@ -4,7 +4,7 @@ import javax.inject.Provider
 
 import com.google.inject.{ Scopes, AbstractModule }
 import com.google.inject.matcher.{ AbstractMatcher, Matchers }
-import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import org.aopalliance.intercept.{ MethodInterceptor, MethodInvocation }
 import org.apache.log4j.{ Level, Logger }
 import org.rogach.scallop.ScallopConf
@@ -39,7 +39,7 @@ class DebugModule(conf: DebugConf) extends AbstractModule {
     override def invoke(in: MethodInvocation): AnyRef = {
       val metrics: Metrics = metricsProvider.get
 
-      metrics.timed(metrics.name("service", in)) {
+      metrics.timed(metrics.name(MetricPrefixes.SERVICE, in)) {
         in.proceed
       }
     }

--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -25,8 +25,6 @@ case class CanceledActionException(msg: String) extends Exception(msg)
 
 case class ConflictingChangeException(msg: String) extends Exception(msg)
 
-case class LostLeadershipException(msg: String) extends Exception(msg)
-
 /*
  * Task upgrade specific exceptions
  */

--- a/src/main/scala/mesosphere/marathon/MarathonLeaderInfo.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonLeaderInfo.scala
@@ -3,14 +3,18 @@ package mesosphere.marathon
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.{ Named, Inject }
 
+import akka.actor.ActorRef
+import akka.event.{ EventStream, EventBus }
 import com.twitter.common.zookeeper.Candidate
 import mesosphere.marathon.api.LeaderInfo
+import mesosphere.marathon.event.{ LocalLeadershipEvent, EventModule }
 import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import mesosphere.marathon.metrics.Metrics.Timer
 
 class MarathonLeaderInfo @Inject() (
     @Named(ModuleNames.NAMED_CANDIDATE) candidate: Option[Candidate],
     @Named(ModuleNames.NAMED_LEADER_ATOMIC_BOOLEAN) leader: AtomicBoolean,
+    @Named(EventModule.busName) eventStream: EventStream,
     metrics: MarathonLeaderInfoMetrics) extends LeaderInfo {
 
   /** Query whether we are the current leader. This should be cheap. */
@@ -22,6 +26,24 @@ class MarathonLeaderInfo @Inject() (
         new String(data, "UTF-8")
       }
     }
+  }
+
+  /**
+    * Subscribe to leadership change events.
+    *
+    * The given actorRef will initally get the current state via the appropriate
+    * [[mesosphere.marathon.event.LocalLeadershipEvent]] message and will
+    * be informed of changes after that.
+    */
+  override def subscribe(self: ActorRef): Unit = {
+    eventStream.subscribe(self, classOf[LocalLeadershipEvent])
+    val currentState = if (elected) LocalLeadershipEvent.ElectedAsLeader else LocalLeadershipEvent.Standby
+    self ! currentState
+  }
+
+  /** Unsubscribe to any leadership change events to this actor ref. */
+  override def unsubscribe(self: ActorRef): Unit = {
+    eventStream.unsubscribe(self, classOf[LocalLeadershipEvent])
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/MarathonLeaderInfo.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonLeaderInfo.scala
@@ -5,7 +5,7 @@ import javax.inject.{ Named, Inject }
 
 import com.twitter.common.zookeeper.Candidate
 import mesosphere.marathon.api.LeaderInfo
-import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import mesosphere.marathon.metrics.Metrics.Timer
 
 class MarathonLeaderInfo @Inject() (
@@ -27,6 +27,6 @@ class MarathonLeaderInfo @Inject() (
 
 class MarathonLeaderInfoMetrics @Inject() (metrics: Metrics) {
   val getLeaderDataTimer: Timer =
-    metrics.timer(metrics.name("service", getClass, "current-leader-host-port"))
+    metrics.timer(metrics.name(MetricPrefixes.SERVICE, getClass, "current-leader-host-port"))
 }
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -16,7 +16,7 @@ import com.twitter.common.zookeeper.Candidate.Leader
 import com.twitter.common.zookeeper.Group.JoinException
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.event.LocalLeadershipEvent
+import mesosphere.marathon.event.{ EventModule, LocalLeadershipEvent }
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.{ AppDefinition, AppRepository, Migration, PathId, Timestamp }
 import mesosphere.marathon.tasks.TaskTracker
@@ -49,7 +49,7 @@ class MarathonSchedulerService @Inject() (
     system: ActorSystem,
     migration: Migration,
     @Named("schedulerActor") schedulerActor: ActorRef,
-    eventStream: EventStream) extends AbstractExecutionThreadService with Leader {
+    @Named(EventModule.busName) eventStream: EventStream) extends AbstractExecutionThreadService with Leader {
 
   import mesosphere.util.ThreadPoolContext.context
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -6,6 +6,7 @@ import java.util.{ Timer, TimerTask }
 import javax.inject.{ Inject, Named }
 
 import akka.actor.{ ActorRef, ActorSystem }
+import akka.event.EventStream
 import akka.pattern.{ after, ask }
 import akka.util.Timeout
 import com.google.common.util.concurrent.AbstractExecutionThreadService
@@ -15,6 +16,7 @@ import com.twitter.common.zookeeper.Candidate.Leader
 import com.twitter.common.zookeeper.Group.JoinException
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.event.LocalLeadershipEvent
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.{ AppDefinition, AppRepository, Migration, PathId, Timestamp }
 import mesosphere.marathon.tasks.TaskTracker
@@ -46,7 +48,8 @@ class MarathonSchedulerService @Inject() (
     driverFactory: SchedulerDriverFactory,
     system: ActorSystem,
     migration: Migration,
-    @Named("schedulerActor") schedulerActor: ActorRef) extends AbstractExecutionThreadService with Leader {
+    @Named("schedulerActor") schedulerActor: ActorRef,
+    eventStream: EventStream) extends AbstractExecutionThreadService with Leader {
 
   import mesosphere.util.ThreadPoolContext.context
 
@@ -273,7 +276,7 @@ class MarathonSchedulerService @Inject() (
   private def defeatLeadership(): Unit = {
     log.info("Defeat leadership")
 
-    schedulerActor ! Suspend(LostLeadershipException("Leadership was defeated"))
+    eventStream.publish(LocalLeadershipEvent.Standby)
 
     timer.cancel()
     timer = newTimer()
@@ -291,7 +294,7 @@ class MarathonSchedulerService @Inject() (
     leader.set(true)
     runDriver(abdicateOption)
 
-    schedulerActor ! Start
+    eventStream.publish(LocalLeadershipEvent.ElectedAsLeader)
 
     // Start the timer
     schedulePeriodicOperations()

--- a/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
@@ -7,6 +7,7 @@ import javax.net.ssl.{ HttpsURLConnection, SSLContext }
 import javax.servlet._
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 
+import akka.actor.ActorRef
 import com.google.inject.Inject
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.io.IO
@@ -26,6 +27,17 @@ import scala.util.control.NonFatal
 trait LeaderInfo {
   /** Query whether we are elected as the current leader. This should be cheap. */
   def elected: Boolean
+
+  /**
+    * Subscribe to leadership change events.
+    *
+    * The given actorRef will initally get the current state via the appropriate
+    * [[mesosphere.marathon.event.LocalLeadershipEvent]] message and will
+    * be informed of changes after that.
+    */
+  def subscribe(self: ActorRef)
+  /** Unsubscribe to any leadership change events to this actor ref. */
+  def unsubscribe(self: ActorRef)
 
   /**
     * Query the host/port of the current leader if any. This might involve network round trips

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -40,6 +40,14 @@ object EventModule {
   final val busName = "events"
 }
 
+/** Local leadership events. They are not delivered via the event endpoints. */
+sealed trait LocalLeadershipEvent
+
+object LocalLeadershipEvent {
+  case object ElectedAsLeader
+  case object Standby
+}
+
 sealed trait MarathonEvent {
   val eventType: String
   val timestamp: String

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -44,8 +44,8 @@ object EventModule {
 sealed trait LocalLeadershipEvent
 
 object LocalLeadershipEvent {
-  case object ElectedAsLeader
-  case object Standby
+  case object ElectedAsLeader extends LocalLeadershipEvent
+  case object Standby extends LocalLeadershipEvent
 }
 
 sealed trait MarathonEvent {

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
@@ -2,9 +2,15 @@ package mesosphere.marathon.event.http
 
 import akka.actor._
 import akka.event.EventStream
+import com.google.inject.Inject
+import mesosphere.marathon.event.LocalLeadershipEvent
 import mesosphere.marathon.event.http.HttpEventStreamActor._
+import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.metrics.Metrics.AtomicIntGauge
 import org.apache.log4j.Logger
 import play.api.libs.json.Json
+
+import scala.util.Try
 
 /**
   * A HttpEventStreamHandle is a reference to the underlying client http stream.
@@ -16,48 +22,116 @@ trait HttpEventStreamHandle {
   def close(): Unit
 }
 
+class HttpEventStreamActorMetrics @Inject() (metrics: Metrics) {
+  val numberOfStreams: AtomicIntGauge =
+    metrics.gauge(metrics.name("api", getClass, "number-of-streams"), new AtomicIntGauge)
+}
+
 /**
   * This actor handles subscriptions from event stream handler.
   * It subscribes to the event stream and pushes all marathon events to all listener.
   * @param eventStream the marathon event stream
   */
-class HttpEventStreamActor(eventStream: EventStream, maxOutstandingMessages: Int) extends Actor {
+class HttpEventStreamActor(
+  eventStream: EventStream,
+  metrics: HttpEventStreamActorMetrics,
+  handleStreamProps: HttpEventStreamHandle => Props)
+    extends Actor {
   //map from handle to actor
-  private[http] var clients = Map.empty[HttpEventStreamHandle, ActorRef]
+  private[http] var streamHandleActors = Map.empty[HttpEventStreamHandle, ActorRef]
   private[this] val log = Logger.getLogger(getClass)
 
-  override def receive: Receive = {
-    case HttpEventStreamConnectionOpen(handle)   => addHandler(handle)
+  override def preStart(): Unit = {
+    metrics.numberOfStreams.setValue(0)
+    eventStream.subscribe(self, classOf[LocalLeadershipEvent])
+  }
+
+  override def postStop(): Unit = {
+    eventStream.unsubscribe(self)
+    metrics.numberOfStreams.setValue(0)
+  }
+
+  override def receive: Receive = standby
+
+  // behaviours
+  private[this] val active: Receive = behaviour(acceptingNewConnections)
+  private[this] val standby: Receive = behaviour(rejectingNewConnections)
+
+  /**
+    * Helper method to create behaviours.
+    * The behaviours only differ in how they deal with new connections.
+    */
+  private[this] def behaviour(newConnectionBehaviour: Receive): Receive = {
+    Seq(
+      handleLeadership,
+      cleanupHandlerActors,
+      newConnectionBehaviour,
+      warnAboutUnknownMessages
+    ).reduceLeft {
+        // Prevent fatal warning about deriving type Any as type parameter
+        _.orElse[Any, Unit](_)
+      }
+  }
+
+  // behaviour components
+
+  /** Immediately close new connections. */
+  private[this] def rejectingNewConnections: Receive = {
+    case HttpEventStreamConnectionOpen(handle) =>
+      log.warn("Ignoring open connection request. Closing handle.")
+      Try(handle.close())
+  }
+
+  /** Accept new connections and create an appropriate handler for them. */
+  private[this] def acceptingNewConnections: Receive = {
+    case HttpEventStreamConnectionOpen(handle) =>
+      metrics.numberOfStreams.setValue(streamHandleActors.size)
+      log.info(s"Add EventStream Handle as event listener: $handle. Current nr of streams: ${streamHandleActors.size}")
+      val actor = context.actorOf(handleStreamProps(handle), handle.id)
+      context.watch(actor)
+      streamHandleActors += handle -> actor
+  }
+
+  /** Switch behavior according to leadership changes. */
+  private[this] def handleLeadership: Receive = {
+    case LocalLeadershipEvent.Standby =>
+      log.info("Now standing by. Closing existing handles and rejecting new.")
+      streamHandleActors.keys.foreach(removeHandler)
+      context.become(standby)
+
+    case LocalLeadershipEvent.ElectedAsLeader =>
+      log.info("Became active. Accepting event streaming requests.")
+      context.become(active)
+  }
+
+  /** Cleanup child actors which are not needed anymore. */
+  private[this] def cleanupHandlerActors: Receive = {
     case HttpEventStreamConnectionClosed(handle) => removeHandler(handle)
-    case Terminated(actor)                       => removeActor(actor)
+    case Terminated(actor)                       => unexpectedTerminationOfHandlerActor(actor)
   }
 
-  def addHandler(handle: HttpEventStreamHandle): Unit = {
-    log.info(s"Add EventStream Handle as event listener: $handle. Current nr of listeners: ${clients.size}")
-    val actor = context.actorOf(Props(
-      classOf[HttpEventStreamHandleActor],
-      handle,
-      eventStream,
-      maxOutstandingMessages), handle.id)
-    context.watch(actor)
-    clients += handle -> actor
-  }
-
-  def removeHandler(handle: HttpEventStreamHandle): Unit = {
-    clients.get(handle).foreach { actor =>
+  private[this] def removeHandler(handle: HttpEventStreamHandle): Unit = {
+    streamHandleActors.get(handle).foreach { actor =>
       context.unwatch(actor)
       context.stop(actor)
-      clients -= handle
-      log.info(s"Removed EventStream Handle as event listener: $handle. Current nr of listeners: ${clients.size}")
+      streamHandleActors -= handle
+      metrics.numberOfStreams.setValue(streamHandleActors.size)
+      log.info(s"Removed EventStream Handle as event listener: $handle. " +
+        s"Current nr of listeners: ${streamHandleActors.size}")
     }
   }
 
-  def removeActor(actor: ActorRef): Unit = {
-    clients.find(_._2 == actor).foreach {
+  private[this] def unexpectedTerminationOfHandlerActor(actor: ActorRef): Unit = {
+    streamHandleActors.find(_._2 == actor).foreach {
       case (handle, ref) =>
         log.error(s"Actor terminated unexpectedly: $handle")
-        clients -= handle
+        streamHandleActors -= handle
+        metrics.numberOfStreams.setValue(streamHandleActors.size)
     }
+  }
+
+  private[this] def warnAboutUnknownMessages: Receive = {
+    case message => log.warn(s"Received unexpected message $message")
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/io/SSLContextUtil.scala
+++ b/src/main/scala/mesosphere/marathon/io/SSLContextUtil.scala
@@ -29,7 +29,7 @@ object SSLContextUtil {
 
     // acquire X509 trust manager from factory
     val context = SSLContext.getInstance("TLS")
-    context.init(/* no key managers */ null, tmf.getTrustManagers, /* no secure random */ null)
+    context.init( /* no key managers */ null, tmf.getTrustManagers, /* no secure random */ null)
     context
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
+++ b/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon.state
 
 import mesosphere.marathon.StoreCommandFailedException
-import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import mesosphere.util.{ LockManager, ThreadPoolContext }
 import mesosphere.util.state.PersistentStore
 import mesosphere.marathon.metrics.Metrics.Histogram
@@ -21,10 +21,11 @@ class MarathonStore[S <: MarathonState[_, S]](
   private[this] val log = LoggerFactory.getLogger(getClass)
 
   private[this] lazy val lockManager = LockManager.create()
+  protected[this] def metricsPrefix = MetricPrefixes.SERVICE
   protected[this] val bytesRead: Histogram =
-    metrics.histogram(metrics.name("service", getClass, s"${ct.runtimeClass.getSimpleName}.read-data-size"))
+    metrics.histogram(metrics.name(metricsPrefix, getClass, s"${ct.runtimeClass.getSimpleName}.read-data-size"))
   protected[this] val bytesWritten: Histogram =
-    metrics.histogram(metrics.name("service", getClass, s"${ct.runtimeClass.getSimpleName}.write-data-size"))
+    metrics.histogram(metrics.name(metricsPrefix, getClass, s"${ct.runtimeClass.getSimpleName}.write-data-size"))
 
   def fetch(key: String): Future[Option[S]] = {
     store.load(prefix + key)

--- a/src/main/scala/mesosphere/marathon/state/StateMetrics.scala
+++ b/src/main/scala/mesosphere/marathon/state/StateMetrics.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.state
 
-import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import mesosphere.marathon.metrics.Metrics.{ Histogram, Meter }
 
 trait StateMetrics {
@@ -8,7 +8,7 @@ trait StateMetrics {
   // metrics!
   protected val metrics: Metrics
 
-  private[this] val prefix: String = "service"
+  private[this] def prefix: String = MetricPrefixes.SERVICE
 
   private[this] val readRequests: Meter = metrics.meter(metrics.name(prefix, getClass, "read-requests"))
   private[this] val readRequestErrors: Meter = metrics.meter(metrics.name(prefix, getClass, "read-request-errors"))

--- a/src/main/scala/mesosphere/marathon/tasks/OfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/OfferMatcher.scala
@@ -4,7 +4,7 @@ import java.util
 
 import com.google.inject.{ Inject }
 import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import mesosphere.marathon.metrics.Metrics.{ Timer, Histogram, Meter }
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.tasks.TaskFactory.CreatedTask
@@ -37,7 +37,7 @@ trait IterativeOfferMatcherConfig extends ScallopConf {
 }
 
 class IterativeOfferMatcherMetrics @Inject() (metrics: Metrics) {
-  val prefix: String = "service"
+  def prefix: String = MetricPrefixes.SERVICE
 
   val tasksLaunched: Meter = metrics.meter(metrics.name(prefix, getClass, "tasks-launched"))
   val tasksLaunchedPerOffer: Histogram = metrics.histogram(metrics.name(prefix, getClass, "tasks-launched-per-offer"))

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -8,7 +8,7 @@ import akka.util.Timeout
 import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.event.{ DeploymentSuccess, MesosStatusUpdateEvent, UpgradeEvent }
+import mesosphere.marathon.event.{ LocalLeadershipEvent, DeploymentSuccess, MesosStatusUpdateEvent, UpgradeEvent }
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state.PathId._
@@ -113,7 +113,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       awaitAssert({
         verify(hcManager).reconcileWith(app.id)
       }, 5.seconds, 10.millis)
@@ -142,7 +142,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! ReconcileTasks
 
       expectMsg(5.seconds, TasksReconciled)
@@ -175,7 +175,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! ScaleApps
 
       awaitAssert({
@@ -198,7 +198,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! ScaleApp("test-app".toPath)
 
       awaitAssert({
@@ -239,7 +239,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! KillTasks(app.id, Set(taskA.getId), scale = true)
 
       expectMsg(5.seconds, TasksKilled(app.id, Set(taskA.getId)))
@@ -284,7 +284,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! KillTasks(app.id, Set(taskA.getId), scale = false)
 
       expectMsg(5.seconds, TasksKilled(app.id, Set(taskA.getId)))
@@ -311,7 +311,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! Deploy(plan)
 
       expectMsg(DeploymentStarted(plan))
@@ -345,7 +345,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! Deploy(plan)
 
       expectMsg(DeploymentStarted(plan))
@@ -386,7 +386,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! Deploy(plan)
 
       expectMsg(DeploymentStarted(plan))
@@ -413,7 +413,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! Deploy(plan)
 
       expectMsgType[DeploymentStarted]
@@ -461,7 +461,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     ))
 
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! Deploy(plan)
 
       // This indicates that the deployment is already running,
@@ -488,7 +488,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = createActor()
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! Deploy(plan)
 
       expectMsgType[DeploymentStarted]
@@ -533,7 +533,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
       }
     ))
     try {
-      schedulerActor ! Start
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! Deploy(plan)
 
       expectMsgType[DeploymentStarted]

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -8,6 +8,7 @@ import akka.util.Timeout
 import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.api.LeaderInfo
 import mesosphere.marathon.event.{ LocalLeadershipEvent, DeploymentSuccess, MesosStatusUpdateEvent, UpgradeEvent }
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.io.storage.StorageProvider
@@ -48,6 +49,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
   var taskIdUtil: TaskIdUtil = _
   var storage: StorageProvider = _
   var taskFailureEventRepository: TaskFailureRepository = _
+  var leaderInfo: LeaderInfo = _
 
   implicit val defaultTimeout: Timeout = 5.seconds
 
@@ -64,6 +66,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     taskIdUtil = new TaskIdUtil
     storage = mock[StorageProvider]
     taskFailureEventRepository = mock[TaskFailureRepository]
+    leaderInfo = mock[LeaderInfo]
 
     when(deploymentRepo.store(any())).thenAnswer(new Answer[Future[DeploymentPlan]] {
       override def answer(p1: InvocationOnMock): Future[DeploymentPlan] = {
@@ -91,6 +94,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
       holder,
       taskIdUtil,
       storage,
+      leaderInfo,
       system.eventStream,
       taskFailureEventRepository,
       mock[MarathonConf]
@@ -455,6 +459,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
       holder,
       taskIdUtil,
       storage,
+      leaderInfo,
       system.eventStream,
       taskFailureEventRepository,
       mock[MarathonConf]
@@ -526,6 +531,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
         holder,
         taskIdUtil,
         storage,
+        leaderInfo,
         system.eventStream,
         taskFailureEventRepository,
         mock[MarathonConf]) {

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{ Timer, TimerTask }
 
 import akka.actor.{ ActorRef, ActorSystem }
+import akka.event.EventStream
 import akka.testkit.{ TestKit, TestProbe }
 import com.codahale.metrics.MetricRegistry
 import com.twitter.common.base.ExceptionalCommand
@@ -76,6 +77,7 @@ class MarathonSchedulerServiceTest
   var scheduler: MarathonScheduler = _
   var migration: Migration = _
   var schedulerActor: ActorRef = _
+  var events: EventStream = _
 
   before {
     probe = TestProbe()
@@ -90,6 +92,7 @@ class MarathonSchedulerServiceTest
     scheduler = mock[MarathonScheduler]
     migration = mock[Migration]
     schedulerActor = probe.ref
+    events = new EventStream()
   }
 
   def driverFactory[T](provide: => SchedulerDriver): SchedulerDriverFactory = {
@@ -114,7 +117,8 @@ class MarathonSchedulerServiceTest
       driverFactory(mock[SchedulerDriver]),
       system,
       migration,
-      schedulerActor
+      schedulerActor,
+      events
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
     }
@@ -143,7 +147,8 @@ class MarathonSchedulerServiceTest
       driverFactory(mock[SchedulerDriver]),
       system,
       migration,
-      schedulerActor
+      schedulerActor,
+      events
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
     }
@@ -172,7 +177,8 @@ class MarathonSchedulerServiceTest
       driverFactory(mock[SchedulerDriver]),
       system,
       migration,
-      schedulerActor
+      schedulerActor,
+      events
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
       override def newTimer() = mockTimer
@@ -209,7 +215,8 @@ class MarathonSchedulerServiceTest
       driverFactory(mock[SchedulerDriver]),
       system,
       migration,
-      schedulerActor
+      schedulerActor,
+      events
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
       override def newTimer() = mockTimer
@@ -238,7 +245,8 @@ class MarathonSchedulerServiceTest
       driverFactory(mock[SchedulerDriver]),
       system,
       migration,
-      schedulerActor
+      schedulerActor,
+      events
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
     }

--- a/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamActorTest.scala
@@ -5,6 +5,7 @@ import akka.event.EventStream
 import akka.testkit._
 import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.api.LeaderInfo
 import mesosphere.marathon.event.LocalLeadershipEvent
 import mesosphere.marathon.event.http.HttpEventStreamActor.{ HttpEventStreamConnectionClosed, HttpEventStreamConnectionOpen }
 import mesosphere.marathon.metrics.Metrics
@@ -80,15 +81,17 @@ class HttpEventStreamActorTest extends TestKit(ActorSystem())
   }
 
   var streamActor: TestActorRef[HttpEventStreamActor] = _
+  var leaderInfo: LeaderInfo = _
   var stream: EventStream = _
   var metrics: HttpEventStreamActorMetrics = _
 
   before {
+    leaderInfo = mock[LeaderInfo]
     stream = mock[EventStream]
     metrics = new HttpEventStreamActorMetrics(new Metrics(new MetricRegistry))
     def handleStreamProps(handle: HttpEventStreamHandle) = Props(new HttpEventStreamHandleActor(handle, stream, 1))
     streamActor = TestActorRef(Props(
-      new HttpEventStreamActor(stream, metrics, handleStreamProps)
+      new HttpEventStreamActor(leaderInfo, metrics, handleStreamProps)
     ))
   }
 }

--- a/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamActorTest.scala
@@ -1,51 +1,94 @@
 package mesosphere.marathon.event.http
 
-import akka.actor.{ ActorSystem, Props }
+import akka.actor.{ Terminated, ActorSystem, Props }
 import akka.event.EventStream
 import akka.testkit._
+import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.event.LocalLeadershipEvent
 import mesosphere.marathon.event.http.HttpEventStreamActor.{ HttpEventStreamConnectionClosed, HttpEventStreamConnectionOpen }
-import org.mockito.Mockito.{ when => call }
+import mesosphere.marathon.metrics.Metrics
+import org.mockito.Mockito.{ when => call, verify, verifyNoMoreInteractions }
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
+import scala.concurrent.duration._
 
 class HttpEventStreamActorTest extends TestKit(ActorSystem())
     with MarathonSpec with Matchers with GivenWhenThen with MockitoSugar with ImplicitSender with BeforeAndAfter {
 
   test("Register Handler") {
-    Given("A handler that wants to connect")
+    Given("A handler that wants to connect and we have an active streamActor")
     val handle = mock[HttpEventStreamHandle]
     call(handle.id).thenReturn("1")
+    streamActor ! LocalLeadershipEvent.ElectedAsLeader
 
     When("A connection open message is sent to the stream actor")
     streamActor ! HttpEventStreamConnectionOpen(handle)
 
     Then("An actor is created and subscribed to the event stream")
-    streamActor.underlyingActor.clients should have size 1
-    streamActor.underlyingActor.clients.get(handle) should be ('nonEmpty)
+    streamActor.underlyingActor.streamHandleActors should have size 1
+    streamActor.underlyingActor.streamHandleActors.get(handle) should be ('nonEmpty)
+  }
+
+  test("Unregister handlers when switching to standby mode") {
+    Given("A handler that wants to connect and we have an active streamActor with one connection")
+    val handle = mock[HttpEventStreamHandle]
+    call(handle.id).thenReturn("1")
+    streamActor ! LocalLeadershipEvent.ElectedAsLeader
+    streamActor ! HttpEventStreamConnectionOpen(handle)
+    val handleActor = streamActor.underlyingActor.streamHandleActors.values.head
+    watch(handleActor)
+
+    When("The stream actor switches to standby mode")
+    streamActor ! LocalLeadershipEvent.Standby
+
+    Then("All handler actors are stopped and the connection is closed")
+    val terminated = expectMsgClass(1.second, classOf[Terminated])
+    terminated.getActor should be(handleActor)
+    streamActor.underlyingActor.streamHandleActors should have size 0
+    streamActor.underlyingActor.streamHandleActors.get(handle) should be ('empty)
+    verify(handle).close()
+  }
+
+  test("Close connection immediately if we are in standby mode") {
+    Given("A handler that wants to connect")
+    val handle = mock[HttpEventStreamHandle]("handle")
+
+    When("A connection open message is sent to the stream actor in standby mode")
+    streamActor ! HttpEventStreamConnectionOpen(handle)
+
+    Then("The connection is immediately closed without creating an actor")
+    streamActor.underlyingActor.streamHandleActors should have size 0
+    streamActor.underlyingActor.streamHandleActors.get(handle) should be ('empty)
+    verify(handle).close()
+    verifyNoMoreInteractions(handle)
   }
 
   test("Unregister an already registered Handler") {
     Given("A registered handler")
     val handle = mock[HttpEventStreamHandle]
     call(handle.id).thenReturn("1")
+    streamActor ! LocalLeadershipEvent.ElectedAsLeader
     streamActor ! HttpEventStreamConnectionOpen(handle)
-    streamActor.underlyingActor.clients should have size 1
+    streamActor.underlyingActor.streamHandleActors should have size 1
 
     When("A connection closed message is sent to the stream actor")
     streamActor ! HttpEventStreamConnectionClosed(handle)
 
     Then("The actor is unsubscribed from the event stream")
-    streamActor.underlyingActor.clients should have size 0
+    streamActor.underlyingActor.streamHandleActors should have size 0
   }
 
   var streamActor: TestActorRef[HttpEventStreamActor] = _
   var stream: EventStream = _
+  var metrics: HttpEventStreamActorMetrics = _
 
   before {
     stream = mock[EventStream]
+    metrics = new HttpEventStreamActorMetrics(new Metrics(new MetricRegistry))
+    def handleStreamProps(handle: HttpEventStreamHandle) = Props(new HttpEventStreamHandleActor(handle, stream, 1))
     streamActor = TestActorRef(Props(
-      new HttpEventStreamActor(stream, 1)
+      new HttpEventStreamActor(stream, metrics, handleStreamProps)
     ))
   }
 }

--- a/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
@@ -1,15 +1,16 @@
 package mesosphere.marathon.integration.setup
 
-import javax.inject.{Inject, Named}
+import javax.inject.{ Inject, Named }
 import javax.ws.rs.core.Response
-import javax.ws.rs.{GET, Path}
+import javax.ws.rs.{ GET, Path }
 
+import akka.actor.ActorRef
 import com.google.common.util.concurrent.Service
 import com.google.inject._
-import mesosphere.chaos.http.{HttpConf, HttpModule, HttpService, RestModule}
+import mesosphere.chaos.http.{ HttpConf, HttpModule, HttpService, RestModule }
 import mesosphere.chaos.metrics.MetricsModule
 import mesosphere.marathon.api._
-import mesosphere.marathon.{LeaderProxyConf, ModuleNames}
+import mesosphere.marathon.{ LeaderProxyConf, ModuleNames }
 import org.rogach.scallop.ScallopConf
 import org.slf4j.LoggerFactory
 
@@ -42,6 +43,9 @@ object ForwarderService {
       val leaderInfo = new LeaderInfo {
         override def elected: Boolean = electedAlias
         override def currentLeaderHostPort(): Option[String] = leaderHostPort
+
+        override def subscribe(self: ActorRef): Unit = ???
+        override def unsubscribe(self: ActorRef): Unit = ???
       }
 
       bind(classOf[LeaderInfo]).toInstance(leaderInfo)


### PR DESCRIPTION
leadership

Also:

* Refactor Leadership management into EventStream messages
* Report the number of open event streams via metrics