### PR TITLE
Fix flaky integration tests.

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/EventSubscribersIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/EventSubscribersIntegrationTest.scala
@@ -14,28 +14,28 @@ class EventSubscribersIntegrationTest
 
   test("adding an event subscriber") {
     When("an event subscriber is added")
-    marathon.subscribe("http://foobar.com:1337").code should be(200)
+    marathon.subscribe("http://localhost:1337").code should be(200)
 
     Then("a notification should be sent to all the subscribers")
-    waitForEvent("subscribe_event").info should contain("callbackUrl" -> "http://foobar.com:1337")
+    waitForEvent("subscribe_event").info should contain("callbackUrl" -> "http://localhost:1337")
 
     And("the subscriber should show up in the list of subscribers")
-    marathon.listSubscribers.value.urls should contain("http://foobar.com:1337")
+    marathon.listSubscribers.value.urls should contain("http://localhost:1337")
 
     // Cleanup
-    marathon.unsubscribe("http://foobar.com:1337")
+    marathon.unsubscribe("http://localhost:1337")
   }
 
   test("removing an event subscriber") {
     When("an event subscriber is removed")
-    marathon.subscribe("http://foobar.com:1337").code should be(200)
-    marathon.listSubscribers.value.urls should contain("http://foobar.com:1337")
-    marathon.unsubscribe("http://foobar.com:1337").code should be(200)
+    marathon.subscribe("http://localhost:1337").code should be(200)
+    marathon.listSubscribers.value.urls should contain("http://localhost:1337")
+    marathon.unsubscribe("http://localhost:1337").code should be(200)
 
     Then("a notification should be sent to all the subscribers")
-    waitForEvent("unsubscribe_event").info should contain("callbackUrl" -> "http://foobar.com:1337")
+    waitForEvent("unsubscribe_event").info should contain("callbackUrl" -> "http://localhost:1337")
 
     And("the subscriber should not show up in the list of subscribers")
-    marathon.listSubscribers.value.urls shouldNot contain("http://foobar.com:1337")
+    marathon.listSubscribers.value.urls shouldNot contain("http://localhost:1337")
   }
 }


### PR DESCRIPTION
The tests in the EventSubscribersIntegrationTest suite were flaky, because they
tried to register foobar.com as an endpoint. Fixed them by using localhost
instead of foobar.com.