### PR TITLE
Fixes #3328 - nicer way of PortDefinition validation.

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/PortDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/PortDefinition.scala
@@ -2,9 +2,7 @@ package mesosphere.marathon.state
 
 import com.wix.accord._
 import com.wix.accord.dsl._
-import com.wix.accord.{ Failure, RuleViolation, Success }
 import mesosphere.marathon.api.v2.Validation._
-import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.Seq
 
@@ -25,24 +23,11 @@ object PortDefinitions {
     ports.map(PortDefinition.apply(_)).toIndexedSeq
   }
 
-  private[this] def uniquePorts: Validator[Seq[PortDefinition]] = new Validator[Seq[PortDefinition]] {
-    override def apply(portDefinitions: Seq[PortDefinition]): Result = {
-      val nonRandomPorts = portDefinitions.map(_.port).filterNot(_ == AppDefinition.RandomPortValue)
-
-      if (nonRandomPorts.size == nonRandomPorts.distinct.size) Success
-      else Failure(Set(RuleViolation("portDefinitions", "Ports must be unique.", None)))
-    }
-  }
-
-  private[this] def uniquePortNames: Validator[Seq[PortDefinition]] = new Validator[Seq[PortDefinition]] {
-    override def apply(portDefinitions: Seq[PortDefinition]): Result = {
-      val portNames = portDefinitions.flatMap(_.name)
-      if (portNames.size == portNames.distinct.size) Success
-      else Failure(Set(RuleViolation("portDefinitions", "Port names must be unique.", None)))
-    }
-  }
-
   implicit val portDefinitionsValidator: Validator[Seq[PortDefinition]] = validator[Seq[PortDefinition]] {
-    portDefinitions => portDefinitions is every(valid) and uniquePorts and uniquePortNames
+    portDefinitions =>
+      portDefinitions is every(valid)
+      portDefinitions is elementsAreUniqueByOptional(_.name, "Port names must be unique.")
+      portDefinitions is elementsAreUniqueBy(_.port, "Ports must be unique.",
+        filter = { port: Int => port != AppDefinition.RandomPortValue })
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/ValidationHelper.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ValidationHelper.scala
@@ -2,12 +2,10 @@ package mesosphere.marathon.api.v2
 
 import com.wix.accord._
 
-/**
-  * Created by alex on 07/01/16.
-  */
 object ValidationHelper {
   case class ViolationMessageAndProperty(message: String, property: Option[String]) {
-    override def toString: String = s"Property: $property Message: $message"
+    override def toString: String = property.map(p => s"Property: $p. Message: $message")
+      .getOrElse(s"Message: $message")
   }
 
   def getAllRuleConstrains(r: Result): Seq[ViolationMessageAndProperty] = {


### PR DESCRIPTION
Does following:
- removes `Some` which was generated in test messages
- simplifies `PortDefintion` validation by introducing the `elementsAreUniqueBy`, `elementsAreUniqueByOptional`, `elementsAreUniqueFilterWith`.

The `elementsAreUniqueBy` accepts mapping functions like `flatMap`, `map`, but is also able to accept combinations of map and filter like:
```Scala
pd is elementsAreUniqueBy(_.port, filter = { port: Int => port != 42 })
```