### PR TITLE
fix servicerouter.py logging

### DIFF
--- a/bin/servicerouter.py
+++ b/bin/servicerouter.py
@@ -731,13 +731,14 @@ def get_arg_parser():
                              "script back at (http://lb1:8080)"
                         )
 
-    default_log_socket = "/var/run/syslog"
+    
+    default_log_socket = "/dev/log"
     if sys.platform == "darwin":
-        default_log_socket = "/dev/log"
+        default_log_socket = "/var/run/syslog"
 
     parser.add_argument("--syslog-socket",
                         help="Socket to write syslog messages to",
-                        default=log_socket
+                        default=default_log_socket
                         )
     parser.add_argument("--haproxy-config",
                         help="Location of haproxy configuration",


### PR DESCRIPTION
servicerouter.py is currently broken in master.
```
[root@srv4.hw.ca1 servicerouter]# ./servicerouter.py
Traceback (most recent call last):
  File "./servicerouter.py", line 792, in <module>
    arg_parser = get_arg_parser()
  File "./servicerouter.py", line 740, in get_arg_parser
    default=log_socket
NameError: global name 'log_socket' is not defined
```

This fixes the problem.