### PR TITLE
add additional s3 uris

### DIFF
--- a/docs/application-basics.md
+++ b/docs/application-basics.md
@@ -102,6 +102,8 @@ A typical pattern in the development and deployment cycle is to have your automa
 * `ftps:`
 * `hdfs:`
 * `s3:`
+* `s3a:`
+* `s3n:`
 
 ## A Simple Docker-based Application
 


### PR DESCRIPTION
When fetching files from S3, Mesos uses the hadoop client.  That client supports two additional [URIs](http://wiki.apache.org/hadoop/AmazonS3) that Marathon can leverage.

In some cases the normal ```s3://``` schema would not be able to find the file/directory specified unless it was setup as described by the docs linked to above.   ```s3n``` and ```s3a``` support fetching files from a more typical s3 bucket setup.

Not a huge deal but may add some clarity.