### PR TITLE
Fixes #1931 - Flag for reviveOffers and offer reject duration

### DIFF
--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/DriverActor.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/DriverActor.scala
@@ -33,6 +33,9 @@ object DriverActor {
     * `override def reconcileTasks(statuses: util.Collection[TaskStatus]): Status`
     */
   case class ReconcileTask(taskStatus: Seq[TaskStatus])
+
+  // Ignored for now. It is implemented in Marathon 0.11.*
+  case object ReviveOffers
 }
 
 class DriverActor(schedulerProps: Props) extends Actor {

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
@@ -46,6 +46,8 @@ class SimulatedDriver(driverProps: Props) extends SchedulerDriver {
     driverCmd(DriverActor.ReconcileTask(statuses.toSeq))
   }
 
+  override def reviveOffers(): Status = driverCmd(DriverActor.ReviveOffers)
+
   override def declineOffer(offerId: OfferID, filters: Filters): Status = Status.DRIVER_RUNNING
 
   override def launchTasks(offerIds: util.Collection[OfferID], tasks: util.Collection[TaskInfo],
@@ -54,7 +56,6 @@ class SimulatedDriver(driverProps: Props) extends SchedulerDriver {
   override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo]): Status = ???
   override def requestResources(requests: util.Collection[Request]): Status = ???
   override def sendFrameworkMessage(executorId: ExecutorID, slaveId: SlaveID, data: Array[Byte]): Status = ???
-  override def reviveOffers(): Status = ???
   override def acknowledgeStatusUpdate(status: TaskStatus): Status = ???
   // Mesos 0.23.x
   //  override def acceptOffers(

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -1,12 +1,13 @@
 package mesosphere.marathon
 
-import mesosphere.marathon.tasks.IterativeOfferMatcherConfig
+import mesosphere.marathon.tasks.{ OfferReviverConf, IterativeOfferMatcherConfig }
 import org.rogach.scallop.ScallopConf
 import scala.sys.SystemProperties
 
 import mesosphere.marathon.io.storage.StorageProvider
 
-trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMatcherConfig with LeaderProxyConf {
+trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMatcherConfig with LeaderProxyConf
+    with OfferReviverConf {
 
   lazy val mesosMaster = opt[String]("master",
     descr = "The URL of the Mesos master",
@@ -167,4 +168,9 @@ trait MarathonConf extends ScallopConf with ZookeeperConf with IterativeOfferMat
     validate = Set("zk", "mesos_zk", "mem").contains,
     default = Some("zk")
   )
+
+  lazy val reviveOffersForNewApps = opt[Boolean]("revive_offers_for_new_apps",
+    descr = "Whether to call reviveOffers for new or changed apps. (Default: do not use reviveOffers) ",
+    default = Some(false))
+
 }

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -64,6 +64,8 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     bind(classOf[HttpConf]).toInstance(http)
     bind(classOf[ZooKeeperClient]).toInstance(zk)
     bind(classOf[LeaderProxyConf]).toInstance(conf)
+    bind(classOf[OfferReviverConf]).toInstance(conf)
+    bind(classOf[IterativeOfferMatcherConfig]).toInstance(conf)
 
     // needs to be eager to break circular dependencies
     bind(classOf[SchedulerCallbacks]).to(classOf[SchedulerCallbacksServiceAdapter]).asEagerSingleton()
@@ -111,10 +113,6 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
 
     system.actorOf(Props(new HttpEventStreamActor(leaderInfo, metrics, handleStreamProps)), "HttpEventStream")
   }
-
-  @Provides
-  @Singleton
-  def provideIterativeOfferMatcherConfig(): IterativeOfferMatcherConfig = conf
 
   @Provides
   @Singleton
@@ -189,6 +187,27 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
           config)
       ).withRouter(RoundRobinPool(nrOfInstances = 1, supervisorStrategy = supervision)),
       "MarathonScheduler")
