### PR TITLE
Fix #1647 by enriching all requests without appropriate request headers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,17 @@
+## Changes from 0.9.0 to 0.10.0
+
+### Breaking changes
+
+Please look at the following changes to check whether you have to verify your setup before upgrading:
+
+* If an http request is made without setting appropriate request headers, the Accept and Content-Type header 
+  is set automatically to `application/json`
+
+
+### Fixed Bugs
+
+- #1647 - Keep the rest-api return format consistent when request headers without "Accept: application/json"
+
 ## Changes from 0.8.2 to 0.9.0
 
 #### Recommended Mesos version is 0.22.1

--- a/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
@@ -60,6 +60,9 @@ class MarathonRestModule extends RestModule {
 
     install(new LeaderProxyFilterModule)
 
+    bind(classOf[SetRequestDefaultsFilter]).asEagerSingleton()
+    filter("/*").through(classOf[SetRequestDefaultsFilter])
+
     bind(classOf[CORSFilter]).asEagerSingleton()
     filter("/*").through(classOf[CORSFilter])
 

--- a/src/main/scala/mesosphere/marathon/api/SetRequestDefaultsFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/SetRequestDefaultsFilter.scala
@@ -1,0 +1,45 @@
+package mesosphere.marathon.api
+
+import java.util
+import javax.servlet._
+import javax.servlet.http.{ HttpServletRequest, HttpServletRequestWrapper }
+
+import scala.collection.JavaConverters._
+
+class SetRequestDefaultsFilter extends Filter {
+
+  //scalastyle:off null
+
+  /**
+    * Wrap original request and provide a consistent representation.
+    * @param request the original request.
+    */
+  class RequestWithDefaults(request: HttpServletRequest) extends HttpServletRequestWrapper(request) {
+    val headers = {
+      var headerMap = request.getHeaderNames.asScala.map(k => k -> request.getHeaders(k)).toMap
+      if (!headerMap.contains("Content-Type")) headerMap += "Content-Type" -> enum("application/json")
+      if (!headerMap.contains("Accept")) headerMap += "Accept" -> enum("application/json")
+      headerMap
+    }.withDefaultValue(null) //I hate it, but this is the default
+
+    override val getHeaderNames: util.Enumeration[String] = new util.Vector(headers.keySet.asJava).elements()
+
+    override def getHeader(name: String): String = {
+      headers.get(name).map(e => if (e.hasMoreElements) e.nextElement() else null).orNull
+    }
+
+    override def getHeaders(name: String): util.Enumeration[String] = headers(name)
+  }
+
+  override def doFilter(rawRequest: ServletRequest, rawResponse: ServletResponse, chain: FilterChain): Unit = {
+    rawRequest match {
+      case request: HttpServletRequest => chain.doFilter(new RequestWithDefaults(request), rawResponse)
+      case _ =>
+        throw new IllegalArgumentException(s"expected http request but got $rawRequest")
+    }
+  }
+
+  override def init(filterConfig: FilterConfig): Unit = {}
+  override def destroy(): Unit = {}
+  private[this] def enum(values: String*) = new util.Vector(values.asJava).elements()
+}

--- a/src/test/scala/mesosphere/marathon/api/SetRequestDefaultsFilterTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/SetRequestDefaultsFilterTest.scala
@@ -1,0 +1,79 @@
+package mesosphere.marathon.api
+
+import java.util
+import javax.servlet.FilterChain
+import javax.servlet.http.{ HttpServletRequestWrapper, HttpServletRequest, HttpServletResponse }
+
+import mesosphere.marathon.MarathonSpec
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito._
+
+import scala.collection.JavaConverters._
+
+class SetRequestDefaultsFilterTest extends MarathonSpec {
+
+  var filter: SetRequestDefaultsFilter = _
+  var response: HttpServletResponse = _
+  var chain: FilterChain = _
+
+  before {
+    filter = new SetRequestDefaultsFilter()
+    response = mock[HttpServletResponse]("response")
+    chain = mock[FilterChain]("chain")
+
+  }
+  private[this] def enum(values: String*) = new util.Vector(values.asJava).elements()
+
+  test("set default Content-Type and Accept") {
+    val request = mock[HttpServletRequest]("request")
+
+    when(request.getHeaderNames).thenReturn(new util.Vector[String]().elements())
+
+    // when doFilter is called
+    filter.doFilter(request, response, chain)
+
+    val requestCaptor = ArgumentCaptor.forClass(classOf[HttpServletRequest])
+    val responseCaptor = ArgumentCaptor.forClass(classOf[HttpServletResponse])
+
+    verify(chain, times(1)).doFilter(requestCaptor.capture(), responseCaptor.capture())
+
+    // we set the default headers
+    val modifiedRequest = requestCaptor.getValue
+    assert(modifiedRequest.getHeader("Content-Type") == "application/json")
+    assert(modifiedRequest.getHeader("Accept") == "application/json")
+
+    // the response is left untouched
+    verifyNoMoreInteractions(response)
+    assert(responseCaptor.getValue == response)
+  }
+
+  test("don't overwrite existing headers") {
+    val request = new HttpServletRequestWrapper(mock[HttpServletRequest]) {
+      val headers = Map(
+        "Content-Type" -> enum("application/text"),
+        "Accept" -> enum("application/text")
+      ).withDefaultValue(null)
+
+      override val getHeaderNames: util.Enumeration[String] = new util.Vector(headers.keySet.asJava).elements()
+      override def getHeader(name: String): String = headers.get(name).map(e => e.nextElement()).orNull
+      override def getHeaders(name: String): util.Enumeration[String] = headers(name)
+    }
+
+    // when doFilter is called
+    filter.doFilter(request, response, chain)
+
+    val requestCaptor = ArgumentCaptor.forClass(classOf[HttpServletRequest])
+    val responseCaptor = ArgumentCaptor.forClass(classOf[HttpServletResponse])
+
+    verify(chain, times(1)).doFilter(requestCaptor.capture(), responseCaptor.capture())
+
+    // we set the default headers
+    val modifiedRequest = requestCaptor.getValue
+    assert(modifiedRequest.getHeader("Content-Type") == "application/text")
+    assert(modifiedRequest.getHeader("Accept") == "application/text")
+
+    // the response is left untouched
+    verifyNoMoreInteractions(response)
+    assert(responseCaptor.getValue == response)
+  }
+}


### PR DESCRIPTION
Wrap original request and enrich that to provide a consistent structure.
Reflect changes in changelog.md.