### PR TITLE
Fixes for #1924 (offers without disk) + #1927 (better logging) for v0.9.1

### DIFF
--- a/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
@@ -82,7 +82,10 @@ class PortsMatcher(
         offeredPortRanges.find(_.range.contains(port)).map { offeredRange =>
           PortWithRole(offeredRange.role, port)
         } orElse {
-          if (failLog) log.info(s"Couldn't find host port $port in any offered range for app [${app.id}]")
+          if (failLog)
+            log.info(
+              s"Offer [${offer.getId.getValue}]. Couldn't find host port $port (of ${requiredPorts.mkString(", ")}) " +
+                s"in any offered range for app [${app.id}]")
           None
         }
       }
@@ -96,7 +99,7 @@ class PortsMatcher(
     takeEnoughPortsOrNone(expectedSize = numberOfPorts) {
       shuffledAvailablePorts.map(Some(_))
     } orElse {
-      log.info(s"Couldn't find $numberOfPorts ports in offer for app [${app.id}]")
+      log.info(s"Offer [${offer.getId.getValue}]. Couldn't find $numberOfPorts ports in offer for app [${app.id}]")
       None
     }
   }
@@ -117,7 +120,7 @@ class PortsMatcher(
       mappings.iterator.map {
         case PortMapping(containerPort, hostPort, servicePort, protocol) if hostPort == 0 =>
           if (!availablePortsWithoutStaticHostPorts.hasNext) {
-            log.info(s"Insufficient ports in offer for app [${app.id}]")
+            log.info(s"Offer [${offer.getId.getValue}]. Insufficient ports in offer for app [${app.id}]")
             None
           }
           else {
@@ -128,7 +131,8 @@ class PortsMatcher(
             case Some(PortRange(role, _)) =>
               Some(PortWithRole(role, pm.hostPort))
             case None =>
-              log.info(s"Cannot find range with host port ${pm.hostPort} for app [${app.id}]")
+              log.info(s"Offer [${offer.getId.getValue}]. " +
+                s"Cannot find range with host port ${pm.hostPort} for app [${app.id}]")
               None
           }
       }

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -5,13 +5,29 @@ import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.tasks.PortsMatcher
 import mesosphere.mesos.protos.{ RangesResource, Resource }
 import org.apache.log4j.Logger
+import org.apache.mesos.Protos
 import org.apache.mesos.Protos.Offer
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
+import scala.collection.mutable
 
 object ResourceMatcher {
   type Role = String
+
+  case class ScalarMatch(requiredValue: Double, offeredValue: Double, role: String) {
+    def matches: Boolean = requiredValue <= offeredValue
+    def matchingRole: Option[Role] = if (matches) Some(role) else None
+
+    override def toString: String = {
+      if (matches) {
+        s"SATISFIED ($requiredValue <= $offeredValue)"
+      }
+      else {
+        s"NOT SATISFIED ($requiredValue > $offeredValue)"
+      }
+    }
+  }
 
   private[this] val log = Logger.getLogger(getClass)
 
@@ -20,27 +36,44 @@ object ResourceMatcher {
   def matchResources(offer: Offer, app: AppDefinition, runningTasks: => Set[MarathonTask],
                      acceptedResourceRoles: Set[String] = Set("*")): Option[ResourceMatch] = {
 
-    val groupedResources = offer.getResourcesList.asScala.groupBy(_.getName)
+    val groupedResources: Map[Role, mutable.Buffer[Protos.Resource]] = offer.getResourcesList.asScala.groupBy(_.getName)
 
-    def findScalarResourceRole(tpe: String, value: Double): Option[Role] =
-      groupedResources.get(tpe).flatMap {
-        _
-          .filter(resource => acceptedResourceRoles(resource.getRole))
-          .find { resource =>
-            resource.getScalar.getValue >= value
-          }.map(_.getRole)
+    def findScalarResource(name: String, requiredValue: Double): Option[ScalarMatch] =
+      groupedResources.get(name).flatMap { resources =>
+        val matchingScalarResources = resources.filter { resource =>
+          acceptedResourceRoles(resource.getRole) && resource.hasScalar
+        }
+
+        val asMatches = matchingScalarResources.map { resource =>
+          ScalarMatch(
+            requiredValue = requiredValue,
+            offeredValue = resource.getScalar.getValue,
+            role = resource.getRole
+          )
+        }
+
+        if (asMatches.isEmpty) {
+          None
+        }
+        else {
+          Some(asMatches.maxBy(_.offeredValue))
+        }
       }
 
-    def cpuRoleOpt: Option[Role] = findScalarResourceRole(Resource.CPUS, app.cpus)
-    def memRoleOpt: Option[Role] = findScalarResourceRole(Resource.MEM, app.mem)
-    def diskRoleOpt: Option[Role] =
+    val cpuMatchOpt: Option[ScalarMatch] = findScalarResource(Resource.CPUS, app.cpus)
+    val memMatchOpt: Option[ScalarMatch] = findScalarResource(Resource.MEM, app.mem)
+    val diskMatchOpt: Option[ScalarMatch] =
       if (app.disk == 0) {
         // Not used in builder since that checks for disk == 0 as well and ignores this role designation
-        Some("")
+        Some(ScalarMatch(requiredValue = 0.0, offeredValue = 0.0, role = ""))
       }
       else {
-        findScalarResourceRole(Resource.DISK, app.disk)
+        findScalarResource(Resource.DISK, app.disk)
       }
+
+    logUnsatisfiedResources(offer, cpuMatchOpt, memMatchOpt, diskMatchOpt)
+
+    def portsOpt: Option[Seq[RangesResource]] = new PortsMatcher(app, offer, acceptedResourceRoles).portRanges
 
     def meetsAllConstraints: Boolean = {
       lazy val tasks = runningTasks
@@ -50,30 +83,41 @@ object ResourceMatcher {
 
       if (badConstraints.nonEmpty) {
         log.warn(
-          s"Offer did not satisfy constraints for app [${app.id}].\n" +
-            s"Conflicting constraints are: [${badConstraints.mkString(", ")}]"
+          s"Offer [${offer.getId.getValue}]. Constraints for app [${app.id}] not satisfied.\n" +
+            s"The conflicting constraints are: [${badConstraints.mkString(", ")}]"
         )
       }
 
       badConstraints.isEmpty
     }
 
-    def portsOpt: Option[Seq[RangesResource]] = new PortsMatcher(app, offer, acceptedResourceRoles).portRanges match {
-      case None =>
-        log.warn("App ports are not available in the offer.")
-        None
-
-      case x @ Some(portRanges) =>
-        log.debug("Met all constraints.")
-        x
-    }
-
     for {
-      cpuRole <- cpuRoleOpt
-      memRole <- memRoleOpt
-      diskRole <- diskRoleOpt
+      cpuRole <- cpuMatchOpt.flatMap(_.matchingRole)
+      memRole <- memMatchOpt.flatMap(_.matchingRole)
+      diskRole <- diskMatchOpt.flatMap(_.matchingRole)
       portRanges <- portsOpt
       if meetsAllConstraints
     } yield ResourceMatch(cpuRole, memRole, diskRole, portRanges)
+  }
+
+  private[this] def logUnsatisfiedResources(offer: Offer,
+                                            cpuMatchOpt: Option[ScalarMatch],
+                                            memMatchOpt: Option[ScalarMatch],
+                                            diskMatchOpt: Option[ScalarMatch]): Unit = {
+    val basicResourceMatches = Map(
+      "cpu" -> cpuMatchOpt,
+      "disk" -> diskMatchOpt,
+      "mem" -> memMatchOpt
+    )
+
+    if (!basicResourceMatches.values.forall(_.map(_.matches).getOrElse(false))) {
+      val basicResourceString = basicResourceMatches.map {
+        case (resource, Some(scalarMatch)) =>
+          s"$resource $scalarMatch"
+        case (resource, None) =>
+          s"$resource not in offer"
+      }.mkString(", ")
+      log.info(s"Offer [${offer.getId.getValue}]. Not all basic resources satisfied: $basicResourceString")
+    }
   }
 }

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -33,7 +33,14 @@ object ResourceMatcher {
 
     def cpuRoleOpt: Option[Role] = findScalarResourceRole(Resource.CPUS, app.cpus)
     def memRoleOpt: Option[Role] = findScalarResourceRole(Resource.MEM, app.mem)
-    def diskRoleOpt: Option[Role] = findScalarResourceRole(Resource.DISK, app.disk)
+    def diskRoleOpt: Option[Role] =
+      if (app.disk == 0) {
+        // Not used in builder since that checks for disk == 0 as well and ignores this role designation
+        Some("")
+      }
+      else {
+        findScalarResourceRole(Resource.DISK, app.disk)
+      }
 
     def meetsAllConstraints: Boolean = {
       lazy val tasks = runningTasks

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -43,10 +43,38 @@ class TaskBuilder(app: AppDefinition,
           build(offer, cpu, mem, disk, ranges)
 
         case _ =>
-          log.debug(
-            s"No matching offer for ${app.id} (need cpus=${app.cpus}, mem=${app.mem}, " +
-              s"disk=${app.disk}, ports=${app.hostPorts}) : " + offer
-          )
+          def logInsufficientResources(): Unit = {
+            val appHostPorts = if (app.requirePorts) app.ports else app.ports.map(_ => 0)
+            val containerHostPorts: Option[Seq[Int]] = app.containerHostPorts
+            val hostPorts = containerHostPorts.getOrElse(appHostPorts)
+            val staticHostPorts = hostPorts.filter(_ != 0)
+            val numberDynamicHostPorts = hostPorts.count(_ == 0)
+
+            val maybeStatic: Option[String] = if (staticHostPorts.nonEmpty) {
+              Some(s"[${staticHostPorts.mkString(", ")}] required")
+            }
+            else {
+              None
+            }
+
+            val maybeDynamic: Option[String] = if (numberDynamicHostPorts > 0) {
+              Some(s"$numberDynamicHostPorts dynamic")
+            }
+            else {
+              None
+            }
+
+            val portStrings = Seq(maybeStatic, maybeDynamic).flatten.mkString(" + ")
+
+            val portsString = s"ports=($portStrings)"
+
+            log.info(
+              s"Offer [${offer.getId.getValue}]. Insufficient resources for [${app.id}] (need cpus=${app.cpus}, " +
+                s"mem=${app.mem}, disk=${app.disk}, $portsString, available in offer:\n" + offer
+            )
+          }
+
+          logInsufficientResources()
           None
       }
   }


### PR DESCRIPTION
This is a cleaned-up/squashed version of the disk + logging changes in marathon-0.9.1-backports.

These changes should be merged into releasing-0.9.2 before creating the RC.