### PR TITLE
add marathon cli integration

### DIFF
--- a/integrations/dcos-cli/Dockerfile.build-cli-base
+++ b/integrations/dcos-cli/Dockerfile.build-cli-base
@@ -1,0 +1,32 @@
+FROM java:8-jdk
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+    echo "deb http://repos.mesosphere.io/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y --force-yes mesos=0.23.0-1.0.debian81 sbt git python3 wget make zookeeperd screen && \
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    pip install virtualenv pytest dcos mock
+
+COPY . /marathon
+
+WORKDIR /
+RUN git clone https://github.com/mesosphere/dcos-cli.git
+
+WORKDIR /dcos-cli
+RUN make env && make packages
+
+WORKDIR /dcos-cli/cli
+RUN make env
+ENV DCOS_CONFIG=/dcos/dcos.toml DCOS_PRODUCTION=false
+
+RUN mkdir /dcos && touch $DCOS_CONFIG
+ENV PATH=$PATH:/dcos-cli/cli/env/bin
+
+RUN dcos config append package.sources https://github.com/mesosphere/universe/archive/version-1.x.zip && \
+    dcos config set marathon.url http://localhost:8080 && \
+    dcos
+
+WORKDIR /marathon
+ENTRYPOINT ["integrations/dcos-cli/configure-cli-tests.sh"]

--- a/integrations/dcos-cli/configure-cli-tests.sh
+++ b/integrations/dcos-cli/configure-cli-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+/etc/init.d/zookeeper start
+cd /marathon
+screen -m -d -S testing -L sbt 'run --zk zk://localhost:2181/marathon --master local'
+
+i=0
+while ! grep "Scheduler actor ready" screenlog.0
+do
+        echo "Waiting for Marathon to boot up..."
+        if [[ $i -gt 600 ]]; then
+                exit 1
+        else
+                sleep 5
+                let "i++"
+        fi
+done
+
+cd /dcos-cli/cli
+py.test tests/integrations/test_marathon.py && py.test tests/integrations/test_marathon_groups.py

