### PR TITLE
Speedup PortsMatcher

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonClusterIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonClusterIntegrationTest.scala
@@ -9,8 +9,8 @@ object MarathonClusterIntegrationTest {
 
 /**
   * Convenient trait to test against a Marathon cluster.
- *
- * The cluster sized is determined by [[IntegrationTestConfig.clusterSize]].
+  *
+  * The cluster sized is determined by [[IntegrationTestConfig.clusterSize]].
   */
 trait MarathonClusterIntegrationTest extends SingleMarathonIntegrationTest { self: Suite =>
   lazy val marathonFacades: Seq[MarathonFacade] = config.marathonUrls.map(url => new MarathonFacade(url, testBasePath))

--- a/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
@@ -17,7 +17,7 @@ class PortWithRoleRandomPortsFromRangesTest extends MarathonSpec {
   private[this] val log = LoggerFactory.getLogger(getClass)
 
   private[this] def portRange(role: String, begin: Long, end: Long): PortRange = {
-    PortRange(role, Range.inclusive(begin.toInt, end.toInt))
+    PortRange(role, begin.toInt, end.toInt)
   }
 
   private[this] def withRandomSeeds(input: Seq[PortRange], expectedOutput: Iterable[PortWithRole]): Unit = {


### PR DESCRIPTION
Scala Range contains is implemented naively.
So don't use that.