### PR TITLE
Fix the json key in documentation

### DIFF
--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/DeploymentsResource_running.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/DeploymentsResource_running.md
@@ -36,7 +36,7 @@ Transfer-Encoding: chunked
 
 [
     {
-        "affectedApplications": [
+        "affectedApps": [
             "/test/service/srv1", 
             "/test/db/mongo1", 
             "/test/frontend/app1"


### PR DESCRIPTION
The correct key should be affectedApps

I found the key to be incorrect here https://mesosphere.github.io/marathon/docs/rest-api.html - I hope I have fixed it in the right place