### PR TITLE
Add a way to override the port for tcp/http/https healthchecks

### DIFF
--- a/docs/docs/health-checks.md
+++ b/docs/docs/health-checks.md
@@ -87,6 +87,8 @@ more details.
 * `ignoreHttp1xx` (Optional. Default: false): Ignore HTTP informational status
 codes 100 to 199. If the HTTP health check returns one of these, the result is
 discarded and the health status of the task remains unchanged.
+* `overridePort` (Optional. Default: None): Send healthchecks to this port
+instead of using portIndex.
 
 #### Health Lifecycle
 

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppDefinition.json
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppDefinition.json
@@ -198,6 +198,11 @@
                         "minimum": 0,
                         "type": "integer"
                     },
+                    "overridePort": {
+                        "maximum": 65535,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
                     "path": {
                         "type": "string"
                     },

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
@@ -82,6 +82,15 @@ Here is an example of an application JSON which includes all fields.
             "maxConsecutiveFailures": 3
         },
         {
+            "protocol": "HTTP",
+            "path": "/machinehealth",
+            "gracePeriodSeconds": 3,
+            "intervalSeconds": 10,
+            "overridePort": 3333,
+            "timeoutSeconds": 10,
+            "maxConsecutiveFailures": 3
+        },
+        {
             "protocol": "TCP",
             "gracePeriodSeconds": 3,
             "intervalSeconds": 5,

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_show.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_show.md
@@ -181,6 +181,17 @@ Transfer-Encoding: chunked
                 "portIndex": 0,
                 "protocol": "HTTP",
                 "timeoutSeconds": 10
+            },
+            {
+                "command": null,
+                "gracePeriodSeconds": 5,
+                "intervalSeconds": 10,
+                "maxConsecutiveFailures": 6,
+                "path": "/machinehealth",
+                "portIndex": 0,
+                "overridePort": 3333,
+                "protocol": "HTTP",
+                "timeoutSeconds": 10
             }
         ],
         "id": "/toggle",
@@ -211,6 +222,14 @@ Transfer-Encoding: chunked
                         "lastFailure": null,
                         "lastSuccess": "2014-09-13T00:25:07.506Z",
                         "taskId": "toggle.802df2ae-3ad4-11e4-a400-56847afe9799"
+                    },
+                    {
+                        "alive": true,
+                        "consecutiveFailures": 0,
+                        "firstSuccess": "2014-09-13T00:20:28.101Z",
+                        "lastFailure": null,
+                        "lastSuccess": "2014-09-13T00:25:07.506Z",
+                        "taskId": "toggle.802df2ae-3ad4-11e4-a400-56847afe9799"
                     }
                 ],
                 "host": "10.141.141.10",
@@ -232,6 +251,14 @@ Transfer-Encoding: chunked
                         "lastFailure": null,
                         "lastSuccess": "2014-09-13T00:25:07.508Z",
                         "taskId": "toggle.7c99814d-3ad4-11e4-a400-56847afe9799"
