### PR TITLE
Fixes #1336 - Add support for ZK authentication

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -104,6 +104,8 @@ The core functionality flags can be also set by environment variable `MARATHON_O
     Additional callback URLs may also be set dynamically via the REST API.
 * `--zk` (Optional. Default: None): ZooKeeper URL for storing state.
     Format: `zk://host1:port1,host2:port2,.../path`
+    - <span class="label label-default">v0.15.4</span> Format: `zk://user@pass:host1:port1,user@pass:host2:port2,.../path`.
+    When authentication is enabled the default ACL will be changed and all subsequent reads must be done using the same auth.
 * `--zk_max_versions` (Optional. Default: None): Limit the number of versions
     stored for one entity.
 * `--zk_timeout` (Optional. Default: 10000 (10 seconds)): Timeout for ZooKeeper

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,6 +11,10 @@
         <appender-ref ref="stdout" />
         <queueSize>1024</queueSize>
     </appender>
+
+    <!-- Don't log ZooKeeper AuthInfo from com.twitter.zk.NativeConnector -->
+    <logger name="native-zk-connector" level="WARN" />
+
     <root level="INFO">
         <appender-ref ref="async"/>
     </root>

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -24,10 +24,15 @@ class MarathonApp extends App {
       "ZooKeeper timeout too large!"
     )
 
-    val client = new ZooKeeperClient(
-      Amount.of(conf.zooKeeperSessionTimeout().toInt, Time.MILLISECONDS),
-      conf.zooKeeperHostAddresses.asJavaCollection
-    )
+    val sessionTimeout = Amount.of(conf.zooKeeperSessionTimeout().toInt, Time.MILLISECONDS)
+    val zooKeeperServers = conf.zooKeeperHostAddresses.asJavaCollection
+    val client = (conf.zkUsername, conf.zkPassword) match {
+      case (Some(user), Some(pass)) =>
+        new ZooKeeperClient(sessionTimeout, ZooKeeperClient.digestCredentials(user, pass), zooKeeperServers)
+
+      case _ =>
+        new ZooKeeperClient(sessionTimeout, zooKeeperServers)
+    }
 
     // Marathon can't do anything useful without a ZK connection
     // so we wait to proceed until one is available

--- a/src/test/scala/mesosphere/marathon/ZookeeperConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/ZookeeperConfTest.scala
@@ -1,5 +1,6 @@
 package mesosphere.marathon
 
+import org.apache.zookeeper.ZooDefs
 import org.rogach.scallop.ScallopConf
 import scala.util.Try
 
@@ -11,6 +12,9 @@ class ZookeeperConfTest extends MarathonSpec {
     assert(opts.zkURL == url)
     assert(opts.zkHosts == "host1:123,host2,host3:312")
     assert(opts.zkPath == "/path")
+    assert(opts.zkUsername.isEmpty)
+    assert(opts.zkPassword.isEmpty)
+    assert(opts.zkDefaultCreationACL == ZooDefs.Ids.OPEN_ACL_UNSAFE)
   }
 
   test("urlParameterWithAuthGetParsed") {
@@ -19,11 +23,16 @@ class ZookeeperConfTest extends MarathonSpec {
     assert(opts.zkURL == url)
     assert(opts.zkHosts == "host1:123,host2,host3:312")
     assert(opts.zkPath == "/path")
+    assert(opts.zkUsername == Some("user1"))
+    assert(opts.zkPassword == Some("pass1"))
+    assert(opts.zkDefaultCreationACL == ZooDefs.Ids.CREATOR_ALL_ACL)
   }
 
   test("wrongURLIsNotParsed") {
     assert(Try(conf("--zk", "zk://host1:foo/path")).isFailure, "No port number")
     assert(Try(conf("--zk", "zk://host1")).isFailure, "No path")
+    assert(Try(conf("--zk", "zk://user@host1:2181/path")).isFailure, "No password")
+    assert(Try(conf("--zk", "zk://:pass@host1:2181/path")).isFailure, "No username")
   }
 
   def conf(args: String*) = {


### PR DESCRIPTION
Hi!

This PR is an attempt to add support for ZooKeeper authentication to Marathon. Just specify user and password to enabled it: `--zk zk://user:password@localhost:2181/marathon`. The auth is used for both `/state` and `/leader`.

When authentication is enabled the default ACL will be changed to `CREATOR_ALL_ACL` and all subsequent reads must be done using the same auth.