### PR TITLE
Fixes #2181 - repeat reviveOffers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -110,6 +110,14 @@ with the `reviveOffers` Mesos scheduler API call. This should result in more spe
 for any reason you dislike this behavior, you can disable it with `--disable_revive_offers_for_new_apps`
 (not recommended).
 
+The order in which mesos receives `reviveOffers` and `declineOffer` calls is not guaranteed. Therefore, as
+long as we still need offers to launch tasks, we repeat the `reviveOffers` call for `--revive_offers_repetitions`
+times so that our last `reviveOffers` will be received after all relevant `declineOffer` calls with high
+probability. 
+
+* `--revive_offers_repetitions` (Optional. Default: 3): 
+    Repeat every reviveOffer request this many times, delayed by the `--min_revive_offers_interval`.
+
 When Marathon has no current use for an offer, it will decline the offer for a configurable period. A short duration 
 might lead to resource starvation for other frameworks if you run many frameworks
 in your cluster. You should only need to reduce it if you use `--disable_revive_offers_for_new_apps`.

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -168,6 +168,14 @@ invocations of this call.
 * <span class="label label-default">v0.11.0</span> `--min_revive_offers_interval` (Optional. Default: 5000): 
     Do not ask for all offers (also already seen ones) more often than this interval (ms).
     
+The order in which mesos receives `reviveOffers` and `declineOffer` calls is not guaranteed. Therefore, as
+long as we still need offers to launch tasks, we repeat the `reviveOffers` call for `--revive_offers_repetitions`
+times so that our last `reviveOffers` will be received after all relevant `declineOffer` calls with high
+probability. 
+
+* <span class="label label-default">v0.11.0</span> `--revive_offers_repetitions` (Optional. Default: 3): 
+    Repeat every reviveOffer request this many times, delayed by the `--min_revive_offers_interval`.
+
 If you want to disable calling reviveOffers (not recommended), you can use:
     
 * <span class="label label-default">v0.11.0</span> `--disable_revive_offers_for_new_apps`

--- a/src/main/scala/mesosphere/marathon/core/flow/ReviveOffersConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/ReviveOffersConfig.scala
@@ -24,4 +24,8 @@ trait ReviveOffersConfig extends ScallopConf {
   lazy val minReviveOffersInterval = opt[Long]("min_revive_offers_interval",
     descr = "Do not ask for all offers (also already seen ones) more often than this interval (ms).",
     default = Some(5000))
+
+  lazy val reviveOffersRepetitions = opt[Int]("revive_offers_repetitions",
+    descr = "Repeat every reviveOffer request this many times, delayed by the --min_revive_offers_interval.",
+    default = Some(3))
 }

--- a/src/test/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActorTest.scala
@@ -1,77 +1,117 @@
 package mesosphere.marathon.core.flow.impl
 
 import akka.actor._
-import akka.testkit.{ TestProbe, TestActorRef }
-import mesosphere.marathon.core.base.{ Clock, ConstantClock }
+import akka.testkit.{ TestActorRef, TestProbe }
+import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.flow.ReviveOffersConfig
+import mesosphere.marathon.core.flow.impl.ReviveOffersActor.TimedCheck
 import mesosphere.marathon.event.{ SchedulerRegisteredEvent, SchedulerReregisteredEvent }
 import mesosphere.marathon.{ MarathonSchedulerDriverHolder, MarathonSpec }
 import org.apache.mesos.SchedulerDriver
-import org.mockito.{ Matchers, ArgumentMatcher, Mockito }
-import org.mockito.internal.matchers.{ Matches, CapturesArguments }
-import org.scalatest.GivenWhenThen
+import org.mockito.Mockito
+import org.scalatest.{ Matchers, GivenWhenThen }
 import rx.lang.scala.Subject
 import rx.lang.scala.subjects.PublishSubject
+
 import scala.concurrent.duration._
 
