### PR TITLE
Upgrade Chaos to v0.7.2

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -242,7 +242,7 @@ object Dependencies {
 object Dependency {
   object V {
     // runtime deps versions
-    val Chaos = "0.7.0"
+    val Chaos = "0.7.2"
     val JacksonCCM = "0.1.2"
     val MesosUtils = "0.23.0"
     val Akka = "2.3.9"


### PR DESCRIPTION
This version includes JVM metrics and requests duration logging.