### PR TITLE
Fixes #2220 - Added --task_launch_confirm_timeout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -150,6 +150,12 @@ All launched tasks are stored before launching them. There is also a new timeout
     When reaching the timeout, only the tasks that we could save within the timeout are also launched.
     All other task launches are temporarily rejected and retried later.
 
+If the mesos master fails over or in other unusual circumstances, a launch task request might get lost.
+You can configure how long Marathon waits for the first `TASK_STAGING` update.
+    
+* <span class="label label-default">v0.11.0</span> `--task_launch_confirm_timeout` (Optional. Default: 10000):
+  Time, in milliseconds, to wait for a task to enter the `TASK_STAGING` state before killing it.
+
 #### No pseudo-deterministic assignment of host ports anymore
 
 If you specify non-zero `"ports"` in your app JSON, they are used as service ports. The old code contained logic that

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -167,6 +167,12 @@ All launched tasks are stored before launching them. There is also a timeout for
     When reaching the timeout, only the tasks that we could save within the timeout are also launched.
     All other task launches are temporarily rejected and retried later.
 
+If the mesos master fails over or in other unusual circumstances, a launch task request might get lost.
+You can configure how long Marathon waits for the first `TASK_STAGING` update.
+    
+* <span class="label label-default">v0.11.0</span> `--task_launch_confirm_timeout` (Optional. Default: 10000):
+  Time, in milliseconds, to wait for a task to enter the `TASK_STAGING` state before killing it.
+
 When the task launch requests in Marathon change because an app definition changes or a backoff delay is overdue,
 Marathon can request all available offers from Mesos again -- even those that it has recently rejected. To avoid
 calling the underlying `reviveOffers` API call to often, you can configure the minimal delay between subsequent

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/DriverActor.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/DriverActor.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import akka.actor.{ Actor, ActorRef, Cancellable, Props }
 import akka.event.LoggingReceive
-import mesosphere.mesos.simulation.DriverActor.{ ReviveOffers, KillTask, LaunchTasks }
+import mesosphere.mesos.simulation.DriverActor.{ ChangeTaskStatus, ReconcileTask, ReviveOffers, KillTask, LaunchTasks }
 import mesosphere.mesos.simulation.SchedulerActor.ResourceOffers
 import org.apache.mesos.Protos._
 import org.apache.mesos.SchedulerDriver
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConversions._
 import scala.concurrent.duration._
