### PR TITLE
Support mesos fetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules
 .Rproj.user
 start.sh
 .DS_Store
+*.ipr
+*.iws

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -202,6 +202,39 @@
       "description": "The executor to use to launch this application. Different executors are available. The simplest one (and the default if none is given) is //cmd, which takes the cmd and executes that on the shell level.",
       "pattern": "^(|\\/\\/cmd|\\/?[^\\/]+(\\/[^\\/]+)*)$"
     },
+    "fetch": {
+      "type": "array",
+      "description": "Provided URIs are passed to Mesos fetcher module and resolved in runtime.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "value": {
+              "type": "string",
+              "description": "URI to be fetched by Mesos fetcher module"
+            }
+          },
+          "executable": {
+            "value": {
+              "type": "boolean",
+              "description": "Set fetched artifact as executable"
+            }
+          },
+          "extract": {
+            "value": {
+              "type": "boolean",
+              "description": "Extract fetched artifact if supported by Mesos fetcher module"
+            }
+          },
+          "cache": {
+            "value": {
+              "type": "boolean",
+              "description": "Cache fetched artifact if supported by Mesos fetcher module"
+            }
+          }
+        }
+      }
+    },
     "healthChecks": {
       "items": {
         "type": "object",

--- a/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
@@ -4,6 +4,8 @@ import java.net.{ URLConnection, HttpURLConnection, URL }
 
 import com.wix.accord._
 import mesosphere.marathon.ValidationFailedException
+import mesosphere.marathon.api.v2.json.V2AppDefinition
+import mesosphere.marathon.state.{ AppDefinition, FetchUri }
 
 import play.api.libs.json._
 
@@ -87,6 +89,25 @@ object Validation {
         }.getOrElse(
           Failure(Set(RuleViolation(url, "url could not be resolved", None)))
         )
+      }
+    }
+  }
+
+  def fetchUriHasSupportedProtocol: Validator[FetchUri] = {
+    lazy val supportedProtocols = Set("http", "https", "ftp", "ftps", "hdfs")
+
+    new Validator[FetchUri] {
+      def apply(uri: FetchUri) = {
+        Try {
+          val value = new URL(uri.uri)
+
+          if (!supportedProtocols.contains(value.getProtocol)) {
+            Failure(Set(RuleViolation(uri.uri, "url has not supported protocol", None)))
+          }
+          else {
+            Success
+          }
+        }.getOrElse(Failure(Set(RuleViolation(uri.uri, "url has invalid syntax", None))))
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/json/V2AppUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/V2AppUpdate.scala
@@ -2,9 +2,11 @@ package mesosphere.marathon.api.v2.json
 
 import java.lang.{ Double => JDouble, Integer => JInt }
 
+import com.wix.accord._
 import mesosphere.marathon.Protos.Constraint
+
 import mesosphere.marathon.health.HealthCheck
-import mesosphere.marathon.state.{ AppDefinition, Container, IpAddress, PathId, Timestamp, UpgradeStrategy }
+import mesosphere.marathon.state.{ AppDefinition, Container, FetchUri, IpAddress, PathId, Timestamp, UpgradeStrategy }
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration.FiniteDuration
@@ -34,6 +36,8 @@ case class V2AppUpdate(
     constraints: Option[Set[Constraint]] = None,
 
     uris: Option[Seq[String]] = None,
+
+    fetch: Option[Seq[FetchUri]] = None,
 
     storeUrls: Option[Seq[String]] = None,
 
@@ -94,6 +98,7 @@ case class V2AppUpdate(
     executor = executor.getOrElse(app.executor),
     constraints = constraints.getOrElse(app.constraints),
     uris = uris.getOrElse(app.uris),
+    fetch = fetch.getOrElse(app.fetch),
     storeUrls = storeUrls.getOrElse(app.storeUrls),
     ports = ports.getOrElse(app.ports),
     requirePorts = requirePorts.getOrElse(app.requirePorts),
@@ -119,11 +124,31 @@ case class V2AppUpdate(
 object V2AppUpdate {
   import com.wix.accord.dsl._
   import mesosphere.marathon.api.v2.Validation._
+
+  private def updateContainsEitherUrisOrFetch: Validator[V2AppUpdate] = {
+    new Validator[V2AppUpdate] {
+      def apply(app: V2AppUpdate): Result = {
+
+        val fetch = app.fetch.getOrElse(AppDefinition.DefaultFetch)
+        val uris = app.uris.getOrElse(AppDefinition.DefaultUris)
+
+        if (fetch.nonEmpty && uris.nonEmpty) {
+          Failure(Set(RuleViolation(app, "AppUpdate must either contain a fetch sequence or a uri sequence", None)))
+        }
+        else {
+          Success
+        }
+      }
+    }
+  }
+
   implicit val appUpdateValidator = validator[V2AppUpdate] { appUp =>
     appUp.id is valid
     appUp.dependencies is valid
     appUp.upgradeStrategy is valid
     appUp.storeUrls is optional(every(urlCanBeResolvedValidator))
     appUp.ports is optional(elementsAreUnique(V2AppDefinition.filterOutRandomPorts))
+    appUp.fetch is optional(every(fetchUriHasSupportedProtocol))
+    appUp is updateContainsEitherUrisOrFetch
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -48,6 +48,8 @@ case class AppDefinition(
 
   uris: Seq[String] = AppDefinition.DefaultUris,
 
+  fetch: Seq[FetchUri] = AppDefinition.DefaultFetch,
+
   storeUrls: Seq[String] = AppDefinition.DefaultStoreUrls,
 
   ports: Seq[JInt] = AppDefinition.DefaultPorts,
@@ -225,6 +227,7 @@ case class AppDefinition(
       disk = resourcesMap.getOrElse(Resource.DISK, this.disk),
       env = envMap,
       uris = proto.getCmd.getUrisList.asScala.map(_.getValue).to[Seq],
+      fetch = proto.getCmd.getUrisList.asScala.map(FetchUri.fromProto).to[Seq],
       storeUrls = proto.getStoreUrlsList.asScala.to[Seq],
       container = containerOption,
       healthChecks = proto.getHealthChecksList.asScala.map(new HealthCheck().mergeFromProto).toSet,
@@ -288,6 +291,7 @@ case class AppDefinition(
         executor != to.executor ||
         constraints != to.constraints ||
         uris != to.uris ||
+        fetch != to.fetch ||
         storeUrls != to.storeUrls ||
         ports != to.ports ||
         requirePorts != to.requirePorts ||
@@ -414,6 +418,8 @@ object AppDefinition {
   val DefaultConstraints: Set[Constraint] = Set.empty
 
   val DefaultUris: Seq[String] = Seq.empty
+
+  val DefaultFetch: Seq[FetchUri] = FetchUri.empty
 
   val DefaultStoreUrls: Seq[String] = Seq.empty
 

--- a/src/main/scala/mesosphere/marathon/state/FetchUri.scala
+++ b/src/main/scala/mesosphere/marathon/state/FetchUri.scala
@@ -1,0 +1,35 @@
+package mesosphere.marathon.state
+
+import org.apache.mesos.{ Protos => mesos }
+import scala.collection.immutable.Seq
+
+/**
+  * Defaults taken from mesos.proto
+  */
+case class FetchUri(
+    uri: String,
+    executable: Boolean = false,
+    extract: Boolean = true,
+    cache: Boolean = false) {
+
+  def toProto(): mesos.CommandInfo.URI =
+    mesos.CommandInfo.URI.newBuilder()
+      .setValue(uri)
+      .setExecutable(executable)
+      .setExtract(extract)
+      .setCache(cache)
+      .build()
+}
+
+object FetchUri {
+
+  val empty: Seq[FetchUri] = Seq.empty
+
+  def fromProto(uri: mesos.CommandInfo.URI): FetchUri =
+    FetchUri(
+      uri = uri.getValue,
+      executable = uri.getExecutable,
+      extract = uri.getExtract,
+      cache = uri.getCache
+    )
+}

--- a/src/main/scala/mesosphere/marathon/state/StateMetrics.scala
+++ b/src/main/scala/mesosphere/marathon/state/StateMetrics.scala
@@ -8,9 +8,8 @@ import scala.util.control.NonFatal
 
 object StateMetrics {
   private[state] class MetricTemplate(
-    metrics: Metrics, prefix: String, metricsClass: Class[_],
-    nanoTime: () => Long = () => System.nanoTime
-  ) {
+      metrics: Metrics, prefix: String, metricsClass: Class[_],
+      nanoTime: () => Long = () => System.nanoTime) {
     def timedFuture[T](f: => Future[T]): Future[T] = {
       requestMeter.mark()
       val t0 = nanoTime()

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -303,6 +303,11 @@ object TaskBuilder {
       })
       builder.addAllUris(uriProtos.asJava)
     }
+
+    if (app.fetch.nonEmpty) {
+      builder.addAllUris(app.fetch.map(_.toProto).asJava)
+    }
+
     //scalastyle:on
 
     app.user.foreach(builder.setUser)

--- a/src/test/scala/mesosphere/marathon/api/validation/V2AppDefinitionValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/V2AppDefinitionValidatorTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.api.validation
 
 import javax.validation.ConstraintValidatorContext
 
-import mesosphere.marathon.{ValidationFailedException, MarathonSpec}
+import mesosphere.marathon.{ ValidationFailedException, MarathonSpec }
 import mesosphere.marathon.Protos.HealthCheckDefinition
 import mesosphere.marathon.api.v2.json.V2AppDefinition
 import mesosphere.marathon.health.HealthCheck

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1038,7 +1038,31 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     assert(uriinfo2.getExtract)
     val uriinfo3 = command.getUris(2)
     assert(uriinfo3.getExtract)
+  }
 
+  test("TaskWillCopyFetchIntoCommand") {
+    val command = TaskBuilder.commandInfo(
+      app = AppDefinition(
+        fetch = Seq(
+          FetchUri(uri = "http://www.example.com", extract = false, cache = true, executable = false),
+          FetchUri(uri = "http://www.example2.com", extract = true, cache = true, executable = true)
+        )
+      ),
+      taskId = Some(TaskID("task-123")),
+      host = Some("host.mega.corp"),
+      ports = Seq(1000, 1001),
+      envPrefix = None
+    )
+
+    assert(command.getUris(0).getValue.contentEquals("http://www.example.com"))
+    assert(command.getUris(0).getCache)
+    assert(!command.getUris(0).getExtract)
+    assert(!command.getUris(0).getExecutable)
+
+    assert(command.getUris(1).getValue.contentEquals("http://www.example2.com"))
+    assert(command.getUris(1).getCache)
+    assert(command.getUris(1).getExtract)
+    assert(command.getUris(1).getExecutable)
   }
 
   // #2865 Multiple explicit ports are mixed up in task json


### PR DESCRIPTION
This PR fixes #1953.

Notes:
- there is new "fetch" field introduced in V2AppDefinition and V2AppUpdate
- "fetch" field is populated with "CommandInfo.uris" when deserializing from proto (as uris field is)
- either "fetch" or "uris" field should be populated with data, never both
