### PR TITLE
#878 - Add slaveId in MarathonTask and API to retrieve Mesos Master URL

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -112,6 +112,10 @@ The core functionality flags can be also set by environment variable `MARATHON_O
     authentication
 * `--mesos_authentication_secret_file` (Optional.): The path to the Mesos secret
     file containing the authentication secret
+* `--mesos_master_url` (Optional.): The URL to the Mesos master facade. By default this
+    value is detected automatically when framework is registered or new Mesos leader is
+    elected.
+    Format: `protocol://host:port/`
 * `--marathon_store_timeout` (Optional. Default: 2000 (2 seconds)): Maximum time
     in milliseconds, to wait for persistent storage operations to complete.
 * <span class="label label-default">v0.10.0</span> `--env_vars_prefix` (Optional. Default: None):

--- a/docs/docs/constraints.md
+++ b/docs/docs/constraints.md
@@ -23,6 +23,8 @@ If the specified attribute is not defined on the slave, then most operators will
 
 Attribute field supports all operators of Marathon.
 
+Note that currently Marathon only supports text values for attributes and will not be able to process any numberic values. For example the attribute pair `foo:bar` will be recognised, but marathon will not be able to match `cpu:4`.
+
 ## Operators
 
 ### UNIQUE operator

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -1967,6 +1967,7 @@ Server: Jetty(8.y.z-SNAPSHOT)
         "local_port_max": 49151,
         "local_port_min": 32767,
         "master": "zk://localhost:2181/mesos",
+        "mesos_master_url": "http://mesos.vm:5050",
         "mesos_role": null,
         "mesos_user": "root",
         "reconciliation_initial_delay": 30000,

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -7536,6 +7536,20 @@ public final class Protos {
      * <code>optional .mesos.TaskStatus status = 9;</code>
      */
     org.apache.mesos.Protos.TaskStatusOrBuilder getStatusOrBuilder();
+
+    // optional .mesos.SlaveID slaveId = 10;
+    /**
+     * <code>optional .mesos.SlaveID slaveId = 10;</code>
+     */
+    boolean hasSlaveId();
+    /**
+     * <code>optional .mesos.SlaveID slaveId = 10;</code>
+     */
+    org.apache.mesos.Protos.SlaveID getSlaveId();
+    /**
+     * <code>optional .mesos.SlaveID slaveId = 10;</code>
+     */
+    org.apache.mesos.Protos.SlaveIDOrBuilder getSlaveIdOrBuilder();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.MarathonTask}
@@ -7661,6 +7675,19 @@ public final class Protos {
                 status_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000020;
+              break;
+            }
+            case 82: {
+              org.apache.mesos.Protos.SlaveID.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000040) == 0x00000040)) {
+                subBuilder = slaveId_.toBuilder();
+              }
+              slaveId_ = input.readMessage(org.apache.mesos.Protos.SlaveID.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(slaveId_);
+                slaveId_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000040;
               break;
             }
           }
@@ -8002,6 +8029,28 @@ public final class Protos {
       return status_;
     }
 
