### PR TITLE
Fix #1681: Allow administratively getting and resetting the taskLaunchDelay

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -40,6 +40,7 @@ title: REST API
   * [DELETE /v2/eventSubscriptions](#delete-/v2/eventsubscriptions) Unregister a callback URL from the event subscribers list
 * [Queue](#queue) <span class="label label-default">v0.7.0</span>
   * [GET /v2/queue](#get-/v2/queue): List content of the staging queue.
+  * [DELETE /v2/queue/{appId}/delay](#delete-/v2/queue/{appId}/delay): <span class="label label-default">v0.10.0</span> Reset the application specific task launch delay.
 * [Server Info](#server-info) <span class="label label-default">v0.7.0</span>
   * [GET /v2/info](#get-/v2/info): Get info about the Marathon Instance
   * [GET /v2/leader](#get-/v2/leader): Get the current leader
@@ -2428,7 +2429,8 @@ Transfer-Encoding: chunked
         {
             "count" : 10,
             "delay": {
-              "overdue": "true"
+              "overdue": "true",
+              "timeLeftSeconds": 784
             }
             "app" : {
                 "cmd" : "tail -f /dev/null",
@@ -2464,6 +2466,30 @@ Transfer-Encoding: chunked
         }
     ]
 }
+{% endhighlight %}
+
+#### DELETE `/v2/queue/{appId}/delay`
+
+The application specific task launch delay can be reset by calling this endpoint 
+
+##### Example
+
+{% highlight http %}
+DELETE /v2/queue/myapp/delay HTTP/1.1
+Accept: */*
+Accept-Encoding: gzip, deflate
+Connection: keep-alive
+Content-Length: 0
+Host: localhost:8080
+User-Agent: HTTPie/0.9.2
+{% endhighlight %}
+
+{% highlight http %}
+HTTP/1.1 204 No Content
+Cache-Control: no-cache, no-store, must-revalidate
+Expires: 0
+Pragma: no-cache
+Server: Jetty(8.1.15.v20140411)
 {% endhighlight %}
 
 ### Server Info

--- a/src/main/resources/mesosphere/marathon/api/v2/QueueResource_index.md
+++ b/src/main/resources/mesosphere/marathon/api/v2/QueueResource_index.md
@@ -1,6 +1,14 @@
 ## GET `/v2/queue`
 
-List all the tasks queued up or waiting to be scheduled.  This is mainly used for troubleshooting and occurs when scaling changes are requested and the volume of scaling changes out paces the ability to schedule those tasks.  
+List all the tasks queued up or waiting to be scheduled.  
+This is mainly used for troubleshooting and occurs when scaling 
+changes are requested and the volume of scaling changes out paces the ability to schedule those tasks.
+  
+In addition to the application in the queue, you see also the task count that needs to be started.
+
+If the task has a rate limit, then a delay to the start gets applied.
+You can see this delay for every application with the seconds to wait before the next launch will be tried.
+
 
 ### Example (as JSON)
 
@@ -8,53 +16,42 @@ List all the tasks queued up or waiting to be scheduled.  This is mainly used fo
 
 ```
 GET /v2/queue HTTP/1.1
-Accept: application/json
-Accept-Encoding: gzip, deflate, compress
-Content-Type: application/json; charset=utf-8
+Accept: */*
+Accept-Encoding: gzip, deflate
+Connection: keep-alive
 Host: localhost:8080
-User-Agent: HTTPie/0.7.2
-
-
+User-Agent: HTTPie/0.9.2
 ```
 
 **Response:**
 
 ```
 HTTP/1.1 200 OK
+Cache-Control: no-cache, no-store, must-revalidate
 Content-Type: application/json
-Server: Jetty(8.y.z-SNAPSHOT)
+Expires: 0
+Pragma: no-cache
+Server: Jetty(8.1.15.v20140411)
 Transfer-Encoding: chunked
 
-{  
-   "queue":[  
-      {  
-         "id":"tomcat",
-         "cmd":"mv *.war apache-tomcat-*/webapps && cd apache-tomcat-* && sed \"s/8080/$PORT/g\" < ./conf/server.xml > ./conf/server-mesos.xml && ./bin/catalina.sh run -config ./conf/server-mesos.xml",
-         "env":{  
-
-         },
-         "instances":3,
-         "cpus":1.0,
-         "mem":512.0,
-         "disk":0.0,
-         "executor":"",
-         "constraints":[  
-
-         ],
-         "uris":[  
-            "/home/vagrant/apache-tomcat-7.0.55.tar.gz",
-            "/home/vagrant/Calendar.war"
-         ],
-         "ports":[  
-            16401
-         ],
-         "container":null,
-         "healthChecks":[  
-
-         ],
-         "version":"2014-08-08T17:04:19.022Z"
-      }
-   ]
+{
+    "queue": [
+        {
+            "app": {
+                "id": "/my/app", 
+                "instances": 100, 
+                "maxLaunchDelaySeconds": 3600, 
+                "mem": 16.0, 
+                "requirePorts": false, 
+                "version": "2015-07-06T15:29:04.554Z"
+            }, 
+            "count": 100, 
+            "delay": {
+                "overdue": false, 
+                "timeLeftSeconds": 784
+            }
+        }
+    ]
 }
 
 ```

--- a/src/main/resources/mesosphere/marathon/api/v2/QueueResource_resetDelay.md
+++ b/src/main/resources/mesosphere/marathon/api/v2/QueueResource_resetDelay.md
@@ -1,0 +1,29 @@
+## DELETE `/v2/queue/{app_id}/delay`
+
+The application specific task launch delay can be reset by calling this endpoint 
+
+### Example 
+
+**Request:**
+
+```
+DELETE /v2/queue/myapp/delay HTTP/1.1
+Accept: */*
+Accept-Encoding: gzip, deflate
+Connection: keep-alive
+Content-Length: 0
+Host: localhost:8080
+User-Agent: HTTPie/0.9.2
+```
+
+**Response:**
+
+```
+HTTP/1.1 204 No Content
+Cache-Control: no-cache, no-store, must-revalidate
+Expires: 0
+Pragma: no-cache
+Server: Jetty(8.1.15.v20140411)
+```
+
+If there is no application in the queue with this identifier a HTTP 404 is returned.

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -1,12 +1,14 @@
 package mesosphere.marathon.api.v2
 
-import javax.ws.rs.{ Path, GET, Consumes, Produces }
-import javax.ws.rs.core.{ MediaType, Response }
-import com.codahale.metrics.annotation.Timed
 import javax.inject.Inject
+import javax.ws.rs._
+import javax.ws.rs.core.{ MediaType, Response }
+
+import com.codahale.metrics.annotation.Timed
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.api.RestResource
 import mesosphere.marathon.api.v2.json.{ Formats, V2AppDefinition }
+import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.tasks.TaskQueue
 import play.api.libs.json.Json
 
@@ -28,11 +30,23 @@ class QueueResource @Inject() (
           "app" -> V2AppDefinition(task.app),
           "count" -> task.count.get(),
           "delay" -> Json.obj(
+            "timeLeftSeconds" -> math.max(0, delay.timeLeft.toSeconds), //deadlines can be negative
             "overdue" -> delay.isOverdue()
           )
         )
     }
 
     ok(Json.obj("queue" -> queuedWithDelay).toString())
+  }
+
+  @DELETE
+  @Path("""{appId:.+}/delay""")
+  def resetDelay(@PathParam("appId") appId: String): Response = {
+    val id = appId.toRootPath
+    taskQueue.listWithDelay.find(_._1.app.id == id).map {
+      case (task, deadline) =>
+        taskQueue.resetDelay(task.app)
+        noContent
+    }.getOrElse(notFound(s"application $appId not found in task queue"))
   }
 }

--- a/src/main/scala/mesosphere/marathon/tasks/TaskQueue.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskQueue.scala
@@ -129,4 +129,12 @@ class TaskQueue {
 
     findMatching(sorted)
   }
+
+  /**
+    * Reset the rate limiting delay for the given app definition
+    * @param app the app definition to reset.
+    */
+  def resetDelay(app: AppDefinition): Unit = {
+    rateLimiter.resetDelay(app)
+  }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -1,50 +1,91 @@
 package mesosphere.marathon.api.v2
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.v2.json.V2AppDefinition
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.tasks.TaskQueue.QueuedTask
 import mesosphere.marathon.{ MarathonConf, MarathonSpec }
 import mesosphere.marathon.tasks.TaskQueue
+import mesosphere.util.Mockito
 import org.scalatest.Matchers
-import play.api.libs.json.{ JsObject, Json }
+import play.api.libs.json._
+import scala.concurrent.duration._
+import scala.collection.immutable.Seq
 
-class QueueResourceTest extends MarathonSpec with Matchers {
+class QueueResourceTest extends MarathonSpec with Matchers with Mockito {
 
-  // regression test for #1210
   test("return well formatted JSON") {
-    val queue = new TaskQueue
-    val app1 = AppDefinition(id = "app1".toRootPath)
-    val app2 = AppDefinition(id = "app2".toRootPath)
+    //given
+    val queue = mock[TaskQueue]
+    val app = AppDefinition(id = "app".toRootPath)
     val resource = new QueueResource(queue, mock[MarathonConf])
+    queue.listWithDelay returns Seq(QueuedTask(app, new AtomicInteger(23)) -> 100.seconds.fromNow)
 
-    queue.add(app1, 4)
-    queue.add(app2, 2)
+    //when
+    val response = resource.index()
 
-    for (_ <- 0 until 10)
-      queue.rateLimiter.addDelay(app2)
-
-    val json = Json.parse(resource.index().getEntity.toString)
-
-    val queuedApp1 = Json.obj(
-      "count" -> 4,
-      "delay" -> Json.obj(
-        "overdue" -> true
-      ),
-      "app" -> V2AppDefinition(app1)
-    )
-
-    val queuedApp2 = Json.obj(
-      "count" -> 2,
-      "delay" -> Json.obj(
-        "overdue" -> false
-      ),
-      "app" -> V2AppDefinition(app2)
-    )
-
+    //then
+    response.getStatus should be(200)
+    val json = Json.parse(response.getEntity.asInstanceOf[String])
     val queuedApps = (json \ "queue").as[Seq[JsObject]]
+    val jsonApp1 = queuedApps.find(_ \ "app" \ "id" == JsString("/app")).get
 
-    assert(queuedApps.contains(queuedApp1))
-    assert(queuedApps.contains(queuedApp2))
+    jsonApp1 \ "app" should be(Json.toJson(V2AppDefinition(app)))
+    jsonApp1 \ "count" should be(Json.toJson(23))
+    jsonApp1 \ "delay" \ "overdue" should be(Json.toJson(false))
+    (jsonApp1 \ "delay" \ "timeLeftSeconds").as[Int] should be(100 +- 5) //the deadline holds the current time...
+  }
+
+  test("the generated info from the queue contains 0 if there is no delay") {
+    //given
+    val queue = mock[TaskQueue]
+    val app = AppDefinition(id = "app".toRootPath)
+    val resource = new QueueResource(queue, mock[MarathonConf])
+    queue.listWithDelay returns Seq(QueuedTask(app, new AtomicInteger(23)) -> -100.seconds.fromNow)
+
+    //when
+    val response = resource.index()
+
+    //then
+    response.getStatus should be(200)
+    val json = Json.parse(response.getEntity.asInstanceOf[String])
+    val queuedApps = (json \ "queue").as[Seq[JsObject]]
+    val jsonApp1 = queuedApps.find(_ \ "app" \ "id" == JsString("/app")).get
+
+    jsonApp1 \ "app" should be(Json.toJson(V2AppDefinition(app)))
+    jsonApp1 \ "count" should be(Json.toJson(23))
+    jsonApp1 \ "delay" \ "overdue" should be(Json.toJson(true))
+    jsonApp1 \ "delay" \ "timeLeftSeconds" should be(Json.toJson(0))
+  }
+
+  test("unknown application backoff can not be removed from the taskqueue") {
+    //given
+    val queue = mock[TaskQueue]
+    val resource = new QueueResource(queue, mock[MarathonConf])
+    queue.listWithDelay returns Seq.empty
+
+    //when
+    val response = resource.resetDelay("unknown")
+
+    //then
+    response.getStatus should be(404)
+  }
+
+  test("application backoff can be removed from the taskqueue") {
+    //given
+    val queue = mock[TaskQueue]
+    val app = AppDefinition(id = "app".toRootPath)
+    val resource = new QueueResource(queue, mock[MarathonConf])
+    queue.listWithDelay returns Seq(QueuedTask(app, new AtomicInteger(23)) -> 100.seconds.fromNow)
+
+    //when
+    val response = resource.resetDelay("app")
+
+    //then
+    response.getStatus should be(204)
+    verify(queue, times(1)).resetDelay(app)
   }
 }


### PR DESCRIPTION
The queue endpoint holds the duration.
A new endpoint is added to allow resetting the task launch duration.