### PR TITLE
Add sbt tmp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules
 .Rproj.user
 start.sh
 .DS_Store
+/sbt
+/sbt-*tgz


### PR DESCRIPTION
sbt stores its distribution in `/sbt` when running from checked in `sbt.sh` (#1990)