--- a/integrations/dcos-cli/run-cli-tests.sh
+++ b/integrations/dcos-cli/run-cli-tests.sh
@@ -1,0 +1,131 @@
+!/bin/bash
+
+#
+# Run the Marathon CLI tests via docker.
+#
+# The script places some files into target/docker-build-volumes.
+# If you keep it around between builds your can greatly speed up resolving artifacts
+# but on the other hand you do not test if all artifacts are still resolvable.
+#
+# Please see integrations/dcos-cli/configure-cli-tests.sh for what the docker is running
+#
+# Usage:
+#  ./run-cli-tests.sh $0 [<unique build id>]
+#
+#  The build id is used as part of the docker image version/container names.
+#
+
+
+
+# be verbose and print all commands, better for debugging
+# set -x
+
+PROJECT_DIR=`dirname $0`/../..
+PROJECT_DIR=$(cd "$PROJECT_DIR"; pwd)
+
+if [ -r "$PROJECT_DIR/bin/run-tests-config.sh" ]; then
+    . "$PROJECT_DIR/bin/run-tests-config.sh"
+fi
+
+function fatal {
+    echo "======== FATAL ERROR ===================================================================================" >&2
+    echo "$*" >&2
+    echo "========================================================================================================" >&2
+    exit 2
+}
+
+BUILD_ID=${1-test}
+
+# We preserve some files across builds if the target directory is not deleted in between.
+# Especially the ivy cache can speed up builds substantially.
+BUILD_VOLUME_DIR="${BUILD_VOLUME_DIR-$PROJECT_DIR/docker-volumes}"
+SBT_DIR="${SBT_DIR-$BUILD_VOLUME_DIR/sbt}"
+IVY2_DIR="${IVY2_DIR-$BUILD_VOLUME_DIR/ivy2}"
+TARGET_DIRS="${TARGET_DIRS-$BUILD_VOLUME_DIR/targets}"
+CLEANUP_TARGET_DIRS="${CLEANUP_TARGET_DIRS-true}"
+CLEANUP_CONTAINERS_ON_EXIT="${CLEANUP_CONTAINERS_ON_EXIT-true}"
+export MARATHON_MAX_TASKS_PER_OFFER="${MARATHON_MAX_TASKS_PER_OFFER-1}"
+NO_DOCKER_CACHE="${NO_DOCKER_CACHE-true}"
+
+cat <<HERE
+BUILD_ID $BUILD_ID
+PROJECT_DIR $PROJECT_DIR
+
+Current configuration
+=====================
+
+Change this by copying run-tests-config-template.sh to run-tests-config.sh and adjusting it to your needs.
+
+Directories:
+
+    BUILD_VOLUME_DIR = "$BUILD_VOLUME_DIR"
+                       (the directory containing the persistent state of the build by default)
+    SBT_DIR          = "$SBT_DIR"
+                       (your sbt config directory)
+    IVY2_DIR         = "$IVY2_DIR"
+                       (your ivy2 configuration and test)
+    TARGET_DIRS      = "$TARGET_DIRS"
+                       (the directory containing your build results)
+
+Docker caching:
+
+    NO_DOCKER_CACHE = "$NO_DOCKER_CACHE" allowed: true or false default: true
+                       (whether to use the docker cache when building the base image)
+
+Cleanup:
+
+    CLEANUP_TARGET_DIRS         = "$CLEANUP_TARGET_DIRS" allowed: true or false default: true
+                                  (whether to clean the build target dirs before building)
+    CLEANUP_CONTAINERS_ON_EXIT  = "$CLEANUP_CONTAINERS_ON_EXIT" allowed: true or false default: true
+                                  (whether to clean/remove container images and containers on exit)
+
+Test parameters:
+
+    MARATHON_MAX_TASKS_PER_OFFER = "$MARATHON_MAX_TASKS_PER_OFFER"
+                                   (see --max_tasks_per_offer)
+
+Building
+========
+
+Started: $(date)
+HERE
+
+mkdir -p "$BUILD_VOLUME_DIR" "$TARGET_DIRS" || fatal "Couldn't created '$BUILD_VOLUME_DIR' '$TARGET_DIRS'" >&2
+
+if [ "$CLEANUP_TARGET_DIRS" = "true" ]; then
+    rm -rf "$TARGET_DIRS" || fatal "Couldn't clean '$TARGET_DIRS'"
+    screen -X -S testing
+fi
+
+# Cleanup left-over containers
+function cleanup {
+    echo Cleaning up volumes
+    docker rmi marathon-buildbase:$BUILD_ID 2>/dev/null
+    docker rm -v -f marathon-itests-$BUILD_ID 2>/dev/null
+}
+
+cleanup
+
+if [ "$CLEANUP_CONTAINERS_ON_EXIT" = "true" ]; then
+    trap cleanup EXIT
+fi
+
+if ! docker build --rm=$NO_DOCKER_CACHE --no-cache=$NO_DOCKER_CACHE -t marathon-buildbase:$BUILD_ID \
+    -f "$PROJECT_DIR/integrations/dcos-cli/Dockerfile.build-cli-base" "$PROJECT_DIR"; then
+    fatal "Build for the buildbase failed" >&2
+fi
+
+docker run \
+    --rm=$CLEANUP_CONTAINERS_ON_EXIT \
+    --name marathon-itests-$BUILD_ID \
+    --memory 4g \
+    --memory-swap 6g \
+    -e MARATHON_MAX_TASKS_PER_OFFER=$MARATHON_MAX_TASKS_PER_OFFER \
+    -v "$SBT_DIR:/root/.sbt" \
+    -v "$IVY2_DIR:/root/.ivy2" \
+    -v "$TARGET_DIRS/main:/marathon/target" \
+    -v "$TARGET_DIRS/project:/marathon/project/target" \
+    -v "$TARGET_DIRS/mesos-simulation:/marathon/mesos-simulation/target" \
+    -i \
+    marathon-buildbase:$BUILD_ID \
+    || fatal "build/tests failed"


### PR DESCRIPTION
After this is merged, we can have it run on teamcity analogously to bin/configure-tests.sh