### PR TITLE
Handle missing disk resource in offers.

### DIFF
--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -170,7 +170,13 @@ class TaskBuilder(app: AppDefinition,
       }
     }
 
-    if (cpuRole.isEmpty || memRole.isEmpty || diskRole.isEmpty) {
+    // If a particular resource type for this framework's role has been fully
+    // allocated on a slave, then the resource offer will not include that
+    // resource at all.
+    //
+    // For this reason, we should reject on empty disk role only if this app
+    // requires a positive amount of disk.
+    if (cpuRole.isEmpty || memRole.isEmpty || diskRole.isEmpty && app.disk > 0.0) {
       return None
     }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.1-SNAPSHOT"
+version in ThisBuild := "0.8.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.1"
+version in ThisBuild := "0.8.1.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.1-RC2"
+version in ThisBuild := "0.8.1-SNAPSHOT"


### PR DESCRIPTION
A minimal patch to handle the case where the disk resources for Marathon's role have been fully allocated.  When a scalar resource goes to zero, Mesos stops including it in resource offers for that slave.  Previously, Marathon would fail to match offers even when the queued task does not require any disk resources, when the disk resource was missing from the offer.

Fixes #1924 for Marathon version `v0.8.1`.  It looks like although the offer matching logic was refactored a bit since then the basic logic was carried over.  A new patch will be required to fix #1924 for `v0.10.0-RC5`.

This was a little difficult to debug, and more verbose logging in the offer matching logic would be a good addition for future versions of Marathon.  See issue #687 on that point.