### PR TITLE
change permissions and add logging

### DIFF
--- a/bin/servicerouter.py
+++ b/bin/servicerouter.py
@@ -435,13 +435,16 @@ class Marathon(object):
         return self.api_req('POST', ['apps'], app_json)
 
     def get_app(self, appid):
+        logger.info('fetching app %s', appid)
         return self.api_req('GET', ['apps', appid])["app"]
 
     # Lists all running apps.
     def list(self):
+        logger.info('fetching apps')
         return self.api_req('GET', ['apps'])["apps"]
 
     def tasks(self):
+        logger.info('fetching tasks')
         return self.api_req('GET', ['tasks'])["tasks"]
 
     def add_subscriber(self, callbackUrl):
@@ -610,6 +613,8 @@ def writeConfig(config, config_file):
     logger.debug("writing config to temp file %s", haproxyTempConfigFile)
     with os.fdopen(fd, 'w') as haproxyTempConfig:
         haproxyTempConfig.write(config)
+
+    os.chmod(haproxyTempConfigFile, 0o644)
 
     # Move into place
     logger.debug("moving temp file %s to %s",

--- a/bin/servicerouter.py
+++ b/bin/servicerouter.py
@@ -622,9 +622,7 @@ def writeConfig(config, config_file):
     perms = 0o644
     if os.path.isfile(config_file):
         perms = stat.S_IMODE(os.lstat(config_file).st_mode)
-
     os.chmod(haproxyTempConfigFile, perms)
-
 
     # Move into place
     logger.debug("moving temp file %s to %s",

--- a/bin/servicerouter.py
+++ b/bin/servicerouter.py
@@ -130,7 +130,9 @@ from wsgiref.simple_server import make_server
 import argparse
 import json
 import logging
+import os
 import os.path
+import stat
 import re
 import requests
 import subprocess
@@ -614,7 +616,15 @@ def writeConfig(config, config_file):
     with os.fdopen(fd, 'w') as haproxyTempConfig:
         haproxyTempConfig.write(config)
 
-    os.chmod(haproxyTempConfigFile, 0o644)
+    # Ensure new config is created with the same
+    # permissions the old file had or use defaults
+    # if config file doesn't exist yet
+    perms = 0o644
+    if os.path.isfile(config_file):
+        perms = stat.S_IMODE(os.lstat(config_file).st_mode)
+
+    os.chmod(haproxyTempConfigFile, perms)
+
 
     # Move into place
     logger.debug("moving temp file %s to %s",


### PR DESCRIPTION
The default package permissions of /etc/haproxy/haproxy.cfg are 0644 on EL and Debian (http://pkgs.fedoraproject.org/cgit/haproxy.git/tree/haproxy.spec#n131). However after running servicerouter they are changed to 0600. This fixes that.

It also adds some additional output which is useful for marathon installations with lots of tasks.