### PR TITLE
AppDeployIntegrationTest: Wait for rollback deployment (master)

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -535,6 +535,7 @@ class AppDeployIntegrationTest
 
     Then("the deployment should be gone")
     waitForEvent("deployment_failed")
+    waitForEvent("deployment_success")
     WaitTestSupport.waitUntil("Deployments get removed from the queue", 30.seconds) {
       marathon.listDeploymentsForBaseGroup().value.isEmpty
     }


### PR DESCRIPTION
The rollback creates a new deployment. We have to wait for it to finish.

The test already includes other code to make it more robust that waiting for the event
should speed things up.

After #2299 is implemented, we can remove the wait hack.