### PR TITLE
Improves #2440 - Test for NotifyLaunchQueueStepImpl

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/steps/NotifyLaunchQueueStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/steps/NotifyLaunchQueueStepImplTest.scala
@@ -1,0 +1,60 @@
+package mesosphere.marathon.core.task.tracker.impl.steps
+
+import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.task.bus.MarathonTaskStatus
+import mesosphere.marathon.core.task.bus.TaskStatusObservables.TaskStatusUpdate
+import mesosphere.marathon.state.{ Timestamp, PathId }
+import mesosphere.marathon.tasks.TaskIdUtil
+import mesosphere.marathon.test.Mockito
+import org.apache.mesos.Protos.{ TaskState, TaskStatus, SlaveID }
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ GivenWhenThen, Matchers, FunSuite }
+
+import scala.concurrent.Future
+
+class NotifyLaunchQueueStepImplTest extends FunSuite with Matchers with GivenWhenThen with Mockito with ScalaFutures {
+  test("name") {
+    new Fixture().step.name should equal("notifyLaunchQueue")
+  }
+
+  test("notifying launch queue") {
+    val f = new Fixture
+    val status = runningTaskStatus
+    val expectedUpdate = TaskStatusUpdate(updateTimestamp, taskId, MarathonTaskStatus(status))
+
+    Given("a status update")
+    f.launchQueue.notifyOfTaskUpdate(expectedUpdate) returns Future.successful(None)
+
+    When("calling processUpdate")
+    f.step.processUpdate(
+      updateTimestamp,
+      appId,
+      maybeTask = None,
+      status = status
+    ).futureValue
+
+    Then("the update is passed to the LaunchQueue")
+    verify(f.launchQueue).notifyOfTaskUpdate(expectedUpdate)
+  }
+
+  private[this] val slaveId = SlaveID.newBuilder().setValue("slave1")
+  private[this] val appId = PathId("/test")
+  private[this] val taskId = TaskIdUtil.newTaskId(appId)
+  private[this] val updateTimestamp = Timestamp(100)
+  private[this] val taskStatusMessage = "some update"
+
+  private[this] val runningTaskStatus =
+    TaskStatus
+      .newBuilder()
+      .setState(TaskState.TASK_RUNNING)
+      .setTaskId(taskId)
+      .setSlaveId(slaveId)
+      .setMessage(taskStatusMessage)
+      .build()
+
+  class Fixture {
+    val launchQueue = mock[LaunchQueue]
+    val step = new NotifyLaunchQueueStepImpl(launchQueue = launchQueue)
+  }
+}

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/steps/PostToEventStreamStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/steps/PostToEventStreamStepImplTest.scala
@@ -9,11 +9,12 @@ import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.tasks.TaskIdUtil
 import mesosphere.marathon.test.{ CaptureLogEvents, CaptureEvents }
 import org.apache.mesos.Protos.{ SlaveID, TaskState, TaskStatus }
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 
 import scala.collection.JavaConverters._
 
-class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhenThen {
+class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhenThen with ScalaFutures {
   test("name") {
     new Fixture().step.name should be ("postTaskStatusEvent")
   }
@@ -31,7 +32,7 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
         appId = appId,
         maybeTask = existingTask,
         status = status
-      )
+      ).futureValue
     }
 
     Then("the appropriate event is posted")
@@ -69,7 +70,7 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
         appId = appId,
         maybeTask = existingTask,
         status = status
-      )
+      ).futureValue
     }
 
     Then("no event gets posted")
@@ -92,7 +93,7 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
         appId = appId,
         maybeTask = existingTask,
         status = status
-      )
+      ).futureValue
     }
 
     Then("no event is posted to the event stream")
@@ -120,7 +121,7 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
         appId = appId,
         maybeTask = existingTask,
         status = status
-      )
+      ).futureValue
     }
 
     Then("the appropriate event is posted")
@@ -151,7 +152,7 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
         appId = appId,
         maybeTask = existingTask,
         status = status
-      )
+      ).futureValue
     }
 
     Then("the appropriate event is posted")
