### PR TITLE
Improve LimitConcurrentRequestsFilterTest

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -276,7 +276,6 @@ case class AppDefinition(
     }
   }
 
-
   // Case class implementation of hashCode+equals is very expensive
   // We know that two apps are equal, if id and version is equals.
   override def equals(obj: Any): Boolean = {

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -183,7 +183,6 @@ case class Group(
   @JsonIgnore
   def withoutChildren: Group = copy(apps = Set.empty, groups = Set.empty)
 
-
   // Case class implementation of hashCode+equals is very expensive
   // We know that two groups are equal, if id and version is equals.
   override def equals(obj: Any): Boolean = {


### PR DESCRIPTION
the `availablePermits` test was ineffective.