### PR TITLE
Raise UI version to 0.15.2 for the next Marathon 0.15 release

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -300,7 +300,7 @@ object Dependency {
     val PlayJson = "2.4.3"
     val JsonSchemaValidator = "2.2.6"
     val RxScala = "0.25.0"
-    val MarathonUI = "0.15.1"
+    val MarathonUI = "0.15.2"
     val MarathonApiConsole = "0.1.1"
     val Graphite = "3.1.2"
     val DataDog = "1.1.3"


### PR DESCRIPTION
Relase: https://github.com/mesosphere/marathon-ui/releases/tag/v0.15.2 