### PR TITLE
Fixes #1931 - CLI args for reviveOffers offer rejection duration

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -1,12 +1,13 @@
 package mesosphere.marathon
 
-import mesosphere.marathon.tasks.IterativeOfferMatcherConfig
+import mesosphere.marathon.tasks.{ OfferReviverConf, IterativeOfferMatcherConfig }
 import org.rogach.scallop.ScallopConf
 import scala.sys.SystemProperties
 
 import mesosphere.marathon.io.storage.StorageProvider
 
-trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMatcherConfig with LeaderProxyConf {
+trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMatcherConfig with LeaderProxyConf
+    with OfferReviverConf {
 
   lazy val mesosMaster = opt[String]("master",
     descr = "The URL of the Mesos master",
@@ -167,4 +168,9 @@ trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMat
     validate = Set("zk", "mesos_zk", "mem").contains,
     default = Some("zk")
   )
+
+  lazy val reviveOffersForNewApps = opt[Boolean]("revive_offers_for_new_apps",
+    descr = "(Default: false) Whether to call reviveOffers for new or changed apps.",
+    default = Some(false))
+
 }

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -191,6 +191,30 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
       "MarathonScheduler")
   }
 
+  @Provides
+  @Singleton
+  def provideOfferReviveConf(): OfferReviverConf = conf
+
+  @Named(OfferReviverActor.NAME)
+  @Provides
+  @Singleton
+  @Inject
+  def provideOfferReviverActor(
+    system: ActorSystem,
+    conf: OfferReviverConf,
+    driverHolder: MarathonSchedulerDriverHolder): ActorRef =
+    {
+      val props = OfferReviverActor.props(conf, driverHolder)
+      system.actorOf(props, OfferReviverActor.NAME)
+    }
+
+  @Provides
+  @Singleton
+  @Inject
+  def provideOfferReviver(@Named(OfferReviverActor.NAME) reviverRef: ActorRef): OfferReviver = {
+    new OfferReviverDelegate(reviverRef)
+  }
+
   @Named(ModuleNames.NAMED_HOST_PORT)
   @Provides
   @Singleton

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -202,9 +202,10 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
   def provideOfferReviverActor(
     system: ActorSystem,
     conf: OfferReviverConf,
+    @Named(EventModule.busName) eventBus: EventStream,
     driverHolder: MarathonSchedulerDriverHolder): ActorRef =
     {
-      val props = OfferReviverActor.props(conf, driverHolder)
+      val props = OfferReviverActor.props(conf, eventBus, driverHolder)
       system.actorOf(props, OfferReviverActor.NAME)
     }
 

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -1,6 +1,9 @@
 package mesosphere.marathon.state
 
+import java.util.concurrent.TimeUnit
+
 import org.joda.time.{ DateTime, DateTimeZone }
