### PR TITLE
Fixes 2550 by changing the order if the leader got elected.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -413,7 +413,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
   @Provides
   @Singleton
   def provideFrameworkIdStore(store: PersistentStore, metrics: Metrics): EntityStore[FrameworkId] = {
-    entityStore(store, metrics, "", () => new FrameworkId(UUID.randomUUID().toString))
+    entityStore(store, metrics, "framework:", () => new FrameworkId(UUID.randomUUID().toString))
   }
 
   @Named(ModuleNames.STORE_GROUP)

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
@@ -17,6 +17,9 @@ object MarathonSchedulerDriver {
                 httpConfig: HttpConf,
                 newScheduler: MarathonScheduler,
                 frameworkId: Option[FrameworkID]): SchedulerDriver = {
+
+    log.info(s"Create new Scheduler Driver with frameworkId: $frameworkId")
+
     val frameworkInfoBuilder = FrameworkInfo.newBuilder()
       .setName(config.frameworkName())
       .setFailoverTimeout(config.mesosFailoverTimeout().toDouble)

--- a/src/main/scala/mesosphere/marathon/state/EntityStoreCache.scala
+++ b/src/main/scala/mesosphere/marathon/state/EntityStoreCache.scala
@@ -83,7 +83,9 @@ class EntityStoreCache[T <: MarathonState[_, T]](store: EntityStore[T])
 
     def handleEntries(names: Seq[String]): Future[Unit] = {
       val (unversionedNames, versionedNames) = names.partition(noVersionKey)
-      log.debug(s"$store Preload and cache entries: $unversionedNames and versioned entries $versionedNames")
+      if (log.isDebugEnabled) {
+        log.debug(s"$store Preload and cache entries: $unversionedNames and versioned entries $versionedNames")
+      }
       //add keys with None for version entries
       versionedNames.foreach(cache.put(_, None))
       //add key with loaded values

--- a/src/main/scala/mesosphere/marathon/state/EntityStoreCache.scala
+++ b/src/main/scala/mesosphere/marathon/state/EntityStoreCache.scala
@@ -83,6 +83,7 @@ class EntityStoreCache[T <: MarathonState[_, T]](store: EntityStore[T])
 
     def handleEntries(names: Seq[String]): Future[Unit] = {
       val (unversionedNames, versionedNames) = names.partition(noVersionKey)
+      log.debug(s"$store Preload and cache entries: $unversionedNames and versioned entries $versionedNames")
       //add keys with None for version entries
       versionedNames.foreach(cache.put(_, None))
       //add key with loaded values
@@ -93,6 +94,7 @@ class EntityStoreCache[T <: MarathonState[_, T]](store: EntityStore[T])
   }
 
   override def onDefeated: Future[Unit] = {
+    log.debug(s"$store Clear all cached entries")
     cache.clear()
     Future.successful(())
   }

--- a/src/main/scala/mesosphere/util/state/FrameworkIdUtil.scala
+++ b/src/main/scala/mesosphere/util/state/FrameworkIdUtil.scala
@@ -3,6 +3,7 @@ package mesosphere.util.state
 import mesosphere.marathon.state.{ Timestamp, EntityStore, MarathonState }
 import org.apache.mesos.Protos
 import org.apache.mesos.Protos.FrameworkID
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Future }
@@ -10,15 +11,22 @@ import scala.concurrent.{ Await, Future }
 /**
   * Utility class for keeping track of a framework ID
   */
-class FrameworkIdUtil(mStore: EntityStore[FrameworkId], timeout: Duration, key: String = "frameworkId") {
+class FrameworkIdUtil(mStore: EntityStore[FrameworkId], timeout: Duration, key: String = "id") {
+
+  private[this] val log = LoggerFactory.getLogger(getClass)
+
   def fetch(): Option[FrameworkID] = {
     Await.result(mStore.fetch(key), timeout).map(_.toProto)
   }
   def store(proto: FrameworkID): FrameworkId = {
+    log.info(s"Store framework id: $proto")
     val frameworkId = FrameworkId(proto.getValue)
     Await.result(mStore.modify(key) { _ => frameworkId }, timeout)
   }
-  def expunge(): Future[Boolean] = mStore.expunge(key)
+  def expunge(): Future[Boolean] = {
+    log.info(s"Expunge framework id!")
+    mStore.expunge(key)
+  }
 }
 
 //TODO: move logic from FrameworkID to FrameworkId (which also implies moving this class)

--- a/src/test/scala/mesosphere/marathon/state/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MigrationTest.scala
@@ -38,6 +38,7 @@ class MigrationTest extends MarathonSpec with Mockito with Matchers with GivenWh
     f.store.update(any) returns Future.successful(mock[PersistentEntity])
     f.store.allIds() returns Future.successful(Seq.empty)
     f.store.initialize() returns Future.successful(())
+    f.store.load(any) returns Future.successful(None)
     f.appRepo.apps() returns Future.successful(Seq.empty)
     f.appRepo.allPathIds() returns Future.successful(Seq.empty)
     f.groupRepo.group("root") returns Future.successful(None)


### PR DESCRIPTION
The second problem is the failing caching mechanism, when the prefix is empty (as this is the case for frameworkId)
Added a migration from frameworkId->framework:id