### PR TITLE
The RAML Console loads the files from /public/api/api.raml

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -300,7 +300,7 @@ object Dependency {
     val JsonSchemaValidator = "2.2.6"
     val RxScala = "0.25.0"
     val MarathonUI = "0.12.0-SNAPSHOT"
-    val MarathonApiConsole = "0.1.0"
+    val MarathonApiConsole = "0.1.1"
     val Graphite = "3.1.2"
     val DataDog = "1.1.3"
     val Logback = "1.1.3"


### PR DESCRIPTION
This does not work on dcos.
Changed the path to relative url: ../public/api/api.raml and created a new version.