### PR TITLE
Fixes #2855 - app creation failing, if path contains same name multiple times

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -106,13 +106,11 @@ case class Group(
   def removeApplication(appId: PathId): Group = copy(apps = apps.filter(_.id != appId))
 
   def makeGroup(gid: PathId): Group = {
-    val restPath = gid.restOf(id)
-    if (gid.isEmpty || restPath.isEmpty) this //group already exists
+    if (gid.isEmpty) this //group already exists
     else {
-      val (change, remaining) = groups.partition(_.id.restOf(id).root == restPath.root)
-      val toUpdate = change.headOption.getOrElse(Group.empty.copy(id = id.append(restPath.rootPath)))
-      val nestedUpdate = if (restPath.isEmpty) toUpdate else toUpdate.makeGroup(restPath.child)
-      this.copy(groups = remaining + nestedUpdate)
+      val (change, remaining) = groups.partition(_.id.restOf(id).root == gid.root)
+      val toUpdate = change.headOption.getOrElse(Group.empty.copy(id = id.append(gid.rootPath)))
+      this.copy(groups = remaining + toUpdate.makeGroup(gid.child))
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -125,7 +125,7 @@ class AppDefinitionFormatsTest
         |  }
         |}""".stripMargin).as[AppDefinition]
 
-    app.versionInfo shouldBe a [OnlyVersion]
+    app.versionInfo shouldBe a[OnlyVersion]
   }
 
   test("FromJSON should fail for empty id") {


### PR DESCRIPTION
Check for rest of a path seems not necessary at this point. The recursive function `makeGroup` receives a `gid` which is already rest of the path. Fixes #2855.
@aquamatthias Could you have a look if I am right with my conclusion? I ran all test locally and they are ok.