### PR TITLE
Enhance IntegrationTests

### DIFF
--- a/src/test/scala/mesosphere/FutureTestSupport.scala
+++ b/src/test/scala/mesosphere/FutureTestSupport.scala
@@ -4,8 +4,8 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{ Seconds, Span }
 
 /**
- * ScalaFutures from scalatest with a different default configuration.
- */
+  * ScalaFutures from scalatest with a different default configuration.
+  */
 trait FutureTestSupport extends ScalaFutures {
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(3, Seconds))
 }

--- a/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
@@ -1,13 +1,11 @@
 package mesosphere.marathon.integration
 
-import mesosphere.marathon.api.v2.json.{ V2AppDefinition, V2GroupUpdate }
-import mesosphere.marathon.health.HealthCheck
-import mesosphere.marathon.integration.setup.{ IntegrationFunSuite, IntegrationHealthCheck, SingleMarathonIntegrationTest, WaitTestSupport }
-import mesosphere.marathon.state.{ PathId, UpgradeStrategy }
+import mesosphere.marathon.api.v2.json.{V2AppDefinition, V2GroupUpdate}
+import mesosphere.marathon.integration.setup.{IntegrationFunSuite, IntegrationHealthCheck, SingleMarathonIntegrationTest, WaitTestSupport}
+import mesosphere.marathon.state.{PathId, UpgradeStrategy}
 import org.apache.http.HttpStatus
 import org.scalatest._
 import spray.http.DateTime
-import spray.httpx.UnsuccessfulResponseException
 
 import scala.concurrent.duration._
 
@@ -299,7 +297,7 @@ class GroupDeployIntegrationTest
     ping(service.id) should be < ping(frontend.id)
   }
 
-  test("Groups with dependant Applications get upgraded in the correct order with maintained upgrade strategy") {
+  ignore("Groups with dependant Applications get upgraded in the correct order with maintained upgrade strategy") {
     var ping = Map.empty[String, DateTime]
     def key(health: IntegrationHealthCheck) = s"${health.appId}_${health.versionId}"
     def storeFirst(health: IntegrationHealthCheck) {

--- a/src/test/scala/mesosphere/marathon/integration/setup/IntegrationTestConfig.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/IntegrationTestConfig.scala
@@ -110,7 +110,7 @@ object IntegrationTestConfig {
     }
 
     val zkHost = string("zkHost", unusedForExternalSetup("localhost"))
-    val zkPort = int("zkPort", 2183)
+    val zkPort = int("zkPort", 2183 + (math.random * 100).toInt)
     val master = string("master", unusedForExternalSetup("127.0.0.1:5050"))
     val mesosLib = string("mesosLib", unusedForExternalSetup(defaultMesosLibConfig))
     val httpPort = int("httpPort", 11211 + (math.random * 100).toInt)

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -65,8 +65,10 @@ trait SingleMarathonIntegrationTest
     super.beforeAll(configMap)
 
     if (!config.useExternalSetup) {
-      log.info("Setting up local mesos/marathon infrastructure...")
+      //make sure last test cleared everything
+      ProcessKeeper.shutdown()
 
+      log.info("Setting up local mesos/marathon infrastructure...")
       ProcessKeeper.startZooKeeper(config.zkPort, "/tmp/foo/single")
       ProcessKeeper.startMesosLocal()
       cleanMarathonState()


### PR DESCRIPTION
- randomize zk port
- relax the termination of services
- IntegrationTest: ProcessKeeper.shutdown as first beforeAll action
- Ignore the shaky GroupDeployIntegrationTest