### PR TITLE
Fix #1853: App can't be deleted because it "does not exist", although /apps still returns it

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -158,6 +158,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     @Named("restMapper") mapper: ObjectMapper,
     system: ActorSystem,
     appRepository: AppRepository,
+    groupRepository: GroupRepository,
     deploymentRepository: DeploymentRepository,
     healthCheckManager: HealthCheckManager,
     taskTracker: TaskTracker,
@@ -179,6 +180,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     def createSchedulerActions(schedulerActor: ActorRef): SchedulerActions = {
       new SchedulerActions(
         appRepository,
+        groupRepository,
         healthCheckManager,
         taskTracker,
         taskQueue,
@@ -376,13 +378,13 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
 
     metrics.gauge("service.mesosphere.marathon.app.count", new Gauge[Int] {
       override def getValue: Int = {
-        Await.result(groupManager.root(false), conf.zkTimeoutDuration).transitiveApps.size
+        Await.result(groupManager.rootGroup(), conf.zkTimeoutDuration).transitiveApps.size
       }
     })
 
     metrics.gauge("service.mesosphere.marathon.group.count", new Gauge[Int] {
       override def getValue: Int = {
-        Await.result(groupManager.root(false), conf.zkTimeoutDuration).transitiveGroups.size
+        Await.result(groupManager.rootGroup(), conf.zkTimeoutDuration).transitiveGroups.size
       }
     })
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -112,9 +112,6 @@ class MarathonSchedulerService @Inject() (
   def cancelDeployment(id: String): Unit =
     schedulerActor ! CancelDeployment(id)
 
-  def listApps(): Iterable[AppDefinition] =
-    Await.result(appRepository.apps(), config.zkTimeoutDuration)
-
   def listAppVersions(appId: PathId): Iterable[Timestamp] =
     Await.result(appRepository.listVersions(appId), config.zkTimeoutDuration)
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -244,7 +244,7 @@ class AppsResource @Inject() (
 
   private def validateApp(app: AppDefinition): AppDefinition = {
     BeanValidation.requireValid(ModelValidation.checkAppConstraints(V2AppDefinition(app), app.id.parent))
-    val conflicts = ModelValidation.checkAppConflicts(app, service)
+    val conflicts = ModelValidation.checkAppConflicts(app, result(groupManager.rootGroup()))
     if (conflicts.nonEmpty) throw new ConflictingChangeException(conflicts.mkString(","))
     app
   }
@@ -269,7 +269,7 @@ class AppsResource @Inject() (
     def containCaseInsensitive(a: String, b: String): Boolean = b.toLowerCase contains a.toLowerCase
     val selectors = label.map(new LabelSelectorParsers().parsed)
 
-    service.listApps().filter { app =>
+    result(groupManager.rootGroup()).transitiveApps.filter { app =>
       val appMatchesCmd = cmd.fold(true)(c => app.cmd.exists(containCaseInsensitive(c, _)))
       val appMatchesId = id.fold(true)(s => containCaseInsensitive(s, app.id.toString))
       val appMatchesLabel = selectors.fold(true)(_.matches(app))

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -3,18 +3,16 @@ package mesosphere.marathon.api.v2
 import java.net.URI
 import javax.inject.Inject
 import javax.ws.rs._
-import javax.ws.rs.core.{ MediaType, Response }
+import javax.ws.rs.core.Response
 
 import com.codahale.metrics.annotation.Timed
-
-import mesosphere.marathon.{ ConflictingChangeException, MarathonConf }
-import mesosphere.marathon.api.{ MarathonMediaType, RestResource }
-import mesosphere.marathon.api.v2.json.{ V2Group, V2GroupUpdate }
 import mesosphere.marathon.api.v2.json.Formats._
+import mesosphere.marathon.api.v2.json.{V2Group, V2GroupUpdate}
+import mesosphere.marathon.api.{MarathonMediaType, RestResource}
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{ Group, GroupManager, PathId, Timestamp }
+import mesosphere.marathon.state.{Group, GroupManager, PathId, Timestamp}
 import mesosphere.marathon.upgrade.DeploymentPlan
-import mesosphere.marathon.{ ConflictingChangeException, MarathonConf }
+import mesosphere.marathon.{ConflictingChangeException, MarathonConf}
 import mesosphere.util.ThreadPoolContext.context
 import play.api.libs.json.Json
 
@@ -36,7 +34,7 @@ class GroupsResource @Inject() (
     */
   @GET
   @Timed
-  def root(): Group = result(groupManager.root())
+  def root(): Group = result(groupManager.rootGroup())
 
   /**
     * Get a specific group, optionally with specific version
@@ -90,7 +88,7 @@ class GroupsResource @Inject() (
     val update = Json.parse(body).as[V2GroupUpdate]
     BeanValidation.requireValid(ModelValidation.checkGroupUpdate(update, needsId = true))
     val effectivePath = update.id.map(_.canonicalPath(id.toRootPath)).getOrElse(id.toRootPath)
-    val current = result(groupManager.root(withLatestApps = false)).findGroup(_.id == effectivePath)
+    val current = result(groupManager.rootGroup()).findGroup(_.id == effectivePath)
     if (current.isDefined)
       throw ConflictingChangeException(s"Group $effectivePath is already created. Use PUT to change this group.")
     val (deployment, path, version) = updateOrCreate(id.toRootPath, update, force)

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -82,7 +82,7 @@ class TasksResource @Inject() (
   @Timed
   def indexTxt(): Response = ok(EndpointsHelper.appsToEndpointString(
     taskTracker,
-    service.listApps().toSeq,
+    result(groupManager.rootGroup()).transitiveApps.toSeq,
     "\t"
   ))
 

--- a/src/main/scala/mesosphere/marathon/state/AppRepository.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppRepository.scala
@@ -4,6 +4,19 @@ import mesosphere.marathon.metrics.Metrics
 import mesosphere.util.ThreadPoolContext.context
 import scala.concurrent.Future
 
+/**
+  * This responsibility is in transit:
+  *
+  * Current state:
+  * - all applications are stored as part of the root group in the group repository for every user intended change
+  * - all applications are stored again in the app repository, if the deployment of that application starts
+  *
+  * Future plan:
+  * - the applications should be always loaded via the groupManager or groupRepository.
+  * - the app repository is used to store versions of the application
+  *
+  * Until this plan is implemented, please think carefully when to use the app repository!
+  */
 class AppRepository(
   val store: EntityStore[AppDefinition],
   val maxVersions: Option[Int] = None,

--- a/src/main/scala/mesosphere/marathon/state/GroupRepository.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupRepository.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.state
 
 import mesosphere.marathon.metrics.Metrics
+
 import scala.concurrent.Future
 
 class GroupRepository(
@@ -10,29 +11,13 @@ class GroupRepository(
   val metrics: Metrics)
     extends EntityRepository[Group] {
 
-  import mesosphere.util.ThreadPoolContext.context
+  val zkRootName = "root"
 
-  def group(id: String, withLatestApps: Boolean = true): Future[Option[Group]] = {
-    if (withLatestApps) fetchWithLatestApp(id) else this.store.fetch(id)
-  }
+  def group(id: String): Future[Option[Group]] = this.store.fetch(id)
+
+  def rootGroup(): Future[Option[Group]] = this.store.fetch(zkRootName)
 
   def group(id: String, version: Timestamp): Future[Option[Group]] = entity(id, version)
-
-  override def currentVersion(id: String): Future[Option[Group]] = fetchWithLatestApp(id)
-
-  //fetch group, while fetching latest app definitions from app repository
-  private def fetchWithLatestApp(key: String): Future[Option[Group]] = {
-    this.store.fetch(key).flatMap {
-      case Some(group) =>
-        Future.sequence(group.transitiveApps.map(app => appRepo.currentVersion(app.id))).map { apps =>
-          val allApps = apps.flatten.map(app => app.id -> app).toMap
-          Some(group.update(group.version) { g =>
-            if (g.apps.isEmpty) g else g.copy(apps = g.apps.map(_.id).flatMap(allApps.get))
-          })
-        }
-      case None => Future.successful(None: Option[Group])
-    }
-  }
 
   def store(path: String, group: Group): Future[Group] = storeWithVersion(path, group.version, group)
 }

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -2,20 +2,19 @@ package mesosphere.marathon
 
 import akka.actor.ActorSystem
 import akka.testkit.{ TestKit, TestProbe }
-import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.health.HealthCheckManager
-import mesosphere.marathon.state.{ PathId, AppDefinition, AppRepository }
-import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker }
-import org.apache.mesos.Protos.{ TaskState, TaskID, TaskStatus }
+import mesosphere.marathon.state.{ AppDefinition, AppRepository, GroupRepository, PathId }
+import mesosphere.marathon.tasks.{ TaskQueue, TaskTracker }
+import org.apache.mesos.Protos.{ TaskID, TaskState, TaskStatus }
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito.{ times, verify, when }
 import org.scalatest.Matchers
 import org.scalatest.mock.MockitoSugar
 
-import scala.concurrent.{ Await, Future }
-import scala.concurrent.duration._
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
 
 class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with MarathonSpec with Matchers with MockitoSugar {
   import system.dispatcher
@@ -27,6 +26,7 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
 
     val scheduler = new SchedulerActions(
       repo,
+      mock[GroupRepository],
       mock[HealthCheckManager],
       taskTracker,
       queue,
@@ -78,6 +78,7 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
 
     val scheduler = new SchedulerActions(
       repo,
+      mock[GroupRepository],
       mock[HealthCheckManager],
       taskTracker,
       queue,
@@ -116,6 +117,7 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
 
     val scheduler = new SchedulerActions(
       repo,
+      mock[GroupRepository],
       mock[HealthCheckManager],
       taskTracker,
       queue,

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -1,13 +1,12 @@
 package mesosphere.marathon.api.v2
 
+import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.api.v2.json.{ V2AppDefinition, V2GroupUpdate }
 import mesosphere.marathon.state.Container.Docker.PortMapping
 import mesosphere.marathon.state.Container._
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
-import mesosphere.marathon.{ MarathonSchedulerService, MarathonSpec }
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network
-import org.mockito.Mockito.when
 import org.scalatest.{ BeforeAndAfterAll, Matchers, OptionValues }
 
 import scala.collection.immutable.Seq
@@ -22,17 +21,15 @@ class ModelValidationTest
     val update = V2GroupUpdate(id = Some("/a/b/c".toPath))
 
     val violations = ModelValidation.checkGroupUpdate(update, true)
-    violations should have size (0)
+    violations should have size 0
   }
 
   test("Model validation should catch new apps that conflict with service ports in existing apps") {
-
     val existingApp = createServicePortApp("/app1".toPath, 3200)
-    val service = mock[MarathonSchedulerService]
-    when(service.listApps()).thenReturn(List(existingApp.toAppDefinition))
+    val group = Group(id = PathId.empty, apps = Set(existingApp.toAppDefinition))
 
     val conflictingApp = createServicePortApp("/app2".toPath, 3200).toAppDefinition
-    val validations = ModelValidation.checkAppConflicts(conflictingApp, service)
+    val validations = ModelValidation.checkAppConflicts(conflictingApp, group)
 
     validations should not be Nil
   }
@@ -40,22 +37,20 @@ class ModelValidationTest
   test("Model validation should allow new apps that do not conflict with service ports in existing apps") {
 
     val existingApp = createServicePortApp("/app1".toPath, 3200)
-    val service = mock[MarathonSchedulerService]
-    when(service.listApps()).thenReturn(List(existingApp.toAppDefinition))
+    val group = Group(id = PathId.empty, apps = Set(existingApp.toAppDefinition))
 
     val conflictingApp = createServicePortApp("/app2".toPath, 3201).toAppDefinition
-    val validations = ModelValidation.checkAppConflicts(conflictingApp, service)
+    val validations = ModelValidation.checkAppConflicts(conflictingApp, group)
 
     validations should be(Nil)
   }
 
   test("Model validation should check for application conflicts") {
     val existingApp = createServicePortApp("/app1".toPath, 3200)
-    val service = mock[MarathonSchedulerService]
-    when(service.listApps()).thenReturn(List(existingApp.toAppDefinition))
+    val group = Group(id = PathId.empty, apps = Set(existingApp.toAppDefinition))
 
     val conflictingApp = existingApp.copy(id = "/app2".toPath).toAppDefinition
-    val validations = ModelValidation.checkAppConflicts(conflictingApp, service)
+    val validations = ModelValidation.checkAppConflicts(conflictingApp, group)
 
     validations should not be Nil
   }

--- a/src/test/scala/mesosphere/marathon/state/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupManagerTest.scala
@@ -3,21 +3,19 @@ package mesosphere.marathon.state
 import java.util.concurrent.atomic.AtomicInteger
 import javax.validation.ConstraintViolationException
 
-import akka.actor.{ ActorRefFactory, ActorSystem }
+import akka.actor.ActorSystem
 import akka.event.EventStream
 import akka.testkit.TestKit
-import com.google.inject.name.Named
-import mesosphere.marathon.event.EventModule
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.tasks.TaskTracker
-import mesosphere.marathon.{ MarathonSpec, MarathonConf, MarathonSchedulerService, PortRangeExhaustedException }
+import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService, MarathonSpec, PortRangeExhaustedException }
 import mesosphere.util.SerializeExecution
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{ times, verify, when }
 import org.rogach.scallop.ScallopConf
+import org.scalatest.Matchers
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{ FunSuite, Matchers }
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
@@ -141,7 +139,7 @@ class GroupManagerTest extends TestKit(ActorSystem("System")) with MockitoSugar 
 
     val group = Group(PathId.empty, Set(AppDefinition("/app1".toPath)), Set(Group("/group1".toPath)))
 
-    when(groupRepo.group("root", withLatestApps = false)).thenReturn(Future.successful(None))
+    when(groupRepo.group(groupRepo.zkRootName)).thenReturn(Future.successful(None))
 
     intercept[ConstraintViolationException] {
       Await.result(manager.update(group.id, _ => group), 3.seconds)


### PR DESCRIPTION
This fix uses the groupManager to list applications instead of the AppsRepository.