### PR TITLE
Setting the default for `--decline-offer-duration` to 120s

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -154,7 +154,7 @@ more tasks when it gets feedback about running and healthy tasks from Mesos.
     Launch tokens per interval.
     
 To prevent overloading Marathon and maintain speedy offer processing, there is a timeout for matching each
-incoming resource offer.
+incoming resource offer, i.e. finding suitable tasks to launch for incoming offers.
 
 * <span class="label label-default">v0.11.0</span> `--offer_matching_timeout` (Optional. Default: 1000): 
     Offer matching timeout (ms). Stop trying to match additional tasks for this offer after this time.
@@ -171,6 +171,12 @@ invocations of this call.
 If you want to disable calling reviveOffers (not recommended), you can use:
     
 * <span class="label label-default">v0.11.0</span> `--disable_revive_offers_for_new_apps`
+
+When Marathon has no current use for an offer, it will decline the offer for a configurable period. This period is
+configurable. A short duration might lead to resource starvation for other frameworks if you run many frameworks
+in your cluster. You should only need to reduce it if you use `--disable_revive_offers_for_new_apps`.
+
+* `--decline_offer_duration` (Default: 120 seconds) The duration (milliseconds) for which to decline offers by default.
 
 
 ### Marathon after 0.8.2 (including) and before 0.11.0

--- a/src/main/scala/mesosphere/marathon/core/launcher/OfferProcessorConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/OfferProcessorConfig.scala
@@ -10,7 +10,7 @@ trait OfferProcessorConfig extends ScallopConf {
     default = Some(1000))
 
   lazy val declineOfferDuration = opt[Long]("decline_offer_duration",
-    descr = "(Default: Use mesos default of 5 seconds) " +
+    descr = "(Default: 120 seconds) " +
       "The duration (milliseconds) for which to decline offers by default",
-    default = None)
+    default = Some(120000))
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/TaskLauncher.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/TaskLauncher.scala
@@ -17,5 +17,5 @@ trait TaskLauncher {
   /**
     * Decline the offer. We cannot use the offer afterwards anymore.
     */
-  def declineOffer(offerID: OfferID, refuseSeconds: Option[Long])
+  def declineOffer(offerID: OfferID, refuseMilliseconds: Option[Long])
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
@@ -21,9 +21,9 @@ private[launcher] class TaskLauncherImpl(
     }
   }
 
-  override def declineOffer(offerID: OfferID, refuseSeconds: Option[Long]): Unit = {
+  override def declineOffer(offerID: OfferID, refuseMilliseconds: Option[Long]): Unit = {
     withDriver(s"declineOffer(${offerID.getValue})") {
-      val filters = refuseSeconds
+      val filters = refuseMilliseconds
         .map(seconds => Protos.Filters.newBuilder().setRefuseSeconds(seconds / 1000.0).build())
         .getOrElse(Protos.Filters.getDefaultInstance)
       _.declineOffer(offerID, filters)

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -75,7 +75,7 @@ class OfferProcessorImplTest extends MarathonSpec {
     Await.result(offerProcessor.processOffer(offer), 1.second)
 
     verify(offerMatcher).matchOffer(deadline, offer)
-    verify(taskLauncher).declineOffer(offerId, refuseSeconds = None)
+    verify(taskLauncher).declineOffer(offerId, refuseMilliseconds = Some(conf.declineOfferDuration()))
   }
 
   test("match crashed => decline") {
@@ -89,15 +89,16 @@ class OfferProcessorImplTest extends MarathonSpec {
     Await.result(offerProcessor.processOffer(offer), 1.second)
 
     verify(offerMatcher).matchOffer(deadline, offer)
-    verify(taskLauncher).declineOffer(offerId, refuseSeconds = None)
+    verify(taskLauncher).declineOffer(offerId, refuseMilliseconds = None)
   }
 
   private[this] var clock: Clock = _
   private[this] var offerMatcher: OfferMatcher = _
   private[this] var taskLauncher: TaskLauncher = _
+  private[this] var conf: OfferProcessorConfig = _
 
   private[this] def createProcessor(): OfferProcessor = {
-    val conf = new OfferProcessorConfig {}
+    conf = new OfferProcessorConfig {}
     conf.afterInit()
 
     clock = ConstantClock()

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
@@ -47,11 +47,11 @@ class TaskLauncherImplTest extends MarathonSpec {
   test("declineOffer without driver") {
     driverHolder.driver = None
 
-    launcher.declineOffer(offerId, refuseSeconds = None)
+    launcher.declineOffer(offerId, refuseMilliseconds = None)
   }
 
   test("declineOffer with driver") {
-    launcher.declineOffer(offerId, refuseSeconds = None)
+    launcher.declineOffer(offerId, refuseMilliseconds = None)
 
     verify(driverHolder.driver.get).declineOffer(offerId, Protos.Filters.getDefaultInstance)
   }


### PR DESCRIPTION
since that prevents resource starvation with many frameworks.