### PR TITLE
Add configurable zk node compression.

### DIFF
--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -20006,11 +20006,22 @@ public final class Protos {
      * <code>required bytes value = 3;</code>
      */
     com.google.protobuf.ByteString getValue();
+
+    // optional bool compressed = 4;
+    /**
+     * <code>optional bool compressed = 4;</code>
+     */
+    boolean hasCompressed();
+    /**
+     * <code>optional bool compressed = 4;</code>
+     */
+    boolean getCompressed();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.ZKStoreEntry}
    *
    * <pre>
+   **
    * Describes a state entry, a versioned (via a UUID) key/value pair.
    * Copied from libmesos (src/messages/state.pro) to ensure
    * compatibility with ZooKeeperState from libmesos.
@@ -20077,6 +20088,11 @@ public final class Protos {
             case 26: {
               bitField0_ |= 0x00000004;
               value_ = input.readBytes();
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000008;
+              compressed_ = input.readBool();
               break;
             }
           }
@@ -20194,10 +20210,27 @@ public final class Protos {
       return value_;
     }
 
+    // optional bool compressed = 4;
+    public static final int COMPRESSED_FIELD_NUMBER = 4;
+    private boolean compressed_;
+    /**
+     * <code>optional bool compressed = 4;</code>
+     */
+    public boolean hasCompressed() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional bool compressed = 4;</code>
+     */
+    public boolean getCompressed() {
+      return compressed_;
+    }
+
     private void initFields() {
       name_ = "";
       uuid_ = com.google.protobuf.ByteString.EMPTY;
       value_ = com.google.protobuf.ByteString.EMPTY;
+      compressed_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -20232,6 +20265,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBytes(3, value_);
       }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeBool(4, compressed_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -20252,6 +20288,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, value_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(4, compressed_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -20335,6 +20375,7 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ZKStoreEntry}
      *
      * <pre>
+     **
      * Describes a state entry, a versioned (via a UUID) key/value pair.
      * Copied from libmesos (src/messages/state.pro) to ensure
      * compatibility with ZooKeeperState from libmesos.
@@ -20381,6 +20422,8 @@ public final class Protos {
         bitField0_ = (bitField0_ & ~0x00000002);
         value_ = com.google.protobuf.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000004);
+        compressed_ = false;
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -20421,6 +20464,10 @@ public final class Protos {
           to_bitField0_ |= 0x00000004;
         }
         result.value_ = value_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.compressed_ = compressed_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -20447,6 +20494,9 @@ public final class Protos {
         }
         if (other.hasValue()) {
           setValue(other.getValue());
+        }
+        if (other.hasCompressed()) {
+          setCompressed(other.getCompressed());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -20633,6 +20683,39 @@ public final class Protos {
         return this;
       }
 
+      // optional bool compressed = 4;
+      private boolean compressed_ ;
+      /**
+       * <code>optional bool compressed = 4;</code>
+       */
+      public boolean hasCompressed() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional bool compressed = 4;</code>
+       */
+      public boolean getCompressed() {
+        return compressed_;
+      }
+      /**
+       * <code>optional bool compressed = 4;</code>
+       */
+      public Builder setCompressed(boolean value) {
+        bitField0_ |= 0x00000008;
+        compressed_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool compressed = 4;</code>
+       */
+      public Builder clearCompressed() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        compressed_ = false;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:mesosphere.marathon.ZKStoreEntry)
     }
 
@@ -20815,9 +20898,10 @@ public final class Protos {
       "\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003" +
       " \002(\0162\020.mesos.TaskState\022\021\n\007message\030\004 \001(\t:" +
       "\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\tti" +
-      "mestamp\030\007 \002(\t\"9\n\014ZKStoreEntry\022\014\n\004name\030\001 " +
-      "\002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014B\035\n\023meso" +
-      "sphere.marathonB\006Protos"
+      "mestamp\030\007 \002(\t\"M\n\014ZKStoreEntry\022\014\n\004name\030\001 " +
+      "\002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\022\n\ncomp" +
+      "ressed\030\004 \001(\010B\035\n\023mesosphere.marathonB\006Pro",
+      "tos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -20925,7 +21009,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ZKStoreEntry_descriptor,
-              new java.lang.String[] { "Name", "Uuid", "Value", });
+              new java.lang.String[] { "Name", "Uuid", "Value", "Compressed", });
           return null;
         }
       };

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -184,4 +184,5 @@ message ZKStoreEntry {
   required string name = 1;
   required bytes uuid = 2;
   required bytes value = 3;
+  optional bool compressed = 4;
 }

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -34,7 +34,7 @@ import mesosphere.marathon.upgrade.{ DeploymentManager, DeploymentPlan }
 import mesosphere.util.SerializeExecution
 import mesosphere.util.state.memory.InMemoryStore
 import mesosphere.util.state.mesos.MesosStateStore
