### PR TITLE
Fixes #2060 - Use V2Group to render group for GroupsResource

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -34,7 +34,7 @@ class GroupsResource @Inject() (
     */
   @GET
   @Timed
-  def root(): Group = result(groupManager.rootGroup())
+  def root(): V2Group = V2Group(result(groupManager.rootGroup()))
 
   /**
     * Get a specific group, optionally with specific version


### PR DESCRIPTION
I honestly don't know how to test this as it is because
right now Group/V2Group are identical. It's only visible if they
are not (which I did in a follow up patch).