### PR TITLE
Add trivago as a user of Marathon

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Across all installations Marathon is managing applications on more than 100,000 
 * [sloppy.io](http://sloppy.io/)
 * [SmartProcure](https://smartprocure.us/)
 * [Strava](https://www.strava.com)
+* [trivago](http://www.trivago.com/)
 * [Viadeo](http://www.viadeo.com)
 * [Wikia](http://www.wikia.com/Wikia)
 * [WooRank](https://www.woorank.com/)


### PR DESCRIPTION
We ([trivago](http://www.trivago.com/)) are using Mesos, Marathon and Chronos in one of our datacenters. This pull request adds trivago as a Marathon user.