### PR TITLE
Fixes #2734 by only using the available assigned ports instead of all…

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupManager.scala
@@ -218,14 +218,16 @@ class GroupManager @Singleton @Inject() (
     }
 
     def assignPorts(app: AppDefinition): AppDefinition = {
-      val alreadyAssigned = mutable.Queue(
+      //all ports that are already assigned in old app definition, but not used in the new definition
+      //if the app uses dynamic ports (0), it will get always the same ports assigned
+      val assignedAndAvailable = mutable.Queue(
         from.app(app.id)
-          .map(_.ports.filter(p => portRange.contains(p)))
+          .map(_.ports.filter(p => portRange.contains(p) && !app.servicePorts.contains(p)))
           .getOrElse(Nil): _*
       )
 
       def nextFreeAppPort: JInt =
-        if (alreadyAssigned.nonEmpty) alreadyAssigned.dequeue()
+        if (assignedAndAvailable.nonEmpty) assignedAndAvailable.dequeue()
         else nextGlobalFreePort
 
       val servicePorts: Seq[JInt] = app.servicePorts.map { port =>

--- a/src/test/scala/mesosphere/marathon/state/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupManagerTest.scala
@@ -80,6 +80,14 @@ class GroupManagerTest extends TestKit(ActorSystem("System")) with MockitoSugar 
     update.transitiveApps.flatMap(_.ports.filter(x => x >= 10 && x <= 20)) should have size 2
   }
 
+  //regression for #2743
+  test("Reassign dynamic service ports specified in the container") {
+    val from = Group(PathId.empty, Set(AppDefinition("/app1".toPath, ports = Seq(10, 11))))
+    val to = Group(PathId.empty, Set(AppDefinition("/app1".toPath, ports = Seq(10, 0, 11))))
+    val update = manager(minServicePort = 10, maxServicePort = 20).assignDynamicServicePorts(from, to)
+    update.app("/app1".toPath).get.ports should be(Seq(10, 12, 11))
+  }
+
   // Regression test for #1365
   test("Export non-dynamic service ports specified in the container to the ports field") {
     import Container.Docker


### PR DESCRIPTION
… dynamically assigned ports.

Problem in short:
step 1: user send ports=[0] this will result in ports=[10000]
step 2: user updates ports to ports=[10000, 0] 
the logic would see 10000 as available free port, remembers that and will it assign to the next dynamic value. This will result in [10000, 10000] which breaks validation.