### PR TITLE
Fixes #2249 - Added killOldTasksDelaySeconds to UpgradeStrategy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ### Fixed Issues
 
-- #2294 - Make boolean command line flags use Scallop's 'toggle'
+- \#2294 - Make boolean command line flags use Scallop's 'toggle'
+- \#2249 - Update delay before killing old tasks
 
 ## Changes from 0.10.0 to 0.11.0
 

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -1530,7 +1530,8 @@ Transfer-Encoding: chunked
                 "maxLaunchDelaySeconds" : 3600,
                 "upgradeStrategy" : {
                    "minimumHealthCapacity" : 1,
-                   "maximumOverCapacity" : 1
+                   "maximumOverCapacity" : 1,
+                   "killOldTasksDelaySeconds" : 0
                 },
                 "dependencies" : [],
                 "mem" : 16,

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppDefinition.json
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppDefinition.json
@@ -268,6 +268,10 @@
                     "maximum": 1.0,
                     "minimum": 0.0,
                     "type": "number"
+                },
+                "killOldTasksDelaySeconds": {
+                    "minimum": 0,
+                    "type": "integer"
                 }
             },
             "type": "object"

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
@@ -100,7 +100,8 @@ Here is an example of an application JSON which includes all fields.
     "maxLaunchDelaySeconds": 3600,
     "upgradeStrategy": {
         "minimumHealthCapacity": 0.5,
-        "maximumOverCapacity": 0.2
+        "maximumOverCapacity": 0.2,
+        "killOldTasksDelaySeconds": 5,
     }
 }
 ```
@@ -287,7 +288,7 @@ This applies also to tasks that are killed due to failing too many health checks
 
 During an upgrade all instances of an application get replaced by a new version.
 The upgradeStrategy controls how Marathon stops old versions and launches
-new versions. It consists of two values:
+new versions. It consists of three values:
 
 * `minimumHealthCapacity` (Optional. Default: 1.0) - a number between `0`and `1`
 that is multiplied with the instance count. This is the minimum number of healthy
@@ -297,6 +298,8 @@ instances are up.
 * `maximumOverCapacity` (Optional. Default: 1.0) - a number between `0` and
 `1` which is multiplied with the instance count. This is the maximum number of
 additional instances launched at any point of time during the upgrade process.
+* `killOldTasksDelaySeconds` (Optional. Default: 0) - The amount of time in 
+seconds to wait to kill an old task when a new task becomes healthy.
 
 The default `minimumHealthCapacity` is `1`, which means no old instance can be
 stopped before another healthy new version is deployed.
@@ -376,7 +379,8 @@ User-Agent: HTTPie/0.8.0
     ],
     "upgradeStrategy": {
         "minimumHealthCapacity": 0.5,
-        "maximumOverCapacity": 0.5
+        "maximumOverCapacity": 0.5,
+        "killOldTasksDelaySeconds": 0
     }
 }
 ```
@@ -442,7 +446,8 @@ Transfer-Encoding: chunked
     "storeUrls": [],
     "upgradeStrategy": {
         "minimumHealthCapacity": 0.5,
-        "maximumOverCapacity": 0.5
+        "maximumOverCapacity": 0.5,
+        "killOldTasksDelaySeconds": 0
     },
     "uris": [],
     "user": null,

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -15812,6 +15812,16 @@ public final class Protos {
      * <code>optional double maximumOverCapacity = 2 [default = 1];</code>
      */
     double getMaximumOverCapacity();
+
+    // optional uint32 killOldTasksDelaySeconds = 3 [default = 0];
+    /**
+     * <code>optional uint32 killOldTasksDelaySeconds = 3 [default = 0];</code>
+     */
+    boolean hasKillOldTasksDelaySeconds();
+    /**
+     * <code>optional uint32 killOldTasksDelaySeconds = 3 [default = 0];</code>
+     */
+    int getKillOldTasksDelaySeconds();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.UpgradeStrategyDefinition}
@@ -15872,6 +15882,11 @@ public final class Protos {
             case 17: {
               bitField0_ |= 0x00000002;
               maximumOverCapacity_ = input.readDouble();
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              killOldTasksDelaySeconds_ = input.readUInt32();
               break;
             }
           }
