### PR TITLE
Fixes #3339 - path output format of object validation is identical to JSON structure

### DIFF
--- a/docs/docs/rest-api/public/api/v2/apps.raml
+++ b/docs/docs/rest-api/public/api/v2/apps.raml
@@ -113,8 +113,10 @@ put:
               "message": "Object is not valid",
               "details": [
                 {
-                  "attribute": "upgradeStrategy.minimumHealthCapacity",
-                  "error": "is greater than 1"
+                  "path": "/upgradeStrategy/minimumHealthCapacity",
+                  "errors": [
+                    "is greater than 1"
+                  ]
                 }
               ]
             }
@@ -163,8 +165,10 @@ post:
               "message": "Object is not valid",
               "details": [
                 {
-                  "attribute": "upgradeStrategy.minimumHealthCapacity",
-                  "error": "is greater than 1"
+                  "path": "/upgradeStrategy/minimumHealthCapacity",
+                  "errors": [
+                    "is greater than 1"
+                  ]
                 }
               ]
             }
@@ -259,8 +263,10 @@ post:
                 "message": "Object is not valid",
                 "details": [
                   {
-                    "attribute": "upgradeStrategy.minimumHealthCapacity",
-                    "error": "is greater than 1"
+                    "path": "/upgradeStrategy/minimumHealthCapacity",
+                    "error": [
+                      "is greater than 1"
+                    ]
                   }
                 ]
               }

--- a/docs/docs/rest-api/public/api/v2/groups.raml
+++ b/docs/docs/rest-api/public/api/v2/groups.raml
@@ -76,8 +76,10 @@ put:
               "message":"Object is not valid",
               "details": [
                 {
-                  "attribute":"apps[0].id",
-                  "error":"identifier /app is not child of /group. Hint: use relative paths."
+                  "path":"/apps(0)/id",
+                  "errors": [
+                    "identifier /app is not child of /group. Hint: use relative paths."
+                  ]
                 }
               ]
             }
@@ -117,8 +119,10 @@ post:
               "message":"Object is not valid",
               "details": [
                 {
-                  "attribute":"apps[0].id",
-                  "error":"identifier /app is not child of /group. Hint: use relative paths."
+                  "path":"/apps(0)/id",
+                  "errors": [
+                    "identifier /app is not child of /group. Hint: use relative paths."
+                  ]
                 }
               ]
             }

--- a/src/test/scala/mesosphere/marathon/api/MarathonExceptionMapperTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/MarathonExceptionMapperTest.scala
@@ -82,7 +82,7 @@ class MarathonExceptionMapperTest extends MarathonSpec with GivenWhenThen with M
     val errors = (entity \ "details").as[Seq[JsObject]]
     errors should have size 1
     val firstError = errors.head
-    (firstError \ "path").as[String] should be("self")
+    (firstError \ "path").as[String] should be("/")
     val errorMsgs = (firstError \ "errors").as[Seq[String]]
     errorMsgs.head should be("AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.")
   }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -176,7 +176,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
 
     Then("The return code indicates a validation error for container.docker")
     response.getStatus should be(422)
-    response.getEntity.toString should include("container.docker")
+    response.getEntity.toString should include("/container/docker")
     response.getEntity.toString should include("must not be empty")
   }
 
@@ -210,7 +210,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
 
     Then("The return code indicates that the hostPath of volumes[0] is missing") // although the wrong field should fail
     response.getStatus should be(422)
-    response.getEntity.toString should include("container.volumes[0].hostPath")
+    response.getEntity.toString should include("/container/volumes(0)/hostPath")
     response.getEntity.toString should include("must not be empty")
   }
 
@@ -236,7 +236,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
 
     Then("The return code indicates a validation error for container.docker")
     response.getStatus should be(422)
-    response.getEntity.toString should include("container.docker")
+    response.getEntity.toString should include("/container/docker")
     response.getEntity.toString should include("must be empty")
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -88,7 +88,7 @@ class ModelValidationTest
       case f: Failure =>
         val errors = (Json.toJson(f) \ "details").as[Seq[JsObject]]
         errors should have size 1
