### PR TITLE
fix tomcat url in example

### DIFF
--- a/examples/Tomcat.json
+++ b/examples/Tomcat.json
@@ -5,7 +5,7 @@
   "cpus": 1.0,
   "instances": 1,
   "uris": [
-    "http://www.gtlib.gatech.edu/pub/apache/tomcat/tomcat-7/v7.0.55/bin/apache-tomcat-7.0.55.tar.gz",
+    "http://www.gtlib.gatech.edu/pub/apache/tomcat/tomcat-7/v7.0.63/bin/apache-tomcat-7.0.63.tar.gz",
     "https://gwt-examples.googlecode.com/files/Calendar.war"
   ]
 }


### PR DESCRIPTION
Seems like `tomcat` was upgraded at gtlib.gatech.edu. The url was updated to: http://www.gtlib.gatech.edu/pub/apache/tomcat/tomcat-7/v7.0.63/bin/apache-tomcat-7.0.63.tar.gz
