### PR TITLE
Remove airbnb from companies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ To develop on the web UI look into the instructions of the [Marathon UI](https:/
 
 Across all installations Marathon is managing applications on more than 100,000 nodes world-wide. These are some of the companies using it:
 
-* [Airbnb](https://www.airbnb.com/)
 * [Allegro Group](http://www.allegrogroup.com)
 * [AllUnite](https://allunite.com/)
 * [Argus Cyber Security](http://argus-sec.com/)


### PR DESCRIPTION
We're no longer using Marathon internally at @Airbnb. Noticed per https://twitter.com/CleverRoffey/status/674334494040567808