### PR TITLE
Fixes #3306 by introducing special purpose methods in TaskTracker

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -19,7 +19,7 @@ class TaskKiller @Inject() (
     appId: PathId,
     findToKill: (Iterable[Task] => Iterable[Task])): Future[Iterable[Task]] = {
 
-    val tasks = taskTracker.appTasksSync(appId).filter(_.launched.isDefined)
+    val tasks = taskTracker.appTasksLaunchedSync(appId)
     if (tasks.nonEmpty) {
       val toKill = findToKill(tasks)
       service.killTasks(appId, toKill)
@@ -34,7 +34,7 @@ class TaskKiller @Inject() (
   def killAndScale(appId: PathId,
                    findToKill: (Iterable[Task] => Iterable[Task]),
                    force: Boolean): Future[DeploymentPlan] = {
-    killAndScale(Map(appId -> findToKill(taskTracker.appTasksSync(appId))), force)
+    killAndScale(Map(appId -> findToKill(taskTracker.appTasksLaunchedSync(appId))), force)
   }
 
   def killAndScale(appTasks: Map[PathId, Iterable[Task]], force: Boolean): Future[DeploymentPlan] = {

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -33,8 +33,8 @@ class QueueResource @Inject() (
     import Formats._
 
     doIfAuthenticated(req, resp) { implicit identity =>
-      val queuedWithDelay = launchQueue.list.filter(t => t.waiting && isAllowedToView(t.app.id)).map {
-        case taskCount: LaunchQueue.QueuedTaskCount =>
+      val queuedWithDelay = launchQueue.list.filter(t => t.inProgress && isAllowedToView(t.app.id)).map {
+        case taskCount: LaunchQueue.QueuedTaskInfo =>
           val timeLeft = clock.now() until taskCount.backOffUntil
           Json.obj(
             "app" -> taskCount.app,
@@ -56,7 +56,7 @@ class QueueResource @Inject() (
     val id = appId.toRootPath
     doIfAuthorized(req, resp, UpdateAppOrGroup, id) { implicit identity =>
       launchQueue.list.find(_.app.id == id).map {
-        case taskCount: LaunchQueue.QueuedTaskCount =>
+        case taskCount: LaunchQueue.QueuedTaskInfo =>
           launchQueue.resetDelay(taskCount.app)
           noContent
       }.getOrElse(notFound(s"application $appId not found in task queue"))

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
@@ -4,7 +4,7 @@ import akka.actor.{ Actor, ActorContext, ActorLogging, ActorRef, Cancellable, Pr
 import akka.event.LoggingReceive
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.flow.OfferReviver
-import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskCount
+import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskInfo
 import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
 import mesosphere.marathon.core.launchqueue.impl.AppTaskLauncherActor.RecheckIfBackOffUntilReached
 import mesosphere.marathon.core.matcher.base
@@ -49,12 +49,12 @@ private[launchqueue] object AppTaskLauncherActor {
 
   /**
     * Increase the task count of the receiver.
-    * The actor responds with a [[QueuedTaskCount]] message.
+    * The actor responds with a [[QueuedTaskInfo]] message.
     */
   case class AddTasks(app: AppDefinition, count: Int) extends Requests
   /**
     * Get the current count.
-    * The actor responds with a [[QueuedTaskCount]] message.
+    * The actor responds with a [[QueuedTaskInfo]] message.
     */
   case object GetCount extends Requests
 
@@ -330,12 +330,12 @@ private class AppTaskLauncherActor(
   }
 
   private[this] def replyWithQueuedTaskCount(): Unit = {
-    sender() ! QueuedTaskCount(
+    sender() ! QueuedTaskInfo(
       app,
       tasksLeftToLaunch = tasksToLaunch,
       taskLaunchesInFlight = inFlightTaskOperations.size,
       // don't count tasks that are not launched in the tasksMap
-      tasksLaunchedOrRunning = tasksMap.values.count(_.launched.isDefined) - inFlightTaskOperations.size,
+      tasksLaunched = tasksMap.values.count(_.launched.isDefined) - inFlightTaskOperations.size,
       backOffUntil.getOrElse(clock.now())
     )
   }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.core.launchqueue.impl
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
-import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskCount
+import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskInfo
 import mesosphere.marathon.core.launchqueue.{ LaunchQueue, LaunchQueueConfig }
 import mesosphere.marathon.core.task.bus.TaskStatusObservables.TaskStatusUpdate
 import mesosphere.marathon.state.{ AppDefinition, PathId }
@@ -18,16 +18,16 @@ private[launchqueue] class LaunchQueueDelegate(
     actorRef: ActorRef,
     rateLimiterRef: ActorRef) extends LaunchQueue {
 
-  override def list: Seq[QueuedTaskCount] = {
+  override def list: Seq[QueuedTaskInfo] = {
     askQueueActor("list")(LaunchQueueDelegate.List)
-      .asInstanceOf[Seq[QueuedTaskCount]]
+      .asInstanceOf[Seq[QueuedTaskInfo]]
   }
 
-  override def get(appId: PathId): Option[QueuedTaskCount] =
-    askQueueActor("get")(LaunchQueueDelegate.Count(appId)).asInstanceOf[Option[QueuedTaskCount]]
+  override def get(appId: PathId): Option[QueuedTaskInfo] =
+    askQueueActor("get")(LaunchQueueDelegate.Count(appId)).asInstanceOf[Option[QueuedTaskInfo]]
 
-  override def notifyOfTaskUpdate(update: TaskStatusUpdate): Future[Option[QueuedTaskCount]] =
-    askQueueActorFuture("notifyOfTaskUpdate")(update).mapTo[Option[QueuedTaskCount]]
+  override def notifyOfTaskUpdate(update: TaskStatusUpdate): Future[Option[QueuedTaskInfo]] =
+    askQueueActorFuture("notifyOfTaskUpdate")(update).mapTo[Option[QueuedTaskInfo]]
 
   override def count(appId: PathId): Int = get(appId).map(_.tasksLeftToLaunch).getOrElse(0)
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTracker.scala
@@ -21,6 +21,7 @@ import scala.concurrent.{ ExecutionContext, Future }
   */
 trait TaskTracker {
 
+  def appTasksLaunchedSync(appId: PathId): Iterable[Task]
   def appTasksSync(appId: PathId): Iterable[Task]
   def appTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Iterable[Task]]
 
@@ -32,6 +33,7 @@ trait TaskTracker {
   def tasksByAppSync: TaskTracker.TasksByApp
   def tasksByApp()(implicit ec: ExecutionContext): Future[TaskTracker.TasksByApp]
 
+  def countLaunchedAppTasksSync(appId: PathId): Int
   def countAppTasksSync(appId: PathId): Int
   def countAppTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Int]
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerDelegate.scala
@@ -46,6 +46,8 @@ private[tracker] class TaskTrackerDelegate(
     tasksByAppTimer.fold(futureCall())(_.timeFuture(futureCall()))
   }
 
+  override def countLaunchedAppTasksSync(appId: PathId): Int =
+    tasksByAppSync.appTasks(appId).count(_.launched.isDefined)
   override def countAppTasksSync(appId: PathId): Int = tasksByAppSync.marathonAppTasks(appId).size
   override def countAppTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Int] =
     tasksByApp().map(_.marathonAppTasks(appId).size)
@@ -61,6 +63,7 @@ private[tracker] class TaskTrackerDelegate(
     tasksByAppSync.appTasks(appId)
   override def appTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Iterable[Task]] =
     tasksByApp().map(_.appTasks(appId))
+  override def appTasksLaunchedSync(appId: PathId): Iterable[Task] = appTasksSync(appId).filter(_.launched.isDefined)
 
   override def task(taskId: Task.Id)(
     implicit ec: ExecutionContext): Future[Option[Task]] =

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
@@ -61,7 +61,7 @@ class HealthCheckActor(
       app.version,
       healthCheck
     )
-    val activeTaskIds = taskTracker.appTasksSync(app.id).map(_.taskId).toSet
+    val activeTaskIds = taskTracker.appTasksLaunchedSync(app.id).map(_.taskId).toSet
     // The Map built with filterKeys wraps the original map and contains a reference to activeTaskIds.
     // Therefore we materialize it into a new map.
     taskHealth = taskHealth.filterKeys(activeTaskIds).iterator.toMap

--- a/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
@@ -17,7 +17,7 @@ class AppStopActor(
     app: AppDefinition,
     val promise: Promise[Unit]) extends StoppingBehavior {
 
-  override var idsToKill: mutable.Set[Task.Id] = taskTracker.appTasksSync(app.id).map(_.taskId).to[mutable.Set]
+  override var idsToKill: mutable.Set[Task.Id] = taskTracker.appTasksLaunchedSync(app.id).map(_.taskId).to[mutable.Set]
 
   def appId: PathId = app.id
 

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -116,7 +116,7 @@ private class DeploymentActor(
   }
 
   def scaleApp(app: AppDefinition, scaleTo: Int, toKill: Option[Iterable[Task]]): Future[Unit] = {
-    val runningTasks = taskTracker.appTasksSync(app.id).filter(_.launched.isDefined)
+    val runningTasks = taskTracker.appTasksLaunchedSync(app.id)
     def killToMeetConstraints(notSentencedAndRunning: Iterable[Task], toKillCount: Int) =
       Constraints.selectTasksToKill(app, notSentencedAndRunning, toKillCount)
 

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -77,10 +77,10 @@ trait StartingBehavior { this: Actor with ActorLogging =>
       taskQueue.add(app)
 
     case Sync =>
-      val actualSize = taskQueue.get(app.id).map(_.totalTaskCount).getOrElse(taskTracker.countAppTasksSync(app.id))
+      val actualSize = taskQueue.get(app.id).map(_.finalTaskCount).getOrElse(taskTracker.countLaunchedAppTasksSync(app.id))
       val tasksToStartNow = Math.max(scaleTo - actualSize, 0)
       if (tasksToStartNow > 0) {
-        log.info(s"Reconciling tasks during app ${app.id.toString} scaling: queuing ${tasksToStartNow} new tasks")
+        log.info(s"Reconciling tasks during app ${app.id.toString} scaling: queuing $tasksToStartNow new tasks")
         taskQueue.add(app, tasksToStartNow)
       }
       context.system.scheduler.scheduleOnce(5.seconds, self, Sync)

--- a/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
@@ -51,7 +51,7 @@ trait StoppingBehavior extends Actor with ActorLogging {
       checkFinished()
 
     case SynchronizeTasks =>
-      val trackerIds = taskTracker.appTasksSync(appId).map(_.taskId).toSet
+      val trackerIds = taskTracker.appTasksLaunchedSync(appId).map(_.taskId).toSet
       idsToKill = idsToKill.filter(trackerIds)
 
       idsToKill.foreach { id =>

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -25,7 +25,7 @@ class TaskReplaceActor(
     promise: Promise[Unit]) extends Actor with ActorLogging {
   import context.dispatcher
 
-  val tasksToKill = taskTracker.appTasksSync(app.id).filter(_.launched.isDefined)
+  val tasksToKill = taskTracker.appTasksLaunchedSync(app.id)
   val appId = app.id
   val version = app.version
   val versionString = app.version.toString

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -21,8 +21,7 @@ class TaskStartActor(
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
   val nrToStart: Int =
-    scaleTo - taskQueue.get(app.id).map(_.totalTaskCount).getOrElse(
-      taskTracker.appTasksSync(app.id).count(_.launched.isDefined))
+    scaleTo - taskQueue.get(app.id).map(_.finalTaskCount).getOrElse(taskTracker.countLaunchedAppTasksSync(app.id))
 
   override def initializeStart(): Unit = {
     if (nrToStart > 0)

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -41,7 +41,7 @@ class LaunchQueueModuleTest
     assert(list.size == 1)
     assert(list.head.app == app)
     assert(list.head.tasksLeftToLaunch == 1)
-    assert(list.head.tasksLaunchedOrRunning == 0)
+    assert(list.head.tasksLaunched == 0)
     assert(list.head.taskLaunchesInFlight == 0)
     verify(taskTracker).tasksByAppSync
   }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -96,7 +96,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     when(taskTracker.tasksByAppSync).thenReturn(TaskTracker.TasksByApp.of(TaskTracker.AppTasks.forTasks("nope".toPath, tasks)))
     when(taskTracker.appTasksSync("nope".toPath)).thenReturn(tasks)
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(Some(app)))
-    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
+    when(taskTracker.countLaunchedAppTasksSync(app.id)).thenReturn(0)
 
     val schedulerActor = createActor()
     try {
@@ -118,7 +118,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[Task])
 
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(Some(app)))
-    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
+    when(taskTracker.countLaunchedAppTasksSync(app.id)).thenReturn(0)
 
     val schedulerActor = createActor()
     try {
@@ -148,7 +148,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     when(repo.currentVersion(app.id))
       .thenReturn(Future.successful(Some(app)))
       .thenReturn(Future.successful(Some(app.copy(instances = 0))))
-    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
+    when(taskTracker.countLaunchedAppTasksSync(app.id)).thenReturn(0)
     when(repo.store(any())).thenReturn(Future.successful(app))
 
     val statusUpdateEvent = MesosStatusUpdateEvent(
@@ -203,7 +203,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     when(repo.currentVersion(app.id))
       .thenReturn(Future.successful(Some(app)))
       .thenReturn(Future.successful(Some(app.copy(instances = 0))))
-    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
+    when(taskTracker.countLaunchedAppTasksSync(app.id)).thenReturn(0)
     when(repo.store(any())).thenReturn(Future.successful(app))
 
     val statusUpdateEvent = MesosStatusUpdateEvent(
@@ -287,6 +287,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(StopApplication(app)))), Timestamp.now())
 
+    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA))
     when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable(taskA))
 
     when(driver.killTask(taskA.taskId.mesosTaskId)).thenAnswer(new Answer[Status] {
@@ -334,6 +335,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     when(repo.store(any())).thenReturn(Future.successful(app))
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(None))
+    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable.empty[Task])
     when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[Task])
     when(repo.expunge(app.id)).thenReturn(Future.successful(Nil))
 
@@ -371,9 +373,9 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     deploymentRepo = mock[DeploymentRepository]
 
     when(deploymentRepo.expunge(any())).thenReturn(Future.successful(Seq(true)))
-
     when(deploymentRepo.all()).thenReturn(Future.successful(Seq(plan)))
     when(deploymentRepo.store(plan)).thenReturn(Future.successful(plan))
+    when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[Task])
 
     val schedulerActor = system.actorOf(
       MarathonSchedulerActor.props(
@@ -413,7 +415,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     when(repo.store(any())).thenReturn(Future.successful(app))
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(None))
-    when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[Task])
+    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable.empty[Task])
     when(repo.expunge(app.id)).thenReturn(Future.successful(Nil))
 
     val schedulerActor = createActor()
@@ -441,7 +443,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     when(repo.store(any())).thenReturn(Future.successful(app))
     when(repo.currentVersion(app.id)).thenReturn(Future.successful(None))
-    when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[Task])
+    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable.empty[Task])
     when(repo.expunge(app.id)).thenReturn(Future.successful(Nil))
 
     val schedulerActor = TestActorRef(
@@ -580,7 +582,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     when(repo.apps()).thenReturn(Future.successful(Nil))
     when(groupRepo.rootGroup()).thenReturn(Future.successful(None))
     when(queue.get(any[PathId])).thenReturn(None)
-    when(taskTracker.countAppTasksSync(any[PathId])).thenReturn(0)
+    when(taskTracker.countLaunchedAppTasksSync(any[PathId])).thenReturn(0)
   }
 
   def createActor() = {

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -34,7 +34,7 @@ class TaskKillerTest extends MarathonSpec
 
   test("AppNotFound") {
     val appId = PathId("invalid")
-    when(tracker.appTasksSync(appId)).thenReturn(Iterable.empty)
+    when(tracker.appTasksLaunchedSync(appId)).thenReturn(Iterable.empty)
 
     val result = taskKiller.kill(appId, (tasks) => Set.empty[Task])
     result.failed.futureValue shouldEqual UnknownAppException(appId)
@@ -80,7 +80,7 @@ class TaskKillerTest extends MarathonSpec
   test("KillRequested without scaling") {
     val appId = PathId(List("my", "app"))
     val tasksToKill = Set(MarathonTestHelper.runningTaskForApp(appId))
-    when(tracker.appTasksSync(appId)).thenReturn(tasksToKill)
+    when(tracker.appTasksLaunchedSync(appId)).thenReturn(tasksToKill)
 
     val result = taskKiller.kill(appId, { tasks =>
       tasks should equal(tasksToKill)

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -4,7 +4,7 @@ import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.core.base.{ Clock, ConstantClock }
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskCount
+import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskInfo
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.test.Mockito
@@ -21,8 +21,8 @@ class QueueResourceTest extends MarathonSpec with Matchers with Mockito with Giv
     //given
     val app = AppDefinition(id = "app".toRootPath)
     queue.list returns Seq(
-      QueuedTaskCount(
-        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunchedOrRunning = 0, clock.now() + 100.seconds
+      QueuedTaskInfo(
+        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunched = 0, clock.now() + 100.seconds
       )
     )
 
@@ -45,8 +45,8 @@ class QueueResourceTest extends MarathonSpec with Matchers with Mockito with Giv
     //given
     val app = AppDefinition(id = "app".toRootPath)
     queue.list returns Seq(
-      QueuedTaskCount(
-        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunchedOrRunning = 0,
+      QueuedTaskInfo(
+        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunched = 0,
         backOffUntil = clock.now() - 100.seconds
       )
     )
@@ -80,8 +80,8 @@ class QueueResourceTest extends MarathonSpec with Matchers with Mockito with Giv
     //given
     val app = AppDefinition(id = "app".toRootPath)
     queue.list returns Seq(
-      QueuedTaskCount(
-        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunchedOrRunning = 0,
+      QueuedTaskInfo(
+        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunched = 0,
         backOffUntil = clock.now() + 100.seconds
       )
     )

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
@@ -4,11 +4,11 @@ import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.state.{ PathId, Timestamp, AppDefinition }
 
 object LaunchQueueTestHelper {
-  val zeroCounts = LaunchQueue.QueuedTaskCount(
+  val zeroCounts = LaunchQueue.QueuedTaskInfo(
     app = AppDefinition(PathId("/thisisignored")),
     tasksLeftToLaunch = 0,
     taskLaunchesInFlight = 0,
-    tasksLaunchedOrRunning = 0,
+    tasksLaunched = 0,
     backOffUntil = Timestamp(0)
   )
 }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskTrackerImplTest.scala
@@ -130,7 +130,7 @@ class TaskTrackerImplTest extends MarathonSpec with Matchers with GivenWhenThen 
   }
 
   test("Count") {
-    testCount(_.countAppTasksSync(_))
+    testCount(_.countLaunchedAppTasksSync(_))
   }
 
   test("Count Async") {

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
@@ -40,7 +40,7 @@ class AppStopActorTest
     val promise = Promise[Unit]()
     val tasks = Set(MarathonTestHelper.runningTask("task_a"), MarathonTestHelper.runningTask("task_b"))
 
-    when(taskTracker.appTasksSync(app.id)).thenReturn(tasks)
+    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(tasks)
 
     val ref = TestActorRef[AppStopActor](
       Props(
@@ -103,7 +103,7 @@ class AppStopActorTest
     val app = AppDefinition(id = PathId("app"), instances = 2)
     val promise = Promise[Unit]()
 
-    when(taskTracker.appTasksSync(app.id)).thenReturn(Iterable.empty[Task])
+    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable.empty[Task])
 
     val ref = TestActorRef[AppStopActor](
       Props(
@@ -128,7 +128,7 @@ class AppStopActorTest
     val promise = Promise[Unit]()
     val tasks = Set(MarathonTestHelper.runningTask("task_a"), MarathonTestHelper.runningTask("task_b"))
 
-    when(taskTracker.appTasksSync(app.id)).thenReturn(tasks)
+    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(tasks)
 
     val ref = TestActorRef[AppStopActor](
       Props(
@@ -157,7 +157,7 @@ class AppStopActorTest
     val promise = Promise[Unit]()
     val tasks = Set(MarathonTestHelper.runningTask("task_a"), MarathonTestHelper.runningTask("task_b"))
 
-    when(taskTracker.appTasksSync(app.id))
+    when(taskTracker.appTasksLaunchedSync(app.id))
       .thenReturn(tasks)
       .thenReturn(Iterable.empty[Task])
 

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -73,10 +73,10 @@ class DeploymentActorTest
 
     val plan = DeploymentPlan(origGroup, targetGroup)
 
-    when(tracker.appTasksSync(app1.id)).thenReturn(Set(task1_1, task1_2))
-    when(tracker.appTasksSync(app2.id)).thenReturn(Set(task2_1))
-    when(tracker.appTasksSync(app3.id)).thenReturn(Set(task3_1))
-    when(tracker.appTasksSync(app4.id)).thenReturn(Set(task4_1))
+    when(tracker.appTasksLaunchedSync(app1.id)).thenReturn(Set(task1_1, task1_2))
+    when(tracker.appTasksLaunchedSync(app2.id)).thenReturn(Set(task2_1))
+    when(tracker.appTasksLaunchedSync(app3.id)).thenReturn(Set(task3_1))
+    when(tracker.appTasksLaunchedSync(app4.id)).thenReturn(Set(task4_1))
 
     when(driver.killTask(task1_2.taskId.mesosTaskId)).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
@@ -180,7 +180,7 @@ class DeploymentActorTest
     val task1_1 = MarathonTestHelper.runningTask("task1_1", appVersion = app.version, startedAt = 0)
     val task1_2 = MarathonTestHelper.runningTask("task1_2", appVersion = app.version, startedAt = 1000)
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Set(task1_1, task1_2))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Set(task1_1, task1_2))
 
     val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
@@ -254,7 +254,7 @@ class DeploymentActorTest
 
     val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable.empty[Task])
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable.empty[Task])
 
     try {
       TestActorRef(
@@ -297,7 +297,7 @@ class DeploymentActorTest
 
     val plan = DeploymentPlan(original = origGroup, target = targetGroup, toKill = Map(app1.id -> Set(task1_2)))
 
-    when(tracker.appTasksSync(app1.id)).thenReturn(Set(task1_1, task1_2, task1_3))
+    when(tracker.appTasksLaunchedSync(app1.id)).thenReturn(Set(task1_1, task1_2, task1_3))
 
     when(driver.killTask(task1_2.taskId.mesosTaskId)).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
@@ -14,14 +14,13 @@ import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, AppRepository, Group, MarathonStore }
-import mesosphere.marathon.test.MarathonActorSupport
+import mesosphere.marathon.test.{ Mockito, MarathonActorSupport }
 import mesosphere.marathon.upgrade.DeploymentActor.Cancel
 import mesosphere.marathon.upgrade.DeploymentManager.{ CancelDeployment, DeploymentFailed, PerformDeployment }
 import mesosphere.marathon.{ MarathonConf, MarathonTestHelper, SchedulerActions }
 import mesosphere.util.state.memory.InMemoryStore
 import org.apache.mesos.SchedulerDriver
 import org.rogach.scallop.ScallopConf
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, FunSuiteLike, Matchers }
 
 import scala.concurrent.Await
@@ -33,7 +32,7 @@ class DeploymentManagerTest
     with Matchers
     with BeforeAndAfter
     with BeforeAndAfterAll
-    with MockitoSugar
+    with Mockito
     with ImplicitSender {
 
   var driver: SchedulerDriver = _
@@ -79,6 +78,7 @@ class DeploymentManagerTest
     val newGroup = Group("/".toRootPath, Set(app))
     val plan = DeploymentPlan(oldGroup, newGroup)
 
+    taskQueue.get(app.id) returns None
     manager ! PerformDeployment(driver, plan)
 
     awaitCond(

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
@@ -96,7 +96,7 @@ class TaskKillActorTest
     val taskB = MarathonTestHelper.runningTask("taskB_id")
     val tasks = mutable.Iterable(taskA, taskB)
 
-    when(taskTracker.appTasksSync(app.id)).thenReturn(mutable.Iterable.empty[Task])
+    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(mutable.Iterable.empty[Task])
 
     val ref = TestActorRef[TaskKillActor](Props(new TaskKillActor(driver, app.id, taskTracker, system.eventStream, tasks.map(_.taskId), promise)))
     watch(ref)
@@ -120,7 +120,7 @@ class TaskKillActorTest
 
     val ref = TestActorRef[TaskKillActor](Props(new TaskKillActor(driver, appId, taskTracker, system.eventStream, tasks.map(_.taskId), promise)))
 
-    when(taskTracker.appTasksSync(appId)).thenReturn(Iterable(taskA, taskB))
+    when(taskTracker.appTasksLaunchedSync(appId)).thenReturn(Iterable(taskA, taskB))
 
     watch(ref)
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -41,7 +41,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable(taskA, taskB))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA, taskB))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID]
@@ -88,7 +88,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable(taskA, taskB))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA, taskB))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID]
@@ -131,7 +131,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable(taskA, taskB, taskC))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID]
@@ -185,7 +185,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable(taskA, taskB, taskC))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       override def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID]
@@ -255,7 +255,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable(taskA, taskB, taskC))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = Task.Id(invocation.getArguments()(0).asInstanceOf[TaskID])
@@ -329,7 +329,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable(taskA, taskB, taskC))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = Task.Id(invocation.getArguments()(0).asInstanceOf[TaskID])
@@ -401,7 +401,7 @@ class TaskReplaceActorTest
 
     var oldTaskCount = 3
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable(taskA, taskB, taskC))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA, taskB, taskC))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = Task.Id(invocation.getArguments()(0).asInstanceOf[TaskID])
@@ -464,7 +464,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable(taskA, taskB))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA, taskB))
 
     val promise = Promise[Unit]()
 
@@ -496,7 +496,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable(taskA, taskB))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA, taskB))
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       var firstKillForTaskB = true
 
@@ -549,7 +549,7 @@ class TaskReplaceActorTest
     val queue = mock[LaunchQueue]
     val tracker = mock[TaskTracker]
 
-    when(tracker.appTasksSync(app.id)).thenReturn(Iterable(taskA, taskB))
+    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable(taskA, taskB))
 
     val promise = Promise[Unit]()
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -93,7 +93,7 @@ class TaskStartActorTest
     (counts, description) <- Seq(
       Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLeftToLaunch = 1)) -> "with one task left to launch",
       Some(LaunchQueueTestHelper.zeroCounts.copy(taskLaunchesInFlight = 1)) -> "with one task in flight",
-      Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLaunchedOrRunning = 1)) -> "with one task already running"
+      Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLaunched = 1)) -> "with one task already running"
     )
   ) {
     test(s"Start success $description") {
@@ -333,7 +333,7 @@ class TaskStartActorTest
     Mockito.reset(launchQueue)
 
     // let existing task die
-    when(taskTracker.countAppTasksSync(app.id)).thenReturn(0)
+    when(taskTracker.countLaunchedAppTasksSync(app.id)).thenReturn(0)
     when(launchQueue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLeftToLaunch = 4)))
     system.eventStream.publish(MesosStatusUpdateEvent(
       slaveId = "", taskId = taskId, taskStatus = "TASK_ERROR", message = "", appId = app.id, host = "",
@@ -353,7 +353,7 @@ class TaskStartActorTest
 
     // launch 4 of the tasks
     when(launchQueue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLeftToLaunch = app.instances)))
-    when(taskTracker.countAppTasksSync(app.id)).thenReturn(4)
+    when(taskTracker.countLaunchedAppTasksSync(app.id)).thenReturn(4)
     List(0, 1, 2, 3) foreach { i =>
       system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id(s"task-$i"), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
     }


### PR DESCRIPTION
and use those instead of filtering results.