### PR TITLE
Improves #1908 - log arguments on startup

### DIFF
--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -83,7 +83,7 @@ class MarathonApp extends App {
   override lazy val conf = new AllConf
 
   def runDefault(): Unit = {
-    log.info(s"Starting Marathon ${BuildInfo.version}")
+    log.info(s"Starting Marathon ${BuildInfo.version} with ${args.mkString(" ")}")
     run(
       classOf[HttpService],
       classOf[MarathonSchedulerService]

--- a/src/main/scala/mesosphere/marathon/MarathonLeaderInfo.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonLeaderInfo.scala
@@ -29,7 +29,8 @@ class MarathonLeaderInfo @Inject() (
     candidate.flatMap { c =>
       val maybeLeaderData: Option[Array[Byte]] = try {
         Option(c.getLeaderData.orNull())
-      } catch {
+      }
+      catch {
         case NonFatal(e) =>
           log.error("error while getting current leader", e)
           None


### PR DESCRIPTION
(Scallop does not easily allow extracting config values)