+  }
+
+  @Named(OfferReviverActor.NAME)
+  @Provides
+  @Singleton
+  @Inject
+  def provideOfferReviverActor(
+    system: ActorSystem,
+    conf: OfferReviverConf,
+    @Named(EventModule.busName) eventBus: EventStream,
+    driverHolder: MarathonSchedulerDriverHolder): ActorRef =
+    {
+      val props = OfferReviverActor.props(conf, eventBus, driverHolder)
+      system.actorOf(props, OfferReviverActor.NAME)
+    }
+
+  @Provides
+  @Singleton
+  @Inject
+  def provideOfferReviver(@Named(OfferReviverActor.NAME) reviverRef: ActorRef): OfferReviver = {
+    new OfferReviverDelegate(reviverRef)
   }
 
   @Named(ModuleNames.NAMED_HOST_PORT)

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -1,6 +1,9 @@
 package mesosphere.marathon.state
 
+import java.util.concurrent.TimeUnit
+
 import org.joda.time.{ DateTime, DateTimeZone }
+import scala.concurrent.duration.FiniteDuration
 import scala.math.Ordered
 
 /**
@@ -12,6 +15,14 @@ abstract case class Timestamp private (utcDateTime: DateTime) extends Ordered[Ti
   override def toString: String = utcDateTime.toString
 
   def toDateTime: DateTime = utcDateTime
+
+  def until(other: Timestamp): FiniteDuration = {
+    val millis = other.utcDateTime.getMillis - utcDateTime.getMillis
+    FiniteDuration(millis, TimeUnit.MILLISECONDS)
+  }
+
+  def +(duration: FiniteDuration): Timestamp = Timestamp(utcDateTime.getMillis + duration.toMillis)
+  def -(duration: FiniteDuration): Timestamp = Timestamp(utcDateTime.getMillis - duration.toMillis)
 }
 
 object Timestamp {

--- a/src/main/scala/mesosphere/marathon/tasks/OfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/OfferMatcher.scala
@@ -25,6 +25,11 @@ trait OfferMatcher {
 }
 
 trait IterativeOfferMatcherConfig extends ScallopConf {
+  lazy val rejectOfferDuration = opt[Long]("reject_offer_duration",
+    descr = "(Default: Use mesos default of 5 seconds) " +
+      "The duration (milliseconds) for which to reject offers by default",
+    default = None)
+
   lazy val maxTasksPerOffer = opt[Int]("max_tasks_per_offer",
     descr = "Maximally launch this number of tasks per offer.",
     default = Some(1),
@@ -187,6 +192,10 @@ class IterativeOfferMatcher @Inject() (
   }
 
   private[tasks] def commitOfferUsagesToDriver(driver: SchedulerDriver, finalOfferUsage: OfferUsages): Unit = {
+    val numberOfTasksToLaunch: Int = finalOfferUsage.usages.map(_.scheduledTasks.size).sum
+    // if the taskLaunchLimit was hit, we might need to get offers back again faster
+    val taskLaunchLimitHit: Boolean = numberOfTasksToLaunch >= maxTasksPerCycle
+
     var usedOffers: Long = 0
     var launchedTasks: Long = 0
     var declinedOffers: Long = 0
@@ -196,8 +205,8 @@ class IterativeOfferMatcher @Inject() (
         val offerIds: util.Collection[OfferID] = Seq(offer.getId).asJavaCollection
         val tasks: util.Collection[TaskInfo] = offerUsage.scheduledTasks.asJavaCollection
         if (log.isDebugEnabled) {
-          log.debug("for offer {} launch tasks {}",
-            Seq(offer.getId, tasks.asScala.map(_.getTaskId.getValue).mkString(", ")): _*)
+          log.debug("Offer [{}]. Launch tasks {}",
+            Seq(offer.getId.getValue, tasks.asScala.map(_.getTaskId.getValue).mkString(", ")): _*)
         }
         driver.launchTasks(offerIds, tasks)
         metrics.tasksLaunchedPerOffer.update(tasks.size())
@@ -205,8 +214,21 @@ class IterativeOfferMatcher @Inject() (
         launchedTasks += tasks.size()
       }
       else {
-        log.debug("declining offer {}", offer.getId)
-        driver.declineOffer(offer.getId)
+        iterativeOfferMatcherConfig.rejectOfferDuration.get match {
+          case Some(durationInMs) if !taskLaunchLimitHit =>
+            val filter = Filters.newBuilder().setRefuseSeconds(durationInMs / 1000.0).build()
+            log.info(s"Offer [${offer.getId.getValue}]. Decline with filter refuseSeconds=${filter.getRefuseSeconds}" +
+              s"(use --${iterativeOfferMatcherConfig.rejectOfferDuration.name} to reconfigure)")
+            driver.declineOffer(offer.getId, filter)
+          case Some(durationInMs) if taskLaunchLimitHit =>
+            log.info(s"Offer [${offer.getId.getValue}]. " +
+              s"Task launch limit reached. Decline with default filter refuseSeconds.")
+            driver.declineOffer(offer.getId)
+          case None =>
+            log.info(s"Offer [${offer.getId.getValue}]. Decline with default filter refuseSeconds " +
+              s"(use --${iterativeOfferMatcherConfig.rejectOfferDuration.name} to configure)")
+            driver.declineOffer(offer.getId)
+        }
         declinedOffers += 1
       }
     }

--- a/src/main/scala/mesosphere/marathon/tasks/OfferReviver.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/OfferReviver.scala
@@ -1,0 +1,8 @@
+package mesosphere.marathon.tasks
+
+/**
+  * Request offers from Mesos that we have already seen because we have new launching requirements.
+  */
+trait OfferReviver {
+  def reviveOffers(): Unit
+}

