### PR TITLE
MarathonSchedulerActor: Remove some indirect dependencies

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -176,7 +176,6 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     system.actorOf(
       Props(
         new MarathonSchedulerActor(
-          mapper,
           appRepository,
           deploymentRepository,
           healthCheckManager,
@@ -184,7 +183,6 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
           taskQueue,
           frameworkIdUtil,
           driverHolder,
-          taskIdUtil,
           storage,
           leaderInfo,
           eventBus,

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Named
 
 import akka.actor.SupervisorStrategy.Restart
-import akka.actor.{ Props, ActorRef, ActorRefFactory, ActorSystem, OneForOneStrategy }
+import akka.actor._
 import akka.event.EventStream
 import akka.routing.RoundRobinPool
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -17,7 +17,7 @@ import com.twitter.common.zookeeper.{ Candidate, CandidateImpl, Group => ZGroup,
 import com.twitter.zk.{ NativeConnector, ZkClient }
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.api.LeaderInfo
-import mesosphere.marathon.event.EventModule
+import mesosphere.marathon.event.{ HistoryActor, EventModule }
 import mesosphere.marathon.event.http.{
   HttpEventStreamActorMetrics,
   HttpEventStreamHandleActor,
@@ -29,7 +29,7 @@ import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker, _ }
-import mesosphere.marathon.upgrade.DeploymentPlan
+import mesosphere.marathon.upgrade.{ DeploymentManager, DeploymentPlan }
 import mesosphere.util.SerializeExecution
 import mesosphere.util.state.memory.InMemoryStore
 import mesosphere.util.state.mesos.MesosStateStore
@@ -148,7 +148,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     }
   }
 
-  //scalastyle:off parameter.number
+  //scalastyle:off parameter.number method.length
   @Named("schedulerActor")
   @Provides
   @Singleton
@@ -173,21 +173,48 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
       case NonFatal(_) => Restart
     }
 
-    system.actorOf(
+    import system.dispatcher
+
+    def createSchedulerActions(schedulerActor: ActorRef): SchedulerActions = {
+      new SchedulerActions(
+        appRepository,
+        healthCheckManager,
+        taskTracker,
+        taskQueue,
+        eventBus,
+        schedulerActor,
+        config)
+    }
+
+    def deploymentManagerProps(schedulerActions: SchedulerActions): Props = {
       Props(
-        new MarathonSchedulerActor(
+        new DeploymentManager(
           appRepository,
-          deploymentRepository,
-          healthCheckManager,
           taskTracker,
           taskQueue,
-          frameworkIdUtil,
-          driverHolder,
+          schedulerActions,
           storage,
-          leaderInfo,
-          eventBus,
-          taskFailureRepository,
-          config)
+          healthCheckManager,
+          eventBus
+        )
+      )
+    }
+
+    val historyActorProps = Props(new HistoryActor(eventBus, taskFailureRepository))
+
+    system.actorOf(
+      MarathonSchedulerActor.props(
+        createSchedulerActions,
+        deploymentManagerProps,
+        historyActorProps,
+        appRepository,
+        deploymentRepository,
+        healthCheckManager,
+        taskTracker,
+        taskQueue,
+        driverHolder,
+        leaderInfo,
+        eventBus
       ).withRouter(RoundRobinPool(nrOfInstances = 1, supervisorStrategy = supervision)),
       "MarathonScheduler")
   }

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -37,7 +37,6 @@ import scala.util.{ Failure, Success, Try }
 class LockingFailedException(msg: String) extends Exception(msg)
 
 class MarathonSchedulerActor(
-    mapper: ObjectMapper,
     appRepository: AppRepository,
     deploymentRepository: DeploymentRepository,
     healthCheckManager: HealthCheckManager,
@@ -45,7 +44,6 @@ class MarathonSchedulerActor(
     taskQueue: TaskQueue,
     frameworkIdUtil: FrameworkIdUtil,
     marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder,
-    taskIdUtil: TaskIdUtil,
     storage: StorageProvider,
     leaderInfo: LeaderInfo,
     eventBus: EventStream,
@@ -64,11 +62,9 @@ class MarathonSchedulerActor(
   override def preStart(): Unit = {
 
     scheduler = new SchedulerActions(
-      mapper,
       appRepository,
       healthCheckManager,
       taskTracker,
-      taskIdUtil,
       taskQueue,
       eventBus,
       self,
@@ -120,7 +116,7 @@ class MarathonSchedulerActor(
       self ! ReconcileHealthChecks
 
     case LocalLeadershipEvent.Standby =>
-      // ignore, FIXME: When we get this while recovering deployments, we become active
+    // ignore, FIXME: When we get this while recovering deployments, we become active
 
     case _                            => stash()
   }
@@ -400,11 +396,9 @@ object MarathonSchedulerActor {
 }
 
 class SchedulerActions(
-    mapper: ObjectMapper,
     appRepository: AppRepository,
     healthCheckManager: HealthCheckManager,
     taskTracker: TaskTracker,
-    taskIdUtil: TaskIdUtil,
     taskQueue: TaskQueue,
     eventBus: EventStream,
     val schedulerActor: ActorRef,

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.api.LeaderInfo
 import mesosphere.marathon.event.LocalLeadershipEvent
 import mesosphere.marathon.event.http.HttpEventStreamActor._
 import mesosphere.marathon.metrics.Metrics.AtomicIntGauge
-import mesosphere.marathon.metrics.{MetricPrefixes, Metrics}
+import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import org.apache.log4j.Logger
 
 import scala.util.Try

--- a/src/test/scala/mesosphere/marathon/ForwardingActor.scala
+++ b/src/test/scala/mesosphere/marathon/ForwardingActor.scala
@@ -1,0 +1,19 @@
+package mesosphere.marathon
+
+import akka.actor.{ Actor, ActorRef, Props }
+
+/**
+  * An actor which forwards all its messages
+  * to the given destination. Useful for testing.
+  */
+class ForwardingActor(destination: ActorRef) extends Actor {
+  override def receive: Receive = {
+    case msg => destination.forward(msg)
+  }
+}
+
+object ForwardingActor {
+  def props(destination: ActorRef): Props = {
+    Props(classOf[ForwardingActor], destination)
+  }
+}

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -3,19 +3,19 @@ package mesosphere.marathon
 import java.util.concurrent.TimeoutException
 
 import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.event.EventStream
 import akka.testkit._
 import akka.util.Timeout
-import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.api.LeaderInfo
-import mesosphere.marathon.event.{ LocalLeadershipEvent, DeploymentSuccess, MesosStatusUpdateEvent, UpgradeEvent }
+import mesosphere.marathon.event._
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker }
-import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep, StopApplication }
+import mesosphere.marathon.upgrade.{ DeploymentManager, DeploymentPlan, DeploymentStep, StopApplication }
 import mesosphere.mesos.protos.Implicits._
 import mesosphere.mesos.protos.TaskID
 import mesosphere.util.state.FrameworkIdUtil
@@ -46,10 +46,12 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
   var frameworkIdUtil: FrameworkIdUtil = _
   var driver: SchedulerDriver = _
   var holder: MarathonSchedulerDriverHolder = _
-  var taskIdUtil: TaskIdUtil = _
   var storage: StorageProvider = _
   var taskFailureEventRepository: TaskFailureRepository = _
   var leaderInfo: LeaderInfo = _
+  var schedulerActions: ActorRef => SchedulerActions = _
+  var deploymentManagerProps: SchedulerActions => Props = _
+  var historyActorProps: Props = _
 
   implicit val defaultTimeout: Timeout = 5.seconds
 
@@ -63,10 +65,21 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     tracker = mock[TaskTracker]
     queue = spy(new TaskQueue)
     frameworkIdUtil = mock[FrameworkIdUtil]
-    taskIdUtil = new TaskIdUtil
     storage = mock[StorageProvider]
     taskFailureEventRepository = mock[TaskFailureRepository]
     leaderInfo = mock[LeaderInfo]
+    deploymentManagerProps = schedulerActions => Props(new DeploymentManager(
+      repo,
+      tracker,
+      queue,
+      schedulerActions,
+      storage,
+      hcManager,
+      system.eventStream
+    ))
+    historyActorProps = Props(new HistoryActor(system.eventStream, taskFailureEventRepository))
+    schedulerActions = ref => new SchedulerActions(
+      repo, hcManager, tracker, queue, new EventStream(), ref, mock[MarathonConf])(system.dispatcher)
 
     when(deploymentRepo.store(any())).thenAnswer(new Answer[Future[DeploymentPlan]] {
       override def answer(p1: InvocationOnMock): Future[DeploymentPlan] = {
@@ -82,22 +95,21 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
   }
 
   def createActor() = {
-    system.actorOf(Props(
-      new MarathonSchedulerActor(
+    system.actorOf(
+      MarathonSchedulerActor.props(
+        schedulerActions,
+        deploymentManagerProps,
+        historyActorProps,
         repo,
         deploymentRepo,
         hcManager,
         tracker,
         queue,
-        frameworkIdUtil,
         holder,
-        storage,
         leaderInfo,
-        system.eventStream,
-        taskFailureEventRepository,
-        mock[MarathonConf]
+        system.eventStream
       )
-    ))
+    )
   }
 
   def stopActor(ref: ActorRef): Unit = {
@@ -446,22 +458,20 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     when(deploymentRepo.all()).thenReturn(Future.successful(Seq(plan)))
     when(deploymentRepo.store(plan)).thenReturn(Future.successful(plan))
 
-    val schedulerActor = system.actorOf(Props(
-      new MarathonSchedulerActor(
+    val schedulerActor = system.actorOf(
+      MarathonSchedulerActor.props(
+        schedulerActions,
+        deploymentManagerProps,
+        historyActorProps,
         repo,
         deploymentRepo,
         hcManager,
         tracker,
         queue,
-        frameworkIdUtil,
         holder,
-        storage,
         leaderInfo,
-        system.eventStream,
-        taskFailureEventRepository,
-        mock[MarathonConf]
-      )
-    ))
+        system.eventStream
+      ))
 
     try {
       schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
@@ -517,23 +527,22 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     when(tracker.get(app.id)).thenReturn(Set.empty[MarathonTask])
     when(repo.expunge(app.id)).thenReturn(Future.successful(Nil))
 
-    val schedulerActor = TestActorRef(Props(
-      new MarathonSchedulerActor(
+    val schedulerActor = TestActorRef(
+      MarathonSchedulerActor.props(
+        schedulerActions,
+        deploymentManagerProps,
+        historyActorProps,
         repo,
         deploymentRepo,
         hcManager,
         tracker,
         queue,
-        frameworkIdUtil,
         holder,
-        storage,
         leaderInfo,
         system.eventStream,
-        taskFailureEventRepository,
-        mock[MarathonConf]) {
-        override val cancellationTimeout = 0.millisecond
-      }
-    ))
+        cancellationTimeout = 0.seconds
+      )
+    )
     try {
       schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       schedulerActor ! Deploy(plan)

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -83,21 +83,20 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
   def createActor() = {
     system.actorOf(Props(
-      classOf[MarathonSchedulerActor],
-      new ObjectMapper(),
-      repo,
-      deploymentRepo,
-      hcManager,
-      tracker,
-      queue,
-      frameworkIdUtil,
-      holder,
-      taskIdUtil,
-      storage,
-      leaderInfo,
-      system.eventStream,
-      taskFailureEventRepository,
-      mock[MarathonConf]
+      new MarathonSchedulerActor(
+        repo,
+        deploymentRepo,
+        hcManager,
+        tracker,
+        queue,
+        frameworkIdUtil,
+        holder,
+        storage,
+        leaderInfo,
+        system.eventStream,
+        taskFailureEventRepository,
+        mock[MarathonConf]
+      )
     ))
   }
 
@@ -448,21 +447,20 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     when(deploymentRepo.store(plan)).thenReturn(Future.successful(plan))
 
     val schedulerActor = system.actorOf(Props(
-      classOf[MarathonSchedulerActor],
-      new ObjectMapper(),
-      repo,
-      deploymentRepo,
-      hcManager,
-      tracker,
-      queue,
-      frameworkIdUtil,
-      holder,
-      taskIdUtil,
-      storage,
-      leaderInfo,
-      system.eventStream,
-      taskFailureEventRepository,
-      mock[MarathonConf]
+      new MarathonSchedulerActor(
+        repo,
+        deploymentRepo,
+        hcManager,
+        tracker,
+        queue,
+        frameworkIdUtil,
+        holder,
+        storage,
+        leaderInfo,
+        system.eventStream,
+        taskFailureEventRepository,
+        mock[MarathonConf]
+      )
     ))
 
     try {
@@ -521,7 +519,6 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     val schedulerActor = TestActorRef(Props(
       new MarathonSchedulerActor(
-        new ObjectMapper(),
         repo,
         deploymentRepo,
         hcManager,
@@ -529,7 +526,6 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
         queue,
         frameworkIdUtil,
         holder,
-        taskIdUtil,
         storage,
         leaderInfo,
         system.eventStream,

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -26,11 +26,9 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
     val taskTracker = mock[TaskTracker]
 
     val scheduler = new SchedulerActions(
-      mock[ObjectMapper],
       repo,
       mock[HealthCheckManager],
       taskTracker,
-      new TaskIdUtil,
       queue,
       system.eventStream,
       TestProbe().ref,
@@ -79,11 +77,9 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
       .build()
 
     val scheduler = new SchedulerActions(
-      mock[ObjectMapper],
       repo,
       mock[HealthCheckManager],
       taskTracker,
-      new TaskIdUtil,
       queue,
       system.eventStream,
       TestProbe().ref,
@@ -119,11 +115,9 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
       .build()
 
     val scheduler = new SchedulerActions(
-      mock[ObjectMapper],
       repo,
       mock[HealthCheckManager],
       taskTracker,
-      new TaskIdUtil,
       queue,
       system.eventStream,
       TestProbe().ref,

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -7,15 +7,15 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.google.common.collect.Lists
 import mesosphere.jackson.CaseClassModule
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
-import mesosphere.marathon.Protos.{Constraint, ServiceDefinition}
+import mesosphere.marathon.Protos.{ Constraint, ServiceDefinition }
 import mesosphere.marathon.api.ModelValidation
-import mesosphere.marathon.api.v2.json.{EnrichedTask, MarathonModule}
-import mesosphere.marathon.health.{HealthCheck, HealthCounts}
+import mesosphere.marathon.api.v2.json.{ EnrichedTask, MarathonModule }
+import mesosphere.marathon.health.{ HealthCheck, HealthCounts }
 import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.upgrade.DeploymentPlan
-import mesosphere.marathon.{MarathonSpec, Protos}
-import org.apache.mesos.{Protos => mesos}
+import mesosphere.marathon.{ MarathonSpec, Protos }
+import org.apache.mesos.{ Protos => mesos }
 import org.scalatest.Matchers
 import play.api.libs.json.Json
 
@@ -440,7 +440,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     val readResult3 = schemaMapper.readValue(json3, classOf[AppDefinition])
     assert(readResult3 == app3)
 
-    import java.lang.{Integer => JInt}
+    import java.lang.{ Integer => JInt }
 
     import mesosphere.marathon.state.Container.Docker.PortMapping
     import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network


### PR DESCRIPTION
The MarathonSchedulerActor constructor did not only get dependencies for itself but also for other actors/SchedulerActions which were create in preStart.