### PR TITLE
Fixes #1835 by creating a deployment for kill with scale, which will …

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.api
 import javax.inject.Inject
 
 import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.state.{ AppDefinition, GroupManager, PathId, Timestamp }
+import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.TaskTracker
 import mesosphere.marathon.upgrade.DeploymentPlan
 import mesosphere.marathon.{ MarathonSchedulerService, UnknownAppException }
@@ -15,10 +15,7 @@ class TaskKiller @Inject() (
     groupManager: GroupManager,
     service: MarathonSchedulerService) {
 
-  def kill(appId: PathId,
-           findToKill: (Set[MarathonTask] => Set[MarathonTask]),
-           force: Boolean): Future[Set[MarathonTask]] = {
-
+  def kill(appId: PathId, findToKill: (Set[MarathonTask] => Set[MarathonTask])): Future[Set[MarathonTask]] = {
     if (taskTracker.contains(appId)) {
       val tasks = taskTracker.get(appId)
       val toKill = findToKill(tasks)
@@ -33,19 +30,19 @@ class TaskKiller @Inject() (
   def killAndScale(appId: PathId,
                    findToKill: (Set[MarathonTask] => Set[MarathonTask]),
                    force: Boolean): Future[DeploymentPlan] = {
-
-    if (taskTracker.contains(appId)) {
-      val tasks = taskTracker.get(appId)
-      val toKill = findToKill(tasks)
-      def scaleExisting(opt: Option[AppDefinition]): AppDefinition = opt
-        .map(app => app.copy(instances = app.instances - toKill.size))
-        .getOrElse(throw new UnknownAppException(appId))
-
-      groupManager.updateApp(appId, scaleExisting, Timestamp.now(), force = force, toKill = toKill)
-    }
-    else {
-      Future.failed(UnknownAppException(appId))
-    }
+    killAndScale(Map(appId -> findToKill(taskTracker.get(appId))), force)
   }
 
+  def killAndScale(appTasks: Map[PathId, Set[MarathonTask]], force: Boolean): Future[DeploymentPlan] = {
+    def scaleApp(app: AppDefinition): AppDefinition = {
+      appTasks.get(app.id).fold(app) { toKill => app.copy(instances = app.instances - toKill.size) }
+    }
+    def updateGroup(group: Group): Group = {
+      group.copy(apps = group.apps.map(scaleApp), groups = group.groups.map(updateGroup))
+    }
+    def killTasks = groupManager.update(PathId.empty, updateGroup, Timestamp.now(), force = force, toKill = appTasks)
+    appTasks.keys.find(id => !taskTracker.contains(id))
+      .map(id => Future.failed(UnknownAppException(id)))
+      .getOrElse(killTasks)
+  }
 }

--- a/src/main/scala/mesosphere/marathon/state/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupManager.scala
@@ -106,8 +106,9 @@ class GroupManager @Singleton @Inject() (
     gid: PathId,
     fn: Group => Group,
     version: Timestamp = Timestamp.now(),
-    force: Boolean = false): Future[DeploymentPlan] =
-    upgrade(gid, _.update(gid, fn, version), version, force)
+    force: Boolean = false,
+    toKill: Map[PathId, Set[MarathonTask]] = Map.empty): Future[DeploymentPlan] =
+    upgrade(gid, _.update(gid, fn, version), version, force, toKill)
 
   /**
     * Update application with given identifier and update function.

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -52,4 +52,6 @@ object Timestamp {
     */
   def now(): Timestamp = Timestamp(System.currentTimeMillis)
 
+  def zero: Timestamp = Timestamp(0)
+
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppTasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppTasksResourceTest.scala
@@ -27,9 +27,9 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     val toKill = Set(MarathonTask.getDefaultInstance)
 
     config.zkTimeoutDuration returns 5.seconds
-    taskKiller.kill(any, any, any) returns Future.successful(toKill)
+    taskKiller.kill(any, any) returns Future.successful(toKill)
 
-    val response = appsTaskResource.deleteMany(appId, host, scale = false, auth.request, auth.response)
+    val response = appsTaskResource.deleteMany(appId, host, scale = false, force = false, auth.request, auth.response)
     response.getStatus shouldEqual 200
     JsonTestHelper
       .assertThatJsonString(response.getEntity.asInstanceOf[String])
@@ -53,14 +53,14 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
 
     config.zkTimeoutDuration returns 5.seconds
     taskTracker.get(appId) returns Set(task1, task2)
-    taskKiller.kill(any, any, any) returns Future.successful(toKill)
+    taskKiller.kill(any, any) returns Future.successful(toKill)
 
-    val response = appsTaskResource.deleteOne(appId.root, task1.getId, scale = false, auth.request, auth.response)
+    val response = appsTaskResource.deleteOne(appId.root, task1.getId, scale = false, force = false, auth.request, auth.response)
     response.getStatus shouldEqual 200
     JsonTestHelper
       .assertThatJsonString(response.getEntity.asInstanceOf[String])
       .correspondsToJsonOf(Json.obj("task" -> toKill.head))
-    verify(taskKiller).kill(equalTo(appId.rootPath), any, force = equalTo(true))
+    verify(taskKiller).kill(equalTo(appId.rootPath), any)
     verifyNoMoreInteractions(taskKiller)
   }
 
@@ -118,12 +118,12 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     indexTxt.getStatus should be(auth.NotAuthenticatedStatus)
 
     When(s"One task is deleted")
-    val deleteOne = appsTaskResource.deleteOne("appId", "taskId", false, req, resp)
+    val deleteOne = appsTaskResource.deleteOne("appId", "taskId", false, false, req, resp)
     Then("we receive a NotAuthenticated response")
     deleteOne.getStatus should be(auth.NotAuthenticatedStatus)
 
     When(s"multiple tasks are deleted")
-    val deleteMany = appsTaskResource.deleteMany("appId", "host", false, req, resp)
+    val deleteMany = appsTaskResource.deleteMany("appId", "host", false, false, req, resp)
     Then("we receive a NotAuthenticated response")
     deleteMany.getStatus should be(auth.NotAuthenticatedStatus)
   }
@@ -147,12 +147,12 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     indexTxt.getStatus should be(auth.UnauthorizedStatus)
 
     When(s"One task is deleted")
-    val deleteOne = appsTaskResource.deleteOne("appId", "taskId", false, req, resp)
+    val deleteOne = appsTaskResource.deleteOne("appId", "taskId", false, false, req, resp)
     Then("we receive a not authorized response")
     deleteOne.getStatus should be(auth.UnauthorizedStatus)
 
     When(s"multiple tasks are deleted")
-    val deleteMany = appsTaskResource.deleteMany("appId", "host", false, req, resp)
+    val deleteMany = appsTaskResource.deleteMany("appId", "host", false, false, req, resp)
     Then("we receive a not authorized response")
     deleteMany.getStatus should be(auth.UnauthorizedStatus)
   }


### PR DESCRIPTION
…be denied if the same app is locked.

The kill operation always returns a result:
 - either a deployment (scale=true)
 - or the tasks that will be killed.