### PR TITLE
update mesosphere.io to mesosphere.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . /marathon
 WORKDIR /marathon
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
-    echo "deb http://repos.mesosphere.io/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
     apt-get install --no-install-recommends -y --force-yes mesos=0.26.0-0.2.145.debian81 && \
     apt-get clean && \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -7,7 +7,7 @@
 FROM java:8-jdk
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
-    echo "deb http://repos.mesosphere.io/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
     apt-get install --no-install-recommends -y --force-yes mesos=0.26.0-0.2.145.debian81 lxc
 

--- a/docs/docs/plugin.md
+++ b/docs/docs/plugin.md
@@ -32,7 +32,7 @@ The plugin mechanism has the following components:
 A separate Marathon plugin interface jar is published in the following Maven repository with every Marathon release:
 
 ```
-http://downloads.mesosphere.io/maven
+http://downloads.mesosphere.com/maven
 ```
 
 with following dependency:

--- a/project/build.scala
+++ b/project/build.scala
@@ -127,7 +127,7 @@ object MarathonBuild extends Build {
     ),
     javacOptions in Compile ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-Xlint:unchecked", "-Xlint:deprecation"),
     resolvers ++= Seq(
-      "Mesosphere Public Repo"    at "http://downloads.mesosphere.io/maven",
+      "Mesosphere Public Repo"    at "http://downloads.mesosphere.com/maven",
       "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
       "Spray Maven Repository"    at "http://repo.spray.io/"
   ),


### PR DESCRIPTION
This PR should update all relevant references to downloads.mesosphere.io and repos.mesosphere.io to use the .com domain instead.

(Note that the S3 bucket name hasn't changed)
