### PR TITLE
Fixes #1943 - Call reviveOffers when already declined offers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ## Changes from 0.10.0 to 0.11.0
 
+### (Potentially) Breaking Changes
+
+* `--revive_offers_for_new_apps` is now the default. If you want to avoid resetting filters
+  if new tasks need to be started, you can disable this by `--disable_revive_offers_for_new_apps`.
+
 ### Overview
 
 #### New `MARATHON_APP_DOCKER_IMAGE` environment variable

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -167,6 +167,10 @@ invocations of this call.
 
 * <span class="label label-default">v0.11.0</span> `--min_revive_offers_interval` (Optional. Default: 5000): 
     Do not ask for all offers (also already seen ones) more often than this interval (ms).
+    
+If you want to disable calling reviveOffers (not recommended), you can use:
+    
+* <span class="label label-default">v0.11.0</span> `--disable_revive_offers_for_new_apps`
 
 
 ### Marathon after 0.8.2 (including) and before 0.11.0

--- a/src/main/scala/mesosphere/marathon/core/flow/FlowModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/FlowModule.scala
@@ -1,17 +1,20 @@
 package mesosphere.marathon.core.flow
 
+import akka.event.EventStream
 import mesosphere.marathon.MarathonSchedulerDriverHolder
 import mesosphere.marathon.core.base.Clock
-import mesosphere.marathon.core.flow.impl.{ OfferMatcherLaunchTokensActor, ReviveOffersActor }
+import mesosphere.marathon.core.flow.impl.{ OfferReviverDelegate, OfferMatcherLaunchTokensActor, ReviveOffersActor }
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
 import mesosphere.marathon.core.task.bus.TaskStatusObservables