+import scala.concurrent.duration.FiniteDuration
 import scala.math.Ordered
 
 /**
@@ -12,6 +15,14 @@ abstract case class Timestamp private (utcDateTime: DateTime) extends Ordered[Ti
   override def toString: String = utcDateTime.toString
 
   def toDateTime: DateTime = utcDateTime
+
+  def until(other: Timestamp): FiniteDuration = {
+    val millis = other.utcDateTime.getMillis - utcDateTime.getMillis
+    FiniteDuration(millis, TimeUnit.MILLISECONDS)
+  }
+
+  def +(duration: FiniteDuration): Timestamp = Timestamp(utcDateTime.getMillis + duration.toMillis)
+  def -(duration: FiniteDuration): Timestamp = Timestamp(utcDateTime.getMillis - duration.toMillis)
 }
 
 object Timestamp {

--- a/src/main/scala/mesosphere/marathon/tasks/OfferReviver.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/OfferReviver.scala
@@ -1,0 +1,5 @@
+package mesosphere.marathon.tasks
+
+trait OfferReviver {
+  def reviveOffers(): Unit
+}

--- a/src/main/scala/mesosphere/marathon/tasks/OfferReviverActor.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/OfferReviverActor.scala
@@ -1,0 +1,63 @@
+package mesosphere.marathon.tasks
+
+import akka.actor.{ Props, Cancellable, ActorLogging, Actor }
+import akka.event.LoggingReceive
+import mesosphere.marathon.MarathonSchedulerDriverHolder
+import mesosphere.marathon.state.Timestamp
+import scala.concurrent.duration._
+
+object OfferReviverActor {
+  final val NAME = "offerReviver"
+
+  def props(conf: OfferReviverConf, driverHolder: MarathonSchedulerDriverHolder): Props = {
+    Props(new OfferReviverActor(conf, driverHolder))
+  }
+}
+
+/**
+  * Revive offers whenever interest is signaled but maximally every 5 seconds.
+  */
+private class OfferReviverActor(
+    conf: OfferReviverConf,
+    driverHolder: MarathonSchedulerDriverHolder) extends Actor with ActorLogging {
+  private[this] var lastRevive: Timestamp = Timestamp(0)
+  private[this] var nextReviveCancellableOpt: Option[Cancellable] = None
+
+  override def postStop(): Unit = {
+    nextReviveCancellableOpt.foreach(_.cancel())
+    nextReviveCancellableOpt = None
+  }
+
+  private[this] def reviveOffers(): Unit = {
+    val now: Timestamp = Timestamp.now()
+    val nextRevive = lastRevive + conf.minReviveOffersInterval().milliseconds
+
+    if (nextRevive <= now) {
+      log.info("Cancel any scheduled revive and revive offers now")
+      nextReviveCancellableOpt.foreach(_.cancel())
+      nextReviveCancellableOpt = None
+
+      driverHolder.driver.foreach(_.reviveOffers())
+      lastRevive = now
+    }
+    else {
+      lazy val untilNextRevive = now until nextRevive
+      if (nextReviveCancellableOpt.isEmpty) {
+        log.info("Schedule next revive at {} in {}", nextRevive, untilNextRevive)
+        nextReviveCancellableOpt = Some(schedulerCheck(untilNextRevive))
+      }
+      else if (log.isDebugEnabled) {
+        log.debug("next revive at {} not yet due for {}, ignore", nextRevive, untilNextRevive)
+      }
+    }
+  }
+
+  override def receive: Receive = LoggingReceive {
+    case OfferReviverDelegate.ReviveOffers => reviveOffers()
+  }
+
+  protected def schedulerCheck(duration: FiniteDuration): Cancellable = {
+    import context.dispatcher
+    context.system.scheduler.scheduleOnce(duration, self, OfferReviverDelegate.ReviveOffers)
+  }
+}

--- a/src/main/scala/mesosphere/marathon/tasks/OfferReviverConf.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/OfferReviverConf.scala
@@ -1,0 +1,11 @@
+package mesosphere.marathon.tasks
+
+import org.rogach.scallop.ScallopConf
+
+trait OfferReviverConf extends ScallopConf {
+  //scalastyle:off magic.number
+
+  lazy val minReviveOffersInterval = opt[Long]("min_revive_offers_interval",
+    descr = "Do not ask for all offers (also already seen ones) more often than this interval (ms).",
+    default = Some(5000))
+}

--- a/src/main/scala/mesosphere/marathon/tasks/OfferReviverDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/OfferReviverDelegate.scala
@@ -1,0 +1,11 @@
+package mesosphere.marathon.tasks
+
+import akka.actor.ActorRef
+
+object OfferReviverDelegate {
+  case object ReviveOffers
+}
+
+class OfferReviverDelegate(offerReviverRef: ActorRef) extends OfferReviver {
+  override def reviveOffers(): Unit = offerReviverRef ! OfferReviverDelegate.ReviveOffers
+}

--- a/src/main/scala/mesosphere/marathon/tasks/TaskQueue.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskQueue.scala
@@ -2,6 +2,8 @@ package mesosphere.marathon.tasks
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import com.google.inject.Inject
+import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.util._
 import org.apache.log4j.Logger
