### PR TITLE
Increase timeout for futures in PersistentStoreTests

### DIFF
--- a/src/test/scala/mesosphere/util/state/PersistentStoreTest.scala
+++ b/src/test/scala/mesosphere/util/state/PersistentStoreTest.scala
@@ -3,12 +3,16 @@ package mesosphere.util.state
 import mesosphere.marathon.StoreCommandFailedException
 import mesosphere.marathon.integration.setup.IntegrationFunSuite
 import org.scalatest.concurrent.ScalaFutures._
-import org.scalatest.{ BeforeAndAfter, Matchers }
+import org.scalatest.time.{Seconds, Span}
+import org.scalatest.{BeforeAndAfter, Matchers}
 
 /**
   * Common  tests for all persistent stores.
   */
 trait PersistentStoreTest extends IntegrationFunSuite with Matchers with BeforeAndAfter {
+
+  //this parameter is used for futureValue timeouts
+  implicit val patienceConfig = PatienceConfig(Span(10, Seconds))
 
   test("Root node gets read"){
     val store = persistentStore


### PR DESCRIPTION
The default timeout for futures to return is 150 millis, which can be too short in some environments and will break the integration tests.