### PR TITLE
Bump docs version to 0.14

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -35,8 +35,8 @@ Marathon packages are available from Mesosphere's [repositories](http://mesosphe
 Download and unpack the latest Marathon release.
 
 ``` bash
-$ curl -O http://downloads.mesosphere.com/marathon/v0.13.0/marathon-0.13.0.tgz
-$ tar xzf marathon-0.13.0.tgz
+$ curl -O http://downloads.mesosphere.com/marathon/v0.14.0/marathon-0.14.0.tgz
+$ tar xzf marathon-0.14.0.tgz
 ```
 
 SHA-256 checksums are available by appending `.sha256` to the URLs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,18 +8,18 @@ title: A cluster-wide init and control system for services in cgroups or Docker 
     A cluster-wide init and control system for services in cgroups or Docker containers
   </p>
   <p>
-    <a href="http://downloads.mesosphere.com/marathon/v0.13.0/marathon-0.13.0.tgz"
+    <a href="http://downloads.mesosphere.com/marathon/v0.14.0/marathon-0.14.0.tgz"
         class="btn btn-lg btn-primary">
-      Download Marathon v0.13.0
+      Download Marathon v0.14.0
     </a>
   </p>
   <a class="btn btn-link"
-      href="http://downloads.mesosphere.com/marathon/v0.13.0/marathon-0.13.0.tgz.sha256">
-    v0.13.0 SHA-256 Checksum
+      href="http://downloads.mesosphere.com/marathon/v0.14.0/marathon-0.14.0.tgz.sha256">
+    v0.14.0 SHA-256 Checksum
   </a> &middot;
   <a class="btn btn-link"
-      href="https://github.com/mesosphere/marathon/releases/tag/v0.13.0">
-    v0.13.0 Release Notes
+      href="https://github.com/mesosphere/marathon/releases/tag/v0.14.0">
+    v0.14.0 Release Notes
   </a>
 </div>
 


### PR DESCRIPTION
Updates the github documentation to v0.14 to reflect the recent release. 