### PR TITLE
Fixes #2254 prevent metrics registration upon regaining leadership (please cherry-pick into 0.11)

### DIFF
--- a/src/main/java/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/java/mesosphere/marathon/metrics/Metrics.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon.metrics
 
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.atomic.AtomicInteger
 
 import com.codahale.metrics.{Gauge, MetricRegistry}
 import com.google.inject.Inject
@@ -41,6 +41,7 @@ class Metrics @Inject() (val registry: MetricRegistry) {
     new Histogram(registry.histogram(name))
   }
 
+  @throws[IllegalArgumentException]("if this function is called multiple times for the same name.")
   def gauge[G <: Gauge[_]](name: String, gauge: G): G = {
     registry.register(name, gauge)
     gauge

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -4,8 +4,12 @@ import akka.actor.ActorRef
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.base.OfferMatcher
-import mesosphere.marathon.core.matcher.manager.impl.{ OfferMatcherManagerDelegate, OfferMatcherManagerActor }
 import mesosphere.marathon.core.matcher.base.util.ActorOfferMatcher
+import mesosphere.marathon.core.matcher.manager.impl.{
+  OfferMatcherManagerActor,
+  OfferMatcherManagerActorMetrics,
+  OfferMatcherManagerDelegate
+}
 import mesosphere.marathon.metrics.Metrics
 import rx.lang.scala.subjects.PublishSubject
 import rx.lang.scala.{ Observable, Subject }
@@ -23,8 +27,11 @@ class OfferMatcherManagerModule(
 
   private[this] lazy val offersWanted: Subject[Boolean] = PublishSubject[Boolean]()
 
+  private[this] lazy val offerMatcherManagerMetrics = new OfferMatcherManagerActorMetrics(metrics)
+
   private[this] val offerMatcherMultiplexer: ActorRef = {
-    val props = OfferMatcherManagerActor.props(metrics, random, clock, offerMatcherConfig, offersWanted)
+    val props = OfferMatcherManagerActor.props(
+      offerMatcherManagerMetrics, random, clock, offerMatcherConfig, offersWanted)
     leadershipModule.startWhenLeader(props, "offerMatcherManager")
   }
 

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
@@ -5,13 +5,12 @@ import akka.event.LoggingReceive
 import akka.pattern.pipe
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.matcher.base.OfferMatcher
-import OfferMatcher.{ MatchedTasks, TaskWithSource }
-import mesosphere.marathon.core.matcher.base.OfferMatcher
+import mesosphere.marathon.core.matcher.base.OfferMatcher.{ MatchedTasks, TaskWithSource }
+import mesosphere.marathon.core.matcher.base.util.ActorOfferMatcher
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerConfig
 import mesosphere.marathon.core.matcher.manager.impl.OfferMatcherManagerActor.{ MatchTimeout, OfferData }
-import mesosphere.marathon.core.matcher.base.util.ActorOfferMatcher
-import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import mesosphere.marathon.metrics.Metrics.AtomicIntGauge
+import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.tasks.ResourceUtil
 import org.apache.mesos.Protos.{ Offer, OfferID, Resource }
@@ -23,13 +22,20 @@ import scala.collection.immutable.Queue
 import scala.util.Random
 import scala.util.control.NonFatal
 
+private[manager] class OfferMatcherManagerActorMetrics(metrics: Metrics) {
+  private[manager] val launchTokenGauge: AtomicIntGauge =
+    metrics.gauge(metrics.name(MetricPrefixes.SERVICE, getClass, "launchTokens"), new AtomicIntGauge)
+  private[manager] val currentOffersGauge: AtomicIntGauge =
+    metrics.gauge(metrics.name(MetricPrefixes.SERVICE, getClass, "currentOffers"), new AtomicIntGauge)
+}
+
 /**
   * This actor offers one interface to a dynamic collection of matchers
   * and includes logic for limiting the amount of launches.
   */
 private[manager] object OfferMatcherManagerActor {
   def props(
-    metrics: Metrics,
+    metrics: OfferMatcherManagerActorMetrics,
     random: Random, clock: Clock,
     offerMatcherConfig: OfferMatcherManagerConfig, offersWanted: Observer[Boolean]): Props = {
     Props(new OfferMatcherManagerActor(metrics, random, clock, offerMatcherConfig, offersWanted))
@@ -68,14 +74,9 @@ private[manager] object OfferMatcherManagerActor {
 }
 
 private class OfferMatcherManagerActor private (
-  metrics: Metrics,
+  metrics: OfferMatcherManagerActorMetrics,
   random: Random, clock: Clock, conf: OfferMatcherManagerConfig, offersWantedObserver: Observer[Boolean])
     extends Actor with ActorLogging {
-
-  private[this] val launchTokenGauge: AtomicIntGauge =
-    metrics.gauge(metrics.name(MetricPrefixes.SERVICE, getClass, "launchTokens"), new AtomicIntGauge)
-  private[this] val currentOffersGauge: AtomicIntGauge =
-    metrics.gauge(metrics.name(MetricPrefixes.SERVICE, getClass, "currentOffers"), new AtomicIntGauge)
 
   private[this] var launchTokens: Int = 0
 
@@ -96,12 +97,12 @@ private class OfferMatcherManagerActor private (
     case OfferMatcherManagerDelegate.SetTaskLaunchTokens(tokens) =>
       val tokensBeforeSet = launchTokens
       launchTokens = tokens
-      launchTokenGauge.setValue(launchTokens)
+      metrics.launchTokenGauge.setValue(launchTokens)
       if (tokens > 0 && tokensBeforeSet <= 0)
         updateOffersWanted()
     case OfferMatcherManagerDelegate.AddTaskLaunchTokens(tokens) =>
       launchTokens += tokens
-      launchTokenGauge.setValue(launchTokens)
+      metrics.launchTokenGauge.setValue(launchTokens)
       if (tokens > 0 && launchTokens == tokens)
         updateOffersWanted()
   }
@@ -141,7 +142,7 @@ private class OfferMatcherManagerActor private (
       val randomizedMatchers = random.shuffle(matchers).to[Queue]
       val data = OfferMatcherManagerActor.OfferData(offer, deadline, sender(), randomizedMatchers, Seq.empty)
       offerQueues += offer.getId -> data
-      currentOffersGauge.setValue(offerQueues.size)
+      metrics.currentOffersGauge.setValue(offerQueues.size)
 
       // deal with the timeout
       import context.dispatcher
@@ -165,7 +166,7 @@ private class OfferMatcherManagerActor private (
 
           val newData: OfferData = data.addTasks(launchTasks)
           launchTokens -= launchTasks.size
-          launchTokenGauge.setValue(launchTokens)
+          metrics.launchTokenGauge.setValue(launchTokens)
           newData
         }
         catch {
@@ -242,7 +243,7 @@ private class OfferMatcherManagerActor private (
   private[this] def sendMatchResult(data: OfferData, resendThisOffer: Boolean): Unit = {
     data.sender ! OfferMatcher.MatchedTasks(data.offer.getId, data.tasks, resendThisOffer)
     offerQueues -= data.offer.getId
-    currentOffersGauge.setValue(offerQueues.size)
+    metrics.currentOffersGauge.setValue(offerQueues.size)
     log.info(s"Finished processing ${data.offer.getId.getValue}. " +
       s"Matched ${data.tasks.size} tasks after ${data.matchPasses} passes. " +
       s"${ResourceUtil.displayResources(data.offer.getResourcesList.asScala)} left.")


### PR DESCRIPTION
When Actors a recreated (i.e. a new instance is created), metrics may not be registered again because this would lead to runtime exceptions. Following the pattern used in HttpEventStreamActor, I extracted the gauges for the OfferMatcherManagerActor into a Metrics-class that will be wired once.

## please cherry-pick into 0.11