### PR TITLE
Update CI to remove pep8 gating on servicerouter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,11 @@ cache:
   directories:
     - $HOME/.sbt
     - $HOME/.ivy2
-addons:
-  apt:
-    packages:
-      - python
-      - python-pip
-      - python-virtualenv
 script:
   - sbt clean coverage doc assembly
-  - source venv/bin/activate
 before_script: # the automated download fails sometimes
     - mkdir -p $HOME/.sbt/launchers/0.13.8/
     - test -r $HOME/.sbt/launchers/0.13.8/sbt-launch.jar || curl -L -o $HOME/.sbt/launchers/0.13.8/sbt-launch.jar http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.8/sbt-launch.jar
-    - virtualenv venv
-    - source venv/bin/activate
 after_success:
   - sbt coverageReport coveralls
 notifications:


### PR DESCRIPTION
servicerouter has been completely removed as of this commit https://github.com/mesosphere/marathon/commit/ec780e71abd21c907e7be98e9ff6752665ddd901 but the gating was added in this commit https://github.com/mesosphere/marathon/commit/0db21940e109a6a27356c0b547e8cd447a88db96#diff-354f30a63fb0907d4ad57269548329e3 . 
This patch completely removes the unneeded apt pkgs and virtualenv stuff.