### PR TITLE
Fixes #1818 - Make Marathon fail on startup errors

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -243,7 +243,7 @@ object Dependencies {
 object Dependency {
   object V {
     // runtime deps versions
-    val Chaos = "0.6.5"
+    val Chaos = "0.6.7"
     val JacksonCCM = "0.1.2"
     val MesosUtils = "0.22.1-1"
     val Akka = "2.3.9"

--- a/src/test/scala/mesosphere/marathon/integration/MarathonStartupIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MarathonStartupIntegrationTest.scala
@@ -1,0 +1,28 @@
+package mesosphere.marathon.integration
+
+import java.io.File
+
+import mesosphere.marathon.integration.setup._
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
+
+class MarathonStartupIntegrationTest extends IntegrationFunSuite
+    with SingleMarathonIntegrationTest
+    with Matchers
+    with BeforeAndAfter
+    with GivenWhenThen {
+  test("Marathon should fail during start, if the HTTP port is already bound") {
+    Given(s"a Marathon process already running on port ${config.marathonBasePort}")
+
+    When("starting another Marathon process using an HTTP port that is already bound")
+    val cwd = new File(".")
+    val failingProcess = ProcessKeeper.startMarathon(
+      cwd,
+      env,
+      List("--http_port", config.marathonBasePort.toString, "--zk", config.zk, "--master", config.master),
+      startupLine = "FATAL Failed to start all services."
+    )
+
+    Then("the new process should fail and exit with an error code")
+    assert(failingProcess.exitValue() > 0)
+  }
+}


### PR DESCRIPTION
Fixes #1818 - Make Marathon fail on startup errors

Upgrade Chaos to the latest version, in order to make
Marathon fail and exit if any of the services can't be started,
e.g., if another process is already bound to the the HTTP port.