-class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
+class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen with Matchers {
   test("do not do anything") {
+    val f = new Fixture()
     When("the actor starts")
-    actorRef.start()
+    f.actorRef.start()
 
     Then("there are no surprising interactions")
-    verifyNoMoreInteractions()
+    f.verifyNoMoreInteractions()
   }
 
   test("revive on first OffersWanted(true)") {
+    val f = new Fixture()
     Given("a started actor")
-    actorRef.start()
+    f.actorRef.start()
 
     When("the actor gets notified of wanted offers")
-    offersWanted.onNext(true)
+    f.offersWanted.onNext(true)
 
     Then("reviveOffers is called")
-    Mockito.verify(driver, Mockito.timeout(1000)).reviveOffers()
-    verifyNoMoreInteractions()
+    Mockito.verify(f.driver, Mockito.timeout(1000)).reviveOffers()
+    f.verifyNoMoreInteractions()
   }
 
   test(s"revive if offers wanted and we receive explicit reviveOffers") {
+    val f = new Fixture()
     Given("a started actor that wants offers")
-    actorRef.start()
-    offersWanted.onNext(true)
-    Mockito.reset(driver)
-    clock += 10.seconds
+    f.actorRef.start()
+    f.offersWanted.onNext(true)
+    Mockito.reset(f.driver)
+    f.clock += 10.seconds
 
     When("we explicitly reviveOffers")
-    val offerReviver = new OfferReviverDelegate(actorRef)
+    val offerReviver = new OfferReviverDelegate(f.actorRef)
     offerReviver.reviveOffers()
 
     Then("reviveOffers is called directly")
-    Mockito.verify(driver, Mockito.timeout(1000)).reviveOffers()
-    verifyNoMoreInteractions()
+    Mockito.verify(f.driver, Mockito.timeout(1000)).reviveOffers()
+    f.verifyNoMoreInteractions()
   }
 
   for (
     reviveEvent <- Seq(
       SchedulerReregisteredEvent("somemaster"),
-      SchedulerRegisteredEvent("frameworkid", "somemaster"),
-      ReviveOffersActor.TimedCheck
+      SchedulerRegisteredEvent("frameworkid", "somemaster")
     )
   ) {
     test(s"revive if offers wanted and we receive $reviveEvent") {
+      val f = new Fixture()
       Given("a started actor that wants offers")
-      actorRef.start()
-      offersWanted.onNext(true)
-      Mockito.reset(driver)
-      clock += 10.seconds
+      f.actorRef.start()
+      f.offersWanted.onNext(true)
+      Mockito.reset(f.driver)
+      f.clock += 10.seconds
 
       When(s"the actor receives an $reviveEvent message")
-      actorRef ! reviveEvent
+      f.actorRef ! reviveEvent
 
       Then("reviveOffers is called directly")
-      Mockito.verify(driver, Mockito.timeout(1000)).reviveOffers()
-      verifyNoMoreInteractions()
+      Mockito.verify(f.driver, Mockito.timeout(1000)).reviveOffers()
+      f.verifyNoMoreInteractions()
     }
+  }
+
+  test(s"NO revive if revivesWanted == 0 and we receive TimedCheck") {
+    val f = new Fixture()
+    Given("a started actor that wants offers")
+    f.actorRef.start()
+    f.offersWanted.onNext(true) // immediate revive, nothing scheduled
+    Mockito.reset(f.driver)
+    f.clock += 10.seconds
+
+    When(s"the actor receives an TimedCheck message")
+    f.actorRef ! TimedCheck
+
+    Then("reviveOffers is NOT called")
+    f.verifyNoMoreInteractions()
+  }
+
+  test(s"revive if revivesWanted > 0 and we receive TimedCheck") {
+    val f = new Fixture()
+    Given("a started actor that wants offers")
+    f.actorRef.start()
+    f.offersWanted.onNext(true) // immediate revive
+    f.offersWanted.onNext(true) // one revive scheduled
+    Mockito.reset(f.driver)
+    f.clock += 10.seconds
+
+    When(s"the actor receives an TimedCheck message")
+    f.actorRef ! TimedCheck
+
+    Then("reviveOffers is called directly")
+    Mockito.verify(f.driver, Mockito.timeout(1000)).reviveOffers()
+
+    And("any scheduled timers are canceled")
+    Mockito.verify(f.actorRef.underlyingActor.cancellable, Mockito.timeout(1000)).cancel()
+
+    f.verifyNoMoreInteractions()
   }
 
   for (
@@ -82,132 +122,179 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
     )
   ) {
     test(s"DO NOT revive if offers NOT wanted and we receive $reviveEvent") {
+      val f = new Fixture()
       Given("a started actor that wants offers")
-      actorRef.start()
-      offersWanted.onNext(false)
-      Mockito.reset(driver)
-      clock += 10.seconds
+      f.actorRef.start()
+      f.offersWanted.onNext(false)
+      Mockito.reset(f.driver)
+      f.clock += 10.seconds
 
       When(s"the actor receives an $reviveEvent message")
-      actorRef ! reviveEvent
+      f.actorRef ! reviveEvent
 
       Then("reviveOffers is NOT called directly")
-      verifyNoMoreInteractions()
+      f.verifyNoMoreInteractions()
     }
   }
 
   test("only one revive for two fast consecutive trues") {
+    val f = new Fixture()
     Given("a started actor")
-    actorRef.start()
+    f.actorRef.start()
 
     When("the actor gets notified twice at the same time of wanted offers")
-    offersWanted.onNext(true)
-    offersWanted.onNext(true)
+    f.offersWanted.onNext(true)
+    f.offersWanted.onNext(true)
 
     Then("it calls reviveOffers once")
-    Mockito.verify(driver, Mockito.timeout(1000)).reviveOffers()
+    Mockito.verify(f.driver, Mockito.timeout(1000)).reviveOffers()
     And("schedules the next revive for in 5 seconds")
-    assert(actorRef.underlyingActor.scheduled == Vector(5.seconds))
-    verifyNoMoreInteractions()
+    assert(f.actorRef.underlyingActor.scheduled == Vector(5.seconds))
+    f.verifyNoMoreInteractions()
   }
 
   test("the third true has no effect") {
+    val f = new Fixture()
     Given("a started actor")
-    actorRef.start()
+    f.actorRef.start()
 
     And("we already received two offers wanted notifications")
-    offersWanted.onNext(true)
-    offersWanted.onNext(true)
-    Mockito.reset(driver)
+    f.offersWanted.onNext(true)
+    f.offersWanted.onNext(true)
+    Mockito.reset(f.driver)
 
     When("we get another offers wanted 3 seconds later")
-    clock += 3.seconds
-    offersWanted.onNext(true)
+    f.clock += 3.seconds
+    f.offersWanted.onNext(true)
 
     Then("nothing happens because our next revive is already scheduled")
-    verifyNoMoreInteractions()
+    f.verifyNoMoreInteractions()
   }
 
   test("Revive timer is cancelled if offers not wanted anymore") {
+    val f = new Fixture()
     Given("we received offersWanted = true two times and thus scheduled a timer")
-    actorRef.start()
-    offersWanted.onNext(true)
-    offersWanted.onNext(true)
+    f.actorRef.start()
+    f.offersWanted.onNext(true)
+    f.offersWanted.onNext(true)
 
-    Mockito.reset(driver)
-    Mockito.reset(actorRef.underlyingActor.cancellable)
+    Mockito.reset(f.driver)
+    Mockito.reset(f.actorRef.underlyingActor.cancellable)
 
     When("we receive a false (= offers not wanted anymore) message")
-    offersWanted.onNext(false)
+    f.offersWanted.onNext(false)
 
     Then("we cancel the timer")
-    Mockito.verify(actorRef.underlyingActor.cancellable, Mockito.timeout(1000)).cancel()
-    verifyNoMoreInteractions()
+    Mockito.verify(f.actorRef.underlyingActor.cancellable, Mockito.timeout(1000)).cancel()
+    f.verifyNoMoreInteractions()
   }
 
   test("Check revives if last offersWanted == true and more than 5.seconds ago") {
+    val f = new Fixture()
     Given("that we received various flipping offers wanted requests")
-    actorRef.start()
-    offersWanted.onNext(true)
-    offersWanted.onNext(false)
-    offersWanted.onNext(true)
+    f.actorRef.start()
+    f.offersWanted.onNext(true)
+    f.offersWanted.onNext(false)
+    f.offersWanted.onNext(true)
 
-    Mockito.reset(driver)
-    Mockito.reset(actorRef.underlyingActor.cancellable)
+    Mockito.reset(f.driver)
+    Mockito.reset(f.actorRef.underlyingActor.cancellable)
 
     And("we wait for 5 seconds")
-    clock += 5.seconds
+    f.clock += 5.seconds
 
     When("we receive a Check message")
-    actorRef ! ReviveOffersActor.TimedCheck
+    f.actorRef ! ReviveOffersActor.TimedCheck
 
     Then("we cancel our now unnecessary timer (which has send this message)")
-    Mockito.verify(actorRef.underlyingActor.cancellable, Mockito.timeout(1000)).cancel()
+    Mockito.verify(f.actorRef.underlyingActor.cancellable, Mockito.timeout(1000)).cancel()
     And("we revive the offers")
-    Mockito.verify(driver, Mockito.timeout(1000)).reviveOffers()
-    verifyNoMoreInteractions()
+    Mockito.verify(f.driver, Mockito.timeout(1000)).reviveOffers()
+    f.verifyNoMoreInteractions()
   }
 
   test("Check does not revives if last offersWanted == false and more than 5.seconds ago") {
+    val f = new Fixture()
     Given("that we received various flipping offers wanted requests")
-    actorRef.start()
-    offersWanted.onNext(true)
-    offersWanted.onNext(true)
-    offersWanted.onNext(false)
+    f.actorRef.start()
+    f.offersWanted.onNext(true)
+    f.offersWanted.onNext(true)
+    f.offersWanted.onNext(false)
 
-    Mockito.reset(driver)
-    Mockito.reset(actorRef.underlyingActor.cancellable)
+    Mockito.reset(f.driver)
+    Mockito.reset(f.actorRef.underlyingActor.cancellable)
 
     And("we wait for 5 seconds")
-    clock += 5.seconds
+    f.clock += 5.seconds
 
     When("we receive a Check message")
-    actorRef ! ReviveOffersActor.TimedCheck
+    f.actorRef ! ReviveOffersActor.TimedCheck
 
     Then("we do not do anything")
-    verifyNoMoreInteractions()
+    f.verifyNoMoreInteractions()
+  }
+
+  test("revive on repeatedly while OffersWanted(true)") {
+    val f = new Fixture(repetitions = 5)
+    Given("a started actor")
+    f.actorRef.start()
+
+    When("the actor gets notified of wanted offers")
+    f.offersWanted.onNext(true)
+
+    Then("reviveOffers is called and we schedule more revives")
+    Mockito.verify(f.driver, Mockito.timeout(1000)).reviveOffers()
+    And("we scheduled the first of many revives")
+    f.actorRef.underlyingActor.scheduled should have size (1)
+    f.actorRef.underlyingActor.revivesNeeded should be (f.repetitions - 1)
+
+    Mockito.reset(f.driver)
+
+    for (i <- 2L to f.repetitions.toLong - 1) {
+      When("the min_revive_offers_interval has passed and we receive a TimedCheck")
+      f.clock += f.conf.minReviveOffersInterval().millis
+      f.actorRef ! ReviveOffersActor.TimedCheck
+
+      Then("reviveOffers is called")
+      Mockito.verify(f.driver, Mockito.timeout(1000)).reviveOffers()
+      Mockito.verifyNoMoreInteractions(f.driver)
+      Mockito.reset(f.driver)
+
+      And("current timer gets canceled")
+      Mockito.verify(f.actorRef.underlyingActor.cancellable).cancel()
+      Mockito.verifyNoMoreInteractions(f.actorRef.underlyingActor.cancellable)
+      Mockito.reset(f.actorRef.underlyingActor.cancellable)
+
+      And("we have scheduled the next revive")
+      f.actorRef.underlyingActor.scheduled should have size i
+      f.actorRef.underlyingActor.revivesNeeded should be (f.repetitions - i)
+    }
+
+    When("the min_revive_offers_interval has passed and we receive our last TimedCheck")
+    f.clock += f.conf.minReviveOffersInterval().millis
+    f.actorRef ! ReviveOffersActor.TimedCheck
+
+    Then("reviveOffers is called for the last time")
+    Mockito.verify(f.driver, Mockito.timeout(1000)).reviveOffers()
+    Mockito.verifyNoMoreInteractions(f.driver)
+    Mockito.reset(f.driver)
+
+    And("current timer gets canceled")
+    Mockito.verify(f.actorRef.underlyingActor.cancellable).cancel()
+    Mockito.verifyNoMoreInteractions(f.actorRef.underlyingActor.cancellable)
+    Mockito.reset(f.actorRef.underlyingActor.cancellable)
+
+    And("we have NOT scheduled the next revive")
+    f.actorRef.underlyingActor.scheduled should have size (f.repetitions.toLong - 1)
+    f.actorRef.underlyingActor.revivesNeeded should be (0)
+
+    f.verifyNoMoreInteractions()
   }
 
   private[this] implicit var actorSystem: ActorSystem = _
