### PR TITLE
Fixes #2938 - do not log giant port lists

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
@@ -244,9 +244,12 @@ private class OfferMatcherManagerActor private (
     data.sender ! OfferMatcher.MatchedTasks(data.offer.getId, data.tasks, resendThisOffer)
     offerQueues -= data.offer.getId
     metrics.currentOffersGauge.setValue(offerQueues.size)
+    //scalastyle:off magic.number
+    val maxRanges = if (log.isDebugEnabled) 1000 else 10
+    //scalastyle:on magic.number
     log.info(s"Finished processing ${data.offer.getId.getValue}. " +
       s"Matched ${data.tasks.size} tasks after ${data.matchPasses} passes. " +
-      s"${ResourceUtil.displayResources(data.offer.getResourcesList.asScala)} left.")
+      s"${ResourceUtil.displayResources(data.offer.getResourcesList.asScala, maxRanges)} left.")
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/tasks/ResourceUtil.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/ResourceUtil.scala
@@ -151,18 +151,27 @@ object ResourceUtil {
     }
   }
 
-  def displayResource(resource: Resource): String = resource.getType match {
-    case Value.Type.SCALAR => s"${resource.getName} ${resource.getScalar.getValue}"
-    case Value.Type.RANGES =>
-      s"${resource.getName} ${
-        resource.getRanges.getRangeList.asScala.map {
-          range => s"${range.getBegin}->${range.getEnd}"
-        }.mkString(",")
-      }"
-    case other: Value.Type => resource.toString
+
+  def displayResource(resource: Resource, maxRanges: Int): String = {
+    def rangesToString(ranges: Seq[Value.Range]): String = {
+      ranges.map { range => s"${range.getBegin}->${range.getEnd}" }.mkString(",")
+    }
+
+    resource.getType match {
+      case Value.Type.SCALAR => s"${resource.getName} ${resource.getScalar.getValue}"
+      case Value.Type.RANGES =>
+        s"${resource.getName} ${
+          val ranges = resource.getRanges.getRangeList.asScala
+          if (ranges.size > maxRanges)
+            s"${rangesToString(ranges.take(maxRanges))} ... (${ranges.size - maxRanges} more)"
+          else
+            rangesToString(ranges)
+        }"
+      case other: Value.Type => resource.toString
+    }
   }
 
-  def displayResources(resources: Iterable[Resource]): String = {
-    resources.map(displayResource).mkString("; ")
+  def displayResources(resources: Iterable[Resource], maxRanges: Int): String = {
+    resources.map(displayResource(_, maxRanges)).mkString("; ")
   }
 }

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -86,6 +86,34 @@ trait MarathonTestHelper {
     offerBuilder
   }
 
+  /**
+    * @param ranges how many port ranges should be included in this offer
+    * @return
+    */
+  def makeBasicOfferWithManyPortRanges(ranges: Int): Offer.Builder = {
+    val role = "*"
+    val cpusResource = ScalarResource(Resource.CPUS, 4.0, role = role)
+    val memResource = ScalarResource(Resource.MEM, 16000, role = role)
+    val diskResource = ScalarResource(Resource.DISK, 1.0, role = role)
+    val portsResource = RangesResource(
+      Resource.PORTS,
+      List.tabulate(ranges)(_ * 2 + 1).map(p => Range(p.toLong, (p + 1).toLong)),
+      role
+    )
+
+    val offerBuilder = Offer.newBuilder
+      .setId(OfferID("1"))
+      .setFrameworkId(FrameworkID("marathon"))
+      .setSlaveId(SlaveID("slave0"))
+      .setHostname("localhost")
+      .addResources(cpusResource)
+      .addResources(memResource)
+      .addResources(diskResource)
+      .addResources(portsResource)
+
+    offerBuilder
+  }
+
   def makeBasicOfferWithRole(cpus: Double, mem: Double, disk: Double,
                              beginPort: Int, endPort: Int, role: String) = {
     val portsResource = RangesResource(

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -9,6 +9,7 @@ import mesosphere.marathon.core.matcher.base.OfferMatcher.{ MatchedTasks, TaskLa
 import mesosphere.marathon.core.matcher.manager.{ OfferMatcherManagerConfig, OfferMatcherManagerModule }
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.Timestamp
+import mesosphere.marathon.tasks.ResourceUtil
 import mesosphere.marathon.test.MarathonShutdownHookSupport
 import org.apache.mesos.Protos.{ Offer, TaskInfo }
 import org.scalatest.{ BeforeAndAfter, FunSuite }
@@ -17,6 +18,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 import scala.util.Random
+import scala.collection.JavaConverters._
 
 class OfferMatcherManagerModuleTest extends FunSuite with BeforeAndAfter with MarathonShutdownHookSupport {
 
@@ -115,6 +117,14 @@ class OfferMatcherManagerModuleTest extends FunSuite with BeforeAndAfter with Ma
       makeOneCPUTask("task2_1"),
       makeOneCPUTask("task2_2")
     ))
+  }
+
+  test("ports of an offer should be displayed in a short notation if they exceed a certain quantity") {
+    //scalastyle:off magic.number
+    val offer: Offer = MarathonTestHelper.makeBasicOfferWithManyPortRanges(100).build()
+    //scalastyle:on magic.number
+    val resources = ResourceUtil.displayResources(offer.getResourcesList.asScala, 10)
+    assert(resources.contains("ports 1->2,3->4,5->6,7->8,9->10,11->12,13->14,15->16,17->18,19->20 ... (90 more)"))
   }
 
   def makeOneCPUTask(idBase: String) = {


### PR DESCRIPTION
Introducing new short notation for logging offers, which include a lot of ranges.

@aquamatthias This time, I created a test for checking the application of short notation in `OfferMatcherManagerModuleTest`. Let me know if the test is not needed in that case.