+    // optional .mesos.SlaveID slaveId = 10;
+    public static final int SLAVEID_FIELD_NUMBER = 10;
+    private org.apache.mesos.Protos.SlaveID slaveId_;
+    /**
+     * <code>optional .mesos.SlaveID slaveId = 10;</code>
+     */
+    public boolean hasSlaveId() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional .mesos.SlaveID slaveId = 10;</code>
+     */
+    public org.apache.mesos.Protos.SlaveID getSlaveId() {
+      return slaveId_;
+    }
+    /**
+     * <code>optional .mesos.SlaveID slaveId = 10;</code>
+     */
+    public org.apache.mesos.Protos.SlaveIDOrBuilder getSlaveIdOrBuilder() {
+      return slaveId_;
+    }
+
     private void initFields() {
       id_ = "";
       host_ = "";
@@ -8012,6 +8061,7 @@ public final class Protos {
       oBSOLETEStatuses_ = java.util.Collections.emptyList();
       version_ = "1970-01-01T00:00:00.000Z";
       status_ = org.apache.mesos.Protos.TaskStatus.getDefaultInstance();
+      slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -8036,6 +8086,12 @@ public final class Protos {
       }
       if (hasStatus()) {
         if (!getStatus().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      if (hasSlaveId()) {
+        if (!getSlaveId().isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -8073,6 +8129,9 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeMessage(9, status_);
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeMessage(10, slaveId_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -8123,6 +8182,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(9, status_);
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(10, slaveId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -8235,6 +8298,7 @@ public final class Protos {
           getAttributesFieldBuilder();
           getOBSOLETEStatusesFieldBuilder();
           getStatusFieldBuilder();
+          getSlaveIdFieldBuilder();
         }
       }
       private static Builder create() {
@@ -8273,6 +8337,12 @@ public final class Protos {
           statusBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000100);
+        if (slaveIdBuilder_ == null) {
+          slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
+        } else {
+          slaveIdBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000200);
         return this;
       }
 
@@ -8351,6 +8421,14 @@ public final class Protos {
           result.status_ = status_;
         } else {
           result.status_ = statusBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        if (slaveIdBuilder_ == null) {
+          result.slaveId_ = slaveId_;
+        } else {
+          result.slaveId_ = slaveIdBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -8454,6 +8532,9 @@ public final class Protos {
         if (other.hasStatus()) {
           mergeStatus(other.getStatus());
         }
+        if (other.hasSlaveId()) {
+          mergeSlaveId(other.getSlaveId());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -8477,6 +8558,12 @@ public final class Protos {
         }
         if (hasStatus()) {
           if (!getStatus().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasSlaveId()) {
+          if (!getSlaveId().isInitialized()) {
             
             return false;
           }
@@ -9476,6 +9563,123 @@ public final class Protos {
           status_ = null;
         }
         return statusBuilder_;
+      }
+
+      // optional .mesos.SlaveID slaveId = 10;
+      private org.apache.mesos.Protos.SlaveID slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder> slaveIdBuilder_;
+      /**
+       * <code>optional .mesos.SlaveID slaveId = 10;</code>
+       */
+      public boolean hasSlaveId() {
+        return ((bitField0_ & 0x00000200) == 0x00000200);
+      }
+      /**
+       * <code>optional .mesos.SlaveID slaveId = 10;</code>
+       */
+      public org.apache.mesos.Protos.SlaveID getSlaveId() {
+        if (slaveIdBuilder_ == null) {
+          return slaveId_;
+        } else {
+          return slaveIdBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .mesos.SlaveID slaveId = 10;</code>
+       */
+      public Builder setSlaveId(org.apache.mesos.Protos.SlaveID value) {
+        if (slaveIdBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          slaveId_ = value;
+          onChanged();
+        } else {
+          slaveIdBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000200;
+        return this;
+      }
+      /**
+       * <code>optional .mesos.SlaveID slaveId = 10;</code>
+       */
+      public Builder setSlaveId(
+          org.apache.mesos.Protos.SlaveID.Builder builderForValue) {
+        if (slaveIdBuilder_ == null) {
+          slaveId_ = builderForValue.build();
+          onChanged();
+        } else {
+          slaveIdBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000200;
+        return this;
+      }
+      /**
+       * <code>optional .mesos.SlaveID slaveId = 10;</code>
+       */
+      public Builder mergeSlaveId(org.apache.mesos.Protos.SlaveID value) {
+        if (slaveIdBuilder_ == null) {
+          if (((bitField0_ & 0x00000200) == 0x00000200) &&
+              slaveId_ != org.apache.mesos.Protos.SlaveID.getDefaultInstance()) {
+            slaveId_ =
+              org.apache.mesos.Protos.SlaveID.newBuilder(slaveId_).mergeFrom(value).buildPartial();
+          } else {
+            slaveId_ = value;
+          }
+          onChanged();
+        } else {
+          slaveIdBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000200;
+        return this;
+      }
+      /**
+       * <code>optional .mesos.SlaveID slaveId = 10;</code>
+       */
+      public Builder clearSlaveId() {
+        if (slaveIdBuilder_ == null) {
+          slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
+          onChanged();
+        } else {
+          slaveIdBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000200);
+        return this;
+      }
+      /**
+       * <code>optional .mesos.SlaveID slaveId = 10;</code>
+       */
+      public org.apache.mesos.Protos.SlaveID.Builder getSlaveIdBuilder() {
+        bitField0_ |= 0x00000200;
+        onChanged();
+        return getSlaveIdFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .mesos.SlaveID slaveId = 10;</code>
+       */
+      public org.apache.mesos.Protos.SlaveIDOrBuilder getSlaveIdOrBuilder() {
+        if (slaveIdBuilder_ != null) {
+          return slaveIdBuilder_.getMessageOrBuilder();
+        } else {
+          return slaveId_;
+        }
+      }
+      /**
+       * <code>optional .mesos.SlaveID slaveId = 10;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder> 
+          getSlaveIdFieldBuilder() {
+        if (slaveIdBuilder_ == null) {
+          slaveIdBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder>(
+                  slaveId_,
+                  getParentForChildren(),
+                  isClean());
+          slaveId_ = null;
+        }
+        return slaveIdBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask)
@@ -20011,6 +20215,7 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ZKStoreEntry}
    *
    * <pre>
+   **
    * Describes a state entry, a versioned (via a UUID) key/value pair.
    * Copied from libmesos (src/messages/state.pro) to ensure
    * compatibility with ZooKeeperState from libmesos.
@@ -20335,6 +20540,7 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ZKStoreEntry}
      *
      * <pre>
+     **
      * Describes a state entry, a versioned (via a UUID) key/value pair.
      * Copied from libmesos (src/messages/state.pro) to ensure
      * compatibility with ZooKeeperState from libmesos.
@@ -20774,50 +20980,51 @@ public final class Protos {
       "xLaunchDelay\030\025 \001(\003:\0073600000\022A\n\025acceptedR" +
       "esourceRoles\030\026 \001(\0132\".mesosphere.marathon" +
       ".ResourceRoles\"\035\n\rResourceRoles\022\014\n\004role\030" +
-      "\001 \003(\t\"\200\002\n\014MarathonTask\022\n\n\002id\030\001 \002(\t\022\014\n\004ho" +
+      "\001 \003(\t\"\241\002\n\014MarathonTask\022\n\n\002id\030\001 \002(\t\022\014\n\004ho" +
       "st\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022$\n\nattributes\030\004 " +
       "\003(\0132\020.mesos.Attribute\022\021\n\tstaged_at\030\005 \001(\003" +
       "\022\022\n\nstarted_at\030\006 \001(\003\022,\n\021OBSOLETE_statuse",
       "s\030\007 \003(\0132\021.mesos.TaskStatus\022)\n\007version\030\010 " +
       "\001(\t:\0301970-01-01T00:00:00.000Z\022!\n\006status\030" +
-      "\t \001(\0132\021.mesos.TaskStatus\"M\n\013MarathonApp\022" +
-      "\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!.mesospher" +
-      "e.marathon.MarathonTask\"1\n\rContainerInfo" +
-      "\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007options\030\002 \003(\014\"\237\004\n\025E" +
-      "xtendedContainerInfo\022\'\n\004type\030\001 \002(\0162\031.mes" +
-      "os.ContainerInfo.Type\022\036\n\007volumes\030\002 \003(\0132\r" +
-      ".mesos.Volume\022E\n\006docker\030\003 \001(\01325.mesosphe" +
-      "re.marathon.ExtendedContainerInfo.Docker",
-      "Info\032\365\002\n\nDockerInfo\022\r\n\005image\030\001 \002(\t\022>\n\007ne" +
-      "twork\030\002 \001(\0162\'.mesos.ContainerInfo.Docker" +
-      "Info.Network:\004HOST\022X\n\rport_mappings\030\003 \003(" +
-      "\0132A.mesosphere.marathon.ExtendedContaine" +
-      "rInfo.DockerInfo.PortMapping\022\031\n\nprivileg" +
-      "ed\030\004 \001(\010:\005false\022$\n\nparameters\030\005 \003(\0132\020.me" +
-      "sos.Parameter\022\030\n\020force_pull_image\030\006 \001(\010\032" +
-      "c\n\013PortMapping\022\021\n\thost_port\030\001 \002(\r\022\026\n\016con" +
-      "tainer_port\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\027\n\014s" +
-      "ervice_port\030d \001(\r:\0010\")\n\020EventSubscribers",
-      "\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016StorageVersio" +
-      "n\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patch" +
-      "\030\003 \002(\r\"Z\n\031UpgradeStrategyDefinition\022\035\n\025m" +
-      "inimumHealthCapacity\030\001 \002(\001\022\036\n\023maximumOve" +
-      "rCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDefinition\022\n" +
-      "\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004apps\030\003 \003(" +
-      "\0132&.mesosphere.marathon.ServiceDefinitio" +
-      "n\0224\n\006groups\030\004 \003(\0132$.mesosphere.marathon." +
-      "GroupDefinition\022\024\n\014dependencies\030\005 \003(\t\"\245\001" +
-      "\n\030DeploymentPlanDefinition\022\n\n\002id\030\001 \002(\t\022\017",
-      "\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002(\0132$.meso" +
-      "sphere.marathon.GroupDefinition\0224\n\006targe" +
-      "t\030\005 \002(\0132$.mesosphere.marathon.GroupDefin" +
-      "ition\"\245\001\n\013TaskFailure\022\016\n\006app_id\030\001 \002(\t\022\036\n" +
-      "\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003" +
-      " \002(\0162\020.mesos.TaskState\022\021\n\007message\030\004 \001(\t:" +
-      "\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\tti" +
-      "mestamp\030\007 \002(\t\"9\n\014ZKStoreEntry\022\014\n\004name\030\001 " +
-      "\002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014B\035\n\023meso" +
-      "sphere.marathonB\006Protos"
+      "\t \001(\0132\021.mesos.TaskStatus\022\037\n\007slaveId\030\n \001(" +
+      "\0132\016.mesos.SlaveID\"M\n\013MarathonApp\022\014\n\004name" +
+      "\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!.mesosphere.marat" +
+      "hon.MarathonTask\"1\n\rContainerInfo\022\017\n\005ima" +
+      "ge\030\001 \002(\014:\000\022\017\n\007options\030\002 \003(\014\"\237\004\n\025Extended" +
+      "ContainerInfo\022\'\n\004type\030\001 \002(\0162\031.mesos.Cont" +
+      "ainerInfo.Type\022\036\n\007volumes\030\002 \003(\0132\r.mesos." +
+      "Volume\022E\n\006docker\030\003 \001(\01325.mesosphere.mara",
+      "thon.ExtendedContainerInfo.DockerInfo\032\365\002" +
+      "\n\nDockerInfo\022\r\n\005image\030\001 \002(\t\022>\n\007network\030\002" +
+      " \001(\0162\'.mesos.ContainerInfo.DockerInfo.Ne" +
+      "twork:\004HOST\022X\n\rport_mappings\030\003 \003(\0132A.mes" +
+      "osphere.marathon.ExtendedContainerInfo.D" +
+      "ockerInfo.PortMapping\022\031\n\nprivileged\030\004 \001(" +
+      "\010:\005false\022$\n\nparameters\030\005 \003(\0132\020.mesos.Par" +
+      "ameter\022\030\n\020force_pull_image\030\006 \001(\010\032c\n\013Port" +
+      "Mapping\022\021\n\thost_port\030\001 \002(\r\022\026\n\016container_" +
+      "port\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\027\n\014service_",
+      "port\030d \001(\r:\0010\")\n\020EventSubscribers\022\025\n\rcal" +
+      "lback_urls\030\001 \003(\t\"=\n\016StorageVersion\022\r\n\005ma" +
+      "jor\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"" +
+      "Z\n\031UpgradeStrategyDefinition\022\035\n\025minimumH" +
+      "ealthCapacity\030\001 \002(\001\022\036\n\023maximumOverCapaci" +
+      "ty\030\002 \001(\001:\0011\"\260\001\n\017GroupDefinition\022\n\n\002id\030\001 " +
+      "\002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.mes" +
+      "osphere.marathon.ServiceDefinition\0224\n\006gr" +
+      "oups\030\004 \003(\0132$.mesosphere.marathon.GroupDe" +
+      "finition\022\024\n\014dependencies\030\005 \003(\t\"\245\001\n\030Deplo",
+      "ymentPlanDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007versi" +
+      "on\030\002 \002(\t\0226\n\010original\030\004 \002(\0132$.mesosphere." +
+      "marathon.GroupDefinition\0224\n\006target\030\005 \002(\013" +
+      "2$.mesosphere.marathon.GroupDefinition\"\245" +
+      "\001\n\013TaskFailure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_i" +
+      "d\030\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003 \002(\0162\020." +
+      "mesos.TaskState\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004ho" +
+      "st\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\ttimestamp" +
+      "\030\007 \002(\t\"9\n\014ZKStoreEntry\022\014\n\004name\030\001 \002(\t\022\014\n\004" +
+      "uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014B\035\n\023mesosphere.",
+      "marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -20853,7 +21060,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_MarathonTask_descriptor,
-              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", });
+              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", });
           internal_static_mesosphere_marathon_MarathonApp_descriptor =
             getDescriptor().getMessageTypes().get(5);
           internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -84,6 +84,7 @@ message MarathonTask {
   repeated mesos.TaskStatus OBSOLETE_statuses = 7;
   optional string version = 8 [default = "1970-01-01T00:00:00.000Z"]; // since 0.7.0
   optional mesos.TaskStatus status = 9;
+  optional mesos.SlaveID slaveId = 10;
 }
 
 message MarathonApp {

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -21,6 +21,11 @@ trait MarathonConf
     required = true,
     noshort = true)
 
+  lazy val mesosMasterUrl = opt[String]("mesos_master_url",
+    descr = "The host and port (e.g. \"http://mesos_host:5050\") of the Mesos master",
+    required = false,
+    noshort = true)
+
   lazy val mesosFailoverTimeout = opt[Long]("failover_timeout",
     descr = "The failover_timeout for mesos in seconds (default: 1 week)",
     default = Some(604800L))

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -71,7 +71,8 @@ trait Formats
       "ports" -> task.getPortsList.asScala,
       "startedAt" -> (if (task.getStartedAt != 0) Timestamp(task.getStartedAt) else JsNull),
       "stagedAt" -> (if (task.getStagedAt != 0) Timestamp(task.getStagedAt) else JsNull),
-      "version" -> task.getVersion
+      "version" -> task.getVersion,
+      "slaveId" -> (if (task.hasSlaveId) task.getSlaveId.getValue else JsNull)
     )
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/json/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/MarathonModule.scala
@@ -148,6 +148,7 @@ class MarathonModule extends Module {
       jgen.writeObjectField("id", task.getId)
       jgen.writeObjectField("host", task.getHost)
       jgen.writeObjectField("ports", task.getPortsList)
+      jgen.writeObjectField("slaveId", task.getSlaveId.getValue)
       jgen.writeObjectField("startedAt", if (startedAt == 0) null else Timestamp(startedAt))
       jgen.writeObjectField("stagedAt", if (stagedAt == 0) null else Timestamp(stagedAt))
       jgen.writeObjectField("version", task.getVersion)

--- a/src/main/scala/mesosphere/marathon/tasks/DefaultTaskFactory.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/DefaultTaskFactory.scala
@@ -9,8 +9,9 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.tasks.TaskFactory.CreatedTask
 import mesosphere.mesos.TaskBuilder
-import org.apache.mesos.Protos.{ TaskInfo, Offer }
+import org.apache.mesos.Protos.Offer
 import org.slf4j.LoggerFactory
+
 import scala.collection.JavaConverters._
 
 class DefaultTaskFactory @Inject() (
@@ -30,7 +31,7 @@ class DefaultTaskFactory @Inject() (
           taskInfo,
           MarathonTasks.makeTask(
             taskInfo.getTaskId.getValue, offer.getHostname, ports,
-            offer.getAttributesList.asScala, app.version
+            offer.getAttributesList.asScala, app.version, offer.getSlaveId
           )
         )
     }

--- a/src/main/scala/mesosphere/marathon/tasks/MarathonTasks.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/MarathonTasks.scala
@@ -1,17 +1,19 @@
 package mesosphere.marathon.tasks
 
-import org.apache.mesos.Protos.Attribute
 import mesosphere.marathon.Protos.MarathonTask
-import scala.collection.JavaConverters._
-import org.apache.mesos.Protos
 import mesosphere.marathon.state.Timestamp
+import org.apache.mesos.Protos
+import org.apache.mesos.Protos.Attribute
+
+import scala.collection.JavaConverters._
 
 object MarathonTasks {
   def makeTask(id: String,
                host: String,
                ports: Iterable[Long],
                attributes: Iterable[Attribute],
-               version: Timestamp): MarathonTask = {
+               version: Timestamp,
+               slaveId: Protos.SlaveID): MarathonTask = {
     MarathonTask.newBuilder()
       .setId(id)
       .setHost(host)
@@ -19,6 +21,7 @@ object MarathonTasks {
       .addAllPorts(ports.map(i => i.toInt: java.lang.Integer).asJava)
       .addAllAttributes(attributes.asJava)
       .setStagedAt(System.currentTimeMillis)
+      .setSlaveId(slaveId)
       .build
   }
 }

--- a/src/main/scala/mesosphere/util/state/MesosLeaderInfo.scala
+++ b/src/main/scala/mesosphere/util/state/MesosLeaderInfo.scala
@@ -1,0 +1,36 @@
+package mesosphere.util.state
+
+import org.apache.mesos.Protos.MasterInfo
+
+/**
+  * Utility class for keeping track of a Mesos Leader
+  */
+trait MesosLeaderInfo {
+
+  /**
+    * Return information about current Mesos master URL
+    * @return String in format "protocol://host:port/" (e.g. "http://mesos.vm:5050/")
+    */
+  def currentLeaderUrl: Option[String]
+
+  def onNewMasterInfo(master: MasterInfo): Unit
+}
+
+case class ConstMesosLeaderInfo(currentLeaderUrl: Option[String]) extends MesosLeaderInfo {
+
+  override def onNewMasterInfo(ignored: MasterInfo): Unit = {}
+}
+
+class MutableMesosLeaderInfo extends MesosLeaderInfo {
+
+  @volatile private[this] var leaderUrl: Option[String] = None
+
+  override def currentLeaderUrl: Option[String] = {
+    leaderUrl
+  }
+
+  override def onNewMasterInfo(master: MasterInfo): Unit = {
+    leaderUrl = Some(s"http://${master.getHostname}:${master.getPort}/")
+  }
+}
+

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -5,6 +5,8 @@ import mesosphere.marathon.state.{ AppDefinition, Group, GroupManager, PathId, T
 import mesosphere.marathon.tasks.{ MarathonTasks, TaskTracker }
 import mesosphere.marathon.upgrade.DeploymentPlan
 import mesosphere.marathon.{ AppLockedException, MarathonSchedulerService, MarathonSpec, UnknownAppException }
+import mesosphere.mesos.protos.Implicits.slaveIDToProto
+import mesosphere.mesos.protos.SlaveID
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.any
 import org.mockito.Mockito._
@@ -50,8 +52,14 @@ class TaskKillerTest extends MarathonSpec
 
   test("KillRequested with scaling") {
     val appId = PathId(List("my", "app"))
-    val task1 = MarathonTasks.makeTask("task-1", "host", ports = Nil, attributes = Nil, version = Timestamp.now())
-    val task2 = MarathonTasks.makeTask("task-2", "host", ports = Nil, attributes = Nil, version = Timestamp.now())
+    val task1 = MarathonTasks.makeTask(
+      "task-1", "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      slaveId = SlaveID("1")
+    )
+    val task2 = MarathonTasks.makeTask(
+      "task-2", "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      slaveId = SlaveID("1")
+    )
     val tasksToKill = Set(task1, task2)
     val originalAppDefinition = AppDefinition(appId, instances = 23)
 
@@ -92,8 +100,14 @@ class TaskKillerTest extends MarathonSpec
 
   test("Kill and scale w/o force should fail if there is a deployment") {
     val appId = PathId(List("my", "app"))
-    val task1 = MarathonTasks.makeTask("task-1", "host", ports = Nil, attributes = Nil, version = Timestamp.now())
-    val task2 = MarathonTasks.makeTask("task-2", "host", ports = Nil, attributes = Nil, version = Timestamp.now())
+    val task1 = MarathonTasks.makeTask(
+      "task-1", "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      slaveId = SlaveID("1")
+    )
+    val task2 = MarathonTasks.makeTask(
+      "task-2", "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      slaveId = SlaveID("1")
+    )
     val tasksToKill = Set(task1, task2)
 
     when(tracker.contains(appId)).thenReturn(true)

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -5,6 +5,8 @@ import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.{ GroupManager, PathId, Timestamp }
 import mesosphere.marathon.tasks.{ MarathonTasks, TaskIdUtil, TaskTracker }
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService, MarathonSpec }
+import mesosphere.mesos.protos.Implicits._
+import mesosphere.mesos.protos._
 import org.mockito.Matchers.{ any, eq => equalTo }
 import org.mockito.Mockito._
 import org.scalatest.Matchers
@@ -46,8 +48,15 @@ class TasksResourceTest extends MarathonSpec with Matchers {
     val bodyBytes = body.toCharArray.map(_.toByte)
     val taskId1 = "task-1"
     val taskId2 = "task-2"
-    val task1 = MarathonTasks.makeTask(taskId1, "host", ports = Nil, attributes = Nil, version = Timestamp.now())
-    val task2 = MarathonTasks.makeTask(taskId2, "host", ports = Nil, attributes = Nil, version = Timestamp.now())
+    val slaveId = SlaveID("some slave ID")
+    val task1 = MarathonTasks.makeTask(
+      taskId1, "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      slaveId = slaveId
+    )
+    val task2 = MarathonTasks.makeTask(
+      taskId2, "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      slaveId = slaveId
+    )
     val app1 = PathId("/my/app-1")
     val app2 = PathId("/my/app-2")
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/V2AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/V2AppDefinitionTest.scala
@@ -2,16 +2,17 @@ package mesosphere.marathon.api.v2.json
 
 import javax.validation.Validation
 
-import com.google.common.collect.Lists
-import mesosphere.marathon.upgrade.DeploymentPlan
-import mesosphere.marathon.{ Protos, MarathonSpec }
-import mesosphere.marathon.Protos.{ Constraint, ServiceDefinition }
+import mesosphere.marathon.{ MarathonSpec, Protos }
+import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.api.v2.ModelValidation
 import mesosphere.marathon.health.{ HealthCheck, HealthCounts }
 import mesosphere.marathon.state.Container.Docker
-import mesosphere.marathon.state._
 import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.state._
+import mesosphere.marathon.upgrade.DeploymentPlan
+import mesosphere.mesos.protos.Implicits.slaveIDToProto
+import mesosphere.mesos.protos.SlaveID
 import org.apache.mesos.{ Protos => mesos }
 import org.scalatest.Matchers
 import play.api.libs.json.Json
@@ -221,7 +222,6 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
     import com.fasterxml.jackson.databind.ObjectMapper
     import com.fasterxml.jackson.module.scala.DefaultScalaModule
     import mesosphere.jackson.CaseClassModule
-    import mesosphere.marathon.api.v2.json.MarathonModule
 
     val mapper = new ObjectMapper
     mapper.registerModule(DefaultScalaModule)
@@ -235,7 +235,8 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
     val readResult1 = mapper.readValue(json1, classOf[V2AppDefinition])
     assert(readResult1 == app1)
 
-    val json2 = """
+    val json2 =
+      """
       {
         "id": "toggle",
         "cmd": "python toggle.py $PORT0",
@@ -252,7 +253,7 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
         "ports": [0],
         "uris": ["http://downloads.mesosphere.com/misc/toggle.tgz"]
       }
-    """
+      """
     val readResult2 = mapper.readValue(json2, classOf[V2AppDefinition])
     assert(readResult2.healthChecks.head.command.isDefined)
 
@@ -310,7 +311,8 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
       ))
     )
 
-    val json4 = """
+    val json4 =
+      """
       {
         "id": "bridged-webapp",
         "cmd": "python3 -m http.server 8080",
@@ -325,13 +327,14 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
           }
         }
       }
-    """
+      """
     val readResult4 = mapper.readValue(json4, classOf[V2AppDefinition])
     assert(readResult4.copy(version = app4.version) == app4)
   }
 
   test("jackson and play-json parsing has the same result") {
-    val fullAppJson = """{
+    val fullAppJson =
+      """{
         "id": "/product/service/my-app",
         "cmd": "env && sleep 300",
         "args": ["/bin/sh", "-c", "env && sleep 300"],
@@ -435,7 +438,6 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
     import com.fasterxml.jackson.module.scala.DefaultScalaModule
     import mesosphere.jackson.CaseClassModule
     import mesosphere.marathon.api.v2.json.Formats._
-    import mesosphere.marathon.api.v2.json.MarathonModule
 
     val mapper = new ObjectMapper
     mapper.registerModule(DefaultScalaModule)
@@ -465,11 +467,10 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
       HealthCounts(0, 0, 0),
       Seq(DeploymentPlan(Group.empty, appGroup.toGroup)))
 
-    import mesosphere.marathon.api.v2.json.Formats.WithTaskCountsAndDeploymentsWrites
     import com.fasterxml.jackson.databind.ObjectMapper
     import com.fasterxml.jackson.module.scala.DefaultScalaModule
     import mesosphere.jackson.CaseClassModule
-    import mesosphere.marathon.api.v2.json.MarathonModule
+    import mesosphere.marathon.api.v2.json.Formats.WithTaskCountsAndDeploymentsWrites
 
     val mapper = new ObjectMapper
     mapper.registerModule(DefaultScalaModule)
@@ -488,6 +489,7 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
       .newBuilder
       .setHost("localhost")
       .setId("my-task")
+      .setSlaveId(SlaveID("0000-0000-0000"))
       .addPorts(9999)
       .setStagedAt(0)
       .setStartedAt(0)
@@ -501,11 +503,10 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
       HealthCounts(0, 0, 0),
       Seq(DeploymentPlan(Group.empty, appGroup.toGroup)))
 
-    import mesosphere.marathon.api.v2.json.Formats.WithTasksAndDeploymentsWrites
     import com.fasterxml.jackson.databind.ObjectMapper
     import com.fasterxml.jackson.module.scala.DefaultScalaModule
     import mesosphere.jackson.CaseClassModule
-    import mesosphere.marathon.api.v2.json.MarathonModule
+    import mesosphere.marathon.api.v2.json.Formats.WithTasksAndDeploymentsWrites
 
     val mapper = new ObjectMapper
     mapper.registerModule(DefaultScalaModule)
@@ -524,6 +525,7 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
       .newBuilder
       .setHost("localhost")
       .setId("my-task")
+      .setSlaveId(SlaveID("0000-0000-0000"))
       .addPorts(9999)
       .setStagedAt(0)
       .setStartedAt(0)
@@ -544,11 +546,10 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
       Seq(DeploymentPlan(Group.empty, appGroup.toGroup)),
       Some(failure))
 
-    import mesosphere.marathon.api.v2.json.Formats.WithTasksAndDeploymentsAndFailuresWrites
     import com.fasterxml.jackson.databind.ObjectMapper
     import com.fasterxml.jackson.module.scala.DefaultScalaModule
     import mesosphere.jackson.CaseClassModule
-    import mesosphere.marathon.api.v2.json.MarathonModule
+    import mesosphere.marathon.api.v2.json.Formats.WithTasksAndDeploymentsAndFailuresWrites
 
     val mapper = new ObjectMapper
     mapper.registerModule(DefaultScalaModule)

--- a/src/test/scala/mesosphere/marathon/tasks/DefaultTaskFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/DefaultTaskFactoryTest.scala
@@ -1,0 +1,45 @@
+package mesosphere.marathon.tasks
+
+import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.state.{ AppDefinition, Timestamp }
+import mesosphere.marathon.{ MarathonConf, MarathonSpec, MarathonTestHelper }
+import mesosphere.mesos.protos.Implicits.{ slaveIDToProto, taskIDToProto }
+import mesosphere.mesos.protos.{ SlaveID, TaskID }
+import org.mockito.Mockito._
+
+class DefaultTaskFactoryTest extends MarathonSpec {
+
+  test("Copy SlaveID from Offer to Task") {
+
+    val offer = MarathonTestHelper.makeBasicOffer()
+      .setHostname("some_host")
+      .setSlaveId(SlaveID("some slave ID"))
+      .build()
+    val version: Timestamp = Timestamp(5)
+    val appDefinition: AppDefinition = AppDefinition(ports = List(), version = version)
+    val runningTasks: Set[MarathonTask] = Set(MarathonTask.newBuilder().setId("some task ID").build())
+
+    when(taskIdUtil.newTaskId(appDefinition.id)).thenReturn(TaskID("some task ID"))
+
+    val task = taskFactory.newTask(appDefinition, offer, runningTasks).get
+
+    val expectedTask = MarathonTasks.makeTask(
+      "some task ID", "some_host", List(),
+      List(), version, offer.getSlaveId
+    )
+    assert(task.marathonTask == expectedTask)
+  }
+
+  var taskIdUtil: TaskIdUtil = _
+  var taskTracker: TaskTracker = _
+  var config: MarathonConf = _
+  var taskFactory: DefaultTaskFactory = _
+
+  before {
+    taskIdUtil = mock[TaskIdUtil]
+    taskTracker = mock[TaskTracker]
+    config = MarathonTestHelper.defaultConfig()
+    taskFactory = new DefaultTaskFactory(taskIdUtil, config, MarathonTestHelper.getSchemaMapper())
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -15,7 +15,7 @@ import mesosphere.marathon.upgrade.DeploymentManager.{ DeploymentFinished, Deplo
 import mesosphere.marathon.{ MarathonSpec, SchedulerActions }
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.mesos.protos.Implicits._
-import mesosphere.mesos.protos.TaskID
+import mesosphere.mesos.protos.{ SlaveID, TaskID }
 import org.apache.mesos.Protos.Status
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Matchers.{ any, same }
@@ -70,11 +70,12 @@ class DeploymentActorTest
     val targetGroup = Group(PathId("/foo/bar"), Set(app1New, app2New, app3))
 
     // setting started at to 0 to make sure this survives
-    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app1.version).toBuilder.setStartedAt(0).build()
-    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app1.version).toBuilder.setStartedAt(1000).build()
-    val task2_1 = MarathonTasks.makeTask("task2_1", "", Nil, Nil, app2.version)
-    val task3_1 = MarathonTasks.makeTask("task3_1", "", Nil, Nil, app3.version)
-    val task4_1 = MarathonTasks.makeTask("task4_1", "", Nil, Nil, app4.version)
+    val slaveId = SlaveID("some slave id")
+    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app1.version, slaveId).toBuilder.setStartedAt(0).build()
+    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app1.version, slaveId).toBuilder.setStartedAt(1000).build()
+    val task2_1 = MarathonTasks.makeTask("task2_1", "", Nil, Nil, app2.version, slaveId)
+    val task3_1 = MarathonTasks.makeTask("task3_1", "", Nil, Nil, app3.version, slaveId)
+    val task4_1 = MarathonTasks.makeTask("task4_1", "", Nil, Nil, app4.version, slaveId)
 
     val plan = DeploymentPlan(origGroup, targetGroup)
 
@@ -174,8 +175,9 @@ class DeploymentActorTest
 
     val targetGroup = Group(PathId("/foo/bar"), Set(appNew))
 
-    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app.version).toBuilder.setStartedAt(0).build()
-    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app.version).toBuilder.setStartedAt(1000).build()
+    val slaveId = SlaveID("some slave id")
+    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app.version, slaveId).toBuilder.setStartedAt(0).build()
+    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app.version, slaveId).toBuilder.setStartedAt(1000).build()
 
     when(tracker.get(app.id)).thenReturn(Set(task1_1, task1_2))
 
@@ -292,9 +294,10 @@ class DeploymentActorTest
 
     val targetGroup = Group(PathId("/foo/bar"), Set(app1New))
 
-    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app1.version).toBuilder.setStartedAt(0).build()
-    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app1.version).toBuilder.setStartedAt(500).build()
-    val task1_3 = MarathonTasks.makeTask("task1_3", "", Nil, Nil, app1.version).toBuilder.setStartedAt(1000).build()
+    val slaveId = SlaveID("some slave id")
+    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app1.version, slaveId).toBuilder.setStartedAt(0).build()
+    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app1.version, slaveId).toBuilder.setStartedAt(500).build()
+    val task1_3 = MarathonTasks.makeTask("task1_3", "", Nil, Nil, app1.version, slaveId).toBuilder.setStartedAt(1000).build()
 
     val plan = DeploymentPlan(original = origGroup, target = targetGroup, toKill = Map(app1.id -> Set(task1_2)))
 

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
@@ -9,13 +9,13 @@ import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.io.storage.StorageProvider
+import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, AppRepository, Group, MarathonStore }
 import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.marathon.upgrade.DeploymentActor.Cancel
 import mesosphere.marathon.upgrade.DeploymentManager.{ CancelDeployment, DeploymentFailed, PerformDeployment }
 import mesosphere.marathon.{ MarathonConf, SchedulerActions }
-import mesosphere.marathon.metrics.Metrics
 import mesosphere.util.state.memory.InMemoryStore
 import org.apache.mesos.SchedulerDriver
 import org.rogach.scallop.ScallopConf
@@ -69,7 +69,10 @@ class DeploymentManagerTest
   }
 
   test("deploy") {
-    val manager = TestActorRef[DeploymentManager](Props(classOf[DeploymentManager], appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus))
+    val manager = TestActorRef[DeploymentManager](
+      Props(classOf[DeploymentManager],
+        appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus)
+    )
 
     val app = AppDefinition("app".toRootPath)
 
@@ -86,7 +89,10 @@ class DeploymentManagerTest
   }
 
   test("StopActor") {
-    val manager = TestActorRef[DeploymentManager](Props(classOf[DeploymentManager], appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus))
+    val manager = TestActorRef[DeploymentManager](
+      Props(classOf[DeploymentManager],
+        appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus)
+    )
     val probe = TestProbe()
 
     probe.setAutoPilot(new AutoPilot {
@@ -105,7 +111,10 @@ class DeploymentManagerTest
   }
 
   test("Cancel deployment") {
-    val manager = TestActorRef[DeploymentManager](Props(classOf[DeploymentManager], appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus))
+    val manager = TestActorRef[DeploymentManager](
+      Props(classOf[DeploymentManager],
+        appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus)
+    )
 
     implicit val timeout = Timeout(1.minute)
 

--- a/src/test/scala/mesosphere/marathon/upgrade/ScalingPropositionTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ScalingPropositionTest.scala
@@ -3,6 +3,8 @@ package mesosphere.marathon.upgrade
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.tasks.MarathonTasks
+import mesosphere.mesos.protos.Implicits.slaveIDToProto
+import mesosphere.mesos.protos.SlaveID
 import org.scalatest.{ FunSuite, Matchers }
 
 class ScalingPropositionTest extends FunSuite with Matchers {
@@ -146,7 +148,9 @@ class ScalingPropositionTest extends FunSuite with Matchers {
 
   // Helper functions
 
-  private def createTask(index: Long) = MarathonTasks.makeTask(s"task-$index", "", Nil, Nil, version = Timestamp(index))
+  private def createTask(index: Long) = MarathonTasks.makeTask(
+    s"task-$index", "", Nil, Nil, version = Timestamp(index), slaveId = SlaveID("1")
+  )
 
   private def noConstraintsToMeet(running: Set[MarathonTask], killCount: Int) = Set.empty[MarathonTask]
 

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -458,7 +458,8 @@ class TaskBuilderTest extends MarathonSpec {
         offer.getHostname,
         tupleOption.get._2,
         offer.getAttributesList.asScala.toList,
-        Timestamp.now())
+        Timestamp.now(),
+        offer.slaveId)
       runningTasks += marathonTask
     }
 
@@ -518,7 +519,8 @@ class TaskBuilderTest extends MarathonSpec {
         tupleOption.get._1.getTaskId.getValue,
         offer.getHostname,
         tupleOption.get._2,
-        offer.getAttributesList.asScala.toList, Timestamp.now())
+        offer.getAttributesList.asScala.toList, Timestamp.now(),
+        offer.slaveId)
       runningTasks += marathonTask
     }
 


### PR DESCRIPTION
This PR prepare backend to expose sandbox URL in GUI https://github.com/mesosphere/marathon/issues/878. 

Sandbox URL is build from 3 pieces

1. Mesos master URL
2. SlaveID
3. TaskID

So I added SlaveID to MarathonTask, and added `/v2/mesos/` API to obtain current Mesos master.