### PR TITLE
Fixes #1455 - Multiple health checks DO NOT MERGE

### DIFF
--- a/src/main/scala/mesosphere/marathon/health/Health.scala
+++ b/src/main/scala/mesosphere/marathon/health/Health.scala
@@ -4,6 +4,7 @@ import mesosphere.marathon.state.Timestamp
 
 case class Health(
     taskId: String,
+    healthy: Boolean, //TODO pay attention to maxConsecutiveFailures and gracePeriod
     firstSuccess: Option[Timestamp] = None,
     lastSuccess: Option[Timestamp] = None,
     lastFailure: Option[Timestamp] = None,
@@ -16,6 +17,7 @@ case class Health(
 
   def update(result: HealthResult): Health = result match {
     case Healthy(_, _, time) => copy(
+      healthy = true,
       firstSuccess = firstSuccess.orElse(Some(time)),
       lastSuccess = Some(time),
       consecutiveFailures = 0

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckAppActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckAppActor.scala
@@ -1,0 +1,64 @@
+package mesosphere.marathon.health
+
+import akka.actor.Actor
+import mesosphere.marathon.{MarathonScheduler, MarathonSchedulerDriverHolder}
+import mesosphere.marathon.state.PathId
+import mesosphere.marathon.tasks.TaskTracker
+import concurrent.duration._
+import collection.mutable
+
+
+class HealthCheckAppActor(appId: PathId,
+                          appVersion: String,
+                          healthChecks: Seq[HealthCheck],
+                          taskTracker: TaskTracker,
+                          marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder,
+                          marathonScheduler: MarathonScheduler) extends Actor {
+
+  import HealthCheckAppActor._
+
+  type TaskId = String
+
+  var tasksHealth: mutable.Map[TaskId, Map[HealthCheck, Health]] = mutable.Map.empty
+
+  override def preStart() = {
+    healthChecks.foreach { hc =>
+      context.system.scheduler.schedule(0.seconds, hc.interval) {
+        self ! StartHealthCheck(hc)
+      }
+    }
+  }
+
+  override def receive: Receive = {
+
+    case UpdateTaskHealth(taskId, healthCheck, health) =>
+      tasksHealth.get(taskId).foreach { hcs =>
+        val result = hcs + (healthCheck -> health)
+        tasksHealth.update(taskId, result)
+
+        val wasHealthy = hcs.values.forall(_.healthy)
+        val healthy = result.values.forall(_.healthy)
+
+
+        //TODO perform killing the task
+        //add some logic to handle the task failure
+        //TODO publish event to somewhere
+      }
+
+    case StartHealthCheck(hc) =>
+      context.actorOf(HealthCheckActor.props(appVersion, hc, self))
+      
+  }
+}
+
+object HealthCheckAppActor {
+
+  //TODO make props
+
+  case class StartHealthCheck(hc: HealthCheck)
+
+  case class UpdateTaskHealth(taskId: String, healthCheck: HealthCheck, health: Health)
+
+  case class HealthCheckFailed(taskId: String, hc: HealthCheck)
+
+}


### PR DESCRIPTION
Here is a start of process of fixing issue #1445.

The idea is to create a new actor called HealthCheckAppActor, which is responsible to aggregate failed health checks from HealthCheckActor. Based on this checks, HealthCheckAppActor should be able to correctly determine if an instance is working, and don't miss any failed health checks.

What should be done next: we should move the application killing logic from HealthCheckActor to HealthCheckAppActor, now it's responsible to making decisions based on task health information. Read TODOs for more information.