### PR TITLE
Add configurable zk node compression.

### DIFF
--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -20576,6 +20576,16 @@ public final class Protos {
      * <code>required bytes value = 3;</code>
      */
     com.google.protobuf.ByteString getValue();
+
+    // optional bool compressed = 4;
+    /**
+     * <code>optional bool compressed = 4;</code>
+     */
+    boolean hasCompressed();
+    /**
+     * <code>optional bool compressed = 4;</code>
+     */
+    boolean getCompressed();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.ZKStoreEntry}
@@ -20648,6 +20658,11 @@ public final class Protos {
             case 26: {
               bitField0_ |= 0x00000004;
               value_ = input.readBytes();
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000008;
+              compressed_ = input.readBool();
               break;
             }
           }
@@ -20765,10 +20780,27 @@ public final class Protos {
       return value_;
     }
 
+    // optional bool compressed = 4;
+    public static final int COMPRESSED_FIELD_NUMBER = 4;
+    private boolean compressed_;
+    /**
+     * <code>optional bool compressed = 4;</code>
+     */
+    public boolean hasCompressed() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional bool compressed = 4;</code>
+     */
+    public boolean getCompressed() {
+      return compressed_;
+    }
+
     private void initFields() {
       name_ = "";
       uuid_ = com.google.protobuf.ByteString.EMPTY;
       value_ = com.google.protobuf.ByteString.EMPTY;
+      compressed_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -20803,6 +20835,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBytes(3, value_);
       }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeBool(4, compressed_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -20823,6 +20858,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, value_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(4, compressed_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -20953,6 +20992,8 @@ public final class Protos {
         bitField0_ = (bitField0_ & ~0x00000002);
         value_ = com.google.protobuf.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000004);
+        compressed_ = false;
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -20993,6 +21034,10 @@ public final class Protos {
           to_bitField0_ |= 0x00000004;
         }
         result.value_ = value_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.compressed_ = compressed_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -21019,6 +21064,9 @@ public final class Protos {
         }
         if (other.hasValue()) {
           setValue(other.getValue());
+        }
+        if (other.hasCompressed()) {
+          setCompressed(other.getCompressed());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -21201,6 +21249,39 @@ public final class Protos {
       public Builder clearValue() {
         bitField0_ = (bitField0_ & ~0x00000004);
         value_ = getDefaultInstance().getValue();
+        onChanged();
+        return this;
+      }
+
+      // optional bool compressed = 4;
+      private boolean compressed_ ;
+      /**
+       * <code>optional bool compressed = 4;</code>
+       */
+      public boolean hasCompressed() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional bool compressed = 4;</code>
+       */
+      public boolean getCompressed() {
+        return compressed_;
+      }
+      /**
+       * <code>optional bool compressed = 4;</code>
+       */
+      public Builder setCompressed(boolean value) {
+        bitField0_ |= 0x00000008;
+        compressed_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool compressed = 4;</code>
+       */
+      public Builder clearCompressed() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        compressed_ = false;
         onChanged();
         return this;
       }
@@ -21390,9 +21471,10 @@ public final class Protos {
       "\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007messa" +
       "ge\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 " +
       "\002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132",
-      "\016.mesos.SlaveID\"9\n\014ZKStoreEntry\022\014\n\004name\030" +
-      "\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014B\035\n\023me" +
-      "sosphere.marathonB\006Protos"
+      "\016.mesos.SlaveID\"M\n\014ZKStoreEntry\022\014\n\004name\030" +
+      "\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\022\n\nco" +
+      "mpressed\030\004 \001(\010B\035\n\023mesosphere.marathonB\006P" +
+      "rotos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -21500,7 +21582,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ZKStoreEntry_descriptor,
-              new java.lang.String[] { "Name", "Uuid", "Value", });
+              new java.lang.String[] { "Name", "Uuid", "Value", "Compressed", });
           return null;
         }
       };

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -188,4 +188,5 @@ message ZKStoreEntry {
   required string name = 1;
   required bytes uuid = 2;
   required bytes value = 3;
+  optional bool compressed = 4;
 }

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -28,10 +28,10 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.{ TaskIdUtil, TaskTracker, _ }
 import mesosphere.marathon.upgrade.{ DeploymentManager, DeploymentPlan }
 import mesosphere.util.SerializeExecution
-import mesosphere.util.state._
 import mesosphere.util.state.memory.InMemoryStore
 import mesosphere.util.state.mesos.MesosStateStore
-import mesosphere.util.state.zk.ZKStore
+import mesosphere.util.state.zk.{ CompressionConf, ZKStore }
+import mesosphere.util.state.{ FrameworkId, FrameworkIdUtil, PersistentStore, _ }
 import org.apache.mesos.state.ZooKeeperState
 import org.apache.zookeeper.ZooDefs
 import org.apache.zookeeper.ZooDefs.Ids
@@ -126,7 +126,8 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
       val client = ZkClient(connector)
         .withAcl(Ids.OPEN_ACL_UNSAFE.asScala)
         .withRetries(3)
-      new ZKStore(client, client(conf.zooKeeperStatePath))
+      val compressionConf = CompressionConf(conf.zooKeeperCompressionEnabled(), conf.zooKeeperCompressionThreshold())
+      new ZKStore(client, client(conf.zooKeeperStatePath), compressionConf)
     }
     def mesosZK(): PersistentStore = {
       val state = new ZooKeeperState(

--- a/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
+++ b/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
@@ -35,6 +35,21 @@ trait ZookeeperConf extends ScallopConf {
     default = Some(25)
   )
 
+  lazy val zooKeeperCompressionEnabled = toggle("zk_compression",
+    descrYes = "Enable compression of zk nodes, if the size of the node is bigger than the configured threshold.",
+    descrNo = "Disable compression of zk nodes",
+    noshort = true,
+    prefix = "disable_",
+    default = Some(true)
+  )
+
+  lazy val zooKeeperCompressionThreshold = opt[Long]("zk_compression_threshold",
+    descr = "Threshold in bytes, when compression is applied to the zk node (Default: 64 KB).",
+    noshort = true,
+    validate = _ >= 0,
+    default = Some(64 * 1024)
+  )
+
   def zooKeeperStatePath: String = "%s/state".format(zkPath)
   def zooKeeperLeaderPath: String = "%s/leader".format(zkPath)
   def zooKeeperServerSetPath: String = "%s/apps".format(zkPath)

--- a/src/main/scala/mesosphere/marathon/io/IO.scala
+++ b/src/main/scala/mesosphere/marathon/io/IO.scala
@@ -2,8 +2,9 @@ package mesosphere.marathon.io
 
 import java.io._
 import java.math.BigInteger
-import java.nio.file.{ Files, Paths, Path }
+import java.nio.file.{ Files, Path, Paths }
 import java.security.{ DigestInputStream, MessageDigest }
+import java.util.zip.{ GZIPInputStream, GZIPOutputStream }
 
 import com.google.common.io.ByteStreams
 
@@ -68,6 +69,21 @@ object IO {
     //scalastyle:off magic.number
     new BigInteger(1, md.digest()).toString(16)
     //scalastyle:on
+  }
+
+  def gzipCompress(bytes: Array[Byte]): Array[Byte] = {
+    val out = new ByteArrayOutputStream(bytes.length)
+    using(new GZIPOutputStream(out)) { gzip =>
+      gzip.write(bytes.toArray)
+      gzip.flush()
+    }
+    out.toByteArray
+  }
+
+  def gzipUncompress(bytes: Array[Byte]): Array[Byte] = {
+    using(new GZIPInputStream(new ByteArrayInputStream(bytes))) { in =>
+      ByteStreams.toByteArray(in)
+    }
   }
 
   def transfer(

--- a/src/test/scala/mesosphere/marathon/io/IOTest.scala
+++ b/src/test/scala/mesosphere/marathon/io/IOTest.scala
@@ -1,0 +1,20 @@
+package mesosphere.marathon.io
+
+import mesosphere.marathon.MarathonSpec
+import org.scalatest.{ Matchers, GivenWhenThen }
+
+class IOTest extends MarathonSpec with GivenWhenThen with Matchers {
+
+  test("Compress / unCompress works") {
+    Given("A byte array")
+    val hello = 1.to(100).map(num => s"Hello number $num!").mkString(", ").getBytes("UTF-8")
+
+    When("compress and decompress")
+    val compressed = IO.gzipCompress(hello)
+    val uncompressed = IO.gzipUncompress(compressed)
+
+    Then("compressed is smaller and round trip works")
+    compressed.length should be < uncompressed.length
+    uncompressed should be(hello)
+  }
+}


### PR DESCRIPTION
Compression information is stored as part of the surrounding protobuf.
Compression can be turned on/off via cmd line flags and is enabled by default.

(cherry picked from commit f68215974c8f6f765c060dcb09a15019daa50416)

Created this PR, because there were lots of conflicts.