### PR TITLE
AppDeployIntegrationTest: Wait for rollback deployment (releasing-0.10)

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -439,6 +439,7 @@ class AppDeployIntegrationTest
 
     Then("the deployment should be gone")
     waitForEvent("deployment_failed")
+    waitForEvent("deployment_success")
     marathon.listDeploymentsForBaseGroup().value should have size 0
 
     Then("the app should also be gone")


### PR DESCRIPTION
The rollback creates a new deployment. We have to wait for it to finish.