### PR TITLE
Use 3 seconds as default timeout for waiting for Futures

### DIFF
--- a/src/test/scala/mesosphere/FutureTestSupport.scala
+++ b/src/test/scala/mesosphere/FutureTestSupport.scala
@@ -1,0 +1,13 @@
+package mesosphere
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{ Seconds, Span }
+
+/**
+ * ScalaFutures from scalatest with a different default configuration.
+ */
+trait FutureTestSupport extends ScalaFutures {
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(3, Seconds))
+}
+
+object FutureTestSupport extends FutureTestSupport

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito with Matchers {
-  import org.scalatest.concurrent.ScalaFutures._
+  import mesosphere.FutureTestSupport._
 
   class Fixture {
     lazy val clock = ConstantClock()

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/DefaultAppInfoServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/DefaultAppInfoServiceTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.{ Matchers, GivenWhenThen }
 import scala.concurrent.Future
 
 class DefaultAppInfoServiceTest extends MarathonSpec with GivenWhenThen with Mockito with Matchers {
-  import org.scalatest.concurrent.ScalaFutures._
+  import mesosphere.FutureTestSupport._
 
   class Fixture {
     lazy val groupManager = mock[GroupManager]

--- a/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
@@ -11,7 +11,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.rogach.scallop.ScallopConf
 import org.scalatest.Matchers
-import org.scalatest.concurrent.ScalaFutures._
+import mesosphere.FutureTestSupport._
 
 import scala.collection.immutable.Seq
 import scala.concurrent._

--- a/src/test/scala/mesosphere/marathon/state/MigrationTo0_11Test.scala
+++ b/src/test/scala/mesosphere/marathon/state/MigrationTo0_11Test.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class MigrationTo0_11Test extends MarathonSpec with GivenWhenThen with Matchers {
-  import org.scalatest.concurrent.ScalaFutures._
+  import mesosphere.FutureTestSupport._
 
   class Fixture {
     lazy val metrics = new Metrics(new MetricRegistry)

--- a/src/test/scala/mesosphere/marathon/state/TaskFailureRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TaskFailureRepositoryTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{ Matchers, GivenWhenThen }
 
 class TaskFailureRepositoryTest extends MarathonSpec with GivenWhenThen with Matchers {
   import TaskFailureTestHelper.taskFailure
-  import org.scalatest.concurrent.ScalaFutures._
+  import mesosphere.FutureTestSupport._
 
   test("store and fetch") {
     Given("an empty repo")

--- a/src/test/scala/mesosphere/marathon/tasks/TaskTrackerTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskTrackerTest.scala
@@ -20,7 +20,7 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.{ reset, spy, times, verify }
 import org.scalatest.{ GivenWhenThen, Matchers }
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.concurrent.ScalaFutures._
+import mesosphere.FutureTestSupport._
 
 import scala.collection._
 import scala.concurrent.duration._

--- a/src/test/scala/mesosphere/util/state/PersistentStoreTest.scala
+++ b/src/test/scala/mesosphere/util/state/PersistentStoreTest.scala
@@ -2,7 +2,7 @@ package mesosphere.util.state
 
 import mesosphere.marathon.StoreCommandFailedException
 import mesosphere.marathon.integration.setup.IntegrationFunSuite
-import org.scalatest.concurrent.ScalaFutures._
+import mesosphere.FutureTestSupport._
 import org.scalatest.time.{ Seconds, Span }
 import org.scalatest.{ BeforeAndAfter, Matchers }
 

--- a/src/test/scala/mesosphere/util/state/memory/InMemoryStoreTest.scala
+++ b/src/test/scala/mesosphere/util/state/memory/InMemoryStoreTest.scala
@@ -2,7 +2,7 @@ package mesosphere.util.state.memory
 
 import mesosphere.util.state.{ PersistentStore, PersistentStoreTest }
 import org.scalatest.Matchers
-import org.scalatest.concurrent.ScalaFutures._
+import mesosphere.FutureTestSupport._
 
 class InMemoryStoreTest extends PersistentStoreTest with Matchers {
 

--- a/src/test/scala/mesosphere/util/state/zk/ZKStoreTest.scala
+++ b/src/test/scala/mesosphere/util/state/zk/ZKStoreTest.scala
@@ -11,7 +11,7 @@ import org.apache.mesos.state.ZooKeeperState
 import org.apache.zookeeper.KeeperException.NoNodeException
 import org.apache.zookeeper.ZooDefs.Ids
 import org.scalatest._
-import org.scalatest.concurrent.ScalaFutures._
+import mesosphere.FutureTestSupport._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._


### PR DESCRIPTION
it was 150ms before and there were a lot failures in code using this.

An alternative would be to use test duration scaling but I like this better.

(A lot of the other durations should not be scaled.)