@@ -39,7 +41,7 @@ object TaskQueue {
 /**
   * Utility class to stage tasks before they get scheduled
   */
-class TaskQueue {
+class TaskQueue @Inject() (conf: MarathonConf, offerReviver: OfferReviver) {
 
   import mesosphere.marathon.tasks.TaskQueue._
 
@@ -70,7 +72,11 @@ class TaskQueue {
     val queuedTask = apps.getOrElseUpdate(
       (app.id, app.version),
       QueuedTask(app, new AtomicInteger(0)))
-    queuedTask.count.addAndGet(count)
+    val oldValue = queuedTask.count.addAndGet(count)
+    if (conf.reviveOffersForNewApps() && oldValue == 0) {
+      log.info("New application definition in queue, reviving offers.")
+      offerReviver.reviveOffers()
+    }
   }
 
   /**

--- a/src/main/scala/mesosphere/marathon/tasks/TaskQueue.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskQueue.scala
@@ -72,7 +72,7 @@ class TaskQueue @Inject() (conf: MarathonConf, offerReviver: OfferReviver) {
     val queuedTask = apps.getOrElseUpdate(
       (app.id, app.version),
       QueuedTask(app, new AtomicInteger(0)))
-    val oldValue = queuedTask.count.addAndGet(count)
+    val oldValue = queuedTask.count.getAndAdd(count)
     if (conf.reviveOffersForNewApps() && oldValue == 0) {
       log.info("New application definition in queue, reviving offers.")
       offerReviver.reviveOffers()

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -14,7 +14,7 @@ import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
-import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker }
+import mesosphere.marathon.tasks.{ OfferReviver, TaskIdUtil, TaskQueue, TaskTracker }
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep, StopApplication }
 import mesosphere.mesos.protos.Implicits._
 import mesosphere.mesos.protos.TaskID
@@ -61,7 +61,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     deploymentRepo = mock[DeploymentRepository]
     hcManager = mock[HealthCheckManager]
     tracker = mock[TaskTracker]
-    queue = spy(new TaskQueue)
+    queue = spy(new TaskQueue(offerReviver = mock[OfferReviver], conf = MarathonTestHelper.defaultConfig()))
     frameworkIdUtil = mock[FrameworkIdUtil]
     taskIdUtil = new TaskIdUtil
     storage = mock[StorageProvider]

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -42,7 +42,7 @@ class MarathonSchedulerTest extends TestKit(ActorSystem("System")) with Marathon
     repo = mock[AppRepository]
     hcManager = mock[HealthCheckManager]
     tracker = mock[TaskTracker]
-    queue = spy(new TaskQueue)
+    queue = spy(new TaskQueue(offerReviver = mock[OfferReviver], conf = MarathonTestHelper.defaultConfig()))
     frameworkIdUtil = mock[FrameworkIdUtil]
     config = defaultConfig(maxTasksPerOffer = 10)
     taskIdUtil = TaskIdUtil
@@ -64,6 +64,7 @@ class MarathonSchedulerTest extends TestKit(ActorSystem("System")) with Marathon
       taskIdUtil,
       mock[ActorSystem],
       config,
+      offerReviver = mock[OfferReviver],
       new SchedulerCallbacks {
         override def disconnected(): Unit = {}
       }

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -34,7 +34,9 @@ trait MarathonTestHelper {
     var args = Seq(
       "--master", "127.0.0.1:5050",
       "--max_tasks_per_offer", maxTasksPerOffer.toString,
-      "--max_tasks_per_offer_cycle", maxTasksPerOfferCycle.toString
+      "--max_tasks_per_offer_cycle", maxTasksPerOfferCycle.toString,
+      "--revive_offers_for_new_apps",
+      "--reject_offer_duration", "3600000"
     )
 
     mesosRole.foreach(args ++= Seq("--mesos_role", _))

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.{ PathId, AppDefinition, AppRepository }
-import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker }
+import mesosphere.marathon.tasks.{ OfferReviver, TaskIdUtil, TaskQueue, TaskTracker }
 import org.apache.mesos.Protos.{ TaskState, TaskID, TaskStatus }
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito.{ times, verify, when }
@@ -21,7 +21,7 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
   import system.dispatcher
 
   test("Reset rate limiter if application is stopped") {
-    val queue = new TaskQueue
+    val queue = new TaskQueue(conf = MarathonTestHelper.defaultConfig(), offerReviver = mock[OfferReviver])
     val repo = mock[AppRepository]
     val taskTracker = mock[TaskTracker]
 
@@ -54,7 +54,7 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
   }
 
   test("Task reconciliation sends known running and staged tasks and empty list") {
-    val queue = new TaskQueue
+    val queue = new TaskQueue(conf = MarathonTestHelper.defaultConfig(), offerReviver = mock[OfferReviver])
     val repo = mock[AppRepository]
     val taskTracker = mock[TaskTracker]
     val driver = mock[SchedulerDriver]
@@ -103,7 +103,7 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
   }
 
   test("Task reconciliation only one empty list, when no tasks are present in Marathon") {
-    val queue = new TaskQueue
+    val queue = new TaskQueue(conf = MarathonTestHelper.defaultConfig(), offerReviver = mock[OfferReviver])
     val repo = mock[AppRepository]
     val taskTracker = mock[TaskTracker]
     val driver = mock[SchedulerDriver]

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -3,8 +3,8 @@ package mesosphere.marathon.api.v2
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.{ MarathonConf, MarathonSpec }
-import mesosphere.marathon.tasks.TaskQueue
+import mesosphere.marathon.{ MarathonTestHelper, MarathonSchedulerDriverHolder, MarathonConf, MarathonSpec }
+import mesosphere.marathon.tasks.{ OfferReviver, TaskQueue }
 import org.scalatest.Matchers
 import play.api.libs.json.{ JsObject, Json }
 
@@ -12,7 +12,7 @@ class QueueResourceTest extends MarathonSpec with Matchers {
 
   // regression test for #1210
   test("return well formatted JSON") {
-    val queue = new TaskQueue
+    val queue = new TaskQueue(conf = MarathonTestHelper.defaultConfig(), offerReviver = mock[OfferReviver])
     val app1 = AppDefinition(id = "app1".toRootPath)
     val app2 = AppDefinition(id = "app2".toRootPath)
     val resource = new QueueResource(queue, mock[MarathonConf])

--- a/src/test/scala/mesosphere/marathon/tasks/IterativeOfferMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/IterativeOfferMatcherTest.scala
@@ -6,10 +6,10 @@ import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
 import mesosphere.marathon.tasks.IterativeOfferMatcher.{ OfferUsage, OfferUsages }
-import mesosphere.marathon.{ MarathonConf, MarathonTestHelper }
+import mesosphere.marathon.{ MarathonSchedulerDriverHolder, MarathonConf, MarathonTestHelper }
 import mesosphere.util.state.PersistentStore
 import mesosphere.util.state.memory.InMemoryStore
-import org.apache.mesos.Protos.{ Offer, OfferID, TaskInfo }
+import org.apache.mesos.Protos.{ Filters, Offer, OfferID, TaskInfo }
 import org.apache.mesos.SchedulerDriver
 import org.mockito.{ ArgumentCaptor, Mockito }
 import org.scalatest.{ FunSuite, GivenWhenThen, ShouldMatchers }
@@ -31,7 +31,7 @@ class IterativeOfferMatcherTest extends FunSuite with GivenWhenThen with ShouldM
   def createEnv(maxTasksPerOffer: Int, maxTasksPerOfferCycle: Int = 1000): Unit = {
     config = MarathonTestHelper.defaultConfig(
       maxTasksPerOffer = maxTasksPerOffer, maxTasksPerOfferCycle = maxTasksPerOfferCycle)
-    taskQueue = new TaskQueue
+    taskQueue = new TaskQueue(MarathonTestHelper.defaultConfig(), offerReviver = OfferReviverDummy())
     state = new InMemoryStore
     metrics = new Metrics(new MetricRegistry)
     iterativeOfferMatcherMetrics = new IterativeOfferMatcherMetrics(metrics)
@@ -173,7 +173,8 @@ class IterativeOfferMatcherTest extends FunSuite with GivenWhenThen with ShouldM
     matcher.commitOfferUsagesToDriver(driver, usages)
 
     Then("expect a declineOffer call")
-    Mockito.verify(driver, Mockito.times(1)).declineOffer(offer.getId)
+    val filter: Filters = Filters.newBuilder().setRefuseSeconds(3600.0).build()
+    Mockito.verify(driver, Mockito.times(1)).declineOffer(offer.getId, filter)
     Mockito.verifyNoMoreInteractions(driver)
   }
 
@@ -233,7 +234,8 @@ class IterativeOfferMatcherTest extends FunSuite with GivenWhenThen with ShouldM
     val launchTasksOffersCaptor = ArgumentCaptor.forClass(classOf[java.util.Collection[OfferID]])
     val taskInfosCaptor = ArgumentCaptor.forClass(classOf[java.util.Collection[TaskInfo]])
     Mockito.verify(driver, Mockito.times(1)).launchTasks(launchTasksOffersCaptor.capture(), taskInfosCaptor.capture())
-    Mockito.verify(driver, Mockito.times(1)).declineOffer(offer2.getId)
+    val filter: Filters = Filters.newBuilder().setRefuseSeconds(3600.0).build()
+    Mockito.verify(driver, Mockito.times(1)).declineOffer(offer2.getId, filter)
     Mockito.verifyNoMoreInteractions(driver)
 
     launchTasksOffersCaptor.getValue.asScala.toSeq should be(Seq(offer.getId))

--- a/src/test/scala/mesosphere/marathon/tasks/OfferReviverDummy.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/OfferReviverDummy.scala
@@ -1,0 +1,9 @@
+package mesosphere.marathon.tasks
+
+object OfferReviverDummy {
+  def apply(): OfferReviver = new OfferReviverDummy()
+}
+
+class OfferReviverDummy extends OfferReviver {
+  override def reviveOffers(): Unit = {}
+}

--- a/src/test/scala/mesosphere/marathon/tasks/TaskQueueTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskQueueTest.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.tasks
 
-import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.{ MarathonTestHelper, MarathonSchedulerDriverHolder, MarathonSpec }
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId.StringPathId
@@ -14,7 +14,7 @@ class TaskQueueTest extends MarathonSpec {
   var queue: TaskQueue = _
 
   before {
-    queue = new TaskQueue()
+    queue = new TaskQueue(MarathonTestHelper.defaultConfig(), OfferReviverDummy())
   }
 
   def buildConstraint(field: String, operator: String, value: String = ""): Constraint = {

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -6,8 +6,15 @@ import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.event.{ HealthStatusChanged, MesosStatusUpdateEvent }
 import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.state.{ AppDefinition, PathId }
-import mesosphere.marathon.tasks.{ TaskQueue, TaskTracker }
-import mesosphere.marathon.{ AppStartCanceledException, MarathonConf, MarathonSpec, SchedulerActions }
+import mesosphere.marathon.tasks.{ OfferReviverDummy, TaskQueue, TaskTracker }
+import mesosphere.marathon.{
+  MarathonTestHelper,
+  MarathonSchedulerDriverHolder,
+  AppStartCanceledException,
+  MarathonConf,
+  MarathonSpec,
+  SchedulerActions
+}
 import mesosphere.util.state.memory.InMemoryStore
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito.verify
@@ -33,7 +40,7 @@ class AppStartActorTest
   before {
     driver = mock[SchedulerDriver]
     scheduler = mock[SchedulerActions]
-    taskQueue = new TaskQueue
+    taskQueue = new TaskQueue(MarathonTestHelper.defaultConfig(), OfferReviverDummy())
     taskTracker = new TaskTracker(new InMemoryStore, mock[MarathonConf], new Metrics(new MetricRegistry))
   }
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -9,8 +9,14 @@ import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
-import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker }
-import mesosphere.marathon.{ MarathonConf, SchedulerActions, TaskUpgradeCanceledException }
+import mesosphere.marathon.tasks.{ OfferReviverDummy, TaskIdUtil, TaskQueue, TaskTracker }
+import mesosphere.marathon.{
+  MarathonTestHelper,
+  MarathonSchedulerDriverHolder,
+  MarathonConf,
+  SchedulerActions,
+  TaskUpgradeCanceledException
+}
 import mesosphere.util.state.memory.InMemoryStore
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito.{ spy, times, verify, when }
@@ -37,7 +43,7 @@ class TaskStartActorTest
   before {
     driver = mock[SchedulerDriver]
     scheduler = mock[SchedulerActions]
-    taskQueue = spy(new TaskQueue)
+    taskQueue = spy(new TaskQueue(MarathonTestHelper.defaultConfig(), OfferReviverDummy()))
     metrics = new Metrics(new MetricRegistry)
     taskTracker = spy(new TaskTracker(new InMemoryStore, mock[MarathonConf], metrics))
   }


### PR DESCRIPTION
`--revive_offers_for_new_apps` if true, revive offers is called when a new app
is added to the `TaskQueue` or if a task of an app with constraints dies. The
latter is necessary, for example, if there is a constraint that only allows
one task per host. In this case, we might accept an offer that we rejected
previously, simply because no task is running on the host anymore.

Also note, that Mesos only filters offers that are a strict sub set of
a rejected offer.

`--reject_offer_duration` allows configuring the duration for which offers
are declined if not matched in mesos.

`--min_revive_offers_interval` if `--revive_offers_for_new_apps` is specified,
do not call reviveOffers more often than this interval. It defaults to 5 seconds.