### PR TITLE
Fixes #2460 - Provide different dev/prod Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,27 @@
+#
+# This is the official docker image that is used for production deployments of docker.
+#
+# It has the marathon startup script as entrypoint.
+#
+# It will reresolve all dependencies on every change (as opposed to Dockerfile.development)
+# but it ultimately results in a smaller docker image.
+#
 FROM java:8-jdk
+
+
+COPY . /marathon
+WORKDIR /marathon
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     echo "deb http://repos.mesosphere.io/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.24.1-0.2.35.debian81 sbt
-
-WORKDIR /marathon
-
-# The build configuration including dependencies changes
-# less frequently than the source code. By separating
-# these steps we can greatly speed up cached local docker builds
-COPY project /marathon/project
-RUN sbt test:compile
-
-COPY . /marathon
-
-RUN sbt -Dsbt.log.format=false assembly && \
+    apt-get install --no-install-recommends -y --force-yes mesos=0.24.1-0.2.35.debian81 sbt && \
+    apt-get clean && \
+    sbt -Dsbt.log.format=false assembly && \
     mv $(find target -name 'marathon-assembly-*.jar' | sort | tail -1) ./ && \
     rm -rf target/* ~/.sbt ~/.ivy2 && \
-    mv marathon-assembly-*.jar target
+    mv marathon-assembly-*.jar target && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENTRYPOINT ["./bin/start"]

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -4,9 +4,6 @@
 # It will NOT reresolve all dependencies on every change (as opposed to Dockerfile)
 # but it ultimately results in a larger docker image.
 #
-# It does also preresolve test libraries (as opposed to Dockerfile.development)
-# but does not override the entry-point etc.
-#
 FROM java:8-jdk
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
@@ -22,7 +19,13 @@ WORKDIR /marathon
 # these steps we can greatly speed up cached local docker builds.
 COPY project /marathon/project
 # even without sources this will resolve all dependencies and compile the scala compiler interfaces
-RUN sbt test:compile
+RUN sbt compile
 
 COPY . /marathon
-RUN sbt test:compile
+
+RUN sbt -Dsbt.log.format=false assembly && \
+        mv $(find target -name 'marathon-assembly-*.jar' | sort | tail -1) ./ && \
+        rm -rf target/* && \
+        mv marathon-assembly-*.jar target
+
+ENTRYPOINT ["./bin/start"]


### PR DESCRIPTION
Dockerfile: The production image optimizing for size (at least a tiny bit)
Dockerfile.build-base: For CI
Dockerfile.development: For faster incremental builds while testing

Should be also backported to 0.11 after merge.