### PR TITLE
Flush after write in transfer

### DIFF
--- a/src/main/scala/mesosphere/marathon/io/IO.scala
+++ b/src/main/scala/mesosphere/marathon/io/IO.scala
@@ -70,6 +70,7 @@ object IO {
         val byteCount = in.read(buffer)
         if (byteCount >= 0 && continue) {
           out.write(buffer, 0, byteCount)
+          out.flush()
           read()
         }
       }


### PR DESCRIPTION
This addresses #1926. However, I'm guessing this could cause a performance regression, so we might want to have a strategy to apply this more selectively only to steaming connections, or pick another strategy.