-        (errors.head \ "path").as[String] should be("name")
+        (errors.head \ "path").as[String] should be("/name")
         (errors.head \ "errors").as[Seq[String]] should have size 2
     }
   }
@@ -106,7 +106,7 @@ class ModelValidationTest
       case f: Failure =>
         val errors = (Json.toJson(f) \ "details").as[Seq[JsObject]]
         errors should have size 1
-        (errors.head \ "path").as[String] should be("groups[0].apps[1]")
+        (errors.head \ "path").as[String] should be("/groups(0)/apps(1)")
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/ValidationHelper.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ValidationHelper.scala
@@ -3,27 +3,16 @@ package mesosphere.marathon.api.v2
 import com.wix.accord._
 
 object ValidationHelper {
-  case class ViolationMessageAndProperty(message: String, property: Option[String]) {
-    override def toString: String = property.map(p => s"Property: $p. Message: $message")
-      .getOrElse(s"Message: $message")
+  case class ViolationMessageAndPath(message: String, path: Option[String]) {
+    override def toString: String = path.map(p => s"Path: $p. Error message: $message")
+      .getOrElse(s"Error message: $message")
   }
 
-  def getAllRuleConstrains(r: Result): Seq[ViolationMessageAndProperty] = {
-    def loop(v: Violation, prop: Option[String]): Seq[ViolationMessageAndProperty] = {
-      v match {
-        case g: GroupViolation =>
-          g.children.flatMap { c =>
-            val nextProp = prop.map(p =>
-              Some(c.description.map(desc => s"$p.$desc").getOrElse(p))).getOrElse(c.description)
-            loop(c, nextProp)
-          }.toSeq
-        case r: RuleViolation => Seq(ViolationMessageAndProperty(r.constraint, prop))
-      }
-    }
-
+  def getAllRuleConstrains(r: Result): Set[ViolationMessageAndPath] = {
     r match {
-      case f: Failure => f.violations.flatMap(v => loop(v, v.description)).toSeq
-      case _          => Seq.empty[ViolationMessageAndProperty]
+      case f: Failure => f.violations.flatMap(Validation.allRuleViolationsWithFullDescription(_))
+        .map(r => ViolationMessageAndPath(r.constraint, r.description))
+      case _ => Set.empty[ViolationMessageAndPath]
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -29,7 +29,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
           val violations = ValidationHelper.getAllRuleConstrains(f)
 
           assert(violations.exists { v =>
-            v.property.contains(path) && v.message == template
+            v.path.contains(path) && v.message == template
           },
             s"Violations:\n${violations.mkString}"
           )
@@ -42,7 +42,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
         case f: Failure =>
           val violations = ValidationHelper.getAllRuleConstrains(f)
           assert(!violations.exists { v =>
-            v.property.contains(path) && v.message == template
+            v.path.contains(path) && v.message == template
           },
             s"Violations:\n${violations.mkString}"
           )
@@ -52,23 +52,23 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     var app = AppDefinition(id = "a b".toRootPath)
     val idError = "must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$'"
     MarathonTestHelper.validateJsonSchema(app, false)
-    shouldViolate(app, "id", idError)
+    shouldViolate(app, "/id", idError)
 
     app = app.copy(id = "a#$%^&*b".toRootPath)
     MarathonTestHelper.validateJsonSchema(app, false)
-    shouldViolate(app, "id", idError)
+    shouldViolate(app, "/id", idError)
 
     app = app.copy(id = "-dash-disallowed-at-start".toRootPath)
     MarathonTestHelper.validateJsonSchema(app, false)
-    shouldViolate(app, "id", idError)
+    shouldViolate(app, "/id", idError)
 
     app = app.copy(id = "dash-disallowed-at-end-".toRootPath)
     MarathonTestHelper.validateJsonSchema(app, false)
-    shouldViolate(app, "id", idError)
+    shouldViolate(app, "/id", idError)
 
     app = app.copy(id = "uppercaseLettersNoGood".toRootPath)
     MarathonTestHelper.validateJsonSchema(app, false)
-    shouldViolate(app, "id", idError)
+    shouldViolate(app, "/id", idError)
 
     app = AppDefinition(
       id = "test".toPath,
@@ -77,7 +77,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     )
     shouldViolate(
       app,
-      "portDefinitions",
+      "/portDefinitions",
       "Ports must be unique."
     )
     MarathonTestHelper.validateJsonSchema(app, false)
@@ -89,7 +89,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     )
     shouldNotViolate(
       app,
-      "portDefinitions",
+      "/portDefinitions",
       "Ports must be unique."
     )
     MarathonTestHelper.validateJsonSchema(app, true)
@@ -111,7 +111,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     )
     shouldViolate(
       app,
-      "container.docker.portMappings",
+      "/container/docker/portMappings",
       "Port names must be unique."
     )
 
@@ -125,7 +125,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     )
     shouldViolate(
       app,
-      "portDefinitions",
+      "/portDefinitions",
       "Port names must be unique."
     )
 
@@ -145,7 +145,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       portDefinitions = Nil)
     shouldNotViolate(
       app,
-      "container.docker.portMappings",
+      "/container/docker/portMappings",
       "Port names must be unique."
     )
 
@@ -157,14 +157,14 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     )
     shouldNotViolate(
       app,
-      "portDefinitions",
+      "/portDefinitions",
       "Port names must be unique."
     )
 
     app = correct.copy(executor = "//cmd")
     shouldNotViolate(
       app,
-      "executor",
+      "/executor",
       "{javax.validation.constraints.Pattern.message}"
     )
     MarathonTestHelper.validateJsonSchema(app)
