### PR TITLE
Fix #2029 - add Produces JSON annotation to AppTasksResource

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -18,6 +18,7 @@ import org.apache.log4j.Logger
 import scala.concurrent.Future
 
 @Consumes(Array(MediaType.APPLICATION_JSON))
+@Produces(Array(MarathonMediaType.PREFERRED_APPLICATION_JSON))
 class AppTasksResource @Inject() (service: MarathonSchedulerService,
                                   taskTracker: TaskTracker,
                                   taskKiller: TaskKiller,
@@ -29,7 +30,6 @@ class AppTasksResource @Inject() (service: MarathonSchedulerService,
   val GroupTasks = """^((?:.+/)|)\*$""".r
 
   @GET
-  @Produces(Array(MarathonMediaType.PREFERRED_APPLICATION_JSON))
   @Timed
   def indexJson(@PathParam("appId") appId: String): Response = {
 


### PR DESCRIPTION
Fixed this issue by (re-) adding an `@Produces` annotation to `AppTasksResource`. Removed the explicit annotation on `indexJson` since the class annotation will hold for all methods that do not otherwise override the annotation.