### PR TITLE
Enable http based plugin extensions

### DIFF
--- a/docs/docs/plugin.md
+++ b/docs/docs/plugin.md
@@ -7,7 +7,8 @@ title: Extend Marathon with Plugins
 
 <div class="alert alert-danger" role="alert">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> Available in Marathon Version 0.12+ <br/>
-  The Marathon plugin functionality is considered alpha, so use this feature at you own risk. We might add, change, or delete any functionality described in this document.  
+  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> Adapted in Marathon Version 0.16 <br/>
+  The Marathon plugin functionality is considered beta, so use this feature at you own risk. We might add, change, or delete any functionality described in this document.  
 </div>
 
 ## Overview
@@ -104,17 +105,27 @@ You can also extend Marathon with a set of several plugins.
 You must provide a plugin descriptor to make sure you are using only valid combinations of plugins.
 The descriptor defines which plugin interface is extended by which service provider.
 Marathon will load this descriptor with all defined plugins during startup.
+
+- plugin (required): the name of the plugin interface 
+- implementation (required): the name of the implementing class
+- configuration (optional): configuration that is available to the plugin via the PluginConfiguration trait.
+- tags (optional): meta data attached to this plugin as simple strings
+- info (optional): meta data attached to this plugin as key/value pair
  
 Example:
 
 ```json
 {
-  "plugins": [
-    {
+  "plugins": {
+    "authorizer": {
       "plugin": "mesosphere.marathon.plugin.auth.Authorizer",
-      "implementation": "my.company.ExampleAuthorizer"
+      "implementation": "my.company.ExampleAuthorizer",
+      "tags": ["some", "tag"],
+      "info": {
+        "some": "info"
+      }
     },
-    {
+    "authenticator": {
       "plugin": "mesosphere.marathon.plugin.auth.Authenticator",
       "implementation": "my.company.ExampleAuthenticator",
       "configuration": {
@@ -129,7 +140,7 @@ Example:
         ]
       }
     }
-  ]
+  }
 }
 ```
 

--- a/docs/docs/rest-api/public/api/api.raml
+++ b/docs/docs/rest-api/public/api/api.raml
@@ -28,6 +28,7 @@ traits: !include traits.raml
 /v2/eventSubscriptions: !include v2/eventSubscriptions.raml
 /v2/info: !include v2/info.raml
 /v2/leader: !include v2/leader.raml
+/v2/plugins: !include v2/plugins.raml
 /v2/queue: !include v2/queue.raml
 
 # no real API endpoints

--- a/docs/docs/rest-api/public/api/v2/plugins.raml
+++ b/docs/docs/rest-api/public/api/v2/plugins.raml
@@ -1,0 +1,34 @@
+
+get:
+  description: Returns the list of all loaded plugins
+  responses:
+    200:
+      description: The list of all loaded plugins
+      body:
+        application/json:
+          example: |
+            {
+                "plugins": [
+                    {
+                        "id": "webjar",
+                        "implementation": "mesosphere.marathon.example.plugin.http.WebJarHandler",
+                        "info": {
+                            "version": "1.2.3",
+                            "array": [ 1, 2, 3, 4, 5, 6 ],
+                            "test": true
+                        },
+                        "plugin": "mesosphere.marathon.plugin.http.HttpRequestHandler",
+                        "tags": [ "webjar", "test" ]
+                    }
+                ]
+            }
+
+/{plugin_id}/{path}:
+  get:
+    description: Get request is handled by the plugin.
+  put:
+    description: Put request is handled by the plugin.
+  post:
+    description: Post request is handled by the plugin.
+  delete:
+    description: Delete request is handled by the plugin.

