### PR TITLE
Bump to mesos 0.27.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /marathon
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.26.0-0.2.145.debian81 && \
+    apt-get install --no-install-recommends -y --force-yes mesos=0.27.0-0.2.190.debian81 && \
     apt-get clean && \
     eval $(sed s/sbt.version/SBT_VERSION/ </marathon/project/build.properties) && \
     mkdir -p /usr/local/bin && \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -7,9 +7,10 @@
 FROM java:8-jdk
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
-    echo "deb http://repos.mesosphere.com/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.26.0-0.2.145.debian81 lxc
+    apt-get install --no-install-recommends -y --force-yes mesos=0.27.1-0.2.198.debian81 lxc
 
 # Install sbt manually
 COPY ./project/build.properties /marathon/project/build.properties


### PR DESCRIPTION
Add the mesosphere jessie testing repository, in order to try mesos RC releases.