### PR TITLE
Fixes #1716 - Add Proxy headers

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
@@ -65,13 +65,19 @@ class LeaderProxyFilter @Inject() (httpConf: HttpConf,
   private[this] val scheme = if (httpConf.disableHttp()) "https" else "http"
 
   private[this] def buildUrl(leaderData: String, request: HttpServletRequest): URL = {
-    if (request.getQueryString != null) {
-      new URL(s"$scheme://$leaderData${request.getRequestURI}?${request.getQueryString}")
-    }
-    else {
-      new URL(s"$scheme://$leaderData${request.getRequestURI}")
-    }
+    buildUrl(leaderData, request.getRequestURI, Option(request.getQueryString))
   }
+
+  private[this] def buildUrl(
+    leaderData: String,
+    requestURI: String = "",
+    queryStringOpt: Option[String] = None): URL =
+    {
+      queryStringOpt match {
+        case Some(queryString) => new URL(s"$scheme://$leaderData$requestURI?$queryString")
+        case None              => new URL(s"$scheme://$leaderData$requestURI")
+      }
+    }
 
   //TODO: fix style issue and enable this scalastyle check
   //scalastyle:off cyclomatic.complexity method.length
@@ -117,6 +123,7 @@ class LeaderProxyFilter @Inject() (httpConf: HttpConf,
         lazy val leaderDataOpt = leaderInfo.currentLeaderHostPort()
 
         if (leaderInfo.elected) {
+          response.addHeader(LeaderProxyFilter.HEADER_MARATHON_LEADER, buildUrl(myHostPort).toString)
           chain.doFilter(request, response)
         }
         else if (leaderDataOpt.forall(_ == myHostPort)) { // either not leader or ourselves
@@ -159,6 +166,7 @@ class LeaderProxyFilter @Inject() (httpConf: HttpConf,
 object LeaderProxyFilter {
   private val log = Logger.getLogger(getClass.getName)
 
+  val HEADER_MARATHON_LEADER: String = "X-Marathon-Leader"
   val ERROR_STATUS_NO_CURRENT_LEADER: String = "Could not determine the current leader"
 }
 
@@ -263,6 +271,7 @@ class JavaUrlConnectionRequestForwarder @Inject() (
           }
         }
       }
+      response.addHeader(HEADER_VIA, viaValue)
 
       IO.using(response.getOutputStream) { output =>
         try {

--- a/src/test/scala/mesosphere/marathon/api/LeaderProxyFilterTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/LeaderProxyFilterTest.scala
@@ -58,6 +58,7 @@ class LeaderProxyFilterTest extends MarathonSpec {
     filter.doFilter(request, response, chain)
 
     // we pass that request down the chain
+    verify(response, times(1)).addHeader(LeaderProxyFilter.HEADER_MARATHON_LEADER, "http://host:10000")
     verify(leaderInfo, times(1)).elected
     verify(chain, times(1)).doFilter(request, response)
   }
@@ -168,6 +169,7 @@ class LeaderProxyFilterTest extends MarathonSpec {
     // we pass that request down the chain
     verify(leaderInfo, times(4)).elected
     verify(leaderInfo, times(3)).currentLeaderHostPort()
+    verify(response, times(1)).addHeader(LeaderProxyFilter.HEADER_MARATHON_LEADER, "http://host:10000")
     verify(chain, times(1)).doFilter(request, response)
   }
 

--- a/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
@@ -121,7 +121,9 @@ object ForwarderService {
   private def startImpl(conf: ForwarderConf, leaderModule: Module, assetPath: String = "/tmp"): Service = {
     val injector = Guice.createInjector(
       new MetricsModule, new HttpModule(conf),
-      new ForwarderAppModule(myHostPort = s"localhost:${conf.httpPort()}", conf, conf),
+      new ForwarderAppModule(
+        myHostPort = if (conf.disableHttp()) s"localhost:${conf.httpsPort()}" else s"localhost:${conf.httpPort()}",
+        conf, conf),
       leaderModule
     )
     val http = injector.getInstance(classOf[HttpService])


### PR DESCRIPTION
X-Marathon-Leader points to current leader and X-Marathon-Via is now also
set in the proxy responses.