### PR TITLE
Fixed duplicate assertion in ConstraintsTest.

### DIFF
--- a/src/test/scala/mesosphere/mesos/ConstraintsTest.scala
+++ b/src/test/scala/mesosphere/mesos/ConstraintsTest.scala
@@ -61,7 +61,7 @@ class ConstraintsTest extends MarathonSpec with GivenWhenThen with Matchers {
     Then("20 tasks got selected and evenly distributed")
     result should have size 20
     result.count(_.getAttributesList.asScala.exists(_.getText.getValue == "rack-1")) should be(10)
-    result.count(_.getAttributesList.asScala.exists(_.getText.getValue == "rack-1")) should be(10)
+    result.count(_.getAttributesList.asScala.exists(_.getText.getValue == "rack-2")) should be(10)
     result.count(_.getAttributesList.asScala.exists(_.getText.getValue == "blue")) should be(10)
     result.count(_.getAttributesList.asScala.exists(_.getText.getValue == "green")) should be(10)
   }


### PR DESCRIPTION
In ConstraintsTest.scala file in one of the test cases was a duplicated assertion. It seems that the second assertion should check "rack-2" not "rack-1".