@@ -172,7 +172,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(executor = "some/relative/path.mte")
     shouldNotViolate(
       app,
-      "executor",
+      "/executor",
       "{javax.validation.constraints.Pattern.message}"
     )
     MarathonTestHelper.validateJsonSchema(app)
@@ -180,7 +180,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(executor = "/some/absolute/path")
     shouldNotViolate(
       app,
-      "executor",
+      "/executor",
       "{javax.validation.constraints.Pattern.message}"
     )
     MarathonTestHelper.validateJsonSchema(app)
@@ -188,7 +188,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(executor = "")
     shouldNotViolate(
       app,
-      "executor",
+      "/executor",
       "{javax.validation.constraints.Pattern.message}"
     )
     MarathonTestHelper.validateJsonSchema(app)
@@ -196,7 +196,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(executor = "/test/")
     shouldViolate(
       app,
-      "executor",
+      "/executor",
       "must fully match regular expression '^(//cmd)|(/?[^/]+(/[^/]+)*)|$'"
     )
     MarathonTestHelper.validateJsonSchema(app, false)
@@ -204,7 +204,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(executor = "/test//path")
     shouldViolate(
       app,
-      "executor",
+      "/executor",
       "must fully match regular expression '^(//cmd)|(/?[^/]+(/[^/]+)*)|$'"
     )
     MarathonTestHelper.validateJsonSchema(app, false)
@@ -212,7 +212,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(cmd = Some("command"), args = Some(Seq("a", "b", "c")))
     shouldViolate(
       app,
-      "value",
+      "/",
       "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'."
     )
     MarathonTestHelper.validateJsonSchema(app, false)
@@ -220,7 +220,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(cmd = None, args = Some(Seq("a", "b", "c")))
     shouldNotViolate(
       app,
-      "value",
+      "/",
       "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'."
     )
     MarathonTestHelper.validateJsonSchema(app)
@@ -228,7 +228,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(upgradeStrategy = UpgradeStrategy(1.2))
     shouldViolate(
       app,
-      "upgradeStrategy.minimumHealthCapacity",
+      "/upgradeStrategy/minimumHealthCapacity",
       "got 1.2, expected between 0.0 and 1.0"
     )
     MarathonTestHelper.validateJsonSchema(app, false)
@@ -236,7 +236,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(upgradeStrategy = UpgradeStrategy(0.5, 1.2))
     shouldViolate(
       app,
-      "upgradeStrategy.maximumOverCapacity",
+      "/upgradeStrategy/maximumOverCapacity",
       "got 1.2, expected between 0.0 and 1.0"
     )
     MarathonTestHelper.validateJsonSchema(app, false)
