### PR TITLE
Add Oracle Linux to OS check

### DIFF
--- a/bin/haproxy-marathon-bridge
+++ b/bin/haproxy-marathon-bridge
@@ -64,7 +64,7 @@ function install_haproxy_system {
     os="AmazonAMI"
   fi
      
-  if [[ $os == "CentOS" ]] || [[ $os == "RHEL" ]] || [[ $os == "AmazonAMI" ]]
+  if [[ $os == "CentOS" ]] || [[ $os == "RHEL" ]] || [[ $os == "AmazonAMI" ]] || [ $os == "OracleServer" ]
   then
     sudo yum install -y haproxy
     sudo chkconfig haproxy on


### PR DESCRIPTION
This tiny patch adds Oracle Linux to the list of OSs recognized by the script.