### PR TITLE
Updated the Dockerfiles to the 0.25.0 Mesos release (dep. to #2462)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     echo "deb http://repos.mesosphere.io/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.24.1-0.2.35.debian81 sbt
+    apt-get install --no-install-recommends -y --force-yes mesos=0.25.0-0.2.70.debian81 sbt
 
 WORKDIR /marathon
 

--- a/Dockerfile.build-base
+++ b/Dockerfile.build-base
@@ -4,7 +4,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     echo "deb http://repos.mesosphere.io/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.24.1-0.2.35.debian81 sbt
+    apt-get install --no-install-recommends -y --force-yes mesos=0.25.0-0.2.70.debian81 sbt
 
 WORKDIR /marathon
 


### PR DESCRIPTION
To my understanding, once https://github.com/mesosphere/marathon/pull/2462 is merged and therefore compatibility with the current Mesos release is regained, the Dockerfiles also need to be updated.

I added the .deb installer from http://open.mesosphere.com/downloads/mesos/#apache-mesos-0.25.0 (http://downloads.mesosphere.io/master/debian/8/mesos_0.25.0-0.2.70.debian81_amd64.deb).

A subsequent build and push to the Docker Hub would be great.