### PR TITLE
Fixes #2982 - synchronize service state methods of MarathonSchedulerS…

### DIFF
--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -371,6 +371,6 @@ class MarathonSchedulerServiceTest
     schedulerService.onElected(mock[ExceptionalCommand[Group.JoinException]])
 
     verify(candidate.get, Mockito.timeout(1000)).offerLeadership(schedulerService)
-    leader.get() should be (false)
+    leader.get() should be(false)
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/MarathonExceptionMapperTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/MarathonExceptionMapperTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.api
 
 import javax.validation.ConstraintViolationException
 
-import mesosphere.marathon.{ValidationFailedException, MarathonSpec}
+import mesosphere.marathon.{ ValidationFailedException, MarathonSpec }
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.v2.json.V2AppDefinition
 import mesosphere.marathon.api.v2.Validation._


### PR DESCRIPTION
…ervice

otherwise we might get abdication calls while we are still starting up.

MarathonSchedulerService should really be rewritten and broken up into
multiple classes.