### PR TITLE
Fixes #1958 - Fix JSON schema for command health check

### DIFF
--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppDefinition.json
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppDefinition.json
@@ -172,7 +172,15 @@
                 "additionalProperties": false,
                 "properties": {
                     "command": {
-                        "type": "string"
+                        "type": "object",
+                        "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "value": {
+                                    "type": "string"
+                                }
+                            }
+                        }
                     },
                     "gracePeriodSeconds": {
                         "minimum": 0,

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -135,6 +135,10 @@ trait MarathonTestHelper {
 
   def validateJsonSchema(app: V2AppDefinition, valid: Boolean = true) {
     val appStr = schemaMapper.writeValueAsString(app)
+    validateJsonSchemaForString(appStr, valid)
+  }
+
+  def validateJsonSchemaForString(appStr: String, valid: Boolean): Unit = {
     val appJson = JsonLoader.fromString(appStr)
     assert(appSchema.validate(appJson).isSuccess == valid)
   }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/V2AppDefinitionSchemaJSONTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/V2AppDefinitionSchemaJSONTest.scala
@@ -1,0 +1,52 @@
+package mesosphere.marathon.api.v2.json
+
+import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec }
+import org.scalatest.GivenWhenThen
+
+/**
+  * Tests that test that the given JSON is rejected by the JSON schema.
+  *
+  * Since the JSON is not representable by an V2AppDefinition,
+  * JSON is used directly.
+  */
+class V2AppDefinitionSchemaJSONTest extends MarathonSpec with GivenWhenThen {
+  test("command health checks WITHOUT a nested value should be rejected") {
+    Given("an app definition WITHOUT a nested value in command section of a health check")
+    val json =
+      """
+        |{
+        |  "id": "/test",
+        |  "cmd": "echo hi",
+        |  "healthChecks": [
+        |    {
+        |      "protocol": "COMMAND",
+        |      "command": "curl -f -X GET http://$HOST:$PORT0/health"
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+
+    Then("validation should fail")
+    MarathonTestHelper.validateJsonSchemaForString(json, valid = false)
+  }
+
+  test("command health checks WITH a nested value should be accepted") {
+    Given("an app definition WITH a nested value in command section of a health check")
+    val json =
+      """
+        |{
+        |  "id": "/test",
+        |  "cmd": "echo hi",
+        |  "healthChecks": [
+        |    {
+        |      "protocol": "COMMAND",
+        |      "command": { "value": "curl -f -X GET http://$HOST:$PORT0/health" }
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+
+    Then("validation should succeed")
+    MarathonTestHelper.validateJsonSchemaForString(json, valid = true)
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/validation/V2AppDefinitionValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/V2AppDefinitionValidatorTest.scala
@@ -5,9 +5,11 @@ import com.github.fge.jackson.JsonLoader
 import javax.validation.ConstraintValidatorContext
 
 import mesosphere.jackson.CaseClassModule
+import mesosphere.marathon.Protos.HealthCheckDefinition
 import mesosphere.marathon.api.v2.json.{ MarathonModule, V2AppDefinition }
 import mesosphere.marathon.MarathonSpec
-import mesosphere.marathon.state.{ Container, PathId, AppDefinition }
+import mesosphere.marathon.health.HealthCheck
+import mesosphere.marathon.state.{ Command, Container, PathId, AppDefinition }
 import mesosphere.marathon.MarathonSpec
 
 class V2AppDefinitionValidatorTest extends MarathonSpec {
@@ -21,6 +23,21 @@ class V2AppDefinitionValidatorTest extends MarathonSpec {
     val app = V2AppDefinition(
       id = PathId("/test"),
       cmd = Some("true"))
+    assert(validator.isValid(app, mock[ConstraintValidatorContext]))
+    validateJsonSchema(app)
+  }
+
+  test("only cmd + command health check") {
+    val app = V2AppDefinition(
+      id = PathId("/test"),
+      cmd = Some("true"),
+      healthChecks = Set(
+        HealthCheck(
+          protocol = HealthCheckDefinition.Protocol.COMMAND,
+          command = Some(Command("curl http://localhost:$PORT"))
+        )
+      )
+    )
     assert(validator.isValid(app, mock[ConstraintValidatorContext]))
     validateJsonSchema(app)
   }


### PR DESCRIPTION
@ssk2 You might want to include that fix in the dcos CLI soon. You cannot create apps with the COMMAND health check currently.

(is there actually an option to ignore the json schema?)