### PR TITLE
Make MarathonTasks.makeTask deterministic

### DIFF
--- a/src/main/scala/mesosphere/marathon/tasks/MarathonTasks.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/MarathonTasks.scala
@@ -20,7 +20,7 @@ object MarathonTasks {
       .setVersion(version.toString())
       .addAllPorts(ports.map(i => i.toInt: java.lang.Integer).asJava)
       .addAllAttributes(attributes.asJava)
-      .setStagedAt(System.currentTimeMillis)
+      .setStagedAt(version.toDateTime.getMillis + 1000)
       .setSlaveId(slaveId)
       .build
   }


### PR DESCRIPTION
and avoid at least one shaky test:

```
*** 1 TEST FAILED ***
DefaultTaskFactoryTest:
- Copy SlaveID from Offer to Task *** FAILED *** (13 milliseconds)
  id: "some task ID"
  host: "some_host"
  staged_at: 1439827846039
  version: "1970-01-01T00:00:00.005Z"
  slaveId {
    value: "some slave ID"
  }
   did not equal id: "some task ID"
  host: "some_host"
  staged_at: 1439827846040
  version: "1970-01-01T00:00:00.005Z"
  slaveId {
    value: "some slave ID"
  } (DefaultTaskFactoryTest.scala:30)
  org.scalatest.exceptions.TestFailedException:
  ...
  at mesosphere.marathon.tasks.DefaultTaskFactoryTest$$anonfun$1.apply$mcV$sp(DefaultTaskFactoryTest.scala:30)
  at mesosphere.marathon.tasks.DefaultTaskFactoryTest$$anonfun$1.apply(DefaultTaskFactoryTest.scala:12)
  at mesosphere.marathon.tasks.DefaultTaskFactoryTest$$anonfun$1.apply(DefaultTaskFactoryTest.scala:12)
  at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)
  at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
  at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
  at org.scalatest.Transformer.apply(Transformer.scala:22)
  ...
```