-import mesosphere.util.state.zk.ZKStore
+import mesosphere.util.state.zk.{ CompressionConf, ZKStore }
 import mesosphere.util.state.{ FrameworkId, FrameworkIdUtil, PersistentStore }
 import org.apache.log4j.Logger
 import org.apache.mesos.state.ZooKeeperState
@@ -128,7 +128,8 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
       val client = ZkClient(connector)
         .withAcl(Ids.OPEN_ACL_UNSAFE.asScala)
         .withRetries(3)
-      new ZKStore(client, client(conf.zooKeeperStatePath))
+      val compressionConf = CompressionConf(conf.zooKeeperCompressionEnabled(), conf.zooKeeperCompressionThreshold())
+      new ZKStore(client, client(conf.zooKeeperStatePath), compressionConf)
     }
     def mesosZK(): PersistentStore = {
       val state = new ZooKeeperState(

--- a/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
+++ b/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
@@ -35,6 +35,21 @@ trait ZookeeperConf extends ScallopConf {
     default = Some(25)
   )
 
+  lazy val zooKeeperCompressionEnabled = toggle("zk_compression",
+    descrYes = "Enable compression of zk nodes, if the size of the node is bigger than the configured threshold.",
+    descrNo = "Disable compression of zk nodes",
+    noshort = true,
+    prefix = "disable_",
+    default = Some(true)
+  )
+
+  lazy val zooKeeperCompressionThreshold = opt[Long]("zk_compression_threshold",
+    descr = "Threshold in bytes, when compression is applied to the zk node (Default: 64 KB).",
+    noshort = true,
+    validate = _ >= 0,
+    default = Some(64 * 1024)
+  )
+
   def zooKeeperStatePath: String = "%s/state".format(zkPath)
   def zooKeeperLeaderPath: String = "%s/leader".format(zkPath)
   def zooKeeperServerSetPath: String = "%s/apps".format(zkPath)

--- a/src/main/scala/mesosphere/marathon/io/IO.scala
+++ b/src/main/scala/mesosphere/marathon/io/IO.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.io
 import java.io._
 import java.math.BigInteger
 import java.security.{ MessageDigest, DigestInputStream }
+import java.util.zip.{ GZIPInputStream, GZIPOutputStream }
 import scala.annotation.tailrec
 
 import com.google.common.io.ByteStreams
@@ -57,6 +58,21 @@ object IO {
     //scalastyle:off magic.number
     new BigInteger(1, md.digest()).toString(16)
     //scalastyle:on
+  }
+
+  def gzipCompress(bytes: Array[Byte]): Array[Byte] = {
+    val out = new ByteArrayOutputStream(bytes.length)
+    using(new GZIPOutputStream(out)) { gzip =>
+      gzip.write(bytes.toArray)
+      gzip.flush()
+    }
+    out.toByteArray
+  }
+
+  def gzipUncompress(bytes: Array[Byte]): Array[Byte] = {
+    using(new GZIPInputStream(new ByteArrayInputStream(bytes))) { in =>
+      ByteStreams.toByteArray(in)
+    }
   }
 
   def transfer(

--- a/src/main/scala/mesosphere/util/state/zk/ZKStore.scala
+++ b/src/main/scala/mesosphere/util/state/zk/ZKStore.scala
@@ -6,18 +6,21 @@ import com.fasterxml.uuid.impl.UUIDUtil
 import com.google.protobuf.{ ByteString, InvalidProtocolBufferException }
 import com.twitter.util.{ Future => TWFuture }
 import com.twitter.zk.{ ZNode, ZkClient }
+import mesosphere.marathon.io.IO
 import mesosphere.marathon.{ Protos, StoreCommandFailedException }
 import mesosphere.util.ThreadPoolContext
 import mesosphere.util.state.zk.ZKStore._
 import mesosphere.util.state.{ PersistentEntity, PersistentStore }
 import org.apache.log4j.Logger
 import org.apache.zookeeper.KeeperException
-import org.apache.zookeeper.KeeperException.{ NodeExistsException, NoNodeException }
+import org.apache.zookeeper.KeeperException.{ NoNodeException, NodeExistsException }
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Future, Promise }
 
-class ZKStore(val client: ZkClient, rootNode: ZNode) extends PersistentStore {
+case class CompressionConf(enabled: Boolean, sizeLimit: Long)
+
+class ZKStore(val client: ZkClient, rootNode: ZNode, compressionConf: CompressionConf) extends PersistentStore {
 
   private[this] val log = Logger.getLogger(getClass)
   private[this] implicit val ec = ThreadPoolContext.context
@@ -41,7 +44,7 @@ class ZKStore(val client: ZkClient, rootNode: ZNode) extends PersistentStore {
     val node = root(key)
     require(node.parent == root, s"Nested paths are not supported: $key")
     val data = ZKData(key, UUID.randomUUID(), content)
-    node.create(data.toProto.toByteArray).asScala
+    node.create(data.toProto(compressionConf).toByteArray).asScala
       .map { n => ZKEntity(n, data, Some(0)) } //first version after create is 0
       .recover(exceptionTransform(s"Can not create entity $key"))
   }
@@ -56,7 +59,7 @@ class ZKStore(val client: ZkClient, rootNode: ZNode) extends PersistentStore {
     val version = zk.version.getOrElse (
       throw new StoreCommandFailedException(s"Can not store entity $entity, since there is no version!")
     )
-    zk.node.setData(zk.data.toProto.toByteArray, version).asScala
+    zk.node.setData(zk.data.toProto(compressionConf).toByteArray, version).asScala
       .map { data => zk.copy(version = Some(data.stat.getVersion)) }
       .recover(exceptionTransform(s"Can not update entity $entity"))
   }
@@ -115,17 +118,25 @@ case class ZKEntity(node: ZNode, data: ZKData, version: Option[Int] = None) exte
 }
 
 case class ZKData(name: String, uuid: UUID, bytes: IndexedSeq[Byte] = Vector.empty) {
-  def toProto: Protos.ZKStoreEntry = Protos.ZKStoreEntry.newBuilder()
-    .setName(name)
-    .setUuid(ByteString.copyFromUtf8(uuid.toString))
-    .setValue(ByteString.copyFrom(bytes.toArray))
-    .build()
+  def toProto(compression: CompressionConf): Protos.ZKStoreEntry = {
+    val (data, compressed) =
+      if (compression.enabled && bytes.length > compression.sizeLimit) (IO.gzipCompress(bytes.toArray), true)
+      else (bytes.toArray, false)
+    Protos.ZKStoreEntry.newBuilder()
+      .setName(name)
+      .setUuid(ByteString.copyFromUtf8(uuid.toString))
+      .setCompressed(compressed)
+      .setValue(ByteString.copyFrom(data))
+      .build()
+  }
 }
 object ZKData {
+  import IO.{ gzipUncompress => uncompress }
   def apply(bytes: Array[Byte]): ZKData = {
     try {
       val proto = Protos.ZKStoreEntry.parseFrom(bytes)
-      new ZKData(proto.getName, UUIDUtil.uuid(proto.getUuid.toByteArray), proto.getValue.toByteArray)
+      val content = if (proto.getCompressed) uncompress(proto.getValue.toByteArray) else proto.getValue.toByteArray
+      new ZKData(proto.getName, UUIDUtil.uuid(proto.getUuid.toByteArray), content)
     }
     catch {
       case ex: InvalidProtocolBufferException =>

--- a/src/test/scala/mesosphere/marathon/io/IOTest.scala
+++ b/src/test/scala/mesosphere/marathon/io/IOTest.scala
@@ -1,0 +1,20 @@
+package mesosphere.marathon.io
+
+import mesosphere.marathon.MarathonSpec
+import org.scalatest.{ Matchers, GivenWhenThen }
+
+class IOTest extends MarathonSpec with GivenWhenThen with Matchers {
+
+  test("Compress / unCompress works") {
+    Given("A byte array")
+    val hello = 1.to(100).map(num => s"Hello number $num!").mkString(", ").getBytes("UTF-8")
+
+    When("compress and decompress")
+    val compressed = IO.gzipCompress(hello)
+    val uncompressed = IO.gzipUncompress(compressed)
+
+    Then("compressed is smaller and round trip works")
+    compressed.length should be < uncompressed.length
+    uncompressed should be(hello)
+  }
+}


### PR DESCRIPTION
Compression information is stored as part of the surrounding protobuf.
Compression can be turned on/off via cmd line flags and is enabled by default.