### PR TITLE
send notifications in parallel to subscribers

### DIFF
--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventActor.scala
@@ -83,7 +83,7 @@ class HttpEventActor(conf: HttpEventConfiguration,
       //remove all unsubscribed callback listener
       limiter = limiter.filterKeys(subscribers.urls).iterator.toMap.withDefaultValue(NoLimit)
       metrics.skippedCallbacks.mark(limited.size)
-      active.foreach(post(_, event, me))
+      active.par.foreach(post(_, event, me))
     }
   }
 
@@ -115,4 +115,3 @@ class HttpEventActor(conf: HttpEventConfiguration,
     }
   }
 }
-


### PR DESCRIPTION
Currently the http callback subscribers are notified sequentially, so if one is experiencing problems it does affect the well functioning of the rest.
From what I gather, the exponential back-off is per endpoint, so parallelizing should alleviate the described problem with no side-effects on the backoff algorithm.