@@ -15946,9 +15961,26 @@ public final class Protos {
       return maximumOverCapacity_;
     }
 
+    // optional uint32 killOldTasksDelaySeconds = 3 [default = 0];
+    public static final int KILLOLDTASKSDELAYSECONDS_FIELD_NUMBER = 3;
+    private int killOldTasksDelaySeconds_;
+    /**
+     * <code>optional uint32 killOldTasksDelaySeconds = 3 [default = 0];</code>
+     */
+    public boolean hasKillOldTasksDelaySeconds() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional uint32 killOldTasksDelaySeconds = 3 [default = 0];</code>
+     */
+    public int getKillOldTasksDelaySeconds() {
+      return killOldTasksDelaySeconds_;
+    }
+
     private void initFields() {
       minimumHealthCapacity_ = 0D;
       maximumOverCapacity_ = 1D;
+      killOldTasksDelaySeconds_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -15972,6 +16004,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeDouble(2, maximumOverCapacity_);
       }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeUInt32(3, killOldTasksDelaySeconds_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -15988,6 +16023,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
           .computeDoubleSize(2, maximumOverCapacity_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(3, killOldTasksDelaySeconds_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -16109,6 +16148,8 @@ public final class Protos {
         bitField0_ = (bitField0_ & ~0x00000001);
         maximumOverCapacity_ = 1D;
         bitField0_ = (bitField0_ & ~0x00000002);
+        killOldTasksDelaySeconds_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -16145,6 +16186,10 @@ public final class Protos {
           to_bitField0_ |= 0x00000002;
         }
         result.maximumOverCapacity_ = maximumOverCapacity_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.killOldTasksDelaySeconds_ = killOldTasksDelaySeconds_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -16166,6 +16211,9 @@ public final class Protos {
         }
         if (other.hasMaximumOverCapacity()) {
           setMaximumOverCapacity(other.getMaximumOverCapacity());
+        }
+        if (other.hasKillOldTasksDelaySeconds()) {
+          setKillOldTasksDelaySeconds(other.getKillOldTasksDelaySeconds());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -16260,6 +16308,39 @@ public final class Protos {
       public Builder clearMaximumOverCapacity() {
         bitField0_ = (bitField0_ & ~0x00000002);
         maximumOverCapacity_ = 1D;
+        onChanged();
+        return this;
+      }
+
+      // optional uint32 killOldTasksDelaySeconds = 3 [default = 0];
+      private int killOldTasksDelaySeconds_ ;
+      /**
+       * <code>optional uint32 killOldTasksDelaySeconds = 3 [default = 0];</code>
+       */
+      public boolean hasKillOldTasksDelaySeconds() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional uint32 killOldTasksDelaySeconds = 3 [default = 0];</code>
+       */
+      public int getKillOldTasksDelaySeconds() {
+        return killOldTasksDelaySeconds_;
+      }
+      /**
+       * <code>optional uint32 killOldTasksDelaySeconds = 3 [default = 0];</code>
+       */
+      public Builder setKillOldTasksDelaySeconds(int value) {
+        bitField0_ |= 0x00000004;
+        killOldTasksDelaySeconds_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 killOldTasksDelaySeconds = 3 [default = 0];</code>
+       */
+      public Builder clearKillOldTasksDelaySeconds() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        killOldTasksDelaySeconds_ = 0;
         onChanged();
         return this;
       }
@@ -21374,25 +21455,26 @@ public final class Protos {
       " \001(\t\022\027\n\014service_port\030d \001(\r:\0010\")\n\020EventSu" +
       "bscribers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016Stor" +
       "ageVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r" +
-      "\022\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefini" +
+      "\022\r\n\005patch\030\003 \002(\r\"\177\n\031UpgradeStrategyDefini" +
       "tion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023m" +
-      "aximumOverCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDef" +
-      "inition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004" +
-      "apps\030\003 \003(\0132&.mesosphere.marathon.Service" +
-      "Definition\0224\n\006groups\030\004 \003(\0132$.mesosphere.",
-      "marathon.GroupDefinition\022\024\n\014dependencies" +
-      "\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002i" +
-      "d\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002" +
-      "(\0132$.mesosphere.marathon.GroupDefinition" +
-      "\0224\n\006target\030\005 \002(\0132$.mesosphere.marathon.G" +
-      "roupDefinition\"\306\001\n\013TaskFailure\022\016\n\006app_id" +
-      "\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037" +
-      "\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007messa" +
-      "ge\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 " +
-      "\002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132",
-      "\016.mesos.SlaveID\"9\n\014ZKStoreEntry\022\014\n\004name\030" +
-      "\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014B\035\n\023me" +
-      "sosphere.marathonB\006Protos"
+      "aximumOverCapacity\030\002 \001(\001:\0011\022#\n\030killOldTa" +
+      "sksDelaySeconds\030\003 \001(\r:\0010\"\260\001\n\017GroupDefini" +
+      "tion\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004app" +
+      "s\030\003 \003(\0132&.mesosphere.marathon.ServiceDef",
+      "inition\0224\n\006groups\030\004 \003(\0132$.mesosphere.mar" +
+      "athon.GroupDefinition\022\024\n\014dependencies\030\005 " +
+      "\003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002id\030\001" +
+      " \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002(\0132" +
+      "$.mesosphere.marathon.GroupDefinition\0224\n" +
+      "\006target\030\005 \002(\0132$.mesosphere.marathon.Grou" +
+      "pDefinition\"\306\001\n\013TaskFailure\022\016\n\006app_id\030\001 " +
+      "\002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037\n\005s" +
+      "tate\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007message\030" +
+      "\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t",
+      "\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016.m" +
+      "esos.SlaveID\"9\n\014ZKStoreEntry\022\014\n\004name\030\001 \002" +
+      "(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014B\035\n\023mesos" +
+      "phere.marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -21476,7 +21558,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor,
-              new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", });
+              new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", "KillOldTasksDelaySeconds", });
           internal_static_mesosphere_marathon_GroupDefinition_descriptor =
             getDescriptor().getMessageTypes().get(11);
           internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -150,7 +150,8 @@ message StorageVersion {
 
 message UpgradeStrategyDefinition {
   required double minimumHealthCapacity = 1;
-  optional double maximumOverCapacity = 2 [default = 1.0];;
+  optional double maximumOverCapacity = 2 [default = 1.0];
+  optional int64 killOldTasksDelaySeconds = 3 [default = 0];
 }
 
 message GroupDefinition {

--- a/src/main/scala/mesosphere/marathon/state/UpgradeStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/state/UpgradeStrategy.scala
@@ -2,18 +2,24 @@ package mesosphere.marathon.state
 
 import mesosphere.marathon.Protos._
 
-case class UpgradeStrategy(minimumHealthCapacity: Double, maximumOverCapacity: Double = 1.0) {
+import scala.concurrent.duration._
+
+case class UpgradeStrategy(minimumHealthCapacity: Double, maximumOverCapacity: Double = 1.0,
+                           killOldTasksDelay: FiniteDuration = UpgradeStrategy.DefaultKillOldTasksDelay) {
   def toProto: UpgradeStrategyDefinition = UpgradeStrategyDefinition.newBuilder
     .setMinimumHealthCapacity(minimumHealthCapacity)
     .setMaximumOverCapacity(maximumOverCapacity)
+    .setKillOldTasksDelaySeconds(killOldTasksDelay.toSeconds.toInt)
     .build
 }
 
 object UpgradeStrategy {
+  val DefaultKillOldTasksDelay = 0.seconds
   def empty: UpgradeStrategy = UpgradeStrategy(1)
   def fromProto(upgradeStrategy: UpgradeStrategyDefinition): UpgradeStrategy =
     UpgradeStrategy(
       upgradeStrategy.getMinimumHealthCapacity,
-      upgradeStrategy.getMaximumOverCapacity
+      upgradeStrategy.getMaximumOverCapacity,
+      upgradeStrategy.getKillOldTasksDelaySeconds.seconds
     )
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -169,14 +169,13 @@ private class DeploymentActor(
     else {
       val promise = Promise[Unit]()
       context.actorOf(
-        Props(
-          new TaskReplaceActor(
-            driver,
-            taskQueue,
-            taskTracker,
-            eventBus,
-            app,
-            promise)))
+        TaskReplaceActor.props(
+          driver,
+          taskQueue,
+          taskTracker,
+          eventBus,
+          app,
+          promise))
       promise.future
     }
   }

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -9,6 +9,7 @@ import org.scalatest.Matchers
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
+import scala.concurrent.duration._
 
 class AppDefinitionTest extends MarathonSpec with Matchers {
 
@@ -40,6 +41,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     assert(!proto1.hasContainer)
     assert(1.0 == proto1.getUpgradeStrategy.getMinimumHealthCapacity)
     assert(1.0 == proto1.getUpgradeStrategy.getMaximumOverCapacity)
+    assert(0 == proto1.getUpgradeStrategy.getKillOldTasksDelaySeconds)
     assert(proto1.hasAcceptedResourceRoles)
     assert(proto1.getAcceptedResourceRoles == Protos.ResourceRoles.newBuilder().addRole("a").addRole("b").build())
 
@@ -55,7 +57,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       instances = 5,
       ports = Seq(8080, 8081),
       executor = "//cmd",
-      upgradeStrategy = UpgradeStrategy(0.7, 0.4)
+      upgradeStrategy = UpgradeStrategy(0.7, 0.4, 1.seconds)
     )
 
     val proto2 = app2.toProto
@@ -71,6 +73,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     assert(proto2.hasContainer)
     assert(0.7 == proto2.getUpgradeStrategy.getMinimumHealthCapacity)
     assert(0.4 == proto2.getUpgradeStrategy.getMaximumOverCapacity)
+    assert(1 == proto2.getUpgradeStrategy.getKillOldTasksDelaySeconds)
     assert(!proto2.hasAcceptedResourceRoles)
   }
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -49,7 +49,7 @@ class TaskReplaceActorTest
     val promise = Promise[Unit]()
 
     val ref = TestActorRef(
-      new TaskReplaceActor(
+      TaskReplaceActor.props(
         driver,
         queue,
         tracker,
@@ -88,7 +88,7 @@ class TaskReplaceActorTest
     val promise = Promise[Unit]()
 
     val ref = TestActorRef(
-      new TaskReplaceActor(
+      TaskReplaceActor.props(
         driver,
         queue,
         tracker,
@@ -123,7 +123,7 @@ class TaskReplaceActorTest
     val promise = Promise[Unit]()
 
     val ref = TestActorRef(
-      new TaskReplaceActor(
+      TaskReplaceActor.props(
         driver,
         queue,
         tracker,
@@ -175,7 +175,7 @@ class TaskReplaceActorTest
     val promise = Promise[Unit]()
 
     val ref = TestActorRef(
-      new TaskReplaceActor(
+      TaskReplaceActor.props(
         driver,
         queue,
         tracker,
@@ -241,7 +241,7 @@ class TaskReplaceActorTest
     val promise = Promise[Unit]()
 
     val ref = TestActorRef(
-      new TaskReplaceActor(
+      TaskReplaceActor.props(
         driver,
         queue,
         tracker,
@@ -311,7 +311,7 @@ class TaskReplaceActorTest
     val promise = Promise[Unit]()
 
     val ref = TestActorRef(
-      new TaskReplaceActor(
+      TaskReplaceActor.props(
         driver,
         queue,
         tracker,
@@ -379,7 +379,7 @@ class TaskReplaceActorTest
     val promise = Promise[Unit]()
 
     val ref = TestActorRef(
-      new TaskReplaceActor(
+      TaskReplaceActor.props(
         driver,
         queue,
         tracker,
@@ -432,7 +432,7 @@ class TaskReplaceActorTest
     val promise = Promise[Unit]()
 
     val ref = TestActorRef(
-      new TaskReplaceActor(
+      TaskReplaceActor.props(
         driver,
         queue,
         tracker,


### PR DESCRIPTION
Added the killOldTasksDelaySeconds option to UpgradeStrategy.
The amount of time in seconds to wait before killing an old
task when a new task becomes healthy.

This only effects updates. It does not delay immediate killing
of tasks to meet the minimumHealthCapacity at the beginning of
an update.