### PR TITLE
Fixes #1556 - advertise HTTPS port for leader if HTTP is disabled

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -141,7 +141,8 @@ The Web Site flags control the behavior of Marathon's web site, including the us
 * `--http_port` (Optional. Default: 8080): The port on which to listen for HTTP
     requests.
 * `--disable_http` (Optional.): Disable HTTP completely. This is only allowed if you configure HTTPS.
-    HTTPS stays enabled.
+    HTTPS stays enabled. <span class="label label-default">v0.9.0</span> Also enables forwarding queries to the
+    leader via HTTPS instead of HTTP.
 * `--https_address` (Optional. Default: all): The address on which to listen
     for HTTPS requests.
 * `--https_port` (Optional. Default: 8443): The port on which to listen for

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -224,7 +224,8 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
   @Provides
   @Singleton
   def provideHostPort: String = {
-    "%s:%d".format(conf.hostname(), http.httpPort())
+    val port = if (http.disableHttp()) http.httpsPort() else http.httpPort()
+    "%s:%d".format(conf.hostname(), port)
   }
 
   @Named(ModuleNames.NAMED_CANDIDATE)


### PR DESCRIPTION
You can test this fix with the provided test certificate like this:

Run

`sbt -Djava.library.path=<YOUR PATH TO MESOS>/lib "run --disable_http --https_port 8443 --master zk://localhost:2181/mesos --zk zk://localhost:2181/master --ssl_keystore_path src/test/resources/test-keystore.jks --ssl_keystore_password password --hostname localhost"`

on one console and the same command with another https_port on another terminal.

The Marathon instance that you started first will be the leader, the other a non-leader. Now connect to both to see that everything works.