### PR TITLE
Do not use user-supplied version timestamp for new applications

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -64,7 +64,10 @@ class AppsResource @Inject() (
   def create(body: Array[Byte],
              @DefaultValue("false")@QueryParam("force") force: Boolean,
              @Context req: HttpServletRequest, @Context resp: HttpServletResponse): Response = {
+    val now = clock.now()
     val app = validateApp(Json.parse(body).as[V2AppDefinition].withCanonizedIds().toAppDefinition)
+      .copy(versionInfo = AppDefinition.VersionInfo.OnlyVersion(now))
+
     doIfAuthorized(req, resp, CreateAppOrGroup, app.id) { identity =>
       def createOrThrow(opt: Option[AppDefinition]) = opt
         .map(_ => throw new ConflictingChangeException(s"An app with id [${app.id}] already exists."))

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -31,7 +31,7 @@ class AppsResourceTest extends MarathonSpec with Matchers with Mockito with Give
 
   test("Create a new app successfully") {
     Given("An app and group")
-    val app = V2AppDefinition(id = PathId("/app"), cmd = Some("cmd"), version = clock.now())
+    val app = V2AppDefinition(id = PathId("/app"), cmd = Some("cmd"), version = Timestamp.zero)
     val group = Group(PathId("/"), Set(app.toAppDefinition))
     val plan = DeploymentPlan(group, group)
     val body = Json.stringify(Json.toJson(app)).getBytes("UTF-8")
@@ -47,7 +47,7 @@ class AppsResourceTest extends MarathonSpec with Matchers with Mockito with Give
 
     And("the JSON is as expected, including a newly generated version")
     val expected = AppInfo(
-      app.toAppDefinition,
+      app.toAppDefinition.copy(versionInfo = AppDefinition.VersionInfo.OnlyVersion(clock.now())),
       maybeTasks = Some(immutable.Seq.empty),
       maybeCounts = Some(TaskCounts.zero),
       maybeDeployments = Some(immutable.Seq(Identifiable(plan.id)))


### PR DESCRIPTION
Reapply lost parts of f3a5ccfbd623de6f6ee4d3792c51419a8392c474