--- a/src/main/scala/mesosphere/marathon/tasks/OfferReviverActor.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/OfferReviverActor.scala
@@ -1,0 +1,95 @@
+package mesosphere.marathon.tasks
+
+import akka.actor.{ Props, Cancellable, ActorLogging, Actor }
+import akka.event.{ EventStream, LoggingReceive }
+import mesosphere.marathon.event.{ SchedulerRegisteredEvent, SchedulerReregisteredEvent }
+import mesosphere.marathon.MarathonSchedulerDriverHolder
+import mesosphere.marathon.state.Timestamp
+import scala.concurrent.duration._
+
+object OfferReviverActor {
+  final val NAME = "offerReviver"
+
+  def props(conf: OfferReviverConf,
+            eventStream: EventStream,
+            driverHolder: MarathonSchedulerDriverHolder): Props = {
+    Props(new OfferReviverActor(conf, eventStream, driverHolder))
+  }
+}
+
+/**
+  * Revive offers whenever interest is signaled but maximally every 5 seconds.
+  */
+private class OfferReviverActor(
+    conf: OfferReviverConf,
+    eventStream: EventStream,
+    driverHolder: MarathonSchedulerDriverHolder) extends Actor with ActorLogging {
+  private[this] var lastRevive: Timestamp = Timestamp(0)
+  private[this] var nextReviveCancellableOpt: Option[Cancellable] = None
+
+  override def preStart(): Unit = {
+    log.info("Starting up")
+
+    // We want to revive offers when the scheduler re-registers
+    // with the Mesos master.
+    eventStream.subscribe(self, classOf[SchedulerReregisteredEvent])
+
+    // For some reason, when the scheduler re-registers with an
+    // existing framework ID, we have observed the `registered`
+    // callback instead.
+    eventStream.subscribe(self, classOf[SchedulerRegisteredEvent])
+  }
+
+  override def postStop(): Unit = {
+    log.info("Stopping")
+
+    nextReviveCancellableOpt.foreach(_.cancel())
+    nextReviveCancellableOpt = None
+
+    eventStream.unsubscribe(self)
+  }
+
+  private[this] def reviveOffers(): Unit = {
+    val now: Timestamp = Timestamp.now()
+    val nextRevive: Timestamp = lastRevive + conf.minReviveOffersInterval().milliseconds
+
+    if (nextRevive <= now) {
+      log.info("=> revive offers NOW, canceling any scheduled revives")
+      nextReviveCancellableOpt.foreach(_.cancel())
+      nextReviveCancellableOpt = None
+
+      driverHolder.driver.foreach(_.reviveOffers())
+      lastRevive = now
+    }
+    else {
+      lazy val untilNextRevive = now until nextRevive
+      if (nextReviveCancellableOpt.isEmpty) {
+        log.info("=> Schedule next revive at {} in {}, adhering to --{} {} (ms)",
+          nextRevive, untilNextRevive, conf.minReviveOffersInterval.name, conf.minReviveOffersInterval())
+        nextReviveCancellableOpt = Some(scheduleCheck(untilNextRevive))
+      }
+      else {
+        log.info("=> Next revive already scheduled at {} not yet due for {}", nextRevive, untilNextRevive)
+      }
+    }
+  }
+
+  override def receive: Receive = LoggingReceive {
+    case OfferReviverDelegate.ReviveOffers =>
+      log.info("Received request to revive offers")
+      reviveOffers()
+
+    case _: SchedulerReregisteredEvent =>
+      log.info("Received scheduler reregistration event")
+      reviveOffers()
+
+    case _: SchedulerRegisteredEvent =>
+      log.info("Received scheduler registration event")
+      reviveOffers()
+  }
+
+  protected def scheduleCheck(duration: FiniteDuration): Cancellable = {
+    import context.dispatcher
+    context.system.scheduler.scheduleOnce(duration, self, OfferReviverDelegate.ReviveOffers)
+  }
+}

