### PR TITLE
Fixes #3266 by introducing an optional precedence (PathId) for OfferMatchers.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
@@ -404,7 +404,10 @@ private class AppTaskLauncherActor(
 
   /** Manage registering this actor as offer matcher. Only register it if tasksToLaunch > 0. */
   private[this] object OfferMatcherRegistration {
-    private[this] val myselfAsOfferMatcher: OfferMatcher = new ActorOfferMatcher(clock, self)
+    private[this] val myselfAsOfferMatcher: OfferMatcher = {
+      //set the precedence only, if this app is resident
+      new ActorOfferMatcher(clock, self, app.residency.map(_ => app.id))
+    }
     private[this] var registeredAsMatcher = false
 
     /** Register/unregister as necessary */

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/OfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/OfferMatcher.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.core.matcher.base
 
 import mesosphere.marathon.core.matcher.base.util.OfferOperation
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.Timestamp
+import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.tasks.ResourceUtil
 import org.apache.mesos.Protos.{ Offer, OfferID, TaskInfo }
 
@@ -95,4 +95,11 @@ trait OfferMatcher {
     * for every returned `org.apache.mesos.Protos.TaskInfo`.
     */
   def matchOffer(deadline: Timestamp, offer: Offer): Future[OfferMatcher.MatchedTaskOps]
+
+  /**
+    * We can optimize the offer routing for different offer matcher in case there are reserved resources.
+    * A defined precedence is used to filter incoming offers with reservations that apply to this filter.
+    * If the filter matches, the offer matcher manager has higher priority than other matchers.
+    */
+  def precedenceFor: Option[PathId] = None
 }

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.MatchedTaskOps
-import mesosphere.marathon.state.Timestamp
+import mesosphere.marathon.state.{ PathId, Timestamp }
 import org.apache.mesos.Protos.Offer
 
 import scala.concurrent.Future
@@ -14,7 +14,9 @@ import scala.concurrent.Future
 /**
   * Provides a thin wrapper around an OfferMatcher implemented as an actors.
   */
-class ActorOfferMatcher(clock: Clock, actorRef: ActorRef) extends OfferMatcher {
+class ActorOfferMatcher(clock: Clock,
+                        actorRef: ActorRef,
+                        override val precedenceFor: Option[PathId]) extends OfferMatcher {
   def matchOffer(deadline: Timestamp, offer: Offer): Future[MatchedTaskOps] = {
     implicit val timeout: Timeout = clock.now().until(deadline)
     val answerFuture = actorRef ? ActorOfferMatcher.MatchOffer(deadline, offer)

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -40,6 +40,6 @@ class OfferMatcherManagerModule(
     * offers.
     */
   val globalOfferMatcherWantsOffers: Observable[Boolean] = offersWanted
-  val globalOfferMatcher: OfferMatcher = new ActorOfferMatcher(clock, offerMatcherMultiplexer)
+  val globalOfferMatcher: OfferMatcher = new ActorOfferMatcher(clock, offerMatcherMultiplexer, None)
   val subOfferMatcherManager: OfferMatcherManager = new OfferMatcherManagerDelegate(offerMatcherMultiplexer)
 }

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -102,6 +102,19 @@ object Task {
     override def toString: String = s"LocalVolume [$idString]"
   }
 
+  object LocalVolumeId {
+    def apply(appId: PathId, path: String): LocalVolumeId = {
+      //FIXME: mock implementation from ME
+      LocalVolumeId(s"${appId.safePath}.$path.random")
+    }
+
+    private val LocalVolumeEncoderRE = "^([^.]+).([^.]+).([^.]+)$".r
+    def unapply(id: String): Option[(PathId, String)] = id match {
+      case LocalVolumeEncoderRE(app, path, _) => Some(PathId.fromSafePath(app) -> path)
+      case _                                  => None
+    }
+  }
+
   /**
     * Represents a task which has been launched (i.e. sent to Mesos for launching).
     */

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializer.scala
@@ -39,7 +39,8 @@ object TaskSerializer {
 
     def reservationWithVolume: Option[Task.ReservationWithVolumes] = {
       if (proto.hasReservationWithVolumes) {
-        Some(ReservationWithVolumes(proto.getReservationWithVolumes.getLocalVolumeIdsList.asScala.map(LocalVolumeId)))
+        Some(ReservationWithVolumes(
+          proto.getReservationWithVolumes.getLocalVolumeIdsList.asScala.map(LocalVolumeId(_))))
       }
       else {
         None

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -87,6 +87,24 @@ object MarathonTestHelper {
     offerBuilder
   }
 
+  def reservedDisk(id: String, size: Double = 4096, role: String = "*",
+                   principal: String = "test", containerPath: String = "/container"): MesosProtos.Resource.Builder = {
+    import MesosProtos.Resource.{ ReservationInfo, DiskInfo }
+    MesosProtos.Resource.newBuilder()
+      .setType(MesosProtos.Value.Type.SCALAR)
+      .setName(Resource.DISK)
+      .setScalar(MesosProtos.Value.Scalar.newBuilder.setValue(size))
+      .setRole(role)
+      .setReservation(ReservationInfo.newBuilder().setPrincipal(principal))
+      .setDisk(DiskInfo.newBuilder()
+        .setPersistence(DiskInfo.Persistence.newBuilder().setId(id))
+        .setVolume(MesosProtos.Volume.newBuilder()
+          .setMode(MesosProtos.Volume.Mode.RW)
+          .setContainerPath(containerPath)
+        )
+      )
+  }
+
   /**
     * @param ranges how many port ranges should be included in this offer
     * @return

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
@@ -1,0 +1,85 @@
+package mesosphere.marathon.core.matcher.manager.impl
+
+import java.util
+import java.util.concurrent.TimeUnit
+
+import akka.pattern.ask
+import akka.testkit.TestActorRef
+import akka.util.Timeout
+import mesosphere.marathon.MarathonTestHelper
+import mesosphere.marathon.core.base.ConstantClock
+import mesosphere.marathon.core.matcher.base.OfferMatcher
+import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerConfig
+import mesosphere.marathon.core.task.Task.LocalVolumeId
+import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.state.PathId
+import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }
+import org.apache.mesos.Protos.Offer
+import org.rogach.scallop.ScallopConf
+import org.scalatest.{ FunSuiteLike, GivenWhenThen, Matchers }
+import rx.lang.scala.Observer
+
+import scala.util.Random
+
+class OfferMatcherManagerActorTest extends MarathonActorSupport with FunSuiteLike with Matchers with GivenWhenThen with Mockito {
+
+  test("The list of OfferMatchers is random without precedence") {
+    Given("OfferMatcher with num normal matchers")
+    val num = 5
+    val f = new Fixture
+    val appId = PathId("/some/app")
+    val manager = f.offerMatcherManager
+    val matchers = 1.to(num).map(_ => f.matcher())
+    matchers.map { matcher => manager ? OfferMatcherManagerDelegate.AddOrUpdateMatcher(matcher) }
+
+    When("The list of offer matchers is fetched")
+    val orderedMatchers = manager.underlyingActor.offerMatchers(f.reservedOffer(appId))
+
+    Then("The list is sorted in the correct order")
+    orderedMatchers should have size num.toLong
+    orderedMatchers should contain theSameElementsAs matchers
+  }
+
+  test("The list of OfferMatchers is sorted by precedence") {
+    Given("OfferMatcher with num precedence and num normal matchers, registered in mixed order")
+    val num = 5
+    val f = new Fixture
+    val appId = PathId("/some/app")
+    val manager = f.offerMatcherManager
+    1.to(num).flatMap(_ => Seq(f.matcher(), f.matcher(Some(appId)))).map { matcher =>
+      manager ? OfferMatcherManagerDelegate.AddOrUpdateMatcher(matcher)
+    }
+
+    When("The list of offer matchers is fetched")
+    val sortedMatchers = manager.underlyingActor.offerMatchers(f.reservedOffer(appId))
+
+    Then("The list is sorted in the correct order")
+    sortedMatchers should have size 2 * num.toLong
+    val (left, right) = sortedMatchers.splitAt(num)
+    left.count(_.precedenceFor.isDefined) should be (num)
+    right.count(_.precedenceFor.isDefined) should be (0)
+  }
+
+  implicit val timeout = Timeout(3, TimeUnit.SECONDS)
+  class Fixture {
+    val metricRegistry = mock[Metrics]
+    val metrics = new OfferMatcherManagerActorMetrics(metricRegistry)
+    val random = new Random(new util.Random())
+    val clock = ConstantClock()
+    val observer = Observer.apply[Boolean]((a: Boolean) => ())
+    object Config extends ScallopConf with OfferMatcherManagerConfig
+    Config.afterInit()
+    val offerMatcherManager = TestActorRef[OfferMatcherManagerActor](OfferMatcherManagerActor.props(metrics, random, clock, Config, observer))
+
+    def matcher(precedence: Option[PathId] = None): OfferMatcher = {
+      val matcher = mock[OfferMatcher]
+      matcher.precedenceFor returns precedence
+      matcher
+    }
+
+    def reservedOffer(appId: PathId, path: String = "/test"): Offer = {
+      import MarathonTestHelper._
+      makeBasicOffer().addResources(reservedDisk(LocalVolumeId(appId, path).idString, containerPath = path)).build()
+    }
+  }
+}


### PR DESCRIPTION
If defined and an offer arrives with a reserved volume that matches the criteria, the matcher gets the offer first.