### PR TITLE
Limit the number of concurrent http requests.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,17 @@ Please look at the following changes to check whether you have to verify your se
 * If an http request is made without setting appropriate request headers, the Accept and Content-Type header 
   is set automatically to `application/json`
 
+### Overview
+
+##### Restrict the number of concurrent HTTP requests
+
+With this number of Marathon it is possible to restrict the number of concurrent http requests.
+This prevents Denial of Service behavior, that has been reported in some installations.
+If the limit of concurrent requests is reached, a HTTP 503 Service Temporarily Unavailable is returned,
+which means that this operation can be retried.
+The option has a sensible default (20), which should be suitable for almost all installations and 
+can be adjusted with the `--http_max_concurrent_requests` command line property.
+
 
 ### Fixed Bugs
 

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -153,7 +153,8 @@ The Web Site flags control the behavior of Marathon's web site, including the us
 * `--ssl_keystore_password` (Optional. Default: None): Password for the keystore
     supplied with the `ssl_keystore_path` option. Required if `ssl_keystore_path` is supplied.
     May also be specified with the `MESOSPHERE_KEYSTORE_PASS` environment variable.
-
+* `--http_max_concurrent_requests` (Optional. Default: 20): the maximum number of
+    concurrent requests, that is allowed before rejecting.
 
 
 

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -53,6 +53,12 @@ trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMat
     noshort = true,
     default = None)
 
+  lazy val maxConcurrentHttpConnections = opt[Int]("http_max_concurrent_requests",
+    descr = "The number of concurrent http requests, that are allowed before rejecting.",
+    noshort = true,
+    default = Some(20)
+  )
+
   lazy val accessControlAllowOrigin = opt[String]("access_control_allow_origin",
     descr = "The origin(s) to allow in Marathon. Not set by default. " +
       "Example values are \"*\", or " +

--- a/src/main/scala/mesosphere/marathon/api/LimitConcurrentRequestsFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LimitConcurrentRequestsFilter.scala
@@ -1,0 +1,31 @@
+package mesosphere.marathon.api
+
+import java.util.concurrent.Semaphore
+import javax.servlet._
+import javax.servlet.http.HttpServletResponse
+
+/**
+  * Limit the number of concurrent http requests.
+  * @param concurrentRequests the maximum number of concurrent requests.
+  */
+class LimitConcurrentRequestsFilter(concurrentRequests: Int) extends Filter {
+
+  private[this] val semaphore = new Semaphore(concurrentRequests)
+
+  override def doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain): Unit = {
+    if (semaphore.tryAcquire()) {
+      try { chain.doFilter(request, response) }
+      finally { semaphore.release() }
+    }
+    else {
+      response match {
+        //scalastyle:off magic.number
+        case r: HttpServletResponse => r.sendError(503, s"Too many concurrent requests! Allowed: $concurrentRequests.")
+        case r: ServletResponse     => throw new IllegalArgumentException(s"Expected http response but got $response")
+      }
+    }
+  }
+
+  override def init(filterConfig: FilterConfig): Unit = {}
+  override def destroy(): Unit = {}
+}

--- a/src/test/scala/mesosphere/marathon/api/LimitConcurrentRequestsFilterTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/LimitConcurrentRequestsFilterTest.scala
@@ -1,0 +1,54 @@
+package mesosphere.marathon.api
+
+import java.util.concurrent.{ TimeUnit, CountDownLatch, Semaphore }
+import javax.servlet.FilterChain
+import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
+
+import mesosphere.marathon.MarathonSpec
+import mesosphere.util.Mockito
+import org.scalatest.{ Matchers, GivenWhenThen }
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class LimitConcurrentRequestsFilterTest extends MarathonSpec with GivenWhenThen with Mockito with Matchers {
+
+  test("Multiple requests below boundary get answered correctly") {
+    Given("A http filter chain")
+    val latch = new CountDownLatch(2)
+    val request = mock[HttpServletRequest]
+    val response = mock[HttpServletResponse]
+    val chain = mock[FilterChain]
+    chain.doFilter(request, response) answers { args => latch.countDown() }
+    val rf = new LimitConcurrentRequestsFilter(2)
+
+    When("requests where made before the limit")
+    Future(rf.doFilter(request, response, chain))
+    Future(rf.doFilter(request, response, chain))
+
+    Then("The requests got answered")
+    latch.await(5, TimeUnit.SECONDS) should be(true)
+  }
+
+  test("Multiple requests above boundary get a 503") {
+    Given("A http filter chain")
+    val semaphore = new Semaphore(1)
+    val latch = new CountDownLatch(1)
+    semaphore.acquire()
+    val request = mock[HttpServletRequest]
+    val response = mock[HttpServletResponse]
+    val chain = mock[FilterChain]
+    chain.doFilter(request, response) answers { args => latch.countDown(); semaphore.acquire() /* blocks*/ }
+    val rf = new LimitConcurrentRequestsFilter(1)
+
+    When("requests where made before the limit")
+    Future(rf.doFilter(request, response, chain))
+    latch.await(5, TimeUnit.SECONDS) should be(true) //make sure, first "request" has passed
+    rf.doFilter(request, response, chain) //no future, since that should fail synchronously
+
+    Then("The requests got answered")
+    verify(chain, times(1)).doFilter(request, response)
+    verify(response, times(1)).sendError(503, "Too many concurrent requests! Allowed: 1.")
+    semaphore.release() //release the blocked thread
+  }
+}

--- a/src/test/scala/mesosphere/util/Mockito.scala
+++ b/src/test/scala/mesosphere/util/Mockito.scala
@@ -1,0 +1,40 @@
+package mesosphere.util
+
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.{ Answer, OngoingStubbing }
+import org.mockito.verification.VerificationMode
+import org.mockito.{ Mockito => M }
+import org.scalatest.mock.MockitoSugar
+
+/**
+  * ScalaTest mockito support is quite limited and ugly.
+  */
+trait Mockito extends MockitoSugar {
+
+  def any[T] = org.mockito.Matchers.any[T]
+  def anyBoolean = org.mockito.Matchers.anyBoolean
+  def anyString = org.mockito.Matchers.anyString
+  def verify[T](t: T, mode: VerificationMode) = M.verify(t, mode)
+  def times(num: Int) = M.times(num)
+  def atLeastOnce = M.atLeastOnce()
+  def atLeast(num: Int) = M.atLeast(num)
+  def atMost(num: Int) = M.atMost(num)
+
+  class MockAnswer[T](function: Array[AnyRef] => T) extends Answer[T] {
+    def answer(invocation: InvocationOnMock): T = {
+      function(invocation.getArguments)
+    }
+  }
+
+  implicit class Stubbed[T](c: => T) {
+    def returns(t: T, t2: T*): OngoingStubbing[T] = {
+      if (t2.isEmpty) M.when(c).thenReturn(t)
+      else t2.foldLeft (M.when(c).thenReturn(t)) { (res, cur) => res.thenReturn(cur) }
+    }
+    def answers(function: Array[AnyRef] => T) = M.when(c).thenAnswer(new MockAnswer(function))
+    def throws[E <: Throwable](e: E*): OngoingStubbing[T] = {
+      if (e.isEmpty) throw new java.lang.IllegalArgumentException("The parameter passed to throws must not be empty")
+      e.drop(1).foldLeft(M.when(c).thenThrow(e.head)) { (res, cur) => res.thenThrow(cur) }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1710 Too many simultaneous requests will kill Marathon.