### PR TITLE
Towards #2709 - Add DiscoveryInfo to IpAddress

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -77,6 +77,32 @@ groups in common. This makes it easy to disallow your staging environment to int
 traffic.
 >>>>>>> Towards #2709 - Add IP-per-task support
 
+#### EXPERIMENTAL: Service Discovery
+
+If an application requires IP-per-task, then it can not request ports to be allocated in the slave. It is
+however still possible to describe the ports that the Application's tasks expose:
+
+```javascript
+{
+  "id": "/i-have-my-own-ip",
+  // ... more settings ...
+  "ipAddress": {
+    "discovery": {
+      "ports": [
+        { "number": 80, "name": "http", "protocol": "tcp" }
+      ]
+    }
+      // ... more settings ...
+  }
+}
+```
+
+Marathon will pass down this information to Mesos (inside the DiscoveryInfo message) when starting new tasks,
+[mesos-dns](https://github.com/mesosphere/mesos-dns) will then expose this information through IN SRV records.
+
+In the future Marathon will also fill in the DiscoveryInfo message for applications that don't require
+IP-per-task.
+
 ### Fixed issues
 - #2558 - If driver finishes with error, Marathon does not abdicate
 - #2734 - Invalid validation for multiple ports

--- a/docs/docs/ip-per-task.md
+++ b/docs/docs/ip-per-task.md
@@ -62,3 +62,30 @@ groups and labels:
 Network security groups only allow network traffic between tasks that have at least one of their configured
 groups in common. This makes it easy to disallow your staging environment to interfere with production
 traffic.
+
+## Service Discovery
+
+If your application requires IP-per-task, then it can not request ports to be allocated in the slave. It is
+however still possible to describe the ports that the Application's tasks expose:
+
+
+```javascript
+{
+  "id": "/i-have-my-own-ip",
+  // ... more settings ...
+  "ipAddress": {
+    "discovery": {
+      "ports": [
+        { "number": 80, "name": "http", "protocol": "tcp" }
+      ]
+    }
+      // ... more settings ...
+  }
+}
+```
+
+Marathon will pass down this information to Mesos (inside the DiscoveryInfo message) when starting new tasks,
+[mesos-dns](https://github.com/mesosphere/mesos-dns) will then expose this information through IN SRV records.
+
+In the future Marathon will also fill in the DiscoveryInfo message for applications that don't require
+IP-per-task.

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -297,12 +297,43 @@
       "type": "object",
       "description": "If an application definition includes the 'ipAddress' field, then Marathon will request a per-task IP from Mesos. A separate ports/portMappings configuration is then disallowed.",
       "properties": {
+        "discovery": {
+          "type": "object",
+          "description": "Information useful for service discovery.",
+          "properties": {
+            "ports": {
+              "type": "array",
+              "description": "Array of objects describing the ports exposed by each task.",
+              "items": {
+                "type": "object",
+                "description": "Port",
+                "properties": {
+                  "number": {
+                    "maximum": 65535,
+                    "minimum": 0,
+                    "type": "integer",
+                    "description": "The port number."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the port.",
+                    "pattern": "^[a-z][a-z0-9-]*$"
+                  },
+                  "protocol": {
+                    "enum": ["tcp", "udp"],
+                    "description": "Protocol of the port (one of ['tcp', 'udp'])."
+                  }
+                }
+              }
+            }
+          }
+        },
         "groups": {
           "type": "array",
           "description": "Array of network groups. One IP address can belong to zero or more network groups. The idea is that containers can only reach containers with which they share at least one network group.",
           "items": {
             "type": "string",
-            "description": "The name of the network group"
+            "description": "The name of the network group."
           }
         },
         "labels": {

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -2427,6 +2427,20 @@ public final class Protos {
      */
     org.apache.mesos.Protos.LabelOrBuilder getLabelsOrBuilder(
         int index);
+
+    // optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;
+    /**
+     * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+     */
+    boolean hasDiscoveryInfo();
+    /**
+     * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+     */
+    mesosphere.marathon.Protos.DiscoveryInfo getDiscoveryInfo();
+    /**
+     * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+     */
+    mesosphere.marathon.Protos.DiscoveryInfoOrBuilder getDiscoveryInfoOrBuilder();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.IpAddress}
@@ -2495,6 +2509,19 @@ public final class Protos {
               labels_.add(input.readMessage(org.apache.mesos.Protos.Label.PARSER, extensionRegistry));
               break;
             }
+            case 26: {
+              mesosphere.marathon.Protos.DiscoveryInfo.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                subBuilder = discoveryInfo_.toBuilder();
+              }
+              discoveryInfo_ = input.readMessage(mesosphere.marathon.Protos.DiscoveryInfo.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(discoveryInfo_);
+                discoveryInfo_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000001;
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -2540,6 +2567,7 @@ public final class Protos {
       return PARSER;
     }
 
+    private int bitField0_;
     // repeated string groups = 1;
     public static final int GROUPS_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList groups_;
@@ -2606,9 +2634,32 @@ public final class Protos {
       return labels_.get(index);
     }
 
+    // optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;
+    public static final int DISCOVERYINFO_FIELD_NUMBER = 3;
+    private mesosphere.marathon.Protos.DiscoveryInfo discoveryInfo_;
+    /**
+     * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+     */
+    public boolean hasDiscoveryInfo() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+     */
+    public mesosphere.marathon.Protos.DiscoveryInfo getDiscoveryInfo() {
+      return discoveryInfo_;
+    }
+    /**
+     * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+     */
+    public mesosphere.marathon.Protos.DiscoveryInfoOrBuilder getDiscoveryInfoOrBuilder() {
+      return discoveryInfo_;
+    }
+
     private void initFields() {
       groups_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       labels_ = java.util.Collections.emptyList();
+      discoveryInfo_ = mesosphere.marathon.Protos.DiscoveryInfo.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -2617,6 +2668,12 @@ public final class Protos {
 
       for (int i = 0; i < getLabelsCount(); i++) {
         if (!getLabels(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      if (hasDiscoveryInfo()) {
+        if (!getDiscoveryInfo().isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -2633,6 +2690,9 @@ public final class Protos {
       }
       for (int i = 0; i < labels_.size(); i++) {
         output.writeMessage(2, labels_.get(i));
+      }
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeMessage(3, discoveryInfo_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -2655,6 +2715,10 @@ public final class Protos {
       for (int i = 0; i < labels_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, labels_.get(i));
+      }
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, discoveryInfo_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -2765,6 +2829,7 @@ public final class Protos {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
           getLabelsFieldBuilder();
+          getDiscoveryInfoFieldBuilder();
         }
       }
       private static Builder create() {
@@ -2781,6 +2846,12 @@ public final class Protos {
         } else {
           labelsBuilder_.clear();
         }
+        if (discoveryInfoBuilder_ == null) {
+          discoveryInfo_ = mesosphere.marathon.Protos.DiscoveryInfo.getDefaultInstance();
+        } else {
+          discoveryInfoBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -2808,6 +2879,7 @@ public final class Protos {
       public mesosphere.marathon.Protos.IpAddress buildPartial() {
         mesosphere.marathon.Protos.IpAddress result = new mesosphere.marathon.Protos.IpAddress(this);
         int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
           groups_ = new com.google.protobuf.UnmodifiableLazyStringList(
               groups_);
@@ -2823,6 +2895,15 @@ public final class Protos {
         } else {
           result.labels_ = labelsBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        if (discoveryInfoBuilder_ == null) {
+          result.discoveryInfo_ = discoveryInfo_;
+        } else {
+          result.discoveryInfo_ = discoveryInfoBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
@@ -2874,6 +2955,9 @@ public final class Protos {
             }
           }
         }
+        if (other.hasDiscoveryInfo()) {
+          mergeDiscoveryInfo(other.getDiscoveryInfo());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -2881,6 +2965,12 @@ public final class Protos {
       public final boolean isInitialized() {
         for (int i = 0; i < getLabelsCount(); i++) {
           if (!getLabels(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasDiscoveryInfo()) {
+          if (!getDiscoveryInfo().isInitialized()) {
             
             return false;
           }
@@ -3240,6 +3330,123 @@ public final class Protos {
         return labelsBuilder_;
       }
 
+      // optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;
+      private mesosphere.marathon.Protos.DiscoveryInfo discoveryInfo_ = mesosphere.marathon.Protos.DiscoveryInfo.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          mesosphere.marathon.Protos.DiscoveryInfo, mesosphere.marathon.Protos.DiscoveryInfo.Builder, mesosphere.marathon.Protos.DiscoveryInfoOrBuilder> discoveryInfoBuilder_;
+      /**
+       * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+       */
+      public boolean hasDiscoveryInfo() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+       */
+      public mesosphere.marathon.Protos.DiscoveryInfo getDiscoveryInfo() {
+        if (discoveryInfoBuilder_ == null) {
+          return discoveryInfo_;
+        } else {
+          return discoveryInfoBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+       */
+      public Builder setDiscoveryInfo(mesosphere.marathon.Protos.DiscoveryInfo value) {
+        if (discoveryInfoBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          discoveryInfo_ = value;
+          onChanged();
+        } else {
+          discoveryInfoBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+       */
+      public Builder setDiscoveryInfo(
+          mesosphere.marathon.Protos.DiscoveryInfo.Builder builderForValue) {
+        if (discoveryInfoBuilder_ == null) {
+          discoveryInfo_ = builderForValue.build();
+          onChanged();
+        } else {
+          discoveryInfoBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+       */
+      public Builder mergeDiscoveryInfo(mesosphere.marathon.Protos.DiscoveryInfo value) {
+        if (discoveryInfoBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+              discoveryInfo_ != mesosphere.marathon.Protos.DiscoveryInfo.getDefaultInstance()) {
+            discoveryInfo_ =
+              mesosphere.marathon.Protos.DiscoveryInfo.newBuilder(discoveryInfo_).mergeFrom(value).buildPartial();
+          } else {
+            discoveryInfo_ = value;
+          }
+          onChanged();
+        } else {
+          discoveryInfoBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+       */
+      public Builder clearDiscoveryInfo() {
+        if (discoveryInfoBuilder_ == null) {
+          discoveryInfo_ = mesosphere.marathon.Protos.DiscoveryInfo.getDefaultInstance();
+          onChanged();
+        } else {
+          discoveryInfoBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+       */
+      public mesosphere.marathon.Protos.DiscoveryInfo.Builder getDiscoveryInfoBuilder() {
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return getDiscoveryInfoFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+       */
+      public mesosphere.marathon.Protos.DiscoveryInfoOrBuilder getDiscoveryInfoOrBuilder() {
+        if (discoveryInfoBuilder_ != null) {
+          return discoveryInfoBuilder_.getMessageOrBuilder();
+        } else {
+          return discoveryInfo_;
+        }
+      }
+      /**
+       * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          mesosphere.marathon.Protos.DiscoveryInfo, mesosphere.marathon.Protos.DiscoveryInfo.Builder, mesosphere.marathon.Protos.DiscoveryInfoOrBuilder> 
+          getDiscoveryInfoFieldBuilder() {
+        if (discoveryInfoBuilder_ == null) {
+          discoveryInfoBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              mesosphere.marathon.Protos.DiscoveryInfo, mesosphere.marathon.Protos.DiscoveryInfo.Builder, mesosphere.marathon.Protos.DiscoveryInfoOrBuilder>(
+                  discoveryInfo_,
+                  getParentForChildren(),
+                  isClean());
+          discoveryInfo_ = null;
+        }
+        return discoveryInfoBuilder_;
+      }
+
       // @@protoc_insertion_point(builder_scope:mesosphere.marathon.IpAddress)
     }
 
@@ -3249,6 +3456,692 @@ public final class Protos {
     }
 
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.IpAddress)
+  }
+
+  public interface DiscoveryInfoOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+
+    // repeated .mesos.Port ports = 1;
+    /**
+     * <code>repeated .mesos.Port ports = 1;</code>
+     */
+    java.util.List<org.apache.mesos.Protos.Port> 
+        getPortsList();
+    /**
+     * <code>repeated .mesos.Port ports = 1;</code>
+     */
+    org.apache.mesos.Protos.Port getPorts(int index);
+    /**
+     * <code>repeated .mesos.Port ports = 1;</code>
+     */
+    int getPortsCount();
+    /**
+     * <code>repeated .mesos.Port ports = 1;</code>
+     */
+    java.util.List<? extends org.apache.mesos.Protos.PortOrBuilder> 
+        getPortsOrBuilderList();
+    /**
+     * <code>repeated .mesos.Port ports = 1;</code>
+     */
+    org.apache.mesos.Protos.PortOrBuilder getPortsOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code mesosphere.marathon.DiscoveryInfo}
+   */
+  public static final class DiscoveryInfo extends
+      com.google.protobuf.GeneratedMessage
+      implements DiscoveryInfoOrBuilder {
+    // Use DiscoveryInfo.newBuilder() to construct.
+    private DiscoveryInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private DiscoveryInfo(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final DiscoveryInfo defaultInstance;
+    public static DiscoveryInfo getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public DiscoveryInfo getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private DiscoveryInfo(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                ports_ = new java.util.ArrayList<org.apache.mesos.Protos.Port>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              ports_.add(input.readMessage(org.apache.mesos.Protos.Port.PARSER, extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          ports_ = java.util.Collections.unmodifiableList(ports_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_DiscoveryInfo_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              mesosphere.marathon.Protos.DiscoveryInfo.class, mesosphere.marathon.Protos.DiscoveryInfo.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<DiscoveryInfo> PARSER =
+        new com.google.protobuf.AbstractParser<DiscoveryInfo>() {
+      public DiscoveryInfo parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new DiscoveryInfo(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<DiscoveryInfo> getParserForType() {
+      return PARSER;
+    }
+
+    // repeated .mesos.Port ports = 1;
+    public static final int PORTS_FIELD_NUMBER = 1;
+    private java.util.List<org.apache.mesos.Protos.Port> ports_;
+    /**
+     * <code>repeated .mesos.Port ports = 1;</code>
+     */
+    public java.util.List<org.apache.mesos.Protos.Port> getPortsList() {
+      return ports_;
+    }
+    /**
+     * <code>repeated .mesos.Port ports = 1;</code>
+     */
+    public java.util.List<? extends org.apache.mesos.Protos.PortOrBuilder> 
+        getPortsOrBuilderList() {
+      return ports_;
+    }
+    /**
+     * <code>repeated .mesos.Port ports = 1;</code>
+     */
+    public int getPortsCount() {
+      return ports_.size();
+    }
+    /**
+     * <code>repeated .mesos.Port ports = 1;</code>
+     */
+    public org.apache.mesos.Protos.Port getPorts(int index) {
+      return ports_.get(index);
+    }
+    /**
+     * <code>repeated .mesos.Port ports = 1;</code>
+     */
+    public org.apache.mesos.Protos.PortOrBuilder getPortsOrBuilder(
+        int index) {
+      return ports_.get(index);
+    }
+
+    private void initFields() {
+      ports_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      for (int i = 0; i < getPortsCount(); i++) {
+        if (!getPorts(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (int i = 0; i < ports_.size(); i++) {
+        output.writeMessage(1, ports_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < ports_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, ports_.get(i));
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static mesosphere.marathon.Protos.DiscoveryInfo parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static mesosphere.marathon.Protos.DiscoveryInfo parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.DiscoveryInfo parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static mesosphere.marathon.Protos.DiscoveryInfo parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.DiscoveryInfo parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static mesosphere.marathon.Protos.DiscoveryInfo parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.DiscoveryInfo parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static mesosphere.marathon.Protos.DiscoveryInfo parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.DiscoveryInfo parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static mesosphere.marathon.Protos.DiscoveryInfo parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(mesosphere.marathon.Protos.DiscoveryInfo prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mesosphere.marathon.DiscoveryInfo}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.DiscoveryInfoOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_DiscoveryInfo_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                mesosphere.marathon.Protos.DiscoveryInfo.class, mesosphere.marathon.Protos.DiscoveryInfo.Builder.class);
+      }
+
+      // Construct using mesosphere.marathon.Protos.DiscoveryInfo.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getPortsFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        if (portsBuilder_ == null) {
+          ports_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          portsBuilder_.clear();
+        }
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_DiscoveryInfo_descriptor;
+      }
+
+      public mesosphere.marathon.Protos.DiscoveryInfo getDefaultInstanceForType() {
+        return mesosphere.marathon.Protos.DiscoveryInfo.getDefaultInstance();
+      }
+
+      public mesosphere.marathon.Protos.DiscoveryInfo build() {
+        mesosphere.marathon.Protos.DiscoveryInfo result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public mesosphere.marathon.Protos.DiscoveryInfo buildPartial() {
+        mesosphere.marathon.Protos.DiscoveryInfo result = new mesosphere.marathon.Protos.DiscoveryInfo(this);
+        int from_bitField0_ = bitField0_;
+        if (portsBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            ports_ = java.util.Collections.unmodifiableList(ports_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.ports_ = ports_;
+        } else {
+          result.ports_ = portsBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof mesosphere.marathon.Protos.DiscoveryInfo) {
+          return mergeFrom((mesosphere.marathon.Protos.DiscoveryInfo)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(mesosphere.marathon.Protos.DiscoveryInfo other) {
+        if (other == mesosphere.marathon.Protos.DiscoveryInfo.getDefaultInstance()) return this;
+        if (portsBuilder_ == null) {
+          if (!other.ports_.isEmpty()) {
+            if (ports_.isEmpty()) {
+              ports_ = other.ports_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensurePortsIsMutable();
+              ports_.addAll(other.ports_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.ports_.isEmpty()) {
+            if (portsBuilder_.isEmpty()) {
+              portsBuilder_.dispose();
+              portsBuilder_ = null;
+              ports_ = other.ports_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              portsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getPortsFieldBuilder() : null;
+            } else {
+              portsBuilder_.addAllMessages(other.ports_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        for (int i = 0; i < getPortsCount(); i++) {
+          if (!getPorts(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        mesosphere.marathon.Protos.DiscoveryInfo parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (mesosphere.marathon.Protos.DiscoveryInfo) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // repeated .mesos.Port ports = 1;
+      private java.util.List<org.apache.mesos.Protos.Port> ports_ =
+        java.util.Collections.emptyList();
+      private void ensurePortsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          ports_ = new java.util.ArrayList<org.apache.mesos.Protos.Port>(ports_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.mesos.Protos.Port, org.apache.mesos.Protos.Port.Builder, org.apache.mesos.Protos.PortOrBuilder> portsBuilder_;
+
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public java.util.List<org.apache.mesos.Protos.Port> getPortsList() {
+        if (portsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(ports_);
+        } else {
+          return portsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public int getPortsCount() {
+        if (portsBuilder_ == null) {
+          return ports_.size();
+        } else {
+          return portsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public org.apache.mesos.Protos.Port getPorts(int index) {
+        if (portsBuilder_ == null) {
+          return ports_.get(index);
+        } else {
+          return portsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public Builder setPorts(
+          int index, org.apache.mesos.Protos.Port value) {
+        if (portsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePortsIsMutable();
+          ports_.set(index, value);
+          onChanged();
+        } else {
+          portsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public Builder setPorts(
+          int index, org.apache.mesos.Protos.Port.Builder builderForValue) {
+        if (portsBuilder_ == null) {
+          ensurePortsIsMutable();
+          ports_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          portsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public Builder addPorts(org.apache.mesos.Protos.Port value) {
+        if (portsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePortsIsMutable();
+          ports_.add(value);
+          onChanged();
+        } else {
+          portsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public Builder addPorts(
+          int index, org.apache.mesos.Protos.Port value) {
+        if (portsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePortsIsMutable();
+          ports_.add(index, value);
+          onChanged();
+        } else {
+          portsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public Builder addPorts(
+          org.apache.mesos.Protos.Port.Builder builderForValue) {
+        if (portsBuilder_ == null) {
+          ensurePortsIsMutable();
+          ports_.add(builderForValue.build());
+          onChanged();
+        } else {
+          portsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public Builder addPorts(
+          int index, org.apache.mesos.Protos.Port.Builder builderForValue) {
+        if (portsBuilder_ == null) {
+          ensurePortsIsMutable();
+          ports_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          portsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public Builder addAllPorts(
+          java.lang.Iterable<? extends org.apache.mesos.Protos.Port> values) {
+        if (portsBuilder_ == null) {
+          ensurePortsIsMutable();
+          super.addAll(values, ports_);
+          onChanged();
+        } else {
+          portsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public Builder clearPorts() {
+        if (portsBuilder_ == null) {
+          ports_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          portsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public Builder removePorts(int index) {
+        if (portsBuilder_ == null) {
+          ensurePortsIsMutable();
+          ports_.remove(index);
+          onChanged();
+        } else {
+          portsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public org.apache.mesos.Protos.Port.Builder getPortsBuilder(
+          int index) {
+        return getPortsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public org.apache.mesos.Protos.PortOrBuilder getPortsOrBuilder(
+          int index) {
+        if (portsBuilder_ == null) {
+          return ports_.get(index);  } else {
+          return portsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public java.util.List<? extends org.apache.mesos.Protos.PortOrBuilder> 
+           getPortsOrBuilderList() {
+        if (portsBuilder_ != null) {
+          return portsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(ports_);
+        }
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public org.apache.mesos.Protos.Port.Builder addPortsBuilder() {
+        return getPortsFieldBuilder().addBuilder(
+            org.apache.mesos.Protos.Port.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public org.apache.mesos.Protos.Port.Builder addPortsBuilder(
+          int index) {
+        return getPortsFieldBuilder().addBuilder(
+            index, org.apache.mesos.Protos.Port.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .mesos.Port ports = 1;</code>
+       */
+      public java.util.List<org.apache.mesos.Protos.Port.Builder> 
+           getPortsBuilderList() {
+        return getPortsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.apache.mesos.Protos.Port, org.apache.mesos.Protos.Port.Builder, org.apache.mesos.Protos.PortOrBuilder> 
+          getPortsFieldBuilder() {
+        if (portsBuilder_ == null) {
+          portsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.apache.mesos.Protos.Port, org.apache.mesos.Protos.Port.Builder, org.apache.mesos.Protos.PortOrBuilder>(
+                  ports_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  getParentForChildren(),
+                  isClean());
+          ports_ = null;
+        }
+        return portsBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:mesosphere.marathon.DiscoveryInfo)
+    }
+
+    static {
+      defaultInstance = new DiscoveryInfo(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:mesosphere.marathon.DiscoveryInfo)
   }
 
   public interface ServiceDefinitionOrBuilder
@@ -22883,6 +23776,11 @@ public final class Protos {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_mesosphere_marathon_DiscoveryInfo_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ServiceDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -22981,79 +23879,81 @@ public final class Protos {
       "es\030\007 \001(\r:\0013\022#\n\007command\030\010 \001(\0132\022.mesos.Com" +
       "mandInfo\022\034\n\rignoreHttp1xx\030\t \001(\010:\005false\022\014" +
       "\n\004port\030\n \001(\r\"5\n\010Protocol\022\010\n\004HTTP\020\000\022\007\n\003TC" +
-      "P\020\001\022\013\n\007COMMAND\020\002\022\t\n\005HTTPS\020\003\"9\n\tIpAddress" +
+      "P\020\001\022\013\n\007COMMAND\020\002\022\t\n\005HTTPS\020\003\"t\n\tIpAddress" +
       "\022\016\n\006groups\030\001 \003(\t\022\034\n\006labels\030\002 \003(\0132\014.mesos" +
-      ".Label\"\206\007\n\021ServiceDefinition\022\n\n\002id\030\001 \002(\t" +
-      "\022\037\n\003cmd\030\002 \002(\0132\022.mesos.CommandInfo\022\021\n\tins" +
-      "tances\030\003 \002(\r\022\"\n\tresources\030\004 \003(\0132\017.mesos.",
-      "Resource\022\023\n\013description\030\005 \001(\t\022\r\n\005ports\030\006" +
-      " \003(\r\0224\n\013constraints\030\007 \003(\0132\037.mesosphere.m" +
-      "arathon.Constraint\022\022\n\010executor\030\010 \002(\t:\000\022>" +
-      "\n\022OBSOLETE_container\030\n \001(\0132\".mesosphere." +
-      "marathon.ContainerInfo\022)\n\007version\030\013 \001(\t:" +
-      "\0301970-01-01T00:00:00.000Z\022@\n\014healthCheck" +
-      "s\030\014 \003(\0132*.mesosphere.marathon.HealthChec" +
-      "kDefinition\022\025\n\007backoff\030\r \001(\003:\0041000\022\033\n\rba" +
-      "ckoffFactor\030\016 \001(\001:\0041.15\022G\n\017upgradeStrate" +
-      "gy\030\017 \001(\0132..mesosphere.marathon.UpgradeSt",
-      "rategyDefinition\022\024\n\014dependencies\030\020 \003(\t\022\021" +
-      "\n\tstoreUrls\030\021 \003(\t\022\034\n\rrequire_ports\030\022 \001(\010" +
-      ":\005false\022=\n\tcontainer\030\023 \001(\0132*.mesosphere." +
-      "marathon.ExtendedContainerInfo\022 \n\006labels" +
-      "\030\024 \003(\0132\020.mesos.Parameter\022\037\n\016maxLaunchDel" +
-      "ay\030\025 \001(\003:\0073600000\022A\n\025acceptedResourceRol" +
-      "es\030\026 \001(\0132\".mesosphere.marathon.ResourceR" +
-      "oles\022\027\n\017last_scaling_at\030\027 \001(\003\022\035\n\025last_co" +
-      "nfig_change_at\030\030 \001(\003\0221\n\tipAddress\030\031 \001(\0132" +
-      "\036.mesosphere.marathon.IpAddress\"\035\n\rResou",
-      "rceRoles\022\014\n\004role\030\001 \003(\t\"\307\002\n\014MarathonTask\022" +
-      "\n\n\002id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r" +
-      "\022$\n\nattributes\030\004 \003(\0132\020.mesos.Attribute\022\021" +
-      "\n\tstaged_at\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003\022,\n" +
-      "\021OBSOLETE_statuses\030\007 \003(\0132\021.mesos.TaskSta" +
-      "tus\022)\n\007version\030\010 \001(\t:\0301970-01-01T00:00:0" +
-      "0.000Z\022!\n\006status\030\t \001(\0132\021.mesos.TaskStatu" +
-      "s\022\037\n\007slaveId\030\n \001(\0132\016.mesos.SlaveID\022$\n\010ne" +
-      "tworks\030\013 \003(\0132\022.mesos.NetworkInfo\"M\n\013Mara" +
-      "thonApp\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!.m",
-      "esosphere.marathon.MarathonTask\"1\n\rConta" +
-      "inerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007options\030\002 \003" +
-      "(\014\"\237\004\n\025ExtendedContainerInfo\022\'\n\004type\030\001 \002" +
-      "(\0162\031.mesos.ContainerInfo.Type\022\036\n\007volumes" +
-      "\030\002 \003(\0132\r.mesos.Volume\022E\n\006docker\030\003 \001(\01325." +
-      "mesosphere.marathon.ExtendedContainerInf" +
-      "o.DockerInfo\032\365\002\n\nDockerInfo\022\r\n\005image\030\001 \002" +
-      "(\t\022>\n\007network\030\002 \001(\0162\'.mesos.ContainerInf" +
-      "o.DockerInfo.Network:\004HOST\022X\n\rport_mappi" +
-      "ngs\030\003 \003(\0132A.mesosphere.marathon.Extended",
-      "ContainerInfo.DockerInfo.PortMapping\022\031\n\n" +
-      "privileged\030\004 \001(\010:\005false\022$\n\nparameters\030\005 " +
-      "\003(\0132\020.mesos.Parameter\022\030\n\020force_pull_imag" +
-      "e\030\006 \001(\010\032c\n\013PortMapping\022\021\n\thost_port\030\001 \002(" +
-      "\r\022\026\n\016container_port\030\002 \002(\r\022\020\n\010protocol\030\003 " +
-      "\001(\t\022\027\n\014service_port\030d \001(\r:\0010\")\n\020EventSub" +
-      "scribers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016Stora" +
-      "geVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022" +
-      "\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefinit" +
-      "ion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023ma",
-      "ximumOverCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDefi" +
-      "nition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004a" +
-      "pps\030\003 \003(\0132&.mesosphere.marathon.ServiceD" +
-      "efinition\0224\n\006groups\030\004 \003(\0132$.mesosphere.m" +
-      "arathon.GroupDefinition\022\024\n\014dependencies\030" +
-      "\005 \003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002id" +
-      "\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002(" +
-      "\0132$.mesosphere.marathon.GroupDefinition\022" +
-      "4\n\006target\030\005 \002(\0132$.mesosphere.marathon.Gr" +
-      "oupDefinition\"\306\001\n\013TaskFailure\022\016\n\006app_id\030",
-      "\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037\n" +
-      "\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007messag" +
-      "e\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 \002" +
-      "(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016" +
-      ".mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004name\030\001" +
-      " \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\ncom" +
-      "pressed\030\004 \001(\010:\005falseB\035\n\023mesosphere.marat" +
-      "honB\006Protos"
+      ".Label\0229\n\rdiscoveryInfo\030\003 \001(\0132\".mesosphe" +
+      "re.marathon.DiscoveryInfo\"+\n\rDiscoveryIn" +
+      "fo\022\032\n\005ports\030\001 \003(\0132\013.mesos.Port\"\206\007\n\021Servi",
+      "ceDefinition\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030\002 \002(\0132\022." +
+      "mesos.CommandInfo\022\021\n\tinstances\030\003 \002(\r\022\"\n\t" +
+      "resources\030\004 \003(\0132\017.mesos.Resource\022\023\n\013desc" +
+      "ription\030\005 \001(\t\022\r\n\005ports\030\006 \003(\r\0224\n\013constrai" +
+      "nts\030\007 \003(\0132\037.mesosphere.marathon.Constrai" +
+      "nt\022\022\n\010executor\030\010 \002(\t:\000\022>\n\022OBSOLETE_conta" +
+      "iner\030\n \001(\0132\".mesosphere.marathon.Contain" +
+      "erInfo\022)\n\007version\030\013 \001(\t:\0301970-01-01T00:0" +
+      "0:00.000Z\022@\n\014healthChecks\030\014 \003(\0132*.mesosp" +
+      "here.marathon.HealthCheckDefinition\022\025\n\007b",
+      "ackoff\030\r \001(\003:\0041000\022\033\n\rbackoffFactor\030\016 \001(" +
+      "\001:\0041.15\022G\n\017upgradeStrategy\030\017 \001(\0132..mesos" +
+      "phere.marathon.UpgradeStrategyDefinition" +
+      "\022\024\n\014dependencies\030\020 \003(\t\022\021\n\tstoreUrls\030\021 \003(" +
+      "\t\022\034\n\rrequire_ports\030\022 \001(\010:\005false\022=\n\tconta" +
+      "iner\030\023 \001(\0132*.mesosphere.marathon.Extende" +
+      "dContainerInfo\022 \n\006labels\030\024 \003(\0132\020.mesos.P" +
+      "arameter\022\037\n\016maxLaunchDelay\030\025 \001(\003:\007360000" +
+      "0\022A\n\025acceptedResourceRoles\030\026 \001(\0132\".mesos" +
+      "phere.marathon.ResourceRoles\022\027\n\017last_sca",
+      "ling_at\030\027 \001(\003\022\035\n\025last_config_change_at\030\030" +
+      " \001(\003\0221\n\tipAddress\030\031 \001(\0132\036.mesosphere.mar" +
+      "athon.IpAddress\"\035\n\rResourceRoles\022\014\n\004role" +
+      "\030\001 \003(\t\"\307\002\n\014MarathonTask\022\n\n\002id\030\001 \002(\t\022\014\n\004h" +
+      "ost\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022$\n\nattributes\030\004" +
+      " \003(\0132\020.mesos.Attribute\022\021\n\tstaged_at\030\005 \001(" +
+      "\003\022\022\n\nstarted_at\030\006 \001(\003\022,\n\021OBSOLETE_status" +
+      "es\030\007 \003(\0132\021.mesos.TaskStatus\022)\n\007version\030\010" +
+      " \001(\t:\0301970-01-01T00:00:00.000Z\022!\n\006status" +
+      "\030\t \001(\0132\021.mesos.TaskStatus\022\037\n\007slaveId\030\n \001",
+      "(\0132\016.mesos.SlaveID\022$\n\010networks\030\013 \003(\0132\022.m" +
+      "esos.NetworkInfo\"M\n\013MarathonApp\022\014\n\004name\030" +
+      "\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!.mesosphere.marath" +
+      "on.MarathonTask\"1\n\rContainerInfo\022\017\n\005imag" +
+      "e\030\001 \002(\014:\000\022\017\n\007options\030\002 \003(\014\"\237\004\n\025ExtendedC" +
+      "ontainerInfo\022\'\n\004type\030\001 \002(\0162\031.mesos.Conta" +
+      "inerInfo.Type\022\036\n\007volumes\030\002 \003(\0132\r.mesos.V" +
+      "olume\022E\n\006docker\030\003 \001(\01325.mesosphere.marat" +
+      "hon.ExtendedContainerInfo.DockerInfo\032\365\002\n" +
+      "\nDockerInfo\022\r\n\005image\030\001 \002(\t\022>\n\007network\030\002 ",
+      "\001(\0162\'.mesos.ContainerInfo.DockerInfo.Net" +
+      "work:\004HOST\022X\n\rport_mappings\030\003 \003(\0132A.meso" +
+      "sphere.marathon.ExtendedContainerInfo.Do" +
+      "ckerInfo.PortMapping\022\031\n\nprivileged\030\004 \001(\010" +
+      ":\005false\022$\n\nparameters\030\005 \003(\0132\020.mesos.Para" +
+      "meter\022\030\n\020force_pull_image\030\006 \001(\010\032c\n\013PortM" +
+      "apping\022\021\n\thost_port\030\001 \002(\r\022\026\n\016container_p" +
+      "ort\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\027\n\014service_p" +
+      "ort\030d \001(\r:\0010\")\n\020EventSubscribers\022\025\n\rcall" +
+      "back_urls\030\001 \003(\t\"=\n\016StorageVersion\022\r\n\005maj",
+      "or\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z" +
+      "\n\031UpgradeStrategyDefinition\022\035\n\025minimumHe" +
+      "althCapacity\030\001 \002(\001\022\036\n\023maximumOverCapacit" +
+      "y\030\002 \001(\001:\0011\"\260\001\n\017GroupDefinition\022\n\n\002id\030\001 \002" +
+      "(\t\022\017\n\007version\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.meso" +
+      "sphere.marathon.ServiceDefinition\0224\n\006gro" +
+      "ups\030\004 \003(\0132$.mesosphere.marathon.GroupDef" +
+      "inition\022\024\n\014dependencies\030\005 \003(\t\"\245\001\n\030Deploy" +
+      "mentPlanDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007versio" +
+      "n\030\002 \002(\t\0226\n\010original\030\004 \002(\0132$.mesosphere.m",
+      "arathon.GroupDefinition\0224\n\006target\030\005 \002(\0132" +
+      "$.mesosphere.marathon.GroupDefinition\"\306\001" +
+      "\n\013TaskFailure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id" +
+      "\030\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003 \002(\0162\020.m" +
+      "esos.TaskState\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004hos" +
+      "t\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\ttimestamp\030" +
+      "\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016.mesos.SlaveID\"T" +
+      "\n\014ZKStoreEntry\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002" +
+      "(\014\022\r\n\005value\030\003 \002(\014\022\031\n\ncompressed\030\004 \001(\010:\005f" +
+      "alseB\035\n\023mesosphere.marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -23077,39 +23977,45 @@ public final class Protos {
           internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_IpAddress_descriptor,
-              new java.lang.String[] { "Groups", "Labels", });
-          internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
+              new java.lang.String[] { "Groups", "Labels", "DiscoveryInfo", });
+          internal_static_mesosphere_marathon_DiscoveryInfo_descriptor =
             getDescriptor().getMessageTypes().get(3);
+          internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_DiscoveryInfo_descriptor,
+              new java.lang.String[] { "Ports", });
+          internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(4);
           internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ServiceDefinition_descriptor,
               new java.lang.String[] { "Id", "Cmd", "Instances", "Resources", "Description", "Ports", "Constraints", "Executor", "OBSOLETEContainer", "Version", "HealthChecks", "Backoff", "BackoffFactor", "UpgradeStrategy", "Dependencies", "StoreUrls", "RequirePorts", "Container", "Labels", "MaxLaunchDelay", "AcceptedResourceRoles", "LastScalingAt", "LastConfigChangeAt", "IpAddress", });
           internal_static_mesosphere_marathon_ResourceRoles_descriptor =
-            getDescriptor().getMessageTypes().get(4);
+            getDescriptor().getMessageTypes().get(5);
           internal_static_mesosphere_marathon_ResourceRoles_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ResourceRoles_descriptor,
               new java.lang.String[] { "Role", });
           internal_static_mesosphere_marathon_MarathonTask_descriptor =
-            getDescriptor().getMessageTypes().get(5);
+            getDescriptor().getMessageTypes().get(6);
           internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_MarathonTask_descriptor,
               new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "Networks", });
           internal_static_mesosphere_marathon_MarathonApp_descriptor =
-            getDescriptor().getMessageTypes().get(6);
+            getDescriptor().getMessageTypes().get(7);
           internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_MarathonApp_descriptor,
               new java.lang.String[] { "Name", "Tasks", });
           internal_static_mesosphere_marathon_ContainerInfo_descriptor =
-            getDescriptor().getMessageTypes().get(7);
+            getDescriptor().getMessageTypes().get(8);
           internal_static_mesosphere_marathon_ContainerInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ContainerInfo_descriptor,
               new java.lang.String[] { "Image", "Options", });
           internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor =
-            getDescriptor().getMessageTypes().get(8);
+            getDescriptor().getMessageTypes().get(9);
           internal_static_mesosphere_marathon_ExtendedContainerInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor,
@@ -23127,43 +24033,43 @@ public final class Protos {
               internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor,
               new java.lang.String[] { "HostPort", "ContainerPort", "Protocol", "ServicePort", });
           internal_static_mesosphere_marathon_EventSubscribers_descriptor =
-            getDescriptor().getMessageTypes().get(9);
+            getDescriptor().getMessageTypes().get(10);
           internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_EventSubscribers_descriptor,
               new java.lang.String[] { "CallbackUrls", });
           internal_static_mesosphere_marathon_StorageVersion_descriptor =
-            getDescriptor().getMessageTypes().get(10);
+            getDescriptor().getMessageTypes().get(11);
           internal_static_mesosphere_marathon_StorageVersion_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_StorageVersion_descriptor,
               new java.lang.String[] { "Major", "Minor", "Patch", });
           internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(11);
+            getDescriptor().getMessageTypes().get(12);
           internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor,
               new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", });
           internal_static_mesosphere_marathon_GroupDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(12);
+            getDescriptor().getMessageTypes().get(13);
           internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_GroupDefinition_descriptor,
               new java.lang.String[] { "Id", "Version", "Apps", "Groups", "Dependencies", });
           internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(13);
+            getDescriptor().getMessageTypes().get(14);
           internal_static_mesosphere_marathon_DeploymentPlanDefinition_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor,
               new java.lang.String[] { "Id", "Version", "Original", "Target", });
           internal_static_mesosphere_marathon_TaskFailure_descriptor =
-            getDescriptor().getMessageTypes().get(14);
+            getDescriptor().getMessageTypes().get(15);
           internal_static_mesosphere_marathon_TaskFailure_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_TaskFailure_descriptor,
               new java.lang.String[] { "AppId", "TaskId", "State", "Message", "Host", "Version", "Timestamp", "SlaveId", });
           internal_static_mesosphere_marathon_ZKStoreEntry_descriptor =
-            getDescriptor().getMessageTypes().get(15);
+            getDescriptor().getMessageTypes().get(16);
           internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_ZKStoreEntry_descriptor,

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -49,6 +49,11 @@ message HealthCheckDefinition {
 message IpAddress {
   repeated string groups = 1;
   repeated mesos.Label labels = 2;
+  optional DiscoveryInfo discoveryInfo = 3;
+}
+
+message DiscoveryInfo {
+  repeated mesos.Port ports = 1;
 }
 
 message ServiceDefinition {

--- a/src/main/scala/mesosphere/marathon/state/DiscoveryInfo.scala
+++ b/src/main/scala/mesosphere/marathon/state/DiscoveryInfo.scala
@@ -1,0 +1,47 @@
+package mesosphere.marathon.state
+
+import scala.collection.JavaConverters._
+import mesosphere.marathon.Protos
+import org.apache.mesos.{ Protos => MesosProtos }
+
+case class DiscoveryInfo(ports: Seq[DiscoveryInfo.Port] = Seq.empty) {
+  def toProto: Protos.DiscoveryInfo = {
+    Protos.DiscoveryInfo.newBuilder
+      .addAllPorts(ports.map(_.toProto).asJava)
+      .build
+  }
+}
+
+object DiscoveryInfo {
+  def empty: DiscoveryInfo = DiscoveryInfo()
+
+  def fromProto(proto: Protos.DiscoveryInfo): DiscoveryInfo = {
+    DiscoveryInfo(
+      proto.getPortsList.asScala.map(Port.fromProto).toList
+    )
+  }
+
+  case class Port(number: Int, name: String, protocol: String) {
+    require(Port.AllowedProtocols(protocol), "protocol can only be 'tcp' or 'udp'")
+
+    def toProto: MesosProtos.Port = {
+      MesosProtos.Port.newBuilder
+        .setNumber(number)
+        .setName(name)
+        .setProtocol(protocol)
+        .build
+    }
+  }
+
+  object Port {
+    val AllowedProtocols: Set[String] = Set("tcp", "udp")
+
+    def fromProto(proto: MesosProtos.Port): Port = {
+      Port(
+        number = proto.getNumber,
+        name = proto.getName,
+        protocol = proto.getProtocol
+      )
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/state/IpAddress.scala
+++ b/src/main/scala/mesosphere/marathon/state/IpAddress.scala
@@ -8,7 +8,8 @@ import org.apache.mesos.{ Protos => mesos }
 
 case class IpAddress(
     groups: Seq[String] = Nil,
-    labels: Map[String, String] = Map.empty[String, String]) {
+    labels: Map[String, String] = Map.empty[String, String],
+    discoveryInfo: DiscoveryInfo = DiscoveryInfo.empty) {
 
   def toProto: Protos.IpAddress = {
     val builder = Protos.IpAddress.newBuilder
@@ -16,18 +17,21 @@ case class IpAddress(
     labels
       .map { case (key, value) => mesos.Label.newBuilder.setKey(key).setValue(value).build }
       .foreach(builder.addLabels)
+    builder.setDiscoveryInfo(discoveryInfo.toProto)
     builder.build
   }
 }
 
 object IpAddress {
-
   def empty: IpAddress = IpAddress()
 
   def fromProto(proto: Protos.IpAddress): IpAddress = {
     IpAddress(
       groups = proto.getGroupsList.asScala.toIndexedSeq,
-      labels = proto.getLabelsList.asScala.map { p => p.getKey -> p.getValue }.toMap
+      labels = proto.getLabelsList.asScala.map { p => p.getKey -> p.getValue }.toMap,
+      discoveryInfo =
+        if (proto.hasDiscoveryInfo) DiscoveryInfo.fromProto(proto.getDiscoveryInfo)
+        else DiscoveryInfo.empty
     )
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/V2AppDefinitionSchemaJSONTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/V2AppDefinitionSchemaJSONTest.scala
@@ -49,4 +49,47 @@ class V2AppDefinitionSchemaJSONTest extends MarathonSpec with GivenWhenThen {
     Then("validation should succeed")
     MarathonTestHelper.validateJsonSchemaForString(json, valid = true)
   }
+
+  test("discoveryInfo ports WITH a correct protocol should be accepted") {
+    Given("an app definition WITH a discovery info with a TCP and a UDP port")
+    val json =
+      """
+        |{
+        |  "id": "/test",
+        |  "cmd": "echo hi",
+        |  "ipAddress": {
+        |    "discovery": {
+        |      "ports": [
+        |        {"name": "dns", "number": 53, "protocol": "udp"},
+        |        {"name": "http", "number": 80, "protocol": "tcp"}
+        |      ]
+        |    }
+        |  }
+        |}
+      """.stripMargin
+
+    Then("validation should succeed")
+    MarathonTestHelper.validateJsonSchemaForString(json, valid = true)
+  }
+
+  test("discoveryInfo ports WITH an incorrect protocol should be rejected") {
+    Given("an app definition WITH a discovery info with a FOO protocol port")
+    val json =
+      """
+        |{
+        |  "id": "/test",
+        |  "cmd": "echo hi",
+        |  "ipAddress": {
+        |    "discovery": {
+        |      "ports": [
+        |        {"name": "dns", "number": 53, "protocol": "foo"}
+        |      ]
+        |    }
+        |  }
+        |}
+      """.stripMargin
+
+    Then("validation should succeed")
+    MarathonTestHelper.validateJsonSchemaForString(json, valid = false)
+  }
 }

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -133,6 +133,33 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     read should be(app)
   }
 
+  test("ipAddress discovery to proto and back again") {
+    val app = AppDefinition(
+      id = "app-with-ip-address".toPath,
+      cmd = Some("sleep 30"),
+      ports = Nil,
+      ipAddress = Some(
+        IpAddress(
+          groups = Seq("a", "b", "c"),
+          labels = Map(
+            "foo" -> "bar",
+            "baz" -> "buzz"
+          ),
+          discoveryInfo = DiscoveryInfo(
+            ports = Vector(DiscoveryInfo.Port(name = "http", number = 80, protocol = "tcp"))
+          )
+        )
+      )
+    )
+
+    val proto = app.toProto
+
+    proto.getIpAddress.hasDiscoveryInfo should be (true)
+    proto.getIpAddress.getDiscoveryInfo.getPortsList.size() should be (1)
+    val read = AppDefinition().mergeFromProto(proto)
+    read should equal(app)
+  }
+
   test("MergeFromProto") {
     val cmd = mesos.CommandInfo.newBuilder
       .setValue("bash foo-*/start -Dhttp.port=$PORT")

--- a/src/test/scala/mesosphere/marathon/state/DiscoveryInfoTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/DiscoveryInfoTest.scala
@@ -1,0 +1,213 @@
+package mesosphere.marathon.state
+
+import org.apache.mesos.{ Protos => MesosProtos }
+import mesosphere.marathon.{ Protos, MarathonSpec }
+import mesosphere.marathon.api.JsonTestHelper
+import mesosphere.marathon.state.DiscoveryInfo.Port
+import org.scalatest.Matchers
+import play.api.libs.json.{ JsPath, JsError, Json }
+import scala.collection.JavaConverters._
+
+class DiscoveryInfoTest extends MarathonSpec with Matchers {
+  import mesosphere.marathon.api.v2.json.Formats._
+
+  class Fixture {
+    lazy val emptyDiscoveryInfo = DiscoveryInfo()
+
+    lazy val discoveryInfoWithPort = DiscoveryInfo(
+      ports = Seq(Port(name = "http", number = 80, protocol = "tcp"))
+    )
+    lazy val discoveryInfoWithTwoPorts = DiscoveryInfo(
+      ports = Seq(
+        Port(name = "dns", number = 53, protocol = "udp"),
+        Port(name = "http", number = 80, protocol = "tcp")
+      )
+    )
+    lazy val discoveryInfoWithTwoPorts2 = DiscoveryInfo(
+      ports = Seq(
+        Port(name = "dnsudp", number = 53, protocol = "udp"),
+        Port(name = "dnstcp", number = 53, protocol = "tcp")
+      )
+    )
+  }
+
+  def fixture(): Fixture = new Fixture
+
+  test("ToProto default DiscoveryInfo") {
+    val f = fixture()
+    val proto = f.emptyDiscoveryInfo.toProto
+
+    proto should be(Protos.DiscoveryInfo.getDefaultInstance)
+  }
+
+  test("ToProto with one port") {
+    val f = fixture()
+    val proto = f.discoveryInfoWithPort.toProto
+
+    val portProto =
+      MesosProtos.Port.newBuilder()
+        .setName("http")
+        .setNumber(80)
+        .setProtocol("tcp")
+        .build()
+
+    proto.getPortsList.asScala.head should equal(portProto)
+  }
+
+  test("ConstructFromProto with default proto") {
+    val f = fixture()
+
+    val defaultProto = Protos.DiscoveryInfo.newBuilder.build
+    val result = DiscoveryInfo.fromProto(defaultProto)
+    result should equal(f.emptyDiscoveryInfo)
+  }
+
+  test("ConstructFromProto with port") {
+    val f = fixture()
+
+    val portProto =
+      MesosProtos.Port.newBuilder()
+        .setName("http")
+        .setNumber(80)
+        .setProtocol("tcp")
+        .build()
+
+    val protoWithPort = Protos.DiscoveryInfo.newBuilder
+      .addAllPorts(Seq(portProto).asJava)
+      .build
+
+    val result = DiscoveryInfo.fromProto(protoWithPort)
+    result should equal(f.discoveryInfoWithPort)
+  }
+
+  test("JSON Serialization round-trip emptyDiscoveryInfo") {
+    val f = fixture()
+    JsonTestHelper.assertSerializationRoundtripWorks(f.emptyDiscoveryInfo)
+  }
+
+  test("JSON Serialization round-trip discoveryInfoWithPort") {
+    val f = fixture()
+    JsonTestHelper.assertSerializationRoundtripWorks(f.discoveryInfoWithPort)
+  }
+
+  private[this] def fromJson(json: String): DiscoveryInfo = {
+    Json.fromJson[DiscoveryInfo](Json.parse(json)).get
+  }
+
+  test("Read empty discovery info") {
+    val json =
+      """
+      {
+        "ports": []
+      }
+      """
+
+    val readResult = fromJson(json)
+
+    val f = fixture()
+    assert(readResult == f.emptyDiscoveryInfo)
+  }
+
+  test("Read discovery info with one port") {
+    val json =
+      """
+      {
+        "ports": [
+          { "name": "http", "number": 80, "protocol": "tcp" }
+        ]
+      }
+      """
+
+    val readResult = fromJson(json)
+
+    val f = fixture()
+    assert(readResult == f.discoveryInfoWithPort)
+  }
+
+  test("Read discovery info with two ports") {
+    val json =
+      """
+      {
+        "ports": [
+          { "name": "dns", "number": 53, "protocol": "udp" },
+          { "name": "http", "number": 80, "protocol": "tcp" }
+        ]
+      }
+      """
+
+    val readResult = fromJson(json)
+
+    val f = fixture()
+    assert(readResult == f.discoveryInfoWithTwoPorts)
+  }
+
+  test("Read discovery info with two ports with the same port number") {
+    val json =
+      """
+      {
+        "ports": [
+          { "name": "dnsudp", "number": 53, "protocol": "udp" },
+          { "name": "dnstcp", "number": 53, "protocol": "tcp" }
+        ]
+      }
+      """
+
+    val readResult = fromJson(json)
+
+    val f = fixture()
+    assert(readResult == f.discoveryInfoWithTwoPorts2)
+  }
+
+  test("Read discovery info with two ports with duplicate port/number") {
+    val json =
+      """
+      {
+        "ports": [
+          { "name": "dns1", "number": 53, "protocol": "udp" },
+          { "name": "dns2", "number": 53, "protocol": "udp" }
+        ]
+      }
+      """
+
+    val readResult = Json.fromJson[DiscoveryInfo](Json.parse(json))
+    readResult should be(JsError(
+      JsPath() \ "ports",
+      "There may be only one port with a particular port number/protocol combination.")
+    )
+  }
+
+  test("Read discovery info with two ports with duplicate name") {
+    val json =
+      """
+      {
+        "ports": [
+          { "name": "dns1", "number": 53, "protocol": "udp" },
+          { "name": "dns1", "number": 53, "protocol": "tcp" }
+        ]
+      }
+      """
+
+    val readResult = Json.fromJson[DiscoveryInfo](Json.parse(json))
+    readResult should be(JsError(
+      JsPath() \ "ports",
+      "Port names are not unique.")
+    )
+  }
+
+  test("Read discovery info with a port with an invalid protocol") {
+    val json =
+      """
+      {
+        "ports": [
+          { "name": "http", "number": 80, "protocol": "foo" }
+        ]
+      }
+      """
+
+    val readResult = Json.fromJson[DiscoveryInfo](Json.parse(json))
+    readResult should be(JsError(
+      (JsPath() \ "ports")(0) \ "protocol",
+      "Invalid protocol. Only 'udp' or 'tcp' are allowed.")
+    )
+  }
+}


### PR DESCRIPTION
Status:

- [x] Add DiscoveryInfo Protocol Buffers to marathon.proto
- [x] Add "discoveryInfo" field to IpAddress
- [x] Add DiscoveryInfo JSON serialization
- [x] Add DiscoveryInfo to AppDefinition.json
- [x] Make TaskBuilder fill DiscoveryInfo (PR #2741)
- [x] Add documentation
- [ ] Testing (E2E-Tests)