### PR TITLE
Use consolidated info of the LaunchQueue to determine

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -22,6 +22,7 @@ object LaunchQueue {
       tasksLaunchedOrRunning: Int,
       backOffUntil: Timestamp) {
     def waiting: Boolean = tasksLeftToLaunch != 0 || taskLaunchesInFlight != 0
+    def totalTaskCount: Int = tasksLeftToLaunch + tasksLaunchedOrRunning + taskLaunchesInFlight
   }
 }
 
@@ -37,8 +38,13 @@ trait LaunchQueue {
 
   /** Request to launch `count` additional tasks conforming to the given app definition. */
   def add(app: AppDefinition, count: Int = 1): Unit
+
+  /** Get information for the given appId. */
+  def get(appId: PathId): Option[QueuedTaskCount]
+
   /** Return how many tasks are still to be launched for this PathId. */
   def count(appId: PathId): Int
+
   /** Remove all task launch requests for the given PathId from this queue. */
   def purge(appId: PathId): Unit
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -22,10 +22,10 @@ private[launchqueue] class LaunchQueueDelegate(
       .asInstanceOf[Seq[QueuedTaskCount]]
   }
 
-  override def count(appId: PathId): Int = {
-    askQueueActor("count")(LaunchQueueDelegate.Count(appId))
-      .asInstanceOf[Option[QueuedTaskCount]].map(_.tasksLeftToLaunch).getOrElse(0)
-  }
+  override def get(appId: PathId): Option[QueuedTaskCount] =
+    askQueueActor("get")(LaunchQueueDelegate.Count(appId)).asInstanceOf[Option[QueuedTaskCount]]
+
+  override def count(appId: PathId): Int = get(appId).map(_.tasksLeftToLaunch).getOrElse(0)
 
   override def listApps: Seq[AppDefinition] = list.map(_.app)
 

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -75,7 +75,7 @@ trait StartingBehavior { this: Actor with ActorLogging =>
       taskQueue.add(app)
 
     case Sync =>
-      val actualSize = taskQueue.count(app.id) + taskTracker.count(app.id)
+      val actualSize = taskQueue.get(app.id).map(_.totalTaskCount).getOrElse(taskTracker.count(app.id))
       val tasksToStartNow = Math.max(scaleTo - actualSize, 0)
       if (tasksToStartNow > 0) {
         log.info(s"Reconciling tasks during app ${app.id.toString} scaling: queuing ${tasksToStartNow} new tasks")

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -20,7 +20,7 @@ class TaskStartActor(
     val scaleTo: Int,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
-  val nrToStart: Int = scaleTo - taskQueue.count(app.id) - taskTracker.count(app.id)
+  val nrToStart: Int = scaleTo - taskQueue.get(app.id).map(_.totalTaskCount).getOrElse(taskTracker.count(app.id))
 
   override def initializeStart(): Unit = {
     if (nrToStart > 0)

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -9,6 +9,7 @@ import akka.util.Timeout
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.api.LeaderInfo
+import mesosphere.marathon.core.launcher.impl.LaunchQueueTestHelper
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.event._
 import mesosphere.marathon.health.HealthCheckManager
@@ -180,6 +181,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     val app = AppDefinition(id = "test-app".toPath, instances = 1)
     val tasks = Set(MarathonTask.newBuilder().setId("task_a").build())
 
+    when(queue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts))
     when(repo.allPathIds()).thenReturn(Future.successful(Seq(app.id)))
     when(tracker.get(app.id)).thenReturn(Set.empty[MarathonTask])
     when(tracker.list).thenReturn(
@@ -209,6 +211,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
   test("ScaleApp") {
     val app = AppDefinition(id = "test-app".toPath, instances = 1)
 
+    when(queue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts))
     when(repo.allIds()).thenReturn(Future.successful(Seq(app.id.toString)))
     when(tracker.get(app.id)).thenReturn(Set.empty[MarathonTask])
 
@@ -235,6 +238,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     val app = AppDefinition(id = "test-app".toPath, instances = 1)
     val taskA = MarathonTask.newBuilder().setId("taskA_id").build()
 
+    when(queue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts))
     when(repo.allIds()).thenReturn(Future.successful(Seq(app.id.toString)))
     when(tracker.get(app.id)).thenReturn(Set[MarathonTask](taskA))
     when(tracker.fetchTask(app.id, taskA.getId))
@@ -281,6 +285,7 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     val app = AppDefinition(id = "test-app".toPath, instances = 1)
     val taskA = MarathonTask.newBuilder().setId("taskA_id").build()
 
+    when(queue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts))
     when(repo.allIds()).thenReturn(Future.successful(Seq(app.id.toString)))
     when(tracker.get(app.id)).thenReturn(Set[MarathonTask](taskA))
     when(tracker.fetchTask(app.id, taskA.getId))

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
@@ -1,0 +1,14 @@
+package mesosphere.marathon.core.launcher.impl
+
+import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.state.{ PathId, Timestamp, AppDefinition }
+
+object LaunchQueueTestHelper {
+  val zeroCounts = LaunchQueue.QueuedTaskCount(
+    app = AppDefinition(PathId("/thisisignored")),
+    tasksLeftToLaunch = 0,
+    taskLaunchesInFlight = 0,
+    tasksLaunchedOrRunning = 0,
+    backOffUntil = Timestamp(0)
+  )
+}


### PR DESCRIPTION
how many more tasks we have to launch.

I hope that will have an effect on the phenomena that we see during scaling: For large numbers of instances that are launched quickly, hitting the target count exactly takes a long time.