--- a/src/main/scala/mesosphere/marathon/tasks/OfferReviverConf.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/OfferReviverConf.scala
@@ -1,0 +1,11 @@
+package mesosphere.marathon.tasks
+
+import org.rogach.scallop.ScallopConf
+
+trait OfferReviverConf extends ScallopConf {
+  //scalastyle:off magic.number
+
+  lazy val minReviveOffersInterval = opt[Long]("min_revive_offers_interval",
+    descr = "Do not ask for all offers (also already seen ones) more often than this interval (ms). (Default: 5000)",
+    default = Some(5000))
+}

--- a/src/main/scala/mesosphere/marathon/tasks/OfferReviverDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/OfferReviverDelegate.scala
@@ -1,0 +1,11 @@
+package mesosphere.marathon.tasks
+
+import akka.actor.ActorRef
+
+object OfferReviverDelegate {
+  case object ReviveOffers
+}
+
+class OfferReviverDelegate(offerReviverRef: ActorRef) extends OfferReviver {
+  override def reviveOffers(): Unit = offerReviverRef ! OfferReviverDelegate.ReviveOffers
+}

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -14,7 +14,7 @@ import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
-import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker }
+import mesosphere.marathon.tasks.{ OfferReviver, TaskIdUtil, TaskQueue, TaskTracker }
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep, StopApplication }
 import mesosphere.mesos.protos.Implicits._
 import mesosphere.mesos.protos.TaskID
@@ -61,7 +61,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     deploymentRepo = mock[DeploymentRepository]
     hcManager = mock[HealthCheckManager]
     tracker = mock[TaskTracker]
-    queue = spy(new TaskQueue)
+    queue = spy(new TaskQueue(offerReviver = mock[OfferReviver], conf = MarathonTestHelper.defaultConfig()))
     frameworkIdUtil = mock[FrameworkIdUtil]
     taskIdUtil = new TaskIdUtil
     storage = mock[StorageProvider]

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -42,7 +42,7 @@ class MarathonSchedulerTest extends TestKit(ActorSystem("System")) with Marathon
     repo = mock[AppRepository]
     hcManager = mock[HealthCheckManager]
     tracker = mock[TaskTracker]
