### PR TITLE
modified call to subprocess.check_call for haproxy reload to close all file descriptors in the child

### DIFF
--- a/bin/servicerouter.py
+++ b/bin/servicerouter.py
@@ -860,7 +860,7 @@ def reloadConfig():
 
     logger.info("reloading using %s", " ".join(reloadCommand))
     try:
-        subprocess.check_call(reloadCommand)
+        subprocess.check_call(reloadCommand, close_fds=True)
     except OSError as ex:
         logger.error("unable to reload config using command %s",
                      " ".join(reloadCommand))


### PR DESCRIPTION
for history, see discussion from marathon_lb project: 
https://github.com/mesosphere/marathon-lb/pull/29

references #2781