### PR TITLE
Fixes #2178 MarathonTask.stagedAt pre-filled with current time

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -35,9 +35,6 @@ class CoreGuiceModule extends AbstractModule {
     leadershipModule.coordinator()
 
   @Provides @Singleton
-  def clock(coreModule: CoreModule): Clock = coreModule.clock
-
-  @Provides @Singleton
   def offerProcessor(coreModule: CoreModule): OfferProcessor = coreModule.launcherModule.offerProcessor
 
   @Provides @Singleton
@@ -58,6 +55,7 @@ class CoreGuiceModule extends AbstractModule {
   final def appInfoService(appInfoModule: AppInfoModule): AppInfoService = appInfoModule.appInfoService
 
   override def configure(): Unit = {
+    bind(classOf[Clock]).toInstance(Clock())
     bind(classOf[CoreModule]).to(classOf[CoreModuleImpl]).in(Scopes.SINGLETON)
     bind(classOf[ActorRef])
       .annotatedWith(Names.named("taskStatusUpdate"))

--- a/src/main/scala/mesosphere/marathon/core/CoreModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModule.scala
@@ -1,6 +1,5 @@
 package mesosphere.marathon.core
 
-import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.launcher.LauncherModule
 import mesosphere.marathon.core.launchqueue.LaunchQueueModule
 import mesosphere.marathon.core.leadership.LeadershipModule
@@ -14,7 +13,6 @@ import mesosphere.marathon.core.task.tracker.TaskTrackerModule
   * (as long as we have them).
   */
 trait CoreModule {
-  def clock: Clock
   def leadershipModule: LeadershipModule
   def taskBusModule: TaskBusModule
   def taskTrackerModule: TaskTrackerModule

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -33,11 +33,11 @@ class CoreModuleImpl @Inject() (
     appRepository: AppRepository,
     taskTracker: TaskTracker,
     taskFactory: TaskFactory,
-    leaderInfo: LeaderInfo) extends CoreModule {
+    leaderInfo: LeaderInfo,
+    clock: Clock) extends CoreModule {
 
   // INFRASTRUCTURE LAYER
 
-  override lazy val clock = Clock()
   private[this] lazy val random = Random
   private[this] lazy val shutdownHookModule = ShutdownHooks()
   private[this] lazy val actorsModule = new ActorsModule(shutdownHookModule, actorSystem)
@@ -47,7 +47,7 @@ class CoreModuleImpl @Inject() (
   // TASKS
 
   override lazy val taskBusModule = new TaskBusModule()
-  override lazy val taskTrackerModule = new TaskTrackerModule(leadershipModule)
+  override lazy val taskTrackerModule = new TaskTrackerModule(leadershipModule, clock)
 
   // OFFER MATCHING AND LAUNCHING TASKS
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTrackerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTrackerModule.scala
@@ -3,19 +3,20 @@ package mesosphere.marathon.core.task.tracker
 import akka.actor.ActorRef
 import akka.event.EventStream
 import mesosphere.marathon.MarathonSchedulerDriverHolder
+import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.task.bus.TaskStatusObservables
-import mesosphere.marathon.core.task.tracker.impl.{ TaskStatusUpdateActor, KillOverdueStagedTasksActor }
+import mesosphere.marathon.core.task.tracker.impl.{ TaskStatusUpdateActor, KillOverdueTasksActor }
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.tasks.{ TaskIdUtil, TaskTracker }
 
 /**
   * This module provides some glue between the task tracker, status updates and various components in the application.
   */
-class TaskTrackerModule(leadershipModule: LeadershipModule) {
+class TaskTrackerModule(leadershipModule: LeadershipModule, clock: Clock) {
   def killOverdueTasks(taskTracker: TaskTracker, marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder): Unit = {
     leadershipModule.startWhenLeader(
-      KillOverdueStagedTasksActor.props(taskTracker, marathonSchedulerDriverHolder),
+      KillOverdueTasksActor.props(taskTracker, marathonSchedulerDriverHolder, clock),
       "killOverdueStagedTasks")
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/KillOverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/KillOverdueTasksActor.scala
@@ -2,26 +2,29 @@ package mesosphere.marathon.core.task.tracker.impl
 
 import akka.actor.{ Actor, ActorLogging, Cancellable, Props }
 import mesosphere.marathon.MarathonSchedulerDriverHolder
+import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.mesos.protos.TaskID
 
 import scala.concurrent.duration._
 
-private[tracker] object KillOverdueStagedTasksActor {
-  def props(taskTracker: TaskTracker, driverHolder: MarathonSchedulerDriverHolder): Props = {
-    Props(new KillOverdueStagedTasksActor(taskTracker, driverHolder))
+private[tracker] object KillOverdueTasksActor {
+  def props(taskTracker: TaskTracker, driverHolder: MarathonSchedulerDriverHolder, clock: Clock): Props = {
+    Props(new KillOverdueTasksActor(taskTracker, driverHolder, clock))
   }
 
   private[tracker] case object Check
 }
 
-private class KillOverdueStagedTasksActor(taskTracker: TaskTracker, driverHolder: MarathonSchedulerDriverHolder)
+private class KillOverdueTasksActor(taskTracker: TaskTracker,
+                                    driverHolder: MarathonSchedulerDriverHolder,
+                                    clock: Clock)
     extends Actor with ActorLogging {
   var checkTicker: Cancellable = _
 
   override def preStart(): Unit = {
     import context.dispatcher
-    checkTicker = context.system.scheduler.schedule(30.seconds, 5.seconds, self, KillOverdueStagedTasksActor.Check)
+    checkTicker = context.system.scheduler.schedule(30.seconds, 5.seconds, self, KillOverdueTasksActor.Check)
   }
 
   override def postStop(): Unit = {
@@ -29,10 +32,11 @@ private class KillOverdueStagedTasksActor(taskTracker: TaskTracker, driverHolder
   }
 
   override def receive: Receive = {
-    case KillOverdueStagedTasksActor.Check =>
+    case KillOverdueTasksActor.Check =>
+      val now = clock.now()
       log.debug("checking for overdue tasks")
       driverHolder.driver.foreach { driver =>
-        taskTracker.checkStagedTasks.foreach { overdueTask =>
+        taskTracker.determineOverdueTasks(now).foreach { overdueTask =>
           import mesosphere.mesos.protos.Implicits._
           log.warning("Killing overdue task '{}'", overdueTask.getId)
           driver.killTask(TaskID(overdueTask.getId))

--- a/src/main/scala/mesosphere/marathon/tasks/DefaultTaskFactory.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/DefaultTaskFactory.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.tasks
 import com.google.inject.Inject
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.tasks.TaskFactory.CreatedTask
 import mesosphere.mesos.TaskBuilder
@@ -13,7 +14,8 @@ import scala.collection.JavaConverters._
 
 class DefaultTaskFactory @Inject() (
   taskIdUtil: TaskIdUtil,
-  config: MarathonConf)
+  config: MarathonConf,
+  clock: Clock)
     extends TaskFactory {
 
   private[this] val log = LoggerFactory.getLogger(getClass)
@@ -26,8 +28,13 @@ class DefaultTaskFactory @Inject() (
         CreatedTask(
           taskInfo,
           MarathonTasks.makeTask(
-            taskInfo.getTaskId.getValue, offer.getHostname, ports,
-            offer.getAttributesList.asScala, app.version, offer.getSlaveId
+            id = taskInfo.getTaskId.getValue,
+            host = offer.getHostname,
+            ports = ports,
+            attributes = offer.getAttributesList.asScala,
+            version = app.version,
+            now = clock.now(),
+            slaveId = offer.getSlaveId
           )
         )
     }

--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -18,10 +18,9 @@ import scala.collection.immutable.Set
 import scala.concurrent.{ Await, Future }
 
 class TaskTracker @Inject() (
-  store: PersistentStore,
-  config: MarathonConf,
-  val metrics: Metrics)
-    extends StateMetrics {
+    store: PersistentStore,
+    config: MarathonConf,
+    val metrics: Metrics) extends StateMetrics {
 
   import mesosphere.marathon.tasks.TaskTracker._
   import mesosphere.util.ThreadPoolContext.context
@@ -105,7 +104,9 @@ class TaskTracker @Inject() (
       case Some(task) =>
         app.tasks.remove(task.getId)
 
-        timedWrite { Await.result(store.delete(getKey(appId, taskId)), timeout) }
+        timedWrite {
+          Await.result(store.delete(getKey(appId, taskId)), timeout)
+        }
 
         log.info(s"Task $taskId expunged and removed from TaskTracker")
 
@@ -154,16 +155,25 @@ class TaskTracker @Inject() (
     }
   }
 
-  def stagedTasks(): Iterable[MarathonTask] = apps.values.flatMap(_.tasks.values.filter(_.getStartedAt == 0))
+  def determineOverdueTasks(now: Timestamp): Iterable[MarathonTask] = {
 
-  def checkStagedTasks: Iterable[MarathonTask] = {
+    /*
+     * One would think that !hasStagedAt would be better for querying these tasks. However, the current implementation
+     * of [[MarathonTasks.makeTask]] will set stagedAt to a non-zero value close to the current system time. Therefore,
+     * all tasks will return a non-zero value for stagedAt so that we cannot use that.
+     *
+     * If, for some reason, a task was created (sent to mesos), but we never received a [[TaskStatus]] update event,
+     * the task will also be killed after reaching the configured maximum.
+     */
+    def notRunningTasks(): Iterable[MarathonTask] = apps.values.flatMap(_.tasks.values.filter(_.getStartedAt == 0))
+
+    val nowMillis = now.toDateTime.getMillis
     // stagedAt is set when the task is created by the scheduler
-    val now = System.currentTimeMillis
-    val expires = now - config.taskLaunchTimeout()
-    val toKill = stagedTasks().filter(_.getStagedAt < expires)
+    val expires = nowMillis - config.taskLaunchTimeout()
+    val toKill = notRunningTasks().filter(_.getStagedAt < expires)
 
     toKill.foreach(t => {
-      log.warn(s"Task '${t.getId}' was staged ${(now - t.getStagedAt) / 1000}s ago and has not yet started")
+      log.warn(s"Task '${t.getId}' was staged ${(nowMillis - t.getStagedAt) / 1000}s ago and has not yet started")
     })
     toKill
   }
@@ -171,7 +181,9 @@ class TaskTracker @Inject() (
   def expungeOrphanedTasks(): Unit = {
     // Remove tasks that don't have any tasks associated with them. Expensive!
     log.info("Expunging orphaned tasks from store")
-    val stateTaskKeys = timedRead { Await.result(store.allIds(), timeout).filter(_.startsWith(PREFIX)) }
+    val stateTaskKeys = timedRead {
+      Await.result(store.allIds(), timeout).filter(_.startsWith(PREFIX))
+    }
     val appsTaskKeys = apps.values.flatMap { app =>
       app.tasks.keys.map(taskId => getKey(app.appName, taskId))
     }.toSet
@@ -188,7 +200,9 @@ class TaskTracker @Inject() (
 
   private[tasks] def fetchApp(appId: PathId): InternalApp = {
     log.debug(s"Fetching app from store $appId")
-    val names = timedRead { Await.result(store.allIds(), timeout).toSet }
+    val names = timedRead {
+      Await.result(store.allIds(), timeout).toSet
+    }
     val tasks = TrieMap[String, MarathonTask]()
     val taskKeys = names.filter(name => name.startsWith(PREFIX + appId.safePath + ID_DELIMITER))
     for {
@@ -297,4 +311,5 @@ object TaskTracker {
   }
 
   case class App(appName: PathId, tasks: Set[MarathonTask], shutdown: Boolean)
+
 }

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -52,12 +52,13 @@ class TaskKillerTest extends MarathonSpec
 
   test("KillRequested with scaling") {
     val appId = PathId(List("my", "app"))
+    val now = Timestamp.now()
     val task1 = MarathonTasks.makeTask(
-      "task-1", "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      "task-1", "host", ports = Nil, attributes = Nil, version = now, now = now,
       slaveId = SlaveID("1")
     )
     val task2 = MarathonTasks.makeTask(
-      "task-2", "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      "task-2", "host", ports = Nil, attributes = Nil, version = Timestamp.now(), now = now,
       slaveId = SlaveID("1")
     )
     val tasksToKill = Set(task1, task2)
@@ -100,12 +101,13 @@ class TaskKillerTest extends MarathonSpec
 
   test("Kill and scale w/o force should fail if there is a deployment") {
     val appId = PathId(List("my", "app"))
+    val now = Timestamp.now()
     val task1 = MarathonTasks.makeTask(
-      "task-1", "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      "task-1", "host", ports = Nil, attributes = Nil, version = Timestamp.now(), now = now,
       slaveId = SlaveID("1")
     )
     val task2 = MarathonTasks.makeTask(
-      "task-2", "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      "task-2", "host", ports = Nil, attributes = Nil, version = Timestamp.now(), now = now,
       slaveId = SlaveID("1")
     )
     val tasksToKill = Set(task1, task2)

--- a/src/test/scala/mesosphere/marathon/api/v2/AppTasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppTasksResourceTest.scala
@@ -1,8 +1,8 @@
 package mesosphere.marathon.api.v2
 
 import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.api.{ JsonTestHelper, TaskKiller }
 import mesosphere.marathon.api.v2.json.Formats._
+import mesosphere.marathon.api.{ JsonTestHelper, TaskKiller }
 import mesosphere.marathon.core.appinfo.EnrichedTask
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.{ GroupManager, PathId, Timestamp }
@@ -13,7 +13,7 @@ import mesosphere.mesos.protos.SlaveID
 import org.mockito.Matchers.{ any, anyBoolean, eq => equalTo }
 import org.mockito.Mockito._
 import org.scalatest.Matchers
-import play.api.libs.json.{ JsValue, Json }
+import play.api.libs.json.Json
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -65,12 +65,13 @@ class AppTasksResourceTest extends MarathonSpec with Matchers {
     val host = "host"
     val appId = PathId("/my/app")
     val slaveId = SlaveID("some slave ID")
+    val now = Timestamp.now()
     val task1 = MarathonTasks.makeTask(
-      "task-1", host, ports = Nil, attributes = Nil, version = Timestamp.now(),
+      "task-1", host, ports = Nil, attributes = Nil, version = Timestamp.now(), now = now,
       slaveId = slaveId
     )
     val task2 = MarathonTasks.makeTask(
-      "task-2", host, ports = Nil, attributes = Nil, version = Timestamp.now(),
+      "task-2", host, ports = Nil, attributes = Nil, version = Timestamp.now(), now = now,
       slaveId = slaveId
     )
     val toKill = Set(task1)
@@ -93,12 +94,13 @@ class AppTasksResourceTest extends MarathonSpec with Matchers {
     val host = "host"
     val appId = PathId("/my/app")
     val slaveId = SlaveID("some slave ID")
+    val now = Timestamp.now()
     val task1 = MarathonTasks.makeTask(
-      "task-1", host, ports = Nil, attributes = Nil, version = Timestamp.now(),
+      "task-1", host, ports = Nil, attributes = Nil, version = Timestamp.now(), now = now,
       slaveId = slaveId
     )
     val task2 = MarathonTasks.makeTask(
-      "task-2", host, ports = Nil, attributes = Nil, version = Timestamp.now(),
+      "task-2", host, ports = Nil, attributes = Nil, version = Timestamp.now(), now = now,
       slaveId = slaveId
     )
 

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -49,12 +49,13 @@ class TasksResourceTest extends MarathonSpec with Matchers {
     val taskId1 = "task-1"
     val taskId2 = "task-2"
     val slaveId = SlaveID("some slave ID")
+    val now = Timestamp.now()
     val task1 = MarathonTasks.makeTask(
-      taskId1, "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      taskId1, "host", ports = Nil, attributes = Nil, version = Timestamp.now(), now = now,
       slaveId = slaveId
     )
     val task2 = MarathonTasks.makeTask(
-      taskId2, "host", ports = Nil, attributes = Nil, version = Timestamp.now(),
+      taskId2, "host", ports = Nil, attributes = Nil, version = Timestamp.now(), now = now,
       slaveId = slaveId
     )
     val app1 = PathId("/my/app-1")

--- a/src/test/scala/mesosphere/marathon/tasks/DefaultTaskFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/DefaultTaskFactoryTest.scala
@@ -1,7 +1,8 @@
 package mesosphere.marathon.tasks
 
 import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.state.{ AppDefinition, Timestamp }
+import mesosphere.marathon.core.base.{ Clock, ConstantClock }
+import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.{ MarathonConf, MarathonSpec, MarathonTestHelper }
 import mesosphere.mesos.protos.Implicits.{ slaveIDToProto, taskIDToProto }
 import mesosphere.mesos.protos.{ SlaveID, TaskID }
@@ -23,8 +24,13 @@ class DefaultTaskFactoryTest extends MarathonSpec {
     val task = taskFactory.newTask(appDefinition, offer, runningTasks).get
 
     val expectedTask = MarathonTasks.makeTask(
-      "some task ID", "some_host", List(),
-      List(), appDefinition.version, offer.getSlaveId
+      id = "some task ID",
+      host = "some_host",
+      ports = List(),
+      attributes = List(),
+      version = appDefinition.version,
+      now = clock.now(),
+      slaveId = offer.getSlaveId
     )
     assert(task.marathonTask == expectedTask)
   }
@@ -33,12 +39,14 @@ class DefaultTaskFactoryTest extends MarathonSpec {
   var taskTracker: TaskTracker = _
   var config: MarathonConf = _
   var taskFactory: DefaultTaskFactory = _
+  var clock: Clock = _
 
   before {
+    clock = ConstantClock()
     taskIdUtil = mock[TaskIdUtil]
     taskTracker = mock[TaskTracker]
     config = MarathonTestHelper.defaultConfig()
-    taskFactory = new DefaultTaskFactory(taskIdUtil, config)
+    taskFactory = new DefaultTaskFactory(taskIdUtil, config, clock)
   }
 
 }

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -2,9 +2,10 @@ package mesosphere.marathon.upgrade
 
 import java.util.UUID
 
-import akka.actor.{ ActorSystem, Props }
+import akka.actor.ActorSystem
 import akka.testkit.{ TestActorRef, TestProbe }
 import akka.util.Timeout
+import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.event.MesosStatusUpdateEvent
 import mesosphere.marathon.health.HealthCheckManager
@@ -13,7 +14,6 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.{ MarathonTasks, TaskTracker }
 import mesosphere.marathon.upgrade.DeploymentManager.{ DeploymentFinished, DeploymentStepInfo }
 import mesosphere.marathon.{ MarathonSpec, SchedulerActions }
-import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.mesos.protos.Implicits._
 import mesosphere.mesos.protos.{ SlaveID, TaskID }
 import org.apache.mesos.Protos.Status
@@ -70,11 +70,11 @@ class DeploymentActorTest
 
     // setting started at to 0 to make sure this survives
     val slaveId = SlaveID("some slave id")
-    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app1.version, slaveId).toBuilder.setStartedAt(0).build()
-    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app1.version, slaveId).toBuilder.setStartedAt(1000).build()
-    val task2_1 = MarathonTasks.makeTask("task2_1", "", Nil, Nil, app2.version, slaveId)
-    val task3_1 = MarathonTasks.makeTask("task3_1", "", Nil, Nil, app3.version, slaveId)
-    val task4_1 = MarathonTasks.makeTask("task4_1", "", Nil, Nil, app4.version, slaveId)
+    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app1.version, Timestamp.now(), slaveId).toBuilder.setStartedAt(0).build()
+    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app1.version, Timestamp.now(), slaveId).toBuilder.setStartedAt(1000).build()
+    val task2_1 = MarathonTasks.makeTask("task2_1", "", Nil, Nil, app2.version, Timestamp.now(), slaveId)
+    val task3_1 = MarathonTasks.makeTask("task3_1", "", Nil, Nil, app3.version, Timestamp.now(), slaveId)
+    val task4_1 = MarathonTasks.makeTask("task4_1", "", Nil, Nil, app4.version, Timestamp.now(), slaveId)
 
     val plan = DeploymentPlan(origGroup, targetGroup)
 
@@ -171,8 +171,8 @@ class DeploymentActorTest
     val targetGroup = Group(PathId("/foo/bar"), Set(appNew))
 
     val slaveId = SlaveID("some slave id")
-    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app.version, slaveId).toBuilder.setStartedAt(0).build()
-    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app.version, slaveId).toBuilder.setStartedAt(1000).build()
+    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app.version, Timestamp.now(), slaveId).toBuilder.setStartedAt(0).build()
+    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app.version, Timestamp.now(), slaveId).toBuilder.setStartedAt(1000).build()
 
     when(tracker.get(app.id)).thenReturn(Set(task1_1, task1_2))
 
@@ -285,9 +285,9 @@ class DeploymentActorTest
     val targetGroup = Group(PathId("/foo/bar"), Set(app1New))
 
     val slaveId = SlaveID("some slave id")
-    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app1.version, slaveId).toBuilder.setStartedAt(0).build()
-    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app1.version, slaveId).toBuilder.setStartedAt(500).build()
-    val task1_3 = MarathonTasks.makeTask("task1_3", "", Nil, Nil, app1.version, slaveId).toBuilder.setStartedAt(1000).build()
+    val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app1.version, Timestamp.now(), slaveId).toBuilder.setStartedAt(0).build()
+    val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app1.version, Timestamp.now(), slaveId).toBuilder.setStartedAt(500).build()
+    val task1_3 = MarathonTasks.makeTask("task1_3", "", Nil, Nil, app1.version, Timestamp.now(), slaveId).toBuilder.setStartedAt(1000).build()
 
     val plan = DeploymentPlan(original = origGroup, target = targetGroup, toKill = Map(app1.id -> Set(task1_2)))
 

--- a/src/test/scala/mesosphere/marathon/upgrade/ScalingPropositionTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ScalingPropositionTest.scala
@@ -149,7 +149,7 @@ class ScalingPropositionTest extends FunSuite with Matchers {
   // Helper functions
 
   private def createTask(index: Long) = MarathonTasks.makeTask(
-    s"task-$index", "", Nil, Nil, version = Timestamp(index), slaveId = SlaveID("1")
+    s"task-$index", "", Nil, Nil, version = Timestamp(index), now = Timestamp.now(), slaveId = SlaveID("1")
   )
 
   private def noConstraintsToMeet(running: Set[MarathonTask], killCount: Int) = Set.empty[MarathonTask]

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -7,17 +7,17 @@ import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state.Container.Docker.PortMapping
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp }
-import mesosphere.marathon.tasks.{ TaskIdUtil, MarathonTasks, TaskTracker }
+import mesosphere.marathon.tasks.{ MarathonTasks, TaskTracker }
 import mesosphere.mesos.protos.{ Resource, TaskID, _ }
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network
 import org.apache.mesos.Protos.{ Offer, _ }
-import org.joda.time.{ DateTimeZone, DateTime }
+import org.joda.time.{ DateTime, DateTimeZone }
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.{ NumericRange, Seq }
+import scala.collection.immutable.Seq
 
 class TaskBuilderTest extends MarathonSpec {
 
@@ -446,12 +446,13 @@ class TaskBuilderTest extends MarathonSpec {
       val tupleOption = builder.buildIfMatches(offer, taskTracker.get(app.id))
       assert(tupleOption.isDefined, message)
       val marathonTask = MarathonTasks.makeTask(
-        tupleOption.get._1.getTaskId.getValue,
-        offer.getHostname,
-        tupleOption.get._2,
-        offer.getAttributesList.asScala.toList,
-        Timestamp.now(),
-        offer.slaveId)
+        id = tupleOption.get._1.getTaskId.getValue,
+        host = offer.getHostname,
+        ports = tupleOption.get._2,
+        attributes = offer.getAttributesList.asScala.toList,
+        version = Timestamp.now(),
+        now = Timestamp.now(),
+        slaveId = offer.slaveId)
       runningTasks += marathonTask
     }
 
@@ -508,11 +509,13 @@ class TaskBuilderTest extends MarathonSpec {
       val tupleOption = builder.buildIfMatches(offer, taskTracker.get(app.id))
       assert(tupleOption.isDefined, message)
       val marathonTask = MarathonTasks.makeTask(
-        tupleOption.get._1.getTaskId.getValue,
-        offer.getHostname,
-        tupleOption.get._2,
-        offer.getAttributesList.asScala.toList, Timestamp.now(),
-        offer.slaveId)
+        id = tupleOption.get._1.getTaskId.getValue,
+        host = offer.getHostname,
+        ports = tupleOption.get._2,
+        attributes = offer.getAttributesList.asScala.toList,
+        version = Timestamp.now(),
+        now = Timestamp.now(),
+        slaveId = offer.slaveId)
       runningTasks += marathonTask
     }
 


### PR DESCRIPTION
Fixes #2178 MarathonTask.stagedAt needs to be pre-filled with a current timestamp (other than the version, which might be really old, not only in tests), because determineOverdueTasks in taskTracker will check against that timestamp whether a task exceeded the taskLaunchTimeout and needs to be killed.