### PR TITLE
Use chaos version 0.8.1.

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -274,7 +274,7 @@ object Dependencies {
 object Dependency {
   object V {
     // runtime deps versions
-    val Chaos = "0.8.0"
+    val Chaos = "0.8.1"
     val JacksonCCM = "0.1.2"
     val MesosUtils = "0.24.0"
     val Akka = "2.3.9"


### PR DESCRIPTION
Can you make sure, the response times are in the log?

Tried 2 requests. The first one has an additional number (response time?). Why not both?
Related: is it possible to remove the time stamp - it is included twice?
```
marathon [2015-10-14 09:59:45,656] INFO 0:0:0:0:0:0:0:1 - - [14/Okt/2015:07:59:45 +0000] "GET //localhost:8080/v2/apps HTTP/1.1" 200 1449010 "-" "HTTPie/0.9.2" 13 (mesosphere.chaos.http.ChaosRequestLog$$EnhancerByGuice$$68f42fa6:qtp1598898814-33)
marathon [2015-10-14 10:02:22,595] INFO 0:0:0:0:0:0:0:1 - - [14/Okt/2015:08:02:22 +0000] "GET //localhost:8080/ui/ HTTP/1.1" 200 395 "-" "HTTPie/0.9.2"  (mesosphere.chaos.http.ChaosRequestLog$$EnhancerByGuice$$68f42fa6:qtp1598898814-33)
```
