### PR TITLE
Adding the use of JAVA_HOME within marathon-framework.

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -96,7 +96,13 @@ function run_jar {
     vm_opts+=( ${j_opt} )
   done
   # TODO: Set main class in pom.xml and use -jar
-  exec java "${vm_opts[@]}" -cp "$marathon_jar" mesosphere.marathon.Main "$@"
+  if [ -n "$JAVA_HOME" ]
+    then
+      JAVA_BIN="$JAVA_HOME/bin/java" 
+    else
+      JAVA_BIN="java"
+  fi
+  exec $JAVA_BIN "${vm_opts[@]}" -cp "$marathon_jar" mesosphere.marathon.Main "$@"
 }
 
 function logged {

--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -96,7 +96,7 @@ function run_jar {
     vm_opts+=( ${j_opt} )
   done
   # TODO: Set main class in pom.xml and use -jar
-  if [ -n "$JAVA_HOME" ]
+  if [ -n "${JAVA_HOME:=}" ]
     then
       JAVA_BIN="$JAVA_HOME/bin/java" 
     else


### PR DESCRIPTION
This would allow to start marathon using the non-default jdk.
Particularly useful to work around issue https://github.com/mesosphere/marathon/issues/1763

Change-Id: I101c9a17fa38e6b88ca562d75bb02b2c1c557279