### PR TITLE
Update OfferMatchingManager.scala to safe max-tasks-per-offer setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ start.sh
 .DS_Store
 *.ipr
 *.iws
+.metadata/

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerConfig.scala
@@ -7,7 +7,7 @@ trait OfferMatcherManagerConfig extends ScallopConf {
 
   lazy val maxTasksPerOffer = opt[Int]("max_tasks_per_offer",
     descr = "Maximum tasks per offer. Do not start more than this number of tasks on a single offer.",
-    default = Some(100))
+    default = Some(1))
 
   lazy val maxTasksPerOfferCycle = opt[Int]("max_tasks_per_offer_cycle",
     descr = "DEPRECATED. NO EFFECT. Maximally launch this number of tasks per offer cycle.",

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -77,7 +77,7 @@ class OfferMatcherManagerModuleTest extends FunSuite with BeforeAndAfter with Ma
     module.subOfferMatcherManager.addSubscription(new CPUOfferMatcher(Seq(task2)))
 
     val matchedTasksFuture: Future[MatchedTaskOps] =
-      module.globalOfferMatcher.matchOffer(clock.now() + 1.second, offer)
+      module.globalOfferMatcher.matchOffer(clock.now() + 2.seconds, offer)
     val matchedTasks: MatchedTaskOps = Await.result(matchedTasksFuture, 3.seconds)
     assert(matchedTasks.launchedTaskInfos.toSet == Set(makeOneCPUTask("task1_1"), makeOneCPUTask("task2_1")))
   }
@@ -92,7 +92,7 @@ class OfferMatcherManagerModuleTest extends FunSuite with BeforeAndAfter with Ma
       module.subOfferMatcherManager.addSubscription(new ConstantOfferMatcher(Seq(task1)))
 
       val matchedTasksFuture: Future[MatchedTaskOps] =
-        module.globalOfferMatcher.matchOffer(clock.now() + 1.second, offer)
+        module.globalOfferMatcher.matchOffer(clock.now() + 10.seconds, offer)
       val matchedTasks: MatchedTaskOps = Await.result(matchedTasksFuture, 3.seconds)
       assert(matchedTasks.opsWithSource.size == launchTokens)
     }
@@ -109,7 +109,7 @@ class OfferMatcherManagerModuleTest extends FunSuite with BeforeAndAfter with Ma
     module.subOfferMatcherManager.addSubscription(new CPUOfferMatcher(Seq(task2)))
 
     val matchedTasksFuture: Future[MatchedTaskOps] =
-      module.globalOfferMatcher.matchOffer(clock.now() + 1.second, offer)
+      module.globalOfferMatcher.matchOffer(clock.now() + 5.seconds, offer)
     val matchedTasks: MatchedTaskOps = Await.result(matchedTasksFuture, 3.seconds)
     assert(matchedTasks.launchedTaskInfos.toSet == Set(
       makeOneCPUTask("task1_1"),


### PR DESCRIPTION
The [docs list](https://mesosphere.github.io/marathon/docs/command-line-flags.html) `--max-tasks-per-offer` as defaulted to 1, which is a safe setting. We default this to 100 in the code and 1000 in DCOS; our tests indicate that anything higher than 5 is unsafe for AWS. Adjusting this to a safe setting so less risk-averse users can adjust on their own.

> --max_tasks_per_offer (Optional. Default: 1): Launch at most this number of tasks per Mesos offer. Usually, there is one offer per cycle and slave. You can speed up launching tasks by increasing this number.

We need to get this important safety feature out ASAP.