### PR TITLE
[0.13] correct staged counts, fix health check reconciliation

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/TaskForStatistics.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/TaskForStatistics.scala
@@ -35,7 +35,9 @@ private[appinfo] object TaskForStatistics {
       new TaskForStatistics(
         version = version,
         running = maybeTaskState.contains(TaskState.TASK_RUNNING),
-        staging = maybeTaskState.contains(TaskState.TASK_STAGING),
+        // Tasks that are staged do not have the taskState set at all, currently.
+        // To make this a bit more robust, we also allow it to be set explicitly.
+        staging = maybeTaskState.isEmpty || maybeTaskState.contains(TaskState.TASK_STAGING),
         healthy = healths.nonEmpty && healths.forall(_.alive),
         unhealthy = healths.exists(!_.alive),
         maybeLifeTime = maybeTaskLifeTime

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
@@ -15,15 +15,15 @@ class TaskCountsTest extends MarathonSpec with GivenWhenThen with Mockito with M
     counts should be(TaskCounts.zero)
   }
 
-  test("one unstaged task") {
+  test("one task without explicit task state is treated as staged task") {
     Given("one unstaged task")
-    val oneUnstagedTask = Seq(
-      unstagedTask("task1")
+    val oneTaskWithoutTaskState = Seq(
+      taskWithoutTaskState("task1")
     )
     When("getting counts")
-    val counts = TaskCounts(appTasks = oneUnstagedTask, statuses = Map.empty)
-    Then("all counts are 0")
-    counts should be(TaskCounts.zero)
+    val counts = TaskCounts(appTasks = oneTaskWithoutTaskState, statuses = Map.empty)
+    Then("the task without taskState is counted as staged")
+    counts should be(TaskCounts.zero.copy(tasksStaged = 1))
   }
 
   test("one staged task") {
@@ -131,7 +131,7 @@ class TaskCountsTest extends MarathonSpec with GivenWhenThen with Mockito with M
       .buildPartial()
   }
 
-  private[this] def unstagedTask(id: String): Protos.MarathonTask = {
+  private[this] def taskWithoutTaskState(id: String): Protos.MarathonTask = {
     Protos.MarathonTask
       .newBuilder()
       .setId(id)


### PR DESCRIPTION
cherry picked to master bugfix commits to the 0.13 release branch:

	Fixes #2322 - count tasks without explicit state as staging
	Fixes #2314 - Do not remove health checks that are still needed 