@@ -205,11 +206,11 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
 
   class Fixture {
     val eventStream = new EventStream()
-    val captureEvents = CaptureEvents(eventStream)
+    val captureEvents = new CaptureEvents(eventStream)
 
     def captureLogAndEvents(block: => Unit): (Vector[ILoggingEvent], Seq[MarathonEvent]) = {
       var logs: Vector[ILoggingEvent] = Vector.empty
-      val events = captureEvents {
+      val events = captureEvents.forBlock {
         logs = CaptureLogEvents.forBlock {
           block
         }

--- a/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
@@ -260,7 +260,7 @@ class MarathonHealthCheckManagerTest extends MarathonSpec with Logging {
     assert(hcManager.list(appId) == Set())
 
     // reconcileWith starts health checks of task 1
-    val captured1 = captureEvents {
+    val captured1 = captureEvents.forBlock {
       assert(hcManager.list(appId) == Set())
       startTask_i(1)
       Await.result(hcManager.reconcileWith(appId), 2.second)
@@ -269,14 +269,14 @@ class MarathonHealthCheckManagerTest extends MarathonSpec with Logging {
     assert(hcManager.list(appId) == healthChecks(1))
 
     // reconcileWith leaves health check running
-    val captured2 = captureEvents {
+    val captured2 = captureEvents.forBlock {
       Await.result(hcManager.reconcileWith(appId), 2.second)
     }
     assert(captured2.isEmpty)
     assert(hcManager.list(appId) == healthChecks(1))
 
     // reconcileWith starts health checks of task 2 and leaves those of task 1 running
-    val captured3 = captureEvents {
+    val captured3 = captureEvents.forBlock {
       startTask_i(2)
       Await.result(hcManager.reconcileWith(appId), 2.second)
     }
@@ -284,7 +284,7 @@ class MarathonHealthCheckManagerTest extends MarathonSpec with Logging {
     assert(hcManager.list(appId) == healthChecks(1) ++ healthChecks(2))
 
     // reconcileWith stops health checks which are not current and which are without tasks
-    val captured4 = captureEvents {
+    val captured4 = captureEvents.forBlock {
       stopTask(appId, tasks(1))
       assert(hcManager.list(appId) == healthChecks(1) ++ healthChecks(2))
       Await.result(hcManager.reconcileWith(appId), 2.second)
@@ -293,7 +293,7 @@ class MarathonHealthCheckManagerTest extends MarathonSpec with Logging {
     assert(hcManager.list(appId) == healthChecks(2))
 
     // reconcileWith leaves current version health checks running after termination
-    val captured5 = captureEvents {
+    val captured5 = captureEvents.forBlock {
       stopTask(appId, tasks(2))
       assert(hcManager.list(appId) == healthChecks(2))
       Await.result(hcManager.reconcileWith(appId), 2.second)
@@ -305,5 +305,5 @@ class MarathonHealthCheckManagerTest extends MarathonSpec with Logging {
     assert(hcManager.list(otherAppId) == otherHealthChecks)
   }
 
-  def captureEvents = CaptureEvents(eventStream)
+  def captureEvents = new CaptureEvents(eventStream)
 }

--- a/src/test/scala/mesosphere/marathon/test/CaptureEvents.scala
+++ b/src/test/scala/mesosphere/marathon/test/CaptureEvents.scala
@@ -6,14 +6,11 @@ import akka.event.EventStream
 import akka.testkit.TestProbe
 import mesosphere.marathon.event.MarathonEvent
 
-case class CaptureEvents(eventStream: EventStream) {
+class CaptureEvents(eventStream: EventStream) {
   /**
     * Captures the events send to the EventStream while the block is executing.
-    *
-    * For issue #2314 not only the end state is important. It is also important, which health checks
-    * were removed incorrectly and then readded afterwards.
     */
-  def apply(block: => Unit): Seq[MarathonEvent] = {
+  def forBlock(block: => Unit): Seq[MarathonEvent] = {
     implicit val actorSystem = ActorSystem("captureEvents")
 
     // yes, this is ugly. Since we only access it in the actor until it terminates, we do have


### PR DESCRIPTION
...also uses futureValue to wait for the Future returned by processUpdate
even if the implementation is synchronous (more robust blackbox testing).

...also refactor the CaptureEvents code a bit.