+import org.slf4j.LoggerFactory
 import rx.lang.scala.Observable
 
 /**
   * This module contains code for managing the flow/backpressure of the application.
   */
 class FlowModule(leadershipModule: LeadershipModule) {
+  private[this] val log = LoggerFactory.getLogger(getClass)
 
   /**
     * Call `reviveOffers` of the `SchedulerDriver` interface whenever there is new interest
@@ -21,15 +24,28 @@ class FlowModule(leadershipModule: LeadershipModule) {
     * @param offersWanted An observable which emits `true` whenever offers are currently wanted or offer interest
     *                     has changed. It should emit `false` when interest in offers is lost.
     * @param driverHolder The driverHolder containing the driver on which to call `reviveOffers`.
+    * @return an offer reviver that allows explicit calls to reviveOffers
     */
-  def reviveOffersWhenOfferMatcherManagerSignalsInterest(
-    clock: Clock, conf: ReviveOffersConfig,
-    offersWanted: Observable[Boolean], driverHolder: MarathonSchedulerDriverHolder): Unit = {
-    lazy val reviveOffersActor = ReviveOffersActor.props(
-      clock, conf,
-      offersWanted, driverHolder
-    )
-    leadershipModule.startWhenLeader(reviveOffersActor, "reviveOffersWhenWanted")
+  def maybeOfferReviver(
+    clock: Clock,
+    conf: ReviveOffersConfig,
+    marathonEventStream: EventStream,
+    offersWanted: Observable[Boolean],
+    driverHolder: MarathonSchedulerDriverHolder): Option[OfferReviver] = {
+
+    if (conf.shouldReviveOffersForNewApps) {
+      lazy val reviveOffersActor = ReviveOffersActor.props(
+        clock, conf, marathonEventStream,
+        offersWanted, driverHolder
+      )
+      val actorRef = leadershipModule.startWhenLeader(reviveOffersActor, "reviveOffersWhenWanted")
+      log.info(s"Calling reviveOffers is enabled. Use --${conf.disableReviveOffersForNewApps.name} to disable.")
+      Some(new OfferReviverDelegate(actorRef))
+    }
+    else {
+      log.info(s"Calling reviveOffers is disabled. Use --${conf.disableReviveOffersForNewApps.name} to enable.")
+      None
+    }
   }
 
   /**

--- a/src/main/scala/mesosphere/marathon/core/flow/OfferReviver.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/OfferReviver.scala
@@ -1,0 +1,5 @@
+package mesosphere.marathon.core.flow
+
+trait OfferReviver {
+  def reviveOffers(): Unit
+}

--- a/src/main/scala/mesosphere/marathon/core/flow/ReviveOffersConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/ReviveOffersConfig.scala
@@ -5,6 +5,22 @@ import org.rogach.scallop.ScallopConf
 trait ReviveOffersConfig extends ScallopConf {
   //scalastyle:off magic.number
 
+  /**
+    * Separate disable option for --revive_offers_for_new_apps since there doesn't seem
+    * to be a syntax to disable a flag in Scallop.
+    */
+  lazy val disableReviveOffersForNewApps = opt[Boolean]("disable_revive_offers_for_new_apps",
+    descr = "Disable reviveOffers for new or changed apps. (Default: use reviveOffers) ",
+    default = Some(false))
+
+  lazy val reviveOffersForNewApps = opt[Boolean]("revive_offers_for_new_apps",
+    descr = "Whether to call reviveOffers for new or changed apps. " +
+      "(Default: use reviveOffers, disable with --disable_revive_offers_for_new_apps) ",
+    hidden = true,
+    default = Some(true))
+
+  lazy val shouldReviveOffersForNewApps = !disableReviveOffersForNewApps() && reviveOffersForNewApps()
+
   lazy val minReviveOffersInterval = opt[Long]("min_revive_offers_interval",
     descr = "Do not ask for all offers (also already seen ones) more often than this interval (ms).",
     default = Some(5000))

--- a/src/main/scala/mesosphere/marathon/core/flow/impl/OfferReviverDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/impl/OfferReviverDelegate.scala
@@ -1,0 +1,12 @@
+package mesosphere.marathon.core.flow.impl
+
+import akka.actor.ActorRef
+import mesosphere.marathon.core.flow.OfferReviver
+
+object OfferReviverDelegate {
+  case object ReviveOffers
+}
+
+class OfferReviverDelegate(offerReviverRef: ActorRef) extends OfferReviver {
+  override def reviveOffers(): Unit = offerReviverRef ! OfferReviverDelegate.ReviveOffers
+}

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.core.launchqueue
 
 import akka.actor.{ ActorRef, Props }
 import mesosphere.marathon.core.base.Clock
+import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.launchqueue.impl.{
   LaunchQueueDelegate,
   AppTaskLauncherActor,
@@ -24,6 +25,7 @@ class LaunchQueueModule(
     clock: Clock,
     subOfferMatcherManager: OfferMatcherManager,
     taskStatusObservables: TaskStatusObservables,
+    maybeOfferReviver: Option[OfferReviver],
     appRepository: AppRepository,
     taskTracker: TaskTracker,
     taskFactory: TaskFactory) {
@@ -49,6 +51,7 @@ class LaunchQueueModule(
       clock,
       taskFactory,
       taskStatusObservables,
+      maybeOfferReviver,
       taskTracker,
       rateLimiterActor)(app, count)
 }

--- a/src/test/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActorTest.scala
@@ -1,9 +1,10 @@
 package mesosphere.marathon.core.flow.impl
 
-import akka.actor.{ Cancellable, ActorSystem, Scheduler }
-import akka.testkit.TestActorRef
+import akka.actor._
+import akka.testkit.{ TestProbe, TestActorRef }
 import mesosphere.marathon.core.base.{ Clock, ConstantClock }
 import mesosphere.marathon.core.flow.ReviveOffersConfig
+import mesosphere.marathon.event.{ SchedulerRegisteredEvent, SchedulerReregisteredEvent }
 import mesosphere.marathon.{ MarathonSchedulerDriverHolder, MarathonSpec }
 import org.apache.mesos.SchedulerDriver
 import org.mockito.{ Matchers, ArgumentMatcher, Mockito }
@@ -19,10 +20,10 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
     actorRef.start()
 
     Then("there are no surprising interactions")
-    // after verifies that there are not further unwanted interactions
+    verifyNoMoreInteractions()
   }
 
-  test("revive on first true") {
+  test("revive on first OffersWanted(true)") {
     Given("a started actor")
     actorRef.start()
 
@@ -30,7 +31,69 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
     offersWanted.onNext(true)
 
     Then("reviveOffers is called")
-    Mockito.verify(driver).reviveOffers()
+    Mockito.verify(driver, Mockito.timeout(1000)).reviveOffers()
+    verifyNoMoreInteractions()
+  }
+
+  test(s"revive if offers wanted and we receive explicit reviveOffers") {
+    Given("a started actor that wants offers")
+    actorRef.start()
+    offersWanted.onNext(true)
+    Mockito.reset(driver)
+    clock += 10.seconds
+
+    When("we explicitly reviveOffers")
+    val offerReviver = new OfferReviverDelegate(actorRef)
+    offerReviver.reviveOffers()
+
+    Then("reviveOffers is called directly")
+    Mockito.verify(driver, Mockito.timeout(1000)).reviveOffers()
+    verifyNoMoreInteractions()
+  }
+
+  for (
+    reviveEvent <- Seq(
+      SchedulerReregisteredEvent("somemaster"),
+      SchedulerRegisteredEvent("frameworkid", "somemaster"),
+      ReviveOffersActor.TimedCheck
+    )
+  ) {
+    test(s"revive if offers wanted and we receive $reviveEvent") {
+      Given("a started actor that wants offers")
+      actorRef.start()
+      offersWanted.onNext(true)
+      Mockito.reset(driver)
+      clock += 10.seconds
+
+      When(s"the actor receives an $reviveEvent message")
+      actorRef ! reviveEvent
+
+      Then("reviveOffers is called directly")
+      Mockito.verify(driver, Mockito.timeout(1000)).reviveOffers()
+      verifyNoMoreInteractions()
+    }
+  }
+
+  for (
+    reviveEvent <- Seq(
+      SchedulerReregisteredEvent("somemaster"),
+      SchedulerRegisteredEvent("frameworkid", "somemaster"),
+      ReviveOffersActor.TimedCheck
+    )
+  ) {
+    test(s"DO NOT revive if offers NOT wanted and we receive $reviveEvent") {
+      Given("a started actor that wants offers")
+      actorRef.start()
+      offersWanted.onNext(false)
+      Mockito.reset(driver)
+      clock += 10.seconds
+
+      When(s"the actor receives an $reviveEvent message")
+      actorRef ! reviveEvent
+
+      Then("reviveOffers is NOT called directly")
+      verifyNoMoreInteractions()
+    }
   }
 
   test("only one revive for two fast consecutive trues") {
@@ -42,9 +105,10 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
     offersWanted.onNext(true)
 
     Then("it calls reviveOffers once")
-    Mockito.verify(driver).reviveOffers()
+    Mockito.verify(driver, Mockito.timeout(1000)).reviveOffers()
     And("schedules the next revive for in 5 seconds")
     assert(actorRef.underlyingActor.scheduled == Vector(5.seconds))
+    verifyNoMoreInteractions()
   }
 
   test("the third true has no effect") {
@@ -61,6 +125,7 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
     offersWanted.onNext(true)
 
     Then("nothing happens because our next revive is already scheduled")
+    verifyNoMoreInteractions()
   }
 
   test("Revive timer is cancelled if offers not wanted anymore") {
@@ -76,7 +141,8 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
     offersWanted.onNext(false)
 
     Then("we cancel the timer")
-    Mockito.verify(actorRef.underlyingActor.cancellable).cancel()
+    Mockito.verify(actorRef.underlyingActor.cancellable, Mockito.timeout(1000)).cancel()
+    verifyNoMoreInteractions()
   }
 
   test("Check revives if last offersWanted == true and more than 5.seconds ago") {
@@ -93,12 +159,13 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
     clock += 5.seconds
 
     When("we receive a Check message")
-    actorRef ! ReviveOffersActor.Check
+    actorRef ! ReviveOffersActor.TimedCheck
 
     Then("we cancel our now unnecessary timer (which has send this message)")
-    Mockito.verify(actorRef.underlyingActor.cancellable).cancel()
+    Mockito.verify(actorRef.underlyingActor.cancellable, Mockito.timeout(1000)).cancel()
     And("we revive the offers")
-    Mockito.verify(driver).reviveOffers()
+    Mockito.verify(driver, Mockito.timeout(1000)).reviveOffers()
+    verifyNoMoreInteractions()
   }
 
   test("Check does not revives if last offersWanted == false and more than 5.seconds ago") {
@@ -115,9 +182,10 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
     clock += 5.seconds
 
     When("we receive a Check message")
-    actorRef ! ReviveOffersActor.Check
+    actorRef ! ReviveOffersActor.TimedCheck
 
     Then("we do not do anything")
+    verifyNoMoreInteractions()
   }
 
   private[this] implicit var actorSystem: ActorSystem = _
@@ -143,16 +211,29 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
   }
 
   after {
-    Mockito.verifyNoMoreInteractions(actorRef.underlyingActor.cancellable)
-
     actorSystem.shutdown()
     actorSystem.awaitTermination()
+  }
+
+  private[this] def verifyNoMoreInteractions(): Unit = {
+    def killActorAndWaitForDeath(): Terminated = {
+      actorRef ! PoisonPill
+      val deathWatch = TestProbe()
+      deathWatch.watch(actorRef)
+      deathWatch.expectMsgClass(classOf[Terminated])
+    }
+
+    Mockito.verifyNoMoreInteractions(actorRef.underlyingActor.cancellable)
+
+    killActorAndWaitForDeath()
 
     Mockito.verifyNoMoreInteractions(driver)
     Mockito.verifyNoMoreInteractions(mockScheduler)
   }
 
-  private class TestableActor extends ReviveOffersActor(clock, conf, offersWanted, driverHolder) {
+  private class TestableActor extends ReviveOffersActor(
+    clock, conf, actorSystem.eventStream, offersWanted, driverHolder
+  ) {
     var scheduled = Vector.empty[FiniteDuration]
     var cancellable = mock[Cancellable]
 

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueModuleTest.scala
@@ -231,6 +231,7 @@ class LaunchQueueModuleTest extends MarathonSpec with BeforeAndAfter with GivenW
       clock,
       subOfferMatcherManager = offerMatcherManager,
       taskStatusObservables = taskBusModule.taskStatusObservables,
+      maybeOfferReviver = None,
       appRepository,
       taskTracker,
       taskFactory

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -74,7 +74,8 @@ trait SingleMarathonIntegrationTest
       val parameters = List(
         "--master", config.master,
         "--event_subscriber", "http_callback",
-        "--access_control_allow_origin", "*"
+        "--access_control_allow_origin", "*",
+        "--min_revive_offers_interval", "100"
       ) ++ extraMarathonParameters
       startMarathon(config.marathonBasePort, parameters: _*)
 


### PR DESCRIPTION
are potentially of use.

Technical debt:

* Decompose AppTaskLauncherActor since it gets to many responsibilities