### PR TITLE
force mode to http if hostname is set for app

### DIFF
--- a/bin/servicerouter.py
+++ b/bin/servicerouter.py
@@ -144,6 +144,7 @@ class ConfigTemplater(object):
       log 127.0.0.1 local0
       log 127.0.0.1 local1 notice
       maxconn 4096
+      tune.ssl.default-dh-param 2048
 
     defaults
       log               global
@@ -493,6 +494,11 @@ def config(apps, groups):
 
         logger.debug("frontend at %s:%d with backend %s",
                      app.bindAddr, app.servicePort, backend)
+
+        # if the app has a hostname set force mode to http
+        # otherwise recent versions of haproxy refuse to start
+        if app.hostname:
+            app.mode = 'http'
 
         frontend_head = templater.haproxy_frontend_head
         frontends += frontend_head.format(


### PR DESCRIPTION
Sets connection mode to http if a host name was set. Without this recent versions of haproxy refuse to start with the error
```
Jul 15 15:17:55 srv2 haproxy-systemd-wrapper[14455]: [WARNING] 195/151754 (14456) : parsing [/etc/haproxy/haproxy.cfg:244] : HTTP log/header format not usable with backend 'kraken_application_search_4242' (needs 'mode http').
Jul 15 15:17:55 srv2 haproxy-systemd-wrapper[14455]: [ALERT] 195/151754 (14456) : Fatal errors found in configuration.
Jul 15 15:17:55 srv2 haproxy-systemd-wrapper[14455]: haproxy-systemd-wrapper: exit, haproxy RC=256
```

Also sets tune.ssl.default-dh-param to get rid of
```
Jul 15 15:28:14 srv2 haproxy-systemd-wrapper[16375]: [WARNING] 195/152814 (17144) : Setting tune.ssl.default-dh-param to 1024 by default, if your workload permits it you should set it to at least 2048. Please set a value >= 1024 to make this warning disappear.
```
