### PR TITLE
Fixes #2618 - Consolidate statusUpdate logic in TaskTracker life cycle methods

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -318,7 +318,7 @@ class MarathonSchedulerService @Inject() (
     // Note that abdication command will be ran upon driver shutdown.
     leader.set(false)
     stopDriver()
-    taskTracker.clear()
+    taskTracker.clearCache()
   }
 
   private def electLeadership(abdicateOption: Option[ExceptionalCommand[JoinException]]): Unit = {

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -114,9 +114,8 @@ private[launcher] class OfferProcessorImpl(
       log.info("Save task [{}]", task.marathonTask.getId)
       val taskId = task.marathonTask.getId
       val appId = TaskIdUtil.appId(taskId)
-      taskTracker.created(appId, task.marathonTask)
       taskTracker
-        .store(appId, task.marathonTask)
+        .created(appId, task.marathonTask)
         .map(_ => Some(task))
         .recoverWith {
           case NonFatal(e) =>

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/steps/UpdateTaskTrackerStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/steps/UpdateTaskTrackerStepImpl.scala
@@ -19,19 +19,7 @@ class UpdateTaskTrackerStepImpl @Inject() (
 
   def processUpdate(
     timestamp: Timestamp, appId: PathId, task: MarathonTask, status: TaskStatus): Future[_] = {
-    val taskId = status.getTaskId
 
-    import org.apache.mesos.Protos.TaskState._
-    status.getState match {
-      case TASK_ERROR | TASK_FAILED | TASK_FINISHED | TASK_KILLED | TASK_LOST =>
-        // Remove from our internal list
-        taskTracker.terminated(appId, taskId.getValue)
-
-      case TASK_RUNNING if !task.hasStartedAt => // was staged and is now running
-        taskTracker.running(appId, status)
-
-      case _ =>
-        taskTracker.statusUpdate(appId, status)
-    }
+    taskTracker.statusUpdate(appId, status)
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/TaskRepository.scala
+++ b/src/main/scala/mesosphere/marathon/state/TaskRepository.scala
@@ -25,7 +25,6 @@ class TaskRepository(
   def store(task: MarathonTask): Future[MarathonTask] = {
     this.store.store(task.getId, MarathonTaskState(task)).map(_.toProto)
   }
-
 }
 
 object TaskRepository {

--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -5,6 +5,7 @@ import javax.inject.Inject
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.Protos._
 import mesosphere.marathon.state.{ PathId, TaskRepository, Timestamp }
+import org.apache.mesos.Protos.TaskState._
 import org.apache.mesos.Protos.{ TaskState, TaskStatus }
 import org.slf4j.LoggerFactory
 
@@ -13,6 +14,23 @@ import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.Set
 import scala.concurrent.{ Await, Future }
 
+/**
+  * The TaskTracker contains the latest known state for every task.
+  *
+  * It also processes new status information as sent by Mesos (see taskUpdate)
+  * and persist it in the associated task state.
+  *
+  * Known deficiencies:
+  *
+  * * There are race conditions in this code involving the synchronization of the repo and the cachedApps
+  *   data structure.
+  * * There are probably race conditions in checking whether to remove the entry for an app.
+  * * Some methods such as list only look into the cached tasks. If the first reconciliation has not yet
+  *   happened, this might not contain all apps. Could be fixed by preloading all tasks on election.
+  * * expungeOrphanedTasks is probably not a good idea. See issue #2620.
+  * * Some methods or data structures use Set[MarathonTask] which leads to performance problems because
+  *   hashCode on MarathonTask is relatively expensive.
+  */
 class TaskTracker @Inject() (
     repo: TaskRepository,
     config: MarathonConf) {
@@ -24,13 +42,14 @@ class TaskTracker @Inject() (
 
   private[this] val log = LoggerFactory.getLogger(getClass.getName)
 
-  private[tasks] val apps = TrieMap[PathId, InternalApp]()
+  private[tasks] val cachedApps = TrieMap[PathId, InternalApp]()
 
+  // FIXME: remove, see documented deficiencies above
   def get(appId: PathId): Set[MarathonTask] =
     getTasks(appId).toSet
 
   def getTasks(appId: PathId): Iterable[MarathonTask] = {
-    getInternal(appId).values
+    getTaskMap(appId).values
   }
 
   def getVersion(appId: PathId, taskId: String): Option[Timestamp] =
@@ -39,102 +58,132 @@ class TaskTracker @Inject() (
         Timestamp(mt.getVersion)
     }
 
-  private[this] def getInternal(appId: PathId): TrieMap[String, MarathonTask] =
-    apps.getOrElseUpdate(appId, fetchApp(appId)).tasks
+  private[this] def getTaskMap(appId: PathId): TrieMap[String, MarathonTask] =
+    getInternalApp(appId).tasks
 
-  def list: Map[PathId, App] = apps.mapValues(_.toApp).toMap
+  private[this] def getInternalApp(appId: PathId): InternalApp = {
+    cachedApps.getOrElseUpdate(appId, fetchApp(appId))
+  }
 
-  def count(appId: PathId): Int = getInternal(appId).size
+  // FIXME: remove, see documented deficiencies above
+  def list: Map[PathId, App] = cachedApps.mapValues(_.toApp).toMap
 
-  def contains(appId: PathId): Boolean = apps.contains(appId)
+  def count(appId: PathId): Int = getTaskMap(appId).size
+
+  // FIXME: remove, see documented deficiencies above
+  def contains(appId: PathId): Boolean = cachedApps.contains(appId)
 
   def take(appId: PathId, n: Int): Set[MarathonTask] = getTasks(appId).iterator.take(n).toSet
 
-  def created(appId: PathId, task: MarathonTask): Unit = {
-    // Keep this here so running() can pick it up
-    // FIXME: Should be persisted here for task reconciliation
-    //        Wont fix for now since this should be completely remodeled in #462
-    getInternal(appId) += (task.getId -> task)
-  }
-
-  def running(appId: PathId, status: TaskStatus): Future[MarathonTask] = {
-    val taskId = status.getTaskId.getValue
-    getInternal(appId).get(taskId) match {
-      case Some(oldTask) if !oldTask.hasStartedAt => // staged
-        val task = oldTask.toBuilder
-          .setStartedAt(System.currentTimeMillis)
-          .setStatus(status)
-          .build
-        getInternal(appId) += (task.getId -> task)
-        store(appId, task).map(_ => task)
-
-      case Some(oldTask) => // running
-        val msg = s"Task for ID $taskId already running, ignoring"
-        log.warn(msg)
-        Future.failed(new Exception(msg))
-
-      case _ =>
-        val msg = s"No staged task for ID $taskId, ignoring"
-        log.warn(msg)
-        Future.failed(new Exception(msg))
+  /**
+    * Create a new task and store it in-memory and in the underlying storage.
+    *
+    * If the task exists already, the returned Future will fail.
+    */
+  def created(appId: PathId, task: MarathonTask): Future[MarathonTask] = {
+    val taskId = task.getId
+    getTaskMap(appId).putIfAbsent(task.getId, task) match {
+      case Some(existingTask) =>
+        Future.failed(new IllegalStateException(s"cannot create task [$taskId] of app [$appId], it already exists"))
+      case None =>
+        repo.store(task).map { task =>
+          log.debug(s"created task [$taskId] of app [$appId]")
+          task
+        }
     }
   }
 
-  def terminated(appId: PathId, taskId: String): Future[Option[MarathonTask]] = {
-    val appTasks = getInternal(appId)
-    val app = apps(appId)
+  /**
+    * Process a status update for an existing task and either updates the tasks or removes
+    * it from the TaskTracker.
+    *
+    * If the task does not exist yet, the returned Future will fail.
+    */
+  def statusUpdate(appId: PathId, status: TaskStatus): Future[_] = {
+    val taskId = status.getTaskId.getValue
+    val app = getInternalApp(appId)
+    val maybeAppTask: Option[MarathonTask] = app.tasks.get(taskId)
 
-    appTasks.get(taskId) match {
+    maybeAppTask match {
       case Some(task) =>
-        app.tasks.remove(task.getId)
-
-        Await.result(repo.expunge(taskId), timeout)
-
-        log.info(s"Task $taskId expunged and removed from TaskTracker")
-
-        if (app.shutdown && app.tasks.isEmpty) {
-          // Are we shutting down this app? If so, remove it
-          remove(appId)
-        }
-
-        Future.successful(Some(task))
+        processUpdate(app, task, status)
       case None =>
-        if (app.shutdown && app.tasks.isEmpty) {
-          // Are we shutting down this app? If so, remove it
-          remove(appId)
-        }
-        Future.successful(None)
+        Future.failed(new IllegalStateException(s"task [$taskId] of app [$appId] does not exist"))
+    }
+  }
+
+  private[this] def processUpdate(app: InternalApp, task: MarathonTask, status: TaskStatus): Future[_] = {
+    def updateTaskOnStateChange(task: MarathonTask): Future[_] = {
+      def statusDidChange(statusA: TaskStatus, statusB: TaskStatus): Boolean = {
+        val healthy = statusB.hasHealthy &&
+          (!statusA.hasHealthy || statusA.getHealthy != statusB.getHealthy)
+
+        healthy || statusA.getState != statusB.getState
+      }
+
+      if (statusDidChange(task.getStatus, status)) {
+        updateTask(task.toBuilder.setStatus(status).build)
+      }
+      else {
+        log.debug(s"Ignoring status update for ${task.getId}. Status did not change.")
+        Future.successful(())
+      }
+    }
+
+    def updateTask(updatedTask: MarathonTask): Future[_] = {
+      val appId = app.appName
+      val taskId: String = updatedTask.getId
+      log.debug(s"updating task [$taskId] of app [$appId]: {}", updatedTask)
+
+      getTaskMap(appId) += (taskId -> updatedTask)
+      repo.store(updatedTask).map(_ => updatedTask)
+    }
+
+    status.getState match {
+      case TASK_ERROR | TASK_FAILED | TASK_FINISHED | TASK_KILLED | TASK_LOST =>
+        removeTask(app, task.getId)
+        Future.successful(())
+      case TASK_RUNNING if !task.hasStartedAt => // was staged, is now running
+        updateTask(task.toBuilder.setStartedAt(System.currentTimeMillis).setStatus(status).build())
+      case _ =>
+        updateTaskOnStateChange(task)
+    }
+  }
+
+  /**
+    * Remove the task for the given app with the given ID completely.
+    *
+    * If the task does not exist, the method will not fail.
+    */
+  def terminated(appId: PathId, taskId: String): Future[_] = {
+    val app = getInternalApp(appId)
+    removeTask(app, taskId)
+    Future.successful(())
+  }
+
+  private[this] def removeTask(app: InternalApp, taskId: String): Unit = {
+    app.tasks.remove(taskId)
+
+    // FIXME: Should use Future as method return value instead of Await
+    Await.result(repo.expunge(taskId), timeout)
+
+    log.info(s"Task $taskId expunged and removed from TaskTracker")
+
+    if (app.shutdown && app.tasks.isEmpty) {
+      // Are we shutting down this app? If so, remove it
+      remove(app.appName)
     }
   }
 
   def shutdown(appId: PathId): Unit = {
-    apps.getOrElseUpdate(appId, fetchApp(appId)).shutdown = true
-    if (apps(appId).tasks.isEmpty) remove(appId)
+    val app = getInternalApp(appId)
+    app.shutdown = true
+    if (app.tasks.isEmpty) remove(appId)
   }
 
   private[this] def remove(appId: PathId): Unit = {
-    apps.remove(appId)
-    log.warn(s"App $appId removed from TaskTracker")
-  }
-
-  def statusUpdate(appId: PathId, status: TaskStatus): Future[Option[MarathonTask]] = {
-    val taskId = status.getTaskId.getValue
-    getInternal(appId).get(taskId) match {
-      case Some(task) if statusDidChange(task.getStatus, status) =>
-        val updatedTask = task.toBuilder
-          .setStatus(status)
-          .build
-        getInternal(appId) += (task.getId -> updatedTask)
-        store(appId, updatedTask).map(_ => Some(updatedTask))
-
-      case Some(task) =>
-        log.debug(s"Ignoring status update for ${task.getId}. Status did not change.")
-        Future.successful(Some(task))
-
-      case _ =>
-        log.warn(s"No task for ID $taskId")
-        Future.successful(None)
-    }
+    cachedApps.remove(appId)
+    log.info(s"App $appId removed from TaskTracker")
   }
 
   def determineOverdueTasks(now: Timestamp): Iterable[MarathonTask] = {
@@ -144,7 +193,7 @@ class TaskTracker @Inject() (
     val stagedExpire = nowMillis - config.taskLaunchTimeout()
     val unconfirmedExpire = nowMillis - config.taskLaunchConfirmTimeout()
 
-    val toKill = apps.values.iterator.flatMap(_.tasks.values).filter { task =>
+    val toKill = cachedApps.values.iterator.flatMap(_.tasks.values).filter { task =>
       /*
      * One would think that !hasStagedAt would be better for querying these tasks. However, the current implementation
      * of [[MarathonTasks.makeTask]] will set stagedAt to a non-zero value close to the current system time. Therefore,
@@ -173,11 +222,12 @@ class TaskTracker @Inject() (
     toKill.toIterable
   }
 
+  // FIXME: Should be removed, see deficiencies above and #2620
   def expungeOrphanedTasks(): Unit = {
     // Remove tasks that don't have any tasks associated with them. Expensive!
     log.info("Expunging orphaned tasks from store")
     val stateTaskKeys = Await.result(repo.allIds(), timeout)
-    val appsTaskKeys = apps.values.flatMap(_.tasks.keys).toSet
+    val appsTaskKeys = cachedApps.values.flatMap(_.tasks.keys).toSet
 
     for (stateTaskKey <- stateTaskKeys) {
       if (!appsTaskKeys.contains(stateTaskKey)) {
@@ -187,6 +237,7 @@ class TaskTracker @Inject() (
     }
   }
 
+  // FIXME: See deficiencies above, should probably be replaced by preloading all tasks on elected
   private[tasks] def fetchApp(appId: PathId): InternalApp = {
     log.debug(s"Fetching app from store $appId")
     val names = Await.result(repo.allIds(), timeout).toSet
@@ -200,21 +251,13 @@ class TaskTracker @Inject() (
     new InternalApp(appId, tasks, false)
   }
 
+  // FIXME: Should probably not go to the repo and expose a Future in the interface
   def fetchTask(taskId: String): Option[MarathonTask] = Await.result(repo.task(taskId), timeout)
-
-  def store(appId: PathId, task: MarathonTask): Future[MarathonTask] = repo.store(task)
 
   /**
     * Clear the in-memory state of the task tracker.
     */
-  def clear(): Unit = apps.clear()
-
-  private[tasks] def statusDidChange(statusA: TaskStatus, statusB: TaskStatus): Boolean = {
-    val healthy = statusB.hasHealthy &&
-      (!statusA.hasHealthy || statusA.getHealthy != statusB.getHealthy)
-
-    healthy || statusA.getState != statusB.getState
-  }
+  def clearCache(): Unit = cachedApps.clear()
 }
 
 object TaskTracker {

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -20,8 +20,8 @@ import mesosphere.marathon.test.Mockito
 import mesosphere.marathon.{ MarathonSchedulerDriverHolder, MarathonSpec, MarathonTestHelper }
 import org.apache.mesos.SchedulerDriver
 import org.mockito.ArgumentCaptor
-import org.scalatest.{ Matchers, GivenWhenThen }
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ GivenWhenThen, Matchers }
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -84,8 +84,7 @@ class TaskStatusUpdateProcessorImplTest
 
     Given("a known task")
     f.taskTracker.fetchTask(update.wrapped.taskId.getValue) returns Some(marathonTask)
-    f.taskTracker.terminated(appId, update.wrapped.taskId.getValue) returns
-      Future.successful(Some(marathonTask))
+    f.taskTracker.statusUpdate(appId, status).asInstanceOf[Future[Unit]] returns Future.successful(())
     f.appRepository.app(appId, version) returns Future.successful(Some(app))
     And("and a cooperative launchQueue")
     f.launchQueue.notifyOfTaskUpdate(any) returns Future.successful(None)
@@ -95,7 +94,7 @@ class TaskStatusUpdateProcessorImplTest
 
     Then("we expect that the appropriate taskTracker methods have been called")
     verify(f.taskTracker).fetchTask(update.wrapped.taskId.getValue)
-    verify(f.taskTracker).terminated(appId, update.wrapped.taskId.getValue)
+    verify(f.taskTracker).statusUpdate(appId, status)
 
     And("the healthCheckManager got informed")
     verify(f.healthCheckManager).update(status, version)


### PR DESCRIPTION
* Added some documentation and logging.
* Move lifecycle hooks next to each other
* Assert that task that is passed to TaskTracker.created does not exist yet.
* Separate processUpdate method from statusUpdate to make scalastyle happy.
* Make methods only used by processUpdate method private.