### PR TITLE
Update Marathon for Mesos 0.25.0.

### DIFF
--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
@@ -46,6 +46,8 @@ class SimulatedDriver(driverProps: Props) extends SchedulerDriver {
     driverCmd(DriverActor.ReconcileTask(statuses.toSeq))
   }
 
+  override def suppressOffers(): Status = driverCmd(DriverActor.SuppressOffers)
+
   override def reviveOffers(): Status = driverCmd(DriverActor.ReviveOffers)
 
   override def declineOffer(offerId: OfferID, filters: Filters): Status = Status.DRIVER_RUNNING

--- a/project/build.scala
+++ b/project/build.scala
@@ -276,7 +276,7 @@ object Dependency {
     // runtime deps versions
     val Chaos = "0.8.1"
     val JacksonCCM = "0.1.2"
-    val MesosUtils = "0.24.0"
+    val MesosUtils = "0.25.0"
     val Akka = "2.3.9"
     val Spray = "1.3.2"
     val TwitterCommons = "0.0.76"

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -20584,7 +20584,7 @@ public final class Protos {
      * <pre>
      * This flag indicates, if the byte array in value is gzip compressed
      * Introduced in Marathon 0.12
-     * Optional to be backward compatible and also with mesos zk storage.
+     * Optional to be backward compatible
      * </pre>
      */
     boolean hasCompressed();
@@ -20594,7 +20594,7 @@ public final class Protos {
      * <pre>
      * This flag indicates, if the byte array in value is gzip compressed
      * Introduced in Marathon 0.12
-     * Optional to be backward compatible and also with mesos zk storage.
+     * Optional to be backward compatible
      * </pre>
      */
     boolean getCompressed();
@@ -20801,7 +20801,7 @@ public final class Protos {
      * <pre>
      * This flag indicates, if the byte array in value is gzip compressed
      * Introduced in Marathon 0.12
-     * Optional to be backward compatible and also with mesos zk storage.
+     * Optional to be backward compatible
      * </pre>
      */
     public boolean hasCompressed() {
@@ -20813,7 +20813,7 @@ public final class Protos {
      * <pre>
      * This flag indicates, if the byte array in value is gzip compressed
      * Introduced in Marathon 0.12
-     * Optional to be backward compatible and also with mesos zk storage.
+     * Optional to be backward compatible
      * </pre>
      */
     public boolean getCompressed() {
@@ -21285,7 +21285,7 @@ public final class Protos {
        * <pre>
        * This flag indicates, if the byte array in value is gzip compressed
        * Introduced in Marathon 0.12
-       * Optional to be backward compatible and also with mesos zk storage.
+       * Optional to be backward compatible
        * </pre>
        */
       public boolean hasCompressed() {
@@ -21297,7 +21297,7 @@ public final class Protos {
        * <pre>
        * This flag indicates, if the byte array in value is gzip compressed
        * Introduced in Marathon 0.12
-       * Optional to be backward compatible and also with mesos zk storage.
+       * Optional to be backward compatible
        * </pre>
        */
       public boolean getCompressed() {
@@ -21309,7 +21309,7 @@ public final class Protos {
        * <pre>
        * This flag indicates, if the byte array in value is gzip compressed
        * Introduced in Marathon 0.12
-       * Optional to be backward compatible and also with mesos zk storage.
+       * Optional to be backward compatible
        * </pre>
        */
       public Builder setCompressed(boolean value) {
@@ -21324,7 +21324,7 @@ public final class Protos {
        * <pre>
        * This flag indicates, if the byte array in value is gzip compressed
        * Introduced in Marathon 0.12
-       * Optional to be backward compatible and also with mesos zk storage.
+       * Optional to be backward compatible
        * </pre>
        */
       public Builder clearCompressed() {

--- a/src/main/proto/mesos/mesos.proto
+++ b/src/main/proto/mesos/mesos.proto
@@ -94,52 +94,198 @@ message ContainerID {
 
 
 /**
- * Describes a framework. The user field is used to determine the
- * Unix user that an executor/task should be launched as. If the user
- * field is set to an empty string Mesos will automagically set it
- * to the current user. Note that the ID is only available after a
- * framework has registered, however, it is included here in order to
- * facilitate scheduler failover (i.e., if it is set then the
- * MesosSchedulerDriver expects the scheduler is performing failover).
- * The amount of time that the master will wait for the scheduler to
- * failover before removing the framework is specified by
- * failover_timeout. If checkpoint is set, framework pid, executor
- * pids and status updates are checkpointed to disk by the slaves.
- * Checkpointing allows a restarted slave to reconnect with old
- * executors and recover status updates, at the cost of disk I/O.
- * The role field is used to group frameworks for allocation
- * decisions, depending on the allocation policy being used.
- * If the hostname field is set to an empty string Mesos will
- * automagically set it to the current hostname.
- * The principal field should match the credential the framework uses
- * in authentication. This field is used for framework API rate
- * exporting and limiting and should be set even if authentication is
- * not enabled if these features are desired.
- * The webui_url field allows a framework to advertise its web UI, so
- * that the Mesos web UI can link to it. It is expected to be a full
- * URL, for example http://my-scheduler.example.com:8080/.
+ * Represents time since the epoch, in nanoseconds.
+ */
+message TimeInfo {
+  required int64 nanoseconds = 1;
+
+  // TODO(josephw): Add time zone information, if necessary.
+}
+
+
+/**
+ * Represents duration in nanoseconds.
+ */
+message DurationInfo {
+  required int64 nanoseconds = 1;
+}
+
+
+/**
+ * A network address.
+ *
+ * TODO(bmahler): Use this more widely.
+ */
+message Address {
+  // May contain a hostname, IP address, or both.
+  optional string hostname = 1;
+  optional string ip = 2;
+
+  required int32 port = 3;
+}
+
+
+/**
+ * Represents a URL.
+ */
+message URL {
+  required string scheme = 1;
+  required Address address = 2;
+  optional string path = 3;
+  repeated Parameter query = 4;
+  optional string fragment = 5;
+}
+
+
+/**
+ * Represents an interval, from a given start time over a given duration.
+ * This interval pertains to an unavailability event, such as maintenance,
+ * and is not a generic interval.
+ */
+message Unavailability {
+  required TimeInfo start = 1;
+
+  // When added to `start`, this represents the end of the interval.
+  // If unspecified, the duration is assumed to be infinite.
+  optional DurationInfo duration = 2;
+
+  // TODO(josephw): Add additional fields for expressing the purpose and
+  // urgency of the unavailability event.
+}
+
+
+/**
+ * Represents a single machine, which may hold one or more slaves.
+ *
+ * NOTE: In order to match a slave to a machine, both the `hostname` and
+ * `ip` must match the values advertised by the slave to the master.
+ * Hostname is not case-sensitive.
+ */
+message MachineID {
+  optional string hostname = 1;
+  optional string ip = 2;
+}
+
+
+/**
+ * Holds information about a single machine, its `mode`, and any other
+ * relevant information which may affect the behavior of the machine.
+ */
+message MachineInfo {
+  // Describes the several states that a machine can be in.  A `Mode`
+  // applies to a machine and to all associated slaves on the machine.
+  enum Mode {
+    // In this mode, a machine is behaving normally;
+    // offering resources, executing tasks, etc.
+    UP = 1;
+
+    // In this mode, all slaves on the machine are expected to cooperate with
+    // frameworks to drain resources.  In general, draining is done ahead of
+    // a pending `unavailability`.  The resources should be drained so as to
+    // maximize utilization prior to the maintenance but without knowingly
+    // violating the frameworks' requirements.
+    DRAINING = 2;
+
+    // In this mode, a machine is not running any tasks and will not offer
+    // any of its resources.  Slaves on the machine will not be allowed to
+    // register with the master.
+    DOWN = 3;
+  }
+
+  required MachineID id = 1;
+  optional Mode mode = 2;
+
+  // Signifies that the machine may be unavailable during the given interval.
+  // See comments in `Unavailability` and for the `unavailability` fields
+  // in `Offer` and `InverseOffer` for more information.
+  optional Unavailability unavailability = 3;
+}
+
+
+/**
+ * Describes a framework.
  */
 message FrameworkInfo {
+  // Used to determine the Unix user that an executor or task should
+  // be launched as. If the user field is set to an empty string Mesos
+  // will automagically set it to the current user.
   required string user = 1;
+
+  // Name of the framework that shows up in the Mesos Web UI.
   required string name = 2;
+
+  // Note that 'id' is only available after a framework has
+  // registered, however, it is included here in order to facilitate
+  // scheduler failover (i.e., if it is set then the
+  // MesosSchedulerDriver expects the scheduler is performing
+  // failover).
   optional FrameworkID id = 3;
+
+  // The amount of time that the master will wait for the scheduler to
+  // failover before it tears down the framework by killing all its
+  // tasks/executors. This should be non-zero if a framework expects
+  // to reconnect after a failover and not lose its tasks/executors.
   optional double failover_timeout = 4 [default = 0.0];
+
+  // If set, framework pid, executor pids and status updates are
+  // checkpointed to disk by the slaves. Checkpointing allows a
+  // restarted slave to reconnect with old executors and recover
+  // status updates, at the cost of disk I/O.
   optional bool checkpoint = 5 [default = false];
+
+  // Used to group frameworks for allocation decisions, depending on
+  // the allocation policy being used.
   optional string role = 6 [default = "*"];
+
+  // Used to indicate the current host from which the scheduler is
+  // registered in the Mesos Web UI. If set to an empty string Mesos
+  // will automagically set it to the current hostname if one is
+  // available.
   optional string hostname = 7;
+
+  // This field should match the credential's principal the framework
+  // uses for authentication. This field is used for framework API
+  // rate limiting and dynamic reservations. It should be set even
+  // if authentication is not enabled if these features are desired.
   optional string principal = 8;
+
+  // This field allows a framework to advertise its web UI, so that
+  // the Mesos web UI can link to it. It is expected to be a full URL,
+  // for example http://my-scheduler.example.com:8080/.
   optional string webui_url = 9;
+
+  message Capability {
+    enum Type {
+      // Receive offers with revocable resources. See 'Resource'
+      // message for details.
+      // TODO(vinod): This is currently a no-op.
+      REVOCABLE_RESOURCES = 1;
+    }
+
+    required Type type = 1;
+  }
+
+  // This field allows a framework to advertise its set of
+  // capabilities (e.g., ability to receive offers for revocable
+  // resources).
+  repeated Capability capabilities = 10;
+
+  // Labels are free-form key value pairs supplied by the framework
+  // scheduler (e.g., to describe additional functionality offered by
+  // the framework). These labels are not interpreted by Mesos itself.
+  optional Labels labels = 11;
 }
 
 
 /**
  * Describes a health check for a task or executor (or any arbitrary
  * process/command). A "strategy" is picked by specifying one of the
- * optional fields, currently only 'http' and 'command' are
- * supported. Specifying more than one strategy is an error.
+ * optional fields; currently only 'command' is supported.
+ * Specifying more than one strategy is an error.
  */
 message HealthCheck {
-  // Describes an HTTP health check.
+  // Describes an HTTP health check. This is not fully implemented and not
+  // recommended for use - see MESOS-2533.
   message HTTP {
     // Port to send the HTTP request.
     required uint32 port = 1;
@@ -159,6 +305,7 @@ message HealthCheck {
     // for specific data in the response.
   }
 
+  // HTTP health check - not yet recommended for use, see MESOS-2533.
   optional HTTP http = 1;
 
   // TODO(benh): Consider adding a URL health check strategy which
@@ -166,12 +313,7 @@ message HealthCheck {
   // encapsulates all the details in a single string field.
 
   // TODO(benh): Other possible health check strategies could include
-  // one for TCP/UDP or a "command". A "command" could be running a
-  // (shell) command to check the healthiness. We'd need to determine
-  // what arguments (or environment variables) we'd want to set so
-  // that the command could do it's job (i.e., do we want to expose
-  // the stdout/stderr and/or the pid to make checking for healthiness
-  // easier).
+  // one for TCP/UDP.
 
   // Amount of time to wait until starting the health checks.
   optional double delay_seconds = 2 [default = 15.0];
@@ -207,7 +349,24 @@ message CommandInfo {
   message URI {
     required string value = 1;
     optional bool executable = 2;
+
+    // In case the fetched file is recognized as an archive, extract
+    // its contents into the sandbox. Note that a cached archive is
+    // not copied from the cache to the sandbox in case extraction
+    // originates from an archive in the cache.
     optional bool extract = 3 [default = true];
+
+    // If this field is "true", the fetcher cache will be used. If not,
+    // fetching bypasses the cache and downloads directly into the
+    // sandbox directory, no matter whether a suitable cache file is
+    // available or not. The former directs the fetcher to download to
+    // the file cache, then copy from there to the sandbox. Subsequent
+    // fetch attempts with the same URI will omit downloading and copy
+    // from the cache as long as the file is resident there. Cache files
+    // may get evicted at any time, which then leads to renewed
+    // downloading. See also "docs/fetcher.md" and
+    // "docs/fetcher-cache-internals.md".
+    optional bool cache = 4;
   }
 
   // Describes a container.
@@ -298,10 +457,35 @@ message ExecutorInfo {
  */
 message MasterInfo {
   required string id = 1;
+
+  // The IP address (only IPv4) as a packed 4-bytes integer,
+  // stored in network order.  Deprecated, use `address.ip` instead.
   required uint32 ip = 2;
+
+  // The TCP port the Master is listening on for incoming
+  // HTTP requests; deprecated, use `address.port` instead.
   required uint32 port = 3 [default = 5050];
+
+  // In the default implementation, this will contain information
+  // about both the IP address, port and Master name; it should really
+  // not be relied upon by external tooling/frameworks and be
+  // considered an "internal" implementation field.
   optional string pid = 4;
+
+  // The server's hostname, if available; it may be unreliable
+  // in environments where the DNS configuration does not resolve
+  // internal hostnames (eg, some public cloud providers).
+  // Deprecated, use `address.hostname` instead.
   optional string hostname = 5;
+
+  // The running Master version, as a string; taken from the
+  // generated "master/version.hpp".
+  optional string version = 6;
+
+  // The full IP address (supports both IPv4 and IPv6 formats)
+  // and supersedes the use of `ip`, `port` and `hostname`.
+  // Since Mesos 0.24.
+  optional Address address = 7;
 }
 
 
@@ -318,6 +502,8 @@ message SlaveInfo {
   repeated Resource resources = 3;
   repeated Attribute attributes = 5;
   optional SlaveID id = 6;
+  // TODO(joerg84): Remove checkpoint field as with 0.22.0
+  // slave checkpointing is enabled for all slaves (MESOS-2317).
   optional bool checkpoint = 7 [default = false];
 }
 
@@ -395,6 +581,28 @@ message Resource {
   optional Value.Set set = 5;
   optional string role = 6 [default = "*"];
 
+  message ReservationInfo {
+    // Describes a dynamic reservation. A dynamic reservation is
+    // acquired by an operator via the '/reserve' HTTP endpoint or by
+    // a framework via the offer cycle by sending back an
+    // 'Offer::Operation::Reserve' message.
+    // NOTE: We currently do not allow frameworks with role "*" to
+    // make dynamic reservations.
+
+    // This field indicates the principal of the operator or framework
+    // that reserved this resource. It is used in conjunction with the
+    // "unreserve" ACL to determine whether the entity attempting to
+    // unreserve this resource is permitted to do so.
+    // NOTE: This field should match the FrameworkInfo.principal of
+    // the framework that reserved this resource.
+    required string principal = 1;
+  }
+
+  // If this is set, this resource was dynamically reserved by an
+  // operator or a framework. Otherwise, this resource is either unreserved
+  // or statically reserved by an operator via the --resources flag.
+  optional ReservationInfo reservation = 8;
+
   message DiskInfo {
     // Describes a persistent disk volume.
     // A persistent disk volume will not be automatically garbage
@@ -428,14 +636,65 @@ message Resource {
   }
 
   optional DiskInfo disk = 7;
+
+  message RevocableInfo {}
+
+  // If this is set, the resources are revocable, i.e., any tasks or
+  // executors launched using these resources could get preempted or
+  // throttled at any time. This could be used by frameworks to run
+  // best effort tasks that do not need strict uptime or performance
+  // guarantees. Note that if this is set, 'disk' or 'reservation'
+  // cannot be set.
+  optional RevocableInfo revocable = 9;
+}
+
+/**
+ * When the network bandwidth caps are enabled and the container
+ * is over its limit, outbound packets may be either delayed or
+ * dropped completely either because it exceeds the maximum bandwidth
+ * allocation for a single container (the cap) or because the combined
+ * network traffic of multiple containers on the host exceeds the
+ * transmit capacity of the host (the share). We can report the
+ * following statistics for each of these conditions exported directly
+ * from the Linux Traffic Control Queueing Discipline.
+ *
+ * id         : name of the limiter, e.g. 'tx_bw_cap'
+ * backlog    : number of packets currently delayed
+ * bytes      : total bytes seen
+ * drops      : number of packets dropped in total
+ * overlimits : number of packets which exceeded allocation
+ * packets    : total packets seen
+ * qlen       : number of packets currently queued
+ * rate_bps   : throughput in bytes/sec
+ * rate_pps   : throughput in packets/sec
+ * requeues   : number of times a packet has been delayed due to
+ *              locking or device contention issues
+ *
+ * More information on the operation of Linux Traffic Control can be
+ * found at http://www.lartc.org/lartc.html.
+ */
+message TrafficControlStatistics {
+  required string id = 1;
+  optional uint64 backlog = 2;
+  optional uint64 bytes = 3;
+  optional uint64 drops = 4;
+  optional uint64 overlimits = 5;
+  optional uint64 packets = 6;
+  optional uint64 qlen = 7;
+  optional uint64 ratebps = 8;
+  optional uint64 ratepps = 9;
+  optional uint64 requeues = 10;
 }
 
 
-/*
+/**
  * A snapshot of resource usage statistics.
  */
 message ResourceStatistics {
   required double timestamp = 1; // Snapshot time, in seconds since the Epoch.
+
+  optional uint32 processes = 30;
+  optional uint32 threads = 31;
 
   // CPU Usage Information:
   // Total CPU time spent in user mode, and kernel mode.
@@ -451,15 +710,52 @@ message ResourceStatistics {
   optional double cpus_throttled_time_secs = 9;
 
   // Memory Usage Information:
-  optional uint64 mem_rss_bytes = 5; // Resident Set Size.
 
-  // Amount of memory resources allocated.
+  // mem_total_bytes was added in 0.23.0 to represent the total memory
+  // of a process in RAM (as opposed to in Swap). This was previously
+  // reported as mem_rss_bytes, which was also changed in 0.23.0 to
+  // represent only the anonymous memory usage, to keep in sync with
+  // Linux kernel's (arguably erroneous) use of terminology.
+  optional uint64 mem_total_bytes = 36;
+
+  // Total memory + swap usage. This is set if swap is enabled.
+  optional uint64 mem_total_memsw_bytes = 37;
+
+  // Hard memory limit for a container.
   optional uint64 mem_limit_bytes = 6;
 
-  // Broken out memory usage information (files, anonymous, and mmaped files)
+  // Soft memory limit for a container.
+  optional uint64 mem_soft_limit_bytes = 38;
+
+  // Broken out memory usage information: pagecache, rss (anonymous),
+  // mmaped files and swap.
+
+  // TODO(chzhcn) mem_file_bytes and mem_anon_bytes are deprecated in
+  // 0.23.0 and will be removed in 0.24.0.
   optional uint64 mem_file_bytes = 10;
   optional uint64 mem_anon_bytes = 11;
+
+  // mem_cache_bytes is added in 0.23.0 to represent page cache usage.
+  optional uint64 mem_cache_bytes = 39;
+
+  // Since 0.23.0, mem_rss_bytes is changed to represent only
+  // anonymous memory usage. Note that neither its requiredness, type,
+  // name nor numeric tag has been changed.
+  optional uint64 mem_rss_bytes = 5;
+
   optional uint64 mem_mapped_file_bytes = 12;
+  // This is only set if swap is enabled.
+  optional uint64 mem_swap_bytes = 40;
+  optional uint64 mem_unevictable_bytes = 41;
+
+  // Number of occurrences of different levels of memory pressure
+  // events reported by memory cgroup. Pressure listening (re)starts
+  // with these values set to 0 when slave (re)starts. See
+  // https://www.kernel.org/doc/Documentation/cgroups/memory.txt for
+  // more details.
+  optional uint64 mem_low_pressure_counter = 32;
+  optional uint64 mem_medium_pressure_counter = 33;
+  optional uint64 mem_critical_pressure_counter = 34;
 
   // Disk Usage Information for executor working directory.
   optional uint64 disk_limit_bytes = 26;
@@ -487,34 +783,38 @@ message ResourceStatistics {
 
   optional double net_tcp_active_connections = 28;
   optional double net_tcp_time_wait_connections = 29;
+
+  // Network traffic flowing into or out of a container can be delayed
+  // or dropped due to congestion or policy inside and outside the
+  // container.
+  repeated TrafficControlStatistics net_traffic_control_statistics = 35;
 }
 
 
 /**
- * Describes a snapshot of the resource usage for an executor.
- *
- * TODO(bmahler): Note that we want to be sending this information
- * to the master, and subsequently to the relevant scheduler. So
- * this proto is designed to be easy for the scheduler to use, this
- * is why we provide the slave id, executor info / task info.
+ * Describes a snapshot of the resource usage for executors.
  */
 message ResourceUsage {
-  required SlaveID slave_id = 1;
-  required FrameworkID framework_id = 2;
+  message Executor {
+    required ExecutorInfo executor_info = 1;
 
-  // Resource usage is for an executor. For tasks launched with
-  // an explicit executor, the executor id is provided. For tasks
-  // launched without an executor, our internal executor will be
-  // used. In this case, we provide the task id here instead, in
-  // order to make this message easier for schedulers to work with.
+    // This includes resources used by the executor itself
+    // as well as its active tasks.
+    repeated Resource allocated = 2;
 
-  optional ExecutorID executor_id = 3; // If present, this executor was
-  optional string executor_name = 4;   // explicitly specified.
+    // Current resource usage. If absent, the containerizer
+    // cannot provide resource usage.
+    optional ResourceStatistics statistics = 3;
 
-  optional TaskID task_id = 5; // If present, the task did not have an executor.
+    // The container id for the executor specified in the executor_info field.
+    required ContainerID container_id = 4;
+  }
 
-  // If missing, the isolation module cannot provide resource usage.
-  optional ResourceStatistics statistics = 6;
+  repeated Executor executors = 1;
+
+  // Slave's total resources including checkpointed dynamic
+  // reservations and persistent volumes.
+  repeated Resource total = 2;
 }
 
 
@@ -614,9 +914,25 @@ message Offer {
   required FrameworkID framework_id = 2;
   required SlaveID slave_id = 3;
   required string hostname = 4;
+
+  // URL for reaching the slave running on the host.
+  optional URL url = 8;
+
   repeated Resource resources = 5;
   repeated Attribute attributes = 7;
   repeated ExecutorID executor_ids = 6;
+
+  // Signifies that the resources in this Offer may be unavailable during
+  // the given interval.  Any tasks launched using these resources may be
+  // killed when the interval arrives.  For example, these resources may be
+  // part of a planned maintenance schedule.
+  //
+  // This field only provides information about a planned unavailability.
+  // The unavailability interval may not necessarily start at exactly this
+  // interval, nor last for exactly the duration of this interval.
+  // The unavailability may also be forever!  See comments in
+  // `Unavailability` for more details.
+  optional Unavailability unavailability = 9;
 
   // Defines an operation that can be performed against offers.
   message Operation {
@@ -655,6 +971,57 @@ message Offer {
     optional Create create = 5;
     optional Destroy destroy = 6;
   }
+}
+
+
+/**
+ * A request to return some resources occupied by a framework.
+ */
+message InverseOffer {
+  // This is the same OfferID as found in normal offers, which allows
+  // re-use of some of the OfferID-only messages.
+  required OfferID id = 1;
+
+  // URL for reaching the slave running on the host.  This enables some
+  // optimizations as described in MESOS-3012, such as allowing the
+  // scheduler driver to bypass the master and talk directly with a slave.
+  optional URL url = 2;
+
+  // The framework that should release its resources.
+  // If no specifics are provided (i.e. which slave), all the framework's
+  // resources are requested back.
+  required FrameworkID framework_id = 3;
+
+  // Specified if the resources need to be released from a particular slave.
+  // All the framework's resources on this slave are requested back,
+  // unless further qualified by the `resources` field.
+  optional SlaveID slave_id = 4;
+
+  // This InverseOffer represents a planned unavailability event in the
+  // specified interval.  Any tasks running on the given framework or slave
+  // may be killed when the interval arrives.  Therefore, frameworks should
+  // aim to gracefully terminate tasks prior to the arrival of the interval.
+  //
+  // For reserved resources, the resources are expected to be returned to the
+  // framework after the unavailability interval.  This is an expectation,
+  // not a guarantee.  For example, if the unavailiability duration is not set,
+  // the resources may be removed permenantly.
+  //
+  // For other resources, there is no guarantee that requested resources will
+  // be returned after the unavailiability interval.  The allocator has no
+  // obligation to re-offer these resources to the prior framework after
+  // the unavailability.
+  required Unavailability unavailability = 5;
+
+  // A list of resources being requested back from the framework,
+  // on the slave identified by `slave_id`.  If no resources are specified
+  // then all resources are being requested back.  For the purpose of
+  // maintenance, this field is always empty (maintenance always requests
+  // all resources back).
+  repeated Resource resources = 6;
+
+  // TODO(josephw): Add additional options for narrowing down the resources
+  // being requested back.  Such as specific executors, tasks, etc.
 }
 
 
@@ -718,16 +1085,20 @@ enum TaskState {
  * Describes the current status of a task.
  */
 message TaskStatus {
-  /** Describes the source of the task status update. */
+  // Describes the source of the task status update.
   enum Source {
     SOURCE_MASTER = 0;
     SOURCE_SLAVE = 1;
     SOURCE_EXECUTOR = 2;
   }
 
-  /** Detailed reason for the task status update. */
+  // Detailed reason for the task status update.
+  //
+  // TODO(bmahler): Differentiate between slave removal reasons
+  // (e.g. unhealthy vs. unregistered for maintenance).
   enum Reason {
     REASON_COMMAND_EXECUTOR_FAILED = 0;
+    REASON_EXECUTOR_PREEMPTED = 17;
     REASON_EXECUTOR_TERMINATED = 1;
     REASON_EXECUTOR_UNREGISTERED = 2;
     REASON_FRAMEWORK_REMOVED = 3;
@@ -737,6 +1108,7 @@ message TaskStatus {
     REASON_MASTER_DISCONNECTED = 7;
     REASON_MEMORY_LIMIT = 8;
     REASON_RECONCILIATION = 9;
+    REASON_RESOURCES_UNKNOWN = 18;
     REASON_SLAVE_DISCONNECTED = 10;
     REASON_SLAVE_REMOVED = 11;
     REASON_SLAVE_RESTARTED = 12;
@@ -763,13 +1135,26 @@ message TaskStatus {
   // driver implicitly acknowledge (default).
   //
   // TODO(bmahler): This is currently overwritten in the scheduler
-  // driver, even if executors set this.
+  // driver and executor driver, but executors will need to set this
+  // to a valid RFC-4122 UUID if using the HTTP API.
   optional bytes uuid = 11;
 
   // Describes whether the task has been determined to be healthy
   // (true) or unhealthy (false) according to the HealthCheck field in
   // the command info.
   optional bool healthy = 8;
+
+  // Labels are free-form key value pairs which are exposed through
+  // master and slave endpoints. Labels will not be interpreted or
+  // acted upon by Mesos itself. As opposed to the data field, labels
+  // will be kept in memory on master and slave processes. Therefore,
+  // labels should be used to tag TaskStatus message with light-weight
+  // meta-data.
+  optional Labels labels = 12;
+
+  // Container related information that is resolved dynamically such as
+  // network address.
+  optional ContainerStatus container_status = 13;
 }
 
 
@@ -846,81 +1231,6 @@ message Credentials {
 
 
 /**
- * ACLs used for authorization.
- */
-message ACL {
-
-  // Entity is used to describe a subject(s) or an object(s) of an ACL.
-  // NOTE:
-  // To allow everyone access to an Entity set its type to 'ANY'.
-  // To deny access to an Entity set its type to 'NONE'.
-  message Entity {
-    enum Type {
-      SOME = 0;
-      ANY = 1;
-      NONE = 2;
-    }
-    optional Type type = 1 [default = SOME];
-    repeated string values = 2; // Ignored for ANY/NONE.
-  }
-
-  // ACLs.
-  message RegisterFramework {
-    // Subjects.
-    required Entity principals = 1; // Framework principals.
-
-    // Objects.
-    required Entity roles = 2; // Roles for resource offers.
-  }
-
-  message RunTask {
-    // Subjects.
-    required Entity principals = 1; // Framework principals.
-
-    // Objects.
-    required Entity users = 2; // Users to run the tasks/executors as.
-  }
-
-  // Which principals are authorized to shutdown frameworks of other
-  // principals.
-  message ShutdownFramework {
-    // Subjects.
-    required Entity principals = 1;
-
-    // Objects.
-    required Entity framework_principals = 2;
-  }
-}
-
-
-/**
- * Collection of ACL.
- *
- * Each authorization request is evaluated against the ACLs in the order
- * they are defined.
- *
- * For simplicity, the ACLs for a given action are not aggregated even
- * when they have the same subjects or objects. The first ACL that
- * matches the request determines whether that request should be
- * permitted or not. An ACL matches iff both the subjects
- * (e.g., clients, principals) and the objects (e.g., urls, users,
- * roles) of the ACL match the request.
- *
- * If none of the ACLs match the request, the 'permissive' field
- * determines whether the request should be permitted or not.
- *
- * TODO(vinod): Do aggregation of ACLs when possible.
- *
- */
-message ACLs {
-  optional bool permissive = 1 [default = true];
-  repeated ACL.RegisterFramework register_frameworks = 2;
-  repeated ACL.RunTask run_tasks = 3;
-  repeated ACL.ShutdownFramework shutdown_frameworks = 4;
-}
-
-
-/**
  * Rate (queries per second, QPS) limit for messages from a framework to master.
  * Strictly speaking they are the combined rate from all frameworks of the same
  * principal.
@@ -965,24 +1275,122 @@ message RateLimits {
 
 
 /**
+ * Describe an image used by tasks or executors. Note that it's only
+ * for tasks or executors launched by MesosContainerizer currently.
+ * TODO(jieyu): This feature not fully supported in 0.24.0. Please do
+ * not use it until this feature is announced.
+ */
+message Image {
+  enum Type {
+    APPC = 1;
+    DOCKER = 2;
+  }
+
+  // Protobuf for specifying an Appc container image. See:
+  // https://github.com/appc/spec/blob/master/spec/aci.md
+  message Appc {
+    // The name of the image.
+    required string name = 1;
+
+    // An image ID is a string of the format "hash-value", where
+    // "hash" is the hash algorithm used and "value" is the hex
+    // encoded string of the digest. Currently the only permitted
+    // hash algorithm is sha512.
+    optional string id = 2;
+
+    // Optional labels. Suggested labels: "version", "os", and "arch".
+    optional Labels labels = 3;
+  }
+
+  message Docker {
+    // The name of the image. Expected in format repository[:tag].
+    required string name = 1;
+  }
+
+  required Type type = 1;
+
+  // Only one of the following image messages should be set to match
+  // the type.
+  optional Appc appc = 2;
+  optional Docker docker = 3;
+}
+
+
+/**
  * Describes a volume mapping either from host to container or vice
  * versa. Both paths can either refer to a directory or a file.
  */
 message Volume {
-  // Absolute path pointing to a directory or file in the container.
-  required string container_path = 1;
-
-  // Absolute path pointing to a directory or file on the host or a path
-  // relative to the container work directory.
-  optional string host_path = 2;
-
   enum Mode {
     RW = 1; // read-write.
     RO = 2; // read-only.
   }
 
   required Mode mode = 3;
+
+  // Path pointing to a directory or file in the container. If the
+  // path is a relative path, it is relative to the container work
+  // directory. If the path is an absolute path, that path must
+  // already exist.
+  required string container_path = 1;
+
+  // The following specifies the source of this volume. At most one of
+  // the following should be set.
+
+  // Absolute path pointing to a directory or file on the host or a
+  // path relative to the container work directory.
+  optional string host_path = 2;
+
+  // The source of the volume is an Image which describes a root
+  // filesystem which will be provisioned by Mesos.
+  optional Image image = 4;
 }
+
+
+/**
+ * Describes a network request by framework as well as network resolution
+ * provided by the the executor or Agent.
+ *
+ * A framework may request the network isolator on the Agent to assign an IP
+ * address to the container being launched. Alternatively, it can provide a
+ * specific IP address to be assigned to the container. The NetworkInfo message
+ * is not interpreted by the Master or Agent and is intended to be use by Agent
+ * modules implementing network isolation. If the modules are missing, the
+ * message is simply ignored. In future, the task launch will fail if there is
+ * no module providing the network isolation capabilities (MESOS-3390).
+ *
+ * An executor, Agent, or an Agent module may append NetworkInfos inside
+ * TaskStatus::container_status to provide information such as the container IP
+ * address and isolation groups.
+ */
+message NetworkInfo {
+  enum Protocol {
+    IPv4 = 1;
+    IPv6 = 2;
+  }
+
+  // Specify IP address requirement. Set protocol to the desired value to
+  // request the network isolator on the Agent to assign an IP address to the
+  // container being launched. If a specific IP address is specified in
+  // ip_address, this field should not be set.
+  optional Protocol protocol = 1;
+
+  // Statically assigned IP provided by the Framework. This IP will be assigned
+  // to the container by the network isolator module on the Agent. This field
+  // should not be used with the protocol field above.
+  // NOTE: It is up to the networking 'provider' (IPAM/Isolator) to interpret
+  // this either as a hint of as a requirement for assigning the IP.
+  optional string ip_address = 2;
+
+  // A group is the name given to a set of logically-related IPs that are
+  // allowed to communicate within themselves. For example, one might want
+  // to create separate groups for isolating dev, testing, qa and prod
+  // deployment environments.
+  repeated string groups = 3;
+
+  // To tag certain metadata to be used by Isolator/IPAM, e.g., rack, etc.
+  optional Labels labels = 4;
+};
 
 
 /**
@@ -1032,11 +1440,32 @@ message ContainerInfo {
     optional bool force_pull_image = 6;
   }
 
+  message MesosInfo {
+    optional Image image = 1;
+  }
+
   required Type type = 1;
   repeated Volume volumes = 2;
   optional string hostname = 4;
 
+  // Only one of the following *Info messages should be set to match
+  // the type.
   optional DockerInfo docker = 3;
+  optional MesosInfo mesos = 5;
+
+  // A list of network requests. A framework can request multiple IP addresses
+  // for the container.
+  repeated NetworkInfo network_infos = 7;
+}
+
+
+/**
+ * Container related information that is resolved during container setup. The
+ * information is sent back to the framework as part of the TaskStatus message.
+ */
+message ContainerStatus {
+  // This field can be reliably used to identify the container IP address.
+  repeated NetworkInfo network_infos = 1;
 }
 
 
@@ -1102,4 +1531,37 @@ message DiscoveryInfo {
   optional string version = 5;
   optional Ports ports = 6;
   optional Labels labels = 7;
+}
+
+
+/**
+* Protobuf for the Appc image manifest JSON schema:
+* https://github.com/appc/spec/blob/master/spec/aci.md#image-manifest-schema
+* Where possible, any field required in the schema is required in the protobuf
+* but some cannot be expressed, e.g., a repeated string that has at least one
+* element. Further validation should be performed after parsing the JSON into
+* the protobuf.
+* This version of Appc protobuf is based on Appc spec version 0.6.1.
+* TODO(xujyan): This protobuf currently defines a subset of fields in the spec
+* that Mesos makes use of to avoid confusion. New fields are going to be added
+* when Mesos starts to support them.
+*/
+message AppcImageManifest {
+  required string acKind = 1;
+  required string acVersion = 2;
+  required string name = 3;
+
+  message Label {
+    required string name = 1;
+    required string value = 2;
+  }
+
+  repeated Label labels = 4;
+
+  message Annotation {
+    required string name = 1;
+    required string value = 2;
+  }
+
+  repeated Annotation annotations = 5;
 }


### PR DESCRIPTION
Mesos added a new method to the _SchedulerDriver_ interface to suppress resource offers (more ergonomic than declining successive offers with long filter timeouts), so there were some small updates required in _SimulatedDriver.scala_.

Regenerated the Marathon protobuf classes based on the 0.25.0 _mesos.proto_.

Ran unit and integration tests, successfully launched and killed tasks on Mesos 0.25.0 using the _mesos-local_ utility.