### PR TITLE
Towards #2709 - IP per Task v3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,12 +7,8 @@ release.
 
 ### Overview
 
-#### Health Checks: allow port instead of portIndex
-Previously, the port to be used for health checks could only be specified by supplying a port index.  Now it
-can also be specified directly using the new `port` field.
-
 #### Improved search in the UI
-Previously, the user could search through applications using a field which filtered all applications, 
+Previously, the user could search through applications using a field which filtered all applications,
 In 0.14.0 we replace the filter with a search which leads to a detailed search result view. There are
 various improvements in the search interaction, including the user being returned to their former group
 context after the search term has been cleared.
@@ -27,7 +23,59 @@ Some changes have been made in order to support IP-per-task in the API. The rele
 definition is exposed in the configuration page, and the `ipAddresses` field is integrated in the task
 detail view.
 
-#### 
+#### Health Checks: allow port instead of portIndex
+Previously, the port to be used for health checks could only be specified by supplying a port index.  Now it
+can also be specified directly using the new `port` field.
+
+#### EXPERIMENTAL: IP-per-task support
+
+This can drastically simplify service discovery, since you can use
+[mesos-dns](https://github.com/mesosphere/mesos-dns) to rely on DNS for service discovery. This enables your
+applications to use address-only (A) DNS records in combination with known ports to connect to other
+services -- as you would do it in a traditional static cluster environment.
+
+You can request an IP-per-task with default settings like this:
+
+```javascript
+{
+  "id": "/i-have-my-own-ip",
+  // ... more settings ...
+  "ipAddress": {}
+}
+```
+
+Marathon passes down the request for the IP to Mesos. You have to make sure that you installed & configured
+the appropriate
+[Network Isolation Modules](https://docs.google.com/document/d/17mXtAmdAXcNBwp_JfrxmZcQrs7EO6ancSbejrqjLQ0g) &
+IP Access Manager (IPAM) modules in Mesos. The Marathon support for this feature requires Mesos v0.26.
+
+If an application requires IP-per-task, then it can not request ports to be allocated in the slave.
+
+Currently, this feature does not work in combination with Docker containers. We might still change some
+aspects of the API and we appreciate your feedback.
+
+#### EXPERIMENTAL: Network security groups
+
+If your IP Access Manager (IPAM) supports it, you can refine your IP configuration using network security
+groups and labels:
+
+```javascript
+{
+  "id": "/i-have-my-own-ip",
+  // ... more settings ...
+  "ipAddress": {
+    "groups": ["production"],
+    "labels": {
+      "some-meaningful-config": "potentially interpreted by the IPAM"
+    }
+  }
+}
+```
+
+Network security groups only allow network traffic between tasks that have at least one of their configured
+groups in common. This makes it easy to disallow your staging environment to interfere with production
+traffic.
+>>>>>>> Towards #2709 - Add IP-per-task support
 
 ### Fixed issues
 - #2558 - If driver finishes with error, Marathon does not abdicate

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -95,6 +95,11 @@ layout: default
         </a>
       </li>
       <li>
+        <a href="{{ site.baseurl }}/docs/ip-per-task.html">
+          IP-per-task
+        </a>
+      </li>
+      <li>
         <a href="{{ site.baseurl }}/docs/plugin.html">
           Plugins
         </a>

--- a/docs/docs/ip-per-task.md
+++ b/docs/docs/ip-per-task.md
@@ -1,0 +1,64 @@
+---
+title: IP-per-task
+---
+
+# IP-per-task
+
+<div class="alert alert-danger" role="alert">
+  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> Available in Marathon Version 0.14.0+ <br/>
+    The IP-per-task functionality is considered experimental, so use htis
+    feature at your own risk. We might add, change, or delete any
+    functionality described in this document, including the API. We
+    appreciate [your feedback](https://github.com/mesosphere/marathon/issues/2709)!
+</div>
+
+
+In version 0.14, Marathon introduced experimental IP-per-task support. With the appropriate configuration,
+every tasks of an app gets its own network interface and IP address.
+
+This can drastically simplify service discovery, since you can use
+[mesos-dns](https://github.com/mesosphere/mesos-dns) to rely on DNS for service discovery. This enables your
+applications to use address-only (A) DNS records in combination with known ports to connect to other
+services -- as you would do it in a traditional static cluster environment.
+
+You can request an IP-per-task with default settings like this:
+
+```javascript
+{
+  "id": "/i-have-my-own-ip",
+  // ... more settings ...
+  "ipAddress": {}
+}
+```
+
+Marathon passes down the request for the IP to Mesos. You have to make sure that you installed & configured
+the appropriate
+[Network Isolation Modules](https://docs.google.com/document/d/17mXtAmdAXcNBwp_JfrxmZcQrs7EO6ancSbejrqjLQ0g) &
+IP Access Manager (IPAM) modules in Mesos. The Marathon support for this feature requires Mesos v0.26.
+
+If an application requires IP-per-task, then it can not request ports to be allocated in the slave.
+
+Currently, this feature does not work in combination with Docker containers. We might still change some
+aspects of the API and we appreciate your feedback.
+
+## Network security groups
+
+If your IP Access Manager (IPAM) supports it, you can refine your IP configuration using network security
+groups and labels:
+
+```javascript
+{
+  "id": "/i-have-my-own-ip",
+  // ... more settings ...
+  "ipAddress": {
+    "groups": ["production"],
+    "labels": {
+      "some-meaningful-config": "potentially interpreted by the IPAM"
+    }
+  }
+}
+```
+
+Network security groups only allow network traffic between tasks that have at least one of their configured
+groups in common. This makes it easy to disallow your staging environment to interfere with production
+traffic.

--- a/docs/docs/rest-api/public/api/v2/examples/app.json
+++ b/docs/docs/rest-api/public/api/v2/examples/app.json
@@ -1,21 +1,47 @@
 {
-  "id": "/tools/docker/registry",
-  "instances": 1,
-  "cpus": 0.5,
-  "mem": 4096,
+  "id": "/foo",
+  "instances": 2,
+  "cmd": "sleep 1000",
+  "cpus": 0.1,
   "disk": 0,
-  "executor": "",
-  "constraints": [],
-  "uris": [],
-  "storeUrls": [],
-  "ports": [
-    5000
+  "mem": 16,
+  "acceptedResourceRoles": [
+    "mesos_role"
   ],
-  "requirePorts": false,
-  "backoffSeconds": 1,
+  "args": [
+    "sleep",
+    "100"
+  ],
   "backoffFactor": 1.15,
-  "maxLaunchDelaySeconds": 3600,
+  "backoffSeconds": 1,
+  "constraints": [
+    [
+      "hostname",
+      "LIKE",
+      "srv2.*"
+    ]
+  ],
   "container": {
+    "docker": {
+      "forcePullImage": false,
+      "image": "mesosphere:marathon/latest",
+      "network": "BRIDGE",
+      "parameters": [
+        {
+          "key": "name",
+          "value": "kdc"
+        }
+      ],
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "servicePort": 10019
+        }
+      ],
+      "privileged": false
+    },
     "type": "DOCKER",
     "volumes": [
       {
@@ -23,28 +49,50 @@
         "hostPath": "/hdd/tools/docker/registry",
         "mode": "RW"
       }
-    ],
-    "docker": {
-      "image": "registry",
-      "network": "BRIDGE",
-      "portMappings": [
-        {
-          "containerPort": 5000,
-          "hostPort": 0,
-          "servicePort": 5000,
-          "protocol": "tcp"
-        }
-      ],
-      "privileged": false,
-      "parameters": [],
-      "forcePullImage": false
+    ]
+  },
+  "dependencies": [
+    "/prod/group"
+  ],
+  "env": {
+    "XPS1": "Test",
+    "XPS2": "Rest"
+  },
+  "executor": "",
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 300,
+      "ignoreHttp1xx": false,
+      "intervalSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "path": "/",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "timeoutSeconds": 20
+    }
+  ],
+  "labels": {
+    "owner": "zeus",
+    "note": "Away from olympus"
+  },
+  "maxLaunchDelaySeconds": 3600,
+  "network": {
+    "groups": [ "dev" ],
+    "labels": {
+      "environment": "dev"
     }
   },
-  "healthChecks": [],
-  "dependencies": [],
+  "ports": [
+    0
+  ],
+  "requirePorts": false,
+  "storeUrls": [],
   "upgradeStrategy": {
-    "minimumHealthCapacity": 1,
-    "maximumOverCapacity": 1
+    "maximumOverCapacity": 1,
+    "minimumHealthCapacity": 1
   },
-  "version": "2015-08-19T21:26:47.616Z"
+  "uris": [
+    "https://foo.com/setup.py"
+  ],
+  "user": "root"
 }

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -293,6 +293,40 @@
       "description": "The amount of memory in MB that is needed for the application per instance.",
       "minimum": 0
     },
+    "ipAddress": {
+      "type": "object",
+      "description": "If an application definition includes the 'ipAddress' field, then Marathon will request a per-task IP from Mesos. A separate ports/portMappings configuration is then disallowed.",
+      "properties": {
+        "groups": {
+          "type": "array",
+          "description": "Array of network groups. One IP address can belong to zero or more network groups. The idea is that containers can only reach containers with which they share at least one network group.",
+          "items": {
+            "type": "string",
+            "description": "The name of the network group"
+          }
+        },
+        "labels": {
+          "type": "object",
+          "description": "Key value pair for meta data on that network interface.",
+          "properties": {},
+          "additionalProperties": true
+        }
+      }
+    },
+    "labels": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "maxLaunchDelaySeconds": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "mem": {
+      "minimum": 0,
+      "type": "number"
+    },
     "ports": {
       "type": "array",
       "description": "An array of required port resources on the agent host. The number of items in the array determines how many dynamic ports are allocated for every task. For every port that is zero, a globally unique (cluster-wide) port is assigned and provided as part of the app definition to be used in load balancing definitions.",

--- a/project/build.scala
+++ b/project/build.scala
@@ -268,6 +268,7 @@ object Dependencies {
     graphite % "compile",
     datadog % "compile",
     marathonApiConsole % "compile",
+    doNotUseMe % "compile",
 
     // test
     Test.diffson % "test",
@@ -341,6 +342,7 @@ object Dependency {
   val marathonApiConsole = "mesosphere.marathon" % "api-console" % V.MarathonApiConsole
   val graphite = "io.dropwizard.metrics" % "metrics-graphite" % V.Graphite
   val datadog = "org.coursera" % "dropwizard-metrics-datadog" % V.DataDog exclude("ch.qos.logback", "logback-classic")
+  val doNotUseMe = "org.apache.mesos" % "mesos" % "0.25.1.donotuse"
 
 
   object Test {

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -2380,6 +2380,877 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.HealthCheckDefinition)
   }
 
+  public interface IpAddressOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+
+    // repeated string groups = 1;
+    /**
+     * <code>repeated string groups = 1;</code>
+     */
+    java.util.List<java.lang.String>
+    getGroupsList();
+    /**
+     * <code>repeated string groups = 1;</code>
+     */
+    int getGroupsCount();
+    /**
+     * <code>repeated string groups = 1;</code>
+     */
+    java.lang.String getGroups(int index);
+    /**
+     * <code>repeated string groups = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getGroupsBytes(int index);
+
+    // repeated .mesos.Label labels = 2;
+    /**
+     * <code>repeated .mesos.Label labels = 2;</code>
+     */
+    java.util.List<org.apache.mesos.Protos.Label> 
+        getLabelsList();
+    /**
+     * <code>repeated .mesos.Label labels = 2;</code>
+     */
+    org.apache.mesos.Protos.Label getLabels(int index);
+    /**
+     * <code>repeated .mesos.Label labels = 2;</code>
+     */
+    int getLabelsCount();
+    /**
+     * <code>repeated .mesos.Label labels = 2;</code>
+     */
+    java.util.List<? extends org.apache.mesos.Protos.LabelOrBuilder> 
+        getLabelsOrBuilderList();
+    /**
+     * <code>repeated .mesos.Label labels = 2;</code>
+     */
+    org.apache.mesos.Protos.LabelOrBuilder getLabelsOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code mesosphere.marathon.IpAddress}
+   */
+  public static final class IpAddress extends
+      com.google.protobuf.GeneratedMessage
+      implements IpAddressOrBuilder {
+    // Use IpAddress.newBuilder() to construct.
+    private IpAddress(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private IpAddress(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final IpAddress defaultInstance;
+    public static IpAddress getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public IpAddress getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private IpAddress(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                groups_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              groups_.add(input.readBytes());
+              break;
+            }
+            case 18: {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                labels_ = new java.util.ArrayList<org.apache.mesos.Protos.Label>();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              labels_.add(input.readMessage(org.apache.mesos.Protos.Label.PARSER, extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          groups_ = new com.google.protobuf.UnmodifiableLazyStringList(groups_);
+        }
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          labels_ = java.util.Collections.unmodifiableList(labels_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_IpAddress_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              mesosphere.marathon.Protos.IpAddress.class, mesosphere.marathon.Protos.IpAddress.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<IpAddress> PARSER =
+        new com.google.protobuf.AbstractParser<IpAddress>() {
+      public IpAddress parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new IpAddress(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<IpAddress> getParserForType() {
+      return PARSER;
+    }
+
+    // repeated string groups = 1;
+    public static final int GROUPS_FIELD_NUMBER = 1;
+    private com.google.protobuf.LazyStringList groups_;
+    /**
+     * <code>repeated string groups = 1;</code>
+     */
+    public java.util.List<java.lang.String>
+        getGroupsList() {
+      return groups_;
+    }
+    /**
+     * <code>repeated string groups = 1;</code>
+     */
+    public int getGroupsCount() {
+      return groups_.size();
+    }
+    /**
+     * <code>repeated string groups = 1;</code>
+     */
+    public java.lang.String getGroups(int index) {
+      return groups_.get(index);
+    }
+    /**
+     * <code>repeated string groups = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getGroupsBytes(int index) {
+      return groups_.getByteString(index);
+    }
+
+    // repeated .mesos.Label labels = 2;
+    public static final int LABELS_FIELD_NUMBER = 2;
+    private java.util.List<org.apache.mesos.Protos.Label> labels_;
+    /**
+     * <code>repeated .mesos.Label labels = 2;</code>
+     */
+    public java.util.List<org.apache.mesos.Protos.Label> getLabelsList() {
+      return labels_;
+    }
+    /**
+     * <code>repeated .mesos.Label labels = 2;</code>
+     */
+    public java.util.List<? extends org.apache.mesos.Protos.LabelOrBuilder> 
+        getLabelsOrBuilderList() {
+      return labels_;
+    }
+    /**
+     * <code>repeated .mesos.Label labels = 2;</code>
+     */
+    public int getLabelsCount() {
+      return labels_.size();
+    }
+    /**
+     * <code>repeated .mesos.Label labels = 2;</code>
+     */
+    public org.apache.mesos.Protos.Label getLabels(int index) {
+      return labels_.get(index);
+    }
+    /**
+     * <code>repeated .mesos.Label labels = 2;</code>
+     */
+    public org.apache.mesos.Protos.LabelOrBuilder getLabelsOrBuilder(
+        int index) {
+      return labels_.get(index);
+    }
+
+    private void initFields() {
+      groups_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      labels_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      for (int i = 0; i < getLabelsCount(); i++) {
+        if (!getLabels(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (int i = 0; i < groups_.size(); i++) {
+        output.writeBytes(1, groups_.getByteString(i));
+      }
+      for (int i = 0; i < labels_.size(); i++) {
+        output.writeMessage(2, labels_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      {
+        int dataSize = 0;
+        for (int i = 0; i < groups_.size(); i++) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeBytesSizeNoTag(groups_.getByteString(i));
+        }
+        size += dataSize;
+        size += 1 * getGroupsList().size();
+      }
+      for (int i = 0; i < labels_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, labels_.get(i));
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static mesosphere.marathon.Protos.IpAddress parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static mesosphere.marathon.Protos.IpAddress parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.IpAddress parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static mesosphere.marathon.Protos.IpAddress parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.IpAddress parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static mesosphere.marathon.Protos.IpAddress parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.IpAddress parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static mesosphere.marathon.Protos.IpAddress parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.IpAddress parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static mesosphere.marathon.Protos.IpAddress parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(mesosphere.marathon.Protos.IpAddress prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mesosphere.marathon.IpAddress}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.IpAddressOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_IpAddress_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                mesosphere.marathon.Protos.IpAddress.class, mesosphere.marathon.Protos.IpAddress.Builder.class);
+      }
+
+      // Construct using mesosphere.marathon.Protos.IpAddress.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getLabelsFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        groups_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        if (labelsBuilder_ == null) {
+          labels_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+        } else {
+          labelsBuilder_.clear();
+        }
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_IpAddress_descriptor;
+      }
+
+      public mesosphere.marathon.Protos.IpAddress getDefaultInstanceForType() {
+        return mesosphere.marathon.Protos.IpAddress.getDefaultInstance();
+      }
+
+      public mesosphere.marathon.Protos.IpAddress build() {
+        mesosphere.marathon.Protos.IpAddress result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public mesosphere.marathon.Protos.IpAddress buildPartial() {
+        mesosphere.marathon.Protos.IpAddress result = new mesosphere.marathon.Protos.IpAddress(this);
+        int from_bitField0_ = bitField0_;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          groups_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              groups_);
+          bitField0_ = (bitField0_ & ~0x00000001);
+        }
+        result.groups_ = groups_;
+        if (labelsBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            labels_ = java.util.Collections.unmodifiableList(labels_);
+            bitField0_ = (bitField0_ & ~0x00000002);
+          }
+          result.labels_ = labels_;
+        } else {
+          result.labels_ = labelsBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof mesosphere.marathon.Protos.IpAddress) {
+          return mergeFrom((mesosphere.marathon.Protos.IpAddress)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(mesosphere.marathon.Protos.IpAddress other) {
+        if (other == mesosphere.marathon.Protos.IpAddress.getDefaultInstance()) return this;
+        if (!other.groups_.isEmpty()) {
+          if (groups_.isEmpty()) {
+            groups_ = other.groups_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureGroupsIsMutable();
+            groups_.addAll(other.groups_);
+          }
+          onChanged();
+        }
+        if (labelsBuilder_ == null) {
+          if (!other.labels_.isEmpty()) {
+            if (labels_.isEmpty()) {
+              labels_ = other.labels_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+            } else {
+              ensureLabelsIsMutable();
+              labels_.addAll(other.labels_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.labels_.isEmpty()) {
+            if (labelsBuilder_.isEmpty()) {
+              labelsBuilder_.dispose();
+              labelsBuilder_ = null;
+              labels_ = other.labels_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+              labelsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getLabelsFieldBuilder() : null;
+            } else {
+              labelsBuilder_.addAllMessages(other.labels_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        for (int i = 0; i < getLabelsCount(); i++) {
+          if (!getLabels(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        mesosphere.marathon.Protos.IpAddress parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (mesosphere.marathon.Protos.IpAddress) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // repeated string groups = 1;
+      private com.google.protobuf.LazyStringList groups_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureGroupsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          groups_ = new com.google.protobuf.LazyStringArrayList(groups_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+      /**
+       * <code>repeated string groups = 1;</code>
+       */
+      public java.util.List<java.lang.String>
+          getGroupsList() {
+        return java.util.Collections.unmodifiableList(groups_);
+      }
+      /**
+       * <code>repeated string groups = 1;</code>
+       */
+      public int getGroupsCount() {
+        return groups_.size();
+      }
+      /**
+       * <code>repeated string groups = 1;</code>
+       */
+      public java.lang.String getGroups(int index) {
+        return groups_.get(index);
+      }
+      /**
+       * <code>repeated string groups = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getGroupsBytes(int index) {
+        return groups_.getByteString(index);
+      }
+      /**
+       * <code>repeated string groups = 1;</code>
+       */
+      public Builder setGroups(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureGroupsIsMutable();
+        groups_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string groups = 1;</code>
+       */
+      public Builder addGroups(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureGroupsIsMutable();
+        groups_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string groups = 1;</code>
+       */
+      public Builder addAllGroups(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureGroupsIsMutable();
+        super.addAll(values, groups_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string groups = 1;</code>
+       */
+      public Builder clearGroups() {
+        groups_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string groups = 1;</code>
+       */
+      public Builder addGroupsBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureGroupsIsMutable();
+        groups_.add(value);
+        onChanged();
+        return this;
+      }
+
+      // repeated .mesos.Label labels = 2;
+      private java.util.List<org.apache.mesos.Protos.Label> labels_ =
+        java.util.Collections.emptyList();
+      private void ensureLabelsIsMutable() {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          labels_ = new java.util.ArrayList<org.apache.mesos.Protos.Label>(labels_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.mesos.Protos.Label, org.apache.mesos.Protos.Label.Builder, org.apache.mesos.Protos.LabelOrBuilder> labelsBuilder_;
+
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public java.util.List<org.apache.mesos.Protos.Label> getLabelsList() {
+        if (labelsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(labels_);
+        } else {
+          return labelsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public int getLabelsCount() {
+        if (labelsBuilder_ == null) {
+          return labels_.size();
+        } else {
+          return labelsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public org.apache.mesos.Protos.Label getLabels(int index) {
+        if (labelsBuilder_ == null) {
+          return labels_.get(index);
+        } else {
+          return labelsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public Builder setLabels(
+          int index, org.apache.mesos.Protos.Label value) {
+        if (labelsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureLabelsIsMutable();
+          labels_.set(index, value);
+          onChanged();
+        } else {
+          labelsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public Builder setLabels(
+          int index, org.apache.mesos.Protos.Label.Builder builderForValue) {
+        if (labelsBuilder_ == null) {
+          ensureLabelsIsMutable();
+          labels_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          labelsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public Builder addLabels(org.apache.mesos.Protos.Label value) {
+        if (labelsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureLabelsIsMutable();
+          labels_.add(value);
+          onChanged();
+        } else {
+          labelsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public Builder addLabels(
+          int index, org.apache.mesos.Protos.Label value) {
+        if (labelsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureLabelsIsMutable();
+          labels_.add(index, value);
+          onChanged();
+        } else {
+          labelsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public Builder addLabels(
+          org.apache.mesos.Protos.Label.Builder builderForValue) {
+        if (labelsBuilder_ == null) {
+          ensureLabelsIsMutable();
+          labels_.add(builderForValue.build());
+          onChanged();
+        } else {
+          labelsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public Builder addLabels(
+          int index, org.apache.mesos.Protos.Label.Builder builderForValue) {
+        if (labelsBuilder_ == null) {
+          ensureLabelsIsMutable();
+          labels_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          labelsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public Builder addAllLabels(
+          java.lang.Iterable<? extends org.apache.mesos.Protos.Label> values) {
+        if (labelsBuilder_ == null) {
+          ensureLabelsIsMutable();
+          super.addAll(values, labels_);
+          onChanged();
+        } else {
+          labelsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public Builder clearLabels() {
+        if (labelsBuilder_ == null) {
+          labels_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+          onChanged();
+        } else {
+          labelsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public Builder removeLabels(int index) {
+        if (labelsBuilder_ == null) {
+          ensureLabelsIsMutable();
+          labels_.remove(index);
+          onChanged();
+        } else {
+          labelsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public org.apache.mesos.Protos.Label.Builder getLabelsBuilder(
+          int index) {
+        return getLabelsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public org.apache.mesos.Protos.LabelOrBuilder getLabelsOrBuilder(
+          int index) {
+        if (labelsBuilder_ == null) {
+          return labels_.get(index);  } else {
+          return labelsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public java.util.List<? extends org.apache.mesos.Protos.LabelOrBuilder> 
+           getLabelsOrBuilderList() {
+        if (labelsBuilder_ != null) {
+          return labelsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(labels_);
+        }
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public org.apache.mesos.Protos.Label.Builder addLabelsBuilder() {
+        return getLabelsFieldBuilder().addBuilder(
+            org.apache.mesos.Protos.Label.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public org.apache.mesos.Protos.Label.Builder addLabelsBuilder(
+          int index) {
+        return getLabelsFieldBuilder().addBuilder(
+            index, org.apache.mesos.Protos.Label.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .mesos.Label labels = 2;</code>
+       */
+      public java.util.List<org.apache.mesos.Protos.Label.Builder> 
+           getLabelsBuilderList() {
+        return getLabelsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.mesos.Protos.Label, org.apache.mesos.Protos.Label.Builder, org.apache.mesos.Protos.LabelOrBuilder> 
+          getLabelsFieldBuilder() {
+        if (labelsBuilder_ == null) {
+          labelsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.apache.mesos.Protos.Label, org.apache.mesos.Protos.Label.Builder, org.apache.mesos.Protos.LabelOrBuilder>(
+                  labels_,
+                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  getParentForChildren(),
+                  isClean());
+          labels_ = null;
+        }
+        return labelsBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:mesosphere.marathon.IpAddress)
+    }
+
+    static {
+      defaultInstance = new IpAddress(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:mesosphere.marathon.IpAddress)
+  }
+
   public interface ServiceDefinitionOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
@@ -2776,6 +3647,20 @@ public final class Protos {
      * <code>optional int64 last_config_change_at = 24;</code>
      */
     long getLastConfigChangeAt();
+
+    // optional .mesosphere.marathon.IpAddress ipAddress = 25;
+    /**
+     * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+     */
+    boolean hasIpAddress();
+    /**
+     * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+     */
+    mesosphere.marathon.Protos.IpAddress getIpAddress();
+    /**
+     * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+     */
+    mesosphere.marathon.Protos.IpAddressOrBuilder getIpAddressOrBuilder();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.ServiceDefinition}
@@ -3015,6 +3900,19 @@ public final class Protos {
             case 192: {
               bitField0_ |= 0x00008000;
               lastConfigChangeAt_ = input.readInt64();
+              break;
+            }
+            case 202: {
+              mesosphere.marathon.Protos.IpAddress.Builder subBuilder = null;
+              if (((bitField0_ & 0x00010000) == 0x00010000)) {
+                subBuilder = ipAddress_.toBuilder();
+              }
+              ipAddress_ = input.readMessage(mesosphere.marathon.Protos.IpAddress.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(ipAddress_);
+                ipAddress_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00010000;
               break;
             }
           }
@@ -3739,6 +4637,28 @@ public final class Protos {
       return lastConfigChangeAt_;
     }
 
+    // optional .mesosphere.marathon.IpAddress ipAddress = 25;
+    public static final int IPADDRESS_FIELD_NUMBER = 25;
+    private mesosphere.marathon.Protos.IpAddress ipAddress_;
+    /**
+     * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+     */
+    public boolean hasIpAddress() {
+      return ((bitField0_ & 0x00010000) == 0x00010000);
+    }
+    /**
+     * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+     */
+    public mesosphere.marathon.Protos.IpAddress getIpAddress() {
+      return ipAddress_;
+    }
+    /**
+     * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+     */
+    public mesosphere.marathon.Protos.IpAddressOrBuilder getIpAddressOrBuilder() {
+      return ipAddress_;
+    }
+
     private void initFields() {
       id_ = "";
       cmd_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
@@ -3763,6 +4683,7 @@ public final class Protos {
       acceptedResourceRoles_ = mesosphere.marathon.Protos.ResourceRoles.getDefaultInstance();
       lastScalingAt_ = 0L;
       lastConfigChangeAt_ = 0L;
+      ipAddress_ = mesosphere.marathon.Protos.IpAddress.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -3827,6 +4748,12 @@ public final class Protos {
       }
       for (int i = 0; i < getLabelsCount(); i++) {
         if (!getLabels(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      if (hasIpAddress()) {
+        if (!getIpAddress().isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -3906,6 +4833,9 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00008000) == 0x00008000)) {
         output.writeInt64(24, lastConfigChangeAt_);
+      }
+      if (((bitField0_ & 0x00010000) == 0x00010000)) {
+        output.writeMessage(25, ipAddress_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -4022,6 +4952,10 @@ public final class Protos {
       if (((bitField0_ & 0x00008000) == 0x00008000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(24, lastConfigChangeAt_);
+      }
+      if (((bitField0_ & 0x00010000) == 0x00010000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(25, ipAddress_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -4140,6 +5074,7 @@ public final class Protos {
           getContainerFieldBuilder();
           getLabelsFieldBuilder();
           getAcceptedResourceRolesFieldBuilder();
+          getIpAddressFieldBuilder();
         }
       }
       private static Builder create() {
@@ -4230,6 +5165,12 @@ public final class Protos {
         bitField0_ = (bitField0_ & ~0x00200000);
         lastConfigChangeAt_ = 0L;
         bitField0_ = (bitField0_ & ~0x00400000);
+        if (ipAddressBuilder_ == null) {
+          ipAddress_ = mesosphere.marathon.Protos.IpAddress.getDefaultInstance();
+        } else {
+          ipAddressBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00800000);
         return this;
       }
 
@@ -4395,6 +5336,14 @@ public final class Protos {
           to_bitField0_ |= 0x00008000;
         }
         result.lastConfigChangeAt_ = lastConfigChangeAt_;
+        if (((from_bitField0_ & 0x00800000) == 0x00800000)) {
+          to_bitField0_ |= 0x00010000;
+        }
+        if (ipAddressBuilder_ == null) {
+          result.ipAddress_ = ipAddress_;
+        } else {
+          result.ipAddress_ = ipAddressBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -4601,6 +5550,9 @@ public final class Protos {
         if (other.hasLastConfigChangeAt()) {
           setLastConfigChangeAt(other.getLastConfigChangeAt());
         }
+        if (other.hasIpAddress()) {
+          mergeIpAddress(other.getIpAddress());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -4664,6 +5616,12 @@ public final class Protos {
         }
         for (int i = 0; i < getLabelsCount(); i++) {
           if (!getLabels(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasIpAddress()) {
+          if (!getIpAddress().isInitialized()) {
             
             return false;
           }
@@ -7106,6 +8064,123 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesosphere.marathon.IpAddress ipAddress = 25;
+      private mesosphere.marathon.Protos.IpAddress ipAddress_ = mesosphere.marathon.Protos.IpAddress.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          mesosphere.marathon.Protos.IpAddress, mesosphere.marathon.Protos.IpAddress.Builder, mesosphere.marathon.Protos.IpAddressOrBuilder> ipAddressBuilder_;
+      /**
+       * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+       */
+      public boolean hasIpAddress() {
+        return ((bitField0_ & 0x00800000) == 0x00800000);
+      }
+      /**
+       * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+       */
+      public mesosphere.marathon.Protos.IpAddress getIpAddress() {
+        if (ipAddressBuilder_ == null) {
+          return ipAddress_;
+        } else {
+          return ipAddressBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+       */
+      public Builder setIpAddress(mesosphere.marathon.Protos.IpAddress value) {
+        if (ipAddressBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ipAddress_ = value;
+          onChanged();
+        } else {
+          ipAddressBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00800000;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+       */
+      public Builder setIpAddress(
+          mesosphere.marathon.Protos.IpAddress.Builder builderForValue) {
+        if (ipAddressBuilder_ == null) {
+          ipAddress_ = builderForValue.build();
+          onChanged();
+        } else {
+          ipAddressBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00800000;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+       */
+      public Builder mergeIpAddress(mesosphere.marathon.Protos.IpAddress value) {
+        if (ipAddressBuilder_ == null) {
+          if (((bitField0_ & 0x00800000) == 0x00800000) &&
+              ipAddress_ != mesosphere.marathon.Protos.IpAddress.getDefaultInstance()) {
+            ipAddress_ =
+              mesosphere.marathon.Protos.IpAddress.newBuilder(ipAddress_).mergeFrom(value).buildPartial();
+          } else {
+            ipAddress_ = value;
+          }
+          onChanged();
+        } else {
+          ipAddressBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00800000;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+       */
+      public Builder clearIpAddress() {
+        if (ipAddressBuilder_ == null) {
+          ipAddress_ = mesosphere.marathon.Protos.IpAddress.getDefaultInstance();
+          onChanged();
+        } else {
+          ipAddressBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00800000);
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+       */
+      public mesosphere.marathon.Protos.IpAddress.Builder getIpAddressBuilder() {
+        bitField0_ |= 0x00800000;
+        onChanged();
+        return getIpAddressFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+       */
+      public mesosphere.marathon.Protos.IpAddressOrBuilder getIpAddressOrBuilder() {
+        if (ipAddressBuilder_ != null) {
+          return ipAddressBuilder_.getMessageOrBuilder();
+        } else {
+          return ipAddress_;
+        }
+      }
+      /**
+       * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          mesosphere.marathon.Protos.IpAddress, mesosphere.marathon.Protos.IpAddress.Builder, mesosphere.marathon.Protos.IpAddressOrBuilder> 
+          getIpAddressFieldBuilder() {
+        if (ipAddressBuilder_ == null) {
+          ipAddressBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              mesosphere.marathon.Protos.IpAddress, mesosphere.marathon.Protos.IpAddress.Builder, mesosphere.marathon.Protos.IpAddressOrBuilder>(
+                  ipAddress_,
+                  getParentForChildren(),
+                  isClean());
+          ipAddress_ = null;
+        }
+        return ipAddressBuilder_;
+      }
+
       // @@protoc_insertion_point(builder_scope:mesosphere.marathon.ServiceDefinition)
     }
 
@@ -7785,6 +8860,31 @@ public final class Protos {
      * <code>optional .mesos.SlaveID slaveId = 10;</code>
      */
     org.apache.mesos.Protos.SlaveIDOrBuilder getSlaveIdOrBuilder();
+
+    // repeated .mesos.NetworkInfo networks = 11;
+    /**
+     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     */
+    java.util.List<org.apache.mesos.Protos.NetworkInfo> 
+        getNetworksList();
+    /**
+     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     */
+    org.apache.mesos.Protos.NetworkInfo getNetworks(int index);
+    /**
+     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     */
+    int getNetworksCount();
+    /**
+     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     */
+    java.util.List<? extends org.apache.mesos.Protos.NetworkInfoOrBuilder> 
+        getNetworksOrBuilderList();
+    /**
+     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     */
+    org.apache.mesos.Protos.NetworkInfoOrBuilder getNetworksOrBuilder(
+        int index);
   }
   /**
    * Protobuf type {@code mesosphere.marathon.MarathonTask}
@@ -7925,6 +9025,14 @@ public final class Protos {
               bitField0_ |= 0x00000040;
               break;
             }
+            case 90: {
+              if (!((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
+                networks_ = new java.util.ArrayList<org.apache.mesos.Protos.NetworkInfo>();
+                mutable_bitField0_ |= 0x00000400;
+              }
+              networks_.add(input.readMessage(org.apache.mesos.Protos.NetworkInfo.PARSER, extensionRegistry));
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -7941,6 +9049,9 @@ public final class Protos {
         }
         if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
           oBSOLETEStatuses_ = java.util.Collections.unmodifiableList(oBSOLETEStatuses_);
+        }
+        if (((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
+          networks_ = java.util.Collections.unmodifiableList(networks_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -8286,6 +9397,42 @@ public final class Protos {
       return slaveId_;
     }
 
+    // repeated .mesos.NetworkInfo networks = 11;
+    public static final int NETWORKS_FIELD_NUMBER = 11;
+    private java.util.List<org.apache.mesos.Protos.NetworkInfo> networks_;
+    /**
+     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     */
+    public java.util.List<org.apache.mesos.Protos.NetworkInfo> getNetworksList() {
+      return networks_;
+    }
+    /**
+     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     */
+    public java.util.List<? extends org.apache.mesos.Protos.NetworkInfoOrBuilder> 
+        getNetworksOrBuilderList() {
+      return networks_;
+    }
+    /**
+     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     */
+    public int getNetworksCount() {
+      return networks_.size();
+    }
+    /**
+     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     */
+    public org.apache.mesos.Protos.NetworkInfo getNetworks(int index) {
+      return networks_.get(index);
+    }
+    /**
+     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     */
+    public org.apache.mesos.Protos.NetworkInfoOrBuilder getNetworksOrBuilder(
+        int index) {
+      return networks_.get(index);
+    }
+
     private void initFields() {
       id_ = "";
       host_ = "";
@@ -8297,6 +9444,7 @@ public final class Protos {
       version_ = "1970-01-01T00:00:00.000Z";
       status_ = org.apache.mesos.Protos.TaskStatus.getDefaultInstance();
       slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
+      networks_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -8327,6 +9475,12 @@ public final class Protos {
       }
       if (hasSlaveId()) {
         if (!getSlaveId().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      for (int i = 0; i < getNetworksCount(); i++) {
+        if (!getNetworks(i).isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -8367,6 +9521,9 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         output.writeMessage(10, slaveId_);
+      }
+      for (int i = 0; i < networks_.size(); i++) {
+        output.writeMessage(11, networks_.get(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -8421,6 +9578,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(10, slaveId_);
+      }
+      for (int i = 0; i < networks_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(11, networks_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -8534,6 +9695,7 @@ public final class Protos {
           getOBSOLETEStatusesFieldBuilder();
           getStatusFieldBuilder();
           getSlaveIdFieldBuilder();
+          getNetworksFieldBuilder();
         }
       }
       private static Builder create() {
@@ -8578,6 +9740,12 @@ public final class Protos {
           slaveIdBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000200);
+        if (networksBuilder_ == null) {
+          networks_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000400);
+        } else {
+          networksBuilder_.clear();
+        }
         return this;
       }
 
@@ -8664,6 +9832,15 @@ public final class Protos {
           result.slaveId_ = slaveId_;
         } else {
           result.slaveId_ = slaveIdBuilder_.build();
+        }
+        if (networksBuilder_ == null) {
+          if (((bitField0_ & 0x00000400) == 0x00000400)) {
+            networks_ = java.util.Collections.unmodifiableList(networks_);
+            bitField0_ = (bitField0_ & ~0x00000400);
+          }
+          result.networks_ = networks_;
+        } else {
+          result.networks_ = networksBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -8770,6 +9947,32 @@ public final class Protos {
         if (other.hasSlaveId()) {
           mergeSlaveId(other.getSlaveId());
         }
+        if (networksBuilder_ == null) {
+          if (!other.networks_.isEmpty()) {
+            if (networks_.isEmpty()) {
+              networks_ = other.networks_;
+              bitField0_ = (bitField0_ & ~0x00000400);
+            } else {
+              ensureNetworksIsMutable();
+              networks_.addAll(other.networks_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.networks_.isEmpty()) {
+            if (networksBuilder_.isEmpty()) {
+              networksBuilder_.dispose();
+              networksBuilder_ = null;
+              networks_ = other.networks_;
+              bitField0_ = (bitField0_ & ~0x00000400);
+              networksBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getNetworksFieldBuilder() : null;
+            } else {
+              networksBuilder_.addAllMessages(other.networks_);
+            }
+          }
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -8799,6 +10002,12 @@ public final class Protos {
         }
         if (hasSlaveId()) {
           if (!getSlaveId().isInitialized()) {
+            
+            return false;
+          }
+        }
+        for (int i = 0; i < getNetworksCount(); i++) {
+          if (!getNetworks(i).isInitialized()) {
             
             return false;
           }
@@ -9915,6 +11124,246 @@ public final class Protos {
           slaveId_ = null;
         }
         return slaveIdBuilder_;
+      }
+
+      // repeated .mesos.NetworkInfo networks = 11;
+      private java.util.List<org.apache.mesos.Protos.NetworkInfo> networks_ =
+        java.util.Collections.emptyList();
+      private void ensureNetworksIsMutable() {
+        if (!((bitField0_ & 0x00000400) == 0x00000400)) {
+          networks_ = new java.util.ArrayList<org.apache.mesos.Protos.NetworkInfo>(networks_);
+          bitField0_ |= 0x00000400;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.mesos.Protos.NetworkInfo, org.apache.mesos.Protos.NetworkInfo.Builder, org.apache.mesos.Protos.NetworkInfoOrBuilder> networksBuilder_;
+
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public java.util.List<org.apache.mesos.Protos.NetworkInfo> getNetworksList() {
+        if (networksBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(networks_);
+        } else {
+          return networksBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public int getNetworksCount() {
+        if (networksBuilder_ == null) {
+          return networks_.size();
+        } else {
+          return networksBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public org.apache.mesos.Protos.NetworkInfo getNetworks(int index) {
+        if (networksBuilder_ == null) {
+          return networks_.get(index);
+        } else {
+          return networksBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public Builder setNetworks(
+          int index, org.apache.mesos.Protos.NetworkInfo value) {
+        if (networksBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureNetworksIsMutable();
+          networks_.set(index, value);
+          onChanged();
+        } else {
+          networksBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public Builder setNetworks(
+          int index, org.apache.mesos.Protos.NetworkInfo.Builder builderForValue) {
+        if (networksBuilder_ == null) {
+          ensureNetworksIsMutable();
+          networks_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          networksBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public Builder addNetworks(org.apache.mesos.Protos.NetworkInfo value) {
+        if (networksBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureNetworksIsMutable();
+          networks_.add(value);
+          onChanged();
+        } else {
+          networksBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public Builder addNetworks(
+          int index, org.apache.mesos.Protos.NetworkInfo value) {
+        if (networksBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureNetworksIsMutable();
+          networks_.add(index, value);
+          onChanged();
+        } else {
+          networksBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public Builder addNetworks(
+          org.apache.mesos.Protos.NetworkInfo.Builder builderForValue) {
+        if (networksBuilder_ == null) {
+          ensureNetworksIsMutable();
+          networks_.add(builderForValue.build());
+          onChanged();
+        } else {
+          networksBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public Builder addNetworks(
+          int index, org.apache.mesos.Protos.NetworkInfo.Builder builderForValue) {
+        if (networksBuilder_ == null) {
+          ensureNetworksIsMutable();
+          networks_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          networksBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public Builder addAllNetworks(
+          java.lang.Iterable<? extends org.apache.mesos.Protos.NetworkInfo> values) {
+        if (networksBuilder_ == null) {
+          ensureNetworksIsMutable();
+          super.addAll(values, networks_);
+          onChanged();
+        } else {
+          networksBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public Builder clearNetworks() {
+        if (networksBuilder_ == null) {
+          networks_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000400);
+          onChanged();
+        } else {
+          networksBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public Builder removeNetworks(int index) {
+        if (networksBuilder_ == null) {
+          ensureNetworksIsMutable();
+          networks_.remove(index);
+          onChanged();
+        } else {
+          networksBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public org.apache.mesos.Protos.NetworkInfo.Builder getNetworksBuilder(
+          int index) {
+        return getNetworksFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public org.apache.mesos.Protos.NetworkInfoOrBuilder getNetworksOrBuilder(
+          int index) {
+        if (networksBuilder_ == null) {
+          return networks_.get(index);  } else {
+          return networksBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public java.util.List<? extends org.apache.mesos.Protos.NetworkInfoOrBuilder> 
+           getNetworksOrBuilderList() {
+        if (networksBuilder_ != null) {
+          return networksBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(networks_);
+        }
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public org.apache.mesos.Protos.NetworkInfo.Builder addNetworksBuilder() {
+        return getNetworksFieldBuilder().addBuilder(
+            org.apache.mesos.Protos.NetworkInfo.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public org.apache.mesos.Protos.NetworkInfo.Builder addNetworksBuilder(
+          int index) {
+        return getNetworksFieldBuilder().addBuilder(
+            index, org.apache.mesos.Protos.NetworkInfo.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       */
+      public java.util.List<org.apache.mesos.Protos.NetworkInfo.Builder> 
+           getNetworksBuilderList() {
+        return getNetworksFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.mesos.Protos.NetworkInfo, org.apache.mesos.Protos.NetworkInfo.Builder, org.apache.mesos.Protos.NetworkInfoOrBuilder> 
+          getNetworksFieldBuilder() {
+        if (networksBuilder_ == null) {
+          networksBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.apache.mesos.Protos.NetworkInfo, org.apache.mesos.Protos.NetworkInfo.Builder, org.apache.mesos.Protos.NetworkInfoOrBuilder>(
+                  networks_,
+                  ((bitField0_ & 0x00000400) == 0x00000400),
+                  getParentForChildren(),
+                  isClean());
+          networks_ = null;
+        }
+        return networksBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask)
@@ -21429,6 +22878,11 @@ public final class Protos {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_mesosphere_marathon_IpAddress_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ServiceDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -21527,75 +22981,79 @@ public final class Protos {
       "es\030\007 \001(\r:\0013\022#\n\007command\030\010 \001(\0132\022.mesos.Com" +
       "mandInfo\022\034\n\rignoreHttp1xx\030\t \001(\010:\005false\022\014" +
       "\n\004port\030\n \001(\r\"5\n\010Protocol\022\010\n\004HTTP\020\000\022\007\n\003TC" +
-      "P\020\001\022\013\n\007COMMAND\020\002\022\t\n\005HTTPS\020\003\"\323\006\n\021ServiceD" +
-      "efinition\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030\002 \002(\0132\022.mes" +
-      "os.CommandInfo\022\021\n\tinstances\030\003 \002(\r\022\"\n\tres" +
-      "ources\030\004 \003(\0132\017.mesos.Resource\022\023\n\013descrip" +
-      "tion\030\005 \001(\t\022\r\n\005ports\030\006 \003(\r\0224\n\013constraints",
-      "\030\007 \003(\0132\037.mesosphere.marathon.Constraint\022" +
-      "\022\n\010executor\030\010 \002(\t:\000\022>\n\022OBSOLETE_containe" +
-      "r\030\n \001(\0132\".mesosphere.marathon.ContainerI" +
-      "nfo\022)\n\007version\030\013 \001(\t:\0301970-01-01T00:00:0" +
-      "0.000Z\022@\n\014healthChecks\030\014 \003(\0132*.mesospher" +
-      "e.marathon.HealthCheckDefinition\022\025\n\007back" +
-      "off\030\r \001(\003:\0041000\022\033\n\rbackoffFactor\030\016 \001(\001:\004" +
-      "1.15\022G\n\017upgradeStrategy\030\017 \001(\0132..mesosphe" +
-      "re.marathon.UpgradeStrategyDefinition\022\024\n" +
-      "\014dependencies\030\020 \003(\t\022\021\n\tstoreUrls\030\021 \003(\t\022\034",
-      "\n\rrequire_ports\030\022 \001(\010:\005false\022=\n\tcontaine" +
-      "r\030\023 \001(\0132*.mesosphere.marathon.ExtendedCo" +
-      "ntainerInfo\022 \n\006labels\030\024 \003(\0132\020.mesos.Para" +
-      "meter\022\037\n\016maxLaunchDelay\030\025 \001(\003:\0073600000\022A" +
-      "\n\025acceptedResourceRoles\030\026 \001(\0132\".mesosphe" +
-      "re.marathon.ResourceRoles\022\027\n\017last_scalin" +
-      "g_at\030\027 \001(\003\022\035\n\025last_config_change_at\030\030 \001(" +
-      "\003\"\035\n\rResourceRoles\022\014\n\004role\030\001 \003(\t\"\241\002\n\014Mar" +
-      "athonTask\022\n\n\002id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005p" +
-      "orts\030\003 \003(\r\022$\n\nattributes\030\004 \003(\0132\020.mesos.A",
-      "ttribute\022\021\n\tstaged_at\030\005 \001(\003\022\022\n\nstarted_a" +
-      "t\030\006 \001(\003\022,\n\021OBSOLETE_statuses\030\007 \003(\0132\021.mes" +
-      "os.TaskStatus\022)\n\007version\030\010 \001(\t:\0301970-01-" +
-      "01T00:00:00.000Z\022!\n\006status\030\t \001(\0132\021.mesos" +
-      ".TaskStatus\022\037\n\007slaveId\030\n \001(\0132\016.mesos.Sla" +
-      "veID\"M\n\013MarathonApp\022\014\n\004name\030\001 \001(\t\0220\n\005tas" +
-      "ks\030\002 \003(\0132!.mesosphere.marathon.MarathonT" +
-      "ask\"1\n\rContainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n" +
-      "\007options\030\002 \003(\014\"\237\004\n\025ExtendedContainerInfo" +
-      "\022\'\n\004type\030\001 \002(\0162\031.mesos.ContainerInfo.Typ",
-      "e\022\036\n\007volumes\030\002 \003(\0132\r.mesos.Volume\022E\n\006doc" +
-      "ker\030\003 \001(\01325.mesosphere.marathon.Extended" +
-      "ContainerInfo.DockerInfo\032\365\002\n\nDockerInfo\022" +
-      "\r\n\005image\030\001 \002(\t\022>\n\007network\030\002 \001(\0162\'.mesos." +
-      "ContainerInfo.DockerInfo.Network:\004HOST\022X" +
-      "\n\rport_mappings\030\003 \003(\0132A.mesosphere.marat" +
-      "hon.ExtendedContainerInfo.DockerInfo.Por" +
-      "tMapping\022\031\n\nprivileged\030\004 \001(\010:\005false\022$\n\np" +
-      "arameters\030\005 \003(\0132\020.mesos.Parameter\022\030\n\020for" +
-      "ce_pull_image\030\006 \001(\010\032c\n\013PortMapping\022\021\n\tho",
-      "st_port\030\001 \002(\r\022\026\n\016container_port\030\002 \002(\r\022\020\n" +
-      "\010protocol\030\003 \001(\t\022\027\n\014service_port\030d \001(\r:\0010" +
-      "\")\n\020EventSubscribers\022\025\n\rcallback_urls\030\001 " +
-      "\003(\t\"=\n\016StorageVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005" +
-      "minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStr" +
-      "ategyDefinition\022\035\n\025minimumHealthCapacity" +
-      "\030\001 \002(\001\022\036\n\023maximumOverCapacity\030\002 \001(\001:\0011\"\260" +
-      "\001\n\017GroupDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007versio" +
-      "n\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.mesosphere.marat" +
-      "hon.ServiceDefinition\0224\n\006groups\030\004 \003(\0132$.",
-      "mesosphere.marathon.GroupDefinition\022\024\n\014d" +
-      "ependencies\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefi" +
-      "nition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010o" +
-      "riginal\030\004 \002(\0132$.mesosphere.marathon.Grou" +
-      "pDefinition\0224\n\006target\030\005 \002(\0132$.mesosphere" +
-      ".marathon.GroupDefinition\"\306\001\n\013TaskFailur" +
-      "e\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mes" +
-      "os.TaskID\022\037\n\005state\030\003 \002(\0162\020.mesos.TaskSta" +
-      "te\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n" +
-      "\007version\030\006 \002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007sla",
-      "veId\030\010 \001(\0132\016.mesos.SlaveID\"T\n\014ZKStoreEnt" +
-      "ry\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030" +
-      "\003 \002(\014\022\031\n\ncompressed\030\004 \001(\010:\005falseB\035\n\023meso" +
-      "sphere.marathonB\006Protos"
+      "P\020\001\022\013\n\007COMMAND\020\002\022\t\n\005HTTPS\020\003\"9\n\tIpAddress" +
+      "\022\016\n\006groups\030\001 \003(\t\022\034\n\006labels\030\002 \003(\0132\014.mesos" +
+      ".Label\"\206\007\n\021ServiceDefinition\022\n\n\002id\030\001 \002(\t" +
+      "\022\037\n\003cmd\030\002 \002(\0132\022.mesos.CommandInfo\022\021\n\tins" +
+      "tances\030\003 \002(\r\022\"\n\tresources\030\004 \003(\0132\017.mesos.",
+      "Resource\022\023\n\013description\030\005 \001(\t\022\r\n\005ports\030\006" +
+      " \003(\r\0224\n\013constraints\030\007 \003(\0132\037.mesosphere.m" +
+      "arathon.Constraint\022\022\n\010executor\030\010 \002(\t:\000\022>" +
+      "\n\022OBSOLETE_container\030\n \001(\0132\".mesosphere." +
+      "marathon.ContainerInfo\022)\n\007version\030\013 \001(\t:" +
+      "\0301970-01-01T00:00:00.000Z\022@\n\014healthCheck" +
+      "s\030\014 \003(\0132*.mesosphere.marathon.HealthChec" +
+      "kDefinition\022\025\n\007backoff\030\r \001(\003:\0041000\022\033\n\rba" +
+      "ckoffFactor\030\016 \001(\001:\0041.15\022G\n\017upgradeStrate" +
+      "gy\030\017 \001(\0132..mesosphere.marathon.UpgradeSt",
+      "rategyDefinition\022\024\n\014dependencies\030\020 \003(\t\022\021" +
+      "\n\tstoreUrls\030\021 \003(\t\022\034\n\rrequire_ports\030\022 \001(\010" +
+      ":\005false\022=\n\tcontainer\030\023 \001(\0132*.mesosphere." +
+      "marathon.ExtendedContainerInfo\022 \n\006labels" +
+      "\030\024 \003(\0132\020.mesos.Parameter\022\037\n\016maxLaunchDel" +
+      "ay\030\025 \001(\003:\0073600000\022A\n\025acceptedResourceRol" +
+      "es\030\026 \001(\0132\".mesosphere.marathon.ResourceR" +
+      "oles\022\027\n\017last_scaling_at\030\027 \001(\003\022\035\n\025last_co" +
+      "nfig_change_at\030\030 \001(\003\0221\n\tipAddress\030\031 \001(\0132" +
+      "\036.mesosphere.marathon.IpAddress\"\035\n\rResou",
+      "rceRoles\022\014\n\004role\030\001 \003(\t\"\307\002\n\014MarathonTask\022" +
+      "\n\n\002id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r" +
+      "\022$\n\nattributes\030\004 \003(\0132\020.mesos.Attribute\022\021" +
+      "\n\tstaged_at\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003\022,\n" +
+      "\021OBSOLETE_statuses\030\007 \003(\0132\021.mesos.TaskSta" +
+      "tus\022)\n\007version\030\010 \001(\t:\0301970-01-01T00:00:0" +
+      "0.000Z\022!\n\006status\030\t \001(\0132\021.mesos.TaskStatu" +
+      "s\022\037\n\007slaveId\030\n \001(\0132\016.mesos.SlaveID\022$\n\010ne" +
+      "tworks\030\013 \003(\0132\022.mesos.NetworkInfo\"M\n\013Mara" +
+      "thonApp\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!.m",
+      "esosphere.marathon.MarathonTask\"1\n\rConta" +
+      "inerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007options\030\002 \003" +
+      "(\014\"\237\004\n\025ExtendedContainerInfo\022\'\n\004type\030\001 \002" +
+      "(\0162\031.mesos.ContainerInfo.Type\022\036\n\007volumes" +
+      "\030\002 \003(\0132\r.mesos.Volume\022E\n\006docker\030\003 \001(\01325." +
+      "mesosphere.marathon.ExtendedContainerInf" +
+      "o.DockerInfo\032\365\002\n\nDockerInfo\022\r\n\005image\030\001 \002" +
+      "(\t\022>\n\007network\030\002 \001(\0162\'.mesos.ContainerInf" +
+      "o.DockerInfo.Network:\004HOST\022X\n\rport_mappi" +
+      "ngs\030\003 \003(\0132A.mesosphere.marathon.Extended",
+      "ContainerInfo.DockerInfo.PortMapping\022\031\n\n" +
+      "privileged\030\004 \001(\010:\005false\022$\n\nparameters\030\005 " +
+      "\003(\0132\020.mesos.Parameter\022\030\n\020force_pull_imag" +
+      "e\030\006 \001(\010\032c\n\013PortMapping\022\021\n\thost_port\030\001 \002(" +
+      "\r\022\026\n\016container_port\030\002 \002(\r\022\020\n\010protocol\030\003 " +
+      "\001(\t\022\027\n\014service_port\030d \001(\r:\0010\")\n\020EventSub" +
+      "scribers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016Stora" +
+      "geVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022" +
+      "\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefinit" +
+      "ion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023ma",
+      "ximumOverCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDefi" +
+      "nition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004a" +
+      "pps\030\003 \003(\0132&.mesosphere.marathon.ServiceD" +
+      "efinition\0224\n\006groups\030\004 \003(\0132$.mesosphere.m" +
+      "arathon.GroupDefinition\022\024\n\014dependencies\030" +
+      "\005 \003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002id" +
+      "\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002(" +
+      "\0132$.mesosphere.marathon.GroupDefinition\022" +
+      "4\n\006target\030\005 \002(\0132$.mesosphere.marathon.Gr" +
+      "oupDefinition\"\306\001\n\013TaskFailure\022\016\n\006app_id\030",
+      "\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037\n" +
+      "\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007messag" +
+      "e\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 \002" +
+      "(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016" +
+      ".mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004name\030\001" +
+      " \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\ncom" +
+      "pressed\030\004 \001(\010:\005falseB\035\n\023mesosphere.marat" +
+      "honB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -21614,38 +23072,44 @@ public final class Protos {
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
               new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "Port", });
-          internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
+          internal_static_mesosphere_marathon_IpAddress_descriptor =
             getDescriptor().getMessageTypes().get(2);
+          internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_IpAddress_descriptor,
+              new java.lang.String[] { "Groups", "Labels", });
+          internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(3);
           internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ServiceDefinition_descriptor,
-              new java.lang.String[] { "Id", "Cmd", "Instances", "Resources", "Description", "Ports", "Constraints", "Executor", "OBSOLETEContainer", "Version", "HealthChecks", "Backoff", "BackoffFactor", "UpgradeStrategy", "Dependencies", "StoreUrls", "RequirePorts", "Container", "Labels", "MaxLaunchDelay", "AcceptedResourceRoles", "LastScalingAt", "LastConfigChangeAt", });
+              new java.lang.String[] { "Id", "Cmd", "Instances", "Resources", "Description", "Ports", "Constraints", "Executor", "OBSOLETEContainer", "Version", "HealthChecks", "Backoff", "BackoffFactor", "UpgradeStrategy", "Dependencies", "StoreUrls", "RequirePorts", "Container", "Labels", "MaxLaunchDelay", "AcceptedResourceRoles", "LastScalingAt", "LastConfigChangeAt", "IpAddress", });
           internal_static_mesosphere_marathon_ResourceRoles_descriptor =
-            getDescriptor().getMessageTypes().get(3);
+            getDescriptor().getMessageTypes().get(4);
           internal_static_mesosphere_marathon_ResourceRoles_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ResourceRoles_descriptor,
               new java.lang.String[] { "Role", });
           internal_static_mesosphere_marathon_MarathonTask_descriptor =
-            getDescriptor().getMessageTypes().get(4);
+            getDescriptor().getMessageTypes().get(5);
           internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_MarathonTask_descriptor,
-              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", });
+              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "Networks", });
           internal_static_mesosphere_marathon_MarathonApp_descriptor =
-            getDescriptor().getMessageTypes().get(5);
+            getDescriptor().getMessageTypes().get(6);
           internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_MarathonApp_descriptor,
               new java.lang.String[] { "Name", "Tasks", });
           internal_static_mesosphere_marathon_ContainerInfo_descriptor =
-            getDescriptor().getMessageTypes().get(6);
+            getDescriptor().getMessageTypes().get(7);
           internal_static_mesosphere_marathon_ContainerInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ContainerInfo_descriptor,
               new java.lang.String[] { "Image", "Options", });
           internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor =
-            getDescriptor().getMessageTypes().get(7);
+            getDescriptor().getMessageTypes().get(8);
           internal_static_mesosphere_marathon_ExtendedContainerInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor,
@@ -21663,43 +23127,43 @@ public final class Protos {
               internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor,
               new java.lang.String[] { "HostPort", "ContainerPort", "Protocol", "ServicePort", });
           internal_static_mesosphere_marathon_EventSubscribers_descriptor =
-            getDescriptor().getMessageTypes().get(8);
+            getDescriptor().getMessageTypes().get(9);
           internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_EventSubscribers_descriptor,
               new java.lang.String[] { "CallbackUrls", });
           internal_static_mesosphere_marathon_StorageVersion_descriptor =
-            getDescriptor().getMessageTypes().get(9);
+            getDescriptor().getMessageTypes().get(10);
           internal_static_mesosphere_marathon_StorageVersion_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_StorageVersion_descriptor,
               new java.lang.String[] { "Major", "Minor", "Patch", });
           internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(10);
+            getDescriptor().getMessageTypes().get(11);
           internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor,
               new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", });
           internal_static_mesosphere_marathon_GroupDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(11);
+            getDescriptor().getMessageTypes().get(12);
           internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_GroupDefinition_descriptor,
               new java.lang.String[] { "Id", "Version", "Apps", "Groups", "Dependencies", });
           internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(12);
+            getDescriptor().getMessageTypes().get(13);
           internal_static_mesosphere_marathon_DeploymentPlanDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor,
               new java.lang.String[] { "Id", "Version", "Original", "Target", });
           internal_static_mesosphere_marathon_TaskFailure_descriptor =
-            getDescriptor().getMessageTypes().get(13);
+            getDescriptor().getMessageTypes().get(14);
           internal_static_mesosphere_marathon_TaskFailure_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_TaskFailure_descriptor,
               new java.lang.String[] { "AppId", "TaskId", "State", "Message", "Host", "Version", "Timestamp", "SlaveId", });
           internal_static_mesosphere_marathon_ZKStoreEntry_descriptor =
-            getDescriptor().getMessageTypes().get(14);
+            getDescriptor().getMessageTypes().get(15);
           internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ZKStoreEntry_descriptor,

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -46,6 +46,11 @@ message HealthCheckDefinition {
   optional uint32 port = 10;
 }
 
+message IpAddress {
+  repeated string groups = 1;
+  repeated mesos.Label labels = 2;
+}
+
 message ServiceDefinition {
   required string id = 1;
   required mesos.CommandInfo cmd = 2;
@@ -71,6 +76,7 @@ message ServiceDefinition {
   optional ResourceRoles acceptedResourceRoles = 22;
   optional int64 last_scaling_at = 23;
   optional int64 last_config_change_at = 24;
+  optional IpAddress ipAddress = 25;
 }
 
 message ResourceRoles {
@@ -88,6 +94,7 @@ message MarathonTask {
   optional string version = 8 [default = "1970-01-01T00:00:00.000Z"]; // since 0.7.0
   optional mesos.TaskStatus status = 9;
   optional mesos.SlaveID slaveId = 10;
+  repeated mesos.NetworkInfo networks = 11;
 }
 
 message MarathonApp {

--- a/src/main/proto/mesos/mesos.proto
+++ b/src/main/proto/mesos/mesos.proto
@@ -1004,11 +1004,11 @@ message InverseOffer {
   //
   // For reserved resources, the resources are expected to be returned to the
   // framework after the unavailability interval.  This is an expectation,
-  // not a guarantee.  For example, if the unavailiability duration is not set,
-  // the resources may be removed permenantly.
+  // not a guarantee.  For example, if the unavailability duration is not set,
+  // the resources may be removed permanently.
   //
   // For other resources, there is no guarantee that requested resources will
-  // be returned after the unavailiability interval.  The allocator has no
+  // be returned after the unavailability interval.  The allocator has no
   // obligation to re-offer these resources to the prior framework after
   // the unavailability.
   required Unavailability unavailability = 5;
@@ -1097,8 +1097,19 @@ message TaskStatus {
   // TODO(bmahler): Differentiate between slave removal reasons
   // (e.g. unhealthy vs. unregistered for maintenance).
   enum Reason {
+    // TODO(jieyu): The default value when a caller doesn't check for
+    // presence is 0 and so ideally the 0 reason is not a valid one.
+    // Since this is not used anywhere, consider removing this reason.
     REASON_COMMAND_EXECUTOR_FAILED = 0;
-    REASON_EXECUTOR_PREEMPTED = 17;
+
+    REASON_CONTAINER_LAUNCH_FAILED = 21;
+    REASON_CONTAINER_LIMITATION = 19;
+    REASON_CONTAINER_LIMITATION_DISK = 20;
+    REASON_CONTAINER_LIMITATION_MEMORY = 8;
+    REASON_CONTAINER_PREEMPTED = 17;
+    REASON_CONTAINER_UPDATE_FAILED = 22;
+    REASON_EXECUTOR_REGISTRATION_TIMEOUT = 23;
+    REASON_EXECUTOR_REREGISTRATION_TIMEOUT = 24;
     REASON_EXECUTOR_TERMINATED = 1;
     REASON_EXECUTOR_UNREGISTERED = 2;
     REASON_FRAMEWORK_REMOVED = 3;
@@ -1106,7 +1117,6 @@ message TaskStatus {
     REASON_INVALID_FRAMEWORKID = 5;
     REASON_INVALID_OFFERS = 6;
     REASON_MASTER_DISCONNECTED = 7;
-    REASON_MEMORY_LIMIT = 8;
     REASON_RECONCILIATION = 9;
     REASON_RESOURCES_UNKNOWN = 18;
     REASON_SLAVE_DISCONNECTED = 10;
@@ -1216,7 +1226,7 @@ message Parameters {
  */
 message Credential {
   required string principal = 1;
-  optional bytes secret = 2;
+  optional string secret = 2;
 }
 
 
@@ -1241,7 +1251,7 @@ message RateLimit {
   optional double qps = 1;
 
   // Principal of framework(s) to be throttled. Should match
-  // FrameworkInfo.princpal and Credential.principal (if using authentication).
+  // FrameworkInfo.principal and Credential.principal (if using authentication).
   required string principal = 2;
 
   // Max number of outstanding messages from frameworks of this principal
@@ -1303,7 +1313,10 @@ message Image {
   }
 
   message Docker {
-    // The name of the image. Expected in format repository[:tag].
+    // The name of the image. Expected format:
+    //   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
+    //
+    // See: https://docs.docker.com/reference/commandline/pull/
     required string name = 1;
   }
 
@@ -1348,16 +1361,20 @@ message Volume {
 
 
 /**
- * Describes a network request by framework as well as network resolution
- * provided by the the executor or Agent.
+ * Describes a network request from a framework as well as network resolution
+ * provided by Mesos.
  *
- * A framework may request the network isolator on the Agent to assign an IP
- * address to the container being launched. Alternatively, it can provide a
- * specific IP address to be assigned to the container. The NetworkInfo message
- * is not interpreted by the Master or Agent and is intended to be use by Agent
- * modules implementing network isolation. If the modules are missing, the
- * message is simply ignored. In future, the task launch will fail if there is
- * no module providing the network isolation capabilities (MESOS-3390).
+ * A Framework may request the network isolator on the Agent to isolate the
+ * container in a network namespace and create a virtual network interface.
+ * The `NetworkInfo` message describes the properties of that virtual
+ * interface, including the IP addresses and network isolation policy
+ * (network group membership).
+ *
+ * The NetworkInfo message is not interpreted by the Master or Agent and is
+ * intended to be used by Agent and Master modules implementing network
+ * isolation. If the modules are missing, the message is simply ignored. In
+ * future, the task launch will fail if there is no module providing the
+ * network isolation capabilities (MESOS-3390).
  *
  * An executor, Agent, or an Agent module may append NetworkInfos inside
  * TaskStatus::container_status to provide information such as the container IP
@@ -1369,23 +1386,57 @@ message NetworkInfo {
     IPv6 = 2;
   }
 
+  // Specifies a request for an IP address, or reports the assigned container
+  // IP address.
+  //
+  // Users can request an automatically assigned IP (for example, via an
+  // IPAM service) or a specific IP by adding a NetworkInfo to the
+  // ContainerInfo for a task.  On a request, specifying neither `protocol`
+  // nor `ip_address` means that any available address may be assigned.
+  message IPAddress {
+    // Specify IP address requirement. Set protocol to the desired value to
+    // request the network isolator on the Agent to assign an IP address to the
+    // container being launched. If a specific IP address is specified in
+    // ip_address, this field should not be set.
+    optional Protocol protocol = 1;
+
+    // Statically assigned IP provided by the Framework. This IP will be
+    // assigned to the container by the network isolator module on the Agent.
+    // This field should not be used with the protocol field above.
+    //
+    // If an explicit address is requested but is unavailable, the network
+    // isolator should fail the task.
+    optional string ip_address = 2;
+  }
+
+  // When included in a ContainerInfo, each of these represent a
+  // request for an IP address. Each request can specify an explicit address
+  // or the IP protocol to use.
+  //
+  // When included in a TaskStatus message, these inform the framework
+  // scheduler about the IP addresses that are bound to the container
+  // interface. When there are no custom network isolator modules installed,
+  // this field is filled in automatically with the Agent IP address.
+  repeated IPAddress ip_addresses = 5;
+
   // Specify IP address requirement. Set protocol to the desired value to
   // request the network isolator on the Agent to assign an IP address to the
   // container being launched. If a specific IP address is specified in
   // ip_address, this field should not be set.
-  optional Protocol protocol = 1;
+  optional Protocol protocol = 1 [deprecated = true]; // Since 0.26.0
 
   // Statically assigned IP provided by the Framework. This IP will be assigned
   // to the container by the network isolator module on the Agent. This field
   // should not be used with the protocol field above.
   // NOTE: It is up to the networking 'provider' (IPAM/Isolator) to interpret
   // this either as a hint of as a requirement for assigning the IP.
-  optional string ip_address = 2;
+  optional string ip_address = 2 [deprecated = true]; // Since 0.26.0
 
-  // A group is the name given to a set of logically-related IPs that are
-  // allowed to communicate within themselves. For example, one might want
-  // to create separate groups for isolating dev, testing, qa and prod
-  // deployment environments.
+  // A group is the name given to a set of logically-related interfaces that
+  // are allowed to communicate among themselves. Network traffic is allowed
+  // between two container interfaces that share at least one network group.
+  // For example, one might want to create separate groups for isolating dev,
+  // testing, qa and prod deployment environments.
   repeated string groups = 3;
 
   // To tag certain metadata to be used by Isolator/IPAM, e.g., rack, etc.
@@ -1473,7 +1524,7 @@ message ContainerStatus {
  * Collection of labels.
  */
 message Labels {
-    repeated Label labels = 1;
+  repeated Label labels = 1;
 }
 
 
@@ -1493,6 +1544,7 @@ message Port {
   required uint32 number = 1;
   optional string name = 2;
   optional string protocol = 3;
+  optional DiscoveryInfo.Visibility visibility = 4;
 }
 
 
@@ -1506,15 +1558,16 @@ message Ports {
 
 /**
 * Service discovery information.
-* The visibility field restricts discovery within a framework
-* (FRAMEWORK), within a Mesos cluster (CLUSTER), or  places no
-* restrictions (EXTERNAL).
-* The environment, location, and version fields provide first class
-* support for common attributes used to differentiate between
-* similar services. The environment may receive values such as
-* PROD/QA/DEV, the location field may receive values like
-* EAST-US/WEST-US/EUROPE/AMEA, and the version field may receive
-* values like v2.0/v0.9. The exact use of these fields is up to each
+* The visibility field restricts discovery within a framework (FRAMEWORK),
+* within a Mesos cluster (CLUSTER), or places no restrictions (EXTERNAL).
+* Each port in the ports field also has an optional visibility field.
+* If visibility is specified for a port, it overrides the default service-wide
+* DiscoveryInfo.visibility for that port.
+* The environment, location, and version fields provide first class support for
+* common attributes used to differentiate between similar services. The
+* environment may receive values such as PROD/QA/DEV, the location field may
+* receive values like EAST-US/WEST-US/EUROPE/AMEA, and the version field may
+* receive values like v2.0/v0.9. The exact use of these fields is up to each
 * service discovery system.
 */
 message DiscoveryInfo {

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
@@ -56,7 +56,7 @@ object MarathonSchedulerDriver {
         config.mesosAuthenticationSecretFile.get.foreach { secretFile =>
           try {
             val secretBytes = ByteString.readFrom(new FileInputStream(secretFile))
-            credentialBuilder.setSecret(secretBytes)
+            credentialBuilder.setSecret(secretBytes.toString)
           }
           catch {
             case cause: Throwable =>

--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.api
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.tasks.TaskTracker
 import org.apache.mesos.Protos.TaskState
+
 import scala.collection.JavaConverters._
 
 object EndpointsHelper {
@@ -17,14 +18,14 @@ object EndpointsHelper {
     apps: Seq[AppDefinition],
     delimiter: String): String = {
     val sb = new StringBuilder
-    for (app <- apps) {
+    for (app <- apps if app.ipAddress.isEmpty) {
       val cleanId = app.id.safePath.replaceAll("\\s+", "_")
       val tasks = taskTracker.get(app.id)
 
       val servicePorts = app.servicePorts
 
       if (servicePorts.isEmpty) {
-        sb.append(s"${cleanId}$delimiter $delimiter")
+        sb.append(s"$cleanId$delimiter $delimiter")
         for (task <- tasks if task.getStatus.getState == TaskState.TASK_RUNNING) {
           sb.append(s"${task.getHost} ")
         }

--- a/src/main/scala/mesosphere/marathon/api/v2/json/V2AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/V2AppDefinition.scala
@@ -65,6 +65,8 @@ case class V2AppDefinition(
 
     acceptedResourceRoles: Option[Set[String]] = None,
 
+    ipAddress: Option[IpAddress] = None,
+
     version: Timestamp = Timestamp.now(),
 
     versionInfo: Option[V2AppDefinition.VersionInfo] = None) extends Timestamped {
@@ -79,7 +81,7 @@ case class V2AppDefinition(
 
   /**
     * Returns the canonical internal representation of this API-specific
-    * application defintion.
+    * application definition.
     */
   def toAppDefinition: AppDefinition = {
     val appVersionInfo = versionInfo match {
@@ -95,7 +97,7 @@ case class V2AppDefinition(
       backoffFactor = backoffFactor, maxLaunchDelay = maxLaunchDelay, container = container,
       healthChecks = healthChecks, dependencies = dependencies, upgradeStrategy = upgradeStrategy,
       labels = labels, acceptedResourceRoles = acceptedResourceRoles,
-      versionInfo = appVersionInfo
+      ipAddress = ipAddress, versionInfo = appVersionInfo
     )
   }
 
@@ -124,6 +126,6 @@ object V2AppDefinition {
       backoff = app.backoff, backoffFactor = app.backoffFactor, maxLaunchDelay = app.maxLaunchDelay,
       container = app.container, healthChecks = app.healthChecks, dependencies = app.dependencies,
       upgradeStrategy = app.upgradeStrategy, labels = app.labels, acceptedResourceRoles = app.acceptedResourceRoles,
-      version = app.version, versionInfo = maybeVersionInfo)
+      ipAddress = app.ipAddress, version = app.version, versionInfo = maybeVersionInfo)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -82,9 +82,18 @@ class CoreGuiceModule extends AbstractModule {
     // (updateTaskTrackerStepImpl) before we notify the launch queue (notifyLaunchQueueStepImpl).
 
     Seq(
+
+      // Update the task tracker _first_.
+      //
+      // Subsequent steps (for example, the health check subsystem) depend on
+      // task tracker lookup to determine the routable host address for running
+      // tasks.  In case this status update is the first TASK_RUNNING update
+      // in IP-per-container mode, we need to store the assigned container
+      // address reliably before attempting to initiate health checks, or
+      // publish events to the bus.
+      updateTaskTrackerStepImpl,
       ContinueOnErrorStep(notifyHealthCheckManagerStepImpl),
       ContinueOnErrorStep(notifyRateLimiterStepImpl),
-      updateTaskTrackerStepImpl,
       ContinueOnErrorStep(notifyLaunchQueueStepImpl),
       ContinueOnErrorStep(taskStatusEmitterPublishImpl),
       ContinueOnErrorStep(postToEventStreamStepImpl),

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
@@ -24,6 +24,9 @@ private[launcher] class TaskLauncherImpl(
   override def launchTasks(offerID: OfferID, taskInfos: Seq[TaskInfo]): Boolean = {
     val launched = withDriver(s"launchTasks($offerID)") { driver =>
       import scala.collection.JavaConverters._
+      if (log.isDebugEnabled) {
+        log.debug(s"Launching tasks on $offerID:\n${taskInfos.mkString("\n")}")
+      }
       driver.launchTasks(Collections.singleton(offerID), taskInfos.asJava)
     }
     if (launched) {

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/steps/PostToEventStreamStepImpl.scala
@@ -8,6 +8,7 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.task.tracker.TaskStatusUpdateStep
 import mesosphere.marathon.event.{ EventModule, MesosStatusUpdateEvent }
 import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.tasks.MarathonTasks
 import org.apache.mesos.Protos.TaskState.{
   TASK_ERROR,
   TASK_FAILED,
@@ -61,6 +62,7 @@ class PostToEventStreamStepImpl @Inject() (
         if (status.hasMessage) status.getMessage else "",
         appId,
         task.getHost,
+        MarathonTasks.ipAddresses(task),
         task.getPortsList.asScala,
         task.getVersion,
         timestamp = timestamp.toString

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -212,6 +212,7 @@ case class MesosStatusUpdateEvent(
   message: String,
   appId: PathId,
   host: String,
+  ipAddresses: Seq[org.apache.mesos.Protos.NetworkInfo.IPAddress],
   ports: Iterable[Integer],
   version: String,
   eventType: String = "status_update_event",

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckWorkerActor.scala
@@ -8,6 +8,7 @@ import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.{
   TCP,
   HTTPS
 }
+import mesosphere.marathon.tasks.MarathonTasks
 
 import akka.actor.{ Actor, ActorLogging, PoisonPill }
 import akka.util.Timeout
@@ -79,7 +80,7 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
   }
 
   def http(task: MarathonTask, check: HealthCheck, port: Int): Future[Option[HealthResult]] = {
-    val host = task.getHost
+    val host = MarathonTasks.effectiveIpAddress(task)
     val rawPath = check.path.getOrElse("")
     val absolutePath = if (rawPath.startsWith("/")) rawPath else s"/$rawPath"
     val url = s"http://$host:$port$absolutePath"
@@ -105,7 +106,7 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
   }
 
   def tcp(task: MarathonTask, check: HealthCheck, port: Int): Future[Option[HealthResult]] = {
-    val host = task.getHost
+    val host = MarathonTasks.effectiveIpAddress(task)
     val address = s"$host:$port"
     val timeoutMillis = check.timeout.toMillis.toInt
     log.debug("Checking the health of [{}] via TCP", address)
@@ -120,7 +121,7 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
   }
 
   def https(task: MarathonTask, check: HealthCheck, port: Int): Future[Option[HealthResult]] = {
-    val host = task.getHost
+    val host = MarathonTasks.effectiveIpAddress(task)
     val rawPath = check.path.getOrElse("")
     val absolutePath = if (rawPath.startsWith("/")) rawPath else s"/$rawPath"
     val url = s"https://$host:$port$absolutePath"

--- a/src/main/scala/mesosphere/marathon/state/IpAddress.scala
+++ b/src/main/scala/mesosphere/marathon/state/IpAddress.scala
@@ -1,0 +1,33 @@
+package mesosphere.marathon.state
+
+import mesosphere.marathon.Protos
+
+import scala.collection.immutable.Seq
+import scala.collection.JavaConverters._
+import org.apache.mesos.{ Protos => mesos }
+
+case class IpAddress(
+    groups: Seq[String] = Nil,
+    labels: Map[String, String] = Map.empty[String, String]) {
+
+  def toProto: Protos.IpAddress = {
+    val builder = Protos.IpAddress.newBuilder
+    groups.foreach(builder.addGroups)
+    labels
+      .map { case (key, value) => mesos.Label.newBuilder.setKey(key).setValue(value).build }
+      .foreach(builder.addLabels)
+    builder.build
+  }
+}
+
+object IpAddress {
+
+  def empty: IpAddress = IpAddress()
+
+  def fromProto(proto: Protos.IpAddress): IpAddress = {
+    IpAddress(
+      groups = proto.getGroupsList.asScala.toIndexedSeq,
+      labels = proto.getLabelsList.asScala.map { p => p.getKey -> p.getValue }.toMap
+    )
+  }
+}

--- a/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
+++ b/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
@@ -72,7 +72,7 @@ object TaskFailure {
     def apply(statusUpdate: MesosStatusUpdateEvent): Option[TaskFailure] = {
       val MesosStatusUpdateEvent(
         slaveId, taskId, taskStateStr, message,
-        appId, host, _, version, _, ts
+        appId, host, _, _, version, _, ts
         ) = statusUpdate
 
       val state = taskState(taskStateStr)

--- a/src/main/scala/mesosphere/marathon/tasks/MarathonTasks.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/MarathonTasks.scala
@@ -8,7 +8,6 @@ import org.apache.mesos.Protos.Attribute
 import scala.collection.JavaConverters._
 
 object MarathonTasks {
-
   /*
    * Despite its name, stagedAt is set on task creation and before the TASK_STAGED notification from Mesos. This is
    * important because we periodically check for any tasks with an old stagedAt timestamp and kill them (See
@@ -31,5 +30,21 @@ object MarathonTasks {
       .setStagedAt(now.toDateTime.getMillis)
       .setSlaveId(slaveId)
       .build
+  }
+
+  def ipAddresses(task: MarathonTask): Seq[Protos.NetworkInfo.IPAddress] = {
+    task.getNetworksList.asScala.flatMap(_.getIpAddressesList.asScala.toList)
+  }
+
+  /**
+    * Returns the IP address (as string) to use connect to the task.
+    *
+    * If the supplied task has at least one NetworkInfo with an IP address
+    * filled in, this function returns the first such address.
+    *
+    * In all other cases, this function returns the slave host address.
+    */
+  def effectiveIpAddress(task: MarathonTask): String = {
+    ipAddresses(task).map(_.getIpAddress).headOption.getOrElse(task.getHost)
   }
 }

--- a/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskTracker.scala
@@ -144,7 +144,11 @@ class TaskTracker @Inject() (
         removeTask(app, task.getId)
         Future.successful(())
       case TASK_RUNNING if !task.hasStartedAt => // was staged, is now running
-        updateTask(task.toBuilder.setStartedAt(System.currentTimeMillis).setStatus(status).build())
+        val builder = task.toBuilder
+        builder.setStartedAt(System.currentTimeMillis).setStatus(status)
+        builder.setStatus(status)
+        if (status.hasContainerStatus) builder.addAllNetworks(status.getContainerStatus.getNetworkInfosList)
+        updateTask(builder.build())
       case _ =>
         updateTaskOnStateChange(task)
     }

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -61,7 +61,7 @@ trait StartingBehavior { this: Actor with ActorLogging =>
   }
 
   final def checkForRunning: Receive = {
-    case MesosStatusUpdateEvent(_, taskId, "TASK_RUNNING", _, app.`id`, _, _, Version, _, _) if !startedRunningTasks(taskId) => // scalastyle:off line.size.limit
+    case MesosStatusUpdateEvent(_, taskId, "TASK_RUNNING", _, app.`id`, _, _, _, Version, _, _) if !startedRunningTasks(taskId) => // scalastyle:off line.size.limit
       startedRunningTasks += taskId
       log.info(s"New task $taskId now running during app ${app.id.toString} scaling, " +
         s"${nrToStart - startedRunningTasks.size} more to go")
@@ -69,7 +69,7 @@ trait StartingBehavior { this: Actor with ActorLogging =>
   }
 
   def commonBehavior: Receive = {
-    case MesosStatusUpdateEvent(_, taskId, StartErrorState(_), _, app.`id`, _, _, Version, _, _) => // scalastyle:off line.size.limit
+    case MesosStatusUpdateEvent(_, taskId, StartErrorState(_), _, app.`id`, _, _, _, Version, _, _) => // scalastyle:off line.size.limit
       log.warning(s"New task $taskId failed during app ${app.id.toString} scaling, queueing another task")
       startedRunningTasks -= taskId
       taskQueue.add(app)

--- a/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
@@ -44,7 +44,7 @@ trait StoppingBehavior extends Actor with ActorLogging {
   val taskFinished = "^TASK_(ERROR|FAILED|FINISHED|LOST|KILLED)$".r
 
   def receive: Receive = {
-    case MesosStatusUpdateEvent(_, taskId, taskFinished(_), _, _, _, _, _, _, _) if idsToKill(taskId) =>
+    case MesosStatusUpdateEvent(_, taskId, taskFinished(_), _, _, _, _, _, _, _, _) if idsToKill(taskId) =>
       idsToKill.remove(taskId)
       log.info(s"Task $taskId has been killed. Waiting for ${idsToKill.size} more tasks to be killed.")
       checkFinished()

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -79,7 +79,7 @@ class TaskReplaceActor(
   }
 
   def taskStateBehavior: Receive = {
-    case MesosStatusUpdateEvent(slaveId, taskId, "TASK_RUNNING", _, `appId`, _, _, `version`, _, _) =>
+    case MesosStatusUpdateEvent(slaveId, taskId, "TASK_RUNNING", _, `appId`, _, _, _, `version`, _, _) =>
       handleStartedTask(taskId)
   }
 
@@ -90,13 +90,13 @@ class TaskReplaceActor(
 
   def commonBehavior: Receive = {
     // New task failed to start, restart it
-    case MesosStatusUpdateEvent(slaveId, taskId, FailedToStart(_), _, `appId`, _, _, `version`, _, _) if !oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
+    case MesosStatusUpdateEvent(slaveId, taskId, FailedToStart(_), _, `appId`, _, _, _, `version`, _, _) if !oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
       log.error(s"New task $taskId failed on slave $slaveId during app $appId restart")
       healthy -= taskId
       taskQueue.add(app)
 
     // Old task successfully killed
-    case MesosStatusUpdateEvent(slaveId, taskId, KillComplete(_), _, `appId`, _, _, _, _, _) if oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
+    case MesosStatusUpdateEvent(slaveId, taskId, KillComplete(_), _, `appId`, _, _, _, _, _, _) if oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
       oldTaskIds -= taskId
       outstandingKills -= taskId
       reconcileNewTasks()

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -159,7 +159,17 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     when(tracker.count(app.id)).thenReturn(0)
     when(repo.store(any())).thenReturn(Future.successful(app))
 
-    val statusUpdateEvent = MesosStatusUpdateEvent("", taskA.getId, "TASK_FAILED", "", app.id, "", Nil, app.version.toString)
+    val statusUpdateEvent = MesosStatusUpdateEvent(
+      slaveId = "",
+      taskId = taskA.getId,
+      taskStatus = "TASK_FAILED",
+      message = "",
+      appId = app.id,
+      host = "",
+      ipAddresses = Nil,
+      ports = Nil,
+      version = app.version.toString
+    )
 
     when(driver.killTask(TaskID(taskA.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
@@ -204,7 +214,11 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
     when(tracker.count(app.id)).thenReturn(0)
     when(repo.store(any())).thenReturn(Future.successful(app))
 
-    val statusUpdateEvent = MesosStatusUpdateEvent("", taskA.getId, "TASK_KILLED", "", app.id, "", Nil, app.version.toString)
+    val statusUpdateEvent = MesosStatusUpdateEvent(
+      slaveId = "", taskId = taskA.getId, taskStatus = "TASK_KILLED", message = "", appId = app.id,
+      host = "", ipAddresses = Nil, ports = Nil, version = "",
+      timestamp = app.version.toString
+    )
 
     when(driver.killTask(TaskID(taskA.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
@@ -285,7 +299,12 @@ class MarathonSchedulerActorTest extends TestKit(ActorSystem("System"))
 
     when(driver.killTask(TaskID(taskA.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", taskA.getId, "TASK_KILLED", "", app.id, "", Nil, app.version.toString))
+        system.eventStream.publish(
+          MesosStatusUpdateEvent(
+            slaveId = "", taskId = taskA.getId, taskStatus = "TASK_KILLED", message = "", appId = app.id, host = "",
+            ipAddresses = Nil, ports = Nil, version = app.version.toString
+          )
+        )
         Status.DRIVER_RUNNING
       }
     })

--- a/src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
@@ -1,0 +1,83 @@
+package mesosphere.marathon.api.v2.json
+
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.api.JsonTestHelper
+import mesosphere.marathon.state.Timestamp
+import org.apache.mesos.{ Protos => MesosProtos }
+
+import scala.collection.JavaConverters._
+
+class MarathonTaskFormatTest extends MarathonSpec {
+  import Formats._
+
+  class Fixture {
+    val taskWithoutIp = MarathonTask.newBuilder
+      .setId("/foo/bar")
+      .setHost("agent1.mesos")
+      .setVersion(Timestamp(1024).toString)
+      .setStagedAt(1024L)
+      .setSlaveId(MesosProtos.SlaveID.newBuilder.setValue("abcd-1234"))
+      .build
+
+    val ip1 = MesosProtos.NetworkInfo.IPAddress.newBuilder().setIpAddress("123.123.123.123").build
+    val ip2 = MesosProtos.NetworkInfo.IPAddress.newBuilder().setIpAddress("123.123.123.124").build
+    val taskWithMultipleIPs = MarathonTask.newBuilder
+      .setId("/foo/bar")
+      .setHost("agent1.mesos")
+      .setVersion(Timestamp(1024).toString)
+      .setStagedAt(1024L)
+      .setSlaveId(MesosProtos.SlaveID.newBuilder.setValue("abcd-1234"))
+      .addAllNetworks(
+        Seq(
+          MesosProtos.NetworkInfo.newBuilder.addIpAddresses(ip1).build,
+          MesosProtos.NetworkInfo.newBuilder.addIpAddresses(ip2).build
+        ).asJava
+      ).build
+  }
+
+  test("JSON serialization of MarathonTask without IPs") {
+    val f = new Fixture()
+    val json =
+      """
+        |{
+        |  "id": "/foo/bar",
+        |  "host": "agent1.mesos",
+        |  "ipAddresses": [],
+        |  "ports": [],
+        |  "startedAt": null,
+        |  "stagedAt": "1970-01-01T00:00:01.024Z",
+        |  "version": "1970-01-01T00:00:01.024Z",
+        |  "slaveId": "abcd-1234"
+        |}
+      """.stripMargin
+    JsonTestHelper.assertThatJsonOf(f.taskWithoutIp).correspondsToJsonString(json)
+  }
+
+  test("JSON serialization of MarathonTask with multiple IPs") {
+    val f = new Fixture()
+    val json =
+      """
+        |{
+        |  "id": "/foo/bar",
+        |  "host": "agent1.mesos",
+        |  "ipAddresses": [
+        |    {
+        |      "ipAddress": "123.123.123.123",
+        |      "protocol": "IPv4"
+        |    },
+        |    {
+        |      "ipAddress": "123.123.123.124",
+        |      "protocol": "IPv4"
+        |    }
+        |  ],
+        |  "ports": [],
+        |  "startedAt": null,
+        |  "stagedAt": "1970-01-01T00:00:01.024Z",
+        |  "version": "1970-01-01T00:00:01.024Z",
+        |  "slaveId": "abcd-1234"
+        |}
+      """.stripMargin
+    JsonTestHelper.assertThatJsonOf(f.taskWithMultipleIPs).correspondsToJsonString(json)
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/v2/json/V2AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/V2AppDefinitionTest.scala
@@ -11,7 +11,8 @@ import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import org.apache.mesos.{ Protos => mesos }
 import org.scalatest.Matchers
-import play.api.libs.json.Json
+import play.api.data.validation.ValidationError
+import play.api.libs.json.{ JsError, Json }
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
@@ -435,5 +436,84 @@ class V2AppDefinitionTest extends MarathonSpec with Matchers {
       """
     val readResult4 = fromJson(json4)
     assert(readResult4.copy(version = app4.version) == app4)
+  }
+
+  test("Read app with ip address") {
+    val app = V2AppDefinition(
+      id = "app-with-network-isolation".toPath,
+      cmd = Some("python3 -m http.server 8080"),
+      ports = Nil,
+      ipAddress = Some(IpAddress(
+        groups = Seq("a", "b", "c"),
+        labels = Map(
+          "foo" -> "bar",
+          "baz" -> "buzz"
+        )
+      ))
+    )
+
+    val json =
+      """
+      {
+        "id": "app-with-network-isolation",
+        "cmd": "python3 -m http.server 8080",
+        "ipAddress": {
+          "groups": ["a", "b", "c"],
+          "labels": {
+            "foo": "bar",
+            "baz": "buzz"
+          }
+        }
+      }
+      """
+
+    val readResult = fromJson(json)
+
+    assert(readResult.copy(version = app.version) == app)
+  }
+
+  test("Read app with ip address and an empty ports list") {
+    val app = V2AppDefinition(
+      id = "app-with-network-isolation".toPath,
+      cmd = Some("python3 -m http.server 8080"),
+      ports = Nil,
+      ipAddress = Some(IpAddress())
+    )
+
+    val json =
+      """
+      {
+        "id": "app-with-network-isolation",
+        "cmd": "python3 -m http.server 8080",
+        "ports": [],
+        "ipAddress": {}
+      }
+      """
+
+    val readResult = fromJson(json)
+
+    assert(readResult.copy(version = app.version) == app)
+  }
+
+  test("App may not have non-empty ports and ipAddress") {
+    val json =
+      """
+      {
+        "id": "app-with-network-isolation",
+        "cmd": "python3 -m http.server 8080",
+        "ports": [0],
+        "ipAddress": {
+          "groups": ["a", "b", "c"],
+          "labels": {
+            "foo": "bar",
+            "baz": "buzz"
+          }
+        }
+      }
+      """
+
+    import Formats._
+    val result = Json.fromJson[V2AppDefinition](Json.parse(json))
+    assert(result == JsError(ValidationError("You cannot specify both an IP address and ports")))
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/steps/PostToEventStreamStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/steps/PostToEventStreamStepImplTest.scala
@@ -6,7 +6,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.event.{ MesosStatusUpdateEvent, MarathonEvent }
 import mesosphere.marathon.state.{ PathId, Timestamp }
-import mesosphere.marathon.tasks.TaskIdUtil
+import mesosphere.marathon.tasks.{ MarathonTasks, TaskIdUtil }
 import mesosphere.marathon.test.{ CaptureLogEvents, CaptureEvents }
 import org.apache.mesos.Protos.{ SlaveID, TaskState, TaskStatus }
 import org.scalatest.concurrent.ScalaFutures
@@ -39,14 +39,15 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
     events should have size 1
     events should be (Seq(
       MesosStatusUpdateEvent(
-        slaveId.getValue,
-        taskId.getValue,
-        status.getState.name,
-        taskStatusMessage,
-        appId,
-        host,
-        portsList.asJava.asScala,
-        version.toString,
+        slaveId = slaveId.getValue,
+        taskId = taskId.getValue,
+        taskStatus = status.getState.name,
+        message = taskStatusMessage,
+        appId = appId,
+        host = host,
+        ipAddresses = Nil,
+        ports = portsList.asJava.asScala,
+        version = version.toString,
         timestamp = updateTimestamp.toString
       )
     ))
@@ -105,14 +106,15 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
     events should have size 1
     events should be (Seq(
       MesosStatusUpdateEvent(
-        slaveId.getValue,
-        taskId.getValue,
-        status.getState.name,
-        taskStatusMessage,
-        appId,
-        host,
-        portsList.asJava.asScala,
-        version.toString,
+        slaveId = slaveId.getValue,
+        taskId = taskId.getValue,
+        taskStatus = status.getState.name,
+        message = taskStatusMessage,
+        appId = appId,
+        host = host,
+        ipAddresses = Nil,
+        ports = portsList.asJava.asScala,
+        version = version.toString,
         timestamp = updateTimestamp.toString
       )
     ))

--- a/src/test/scala/mesosphere/marathon/event/HistoryActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/HistoryActorTest.scala
@@ -5,7 +5,7 @@ import akka.testkit.{ ImplicitSender, TestActorRef, TestKit }
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ TaskFailure, TaskFailureRepository, Timestamp }
-import org.apache.mesos.Protos.TaskState
+import org.apache.mesos.Protos.{ NetworkInfo, TaskState }
 import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
@@ -79,14 +79,24 @@ class HistoryActorTest
     verify(failureRepo, times(0)).store(any(), any())
   }
 
-  private def statusMessage(state: TaskState) = MesosStatusUpdateEvent(
-    slaveId = "slaveId",
-    taskId = "taskId",
-    taskStatus = state.name(),
-    message = "message",
-    appId = "appId".toPath,
-    host = "host",
-    ports = Nil,
-    version = Timestamp.now().toString
-  )
+  private def statusMessage(state: TaskState) = {
+    val ipAddress: NetworkInfo.IPAddress =
+      NetworkInfo.IPAddress
+        .newBuilder()
+        .setIpAddress("123.123.123.123")
+        .setProtocol(NetworkInfo.Protocol.IPv4)
+        .build()
+
+    MesosStatusUpdateEvent(
+      slaveId = "slaveId",
+      taskId = "taskId",
+      taskStatus = state.name(),
+      message = "message",
+      appId = "appId".toPath,
+      host = "host",
+      ipAddresses = Seq(ipAddress),
+      ports = Nil,
+      version = Timestamp.now().toString
+    )
+  }
 }

--- a/src/test/scala/mesosphere/marathon/integration/setup/V2TestFormats.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/V2TestFormats.scala
@@ -5,6 +5,7 @@ import mesosphere.marathon.event._
 import mesosphere.marathon.event.http.EventSubscribers
 import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.upgrade.DeploymentPlan
+import org.apache.mesos.Protos
 import play.api.libs.json._
 
 /**

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -109,6 +109,30 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     read should be(app)
   }
 
+  test("ipAddress to proto and back again") {
+    val app = AppDefinition(
+      id = "app-with-ip-address".toPath,
+      cmd = Some("sleep 30"),
+      ports = Nil,
+      ipAddress = Some(
+        IpAddress(
+          groups = Seq("a", "b", "c"),
+          labels = Map(
+            "foo" -> "bar",
+            "baz" -> "buzz"
+          )
+        )
+      )
+    )
+
+    val proto = app.toProto
+    proto.getId should be("app-with-ip-address")
+    proto.hasIpAddress should be (true)
+
+    val read = AppDefinition().mergeFromProto(proto)
+    read should be(app)
+  }
+
   test("MergeFromProto") {
     val cmd = mesos.CommandInfo.newBuilder
       .setValue("bash foo-*/start -Dhttp.port=$PORT")

--- a/src/test/scala/mesosphere/marathon/state/IpAddressTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/IpAddressTest.scala
@@ -1,0 +1,148 @@
+package mesosphere.marathon.state
+
+import mesosphere.marathon.Protos
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.api.JsonTestHelper
+import org.apache.mesos.{ Protos => mesos }
+import org.scalatest.Matchers
+import play.api.libs.json.Json
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
+
+class IpAddressTest extends MarathonSpec with Matchers {
+  import mesosphere.marathon.api.v2.json.Formats._
+
+  class Fixture {
+
+    lazy val defaultIpAddress = IpAddress()
+
+    lazy val ipAddressWithGroups = IpAddress(
+      groups = Vector("foo", "bar"),
+      labels = Map.empty
+    )
+
+    lazy val ipAddressWithGroupsAndLabels = IpAddress(
+      groups = Vector("a", "b", "c"),
+      labels = Map(
+        "foo" -> "bar",
+        "baz" -> "buzz"
+      )
+    )
+
+  }
+
+  def fixture(): Fixture = new Fixture
+
+  test("ToProto default IpAddress") {
+    // this is slightly artificial, since every IpAddress should have at least one group
+    val f = fixture()
+    val proto = f.defaultIpAddress.toProto
+    proto should be(Protos.IpAddress.getDefaultInstance)
+  }
+
+  test("ToProto with groups") {
+    val f = fixture()
+    val proto = f.ipAddressWithGroups.toProto
+    proto.getGroupsList.asScala should equal(f.ipAddressWithGroups.groups)
+    proto.getLabelsList.asScala should be(empty)
+  }
+
+  test("ToProto with groups and labels") {
+    val f = fixture()
+    val proto = f.ipAddressWithGroupsAndLabels.toProto
+    proto.getGroupsList.asScala should equal(f.ipAddressWithGroupsAndLabels.groups)
+    proto.getLabelsList.asScala.map(kv => kv.getKey -> kv.getValue).toMap should
+      equal(f.ipAddressWithGroupsAndLabels.labels)
+  }
+
+  test("ConstructFromProto with default proto") {
+    val f = fixture()
+
+    val defaultProto = Protos.IpAddress.newBuilder.build
+    val result = IpAddress.fromProto(defaultProto)
+    result should equal(f.defaultIpAddress)
+  }
+
+  test("ConstructFromProto with groups") {
+    val f = fixture()
+    val protoWithGroups = Protos.IpAddress.newBuilder
+      .addAllGroups(Seq("foo", "bar").asJava)
+      .build
+    val result = IpAddress.fromProto(protoWithGroups)
+    result should equal(f.ipAddressWithGroups)
+  }
+
+  test("ConstructFromProto with groups and labels") {
+    val f = fixture()
+    val protoWithGroupsAndLabels = Protos.IpAddress.newBuilder
+      .addAllGroups(Seq("a", "b", "c").asJava)
+      .addLabels(mesos.Label.newBuilder.setKey("foo").setValue("bar"))
+      .addLabels(mesos.Label.newBuilder.setKey("baz").setValue("buzz"))
+      .build
+    val result = IpAddress.fromProto(protoWithGroupsAndLabels)
+    result should equal(f.ipAddressWithGroupsAndLabels)
+  }
+
+  test("JSON Serialization round-trip defaultIpAddress") {
+    val f = fixture()
+    JsonTestHelper.assertSerializationRoundtripWorks(f.defaultIpAddress)
+  }
+
+  test("JSON Serialization round-trip ipAddressWithGroups") {
+    val f = fixture()
+    JsonTestHelper.assertSerializationRoundtripWorks(f.ipAddressWithGroups)
+  }
+
+  test("JSON Serialization round-trip ipAddressWithGroupsAndLabels") {
+    val f = fixture()
+    JsonTestHelper.assertSerializationRoundtripWorks(f.ipAddressWithGroupsAndLabels)
+  }
+
+  private[this] def fromJson(json: String): IpAddress = {
+    Json.fromJson[IpAddress](Json.parse(json)).get
+  }
+
+  test("Reading empty IpAddress from JSON") {
+    val json =
+      """
+      {}
+      """
+
+    val readResult = fromJson(json)
+    val f = fixture()
+    readResult should equal(f.defaultIpAddress)
+  }
+
+  test("Reading IpAddress with groups from JSON") {
+    val json =
+      """
+      {
+        "groups": ["foo", "bar"]
+      }
+      """
+
+    val readResult = fromJson(json)
+    val f = fixture()
+    readResult should equal(f.ipAddressWithGroups)
+  }
+
+  test("Reading complete IpAddress from JSON") {
+    val json =
+      """
+      {
+        "groups": ["a", "b", "c"],
+        "labels": {
+          "foo": "bar",
+          "baz": "buzz"
+        }
+      }
+      """
+
+    val readResult = fromJson(json)
+    val f = fixture()
+    readResult should equal(f.ipAddressWithGroupsAndLabels)
+  }
+
+}
+

--- a/src/test/scala/mesosphere/marathon/state/MarathonTaskStateTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MarathonTaskStateTest.scala
@@ -30,7 +30,7 @@ class MarathonTaskStateTest extends MarathonSpec with GivenWhenThen with Matcher
     val proto = makeTask("app/foo", "superhost", 23000, version = None)
     val merged = dummyState.mergeFromProto(proto)
 
-    Then("The 'merged' state does not have a version because mergeFromProto does not merge but cerate a new instance based on the given proto")
+    Then("The 'merged' state does not have a version because mergeFromProto does not merge but create a new instance based on the given proto")
     merged.toProto shouldEqual proto
   }
 

--- a/src/test/scala/mesosphere/marathon/tasks/MarathonTasksTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/MarathonTasksTest.scala
@@ -1,0 +1,130 @@
+package mesosphere.marathon.tasks
+
+import scala.collection.JavaConverters._
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.Protos._
+import mesosphere.marathon.state.Timestamp
+import org.apache.mesos.{ Protos => mesos }
+import org.scalatest.Matchers
+
+class MarathonTasksTest extends MarathonSpec with Matchers {
+
+  class Fixture {
+
+    val networkWithoutIp = mesos.NetworkInfo.newBuilder.build()
+
+    val ip1 = mesos.NetworkInfo.IPAddress.newBuilder().setIpAddress("123.123.123.123").build()
+
+    val ip2 = mesos.NetworkInfo.IPAddress.newBuilder().setIpAddress("123.123.123.124").build()
+
+    val networkWithOneIp1 = mesos.NetworkInfo.newBuilder.addIpAddresses(ip1).build()
+    val networkWithOneIp2 = mesos.NetworkInfo.newBuilder.addIpAddresses(ip2).build()
+
+    val networkWithMultipleIps = mesos.NetworkInfo.newBuilder.addAllIpAddresses(Seq(ip1, ip2).asJava).build()
+
+    val taskWithoutIp = MarathonTask.newBuilder
+      .setId("/foo/bar")
+      .setHost("agent1.mesos")
+      .setVersion(Timestamp(1024).toString)
+      .setStagedAt(1024L)
+      .setSlaveId(mesos.SlaveID.newBuilder.setValue("abcd-1234"))
+      .build
+
+    val taskWithOneIp = MarathonTask.newBuilder
+      .setId("/foo/bar")
+      .setHost("agent1.mesos")
+      .setVersion(Timestamp(1024).toString)
+      .setStagedAt(1024L)
+      .setSlaveId(mesos.SlaveID.newBuilder.setValue("abcd-1234"))
+      .addNetworks(networkWithOneIp1)
+      .build
+
+    val taskWithMultipleNetworksAndOneIp = MarathonTask.newBuilder
+      .setId("/foo/bar")
+      .setHost("agent1.mesos")
+      .setVersion(Timestamp(1024).toString)
+      .setStagedAt(1024L)
+      .setSlaveId(mesos.SlaveID.newBuilder
+        .setValue("abcd-1234"))
+      .addNetworks(networkWithoutIp)
+      .addNetworks(networkWithOneIp1)
+      .build
+
+    val taskWithMultipleNetworkAndNoIp = MarathonTask.newBuilder
+      .setId("/foo/bar")
+      .setHost("agent1.mesos")
+      .setVersion(Timestamp(1024).toString)
+      .setStagedAt(1024L)
+      .setSlaveId(mesos.SlaveID.newBuilder.setValue("abcd-1234"))
+      .addNetworks(networkWithoutIp)
+      .addNetworks(networkWithoutIp)
+      .build
+
+    val taskWithOneNetworkAndMultipleIPs = MarathonTask.newBuilder
+      .setId("/foo/bar")
+      .setHost("agent1.mesos")
+      .setVersion(Timestamp(1024).toString)
+      .setStagedAt(1024L)
+      .setSlaveId(mesos.SlaveID.newBuilder.setValue("abcd-1234"))
+      .addNetworks(networkWithMultipleIps)
+      .build
+
+    val taskWithMultipleNetworkAndMultipleIPs = MarathonTask.newBuilder
+      .setId("/foo/bar")
+      .setHost("agent1.mesos")
+      .setVersion(Timestamp(1024).toString)
+      .setStagedAt(1024L)
+      .setSlaveId(mesos.SlaveID.newBuilder.setValue("abcd-1234"))
+      .addNetworks(networkWithOneIp1)
+      .addNetworks(networkWithOneIp2)
+      .build
+  }
+
+  test("Compute effectiveIpAddress for MarathonTask instances without their own IP addresses") {
+    val f = new Fixture
+    MarathonTasks.effectiveIpAddress(f.taskWithoutIp) should equal ("agent1.mesos")
+  }
+
+  test("Compute effectiveIpAddress for MarathonTask instances with one NetworkInfo") {
+    val f = new Fixture
+    MarathonTasks.effectiveIpAddress(f.taskWithOneIp) should equal ("123.123.123.123")
+  }
+
+  test("Compute effectiveIpAddress for MarathonTask instances with multiple NetworkInfos") {
+    val f = new Fixture
+    MarathonTasks.effectiveIpAddress(f.taskWithMultipleNetworksAndOneIp) should equal ("123.123.123.123")
+    MarathonTasks.effectiveIpAddress(f.taskWithMultipleNetworkAndNoIp) should equal ("agent1.mesos")
+  }
+
+  test("ipAddresses returns an empty list for MarathonTask instances with no IPs") {
+    val f = new Fixture
+    MarathonTasks.ipAddresses(f.taskWithoutIp) should be (empty)
+  }
+
+  test("ipAddresses returns an empty list for MarathonTask instances with no IPs and multiple NetworkInfos") {
+    val f = new Fixture
+    MarathonTasks.ipAddresses(f.taskWithMultipleNetworkAndNoIp) should be (empty)
+  }
+
+  test("ipAddresses returns all IPs for MarathonTask instances with multiple IPs") {
+    val f = new Fixture
+    MarathonTasks.ipAddresses(f.taskWithMultipleNetworkAndMultipleIPs) should equal(Seq(f.ip1, f.ip2))
+  }
+
+  test("ipAddresses returns all IPs for MarathonTask instances with multiple IPs and multiple NetworkInfos") {
+    val f = new Fixture
+    MarathonTasks.ipAddresses(f.taskWithMultipleNetworkAndMultipleIPs) should equal(Seq(f.ip1, f.ip2))
+  }
+
+  test("ipAddresses returns one IP for MarathonTask instances with one IP and one NetworkInfo") {
+    val f = new Fixture
+    MarathonTasks.ipAddresses(f.taskWithOneIp) should equal(Seq(f.ip1))
+  }
+
+  test("ipAddresses returns one IP for MarathonTask instances with one IP and multiple NetworkInfo") {
+    val f = new Fixture
+    MarathonTasks.ipAddresses(f.taskWithMultipleNetworksAndOneIp) should equal(Seq(f.ip1))
+  }
+
+}
+

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -53,8 +53,19 @@ class AppStartActorTest
     )
     watch(ref)
 
-    system.eventStream.publish(MesosStatusUpdateEvent("", "task_a", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
-    system.eventStream.publish(MesosStatusUpdateEvent("", "task_b", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
+    system.eventStream.publish(
+      MesosStatusUpdateEvent(
+        slaveId = "", taskId = "task_a",
+        taskStatus = "TASK_RUNNING", message = "", appId = app
+          .id, host = "", ipAddresses = Nil, ports = Nil, version = app.version.toString
+      )
+    )
+    system.eventStream.publish(
+      MesosStatusUpdateEvent(
+        slaveId = "", taskId = "task_b", taskStatus = "TASK_RUNNING", message = "", appId = app.id, host = "",
+        ipAddresses = Nil, ports = Nil, version = app.version.toString
+      )
+    )
 
     Await.result(promise.future, 5.seconds)
 

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
@@ -63,10 +63,16 @@ class AppStopActorTest
     )
 
     val statusUpdateEventA =
-      MesosStatusUpdateEvent("", "task_a", "TASK_FAILED", "", app.id, "", Nil, app.version.toString)
+      MesosStatusUpdateEvent(
+        slaveId = "", taskId = "task_a", taskStatus = "TASK_FAILED", message = "", appId = app.id, host = "",
+        ipAddresses = Nil, ports = Nil, version = app.version.toString
+      )
 
     val statusUpdateEventB =
-      MesosStatusUpdateEvent("", "task_b", "TASK_LOST", "", app.id, "", Nil, app.version.toString)
+      MesosStatusUpdateEvent(
+        slaveId = "", taskId = "task_b", taskStatus = "TASK_LOST", message = "", appId = app.id, host = "",
+        ipAddresses = Nil, ports = Nil, version = app.version.toString
+      )
 
     val Some(taskFailureA) =
       TaskFailure.FromMesosStatusUpdateEvent(statusUpdateEventA)

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -85,14 +85,18 @@ class DeploymentActorTest
 
     when(driver.killTask(TaskID(task1_2.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", "task1_2", "TASK_KILLED", "", app1.id, "", Nil, app1New.version.toString))
+        system.eventStream.publish(MesosStatusUpdateEvent(
+          slaveId = "", taskId = "task1_2", taskStatus = "TASK_KILLED", message = "", appId = app1.id, host = "",
+          ipAddresses = Nil, ports = Nil, version = app1New.version.toString))
         Status.DRIVER_RUNNING
       }
     })
 
     when(driver.killTask(TaskID(task2_1.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", "task2_1", "TASK_KILLED", "", app2.id, "", Nil, app2.version.toString))
+        system.eventStream.publish(MesosStatusUpdateEvent(
+          slaveId = "", taskId = "task2_1", taskStatus = "TASK_KILLED", message = "", appId = app2.id, host = "",
+          ipAddresses = Nil, ports = Nil, version = app2.version.toString))
         Status.DRIVER_RUNNING
       }
     })
@@ -101,28 +105,36 @@ class DeploymentActorTest
       def answer(invocation: InvocationOnMock): Boolean = {
         println(invocation.getArguments.toSeq)
         for (i <- 0 until invocation.getArguments()(1).asInstanceOf[Int])
-          system.eventStream.publish(MesosStatusUpdateEvent("", UUID.randomUUID().toString, "TASK_RUNNING", "", app2.id, "", Nil, app2New.version.toString))
+          system.eventStream.publish(MesosStatusUpdateEvent(
+            slaveId = "", taskId = UUID.randomUUID().toString, taskStatus = "TASK_RUNNING", message = "",
+            appId = app2.id, host = "", ipAddresses = Nil, ports = Nil, version = app2New.version.toString)
+          )
         true
       }
     })
 
     when(scheduler.startApp(driver, app3)).thenAnswer(new Answer[Future[Unit]] {
       def answer(invocation: InvocationOnMock): Future[Unit] = {
-        // system.eventStream.publish(MesosStatusUpdateEvent("", "task3_1", "TASK_RUNNING", "", app3.id, "", Nil, app3.version.toString))
+        // system.eventStream.publish(MesosStatusUpdateEvent("", "task3_1", "TASK_RUNNING", "", app3.id, "", "", Nil, app3.version.toString))
         Future.successful(())
       }
     })
 
     when(scheduler.scale(driver, app3)).thenAnswer(new Answer[Future[Unit]] {
       def answer(invocation: InvocationOnMock): Future[Unit] = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", "task3_1", "TASK_RUNNING", "", app3.id, "", Nil, app3.version.toString))
+        system.eventStream.publish(MesosStatusUpdateEvent(
+          slaveId = "", taskId = "task3_1", taskStatus = "TASK_RUNNING", message = "", appId = app3.id, host = "",
+          ipAddresses = Nil, ports = Nil, version = app3.version.toString))
         Future.successful(())
       }
     })
 
     when(driver.killTask(TaskID(task4_1.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", "task4_1", "TASK_FINISHED", "", app4.id, "", Nil, app4.version.toString))
+        system.eventStream.publish(MesosStatusUpdateEvent(
+          slaveId = "", taskId = "task4_1", taskStatus = "TASK_FINISHED", message = "", appId = app4.id,
+          host = "", ipAddresses = Nil, ports = Nil, version = app4.version.toString
+        ))
         Status.DRIVER_RUNNING
       }
     })
@@ -180,14 +192,14 @@ class DeploymentActorTest
 
     when(driver.killTask(TaskID(task1_1.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", "task1_1", "TASK_KILLED", "", app.id, "", Nil, app.version.toString))
+        system.eventStream.publish(MesosStatusUpdateEvent("", "task1_1", "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString))
         Status.DRIVER_RUNNING
       }
     })
 
     when(driver.killTask(TaskID(task1_2.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", "task1_2", "TASK_KILLED", "", app.id, "", Nil, app.version.toString))
+        system.eventStream.publish(MesosStatusUpdateEvent("", "task1_2", "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString))
         Status.DRIVER_RUNNING
       }
     })
@@ -201,7 +213,7 @@ class DeploymentActorTest
     when(queue.add(same(appNew), any[Int])).thenAnswer(new Answer[Boolean] {
       def answer(invocation: InvocationOnMock): Boolean = {
         for (i <- 0 until invocation.getArguments()(1).asInstanceOf[Int])
-          system.eventStream.publish(MesosStatusUpdateEvent("", s"task1_${taskIDs.next()}", "TASK_RUNNING", "", app.id, "", Nil, appNew.version.toString))
+          system.eventStream.publish(MesosStatusUpdateEvent("", s"task1_${taskIDs.next()}", "TASK_RUNNING", "", app.id, "", Nil, Nil, appNew.version.toString))
         true
       }
     })
@@ -295,7 +307,7 @@ class DeploymentActorTest
 
     when(driver.killTask(TaskID(task1_2.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", "task1_2", "TASK_KILLED", "", app1.id, "", Nil, app1New.version.toString))
+        system.eventStream.publish(MesosStatusUpdateEvent("", "task1_2", "TASK_KILLED", "", app1.id, "", Nil, Nil, app1New.version.toString))
         Status.DRIVER_RUNNING
       }
     })

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
@@ -49,8 +49,8 @@ class TaskKillActorTest
 
     watch(ref)
 
-    system.eventStream.publish(MesosStatusUpdateEvent("", taskA.getId, "TASK_KILLED", "", PathId.empty, "", Nil, ""))
-    system.eventStream.publish(MesosStatusUpdateEvent("", taskB.getId, "TASK_KILLED", "", PathId.empty, "", Nil, ""))
+    system.eventStream.publish(MesosStatusUpdateEvent("", taskA.getId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
+    system.eventStream.publish(MesosStatusUpdateEvent("", taskB.getId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
 
     Await.result(promise.future, 5.seconds) should be(())
     verify(driver).killTask(TaskID.newBuilder().setValue(taskA.getId).build())
@@ -133,8 +133,8 @@ class TaskKillActorTest
 
     ref ! SynchronizeTasks
 
-    system.eventStream.publish(MesosStatusUpdateEvent("", taskA.getId, "TASK_KILLED", "", PathId.empty, "", Nil, ""))
-    system.eventStream.publish(MesosStatusUpdateEvent("", taskB.getId, "TASK_KILLED", "", PathId.empty, "", Nil, ""))
+    system.eventStream.publish(MesosStatusUpdateEvent("", taskA.getId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
+    system.eventStream.publish(MesosStatusUpdateEvent("", taskB.getId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
 
     Await.result(promise.future, 5.seconds) should be(())
     verify(driver, times(2)).killTask(TaskID.newBuilder().setValue(taskA.getId).build())

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -49,7 +49,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
         system.eventStream.publish(update)
         Status.DRIVER_RUNNING
       }
@@ -69,7 +69,7 @@ class TaskReplaceActorTest
     watch(ref)
 
     for (i <- 0 until app.instances)
-      ref ! MesosStatusUpdateEvent("", s"task_$i", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString)
+      ref ! MesosStatusUpdateEvent("", s"task_$i", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString)
 
     Await.result(promise.future, 5.seconds)
     verify(queue).resetDelay(app)
@@ -96,7 +96,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
         system.eventStream.publish(update)
         Status.DRIVER_RUNNING
       }
@@ -139,7 +139,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
         system.eventStream.publish(update)
         Status.DRIVER_RUNNING
       }
@@ -161,8 +161,8 @@ class TaskReplaceActorTest
     eventually { verify(driver, times(2)).killTask(_) }
     eventually { app: AppDefinition => verify(queue, times(2)).add(app) }
 
-    ref ! MesosStatusUpdateEvent("", "task_1", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString)
-    ref ! MesosStatusUpdateEvent("", "task_2", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString)
+    ref ! MesosStatusUpdateEvent("", "task_1", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString)
+    ref ! MesosStatusUpdateEvent("", "task_2", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString)
 
     Await.result(promise.future, 5.seconds)
 
@@ -193,7 +193,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       override def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
         system.eventStream.publish(update)
 
         oldTaskCount -= 1
@@ -263,7 +263,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
         system.eventStream.publish(update)
 
         oldTaskCount -= 1
@@ -285,7 +285,7 @@ class TaskReplaceActorTest
     watch(ref)
 
     // only one task is queued directly
-    val queueOrder = org.mockito.Mockito.inOrder(queue);
+    val queueOrder = org.mockito.Mockito.inOrder(queue)
     eventually { queueOrder.verify(queue).add(_: AppDefinition, 1) }
 
     // ceiling(minimumHealthCapacity * 3) = 2 are left running
@@ -337,7 +337,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
         system.eventStream.publish(update)
 
         oldTaskCount -= 1
@@ -359,7 +359,7 @@ class TaskReplaceActorTest
     watch(ref)
 
     // only one task is queued directly, all old still running
-    val queueOrder = org.mockito.Mockito.inOrder(queue);
+    val queueOrder = org.mockito.Mockito.inOrder(queue)
     eventually { queueOrder.verify(queue).add(_: AppDefinition, 1) }
     assert(oldTaskCount == 3)
 
@@ -409,7 +409,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
         system.eventStream.publish(update)
 
         oldTaskCount -= 1
@@ -431,7 +431,7 @@ class TaskReplaceActorTest
     watch(ref)
 
     // two tasks are queued directly, all old still running
-    val queueOrder = org.mockito.Mockito.inOrder(queue);
+    val queueOrder = org.mockito.Mockito.inOrder(queue)
     eventually { queueOrder.verify(queue).add(_: AppDefinition, 2) }
     assert(oldTaskCount == 3)
 
@@ -511,7 +511,7 @@ class TaskReplaceActorTest
           firstKillForTaskB = false
         }
         else {
-          val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, app.version.toString)
+          val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
           system.eventStream.publish(update)
         }
         Status.DRIVER_RUNNING
@@ -535,7 +535,7 @@ class TaskReplaceActorTest
     ref ! RetryKills
 
     for (i <- 0 until app.instances)
-      ref ! MesosStatusUpdateEvent("", s"task_$i", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString)
+      ref ! MesosStatusUpdateEvent("", s"task_$i", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString)
 
     Await.result(promise.future, 5.seconds)
     verify(queue).resetDelay(app)
@@ -569,7 +569,7 @@ class TaskReplaceActorTest
     watch(ref)
 
     for (i <- 0 until app.instances)
-      ref ! MesosStatusUpdateEvent("", s"task_$i", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString)
+      ref ! MesosStatusUpdateEvent("", s"task_$i", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString)
 
     intercept[Exception] {
       Await.result(promise.future, 5.seconds)

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -77,7 +77,7 @@ class TaskStartActorTest
       verify(launchQueue, Mockito.timeout(3000)).add(app, app.instances)
 
       for (i <- 0 until app.instances)
-        system.eventStream.publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
+        system.eventStream.publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
 
       Await.result(promise.future, 3.seconds) should be(())
 
@@ -118,7 +118,7 @@ class TaskStartActorTest
       for (i <- 0 until (app.instances - 1))
         system
           .eventStream
-          .publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
+          .publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
 
       Await.result(promise.future, 3.seconds) should be(())
 
@@ -153,7 +153,7 @@ class TaskStartActorTest
     verify(launchQueue, Mockito.timeout(3000)).add(app, app.instances - 1)
 
     for (i <- 0 until (app.instances - 1))
-      system.eventStream.publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
+      system.eventStream.publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
 
     Await.result(promise.future, 3.seconds) should be(())
 
@@ -289,12 +289,12 @@ class TaskStartActorTest
 
     verify(launchQueue, Mockito.timeout(3000)).add(app, app.instances)
 
-    system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_FAILED", "", app.id, "", Nil, app.version.toString))
+    system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_FAILED", "", app.id, "", Nil, Nil, app.version.toString))
 
     verify(launchQueue, Mockito.timeout(3000)).add(app, 1)
 
     for (i <- 0 until app.instances)
-      system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
+      system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
 
     Await.result(promise.future, 3.seconds) should be(())
 
@@ -338,7 +338,7 @@ class TaskStartActorTest
     // we mock instead
     when(taskTracker.count(app.id)).thenReturn(0)
     when(launchQueue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLeftToLaunch = 4)))
-    system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_ERROR", "", app.id, "", Nil, task.getVersion))
+    system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_ERROR", "", app.id, "", Nil, Nil, task.getVersion))
 
     // sync will reschedule task
     ref ! StartingBehavior.Sync
@@ -352,7 +352,7 @@ class TaskStartActorTest
     when(launchQueue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLeftToLaunch = app.instances)))
     when(taskTracker.count(app.id)).thenReturn(4)
     List(0, 1, 2, 3) foreach { i =>
-      system.eventStream.publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, app.version.toString))
+      system.eventStream.publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
     }
 
     // it finished early


### PR DESCRIPTION
Status Phase 1:

- [x] Health Checks need a specific port value instead of portIndex (PR #2731) (Merged)
- [x] UI Changes
- [x] AppDefinition/V2AppDefinition updated to reflect the latest design doc
- [x] DiscoveryInfo introduced in PR #2745
- [x] Update MarathonTask to reflect the latest design doc
  - [x] Remove outdated code
  - [x] Introduce "ipAddresses" field
  - [x] Filter out tasks with "ipAddress" from the TXT endpoint
- [x] Make Health Checks use "ipAddress" if available (the first one should be used in case of multiple ones)
- [x] Add Validation rule that makes sure IpAddress and port cannot both be supplied. If IpAddress is supplied, then the app needs NO port, but the current default is to assign one.
- [x] ~~Add a default group to the ipAddress if the user doesn't specify a list of groups.~~ --> To rely on the user definition should be sufficient for the MVP
- [x] ~~Make the name of the default group configurable.~~ --> To rely on the user definition should be sufficient for the MVP
- [x] Add Documentation.
- [ ] Remove the Mesos "doNotUseMe" dependency created to develop based on the Mesos v0.26 RC.
- [x] ~~Add integration tests (might be blocked by lack of DCOS image with net-modules)~~ --> There will be no TestSetup for this Milestone except the NetModules Vagrant Image, which is not sufficient for integration tests.

Further Work (not part of this PR):
-  Add a default group to the ipAddress if the user doesn't specify a list of groups.
-  Make the name of the default group configurable.
-  Add integration tests (might be blocked by lack of DCOS image with net-modules)
