### PR TITLE
Towards #3041 - Use new "Task" in more places instead of "MarathonTask"

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -18,7 +18,7 @@ object EndpointsHelper {
 
     val sb = new StringBuilder
     for (app <- apps if app.ipAddress.isEmpty) {
-      val tasks = tasksMap.appTasks(app.id)
+      val tasks = tasksMap.marathonAppTasks(app.id)
       val cleanId = app.id.safePath
 
       val servicePorts = app.servicePorts

--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -20,7 +20,7 @@ class TaskKiller @Inject() (
     findToKill: (Iterable[MarathonTask] => Iterable[MarathonTask])): Future[Iterable[MarathonTask]] = {
 
     if (taskTracker.hasAppTasksSync(appId)) {
-      val tasks = taskTracker.appTasksSync(appId)
+      val tasks = taskTracker.marathonAppTasksSync(appId)
       val toKill = findToKill(tasks)
       service.killTasks(appId, toKill)
       Future.successful(toKill)
@@ -33,7 +33,7 @@ class TaskKiller @Inject() (
   def killAndScale(appId: PathId,
                    findToKill: (Iterable[MarathonTask] => Iterable[MarathonTask]),
                    force: Boolean): Future[DeploymentPlan] = {
-    killAndScale(Map(appId -> findToKill(taskTracker.appTasksSync(appId))), force)
+    killAndScale(Map(appId -> findToKill(taskTracker.marathonAppTasksSync(appId))), force)
   }
 
   def killAndScale(appTasks: Map[PathId, Iterable[MarathonTask]], force: Boolean): Future[DeploymentPlan] = {

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -44,7 +44,7 @@ class AppTasksResource @Inject() (service: MarathonSchedulerService,
       def tasks(appIds: Set[PathId]): Set[EnrichedTask] = for {
         id <- appIds
         health = result(healthCheckManager.statuses(id))
-        task <- taskMap.appTasks(id)
+        task <- taskMap.marathonAppTasks(id)
       } yield EnrichedTask(id, task, health.getOrElse(task.getId, Nil))
 
       val matchingApps = appId match {

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -11,6 +11,7 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.{ EndpointsHelper, MarathonMediaType, TaskKiller, _ }
 import mesosphere.marathon.core.appinfo.EnrichedTask
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, KillTask }
@@ -60,7 +61,7 @@ class TasksResource @Inject() (
       val taskList = taskTracker.tasksByAppSync
 
       val tasks = taskList.appTasksMap.values.view.flatMap { app =>
-        app.tasks.view.map(t => app.appId -> t)
+        app.marathonTasks.view.map(t => app.appId -> t)
       }
 
       val appIds = taskList.allAppIdsWithTasks
@@ -135,7 +136,7 @@ class TasksResource @Inject() (
       }
 
       val taskByApps = taskToAppIds
-        .flatMap { case (taskId, appId) => taskTracker.marathonTaskSync(appId, taskId) }
+        .flatMap { case (taskId, appId) => taskTracker.marathonTaskSync(Task.Id(taskId)) }
         .groupBy { x => taskIdUtil.appId(x.getId) }
         .map{ case (app, tasks) => app -> tasks.toSet }
 

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -4,6 +4,7 @@ import mesosphere.marathon.MarathonSchedulerService
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.appinfo.{ AppInfo, EnrichedTask, TaskCounts, TaskStatsByVersion }
 import mesosphere.marathon.core.base.Clock
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.task.tracker.TaskTracker.AppTasks
 import mesosphere.marathon.health.{ Health, HealthCheckManager }
@@ -86,7 +87,7 @@ class AppInfoBaseData(
   private[this] class AppData(app: AppDefinition) {
     lazy val now: Timestamp = clock.now()
 
-    lazy val tasksFuture: Future[Iterable[MarathonTask]] = tasksByAppFuture.map(_.appTasks(app.id))
+    lazy val tasksFuture: Future[Iterable[MarathonTask]] = tasksByAppFuture.map(_.marathonAppTasks(app.id))
 
     lazy val healthCountsFuture: Future[Map[String, Seq[Health]]] = {
       log.debug(s"retrieving health counts for app [${app.id}]")
@@ -122,11 +123,11 @@ class AppInfoBaseData(
 
     lazy val enrichedTasksFuture: Future[Seq[EnrichedTask]] = {
       def statusesToEnrichedTasks(
-        tasksById: Map[String, MarathonTask],
+        tasksById: Map[Task.Id, MarathonTask],
         statuses: Map[String, collection.Seq[Health]]): Seq[EnrichedTask] = {
         for {
           (taskId, healthResults) <- statuses.to[Seq]
-          task <- tasksById.get(taskId)
+          task <- tasksById.get(Task.Id(taskId))
         } yield EnrichedTask(app.id, task, healthResults)
       }
 

--- a/src/main/scala/mesosphere/marathon/core/task/bus/TaskStatusObservables.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/TaskStatusObservables.scala
@@ -1,14 +1,13 @@
 package mesosphere.marathon.core.task.bus
 
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.TaskStatusObservables.TaskStatusUpdate
 import mesosphere.marathon.state.{ PathId, Timestamp }
-import mesosphere.marathon.tasks.TaskIdUtil
-import org.apache.mesos.Protos.TaskID
 import rx.lang.scala.Observable
 
 object TaskStatusObservables {
-  case class TaskStatusUpdate(timestamp: Timestamp, taskId: TaskID, status: MarathonTaskStatus) {
-    lazy val appId: PathId = TaskIdUtil.appId(taskId)
+  case class TaskStatusUpdate(timestamp: Timestamp, taskId: Task.Id, status: MarathonTaskStatus) {
+    def appId: PathId = taskId.appId
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/TaskCreationHandler.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/TaskCreationHandler.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon.core.task.tracker
 
-import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.state.PathId
+import mesosphere.marathon.core.task.Task
 
 import scala.concurrent.Future
 
@@ -15,12 +14,12 @@ trait TaskCreationHandler {
     * If the task exists already, the existing task will be overwritten so make sure
     * that you generate unique IDs.
     */
-  def created(appId: PathId, task: MarathonTask): Future[MarathonTask]
+  def created(task: Task): Future[Task]
 
   /**
     * Remove the task for the given app with the given ID completely.
     *
     * If the task does not exist, the returned Future will not fail.
     */
-  def terminated(appId: PathId, taskId: String): Future[_]
+  def terminated(taskId: Task.Id): Future[_]
 }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessor.scala
@@ -8,13 +8,15 @@ import org.apache.mesos.Protos.TaskStatus
 import scala.concurrent.{ ExecutionContext, Future }
 
 private[tracker] object TaskOpProcessor {
-  case class Operation(deadline: Timestamp, sender: ActorRef, appId: PathId, taskId: Task.Id, action: Action)
+  case class Operation(deadline: Timestamp, sender: ActorRef, taskId: Task.Id, action: Action) {
+    def appId: PathId = taskId.appId
+  }
 
   sealed trait Action
 
   object Action {
     /** Update an existing task or create a new task. */
-    case class Update(taskState: Task) extends Action {
+    case class Update(task: Task) extends Action {
       override def toString: String = "Update/Create"
     }
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerDelegate.scala
@@ -46,24 +46,29 @@ private[tracker] class TaskTrackerDelegate(
     tasksByAppTimer.fold(futureCall())(_.timeFuture(futureCall()))
   }
 
-  override def countAppTasksSync(appId: PathId): Int = tasksByAppSync.appTasks(appId).size
+  override def countAppTasksSync(appId: PathId): Int = tasksByAppSync.marathonAppTasks(appId).size
   override def countAppTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Int] =
-    tasksByApp().map(_.appTasks(appId).size)
-  override def marathonTaskSync(appId: PathId, taskId: String): Option[MarathonTask] =
-    tasksByAppSync.marathonTask(appId, taskId)
-  override def marathonTask(appId: PathId, taskId: String)(implicit e: ExecutionContext): Future[Option[MarathonTask]] =
-    tasksByApp().map(_.marathonTask(appId, taskId))
+    tasksByApp().map(_.marathonAppTasks(appId).size)
+  override def marathonTaskSync(taskId: Task.Id): Option[MarathonTask] =
+    tasksByAppSync.marathonTask(taskId)
+  override def marathonTask(taskId: Task.Id)(implicit e: ExecutionContext): Future[Option[MarathonTask]] =
+    tasksByApp().map(_.marathonTask(taskId))
   override def hasAppTasksSync(appId: PathId): Boolean = tasksByAppSync.hasAppTasks(appId)
   override def hasAppTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Boolean] =
     tasksByApp().map(_.hasAppTasks(appId))
-  override def appTasksSync(appId: PathId): Iterable[MarathonTask] = tasksByAppSync.appTasks(appId)
-  override def appTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Iterable[MarathonTask]] =
+  override def marathonAppTasksSync(appId: PathId): Iterable[MarathonTask] =
+    tasksByAppSync.marathonAppTasks(appId)
+  override def marathonAppTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Iterable[MarathonTask]] =
+    tasksByApp().map(_.marathonAppTasks(appId))
+
+  override def appTasksSync(appId: PathId): Iterable[Task] =
+    tasksByAppSync.appTasks(appId)
+  override def appTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Iterable[Task]] =
     tasksByApp().map(_.appTasks(appId))
 
-  override def task(
-    appId: PathId, taskId: Task.Id)(
-      implicit ec: ExecutionContext): Future[Option[Task]] =
-    tasksByApp().map(_.taskState(appId, taskId))
+  override def task(taskId: Task.Id)(
+    implicit ec: ExecutionContext): Future[Option[Task]] =
+    tasksByApp().map(_.taskState(taskId))
 
   private[this] val tasksByAppTimer =
     metrics.map(metrics => metrics.timer(metrics.name(MetricPrefixes.SERVICE, getClass, "tasksByApp")))

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskUpdateActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskUpdateActor.scala
@@ -84,7 +84,7 @@ private[impl] class TaskUpdateActor(
   }
 
   def receive: Receive = LoggingReceive {
-    case ProcessTaskOp(op @ TaskOpProcessor.Operation(deadline, _, _, taskId, _)) =>
+    case ProcessTaskOp(op @ TaskOpProcessor.Operation(deadline, _, taskId, _)) =>
       val oldQueue: Queue[TaskOpProcessor.Operation] = operationsByTaskId(taskId)
       val newQueue = oldQueue :+ op
       operationsByTaskId += taskId -> newQueue

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -53,8 +53,8 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     val taskId = status.getTaskId
     val appId = taskIdUtil.appId(taskId)
 
-    taskTracker.task(appId, Task.Id(taskId.getValue)).flatMap {
-      case Some(taskState) if taskState.launchedTask.isDefined =>
+    taskTracker.task(Task.Id(taskId.getValue)).flatMap {
+      case Some(taskState) if taskState.launched.isDefined =>
         processUpdate(
           timestamp = now,
           appId = appId,

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyLaunchQueueStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyLaunchQueueStepImpl.scala
@@ -4,6 +4,7 @@ import javax.inject.Inject
 
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.MarathonTaskStatus
 import mesosphere.marathon.core.task.bus.TaskStatusObservables.TaskStatusUpdate
 import mesosphere.marathon.core.task.update.TaskStatusUpdateStep
@@ -20,7 +21,7 @@ class NotifyLaunchQueueStepImpl @Inject() (launchQueue: LaunchQueue) extends Tas
 
   override def processUpdate(
     timestamp: Timestamp, appId: PathId, task: MarathonTask, status: TaskStatus): Future[_] = {
-    val taskId = status.getTaskId
+    val taskId = Task.Id(status.getTaskId)
     val update = TaskStatusUpdate(timestamp, taskId, MarathonTaskStatus(status))
     launchQueue.notifyOfTaskUpdate(update)
   }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/TaskStatusEmitterPublishStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/TaskStatusEmitterPublishStepImpl.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.core.task.update.impl.steps
 import javax.inject.Inject
 
 import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.TaskStatusObservables.TaskStatusUpdate
 import mesosphere.marathon.core.task.bus.{ MarathonTaskStatus, TaskStatusEmitter }
 import mesosphere.marathon.core.task.update.TaskStatusUpdateStep
@@ -19,7 +20,7 @@ class TaskStatusEmitterPublishStepImpl @Inject() (taskStatusEmitter: TaskStatusE
 
   override def processUpdate(
     timestamp: Timestamp, appId: PathId, task: MarathonTask, status: TaskStatus): Future[_] = {
-    val taskId = status.getTaskId
+    val taskId = Task.Id(status.getTaskId)
     taskStatusEmitter.publish(TaskStatusUpdate(timestamp, taskId, MarathonTaskStatus(status)))
     Future.successful(())
   }

--- a/src/main/scala/mesosphere/marathon/tasks/DefaultTaskFactory.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/DefaultTaskFactory.scala
@@ -4,6 +4,7 @@ import com.google.inject.Inject
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.base.Clock
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.tasks.TaskFactory.CreatedTask
 import mesosphere.mesos.TaskBuilder
@@ -20,21 +21,29 @@ class DefaultTaskFactory @Inject() (
 
   private[this] val log = LoggerFactory.getLogger(getClass)
 
-  def newTask(app: AppDefinition, offer: Offer, runningTasks: Iterable[MarathonTask]): Option[CreatedTask] = {
+  override def newTask(app: AppDefinition, offer: Offer, runningTasks: Iterable[Task]): Option[CreatedTask] = {
     log.debug("newTask")
 
     new TaskBuilder(app, taskIdUtil.newTaskId, config).buildIfMatches(offer, runningTasks).map {
       case (taskInfo, ports) =>
-        val marathonTask: MarathonTask = MarathonTasks.makeTask(
-          id = taskInfo.getTaskId.getValue,
-          host = offer.getHostname,
-          ports = ports,
-          attributes = offer.getAttributesList.asScala,
-          version = app.version,
-          now = clock.now(),
-          slaveId = offer.getSlaveId
+        val task = Task(
+          taskId = Task.Id(taskInfo.getTaskId),
+          agentInfo = Task.AgentInfo(
+            host = offer.getHostname,
+            agentId = Some(offer.getSlaveId.getValue),
+            attributes = offer.getAttributesList.asScala
+          ),
+          launched = Some(
+            Task.Launched(
+              appVersion = app.version,
+              status = Task.Status(
+                stagedAt = clock.now()
+              ),
+              networking = Task.HostPorts(ports)
+            )
+          )
         )
-        CreatedTask(taskInfo, marathonTask)
+        CreatedTask(taskInfo, task)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/tasks/MarathonTasks.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/MarathonTasks.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.tasks
 
 import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
 import org.apache.mesos.Protos
 import org.apache.mesos.Protos.Attribute
@@ -8,30 +9,8 @@ import org.apache.mesos.Protos.Attribute
 import scala.collection.JavaConverters._
 
 object MarathonTasks {
-  /*
-   * Despite its name, stagedAt is set on task creation and before the TASK_STAGED notification from Mesos. This is
-   * important because we periodically check for any tasks with an old stagedAt timestamp and kill them (See
-   * KillOverdueTasksActor). If stagedAt remains 0 and this check is executed, the task will be killed
-   * after being created, given that the check is triggered before we receive a TASK_STAGED notification.
-   */
-  def makeTask(id: String,
-               host: String,
-               ports: Iterable[Int],
-               attributes: Iterable[Attribute],
-               version: Timestamp,
-               now: Timestamp,
-               slaveId: Protos.SlaveID): MarathonTask = {
-    MarathonTask.newBuilder()
-      .setId(id)
-      .setHost(host)
-      .setVersion(version.toString())
-      .addAllPorts(ports.map(i => i: java.lang.Integer).asJava)
-      .addAllAttributes(attributes.asJava)
-      .setStagedAt(now.toDateTime.getMillis)
-      .setSlaveId(slaveId)
-      .build
-  }
 
+  // FIXME(PK): Move to Task
   def ipAddresses(task: MarathonTask): Seq[Protos.NetworkInfo.IPAddress] = {
     task.getNetworksList.asScala.flatMap(_.getIpAddressesList.asScala.toList)
   }
@@ -44,6 +23,7 @@ object MarathonTasks {
     *
     * In all other cases, this function returns the slave host address.
     */
+  // FIXME(PK): Move to Task
   def effectiveIpAddress(app: AppDefinition, task: MarathonTask): String = {
     val maybeContainerIp: Option[String] = ipAddresses(task).map(_.getIpAddress).headOption
 
@@ -55,5 +35,6 @@ object MarathonTasks {
     }
   }
 
+  // FIXME(PK): Move to Task
   def taskMap(tasks: Iterable[MarathonTask]): Map[String, MarathonTask] = tasks.map(task => task.getId -> task).toMap
 }

--- a/src/main/scala/mesosphere/marathon/tasks/TaskFactory.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskFactory.scala
@@ -1,8 +1,8 @@
 package mesosphere.marathon.tasks
 
-import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.AppDefinition
-import org.apache.mesos.Protos.{ TaskInfo, Offer }
+import org.apache.mesos.Protos.{ Offer, TaskInfo }
 
 /** Create tasks from app definitions and offers. */
 trait TaskFactory {
@@ -11,10 +11,10 @@ trait TaskFactory {
   /**
     * Return the corresponding task if and only if the offer matches the app.
     */
-  def newTask(app: AppDefinition, offer: Offer, runningTasks: Iterable[MarathonTask]): Option[CreatedTask]
+  def newTask(app: AppDefinition, offer: Offer, runningTasks: Iterable[Task]): Option[CreatedTask]
 }
 
 object TaskFactory {
-  case class CreatedTask(mesosTask: TaskInfo, marathonTask: MarathonTask)
+  case class CreatedTask(mesosTask: TaskInfo, task: Task)
 }
 

--- a/src/main/scala/mesosphere/marathon/tasks/TaskIDUtil.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/TaskIDUtil.scala
@@ -7,14 +7,17 @@ import org.apache.mesos.Protos.TaskID
 /**
   * Utility functions for dealing with TaskIDs
   */
+// FIXME(PK): Remove, merge into Task.Id
 class TaskIdUtil {
   val appDelimiter = "."
   val TaskIdRegex = """^(.+)[\._]([^_\.]+)$""".r
   val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
 
+  // FIXME(PK): Remove, see task.appId
   def appId(taskId: TaskID): PathId = appId(taskId.getValue)
 
   // this should actually be a try or option
+  // FIXME(PK): Remove, see task.appId
   def appId(taskId: String): PathId = {
     taskId match {
       case TaskIdRegex(appId, uuid) => PathId.fromSafePath(appId)
@@ -22,6 +25,7 @@ class TaskIdUtil {
     }
   }
 
+  // FIXME(PK): remove, merge with Task.Id.random
   def newTaskId(appId: PathId): TaskID = {
     val taskId = appId.safePath + appDelimiter + uuidGenerator.generate()
     TaskID.newBuilder()

--- a/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
@@ -16,7 +16,7 @@ class AppStopActor(
     app: AppDefinition,
     val promise: Promise[Unit]) extends StoppingBehavior {
 
-  var idsToKill: mutable.Set[String] = taskTracker.appTasksSync(app.id).map(_.getId).to[mutable.Set]
+  var idsToKill: mutable.Set[String] = taskTracker.marathonAppTasksSync(app.id).map(_.getId).to[mutable.Set]
 
   def appId: PathId = app.id
 

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -116,7 +116,7 @@ private class DeploymentActor(
   }
 
   def scaleApp(app: AppDefinition, scaleTo: Int, toKill: Option[Iterable[MarathonTask]]): Future[Unit] = {
-    val runningTasks = taskTracker.appTasksSync(app.id)
+    val runningTasks = taskTracker.marathonAppTasksSync(app.id)
     def killToMeetConstraints(notSentencedAndRunning: Iterable[MarathonTask], toKillCount: Int) =
       Constraints.selectTasksToKill(app, notSentencedAndRunning, toKillCount)
 

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -70,7 +70,7 @@ trait StartingBehavior { this: Actor with ActorLogging =>
 
   def commonBehavior: Receive = {
     case MesosStatusUpdateEvent(_, taskId, StartErrorState(_), _, app.`id`, _, _, _, Version, _, _) => // scalastyle:off line.size.limit
-      log.warning(s"New task $taskId failed during app ${app.id.toString} scaling, queueing another task")
+      log.warning(s"New task [$taskId] failed during app ${app.id.toString} scaling, queueing another task")
       startedRunningTasks -= taskId
       taskQueue.add(app)
 

--- a/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
@@ -50,7 +50,7 @@ trait StoppingBehavior extends Actor with ActorLogging {
       checkFinished()
 
     case SynchronizeTasks =>
-      val trackerIds = taskTracker.appTasksSync(appId).map(_.getId).toSet
+      val trackerIds = taskTracker.marathonAppTasksSync(appId).map(_.getId).toSet
       idsToKill = idsToKill.filter(trackerIds)
 
       idsToKill.foreach { id =>

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -24,7 +24,7 @@ class TaskReplaceActor(
     promise: Promise[Unit]) extends Actor with ActorLogging {
   import context.dispatcher
 
-  val tasksToKill = taskTracker.appTasksSync(app.id)
+  val tasksToKill = taskTracker.marathonAppTasksSync(app.id)
   val appId = app.id
   val version = app.version.toString
   var healthy = Set.empty[String]

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -4,6 +4,7 @@ import com.google.protobuf.{ ByteString, TextFormat }
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon._
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.state.{ AppDefinition, DiscoveryInfo, IpAddress, PathId }
 import mesosphere.mesos.ResourceMatcher.ResourceMatch
@@ -24,7 +25,7 @@ class TaskBuilder(app: AppDefinition,
 
   val log = LoggerFactory.getLogger(getClass.getName)
 
-  def buildIfMatches(offer: Offer, runningTasks: => Iterable[MarathonTask]): Option[(TaskInfo, Seq[Int])] = {
+  def buildIfMatches(offer: Offer, runningTasks: => Iterable[Task]): Option[(TaskInfo, Seq[Int])] = {
 
     val acceptedResourceRoles: Set[String] = app.acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet)
 

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -43,7 +43,7 @@ class SchedulerActionsTest extends MarathonActorSupport with MarathonSpec with M
     val app = AppDefinition(id = PathId("/myapp"))
 
     when(repo.expunge(app.id)).thenReturn(Future.successful(Seq(true)))
-    when(taskTracker.appTasksSync(app.id)).thenReturn(Set.empty[Protos.MarathonTask])
+    when(taskTracker.marathonAppTasksSync(app.id)).thenReturn(Set.empty[Protos.MarathonTask])
 
     val res = scheduler.stopApp(mock[SchedulerDriver], app)
 

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -1,5 +1,6 @@
 package mesosphere.marathon.core.task.bus
 
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.TaskStatusObservables.TaskStatusUpdate
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.tasks.TaskIdUtil
@@ -12,6 +13,10 @@ class TaskStatusUpdateTestHelper(val wrapped: TaskStatusUpdate) {
   }
 
   def withTaskId(taskId: TaskID): TaskStatusUpdateTestHelper = TaskStatusUpdateTestHelper {
+    wrapped.copy(taskId = Task.Id(taskId))
+  }
+
+  def withTaskId(taskId: Task.Id): TaskStatusUpdateTestHelper = TaskStatusUpdateTestHelper {
     wrapped.copy(taskId = taskId)
   }
 
@@ -29,7 +34,7 @@ object TaskStatusUpdateTestHelper {
     new TaskStatusUpdateTestHelper(update)
 
   private def newTaskID(appId: String) = {
-    TaskIdUtil.newTaskId(PathId(appId))
+    Task.Id.forApp(PathId(appId))
   }
 
   val taskId = newTaskID("/app")

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/StatusUpdateActionResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/StatusUpdateActionResolverTest.scala
@@ -25,16 +25,16 @@ class StatusUpdateActionResolverTest
     val f = new Fixture
     Given("a taskID without task")
     val appId = PathId("/app")
-    val taskId = Task.Id("task1")
-    f.taskTracker.task(appId, taskId) returns Future.successful(None)
+    val taskId = Task.Id.forApp(appId)
+    f.taskTracker.task(taskId) returns Future.successful(None)
     And("a status update")
     val update = TaskStatus.getDefaultInstance
 
     When("resolve is called")
-    val action = f.actionResolver.resolve(appId, taskId, update).futureValue
+    val action = f.actionResolver.resolve(taskId, update).futureValue
 
     Then("getTAskAsync is called")
-    verify(f.taskTracker).task(appId, taskId)
+    verify(f.taskTracker).task(taskId)
 
     And("a fail action is returned")
     action.getClass should be(classOf[TaskOpProcessor.Action.Fail])

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializerTest.scala
@@ -17,7 +17,7 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
     val marathonTask = MarathonTask.newBuilder().setId("task").setHost(sampleHost).setLaunchCounter(0).build()
 
     When("we convert it to task")
-    val taskState = TaskSerializer.taskState(marathonTask)
+    val taskState = TaskSerializer.task(marathonTask)
 
     Then("we get a minimal task State")
     val expectedState = Task(
@@ -25,7 +25,7 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
       Task.AgentInfo(host = sampleHost, agentId = None, attributes = Iterable.empty),
       reservationWithVolume = None,
       launchCounter = 0,
-      launchedTask = None
+      launched = None
     )
 
     taskState should be(expectedState)
@@ -42,7 +42,7 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
     val marathonTask = completeTask
 
     When("we convert it to task")
-    val taskState = TaskSerializer.taskState(marathonTask)
+    val taskState = TaskSerializer.task(marathonTask)
 
     Then("we get the expected task state")
     val expectedState = fullSampleTaskStateWithoutNetworking
@@ -65,11 +65,11 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
         .build()
 
     When("we convert it to task")
-    val taskState = TaskSerializer.taskState(marathonTask)
+    val taskState = TaskSerializer.task(marathonTask)
 
     Then("we get the expected task state")
     val expectedState = fullSampleTaskStateWithoutNetworking.copy(
-      launchedTask = fullSampleTaskStateWithoutNetworking.launchedTask.map(
+      launched = fullSampleTaskStateWithoutNetworking.launched.map(
         _.copy(networking = Task.HostPorts(samplePorts)
         ))
     )
@@ -93,11 +93,11 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
 
     When("we convert it to task")
     println(marathonTask)
-    val taskState = TaskSerializer.taskState(marathonTask)
+    val taskState = TaskSerializer.task(marathonTask)
 
     Then("we get the expected task state")
     val expectedState = fullSampleTaskStateWithoutNetworking.copy(
-      launchedTask = fullSampleTaskStateWithoutNetworking.launchedTask.map(
+      launched = fullSampleTaskStateWithoutNetworking.launched.map(
         _.copy(networking = Task.NetworkInfoList(sampleNetworks)
         ))
     )
@@ -119,7 +119,7 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
   private[this] val appVersion: Timestamp = Timestamp(3)
   private[this] val sampleTaskStatus: TaskStatus =
     MesosProtos.TaskStatus.newBuilder()
-      .setTaskId(MesosProtos.TaskID.newBuilder().setValue(taskId.id))
+      .setTaskId(MesosProtos.TaskID.newBuilder().setValue(taskId.idString))
       .setState(MesosProtos.TaskState.TASK_RUNNING)
       .build()
   private[this] val sampleSlaveId: MesosProtos.SlaveID.Builder = MesosProtos.SlaveID.newBuilder().setValue("slaveId")
@@ -134,13 +134,13 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
     Task.AgentInfo(host = sampleHost, agentId = Some(sampleSlaveId.getValue), attributes = sampleAttributes),
     reservationWithVolume = Some(Task.ReservationWithVolume),
     launchCounter = 10,
-    launchedTask = Some(
-      Task.LaunchedTask(
+    launched = Some(
+      Task.Launched(
         appVersion = appVersion,
-        status = Task.TaskStatus(
+        status = Task.Status(
           stagedAt = Timestamp(stagedAtLong),
           startedAt = Some(Timestamp(startedAtLong)),
-          status = Some(sampleTaskStatus)
+          mesosStatus = Some(sampleTaskStatus)
         ),
         networking = Task.NoNetworking
       )
@@ -149,7 +149,7 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
   private[this] val completeTask =
     MarathonTask
       .newBuilder()
-      .setId(taskId.id)
+      .setId(taskId.idString)
       .setHost(sampleHost)
       .addAllAttributes(sampleAttributes.asJava)
       .setStagedAt(stagedAtLong)

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActorTest.scala
@@ -47,7 +47,7 @@ class TaskTrackerActorTest
     When("the task tracker actor gets a ForwardTaskOp")
     val deadline = Timestamp.zero // ignored
     f.taskTrackerActor ! TaskTrackerActor.ForwardTaskOp(
-      deadline, PathId("/ignored"), Task.Id("task1"), TaskOpProcessor.Action.Noop
+      deadline, Task.Id("task1"), TaskOpProcessor.Action.Noop
     )
 
     Then("it will eventuall die")
@@ -111,9 +111,9 @@ class TaskTrackerActorTest
     val f = new Fixture
     Given("an empty task loader result")
     val appId: PathId = PathId("/app")
-    val stagedTask = MarathonTestHelper.stagedTaskProto("staged")
-    val runningTask1 = MarathonTestHelper.runningTaskProto("running1")
-    val runningTask2 = MarathonTestHelper.runningTaskProto("running2")
+    val stagedTask = MarathonTestHelper.stagedTaskProto(appId)
+    val runningTask1 = MarathonTestHelper.runningTaskProto(appId)
+    val runningTask2 = MarathonTestHelper.runningTaskProto(appId)
     val appDataMap = TaskTracker.TasksByApp.of(
       TaskTracker.AppTasks(appId, Iterable(stagedTask, runningTask1, runningTask2))
     )
@@ -121,7 +121,7 @@ class TaskTrackerActorTest
 
     When("staged task gets deleted")
     val probe = TestProbe()
-    probe.send(f.taskTrackerActor, TaskTrackerActor.TaskRemoved(appId, Task.Id(stagedTask.getId), TaskTrackerActor.Ack(probe.ref, ())))
+    probe.send(f.taskTrackerActor, TaskTrackerActor.TaskRemoved(Task.Id(stagedTask.getId), TaskTrackerActor.Ack(probe.ref, ())))
     probe.expectMsg(())
 
     Then("it will have set the correct metric counts")
@@ -129,7 +129,7 @@ class TaskTrackerActorTest
     f.actorMetrics.stagedCount.getValue should be(0)
 
     When("running task gets deleted")
-    probe.send(f.taskTrackerActor, TaskTrackerActor.TaskRemoved(appId, Task.Id(runningTask1.getId), TaskTrackerActor.Ack(probe.ref, ())))
+    probe.send(f.taskTrackerActor, TaskTrackerActor.TaskRemoved(Task.Id(runningTask1.getId), TaskTrackerActor.Ack(probe.ref, ())))
     probe.expectMsg(())
 
     Then("it will have set the correct metric counts")
@@ -141,9 +141,9 @@ class TaskTrackerActorTest
     val f = new Fixture
     Given("an empty task loader result")
     val appId: PathId = PathId("/app")
-    val stagedTask = MarathonTestHelper.stagedTaskProto("stagedThenRunning")
-    val runningTask1 = MarathonTestHelper.runningTaskProto("running1")
-    val runningTask2 = MarathonTestHelper.runningTaskProto("running2")
+    val stagedTask = MarathonTestHelper.stagedTaskProto(appId)
+    val runningTask1 = MarathonTestHelper.runningTaskProto(appId)
+    val runningTask2 = MarathonTestHelper.runningTaskProto(appId)
     val appDataMap = TaskTracker.TasksByApp.of(
       TaskTracker.AppTasks(appId, Iterable(stagedTask, runningTask1, runningTask2))
     )
@@ -151,9 +151,9 @@ class TaskTrackerActorTest
 
     When("staged task transitions to running")
     val probe = TestProbe()
-    val stagedTaskNowRunning = MarathonTestHelper.runningTaskProto("stagedThenRunning")
-    val taskState = TaskSerializer.taskState(stagedTaskNowRunning)
-    probe.send(f.taskTrackerActor, TaskTrackerActor.TaskUpdated(appId, taskState, TaskTrackerActor.Ack(probe.ref, ())))
+    val stagedTaskNowRunning = MarathonTestHelper.runningTaskProto(stagedTask.getId)
+    val taskState = TaskSerializer.task(stagedTaskNowRunning)
+    probe.send(f.taskTrackerActor, TaskTrackerActor.TaskUpdated(taskState, TaskTrackerActor.Ack(probe.ref, ())))
     probe.expectMsg(())
 
     Then("it will have set the correct metric counts")
@@ -165,9 +165,9 @@ class TaskTrackerActorTest
     val f = new Fixture
     Given("an empty task loader result")
     val appId: PathId = PathId("/app")
-    val stagedTask = MarathonTestHelper.stagedTaskProto("staged")
-    val runningTask1 = MarathonTestHelper.runningTaskProto("running1")
-    val runningTask2 = MarathonTestHelper.runningTaskProto("running2")
+    val stagedTask = MarathonTestHelper.stagedTaskProto(appId)
+    val runningTask1 = MarathonTestHelper.runningTaskProto(appId)
+    val runningTask2 = MarathonTestHelper.runningTaskProto(appId)
     val appDataMap = TaskTracker.TasksByApp.of(
       TaskTracker.AppTasks(appId, Iterable(stagedTask, runningTask1, runningTask2))
     )
@@ -175,9 +175,9 @@ class TaskTrackerActorTest
 
     When("a new staged task gets added")
     val probe = TestProbe()
-    val newTask = MarathonTestHelper.stagedTaskProto("newTask")
-    val taskState = TaskSerializer.taskState(newTask)
-    probe.send(f.taskTrackerActor, TaskTrackerActor.TaskUpdated(appId, taskState, TaskTrackerActor.Ack(probe.ref, ())))
+    val newTask = MarathonTestHelper.stagedTaskProto(appId)
+    val taskState = TaskSerializer.task(newTask)
+    probe.send(f.taskTrackerActor, TaskTrackerActor.TaskUpdated(taskState, TaskTrackerActor.Ack(probe.ref, ())))
     probe.expectMsg(())
 
     Then("it will have set the correct metric counts")

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskUpdateActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskUpdateActorTest.scala
@@ -24,9 +24,9 @@ class TaskUpdateActorTest
 
     Given("an op")
     val appId = PathId("/app")
-    val taskId = "task1"
+    val taskId = Task.Id.forApp(appId)
     val op = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, appId, Task.Id(taskId), TaskOpProcessor.Action.Expunge
+      f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskOpProcessor.Action.Expunge
     )
 
     And("a processor that fails immediately")
@@ -52,9 +52,9 @@ class TaskUpdateActorTest
 
     Given("an op with an already reached deadline")
     val appId = PathId("/app")
-    val taskId = "task1"
+    val taskId = Task.Id.forApp(appId)
     val op = TaskOpProcessor.Operation(
-      f.clock.now, f.opInitiator.ref, appId, Task.Id(taskId), TaskOpProcessor.Action.Expunge
+      f.clock.now, f.opInitiator.ref, taskId, TaskOpProcessor.Action.Expunge
     )
 
     And("a processor that succeeds immediately")
@@ -89,9 +89,9 @@ class TaskUpdateActorTest
 
     Given("an op")
     val appId = PathId("/app")
-    val taskId = "task1"
+    val taskId = Task.Id.forApp(appId)
     val op = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, appId, Task.Id(taskId), TaskOpProcessor.Action.Expunge
+      f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskOpProcessor.Action.Expunge
     )
 
     And("a processor that processes it immediately")
@@ -116,9 +116,9 @@ class TaskUpdateActorTest
 
     Given("an op")
     val appId = PathId("/app")
-    val taskId = "task1"
+    val taskId = Task.Id.forApp(appId)
     val op = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, appId, Task.Id(taskId), TaskOpProcessor.Action.Expunge
+      f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskOpProcessor.Action.Expunge
     )
 
     And("a processor that does not return")
@@ -143,13 +143,13 @@ class TaskUpdateActorTest
 
     Given("an op")
     val appId = PathId("/app")
-    val task1Id = "task1"
+    val task1Id = Task.Id.forApp(appId)
     val op1 = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, appId, Task.Id(task1Id), TaskOpProcessor.Action.Expunge
+      f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskOpProcessor.Action.Expunge
     )
-    val task2Id = "task2"
+    val task2Id = Task.Id.forApp(appId)
     val op2 = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, appId, Task.Id(task2Id), TaskOpProcessor.Action.Expunge
+      f.oneSecondInFuture, f.opInitiator.ref, task2Id, TaskOpProcessor.Action.Expunge
     )
 
     And("a processor that does not return")
@@ -183,7 +183,7 @@ class TaskUpdateActorTest
     f.updateActor.underlyingActor.operationsByTaskId should have size 1
 
     And("but the first task still does have a queue")
-    f.updateActor.underlyingActor.operationsByTaskId(Task.Id(task1Id)) should have size 1
+    f.updateActor.underlyingActor.operationsByTaskId(task1Id) should have size 1
   }
 
   test("ops for the same task are processed sequentially") {
@@ -191,12 +191,12 @@ class TaskUpdateActorTest
 
     Given("an op")
     val appId = PathId("/app")
-    val task1Id = "task1"
+    val task1Id = Task.Id.forApp(appId)
     val op1 = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, appId, Task.Id(task1Id), TaskOpProcessor.Action.Expunge
+      f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskOpProcessor.Action.Expunge
     )
     val op2 = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, appId, Task.Id(task1Id), TaskOpProcessor.Action.Noop
+      f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskOpProcessor.Action.Noop
     )
 
     And("a processor that does not return")

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -34,17 +34,17 @@ class TaskStatusUpdateProcessorImplTest
     val origUpdate = TaskStatusUpdateTestHelper.finished // everything != lost is handled in the same way
     val status = origUpdate.wrapped.status.mesosStatus.get.toBuilder.setTaskId(TaskIdUtil.newTaskId(appId)).build()
     val update = origUpdate.withTaskId(status.getTaskId)
-    val taskId = Task.Id(update.wrapped.taskId.getValue)
+    val taskId = update.wrapped.taskId
 
     Given("an unknown task")
     import scala.concurrent.ExecutionContext.Implicits.global
-    f.taskTracker.task(appId, taskId)(global) returns Future.successful(None)
+    f.taskTracker.task(taskId)(global) returns Future.successful(None)
 
     When("we process the updated")
     f.updateProcessor.publish(status).futureValue
 
     Then("we expect that the appropriate taskTracker methods have been called")
-    verify(f.taskTracker).task(appId, taskId)(global)
+    verify(f.taskTracker).task(taskId)(global)
 
     And("the task kill gets initiated")
     verify(f.schedulerDriver).killTask(status.getTaskId)
@@ -60,19 +60,19 @@ class TaskStatusUpdateProcessorImplTest
     val origUpdate = TaskStatusUpdateTestHelper.finished // everything != lost is handled in the same way
     val status = origUpdate.wrapped.status.mesosStatus.get.toBuilder.setTaskId(TaskIdUtil.newTaskId(appId)).build()
     val update = origUpdate.withTaskId(status.getTaskId)
-    val taskId = Task.Id(update.wrapped.taskId.getValue)
+    val taskId = update.wrapped.taskId
 
     Given("an unknown task")
     import scala.concurrent.ExecutionContext.Implicits.global
-    f.taskTracker.task(appId, taskId)(global) returns Future.successful(
-      Some(MarathonTestHelper.mininimalTask(taskId.id))
+    f.taskTracker.task(taskId)(global) returns Future.successful(
+      Some(MarathonTestHelper.mininimalTask(taskId.idString))
     )
 
     When("we process the updated")
     f.updateProcessor.publish(status).futureValue
 
     Then("we expect that the appropriate taskTracker methods have been called")
-    verify(f.taskTracker).task(appId, taskId)(global)
+    verify(f.taskTracker).task(taskId)(global)
 
     And("the task kill gets initiated")
     verify(f.schedulerDriver).killTask(status.getTaskId)
@@ -89,17 +89,17 @@ class TaskStatusUpdateProcessorImplTest
     val origUpdate = TaskStatusUpdateTestHelper.lost
     val status = origUpdate.wrapped.status.mesosStatus.get.toBuilder.setTaskId(TaskIdUtil.newTaskId(appId)).build()
     val update = origUpdate.withTaskId(status.getTaskId)
-    val taskId = Task.Id(update.wrapped.taskId.getValue)
+    val taskId = update.wrapped.taskId
 
     Given("an unknown task")
     import scala.concurrent.ExecutionContext.Implicits.global
-    f.taskTracker.task(appId, taskId)(global) returns Future.successful(None)
+    f.taskTracker.task(taskId)(global) returns Future.successful(None)
 
     When("we process the updated")
     f.updateProcessor.publish(status).futureValue
 
     Then("we expect that the appropriate taskTracker methods have been called")
-    verify(f.taskTracker).task(appId, taskId)(global)
+    verify(f.taskTracker).task(taskId)(global)
 
     And("the update has been acknowledged")
     verify(f.schedulerDriver).acknowledgeStatusUpdate(status)
@@ -114,11 +114,11 @@ class TaskStatusUpdateProcessorImplTest
     val origUpdate = TaskStatusUpdateTestHelper.finished
     val status = origUpdate.wrapped.status.mesosStatus.get.toBuilder.setTaskId(TaskIdUtil.newTaskId(appId)).build()
     val update = origUpdate.withTaskId(status.getTaskId)
-    val taskId = Task.Id(update.wrapped.taskId.getValue)
+    val taskId = update.wrapped.taskId
 
     Given("a known task")
     import scala.concurrent.ExecutionContext.Implicits.global
-    f.taskTracker.task(appId, taskId) returns Future.successful(Some(taskState))
+    f.taskTracker.task(taskId) returns Future.successful(Some(taskState))
     f.taskUpdater.statusUpdate(appId, status).asInstanceOf[Future[Unit]] returns Future.successful(())
     f.appRepository.app(appId, version) returns Future.successful(Some(app))
     And("and a cooperative launchQueue")
@@ -128,7 +128,7 @@ class TaskStatusUpdateProcessorImplTest
     f.updateProcessor.publish(status).futureValue
 
     Then("we expect that the appropriate taskTracker methods have been called")
-    verify(f.taskTracker).task(appId, taskId)
+    verify(f.taskTracker).task(taskId)
     verify(f.taskUpdater).statusUpdate(appId, status)
 
     And("the healthCheckManager got informed")

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyLaunchQueueStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyLaunchQueueStepImplTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.core.task.update.impl.steps
 
 import mesosphere.marathon.MarathonTestHelper
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.MarathonTaskStatus
 import mesosphere.marathon.core.task.bus.TaskStatusObservables.TaskStatusUpdate
 import mesosphere.marathon.state.{ Timestamp, PathId }
@@ -21,7 +22,7 @@ class NotifyLaunchQueueStepImplTest extends FunSuite with Matchers with GivenWhe
   test("notifying launch queue") {
     val f = new Fixture
     val status = runningTaskStatus
-    val expectedUpdate = TaskStatusUpdate(updateTimestamp, taskId, MarathonTaskStatus(status))
+    val expectedUpdate = TaskStatusUpdate(updateTimestamp, Task.Id(taskId), MarathonTaskStatus(status))
 
     Given("a status update")
     f.launchQueue.notifyOfTaskUpdate(expectedUpdate) returns Future.successful(None)

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckActorTest.scala
@@ -45,7 +45,7 @@ class HealthCheckActorTest
       .setVersion(appVersion)
       .build()
 
-    when(tracker.appTasksSync(appId)).thenReturn(Set(task))
+    when(tracker.marathonAppTasksSync(appId)).thenReturn(Set(task))
 
     val holder: MarathonSchedulerDriverHolder = new MarathonSchedulerDriverHolder
     val actor = TestActorRef[HealthCheckActor](

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
@@ -40,7 +40,7 @@ class AppStopActorTest
     val promise = Promise[Unit]()
     val tasks = Set(marathonTask("task_a"), marathonTask("task_b"))
 
-    when(taskTracker.appTasksSync(app.id)).thenReturn(tasks)
+    when(taskTracker.marathonAppTasksSync(app.id)).thenReturn(tasks)
 
     val ref = TestActorRef[AppStopActor](
       Props(
@@ -103,7 +103,7 @@ class AppStopActorTest
     val app = AppDefinition(id = PathId("app"), instances = 2)
     val promise = Promise[Unit]()
 
-    when(taskTracker.appTasksSync(app.id)).thenReturn(Set.empty[MarathonTask])
+    when(taskTracker.marathonAppTasksSync(app.id)).thenReturn(Set.empty[MarathonTask])
 
     val ref = TestActorRef[AppStopActor](
       Props(
@@ -128,7 +128,7 @@ class AppStopActorTest
     val promise = Promise[Unit]()
     val tasks = Set(marathonTask("task_a"), marathonTask("task_b"))
 
-    when(taskTracker.appTasksSync(app.id)).thenReturn(tasks)
+    when(taskTracker.marathonAppTasksSync(app.id)).thenReturn(tasks)
 
     val ref = TestActorRef[AppStopActor](
       Props(
@@ -157,7 +157,7 @@ class AppStopActorTest
     val promise = Promise[Unit]()
     val tasks = Set(marathonTask("task_a"), marathonTask("task_b"))
 
-    when(taskTracker.appTasksSync(app.id))
+    when(taskTracker.marathonAppTasksSync(app.id))
       .thenReturn(tasks)
       .thenReturn(Set.empty[MarathonTask])
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
@@ -97,7 +97,7 @@ class TaskKillActorTest
     val taskB = MarathonTask.newBuilder().setId("taskB_id").build()
     val tasks = mutable.Set(taskA, taskB)
 
-    when(taskTracker.appTasksSync(app.id))
+    when(taskTracker.marathonAppTasksSync(app.id))
       .thenReturn(Set.empty[MarathonTask])
 
     val ref = TestActorRef[TaskKillActor](Props(classOf[TaskKillActor], driver, app.id, taskTracker, system.eventStream, tasks.toSet, promise))
@@ -122,7 +122,7 @@ class TaskKillActorTest
 
     val ref = TestActorRef[TaskKillActor](Props(classOf[TaskKillActor], driver, appId, taskTracker, system.eventStream, tasks, promise))
 
-    when(taskTracker.appTasksSync(appId)).thenReturn(Set(taskA, taskB))
+    when(taskTracker.marathonAppTasksSync(appId)).thenReturn(Set(taskA, taskB))
 
     watch(ref)
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -41,7 +41,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB))
+    when(tracker.marathonAppTasksSync(app.id)).thenReturn(Set(taskA, taskB))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -88,7 +88,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB))
+    when(tracker.marathonAppTasksSync(app.id)).thenReturn(Set(taskA, taskB))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -131,7 +131,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(tracker.marathonAppTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -185,7 +185,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(tracker.marathonAppTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       override def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -255,7 +255,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(tracker.marathonAppTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -329,7 +329,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(tracker.marathonAppTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -401,7 +401,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
+    when(tracker.marathonAppTasksSync(app.id)).thenReturn(Set(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID].getValue
@@ -464,7 +464,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB))
+    when(tracker.marathonAppTasksSync(app.id)).thenReturn(Set(taskA, taskB))
 
     val promise = Promise[Unit]()
 
@@ -496,7 +496,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB))
+    when(tracker.marathonAppTasksSync(app.id)).thenReturn(Set(taskA, taskB))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       var firstKillForTaskB = true
 
@@ -549,7 +549,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(taskA, taskB))
+    when(tracker.marathonAppTasksSync(app.id)).thenReturn(Set(taskA, taskB))
 
     val promise = Promise[Unit]()
 


### PR DESCRIPTION
* Get rid of appId in some place where it is redundant
* Use Task.Id in Map structures inside the TaskTracker and the AppTaskLaunchActor