@@ -244,7 +244,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(upgradeStrategy = UpgradeStrategy(-1.2))
     shouldViolate(
       app,
-      "upgradeStrategy.minimumHealthCapacity",
+      "/upgradeStrategy/minimumHealthCapacity",
       "got -1.2, expected between 0.0 and 1.0"
     )
     MarathonTestHelper.validateJsonSchema(app, false)
@@ -252,7 +252,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = correct.copy(upgradeStrategy = UpgradeStrategy(0.5, -1.2))
     shouldViolate(
       app,
-      "upgradeStrategy.maximumOverCapacity",
+      "/upgradeStrategy/maximumOverCapacity",
       "got -1.2, expected between 0.0 and 1.0"
     )
     MarathonTestHelper.validateJsonSchema(app, false)
@@ -272,7 +272,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     )
     shouldNotViolate(
       app,
-      "",
+      "/",
       "Health check port indices must address an element of the ports array or container port mappings."
     )
     MarathonTestHelper.validateJsonSchema(app, false) // missing image
@@ -289,7 +289,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     )
     shouldNotViolate(
       app,
-      "",
+      "/",
       "Health check port indices must address an element of the ports array or container port mappings."
     )
     MarathonTestHelper.validateJsonSchema(app, false) // missing image
@@ -300,7 +300,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
 
     shouldViolate(
       app,
-      "value",
+      "/",
       "Health check port indices must address an element of the ports array or container port mappings."
     )
 
@@ -312,7 +312,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
 
     shouldViolate(
       app,
-      "fetch.[1]",
+      "/fetch(1)",
       "URI has invalid syntax."
     )
 
@@ -323,7 +323,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     )
 
     shouldNotViolate(app,
-      "fetch.[1]",
+      "/fetch(1)",
       "URI has invalid syntax."
     )
   }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -28,21 +28,21 @@ class AppUpdateTest extends MarathonSpec {
       val violations = validate(update)
       assert(violations.isFailure)
       assert(ValidationHelper.getAllRuleConstrains(violations).exists(v =>
-        v.property.getOrElse(false) == path && v.message == template
+        v.path.getOrElse(false) == path && v.message == template
       ))
     }
 
     def shouldNotViolate(update: AppUpdate, path: String, template: String): Unit = {
       val violations = validate(update)
       assert(!ValidationHelper.getAllRuleConstrains(violations).exists(v =>
-        v.property.getOrElse(false) == path && v.message == template))
+        v.path.getOrElse(false) == path && v.message == template))
     }
 
     val update = AppUpdate()
 
     shouldViolate(
       update.copy(portDefinitions = Some(PortDefinitions(9000, 8080, 9000))),
-      "portDefinitions",
+      "/portDefinitions",
       "Ports must be unique."
     )
 
@@ -51,7 +51,7 @@ class AppUpdateTest extends MarathonSpec {
         PortDefinition(port = 9000, name = Some("foo")),
         PortDefinition(port = 9001, name = Some("foo"))))
       ),
-      "portDefinitions",
+      "/portDefinitions",
       "Port names must be unique."
     )
 
@@ -60,7 +60,7 @@ class AppUpdateTest extends MarathonSpec {
         PortDefinition(port = 9000, name = Some("foo")),
         PortDefinition(port = 9001, name = Some("bar"))))
       ),
-      "portDefinitions",
+      "/portDefinitions",
       "Port names must be unique."
     )
   }

--- a/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
@@ -261,9 +261,9 @@ class ResidentTaskIntegrationTest
     }
 
     /**
-     * Resident Tasks reside in the TaskTracker even after they terminate and after the associated app is deleted.
-     * To prevent spurious state in the above test cases, each test case should use a unique appId.
-     */
+      * Resident Tasks reside in the TaskTracker even after they terminate and after the associated app is deleted.
+      * To prevent spurious state in the above test cases, each test case should use a unique appId.
+      */
     object IdGenerator {
       private[this] var index: Int = 0
       def generate(): String = {


### PR DESCRIPTION
As discussed in #3339, following changes have been applied:

1. replace `[` `]` with `(` `)` respectively
2. replace `.` by `/`
3. prepend `/` at the root of each path. This would also replace self with `/` in root-only errors
4. replace `self` with `/`
5. correct docs