### PR TITLE
Fixes #3241 - consistent JSON error output.

### DIFF
--- a/src/test/scala/mesosphere/marathon/api/MarathonExceptionMapperTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/MarathonExceptionMapperTest.scala
@@ -1,7 +1,5 @@
 package mesosphere.marathon.api
 
-import javax.validation.ConstraintViolationException
-
 import mesosphere.marathon.{ ValidationFailedException, MarathonSpec }
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.v2.Validation._
@@ -84,7 +82,8 @@ class MarathonExceptionMapperTest extends MarathonSpec with GivenWhenThen with M
     val errors = (entity \ "details").as[Seq[JsObject]]
     errors should have size 1
     val firstError = errors.head
-    (firstError \ "attribute").as[String] should be("value")
-    (firstError \ "error").as[String] should be("AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.")
+    (firstError \ "path").as[String] should be("self")
+    val errorMsgs = (firstError \ "errors").as[Seq[String]]
+    errorMsgs.head should be("AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.")
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.api.v2
 
 import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.api.v2.json.Formats._
-import mesosphere.marathon.api.v2.json.{ GroupUpdate, GroupUpdate$ }
+import mesosphere.marathon.api.v2.json.GroupUpdate
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.test.Mockito

--- a/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
@@ -5,6 +5,7 @@ import mesosphere.marathon.integration.setup.{ IntegrationFunSuite, IntegrationH
 import mesosphere.marathon.state.{ AppDefinition, PathId, UpgradeStrategy }
 import org.apache.http.HttpStatus
 import org.scalatest._
+import play.api.libs.json.JsObject
 import spray.http.DateTime
 
 import scala.concurrent.duration._
@@ -256,8 +257,9 @@ class GroupDeployIntegrationTest
     When("The group gets posted")
     val result = marathon.createGroup(group)
 
-    Then("An unsuccessfull response has been posted, with an error indicating cyclic dependencies")
-    (result.entityJson \\ "error").filter(j => j.as[String].contains("cyclic dependencies")) should have size 1
+    Then("An unsuccessful response has been posted, with an error indicating cyclic dependencies")
+    val errors = (result.entityJson \ "details" \\ "errors").flatMap(_.as[Seq[String]])
+    errors.find(_.contains("cyclic dependencies")) shouldBe defined
   }
 
   test("Applications with dependencies get deployed in the correct order") {


### PR DESCRIPTION
Fixes #3241 applying following changes to JSON output of errors:

1. `attribute` field renamed to `path`
2. `error` field renamed to `errors`
3. `errors` field contains a list of errors caused by an attribute, which location can be found in `path`
4. root `path` information is no longer labeled as `value`, but as `self`
5. `.value` should never terminate a path (e.g. `apps[0].value` is replaced by `apps[0]`)
6. `"path": "self"` if there is no description about the point of failure at all