### PR TITLE
Update to visualiser 1.6.3

### DIFF
--- a/src/main/resources/assets/3d/js/main.js
+++ b/src/main/resources/assets/3d/js/main.js
@@ -378,7 +378,7 @@
       currentTotalCounter = totalRunning;
       hudElements.loading.className = "";
       // Set starting timers
-      if (!startTime && totalInstances) {
+      if (!startTime && totalInstances && totalRunning > 0) {
         startTime = new Date().getTime();
         targetTime = startTime + config.targetStopwatchSeconds;
       }


### PR DESCRIPTION
Start stopwatch on first started instances, not on polling