### PR TITLE
Replace MarathonTask by Task in the /v2/ endpoints

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/appinfo/EnrichedTask.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/EnrichedTask.scala
@@ -1,11 +1,11 @@
 package mesosphere.marathon.core.appinfo
 
-import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.health.Health
 import mesosphere.marathon.state.PathId
 
 case class EnrichedTask(
   appId: PathId,
-  task: MarathonTask,
+  task: Task,
   healthCheckResults: Seq[Health],
   servicePorts: Seq[Int] = Nil)

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon.core.appinfo.impl
 
 import mesosphere.marathon.MarathonSchedulerService
-import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.appinfo.{ AppInfo, EnrichedTask, TaskCounts, TaskStatsByVersion }
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.task.Task
@@ -121,7 +120,7 @@ class AppInfoBaseData(
 
     lazy val enrichedTasksFuture: Future[Seq[EnrichedTask]] = {
       def statusesToEnrichedTasks(
-        tasksById: Map[Task.Id, MarathonTask],
+        tasksById: Map[Task.Id, Task],
         statuses: Map[Task.Id, collection.Seq[Health]]): Seq[EnrichedTask] = {
         for {
           (taskId, healthResults) <- statuses.to[Seq]
@@ -131,7 +130,7 @@ class AppInfoBaseData(
 
       log.debug(s"assembling rich tasks for app [${app.id}]")
 
-      val tasksByIdFuture = tasksByAppFuture.map(_.appTasksMap.get(app.id).map(_.taskMap).getOrElse(Map.empty))
+      val tasksByIdFuture = tasksByAppFuture.map(_.appTasksMap.get(app.id).map(_.taskStateMap).getOrElse(Map.empty))
       val healthStatusesFutures = healthCheckManager.statuses(app.id)
       for {
         tasksById <- tasksByIdFuture

--- a/src/main/scala/mesosphere/marathon/state/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupManager.scala
@@ -6,7 +6,6 @@ import javax.inject.{ Inject, Named }
 import akka.event.EventStream
 import com.google.inject.Singleton
 
-import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.event.{ EventModule, GroupChangeFailed, GroupChangeSuccess }
 import mesosphere.marathon.io.PathFun
 import mesosphere.marathon.io.storage.StorageProvider

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -4,7 +4,6 @@ import java.net.URL
 
 import akka.actor._
 import akka.event.EventStream
-import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.SchedulerActions
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.Task

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskStatsByVersionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskStatsByVersionTest.scala
@@ -4,9 +4,8 @@ import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.health.Health
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
-import mesosphere.marathon.{ MarathonTestHelper, Protos, MarathonSpec }
+import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec }
 import org.scalatest.{ Matchers, GivenWhenThen }
-import org.apache.mesos.{ Protos => mesos }
 import play.api.libs.json.Json
 import scala.concurrent.duration._
 
@@ -60,7 +59,7 @@ class TaskStatsByVersionTest extends MarathonSpec with GivenWhenThen with Matche
     )
     Then("we get the correct stats")
     import mesosphere.marathon.api.v2.json.Formats._
-    withClue(Json.prettyPrint(Json.obj("stats" -> stats, "tasks" -> tasks.map(_.marathonTask)))) {
+    withClue(Json.prettyPrint(Json.obj("stats" -> stats, "tasks" -> tasks))) {
       stats.maybeWithOutdatedConfig should not be empty
       stats.maybeWithLatestConfig should not be empty
       stats.maybeStartedAfterLastScaling should not be empty

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -87,13 +87,13 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
     Then("we get a tasks object in the appInfo")
     appInfo.maybeTasks should not be empty
     appInfo.maybeTasks.get.map(_.appId.toString) should have size (3)
-    appInfo.maybeTasks.get.map(_.task.getId).toSet should be (Set("task1", "task2", "task3"))
+    appInfo.maybeTasks.get.map(_.task.taskId.idString).toSet should be (Set("task1", "task2", "task3"))
 
     appInfo should be(AppInfo(app, maybeTasks = Some(
       Seq(
-        EnrichedTask(app.id, running1.marathonTask, Seq.empty),
-        EnrichedTask(app.id, running2.marathonTask, Seq(alive)),
-        EnrichedTask(app.id, running3.marathonTask, Seq(unhealthy))
+        EnrichedTask(app.id, running1, Seq.empty),
+        EnrichedTask(app.id, running2, Seq(alive)),
+        EnrichedTask(app.id, running3, Seq(unhealthy))
       )
     )))
 


### PR DESCRIPTION
Introduce TaskWrites that handles th different optional cases as well as local volumes.
Fix all tests, that rely on the old Writes function.