### PR TITLE
Improves #1988 - Consolidate logging

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -10,7 +10,7 @@ import net.virtualvoid.sbt.graph.Plugin.graphSettings
 import org.scalastyle.sbt.ScalastylePlugin.{ buildSettings => styleSettings }
 import scalariform.formatter.preferences._
 import sbtbuildinfo.Plugin._
-import spray.revolver.RevolverPlugin.Revolver.{settings => revolverSettings}
+import spray.revolver.RevolverPlugin.Revolver.{ settings => revolverSettings }
 import sbtrelease._
 import ReleasePlugin._
 import ReleaseStateTransformations._
@@ -255,7 +255,6 @@ object Dependencies {
     hadoopCommon % "compile",
     beanUtils % "compile",
     scallop % "compile",
-    diffson % "test",
     playJson % "compile",
     jsonSchemaValidator % "compile",
     twitterZk % "compile",
@@ -263,6 +262,7 @@ object Dependencies {
     marathonUI % "compile",
 
     // test
+    diffson % "test",
     Test.scalatest % "test",
     Test.mockito % "test",
     Test.akkaTestKit % "test"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,12 +3,3 @@ akka {
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
 }
-
-spray.can.host-connector {
-  max-connections = 3
-  max-retries = 1
-  max-redirects = 0
-  pipelining = off
-  idle-timeout = 3s
-  client = ${spray.can.client}
-}

--- a/src/main/scala/mesosphere/marathon/DebugConf.scala
+++ b/src/main/scala/mesosphere/marathon/DebugConf.scala
@@ -8,6 +8,7 @@ import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import org.aopalliance.intercept.{ MethodInterceptor, MethodInvocation }
 import org.apache.log4j.{ Level, Logger }
 import org.rogach.scallop.ScallopConf
+import org.slf4j.LoggerFactory
 
 /**
   * Options related to debugging marathon.
@@ -58,7 +59,7 @@ class DebugModule(conf: DebugConf) extends AbstractModule {
   class TracingBehavior(metrics: Provider[Metrics]) extends MethodInterceptor {
     override def invoke(in: MethodInvocation): AnyRef = {
       val className = metrics.get.className(in.getThis.getClass)
-      val logger = Logger.getLogger(className)
+      val logger = LoggerFactory.getLogger(className)
       val method = s"""$className.${in.getMethod.getName}(${in.getArguments.mkString(", ")})"""
       logger.trace(s">>> $method")
       val result = in.proceed()

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -11,13 +11,13 @@ import mesosphere.marathon.core.CoreGuiceModule
 import mesosphere.marathon.core.plugin.PluginConfiguration
 import mesosphere.marathon.event.http.{ HttpEventConfiguration, HttpEventModule }
 import mesosphere.marathon.event.{ EventConfiguration, EventModule }
-import org.apache.log4j.Logger
 import org.rogach.scallop.ScallopConf
+import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 
 class MarathonApp extends App {
-  val log = Logger.getLogger(getClass.getName)
+  val log = LoggerFactory.getLogger(getClass.getName)
 
   lazy val zk: ZooKeeperClient = {
     require(

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -36,10 +36,10 @@ import mesosphere.util.state._
 import mesosphere.util.state.memory.InMemoryStore
 import mesosphere.util.state.mesos.MesosStateStore
 import mesosphere.util.state.zk.ZKStore
-import org.apache.log4j.Logger
 import org.apache.mesos.state.ZooKeeperState
 import org.apache.zookeeper.ZooDefs
 import org.apache.zookeeper.ZooDefs.Ids
+import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Await
@@ -60,7 +60,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
 
   //scalastyle:off magic.number
 
-  val log = Logger.getLogger(getClass.getName)
+  val log = LoggerFactory.getLogger(getClass.getName)
 
   def configure() {
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -25,9 +25,9 @@ import mesosphere.marathon.upgrade.DeploymentManager.{ CancelDeployment, Deploym
 import mesosphere.marathon.upgrade.DeploymentPlan
 import mesosphere.util.PromiseActor
 import mesosphere.util.state.FrameworkIdUtil
-import org.apache.log4j.Logger
 import org.apache.mesos.Protos.FrameworkID
 import org.apache.mesos.SchedulerDriver
+import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
@@ -77,7 +77,7 @@ class MarathonSchedulerService @Inject() (
 
   private[mesosphere] var timer = newTimer()
 
-  val log = Logger.getLogger(getClass.getName)
+  val log = LoggerFactory.getLogger(getClass.getName)
 
   // FIXME: Remove from this class
   def frameworkId: Option[FrameworkID] = {

--- a/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
@@ -13,7 +13,6 @@ import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.io.IO
 import mesosphere.marathon.{ LeaderProxyConf, ModuleNames }
 import org.apache.http.HttpStatus
-import org.apache.log4j.Logger
 import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
@@ -164,7 +163,7 @@ class LeaderProxyFilter @Inject() (httpConf: HttpConf,
 }
 
 object LeaderProxyFilter {
-  private val log = Logger.getLogger(getClass.getName)
+  private val log = LoggerFactory.getLogger(getClass.getName)
 
   val HEADER_MARATHON_LEADER: String = "X-Marathon-Leader"
   val ERROR_STATUS_NO_CURRENT_LEADER: String = "Could not determine the current leader"

--- a/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
@@ -5,6 +5,7 @@ import javax.ws.rs.ext.{ Provider, ExceptionMapper }
 import javax.ws.rs.core.{ MediaType, Response }
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.google.inject.Singleton
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.TimeoutException
 import mesosphere.marathon.{
@@ -17,14 +18,13 @@ import com.sun.jersey.api.NotFoundException
 import com.fasterxml.jackson.core.JsonParseException
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.Response.Status
-import org.apache.log4j.Logger
 import play.api.libs.json.{ Json, JsObject, JsResultException }
 
 @Provider
 @Singleton
 class MarathonExceptionMapper extends ExceptionMapper[Exception] {
 
-  private[this] val log = Logger.getLogger(getClass.getName)
+  private[this] val log = LoggerFactory.getLogger(getClass.getName)
 
   def toResponse(exception: Exception): Response = {
     // WebApplicationException are things like invalid requests etc, no need to log a stack trace

--- a/src/main/scala/mesosphere/marathon/api/WebJarServlet.scala
+++ b/src/main/scala/mesosphere/marathon/api/WebJarServlet.scala
@@ -4,11 +4,11 @@ import java.net.URI
 import javax.servlet.http.{ HttpServlet, HttpServletRequest, HttpServletResponse }
 
 import mesosphere.marathon.io.IO
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 class WebJarServlet extends HttpServlet {
 
-  private[this] val log = Logger.getLogger(getClass)
+  private[this] val log = LoggerFactory.getLogger(getClass)
 
   //scalastyle:off method.length
   override def doGet(req: HttpServletRequest, resp: HttpServletResponse): Unit = {

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -7,15 +7,14 @@ import javax.ws.rs.core.{ MediaType, Response }
 import com.codahale.metrics.annotation.Timed
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.api.v2.json.Formats._
-import mesosphere.marathon.api.{ MarathonMediaType, TaskKiller, EndpointsHelper, RestResource }
+import mesosphere.marathon.api.{ EndpointsHelper, MarathonMediaType, RestResource, TaskKiller }
 import mesosphere.marathon.core.appinfo.EnrichedTask
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ GroupManager, PathId }
 import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService, UnknownAppException }
-import org.apache.log4j.Logger
-import play.api.libs.json.Json
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 
@@ -28,7 +27,7 @@ class AppTasksResource @Inject() (service: MarathonSchedulerService,
                                   val config: MarathonConf,
                                   groupManager: GroupManager) extends RestResource {
 
-  val log = Logger.getLogger(getClass.getName)
+  val log = LoggerFactory.getLogger(getClass.getName)
   val GroupTasks = """^((?:.+/)|)\*$""".r
 
   @GET

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -6,19 +6,17 @@ import javax.ws.rs.core.{ MediaType, Response }
 import com.codahale.metrics.annotation.Timed
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.v2.json.V2AppDefinition
-import org.apache.log4j.Logger
-
-import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.{ MarathonMediaType, RestResource }
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{ Timestamp }
+import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService }
+import org.slf4j.LoggerFactory
 
 @Produces(Array(MarathonMediaType.PREFERRED_APPLICATION_JSON))
 @Consumes(Array(MediaType.APPLICATION_JSON))
 class AppVersionsResource(service: MarathonSchedulerService, val config: MarathonConf) extends RestResource {
 
-  val log = Logger.getLogger(getClass.getName)
+  val log = LoggerFactory.getLogger(getClass.getName)
 
   @GET
   @Timed

--- a/src/main/scala/mesosphere/marathon/api/v2/LabelSelector.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LabelSelector.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.api.v2
 
 import mesosphere.marathon.core.appinfo.AppSelector
 import mesosphere.marathon.state.AppDefinition
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 import scala.util.control.NonFatal
 import scala.util.parsing.combinator.RegexParsers
@@ -39,7 +39,7 @@ case class LabelSelectors(selectors: Seq[LabelSelector]) extends AppSelector {
   */
 class LabelSelectorParsers extends RegexParsers {
 
-  private[this] val log = Logger.getLogger(getClass.getName)
+  private[this] val log = LoggerFactory.getLogger(getClass.getName)
 
   //Allowed characters are A-Za-z0-9._- All other characters can be used, but need to be escaped.
   def term: Parser[String] = """(\\.|[-A-Za-z0-9_.])+""".r ^^ { _.replaceAll("""\\(.)""", "$1") }

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -14,8 +14,8 @@ import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.GroupManager
 import mesosphere.marathon.tasks.{ TaskIdUtil, TaskTracker }
 import mesosphere.marathon.{ BadRequestException, MarathonConf, MarathonSchedulerService }
-import org.apache.log4j.Logger
 import org.apache.mesos.Protos.TaskState
+import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 
 import scala.collection.IterableView
@@ -31,7 +31,7 @@ class TasksResource @Inject() (
     healthCheckManager: HealthCheckManager,
     taskIdUtil: TaskIdUtil) extends RestResource {
 
-  val log = Logger.getLogger(getClass.getName)
+  val log = LoggerFactory.getLogger(getClass.getName)
 
   @GET
   @Produces(Array(MarathonMediaType.PREFERRED_APPLICATION_JSON))

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiter.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiter.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 
@@ -69,7 +69,7 @@ private[launchqueue] class RateLimiter(clock: Clock) {
 }
 
 private object RateLimiter {
-  private val log = Logger.getLogger(getClass.getName)
+  private val log = LoggerFactory.getLogger(getClass.getName)
 
   private object Delay {
     def apply(clock: Clock, app: AppDefinition): Delay = Delay(clock, app.backoff)

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -1,14 +1,15 @@
 package mesosphere.marathon.event
 
+import javax.inject.Named
+
+import akka.actor.ActorSystem
+import akka.event.EventStream
+import com.google.inject.{ AbstractModule, Inject, Provides, Singleton }
 import mesosphere.marathon.health.HealthCheck
+import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep }
 import org.rogach.scallop.ScallopConf
-import com.google.inject.{ Inject, Singleton, Provides, AbstractModule }
-import akka.event.EventStream
-import javax.inject.Named
-import org.apache.log4j.Logger
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
-import akka.actor.ActorSystem
+import org.slf4j.LoggerFactory
 
 //scalastyle:off number.of.types
 
@@ -28,7 +29,7 @@ trait EventConfiguration extends ScallopConf {
 
 class EventModule(conf: EventConfiguration) extends AbstractModule {
 
-  val log = Logger.getLogger(getClass.getName)
+  val log = LoggerFactory.getLogger(getClass.getName)
   def configure() {}
 
   @Named(EventModule.busName)

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventModule.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventModule.scala
@@ -5,19 +5,18 @@ import java.util.concurrent.Executors
 import akka.actor.{ ActorRef, ActorSystem, Props }
 import akka.pattern.ask
 import akka.util.Timeout
-import com.codahale.metrics.MetricRegistry
 import com.google.inject.name.Named
 import com.google.inject.{ AbstractModule, Provides, Scopes, Singleton }
 import mesosphere.marathon.event.{ MarathonSubscriptionEvent, Subscribe }
+import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{ EntityStore, MarathonStore }
 import mesosphere.util.state.PersistentStore
-import org.apache.log4j.Logger
 import org.rogach.scallop.ScallopConf
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import mesosphere.marathon.metrics.Metrics
 
 trait HttpEventConfiguration extends ScallopConf {
 
@@ -32,7 +31,7 @@ trait HttpEventConfiguration extends ScallopConf {
 
 class HttpEventModule(httpEventConfiguration: HttpEventConfiguration) extends AbstractModule {
 
-  val log = Logger.getLogger(getClass.getName)
+  val log = LoggerFactory.getLogger(getClass.getName)
 
   def configure() {
     bind(classOf[HttpCallbackEventSubscriber]).asEagerSingleton()

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventStreamActor.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.event.LocalLeadershipEvent
 import mesosphere.marathon.event.http.HttpEventStreamActor._
 import mesosphere.marathon.metrics.Metrics.AtomicIntGauge
 import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 import scala.util.Try
 
@@ -37,7 +37,7 @@ class HttpEventStreamActor(
     extends Actor {
   //map from handle to actor
   private[http] var streamHandleActors = Map.empty[HttpEventStreamHandle, ActorRef]
-  private[this] val log = Logger.getLogger(getClass)
+  private[this] val log = LoggerFactory.getLogger(getClass)
 
   override def preStart(): Unit = {
     metrics.numberOfStreams.setValue(0)

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
@@ -2,15 +2,15 @@ package mesosphere.marathon.health
 
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 
-import org.apache.log4j.Logger
 import org.apache.mesos.Protos.TaskStatus
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 import scala.collection.immutable.{ Seq, Map }
 
 trait HealthCheckManager {
 
-  protected[this] val log = Logger.getLogger(getClass.getName)
+  protected[this] val log = LoggerFactory.getLogger(getClass.getName)
 
   /**
     * Returns the active health checks for the app with the supplied id.

--- a/src/main/scala/mesosphere/marathon/state/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupManager.scala
@@ -16,7 +16,7 @@ import mesosphere.marathon.upgrade._
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService, ModuleNames, PortRangeExhaustedException }
 import mesosphere.util.SerializeExecution
 import mesosphere.util.ThreadPoolContext.context
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.Seq
 import scala.collection.mutable
@@ -37,7 +37,7 @@ class GroupManager @Singleton @Inject() (
     config: MarathonConf,
     @Named(EventModule.busName) eventBus: EventStream) extends PathFun {
 
-  private[this] val log = Logger.getLogger(getClass.getName)
+  private[this] val log = LoggerFactory.getLogger(getClass.getName)
   private[this] val zkName = groupRepo.zkRootName
 
   def rootGroup(): Future[Group] =

--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -8,8 +8,8 @@ import mesosphere.marathon.Protos._
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{ PathId, StateMetrics, Timestamp }
 import mesosphere.util.state.{ PersistentEntity, PersistentStore }
-import org.apache.log4j.Logger
 import org.apache.mesos.Protos.{ TaskState, TaskStatus }
+import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.collection._
@@ -27,7 +27,7 @@ class TaskTracker @Inject() (
 
   implicit val timeout = config.zkTimeoutDuration
 
-  private[this] val log = Logger.getLogger(getClass.getName)
+  private[this] val log = LoggerFactory.getLogger(getClass.getName)
 
   val PREFIX = "task:"
   val ID_DELIMITER = ":"

--- a/src/main/scala/mesosphere/mesos/Constraints.scala
+++ b/src/main/scala/mesosphere/mesos/Constraints.scala
@@ -1,12 +1,12 @@
 package mesosphere.mesos
 
+import mesosphere.marathon.Protos.Constraint.Operator
+import mesosphere.marathon.Protos.{ Constraint, MarathonTask }
 import mesosphere.marathon.state.AppDefinition
+import org.apache.mesos.Protos.Offer
+import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
-import mesosphere.marathon.Protos.{ MarathonTask, Constraint }
-import mesosphere.marathon.Protos.Constraint.Operator
-import org.apache.log4j.Logger
-import org.apache.mesos.Protos.Offer
 import scala.util.Try
 
 object Int {
@@ -15,7 +15,7 @@ object Int {
 
 object Constraints {
 
-  private[this] val log = Logger.getLogger(getClass.getName)
+  private[this] val log = LoggerFactory.getLogger(getClass.getName)
   val GroupByDefault = 0
 
   private def getIntValue(s: String, default: Int): Int = s match {

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -4,9 +4,9 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.tasks.PortsMatcher
 import mesosphere.mesos.protos.{ RangesResource, Resource }
-import org.apache.log4j.Logger
 import org.apache.mesos.Protos
 import org.apache.mesos.Protos.Offer
+import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
@@ -29,7 +29,7 @@ object ResourceMatcher {
     }
   }
 
-  private[this] val log = Logger.getLogger(getClass)
+  private[this] val log = LoggerFactory.getLogger(getClass)
 
   case class ResourceMatch(cpuRole: Role, memRole: Role, diskRole: Role, ports: Seq[RangesResource])
 

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -5,13 +5,13 @@ import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon._
 import mesosphere.marathon.api.v2.json.V2AppDefinition
-import mesosphere.marathon.state.{ AppDefinition, PathId }
 import mesosphere.marathon.health.HealthCheck
+import mesosphere.marathon.state.{ AppDefinition, PathId }
 import mesosphere.mesos.ResourceMatcher.ResourceMatch
 import mesosphere.mesos.protos.{ RangesResource, Resource, ScalarResource }
-import org.apache.log4j.Logger
 import org.apache.mesos.Protos.Environment._
 import org.apache.mesos.Protos.{ HealthCheck => _, _ }
+import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 
 import scala.collection.JavaConverters._
@@ -23,7 +23,7 @@ class TaskBuilder(app: AppDefinition,
 
   import mesosphere.mesos.protos.Implicits._
 
-  val log = Logger.getLogger(getClass.getName)
+  val log = LoggerFactory.getLogger(getClass.getName)
 
   def buildIfMatches(offer: Offer, runningTasks: => Iterable[MarathonTask]): Option[(TaskInfo, Seq[Long])] = {
 

--- a/src/main/scala/mesosphere/util/Logging.scala
+++ b/src/main/scala/mesosphere/util/Logging.scala
@@ -1,7 +1,7 @@
 package mesosphere.util
 
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 trait Logging {
-  protected[this] val log = Logger.getLogger(getClass.getName)
+  protected[this] val log = LoggerFactory.getLogger(getClass.getName)
 }

--- a/src/main/scala/mesosphere/util/SerializeExecutionActor.scala
+++ b/src/main/scala/mesosphere/util/SerializeExecutionActor.scala
@@ -4,7 +4,7 @@ import javax.annotation.PreDestroy
 
 import akka.actor.{ Actor, ActorRefFactory, PoisonPill, Props, Status }
 import akka.pattern.pipe
-import org.apache.log4j.Logger
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
@@ -22,7 +22,7 @@ import scala.util.control.NonFatal
   * }}}
   */
 object SerializeExecution {
-  private val log = Logger.getLogger(getClass.getName)
+  private val log = LoggerFactory.getLogger(getClass.getName)
 
   def apply[T](actorRefFactory: ActorRefFactory, actorName: String): SerializeExecution = {
     new SerializeExecution(actorRefFactory, actorName)
@@ -85,6 +85,6 @@ private[util] class SerializeExecutionActor extends Actor {
 }
 
 private[util] object SerializeExecutionActor {
-  private val log = Logger.getLogger(getClass.getName)
+  private val log = LoggerFactory.getLogger(getClass.getName)
   case class Execute[T](func: () => Future[T])
 }

--- a/src/main/scala/mesosphere/util/state/mesos/MesosStateStore.scala
+++ b/src/main/scala/mesosphere/util/state/mesos/MesosStateStore.scala
@@ -4,17 +4,17 @@ import mesosphere.marathon.StoreCommandFailedException
 import mesosphere.util.BackToTheFuture.Timeout
 import mesosphere.util.ThreadPoolContext
 import mesosphere.util.state.{ PersistentEntity, PersistentStore }
-import org.apache.log4j.Logger
-import org.apache.mesos.state.{ Variable, State }
+import org.apache.mesos.state.{ State, Variable }
+import org.slf4j.LoggerFactory
 
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
-import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 class MesosStateStore(state: State, timeout: Duration) extends PersistentStore {
 
-  private[this] val log = Logger.getLogger(getClass)
+  private[this] val log = LoggerFactory.getLogger(getClass)
   implicit val timeoutDuration = Timeout(timeout)
   implicit val ec = ThreadPoolContext.context
   import mesosphere.util.BackToTheFuture.futureToFuture

--- a/src/main/scala/mesosphere/util/state/zk/ZKStore.scala
+++ b/src/main/scala/mesosphere/util/state/zk/ZKStore.scala
@@ -10,15 +10,15 @@ import mesosphere.marathon.{ Protos, StoreCommandFailedException }
 import mesosphere.util.ThreadPoolContext
 import mesosphere.util.state.zk.ZKStore._
 import mesosphere.util.state.{ PersistentEntity, PersistentStore, PersistentStoreManagement }
-import org.apache.log4j.Logger
 import org.apache.zookeeper.KeeperException
 import org.apache.zookeeper.KeeperException.{ NoNodeException, NodeExistsException }
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ Future, Promise }
 
 class ZKStore(val client: ZkClient, root: ZNode) extends PersistentStore with PersistentStoreManagement {
 
-  private[this] val log = Logger.getLogger(getClass)
+  private[this] val log = LoggerFactory.getLogger(getClass)
   private[this] implicit val ec = ThreadPoolContext.context
 
   /**

--- a/src/test/scala/mesosphere/marathon/integration/setup/HttpServiceTestModule.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/HttpServiceTestModule.scala
@@ -1,22 +1,18 @@
 package mesosphere.marathon.integration.setup
 
+import javax.inject.Inject
+import javax.ws.rs._
+import javax.ws.rs.core.{ MediaType, Response }
+
+import com.google.inject.Scopes
+import mesosphere.chaos.http.RestModule
 import mesosphere.marathon.state.PathId._
-import play.api.libs.json.{ Json, JsValue }
+import org.slf4j.LoggerFactory
+import play.api.libs.json.{ JsValue, Json }
+import spray.http.HttpResponse
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Awaitable }
-import scala.reflect.ClassTag
-import com.google.inject.Scopes
-import javax.ws.rs._
-import javax.ws.rs.core.{ Response, MediaType }
-import javax.inject.Inject
-import org.apache.log4j.Logger
-import spray.httpx.marshalling.{ MarshallingContext, Marshaller }
-import spray.http.{ ContentTypes, HttpEntity }
-import spray.httpx.UnsuccessfulResponseException
-import spray.http.HttpResponse
-import mesosphere.chaos.http.RestModule
-import mesosphere.marathon.api.{ BaseRestModule, MarathonRestModule }
 
 /**
   * Result of an REST operation.
@@ -74,7 +70,7 @@ case class CallbackEvent(eventType: String, info: Map[String, Any])
 @Path("callback")
 class CallbackEventHandler @Inject() () {
 
-  private[this] val log = Logger.getLogger(getClass.getName)
+  private[this] val log = LoggerFactory.getLogger(getClass.getName)
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))

--- a/src/test/scala/mesosphere/marathon/integration/setup/ProcessKeeper.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ProcessKeeper.scala
@@ -9,8 +9,8 @@ import com.google.inject.Guice
 import mesosphere.chaos.http.{ HttpConf, HttpModule, HttpService }
 import mesosphere.chaos.metrics.MetricsModule
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.Logger
 import org.rogach.scallop.ScallopConf
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
@@ -26,7 +26,7 @@ import scala.util.{ Failure, Success, Try }
   */
 object ProcessKeeper {
 
-  private[this] val log = Logger.getLogger(getClass.getName)
+  private[this] val log = LoggerFactory.getLogger(getClass.getName)
   private[this] var processes = List.empty[Process]
   private[this] var services = List.empty[Service]
 


### PR DESCRIPTION
Removed direct usage of log4j from all classes, except for DebugModule,
where it is used to set the root logger level.

Added akka configuration to log via slf4j.

Pending: move logging backend to logback