### PR TITLE
Fixes #2688 - Updates should handle failover

### DIFF
--- a/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
@@ -1,5 +1,6 @@
 package mesosphere.marathon.health
 
+import akka.actor.ActorRef
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 
 import org.apache.mesos.Protos.TaskStatus
@@ -52,6 +53,12 @@ trait HealthCheckManager {
     * from Mesos.
     */
   def update(taskStatus: TaskStatus, version: Timestamp): Unit
+
+  /**
+    * Requests the health of all tasks of the supplied appId and appVersion.
+    * Sends an AppHealth message to requester.
+    */
+  def requestHealth(appId: PathId, appVersion: Timestamp, requester: ActorRef): Unit
 
   /**
     * Returns the health status of the supplied task.

--- a/src/main/scala/mesosphere/marathon/health/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/health/MarathonHealthCheckManager.scala
@@ -187,6 +187,15 @@ class MarathonHealthCheckManager @Inject() (
       }
     }
 
+  override def requestHealth(
+    appId: PathId,
+    appVersion: Timestamp,
+    requester: ActorRef): Unit = {
+    listActive(appId, appVersion).foreach { activeHealthCheck =>
+      activeHealthCheck.actor.tell(GetAppHealth, requester)
+    }
+  }
+
   override def status(
     appId: PathId,
     taskId: String): Future[Seq[Health]] = {

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -174,6 +174,7 @@ private class DeploymentActor(
             driver,
             taskQueue,
             taskTracker,
+            healthCheckManager,
             eventBus,
             app,
             promise)))


### PR DESCRIPTION
The TaskReplaceActor now assesses the current
state of an app instead of assuming all existing
apps are of the old version and healthy.

This change fixes #2688 where apps could be scaled
below their minimum health capacity during an
update if Marathon failed over.

Added new unit tests to show issue.