+                    },
+                    {
+                        "alive": true,
+                        "consecutiveFailures": 0,
+                        "firstSuccess": "2014-09-13T00:20:28.101Z",
+                        "lastFailure": null,
+                        "lastSuccess": "2014-09-13T00:25:07.506Z",
+                        "taskId": "toggle.802df2ae-3ad4-11e4-a400-56847afe9799"
                     }
                 ],
                 "host": "10.141.141.10",

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -1005,6 +1005,16 @@ public final class Protos {
      * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
      */
     boolean getIgnoreHttp1Xx();
+
+    // optional uint32 overridePort = 10;
+    /**
+     * <code>optional uint32 overridePort = 10;</code>
+     */
+    boolean hasOverridePort();
+    /**
+     * <code>optional uint32 overridePort = 10;</code>
+     */
+    int getOverridePort();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
@@ -1114,6 +1124,11 @@ public final class Protos {
             case 72: {
               bitField0_ |= 0x00000100;
               ignoreHttp1Xx_ = input.readBool();
+              break;
+            }
+            case 80: {
+              bitField0_ |= 0x00000200;
+              overridePort_ = input.readUInt32();
               break;
             }
           }
@@ -1445,6 +1460,22 @@ public final class Protos {
       return ignoreHttp1Xx_;
     }
 
+    // optional uint32 overridePort = 10;
+    public static final int OVERRIDEPORT_FIELD_NUMBER = 10;
+    private int overridePort_;
+    /**
+     * <code>optional uint32 overridePort = 10;</code>
+     */
+    public boolean hasOverridePort() {
+      return ((bitField0_ & 0x00000200) == 0x00000200);
+    }
+    /**
+     * <code>optional uint32 overridePort = 10;</code>
+     */
+    public int getOverridePort() {
+      return overridePort_;
+    }
+
     private void initFields() {
       protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
       portIndex_ = 0;
@@ -1455,6 +1486,7 @@ public final class Protos {
       maxConsecutiveFailures_ = 3;
       command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
       ignoreHttp1Xx_ = false;
+      overridePort_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1509,6 +1541,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         output.writeBool(9, ignoreHttp1Xx_);
       }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        output.writeUInt32(10, overridePort_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -1553,6 +1588,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(9, ignoreHttp1Xx_);
+      }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(10, overridePort_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1693,6 +1732,8 @@ public final class Protos {
         bitField0_ = (bitField0_ & ~0x00000080);
         ignoreHttp1Xx_ = false;
         bitField0_ = (bitField0_ & ~0x00000100);
+        overridePort_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000200);
         return this;
       }
 
@@ -1761,6 +1802,10 @@ public final class Protos {
           to_bitField0_ |= 0x00000100;
         }
         result.ignoreHttp1Xx_ = ignoreHttp1Xx_;
+        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+          to_bitField0_ |= 0x00000200;
+        }
+        result.overridePort_ = overridePort_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1805,6 +1850,9 @@ public final class Protos {
         }
         if (other.hasIgnoreHttp1Xx()) {
           setIgnoreHttp1Xx(other.getIgnoreHttp1Xx());
+        }
+        if (other.hasOverridePort()) {
+          setOverridePort(other.getOverridePort());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -2292,6 +2340,39 @@ public final class Protos {
       public Builder clearIgnoreHttp1Xx() {
         bitField0_ = (bitField0_ & ~0x00000100);
         ignoreHttp1Xx_ = false;
+        onChanged();
+        return this;
+      }
+
+      // optional uint32 overridePort = 10;
+      private int overridePort_ ;
+      /**
+       * <code>optional uint32 overridePort = 10;</code>
+       */
+      public boolean hasOverridePort() {
+        return ((bitField0_ & 0x00000200) == 0x00000200);
+      }
+      /**
+       * <code>optional uint32 overridePort = 10;</code>
+       */
+      public int getOverridePort() {
+        return overridePort_;
+      }
+      /**
+       * <code>optional uint32 overridePort = 10;</code>
+       */
+      public Builder setOverridePort(int value) {
+        bitField0_ |= 0x00000200;
+        overridePort_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 overridePort = 10;</code>
+       */
+      public Builder clearOverridePort() {
+        bitField0_ = (bitField0_ & ~0x00000200);
+        overridePort_ = 0;
         onChanged();
         return this;
       }
@@ -21444,7 +21525,7 @@ public final class Protos {
       "\030\001 \002(\t\022:\n\010operator\030\002 \002(\0162(.mesosphere.ma" +
       "rathon.Constraint.Operator\022\r\n\005value\030\003 \001(" +
       "\t\"G\n\010Operator\022\n\n\006UNIQUE\020\000\022\010\n\004LIKE\020\001\022\013\n\007C" +
-      "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\"\373\002\n\025H" +
+      "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\"\221\003\n\025H" +
       "ealthCheckDefinition\022E\n\010protocol\030\001 \002(\01623" +
       ".mesosphere.marathon.HealthCheckDefiniti" +
       "on.Protocol\022\024\n\tportIndex\030\002 \002(\r:\0010\022\036\n\022gra" +
@@ -21453,76 +21534,76 @@ public final class Protos {
       "20\022\017\n\004path\030\006 \001(\t:\001/\022!\n\026maxConsecutiveFai" +
       "lures\030\007 \001(\r:\0013\022#\n\007command\030\010 \001(\0132\022.mesos." +
       "CommandInfo\022\034\n\rignoreHttp1xx\030\t \001(\010:\005fals" +
-      "e\"5\n\010Protocol\022\010\n\004HTTP\020\000\022\007\n\003TCP\020\001\022\013\n\007COMM" +
-      "AND\020\002\022\t\n\005HTTPS\020\003\"\323\006\n\021ServiceDefinition\022\n" +
-      "\n\002id\030\001 \002(\t\022\037\n\003cmd\030\002 \002(\0132\022.mesos.CommandI" +
-      "nfo\022\021\n\tinstances\030\003 \002(\r\022\"\n\tresources\030\004 \003(" +
-      "\0132\017.mesos.Resource\022\023\n\013description\030\005 \001(\t\022" +
-      "\r\n\005ports\030\006 \003(\r\0224\n\013constraints\030\007 \003(\0132\037.me",
-      "sosphere.marathon.Constraint\022\022\n\010executor" +
-      "\030\010 \002(\t:\000\022>\n\022OBSOLETE_container\030\n \001(\0132\".m" +
-      "esosphere.marathon.ContainerInfo\022)\n\007vers" +
-      "ion\030\013 \001(\t:\0301970-01-01T00:00:00.000Z\022@\n\014h" +
-      "ealthChecks\030\014 \003(\0132*.mesosphere.marathon." +
-      "HealthCheckDefinition\022\025\n\007backoff\030\r \001(\003:\004" +
-      "1000\022\033\n\rbackoffFactor\030\016 \001(\001:\0041.15\022G\n\017upg" +
-      "radeStrategy\030\017 \001(\0132..mesosphere.marathon" +
-      ".UpgradeStrategyDefinition\022\024\n\014dependenci" +
-      "es\030\020 \003(\t\022\021\n\tstoreUrls\030\021 \003(\t\022\034\n\rrequire_p",
-      "orts\030\022 \001(\010:\005false\022=\n\tcontainer\030\023 \001(\0132*.m" +
-      "esosphere.marathon.ExtendedContainerInfo" +
-      "\022 \n\006labels\030\024 \003(\0132\020.mesos.Parameter\022\037\n\016ma" +
-      "xLaunchDelay\030\025 \001(\003:\0073600000\022A\n\025acceptedR" +
-      "esourceRoles\030\026 \001(\0132\".mesosphere.marathon" +
-      ".ResourceRoles\022\027\n\017last_scaling_at\030\027 \001(\003\022" +
-      "\035\n\025last_config_change_at\030\030 \001(\003\"\035\n\rResour" +
-      "ceRoles\022\014\n\004role\030\001 \003(\t\"\241\002\n\014MarathonTask\022\n" +
-      "\n\002id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022" +
-      "$\n\nattributes\030\004 \003(\0132\020.mesos.Attribute\022\021\n",
-      "\tstaged_at\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003\022,\n\021" +
-      "OBSOLETE_statuses\030\007 \003(\0132\021.mesos.TaskStat" +
-      "us\022)\n\007version\030\010 \001(\t:\0301970-01-01T00:00:00" +
-      ".000Z\022!\n\006status\030\t \001(\0132\021.mesos.TaskStatus" +
-      "\022\037\n\007slaveId\030\n \001(\0132\016.mesos.SlaveID\"M\n\013Mar" +
-      "athonApp\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!." +
-      "mesosphere.marathon.MarathonTask\"1\n\rCont" +
-      "ainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007options\030\002 " +
-      "\003(\014\"\237\004\n\025ExtendedContainerInfo\022\'\n\004type\030\001 " +
-      "\002(\0162\031.mesos.ContainerInfo.Type\022\036\n\007volume",
-      "s\030\002 \003(\0132\r.mesos.Volume\022E\n\006docker\030\003 \001(\01325" +
-      ".mesosphere.marathon.ExtendedContainerIn" +
-      "fo.DockerInfo\032\365\002\n\nDockerInfo\022\r\n\005image\030\001 " +
-      "\002(\t\022>\n\007network\030\002 \001(\0162\'.mesos.ContainerIn" +
-      "fo.DockerInfo.Network:\004HOST\022X\n\rport_mapp" +
-      "ings\030\003 \003(\0132A.mesosphere.marathon.Extende" +
-      "dContainerInfo.DockerInfo.PortMapping\022\031\n" +
-      "\nprivileged\030\004 \001(\010:\005false\022$\n\nparameters\030\005" +
-      " \003(\0132\020.mesos.Parameter\022\030\n\020force_pull_ima" +
-      "ge\030\006 \001(\010\032c\n\013PortMapping\022\021\n\thost_port\030\001 \002",
-      "(\r\022\026\n\016container_port\030\002 \002(\r\022\020\n\010protocol\030\003" +
-      " \001(\t\022\027\n\014service_port\030d \001(\r:\0010\")\n\020EventSu" +
-      "bscribers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016Stor" +
-      "ageVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r" +
-      "\022\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefini" +
-      "tion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023m" +
-      "aximumOverCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDef" +
-      "inition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004" +
-      "apps\030\003 \003(\0132&.mesosphere.marathon.Service" +
-      "Definition\0224\n\006groups\030\004 \003(\0132$.mesosphere.",
-      "marathon.GroupDefinition\022\024\n\014dependencies" +
-      "\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002i" +
-      "d\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002" +
-      "(\0132$.mesosphere.marathon.GroupDefinition" +
-      "\0224\n\006target\030\005 \002(\0132$.mesosphere.marathon.G" +
-      "roupDefinition\"\306\001\n\013TaskFailure\022\016\n\006app_id" +
-      "\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037" +
-      "\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007messa" +
-      "ge\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 " +
-      "\002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132",
-      "\016.mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004name\030" +
-      "\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\nco" +
-      "mpressed\030\004 \001(\010:\005falseB\035\n\023mesosphere.mara" +
-      "thonB\006Protos"
+      "e\022\024\n\014overridePort\030\n \001(\r\"5\n\010Protocol\022\010\n\004H" +
+      "TTP\020\000\022\007\n\003TCP\020\001\022\013\n\007COMMAND\020\002\022\t\n\005HTTPS\020\003\"\323" +
+      "\006\n\021ServiceDefinition\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030" +
+      "\002 \002(\0132\022.mesos.CommandInfo\022\021\n\tinstances\030\003" +
+      " \002(\r\022\"\n\tresources\030\004 \003(\0132\017.mesos.Resource" +
+      "\022\023\n\013description\030\005 \001(\t\022\r\n\005ports\030\006 \003(\r\0224\n\013",
+      "constraints\030\007 \003(\0132\037.mesosphere.marathon." +
+      "Constraint\022\022\n\010executor\030\010 \002(\t:\000\022>\n\022OBSOLE" +
+      "TE_container\030\n \001(\0132\".mesosphere.marathon" +
+      ".ContainerInfo\022)\n\007version\030\013 \001(\t:\0301970-01" +
+      "-01T00:00:00.000Z\022@\n\014healthChecks\030\014 \003(\0132" +
+      "*.mesosphere.marathon.HealthCheckDefinit" +
+      "ion\022\025\n\007backoff\030\r \001(\003:\0041000\022\033\n\rbackoffFac" +
+      "tor\030\016 \001(\001:\0041.15\022G\n\017upgradeStrategy\030\017 \001(\013" +
+      "2..mesosphere.marathon.UpgradeStrategyDe" +
+      "finition\022\024\n\014dependencies\030\020 \003(\t\022\021\n\tstoreU",
+      "rls\030\021 \003(\t\022\034\n\rrequire_ports\030\022 \001(\010:\005false\022" +
+      "=\n\tcontainer\030\023 \001(\0132*.mesosphere.marathon" +
+      ".ExtendedContainerInfo\022 \n\006labels\030\024 \003(\0132\020" +
+      ".mesos.Parameter\022\037\n\016maxLaunchDelay\030\025 \001(\003" +
+      ":\0073600000\022A\n\025acceptedResourceRoles\030\026 \001(\013" +
+      "2\".mesosphere.marathon.ResourceRoles\022\027\n\017" +
+      "last_scaling_at\030\027 \001(\003\022\035\n\025last_config_cha" +
+      "nge_at\030\030 \001(\003\"\035\n\rResourceRoles\022\014\n\004role\030\001 " +
+      "\003(\t\"\241\002\n\014MarathonTask\022\n\n\002id\030\001 \002(\t\022\014\n\004host" +
+      "\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022$\n\nattributes\030\004 \003(",
+      "\0132\020.mesos.Attribute\022\021\n\tstaged_at\030\005 \001(\003\022\022" +
+      "\n\nstarted_at\030\006 \001(\003\022,\n\021OBSOLETE_statuses\030" +
+      "\007 \003(\0132\021.mesos.TaskStatus\022)\n\007version\030\010 \001(" +
+      "\t:\0301970-01-01T00:00:00.000Z\022!\n\006status\030\t " +
+      "\001(\0132\021.mesos.TaskStatus\022\037\n\007slaveId\030\n \001(\0132" +
+      "\016.mesos.SlaveID\"M\n\013MarathonApp\022\014\n\004name\030\001" +
+      " \001(\t\0220\n\005tasks\030\002 \003(\0132!.mesosphere.maratho" +
+      "n.MarathonTask\"1\n\rContainerInfo\022\017\n\005image" +
+      "\030\001 \002(\014:\000\022\017\n\007options\030\002 \003(\014\"\237\004\n\025ExtendedCo" +
+      "ntainerInfo\022\'\n\004type\030\001 \002(\0162\031.mesos.Contai",
+      "nerInfo.Type\022\036\n\007volumes\030\002 \003(\0132\r.mesos.Vo" +
+      "lume\022E\n\006docker\030\003 \001(\01325.mesosphere.marath" +
+      "on.ExtendedContainerInfo.DockerInfo\032\365\002\n\n" +
+      "DockerInfo\022\r\n\005image\030\001 \002(\t\022>\n\007network\030\002 \001" +
+      "(\0162\'.mesos.ContainerInfo.DockerInfo.Netw" +
+      "ork:\004HOST\022X\n\rport_mappings\030\003 \003(\0132A.mesos" +
+      "phere.marathon.ExtendedContainerInfo.Doc" +
+      "kerInfo.PortMapping\022\031\n\nprivileged\030\004 \001(\010:" +
+      "\005false\022$\n\nparameters\030\005 \003(\0132\020.mesos.Param" +
+      "eter\022\030\n\020force_pull_image\030\006 \001(\010\032c\n\013PortMa",
+      "pping\022\021\n\thost_port\030\001 \002(\r\022\026\n\016container_po" +
+      "rt\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\027\n\014service_po" +
+      "rt\030d \001(\r:\0010\")\n\020EventSubscribers\022\025\n\rcallb" +
+      "ack_urls\030\001 \003(\t\"=\n\016StorageVersion\022\r\n\005majo" +
+      "r\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z\n" +
+      "\031UpgradeStrategyDefinition\022\035\n\025minimumHea" +
+      "lthCapacity\030\001 \002(\001\022\036\n\023maximumOverCapacity" +
+      "\030\002 \001(\001:\0011\"\260\001\n\017GroupDefinition\022\n\n\002id\030\001 \002(" +
+      "\t\022\017\n\007version\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.mesos" +
+      "phere.marathon.ServiceDefinition\0224\n\006grou",
+      "ps\030\004 \003(\0132$.mesosphere.marathon.GroupDefi" +
+      "nition\022\024\n\014dependencies\030\005 \003(\t\"\245\001\n\030Deploym" +
+      "entPlanDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007version" +
+      "\030\002 \002(\t\0226\n\010original\030\004 \002(\0132$.mesosphere.ma" +
+      "rathon.GroupDefinition\0224\n\006target\030\005 \002(\0132$" +
+      ".mesosphere.marathon.GroupDefinition\"\306\001\n" +
+      "\013TaskFailure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id\030" +
+      "\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003 \002(\0162\020.me" +
+      "sos.TaskState\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004host" +
+      "\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\ttimestamp\030\007",
+      " \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016.mesos.SlaveID\"T\n" +
+      "\014ZKStoreEntry\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002(" +
+      "\014\022\r\n\005value\030\003 \002(\014\022\031\n\ncompressed\030\004 \001(\010:\005fa" +
+      "lseB\035\n\023mesosphere.marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -21540,7 +21621,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
-              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", });
+              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "OverridePort", });
           internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
             getDescriptor().getMessageTypes().get(2);
           internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -43,6 +43,7 @@ message HealthCheckDefinition {
   optional uint32 maxConsecutiveFailures = 7 [default = 3];
   optional mesos.CommandInfo command = 8;
   optional bool ignoreHttp1xx = 9 [default = false];
+  optional uint32 overridePort = 10;
 }
 
 message ServiceDefinition {

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -356,7 +356,8 @@ trait HealthCheckFormats {
       (__ \ "intervalSeconds").formatNullable[Long].withDefault(DefaultInterval.toSeconds).asSeconds ~
       (__ \ "timeoutSeconds").formatNullable[Long].withDefault(DefaultTimeout.toSeconds).asSeconds ~
       (__ \ "maxConsecutiveFailures").formatNullable[Integer].withDefault(DefaultMaxConsecutiveFailures) ~
-      (__ \ "ignoreHttp1xx").formatNullable[Boolean].withDefault(DefaultIgnoreHttp1xx)
+      (__ \ "ignoreHttp1xx").formatNullable[Boolean].withDefault(DefaultIgnoreHttp1xx) ~
+      (__ \ "overridePort").formatNullable[Integer]
     )(HealthCheck.apply, unlift(HealthCheck.unapply))
   }
 }

--- a/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
@@ -29,7 +29,9 @@ case class HealthCheck(
 
   maxConsecutiveFailures: JInt = HealthCheck.DefaultMaxConsecutiveFailures,
 
-  ignoreHttp1xx: Boolean = HealthCheck.DefaultIgnoreHttp1xx)
+  ignoreHttp1xx: Boolean = HealthCheck.DefaultIgnoreHttp1xx,
+
+  overridePort: Option[JInt] = HealthCheck.DefaultOverridePort)
     extends MarathonState[Protos.HealthCheckDefinition, HealthCheck] {
 
   def toProto: Protos.HealthCheckDefinition = {
@@ -45,6 +47,8 @@ case class HealthCheck(
     command foreach { c => builder.setCommand(c.toProto) }
 
     path foreach builder.setPath
+
+    overridePort foreach { p => builder.setOverridePort(p.toInt) }
 
     builder.build
   }
@@ -62,7 +66,9 @@ case class HealthCheck(
       timeout = proto.getTimeoutSeconds.seconds,
       interval = proto.getIntervalSeconds.seconds,
       maxConsecutiveFailures = proto.getMaxConsecutiveFailures,
-      ignoreHttp1xx = proto.getIgnoreHttp1Xx
+      ignoreHttp1xx = proto.getIgnoreHttp1Xx,
+      overridePort =
+        if (proto.hasOverridePort) Some(proto.getOverridePort) else None
     )
 
   def mergeFromProto(bytes: Array[Byte]): HealthCheck =
@@ -110,4 +116,5 @@ object HealthCheck {
   val DefaultTimeout = 20.seconds
   val DefaultMaxConsecutiveFailures = 3
   val DefaultIgnoreHttp1xx = false
+  val DefaultOverridePort = None
 }

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -31,6 +31,29 @@ class HealthCheckTest extends MarathonSpec {
     assert(10 == proto.getGracePeriodSeconds)
     assert(60 == proto.getIntervalSeconds)
     assert(0 == proto.getMaxConsecutiveFailures)
+    assert(!proto.hasOverridePort)
+  }
+
+  test("ToProtoOverridePort") {
+    val healthCheck = HealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.HTTP,
+      portIndex = 0,
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      maxConsecutiveFailures = 0,
+      overridePort = Some(12345)
+    )
+
+    val proto = healthCheck.toProto
+
+    assert("/health" == proto.getPath)
+    assert(Protocol.HTTP == proto.getProtocol)
+    assert(0 == proto.getPortIndex)
+    assert(10 == proto.getGracePeriodSeconds)
+    assert(60 == proto.getIntervalSeconds)
+    assert(0 == proto.getMaxConsecutiveFailures)
+    assert(12345 == proto.getOverridePort)
   }
 
   test("ToProtoTcp") {
@@ -60,6 +83,7 @@ class HealthCheckTest extends MarathonSpec {
       .setIntervalSeconds(60)
       .setTimeoutSeconds(10)
       .setMaxConsecutiveFailures(10)
+      .setOverridePort(12345)
       .build
 
     val mergeResult = HealthCheck().mergeFromProto(proto)
@@ -71,7 +95,8 @@ class HealthCheckTest extends MarathonSpec {
       gracePeriod = 10.seconds,
       interval = 60.seconds,
       timeout = 10.seconds,
-      maxConsecutiveFailures = 10
+      maxConsecutiveFailures = 10,
+      overridePort = Some(12345)
     )
 
     assert(mergeResult == expectedResult)

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
@@ -82,4 +82,16 @@ class HealthCheckWorkerActorTest
     expectTerminated(ref)
   }
 
+  test("getPort") {
+    val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
+
+    val check = new HealthCheck(overridePort = Some(1234))
+    val task = Protos.MarathonTask
+      .newBuilder
+      .setHost("fakehostname")
+      .setId("test_id")
+      .addPorts(4321)
+      .build()
+    assert(ref.underlyingActor.getPort(task, check) == Some(1234))
+  }
 }


### PR DESCRIPTION
This makes it possible to have Marathon healthcheck a different (fixed) port on the host where a task is running, or to healthcheck a different host entirely.

For context, we use uber/hacheck as part of our load balancing layer. This allows operators to remove machines from service before performing maintenance, by running `hadown all`. This will cause all healthchecks that go through hacheck to fail. Unfortunately, Marathon has no idea that a box is marked down, so it will happily deploy tasks to that box, even though they will never be load balanced.

We would like to have Marathon healthcheck http://${host}:3333/spool/all/0/status, which will return 5xx if a box is `hadown`ed. This patch would allow this by setting up a healthcheck that looks like:

```
{
  "protocol": "http",
  "path": "/spool/all/0/status",
  "overridePort": 6666,
  ...
}
```