### PR TITLE
Add the content length to WSGI input reading

### DIFF
--- a/bin/servicerouter.py
+++ b/bin/servicerouter.py
@@ -762,18 +762,20 @@ def run_server(marathon, callback_url, config_file, groups):
     # TODO(cmaloney): Switch to a sane http server
     # TODO(cmaloney): Good exception catching, etc
     def wsgi_app(env, start_response):
-        subscriber.handle_event(json.load(env['wsgi.input']))
+        length = int(env['CONTENT_LENGTH'])
+        data = env['wsgi.input'].read(length)
+        subscriber.handle_event(json.loads(data))
         # TODO(cmaloney): Make this have a simple useful webui for debugging /
         # monitoring
         start_response('200 OK', [('Content-Type', 'text/html')])
 
-        return "Got it"
+        return "Got it\n"
 
     try:
         port = int(callback_url.split(':')[-1])
     except ValueError:
         port = 8000  # no port or invalid port specified
-    print "Serving on port {}...".format(port)
+    logger.info("Serving on port {}...".format(port))
     httpd = make_server('', port, wsgi_app)
     httpd.serve_forever()
 


### PR DESCRIPTION
This is required to stop the input from being indefinitely read, and
thereby blocking the response