### PR TITLE
Rename Group#updateApp to Group#updateApps

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -86,7 +86,7 @@ class GroupsResource @Inject() (
   }
 
   /**
-    * Create or update a group.
+    * Create a group.
     * If the path to the group does not exist, it gets created.
     * @param id is the identifier of the the group to update.
     * @param force if the change has to be forced. A running upgrade process will be halted and the new one is started.
@@ -203,7 +203,7 @@ class GroupsResource @Inject() (
         )
       }
       val scaleChange = update.scaleBy.map { scale =>
-        group.updateApp(version) { app => app.copy(instances = (app.instances * scale).ceil.toInt) }
+        group.updateApps(version) { app => app.copy(instances = (app.instances * scale).ceil.toInt) }
       }
       versionChange orElse scaleChange getOrElse update.apply(V2Group(group), version).toGroup()
     }

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -59,7 +59,7 @@ case class Group(
     }
   }
 
-  def updateApp(timestamp: Timestamp = Timestamp.now())(fn: AppDefinition => AppDefinition): Group = {
+  def updateApps(timestamp: Timestamp = Timestamp.now())(fn: AppDefinition => AppDefinition): Group = {
     update(timestamp) { group => group.copy(apps = group.apps.map(fn)) }
   }
 

--- a/src/main/scala/mesosphere/marathon/state/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupManager.scala
@@ -186,7 +186,7 @@ class GroupManager @Singleton @Inject() (
         //it will only change, if the content changes.
         val downloads = mutable.Map(paths.toSeq.filterNot{ case (url, path) => storage.item(path).exists }: _*)
         val actions = Seq.newBuilder[ResolveArtifacts]
-        group.updateApp(group.version) { app =>
+        group.updateApps(group.version) { app =>
           if (app.storeUrls.isEmpty) app else {
             val storageUrls = app.storeUrls.map(paths).map(storage.item(_).url)
             val resolved = app.copy(uris = app.uris ++ storageUrls, storeUrls = Seq.empty)


### PR DESCRIPTION
The renamed method updates all apps, not just one. There's another
Group#updateApp that will only update one app. I left that one
unchanged.

Also updated a comment int GroupsResource. POST /v2/groups/<group> does
not allow updates.