### PR TITLE
Fixes #2599 by adding the event subscriber store to the leader ship callbacks

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -120,8 +120,9 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     @Named(ModuleNames.STORE_DEPLOYMENT_PLAN) deployment: EntityStore[DeploymentPlan],
     @Named(ModuleNames.STORE_FRAMEWORK_ID) frameworkId: EntityStore[FrameworkId],
     @Named(ModuleNames.STORE_TASK_FAILURES) taskFailure: EntityStore[TaskFailure],
+    @Named(ModuleNames.STORE_EVENT_SUBSCRIBERS) subscribers: EntityStore[EventSubscribers],
     @Named(ModuleNames.STORE_TASK) task: EntityStore[MarathonTaskState]): Seq[LeadershipCallback] = {
-    Seq(app, group, deployment, frameworkId, taskFailure, task).collect { case l: LeadershipCallback => l }
+    Seq(app, group, deployment, frameworkId, taskFailure, task, subscribers).collect { case l: LeadershipCallback => l }
   }
 
   @Named(ModuleNames.HTTP_EVENT_STREAM)


### PR DESCRIPTION
You already mentioned, that we should think about a structure to not forget setup logic. We did...

After Review: Cherry pick on master