### PR TITLE
Build for jdk 8 target.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: scala
 jdk:
-  - openjdk6
+  - oraclejdk8
 scala:
   - 2.11.7
 cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-FROM mesosphere/mesos:0.22.1-1.0.ubuntu1404
+FROM java:8-jdk
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y \
-    default-jdk \
-    scala \
-    curl
-
-RUN curl -SsL -O http://dl.bintray.com/sbt/debian/sbt-0.13.5.deb && \
-    dpkg -i sbt-0.13.5.deb
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+    echo "deb http://repos.mesosphere.io/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y --force-yes mesos=0.23.0-1.0.debian81 sbt
 
 COPY . /marathon
 WORKDIR /marathon

--- a/Dockerfile.build-base
+++ b/Dockerfile.build-base
@@ -1,13 +1,10 @@
-FROM mesosphere/mesos:0.22.1-1.0.ubuntu1404
+FROM java:8-jdk
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y \
-    default-jdk \
-    curl
-
-RUN curl -SsL -O http://dl.bintray.com/sbt/debian/sbt-0.13.5.deb && \
-    dpkg -i sbt-0.13.5.deb
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+    echo "deb http://repos.mesosphere.io/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y --force-yes mesos=0.23.0-1.0.debian81 sbt
 
 COPY . /marathon
 WORKDIR /marathon

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -43,7 +43,7 @@ SBT_DIR="${SBT_DIR-$BUILD_VOLUME_DIR/sbt}"
 IVY2_DIR="${IVY2_DIR-$BUILD_VOLUME_DIR/ivy2}"
 TARGET_DIRS="${TARGET_DIRS-$BUILD_VOLUME_DIR/targets}"
 CLEANUP_TARGET_DIRS="${CLEANUP_TARGET_DIRS-true}"
-CLEANUP_CONTAINERS_ON_EXIT="${CLEANUP_CONTAINERS-true}"
+CLEANUP_CONTAINERS_ON_EXIT="${CLEANUP_CONTAINERS_ON_EXIT-true}"
 export MARATHON_MAX_TASKS_PER_OFFER="${MARATHON_MAX_TASKS_PER_OFFER-1}"
 NO_DOCKER_CACHE="${NO_DOCKER_CACHE-true}"
 
@@ -126,7 +126,6 @@ docker run \
     -i \
     marathon-buildbase:$BUILD_ID \
     bash -c '
-    sbt -Dsbt.log.format=false test:compile &&\
     sbt -Dsbt.log.format=false test integration:test &&\
     sbt -Dsbt.log.format=false "project mesosSimulation" integration:test "test:runMain mesosphere.mesos.scale.DisplayAppScalingResults"' \
     || fatal "build/tests failed"

--- a/project/build.scala
+++ b/project/build.scala
@@ -95,7 +95,7 @@ object MarathonBuild extends Build {
     crossScalaVersions := Seq(scalaVersion.value),
     scalacOptions in Compile ++= Seq(
       "-encoding", "UTF-8",
-      "-target:jvm-1.6",
+      "-target:jvm-1.8",
       "-deprecation",
       "-feature",
       "-unchecked",
@@ -106,7 +106,7 @@ object MarathonBuild extends Build {
       "-Yno-adapted-args",
       "-Ywarn-numeric-widen"
     ),
-    javacOptions in Compile ++= Seq("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation"),
+    javacOptions in Compile ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-Xlint:unchecked", "-Xlint:deprecation"),
     resolvers ++= Seq(
       "Mesosphere Public Repo"    at "http://downloads.mesosphere.io/maven",
       "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -443,7 +443,9 @@ class AppDeployIntegrationTest
 
     Then("the deployment should be gone")
     waitForEvent("deployment_failed")
-    marathon.listDeploymentsForBaseGroup().value should have size 0
+    WaitTestSupport.waitUntil("Deployments get removed from the queue", 30.seconds) {
+      marathon.listDeploymentsForBaseGroup().value.isEmpty
+    }
 
     Then("the app should also be gone")
     val result = intercept[UnsuccessfulResponseException] {

--- a/src/test/scala/mesosphere/marathon/integration/TaskQueueIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/TaskQueueIntegrationTest.scala
@@ -1,6 +1,5 @@
 package mesosphere.marathon.integration
 
-import java.lang.{ Integer => JInt }
 
 import mesosphere.marathon.Protos
 import mesosphere.marathon.Protos.Constraint.Operator
@@ -8,6 +7,7 @@ import mesosphere.marathon.api.v2.json.V2AppDefinition
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.state.AppDefinition
 import org.scalatest.{ GivenWhenThen, Matchers }
+import scala.concurrent.duration._
 
 class TaskQueueIntegrationTest extends IntegrationFunSuite with SingleMarathonIntegrationTest with GivenWhenThen with Matchers {
   test("GET /v2/queue with an empty queue") {
@@ -31,6 +31,7 @@ class TaskQueueIntegrationTest extends IntegrationFunSuite with SingleMarathonIn
     create.code should be (201) // Created
 
     Then("the app shows up in the task queue")
+    WaitTestSupport.waitUntil("Deployment is put in the deployment queue", 30.seconds) { marathon.taskQueue().value.queue.size == 1 }
     val response = marathon.taskQueue()
     response.code should be (200)
 

--- a/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
@@ -76,6 +76,7 @@ object ForwarderService {
 
     ProcessKeeper.startJavaProcess(
       s"app_${conf.httpPort()}",
+      heapInMegs = 128,
       arguments = List(ForwarderService.className, "helloApp") ++ args,
       upWhen = _.contains("Started SelectChannelConnector"))
   }
@@ -85,6 +86,7 @@ object ForwarderService {
 
     ProcessKeeper.startJavaProcess(
       s"forwarder_${conf.httpPort()}",
+      heapInMegs =  128,
       arguments = List(ForwarderService.className, "forwarder", forwardToPort.toString) ++ args,
       upWhen = _.contains("SelectChannelConnector@"))
   }

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -131,7 +131,7 @@ trait SingleMarathonIntegrationTest
     val javaExecutable = sys.props.get("java.home").fold("java")(_ + "/bin/java")
     val classPath = sys.props.getOrElse("java.class.path", "target/classes").replaceAll(" ", "")
     val main = classOf[AppMock].getName
-    s"""$javaExecutable -classpath $classPath $main"""
+    s"""$javaExecutable -Xmx64m -classpath $classPath $main"""
   }
 
   /**


### PR DESCRIPTION
Docker: rely on the official jdk 8 container and install mesos afterwards.
IntegrationTests: set max heap mem explicitly for all launched applications.