### PR TITLE
Towards #2709 - Allow port instead of portIndex for health checks

### DIFF
--- a/docs/docs/health-checks.md
+++ b/docs/docs/health-checks.md
@@ -65,30 +65,43 @@ more details.
 
 #### Health check options
 
+The first thing you need to decide is the protocol of your health check:
+
+* `protocol` (Optional. Default: "HTTP"): Protocol of the requests to be
+  performed. One of "HTTP"/"TCP"/"COMMAND".
+
+HTTP/TCP health checks are executed by Marathon and thus test the reachability from
+the current Marathon leader. COMMAND health checks are locally executed by Mesos on
+the agent running the corresponding task.
+
+Options applicable to every protocol:
+
 * `gracePeriodSeconds` (Optional. Default: 300): Health check failures are
   ignored within this number of seconds or until the task becomes healthy for
   the first time.
 * `intervalSeconds` (Optional. Default: 60): Number of seconds to wait between
   health checks.
-* `maxConsecutiveFailures`(Optional. Default: 3) : Number of consecutive health
+* `maxConsecutiveFailures`(Optional. Default: 3): Number of consecutive health
   check failures after which the unhealthy task should be killed. If this value
   is `0`, then tasks will not be killed due to failing this check.
-* `path` (Optional. Default: "/"): Path to endpoint exposed by the task that
-  will provide health  status. Example: "/path/to/health".
-  _Note: only used if `protocol == "HTTP"`._
-* `portIndex` (Optional. Default: 0): Index in this app's `ports` array to be
+* `timeoutSeconds` (Optional. Default: 20): Number of seconds after which a
+  health check is considered a failure regardless of the response.
+
+For TCP/HTTP health checks, you need to specify either `port` or `portIndex`:
+
+* `portIndex` (Optional. Default: None): Index in this app's `ports` array to be
   used for health requests. An index is used so the app can use random ports,
   like "[0, 0, 0]" for example, and tasks could be started with port environment
   variables like `$PORT1`.
-* `protocol` (Optional. Default: "HTTP"): Protocol of the requests to be
-  performed. One of "HTTP" or "TCP".
-* `timeoutSeconds` (Optional. Default: 20): Number of seconds after which a
-  health check is considered a failure regardless of the response.
+* `port` (Optional. Default: None): Port number to be used for health requests.
+
+The following options only apply to HTTP health checks:
+
+* `path` (Optional. Default: "/"): Path to endpoint exposed by the task that
+  will provide health  status. Example: "/path/to/health".
 * `ignoreHttp1xx` (Optional. Default: false): Ignore HTTP informational status
-codes 100 to 199. If the HTTP health check returns one of these, the result is
-discarded and the health status of the task remains unchanged.
-* `overridePort` (Optional. Default: None): Send healthchecks to this port
-instead of using portIndex.
+  codes 100 to 199. If the HTTP health check returns one of these, the result is
+  discarded and the health status of the task remains unchanged.
 
 #### Health Lifecycle
 

--- a/docs/docs/health-checks.md
+++ b/docs/docs/health-checks.md
@@ -87,6 +87,8 @@ more details.
 * `ignoreHttp1xx` (Optional. Default: false): Ignore HTTP informational status
 codes 100 to 199. If the HTTP health check returns one of these, the result is
 discarded and the health status of the task remains unchanged.
+* `overridePort` (Optional. Default: None): Send healthchecks to this port
+instead of using portIndex.
 
 #### Health Lifecycle
 

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppDefinition.json
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppDefinition.json
@@ -198,7 +198,7 @@
                         "minimum": 0,
                         "type": "integer"
                     },
-                    "overridePort": {
+                    "port": {
                         "maximum": 65535,
                         "minimum": 0,
                         "type": "integer"

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppDefinition.json
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppDefinition.json
@@ -198,6 +198,11 @@
                         "minimum": 0,
                         "type": "integer"
                     },
+                    "overridePort": {
+                        "maximum": 65535,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
                     "path": {
                         "type": "string"
                     },

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
@@ -86,7 +86,7 @@ Here is an example of an application JSON which includes all fields.
             "path": "/machinehealth",
             "gracePeriodSeconds": 3,
             "intervalSeconds": 10,
-            "overridePort": 3333,
+            "port": 3333,
             "timeoutSeconds": 10,
             "maxConsecutiveFailures": 3
         },

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
@@ -82,6 +82,15 @@ Here is an example of an application JSON which includes all fields.
             "maxConsecutiveFailures": 3
         },
         {
+            "protocol": "HTTP",
+            "path": "/machinehealth",
+            "gracePeriodSeconds": 3,
+            "intervalSeconds": 10,
+            "overridePort": 3333,
+            "timeoutSeconds": 10,
+            "maxConsecutiveFailures": 3
+        },
+        {
             "protocol": "TCP",
             "gracePeriodSeconds": 3,
             "intervalSeconds": 5,

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_show.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_show.md
@@ -188,7 +188,6 @@ Transfer-Encoding: chunked
                 "intervalSeconds": 10,
                 "maxConsecutiveFailures": 6,
                 "path": "/machinehealth",
-                "portIndex": 0,
                 "overridePort": 3333,
                 "protocol": "HTTP",
                 "timeoutSeconds": 10

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_show.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_show.md
@@ -181,6 +181,17 @@ Transfer-Encoding: chunked
                 "portIndex": 0,
                 "protocol": "HTTP",
                 "timeoutSeconds": 10
+            },
+            {
+                "command": null,
+                "gracePeriodSeconds": 5,
+                "intervalSeconds": 10,
+                "maxConsecutiveFailures": 6,
+                "path": "/machinehealth",
+                "portIndex": 0,
+                "overridePort": 3333,
+                "protocol": "HTTP",
+                "timeoutSeconds": 10
             }
         ],
         "id": "/toggle",
@@ -211,6 +222,14 @@ Transfer-Encoding: chunked
                         "lastFailure": null,
                         "lastSuccess": "2014-09-13T00:25:07.506Z",
                         "taskId": "toggle.802df2ae-3ad4-11e4-a400-56847afe9799"
+                    },
+                    {
+                        "alive": true,
+                        "consecutiveFailures": 0,
+                        "firstSuccess": "2014-09-13T00:20:28.101Z",
+                        "lastFailure": null,
+                        "lastSuccess": "2014-09-13T00:25:07.506Z",
+                        "taskId": "toggle.802df2ae-3ad4-11e4-a400-56847afe9799"
                     }
                 ],
                 "host": "10.141.141.10",
@@ -232,6 +251,14 @@ Transfer-Encoding: chunked
                         "lastFailure": null,
                         "lastSuccess": "2014-09-13T00:25:07.508Z",
                         "taskId": "toggle.7c99814d-3ad4-11e4-a400-56847afe9799"
+                    },
+                    {
+                        "alive": true,
+                        "consecutiveFailures": 0,
+                        "firstSuccess": "2014-09-13T00:20:28.101Z",
+                        "lastFailure": null,
+                        "lastSuccess": "2014-09-13T00:25:07.506Z",
+                        "taskId": "toggle.802df2ae-3ad4-11e4-a400-56847afe9799"
                     }
                 ],
                 "host": "10.141.141.10",

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -208,6 +208,11 @@
           "path": {
             "type": "string"
           },
