### PR TITLE
Tests: ProcessKeeper reports total number of processes on process

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/setup/ProcessKeeper.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ProcessKeeper.scala
@@ -119,7 +119,7 @@ object ProcessKeeper {
         result match {
           case ProcessExited =>
             throw new IllegalStateException(s"Process $name exited before coming up. Give up. $processBuilder")
-          case ProcessIsUp => log.info(s"Process $name is up and running.")
+          case ProcessIsUp => log.info(s"Process $name is up and running. ${processes.size} processes in total.")
         }
       case Failure(_) =>
         process.destroy()


### PR DESCRIPTION
launch.

This might be useful to detect resource overuse or something like that.