### PR TITLE
Added leaderDuration metric

### DIFF
--- a/docs/docs/metrics.md
+++ b/docs/docs/metrics.md
@@ -32,6 +32,10 @@ be available under "stats.gauges.marathon_test.service.mesosphere.marathon.uptim
 in milliseconds. This is helpful to diagnose stability problems which cause
 Marathon to restart.
 
+`service.mesosphere.marathon.leaderDuration` (gauge) - The duration since the last leader election happened
+in milliseconds. This is helpful to diagnose stability problems and how often leader election happens.
+
+
 ### App/group/task counts
 
 `service.mesosphere.marathon.app.count` (gauge) - The number of defined apps. In general,

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -9,6 +9,7 @@ import akka.actor.{ ActorRef, ActorSystem }
 import akka.event.EventStream
 import akka.pattern.{ after, ask }
 import akka.util.Timeout
+import com.codahale.metrics.Gauge
 import com.google.common.util.concurrent.AbstractExecutionThreadService
 import com.twitter.common.base.ExceptionalCommand
 import com.twitter.common.zookeeper.Candidate
@@ -19,6 +20,7 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.leadership.LeadershipCoordinator
 import mesosphere.marathon.event.{ EventModule, LocalLeadershipEvent }
 import mesosphere.marathon.health.HealthCheckManager
+import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{ AppDefinition, AppRepository, Migration, PathId, Timestamp }
 import mesosphere.marathon.upgrade.DeploymentManager.{ CancelDeployment, DeploymentStepInfo }
 import mesosphere.marathon.upgrade.DeploymentPlan
@@ -27,6 +29,7 @@ import mesosphere.util.state.FrameworkIdUtil
 import org.apache.mesos.Protos.FrameworkID
 import org.apache.mesos.SchedulerDriver
 import org.slf4j.LoggerFactory
+import com.codahale.metrics.MetricRegistry
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
@@ -73,7 +76,8 @@ class MarathonSchedulerService @Inject() (
   migration: Migration,
   @Named("schedulerActor") schedulerActor: ActorRef,
   @Named(EventModule.busName) eventStream: EventStream,
-  leadershipCallbacks: Seq[LeadershipCallback] = Seq.empty)
+  leadershipCallbacks: Seq[LeadershipCallback] = Seq.empty,
+  metrics: Metrics = new Metrics(new MetricRegistry))
     extends AbstractExecutionThreadService with Leader with LeadershipAbdication {
 
   import scala.concurrent.ExecutionContext.Implicits.global
@@ -289,6 +293,9 @@ class MarathonSchedulerService @Inject() (
 
       // We successfully took over leadership. Time to reset backoff
       resetOfferLeadershipBackOff()
+
+      // Start the leader duration metric
+      startLeaderDurationMetric()
     }
     catch {
       case NonFatal(e) => // catch Scala and Java exceptions
@@ -311,6 +318,7 @@ class MarathonSchedulerService @Inject() (
     // Note that abdication command will be ran upon driver shutdown.
     leader.set(false)
     stopDriver()
+    stopLeaderDurationMetric()
   }
 
   private def electLeadership(abdicateOption: Option[ExceptionalCommand[JoinException]]): Unit = synchronized {
@@ -416,5 +424,19 @@ class MarathonSchedulerService @Inject() (
       abdicationCommand()
       offerLeadership()
     }
+  }
+
+  private def startLeaderDurationMetric() = {
+    metrics.gauge("service.mesosphere.marathon.leaderDuration", new Gauge[Long] {
+      val startedAt = System.currentTimeMillis()
+
+      override def getValue: Long =
+        {
+          System.currentTimeMillis() - startedAt
+        }
+    })
+  }
+  private def stopLeaderDurationMetric() = {
+    metrics.registry.remove("service.mesosphere.marathon.leaderDuration")
   }
 }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -186,7 +186,8 @@ class MarathonSchedulerServiceTest
       system,
       migration,
       schedulerActor,
-      events
+      events,
+      metrics = new Metrics(new MetricRegistry)
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
       override def newTimer() = mockTimer


### PR DESCRIPTION
Addressing the issue,
https://github.com/mesosphere/marathon/issues/3010

Created a metric service.mesosphere.marathon.leaderDuration that gets reset every time a node is elected as a leader, removed everytime its defeated
