### PR TITLE
Fixes #2147 - Remove unnecessary assertions

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/V2AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/V2AppDefinition.scala
@@ -69,11 +69,6 @@ case class V2AppDefinition(
 
     versionInfo: Option[V2AppDefinition.VersionInfo] = None) extends Timestamped {
 
-  assert(
-    portIndicesAreValid(),
-    "Health check port indices must address an element of the ports array or container port mappings."
-  )
-
   /**
     * Returns true if all health check port index values are in the range
     * of ths app's ports array, or if defined, the array of container

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -75,11 +75,6 @@ case class AppDefinition(
 
   import mesosphere.mesos.protos.Implicits._
 
-  assert(
-    portIndicesAreValid(),
-    "Health check port indices must address an element of the ports array or container port mappings."
-  )
-
   /**
     * Returns true if all health check port index values are in the range
     * of ths app's ports array, or if defined, the array of container

--- a/src/test/scala/mesosphere/marathon/api/v2/json/V2AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/V2AppDefinitionTest.scala
@@ -210,6 +210,16 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
       "Health check port indices must address an element of the ports array or container port mappings."
     )
     validateJsonSchema(app, false) // missing image
+
+    app = correct.copy(
+      healthChecks = Set(HealthCheck(portIndex = 1))
+    )
+    shouldViolate(
+      app,
+      "",
+      "Health check port indices must address an element of the ports array or container port mappings."
+    )
+    validateJsonSchema(app)
   }
 
   test("SerializationRoundtrip empty") {


### PR DESCRIPTION
Deleted assertions are covered by `PortIndicesValidator`
I added new test case in `V2AppdefinitionTest` that was broken
before, because of those assertions.