### PR TITLE
Kill tasks in batches.

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
@@ -20,9 +20,4 @@ class AppStopActor(
   override var idsToKill: mutable.Set[Task.Id] = taskTracker.appTasksSync(app.id).map(_.taskId).to[mutable.Set]
 
   def appId: PathId = app.id
-
-  def initializeStop(): Unit = {
-    eventBus.subscribe(self, classOf[MesosStatusUpdateEvent])
-    for (id <- idsToKill) driver.killTask(id.mesosTaskId)
-  }
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
@@ -7,12 +7,13 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.event.MesosStatusUpdateEvent
 import mesosphere.marathon.state.PathId
-import mesosphere.marathon.upgrade.StoppingBehavior.SynchronizeTasks
+import mesosphere.marathon.upgrade.StoppingBehavior.{ KillNextBatch, KillAllTasks }
 import org.apache.mesos.{ Protos, SchedulerDriver }
 
 import scala.collection.mutable
 import scala.concurrent.Promise
 import scala.concurrent.duration._
+import scala.math.min
 
 trait StoppingBehavior extends Actor with ActorLogging {
   import context.dispatcher
@@ -23,15 +24,14 @@ trait StoppingBehavior extends Actor with ActorLogging {
   def taskTracker: TaskTracker
   def appId: PathId
   var idsToKill: mutable.Set[Task.Id]
+  var remainingIdsToKill: mutable.Queue[Task.Id] = mutable.Queue.empty
   var periodicalCheck: Cancellable = _
 
-  def initializeStop(): Unit
-
   final override def preStart(): Unit = {
+    log.info(s"Killing ${idsToKill.size} instances")
+
     eventBus.subscribe(self, classOf[MesosStatusUpdateEvent])
-    initializeStop()
-    scheduleSynchronization()
-    checkFinished()
+    initKillAllTasks()
   }
 
   final override def postStop(): Unit = {
@@ -47,35 +47,56 @@ trait StoppingBehavior extends Actor with ActorLogging {
   def receive: Receive = {
     case MesosStatusUpdateEvent(_, taskId, taskFinished(_), _, _, _, _, _, _, _, _) if idsToKill(taskId) =>
       idsToKill.remove(taskId)
+      killNextTasks(1)
       log.info(s"Task $taskId has been killed. Waiting for ${idsToKill.size} more tasks to be killed.")
       checkFinished()
 
-    case SynchronizeTasks =>
+    case KillAllTasks =>
       val trackerIds = taskTracker.appTasksSync(appId).map(_.taskId).toSet
       idsToKill = idsToKill.filter(trackerIds)
+      remainingIdsToKill = mutable.Queue(idsToKill.toSeq: _*)
+      scheduleNextBatch()
 
-      idsToKill.foreach { id =>
-        driver.killTask(id.mesosTaskId)
-      }
-
-      scheduleSynchronization()
-      checkFinished()
+    case KillNextBatch =>
+      killNextTasks(100)
+      scheduleNextBatch()
 
     case x: MesosStatusUpdateEvent => log.debug(s"Received $x")
   }
 
-  def checkFinished(): Unit =
+  def killNextTasks(toKill: Int): Unit = {
+    (0 until min(toKill, remainingIdsToKill.size)) foreach { _ =>
+      driver.killTask(remainingIdsToKill.dequeue().mesosTaskId)
+    }
+  }
+
+  def initKillAllTasks(): Unit = {
+    remainingIdsToKill = mutable.Queue(idsToKill.toSeq: _*)
+    scheduleNextBatch()
+  }
+
+  def checkFinished(): Unit = {
     if (idsToKill.isEmpty) {
       log.info("Successfully killed all the tasks")
       promise.success(())
-      periodicalCheck.cancel()
       context.stop(self)
     }
+  }
 
-  def scheduleSynchronization(): Unit =
-    periodicalCheck = context.system.scheduler.scheduleOnce(5.seconds, self, SynchronizeTasks)
+  def scheduleKillAllTasks(): Unit =
+    periodicalCheck = context.system.scheduler.scheduleOnce(5.seconds, self, KillAllTasks)
+
+  def scheduleNextBatch(): Unit = {
+    if (remainingIdsToKill.nonEmpty) context.system.scheduler.scheduleOnce(2.seconds, self, KillNextBatch)
+    else {
+      log.info("Retry kill")
+      checkFinished()
+      scheduleKillAllTasks()
+    }
+  }
 }
 
 object StoppingBehavior {
-  case object SynchronizeTasks
+  case object KillNextBatch
+  case object KillAllTasks
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskKillActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskKillActor.scala
@@ -19,13 +19,6 @@ class TaskKillActor(
     val promise: Promise[Unit]) extends StoppingBehavior {
 
   override var idsToKill = tasksToKill.to[mutable.Set]
-
-  def initializeStop(): Unit = {
-    log.info(s"Killing ${tasksToKill.size} instances")
-    for (taskId <- tasksToKill) {
-      driver.killTask(taskId.mesosTaskId)
-    }
-  }
 }
 
 object TaskKillActor {


### PR DESCRIPTION
Instead of send kill requests for all tasks at once we send them in batches.