--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/http/HttpRequest.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/http/HttpRequest.scala
@@ -6,6 +6,12 @@ package mesosphere.marathon.plugin.http
 trait HttpRequest {
 
   /**
+    * Returns the name of the HTTP method with which this request was made.
+    * For example, GET, POST, or PUT.
+    */
+  def method: String
+
+  /**
     * Get the header values for given header name
     * @param name the name of the header
     * @return the seq of values

--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/http/HttpRequestHandler.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/http/HttpRequestHandler.scala
@@ -1,0 +1,17 @@
+package mesosphere.marathon.plugin.http
+
+import mesosphere.marathon.plugin.plugin.Plugin
+
+/**
+  * A HttpRequestHandler plugin extends Marathon by handling HTTP Requests and provifing HTTP Responses.
+  */
+trait HttpRequestHandler extends Plugin {
+
+  /**
+    * Serve a http request and fill the response.
+    * @param request the request object.
+    * @param response the response object to fill.
+    */
+  def serve(request: HttpRequest, response: HttpResponse): Unit
+
+}

--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/http/HttpRequestHandlerBase.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/http/HttpRequestHandlerBase.scala
@@ -1,0 +1,38 @@
+package mesosphere.marathon.plugin.http
+
+import java.net.{ URL, URLConnection }
+import com.google.common.io.Resources
+
+/**
+  * The HttpRequestHandlerBase extends the HttpRequestHandler by
+  * providing functionality to serve content packaged as resource.
+  */
+//scalastyle:off magic.number
+abstract class HttpRequestHandlerBase extends HttpRequestHandler {
+
+  protected[this] def serveResource(path: String, response: HttpResponse): Unit = {
+    val content = withResource(path) { url =>
+      response.body(mediaMime(url), Resources.toByteArray(url))
+      response.status(200)
+    }
+    content.getOrElse(response.status(404))
+  }
+
+  protected[this] def withResource[T](path: String)(fn: URL => T): Option[T] = {
+    Option(getClass.getResource(path)).map(fn)
+  }
+
+  protected[this] def mediaMime(url: URL): String = {
+    url.getPath.split("\\.").lastOption.flatMap(wellKnownMimes.get)
+      .orElse(Option(URLConnection.guessContentTypeFromName(url.toString)))
+      .getOrElse("application/octet-stream")
+  }
+
+  protected[this] val wellKnownMimes = Map (
+    "css" -> "text/css",
+    "js" -> "application/javascript",
+    "eot" -> "application/vnd.ms-fontobject",
+    "svg" -> "image/svg+xml",
+    "ttf" -> "application/font-ttf"
+  )
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -232,7 +232,8 @@ object Dependencies {
   import Dependency._
 
   val pluginInterface = Seq(
-    playJson % "compile"
+    playJson % "compile",
+    guava % "compile"
   )
 
   val excludeSlf4jLog4j12 = ExclusionRule(organization = "org.slf4j", name = "slf4j-log4j12")
@@ -282,6 +283,7 @@ object Dependency {
   object V {
     // runtime deps versions
     val Chaos = "0.8.4"
+    val Guava = "18.0"
     val JacksonCCM = "0.1.2"
     val MesosUtils = "0.26.0"
     val Akka = "2.3.9"
@@ -321,6 +323,7 @@ object Dependency {
   val sprayHttpx = "io.spray" %% "spray-httpx" % V.Spray
   val playJson = "com.typesafe.play" %% "play-json" % V.PlayJson
   val chaos = "mesosphere" %% "chaos" % V.Chaos exclude("org.glassfish.web", "javax.el")
+  val guava = "com.google.guava" % "guava" % V.Guava
   val mesosUtils = "mesosphere" %% "mesos-utils" % V.MesosUtils
   val jacksonCaseClass = "mesosphere" %% "jackson-case-class-module" % V.JacksonCCM
   val jerseyServlet =  "com.sun.jersey" % "jersey-servlet" % V.Jersey

--- a/src/main/scala/mesosphere/marathon/api/AuthResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/AuthResource.scala
@@ -1,15 +1,11 @@
 package mesosphere.marathon.api
 
-import java.net.URI
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
-import javax.ws.rs.core.Response.Status
-import javax.ws.rs.core.{ NewCookie, Response }
+import javax.ws.rs.core.Response
 
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.plugin.http.{ HttpRequest, HttpResponse }
+import mesosphere.marathon.plugin.http.HttpResponse
 import mesosphere.marathon.state.PathId
-
-import scala.collection.JavaConverters._
 
 /**
   * Base trait for authentication and authorization in http resource endpoints.
@@ -51,38 +47,6 @@ trait AuthResource extends RestResource {
 
   def isAllowedToView(pathId: PathId)(implicit identity: Identity): Boolean = {
     authorizer.isAuthorized(identity, ViewAppOrGroup, pathId)
-  }
-
-  private class RequestFacade(request: HttpServletRequest) extends HttpRequest {
-    // Jersey will not allow calls to the request object from another thread
-    // To circumvent that, we have to copy all data during creation
-    val headers = request.getHeaderNames.asScala.map(header => header -> request.getHeaders(header).asScala.toSeq).toMap
-    val path = request.getRequestURI
-    val cookies = request.getCookies
-    val params = request.getParameterMap
-    val remoteAddr = request.getRemoteAddr
-    override def header(name: String): Seq[String] = headers.getOrElse(name, Seq.empty)
-    override def requestPath: String = path
-    override def cookie(name: String): Option[String] = cookies.find(_.getName == name).map(_.getValue)
-    override def queryParam(name: String): Seq[String] = params.asScala.get(name).map(_.toSeq).getOrElse(Seq.empty)
-  }
-
-  private class ResponseFacade extends HttpResponse {
-    private[this] var builder = Response.status(Status.UNAUTHORIZED)
-    override def header(name: String, value: String): Unit = builder.header(name, value)
-    override def status(code: Int): Unit = builder = builder.status(code)
-    override def sendRedirect(location: String): Unit = {
-      builder.status(Status.TEMPORARY_REDIRECT).location(new URI(location))
-    }
-    override def cookie(name: String, value: String, maxAge: Int, secure: Boolean): Unit = {
-      //scalastyle:off null
-      builder.cookie(new NewCookie(name, value, null, null, null, maxAge.toInt, secure))
-    }
-    override def body(mediaType: String, bytes: Array[Byte]): Unit = {
-      builder.`type`(mediaType)
-      builder.entity(bytes)
-    }
-    def response: Response = builder.build()
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
@@ -50,6 +50,7 @@ class MarathonRestModule extends BaseRestModule {
     bind(classOf[v2.DeploymentsResource]).in(Scopes.SINGLETON)
     bind(classOf[v2.ArtifactsResource]).in(Scopes.SINGLETON)
     bind(classOf[v2.SchemaResource]).in(Scopes.SINGLETON)
+    bind(classOf[v2.PluginsResource]).in(Scopes.SINGLETON)
 
     install(new LeaderProxyFilterModule)
 

--- a/src/main/scala/mesosphere/marathon/api/RequestFacade.scala
+++ b/src/main/scala/mesosphere/marathon/api/RequestFacade.scala
@@ -1,0 +1,22 @@
+package mesosphere.marathon.api
+
+import javax.servlet.http.HttpServletRequest
+
+import mesosphere.marathon.plugin.http.HttpRequest
+
+import scala.collection.JavaConverters._
+
+class RequestFacade(request: HttpServletRequest, path: String) extends HttpRequest {
+  def this(request: HttpServletRequest) = this(request, request.getRequestURI)
+  // Jersey will not allow calls to the request object from another thread
+  // To circumvent that, we have to copy all data during creation
+  val headers = request.getHeaderNames.asScala.map(header => header -> request.getHeaders(header).asScala.toSeq).toMap
+  val cookies = request.getCookies
+  val params = request.getParameterMap
+  val remoteAddr = request.getRemoteAddr
+  override def header(name: String): Seq[String] = headers.getOrElse(name, Seq.empty)
+  override def requestPath: String = path
+  override def cookie(name: String): Option[String] = cookies.find(_.getName == name).map(_.getValue)
+  override def queryParam(name: String): Seq[String] = params.asScala.get(name).map(_.toSeq).getOrElse(Seq.empty)
+  override def method: String = request.getMethod
+}

--- a/src/main/scala/mesosphere/marathon/api/ResponseFacade.scala
+++ b/src/main/scala/mesosphere/marathon/api/ResponseFacade.scala
@@ -1,0 +1,25 @@
+package mesosphere.marathon.api
+
+import java.net.URI
+import javax.ws.rs.core.Response.Status
+import javax.ws.rs.core.{ NewCookie, Response }
+
+import mesosphere.marathon.plugin.http.HttpResponse
+
+class ResponseFacade extends HttpResponse {
+  private[this] var builder = Response.status(Status.UNAUTHORIZED)
+  override def header(name: String, value: String): Unit = builder.header(name, value)
+  override def status(code: Int): Unit = builder = builder.status(code)
+  override def sendRedirect(location: String): Unit = {
+    builder.status(Status.TEMPORARY_REDIRECT).location(new URI(location))
+  }
+  override def cookie(name: String, value: String, maxAge: Int, secure: Boolean): Unit = {
+    //scalastyle:off null
+    builder.cookie(new NewCookie(name, value, null, null, null, maxAge.toInt, secure))
+  }
+  override def body(mediaType: String, bytes: Array[Byte]): Unit = {
+    builder.`type`(mediaType)
+    builder.entity(bytes)
+  }
+  def response: Response = builder.build()
+}

--- a/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
@@ -1,0 +1,66 @@
+package mesosphere.marathon.api.v2
+
+import javax.inject.Inject
+import javax.servlet.http.HttpServletRequest
+import javax.ws.rs._
+import javax.ws.rs.core.{ Context, Response }
+
+import mesosphere.marathon.MarathonConf
+import mesosphere.marathon.api.v2.json.Formats._
+import mesosphere.marathon.api.{ MarathonMediaType, RequestFacade, ResponseFacade, RestResource }
+import mesosphere.marathon.core.plugin.PluginDefinitions
+import mesosphere.marathon.plugin.http.{ HttpRequest, HttpRequestHandler, HttpResponse }
+
+@Path("v2/plugins")
+class PluginsResource @Inject() (val config: MarathonConf,
+                                 requestHandlers: Seq[HttpRequestHandler],
+                                 definitions: PluginDefinitions) extends RestResource {
+
+  val pluginIdToHandler = definitions.plugins
+    .filter(_.plugin == classOf[HttpRequestHandler].getName)
+    .flatMap { d => requestHandlers.find(_.getClass.getName == d.implementation).map(d.id -> _) }
+    .toMap
+
+  @GET
+  @Produces(Array(MarathonMediaType.PREFERRED_APPLICATION_JSON))
+  def plugins(): Response = ok(jsonString(definitions))
+
+  @GET
+  @Path("""{pluginId}/{path:.+}""")
+  def get(@PathParam("pluginId") pluginId: String,
+          @PathParam("path") path: String,
+          @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
+
+  @HEAD
+  @Path("""{pluginId}/{path:.+}""")
+  def head(@PathParam("pluginId") pluginId: String,
+           @PathParam("path") path: String,
+           @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
+
+  @PUT
+  @Path("""{pluginId}/{path:.+}""")
+  def put(@PathParam("pluginId") pluginId: String,
+          @PathParam("path") path: String,
+          @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
+
+  @POST
+  @Path("""{pluginId}/{path:.+}""")
+  def post(@PathParam("pluginId") pluginId: String,
+           @PathParam("path") path: String,
+           @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
+
+  @DELETE
+  @Path("""{pluginId}/{path:.+}""")
+  def delete(@PathParam("pluginId") pluginId: String,
+             @PathParam("path") path: String,
+             @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
+
+  private[this] def handleRequest(pluginId: String, path: String, req: HttpServletRequest): Response = {
+    pluginIdToHandler.get(pluginId).map { handler =>
+      val request = new RequestFacade(req, path)
+      val response = new ResponseFacade
+      handler.serve(request, response)
+      response.response
+    }.getOrElse(notFound(s"No plugin with this pluginId: $pluginId"))
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -11,10 +11,10 @@ import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.leadership.{ LeadershipCoordinator, LeadershipModule }
-import mesosphere.marathon.core.plugin.PluginManager
+import mesosphere.marathon.core.plugin.{ PluginDefinitions, PluginManager }
 import mesosphere.marathon.core.task.bus.{ TaskStatusEmitter, TaskStatusObservables }
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
-import mesosphere.marathon.core.task.update.impl.{ ThrottlingTaskStatusUpdateProcessor }
+import mesosphere.marathon.core.task.update.impl.ThrottlingTaskStatusUpdateProcessor
 import mesosphere.marathon.core.task.tracker.{ TaskCreationHandler, TaskTracker, TaskUpdater }
 import mesosphere.marathon.core.task.update.impl.TaskStatusUpdateProcessorImpl
 import mesosphere.marathon.core.task.update.impl.steps.{
@@ -30,6 +30,7 @@ import mesosphere.marathon.core.task.update.impl.steps.{
 import mesosphere.marathon.core.task.update.{ TaskStatusUpdateProcessor, TaskStatusUpdateStep }
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer }
+import mesosphere.marathon.plugin.http.HttpRequestHandler
 import mesosphere.util.{ CapConcurrentExecutionsMetrics, CapConcurrentExecutions }
 
 /**
@@ -80,6 +81,9 @@ class CoreGuiceModule extends AbstractModule {
   def pluginManager(coreModule: CoreModule): PluginManager = coreModule.pluginModule.pluginManager
 
   @Provides @Singleton
+  def pluginDefinitions(coreModule: CoreModule): PluginDefinitions = coreModule.pluginModule.pluginManager.definitions
+
+  @Provides @Singleton
   def authorizer(coreModule: CoreModule): Authorizer = coreModule.authModule.authorizer
 
   @Provides @Singleton
@@ -118,6 +122,11 @@ class CoreGuiceModule extends AbstractModule {
       ContinueOnErrorStep(postToEventStreamStepImpl),
       ContinueOnErrorStep(scaleAppUpdateStepImpl)
     )
+  }
+
+  @Provides @Singleton
+  def pluginHttpRequestHandler(coreModule: CoreModule): Seq[HttpRequestHandler] = {
+    coreModule.pluginModule.httpRequestHandler
   }
 
   override def configure(): Unit = {

--- a/src/main/scala/mesosphere/marathon/core/plugin/PluginDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/plugin/PluginDefinition.scala
@@ -1,0 +1,12 @@
+package mesosphere.marathon.core.plugin
+
+import play.api.libs.json.JsObject
+
+case class PluginDefinition(id: String,
+                            plugin: String,
+                            implementation: String,
+                            tags: Option[Set[String]],
+                            configuration: Option[JsObject],
+                            info: Option[JsObject])
+
+case class PluginDefinitions(plugins: Seq[PluginDefinition])

--- a/src/main/scala/mesosphere/marathon/core/plugin/PluginManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/plugin/PluginManager.scala
@@ -6,4 +6,6 @@ trait PluginManager {
 
   def plugins[T](implicit ct: ClassTag[T]): Seq[T]
 
+  def definitions: PluginDefinitions
+
 }

--- a/src/main/scala/mesosphere/marathon/core/plugin/PluginModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/plugin/PluginModule.scala
@@ -1,9 +1,12 @@
 package mesosphere.marathon.core.plugin
 
 import mesosphere.marathon.core.plugin.impl.PluginManagerImpl
+import mesosphere.marathon.plugin.http.HttpRequestHandler
 
 class PluginModule(config: PluginManagerConfiguration) {
 
   lazy val pluginManager: PluginManager = PluginManagerImpl(config)
+
+  lazy val httpRequestHandler: Seq[HttpRequestHandler] = pluginManager.plugins[HttpRequestHandler]
 
 }


### PR DESCRIPTION
By defining an abstract http handler trait, as well as a PluginsResource to handle plugin requests.
Idea:
-GET /v2/plugins will list all available HttpHandler implementations
-GET/HEAD/PUT/POST/DELETE /v2/plugins/<context_path>/xxx/yyy will be handled by the plugin  that handles the defined context path (defined by the plugin). The path /xxx/yyy has to be handled by the plugin.

I will create an example in the marathon-example-plugins project.

@orlandohohmeier @aldipower: comments welcome
