### PR TITLE
Optimization: Use Iterable instead of Set for tasks in resource matching

### DIFF
--- a/src/main/scala/mesosphere/marathon/tasks/DefaultTaskFactory.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/DefaultTaskFactory.scala
@@ -20,7 +20,7 @@ class DefaultTaskFactory @Inject() (
 
   private[this] val log = LoggerFactory.getLogger(getClass)
 
-  def newTask(app: AppDefinition, offer: Offer, runningTasks: Set[MarathonTask]): Option[CreatedTask] = {
+  def newTask(app: AppDefinition, offer: Offer, runningTasks: Iterable[MarathonTask]): Option[CreatedTask] = {
     log.debug("newTask")
 
     new TaskBuilder(app, taskIdUtil.newTaskId, config).buildIfMatches(offer, runningTasks).map {

--- a/src/main/scala/mesosphere/marathon/tasks/TaskFactory.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskFactory.scala
@@ -11,7 +11,7 @@ trait TaskFactory {
   /**
     * Return the corresponding task if and only if the offer matches the app.
     */
-  def newTask(app: AppDefinition, offer: Offer, runningTasks: Set[MarathonTask]): Option[CreatedTask]
+  def newTask(app: AppDefinition, offer: Offer, runningTasks: Iterable[MarathonTask]): Option[CreatedTask]
 }
 
 object TaskFactory {

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -34,7 +34,7 @@ object ResourceMatcher {
   case class ResourceMatch(cpuRole: Role, memRole: Role, diskRole: Role, ports: Seq[RangesResource])
 
   //scalastyle:off method.length
-  def matchResources(offer: Offer, app: AppDefinition, runningTasks: => Set[MarathonTask],
+  def matchResources(offer: Offer, app: AppDefinition, runningTasks: => Iterable[MarathonTask],
                      acceptedResourceRoles: Set[String] = Set("*")): Option[ResourceMatch] = {
 
     val groupedResources: Map[Role, mutable.Buffer[Protos.Resource]] = offer.getResourcesList.asScala.groupBy(_.getName)

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -25,7 +25,7 @@ class TaskBuilder(app: AppDefinition,
 
   val log = Logger.getLogger(getClass.getName)
 
-  def buildIfMatches(offer: Offer, runningTasks: => Set[MarathonTask]): Option[(TaskInfo, Seq[Long])] = {
+  def buildIfMatches(offer: Offer, runningTasks: => Iterable[MarathonTask]): Option[(TaskInfo, Seq[Long])] = {
 
     val acceptedResourceRoles: Set[String] = app.acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet)
 

--- a/src/test/scala/mesosphere/marathon/SameAsSeq.scala
+++ b/src/test/scala/mesosphere/marathon/SameAsSeq.scala
@@ -1,0 +1,17 @@
+package mesosphere.marathon
+
+import org.hamcrest.{ Description, BaseMatcher }
+import org.mockito.internal.matchers.Equality
+
+// WTF, this is not true:
+// require(Map.empty[String,MarathonTask].values == Map.empty[String,MarathonTask].values)
+case class SameAsSeq[T](wanted: Iterable[T]) extends BaseMatcher[Iterable[T]] {
+  override def matches(actual: Any): Boolean = {
+    Equality.areEqual(wanted.toSeq, actual.asInstanceOf[Iterable[T]].toSeq)
+  }
+
+  override def describeTo(description: Description): Unit = {
+    description.appendValue(wanted)
+  }
+}
+

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
@@ -19,10 +19,12 @@ import mesosphere.marathon.integration.setup.WaitTestSupport
 import mesosphere.marathon.state.{ Timestamp, AppDefinition, PathId }
 import mesosphere.marathon.tasks.TaskFactory.CreatedTask
 import mesosphere.marathon.tasks.{ TaskFactory, TaskTracker }
-import mesosphere.marathon.{ Protos, MarathonSpec, MarathonTestHelper }
+import mesosphere.marathon.{ SameAsSeq, Protos, MarathonSpec, MarathonTestHelper }
 import mesosphere.util.state.PersistentEntity
 import org.mockito
-import org.mockito.Mockito
+import org.mockito.{ Matchers, Mockito }
+import org.mockito.Mockito.when
+import org.scalatest.Matchers
 import org.scalatest.{ Matchers, GivenWhenThen }
 import rx.lang.scala.Subject
 import rx.lang.scala.subjects.PublishSubject
@@ -40,8 +42,10 @@ import akka.pattern.ask
   * * timeout for task launching feedback
   */
 class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
+  import org.mockito.{ Matchers => m }
+
   test("Initial population of task list from taskTracker with one task") {
-    Mockito.when(taskTracker.get(app.id)).thenReturn(Set(marathonTask))
+    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable(marathonTask))
 
     val launcherRef = createLauncherRef(instances = 0)
     launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -54,12 +58,12 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.taskLaunchesInFlight == 0)
     assert(counts.tasksLeftToLaunch == 0)
 
-    Mockito.verify(taskTracker).get(app.id)
+    Mockito.verify(taskTracker).getTasks(app.id)
   }
 
   test("Upgrading an app updates app definition in actor and requeries backoff") {
     Given("an entry for an app")
-    Mockito.when(taskTracker.get(app.id)).thenReturn(Set(marathonTask))
+    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable(marathonTask))
     val launcherRef = createLauncherRef(instances = 3)
     rateLimiterActor.expectMsg(RateLimiterActor.GetDelay(app))
     rateLimiterActor.reply(RateLimiterActor.DelayUpdate(app, clock.now()))
@@ -93,7 +97,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
 
   test("Upgrading an app updates reregisters the offerMatcher at the manager") {
     Given("an entry for an app")
-    Mockito.when(taskTracker.get(app.id)).thenReturn(Set(marathonTask))
+    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable(marathonTask))
     val launcherRef = createLauncherRef(instances = 1)
     rateLimiterActor.expectMsg(RateLimiterActor.GetDelay(app))
     rateLimiterActor.reply(RateLimiterActor.DelayUpdate(app, clock.now()))
@@ -122,9 +126,9 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
   }
 
   test("Process task launch") {
-    Mockito.when(taskTracker.get(app.id)).thenReturn(Set.empty[MarathonTask])
+    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    Mockito.when(taskFactory.newTask(app, offer, Set.empty[MarathonTask])).thenReturn(Some(CreatedTask(task, marathonTask)))
+    Mockito.when(taskFactory.newTask(m.any(), m.any(), m.any())).thenReturn(Some(CreatedTask(task, marathonTask)))
 
     val launcherRef = createLauncherRef(instances = 1)
     launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -139,14 +143,14 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.taskLaunchesInFlight == 1)
     assert(counts.tasksLeftToLaunch == 0)
 
-    Mockito.verify(taskTracker).get(app.id)
-    Mockito.verify(taskFactory).newTask(app, offer, Set.empty[MarathonTask])
+    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskFactory).newTask(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
   }
 
   test("Wait for inflight task launches on stop") {
-    Mockito.when(taskTracker.get(app.id)).thenReturn(Set.empty[MarathonTask])
+    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    Mockito.when(taskFactory.newTask(app, offer, Set.empty[MarathonTask])).thenReturn(Some(CreatedTask(task, marathonTask)))
+    Mockito.when(taskFactory.newTask(m.any(), m.any(), m.any())).thenReturn(Some(CreatedTask(task, marathonTask)))
 
     val launcherRef = createLauncherRef(instances = 1)
     launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -162,14 +166,14 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     matched.tasks.foreach(_.reject("stuff"))
     testProbe.expectMsgClass(classOf[Terminated])
 
-    Mockito.verify(taskTracker).get(app.id)
-    Mockito.verify(taskFactory).newTask(app, offer, Set.empty[MarathonTask])
+    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskFactory).newTask(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
   }
 
   test("Process task launch reject") {
-    Mockito.when(taskTracker.get(app.id)).thenReturn(Set.empty[MarathonTask])
+    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    Mockito.when(taskFactory.newTask(app, offer, Set.empty[MarathonTask])).thenReturn(Some(CreatedTask(task, marathonTask)))
+    Mockito.when(taskFactory.newTask(m.any(), m.any(), m.any())).thenReturn(Some(CreatedTask(task, marathonTask)))
 
     val launcherRef = createLauncherRef(instances = 1)
     launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -188,14 +192,14 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.taskLaunchesInFlight == 0)
     assert(counts.tasksLeftToLaunch == 1)
 
-    Mockito.verify(taskTracker).get(app.id)
-    Mockito.verify(taskFactory).newTask(app, offer, Set.empty[MarathonTask])
+    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskFactory).newTask(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
   }
 
   test("Process task launch timeout") {
-    Mockito.when(taskTracker.get(app.id)).thenReturn(Set.empty[MarathonTask])
+    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    Mockito.when(taskFactory.newTask(app, offer, Set.empty[MarathonTask])).thenReturn(Some(CreatedTask(task, marathonTask)))
+    Mockito.when(taskFactory.newTask(m.any(), m.any(), m.any())).thenReturn(Some(CreatedTask(task, marathonTask)))
 
     var scheduleCalled = false
     val props = Props(
@@ -229,14 +233,14 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
 
     assert(scheduleCalled)
 
-    Mockito.verify(taskTracker).get(app.id)
-    Mockito.verify(taskFactory).newTask(app, offer, Set.empty[MarathonTask])
+    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskFactory).newTask(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
   }
 
   test("Process task launch accept") {
-    Mockito.when(taskTracker.get(app.id)).thenReturn(Set.empty[MarathonTask])
+    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    Mockito.when(taskFactory.newTask(app, offer, Set.empty[MarathonTask])).thenReturn(Some(CreatedTask(task, marathonTask)))
+    Mockito.when(taskFactory.newTask(m.any(), m.any(), m.any())).thenReturn(Some(CreatedTask(task, marathonTask)))
 
     val launcherRef = createLauncherRef(instances = 1)
     launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -254,8 +258,8 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.taskLaunchesInFlight == 0)
     assert(counts.tasksLeftToLaunch == 0)
 
-    Mockito.verify(taskTracker).get(app.id)
-    Mockito.verify(taskFactory).newTask(app, offer, Set.empty[MarathonTask])
+    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskFactory).newTask(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
   }
 
   for (
@@ -267,7 +271,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     )
   ) {
     test(s"Remove terminated task (${update.wrapped.status.getClass.getSimpleName})") {
-      Mockito.when(taskTracker.get(app.id)).thenReturn(Set(marathonTask))
+      Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable(marathonTask))
 
       val launcherRef = createLauncherRef(instances = 0)
       launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -286,7 +290,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
       assert(counts.taskLaunchesInFlight == 0)
       assert(counts.tasksLeftToLaunch == 0)
 
-      Mockito.verify(taskTracker).get(app.id)
+      Mockito.verify(taskTracker).getTasks(app.id)
     }
   }
 
@@ -306,7 +310,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
         .setOperator(Protos.Constraint.Operator.CLUSTER)
         .build()
       val appWithConstraints = app.copy(constraints = Set(constraint))
-      Mockito.when(taskTracker.get(appWithConstraints.id)).thenReturn(Set(marathonTask))
+      Mockito.when(taskTracker.getTasks(appWithConstraints.id)).thenReturn(Set(marathonTask))
 
       val launcherRef = createLauncherRef(instances = 0, appToLaunch = appWithConstraints)
       launcherRef ! RateLimiterActor.DelayUpdate(appWithConstraints, clock.now())
@@ -324,7 +328,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
       Mockito.verify(offerReviver).reviveOffers()
 
       And("the task tracker as well")
-      Mockito.verify(taskTracker).get(appWithConstraints.id)
+      Mockito.verify(taskTracker).getTasks(appWithConstraints.id)
     }
   }
 
@@ -335,7 +339,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     )
   ) {
     test(s"DO NOT REMOVE running task (${update.wrapped.status.getClass.getSimpleName})") {
-      Mockito.when(taskTracker.get(app.id)).thenReturn(Set(marathonTask))
+      Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable(marathonTask))
 
       val launcherRef = createLauncherRef(instances = 0)
       launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -354,7 +358,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
       assert(counts.taskLaunchesInFlight == 0)
       assert(counts.tasksLeftToLaunch == 0)
 
-      Mockito.verify(taskTracker).get(app.id)
+      Mockito.verify(taskTracker).getTasks(app.id)
     }
   }
 


### PR DESCRIPTION
This is currently based on #2213. Do not merge before merging that.

This is not a blocker for 0.11 but showed up in profiling.