### PR TITLE
allow disabling syslog via /etc/marathon/conf/?no-logger'

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -77,7 +77,13 @@ function load_options_and_log {
 
   if [[ "${cmd[@]} $@" == *'--no-logger'* ]]
   then
-    "${cmd[@]}" ${@//--no-logger/}
+    local clean_cmd=()
+    for i in "${cmd[@]}" "$@"; do
+      if [[ "${i}" != "--no-logger" ]]; then
+        clean_cmd+=( "${i}" )
+      fi
+    done
+    "${clean_cmd[@]}"
   else
     logged marathon "${cmd[@]}" "$@"
   fi


### PR DESCRIPTION
For people using upstart/sysvinit and wish to not have the logs go to syslog, they can drop `/etc/marathon/conf/?no-logger` on the system without resorting to editing the distributed upstart/sysvinit scripts to pass `--no-logger`