### PR TITLE
Improves #1644 - Add some integration tests for /v2/apps endpoints.

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -47,7 +47,8 @@ trait SingleMarathonIntegrationTest
   override lazy val marathon: MarathonFacade = new MarathonFacade(config.marathonUrl, testBasePath)
 
   lazy val marathonProxy = {
-    startMarathon(config.marathonPort + 1, "--master", config.master, "--event_subscriber", "http_callback")
+    startMarathon(config.marathonPort + 1, "--master", config.master, "--event_subscriber", "http_callback",
+      "--enable_metrics")
     new MarathonFacade(config.copy(marathonPort = config.marathonPort + 1).marathonUrl, testBasePath)
   }
 


### PR DESCRIPTION
This is the first of a series of commits to increase our integration tests coverage.