### PR TITLE
Send redirects as relative URL (without Host)

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/WebJarServlet.scala
+++ b/src/main/scala/mesosphere/marathon/api/WebJarServlet.scala
@@ -58,9 +58,9 @@ class WebJarServlet extends HttpServlet {
     }
 
     //special rule for accessing root -> redirect to ui main page
-    if (req.getRequestURI == "/") resp.sendRedirect("/ui/")
+    if (req.getRequestURI == "/") sendRedirect(resp, "/ui/")
     //if a directory is requested, redirect to trailing slash
-    else if (!file.contains(".")) resp.sendRedirect(req.getRequestURI + "/") //request /ui -> /ui/
+    else if (!file.contains(".")) sendRedirect(resp, req.getRequestURI + "/") //request /ui -> /ui/
     //if we come here, it must be a resource
     else sendResourceNormalized(resourceURI, mime)
   }
@@ -72,5 +72,10 @@ class WebJarServlet extends HttpServlet {
       case "ttf" => "application/font-ttf"
       case _     => "application/octet-stream"
     }
+  }
+
+  private[this] def sendRedirect(response: HttpServletResponse, location: String): Unit = {
+    response.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY)
+    response.setHeader("Location", location)
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/WebJarServletTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/WebJarServletTest.scala
@@ -20,7 +20,8 @@ class WebJarServletTest extends MarathonSpec with Mockito with GivenWhenThen wit
     servlet.doGet(request, response)
 
     Then("A redirect response is send")
-    verify(response, atLeastOnce).sendRedirect("/ui/")
+    verify(response, atLeastOnce).setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY)
+    verify(response, atLeastOnce).setHeader("Location", "/ui/")
   }
 
   test("Get a directory without leading / will send a redirect") {
@@ -32,7 +33,8 @@ class WebJarServletTest extends MarathonSpec with Mockito with GivenWhenThen wit
     servlet.doGet(request, response)
 
     Then("A redirect response is send")
-    verify(response, atLeastOnce).sendRedirect("/some/directory/")
+    verify(response, atLeastOnce).setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY)
+    verify(response, atLeastOnce).setHeader("Location", "/some/directory/")
   }
 
   test("Get a non existing path will return 404"){


### PR DESCRIPTION
sendRedirect does always specify the host.
use a separate method for that.