### PR TITLE
Fixes #2543 - relative path in application dependencies within a group.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/V2GroupUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/V2GroupUpdate.scala
@@ -38,7 +38,7 @@ case class V2GroupUpdate(
 
   def toApp(gid: PathId, app: V2AppDefinition, version: Timestamp): V2AppDefinition = {
     val appId = app.id.canonicalPath(gid)
-    app.copy(id = appId, dependencies = app.dependencies.map(_.canonicalPath(appId)), version = version)
+    app.copy(id = appId, dependencies = app.dependencies.map(_.canonicalPath(gid)), version = version)
   }
 
   def toGroup(gid: PathId, version: Timestamp): V2Group = V2Group(


### PR DESCRIPTION
Relative paths of application dependencies were converted to absolute paths up to the application it depended on. E.g.:
  app1: id="/apps/app1"
  app2: id="/apps/app2", dependencies="app1"
were converted to:
  app2: id="/apps/app2", dependencies="/apps/app2/app1"
This behaviour was changed to:
  app2: id="/apps/app2", dependencies="/apps/app1"
The relative path is now relative to the group and not to the application.