### PR TITLE
Fixes #1573 - Report number of apps/groups in metrics

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -9,6 +9,7 @@ import akka.actor.SupervisorStrategy.Restart
 import akka.actor.{ Props, ActorRef, ActorRefFactory, ActorSystem, OneForOneStrategy }
 import akka.event.EventStream
 import akka.routing.RoundRobinPool
+import com.codahale.metrics.Gauge
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.inject._
 import com.google.inject.name.Names
@@ -41,6 +42,7 @@ import org.apache.zookeeper.ZooDefs
 import org.apache.zookeeper.ZooDefs.Ids
 
 import scala.collection.JavaConverters._
+import scala.concurrent.Await
 import scala.util.control.NonFatal
 
 object ModuleNames {
@@ -81,7 +83,6 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     bind(classOf[TaskFactory]).to(classOf[DefaultTaskFactory]).in(Scopes.SINGLETON)
     bind(classOf[IterativeOfferMatcherMetrics]).in(Scopes.SINGLETON)
     bind(classOf[OfferMatcher]).to(classOf[IterativeOfferMatcher]).in(Scopes.SINGLETON)
-    bind(classOf[GroupManager]).in(Scopes.SINGLETON)
 
     bind(classOf[HealthCheckManager]).to(classOf[MarathonHealthCheckManager]).asEagerSingleton()
 
@@ -324,5 +325,41 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
   @Singleton
   def provideSerializeGroupUpdates(actorRefFactory: ActorRefFactory): SerializeExecution = {
     SerializeExecution(actorRefFactory, "serializeGroupUpdates")
+  }
+
+  @Provides
+  @Singleton
+  def provideGroupManager(
+    @Named(ModuleNames.NAMED_SERIALIZE_GROUP_UPDATES) serializeUpdates: SerializeExecution,
+    scheduler: MarathonSchedulerService,
+    taskTracker: TaskTracker,
+    groupRepo: GroupRepository,
+    storage: StorageProvider,
+    config: MarathonConf,
+    @Named(EventModule.busName) eventBus: EventStream,
+    metrics: Metrics): GroupManager = {
+    val groupManager: GroupManager = new GroupManager(
+      serializeUpdates,
+      scheduler,
+      taskTracker,
+      groupRepo,
+      storage,
+      config,
+      eventBus
+    )
+
+    metrics.gauge("service.mesosphere.marathon.app.count", new Gauge[Int] {
+      override def getValue: Int = {
+        Await.result(groupManager.root(false), conf.zkTimeoutDuration).transitiveApps.size
+      }
+    })
+
+    metrics.gauge("service.mesosphere.marathon.group.count", new Gauge[Int] {
+      override def getValue: Int = {
+        Await.result(groupManager.root(false), conf.zkTimeoutDuration).transitiveGroups.size
+      }
+    })
+
+    groupManager
   }
 }

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -120,7 +120,7 @@ class MarathonSchedulerActor(
       self ! ReconcileHealthChecks
 
     case LocalLeadershipEvent.Standby =>
-      // ignore, FIXME: When we get this while recovering deployments, we become active
+    // ignore, FIXME: When we get this while recovering deployments, we become active
 
     case _                            => stash()
   }

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.api.LeaderInfo
 import mesosphere.marathon.event.LocalLeadershipEvent
 import mesosphere.marathon.event.http.HttpEventStreamActor._
 import mesosphere.marathon.metrics.Metrics.AtomicIntGauge
-import mesosphere.marathon.metrics.{MetricPrefixes, Metrics}
+import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import org.apache.log4j.Logger
 
 import scala.util.Try


### PR DESCRIPTION
Added the number of add/groups to the metrics exposed by Marathon.

Note: With this change, Marathon will load all the groups from ZK each
time the /metrics endpoint is hit. If this becomes a performance
issue, we can cache the metrics and move the refreshing logic to an
actor. I decided to try to avoid premature optimizations.