### PR TITLE
servicerouter.py - enhances the error output for bad requests

### DIFF
--- a/bin/servicerouter.py
+++ b/bin/servicerouter.py
@@ -437,7 +437,9 @@ class Marathon(object):
             )
             if response.status_code == 200:
                 break
-
+        if 'message' in response.json():
+            response.reason = "%s (%s)" % (response.reason,
+              response.json()['message'])
         response.raise_for_status()
         return response
 


### PR DESCRIPTION
When trying to run servicerouter.py as a callback on any marathon
instance that does not have callbacks enabled, it raised a nonsense
error message.

This MR enhances the provided error reason with the marathon specific message, if present.

Example old error:
```
[12:32] marfri@dhcp-workcat ~/work/marathon # ./bin/servicerouter.py -m "http://marathon1:8080" -l http://lb1:4242
Traceback (most recent call last):
  File "./bin/servicerouter.py", line 853, in <module>
    run_server(marathon, args.listening, args.haproxy_config, args.group)
  File "./bin/servicerouter.py", line 792, in run_server
    groups)
  File "./bin/servicerouter.py", line 727, in __init__
    marathon.add_subscriber(addr)
  File "./bin/servicerouter.py", line 468, in add_subscriber
    params={'callbackUrl': callbackUrl})
  File "./bin/servicerouter.py", line 446, in api_req
    return self.api_req_raw(method, path, **kwargs).json()
  File "./bin/servicerouter.py", line 442, in api_req_raw
    response.raise_for_status()
  File "/usr/local/lib/python2.7/site-packages/requests/models.py", line 825, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request
```

New error message:
```
[12:32] marfri@dhcp-workcat ~/work/marathon # ./bin/servicerouter.py -m "http://marathon1:8080" -l http://lb1:4242
Traceback (most recent call last):
  File "./bin/servicerouter.py", line 853, in <module>
    run_server(marathon, args.listening, args.haproxy_config, args.group)
  File "./bin/servicerouter.py", line 792, in run_server
    groups)
  File "./bin/servicerouter.py", line 727, in __init__
    marathon.add_subscriber(addr)
  File "./bin/servicerouter.py", line 468, in add_subscriber
    params={'callbackUrl': callbackUrl})
  File "./bin/servicerouter.py", line 446, in api_req
    return self.api_req_raw(method, path, **kwargs).json()
  File "./bin/servicerouter.py", line 442, in api_req_raw
    response.raise_for_status()
  File "/usr/local/lib/python2.7/site-packages/requests/models.py", line 825, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request (http event callback system is not running on this Marathon instance. Please re-start this instance with "--event_subscriber http_callback".)
```

Also I am unsure if this really is a 400 error but rather a 500 as its the server side that isnt properly configured but anyhow the request is "bad" in this case so I guess 400 is still ok.