+import scala.util.Random
 
 object DriverActor {
   case class DeclineOffer(offerId: OfferID)
@@ -38,6 +39,8 @@ object DriverActor {
   case class ReconcileTask(taskStatus: Seq[TaskStatus])
 
   case object ReviveOffers
+
+  private case class ChangeTaskStatus(taskStatus: TaskStatus)
 }
 
 class DriverActor(schedulerProps: Props) extends Actor {
@@ -45,8 +48,23 @@ class DriverActor(schedulerProps: Props) extends Actor {
 
   private[this] val numberOfOffersPerCycle: Int = 10
 
+  // use random seed to get reproducable results
+  private[this] val random = {
+    val seed = System.currentTimeMillis()
+    log.info(s"Random seed for this test run: $seed")
+    new Random(new java.util.Random(seed))
+  }
+
   private[this] var periodicOffers: Option[Cancellable] = None
   private[this] var scheduler: ActorRef = _
+
+  private[this] var tasks: Map[String, TaskStatus] = Map.empty.withDefault { taskId =>
+    TaskStatus.newBuilder()
+      .setSource(TaskStatus.Source.SOURCE_SLAVE)
+      .setTaskId(TaskID.newBuilder().setValue(taskId).build())
+      .setState(TaskState.TASK_LOST)
+      .build()
+  }
 
   //scalastyle:off magic.number
   private[this] def offer: Offer = {
@@ -103,32 +121,75 @@ class DriverActor(schedulerProps: Props) extends Actor {
       scheduler ! driver
 
     case LaunchTasks(offers, tasks) =>
-      log.debug(s"launch tasks $offers, $tasks")
-      tasks.foreach { taskInfo: TaskInfo =>
-        scheduler ! TaskStatus.newBuilder()
-          .setSource(TaskStatus.Source.SOURCE_EXECUTOR)
-          .setTaskId(taskInfo.getTaskId)
-          .setState(TaskState.TASK_STAGING)
-          .build()
-      }
-      tasks.foreach { taskInfo: TaskInfo =>
-        scheduler ! TaskStatus.newBuilder()
-          .setSource(TaskStatus.Source.SOURCE_EXECUTOR)
-          .setTaskId(taskInfo.getTaskId)
-          .setState(TaskState.TASK_RUNNING)
-          .build()
-      }
+      simulateTaskLaunch(offers, tasks)
 
     case KillTask(taskId) =>
-      log.debug(s"kill tasks $taskId")
-      scheduler ! TaskStatus.newBuilder()
-        .setSource(TaskStatus.Source.SOURCE_EXECUTOR)
-        .setTaskId(taskId)
-        .setState(TaskState.TASK_KILLED)
-        .build()
+      log.debug(s"kill task $taskId")
 
-    case ReviveOffers => scheduler ! offers
+      tasks.get(taskId.getValue) match {
+        case Some(task) =>
+          scheduleStatusChange(toState = TaskState.TASK_KILLED, afterDuration = 2.seconds)(taskID = taskId)
+        case None =>
+          scheduleStatusChange(toState = TaskState.TASK_LOST, afterDuration = 1.second)(taskID = taskId)
+      }
 
-    case _            =>
+    case ReviveOffers =>
+      scheduler ! offers
+
+    case ChangeTaskStatus(status) =>
+      changeTaskStatus(status)
+
+    case ReconcileTask(taskStatuses) =>
+      if (taskStatuses.isEmpty) {
+        tasks.values.foreach(scheduler ! _)
+      }
+      else {
+        taskStatuses.iterator.map(_.getTaskId.getValue).map(tasks).foreach(scheduler ! _)
+      }
   }
+
+  def simulateTaskLaunch(offers: Seq[OfferID], tasksToLaunch: Seq[TaskInfo]): Unit = {
+    if (random.nextDouble() > 0.001) {
+      log.debug(s"launch tasksToLaunch $offers, $tasksToLaunch")
+      tasksToLaunch.map(_.getTaskId).foreach {
+        scheduleStatusChange(toState = TaskState.TASK_STAGING, afterDuration = 1.second)
+      }
+
+      if (random.nextDouble() > 0.001) {
+        tasksToLaunch.map(_.getTaskId).foreach {
+          scheduleStatusChange(toState = TaskState.TASK_RUNNING, afterDuration = 5.seconds)
+        }
+      }
+      else {
+        tasksToLaunch.map(_.getTaskId).foreach {
+          scheduleStatusChange(toState = TaskState.TASK_FAILED, afterDuration = 5.seconds)
+        }
+      }
+    }
+    else {
+      log.debug("simulating lost launch")
+    }
+  }
+
+  private[this] def changeTaskStatus(status: TaskStatus): Unit = {
+    status.getState match {
+      case TaskState.TASK_ERROR | TaskState.TASK_FAILED | TaskState.TASK_FINISHED | TaskState.TASK_LOST =>
+        tasks -= status.getTaskId.getValue
+      case _ =>
+        tasks += (status.getTaskId.getValue -> status)
+    }
+    log.info(s"${tasks.size} tasks")
+    scheduler ! status
+  }
+
+  private[this] def scheduleStatusChange(toState: TaskState, afterDuration: FiniteDuration)(taskID: TaskID): Unit = {
+    val newStatus = TaskStatus.newBuilder()
+      .setSource(TaskStatus.Source.SOURCE_EXECUTOR)
+      .setTaskId(taskID)
+      .setState(toState)
+      .build()
+    import context.dispatcher
+    context.system.scheduler.scheduleOnce(afterDuration, self, ChangeTaskStatus(newStatus))
+  }
+
 }

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
@@ -40,7 +40,9 @@ class SingleAppScalingTest
 
     ProcessKeeper.startMarathon(cwd, env,
       List("--http_port", port.toString, "--zk", config.zk, "--enable_metrics",
-        "--max_tasks_per_offer", maxTasksPerOffer) ++ args.toList,
+        "--max_tasks_per_offer", maxTasksPerOffer,
+        "--task_launch_timeout", "20000",
+        "--task_launch_confirm_timeout", "1000") ++ args.toList,
       mainClass = "mesosphere.mesos.simulation.SimulateMesosMain")
   }
 

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -122,6 +122,11 @@ trait MarathonConf
     true
   }
 
+  lazy val taskLaunchConfirmTimeout = opt[Long]("task_launch_confirm_timeout",
+    descr = "Time, in milliseconds, to wait for a task to enter " +
+      "the TASK_STAGING state before killing it.",
+    default = Some(10000L))
+
   lazy val taskLaunchTimeout = opt[Long]("task_launch_timeout",
     descr = "(deprecated) Time, in milliseconds, to wait for a task to enter " +
       "the TASK_RUNNING state before killing it. NOTE: this is a temporary " +

--- a/src/main/scala/mesosphere/marathon/tasks/MarathonTasks.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/MarathonTasks.scala
@@ -28,7 +28,7 @@ object MarathonTasks {
       .setVersion(version.toString())
       .addAllPorts(ports.map(i => i.toInt: java.lang.Integer).asJava)
       .addAllAttributes(attributes.asJava)
-      .setStagedAt(now.toDateTime.getMillis + 1000)
+      .setStagedAt(now.toDateTime.getMillis)
       .setSlaveId(slaveId)
       .build
   }


### PR DESCRIPTION
to handle the case where a launchTasks request isn't
answered more timely.

This commit also makes it easy to demonstrates the issue by improving the mesos simulation:

* reviveOffers
* sporadic simulated failures