-    queue = spy(new TaskQueue)
+    queue = spy(new TaskQueue(offerReviver = mock[OfferReviver], conf = MarathonTestHelper.defaultConfig()))
     frameworkIdUtil = mock[FrameworkIdUtil]
     config = defaultConfig(maxTasksPerOffer = 10)
     taskIdUtil = TaskIdUtil
@@ -64,6 +64,7 @@ class MarathonSchedulerTest extends TestKit(ActorSystem("System")) with Marathon
       taskIdUtil,
       mock[ActorSystem],
       config,
+      offerReviver = mock[OfferReviver],
       new SchedulerCallbacks {
         override def disconnected(): Unit = {}
       }
@@ -240,7 +241,7 @@ class MarathonSchedulerTest extends TestKit(ActorSystem("System")) with Marathon
   test("Publishes event when disconnected") {
     val driver = mock[SchedulerDriver]
 
-    eventBus.subscribe(probe.ref, classOf[SchedulerDisconnectedEvent])
+    eventStream.subscribe(probe.ref, classOf[SchedulerDisconnectedEvent])
 
     scheduler.disconnected(driver)
 
@@ -250,7 +251,7 @@ class MarathonSchedulerTest extends TestKit(ActorSystem("System")) with Marathon
       assert(msg.eventType == "scheduler_reregistered_event")
     }
     finally {
-      eventBus.unsubscribe(probe.ref)
+      eventStream.unsubscribe(probe.ref)
     }
   }
   */

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -29,13 +29,18 @@ trait MarathonTestHelper {
     maxTasksPerOffer: Int = 1,
     maxTasksPerOfferCycle: Int = 10,
     mesosRole: Option[String] = None,
-    acceptedResourceRoles: Option[Set[String]] = None): MarathonConf = {
+    acceptedResourceRoles: Option[Set[String]] = None,
+    reviveOffersForNewApps: Option[Boolean] = Some(true),
+    rejectOfferDuration: Option[Long] = Some(3600000)): MarathonConf = {
 
     var args = Seq(
       "--master", "127.0.0.1:5050",
       "--max_tasks_per_offer", maxTasksPerOffer.toString,
       "--max_tasks_per_offer_cycle", maxTasksPerOfferCycle.toString
     )
+
+    reviveOffersForNewApps.foreach(_ => args ++= Seq("--revive_offers_for_new_apps"))
+    rejectOfferDuration.foreach(duration => args ++= Seq("--reject_offer_duration", duration.toString))
 
     mesosRole.foreach(args ++= Seq("--mesos_role", _))
     acceptedResourceRoles.foreach(v => args ++= Seq("--default_accepted_resource_roles", v.mkString(",")))

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.{ PathId, AppDefinition, AppRepository }
-import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker }
+import mesosphere.marathon.tasks.{ OfferReviver, TaskIdUtil, TaskQueue, TaskTracker }
 import org.apache.mesos.Protos.{ TaskState, TaskID, TaskStatus }
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito.{ times, verify, when }
@@ -21,7 +21,7 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
   import system.dispatcher
 
   test("Reset rate limiter if application is stopped") {
-    val queue = new TaskQueue
+    val queue = new TaskQueue(conf = MarathonTestHelper.defaultConfig(), offerReviver = mock[OfferReviver])
     val repo = mock[AppRepository]
     val taskTracker = mock[TaskTracker]
 
@@ -54,7 +54,7 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
   }
 
   test("Task reconciliation sends known running and staged tasks and empty list") {
-    val queue = new TaskQueue
+    val queue = new TaskQueue(conf = MarathonTestHelper.defaultConfig(), offerReviver = mock[OfferReviver])
     val repo = mock[AppRepository]
     val taskTracker = mock[TaskTracker]
     val driver = mock[SchedulerDriver]
@@ -103,7 +103,7 @@ class SchedulerActionsTest extends TestKit(ActorSystem("TestSystem")) with Marat
   }
 
   test("Task reconciliation only one empty list, when no tasks are present in Marathon") {
-    val queue = new TaskQueue
+    val queue = new TaskQueue(conf = MarathonTestHelper.defaultConfig(), offerReviver = mock[OfferReviver])
     val repo = mock[AppRepository]
     val taskTracker = mock[TaskTracker]
     val driver = mock[SchedulerDriver]

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -3,8 +3,8 @@ package mesosphere.marathon.api.v2
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.{ MarathonConf, MarathonSpec }
-import mesosphere.marathon.tasks.TaskQueue
+import mesosphere.marathon.{ MarathonTestHelper, MarathonSchedulerDriverHolder, MarathonConf, MarathonSpec }
+import mesosphere.marathon.tasks.{ OfferReviver, TaskQueue }
 import org.scalatest.Matchers
 import play.api.libs.json.{ JsObject, Json }
 
@@ -12,7 +12,7 @@ class QueueResourceTest extends MarathonSpec with Matchers {
 
   // regression test for #1210
   test("return well formatted JSON") {
-    val queue = new TaskQueue
+    val queue = new TaskQueue(conf = MarathonTestHelper.defaultConfig(), offerReviver = mock[OfferReviver])
     val app1 = AppDefinition(id = "app1".toRootPath)
     val app2 = AppDefinition(id = "app2".toRootPath)
     val resource = new QueueResource(queue, mock[MarathonConf])

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -68,7 +68,12 @@ trait SingleMarathonIntegrationTest
       ProcessKeeper.startMesosLocal()
       cleanMarathonState()
 
-      startMarathon(config.marathonPort, "--master", config.master, "--event_subscriber", "http_callback")
+      startMarathon(
+        config.marathonPort, "--master", config.master, "--event_subscriber", "http_callback",
+        "--revive_offers_for_new_apps",
+        "--reject_offer_duration", "3600000",
+        "--min_revive_offers_interval", "100"
+      )
       log.info("Setting up local mesos/marathon infrastructure: done.")
     }
     else {

--- a/src/test/scala/mesosphere/marathon/tasks/OfferReviverActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/OfferReviverActorTest.scala
@@ -1,0 +1,130 @@
+package mesosphere.marathon.tasks
+
+import akka.actor.{ Cancellable, Props, Terminated, PoisonPill, ActorRef, ActorSystem }
+import akka.event.Logging.Debug
+import akka.event.{ Logging, EventStream }
+import akka.testkit.TestProbe
+import mesosphere.marathon.event.{ SchedulerRegisteredEvent, SchedulerReregisteredEvent }
+import mesosphere.marathon.{ MarathonSchedulerDriverHolder, MarathonSpec }
+import org.apache.mesos.SchedulerDriver
+import org.mockito.Mockito
+import org.scalatest.{ Matchers, GivenWhenThen, BeforeAndAfter }
+
+import scala.concurrent.duration.FiniteDuration
+
+class OfferReviverActorTest extends MarathonSpec with BeforeAndAfter with GivenWhenThen with Matchers {
+  private[this] implicit var actorSystem: ActorSystem = _
+  private[this] var eventStream: EventStream = _
+  private[this] var driverHolder: MarathonSchedulerDriverHolder = _
+  private[this] var conf: OfferReviverConf = _
+  private[this] var delegate: OfferReviverDelegate = _
+
+  test("Revive offers on ReviveOffers message") {
+    val actorRef = startActor()
+
+    When("calling revive offers")
+    delegate.reviveOffers()
+
+    And("waiting for actor to process all messages and die")
+    actorRef ! PoisonPill
+    val probe = TestProbe()
+    probe.watch(actorRef)
+    probe.expectMsgAnyClassOf(classOf[Terminated])
+
+    Then("we get a reviveOffer call")
+    Mockito.verify(driverHolder.driver.get).reviveOffers()
+  }
+
+  test("Second revive offers results in scheduling") {
+    @volatile
+    var scheduleCheckCalled = 0
+
+    val actorRef = startActor(Props(
+      new OfferReviverActor(conf, eventStream, driverHolder) {
+        override protected def scheduleCheck(duration: FiniteDuration): Cancellable = {
+          scheduleCheckCalled += 1
+          mock[Cancellable]
+        }
+      }
+    ))
+
+    When("calling revive offers")
+    delegate.reviveOffers()
+    delegate.reviveOffers()
+
+    And("waiting for actor to process all messages and die")
+    actorRef ! PoisonPill
+    val probe = TestProbe()
+    probe.watch(actorRef)
+    probe.expectMsgAnyClassOf(classOf[Terminated])
+
+    Then("we get ONE reviveOffer call")
+    Mockito.verify(driverHolder.driver.get).reviveOffers()
+    And("we get one scheduleCheck call")
+    scheduleCheckCalled should be(1)
+  }
+
+  test("Revive offers on SchedulerReregisteredEvent message") {
+    val actorRef = startActor()
+
+    When("sending SchedulerReregisteredEvent")
+    eventStream.publish(SchedulerReregisteredEvent("somemaster"))
+
+    And("waiting for actor to process all messages and die")
+    actorRef ! PoisonPill
+    val probe = TestProbe()
+    probe.watch(actorRef)
+    probe.expectMsgAnyClassOf(classOf[Terminated])
+
+    Then("we get a reviveOffer call")
+    Mockito.verify(driverHolder.driver.get).reviveOffers()
+  }
+
+  test("Revive offers on SchedulerRegisteredEvent message") {
+    val actorRef = startActor()
+
+    When("sending SchedulerRegisteredEvent")
+    eventStream.publish(SchedulerRegisteredEvent("frameworkid", "somemaster"))
+
+    And("waiting for actor to process all messages and die")
+    actorRef ! PoisonPill
+    val probe = TestProbe()
+    probe.watch(actorRef)
+    probe.expectMsgAnyClassOf(classOf[Terminated])
+
+    Then("we get a reviveOffer call")
+    Mockito.verify(driverHolder.driver.get).reviveOffers()
+  }
+
+  before {
+    actorSystem = ActorSystem()
+    eventStream = new EventStream(debug = true)
+    driverHolder = new MarathonSchedulerDriverHolder()
+    driverHolder.driver = Some(mock[SchedulerDriver])
+    conf = new OfferReviverConf {}
+    conf.afterInit()
+  }
+
+  private[this] def startActor(props: Props = OfferReviverActor.props(conf, eventStream, driverHolder)): ActorRef = {
+    val eventStreamProbe = TestProbe()
+    eventStream.subscribe(eventStreamProbe.ref, classOf[Debug])
+    val actorRef = actorSystem.actorOf(
+      props,
+      OfferReviverActor.NAME
+    )
+    delegate = new OfferReviverDelegate(actorRef)
+
+    // wait for actor to subscribe to event stream
+    eventStreamProbe.expectMsgPF() {
+      case Logging.Debug(_, _, message) if message.toString.startsWith("subscribing " + actorRef) =>
+      // noop
+    }
+
+    actorRef
+  }
+
+  after {
+    actorSystem.shutdown()
+    actorSystem.awaitTermination()
+  }
+}

--- a/src/test/scala/mesosphere/marathon/tasks/OfferReviverDummy.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/OfferReviverDummy.scala
@@ -1,0 +1,9 @@
+package mesosphere.marathon.tasks
+
+object OfferReviverDummy {
+  def apply(): OfferReviver = new OfferReviverDummy()
+}
+
+class OfferReviverDummy extends OfferReviver {
+  override def reviveOffers(): Unit = {}
+}

--- a/src/test/scala/mesosphere/marathon/tasks/TaskQueueTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskQueueTest.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.tasks
 
-import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.{ MarathonTestHelper, MarathonSchedulerDriverHolder, MarathonSpec }
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId.StringPathId
@@ -14,7 +14,7 @@ class TaskQueueTest extends MarathonSpec {
   var queue: TaskQueue = _
 
   before {
-    queue = new TaskQueue()
+    queue = new TaskQueue(MarathonTestHelper.defaultConfig(), OfferReviverDummy())
   }
 
   def buildConstraint(field: String, operator: String, value: String = ""): Constraint = {

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -6,8 +6,15 @@ import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.event.{ HealthStatusChanged, MesosStatusUpdateEvent }
 import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.state.{ AppDefinition, PathId }
-import mesosphere.marathon.tasks.{ TaskQueue, TaskTracker }
-import mesosphere.marathon.{ AppStartCanceledException, MarathonConf, MarathonSpec, SchedulerActions }
+import mesosphere.marathon.tasks.{ OfferReviverDummy, TaskQueue, TaskTracker }
+import mesosphere.marathon.{
+  MarathonTestHelper,
+  MarathonSchedulerDriverHolder,
+  AppStartCanceledException,
+  MarathonConf,
+  MarathonSpec,
+  SchedulerActions
+}
 import mesosphere.util.state.memory.InMemoryStore
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito.verify
@@ -33,7 +40,7 @@ class AppStartActorTest
   before {
     driver = mock[SchedulerDriver]
     scheduler = mock[SchedulerActions]
-    taskQueue = new TaskQueue
+    taskQueue = new TaskQueue(MarathonTestHelper.defaultConfig(), OfferReviverDummy())
     taskTracker = new TaskTracker(new InMemoryStore, mock[MarathonConf], new Metrics(new MetricRegistry))
   }
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -9,8 +9,14 @@ import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
-import mesosphere.marathon.tasks.{ TaskIdUtil, TaskQueue, TaskTracker }
-import mesosphere.marathon.{ MarathonConf, SchedulerActions, TaskUpgradeCanceledException }
+import mesosphere.marathon.tasks.{ OfferReviverDummy, TaskIdUtil, TaskQueue, TaskTracker }
+import mesosphere.marathon.{
+  MarathonTestHelper,
+  MarathonSchedulerDriverHolder,
+  MarathonConf,
+  SchedulerActions,
+  TaskUpgradeCanceledException
+}
 import mesosphere.util.state.memory.InMemoryStore
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito.{ spy, times, verify, when }
@@ -37,7 +43,7 @@ class TaskStartActorTest
   before {
     driver = mock[SchedulerDriver]
     scheduler = mock[SchedulerActions]
-    taskQueue = spy(new TaskQueue)
+    taskQueue = spy(new TaskQueue(MarathonTestHelper.defaultConfig(), OfferReviverDummy()))
     metrics = new Metrics(new MetricRegistry)
     taskTracker = spy(new TaskTracker(new InMemoryStore, mock[MarathonConf], metrics))
   }


### PR DESCRIPTION
`--revive_offers_for_new_apps` if true, revive offers is called when a new app
is added to the `TaskQueue` or if a task of an app with constraints dies. The
latter is necessary, for example, if there is a constraint that only allows
one task per host. In this case, we might accept an offer that we rejected
previously, simply because no task is running on the host anymore.

Also note, that Mesos only filters offers that are a strict sub set of
a rejected offer.

`--reject_offer_duration` allows configuring the duration for which offers
are declined if not matched in mesos.

`--min_revive_offers_interval` if `--revive_offers_for_new_apps` is specified,
do not call reviveOffers more often than this interval. It defaults to 5 seconds.