-  private[this] val conf = new ReviveOffersConfig {}
-  conf.afterInit()
-  private[this] var clock: ConstantClock = _
-  private[this] var actorRef: TestActorRef[TestableActor] = _
-  private[this] var offersWanted: Subject[Boolean] = _
-  private[this] var driver: SchedulerDriver = _
-  private[this] var driverHolder: MarathonSchedulerDriverHolder = _
-  private[this] var mockScheduler: Scheduler = _
 
   before {
     actorSystem = ActorSystem()
-    clock = ConstantClock()
-    offersWanted = PublishSubject()
-    driver = mock[SchedulerDriver]
-    driverHolder = new MarathonSchedulerDriverHolder
-    driverHolder.driver = Some(driver)
-    mockScheduler = mock[Scheduler]
-
-    actorRef = TestActorRef(new TestableActor)
   }
 
   after {
@@ -215,31 +302,54 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen {
     actorSystem.awaitTermination()
   }
 
-  private[this] def verifyNoMoreInteractions(): Unit = {
-    def killActorAndWaitForDeath(): Terminated = {
-      actorRef ! PoisonPill
-      val deathWatch = TestProbe()
-      deathWatch.watch(actorRef)
-      deathWatch.expectMsgClass(classOf[Terminated])
+  class Fixture(val repetitions: Int = 1) {
+    lazy val conf: ReviveOffersConfig = {
+      val conf = new ReviveOffersConfig {
+        override lazy val reviveOffersRepetitions = opt[Int]("revive_offers_repetitions",
+          descr = "Repeat every reviveOffer request this many times, delayed by the --min_revive_offers_interval.",
+          default = Some(repetitions))
+      }
+      conf.afterInit()
+      conf
+    }
+    lazy val clock: ConstantClock = ConstantClock()
+    lazy val offersWanted: Subject[Boolean] = PublishSubject()
+    lazy val driver: SchedulerDriver = mock[SchedulerDriver]
+    lazy val driverHolder: MarathonSchedulerDriverHolder = {
+      val holder = new MarathonSchedulerDriverHolder
+      holder.driver = Some(driver)
+      holder
+    }
+    lazy val mockScheduler: Scheduler = mock[Scheduler]
+    lazy val actorRef = TestActorRef(new TestableActor)
+
+    def verifyNoMoreInteractions(): Unit = {
+      def killActorAndWaitForDeath(): Terminated = {
+        actorRef ! PoisonPill
+        val deathWatch = TestProbe()
+        deathWatch.watch(actorRef)
+        deathWatch.expectMsgClass(classOf[Terminated])
+      }
+
+      Mockito.verifyNoMoreInteractions(actorRef.underlyingActor.cancellable)
+
+      killActorAndWaitForDeath()
+
+      Mockito.verifyNoMoreInteractions(driver)
+      Mockito.verifyNoMoreInteractions(mockScheduler)
     }
 
-    Mockito.verifyNoMoreInteractions(actorRef.underlyingActor.cancellable)
+    class TestableActor extends ReviveOffersActor(
+      clock, conf, actorSystem.eventStream, offersWanted, driverHolder
+    ) {
+      var scheduled = Vector.empty[FiniteDuration]
+      var cancellable = mock[Cancellable]
 
-    killActorAndWaitForDeath()
-
-    Mockito.verifyNoMoreInteractions(driver)
-    Mockito.verifyNoMoreInteractions(mockScheduler)
-  }
-
-  private class TestableActor extends ReviveOffersActor(
-    clock, conf, actorSystem.eventStream, offersWanted, driverHolder
-  ) {
-    var scheduled = Vector.empty[FiniteDuration]
-    var cancellable = mock[Cancellable]
-
-    override protected def schedulerCheck(duration: FiniteDuration): Cancellable = {
-      scheduled :+= duration
-      cancellable
+      override protected def schedulerCheck(duration: FiniteDuration): Cancellable = {
+        scheduled :+= duration
+        cancellable
+      }
     }
+
   }
 }

--- a/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.integration
 
 import mesosphere.marathon.api.v2.json.{ V2AppDefinition, V2GroupUpdate }
+import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.integration.setup.{ IntegrationFunSuite, IntegrationHealthCheck, SingleMarathonIntegrationTest, WaitTestSupport }
 import mesosphere.marathon.state.{ PathId, UpgradeStrategy }
 import org.apache.http.HttpStatus


### PR DESCRIPTION
because it could be processed out-of-order and thus not revive
all relevant offers.