### PR TITLE
Clarify behavior of portIndex and port health check options.

### DIFF
--- a/docs/docs/health-checks.md
+++ b/docs/docs/health-checks.md
@@ -87,9 +87,9 @@ Options applicable to every protocol:
 * `timeoutSeconds` (Optional. Default: 20): Number of seconds after which a
   health check is considered a failure regardless of the response.
 
-For TCP/HTTP health checks, you need to specify either `port` or `portIndex`:
+For TCP/HTTP health checks, either `port` or `portIndex` may be used. If none is provided, `portIndex` is assumed. If `port` is provided, it takes precedence overriding any `portIndex` option.
 
-* `portIndex` (Optional. Default: None): Index in this app's `ports` array to be
+* `portIndex` (Optional. Default: 0): Index in this app's `ports` array to be
   used for health requests. An index is used so the app can use random ports,
   like "[0, 0, 0]" for example, and tasks could be started with port environment
   variables like `$PORT1`.


### PR DESCRIPTION
Relates to #3140.

@meichstedt: I gave things a second thought: Contrary to [your option](https://github.com/mesosphere/marathon/issues/3140#issuecomment-184121372), I decided to revert  `portIndex`'s default value back to 0 but add a description on how `portIndex` and `port` relate to each other. My rationale here is that while the default value may technically be `None` with a fallback to 0 for backwards compatibility reasons, from a consumer's perspective that's an unimportant implementation detail: The external behavior which can be observed is that by not providing any of the two options, Marathon will assume `portIndex` to be 0. In that sense, a user does not need to specify a particular option, which is what the current documentation says.

Regarding the

> If `port` is provided, it takes precedence overriding any `portIndex` option.

part: I did not actually verify this. In case this is not how Marathon behaves, please let me know.

Happy to discuss. :)