### PR TITLE
Support mesos fetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules
 .Rproj.user
 start.sh
 .DS_Store
+*.ipr
+*.iws

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -202,6 +202,40 @@
       "description": "The executor to use to launch this application. Different executors are available. The simplest one (and the default if none is given) is //cmd, which takes the cmd and executes that on the shell level.",
       "pattern": "^(|\\/\\/cmd|\\/?[^\\/]+(\\/[^\\/]+)*)$"
     },
+    "fetch": {
+      "type": "array",
+      "description": "Provided URIs are passed to Mesos fetcher module and resolved in runtime.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "uri": {
+            "value": {
+              "type": "string",
+              "description": "URI to be fetched by Mesos fetcher module"
+            }
+          },
+          "executable": {
+            "value": {
+              "type": "boolean",
+              "description": "Set fetched artifact as executable"
+            }
+          },
+          "extract": {
+            "value": {
+              "type": "boolean",
+              "description": "Extract fetched artifact if supported by Mesos fetcher module"
+            }
+          },
+          "cache": {
+            "value": {
+              "type": "boolean",
+              "description": "Cache fetched artifact if supported by Mesos fetcher module"
+            }
+          }
+        }
+      }
+    },
     "healthChecks": {
       "items": {
         "type": "object",

--- a/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
@@ -1,10 +1,10 @@
 package mesosphere.marathon.api.v2
 
-import java.net.{ URLConnection, HttpURLConnection, URL }
+import java.net._
 
 import com.wix.accord._
 import mesosphere.marathon.ValidationFailedException
-
+import mesosphere.marathon.state.FetchUri
 import play.api.libs.json._
 
 import scala.reflect.ClassTag
@@ -88,6 +88,20 @@ object Validation {
         }.getOrElse(
           Failure(Set(RuleViolation(url, "url could not be resolved", None)))
         )
+      }
+    }
+  }
+
+  def fetchUriIsValid: Validator[FetchUri] = {
+    new Validator[FetchUri] {
+      def apply(uri: FetchUri) = {
+        try {
+          new URI(uri.uri)
+          Success
+        }
+        catch {
+          case _: URISyntaxException => Failure(Set(RuleViolation(uri.uri, "URI has invalid syntax.", None)))
+        }
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
@@ -7,9 +7,10 @@ import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation._
 
 import mesosphere.marathon.Protos.Constraint
+
 import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.state.AppDefinition.VersionInfo.{ OnlyVersion, NoVersion }
-import mesosphere.marathon.state.{ AppDefinition, Container, IpAddress, PathId, Timestamp, UpgradeStrategy }
+import mesosphere.marathon.state.{ AppDefinition, Container, FetchUri, IpAddress, PathId, Timestamp, UpgradeStrategy }
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration.FiniteDuration
@@ -38,7 +39,7 @@ case class AppUpdate(
 
     constraints: Option[Set[Constraint]] = None,
 
-    uris: Option[Seq[String]] = None,
+    fetch: Option[Seq[FetchUri]] = None,
 
     storeUrls: Option[Seq[String]] = None,
 
@@ -91,7 +92,7 @@ case class AppUpdate(
     disk = disk.getOrElse(app.disk),
     executor = executor.getOrElse(app.executor),
     constraints = constraints.getOrElse(app.constraints),
-    uris = uris.getOrElse(app.uris),
+    fetch = fetch.getOrElse(app.fetch),
     storeUrls = storeUrls.getOrElse(app.storeUrls),
     ports = ports.getOrElse(app.ports),
     requirePorts = requirePorts.getOrElse(app.requirePorts),
@@ -121,5 +122,6 @@ object AppUpdate {
     appUp.upgradeStrategy is valid
     appUp.storeUrls is optional(every(urlCanBeResolvedValidator))
     appUp.ports is optional(elementsAreUnique(AppDefinition.filterOutRandomPorts))
+    appUp.fetch is optional(every(fetchUriIsValid))
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -47,7 +47,7 @@ case class AppDefinition(
 
   constraints: Set[Constraint] = AppDefinition.DefaultConstraints,
 
-  uris: Seq[String] = AppDefinition.DefaultUris,
+  fetch: Seq[FetchUri] = AppDefinition.DefaultFetch,
 
   storeUrls: Seq[String] = AppDefinition.DefaultStoreUrls,
 
@@ -225,7 +225,7 @@ case class AppDefinition(
       mem = resourcesMap.getOrElse(Resource.MEM, this.mem),
       disk = resourcesMap.getOrElse(Resource.DISK, this.disk),
       env = envMap,
-      uris = proto.getCmd.getUrisList.asScala.map(_.getValue).to[Seq],
+      fetch = proto.getCmd.getUrisList.asScala.map(FetchUri.fromProto).to[Seq],
       storeUrls = proto.getStoreUrlsList.asScala.to[Seq],
       container = containerOption,
       healthChecks = proto.getHealthChecksList.asScala.map(new HealthCheck().mergeFromProto).toSet,
@@ -288,7 +288,7 @@ case class AppDefinition(
         disk != to.disk ||
         executor != to.executor ||
         constraints != to.constraints ||
-        uris != to.uris ||
+        fetch != to.fetch ||
         storeUrls != to.storeUrls ||
         ports != to.ports ||
         requirePorts != to.requirePorts ||
@@ -421,6 +421,8 @@ object AppDefinition {
 
   val DefaultUris: Seq[String] = Seq.empty
 
+  val DefaultFetch: Seq[FetchUri] = FetchUri.empty
+
   val DefaultStoreUrls: Seq[String] = Seq.empty
 
   val DefaultPorts: Seq[JInt] = Seq(RandomPortValue)
@@ -468,6 +470,7 @@ object AppDefinition {
     appDef is containsCmdArgsContainerValidator
     appDef is portIndicesAreValid
     appDef.instances.intValue should be >= 0
+    appDef.fetch is every(fetchUriIsValid)
   }
 
   def filterOutRandomPorts(ports: scala.Seq[JInt]): scala.Seq[JInt] = {

--- a/src/main/scala/mesosphere/marathon/state/FetchUri.scala
+++ b/src/main/scala/mesosphere/marathon/state/FetchUri.scala
@@ -1,0 +1,45 @@
+package mesosphere.marathon.state
+
+import org.apache.mesos.{ Protos => mesos }
+import scala.collection.immutable.Seq
+
+/**
+  * Defaults taken from mesos.proto
+  */
+case class FetchUri(
+    uri: String,
+    extract: Boolean = true,
+    executable: Boolean = false,
+    cache: Boolean = false) {
+
+  def toProto(): mesos.CommandInfo.URI =
+    mesos.CommandInfo.URI.newBuilder()
+      .setValue(uri)
+      .setExecutable(executable)
+      .setExtract(extract)
+      .setCache(cache)
+      .build()
+}
+
+object FetchUri {
+
+  val empty: Seq[FetchUri] = Seq.empty
+
+  def fromProto(uri: mesos.CommandInfo.URI): FetchUri =
+    FetchUri(
+      uri = uri.getValue,
+      executable = uri.getExecutable,
+      extract = uri.getExtract,
+      cache = uri.getCache
+    )
+
+  def isExtract(uri: String): Boolean = {
+    uri.endsWith(".tgz") ||
+      uri.endsWith(".tar.gz") ||
+      uri.endsWith(".tbz2") ||
+      uri.endsWith(".tar.bz2") ||
+      uri.endsWith(".txz") ||
+      uri.endsWith(".tar.xz") ||
+      uri.endsWith(".zip")
+  }
+}

--- a/src/main/scala/mesosphere/marathon/state/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupManager.scala
@@ -190,7 +190,7 @@ class GroupManager @Singleton @Inject() (
         group.updateApps(group.version) { app =>
           if (app.storeUrls.isEmpty) app else {
             val storageUrls = app.storeUrls.map(paths).map(storage.item(_).url)
-            val resolved = app.copy(uris = app.uris ++ storageUrls, storeUrls = Seq.empty)
+            val resolved = app.copy(fetch = app.fetch ++ storageUrls.map(FetchUri.apply(_)), storeUrls = Seq.empty)
             val appDownloads: Map[URL, String] =
               app.storeUrls
                 .flatMap { url => downloads.remove(url).map { path => new URL(url) -> path } }.toMap

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -292,31 +292,13 @@ object TaskBuilder {
       if (app.container.isEmpty) builder.setValue(argv.head)
     }
 
-    //scalastyle:off null
-    if (app.uris != null) {
-      val uriProtos = app.uris.map(uri => {
-        CommandInfo.URI.newBuilder()
-          .setValue(uri)
-          .setExtract(isExtract(uri))
-          .build()
-      })
-      builder.addAllUris(uriProtos.asJava)
+    if (app.fetch.nonEmpty) {
+      builder.addAllUris(app.fetch.map(_.toProto).asJava)
     }
-    //scalastyle:on
 
     app.user.foreach(builder.setUser)
 
     builder.build
-  }
-
-  private def isExtract(stringUri: String): Boolean = {
-    stringUri.endsWith(".tgz") ||
-      stringUri.endsWith(".tar.gz") ||
-      stringUri.endsWith(".tbz2") ||
-      stringUri.endsWith(".tar.bz2") ||
-      stringUri.endsWith(".txz") ||
-      stringUri.endsWith(".tar.xz") ||
-      stringUri.endsWith(".zip")
   }
 
   def environment(vars: Map[String, String]): Environment = {

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -13,7 +13,8 @@ class AppDefinitionFormatsTest
     extends MarathonSpec
     with V2Formats
     with HealthCheckFormats
-    with Matchers {
+    with Matchers
+    with FetchUriFormats {
 
   import Formats.PathIdFormat
 
@@ -55,6 +56,7 @@ class AppDefinitionFormatsTest
     (r1 \ "executor").as[String] should equal (DefaultExecutor)
     (r1 \ "constraints").as[Set[Constraint]] should equal (DefaultConstraints)
     (r1 \ "uris").as[Seq[String]] should equal (DefaultUris)
+    (r1 \ "fetch").as[Seq[FetchUri]] should equal (DefaultFetch)
     (r1 \ "storeUrls").as[Seq[String]] should equal (DefaultStoreUrls)
     (r1 \ "ports").as[Seq[Long]] should equal (DefaultPorts.map(_.toInt))
     (r1 \ "requirePorts").as[Boolean] should equal (DefaultRequirePorts)
@@ -100,7 +102,7 @@ class AppDefinitionFormatsTest
     r1.disk should equal (DefaultDisk)
     r1.executor should equal (DefaultExecutor)
     r1.constraints should equal (DefaultConstraints)
-    r1.uris should equal (DefaultUris)
+    r1.fetch should equal (DefaultFetch)
     r1.storeUrls should equal (DefaultStoreUrls)
     r1.ports should equal (DefaultPorts)
     r1.requirePorts should equal (DefaultRequirePorts)

--- a/src/test/scala/mesosphere/marathon/integration/setup/V2TestFormats.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/V2TestFormats.scala
@@ -65,7 +65,7 @@ object V2TestFormats {
       "disk" -> update.disk.map(_.toDouble),
       "executor" -> update.executor,
       "constraints" -> update.constraints,
-      "uris" -> update.uris,
+      "fetch" -> update.fetch,
       "storeUrls" -> update.storeUrls,
       "ports" -> update.ports,
       "requirePorts" -> update.requirePorts,


### PR DESCRIPTION
Few notes:

- there is new "fetch" field introduced in V2 API
- fetch field is serialized into CommandInfo.Uri (shared with "uris" field)
- when deserializing CommandInfo.Uri into AppDefinition both "uris" and "fetch" fields are populated
- when using V2AppDefinition, V2AppUpdate validation occurs that checks if only one of [fetch, uris]s fields are populated with data
- this change is backward-compatible, new field allows to pass known fetcher flags at the moment (executable, cached, extract)
- fetch uri is checked against known and supported protocols by the mesos fetcher (http(s), ftp(s), hdfs)