+          "port": {
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
+          },
           "portIndex": {
             "minimum": 0,
             "type": "integer"

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -1005,6 +1005,16 @@ public final class Protos {
      * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
      */
     boolean getIgnoreHttp1Xx();
+
+    // optional uint32 overridePort = 10;
+    /**
+     * <code>optional uint32 overridePort = 10;</code>
+     */
+    boolean hasOverridePort();
+    /**
+     * <code>optional uint32 overridePort = 10;</code>
+     */
+    int getOverridePort();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
@@ -1114,6 +1124,11 @@ public final class Protos {
             case 72: {
               bitField0_ |= 0x00000100;
               ignoreHttp1Xx_ = input.readBool();
+              break;
+            }
+            case 80: {
+              bitField0_ |= 0x00000200;
+              overridePort_ = input.readUInt32();
               break;
             }
           }
@@ -1445,6 +1460,22 @@ public final class Protos {
       return ignoreHttp1Xx_;
     }
 
+    // optional uint32 overridePort = 10;
+    public static final int OVERRIDEPORT_FIELD_NUMBER = 10;
+    private int overridePort_;
+    /**
+     * <code>optional uint32 overridePort = 10;</code>
+     */
+    public boolean hasOverridePort() {
+      return ((bitField0_ & 0x00000200) == 0x00000200);
+    }
+    /**
+     * <code>optional uint32 overridePort = 10;</code>
+     */
+    public int getOverridePort() {
+      return overridePort_;
+    }
+
     private void initFields() {
       protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
       portIndex_ = 0;
@@ -1455,6 +1486,7 @@ public final class Protos {
       maxConsecutiveFailures_ = 3;
       command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
       ignoreHttp1Xx_ = false;
+      overridePort_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1509,6 +1541,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         output.writeBool(9, ignoreHttp1Xx_);
       }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        output.writeUInt32(10, overridePort_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -1553,6 +1588,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(9, ignoreHttp1Xx_);
+      }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(10, overridePort_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1693,6 +1732,8 @@ public final class Protos {
         bitField0_ = (bitField0_ & ~0x00000080);
         ignoreHttp1Xx_ = false;
         bitField0_ = (bitField0_ & ~0x00000100);
+        overridePort_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000200);
         return this;
       }
 
@@ -1761,6 +1802,10 @@ public final class Protos {
           to_bitField0_ |= 0x00000100;
         }
         result.ignoreHttp1Xx_ = ignoreHttp1Xx_;
+        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+          to_bitField0_ |= 0x00000200;
+        }
+        result.overridePort_ = overridePort_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1805,6 +1850,9 @@ public final class Protos {
         }
         if (other.hasIgnoreHttp1Xx()) {
           setIgnoreHttp1Xx(other.getIgnoreHttp1Xx());
+        }
+        if (other.hasOverridePort()) {
+          setOverridePort(other.getOverridePort());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -2292,6 +2340,39 @@ public final class Protos {
       public Builder clearIgnoreHttp1Xx() {
         bitField0_ = (bitField0_ & ~0x00000100);
         ignoreHttp1Xx_ = false;
+        onChanged();
+        return this;
+      }
+
+      // optional uint32 overridePort = 10;
+      private int overridePort_ ;
+      /**
+       * <code>optional uint32 overridePort = 10;</code>
+       */
+      public boolean hasOverridePort() {
+        return ((bitField0_ & 0x00000200) == 0x00000200);
+      }
+      /**
+       * <code>optional uint32 overridePort = 10;</code>
+       */
+      public int getOverridePort() {
+        return overridePort_;
+      }
+      /**
+       * <code>optional uint32 overridePort = 10;</code>
+       */
+      public Builder setOverridePort(int value) {
+        bitField0_ |= 0x00000200;
+        overridePort_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 overridePort = 10;</code>
+       */
+      public Builder clearOverridePort() {
+        bitField0_ = (bitField0_ & ~0x00000200);
+        overridePort_ = 0;
         onChanged();
         return this;
       }
@@ -21444,7 +21525,7 @@ public final class Protos {
       "\030\001 \002(\t\022:\n\010operator\030\002 \002(\0162(.mesosphere.ma" +
       "rathon.Constraint.Operator\022\r\n\005value\030\003 \001(" +
       "\t\"G\n\010Operator\022\n\n\006UNIQUE\020\000\022\010\n\004LIKE\020\001\022\013\n\007C" +
-      "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\"\373\002\n\025H" +
+      "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\"\221\003\n\025H" +
       "ealthCheckDefinition\022E\n\010protocol\030\001 \002(\01623" +
       ".mesosphere.marathon.HealthCheckDefiniti" +
       "on.Protocol\022\024\n\tportIndex\030\002 \002(\r:\0010\022\036\n\022gra" +
@@ -21453,76 +21534,76 @@ public final class Protos {
       "20\022\017\n\004path\030\006 \001(\t:\001/\022!\n\026maxConsecutiveFai" +
       "lures\030\007 \001(\r:\0013\022#\n\007command\030\010 \001(\0132\022.mesos." +
       "CommandInfo\022\034\n\rignoreHttp1xx\030\t \001(\010:\005fals" +
-      "e\"5\n\010Protocol\022\010\n\004HTTP\020\000\022\007\n\003TCP\020\001\022\013\n\007COMM" +
-      "AND\020\002\022\t\n\005HTTPS\020\003\"\323\006\n\021ServiceDefinition\022\n" +
-      "\n\002id\030\001 \002(\t\022\037\n\003cmd\030\002 \002(\0132\022.mesos.CommandI" +
-      "nfo\022\021\n\tinstances\030\003 \002(\r\022\"\n\tresources\030\004 \003(" +
-      "\0132\017.mesos.Resource\022\023\n\013description\030\005 \001(\t\022" +
-      "\r\n\005ports\030\006 \003(\r\0224\n\013constraints\030\007 \003(\0132\037.me",
-      "sosphere.marathon.Constraint\022\022\n\010executor" +
-      "\030\010 \002(\t:\000\022>\n\022OBSOLETE_container\030\n \001(\0132\".m" +
-      "esosphere.marathon.ContainerInfo\022)\n\007vers" +
-      "ion\030\013 \001(\t:\0301970-01-01T00:00:00.000Z\022@\n\014h" +
-      "ealthChecks\030\014 \003(\0132*.mesosphere.marathon." +
-      "HealthCheckDefinition\022\025\n\007backoff\030\r \001(\003:\004" +
-      "1000\022\033\n\rbackoffFactor\030\016 \001(\001:\0041.15\022G\n\017upg" +
-      "radeStrategy\030\017 \001(\0132..mesosphere.marathon" +
-      ".UpgradeStrategyDefinition\022\024\n\014dependenci" +
-      "es\030\020 \003(\t\022\021\n\tstoreUrls\030\021 \003(\t\022\034\n\rrequire_p",
-      "orts\030\022 \001(\010:\005false\022=\n\tcontainer\030\023 \001(\0132*.m" +
-      "esosphere.marathon.ExtendedContainerInfo" +
-      "\022 \n\006labels\030\024 \003(\0132\020.mesos.Parameter\022\037\n\016ma" +
-      "xLaunchDelay\030\025 \001(\003:\0073600000\022A\n\025acceptedR" +
-      "esourceRoles\030\026 \001(\0132\".mesosphere.marathon" +
-      ".ResourceRoles\022\027\n\017last_scaling_at\030\027 \001(\003\022" +
-      "\035\n\025last_config_change_at\030\030 \001(\003\"\035\n\rResour" +
-      "ceRoles\022\014\n\004role\030\001 \003(\t\"\241\002\n\014MarathonTask\022\n" +
-      "\n\002id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022" +
-      "$\n\nattributes\030\004 \003(\0132\020.mesos.Attribute\022\021\n",
-      "\tstaged_at\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003\022,\n\021" +
-      "OBSOLETE_statuses\030\007 \003(\0132\021.mesos.TaskStat" +
-      "us\022)\n\007version\030\010 \001(\t:\0301970-01-01T00:00:00" +
-      ".000Z\022!\n\006status\030\t \001(\0132\021.mesos.TaskStatus" +
-      "\022\037\n\007slaveId\030\n \001(\0132\016.mesos.SlaveID\"M\n\013Mar" +
-      "athonApp\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!." +
-      "mesosphere.marathon.MarathonTask\"1\n\rCont" +
-      "ainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007options\030\002 " +
-      "\003(\014\"\237\004\n\025ExtendedContainerInfo\022\'\n\004type\030\001 " +
-      "\002(\0162\031.mesos.ContainerInfo.Type\022\036\n\007volume",
-      "s\030\002 \003(\0132\r.mesos.Volume\022E\n\006docker\030\003 \001(\01325" +
-      ".mesosphere.marathon.ExtendedContainerIn" +
-      "fo.DockerInfo\032\365\002\n\nDockerInfo\022\r\n\005image\030\001 " +
-      "\002(\t\022>\n\007network\030\002 \001(\0162\'.mesos.ContainerIn" +
-      "fo.DockerInfo.Network:\004HOST\022X\n\rport_mapp" +
-      "ings\030\003 \003(\0132A.mesosphere.marathon.Extende" +
-      "dContainerInfo.DockerInfo.PortMapping\022\031\n" +
-      "\nprivileged\030\004 \001(\010:\005false\022$\n\nparameters\030\005" +
-      " \003(\0132\020.mesos.Parameter\022\030\n\020force_pull_ima" +
-      "ge\030\006 \001(\010\032c\n\013PortMapping\022\021\n\thost_port\030\001 \002",
-      "(\r\022\026\n\016container_port\030\002 \002(\r\022\020\n\010protocol\030\003" +
-      " \001(\t\022\027\n\014service_port\030d \001(\r:\0010\")\n\020EventSu" +
-      "bscribers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016Stor" +
-      "ageVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r" +
-      "\022\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefini" +
-      "tion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023m" +
-      "aximumOverCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDef" +
-      "inition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004" +
-      "apps\030\003 \003(\0132&.mesosphere.marathon.Service" +
-      "Definition\0224\n\006groups\030\004 \003(\0132$.mesosphere.",
-      "marathon.GroupDefinition\022\024\n\014dependencies" +
-      "\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002i" +
-      "d\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002" +
-      "(\0132$.mesosphere.marathon.GroupDefinition" +
-      "\0224\n\006target\030\005 \002(\0132$.mesosphere.marathon.G" +
-      "roupDefinition\"\306\001\n\013TaskFailure\022\016\n\006app_id" +
-      "\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037" +
-      "\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007messa" +
-      "ge\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 " +
-      "\002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132",
-      "\016.mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004name\030" +
-      "\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\nco" +
-      "mpressed\030\004 \001(\010:\005falseB\035\n\023mesosphere.mara" +
-      "thonB\006Protos"
+      "e\022\024\n\014overridePort\030\n \001(\r\"5\n\010Protocol\022\010\n\004H" +
+      "TTP\020\000\022\007\n\003TCP\020\001\022\013\n\007COMMAND\020\002\022\t\n\005HTTPS\020\003\"\323" +
+      "\006\n\021ServiceDefinition\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030" +
+      "\002 \002(\0132\022.mesos.CommandInfo\022\021\n\tinstances\030\003" +
+      " \002(\r\022\"\n\tresources\030\004 \003(\0132\017.mesos.Resource" +
+      "\022\023\n\013description\030\005 \001(\t\022\r\n\005ports\030\006 \003(\r\0224\n\013",
+      "constraints\030\007 \003(\0132\037.mesosphere.marathon." +
+      "Constraint\022\022\n\010executor\030\010 \002(\t:\000\022>\n\022OBSOLE" +
+      "TE_container\030\n \001(\0132\".mesosphere.marathon" +
+      ".ContainerInfo\022)\n\007version\030\013 \001(\t:\0301970-01" +
+      "-01T00:00:00.000Z\022@\n\014healthChecks\030\014 \003(\0132" +
+      "*.mesosphere.marathon.HealthCheckDefinit" +
+      "ion\022\025\n\007backoff\030\r \001(\003:\0041000\022\033\n\rbackoffFac" +
+      "tor\030\016 \001(\001:\0041.15\022G\n\017upgradeStrategy\030\017 \001(\013" +
+      "2..mesosphere.marathon.UpgradeStrategyDe" +
+      "finition\022\024\n\014dependencies\030\020 \003(\t\022\021\n\tstoreU",
+      "rls\030\021 \003(\t\022\034\n\rrequire_ports\030\022 \001(\010:\005false\022" +
+      "=\n\tcontainer\030\023 \001(\0132*.mesosphere.marathon" +
+      ".ExtendedContainerInfo\022 \n\006labels\030\024 \003(\0132\020" +
+      ".mesos.Parameter\022\037\n\016maxLaunchDelay\030\025 \001(\003" +
+      ":\0073600000\022A\n\025acceptedResourceRoles\030\026 \001(\013" +
+      "2\".mesosphere.marathon.ResourceRoles\022\027\n\017" +
+      "last_scaling_at\030\027 \001(\003\022\035\n\025last_config_cha" +
+      "nge_at\030\030 \001(\003\"\035\n\rResourceRoles\022\014\n\004role\030\001 " +
+      "\003(\t\"\241\002\n\014MarathonTask\022\n\n\002id\030\001 \002(\t\022\014\n\004host" +
+      "\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022$\n\nattributes\030\004 \003(",
+      "\0132\020.mesos.Attribute\022\021\n\tstaged_at\030\005 \001(\003\022\022" +
+      "\n\nstarted_at\030\006 \001(\003\022,\n\021OBSOLETE_statuses\030" +
+      "\007 \003(\0132\021.mesos.TaskStatus\022)\n\007version\030\010 \001(" +
+      "\t:\0301970-01-01T00:00:00.000Z\022!\n\006status\030\t " +
+      "\001(\0132\021.mesos.TaskStatus\022\037\n\007slaveId\030\n \001(\0132" +
+      "\016.mesos.SlaveID\"M\n\013MarathonApp\022\014\n\004name\030\001" +
+      " \001(\t\0220\n\005tasks\030\002 \003(\0132!.mesosphere.maratho" +
+      "n.MarathonTask\"1\n\rContainerInfo\022\017\n\005image" +
+      "\030\001 \002(\014:\000\022\017\n\007options\030\002 \003(\014\"\237\004\n\025ExtendedCo" +
+      "ntainerInfo\022\'\n\004type\030\001 \002(\0162\031.mesos.Contai",
+      "nerInfo.Type\022\036\n\007volumes\030\002 \003(\0132\r.mesos.Vo" +
+      "lume\022E\n\006docker\030\003 \001(\01325.mesosphere.marath" +
+      "on.ExtendedContainerInfo.DockerInfo\032\365\002\n\n" +
+      "DockerInfo\022\r\n\005image\030\001 \002(\t\022>\n\007network\030\002 \001" +
+      "(\0162\'.mesos.ContainerInfo.DockerInfo.Netw" +
+      "ork:\004HOST\022X\n\rport_mappings\030\003 \003(\0132A.mesos" +
+      "phere.marathon.ExtendedContainerInfo.Doc" +
+      "kerInfo.PortMapping\022\031\n\nprivileged\030\004 \001(\010:" +
+      "\005false\022$\n\nparameters\030\005 \003(\0132\020.mesos.Param" +
+      "eter\022\030\n\020force_pull_image\030\006 \001(\010\032c\n\013PortMa",
+      "pping\022\021\n\thost_port\030\001 \002(\r\022\026\n\016container_po" +
+      "rt\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\027\n\014service_po" +
+      "rt\030d \001(\r:\0010\")\n\020EventSubscribers\022\025\n\rcallb" +
+      "ack_urls\030\001 \003(\t\"=\n\016StorageVersion\022\r\n\005majo" +
+      "r\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z\n" +
+      "\031UpgradeStrategyDefinition\022\035\n\025minimumHea" +
+      "lthCapacity\030\001 \002(\001\022\036\n\023maximumOverCapacity" +
+      "\030\002 \001(\001:\0011\"\260\001\n\017GroupDefinition\022\n\n\002id\030\001 \002(" +
+      "\t\022\017\n\007version\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.mesos" +
+      "phere.marathon.ServiceDefinition\0224\n\006grou",
+      "ps\030\004 \003(\0132$.mesosphere.marathon.GroupDefi" +
+      "nition\022\024\n\014dependencies\030\005 \003(\t\"\245\001\n\030Deploym" +
+      "entPlanDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007version" +
+      "\030\002 \002(\t\0226\n\010original\030\004 \002(\0132$.mesosphere.ma" +
+      "rathon.GroupDefinition\0224\n\006target\030\005 \002(\0132$" +
+      ".mesosphere.marathon.GroupDefinition\"\306\001\n" +
+      "\013TaskFailure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id\030" +
+      "\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003 \002(\0162\020.me" +
+      "sos.TaskState\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004host" +
+      "\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\ttimestamp\030\007",
+      " \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016.mesos.SlaveID\"T\n" +
+      "\014ZKStoreEntry\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002(" +
+      "\014\022\r\n\005value\030\003 \002(\014\022\031\n\ncompressed\030\004 \001(\010:\005fa" +
+      "lseB\035\n\023mesosphere.marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -21540,7 +21621,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
-              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", });
+              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "OverridePort", });
           internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
             getDescriptor().getMessageTypes().get(2);
           internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -905,13 +905,13 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.HealthCheckDefinition.Protocol getProtocol();
 
-    // required uint32 portIndex = 2 [default = 0];
+    // optional uint32 portIndex = 2;
     /**
-     * <code>required uint32 portIndex = 2 [default = 0];</code>
+     * <code>optional uint32 portIndex = 2;</code>
      */
     boolean hasPortIndex();
     /**
-     * <code>required uint32 portIndex = 2 [default = 0];</code>
+     * <code>optional uint32 portIndex = 2;</code>
      */
     int getPortIndex();
 
@@ -1006,15 +1006,15 @@ public final class Protos {
      */
     boolean getIgnoreHttp1Xx();
 
-    // optional uint32 overridePort = 10;
+    // optional uint32 port = 10;
     /**
-     * <code>optional uint32 overridePort = 10;</code>
+     * <code>optional uint32 port = 10;</code>
      */
-    boolean hasOverridePort();
+    boolean hasPort();
     /**
-     * <code>optional uint32 overridePort = 10;</code>
+     * <code>optional uint32 port = 10;</code>
      */
-    int getOverridePort();
+    int getPort();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
@@ -1128,7 +1128,7 @@ public final class Protos {
             }
             case 80: {
               bitField0_ |= 0x00000200;
-              overridePort_ = input.readUInt32();
+              port_ = input.readUInt32();
               break;
             }
           }
@@ -1287,17 +1287,17 @@ public final class Protos {
       return protocol_;
     }
 
-    // required uint32 portIndex = 2 [default = 0];
+    // optional uint32 portIndex = 2;
     public static final int PORTINDEX_FIELD_NUMBER = 2;
     private int portIndex_;
     /**
-     * <code>required uint32 portIndex = 2 [default = 0];</code>
+     * <code>optional uint32 portIndex = 2;</code>
      */
     public boolean hasPortIndex() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>required uint32 portIndex = 2 [default = 0];</code>
+     * <code>optional uint32 portIndex = 2;</code>
      */
     public int getPortIndex() {
       return portIndex_;
@@ -1460,20 +1460,20 @@ public final class Protos {
       return ignoreHttp1Xx_;
     }
 
-    // optional uint32 overridePort = 10;
-    public static final int OVERRIDEPORT_FIELD_NUMBER = 10;
-    private int overridePort_;
+    // optional uint32 port = 10;
+    public static final int PORT_FIELD_NUMBER = 10;
+    private int port_;
     /**
-     * <code>optional uint32 overridePort = 10;</code>
+     * <code>optional uint32 port = 10;</code>
      */
-    public boolean hasOverridePort() {
+    public boolean hasPort() {
       return ((bitField0_ & 0x00000200) == 0x00000200);
     }
     /**
-     * <code>optional uint32 overridePort = 10;</code>
+     * <code>optional uint32 port = 10;</code>
      */
-    public int getOverridePort() {
-      return overridePort_;
+    public int getPort() {
+      return port_;
     }
 
     private void initFields() {
@@ -1486,7 +1486,7 @@ public final class Protos {
       maxConsecutiveFailures_ = 3;
       command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
       ignoreHttp1Xx_ = false;
-      overridePort_ = 0;
+      port_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1494,10 +1494,6 @@ public final class Protos {
       if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasProtocol()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasPortIndex()) {
         memoizedIsInitialized = 0;
         return false;
       }
@@ -1542,7 +1538,7 @@ public final class Protos {
         output.writeBool(9, ignoreHttp1Xx_);
       }
       if (((bitField0_ & 0x00000200) == 0x00000200)) {
-        output.writeUInt32(10, overridePort_);
+        output.writeUInt32(10, port_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -1591,7 +1587,7 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000200) == 0x00000200)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(10, overridePort_);
+          .computeUInt32Size(10, port_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1732,7 +1728,7 @@ public final class Protos {
         bitField0_ = (bitField0_ & ~0x00000080);
         ignoreHttp1Xx_ = false;
         bitField0_ = (bitField0_ & ~0x00000100);
-        overridePort_ = 0;
+        port_ = 0;
         bitField0_ = (bitField0_ & ~0x00000200);
         return this;
       }
@@ -1805,7 +1801,7 @@ public final class Protos {
         if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
           to_bitField0_ |= 0x00000200;
         }
-        result.overridePort_ = overridePort_;
+        result.port_ = port_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1851,8 +1847,8 @@ public final class Protos {
         if (other.hasIgnoreHttp1Xx()) {
           setIgnoreHttp1Xx(other.getIgnoreHttp1Xx());
         }
-        if (other.hasOverridePort()) {
-          setOverridePort(other.getOverridePort());
+        if (other.hasPort()) {
+          setPort(other.getPort());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -1860,10 +1856,6 @@ public final class Protos {
 
       public final boolean isInitialized() {
         if (!hasProtocol()) {
-          
-          return false;
-        }
-        if (!hasPortIndex()) {
           
           return false;
         }
@@ -1931,22 +1923,22 @@ public final class Protos {
         return this;
       }
 
-      // required uint32 portIndex = 2 [default = 0];
+      // optional uint32 portIndex = 2;
       private int portIndex_ ;
       /**
-       * <code>required uint32 portIndex = 2 [default = 0];</code>
+       * <code>optional uint32 portIndex = 2;</code>
        */
       public boolean hasPortIndex() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>required uint32 portIndex = 2 [default = 0];</code>
+       * <code>optional uint32 portIndex = 2;</code>
        */
       public int getPortIndex() {
         return portIndex_;
       }
       /**
-       * <code>required uint32 portIndex = 2 [default = 0];</code>
+       * <code>optional uint32 portIndex = 2;</code>
        */
       public Builder setPortIndex(int value) {
         bitField0_ |= 0x00000002;
@@ -1955,7 +1947,7 @@ public final class Protos {
         return this;
       }
       /**
-       * <code>required uint32 portIndex = 2 [default = 0];</code>
+       * <code>optional uint32 portIndex = 2;</code>
        */
       public Builder clearPortIndex() {
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -2344,35 +2336,35 @@ public final class Protos {
         return this;
       }
 
-      // optional uint32 overridePort = 10;
-      private int overridePort_ ;
+      // optional uint32 port = 10;
+      private int port_ ;
       /**
-       * <code>optional uint32 overridePort = 10;</code>
+       * <code>optional uint32 port = 10;</code>
        */
-      public boolean hasOverridePort() {
+      public boolean hasPort() {
         return ((bitField0_ & 0x00000200) == 0x00000200);
       }
       /**
-       * <code>optional uint32 overridePort = 10;</code>
+       * <code>optional uint32 port = 10;</code>
        */
-      public int getOverridePort() {
-        return overridePort_;
+      public int getPort() {
+        return port_;
       }
       /**
-       * <code>optional uint32 overridePort = 10;</code>
+       * <code>optional uint32 port = 10;</code>
        */
-      public Builder setOverridePort(int value) {
+      public Builder setPort(int value) {
         bitField0_ |= 0x00000200;
-        overridePort_ = value;
+        port_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional uint32 overridePort = 10;</code>
+       * <code>optional uint32 port = 10;</code>
        */
-      public Builder clearOverridePort() {
+      public Builder clearPort() {
         bitField0_ = (bitField0_ & ~0x00000200);
-        overridePort_ = 0;
+        port_ = 0;
         onChanged();
         return this;
       }
@@ -21525,85 +21517,85 @@ public final class Protos {
       "\030\001 \002(\t\022:\n\010operator\030\002 \002(\0162(.mesosphere.ma" +
       "rathon.Constraint.Operator\022\r\n\005value\030\003 \001(" +
       "\t\"G\n\010Operator\022\n\n\006UNIQUE\020\000\022\010\n\004LIKE\020\001\022\013\n\007C" +
-      "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\"\221\003\n\025H" +
+      "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\"\206\003\n\025H" +
       "ealthCheckDefinition\022E\n\010protocol\030\001 \002(\01623" +
       ".mesosphere.marathon.HealthCheckDefiniti" +
-      "on.Protocol\022\024\n\tportIndex\030\002 \002(\r:\0010\022\036\n\022gra" +
-      "cePeriodSeconds\030\003 \001(\r:\00215\022\033\n\017intervalSec",
-      "onds\030\004 \001(\r:\00210\022\032\n\016timeoutSeconds\030\005 \001(\r:\002" +
-      "20\022\017\n\004path\030\006 \001(\t:\001/\022!\n\026maxConsecutiveFai" +
-      "lures\030\007 \001(\r:\0013\022#\n\007command\030\010 \001(\0132\022.mesos." +
-      "CommandInfo\022\034\n\rignoreHttp1xx\030\t \001(\010:\005fals" +
-      "e\022\024\n\014overridePort\030\n \001(\r\"5\n\010Protocol\022\010\n\004H" +
-      "TTP\020\000\022\007\n\003TCP\020\001\022\013\n\007COMMAND\020\002\022\t\n\005HTTPS\020\003\"\323" +
-      "\006\n\021ServiceDefinition\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030" +
-      "\002 \002(\0132\022.mesos.CommandInfo\022\021\n\tinstances\030\003" +
-      " \002(\r\022\"\n\tresources\030\004 \003(\0132\017.mesos.Resource" +
-      "\022\023\n\013description\030\005 \001(\t\022\r\n\005ports\030\006 \003(\r\0224\n\013",
-      "constraints\030\007 \003(\0132\037.mesosphere.marathon." +
-      "Constraint\022\022\n\010executor\030\010 \002(\t:\000\022>\n\022OBSOLE" +
-      "TE_container\030\n \001(\0132\".mesosphere.marathon" +
-      ".ContainerInfo\022)\n\007version\030\013 \001(\t:\0301970-01" +
-      "-01T00:00:00.000Z\022@\n\014healthChecks\030\014 \003(\0132" +
-      "*.mesosphere.marathon.HealthCheckDefinit" +
-      "ion\022\025\n\007backoff\030\r \001(\003:\0041000\022\033\n\rbackoffFac" +
-      "tor\030\016 \001(\001:\0041.15\022G\n\017upgradeStrategy\030\017 \001(\013" +
-      "2..mesosphere.marathon.UpgradeStrategyDe" +
-      "finition\022\024\n\014dependencies\030\020 \003(\t\022\021\n\tstoreU",
-      "rls\030\021 \003(\t\022\034\n\rrequire_ports\030\022 \001(\010:\005false\022" +
-      "=\n\tcontainer\030\023 \001(\0132*.mesosphere.marathon" +
-      ".ExtendedContainerInfo\022 \n\006labels\030\024 \003(\0132\020" +
-      ".mesos.Parameter\022\037\n\016maxLaunchDelay\030\025 \001(\003" +
-      ":\0073600000\022A\n\025acceptedResourceRoles\030\026 \001(\013" +
-      "2\".mesosphere.marathon.ResourceRoles\022\027\n\017" +
-      "last_scaling_at\030\027 \001(\003\022\035\n\025last_config_cha" +
-      "nge_at\030\030 \001(\003\"\035\n\rResourceRoles\022\014\n\004role\030\001 " +
-      "\003(\t\"\241\002\n\014MarathonTask\022\n\n\002id\030\001 \002(\t\022\014\n\004host" +
-      "\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022$\n\nattributes\030\004 \003(",
-      "\0132\020.mesos.Attribute\022\021\n\tstaged_at\030\005 \001(\003\022\022" +
-      "\n\nstarted_at\030\006 \001(\003\022,\n\021OBSOLETE_statuses\030" +
-      "\007 \003(\0132\021.mesos.TaskStatus\022)\n\007version\030\010 \001(" +
-      "\t:\0301970-01-01T00:00:00.000Z\022!\n\006status\030\t " +
-      "\001(\0132\021.mesos.TaskStatus\022\037\n\007slaveId\030\n \001(\0132" +
-      "\016.mesos.SlaveID\"M\n\013MarathonApp\022\014\n\004name\030\001" +
-      " \001(\t\0220\n\005tasks\030\002 \003(\0132!.mesosphere.maratho" +
-      "n.MarathonTask\"1\n\rContainerInfo\022\017\n\005image" +
-      "\030\001 \002(\014:\000\022\017\n\007options\030\002 \003(\014\"\237\004\n\025ExtendedCo" +
-      "ntainerInfo\022\'\n\004type\030\001 \002(\0162\031.mesos.Contai",
-      "nerInfo.Type\022\036\n\007volumes\030\002 \003(\0132\r.mesos.Vo" +
-      "lume\022E\n\006docker\030\003 \001(\01325.mesosphere.marath" +
-      "on.ExtendedContainerInfo.DockerInfo\032\365\002\n\n" +
-      "DockerInfo\022\r\n\005image\030\001 \002(\t\022>\n\007network\030\002 \001" +
-      "(\0162\'.mesos.ContainerInfo.DockerInfo.Netw" +
-      "ork:\004HOST\022X\n\rport_mappings\030\003 \003(\0132A.mesos" +
-      "phere.marathon.ExtendedContainerInfo.Doc" +
-      "kerInfo.PortMapping\022\031\n\nprivileged\030\004 \001(\010:" +
-      "\005false\022$\n\nparameters\030\005 \003(\0132\020.mesos.Param" +
-      "eter\022\030\n\020force_pull_image\030\006 \001(\010\032c\n\013PortMa",
-      "pping\022\021\n\thost_port\030\001 \002(\r\022\026\n\016container_po" +
-      "rt\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\027\n\014service_po" +
-      "rt\030d \001(\r:\0010\")\n\020EventSubscribers\022\025\n\rcallb" +
-      "ack_urls\030\001 \003(\t\"=\n\016StorageVersion\022\r\n\005majo" +
-      "r\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z\n" +
-      "\031UpgradeStrategyDefinition\022\035\n\025minimumHea" +
-      "lthCapacity\030\001 \002(\001\022\036\n\023maximumOverCapacity" +
-      "\030\002 \001(\001:\0011\"\260\001\n\017GroupDefinition\022\n\n\002id\030\001 \002(" +
-      "\t\022\017\n\007version\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.mesos" +
-      "phere.marathon.ServiceDefinition\0224\n\006grou",
-      "ps\030\004 \003(\0132$.mesosphere.marathon.GroupDefi" +
-      "nition\022\024\n\014dependencies\030\005 \003(\t\"\245\001\n\030Deploym" +
-      "entPlanDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007version" +
-      "\030\002 \002(\t\0226\n\010original\030\004 \002(\0132$.mesosphere.ma" +
-      "rathon.GroupDefinition\0224\n\006target\030\005 \002(\0132$" +
-      ".mesosphere.marathon.GroupDefinition\"\306\001\n" +
-      "\013TaskFailure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id\030" +
-      "\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003 \002(\0162\020.me" +
-      "sos.TaskState\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004host" +
-      "\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\ttimestamp\030\007",
-      " \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016.mesos.SlaveID\"T\n" +
-      "\014ZKStoreEntry\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002(" +
-      "\014\022\r\n\005value\030\003 \002(\014\022\031\n\ncompressed\030\004 \001(\010:\005fa" +
-      "lseB\035\n\023mesosphere.marathonB\006Protos"
+      "on.Protocol\022\021\n\tportIndex\030\002 \001(\r\022\036\n\022graceP" +
+      "eriodSeconds\030\003 \001(\r:\00215\022\033\n\017intervalSecond",
+      "s\030\004 \001(\r:\00210\022\032\n\016timeoutSeconds\030\005 \001(\r:\00220\022" +
+      "\017\n\004path\030\006 \001(\t:\001/\022!\n\026maxConsecutiveFailur" +
+      "es\030\007 \001(\r:\0013\022#\n\007command\030\010 \001(\0132\022.mesos.Com" +
+      "mandInfo\022\034\n\rignoreHttp1xx\030\t \001(\010:\005false\022\014" +
+      "\n\004port\030\n \001(\r\"5\n\010Protocol\022\010\n\004HTTP\020\000\022\007\n\003TC" +
+      "P\020\001\022\013\n\007COMMAND\020\002\022\t\n\005HTTPS\020\003\"\323\006\n\021ServiceD" +
+      "efinition\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030\002 \002(\0132\022.mes" +
+      "os.CommandInfo\022\021\n\tinstances\030\003 \002(\r\022\"\n\tres" +
+      "ources\030\004 \003(\0132\017.mesos.Resource\022\023\n\013descrip" +
+      "tion\030\005 \001(\t\022\r\n\005ports\030\006 \003(\r\0224\n\013constraints",
+      "\030\007 \003(\0132\037.mesosphere.marathon.Constraint\022" +
+      "\022\n\010executor\030\010 \002(\t:\000\022>\n\022OBSOLETE_containe" +
+      "r\030\n \001(\0132\".mesosphere.marathon.ContainerI" +
+      "nfo\022)\n\007version\030\013 \001(\t:\0301970-01-01T00:00:0" +
+      "0.000Z\022@\n\014healthChecks\030\014 \003(\0132*.mesospher" +
+      "e.marathon.HealthCheckDefinition\022\025\n\007back" +
+      "off\030\r \001(\003:\0041000\022\033\n\rbackoffFactor\030\016 \001(\001:\004" +
+      "1.15\022G\n\017upgradeStrategy\030\017 \001(\0132..mesosphe" +
+      "re.marathon.UpgradeStrategyDefinition\022\024\n" +
+      "\014dependencies\030\020 \003(\t\022\021\n\tstoreUrls\030\021 \003(\t\022\034",
+      "\n\rrequire_ports\030\022 \001(\010:\005false\022=\n\tcontaine" +
+      "r\030\023 \001(\0132*.mesosphere.marathon.ExtendedCo" +
+      "ntainerInfo\022 \n\006labels\030\024 \003(\0132\020.mesos.Para" +
+      "meter\022\037\n\016maxLaunchDelay\030\025 \001(\003:\0073600000\022A" +
+      "\n\025acceptedResourceRoles\030\026 \001(\0132\".mesosphe" +
+      "re.marathon.ResourceRoles\022\027\n\017last_scalin" +
+      "g_at\030\027 \001(\003\022\035\n\025last_config_change_at\030\030 \001(" +
+      "\003\"\035\n\rResourceRoles\022\014\n\004role\030\001 \003(\t\"\241\002\n\014Mar" +
+      "athonTask\022\n\n\002id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005p" +
+      "orts\030\003 \003(\r\022$\n\nattributes\030\004 \003(\0132\020.mesos.A",
+      "ttribute\022\021\n\tstaged_at\030\005 \001(\003\022\022\n\nstarted_a" +
+      "t\030\006 \001(\003\022,\n\021OBSOLETE_statuses\030\007 \003(\0132\021.mes" +
+      "os.TaskStatus\022)\n\007version\030\010 \001(\t:\0301970-01-" +
+      "01T00:00:00.000Z\022!\n\006status\030\t \001(\0132\021.mesos" +
+      ".TaskStatus\022\037\n\007slaveId\030\n \001(\0132\016.mesos.Sla" +
+      "veID\"M\n\013MarathonApp\022\014\n\004name\030\001 \001(\t\0220\n\005tas" +
+      "ks\030\002 \003(\0132!.mesosphere.marathon.MarathonT" +
+      "ask\"1\n\rContainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n" +
+      "\007options\030\002 \003(\014\"\237\004\n\025ExtendedContainerInfo" +
+      "\022\'\n\004type\030\001 \002(\0162\031.mesos.ContainerInfo.Typ",
+      "e\022\036\n\007volumes\030\002 \003(\0132\r.mesos.Volume\022E\n\006doc" +
+      "ker\030\003 \001(\01325.mesosphere.marathon.Extended" +
+      "ContainerInfo.DockerInfo\032\365\002\n\nDockerInfo\022" +
+      "\r\n\005image\030\001 \002(\t\022>\n\007network\030\002 \001(\0162\'.mesos." +
+      "ContainerInfo.DockerInfo.Network:\004HOST\022X" +
+      "\n\rport_mappings\030\003 \003(\0132A.mesosphere.marat" +
+      "hon.ExtendedContainerInfo.DockerInfo.Por" +
+      "tMapping\022\031\n\nprivileged\030\004 \001(\010:\005false\022$\n\np" +
+      "arameters\030\005 \003(\0132\020.mesos.Parameter\022\030\n\020for" +
+      "ce_pull_image\030\006 \001(\010\032c\n\013PortMapping\022\021\n\tho",
+      "st_port\030\001 \002(\r\022\026\n\016container_port\030\002 \002(\r\022\020\n" +
+      "\010protocol\030\003 \001(\t\022\027\n\014service_port\030d \001(\r:\0010" +
+      "\")\n\020EventSubscribers\022\025\n\rcallback_urls\030\001 " +
+      "\003(\t\"=\n\016StorageVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005" +
+      "minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStr" +
+      "ategyDefinition\022\035\n\025minimumHealthCapacity" +
+      "\030\001 \002(\001\022\036\n\023maximumOverCapacity\030\002 \001(\001:\0011\"\260" +
+      "\001\n\017GroupDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007versio" +
+      "n\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.mesosphere.marat" +
+      "hon.ServiceDefinition\0224\n\006groups\030\004 \003(\0132$.",
+      "mesosphere.marathon.GroupDefinition\022\024\n\014d" +
+      "ependencies\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefi" +
+      "nition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010o" +
+      "riginal\030\004 \002(\0132$.mesosphere.marathon.Grou" +
+      "pDefinition\0224\n\006target\030\005 \002(\0132$.mesosphere" +
+      ".marathon.GroupDefinition\"\306\001\n\013TaskFailur" +
+      "e\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mes" +
+      "os.TaskID\022\037\n\005state\030\003 \002(\0162\020.mesos.TaskSta" +
+      "te\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n" +
+      "\007version\030\006 \002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007sla",
+      "veId\030\010 \001(\0132\016.mesos.SlaveID\"T\n\014ZKStoreEnt" +
+      "ry\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030" +
+      "\003 \002(\014\022\031\n\ncompressed\030\004 \001(\010:\005falseB\035\n\023meso" +
+      "sphere.marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -21621,7 +21613,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
-              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "OverridePort", });
+              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "Port", });
           internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
             getDescriptor().getMessageTypes().get(2);
           internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -43,6 +43,7 @@ message HealthCheckDefinition {
   optional uint32 maxConsecutiveFailures = 7 [default = 3];
   optional mesos.CommandInfo command = 8;
   optional bool ignoreHttp1xx = 9 [default = false];
+  optional uint32 overridePort = 10;
 }
 
 message ServiceDefinition {

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -35,7 +35,7 @@ message HealthCheckDefinition {
     HTTPS = 3;
   }
   required Protocol protocol = 1;
-  required uint32 portIndex = 2 [default = 0];
+  optional uint32 portIndex = 2;
   optional uint32 gracePeriodSeconds = 3 [default = 15];
   optional uint32 intervalSeconds = 4 [default = 10];
   optional uint32 timeoutSeconds = 5 [default = 20];
@@ -43,7 +43,7 @@ message HealthCheckDefinition {
   optional uint32 maxConsecutiveFailures = 7 [default = 3];
   optional mesos.CommandInfo command = 8;
   optional bool ignoreHttp1xx = 9 [default = false];
-  optional uint32 overridePort = 10;
+  optional uint32 port = 10;
 }
 
 message ServiceDefinition {

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -356,7 +356,8 @@ trait HealthCheckFormats {
       (__ \ "intervalSeconds").formatNullable[Long].withDefault(DefaultInterval.toSeconds).asSeconds ~
       (__ \ "timeoutSeconds").formatNullable[Long].withDefault(DefaultTimeout.toSeconds).asSeconds ~
       (__ \ "maxConsecutiveFailures").formatNullable[Integer].withDefault(DefaultMaxConsecutiveFailures) ~
-      (__ \ "ignoreHttp1xx").formatNullable[Boolean].withDefault(DefaultIgnoreHttp1xx)
+      (__ \ "ignoreHttp1xx").formatNullable[Boolean].withDefault(DefaultIgnoreHttp1xx) ~
+      (__ \ "overridePort").formatNullable[Integer]
     )(HealthCheck.apply, unlift(HealthCheck.unapply))
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/validation/HealthCheckValidator.scala
+++ b/src/main/scala/mesosphere/marathon/api/validation/HealthCheckValidator.scala
@@ -4,20 +4,30 @@ import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import javax.validation.{ ConstraintValidator, ConstraintValidatorContext }
 
+/**
+  * FIXME: This is not called when an V2AppDefinition is called because the recursion apparently doesn't work
+  * with Scala Seq.
+  *
+  * We cannot re-enable it because it would break backwards compatibility in weird ways. If users hard already
+  * one invalid app definition, each deployment would cause a complete revalidation of the root group
+  * including the invalid one. Until the user changed all invalid apps, the user would get weird validation
+  * errors for every deployment potentially unrelated to the deployed apps.
+  */
 class HealthCheckValidator
     extends ConstraintValidator[ValidHealthCheck, HealthCheck] {
 
   def initialize(annotation: ValidHealthCheck): Unit = {}
 
   def isValid(hc: HealthCheck, context: ConstraintValidatorContext): Boolean = {
+    def eitherPortIndexOrPort: Boolean = hc.portIndex.isDefined ^ hc.port.isDefined
+
     val hasCommand = hc.command.isDefined
     val hasPath = hc.path.isDefined
     hc.protocol match {
-      case Protocol.COMMAND => hasCommand && !hasPath
-      case Protocol.HTTP    => !hasCommand
-      case Protocol.TCP     => !hasCommand && !hasPath
+      case Protocol.COMMAND => hasCommand && !hasPath && hc.port.isEmpty
+      case Protocol.HTTP    => !hasCommand && eitherPortIndexOrPort
+      case Protocol.TCP     => !hasCommand && !hasPath && eitherPortIndexOrPort
       case _                => true
     }
   }
-
 }

--- a/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
@@ -29,7 +29,9 @@ case class HealthCheck(
 
   maxConsecutiveFailures: JInt = HealthCheck.DefaultMaxConsecutiveFailures,
 
-  ignoreHttp1xx: Boolean = HealthCheck.DefaultIgnoreHttp1xx)
+  ignoreHttp1xx: Boolean = HealthCheck.DefaultIgnoreHttp1xx,
+
+  overridePort: Option[JInt] = HealthCheck.DefaultOverridePort)
     extends MarathonState[Protos.HealthCheckDefinition, HealthCheck] {
 
   def toProto: Protos.HealthCheckDefinition = {
@@ -45,6 +47,8 @@ case class HealthCheck(
     command foreach { c => builder.setCommand(c.toProto) }
 
     path foreach builder.setPath
+
+    overridePort foreach { p => builder.setOverridePort(p.toInt) }
 
     builder.build
   }
@@ -62,7 +66,9 @@ case class HealthCheck(
       timeout = proto.getTimeoutSeconds.seconds,
       interval = proto.getIntervalSeconds.seconds,
       maxConsecutiveFailures = proto.getMaxConsecutiveFailures,
-      ignoreHttp1xx = proto.getIgnoreHttp1Xx
+      ignoreHttp1xx = proto.getIgnoreHttp1Xx,
+      overridePort =
+        if (proto.hasOverridePort) Some(proto.getOverridePort) else None
     )
 
   def mergeFromProto(bytes: Array[Byte]): HealthCheck =
@@ -110,4 +116,5 @@ object HealthCheck {
   val DefaultTimeout = 20.seconds
   val DefaultMaxConsecutiveFailures = 3
   val DefaultIgnoreHttp1xx = false
+  val DefaultOverridePort = None
 }

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -83,7 +83,7 @@ case class AppDefinition(
   def portIndicesAreValid(): Boolean = {
     val validPortIndices = hostPorts.indices
     healthChecks.forall { hc =>
-      hc.protocol == Protocol.COMMAND || (validPortIndices contains hc.portIndex)
+      hc.protocol == Protocol.COMMAND || hc.portIndex.forall(validPortIndices.contains(_))
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -31,6 +31,29 @@ class HealthCheckTest extends MarathonSpec {
     assert(10 == proto.getGracePeriodSeconds)
     assert(60 == proto.getIntervalSeconds)
     assert(0 == proto.getMaxConsecutiveFailures)
+    assert(!proto.hasOverridePort)
+  }
+
+  test("ToProtoOverridePort") {
+    val healthCheck = HealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.HTTP,
+      portIndex = 0,
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      maxConsecutiveFailures = 0,
+      overridePort = Some(12345)
+    )
+
+    val proto = healthCheck.toProto
+
+    assert("/health" == proto.getPath)
+    assert(Protocol.HTTP == proto.getProtocol)
+    assert(0 == proto.getPortIndex)
+    assert(10 == proto.getGracePeriodSeconds)
+    assert(60 == proto.getIntervalSeconds)
+    assert(0 == proto.getMaxConsecutiveFailures)
+    assert(12345 == proto.getOverridePort)
   }
 
   test("ToProtoTcp") {
@@ -60,6 +83,7 @@ class HealthCheckTest extends MarathonSpec {
       .setIntervalSeconds(60)
       .setTimeoutSeconds(10)
       .setMaxConsecutiveFailures(10)
+      .setOverridePort(12345)
       .build
 
     val mergeResult = HealthCheck().mergeFromProto(proto)
@@ -71,7 +95,8 @@ class HealthCheckTest extends MarathonSpec {
       gracePeriod = 10.seconds,
       interval = 60.seconds,
       timeout = 10.seconds,
-      maxConsecutiveFailures = 10
+      maxConsecutiveFailures = 10,
+      overridePort = Some(12345)
     )
 
     assert(mergeResult == expectedResult)

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -2,7 +2,6 @@ package mesosphere.marathon.health
 
 import javax.validation.Validation
 
-import mesosphere.jackson.CaseClassModule
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.state.Command
 import mesosphere.marathon.{ MarathonSpec, Protos }
@@ -17,7 +16,7 @@ class HealthCheckTest extends MarathonSpec {
     val healthCheck = HealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTP,
-      portIndex = 0,
+      portIndex = Some(0),
       gracePeriod = 10.seconds,
       interval = 60.seconds,
       maxConsecutiveFailures = 0
@@ -31,35 +30,34 @@ class HealthCheckTest extends MarathonSpec {
     assert(10 == proto.getGracePeriodSeconds)
     assert(60 == proto.getIntervalSeconds)
     assert(0 == proto.getMaxConsecutiveFailures)
-    assert(!proto.hasOverridePort)
+    assert(!proto.hasPort)
   }
 
-  test("ToProtoOverridePort") {
+  test("ToProto with port") {
     val healthCheck = HealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTP,
-      portIndex = 0,
       gracePeriod = 10.seconds,
       interval = 60.seconds,
       maxConsecutiveFailures = 0,
-      overridePort = Some(12345)
+      port = Some(12345)
     )
 
     val proto = healthCheck.toProto
 
     assert("/health" == proto.getPath)
     assert(Protocol.HTTP == proto.getProtocol)
-    assert(0 == proto.getPortIndex)
+    assert(!proto.hasPortIndex)
     assert(10 == proto.getGracePeriodSeconds)
     assert(60 == proto.getIntervalSeconds)
     assert(0 == proto.getMaxConsecutiveFailures)
-    assert(12345 == proto.getOverridePort)
+    assert(12345 == proto.getPort)
   }
 
   test("ToProtoTcp") {
     val healthCheck = HealthCheck(
       protocol = Protocol.TCP,
-      portIndex = 1,
+      portIndex = Some(1),
       gracePeriod = 7.seconds,
       interval = 35.seconds,
       maxConsecutiveFailures = 10
@@ -74,7 +72,7 @@ class HealthCheckTest extends MarathonSpec {
     assert(10 == proto.getMaxConsecutiveFailures)
   }
 
-  test("MergeFromProto") {
+  test("MergeFromProto with portIndex") {
     val proto = Protos.HealthCheckDefinition.newBuilder
       .setPath("/health")
       .setProtocol(Protocol.HTTP)
@@ -83,7 +81,6 @@ class HealthCheckTest extends MarathonSpec {
       .setIntervalSeconds(60)
       .setTimeoutSeconds(10)
       .setMaxConsecutiveFailures(10)
-      .setOverridePort(12345)
       .build
 
     val mergeResult = HealthCheck().mergeFromProto(proto)
@@ -91,12 +88,65 @@ class HealthCheckTest extends MarathonSpec {
     val expectedResult = HealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTP,
-      portIndex = 0,
+      portIndex = Some(0),
       gracePeriod = 10.seconds,
       interval = 60.seconds,
       timeout = 10.seconds,
       maxConsecutiveFailures = 10,
-      overridePort = Some(12345)
+      port = None
+    )
+
+    assert(mergeResult == expectedResult)
+  }
+
+  test("MergeFromProto with port") {
+    val proto = Protos.HealthCheckDefinition.newBuilder
+      .setPath("/health")
+      .setProtocol(Protocol.HTTP)
+      .setGracePeriodSeconds(10)
+      .setIntervalSeconds(60)
+      .setTimeoutSeconds(10)
+      .setMaxConsecutiveFailures(10)
+      .setPort(12345)
+      .build
+
+    val mergeResult = HealthCheck().mergeFromProto(proto)
+
+    val expectedResult = HealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.HTTP,
+      portIndex = None,
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      timeout = 10.seconds,
+      maxConsecutiveFailures = 10,
+      port = Some(12345)
+    )
+
+    assert(mergeResult == expectedResult)
+  }
+
+  test("MergeFromProto with neither port nor portIndex") {
+    val proto = Protos.HealthCheckDefinition.newBuilder
+      .setPath("/health")
+      .setProtocol(Protocol.HTTP)
+      .setGracePeriodSeconds(10)
+      .setIntervalSeconds(60)
+      .setTimeoutSeconds(10)
+      .setMaxConsecutiveFailures(10)
+      .build
+
+    val mergeResult = HealthCheck().mergeFromProto(proto)
+
+    val expectedResult = HealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.HTTP,
+      portIndex = Some(0),
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      timeout = 10.seconds,
+      maxConsecutiveFailures = 10,
+      port = None
     )
 
     assert(mergeResult == expectedResult)
@@ -117,7 +167,7 @@ class HealthCheckTest extends MarathonSpec {
     val expectedResult = HealthCheck(
       path = None,
       protocol = Protocol.TCP,
-      portIndex = 1,
+      portIndex = Some(1),
       gracePeriod = 7.seconds,
       interval = 35.seconds,
       timeout = 10.seconds,
@@ -143,7 +193,7 @@ class HealthCheckTest extends MarathonSpec {
     val expectedResult = HealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTPS,
-      portIndex = 0,
+      portIndex = Some(0),
       gracePeriod = 10.seconds,
       interval = 60.seconds,
       timeout = 10.seconds,
@@ -174,7 +224,6 @@ class HealthCheckTest extends MarathonSpec {
       """
         {
           "protocol": "COMMAND",
-          "portIndex": 0,
           "command": { "value": "echo healthy" },
           "gracePeriodSeconds": 300,
           "intervalSeconds": 60,
@@ -191,55 +240,130 @@ class HealthCheckTest extends MarathonSpec {
     assert(readResult == expected)
   }
 
-  test("Validation") {
-    val validator = Validation.buildDefaultValidatorFactory().getValidator
-
-    def shouldViolate(hc: HealthCheck, template: String) = {
-      val violations = validator.validate(hc).asScala
-      assert(violations.exists(_.getMessageTemplate == template))
-    }
-
-    def shouldNotViolate(hc: HealthCheck, template: String) = {
-      val violations = validator.validate(hc).asScala
-      assert(!violations.exists(_.getMessageTemplate == template))
-    }
-
-    shouldNotViolate(HealthCheck(), "")
-
-    shouldViolate(
-      HealthCheck(protocol = Protocol.COMMAND, path = Some("/health")),
-      "Health check protocol must match supplied fields."
-    )
-
-    shouldViolate(
-      HealthCheck(protocol = Protocol.COMMAND, command = None),
-      "Health check protocol must match supplied fields."
-    )
-
-    shouldViolate(
+  test("Read COMMAND health check (portIndex may be provided for backwards-compatibility)") {
+    val json =
+      """
+        {
+          "protocol": "COMMAND",
+          "command": { "value": "echo healthy" },
+          "portIndex": 0,
+          "gracePeriodSeconds": 300,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 3
+        }
+      """
+    val expected =
       HealthCheck(
-        protocol = Protocol.HTTP,
-        command = Some(Command("echo healthy"))
-      ),
-      "Health check protocol must match supplied fields."
-    )
-
-    shouldViolate(
-      HealthCheck(
-        protocol = Protocol.TCP,
-        path = Some("/")
-      ),
-      "Health check protocol must match supplied fields."
-    )
-
-    shouldViolate(
-      HealthCheck(
-        protocol = Protocol.TCP,
-        command = Some(Command("echo healthy"))
-      ),
-      "Health check protocol must match supplied fields."
-    )
-
+        protocol = Protocol.COMMAND,
+        command = Some(Command("echo healthy")),
+        portIndex = Some(0)
+      )
+    val readResult = fromJson(json)
+    assert(readResult == expected)
   }
 
+  val validator = Validation.buildDefaultValidatorFactory().getValidator
+
+  def shouldBeInvalid(hc: HealthCheck) = {
+    val violations = validator.validate(hc).asScala
+    assert(violations.nonEmpty)
+  }
+
+  def shouldBeValid(hc: HealthCheck) = {
+    val violations = validator.validate(hc).asScala
+    assert(violations.isEmpty, s"violations: $violations")
+  }
+
+  test("A default HealthCheck should be valid") {
+    // portIndex is added in the Format conversion of the app
+    shouldBeValid(HealthCheck(portIndex = Some(0)))
+  }
+
+  test("path is not accepted for a COMMAND HealthCheck") {
+    shouldBeInvalid(HealthCheck(protocol = Protocol.COMMAND, path = Some("/health")))
+  }
+
+  test("command is required for a COMMAND HealthCheck") {
+    shouldBeInvalid(HealthCheck(protocol = Protocol.COMMAND, command = None))
+  }
+
+  test("command is not accepted for a HTTP HealthCheck") {
+    shouldBeInvalid(HealthCheck(
+      protocol = Protocol.HTTP,
+      command = Some(Command("echo healthy"))
+    ))
+  }
+
+  test("path is not accepted for a TCP HealthCheck") {
+    shouldBeInvalid(HealthCheck(
+      protocol = Protocol.TCP,
+      path = Some("/")
+    ))
+  }
+
+  test("command is not accepted for a TCP HealthCheck") {
+    shouldBeInvalid(HealthCheck(
+      protocol = Protocol.TCP,
+      command = Some(Command("echo healthy"))
+    ))
+  }
+
+  test("port is not accepted for a COMMAND HealthCheck") {
+    shouldBeInvalid(HealthCheck(
+      protocol = Protocol.COMMAND,
+      port = Some(1)
+    ))
+  }
+
+  test("portIndex is not accepted for a COMMAND HealthCheck") {
+    shouldBeInvalid(HealthCheck(
+      protocol = Protocol.COMMAND,
+      portIndex = Some(0)
+    ))
+  }
+
+  test("both port and portIndex are not accepted at the same time for a HTTP HealthCheck") {
+    shouldBeInvalid(HealthCheck(
+      protocol = Protocol.HTTP,
+      port = Some(1),
+      portIndex = Some(0)
+    ))
+  }
+
+  test("both port and portIndex are not accepted at the same time for a TCP HealthCheck") {
+    shouldBeInvalid(HealthCheck(
+      protocol = Protocol.TCP,
+      port = Some(1),
+      portIndex = Some(0)
+    ))
+  }
+
+  test("port is accepted for a HTTP HealthCheck") {
+    shouldBeValid(HealthCheck(
+      protocol = Protocol.HTTP,
+      port = Some(1)
+    ))
+  }
+
+  test("port is accepted for a TCP HealthCheck") {
+    shouldBeValid(HealthCheck(
+      protocol = Protocol.TCP,
+      port = Some(1)
+    ))
+  }
+
+  test("portIndex is accepted for a HTTP HealthCheck") {
+    shouldBeValid(HealthCheck(
+      protocol = Protocol.HTTP,
+      portIndex = Some(0)
+    ))
+  }
+
+  test("portIndex is accepted for a TCP HealthCheck") {
+    shouldBeValid(HealthCheck(
+      protocol = Protocol.TCP,
+      portIndex = Some(0)
+    ))
+  }
 }

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
@@ -42,7 +42,7 @@ class HealthCheckWorkerActorTest
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
 
-    ref ! HealthCheckJob(task, HealthCheck(protocol = Protocol.TCP))
+    ref ! HealthCheckJob(task, HealthCheck(protocol = Protocol.TCP, portIndex = Some(0)))
 
     try { Await.result(res, 1.seconds) }
     finally { socket.close() }
@@ -69,7 +69,7 @@ class HealthCheckWorkerActorTest
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
 
-    ref ! HealthCheckJob(task, HealthCheck(protocol = Protocol.TCP))
+    ref ! HealthCheckJob(task, HealthCheck(protocol = Protocol.TCP, portIndex = Some(0)))
 
     try { Await.result(res, 1.seconds) }
     finally { socket.close() }
@@ -85,7 +85,7 @@ class HealthCheckWorkerActorTest
   test("getPort") {
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
 
-    val check = new HealthCheck(overridePort = Some(1234))
+    val check = new HealthCheck(port = Some(1234))
     val task = Protos.MarathonTask
       .newBuilder
       .setHost("fakehostname")

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
@@ -82,4 +82,16 @@ class HealthCheckWorkerActorTest
     expectTerminated(ref)
   }
 
+  test("getPort") {
+    val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
+
+    val check = new HealthCheck(overridePort = Some(1234))
+    val task = Protos.MarathonTask
+      .newBuilder
+      .setHost("fakehostname")
+      .setId("test_id")
+      .addPorts(4321)
+      .build()
+    assert(ref.underlyingActor.getPort(task, check) == Some(1234))
+  }
 }


### PR DESCRIPTION
  * Improved health check documentation
  * Replaced JInt with scala Int in HealthCheck case class
  * Automatically add `"portIndex": 0` when necessary to preserve backwards compatibility