### PR TITLE
Dockerfile*: Separate resolving dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,15 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     apt-get update && \
     apt-get install --no-install-recommends -y --force-yes mesos=0.23.0-1.0.debian81 sbt
 
-COPY . /marathon
 WORKDIR /marathon
+
+# The build configuration including dependencies changes
+# less frequently than the source code. By separating
+# these steps we can greatly speed up cached local docker builds
+COPY project /marathon/project
+RUN sbt update test:update
+
+COPY . /marathon
 
 RUN sbt -Dsbt.log.format=false assembly && \
     mv $(find target -name 'marathon-assembly-*.jar' | sort | tail -1) ./ && \

--- a/Dockerfile.build-base
+++ b/Dockerfile.build-base
@@ -6,5 +6,12 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     apt-get update && \
     apt-get install --no-install-recommends -y --force-yes mesos=0.23.0-1.0.debian81 sbt
 
-COPY . /marathon
 WORKDIR /marathon
+
+# The build configuration including dependencies changes
+# less frequently than the source code. By separating
+# these steps we can greatly speed up cached local docker builds.
+COPY project /marathon/project
+RUN sbt update test:update
+
+COPY . /marathon


### PR DESCRIPTION
from the rest of the build to speed up local cached builds.

not essential but helps while testing