### PR TITLE
Fixed #3003 - Consistent names for the TaskTracker interface

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -14,11 +14,11 @@ object EndpointsHelper {
     taskTracker: TaskTracker,
     apps: Seq[AppDefinition],
     delimiter: String): String = {
-    val tasksMap = taskTracker.list
+    val tasksMap = taskTracker.tasksByAppSync
 
     val sb = new StringBuilder
     for (app <- apps if app.ipAddress.isEmpty) {
-      val tasks = tasksMap.getTasks(app.id)
+      val tasks = tasksMap.appTasks(app.id)
       val cleanId = app.id.safePath
 
       val servicePorts = app.servicePorts

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -57,13 +57,13 @@ class TasksResource @Inject() (
       //scalastyle:on
       val statusSet = statuses.asScala.flatMap(toTaskState).toSet
 
-      val taskList = taskTracker.list
+      val taskList = taskTracker.tasksByAppSync
 
-      val tasks = taskList.appTasks.values.view.flatMap { app =>
+      val tasks = taskList.appTasksMap.values.view.flatMap { app =>
         app.tasks.view.map(t => app.appId -> t)
       }
 
-      val appIds = taskList.keySet
+      val appIds = taskList.allAppIdsWithTasks
 
       val appToPorts = appIds.map { appId =>
         appId -> service.getApp(appId).map(_.servicePorts).getOrElse(Nil)
@@ -135,7 +135,7 @@ class TasksResource @Inject() (
       }
 
       val taskByApps = taskToAppIds
-        .flatMap { case (taskId, appId) => taskTracker.getTask(appId, taskId) }
+        .flatMap { case (taskId, appId) => taskTracker.taskSync(appId, taskId) }
         .groupBy { x => taskIdUtil.appId(x.getId) }
         .map{ case (app, tasks) => app -> tasks.toSet }
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
@@ -106,7 +106,7 @@ private class AppTaskLauncherActor(
     log.info("Started appTaskLaunchActor for {} version {} with initial count {}",
       app.id, app.version, tasksToLaunch)
 
-    val runningTasks = taskTracker.getTasks(app.id)
+    val runningTasks = taskTracker.appTasksSync(app.id)
     tasksMap = runningTasks.map(task => task.getId -> task).toMap
 
     rateLimiterActor ! RateLimiterActor.GetDelay(app)

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/KillOverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/KillOverdueTasksActor.scala
@@ -47,7 +47,7 @@ private[jobs] object KillOverdueTasksActor {
       val stagedExpire = nowMillis - config.taskLaunchTimeout()
       val unconfirmedExpire = nowMillis - config.taskLaunchConfirmTimeout()
 
-      val toKill = taskTracker.list.tasks.filter { task =>
+      val toKill = taskTracker.tasksByAppSync.allTasks.filter { task =>
         /*
        * One would think that !hasStagedAt would be better for querying these tasks. However, the current implementation
        * of [[MarathonTasks.makeTask]] will set stagedAt to a non-zero value close to the current system time.

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskLoader.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskLoader.scala
@@ -5,8 +5,8 @@ import mesosphere.marathon.core.task.tracker.TaskTracker
 import scala.concurrent.Future
 
 /**
-  * Loads all task data into an [[TaskTracker.AppDataMap]].
+  * Loads all task data into an [[TaskTracker.TasksByApp]].
   */
 private[tracker] trait TaskLoader {
-  def loadTasks(): Future[TaskTracker.AppDataMap]
+  def loadTasks(): Future[TaskTracker.TasksByApp]
 }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskLoaderImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskLoaderImpl.scala
@@ -8,14 +8,14 @@ import org.slf4j.LoggerFactory
 import scala.concurrent.Future
 
 /**
-  * Loads all task data into an [[TaskTracker.AppDataMap]] from a [[TaskRepository]].
+  * Loads all task data into an [[TaskTracker.TasksByApp]] from a [[TaskRepository]].
   */
 private[tracker] class TaskLoaderImpl(repo: TaskRepository) extends TaskLoader {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   private[this] val log = LoggerFactory.getLogger(getClass.getName)
 
-  override def loadTasks(): Future[TaskTracker.AppDataMap] = {
+  override def loadTasks(): Future[TaskTracker.TasksByApp] = {
     for {
       names <- repo.allIds()
       _ = log.info(s"About to load ${names.size} tasks")
@@ -25,9 +25,9 @@ private[tracker] class TaskLoaderImpl(repo: TaskRepository) extends TaskLoader {
       val tasksByApp = tasks.groupBy(task => TaskIdUtil.appId(task.getId))
       val map = tasksByApp.iterator.map {
         case (appId, appTasks) =>
-          appId -> TaskTracker.App(appId, appTasks.map(task => task.getId -> task).toMap)
+          appId -> TaskTracker.AppTasks(appId, appTasks.map(task => task.getId -> task).toMap)
       }.toMap
-      TaskTracker.AppDataMap.of(map)
+      TaskTracker.TasksByApp.of(map)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
@@ -36,7 +36,7 @@ private[tracker] object TaskOpProcessorImpl {
     def resolve(
       appId: PathId, taskId: String, status: TaskStatus)(
         implicit ec: ExecutionContext): Future[Action] = {
-      directTaskTracker.getTaskAsync(appId, taskId).map {
+      directTaskTracker.task(appId, taskId).map {
         case Some(existingTask) =>
           resolveForExistingTask(existingTask, status)
         case None =>

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -52,7 +52,7 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     val taskId = status.getTaskId
     val appId = taskIdUtil.appId(taskId)
 
-    taskTracker.getTaskAsync(appId, taskId.getValue).flatMap {
+    taskTracker.task(appId, taskId.getValue).flatMap {
       case Some(task) =>
         processUpdate(
           timestamp = now,

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
@@ -63,7 +63,7 @@ class HealthCheckActor(
       app.version,
       healthCheck
     )
-    val activeTaskIds = taskTracker.getTasks(app.id).map(_.getId).toSet
+    val activeTaskIds = taskTracker.appTasksSync(app.id).map(_.getId).toSet
     // The Map built with filterKeys wraps the original map and contains a reference to activeTaskIds.
     // Therefore we materialize it into a new map.
     taskHealth = taskHealth.filterKeys(activeTaskIds).iterator.toMap
@@ -86,7 +86,7 @@ class HealthCheckActor(
 
   def dispatchJobs(): Unit = {
     log.debug("Dispatching health check jobs to workers")
-    taskTracker.getTasks(app.id).foreach { task =>
+    taskTracker.appTasksSync(app.id).foreach { task =>
       if (task.getVersion == app.version.toString && task.hasStartedAt) {
         log.debug("Dispatching health check job for task [{}]", task.getId)
         val worker: ActorRef = context.actorOf(workerProps)
@@ -143,7 +143,7 @@ class HealthCheckActor(
         case Healthy(_, _, _) =>
           health.update(result)
         case Unhealthy(_, _, _, _) =>
-          taskTracker.getTask(app.id, taskId) match {
+          taskTracker.taskSync(app.id, taskId) match {
             case Some(task) =>
               if (ignoreFailures(task, health)) {
                 // Don't update health

--- a/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
@@ -16,7 +16,7 @@ class AppStopActor(
     app: AppDefinition,
     val promise: Promise[Unit]) extends StoppingBehavior {
 
-  var idsToKill: mutable.Set[String] = taskTracker.getTasks(app.id).map(_.getId).to[mutable.Set]
+  var idsToKill: mutable.Set[String] = taskTracker.appTasksSync(app.id).map(_.getId).to[mutable.Set]
 
   def appId: PathId = app.id
 

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -116,7 +116,7 @@ private class DeploymentActor(
   }
 
   def scaleApp(app: AppDefinition, scaleTo: Int, toKill: Option[Iterable[MarathonTask]]): Future[Unit] = {
-    val runningTasks = taskTracker.getTasks(app.id)
+    val runningTasks = taskTracker.appTasksSync(app.id)
     def killToMeetConstraints(notSentencedAndRunning: Iterable[MarathonTask], toKillCount: Int) =
       Constraints.selectTasksToKill(app, notSentencedAndRunning, toKillCount)
 

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -75,7 +75,7 @@ trait StartingBehavior { this: Actor with ActorLogging =>
       taskQueue.add(app)
 
     case Sync =>
-      val actualSize = taskQueue.get(app.id).map(_.totalTaskCount).getOrElse(taskTracker.count(app.id))
+      val actualSize = taskQueue.get(app.id).map(_.totalTaskCount).getOrElse(taskTracker.countAppTasksSync(app.id))
       val tasksToStartNow = Math.max(scaleTo - actualSize, 0)
       if (tasksToStartNow > 0) {
         log.info(s"Reconciling tasks during app ${app.id.toString} scaling: queuing ${tasksToStartNow} new tasks")

--- a/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
@@ -50,7 +50,7 @@ trait StoppingBehavior extends Actor with ActorLogging {
       checkFinished()
 
     case SynchronizeTasks =>
-      val trackerIds = taskTracker.getTasks(appId).map(_.getId).toSet
+      val trackerIds = taskTracker.appTasksSync(appId).map(_.getId).toSet
       idsToKill = idsToKill.filter(trackerIds)
 
       idsToKill.foreach { id =>

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -24,7 +24,7 @@ class TaskReplaceActor(
     promise: Promise[Unit]) extends Actor with ActorLogging {
   import context.dispatcher
 
-  val tasksToKill = taskTracker.getTasks(app.id)
+  val tasksToKill = taskTracker.appTasksSync(app.id)
   val appId = app.id
   val version = app.version.toString
   var healthy = Set.empty[String]

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -20,7 +20,8 @@ class TaskStartActor(
     val scaleTo: Int,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
-  val nrToStart: Int = scaleTo - taskQueue.get(app.id).map(_.totalTaskCount).getOrElse(taskTracker.count(app.id))
+  val nrToStart: Int =
+    scaleTo - taskQueue.get(app.id).map(_.totalTaskCount).getOrElse(taskTracker.countAppTasksSync(app.id))
 
   override def initializeStart(): Unit = {
     if (nrToStart > 0)

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -35,7 +35,7 @@ class LaunchQueueModuleTest
 
   test("An added queue item is returned in list") {
     Given("a task queue with one item")
-    call(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    call(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     taskQueue.add(app)
 
     When("querying its contents")
@@ -47,12 +47,12 @@ class LaunchQueueModuleTest
     assert(list.head.tasksLeftToLaunch == 1)
     assert(list.head.tasksLaunchedOrRunning == 0)
     assert(list.head.taskLaunchesInFlight == 0)
-    verify(taskTracker).getTasks(app.id)
+    verify(taskTracker).appTasksSync(app.id)
   }
 
   test("An added queue item is reflected via count") {
     Given("a task queue with one item")
-    call(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    call(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     taskQueue.add(app)
 
     When("querying its count")
@@ -60,12 +60,12 @@ class LaunchQueueModuleTest
 
     Then("we get a count == 1")
     assert(count == 1)
-    verify(taskTracker).getTasks(app.id)
+    verify(taskTracker).appTasksSync(app.id)
   }
 
   test("A purged queue item has a count of 0") {
     Given("a task queue with one item which is purged")
-    call(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    call(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     taskQueue.add(app)
     taskQueue.purge(app.id)
 
@@ -74,12 +74,12 @@ class LaunchQueueModuleTest
 
     Then("we get a count == 0")
     assert(count == 0)
-    verify(taskTracker).getTasks(app.id)
+    verify(taskTracker).appTasksSync(app.id)
   }
 
   test("A re-added queue item has a count of 1") {
     Given("a task queue with one item which is purged")
-    call(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    call(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     taskQueue.add(app)
     taskQueue.purge(app.id)
     taskQueue.add(app)
@@ -89,12 +89,12 @@ class LaunchQueueModuleTest
 
     Then("we get a count == 1")
     assert(count == 1)
-    verify(taskTracker, times(2)).getTasks(app.id)
+    verify(taskTracker, times(2)).appTasksSync(app.id)
   }
 
   test("adding a queue item registers new offer matcher") {
     Given("An empty task tracker")
-    call(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    call(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
 
     When("Adding an app to the taskQueue")
     taskQueue.add(app)
@@ -103,12 +103,12 @@ class LaunchQueueModuleTest
     WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
       offerMatcherManager.offerMatchers.size == 1
     }
-    verify(taskTracker).getTasks(app.id)
+    verify(taskTracker).appTasksSync(app.id)
   }
 
   test("purging a queue item UNregisters offer matcher") {
     Given("An app in the queue")
-    call(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    call(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     taskQueue.add(app)
 
     When("The app is purged")
@@ -116,14 +116,14 @@ class LaunchQueueModuleTest
 
     Then("No offer matchers remain registered")
     assert(offerMatcherManager.offerMatchers.isEmpty)
-    verify(taskTracker).getTasks(app.id)
+    verify(taskTracker).appTasksSync(app.id)
   }
 
   test("an offer gets unsuccessfully matched against an item in the queue") {
     val offer = MarathonTestHelper.makeBasicOffer().build()
 
     Given("An app in the queue")
-    call(taskTracker.getTasks(app.id)).thenReturn(Map.empty[String, MarathonTask].values)
+    call(taskTracker.appTasksSync(app.id)).thenReturn(Map.empty[String, MarathonTask].values)
     taskQueue.add(app)
     WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
       offerMatcherManager.offerMatchers.size == 1
@@ -139,7 +139,7 @@ class LaunchQueueModuleTest
     assert(matchedTasks.offerId == offer.getId)
     assert(matchedTasks.tasks == Seq.empty)
 
-    verify(taskTracker).getTasks(app.id)
+    verify(taskTracker).appTasksSync(app.id)
   }
 
   test("an offer gets successfully matched against an item in the queue") {
@@ -150,7 +150,7 @@ class LaunchQueueModuleTest
     val createdTask = CreatedTask(mesosTask, marathonTask)
 
     Given("An app in the queue")
-    call(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    call(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     call(taskFactory.newTask(Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Some(createdTask))
     taskQueue.add(app)
     WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
@@ -166,7 +166,7 @@ class LaunchQueueModuleTest
     assert(matchedTasks.offerId == offer.getId)
     assert(matchedTasks.tasks.map(_.taskInfo) == Seq(mesosTask))
 
-    verify(taskTracker).getTasks(app.id)
+    verify(taskTracker).appTasksSync(app.id)
   }
 
   private[this] val app = MarathonTestHelper.makeBasicApp().copy(id = PathId("/app"))

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -62,11 +62,11 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     val tasks = Set(MarathonTask.newBuilder().setId("task_a").build())
 
     when(repo.allPathIds()).thenReturn(Future.successful(Seq(app.id)))
-    when(taskTracker.getTasks(app.id)).thenReturn(Set.empty[MarathonTask])
-    when(taskTracker.list).thenReturn(TaskTracker.AppDataMap.of(TaskTracker.App("nope".toPath, tasks)))
-    when(taskTracker.getTasks("nope".toPath)).thenReturn(tasks)
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Set.empty[MarathonTask])
+    when(taskTracker.tasksByAppSync).thenReturn(TaskTracker.TasksByApp.of(TaskTracker.AppTasks("nope".toPath, tasks)))
+    when(taskTracker.appTasksSync("nope".toPath)).thenReturn(tasks)
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(Some(app)))
-    when(taskTracker.count(app.id)).thenReturn(0)
+    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
 
     val schedulerActor = createActor()
     try {
@@ -90,11 +90,11 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     when(queue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts))
     when(repo.allPathIds()).thenReturn(Future.successful(Seq(app.id)))
-    when(taskTracker.getTasks(app.id)).thenReturn(Set.empty[MarathonTask])
-    when(taskTracker.list).thenReturn(TaskTracker.AppDataMap.of(TaskTracker.App("nope".toPath, tasks)))
-    when(taskTracker.getTasks("nope".toPath)).thenReturn(tasks)
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Set.empty[MarathonTask])
+    when(taskTracker.tasksByAppSync).thenReturn(TaskTracker.TasksByApp.of(TaskTracker.AppTasks("nope".toPath, tasks)))
+    when(taskTracker.appTasksSync("nope".toPath)).thenReturn(tasks)
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(Some(app)))
-    when(taskTracker.count(app.id)).thenReturn(0)
+    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
 
     val schedulerActor = createActor()
     try {
@@ -113,10 +113,10 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     when(queue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts))
     when(repo.allIds()).thenReturn(Future.successful(Seq(app.id.toString)))
-    when(taskTracker.getTasks(app.id)).thenReturn(Set.empty[MarathonTask])
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Set.empty[MarathonTask])
 
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(Some(app)))
-    when(taskTracker.count(app.id)).thenReturn(0)
+    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
 
     val schedulerActor = createActor()
     try {
@@ -138,15 +138,15 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     when(queue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts))
     when(repo.allIds()).thenReturn(Future.successful(Seq(app.id.toString)))
-    when(taskTracker.getTasks(app.id)).thenReturn(Set[MarathonTask](taskA))
-    when(taskTracker.getTask(app.id, taskA.getId))
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Set[MarathonTask](taskA))
+    when(taskTracker.taskSync(app.id, taskA.getId))
       .thenReturn(Some(taskA))
       .thenReturn(None)
 
     when(repo.currentVersion(app.id))
       .thenReturn(Future.successful(Some(app)))
       .thenReturn(Future.successful(Some(app.copy(instances = 0))))
-    when(taskTracker.count(app.id)).thenReturn(0)
+    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
     when(repo.store(any())).thenReturn(Future.successful(app))
 
     val statusUpdateEvent = MesosStatusUpdateEvent(
@@ -193,15 +193,15 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     when(queue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts))
     when(repo.allIds()).thenReturn(Future.successful(Seq(app.id.toString)))
-    when(taskTracker.getTasks(app.id)).thenReturn(Set[MarathonTask](taskA))
-    when(taskTracker.getTask(app.id, taskA.getId))
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Set[MarathonTask](taskA))
+    when(taskTracker.taskSync(app.id, taskA.getId))
       .thenReturn(Some(taskA))
       .thenReturn(None)
 
     when(repo.currentVersion(app.id))
       .thenReturn(Future.successful(Some(app)))
       .thenReturn(Future.successful(Some(app.copy(instances = 0))))
-    when(taskTracker.count(app.id)).thenReturn(0)
+    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
     when(repo.store(any())).thenReturn(Future.successful(app))
 
     val statusUpdateEvent = MesosStatusUpdateEvent(
@@ -285,7 +285,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(StopApplication(app)))), Timestamp.now())
 
-    when(taskTracker.getTasks(app.id)).thenReturn(Set(taskA))
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Set(taskA))
 
     when(driver.killTask(TaskID(taskA.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
@@ -332,7 +332,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     when(repo.store(any())).thenReturn(Future.successful(app))
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(None))
-    when(taskTracker.getTasks(app.id)).thenReturn(Set.empty[MarathonTask])
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Set.empty[MarathonTask])
     when(repo.expunge(app.id)).thenReturn(Future.successful(Nil))
 
     val schedulerActor = createActor()
@@ -411,7 +411,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     when(repo.store(any())).thenReturn(Future.successful(app))
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(None))
-    when(taskTracker.getTasks(app.id)).thenReturn(Set.empty[MarathonTask])
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Set.empty[MarathonTask])
     when(repo.expunge(app.id)).thenReturn(Future.successful(Nil))
 
     val schedulerActor = createActor()
@@ -439,7 +439,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     when(repo.store(any())).thenReturn(Future.successful(app))
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(None))
-    when(taskTracker.getTasks(app.id)).thenReturn(Set.empty[MarathonTask])
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Set.empty[MarathonTask])
     when(repo.expunge(app.id)).thenReturn(Future.successful(Nil))
 
     val schedulerActor = TestActorRef(
@@ -532,7 +532,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     when(repo.apps()).thenReturn(Future.successful(Nil))
     when(groupRepo.rootGroup()).thenReturn(Future.successful(None))
     when(queue.get(any[PathId])).thenReturn(None)
-    when(taskTracker.count(any[PathId])).thenReturn(0)
+    when(taskTracker.countAppTasksSync(any[PathId])).thenReturn(0)
   }
 
   def createActor() = {

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -37,7 +37,7 @@ class TaskKillerTest extends MarathonSpec
 
   test("AppNotFound") {
     val appId = PathId("invalid")
-    when(tracker.contains(appId)).thenReturn(false)
+    when(tracker.hasAppTasksSync(appId)).thenReturn(false)
 
     val result = taskKiller.kill(appId, (tasks) => Set.empty[MarathonTask])
     result.failed.futureValue shouldEqual UnknownAppException(appId)
@@ -45,7 +45,7 @@ class TaskKillerTest extends MarathonSpec
 
   test("AppNotFound with scaling") {
     val appId = PathId("invalid")
-    when(tracker.contains(appId)).thenReturn(false)
+    when(tracker.hasAppTasksSync(appId)).thenReturn(false)
 
     val result = taskKiller.killAndScale(appId, (tasks) => Set.empty[MarathonTask], force = true)
     result.failed.futureValue shouldEqual UnknownAppException(appId)
@@ -65,7 +65,7 @@ class TaskKillerTest extends MarathonSpec
     val tasksToKill = Set(task1, task2)
     val originalAppDefinition = AppDefinition(appId, instances = 23)
 
-    when(tracker.contains(appId)).thenReturn(true)
+    when(tracker.hasAppTasksSync(appId)).thenReturn(true)
     when(groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
 
     val groupUpdateCaptor = ArgumentCaptor.forClass(classOf[(Group) => Group])
@@ -89,7 +89,7 @@ class TaskKillerTest extends MarathonSpec
   test("KillRequested without scaling") {
     val appId = PathId(List("my", "app"))
     val tasksToKill = Set(MarathonTask.getDefaultInstance)
-    when(tracker.contains(appId)).thenReturn(true)
+    when(tracker.hasAppTasksSync(appId)).thenReturn(true)
 
     val result = taskKiller.kill(appId, (tasks) => tasksToKill)
     result.futureValue shouldEqual tasksToKill
@@ -110,7 +110,7 @@ class TaskKillerTest extends MarathonSpec
     )
     val tasksToKill = Set(task1, task2)
 
-    when(tracker.contains(appId)).thenReturn(true)
+    when(tracker.hasAppTasksSync(appId)).thenReturn(true)
     when(groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
     val groupUpdateCaptor = ArgumentCaptor.forClass(classOf[(Group) => Group])
     val forceCaptor = ArgumentCaptor.forClass(classOf[Boolean])

--- a/src/test/scala/mesosphere/marathon/api/v2/AppTasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppTasksResourceTest.scala
@@ -53,7 +53,7 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     val toKill = Set(task1)
 
     config.zkTimeoutDuration returns 5.seconds
-    taskTracker.getTasks(appId) returns Set(task1, task2)
+    taskTracker.appTasksSync(appId) returns Set(task1, task2)
     taskKiller.kill(any, any) returns Future.successful(toKill)
 
     val response = appsTaskResource.deleteOne(appId.root, task1.getId, scale = false, force = false, auth.request, auth.response)
@@ -80,7 +80,7 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     )
 
     config.zkTimeoutDuration returns 5.seconds
-    taskTracker.list returns TaskTracker.AppDataMap.of(TaskTracker.App(appId, Iterable(task1, task2)))
+    taskTracker.tasksByAppSync returns TaskTracker.TasksByApp.of(TaskTracker.AppTasks(appId, Iterable(task1, task2)))
     healthCheckManager.statuses(appId) returns Future.successful(
       collection.immutable.Map("" -> collection.immutable.Seq())
     )

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -44,8 +44,8 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     )
 
     config.zkTimeoutDuration returns 5.seconds
-    taskTracker.getTask(app1, taskId1) returns Some(task1)
-    taskTracker.getTask(app2, taskId2) returns Some(task2)
+    taskTracker.taskSync(app1, taskId1) returns Some(task1)
+    taskTracker.taskSync(app2, taskId2) returns Some(task2)
     taskKiller.kill(any, any) returns Future.successful(Set.empty[MarathonTask])
 
     When("we ask to kill both tasks")
@@ -87,8 +87,8 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     )
 
     config.zkTimeoutDuration returns 5.seconds
-    taskTracker.getTask(app1, taskId1) returns Some(task1)
-    taskTracker.getTask(app2, taskId2) returns Some(task2)
+    taskTracker.taskSync(app1, taskId1) returns Some(task1)
+    taskTracker.taskSync(app2, taskId2) returns Some(task2)
     taskKiller.killAndScale(any, any) returns Future.successful(deploymentPlan)
 
     When("we ask to kill both tasks")

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -125,7 +125,7 @@ class AppDefinitionFormatsTest
         |  }
         |}""".stripMargin).as[AppDefinition]
 
-    app.versionInfo shouldBe a [OnlyVersion]
+    app.versionInfo shouldBe a[OnlyVersion]
   }
 
   test("FromJSON should fail for empty id") {

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -72,8 +72,8 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
     val running3 = running1.toBuilder.setId("task3").buildPartial()
 
     import scala.concurrent.ExecutionContext.Implicits.global
-    f.taskTracker.listAsync()(global) returns
-      Future.successful(TaskTracker.AppDataMap.of(TaskTracker.App(app.id, Iterable(running1, running2, running3))))
+    f.taskTracker.tasksByApp()(global) returns
+      Future.successful(TaskTracker.TasksByApp.of(TaskTracker.AppTasks(app.id, Iterable(running1, running2, running3))))
 
     val alive = Health("task2", lastSuccess = Some(Timestamp(1)))
     val unhealthy = Health("task3", lastFailure = Some(Timestamp(1)))
@@ -103,7 +103,7 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
     )))
 
     And("the taskTracker should have been called")
-    verify(f.taskTracker, times(1)).listAsync()(global)
+    verify(f.taskTracker, times(1)).tasksByApp()(global)
 
     And("the healthCheckManager as well")
     verify(f.healthCheckManager, times(1)).statuses(app.id)
@@ -128,8 +128,8 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
     val running2 = running.toBuilder.setId("task3").buildPartial()
 
     import scala.concurrent.ExecutionContext.Implicits.global
-    f.taskTracker.listAsync()(global) returns
-      Future.successful(TaskTracker.AppDataMap.of(TaskTracker.App(app.id, Iterable(staged, running, running2))))
+    f.taskTracker.tasksByApp()(global) returns
+      Future.successful(TaskTracker.TasksByApp.of(TaskTracker.AppTasks(app.id, Iterable(staged, running, running2))))
 
     f.healthCheckManager.statuses(app.id) returns Future.successful(
       Map(
@@ -148,7 +148,7 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
     )))
 
     And("the taskTracker should have been called")
-    verify(f.taskTracker, times(1)).listAsync()(global)
+    verify(f.taskTracker, times(1)).tasksByApp()(global)
 
     And("the healthCheckManager as well")
     verify(f.healthCheckManager, times(1)).statuses(app.id)
@@ -262,8 +262,8 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
 
     import scala.concurrent.ExecutionContext.Implicits.global
     val tasks: Set[MarathonTask] = Set(staged, running, running2)
-    f.taskTracker.listAsync()(global) returns
-      Future.successful(TaskTracker.AppDataMap.of(TaskTracker.App(app.id, tasks)))
+    f.taskTracker.tasksByApp()(global) returns
+      Future.successful(TaskTracker.TasksByApp.of(TaskTracker.AppTasks(app.id, tasks)))
 
     val statuses: Map[String, Seq[Health]] = Map(
       "task1" -> Seq(),
@@ -292,7 +292,7 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
     }
 
     And("the taskTracker should have been called")
-    verify(f.taskTracker, times(1)).listAsync()(global)
+    verify(f.taskTracker, times(1)).tasksByApp()(global)
 
     And("the healthCheckManager as well")
     verify(f.healthCheckManager, times(1)).statuses(app.id)

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
@@ -39,7 +39,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
   import org.mockito.{ Matchers => m }
 
   test("Initial population of task list from taskTracker with one task") {
-    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable(marathonTask))
+    Mockito.when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable(marathonTask))
 
     val launcherRef = createLauncherRef(instances = 0)
     launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -52,12 +52,12 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.taskLaunchesInFlight == 0)
     assert(counts.tasksLeftToLaunch == 0)
 
-    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskTracker).appTasksSync(app.id)
   }
 
   test("Upgrading an app updates app definition in actor and requeries backoff") {
     Given("an entry for an app")
-    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable(marathonTask))
+    Mockito.when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable(marathonTask))
     val launcherRef = createLauncherRef(instances = 3)
     rateLimiterActor.expectMsg(RateLimiterActor.GetDelay(app))
     rateLimiterActor.reply(RateLimiterActor.DelayUpdate(app, clock.now()))
@@ -91,7 +91,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
 
   test("Upgrading an app updates reregisters the offerMatcher at the manager") {
     Given("an entry for an app")
-    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable(marathonTask))
+    Mockito.when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable(marathonTask))
     val launcherRef = createLauncherRef(instances = 1)
     rateLimiterActor.expectMsg(RateLimiterActor.GetDelay(app))
     rateLimiterActor.reply(RateLimiterActor.DelayUpdate(app, clock.now()))
@@ -120,7 +120,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
   }
 
   test("Process task launch") {
-    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    Mockito.when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     val offer = MarathonTestHelper.makeBasicOffer().build()
     Mockito.when(taskFactory.newTask(m.any(), m.any(), m.any())).thenReturn(Some(CreatedTask(task, marathonTask)))
 
@@ -137,12 +137,12 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.taskLaunchesInFlight == 1)
     assert(counts.tasksLeftToLaunch == 0)
 
-    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskTracker).appTasksSync(app.id)
     Mockito.verify(taskFactory).newTask(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
   }
 
   test("Wait for inflight task launches on stop") {
-    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    Mockito.when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     val offer = MarathonTestHelper.makeBasicOffer().build()
     Mockito.when(taskFactory.newTask(m.any(), m.any(), m.any())).thenReturn(Some(CreatedTask(task, marathonTask)))
 
@@ -160,12 +160,12 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     matched.tasks.foreach(_.reject("stuff"))
     testProbe.expectMsgClass(classOf[Terminated])
 
-    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskTracker).appTasksSync(app.id)
     Mockito.verify(taskFactory).newTask(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
   }
 
   test("Process task launch reject") {
-    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    Mockito.when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     val offer = MarathonTestHelper.makeBasicOffer().build()
     Mockito.when(taskFactory.newTask(m.any(), m.any(), m.any())).thenReturn(Some(CreatedTask(task, marathonTask)))
 
@@ -186,12 +186,12 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.taskLaunchesInFlight == 0)
     assert(counts.tasksLeftToLaunch == 1)
 
-    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskTracker).appTasksSync(app.id)
     Mockito.verify(taskFactory).newTask(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
   }
 
   test("Process task launch timeout") {
-    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    Mockito.when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     val offer = MarathonTestHelper.makeBasicOffer().build()
     Mockito.when(taskFactory.newTask(m.any(), m.any(), m.any())).thenReturn(Some(CreatedTask(task, marathonTask)))
 
@@ -227,12 +227,12 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
 
     assert(scheduleCalled)
 
-    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskTracker).appTasksSync(app.id)
     Mockito.verify(taskFactory).newTask(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
   }
 
   test("Process task launch accept") {
-    Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable.empty[MarathonTask])
+    Mockito.when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[MarathonTask])
     val offer = MarathonTestHelper.makeBasicOffer().build()
     Mockito.when(taskFactory.newTask(m.any(), m.any(), m.any())).thenReturn(Some(CreatedTask(task, marathonTask)))
 
@@ -252,7 +252,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.taskLaunchesInFlight == 0)
     assert(counts.tasksLeftToLaunch == 0)
 
-    Mockito.verify(taskTracker).getTasks(app.id)
+    Mockito.verify(taskTracker).appTasksSync(app.id)
     Mockito.verify(taskFactory).newTask(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
   }
 
@@ -265,7 +265,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     )
   ) {
     test(s"Remove terminated task (${update.wrapped.status.getClass.getSimpleName})") {
-      Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable(marathonTask))
+      Mockito.when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable(marathonTask))
 
       val launcherRef = createLauncherRef(instances = 0)
       launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -285,7 +285,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
       assert(counts.taskLaunchesInFlight == 0)
       assert(counts.tasksLeftToLaunch == 0)
 
-      Mockito.verify(taskTracker).getTasks(app.id)
+      Mockito.verify(taskTracker).appTasksSync(app.id)
     }
   }
 
@@ -305,7 +305,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
         .setOperator(Protos.Constraint.Operator.CLUSTER)
         .build()
       val appWithConstraints = app.copy(constraints = Set(constraint))
-      Mockito.when(taskTracker.getTasks(appWithConstraints.id)).thenReturn(Set(marathonTask))
+      Mockito.when(taskTracker.appTasksSync(appWithConstraints.id)).thenReturn(Set(marathonTask))
 
       val launcherRef = createLauncherRef(instances = 0, appToLaunch = appWithConstraints)
       launcherRef ! RateLimiterActor.DelayUpdate(appWithConstraints, clock.now())
@@ -320,7 +320,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
       Mockito.verify(offerReviver).reviveOffers()
 
       And("the task tracker as well")
-      Mockito.verify(taskTracker).getTasks(appWithConstraints.id)
+      Mockito.verify(taskTracker).appTasksSync(appWithConstraints.id)
     }
   }
 
@@ -331,7 +331,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     )
   ) {
     test(s"DO NOT REMOVE running task (${update.wrapped.status.getClass.getSimpleName})") {
-      Mockito.when(taskTracker.getTasks(app.id)).thenReturn(Iterable(marathonTask))
+      Mockito.when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable(marathonTask))
 
       val launcherRef = createLauncherRef(instances = 0)
       launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -351,7 +351,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
       assert(counts.taskLaunchesInFlight == 0)
       assert(counts.tasksLeftToLaunch == 0)
 
-      Mockito.verify(taskTracker).getTasks(app.id)
+      Mockito.verify(taskTracker).appTasksSync(app.id)
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/StatusUpdateActionResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/StatusUpdateActionResolverTest.scala
@@ -24,7 +24,7 @@ class StatusUpdateActionResolverTest
     Given("a taskID without task")
     val appId = PathId("/app")
     val taskId = "task1"
-    f.taskTracker.getTaskAsync(appId, taskId) returns Future.successful(None)
+    f.taskTracker.task(appId, taskId) returns Future.successful(None)
     And("a status update")
     val update = TaskStatus.getDefaultInstance
 
@@ -32,7 +32,7 @@ class StatusUpdateActionResolverTest
     val action = f.actionResolver.resolve(appId, taskId, update).futureValue
 
     Then("getTAskAsync is called")
-    verify(f.taskTracker).getTaskAsync(appId, taskId)
+    verify(f.taskTracker).task(appId, taskId)
 
     And("a fail action is returned")
     action.getClass should be(classOf[TaskOpProcessor.Action.Fail])

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskLoaderImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskLoaderImplTest.scala
@@ -24,7 +24,7 @@ class TaskLoaderImplTest
     verify(f.taskRepository).allIds()
 
     And("our data is empty")
-    loaded.futureValue.appTasks should be(empty)
+    loaded.futureValue.allTasks should be(empty)
 
     And("there are no more interactions")
     f.verifyNoMoreInteractions()
@@ -51,9 +51,9 @@ class TaskLoaderImplTest
 
     Then("the resulting data is correct")
     // we do not need to verify the mocked calls because the only way to get the data is to perform the calls
-    val appData1 = TaskTracker.App(app1Id, Map(app1task1.getId -> app1task1, app1task2.getId -> app1task2))
-    val appData2 = TaskTracker.App(app2Id, Map(app2task1.getId -> app2task1))
-    val expectedData = TaskTracker.AppDataMap.of(appData1, appData2)
+    val appData1 = TaskTracker.AppTasks(app1Id, Map(app1task1.getId -> app1task1, app1task2.getId -> app1task2))
+    val appData2 = TaskTracker.AppTasks(app2Id, Map(app2task1.getId -> app2task1))
+    val expectedData = TaskTracker.TasksByApp.of(appData1, appData2)
     loaded.futureValue should equal(expectedData)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActorTest.scala
@@ -41,7 +41,7 @@ class TaskTrackerActorTest
       override def updaterProps(trackerRef: ActorRef): Props = failProps
     }
     And("an empty task loader result")
-    f.taskLoader.loadTasks() returns Future.successful(TaskTracker.AppDataMap.empty)
+    f.taskLoader.loadTasks() returns Future.successful(TaskTracker.TasksByApp.empty)
 
     When("the task tracker actor gets a ForwardTaskOp")
     val deadline = Timestamp.zero // ignored
@@ -57,7 +57,7 @@ class TaskTrackerActorTest
   test("taskTrackerActor answers with loaded data (empty)") {
     val f = new Fixture
     Given("an empty task loader result")
-    val appDataMap = TaskTracker.AppDataMap.empty
+    val appDataMap = TaskTracker.TasksByApp.empty
     f.taskLoader.loadTasks() returns Future.successful(appDataMap)
 
     When("the task tracker actor gets a List query")
@@ -73,7 +73,7 @@ class TaskTrackerActorTest
     Given("an empty task loader result")
     val appId: PathId = PathId("/app")
     val task = MarathonTestHelper.dummyTask(appId)
-    val appDataMap = TaskTracker.AppDataMap.of(TaskTracker.App(appId, Map(task.getId -> task)))
+    val appDataMap = TaskTracker.TasksByApp.of(TaskTracker.AppTasks(appId, Map(task.getId -> task)))
     f.taskLoader.loadTasks() returns Future.successful(appDataMap)
 
     When("the task tracker actor gets a List query")
@@ -91,8 +91,8 @@ class TaskTrackerActorTest
     val stagedTask = MarathonTestHelper.stagedTask("staged")
     val runningTask1 = MarathonTestHelper.runningTask("running1")
     val runningTask2 = MarathonTestHelper.runningTask("running2")
-    val appDataMap = TaskTracker.AppDataMap.of(
-      TaskTracker.App(appId, Iterable(stagedTask, runningTask1, runningTask2))
+    val appDataMap = TaskTracker.TasksByApp.of(
+      TaskTracker.AppTasks(appId, Iterable(stagedTask, runningTask1, runningTask2))
     )
     f.taskLoader.loadTasks() returns Future.successful(appDataMap)
 
@@ -113,8 +113,8 @@ class TaskTrackerActorTest
     val stagedTask = MarathonTestHelper.stagedTask("staged")
     val runningTask1 = MarathonTestHelper.runningTask("running1")
     val runningTask2 = MarathonTestHelper.runningTask("running2")
-    val appDataMap = TaskTracker.AppDataMap.of(
-      TaskTracker.App(appId, Iterable(stagedTask, runningTask1, runningTask2))
+    val appDataMap = TaskTracker.TasksByApp.of(
+      TaskTracker.AppTasks(appId, Iterable(stagedTask, runningTask1, runningTask2))
     )
     f.taskLoader.loadTasks() returns Future.successful(appDataMap)
 
@@ -143,8 +143,8 @@ class TaskTrackerActorTest
     val stagedTask = MarathonTestHelper.stagedTask("stagedThenRunning")
     val runningTask1 = MarathonTestHelper.runningTask("running1")
     val runningTask2 = MarathonTestHelper.runningTask("running2")
-    val appDataMap = TaskTracker.AppDataMap.of(
-      TaskTracker.App(appId, Iterable(stagedTask, runningTask1, runningTask2))
+    val appDataMap = TaskTracker.TasksByApp.of(
+      TaskTracker.AppTasks(appId, Iterable(stagedTask, runningTask1, runningTask2))
     )
     f.taskLoader.loadTasks() returns Future.successful(appDataMap)
 
@@ -166,8 +166,8 @@ class TaskTrackerActorTest
     val stagedTask = MarathonTestHelper.stagedTask("staged")
     val runningTask1 = MarathonTestHelper.runningTask("running1")
     val runningTask2 = MarathonTestHelper.runningTask("running2")
-    val appDataMap = TaskTracker.AppDataMap.of(
-      TaskTracker.App(appId, Iterable(stagedTask, runningTask1, runningTask2))
+    val appDataMap = TaskTracker.TasksByApp.of(
+      TaskTracker.AppTasks(appId, Iterable(stagedTask, runningTask1, runningTask2))
     )
     f.taskLoader.loadTasks() returns Future.successful(appDataMap)
 

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -37,13 +37,13 @@ class TaskStatusUpdateProcessorImplTest
 
     Given("an unknown task")
     import scala.concurrent.ExecutionContext.Implicits.global
-    f.taskTracker.getTaskAsync(appId, update.wrapped.taskId.getValue)(global) returns Future.successful(None)
+    f.taskTracker.task(appId, update.wrapped.taskId.getValue)(global) returns Future.successful(None)
 
     When("we process the updated")
     f.updateProcessor.publish(status).futureValue
 
     Then("we expect that the appropriate taskTracker methods have been called")
-    verify(f.taskTracker).getTaskAsync(appId, update.wrapped.taskId.getValue)(global)
+    verify(f.taskTracker).task(appId, update.wrapped.taskId.getValue)(global)
 
     And("the task kill gets initiated")
     verify(f.schedulerDriver).killTask(status.getTaskId)
@@ -63,13 +63,13 @@ class TaskStatusUpdateProcessorImplTest
 
     Given("an unknown task")
     import scala.concurrent.ExecutionContext.Implicits.global
-    f.taskTracker.getTaskAsync(appId, update.wrapped.taskId.getValue)(global) returns Future.successful(None)
+    f.taskTracker.task(appId, update.wrapped.taskId.getValue)(global) returns Future.successful(None)
 
     When("we process the updated")
     f.updateProcessor.publish(status).futureValue
 
     Then("we expect that the appropriate taskTracker methods have been called")
-    verify(f.taskTracker).getTaskAsync(appId, update.wrapped.taskId.getValue)(global)
+    verify(f.taskTracker).task(appId, update.wrapped.taskId.getValue)(global)
 
     And("the update has been acknowledged")
     verify(f.schedulerDriver).acknowledgeStatusUpdate(status)
@@ -87,7 +87,7 @@ class TaskStatusUpdateProcessorImplTest
 
     Given("a known task")
     import scala.concurrent.ExecutionContext.Implicits.global
-    f.taskTracker.getTaskAsync(appId, update.wrapped.taskId.getValue) returns Future.successful(Some(marathonTask))
+    f.taskTracker.task(appId, update.wrapped.taskId.getValue) returns Future.successful(Some(marathonTask))
     f.taskUpdater.statusUpdate(appId, status).asInstanceOf[Future[Unit]] returns Future.successful(())
     f.appRepository.app(appId, version) returns Future.successful(Some(app))
     And("and a cooperative launchQueue")
@@ -97,7 +97,7 @@ class TaskStatusUpdateProcessorImplTest
     f.updateProcessor.publish(status).futureValue
 
     Then("we expect that the appropriate taskTracker methods have been called")
-    verify(f.taskTracker).getTaskAsync(appId, update.wrapped.taskId.getValue)
+    verify(f.taskTracker).task(appId, update.wrapped.taskId.getValue)
     verify(f.taskUpdater).statusUpdate(appId, status)
 
     And("the healthCheckManager got informed")

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckActorTest.scala
@@ -45,7 +45,7 @@ class HealthCheckActorTest
       .setVersion(appVersion)
       .build()
 
-    when(tracker.getTasks(appId)).thenReturn(Set(task))
+    when(tracker.appTasksSync(appId)).thenReturn(Set(task))
 
     val holder: MarathonSchedulerDriverHolder = new MarathonSchedulerDriverHolder
     val actor = TestActorRef[HealthCheckActor](

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
@@ -40,7 +40,7 @@ class AppStopActorTest
     val promise = Promise[Unit]()
     val tasks = Set(marathonTask("task_a"), marathonTask("task_b"))
 
-    when(taskTracker.getTasks(app.id)).thenReturn(tasks)
+    when(taskTracker.appTasksSync(app.id)).thenReturn(tasks)
 
     val ref = TestActorRef[AppStopActor](
       Props(
@@ -103,7 +103,7 @@ class AppStopActorTest
     val app = AppDefinition(id = PathId("app"), instances = 2)
     val promise = Promise[Unit]()
 
-    when(taskTracker.getTasks(app.id)).thenReturn(Set.empty[MarathonTask])
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Set.empty[MarathonTask])
 
     val ref = TestActorRef[AppStopActor](
       Props(
@@ -128,7 +128,7 @@ class AppStopActorTest
     val promise = Promise[Unit]()
     val tasks = Set(marathonTask("task_a"), marathonTask("task_b"))
 
-    when(taskTracker.getTasks(app.id)).thenReturn(tasks)
+    when(taskTracker.appTasksSync(app.id)).thenReturn(tasks)
 
     val ref = TestActorRef[AppStopActor](
       Props(
@@ -157,7 +157,7 @@ class AppStopActorTest
     val promise = Promise[Unit]()
     val tasks = Set(marathonTask("task_a"), marathonTask("task_b"))
 
-    when(taskTracker.getTasks(app.id))
+    when(taskTracker.appTasksSync(app.id))
       .thenReturn(tasks)
       .thenReturn(Set.empty[MarathonTask])
 

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -79,10 +79,10 @@ class DeploymentActorTest
 
     val plan = DeploymentPlan(origGroup, targetGroup)
 
-    when(tracker.getTasks(app1.id)).thenReturn(Set(task1_1, task1_2))
-    when(tracker.getTasks(app2.id)).thenReturn(Set(task2_1))
-    when(tracker.getTasks(app3.id)).thenReturn(Set(task3_1))
-    when(tracker.getTasks(app4.id)).thenReturn(Set(task4_1))
+    when(tracker.appTasksSync(app1.id)).thenReturn(Set(task1_1, task1_2))
+    when(tracker.appTasksSync(app2.id)).thenReturn(Set(task2_1))
+    when(tracker.appTasksSync(app3.id)).thenReturn(Set(task3_1))
+    when(tracker.appTasksSync(app4.id)).thenReturn(Set(task4_1))
 
     when(driver.killTask(TaskID(task1_2.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
@@ -187,7 +187,7 @@ class DeploymentActorTest
     val task1_1 = MarathonTasks.makeTask("task1_1", "", Nil, Nil, app.version, Timestamp.now(), slaveId).toBuilder.setStartedAt(0).build()
     val task1_2 = MarathonTasks.makeTask("task1_2", "", Nil, Nil, app.version, Timestamp.now(), slaveId).toBuilder.setStartedAt(1000).build()
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(task1_1, task1_2))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(task1_1, task1_2))
 
     val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
@@ -260,7 +260,7 @@ class DeploymentActorTest
 
     val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
-    when(tracker.getTasks(app.id)).thenReturn(Set[MarathonTask]())
+    when(tracker.appTasksSync(app.id)).thenReturn(Set[MarathonTask]())
 
     try {
       TestActorRef(
@@ -304,7 +304,7 @@ class DeploymentActorTest
 
     val plan = DeploymentPlan(original = origGroup, target = targetGroup, toKill = Map(app1.id -> Set(task1_2)))
 
-    when(tracker.getTasks(app1.id)).thenReturn(Set(task1_1, task1_2, task1_3))
+    when(tracker.appTasksSync(app1.id)).thenReturn(Set(task1_1, task1_2, task1_3))
 
     when(driver.killTask(TaskID(task1_2.getId))).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
@@ -97,7 +97,7 @@ class TaskKillActorTest
     val taskB = MarathonTask.newBuilder().setId("taskB_id").build()
     val tasks = mutable.Set(taskA, taskB)
 
-    when(taskTracker.getTasks(app.id))
+    when(taskTracker.appTasksSync(app.id))
       .thenReturn(Set.empty[MarathonTask])
 
     val ref = TestActorRef[TaskKillActor](Props(classOf[TaskKillActor], driver, app.id, taskTracker, system.eventStream, tasks.toSet, promise))
@@ -122,7 +122,7 @@ class TaskKillActorTest
 
     val ref = TestActorRef[TaskKillActor](Props(classOf[TaskKillActor], driver, appId, taskTracker, system.eventStream, tasks, promise))
 
-    when(taskTracker.getTasks(appId)).thenReturn(Set(taskA, taskB))
+    when(taskTracker.appTasksSync(appId)).thenReturn(Set(taskA, taskB))
 
     watch(ref)
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -41,7 +41,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(taskA, taskB))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -88,7 +88,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(taskA, taskB))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -131,7 +131,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -185,7 +185,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       override def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -255,7 +255,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -329,7 +329,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -401,7 +401,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -464,7 +464,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(taskA, taskB))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB))
 
     val promise = Promise[Unit]()
 
@@ -496,7 +496,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(taskA, taskB))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       var firstKillForTaskB = true
 
@@ -549,7 +549,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.getTasks(app.id)).thenReturn(Set(taskA, taskB))
+    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB))
 
     val promise = Promise[Unit]()
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -341,7 +341,7 @@ class TaskStartActorTest
     // let existing task die
     // doesn't work because it needs Zookeeper: taskTracker.terminated(app.id, taskStatus)
     // we mock instead
-    when(taskTracker.count(app.id)).thenReturn(0)
+    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
     when(launchQueue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLeftToLaunch = 4)))
     system.eventStream.publish(MesosStatusUpdateEvent("", "", "TASK_ERROR", "", app.id, "", Nil, Nil, task.getVersion))
 
@@ -355,7 +355,7 @@ class TaskStartActorTest
 
     // launch 4 of the tasks
     when(launchQueue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLeftToLaunch = app.instances)))
-    when(taskTracker.count(app.id)).thenReturn(4)
+    when(taskTracker.countAppTasksSync(app.id)).thenReturn(4)
     List(0, 1, 2, 3) foreach { i =>
       system.eventStream.publish(MesosStatusUpdateEvent("", s"task-$i", "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
     }


### PR DESCRIPTION
I used mostly IntelliJs renaming feature and then organize imports.
In some cases I had to change names manually.