### PR TITLE
Fixes #3232 by handling terminating status updates for resident tasks:

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -6,6 +6,7 @@ import mesosphere.marathon.core.task.Task.Launched
 import mesosphere.marathon.core.task.tracker.impl.TaskSerializer
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import org.apache.mesos.Protos.TaskState
+import org.apache.mesos.Protos.TaskState._
 import org.apache.mesos.{ Protos => MesosProtos }
 
 /**
@@ -172,4 +173,13 @@ object Task {
   }
 
   case object NoNetworking extends Networking
+
+  object Terminated {
+    def isTerminated(state: TaskState): Boolean = state match {
+      case TASK_ERROR | TASK_FAILED | TASK_FINISHED | TASK_KILLED | TASK_LOST => true
+      case _ => false
+    }
+
+    def unapply(state: TaskState): Option[TaskState] = if (isTerminated(state)) Some(state) else None
+  }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessor.scala
@@ -23,6 +23,9 @@ private[tracker] object TaskOpProcessor {
     /** Remove a task. */
     case object Expunge extends Action
 
+    /** Remove the launch information from a task */
+    case class Unlaunch(task: Task) extends Action
+
     /**
       * Update a task according to a status update.
       *

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -5,6 +5,7 @@ import javax.inject.Named
 import akka.event.EventStream
 import com.google.inject.Inject
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.Task.Terminated
 import mesosphere.marathon.core.task.update.TaskStatusUpdateStep
 import mesosphere.marathon.event.{ EventModule, MesosStatusUpdateEvent }
 import mesosphere.marathon.state.Timestamp
@@ -34,7 +35,7 @@ class PostToEventStreamStepImpl @Inject() (
   override def processUpdate(timestamp: Timestamp, task: Task, status: TaskStatus): Future[_] = {
 
     status.getState match {
-      case TASK_ERROR | TASK_FAILED | TASK_FINISHED | TASK_KILLED | TASK_LOST =>
+      case Terminated(_) =>
         postEvent(timestamp, status, task)
       case TASK_RUNNING if task.launched.exists(!_.hasStartedRunning) => // staged, not running
         postEvent(timestamp, status, task)

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
@@ -6,6 +6,7 @@ import akka.actor.ActorRef
 import com.google.inject.Inject
 import mesosphere.marathon.MarathonSchedulerActor.ScaleApp
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.Task.Terminated
 import mesosphere.marathon.core.task.update.TaskStatusUpdateStep
 import mesosphere.marathon.state.Timestamp
 import org.apache.mesos.Protos.TaskStatus
@@ -25,10 +26,8 @@ class ScaleAppUpdateStepImpl @Inject() (
   override def processUpdate(timestamp: Timestamp, task: Task, status: TaskStatus): Future[_] = {
     val taskId = task.taskId
 
-    import org.apache.mesos.Protos.TaskState._
-
     status.getState match {
-      case TASK_ERROR | TASK_FAILED | TASK_FINISHED | TASK_KILLED | TASK_LOST =>
+      case Terminated(_) =>
         // Remove from our internal list
         log.info(s"initiating a scale check for app [${taskId.appId}] after $taskId terminated")
         schedulerActor ! ScaleApp(taskId.appId)

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -251,6 +251,15 @@ object MarathonTestHelper {
     )
   }
 
+  def taskReservation: Task.ReservationWithVolumes = {
+    Task.ReservationWithVolumes(Seq.empty)
+  }
+
+  def taskLaunched: Task.Launched = {
+    val now = Timestamp.now()
+    Task.Launched(now, status = Task.Status(now), networking = Task.NoNetworking)
+  }
+
   def startingTaskForApp(appId: PathId, appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task =
     startingTask(
       Task.Id.forApp(appId).idString,
@@ -342,7 +351,7 @@ object MarathonTestHelper {
       .buildPartial()
   }
 
-  private[this] def statusForState(taskId: String, state: MesosProtos.TaskState): MesosProtos.TaskStatus = {
+  def statusForState(taskId: String, state: MesosProtos.TaskState): MesosProtos.TaskStatus = {
     MesosProtos.TaskStatus
       .newBuilder()
       .setTaskId(TaskID.newBuilder().setValue(taskId))


### PR DESCRIPTION
- introduce an Unlaunch operation
- Handling Unlaunch by removing the task launch information