### PR TITLE
Make sure to not match on every zk option.

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -66,7 +66,7 @@ function load_options_and_log {
   # Default zk and master option
   if [[ -s /etc/mesos/zk ]]
   then
-    if [[ "${cmd[@]} $@" != *'--zk'* ]]
+    if [[ "${cmd[@]} $@" != *'--zk '* ]]
     then
       cmd+=( --zk "$(cut -d / -f 1-3 /etc/mesos/zk)/marathon" )
     fi
@@ -106,7 +106,7 @@ function run_jar {
   # TODO: Set main class in pom.xml and use -jar
   if [ -n "${JAVA_HOME:=}" ]
     then
-      JAVA_BIN="$JAVA_HOME/bin/java" 
+      JAVA_BIN="$JAVA_HOME/bin/java"
     else
       JAVA_BIN="java"
   fi


### PR DESCRIPTION
The script allows for the passing of zk run commands as files under the
proper conf_dir. If an option like zk_timeout is changed with this
method, the wildcard will attempt to match that as the option to pass to
the --zk command. The extra space after the --zk line in this script
should only match if someone is actually passing that exact command.