### PR TITLE
Fixes #2352 - Update healtcheck documentation

### DIFF
--- a/docs/docs/health-checks.md
+++ b/docs/docs/health-checks.md
@@ -45,7 +45,12 @@ OR
 
 OR
 
-*Note:* Command health checks are currently not compatible with dockerized tasks. 
+*Note:* Command health checks in combination with dockerized tasks were
+broken in Mesos v0.23.0 and v0.24.0. This issue has been fixed in
+v0.23.1 and v0.24.1.
+
+See [MESOS-3136](https://issues.apache.org/jira/browse/MESOS-3136) for
+more details.
 
 ```json
 {


### PR DESCRIPTION
Docker COMMAND healthchecks were recently fixed. They patch was also
backported and release as part of Mesos v0.23.1 and v0.24.1.