### PR TITLE
Towards #3221 reservation timeouts

### DIFF
--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -10370,20 +10370,6 @@ public final class Protos {
      * </pre>
      */
     mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder getReservationOrBuilder();
-
-    // optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;
-    /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-     */
-    boolean hasReservedState();
-    /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-     */
-    mesosphere.marathon.Protos.MarathonTask.ReservedState getReservedState();
-    /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-     */
-    mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder getReservedStateOrBuilder();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.MarathonTask}
@@ -10545,19 +10531,6 @@ public final class Protos {
               bitField0_ |= 0x00000080;
               break;
             }
-            case 106: {
-              mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000100) == 0x00000100)) {
-                subBuilder = reservedState_.toBuilder();
-              }
-              reservedState_ = input.readMessage(mesosphere.marathon.Protos.MarathonTask.ReservedState.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(reservedState_);
-                reservedState_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000100;
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -10631,6 +10604,20 @@ public final class Protos {
        */
       com.google.protobuf.ByteString
           getLocalVolumeIdsBytes(int index);
+
+      // required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;
+      /**
+       * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+       */
+      boolean hasState();
+      /**
+       * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+       */
+      mesosphere.marathon.Protos.MarathonTask.Reservation.State getState();
+      /**
+       * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+       */
+      mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder getStateOrBuilder();
     }
     /**
      * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation}
@@ -10691,6 +10678,19 @@ public final class Protos {
                 localVolumeIds_.add(input.readBytes());
                 break;
               }
+              case 18: {
+                mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder subBuilder = null;
+                if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                  subBuilder = state_.toBuilder();
+                }
+                state_ = input.readMessage(mesosphere.marathon.Protos.MarathonTask.Reservation.State.PARSER, extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(state_);
+                  state_ = subBuilder.buildPartial();
+                }
+                bitField0_ |= 0x00000001;
+                break;
+              }
             }
           }
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -10733,6 +10733,1406 @@ public final class Protos {
         return PARSER;
       }
 
+      public interface StateOrBuilder
+          extends com.google.protobuf.MessageOrBuilder {
+
+        // required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
+         */
+        boolean hasType();
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
+         */
+        mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type getType();
+
+        // optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+         */
+        boolean hasTimeout();
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+         */
+        mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout getTimeout();
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+         */
+        mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder getTimeoutOrBuilder();
+      }
+      /**
+       * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State}
+       */
+      public static final class State extends
+          com.google.protobuf.GeneratedMessage
+          implements StateOrBuilder {
+        // Use State.newBuilder() to construct.
+        private State(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+          super(builder);
+          this.unknownFields = builder.getUnknownFields();
+        }
+        private State(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+        private static final State defaultInstance;
+        public static State getDefaultInstance() {
+          return defaultInstance;
+        }
+
+        public State getDefaultInstanceForType() {
+          return defaultInstance;
+        }
+
+        private final com.google.protobuf.UnknownFieldSet unknownFields;
+        @java.lang.Override
+        public final com.google.protobuf.UnknownFieldSet
+            getUnknownFields() {
+          return this.unknownFields;
+        }
+        private State(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          initFields();
+          int mutable_bitField0_ = 0;
+          com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+              com.google.protobuf.UnknownFieldSet.newBuilder();
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(input, unknownFields,
+                                         extensionRegistry, tag)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  int rawValue = input.readEnum();
+                  mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type value = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type.valueOf(rawValue);
+                  if (value == null) {
+                    unknownFields.mergeVarintField(1, rawValue);
+                  } else {
+                    bitField0_ |= 0x00000001;
+                    type_ = value;
+                  }
+                  break;
+                }
+                case 18: {
+                  mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder subBuilder = null;
+                  if (((bitField0_ & 0x00000002) == 0x00000002)) {
+                    subBuilder = timeout_.toBuilder();
+                  }
+                  timeout_ = input.readMessage(mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.PARSER, extensionRegistry);
+                  if (subBuilder != null) {
+                    subBuilder.mergeFrom(timeout_);
+                    timeout_ = subBuilder.buildPartial();
+                  }
+                  bitField0_ |= 0x00000002;
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw e.setUnfinishedMessage(this);
+          } catch (java.io.IOException e) {
+            throw new com.google.protobuf.InvalidProtocolBufferException(
+                e.getMessage()).setUnfinishedMessage(this);
+          } finally {
+            this.unknownFields = unknownFields.build();
+            makeExtensionsImmutable();
+          }
+        }
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor;
+        }
+
+        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  mesosphere.marathon.Protos.MarathonTask.Reservation.State.class, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder.class);
+        }
+
+        public static com.google.protobuf.Parser<State> PARSER =
+            new com.google.protobuf.AbstractParser<State>() {
+          public State parsePartialFrom(
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws com.google.protobuf.InvalidProtocolBufferException {
+            return new State(input, extensionRegistry);
+          }
+        };
+
+        @java.lang.Override
+        public com.google.protobuf.Parser<State> getParserForType() {
+          return PARSER;
+        }
+
+        /**
+         * Protobuf enum {@code mesosphere.marathon.MarathonTask.Reservation.State.Type}
+         */
+        public enum Type
+            implements com.google.protobuf.ProtocolMessageEnum {
+          /**
+           * <code>New = 1;</code>
+           */
+          New(0, 1),
+          /**
+           * <code>Launched = 2;</code>
+           */
+          Launched(1, 2),
+          /**
+           * <code>Suspended = 3;</code>
+           */
+          Suspended(2, 3),
+          /**
+           * <code>Garbage = 4;</code>
+           */
+          Garbage(3, 4),
+          /**
+           * <code>Unknown = 5;</code>
+           */
+          Unknown(4, 5),
+          ;
+
+          /**
+           * <code>New = 1;</code>
+           */
+          public static final int New_VALUE = 1;
+          /**
+           * <code>Launched = 2;</code>
+           */
+          public static final int Launched_VALUE = 2;
+          /**
+           * <code>Suspended = 3;</code>
+           */
+          public static final int Suspended_VALUE = 3;
+          /**
+           * <code>Garbage = 4;</code>
+           */
+          public static final int Garbage_VALUE = 4;
+          /**
+           * <code>Unknown = 5;</code>
+           */
+          public static final int Unknown_VALUE = 5;
+
+
+          public final int getNumber() { return value; }
+
+          public static Type valueOf(int value) {
+            switch (value) {
+              case 1: return New;
+              case 2: return Launched;
+              case 3: return Suspended;
+              case 4: return Garbage;
+              case 5: return Unknown;
+              default: return null;
+            }
+          }
+
+          public static com.google.protobuf.Internal.EnumLiteMap<Type>
+              internalGetValueMap() {
+            return internalValueMap;
+          }
+          private static com.google.protobuf.Internal.EnumLiteMap<Type>
+              internalValueMap =
+                new com.google.protobuf.Internal.EnumLiteMap<Type>() {
+                  public Type findValueByNumber(int number) {
+                    return Type.valueOf(number);
+                  }
+                };
+
+          public final com.google.protobuf.Descriptors.EnumValueDescriptor
+              getValueDescriptor() {
+            return getDescriptor().getValues().get(index);
+          }
+          public final com.google.protobuf.Descriptors.EnumDescriptor
+              getDescriptorForType() {
+            return getDescriptor();
+          }
+          public static final com.google.protobuf.Descriptors.EnumDescriptor
+              getDescriptor() {
+            return mesosphere.marathon.Protos.MarathonTask.Reservation.State.getDescriptor().getEnumTypes().get(0);
+          }
+
+          private static final Type[] VALUES = values();
+
+          public static Type valueOf(
+              com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+            if (desc.getType() != getDescriptor()) {
+              throw new java.lang.IllegalArgumentException(
+                "EnumValueDescriptor is not for this type.");
+            }
+            return VALUES[desc.getIndex()];
+          }
+
+          private final int index;
+          private final int value;
+
+          private Type(int index, int value) {
+            this.index = index;
+            this.value = value;
+          }
+
+          // @@protoc_insertion_point(enum_scope:mesosphere.marathon.MarathonTask.Reservation.State.Type)
+        }
+
+        public interface TimeoutOrBuilder
+            extends com.google.protobuf.MessageOrBuilder {
+
+          // required int64 initiated = 1;
+          /**
+           * <code>required int64 initiated = 1;</code>
+           */
+          boolean hasInitiated();
+          /**
+           * <code>required int64 initiated = 1;</code>
+           */
+          long getInitiated();
+
+          // required int64 deadline = 2;
+          /**
+           * <code>required int64 deadline = 2;</code>
+           */
+          boolean hasDeadline();
+          /**
+           * <code>required int64 deadline = 2;</code>
+           */
+          long getDeadline();
+
+          // required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
+           */
+          boolean hasReason();
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
+           */
+          mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason getReason();
+        }
+        /**
+         * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State.Timeout}
+         */
+        public static final class Timeout extends
+            com.google.protobuf.GeneratedMessage
+            implements TimeoutOrBuilder {
+          // Use Timeout.newBuilder() to construct.
+          private Timeout(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+            super(builder);
+            this.unknownFields = builder.getUnknownFields();
+          }
+          private Timeout(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+          private static final Timeout defaultInstance;
+          public static Timeout getDefaultInstance() {
+            return defaultInstance;
+          }
+
+          public Timeout getDefaultInstanceForType() {
+            return defaultInstance;
+          }
+
+          private final com.google.protobuf.UnknownFieldSet unknownFields;
+          @java.lang.Override
+          public final com.google.protobuf.UnknownFieldSet
+              getUnknownFields() {
+            return this.unknownFields;
+          }
+          private Timeout(
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws com.google.protobuf.InvalidProtocolBufferException {
+            initFields();
+            int mutable_bitField0_ = 0;
+            com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+                com.google.protobuf.UnknownFieldSet.newBuilder();
+            try {
+              boolean done = false;
+              while (!done) {
+                int tag = input.readTag();
+                switch (tag) {
+                  case 0:
+                    done = true;
+                    break;
+                  default: {
+                    if (!parseUnknownField(input, unknownFields,
+                                           extensionRegistry, tag)) {
+                      done = true;
+                    }
+                    break;
+                  }
+                  case 8: {
+                    bitField0_ |= 0x00000001;
+                    initiated_ = input.readInt64();
+                    break;
+                  }
+                  case 16: {
+                    bitField0_ |= 0x00000002;
+                    deadline_ = input.readInt64();
+                    break;
+                  }
+                  case 24: {
+                    int rawValue = input.readEnum();
+                    mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason value = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason.valueOf(rawValue);
+                    if (value == null) {
+                      unknownFields.mergeVarintField(3, rawValue);
+                    } else {
+                      bitField0_ |= 0x00000004;
+                      reason_ = value;
+                    }
+                    break;
+                  }
+                }
+              }
+            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+              throw e.setUnfinishedMessage(this);
+            } catch (java.io.IOException e) {
+              throw new com.google.protobuf.InvalidProtocolBufferException(
+                  e.getMessage()).setUnfinishedMessage(this);
+            } finally {
+              this.unknownFields = unknownFields.build();
+              makeExtensionsImmutable();
+            }
+          }
+          public static final com.google.protobuf.Descriptors.Descriptor
+              getDescriptor() {
+            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor;
+          }
+
+          protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+              internalGetFieldAccessorTable() {
+            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable
+                .ensureFieldAccessorsInitialized(
+                    mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.class, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder.class);
+          }
+
+          public static com.google.protobuf.Parser<Timeout> PARSER =
+              new com.google.protobuf.AbstractParser<Timeout>() {
+            public Timeout parsePartialFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+              return new Timeout(input, extensionRegistry);
+            }
+          };
+
+          @java.lang.Override
+          public com.google.protobuf.Parser<Timeout> getParserForType() {
+            return PARSER;
+          }
+
+          /**
+           * Protobuf enum {@code mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason}
+           */
+          public enum Reason
+              implements com.google.protobuf.ProtocolMessageEnum {
+            /**
+             * <code>RelaunchEscalationTimeout = 1;</code>
+             */
+            RelaunchEscalationTimeout(0, 1),
+            /**
+             * <code>ReservationTimeout = 2;</code>
+             */
+            ReservationTimeout(1, 2),
+            ;
+
+            /**
+             * <code>RelaunchEscalationTimeout = 1;</code>
+             */
+            public static final int RelaunchEscalationTimeout_VALUE = 1;
+            /**
+             * <code>ReservationTimeout = 2;</code>
+             */
+            public static final int ReservationTimeout_VALUE = 2;
+
+
+            public final int getNumber() { return value; }
+
+            public static Reason valueOf(int value) {
+              switch (value) {
+                case 1: return RelaunchEscalationTimeout;
+                case 2: return ReservationTimeout;
+                default: return null;
+              }
+            }
+
+            public static com.google.protobuf.Internal.EnumLiteMap<Reason>
+                internalGetValueMap() {
+              return internalValueMap;
+            }
+            private static com.google.protobuf.Internal.EnumLiteMap<Reason>
+                internalValueMap =
+                  new com.google.protobuf.Internal.EnumLiteMap<Reason>() {
+                    public Reason findValueByNumber(int number) {
+                      return Reason.valueOf(number);
+                    }
+                  };
+
+            public final com.google.protobuf.Descriptors.EnumValueDescriptor
+                getValueDescriptor() {
+              return getDescriptor().getValues().get(index);
+            }
+            public final com.google.protobuf.Descriptors.EnumDescriptor
+                getDescriptorForType() {
+              return getDescriptor();
+            }
+            public static final com.google.protobuf.Descriptors.EnumDescriptor
+                getDescriptor() {
+              return mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.getDescriptor().getEnumTypes().get(0);
+            }
+
+            private static final Reason[] VALUES = values();
+
+            public static Reason valueOf(
+                com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+              if (desc.getType() != getDescriptor()) {
+                throw new java.lang.IllegalArgumentException(
+                  "EnumValueDescriptor is not for this type.");
+              }
+              return VALUES[desc.getIndex()];
+            }
+
+            private final int index;
+            private final int value;
+
+            private Reason(int index, int value) {
+              this.index = index;
+              this.value = value;
+            }
+
+            // @@protoc_insertion_point(enum_scope:mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason)
+          }
+
+          private int bitField0_;
+          // required int64 initiated = 1;
+          public static final int INITIATED_FIELD_NUMBER = 1;
+          private long initiated_;
+          /**
+           * <code>required int64 initiated = 1;</code>
+           */
+          public boolean hasInitiated() {
+            return ((bitField0_ & 0x00000001) == 0x00000001);
+          }
+          /**
+           * <code>required int64 initiated = 1;</code>
+           */
+          public long getInitiated() {
+            return initiated_;
+          }
+
+          // required int64 deadline = 2;
+          public static final int DEADLINE_FIELD_NUMBER = 2;
+          private long deadline_;
+          /**
+           * <code>required int64 deadline = 2;</code>
+           */
+          public boolean hasDeadline() {
+            return ((bitField0_ & 0x00000002) == 0x00000002);
+          }
+          /**
+           * <code>required int64 deadline = 2;</code>
+           */
+          public long getDeadline() {
+            return deadline_;
+          }
+
+          // required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;
+          public static final int REASON_FIELD_NUMBER = 3;
+          private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason reason_;
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
+           */
+          public boolean hasReason() {
+            return ((bitField0_ & 0x00000004) == 0x00000004);
+          }
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
+           */
+          public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason getReason() {
+            return reason_;
+          }
+
+          private void initFields() {
+            initiated_ = 0L;
+            deadline_ = 0L;
+            reason_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason.RelaunchEscalationTimeout;
+          }
+          private byte memoizedIsInitialized = -1;
+          public final boolean isInitialized() {
+            byte isInitialized = memoizedIsInitialized;
+            if (isInitialized != -1) return isInitialized == 1;
+
+            if (!hasInitiated()) {
+              memoizedIsInitialized = 0;
+              return false;
+            }
+            if (!hasDeadline()) {
+              memoizedIsInitialized = 0;
+              return false;
+            }
+            if (!hasReason()) {
+              memoizedIsInitialized = 0;
+              return false;
+            }
+            memoizedIsInitialized = 1;
+            return true;
+          }
+
+          public void writeTo(com.google.protobuf.CodedOutputStream output)
+                              throws java.io.IOException {
+            getSerializedSize();
+            if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              output.writeInt64(1, initiated_);
+            }
+            if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              output.writeInt64(2, deadline_);
+            }
+            if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              output.writeEnum(3, reason_.getNumber());
+            }
+            getUnknownFields().writeTo(output);
+          }
+
+          private int memoizedSerializedSize = -1;
+          public int getSerializedSize() {
+            int size = memoizedSerializedSize;
+            if (size != -1) return size;
+
+            size = 0;
+            if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              size += com.google.protobuf.CodedOutputStream
+                .computeInt64Size(1, initiated_);
+            }
+            if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              size += com.google.protobuf.CodedOutputStream
+                .computeInt64Size(2, deadline_);
+            }
+            if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              size += com.google.protobuf.CodedOutputStream
+                .computeEnumSize(3, reason_.getNumber());
+            }
+            size += getUnknownFields().getSerializedSize();
+            memoizedSerializedSize = size;
+            return size;
+          }
+
+          private static final long serialVersionUID = 0L;
+          @java.lang.Override
+          protected java.lang.Object writeReplace()
+              throws java.io.ObjectStreamException {
+            return super.writeReplace();
+          }
+
+          public static mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parseFrom(
+              com.google.protobuf.ByteString data)
+              throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data);
+          }
+          public static mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parseFrom(
+              com.google.protobuf.ByteString data,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data, extensionRegistry);
+          }
+          public static mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parseFrom(byte[] data)
+              throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data);
+          }
+          public static mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parseFrom(
+              byte[] data,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data, extensionRegistry);
+          }
+          public static mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parseFrom(java.io.InputStream input)
+              throws java.io.IOException {
+            return PARSER.parseFrom(input);
+          }
+          public static mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parseFrom(
+              java.io.InputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
+            return PARSER.parseFrom(input, extensionRegistry);
+          }
+          public static mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parseDelimitedFrom(java.io.InputStream input)
+              throws java.io.IOException {
+            return PARSER.parseDelimitedFrom(input);
+          }
+          public static mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parseDelimitedFrom(
+              java.io.InputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
+            return PARSER.parseDelimitedFrom(input, extensionRegistry);
+          }
+          public static mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parseFrom(
+              com.google.protobuf.CodedInputStream input)
+              throws java.io.IOException {
+            return PARSER.parseFrom(input);
+          }
+          public static mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parseFrom(
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
+            return PARSER.parseFrom(input, extensionRegistry);
+          }
+
+          public static Builder newBuilder() { return Builder.create(); }
+          public Builder newBuilderForType() { return newBuilder(); }
+          public static Builder newBuilder(mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout prototype) {
+            return newBuilder().mergeFrom(prototype);
+          }
+          public Builder toBuilder() { return newBuilder(this); }
+
+          @java.lang.Override
+          protected Builder newBuilderForType(
+              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            Builder builder = new Builder(parent);
+            return builder;
+          }
+          /**
+           * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State.Timeout}
+           */
+          public static final class Builder extends
+              com.google.protobuf.GeneratedMessage.Builder<Builder>
+             implements mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder {
+            public static final com.google.protobuf.Descriptors.Descriptor
+                getDescriptor() {
+              return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor;
+            }
+
+            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+                internalGetFieldAccessorTable() {
+              return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable
+                  .ensureFieldAccessorsInitialized(
+                      mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.class, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder.class);
+            }
+
+            // Construct using mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.newBuilder()
+            private Builder() {
+              maybeForceBuilderInitialization();
+            }
+
+            private Builder(
+                com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+              super(parent);
+              maybeForceBuilderInitialization();
+            }
+            private void maybeForceBuilderInitialization() {
+              if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+              }
+            }
+            private static Builder create() {
+              return new Builder();
+            }
+
+            public Builder clear() {
+              super.clear();
+              initiated_ = 0L;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              deadline_ = 0L;
+              bitField0_ = (bitField0_ & ~0x00000002);
+              reason_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason.RelaunchEscalationTimeout;
+              bitField0_ = (bitField0_ & ~0x00000004);
+              return this;
+            }
+
+            public Builder clone() {
+              return create().mergeFrom(buildPartial());
+            }
+
+            public com.google.protobuf.Descriptors.Descriptor
+                getDescriptorForType() {
+              return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor;
+            }
+
+            public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout getDefaultInstanceForType() {
+              return mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.getDefaultInstance();
+            }
+
+            public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout build() {
+              mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout result = buildPartial();
+              if (!result.isInitialized()) {
+                throw newUninitializedMessageException(result);
+              }
+              return result;
+            }
+
+            public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout buildPartial() {
+              mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout result = new mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout(this);
+              int from_bitField0_ = bitField0_;
+              int to_bitField0_ = 0;
+              if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+                to_bitField0_ |= 0x00000001;
+              }
+              result.initiated_ = initiated_;
+              if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+                to_bitField0_ |= 0x00000002;
+              }
+              result.deadline_ = deadline_;
+              if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+                to_bitField0_ |= 0x00000004;
+              }
+              result.reason_ = reason_;
+              result.bitField0_ = to_bitField0_;
+              onBuilt();
+              return result;
+            }
+
+            public Builder mergeFrom(com.google.protobuf.Message other) {
+              if (other instanceof mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout) {
+                return mergeFrom((mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout)other);
+              } else {
+                super.mergeFrom(other);
+                return this;
+              }
+            }
+
+            public Builder mergeFrom(mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout other) {
+              if (other == mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.getDefaultInstance()) return this;
+              if (other.hasInitiated()) {
+                setInitiated(other.getInitiated());
+              }
+              if (other.hasDeadline()) {
+                setDeadline(other.getDeadline());
+              }
+              if (other.hasReason()) {
+                setReason(other.getReason());
+              }
+              this.mergeUnknownFields(other.getUnknownFields());
+              return this;
+            }
+
+            public final boolean isInitialized() {
+              if (!hasInitiated()) {
+                
+                return false;
+              }
+              if (!hasDeadline()) {
+                
+                return false;
+              }
+              if (!hasReason()) {
+                
+                return false;
+              }
+              return true;
+            }
+
+            public Builder mergeFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws java.io.IOException {
+              mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout parsedMessage = null;
+              try {
+                parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+              } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                parsedMessage = (mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout) e.getUnfinishedMessage();
+                throw e;
+              } finally {
+                if (parsedMessage != null) {
+                  mergeFrom(parsedMessage);
+                }
+              }
+              return this;
+            }
+            private int bitField0_;
+
+            // required int64 initiated = 1;
+            private long initiated_ ;
+            /**
+             * <code>required int64 initiated = 1;</code>
+             */
+            public boolean hasInitiated() {
+              return ((bitField0_ & 0x00000001) == 0x00000001);
+            }
+            /**
+             * <code>required int64 initiated = 1;</code>
+             */
+            public long getInitiated() {
+              return initiated_;
+            }
+            /**
+             * <code>required int64 initiated = 1;</code>
+             */
+            public Builder setInitiated(long value) {
+              bitField0_ |= 0x00000001;
+              initiated_ = value;
+              onChanged();
+              return this;
+            }
+            /**
+             * <code>required int64 initiated = 1;</code>
+             */
+            public Builder clearInitiated() {
+              bitField0_ = (bitField0_ & ~0x00000001);
+              initiated_ = 0L;
+              onChanged();
+              return this;
+            }
+
+            // required int64 deadline = 2;
+            private long deadline_ ;
+            /**
+             * <code>required int64 deadline = 2;</code>
+             */
+            public boolean hasDeadline() {
+              return ((bitField0_ & 0x00000002) == 0x00000002);
+            }
+            /**
+             * <code>required int64 deadline = 2;</code>
+             */
+            public long getDeadline() {
+              return deadline_;
+            }
+            /**
+             * <code>required int64 deadline = 2;</code>
+             */
+            public Builder setDeadline(long value) {
+              bitField0_ |= 0x00000002;
+              deadline_ = value;
+              onChanged();
+              return this;
+            }
+            /**
+             * <code>required int64 deadline = 2;</code>
+             */
+            public Builder clearDeadline() {
+              bitField0_ = (bitField0_ & ~0x00000002);
+              deadline_ = 0L;
+              onChanged();
+              return this;
+            }
+
+            // required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;
+            private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason reason_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason.RelaunchEscalationTimeout;
+            /**
+             * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
+             */
+            public boolean hasReason() {
+              return ((bitField0_ & 0x00000004) == 0x00000004);
+            }
+            /**
+             * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
+             */
+            public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason getReason() {
+              return reason_;
+            }
+            /**
+             * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
+             */
+            public Builder setReason(mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason value) {
+              if (value == null) {
+                throw new NullPointerException();
+              }
+              bitField0_ |= 0x00000004;
+              reason_ = value;
+              onChanged();
+              return this;
+            }
+            /**
+             * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
+             */
+            public Builder clearReason() {
+              bitField0_ = (bitField0_ & ~0x00000004);
+              reason_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason.RelaunchEscalationTimeout;
+              onChanged();
+              return this;
+            }
+
+            // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask.Reservation.State.Timeout)
+          }
+
+          static {
+            defaultInstance = new Timeout(true);
+            defaultInstance.initFields();
+          }
+
+          // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask.Reservation.State.Timeout)
+        }
+
+        private int bitField0_;
+        // required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;
+        public static final int TYPE_FIELD_NUMBER = 1;
+        private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type type_;
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
+         */
+        public boolean hasType() {
+          return ((bitField0_ & 0x00000001) == 0x00000001);
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type getType() {
+          return type_;
+        }
+
+        // optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;
+        public static final int TIMEOUT_FIELD_NUMBER = 2;
+        private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout timeout_;
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+         */
+        public boolean hasTimeout() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout getTimeout() {
+          return timeout_;
+        }
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder getTimeoutOrBuilder() {
+          return timeout_;
+        }
+
+        private void initFields() {
+          type_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type.New;
+          timeout_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.getDefaultInstance();
+        }
+        private byte memoizedIsInitialized = -1;
+        public final boolean isInitialized() {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized != -1) return isInitialized == 1;
+
+          if (!hasType()) {
+            memoizedIsInitialized = 0;
+            return false;
+          }
+          if (hasTimeout()) {
+            if (!getTimeout().isInitialized()) {
+              memoizedIsInitialized = 0;
+              return false;
+            }
+          }
+          memoizedIsInitialized = 1;
+          return true;
+        }
+
+        public void writeTo(com.google.protobuf.CodedOutputStream output)
+                            throws java.io.IOException {
+          getSerializedSize();
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            output.writeEnum(1, type_.getNumber());
+          }
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            output.writeMessage(2, timeout_);
+          }
+          getUnknownFields().writeTo(output);
+        }
+
+        private int memoizedSerializedSize = -1;
+        public int getSerializedSize() {
+          int size = memoizedSerializedSize;
+          if (size != -1) return size;
+
+          size = 0;
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            size += com.google.protobuf.CodedOutputStream
+              .computeEnumSize(1, type_.getNumber());
+          }
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            size += com.google.protobuf.CodedOutputStream
+              .computeMessageSize(2, timeout_);
+          }
+          size += getUnknownFields().getSerializedSize();
+          memoizedSerializedSize = size;
+          return size;
+        }
+
+        private static final long serialVersionUID = 0L;
+        @java.lang.Override
+        protected java.lang.Object writeReplace()
+            throws java.io.ObjectStreamException {
+          return super.writeReplace();
+        }
+
+        public static mesosphere.marathon.Protos.MarathonTask.Reservation.State parseFrom(
+            com.google.protobuf.ByteString data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return PARSER.parseFrom(data);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.Reservation.State parseFrom(
+            com.google.protobuf.ByteString data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return PARSER.parseFrom(data, extensionRegistry);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.Reservation.State parseFrom(byte[] data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return PARSER.parseFrom(data);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.Reservation.State parseFrom(
+            byte[] data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return PARSER.parseFrom(data, extensionRegistry);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.Reservation.State parseFrom(java.io.InputStream input)
+            throws java.io.IOException {
+          return PARSER.parseFrom(input);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.Reservation.State parseFrom(
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          return PARSER.parseFrom(input, extensionRegistry);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.Reservation.State parseDelimitedFrom(java.io.InputStream input)
+            throws java.io.IOException {
+          return PARSER.parseDelimitedFrom(input);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.Reservation.State parseDelimitedFrom(
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          return PARSER.parseDelimitedFrom(input, extensionRegistry);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.Reservation.State parseFrom(
+            com.google.protobuf.CodedInputStream input)
+            throws java.io.IOException {
+          return PARSER.parseFrom(input);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.Reservation.State parseFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          return PARSER.parseFrom(input, extensionRegistry);
+        }
+
+        public static Builder newBuilder() { return Builder.create(); }
+        public Builder newBuilderForType() { return newBuilder(); }
+        public static Builder newBuilder(mesosphere.marathon.Protos.MarathonTask.Reservation.State prototype) {
+          return newBuilder().mergeFrom(prototype);
+        }
+        public Builder toBuilder() { return newBuilder(this); }
+
+        @java.lang.Override
+        protected Builder newBuilderForType(
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          Builder builder = new Builder(parent);
+          return builder;
+        }
+        /**
+         * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State}
+         */
+        public static final class Builder extends
+            com.google.protobuf.GeneratedMessage.Builder<Builder>
+           implements mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder {
+          public static final com.google.protobuf.Descriptors.Descriptor
+              getDescriptor() {
+            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor;
+          }
+
+          protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+              internalGetFieldAccessorTable() {
+            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable
+                .ensureFieldAccessorsInitialized(
+                    mesosphere.marathon.Protos.MarathonTask.Reservation.State.class, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder.class);
+          }
+
+          // Construct using mesosphere.marathon.Protos.MarathonTask.Reservation.State.newBuilder()
+          private Builder() {
+            maybeForceBuilderInitialization();
+          }
+
+          private Builder(
+              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            super(parent);
+            maybeForceBuilderInitialization();
+          }
+          private void maybeForceBuilderInitialization() {
+            if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+              getTimeoutFieldBuilder();
+            }
+          }
+          private static Builder create() {
+            return new Builder();
+          }
+
+          public Builder clear() {
+            super.clear();
+            type_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type.New;
+            bitField0_ = (bitField0_ & ~0x00000001);
+            if (timeoutBuilder_ == null) {
+              timeout_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.getDefaultInstance();
+            } else {
+              timeoutBuilder_.clear();
+            }
+            bitField0_ = (bitField0_ & ~0x00000002);
+            return this;
+          }
+
+          public Builder clone() {
+            return create().mergeFrom(buildPartial());
+          }
+
+          public com.google.protobuf.Descriptors.Descriptor
+              getDescriptorForType() {
+            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor;
+          }
+
+          public mesosphere.marathon.Protos.MarathonTask.Reservation.State getDefaultInstanceForType() {
+            return mesosphere.marathon.Protos.MarathonTask.Reservation.State.getDefaultInstance();
+          }
+
+          public mesosphere.marathon.Protos.MarathonTask.Reservation.State build() {
+            mesosphere.marathon.Protos.MarathonTask.Reservation.State result = buildPartial();
+            if (!result.isInitialized()) {
+              throw newUninitializedMessageException(result);
+            }
+            return result;
+          }
+
+          public mesosphere.marathon.Protos.MarathonTask.Reservation.State buildPartial() {
+            mesosphere.marathon.Protos.MarathonTask.Reservation.State result = new mesosphere.marathon.Protos.MarathonTask.Reservation.State(this);
+            int from_bitField0_ = bitField0_;
+            int to_bitField0_ = 0;
+            if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+              to_bitField0_ |= 0x00000001;
+            }
+            result.type_ = type_;
+            if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+              to_bitField0_ |= 0x00000002;
+            }
+            if (timeoutBuilder_ == null) {
+              result.timeout_ = timeout_;
+            } else {
+              result.timeout_ = timeoutBuilder_.build();
+            }
+            result.bitField0_ = to_bitField0_;
+            onBuilt();
+            return result;
+          }
+
+          public Builder mergeFrom(com.google.protobuf.Message other) {
+            if (other instanceof mesosphere.marathon.Protos.MarathonTask.Reservation.State) {
+              return mergeFrom((mesosphere.marathon.Protos.MarathonTask.Reservation.State)other);
+            } else {
+              super.mergeFrom(other);
+              return this;
+            }
+          }
+
+          public Builder mergeFrom(mesosphere.marathon.Protos.MarathonTask.Reservation.State other) {
+            if (other == mesosphere.marathon.Protos.MarathonTask.Reservation.State.getDefaultInstance()) return this;
+            if (other.hasType()) {
+              setType(other.getType());
+            }
+            if (other.hasTimeout()) {
+              mergeTimeout(other.getTimeout());
+            }
+            this.mergeUnknownFields(other.getUnknownFields());
+            return this;
+          }
+
+          public final boolean isInitialized() {
+            if (!hasType()) {
+              
+              return false;
+            }
+            if (hasTimeout()) {
+              if (!getTimeout().isInitialized()) {
+                
+                return false;
+              }
+            }
+            return true;
+          }
+
+          public Builder mergeFrom(
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
+            mesosphere.marathon.Protos.MarathonTask.Reservation.State parsedMessage = null;
+            try {
+              parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+              parsedMessage = (mesosphere.marathon.Protos.MarathonTask.Reservation.State) e.getUnfinishedMessage();
+              throw e;
+            } finally {
+              if (parsedMessage != null) {
+                mergeFrom(parsedMessage);
+              }
+            }
+            return this;
+          }
+          private int bitField0_;
+
+          // required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;
+          private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type type_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type.New;
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
+           */
+          public boolean hasType() {
+            return ((bitField0_ & 0x00000001) == 0x00000001);
+          }
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
+           */
+          public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type getType() {
+            return type_;
+          }
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
+           */
+          public Builder setType(mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type value) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            bitField0_ |= 0x00000001;
+            type_ = value;
+            onChanged();
+            return this;
+          }
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
+           */
+          public Builder clearType() {
+            bitField0_ = (bitField0_ & ~0x00000001);
+            type_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type.New;
+            onChanged();
+            return this;
+          }
+
+          // optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;
+          private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout timeout_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.getDefaultInstance();
+          private com.google.protobuf.SingleFieldBuilder<
+              mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder> timeoutBuilder_;
+          /**
+           * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+           */
+          public boolean hasTimeout() {
+            return ((bitField0_ & 0x00000002) == 0x00000002);
+          }
+          /**
+           * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+           */
+          public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout getTimeout() {
+            if (timeoutBuilder_ == null) {
+              return timeout_;
+            } else {
+              return timeoutBuilder_.getMessage();
+            }
+          }
+          /**
+           * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+           */
+          public Builder setTimeout(mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout value) {
+            if (timeoutBuilder_ == null) {
+              if (value == null) {
+                throw new NullPointerException();
+              }
+              timeout_ = value;
+              onChanged();
+            } else {
+              timeoutBuilder_.setMessage(value);
+            }
+            bitField0_ |= 0x00000002;
+            return this;
+          }
+          /**
+           * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+           */
+          public Builder setTimeout(
+              mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder builderForValue) {
+            if (timeoutBuilder_ == null) {
+              timeout_ = builderForValue.build();
+              onChanged();
+            } else {
+              timeoutBuilder_.setMessage(builderForValue.build());
+            }
+            bitField0_ |= 0x00000002;
+            return this;
+          }
+          /**
+           * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+           */
+          public Builder mergeTimeout(mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout value) {
+            if (timeoutBuilder_ == null) {
+              if (((bitField0_ & 0x00000002) == 0x00000002) &&
+                  timeout_ != mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.getDefaultInstance()) {
+                timeout_ =
+                  mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.newBuilder(timeout_).mergeFrom(value).buildPartial();
+              } else {
+                timeout_ = value;
+              }
+              onChanged();
+            } else {
+              timeoutBuilder_.mergeFrom(value);
+            }
+            bitField0_ |= 0x00000002;
+            return this;
+          }
+          /**
+           * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+           */
+          public Builder clearTimeout() {
+            if (timeoutBuilder_ == null) {
+              timeout_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.getDefaultInstance();
+              onChanged();
+            } else {
+              timeoutBuilder_.clear();
+            }
+            bitField0_ = (bitField0_ & ~0x00000002);
+            return this;
+          }
+          /**
+           * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+           */
+          public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder getTimeoutBuilder() {
+            bitField0_ |= 0x00000002;
+            onChanged();
+            return getTimeoutFieldBuilder().getBuilder();
+          }
+          /**
+           * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+           */
+          public mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder getTimeoutOrBuilder() {
+            if (timeoutBuilder_ != null) {
+              return timeoutBuilder_.getMessageOrBuilder();
+            } else {
+              return timeout_;
+            }
+          }
+          /**
+           * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
+           */
+          private com.google.protobuf.SingleFieldBuilder<
+              mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder> 
+              getTimeoutFieldBuilder() {
+            if (timeoutBuilder_ == null) {
+              timeoutBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+                  mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder>(
+                      timeout_,
+                      getParentForChildren(),
+                      isClean());
+              timeout_ = null;
+            }
+            return timeoutBuilder_;
+          }
+
+          // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask.Reservation.State)
+        }
+
+        static {
+          defaultInstance = new State(true);
+          defaultInstance.initFields();
+        }
+
+        // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask.Reservation.State)
+      }
+
+      private int bitField0_;
       // repeated string local_volume_ids = 1;
       public static final int LOCAL_VOLUME_IDS_FIELD_NUMBER = 1;
       private com.google.protobuf.LazyStringList localVolumeIds_;
@@ -10763,14 +12163,45 @@ public final class Protos {
         return localVolumeIds_.getByteString(index);
       }
 
+      // required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;
+      public static final int STATE_FIELD_NUMBER = 2;
+      private mesosphere.marathon.Protos.MarathonTask.Reservation.State state_;
+      /**
+       * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+       */
+      public boolean hasState() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+       */
+      public mesosphere.marathon.Protos.MarathonTask.Reservation.State getState() {
+        return state_;
+      }
+      /**
+       * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+       */
+      public mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder getStateOrBuilder() {
+        return state_;
+      }
+
       private void initFields() {
         localVolumeIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        state_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.getDefaultInstance();
       }
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
         if (isInitialized != -1) return isInitialized == 1;
 
+        if (!hasState()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        if (!getState().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
         memoizedIsInitialized = 1;
         return true;
       }
@@ -10780,6 +12211,9 @@ public final class Protos {
         getSerializedSize();
         for (int i = 0; i < localVolumeIds_.size(); i++) {
           output.writeBytes(1, localVolumeIds_.getByteString(i));
+        }
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          output.writeMessage(2, state_);
         }
         getUnknownFields().writeTo(output);
       }
@@ -10798,6 +12232,10 @@ public final class Protos {
           }
           size += dataSize;
           size += 1 * getLocalVolumeIdsList().size();
+        }
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(2, state_);
         }
         size += getUnknownFields().getSerializedSize();
         memoizedSerializedSize = size;
@@ -10907,6 +12345,7 @@ public final class Protos {
         }
         private void maybeForceBuilderInitialization() {
           if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+            getStateFieldBuilder();
           }
         }
         private static Builder create() {
@@ -10917,6 +12356,12 @@ public final class Protos {
           super.clear();
           localVolumeIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
           bitField0_ = (bitField0_ & ~0x00000001);
+          if (stateBuilder_ == null) {
+            state_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.getDefaultInstance();
+          } else {
+            stateBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000002);
           return this;
         }
 
@@ -10944,12 +12389,22 @@ public final class Protos {
         public mesosphere.marathon.Protos.MarathonTask.Reservation buildPartial() {
           mesosphere.marathon.Protos.MarathonTask.Reservation result = new mesosphere.marathon.Protos.MarathonTask.Reservation(this);
           int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
           if (((bitField0_ & 0x00000001) == 0x00000001)) {
             localVolumeIds_ = new com.google.protobuf.UnmodifiableLazyStringList(
                 localVolumeIds_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
           result.localVolumeIds_ = localVolumeIds_;
+          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          if (stateBuilder_ == null) {
+            result.state_ = state_;
+          } else {
+            result.state_ = stateBuilder_.build();
+          }
+          result.bitField0_ = to_bitField0_;
           onBuilt();
           return result;
         }
@@ -10975,11 +12430,22 @@ public final class Protos {
             }
             onChanged();
           }
+          if (other.hasState()) {
+            mergeState(other.getState());
+          }
           this.mergeUnknownFields(other.getUnknownFields());
           return this;
         }
 
         public final boolean isInitialized() {
+          if (!hasState()) {
+            
+            return false;
+          }
+          if (!getState().isInitialized()) {
+            
+            return false;
+          }
           return true;
         }
 
@@ -11095,6 +12561,123 @@ public final class Protos {
           return this;
         }
 
+        // required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;
+        private mesosphere.marathon.Protos.MarathonTask.Reservation.State state_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.getDefaultInstance();
+        private com.google.protobuf.SingleFieldBuilder<
+            mesosphere.marathon.Protos.MarathonTask.Reservation.State, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder> stateBuilder_;
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+         */
+        public boolean hasState() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.Reservation.State getState() {
+          if (stateBuilder_ == null) {
+            return state_;
+          } else {
+            return stateBuilder_.getMessage();
+          }
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+         */
+        public Builder setState(mesosphere.marathon.Protos.MarathonTask.Reservation.State value) {
+          if (stateBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            state_ = value;
+            onChanged();
+          } else {
+            stateBuilder_.setMessage(value);
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+         */
+        public Builder setState(
+            mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder builderForValue) {
+          if (stateBuilder_ == null) {
+            state_ = builderForValue.build();
+            onChanged();
+          } else {
+            stateBuilder_.setMessage(builderForValue.build());
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+         */
+        public Builder mergeState(mesosphere.marathon.Protos.MarathonTask.Reservation.State value) {
+          if (stateBuilder_ == null) {
+            if (((bitField0_ & 0x00000002) == 0x00000002) &&
+                state_ != mesosphere.marathon.Protos.MarathonTask.Reservation.State.getDefaultInstance()) {
+              state_ =
+                mesosphere.marathon.Protos.MarathonTask.Reservation.State.newBuilder(state_).mergeFrom(value).buildPartial();
+            } else {
+              state_ = value;
+            }
+            onChanged();
+          } else {
+            stateBuilder_.mergeFrom(value);
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+         */
+        public Builder clearState() {
+          if (stateBuilder_ == null) {
+            state_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.getDefaultInstance();
+            onChanged();
+          } else {
+            stateBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder getStateBuilder() {
+          bitField0_ |= 0x00000002;
+          onChanged();
+          return getStateFieldBuilder().getBuilder();
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder getStateOrBuilder() {
+          if (stateBuilder_ != null) {
+            return stateBuilder_.getMessageOrBuilder();
+          } else {
+            return state_;
+          }
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
+         */
+        private com.google.protobuf.SingleFieldBuilder<
+            mesosphere.marathon.Protos.MarathonTask.Reservation.State, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder> 
+            getStateFieldBuilder() {
+          if (stateBuilder_ == null) {
+            stateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+                mesosphere.marathon.Protos.MarathonTask.Reservation.State, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder>(
+                    state_,
+                    getParentForChildren(),
+                    isClean());
+            state_ = null;
+          }
+          return stateBuilder_;
+        }
+
         // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask.Reservation)
       }
 
@@ -11104,1396 +12687,6 @@ public final class Protos {
       }
 
       // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask.Reservation)
-    }
-
-    public interface ReservedStateOrBuilder
-        extends com.google.protobuf.MessageOrBuilder {
-
-      // required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;
-      /**
-       * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
-       */
-      boolean hasType();
-      /**
-       * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
-       */
-      mesosphere.marathon.Protos.MarathonTask.ReservedState.Type getType();
-
-      // optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-       */
-      boolean hasTimeout();
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-       */
-      mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout getTimeout();
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-       */
-      mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder getTimeoutOrBuilder();
-    }
-    /**
-     * Protobuf type {@code mesosphere.marathon.MarathonTask.ReservedState}
-     */
-    public static final class ReservedState extends
-        com.google.protobuf.GeneratedMessage
-        implements ReservedStateOrBuilder {
-      // Use ReservedState.newBuilder() to construct.
-      private ReservedState(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-        super(builder);
-        this.unknownFields = builder.getUnknownFields();
-      }
-      private ReservedState(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-      private static final ReservedState defaultInstance;
-      public static ReservedState getDefaultInstance() {
-        return defaultInstance;
-      }
-
-      public ReservedState getDefaultInstanceForType() {
-        return defaultInstance;
-      }
-
-      private final com.google.protobuf.UnknownFieldSet unknownFields;
-      @java.lang.Override
-      public final com.google.protobuf.UnknownFieldSet
-          getUnknownFields() {
-        return this.unknownFields;
-      }
-      private ReservedState(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        initFields();
-        int mutable_bitField0_ = 0;
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-            com.google.protobuf.UnknownFieldSet.newBuilder();
-        try {
-          boolean done = false;
-          while (!done) {
-            int tag = input.readTag();
-            switch (tag) {
-              case 0:
-                done = true;
-                break;
-              default: {
-                if (!parseUnknownField(input, unknownFields,
-                                       extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
-              case 8: {
-                int rawValue = input.readEnum();
-                mesosphere.marathon.Protos.MarathonTask.ReservedState.Type value = mesosphere.marathon.Protos.MarathonTask.ReservedState.Type.valueOf(rawValue);
-                if (value == null) {
-                  unknownFields.mergeVarintField(1, rawValue);
-                } else {
-                  bitField0_ |= 0x00000001;
-                  type_ = value;
-                }
-                break;
-              }
-              case 18: {
-                mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder subBuilder = null;
-                if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                  subBuilder = timeout_.toBuilder();
-                }
-                timeout_ = input.readMessage(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.PARSER, extensionRegistry);
-                if (subBuilder != null) {
-                  subBuilder.mergeFrom(timeout_);
-                  timeout_ = subBuilder.buildPartial();
-                }
-                bitField0_ |= 0x00000002;
-                break;
-              }
-            }
-          }
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          throw e.setUnfinishedMessage(this);
-        } catch (java.io.IOException e) {
-          throw new com.google.protobuf.InvalidProtocolBufferException(
-              e.getMessage()).setUnfinishedMessage(this);
-        } finally {
-          this.unknownFields = unknownFields.build();
-          makeExtensionsImmutable();
-        }
-      }
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                mesosphere.marathon.Protos.MarathonTask.ReservedState.class, mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder.class);
-      }
-
-      public static com.google.protobuf.Parser<ReservedState> PARSER =
-          new com.google.protobuf.AbstractParser<ReservedState>() {
-        public ReservedState parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ReservedState(input, extensionRegistry);
-        }
-      };
-
-      @java.lang.Override
-      public com.google.protobuf.Parser<ReservedState> getParserForType() {
-        return PARSER;
-      }
-
-      /**
-       * Protobuf enum {@code mesosphere.marathon.MarathonTask.ReservedState.Type}
-       */
-      public enum Type
-          implements com.google.protobuf.ProtocolMessageEnum {
-        /**
-         * <code>New = 1;</code>
-         */
-        New(0, 1),
-        /**
-         * <code>Suspended = 2;</code>
-         */
-        Suspended(1, 2),
-        /**
-         * <code>Garbage = 3;</code>
-         */
-        Garbage(2, 3),
-        /**
-         * <code>Unknown = 4;</code>
-         */
-        Unknown(3, 4),
-        ;
-
-        /**
-         * <code>New = 1;</code>
-         */
-        public static final int New_VALUE = 1;
-        /**
-         * <code>Suspended = 2;</code>
-         */
-        public static final int Suspended_VALUE = 2;
-        /**
-         * <code>Garbage = 3;</code>
-         */
-        public static final int Garbage_VALUE = 3;
-        /**
-         * <code>Unknown = 4;</code>
-         */
-        public static final int Unknown_VALUE = 4;
-
-
-        public final int getNumber() { return value; }
-
-        public static Type valueOf(int value) {
-          switch (value) {
-            case 1: return New;
-            case 2: return Suspended;
-            case 3: return Garbage;
-            case 4: return Unknown;
-            default: return null;
-          }
-        }
-
-        public static com.google.protobuf.Internal.EnumLiteMap<Type>
-            internalGetValueMap() {
-          return internalValueMap;
-        }
-        private static com.google.protobuf.Internal.EnumLiteMap<Type>
-            internalValueMap =
-              new com.google.protobuf.Internal.EnumLiteMap<Type>() {
-                public Type findValueByNumber(int number) {
-                  return Type.valueOf(number);
-                }
-              };
-
-        public final com.google.protobuf.Descriptors.EnumValueDescriptor
-            getValueDescriptor() {
-          return getDescriptor().getValues().get(index);
-        }
-        public final com.google.protobuf.Descriptors.EnumDescriptor
-            getDescriptorForType() {
-          return getDescriptor();
-        }
-        public static final com.google.protobuf.Descriptors.EnumDescriptor
-            getDescriptor() {
-          return mesosphere.marathon.Protos.MarathonTask.ReservedState.getDescriptor().getEnumTypes().get(0);
-        }
-
-        private static final Type[] VALUES = values();
-
-        public static Type valueOf(
-            com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-          if (desc.getType() != getDescriptor()) {
-            throw new java.lang.IllegalArgumentException(
-              "EnumValueDescriptor is not for this type.");
-          }
-          return VALUES[desc.getIndex()];
-        }
-
-        private final int index;
-        private final int value;
-
-        private Type(int index, int value) {
-          this.index = index;
-          this.value = value;
-        }
-
-        // @@protoc_insertion_point(enum_scope:mesosphere.marathon.MarathonTask.ReservedState.Type)
-      }
-
-      public interface TimeoutOrBuilder
-          extends com.google.protobuf.MessageOrBuilder {
-
-        // required int64 initiated = 1;
-        /**
-         * <code>required int64 initiated = 1;</code>
-         */
-        boolean hasInitiated();
-        /**
-         * <code>required int64 initiated = 1;</code>
-         */
-        long getInitiated();
-
-        // required int64 deadline = 2;
-        /**
-         * <code>required int64 deadline = 2;</code>
-         */
-        boolean hasDeadline();
-        /**
-         * <code>required int64 deadline = 2;</code>
-         */
-        long getDeadline();
-
-        // required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;
-        /**
-         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
-         */
-        boolean hasReason();
-        /**
-         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
-         */
-        mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason getReason();
-      }
-      /**
-       * Protobuf type {@code mesosphere.marathon.MarathonTask.ReservedState.Timeout}
-       */
-      public static final class Timeout extends
-          com.google.protobuf.GeneratedMessage
-          implements TimeoutOrBuilder {
-        // Use Timeout.newBuilder() to construct.
-        private Timeout(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-          super(builder);
-          this.unknownFields = builder.getUnknownFields();
-        }
-        private Timeout(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-        private static final Timeout defaultInstance;
-        public static Timeout getDefaultInstance() {
-          return defaultInstance;
-        }
-
-        public Timeout getDefaultInstanceForType() {
-          return defaultInstance;
-        }
-
-        private final com.google.protobuf.UnknownFieldSet unknownFields;
-        @java.lang.Override
-        public final com.google.protobuf.UnknownFieldSet
-            getUnknownFields() {
-          return this.unknownFields;
-        }
-        private Timeout(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          initFields();
-          int mutable_bitField0_ = 0;
-          com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-              com.google.protobuf.UnknownFieldSet.newBuilder();
-          try {
-            boolean done = false;
-            while (!done) {
-              int tag = input.readTag();
-              switch (tag) {
-                case 0:
-                  done = true;
-                  break;
-                default: {
-                  if (!parseUnknownField(input, unknownFields,
-                                         extensionRegistry, tag)) {
-                    done = true;
-                  }
-                  break;
-                }
-                case 8: {
-                  bitField0_ |= 0x00000001;
-                  initiated_ = input.readInt64();
-                  break;
-                }
-                case 16: {
-                  bitField0_ |= 0x00000002;
-                  deadline_ = input.readInt64();
-                  break;
-                }
-                case 24: {
-                  int rawValue = input.readEnum();
-                  mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason value = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason.valueOf(rawValue);
-                  if (value == null) {
-                    unknownFields.mergeVarintField(3, rawValue);
-                  } else {
-                    bitField0_ |= 0x00000004;
-                    reason_ = value;
-                  }
-                  break;
-                }
-              }
-            }
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw e.setUnfinishedMessage(this);
-          } catch (java.io.IOException e) {
-            throw new com.google.protobuf.InvalidProtocolBufferException(
-                e.getMessage()).setUnfinishedMessage(this);
-          } finally {
-            this.unknownFields = unknownFields.build();
-            makeExtensionsImmutable();
-          }
-        }
-        public static final com.google.protobuf.Descriptors.Descriptor
-            getDescriptor() {
-          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor;
-        }
-
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-            internalGetFieldAccessorTable() {
-          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_fieldAccessorTable
-              .ensureFieldAccessorsInitialized(
-                  mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.class, mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder.class);
-        }
-
-        public static com.google.protobuf.Parser<Timeout> PARSER =
-            new com.google.protobuf.AbstractParser<Timeout>() {
-          public Timeout parsePartialFrom(
-              com.google.protobuf.CodedInputStream input,
-              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws com.google.protobuf.InvalidProtocolBufferException {
-            return new Timeout(input, extensionRegistry);
-          }
-        };
-
-        @java.lang.Override
-        public com.google.protobuf.Parser<Timeout> getParserForType() {
-          return PARSER;
-        }
-
-        /**
-         * Protobuf enum {@code mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason}
-         */
-        public enum Reason
-            implements com.google.protobuf.ProtocolMessageEnum {
-          /**
-           * <code>RelaunchEscalationTimeout = 1;</code>
-           */
-          RelaunchEscalationTimeout(0, 1),
-          /**
-           * <code>ReservationTimeout = 2;</code>
-           */
-          ReservationTimeout(1, 2),
-          ;
-
-          /**
-           * <code>RelaunchEscalationTimeout = 1;</code>
-           */
-          public static final int RelaunchEscalationTimeout_VALUE = 1;
-          /**
-           * <code>ReservationTimeout = 2;</code>
-           */
-          public static final int ReservationTimeout_VALUE = 2;
-
-
-          public final int getNumber() { return value; }
-
-          public static Reason valueOf(int value) {
-            switch (value) {
-              case 1: return RelaunchEscalationTimeout;
-              case 2: return ReservationTimeout;
-              default: return null;
-            }
-          }
-
-          public static com.google.protobuf.Internal.EnumLiteMap<Reason>
-              internalGetValueMap() {
-            return internalValueMap;
-          }
-          private static com.google.protobuf.Internal.EnumLiteMap<Reason>
-              internalValueMap =
-                new com.google.protobuf.Internal.EnumLiteMap<Reason>() {
-                  public Reason findValueByNumber(int number) {
-                    return Reason.valueOf(number);
-                  }
-                };
-
-          public final com.google.protobuf.Descriptors.EnumValueDescriptor
-              getValueDescriptor() {
-            return getDescriptor().getValues().get(index);
-          }
-          public final com.google.protobuf.Descriptors.EnumDescriptor
-              getDescriptorForType() {
-            return getDescriptor();
-          }
-          public static final com.google.protobuf.Descriptors.EnumDescriptor
-              getDescriptor() {
-            return mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDescriptor().getEnumTypes().get(0);
-          }
-
-          private static final Reason[] VALUES = values();
-
-          public static Reason valueOf(
-              com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-            if (desc.getType() != getDescriptor()) {
-              throw new java.lang.IllegalArgumentException(
-                "EnumValueDescriptor is not for this type.");
-            }
-            return VALUES[desc.getIndex()];
-          }
-
-          private final int index;
-          private final int value;
-
-          private Reason(int index, int value) {
-            this.index = index;
-            this.value = value;
-          }
-
-          // @@protoc_insertion_point(enum_scope:mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason)
-        }
-
-        private int bitField0_;
-        // required int64 initiated = 1;
-        public static final int INITIATED_FIELD_NUMBER = 1;
-        private long initiated_;
-        /**
-         * <code>required int64 initiated = 1;</code>
-         */
-        public boolean hasInitiated() {
-          return ((bitField0_ & 0x00000001) == 0x00000001);
-        }
-        /**
-         * <code>required int64 initiated = 1;</code>
-         */
-        public long getInitiated() {
-          return initiated_;
-        }
-
-        // required int64 deadline = 2;
-        public static final int DEADLINE_FIELD_NUMBER = 2;
-        private long deadline_;
-        /**
-         * <code>required int64 deadline = 2;</code>
-         */
-        public boolean hasDeadline() {
-          return ((bitField0_ & 0x00000002) == 0x00000002);
-        }
-        /**
-         * <code>required int64 deadline = 2;</code>
-         */
-        public long getDeadline() {
-          return deadline_;
-        }
-
-        // required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;
-        public static final int REASON_FIELD_NUMBER = 3;
-        private mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason reason_;
-        /**
-         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
-         */
-        public boolean hasReason() {
-          return ((bitField0_ & 0x00000004) == 0x00000004);
-        }
-        /**
-         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
-         */
-        public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason getReason() {
-          return reason_;
-        }
-
-        private void initFields() {
-          initiated_ = 0L;
-          deadline_ = 0L;
-          reason_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason.RelaunchEscalationTimeout;
-        }
-        private byte memoizedIsInitialized = -1;
-        public final boolean isInitialized() {
-          byte isInitialized = memoizedIsInitialized;
-          if (isInitialized != -1) return isInitialized == 1;
-
-          if (!hasInitiated()) {
-            memoizedIsInitialized = 0;
-            return false;
-          }
-          if (!hasDeadline()) {
-            memoizedIsInitialized = 0;
-            return false;
-          }
-          if (!hasReason()) {
-            memoizedIsInitialized = 0;
-            return false;
-          }
-          memoizedIsInitialized = 1;
-          return true;
-        }
-
-        public void writeTo(com.google.protobuf.CodedOutputStream output)
-                            throws java.io.IOException {
-          getSerializedSize();
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            output.writeInt64(1, initiated_);
-          }
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
-            output.writeInt64(2, deadline_);
-          }
-          if (((bitField0_ & 0x00000004) == 0x00000004)) {
-            output.writeEnum(3, reason_.getNumber());
-          }
-          getUnknownFields().writeTo(output);
-        }
-
-        private int memoizedSerializedSize = -1;
-        public int getSerializedSize() {
-          int size = memoizedSerializedSize;
-          if (size != -1) return size;
-
-          size = 0;
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            size += com.google.protobuf.CodedOutputStream
-              .computeInt64Size(1, initiated_);
-          }
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
-            size += com.google.protobuf.CodedOutputStream
-              .computeInt64Size(2, deadline_);
-          }
-          if (((bitField0_ & 0x00000004) == 0x00000004)) {
-            size += com.google.protobuf.CodedOutputStream
-              .computeEnumSize(3, reason_.getNumber());
-          }
-          size += getUnknownFields().getSerializedSize();
-          memoizedSerializedSize = size;
-          return size;
-        }
-
-        private static final long serialVersionUID = 0L;
-        @java.lang.Override
-        protected java.lang.Object writeReplace()
-            throws java.io.ObjectStreamException {
-          return super.writeReplace();
-        }
-
-        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
-            com.google.protobuf.ByteString data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          return PARSER.parseFrom(data);
-        }
-        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
-            com.google.protobuf.ByteString data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          return PARSER.parseFrom(data, extensionRegistry);
-        }
-        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(byte[] data)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          return PARSER.parseFrom(data);
-        }
-        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
-            byte[] data,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          return PARSER.parseFrom(data, extensionRegistry);
-        }
-        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(java.io.InputStream input)
-            throws java.io.IOException {
-          return PARSER.parseFrom(input);
-        }
-        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-          return PARSER.parseFrom(input, extensionRegistry);
-        }
-        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseDelimitedFrom(java.io.InputStream input)
-            throws java.io.IOException {
-          return PARSER.parseDelimitedFrom(input);
-        }
-        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseDelimitedFrom(
-            java.io.InputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-          return PARSER.parseDelimitedFrom(input, extensionRegistry);
-        }
-        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
-            com.google.protobuf.CodedInputStream input)
-            throws java.io.IOException {
-          return PARSER.parseFrom(input);
-        }
-        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-          return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static Builder newBuilder() { return Builder.create(); }
-        public Builder newBuilderForType() { return newBuilder(); }
-        public static Builder newBuilder(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout prototype) {
-          return newBuilder().mergeFrom(prototype);
-        }
-        public Builder toBuilder() { return newBuilder(this); }
-
-        @java.lang.Override
-        protected Builder newBuilderForType(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-          Builder builder = new Builder(parent);
-          return builder;
-        }
-        /**
-         * Protobuf type {@code mesosphere.marathon.MarathonTask.ReservedState.Timeout}
-         */
-        public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder>
-           implements mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder {
-          public static final com.google.protobuf.Descriptors.Descriptor
-              getDescriptor() {
-            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor;
-          }
-
-          protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-              internalGetFieldAccessorTable() {
-            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_fieldAccessorTable
-                .ensureFieldAccessorsInitialized(
-                    mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.class, mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder.class);
-          }
-
-          // Construct using mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.newBuilder()
-          private Builder() {
-            maybeForceBuilderInitialization();
-          }
-
-          private Builder(
-              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-            super(parent);
-            maybeForceBuilderInitialization();
-          }
-          private void maybeForceBuilderInitialization() {
-            if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-            }
-          }
-          private static Builder create() {
-            return new Builder();
-          }
-
-          public Builder clear() {
-            super.clear();
-            initiated_ = 0L;
-            bitField0_ = (bitField0_ & ~0x00000001);
-            deadline_ = 0L;
-            bitField0_ = (bitField0_ & ~0x00000002);
-            reason_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason.RelaunchEscalationTimeout;
-            bitField0_ = (bitField0_ & ~0x00000004);
-            return this;
-          }
-
-          public Builder clone() {
-            return create().mergeFrom(buildPartial());
-          }
-
-          public com.google.protobuf.Descriptors.Descriptor
-              getDescriptorForType() {
-            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor;
-          }
-
-          public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout getDefaultInstanceForType() {
-            return mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance();
-          }
-
-          public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout build() {
-            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout result = buildPartial();
-            if (!result.isInitialized()) {
-              throw newUninitializedMessageException(result);
-            }
-            return result;
-          }
-
-          public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout buildPartial() {
-            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout result = new mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout(this);
-            int from_bitField0_ = bitField0_;
-            int to_bitField0_ = 0;
-            if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-              to_bitField0_ |= 0x00000001;
-            }
-            result.initiated_ = initiated_;
-            if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-              to_bitField0_ |= 0x00000002;
-            }
-            result.deadline_ = deadline_;
-            if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-              to_bitField0_ |= 0x00000004;
-            }
-            result.reason_ = reason_;
-            result.bitField0_ = to_bitField0_;
-            onBuilt();
-            return result;
-          }
-
-          public Builder mergeFrom(com.google.protobuf.Message other) {
-            if (other instanceof mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout) {
-              return mergeFrom((mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout)other);
-            } else {
-              super.mergeFrom(other);
-              return this;
-            }
-          }
-
-          public Builder mergeFrom(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout other) {
-            if (other == mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance()) return this;
-            if (other.hasInitiated()) {
-              setInitiated(other.getInitiated());
-            }
-            if (other.hasDeadline()) {
-              setDeadline(other.getDeadline());
-            }
-            if (other.hasReason()) {
-              setReason(other.getReason());
-            }
-            this.mergeUnknownFields(other.getUnknownFields());
-            return this;
-          }
-
-          public final boolean isInitialized() {
-            if (!hasInitiated()) {
-              
-              return false;
-            }
-            if (!hasDeadline()) {
-              
-              return false;
-            }
-            if (!hasReason()) {
-              
-              return false;
-            }
-            return true;
-          }
-
-          public Builder mergeFrom(
-              com.google.protobuf.CodedInputStream input,
-              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws java.io.IOException {
-            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parsedMessage = null;
-            try {
-              parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-              parsedMessage = (mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout) e.getUnfinishedMessage();
-              throw e;
-            } finally {
-              if (parsedMessage != null) {
-                mergeFrom(parsedMessage);
-              }
-            }
-            return this;
-          }
-          private int bitField0_;
-
-          // required int64 initiated = 1;
-          private long initiated_ ;
-          /**
-           * <code>required int64 initiated = 1;</code>
-           */
-          public boolean hasInitiated() {
-            return ((bitField0_ & 0x00000001) == 0x00000001);
-          }
-          /**
-           * <code>required int64 initiated = 1;</code>
-           */
-          public long getInitiated() {
-            return initiated_;
-          }
-          /**
-           * <code>required int64 initiated = 1;</code>
-           */
-          public Builder setInitiated(long value) {
-            bitField0_ |= 0x00000001;
-            initiated_ = value;
-            onChanged();
-            return this;
-          }
-          /**
-           * <code>required int64 initiated = 1;</code>
-           */
-          public Builder clearInitiated() {
-            bitField0_ = (bitField0_ & ~0x00000001);
-            initiated_ = 0L;
-            onChanged();
-            return this;
-          }
-
-          // required int64 deadline = 2;
-          private long deadline_ ;
-          /**
-           * <code>required int64 deadline = 2;</code>
-           */
-          public boolean hasDeadline() {
-            return ((bitField0_ & 0x00000002) == 0x00000002);
-          }
-          /**
-           * <code>required int64 deadline = 2;</code>
-           */
-          public long getDeadline() {
-            return deadline_;
-          }
-          /**
-           * <code>required int64 deadline = 2;</code>
-           */
-          public Builder setDeadline(long value) {
-            bitField0_ |= 0x00000002;
-            deadline_ = value;
-            onChanged();
-            return this;
-          }
-          /**
-           * <code>required int64 deadline = 2;</code>
-           */
-          public Builder clearDeadline() {
-            bitField0_ = (bitField0_ & ~0x00000002);
-            deadline_ = 0L;
-            onChanged();
-            return this;
-          }
-
-          // required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;
-          private mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason reason_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason.RelaunchEscalationTimeout;
-          /**
-           * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
-           */
-          public boolean hasReason() {
-            return ((bitField0_ & 0x00000004) == 0x00000004);
-          }
-          /**
-           * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
-           */
-          public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason getReason() {
-            return reason_;
-          }
-          /**
-           * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
-           */
-          public Builder setReason(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason value) {
-            if (value == null) {
-              throw new NullPointerException();
-            }
-            bitField0_ |= 0x00000004;
-            reason_ = value;
-            onChanged();
-            return this;
-          }
-          /**
-           * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
-           */
-          public Builder clearReason() {
-            bitField0_ = (bitField0_ & ~0x00000004);
-            reason_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason.RelaunchEscalationTimeout;
-            onChanged();
-            return this;
-          }
-
-          // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask.ReservedState.Timeout)
-        }
-
-        static {
-          defaultInstance = new Timeout(true);
-          defaultInstance.initFields();
-        }
-
-        // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask.ReservedState.Timeout)
-      }
-
-      private int bitField0_;
-      // required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;
-      public static final int TYPE_FIELD_NUMBER = 1;
-      private mesosphere.marathon.Protos.MarathonTask.ReservedState.Type type_;
-      /**
-       * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
-       */
-      public boolean hasType() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
-      }
-      /**
-       * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
-       */
-      public mesosphere.marathon.Protos.MarathonTask.ReservedState.Type getType() {
-        return type_;
-      }
-
-      // optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;
-      public static final int TIMEOUT_FIELD_NUMBER = 2;
-      private mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout timeout_;
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-       */
-      public boolean hasTimeout() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
-      }
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-       */
-      public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout getTimeout() {
-        return timeout_;
-      }
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-       */
-      public mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder getTimeoutOrBuilder() {
-        return timeout_;
-      }
-
-      private void initFields() {
-        type_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Type.New;
-        timeout_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance();
-      }
-      private byte memoizedIsInitialized = -1;
-      public final boolean isInitialized() {
-        byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
-
-        if (!hasType()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-        if (hasTimeout()) {
-          if (!getTimeout().isInitialized()) {
-            memoizedIsInitialized = 0;
-            return false;
-          }
-        }
-        memoizedIsInitialized = 1;
-        return true;
-      }
-
-      public void writeTo(com.google.protobuf.CodedOutputStream output)
-                          throws java.io.IOException {
-        getSerializedSize();
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          output.writeEnum(1, type_.getNumber());
-        }
-        if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          output.writeMessage(2, timeout_);
-        }
-        getUnknownFields().writeTo(output);
-      }
-
-      private int memoizedSerializedSize = -1;
-      public int getSerializedSize() {
-        int size = memoizedSerializedSize;
-        if (size != -1) return size;
-
-        size = 0;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          size += com.google.protobuf.CodedOutputStream
-            .computeEnumSize(1, type_.getNumber());
-        }
-        if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          size += com.google.protobuf.CodedOutputStream
-            .computeMessageSize(2, timeout_);
-        }
-        size += getUnknownFields().getSerializedSize();
-        memoizedSerializedSize = size;
-        return size;
-      }
-
-      private static final long serialVersionUID = 0L;
-      @java.lang.Override
-      protected java.lang.Object writeReplace()
-          throws java.io.ObjectStreamException {
-        return super.writeReplace();
-      }
-
-      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
-          com.google.protobuf.ByteString data)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data);
-      }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
-          com.google.protobuf.ByteString data,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data, extensionRegistry);
-      }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(byte[] data)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data);
-      }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
-          byte[] data,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data, extensionRegistry);
-      }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(java.io.InputStream input)
-          throws java.io.IOException {
-        return PARSER.parseFrom(input);
-      }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
-          java.io.InputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        return PARSER.parseFrom(input, extensionRegistry);
-      }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseDelimitedFrom(java.io.InputStream input)
-          throws java.io.IOException {
-        return PARSER.parseDelimitedFrom(input);
-      }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseDelimitedFrom(
-          java.io.InputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        return PARSER.parseDelimitedFrom(input, extensionRegistry);
-      }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
-          com.google.protobuf.CodedInputStream input)
-          throws java.io.IOException {
-        return PARSER.parseFrom(input);
-      }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        return PARSER.parseFrom(input, extensionRegistry);
-      }
-
-      public static Builder newBuilder() { return Builder.create(); }
-      public Builder newBuilderForType() { return newBuilder(); }
-      public static Builder newBuilder(mesosphere.marathon.Protos.MarathonTask.ReservedState prototype) {
-        return newBuilder().mergeFrom(prototype);
-      }
-      public Builder toBuilder() { return newBuilder(this); }
-
-      @java.lang.Override
-      protected Builder newBuilderForType(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        Builder builder = new Builder(parent);
-        return builder;
-      }
-      /**
-       * Protobuf type {@code mesosphere.marathon.MarathonTask.ReservedState}
-       */
-      public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder {
-        public static final com.google.protobuf.Descriptors.Descriptor
-            getDescriptor() {
-          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor;
-        }
-
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-            internalGetFieldAccessorTable() {
-          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_fieldAccessorTable
-              .ensureFieldAccessorsInitialized(
-                  mesosphere.marathon.Protos.MarathonTask.ReservedState.class, mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder.class);
-        }
-
-        // Construct using mesosphere.marathon.Protos.MarathonTask.ReservedState.newBuilder()
-        private Builder() {
-          maybeForceBuilderInitialization();
-        }
-
-        private Builder(
-            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-          super(parent);
-          maybeForceBuilderInitialization();
-        }
-        private void maybeForceBuilderInitialization() {
-          if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-            getTimeoutFieldBuilder();
-          }
-        }
-        private static Builder create() {
-          return new Builder();
-        }
-
-        public Builder clear() {
-          super.clear();
-          type_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Type.New;
-          bitField0_ = (bitField0_ & ~0x00000001);
-          if (timeoutBuilder_ == null) {
-            timeout_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance();
-          } else {
-            timeoutBuilder_.clear();
-          }
-          bitField0_ = (bitField0_ & ~0x00000002);
-          return this;
-        }
-
-        public Builder clone() {
-          return create().mergeFrom(buildPartial());
-        }
-
-        public com.google.protobuf.Descriptors.Descriptor
-            getDescriptorForType() {
-          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor;
-        }
-
-        public mesosphere.marathon.Protos.MarathonTask.ReservedState getDefaultInstanceForType() {
-          return mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance();
-        }
-
-        public mesosphere.marathon.Protos.MarathonTask.ReservedState build() {
-          mesosphere.marathon.Protos.MarathonTask.ReservedState result = buildPartial();
-          if (!result.isInitialized()) {
-            throw newUninitializedMessageException(result);
-          }
-          return result;
-        }
-
-        public mesosphere.marathon.Protos.MarathonTask.ReservedState buildPartial() {
-          mesosphere.marathon.Protos.MarathonTask.ReservedState result = new mesosphere.marathon.Protos.MarathonTask.ReservedState(this);
-          int from_bitField0_ = bitField0_;
-          int to_bitField0_ = 0;
-          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-            to_bitField0_ |= 0x00000001;
-          }
-          result.type_ = type_;
-          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-            to_bitField0_ |= 0x00000002;
-          }
-          if (timeoutBuilder_ == null) {
-            result.timeout_ = timeout_;
-          } else {
-            result.timeout_ = timeoutBuilder_.build();
-          }
-          result.bitField0_ = to_bitField0_;
-          onBuilt();
-          return result;
-        }
-
-        public Builder mergeFrom(com.google.protobuf.Message other) {
-          if (other instanceof mesosphere.marathon.Protos.MarathonTask.ReservedState) {
-            return mergeFrom((mesosphere.marathon.Protos.MarathonTask.ReservedState)other);
-          } else {
-            super.mergeFrom(other);
-            return this;
-          }
-        }
-
-        public Builder mergeFrom(mesosphere.marathon.Protos.MarathonTask.ReservedState other) {
-          if (other == mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance()) return this;
-          if (other.hasType()) {
-            setType(other.getType());
-          }
-          if (other.hasTimeout()) {
-            mergeTimeout(other.getTimeout());
-          }
-          this.mergeUnknownFields(other.getUnknownFields());
-          return this;
-        }
-
-        public final boolean isInitialized() {
-          if (!hasType()) {
-            
-            return false;
-          }
-          if (hasTimeout()) {
-            if (!getTimeout().isInitialized()) {
-              
-              return false;
-            }
-          }
-          return true;
-        }
-
-        public Builder mergeFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-          mesosphere.marathon.Protos.MarathonTask.ReservedState parsedMessage = null;
-          try {
-            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            parsedMessage = (mesosphere.marathon.Protos.MarathonTask.ReservedState) e.getUnfinishedMessage();
-            throw e;
-          } finally {
-            if (parsedMessage != null) {
-              mergeFrom(parsedMessage);
-            }
-          }
-          return this;
-        }
-        private int bitField0_;
-
-        // required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;
-        private mesosphere.marathon.Protos.MarathonTask.ReservedState.Type type_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Type.New;
-        /**
-         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
-         */
-        public boolean hasType() {
-          return ((bitField0_ & 0x00000001) == 0x00000001);
-        }
-        /**
-         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
-         */
-        public mesosphere.marathon.Protos.MarathonTask.ReservedState.Type getType() {
-          return type_;
-        }
-        /**
-         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
-         */
-        public Builder setType(mesosphere.marathon.Protos.MarathonTask.ReservedState.Type value) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          bitField0_ |= 0x00000001;
-          type_ = value;
-          onChanged();
-          return this;
-        }
-        /**
-         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
-         */
-        public Builder clearType() {
-          bitField0_ = (bitField0_ & ~0x00000001);
-          type_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Type.New;
-          onChanged();
-          return this;
-        }
-
-        // optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;
-        private mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout timeout_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance();
-        private com.google.protobuf.SingleFieldBuilder<
-            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout, mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder> timeoutBuilder_;
-        /**
-         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-         */
-        public boolean hasTimeout() {
-          return ((bitField0_ & 0x00000002) == 0x00000002);
-        }
-        /**
-         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-         */
-        public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout getTimeout() {
-          if (timeoutBuilder_ == null) {
-            return timeout_;
-          } else {
-            return timeoutBuilder_.getMessage();
-          }
-        }
-        /**
-         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-         */
-        public Builder setTimeout(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout value) {
-          if (timeoutBuilder_ == null) {
-            if (value == null) {
-              throw new NullPointerException();
-            }
-            timeout_ = value;
-            onChanged();
-          } else {
-            timeoutBuilder_.setMessage(value);
-          }
-          bitField0_ |= 0x00000002;
-          return this;
-        }
-        /**
-         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-         */
-        public Builder setTimeout(
-            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder builderForValue) {
-          if (timeoutBuilder_ == null) {
-            timeout_ = builderForValue.build();
-            onChanged();
-          } else {
-            timeoutBuilder_.setMessage(builderForValue.build());
-          }
-          bitField0_ |= 0x00000002;
-          return this;
-        }
-        /**
-         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-         */
-        public Builder mergeTimeout(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout value) {
-          if (timeoutBuilder_ == null) {
-            if (((bitField0_ & 0x00000002) == 0x00000002) &&
-                timeout_ != mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance()) {
-              timeout_ =
-                mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.newBuilder(timeout_).mergeFrom(value).buildPartial();
-            } else {
-              timeout_ = value;
-            }
-            onChanged();
-          } else {
-            timeoutBuilder_.mergeFrom(value);
-          }
-          bitField0_ |= 0x00000002;
-          return this;
-        }
-        /**
-         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-         */
-        public Builder clearTimeout() {
-          if (timeoutBuilder_ == null) {
-            timeout_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance();
-            onChanged();
-          } else {
-            timeoutBuilder_.clear();
-          }
-          bitField0_ = (bitField0_ & ~0x00000002);
-          return this;
-        }
-        /**
-         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-         */
-        public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder getTimeoutBuilder() {
-          bitField0_ |= 0x00000002;
-          onChanged();
-          return getTimeoutFieldBuilder().getBuilder();
-        }
-        /**
-         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-         */
-        public mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder getTimeoutOrBuilder() {
-          if (timeoutBuilder_ != null) {
-            return timeoutBuilder_.getMessageOrBuilder();
-          } else {
-            return timeout_;
-          }
-        }
-        /**
-         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
-         */
-        private com.google.protobuf.SingleFieldBuilder<
-            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout, mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder> 
-            getTimeoutFieldBuilder() {
-          if (timeoutBuilder_ == null) {
-            timeoutBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-                mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout, mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder>(
-                    timeout_,
-                    getParentForChildren(),
-                    isClean());
-            timeout_ = null;
-          }
-          return timeoutBuilder_;
-        }
-
-        // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask.ReservedState)
-      }
-
-      static {
-        defaultInstance = new ReservedState(true);
-        defaultInstance.initFields();
-      }
-
-      // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask.ReservedState)
     }
 
     private int bitField0_;
@@ -12879,28 +13072,6 @@ public final class Protos {
       return reservation_;
     }
 
-    // optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;
-    public static final int RESERVED_STATE_FIELD_NUMBER = 13;
-    private mesosphere.marathon.Protos.MarathonTask.ReservedState reservedState_;
-    /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-     */
-    public boolean hasReservedState() {
-      return ((bitField0_ & 0x00000100) == 0x00000100);
-    }
-    /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-     */
-    public mesosphere.marathon.Protos.MarathonTask.ReservedState getReservedState() {
-      return reservedState_;
-    }
-    /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-     */
-    public mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder getReservedStateOrBuilder() {
-      return reservedState_;
-    }
-
     private void initFields() {
       id_ = "";
       host_ = "";
@@ -12914,7 +13085,6 @@ public final class Protos {
       slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
       networks_ = java.util.Collections.emptyList();
       reservation_ = mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance();
-      reservedState_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -12955,8 +13125,8 @@ public final class Protos {
           return false;
         }
       }
-      if (hasReservedState()) {
-        if (!getReservedState().isInitialized()) {
+      if (hasReservation()) {
+        if (!getReservation().isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -13003,9 +13173,6 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         output.writeMessage(12, reservation_);
-      }
-      if (((bitField0_ & 0x00000100) == 0x00000100)) {
-        output.writeMessage(13, reservedState_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -13068,10 +13235,6 @@ public final class Protos {
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(12, reservation_);
-      }
-      if (((bitField0_ & 0x00000100) == 0x00000100)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(13, reservedState_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -13187,7 +13350,6 @@ public final class Protos {
           getSlaveIdFieldBuilder();
           getNetworksFieldBuilder();
           getReservationFieldBuilder();
-          getReservedStateFieldBuilder();
         }
       }
       private static Builder create() {
@@ -13244,12 +13406,6 @@ public final class Protos {
           reservationBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000800);
-        if (reservedStateBuilder_ == null) {
-          reservedState_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance();
-        } else {
-          reservedStateBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00001000);
         return this;
       }
 
@@ -13353,14 +13509,6 @@ public final class Protos {
           result.reservation_ = reservation_;
         } else {
           result.reservation_ = reservationBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
-          to_bitField0_ |= 0x00000100;
-        }
-        if (reservedStateBuilder_ == null) {
-          result.reservedState_ = reservedState_;
-        } else {
-          result.reservedState_ = reservedStateBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -13496,9 +13644,6 @@ public final class Protos {
         if (other.hasReservation()) {
           mergeReservation(other.getReservation());
         }
-        if (other.hasReservedState()) {
-          mergeReservedState(other.getReservedState());
-        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -13538,8 +13683,8 @@ public final class Protos {
             return false;
           }
         }
-        if (hasReservedState()) {
-          if (!getReservedState().isInitialized()) {
+        if (hasReservation()) {
+          if (!getReservation().isInitialized()) {
             
             return false;
           }
@@ -15049,123 +15194,6 @@ public final class Protos {
           reservation_ = null;
         }
         return reservationBuilder_;
-      }
-
-      // optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;
-      private mesosphere.marathon.Protos.MarathonTask.ReservedState reservedState_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          mesosphere.marathon.Protos.MarathonTask.ReservedState, mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder> reservedStateBuilder_;
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-       */
-      public boolean hasReservedState() {
-        return ((bitField0_ & 0x00001000) == 0x00001000);
-      }
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-       */
-      public mesosphere.marathon.Protos.MarathonTask.ReservedState getReservedState() {
-        if (reservedStateBuilder_ == null) {
-          return reservedState_;
-        } else {
-          return reservedStateBuilder_.getMessage();
-        }
-      }
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-       */
-      public Builder setReservedState(mesosphere.marathon.Protos.MarathonTask.ReservedState value) {
-        if (reservedStateBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          reservedState_ = value;
-          onChanged();
-        } else {
-          reservedStateBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00001000;
-        return this;
-      }
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-       */
-      public Builder setReservedState(
-          mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder builderForValue) {
-        if (reservedStateBuilder_ == null) {
-          reservedState_ = builderForValue.build();
-          onChanged();
-        } else {
-          reservedStateBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00001000;
-        return this;
-      }
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-       */
-      public Builder mergeReservedState(mesosphere.marathon.Protos.MarathonTask.ReservedState value) {
-        if (reservedStateBuilder_ == null) {
-          if (((bitField0_ & 0x00001000) == 0x00001000) &&
-              reservedState_ != mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance()) {
-            reservedState_ =
-              mesosphere.marathon.Protos.MarathonTask.ReservedState.newBuilder(reservedState_).mergeFrom(value).buildPartial();
-          } else {
-            reservedState_ = value;
-          }
-          onChanged();
-        } else {
-          reservedStateBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00001000;
-        return this;
-      }
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-       */
-      public Builder clearReservedState() {
-        if (reservedStateBuilder_ == null) {
-          reservedState_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance();
-          onChanged();
-        } else {
-          reservedStateBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00001000);
-        return this;
-      }
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-       */
-      public mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder getReservedStateBuilder() {
-        bitField0_ |= 0x00001000;
-        onChanged();
-        return getReservedStateFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-       */
-      public mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder getReservedStateOrBuilder() {
-        if (reservedStateBuilder_ != null) {
-          return reservedStateBuilder_.getMessageOrBuilder();
-        } else {
-          return reservedState_;
-        }
-      }
-      /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          mesosphere.marathon.Protos.MarathonTask.ReservedState, mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder> 
-          getReservedStateFieldBuilder() {
-        if (reservedStateBuilder_ == null) {
-          reservedStateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              mesosphere.marathon.Protos.MarathonTask.ReservedState, mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder>(
-                  reservedState_,
-                  getParentForChildren(),
-                  isClean());
-          reservedState_ = null;
-        }
-        return reservedStateBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask)
@@ -29652,15 +29680,15 @@ public final class Protos {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor;
+    internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_mesosphere_marathon_MarathonTask_ReservedState_fieldAccessorTable;
+      internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor;
+    internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_fieldAccessorTable;
+      internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonApp_descriptor;
   private static
@@ -29790,7 +29818,7 @@ public final class Protos {
       "athon.IpAddress\022;\n\tresidency\030\032 \001(\0132(.mes" +
       "osphere.marathon.ResidencyDefinition\022$\n\017" +
       "portDefinitions\030\033 \003(\0132\013.mesos.Port\"\035\n\rRe" +
-      "sourceRoles\022\014\n\004role\030\001 \003(\t\"\231\007\n\014MarathonTa" +
+      "sourceRoles\022\014\n\004role\030\001 \003(\t\"\247\007\n\014MarathonTa" +
       "sk\022\n\n\002id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 " +
       "\003(\r\022$\n\nattributes\030\004 \003(\0132\020.mesos.Attribut" +
       "e\022\021\n\tstaged_at\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003" +
@@ -29800,71 +29828,72 @@ public final class Protos {
       "atus\022\037\n\007slaveId\030\n \001(\0132\016.mesos.SlaveID\022$\n" +
       "\010networks\030\013 \003(\0132\022.mesos.NetworkInfo\022B\n\013r" +
       "eservation\030\014 \001(\0132-.mesosphere.marathon.M" +
-      "arathonTask.Reservation\022G\n\016reserved_stat" +
-      "e\030\r \001(\0132/.mesosphere.marathon.MarathonTa" +
-      "sk.ReservedState\032\'\n\013Reservation\022\030\n\020local" +
-      "_volume_ids\030\001 \003(\t\032\231\003\n\rReservedState\022B\n\004t" +
-      "ype\030\001 \002(\01624.mesosphere.marathon.Marathon",
-      "Task.ReservedState.Type\022H\n\007timeout\030\002 \001(\013" +
-      "27.mesosphere.marathon.MarathonTask.Rese" +
-      "rvedState.Timeout\032\277\001\n\007Timeout\022\021\n\tinitiat" +
-      "ed\030\001 \002(\003\022\020\n\010deadline\030\002 \002(\003\022N\n\006reason\030\003 \002" +
-      "(\0162>.mesosphere.marathon.MarathonTask.Re" +
-      "servedState.Timeout.Reason\"?\n\006Reason\022\035\n\031" +
+      "arathonTask.Reservation\032\231\004\n\013Reservation\022" +
+      "\030\n\020local_volume_ids\030\001 \003(\t\022B\n\005state\030\002 \002(\013" +
+      "23.mesosphere.marathon.MarathonTask.Rese" +
+      "rvation.State\032\253\003\n\005State\022F\n\004type\030\001 \002(\01628." +
+      "mesosphere.marathon.MarathonTask.Reserva",
+      "tion.State.Type\022L\n\007timeout\030\002 \001(\0132;.mesos" +
+      "phere.marathon.MarathonTask.Reservation." +
+      "State.Timeout\032\303\001\n\007Timeout\022\021\n\tinitiated\030\001" +
+      " \002(\003\022\020\n\010deadline\030\002 \002(\003\022R\n\006reason\030\003 \002(\0162B" +
+      ".mesosphere.marathon.MarathonTask.Reserv" +
+      "ation.State.Timeout.Reason\"?\n\006Reason\022\035\n\031" +
       "RelaunchEscalationTimeout\020\001\022\026\n\022Reservati" +
-      "onTimeout\020\002\"8\n\004Type\022\007\n\003New\020\001\022\r\n\tSuspende" +
-      "d\020\002\022\013\n\007Garbage\020\003\022\013\n\007Unknown\020\004\"M\n\013Maratho" +
-      "nApp\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!.meso",
-      "sphere.marathon.MarathonTask\"1\n\rContaine" +
-      "rInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007options\030\002 \003(\014\"" +
-      "\332\004\n\025ExtendedContainerInfo\022\'\n\004type\030\001 \002(\0162" +
-      "\031.mesos.ContainerInfo.Type\022,\n\007volumes\030\002 " +
-      "\003(\0132\033.mesosphere.marathon.Volume\022E\n\006dock" +
-      "er\030\003 \001(\01325.mesosphere.marathon.ExtendedC" +
-      "ontainerInfo.DockerInfo\032\242\003\n\nDockerInfo\022\r" +
-      "\n\005image\030\001 \002(\t\022>\n\007network\030\002 \001(\0162\'.mesos.C" +
-      "ontainerInfo.DockerInfo.Network:\004HOST\022X\n" +
-      "\rport_mappings\030\003 \003(\0132A.mesosphere.marath",
-      "on.ExtendedContainerInfo.DockerInfo.Port" +
-      "Mapping\022\031\n\nprivileged\030\004 \001(\010:\005false\022$\n\npa" +
-      "rameters\030\005 \003(\0132\020.mesos.Parameter\022\030\n\020forc" +
-      "e_pull_image\030\006 \001(\010\032\217\001\n\013PortMapping\022\021\n\tho" +
-      "st_port\030\001 \002(\r\022\026\n\016container_port\030\002 \002(\r\022\020\n" +
-      "\010protocol\030\003 \001(\t\022\014\n\004name\030\004 \001(\t\022\034\n\006labels\030" +
-      "\005 \003(\0132\014.mesos.Label\022\027\n\014service_port\030d \001(" +
-      "\r:\0010\"\336\001\n\006Volume\022 \n\004mode\030\003 \002(\0162\022.mesos.Vo" +
-      "lume.Mode\022\026\n\016container_path\030\001 \002(\t\022\021\n\thos" +
-      "t_path\030\002 \001(\t\022\033\n\005image\030\004 \001(\0132\014.mesos.Imag",
-      "e\022D\n\npersistent\030\005 \001(\01320.mesosphere.marat" +
-      "hon.Volume.PersistentVolumeInfo\032$\n\024Persi" +
-      "stentVolumeInfo\022\014\n\004size\030\001 \002(\004\")\n\020EventSu" +
-      "bscribers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016Stor" +
-      "ageVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r" +
-      "\022\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefini" +
-      "tion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023m" +
-      "aximumOverCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDef" +
-      "inition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004" +
-      "apps\030\003 \003(\0132&.mesosphere.marathon.Service",
-      "Definition\0224\n\006groups\030\004 \003(\0132$.mesosphere." +
-      "marathon.GroupDefinition\022\024\n\014dependencies" +
-      "\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002i" +
-      "d\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002" +
-      "(\0132$.mesosphere.marathon.GroupDefinition" +
-      "\0224\n\006target\030\005 \002(\0132$.mesosphere.marathon.G" +
-      "roupDefinition\"\306\001\n\013TaskFailure\022\016\n\006app_id" +
-      "\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037" +
-      "\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007messa" +
-      "ge\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 ",
-      "\002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132" +
-      "\016.mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004name\030" +
-      "\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\nco" +
-      "mpressed\030\004 \001(\010:\005false\"\326\001\n\023ResidencyDefin" +
-      "ition\022(\n relaunchEscalationTimeoutSecond" +
-      "s\030\001 \001(\003\022S\n\020taskLostBehavior\030\002 \001(\01629.meso" +
-      "sphere.marathon.ResidencyDefinition.Task" +
-      "LostBehavior\"@\n\020TaskLostBehavior\022\032\n\026RELA" +
-      "UNCH_AFTER_TIMEOUT\020\000\022\020\n\014WAIT_FOREVER\020\001B\035" +
-      "\n\023mesosphere.marathonB\006Protos"
+      "onTimeout\020\002\"F\n\004Type\022\007\n\003New\020\001\022\014\n\010Launched" +
+      "\020\002\022\r\n\tSuspended\020\003\022\013\n\007Garbage\020\004\022\013\n\007Unknow" +
+      "n\020\005\"M\n\013MarathonApp\022\014\n\004name\030\001 \001(\t\0220\n\005task",
+      "s\030\002 \003(\0132!.mesosphere.marathon.MarathonTa" +
+      "sk\"1\n\rContainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007" +
+      "options\030\002 \003(\014\"\332\004\n\025ExtendedContainerInfo\022" +
+      "\'\n\004type\030\001 \002(\0162\031.mesos.ContainerInfo.Type" +
+      "\022,\n\007volumes\030\002 \003(\0132\033.mesosphere.marathon." +
+      "Volume\022E\n\006docker\030\003 \001(\01325.mesosphere.mara" +
+      "thon.ExtendedContainerInfo.DockerInfo\032\242\003" +
+      "\n\nDockerInfo\022\r\n\005image\030\001 \002(\t\022>\n\007network\030\002" +
+      " \001(\0162\'.mesos.ContainerInfo.DockerInfo.Ne" +
+      "twork:\004HOST\022X\n\rport_mappings\030\003 \003(\0132A.mes",
+      "osphere.marathon.ExtendedContainerInfo.D" +
+      "ockerInfo.PortMapping\022\031\n\nprivileged\030\004 \001(" +
+      "\010:\005false\022$\n\nparameters\030\005 \003(\0132\020.mesos.Par" +
+      "ameter\022\030\n\020force_pull_image\030\006 \001(\010\032\217\001\n\013Por" +
+      "tMapping\022\021\n\thost_port\030\001 \002(\r\022\026\n\016container" +
+      "_port\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\014\n\004name\030\004 " +
+      "\001(\t\022\034\n\006labels\030\005 \003(\0132\014.mesos.Label\022\027\n\014ser" +
+      "vice_port\030d \001(\r:\0010\"\336\001\n\006Volume\022 \n\004mode\030\003 " +
+      "\002(\0162\022.mesos.Volume.Mode\022\026\n\016container_pat" +
+      "h\030\001 \002(\t\022\021\n\thost_path\030\002 \001(\t\022\033\n\005image\030\004 \001(",
+      "\0132\014.mesos.Image\022D\n\npersistent\030\005 \001(\01320.me" +
+      "sosphere.marathon.Volume.PersistentVolum" +
+      "eInfo\032$\n\024PersistentVolumeInfo\022\014\n\004size\030\001 " +
+      "\002(\004\")\n\020EventSubscribers\022\025\n\rcallback_urls" +
+      "\030\001 \003(\t\"=\n\016StorageVersion\022\r\n\005major\030\001 \002(\r\022" +
+      "\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z\n\031Upgrade" +
+      "StrategyDefinition\022\035\n\025minimumHealthCapac" +
+      "ity\030\001 \002(\001\022\036\n\023maximumOverCapacity\030\002 \001(\001:\001" +
+      "1\"\260\001\n\017GroupDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007ver" +
+      "sion\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.mesosphere.ma",
+      "rathon.ServiceDefinition\0224\n\006groups\030\004 \003(\013" +
+      "2$.mesosphere.marathon.GroupDefinition\022\024" +
+      "\n\014dependencies\030\005 \003(\t\"\245\001\n\030DeploymentPlanD" +
+      "efinition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226" +
+      "\n\010original\030\004 \002(\0132$.mesosphere.marathon.G" +
+      "roupDefinition\0224\n\006target\030\005 \002(\0132$.mesosph" +
+      "ere.marathon.GroupDefinition\"\306\001\n\013TaskFai" +
+      "lure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r." +
+      "mesos.TaskID\022\037\n\005state\030\003 \002(\0162\020.mesos.Task" +
+      "State\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000",
+      "\022\017\n\007version\030\006 \002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007" +
+      "slaveId\030\010 \001(\0132\016.mesos.SlaveID\"T\n\014ZKStore" +
+      "Entry\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005val" +
+      "ue\030\003 \002(\014\022\031\n\ncompressed\030\004 \001(\010:\005false\"\326\001\n\023" +
+      "ResidencyDefinition\022(\n relaunchEscalatio" +
+      "nTimeoutSeconds\030\001 \001(\003\022S\n\020taskLostBehavio" +
+      "r\030\002 \001(\01629.mesosphere.marathon.ResidencyD" +
+      "efinition.TaskLostBehavior\"@\n\020TaskLostBe" +
+      "havior\022\032\n\026RELAUNCH_AFTER_TIMEOUT\020\000\022\020\n\014WA" +
+      "IT_FOREVER\020\001B\035\n\023mesosphere.marathonB\006Pro",
+      "tos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -29912,24 +29941,24 @@ public final class Protos {
           internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_MarathonTask_descriptor,
-              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "Networks", "Reservation", "ReservedState", });
+              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "Networks", "Reservation", });
           internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor =
             internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(0);
           internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor,
-              new java.lang.String[] { "LocalVolumeIds", });
-          internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor =
-            internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(1);
-          internal_static_mesosphere_marathon_MarathonTask_ReservedState_fieldAccessorTable = new
+              new java.lang.String[] { "LocalVolumeIds", "State", });
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor =
+            internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor,
+              internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor,
               new java.lang.String[] { "Type", "Timeout", });
-          internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor =
-            internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_fieldAccessorTable = new
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor =
+            internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor,
+              internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor,
               new java.lang.String[] { "Initiated", "Deadline", "Reason", });
           internal_static_mesosphere_marathon_MarathonApp_descriptor =
             getDescriptor().getMessageTypes().get(7);

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -10345,31 +10345,45 @@ public final class Protos {
     org.apache.mesos.Protos.NetworkInfoOrBuilder getNetworksOrBuilder(
         int index);
 
-    // optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;
+    // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
     /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+     * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
      *
      * <pre>
      * since 0.16, a list of volumes can be associated with the task ID
      * </pre>
      */
-    boolean hasReservationWithVolumes();
+    boolean hasReservation();
     /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+     * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
      *
      * <pre>
      * since 0.16, a list of volumes can be associated with the task ID
      * </pre>
      */
-    mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes getReservationWithVolumes();
+    mesosphere.marathon.Protos.MarathonTask.Reservation getReservation();
     /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+     * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
      *
      * <pre>
      * since 0.16, a list of volumes can be associated with the task ID
      * </pre>
      */
-    mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumesOrBuilder getReservationWithVolumesOrBuilder();
+    mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder getReservationOrBuilder();
+
+    // optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;
+    /**
+     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+     */
+    boolean hasReservedState();
+    /**
+     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+     */
+    mesosphere.marathon.Protos.MarathonTask.ReservedState getReservedState();
+    /**
+     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+     */
+    mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder getReservedStateOrBuilder();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.MarathonTask}
@@ -10519,16 +10533,29 @@ public final class Protos {
               break;
             }
             case 98: {
-              mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.Builder subBuilder = null;
+              mesosphere.marathon.Protos.MarathonTask.Reservation.Builder subBuilder = null;
               if (((bitField0_ & 0x00000080) == 0x00000080)) {
-                subBuilder = reservationWithVolumes_.toBuilder();
+                subBuilder = reservation_.toBuilder();
               }
-              reservationWithVolumes_ = input.readMessage(mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.PARSER, extensionRegistry);
+              reservation_ = input.readMessage(mesosphere.marathon.Protos.MarathonTask.Reservation.PARSER, extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom(reservationWithVolumes_);
-                reservationWithVolumes_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom(reservation_);
+                reservation_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000080;
+              break;
+            }
+            case 106: {
+              mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000100) == 0x00000100)) {
+                subBuilder = reservedState_.toBuilder();
+              }
+              reservedState_ = input.readMessage(mesosphere.marathon.Protos.MarathonTask.ReservedState.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(reservedState_);
+                reservedState_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000100;
               break;
             }
           }
@@ -10582,7 +10609,7 @@ public final class Protos {
       return PARSER;
     }
 
-    public interface ReservationWithVolumesOrBuilder
+    public interface ReservationOrBuilder
         extends com.google.protobuf.MessageOrBuilder {
 
       // repeated string local_volume_ids = 1;
@@ -10606,24 +10633,24 @@ public final class Protos {
           getLocalVolumeIdsBytes(int index);
     }
     /**
-     * Protobuf type {@code mesosphere.marathon.MarathonTask.ReservationWithVolumes}
+     * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation}
      */
-    public static final class ReservationWithVolumes extends
+    public static final class Reservation extends
         com.google.protobuf.GeneratedMessage
-        implements ReservationWithVolumesOrBuilder {
-      // Use ReservationWithVolumes.newBuilder() to construct.
-      private ReservationWithVolumes(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+        implements ReservationOrBuilder {
+      // Use Reservation.newBuilder() to construct.
+      private Reservation(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
         this.unknownFields = builder.getUnknownFields();
       }
-      private ReservationWithVolumes(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+      private Reservation(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
 
-      private static final ReservationWithVolumes defaultInstance;
-      public static ReservationWithVolumes getDefaultInstance() {
+      private static final Reservation defaultInstance;
+      public static Reservation getDefaultInstance() {
         return defaultInstance;
       }
 
-      public ReservationWithVolumes getDefaultInstanceForType() {
+      public Reservation getDefaultInstanceForType() {
         return defaultInstance;
       }
 
@@ -10633,7 +10660,7 @@ public final class Protos {
           getUnknownFields() {
         return this.unknownFields;
       }
-      private ReservationWithVolumes(
+      private Reservation(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
@@ -10681,28 +10708,28 @@ public final class Protos {
       }
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservationWithVolumes_descriptor;
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservationWithVolumes_fieldAccessorTable
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.class, mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.Builder.class);
+                mesosphere.marathon.Protos.MarathonTask.Reservation.class, mesosphere.marathon.Protos.MarathonTask.Reservation.Builder.class);
       }
 
-      public static com.google.protobuf.Parser<ReservationWithVolumes> PARSER =
-          new com.google.protobuf.AbstractParser<ReservationWithVolumes>() {
-        public ReservationWithVolumes parsePartialFrom(
+      public static com.google.protobuf.Parser<Reservation> PARSER =
+          new com.google.protobuf.AbstractParser<Reservation>() {
+        public Reservation parsePartialFrom(
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ReservationWithVolumes(input, extensionRegistry);
+          return new Reservation(input, extensionRegistry);
         }
       };
 
       @java.lang.Override
-      public com.google.protobuf.Parser<ReservationWithVolumes> getParserForType() {
+      public com.google.protobuf.Parser<Reservation> getParserForType() {
         return PARSER;
       }
 
@@ -10784,53 +10811,53 @@ public final class Protos {
         return super.writeReplace();
       }
 
-      public static mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parseFrom(
+      public static mesosphere.marathon.Protos.MarathonTask.Reservation parseFrom(
           com.google.protobuf.ByteString data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parseFrom(
+      public static mesosphere.marathon.Protos.MarathonTask.Reservation parseFrom(
           com.google.protobuf.ByteString data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parseFrom(byte[] data)
+      public static mesosphere.marathon.Protos.MarathonTask.Reservation parseFrom(byte[] data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parseFrom(
+      public static mesosphere.marathon.Protos.MarathonTask.Reservation parseFrom(
           byte[] data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parseFrom(java.io.InputStream input)
+      public static mesosphere.marathon.Protos.MarathonTask.Reservation parseFrom(java.io.InputStream input)
           throws java.io.IOException {
         return PARSER.parseFrom(input);
       }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parseFrom(
+      public static mesosphere.marathon.Protos.MarathonTask.Reservation parseFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         return PARSER.parseFrom(input, extensionRegistry);
       }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parseDelimitedFrom(java.io.InputStream input)
+      public static mesosphere.marathon.Protos.MarathonTask.Reservation parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return PARSER.parseDelimitedFrom(input);
       }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parseDelimitedFrom(
+      public static mesosphere.marathon.Protos.MarathonTask.Reservation parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         return PARSER.parseDelimitedFrom(input, extensionRegistry);
       }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parseFrom(
+      public static mesosphere.marathon.Protos.MarathonTask.Reservation parseFrom(
           com.google.protobuf.CodedInputStream input)
           throws java.io.IOException {
         return PARSER.parseFrom(input);
       }
-      public static mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parseFrom(
+      public static mesosphere.marathon.Protos.MarathonTask.Reservation parseFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
@@ -10839,7 +10866,7 @@ public final class Protos {
 
       public static Builder newBuilder() { return Builder.create(); }
       public Builder newBuilderForType() { return newBuilder(); }
-      public static Builder newBuilder(mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes prototype) {
+      public static Builder newBuilder(mesosphere.marathon.Protos.MarathonTask.Reservation prototype) {
         return newBuilder().mergeFrom(prototype);
       }
       public Builder toBuilder() { return newBuilder(this); }
@@ -10851,24 +10878,24 @@ public final class Protos {
         return builder;
       }
       /**
-       * Protobuf type {@code mesosphere.marathon.MarathonTask.ReservationWithVolumes}
+       * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation}
        */
       public static final class Builder extends
           com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumesOrBuilder {
+         implements mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
-          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservationWithVolumes_descriptor;
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor;
         }
 
         protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservationWithVolumes_fieldAccessorTable
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
-                  mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.class, mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.Builder.class);
+                  mesosphere.marathon.Protos.MarathonTask.Reservation.class, mesosphere.marathon.Protos.MarathonTask.Reservation.Builder.class);
         }
 
-        // Construct using mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.newBuilder()
+        // Construct using mesosphere.marathon.Protos.MarathonTask.Reservation.newBuilder()
         private Builder() {
           maybeForceBuilderInitialization();
         }
@@ -10899,23 +10926,23 @@ public final class Protos {
 
         public com.google.protobuf.Descriptors.Descriptor
             getDescriptorForType() {
-          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservationWithVolumes_descriptor;
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor;
         }
 
-        public mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes getDefaultInstanceForType() {
-          return mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.getDefaultInstance();
+        public mesosphere.marathon.Protos.MarathonTask.Reservation getDefaultInstanceForType() {
+          return mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance();
         }
 
-        public mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes build() {
-          mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes result = buildPartial();
+        public mesosphere.marathon.Protos.MarathonTask.Reservation build() {
+          mesosphere.marathon.Protos.MarathonTask.Reservation result = buildPartial();
           if (!result.isInitialized()) {
             throw newUninitializedMessageException(result);
           }
           return result;
         }
 
-        public mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes buildPartial() {
-          mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes result = new mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes(this);
+        public mesosphere.marathon.Protos.MarathonTask.Reservation buildPartial() {
+          mesosphere.marathon.Protos.MarathonTask.Reservation result = new mesosphere.marathon.Protos.MarathonTask.Reservation(this);
           int from_bitField0_ = bitField0_;
           if (((bitField0_ & 0x00000001) == 0x00000001)) {
             localVolumeIds_ = new com.google.protobuf.UnmodifiableLazyStringList(
@@ -10928,16 +10955,16 @@ public final class Protos {
         }
 
         public Builder mergeFrom(com.google.protobuf.Message other) {
-          if (other instanceof mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes) {
-            return mergeFrom((mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes)other);
+          if (other instanceof mesosphere.marathon.Protos.MarathonTask.Reservation) {
+            return mergeFrom((mesosphere.marathon.Protos.MarathonTask.Reservation)other);
           } else {
             super.mergeFrom(other);
             return this;
           }
         }
 
-        public Builder mergeFrom(mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes other) {
-          if (other == mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.getDefaultInstance()) return this;
+        public Builder mergeFrom(mesosphere.marathon.Protos.MarathonTask.Reservation other) {
+          if (other == mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance()) return this;
           if (!other.localVolumeIds_.isEmpty()) {
             if (localVolumeIds_.isEmpty()) {
               localVolumeIds_ = other.localVolumeIds_;
@@ -10960,11 +10987,11 @@ public final class Protos {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes parsedMessage = null;
+          mesosphere.marathon.Protos.MarathonTask.Reservation parsedMessage = null;
           try {
             parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
           } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            parsedMessage = (mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes) e.getUnfinishedMessage();
+            parsedMessage = (mesosphere.marathon.Protos.MarathonTask.Reservation) e.getUnfinishedMessage();
             throw e;
           } finally {
             if (parsedMessage != null) {
@@ -11068,15 +11095,1405 @@ public final class Protos {
           return this;
         }
 
-        // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask.ReservationWithVolumes)
+        // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask.Reservation)
       }
 
       static {
-        defaultInstance = new ReservationWithVolumes(true);
+        defaultInstance = new Reservation(true);
         defaultInstance.initFields();
       }
 
-      // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask.ReservationWithVolumes)
+      // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask.Reservation)
+    }
+
+    public interface ReservedStateOrBuilder
+        extends com.google.protobuf.MessageOrBuilder {
+
+      // required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;
+      /**
+       * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
+       */
+      boolean hasType();
+      /**
+       * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
+       */
+      mesosphere.marathon.Protos.MarathonTask.ReservedState.Type getType();
+
+      // optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+       */
+      boolean hasTimeout();
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+       */
+      mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout getTimeout();
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+       */
+      mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder getTimeoutOrBuilder();
+    }
+    /**
+     * Protobuf type {@code mesosphere.marathon.MarathonTask.ReservedState}
+     */
+    public static final class ReservedState extends
+        com.google.protobuf.GeneratedMessage
+        implements ReservedStateOrBuilder {
+      // Use ReservedState.newBuilder() to construct.
+      private ReservedState(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+        super(builder);
+        this.unknownFields = builder.getUnknownFields();
+      }
+      private ReservedState(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+      private static final ReservedState defaultInstance;
+      public static ReservedState getDefaultInstance() {
+        return defaultInstance;
+      }
+
+      public ReservedState getDefaultInstanceForType() {
+        return defaultInstance;
+      }
+
+      private final com.google.protobuf.UnknownFieldSet unknownFields;
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+          getUnknownFields() {
+        return this.unknownFields;
+      }
+      private ReservedState(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        initFields();
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(input, unknownFields,
+                                       extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+              case 8: {
+                int rawValue = input.readEnum();
+                mesosphere.marathon.Protos.MarathonTask.ReservedState.Type value = mesosphere.marathon.Protos.MarathonTask.ReservedState.Type.valueOf(rawValue);
+                if (value == null) {
+                  unknownFields.mergeVarintField(1, rawValue);
+                } else {
+                  bitField0_ |= 0x00000001;
+                  type_ = value;
+                }
+                break;
+              }
+              case 18: {
+                mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder subBuilder = null;
+                if (((bitField0_ & 0x00000002) == 0x00000002)) {
+                  subBuilder = timeout_.toBuilder();
+                }
+                timeout_ = input.readMessage(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.PARSER, extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(timeout_);
+                  timeout_ = subBuilder.buildPartial();
+                }
+                bitField0_ |= 0x00000002;
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e.getMessage()).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                mesosphere.marathon.Protos.MarathonTask.ReservedState.class, mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder.class);
+      }
+
+      public static com.google.protobuf.Parser<ReservedState> PARSER =
+          new com.google.protobuf.AbstractParser<ReservedState>() {
+        public ReservedState parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new ReservedState(input, extensionRegistry);
+        }
+      };
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<ReservedState> getParserForType() {
+        return PARSER;
+      }
+
+      /**
+       * Protobuf enum {@code mesosphere.marathon.MarathonTask.ReservedState.Type}
+       */
+      public enum Type
+          implements com.google.protobuf.ProtocolMessageEnum {
+        /**
+         * <code>New = 1;</code>
+         */
+        New(0, 1),
+        /**
+         * <code>Suspended = 2;</code>
+         */
+        Suspended(1, 2),
+        /**
+         * <code>Garbage = 3;</code>
+         */
+        Garbage(2, 3),
+        /**
+         * <code>Unknown = 4;</code>
+         */
+        Unknown(3, 4),
+        ;
+
+        /**
+         * <code>New = 1;</code>
+         */
+        public static final int New_VALUE = 1;
+        /**
+         * <code>Suspended = 2;</code>
+         */
+        public static final int Suspended_VALUE = 2;
+        /**
+         * <code>Garbage = 3;</code>
+         */
+        public static final int Garbage_VALUE = 3;
+        /**
+         * <code>Unknown = 4;</code>
+         */
+        public static final int Unknown_VALUE = 4;
+
+
+        public final int getNumber() { return value; }
+
+        public static Type valueOf(int value) {
+          switch (value) {
+            case 1: return New;
+            case 2: return Suspended;
+            case 3: return Garbage;
+            case 4: return Unknown;
+            default: return null;
+          }
+        }
+
+        public static com.google.protobuf.Internal.EnumLiteMap<Type>
+            internalGetValueMap() {
+          return internalValueMap;
+        }
+        private static com.google.protobuf.Internal.EnumLiteMap<Type>
+            internalValueMap =
+              new com.google.protobuf.Internal.EnumLiteMap<Type>() {
+                public Type findValueByNumber(int number) {
+                  return Type.valueOf(number);
+                }
+              };
+
+        public final com.google.protobuf.Descriptors.EnumValueDescriptor
+            getValueDescriptor() {
+          return getDescriptor().getValues().get(index);
+        }
+        public final com.google.protobuf.Descriptors.EnumDescriptor
+            getDescriptorForType() {
+          return getDescriptor();
+        }
+        public static final com.google.protobuf.Descriptors.EnumDescriptor
+            getDescriptor() {
+          return mesosphere.marathon.Protos.MarathonTask.ReservedState.getDescriptor().getEnumTypes().get(0);
+        }
+
+        private static final Type[] VALUES = values();
+
+        public static Type valueOf(
+            com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+          if (desc.getType() != getDescriptor()) {
+            throw new java.lang.IllegalArgumentException(
+              "EnumValueDescriptor is not for this type.");
+          }
+          return VALUES[desc.getIndex()];
+        }
+
+        private final int index;
+        private final int value;
+
+        private Type(int index, int value) {
+          this.index = index;
+          this.value = value;
+        }
+
+        // @@protoc_insertion_point(enum_scope:mesosphere.marathon.MarathonTask.ReservedState.Type)
+      }
+
+      public interface TimeoutOrBuilder
+          extends com.google.protobuf.MessageOrBuilder {
+
+        // required int64 initiated = 1;
+        /**
+         * <code>required int64 initiated = 1;</code>
+         */
+        boolean hasInitiated();
+        /**
+         * <code>required int64 initiated = 1;</code>
+         */
+        long getInitiated();
+
+        // required int64 deadline = 2;
+        /**
+         * <code>required int64 deadline = 2;</code>
+         */
+        boolean hasDeadline();
+        /**
+         * <code>required int64 deadline = 2;</code>
+         */
+        long getDeadline();
+
+        // required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
+         */
+        boolean hasReason();
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
+         */
+        mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason getReason();
+      }
+      /**
+       * Protobuf type {@code mesosphere.marathon.MarathonTask.ReservedState.Timeout}
+       */
+      public static final class Timeout extends
+          com.google.protobuf.GeneratedMessage
+          implements TimeoutOrBuilder {
+        // Use Timeout.newBuilder() to construct.
+        private Timeout(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+          super(builder);
+          this.unknownFields = builder.getUnknownFields();
+        }
+        private Timeout(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+        private static final Timeout defaultInstance;
+        public static Timeout getDefaultInstance() {
+          return defaultInstance;
+        }
+
+        public Timeout getDefaultInstanceForType() {
+          return defaultInstance;
+        }
+
+        private final com.google.protobuf.UnknownFieldSet unknownFields;
+        @java.lang.Override
+        public final com.google.protobuf.UnknownFieldSet
+            getUnknownFields() {
+          return this.unknownFields;
+        }
+        private Timeout(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          initFields();
+          int mutable_bitField0_ = 0;
+          com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+              com.google.protobuf.UnknownFieldSet.newBuilder();
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                default: {
+                  if (!parseUnknownField(input, unknownFields,
+                                         extensionRegistry, tag)) {
+                    done = true;
+                  }
+                  break;
+                }
+                case 8: {
+                  bitField0_ |= 0x00000001;
+                  initiated_ = input.readInt64();
+                  break;
+                }
+                case 16: {
+                  bitField0_ |= 0x00000002;
+                  deadline_ = input.readInt64();
+                  break;
+                }
+                case 24: {
+                  int rawValue = input.readEnum();
+                  mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason value = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason.valueOf(rawValue);
+                  if (value == null) {
+                    unknownFields.mergeVarintField(3, rawValue);
+                  } else {
+                    bitField0_ |= 0x00000004;
+                    reason_ = value;
+                  }
+                  break;
+                }
+              }
+            }
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw e.setUnfinishedMessage(this);
+          } catch (java.io.IOException e) {
+            throw new com.google.protobuf.InvalidProtocolBufferException(
+                e.getMessage()).setUnfinishedMessage(this);
+          } finally {
+            this.unknownFields = unknownFields.build();
+            makeExtensionsImmutable();
+          }
+        }
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor;
+        }
+
+        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.class, mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder.class);
+        }
+
+        public static com.google.protobuf.Parser<Timeout> PARSER =
+            new com.google.protobuf.AbstractParser<Timeout>() {
+          public Timeout parsePartialFrom(
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws com.google.protobuf.InvalidProtocolBufferException {
+            return new Timeout(input, extensionRegistry);
+          }
+        };
+
+        @java.lang.Override
+        public com.google.protobuf.Parser<Timeout> getParserForType() {
+          return PARSER;
+        }
+
+        /**
+         * Protobuf enum {@code mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason}
+         */
+        public enum Reason
+            implements com.google.protobuf.ProtocolMessageEnum {
+          /**
+           * <code>RelaunchEscalationTimeout = 1;</code>
+           */
+          RelaunchEscalationTimeout(0, 1),
+          /**
+           * <code>ReservationTimeout = 2;</code>
+           */
+          ReservationTimeout(1, 2),
+          ;
+
+          /**
+           * <code>RelaunchEscalationTimeout = 1;</code>
+           */
+          public static final int RelaunchEscalationTimeout_VALUE = 1;
+          /**
+           * <code>ReservationTimeout = 2;</code>
+           */
+          public static final int ReservationTimeout_VALUE = 2;
+
+
+          public final int getNumber() { return value; }
+
+          public static Reason valueOf(int value) {
+            switch (value) {
+              case 1: return RelaunchEscalationTimeout;
+              case 2: return ReservationTimeout;
+              default: return null;
+            }
+          }
+
+          public static com.google.protobuf.Internal.EnumLiteMap<Reason>
+              internalGetValueMap() {
+            return internalValueMap;
+          }
+          private static com.google.protobuf.Internal.EnumLiteMap<Reason>
+              internalValueMap =
+                new com.google.protobuf.Internal.EnumLiteMap<Reason>() {
+                  public Reason findValueByNumber(int number) {
+                    return Reason.valueOf(number);
+                  }
+                };
+
+          public final com.google.protobuf.Descriptors.EnumValueDescriptor
+              getValueDescriptor() {
+            return getDescriptor().getValues().get(index);
+          }
+          public final com.google.protobuf.Descriptors.EnumDescriptor
+              getDescriptorForType() {
+            return getDescriptor();
+          }
+          public static final com.google.protobuf.Descriptors.EnumDescriptor
+              getDescriptor() {
+            return mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDescriptor().getEnumTypes().get(0);
+          }
+
+          private static final Reason[] VALUES = values();
+
+          public static Reason valueOf(
+              com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+            if (desc.getType() != getDescriptor()) {
+              throw new java.lang.IllegalArgumentException(
+                "EnumValueDescriptor is not for this type.");
+            }
+            return VALUES[desc.getIndex()];
+          }
+
+          private final int index;
+          private final int value;
+
+          private Reason(int index, int value) {
+            this.index = index;
+            this.value = value;
+          }
+
+          // @@protoc_insertion_point(enum_scope:mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason)
+        }
+
+        private int bitField0_;
+        // required int64 initiated = 1;
+        public static final int INITIATED_FIELD_NUMBER = 1;
+        private long initiated_;
+        /**
+         * <code>required int64 initiated = 1;</code>
+         */
+        public boolean hasInitiated() {
+          return ((bitField0_ & 0x00000001) == 0x00000001);
+        }
+        /**
+         * <code>required int64 initiated = 1;</code>
+         */
+        public long getInitiated() {
+          return initiated_;
+        }
+
+        // required int64 deadline = 2;
+        public static final int DEADLINE_FIELD_NUMBER = 2;
+        private long deadline_;
+        /**
+         * <code>required int64 deadline = 2;</code>
+         */
+        public boolean hasDeadline() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <code>required int64 deadline = 2;</code>
+         */
+        public long getDeadline() {
+          return deadline_;
+        }
+
+        // required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;
+        public static final int REASON_FIELD_NUMBER = 3;
+        private mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason reason_;
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
+         */
+        public boolean hasReason() {
+          return ((bitField0_ & 0x00000004) == 0x00000004);
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason getReason() {
+          return reason_;
+        }
+
+        private void initFields() {
+          initiated_ = 0L;
+          deadline_ = 0L;
+          reason_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason.RelaunchEscalationTimeout;
+        }
+        private byte memoizedIsInitialized = -1;
+        public final boolean isInitialized() {
+          byte isInitialized = memoizedIsInitialized;
+          if (isInitialized != -1) return isInitialized == 1;
+
+          if (!hasInitiated()) {
+            memoizedIsInitialized = 0;
+            return false;
+          }
+          if (!hasDeadline()) {
+            memoizedIsInitialized = 0;
+            return false;
+          }
+          if (!hasReason()) {
+            memoizedIsInitialized = 0;
+            return false;
+          }
+          memoizedIsInitialized = 1;
+          return true;
+        }
+
+        public void writeTo(com.google.protobuf.CodedOutputStream output)
+                            throws java.io.IOException {
+          getSerializedSize();
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            output.writeInt64(1, initiated_);
+          }
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            output.writeInt64(2, deadline_);
+          }
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+            output.writeEnum(3, reason_.getNumber());
+          }
+          getUnknownFields().writeTo(output);
+        }
+
+        private int memoizedSerializedSize = -1;
+        public int getSerializedSize() {
+          int size = memoizedSerializedSize;
+          if (size != -1) return size;
+
+          size = 0;
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            size += com.google.protobuf.CodedOutputStream
+              .computeInt64Size(1, initiated_);
+          }
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            size += com.google.protobuf.CodedOutputStream
+              .computeInt64Size(2, deadline_);
+          }
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+            size += com.google.protobuf.CodedOutputStream
+              .computeEnumSize(3, reason_.getNumber());
+          }
+          size += getUnknownFields().getSerializedSize();
+          memoizedSerializedSize = size;
+          return size;
+        }
+
+        private static final long serialVersionUID = 0L;
+        @java.lang.Override
+        protected java.lang.Object writeReplace()
+            throws java.io.ObjectStreamException {
+          return super.writeReplace();
+        }
+
+        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
+            com.google.protobuf.ByteString data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return PARSER.parseFrom(data);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
+            com.google.protobuf.ByteString data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return PARSER.parseFrom(data, extensionRegistry);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(byte[] data)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return PARSER.parseFrom(data);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
+            byte[] data,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return PARSER.parseFrom(data, extensionRegistry);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(java.io.InputStream input)
+            throws java.io.IOException {
+          return PARSER.parseFrom(input);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          return PARSER.parseFrom(input, extensionRegistry);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseDelimitedFrom(java.io.InputStream input)
+            throws java.io.IOException {
+          return PARSER.parseDelimitedFrom(input);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseDelimitedFrom(
+            java.io.InputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          return PARSER.parseDelimitedFrom(input, extensionRegistry);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
+            com.google.protobuf.CodedInputStream input)
+            throws java.io.IOException {
+          return PARSER.parseFrom(input);
+        }
+        public static mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parseFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          return PARSER.parseFrom(input, extensionRegistry);
+        }
+
+        public static Builder newBuilder() { return Builder.create(); }
+        public Builder newBuilderForType() { return newBuilder(); }
+        public static Builder newBuilder(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout prototype) {
+          return newBuilder().mergeFrom(prototype);
+        }
+        public Builder toBuilder() { return newBuilder(this); }
+
+        @java.lang.Override
+        protected Builder newBuilderForType(
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          Builder builder = new Builder(parent);
+          return builder;
+        }
+        /**
+         * Protobuf type {@code mesosphere.marathon.MarathonTask.ReservedState.Timeout}
+         */
+        public static final class Builder extends
+            com.google.protobuf.GeneratedMessage.Builder<Builder>
+           implements mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder {
+          public static final com.google.protobuf.Descriptors.Descriptor
+              getDescriptor() {
+            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor;
+          }
+
+          protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+              internalGetFieldAccessorTable() {
+            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_fieldAccessorTable
+                .ensureFieldAccessorsInitialized(
+                    mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.class, mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder.class);
+          }
+
+          // Construct using mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.newBuilder()
+          private Builder() {
+            maybeForceBuilderInitialization();
+          }
+
+          private Builder(
+              com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+            super(parent);
+            maybeForceBuilderInitialization();
+          }
+          private void maybeForceBuilderInitialization() {
+            if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+            }
+          }
+          private static Builder create() {
+            return new Builder();
+          }
+
+          public Builder clear() {
+            super.clear();
+            initiated_ = 0L;
+            bitField0_ = (bitField0_ & ~0x00000001);
+            deadline_ = 0L;
+            bitField0_ = (bitField0_ & ~0x00000002);
+            reason_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason.RelaunchEscalationTimeout;
+            bitField0_ = (bitField0_ & ~0x00000004);
+            return this;
+          }
+
+          public Builder clone() {
+            return create().mergeFrom(buildPartial());
+          }
+
+          public com.google.protobuf.Descriptors.Descriptor
+              getDescriptorForType() {
+            return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor;
+          }
+
+          public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout getDefaultInstanceForType() {
+            return mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance();
+          }
+
+          public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout build() {
+            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout result = buildPartial();
+            if (!result.isInitialized()) {
+              throw newUninitializedMessageException(result);
+            }
+            return result;
+          }
+
+          public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout buildPartial() {
+            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout result = new mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout(this);
+            int from_bitField0_ = bitField0_;
+            int to_bitField0_ = 0;
+            if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+              to_bitField0_ |= 0x00000001;
+            }
+            result.initiated_ = initiated_;
+            if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+              to_bitField0_ |= 0x00000002;
+            }
+            result.deadline_ = deadline_;
+            if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+              to_bitField0_ |= 0x00000004;
+            }
+            result.reason_ = reason_;
+            result.bitField0_ = to_bitField0_;
+            onBuilt();
+            return result;
+          }
+
+          public Builder mergeFrom(com.google.protobuf.Message other) {
+            if (other instanceof mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout) {
+              return mergeFrom((mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout)other);
+            } else {
+              super.mergeFrom(other);
+              return this;
+            }
+          }
+
+          public Builder mergeFrom(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout other) {
+            if (other == mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance()) return this;
+            if (other.hasInitiated()) {
+              setInitiated(other.getInitiated());
+            }
+            if (other.hasDeadline()) {
+              setDeadline(other.getDeadline());
+            }
+            if (other.hasReason()) {
+              setReason(other.getReason());
+            }
+            this.mergeUnknownFields(other.getUnknownFields());
+            return this;
+          }
+
+          public final boolean isInitialized() {
+            if (!hasInitiated()) {
+              
+              return false;
+            }
+            if (!hasDeadline()) {
+              
+              return false;
+            }
+            if (!hasReason()) {
+              
+              return false;
+            }
+            return true;
+          }
+
+          public Builder mergeFrom(
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
+            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout parsedMessage = null;
+            try {
+              parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+              parsedMessage = (mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout) e.getUnfinishedMessage();
+              throw e;
+            } finally {
+              if (parsedMessage != null) {
+                mergeFrom(parsedMessage);
+              }
+            }
+            return this;
+          }
+          private int bitField0_;
+
+          // required int64 initiated = 1;
+          private long initiated_ ;
+          /**
+           * <code>required int64 initiated = 1;</code>
+           */
+          public boolean hasInitiated() {
+            return ((bitField0_ & 0x00000001) == 0x00000001);
+          }
+          /**
+           * <code>required int64 initiated = 1;</code>
+           */
+          public long getInitiated() {
+            return initiated_;
+          }
+          /**
+           * <code>required int64 initiated = 1;</code>
+           */
+          public Builder setInitiated(long value) {
+            bitField0_ |= 0x00000001;
+            initiated_ = value;
+            onChanged();
+            return this;
+          }
+          /**
+           * <code>required int64 initiated = 1;</code>
+           */
+          public Builder clearInitiated() {
+            bitField0_ = (bitField0_ & ~0x00000001);
+            initiated_ = 0L;
+            onChanged();
+            return this;
+          }
+
+          // required int64 deadline = 2;
+          private long deadline_ ;
+          /**
+           * <code>required int64 deadline = 2;</code>
+           */
+          public boolean hasDeadline() {
+            return ((bitField0_ & 0x00000002) == 0x00000002);
+          }
+          /**
+           * <code>required int64 deadline = 2;</code>
+           */
+          public long getDeadline() {
+            return deadline_;
+          }
+          /**
+           * <code>required int64 deadline = 2;</code>
+           */
+          public Builder setDeadline(long value) {
+            bitField0_ |= 0x00000002;
+            deadline_ = value;
+            onChanged();
+            return this;
+          }
+          /**
+           * <code>required int64 deadline = 2;</code>
+           */
+          public Builder clearDeadline() {
+            bitField0_ = (bitField0_ & ~0x00000002);
+            deadline_ = 0L;
+            onChanged();
+            return this;
+          }
+
+          // required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;
+          private mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason reason_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason.RelaunchEscalationTimeout;
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
+           */
+          public boolean hasReason() {
+            return ((bitField0_ & 0x00000004) == 0x00000004);
+          }
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
+           */
+          public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason getReason() {
+            return reason_;
+          }
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
+           */
+          public Builder setReason(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason value) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            bitField0_ |= 0x00000004;
+            reason_ = value;
+            onChanged();
+            return this;
+          }
+          /**
+           * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Timeout.Reason reason = 3;</code>
+           */
+          public Builder clearReason() {
+            bitField0_ = (bitField0_ & ~0x00000004);
+            reason_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Reason.RelaunchEscalationTimeout;
+            onChanged();
+            return this;
+          }
+
+          // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask.ReservedState.Timeout)
+        }
+
+        static {
+          defaultInstance = new Timeout(true);
+          defaultInstance.initFields();
+        }
+
+        // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask.ReservedState.Timeout)
+      }
+
+      private int bitField0_;
+      // required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;
+      public static final int TYPE_FIELD_NUMBER = 1;
+      private mesosphere.marathon.Protos.MarathonTask.ReservedState.Type type_;
+      /**
+       * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
+       */
+      public boolean hasType() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
+       */
+      public mesosphere.marathon.Protos.MarathonTask.ReservedState.Type getType() {
+        return type_;
+      }
+
+      // optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;
+      public static final int TIMEOUT_FIELD_NUMBER = 2;
+      private mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout timeout_;
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+       */
+      public boolean hasTimeout() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+       */
+      public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout getTimeout() {
+        return timeout_;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+       */
+      public mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder getTimeoutOrBuilder() {
+        return timeout_;
+      }
+
+      private void initFields() {
+        type_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Type.New;
+        timeout_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance();
+      }
+      private byte memoizedIsInitialized = -1;
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized != -1) return isInitialized == 1;
+
+        if (!hasType()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        if (hasTimeout()) {
+          if (!getTimeout().isInitialized()) {
+            memoizedIsInitialized = 0;
+            return false;
+          }
+        }
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        getSerializedSize();
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          output.writeEnum(1, type_.getNumber());
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          output.writeMessage(2, timeout_);
+        }
+        getUnknownFields().writeTo(output);
+      }
+
+      private int memoizedSerializedSize = -1;
+      public int getSerializedSize() {
+        int size = memoizedSerializedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeEnumSize(1, type_.getNumber());
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(2, timeout_);
+        }
+        size += getUnknownFields().getSerializedSize();
+        memoizedSerializedSize = size;
+        return size;
+      }
+
+      private static final long serialVersionUID = 0L;
+      @java.lang.Override
+      protected java.lang.Object writeReplace()
+          throws java.io.ObjectStreamException {
+        return super.writeReplace();
+      }
+
+      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input);
+      }
+      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input, extensionRegistry);
+      }
+      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return PARSER.parseDelimitedFrom(input);
+      }
+      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      }
+      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input);
+      }
+      public static mesosphere.marathon.Protos.MarathonTask.ReservedState parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input, extensionRegistry);
+      }
+
+      public static Builder newBuilder() { return Builder.create(); }
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder(mesosphere.marathon.Protos.MarathonTask.ReservedState prototype) {
+        return newBuilder().mergeFrom(prototype);
+      }
+      public Builder toBuilder() { return newBuilder(this); }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mesosphere.marathon.MarathonTask.ReservedState}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessage.Builder<Builder>
+         implements mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor;
+        }
+
+        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  mesosphere.marathon.Protos.MarathonTask.ReservedState.class, mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder.class);
+        }
+
+        // Construct using mesosphere.marathon.Protos.MarathonTask.ReservedState.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+            getTimeoutFieldBuilder();
+          }
+        }
+        private static Builder create() {
+          return new Builder();
+        }
+
+        public Builder clear() {
+          super.clear();
+          type_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Type.New;
+          bitField0_ = (bitField0_ & ~0x00000001);
+          if (timeoutBuilder_ == null) {
+            timeout_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance();
+          } else {
+            timeoutBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+
+        public Builder clone() {
+          return create().mergeFrom(buildPartial());
+        }
+
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor;
+        }
+
+        public mesosphere.marathon.Protos.MarathonTask.ReservedState getDefaultInstanceForType() {
+          return mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance();
+        }
+
+        public mesosphere.marathon.Protos.MarathonTask.ReservedState build() {
+          mesosphere.marathon.Protos.MarathonTask.ReservedState result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        public mesosphere.marathon.Protos.MarathonTask.ReservedState buildPartial() {
+          mesosphere.marathon.Protos.MarathonTask.ReservedState result = new mesosphere.marathon.Protos.MarathonTask.ReservedState(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          result.type_ = type_;
+          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+            to_bitField0_ |= 0x00000002;
+          }
+          if (timeoutBuilder_ == null) {
+            result.timeout_ = timeout_;
+          } else {
+            result.timeout_ = timeoutBuilder_.build();
+          }
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof mesosphere.marathon.Protos.MarathonTask.ReservedState) {
+            return mergeFrom((mesosphere.marathon.Protos.MarathonTask.ReservedState)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(mesosphere.marathon.Protos.MarathonTask.ReservedState other) {
+          if (other == mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance()) return this;
+          if (other.hasType()) {
+            setType(other.getType());
+          }
+          if (other.hasTimeout()) {
+            mergeTimeout(other.getTimeout());
+          }
+          this.mergeUnknownFields(other.getUnknownFields());
+          return this;
+        }
+
+        public final boolean isInitialized() {
+          if (!hasType()) {
+            
+            return false;
+          }
+          if (hasTimeout()) {
+            if (!getTimeout().isInitialized()) {
+              
+              return false;
+            }
+          }
+          return true;
+        }
+
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          mesosphere.marathon.Protos.MarathonTask.ReservedState parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (mesosphere.marathon.Protos.MarathonTask.ReservedState) e.getUnfinishedMessage();
+            throw e;
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        // required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;
+        private mesosphere.marathon.Protos.MarathonTask.ReservedState.Type type_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Type.New;
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
+         */
+        public boolean hasType() {
+          return ((bitField0_ & 0x00000001) == 0x00000001);
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.ReservedState.Type getType() {
+          return type_;
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
+         */
+        public Builder setType(mesosphere.marathon.Protos.MarathonTask.ReservedState.Type value) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          bitField0_ |= 0x00000001;
+          type_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>required .mesosphere.marathon.MarathonTask.ReservedState.Type type = 1;</code>
+         */
+        public Builder clearType() {
+          bitField0_ = (bitField0_ & ~0x00000001);
+          type_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Type.New;
+          onChanged();
+          return this;
+        }
+
+        // optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;
+        private mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout timeout_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance();
+        private com.google.protobuf.SingleFieldBuilder<
+            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout, mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder> timeoutBuilder_;
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+         */
+        public boolean hasTimeout() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout getTimeout() {
+          if (timeoutBuilder_ == null) {
+            return timeout_;
+          } else {
+            return timeoutBuilder_.getMessage();
+          }
+        }
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+         */
+        public Builder setTimeout(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout value) {
+          if (timeoutBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            timeout_ = value;
+            onChanged();
+          } else {
+            timeoutBuilder_.setMessage(value);
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+         */
+        public Builder setTimeout(
+            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder builderForValue) {
+          if (timeoutBuilder_ == null) {
+            timeout_ = builderForValue.build();
+            onChanged();
+          } else {
+            timeoutBuilder_.setMessage(builderForValue.build());
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+         */
+        public Builder mergeTimeout(mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout value) {
+          if (timeoutBuilder_ == null) {
+            if (((bitField0_ & 0x00000002) == 0x00000002) &&
+                timeout_ != mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance()) {
+              timeout_ =
+                mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.newBuilder(timeout_).mergeFrom(value).buildPartial();
+            } else {
+              timeout_ = value;
+            }
+            onChanged();
+          } else {
+            timeoutBuilder_.mergeFrom(value);
+          }
+          bitField0_ |= 0x00000002;
+          return this;
+        }
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+         */
+        public Builder clearTimeout() {
+          if (timeoutBuilder_ == null) {
+            timeout_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.getDefaultInstance();
+            onChanged();
+          } else {
+            timeoutBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder getTimeoutBuilder() {
+          bitField0_ |= 0x00000002;
+          onChanged();
+          return getTimeoutFieldBuilder().getBuilder();
+        }
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+         */
+        public mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder getTimeoutOrBuilder() {
+          if (timeoutBuilder_ != null) {
+            return timeoutBuilder_.getMessageOrBuilder();
+          } else {
+            return timeout_;
+          }
+        }
+        /**
+         * <code>optional .mesosphere.marathon.MarathonTask.ReservedState.Timeout timeout = 2;</code>
+         */
+        private com.google.protobuf.SingleFieldBuilder<
+            mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout, mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder> 
+            getTimeoutFieldBuilder() {
+          if (timeoutBuilder_ == null) {
+            timeoutBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+                mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout, mesosphere.marathon.Protos.MarathonTask.ReservedState.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedState.TimeoutOrBuilder>(
+                    timeout_,
+                    getParentForChildren(),
+                    isClean());
+            timeout_ = null;
+          }
+          return timeoutBuilder_;
+        }
+
+        // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask.ReservedState)
+      }
+
+      static {
+        defaultInstance = new ReservedState(true);
+        defaultInstance.initFields();
+      }
+
+      // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask.ReservedState)
     }
 
     private int bitField0_;
@@ -11428,38 +12845,60 @@ public final class Protos {
       return networks_.get(index);
     }
 
-    // optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;
-    public static final int RESERVATION_WITH_VOLUMES_FIELD_NUMBER = 12;
-    private mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes reservationWithVolumes_;
+    // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
+    public static final int RESERVATION_FIELD_NUMBER = 12;
+    private mesosphere.marathon.Protos.MarathonTask.Reservation reservation_;
     /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+     * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
      *
      * <pre>
      * since 0.16, a list of volumes can be associated with the task ID
      * </pre>
      */
-    public boolean hasReservationWithVolumes() {
+    public boolean hasReservation() {
       return ((bitField0_ & 0x00000080) == 0x00000080);
     }
     /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+     * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
      *
      * <pre>
      * since 0.16, a list of volumes can be associated with the task ID
      * </pre>
      */
-    public mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes getReservationWithVolumes() {
-      return reservationWithVolumes_;
+    public mesosphere.marathon.Protos.MarathonTask.Reservation getReservation() {
+      return reservation_;
     }
     /**
-     * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+     * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
      *
      * <pre>
      * since 0.16, a list of volumes can be associated with the task ID
      * </pre>
      */
-    public mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumesOrBuilder getReservationWithVolumesOrBuilder() {
-      return reservationWithVolumes_;
+    public mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder getReservationOrBuilder() {
+      return reservation_;
+    }
+
+    // optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;
+    public static final int RESERVED_STATE_FIELD_NUMBER = 13;
+    private mesosphere.marathon.Protos.MarathonTask.ReservedState reservedState_;
+    /**
+     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+     */
+    public boolean hasReservedState() {
+      return ((bitField0_ & 0x00000100) == 0x00000100);
+    }
+    /**
+     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+     */
+    public mesosphere.marathon.Protos.MarathonTask.ReservedState getReservedState() {
+      return reservedState_;
+    }
+    /**
+     * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+     */
+    public mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder getReservedStateOrBuilder() {
+      return reservedState_;
     }
 
     private void initFields() {
@@ -11474,7 +12913,8 @@ public final class Protos {
       status_ = org.apache.mesos.Protos.TaskStatus.getDefaultInstance();
       slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
       networks_ = java.util.Collections.emptyList();
-      reservationWithVolumes_ = mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.getDefaultInstance();
+      reservation_ = mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance();
+      reservedState_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -11511,6 +12951,12 @@ public final class Protos {
       }
       for (int i = 0; i < getNetworksCount(); i++) {
         if (!getNetworks(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      if (hasReservedState()) {
+        if (!getReservedState().isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -11556,7 +13002,10 @@ public final class Protos {
         output.writeMessage(11, networks_.get(i));
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
-        output.writeMessage(12, reservationWithVolumes_);
+        output.writeMessage(12, reservation_);
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        output.writeMessage(13, reservedState_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -11618,7 +13067,11 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(12, reservationWithVolumes_);
+          .computeMessageSize(12, reservation_);
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(13, reservedState_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -11733,7 +13186,8 @@ public final class Protos {
           getStatusFieldBuilder();
           getSlaveIdFieldBuilder();
           getNetworksFieldBuilder();
-          getReservationWithVolumesFieldBuilder();
+          getReservationFieldBuilder();
+          getReservedStateFieldBuilder();
         }
       }
       private static Builder create() {
@@ -11784,12 +13238,18 @@ public final class Protos {
         } else {
           networksBuilder_.clear();
         }
-        if (reservationWithVolumesBuilder_ == null) {
-          reservationWithVolumes_ = mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.getDefaultInstance();
+        if (reservationBuilder_ == null) {
+          reservation_ = mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance();
         } else {
-          reservationWithVolumesBuilder_.clear();
+          reservationBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000800);
+        if (reservedStateBuilder_ == null) {
+          reservedState_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance();
+        } else {
+          reservedStateBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00001000);
         return this;
       }
 
@@ -11889,10 +13349,18 @@ public final class Protos {
         if (((from_bitField0_ & 0x00000800) == 0x00000800)) {
           to_bitField0_ |= 0x00000080;
         }
-        if (reservationWithVolumesBuilder_ == null) {
-          result.reservationWithVolumes_ = reservationWithVolumes_;
+        if (reservationBuilder_ == null) {
+          result.reservation_ = reservation_;
         } else {
-          result.reservationWithVolumes_ = reservationWithVolumesBuilder_.build();
+          result.reservation_ = reservationBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
+          to_bitField0_ |= 0x00000100;
+        }
+        if (reservedStateBuilder_ == null) {
+          result.reservedState_ = reservedState_;
+        } else {
+          result.reservedState_ = reservedStateBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -12025,8 +13493,11 @@ public final class Protos {
             }
           }
         }
-        if (other.hasReservationWithVolumes()) {
-          mergeReservationWithVolumes(other.getReservationWithVolumes());
+        if (other.hasReservation()) {
+          mergeReservation(other.getReservation());
+        }
+        if (other.hasReservedState()) {
+          mergeReservedState(other.getReservedState());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -12063,6 +13534,12 @@ public final class Protos {
         }
         for (int i = 0; i < getNetworksCount(); i++) {
           if (!getNetworks(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasReservedState()) {
+          if (!getReservedState().isInitialized()) {
             
             return false;
           }
@@ -13421,157 +14898,274 @@ public final class Protos {
         return networksBuilder_;
       }
 
-      // optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;
-      private mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes reservationWithVolumes_ = mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.getDefaultInstance();
+      // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
+      private mesosphere.marathon.Protos.MarathonTask.Reservation reservation_ = mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
-          mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes, mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.Builder, mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumesOrBuilder> reservationWithVolumesBuilder_;
+          mesosphere.marathon.Protos.MarathonTask.Reservation, mesosphere.marathon.Protos.MarathonTask.Reservation.Builder, mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder> reservationBuilder_;
       /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+       * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
        *
        * <pre>
        * since 0.16, a list of volumes can be associated with the task ID
        * </pre>
        */
-      public boolean hasReservationWithVolumes() {
+      public boolean hasReservation() {
         return ((bitField0_ & 0x00000800) == 0x00000800);
       }
       /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+       * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
        *
        * <pre>
        * since 0.16, a list of volumes can be associated with the task ID
        * </pre>
        */
-      public mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes getReservationWithVolumes() {
-        if (reservationWithVolumesBuilder_ == null) {
-          return reservationWithVolumes_;
+      public mesosphere.marathon.Protos.MarathonTask.Reservation getReservation() {
+        if (reservationBuilder_ == null) {
+          return reservation_;
         } else {
-          return reservationWithVolumesBuilder_.getMessage();
+          return reservationBuilder_.getMessage();
         }
       }
       /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+       * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
        *
        * <pre>
        * since 0.16, a list of volumes can be associated with the task ID
        * </pre>
        */
-      public Builder setReservationWithVolumes(mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes value) {
-        if (reservationWithVolumesBuilder_ == null) {
+      public Builder setReservation(mesosphere.marathon.Protos.MarathonTask.Reservation value) {
+        if (reservationBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          reservationWithVolumes_ = value;
+          reservation_ = value;
           onChanged();
         } else {
-          reservationWithVolumesBuilder_.setMessage(value);
+          reservationBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000800;
         return this;
       }
       /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+       * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
        *
        * <pre>
        * since 0.16, a list of volumes can be associated with the task ID
        * </pre>
        */
-      public Builder setReservationWithVolumes(
-          mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.Builder builderForValue) {
-        if (reservationWithVolumesBuilder_ == null) {
-          reservationWithVolumes_ = builderForValue.build();
+      public Builder setReservation(
+          mesosphere.marathon.Protos.MarathonTask.Reservation.Builder builderForValue) {
+        if (reservationBuilder_ == null) {
+          reservation_ = builderForValue.build();
           onChanged();
         } else {
-          reservationWithVolumesBuilder_.setMessage(builderForValue.build());
+          reservationBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000800;
         return this;
       }
       /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+       * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
        *
        * <pre>
        * since 0.16, a list of volumes can be associated with the task ID
        * </pre>
        */
-      public Builder mergeReservationWithVolumes(mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes value) {
-        if (reservationWithVolumesBuilder_ == null) {
+      public Builder mergeReservation(mesosphere.marathon.Protos.MarathonTask.Reservation value) {
+        if (reservationBuilder_ == null) {
           if (((bitField0_ & 0x00000800) == 0x00000800) &&
-              reservationWithVolumes_ != mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.getDefaultInstance()) {
-            reservationWithVolumes_ =
-              mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.newBuilder(reservationWithVolumes_).mergeFrom(value).buildPartial();
+              reservation_ != mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance()) {
+            reservation_ =
+              mesosphere.marathon.Protos.MarathonTask.Reservation.newBuilder(reservation_).mergeFrom(value).buildPartial();
           } else {
-            reservationWithVolumes_ = value;
+            reservation_ = value;
           }
           onChanged();
         } else {
-          reservationWithVolumesBuilder_.mergeFrom(value);
+          reservationBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000800;
         return this;
       }
       /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+       * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
        *
        * <pre>
        * since 0.16, a list of volumes can be associated with the task ID
        * </pre>
        */
-      public Builder clearReservationWithVolumes() {
-        if (reservationWithVolumesBuilder_ == null) {
-          reservationWithVolumes_ = mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.getDefaultInstance();
+      public Builder clearReservation() {
+        if (reservationBuilder_ == null) {
+          reservation_ = mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance();
           onChanged();
         } else {
-          reservationWithVolumesBuilder_.clear();
+          reservationBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000800);
         return this;
       }
       /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+       * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
        *
        * <pre>
        * since 0.16, a list of volumes can be associated with the task ID
        * </pre>
        */
-      public mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.Builder getReservationWithVolumesBuilder() {
+      public mesosphere.marathon.Protos.MarathonTask.Reservation.Builder getReservationBuilder() {
         bitField0_ |= 0x00000800;
         onChanged();
-        return getReservationWithVolumesFieldBuilder().getBuilder();
+        return getReservationFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+       * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
        *
        * <pre>
        * since 0.16, a list of volumes can be associated with the task ID
        * </pre>
        */
-      public mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumesOrBuilder getReservationWithVolumesOrBuilder() {
-        if (reservationWithVolumesBuilder_ != null) {
-          return reservationWithVolumesBuilder_.getMessageOrBuilder();
+      public mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder getReservationOrBuilder() {
+        if (reservationBuilder_ != null) {
+          return reservationBuilder_.getMessageOrBuilder();
         } else {
-          return reservationWithVolumes_;
+          return reservation_;
         }
       }
       /**
-       * <code>optional .mesosphere.marathon.MarathonTask.ReservationWithVolumes reservation_with_volumes = 12;</code>
+       * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
        *
        * <pre>
        * since 0.16, a list of volumes can be associated with the task ID
        * </pre>
        */
       private com.google.protobuf.SingleFieldBuilder<
-          mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes, mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.Builder, mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumesOrBuilder> 
-          getReservationWithVolumesFieldBuilder() {
-        if (reservationWithVolumesBuilder_ == null) {
-          reservationWithVolumesBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes, mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumes.Builder, mesosphere.marathon.Protos.MarathonTask.ReservationWithVolumesOrBuilder>(
-                  reservationWithVolumes_,
+          mesosphere.marathon.Protos.MarathonTask.Reservation, mesosphere.marathon.Protos.MarathonTask.Reservation.Builder, mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder> 
+          getReservationFieldBuilder() {
+        if (reservationBuilder_ == null) {
+          reservationBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              mesosphere.marathon.Protos.MarathonTask.Reservation, mesosphere.marathon.Protos.MarathonTask.Reservation.Builder, mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder>(
+                  reservation_,
                   getParentForChildren(),
                   isClean());
-          reservationWithVolumes_ = null;
+          reservation_ = null;
         }
-        return reservationWithVolumesBuilder_;
+        return reservationBuilder_;
+      }
+
+      // optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;
+      private mesosphere.marathon.Protos.MarathonTask.ReservedState reservedState_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          mesosphere.marathon.Protos.MarathonTask.ReservedState, mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder> reservedStateBuilder_;
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+       */
+      public boolean hasReservedState() {
+        return ((bitField0_ & 0x00001000) == 0x00001000);
+      }
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+       */
+      public mesosphere.marathon.Protos.MarathonTask.ReservedState getReservedState() {
+        if (reservedStateBuilder_ == null) {
+          return reservedState_;
+        } else {
+          return reservedStateBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+       */
+      public Builder setReservedState(mesosphere.marathon.Protos.MarathonTask.ReservedState value) {
+        if (reservedStateBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          reservedState_ = value;
+          onChanged();
+        } else {
+          reservedStateBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00001000;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+       */
+      public Builder setReservedState(
+          mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder builderForValue) {
+        if (reservedStateBuilder_ == null) {
+          reservedState_ = builderForValue.build();
+          onChanged();
+        } else {
+          reservedStateBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00001000;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+       */
+      public Builder mergeReservedState(mesosphere.marathon.Protos.MarathonTask.ReservedState value) {
+        if (reservedStateBuilder_ == null) {
+          if (((bitField0_ & 0x00001000) == 0x00001000) &&
+              reservedState_ != mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance()) {
+            reservedState_ =
+              mesosphere.marathon.Protos.MarathonTask.ReservedState.newBuilder(reservedState_).mergeFrom(value).buildPartial();
+          } else {
+            reservedState_ = value;
+          }
+          onChanged();
+        } else {
+          reservedStateBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00001000;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+       */
+      public Builder clearReservedState() {
+        if (reservedStateBuilder_ == null) {
+          reservedState_ = mesosphere.marathon.Protos.MarathonTask.ReservedState.getDefaultInstance();
+          onChanged();
+        } else {
+          reservedStateBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00001000);
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+       */
+      public mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder getReservedStateBuilder() {
+        bitField0_ |= 0x00001000;
+        onChanged();
+        return getReservedStateFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+       */
+      public mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder getReservedStateOrBuilder() {
+        if (reservedStateBuilder_ != null) {
+          return reservedStateBuilder_.getMessageOrBuilder();
+        } else {
+          return reservedState_;
+        }
+      }
+      /**
+       * <code>optional .mesosphere.marathon.MarathonTask.ReservedState reserved_state = 13;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          mesosphere.marathon.Protos.MarathonTask.ReservedState, mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder> 
+          getReservedStateFieldBuilder() {
+        if (reservedStateBuilder_ == null) {
+          reservedStateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              mesosphere.marathon.Protos.MarathonTask.ReservedState, mesosphere.marathon.Protos.MarathonTask.ReservedState.Builder, mesosphere.marathon.Protos.MarathonTask.ReservedStateOrBuilder>(
+                  reservedState_,
+                  getParentForChildren(),
+                  isClean());
+          reservedState_ = null;
+        }
+        return reservedStateBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:mesosphere.marathon.MarathonTask)
@@ -28053,10 +29647,20 @@ public final class Protos {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
-    internal_static_mesosphere_marathon_MarathonTask_ReservationWithVolumes_descriptor;
+    internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_mesosphere_marathon_MarathonTask_ReservationWithVolumes_fieldAccessorTable;
+      internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_mesosphere_marathon_MarathonTask_ReservedState_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonApp_descriptor;
   private static
@@ -28186,7 +29790,7 @@ public final class Protos {
       "athon.IpAddress\022;\n\tresidency\030\032 \001(\0132(.mes" +
       "osphere.marathon.ResidencyDefinition\022$\n\017" +
       "portDefinitions\030\033 \003(\0132\013.mesos.Port\"\035\n\rRe" +
-      "sourceRoles\022\014\n\004role\030\001 \003(\t\"\327\003\n\014MarathonTa" +
+      "sourceRoles\022\014\n\004role\030\001 \003(\t\"\231\007\n\014MarathonTa" +
       "sk\022\n\n\002id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 " +
       "\003(\r\022$\n\nattributes\030\004 \003(\0132\020.mesos.Attribut" +
       "e\022\021\n\tstaged_at\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003" +
@@ -28194,62 +29798,73 @@ public final class Protos {
       "Status\022)\n\007version\030\010 \001(\t:\0301970-01-01T00:0" +
       "0:00.000Z\022!\n\006status\030\t \001(\0132\021.mesos.TaskSt" +
       "atus\022\037\n\007slaveId\030\n \001(\0132\016.mesos.SlaveID\022$\n" +
-      "\010networks\030\013 \003(\0132\022.mesos.NetworkInfo\022Z\n\030r" +
-      "eservation_with_volumes\030\014 \001(\01328.mesosphe" +
-      "re.marathon.MarathonTask.ReservationWith" +
-      "Volumes\0322\n\026ReservationWithVolumes\022\030\n\020loc" +
-      "al_volume_ids\030\001 \003(\t\"M\n\013MarathonApp\022\014\n\004na" +
-      "me\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!.mesosphere.mar" +
-      "athon.MarathonTask\"1\n\rContainerInfo\022\017\n\005i",
-      "mage\030\001 \002(\014:\000\022\017\n\007options\030\002 \003(\014\"\332\004\n\025Extend" +
-      "edContainerInfo\022\'\n\004type\030\001 \002(\0162\031.mesos.Co" +
-      "ntainerInfo.Type\022,\n\007volumes\030\002 \003(\0132\033.meso" +
-      "sphere.marathon.Volume\022E\n\006docker\030\003 \001(\01325" +
-      ".mesosphere.marathon.ExtendedContainerIn" +
-      "fo.DockerInfo\032\242\003\n\nDockerInfo\022\r\n\005image\030\001 " +
-      "\002(\t\022>\n\007network\030\002 \001(\0162\'.mesos.ContainerIn" +
-      "fo.DockerInfo.Network:\004HOST\022X\n\rport_mapp" +
-      "ings\030\003 \003(\0132A.mesosphere.marathon.Extende" +
-      "dContainerInfo.DockerInfo.PortMapping\022\031\n",
-      "\nprivileged\030\004 \001(\010:\005false\022$\n\nparameters\030\005" +
-      " \003(\0132\020.mesos.Parameter\022\030\n\020force_pull_ima" +
-      "ge\030\006 \001(\010\032\217\001\n\013PortMapping\022\021\n\thost_port\030\001 " +
-      "\002(\r\022\026\n\016container_port\030\002 \002(\r\022\020\n\010protocol\030" +
-      "\003 \001(\t\022\014\n\004name\030\004 \001(\t\022\034\n\006labels\030\005 \003(\0132\014.me" +
-      "sos.Label\022\027\n\014service_port\030d \001(\r:\0010\"\336\001\n\006V" +
-      "olume\022 \n\004mode\030\003 \002(\0162\022.mesos.Volume.Mode\022" +
-      "\026\n\016container_path\030\001 \002(\t\022\021\n\thost_path\030\002 \001" +
-      "(\t\022\033\n\005image\030\004 \001(\0132\014.mesos.Image\022D\n\npersi" +
-      "stent\030\005 \001(\01320.mesosphere.marathon.Volume",
-      ".PersistentVolumeInfo\032$\n\024PersistentVolum" +
-      "eInfo\022\014\n\004size\030\001 \002(\004\")\n\020EventSubscribers\022" +
-      "\025\n\rcallback_urls\030\001 \003(\t\"=\n\016StorageVersion" +
-      "\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030" +
-      "\003 \002(\r\"Z\n\031UpgradeStrategyDefinition\022\035\n\025mi" +
-      "nimumHealthCapacity\030\001 \002(\001\022\036\n\023maximumOver" +
-      "Capacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDefinition\022\n\n" +
-      "\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004apps\030\003 \003(\013" +
-      "2&.mesosphere.marathon.ServiceDefinition" +
-      "\0224\n\006groups\030\004 \003(\0132$.mesosphere.marathon.G",
-      "roupDefinition\022\024\n\014dependencies\030\005 \003(\t\"\245\001\n" +
-      "\030DeploymentPlanDefinition\022\n\n\002id\030\001 \002(\t\022\017\n" +
-      "\007version\030\002 \002(\t\0226\n\010original\030\004 \002(\0132$.mesos" +
-      "phere.marathon.GroupDefinition\0224\n\006target" +
-      "\030\005 \002(\0132$.mesosphere.marathon.GroupDefini" +
-      "tion\"\306\001\n\013TaskFailure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007" +
-      "task_id\030\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003 " +
-      "\002(\0162\020.mesos.TaskState\022\021\n\007message\030\004 \001(\t:\000" +
-      "\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\ttim" +
-      "estamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016.mesos.Sl",
-      "aveID\"T\n\014ZKStoreEntry\022\014\n\004name\030\001 \002(\t\022\014\n\004u" +
-      "uid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\ncompressed\030\004" +
-      " \001(\010:\005false\"\326\001\n\023ResidencyDefinition\022(\n r" +
-      "elaunchEscalationTimeoutSeconds\030\001 \001(\003\022S\n" +
-      "\020taskLostBehavior\030\002 \001(\01629.mesosphere.mar" +
-      "athon.ResidencyDefinition.TaskLostBehavi" +
-      "or\"@\n\020TaskLostBehavior\022\032\n\026RELAUNCH_AFTER" +
-      "_TIMEOUT\020\000\022\020\n\014WAIT_FOREVER\020\001B\035\n\023mesosphe" +
-      "re.marathonB\006Protos"
+      "\010networks\030\013 \003(\0132\022.mesos.NetworkInfo\022B\n\013r" +
+      "eservation\030\014 \001(\0132-.mesosphere.marathon.M" +
+      "arathonTask.Reservation\022G\n\016reserved_stat" +
+      "e\030\r \001(\0132/.mesosphere.marathon.MarathonTa" +
+      "sk.ReservedState\032\'\n\013Reservation\022\030\n\020local" +
+      "_volume_ids\030\001 \003(\t\032\231\003\n\rReservedState\022B\n\004t" +
+      "ype\030\001 \002(\01624.mesosphere.marathon.Marathon",
+      "Task.ReservedState.Type\022H\n\007timeout\030\002 \001(\013" +
+      "27.mesosphere.marathon.MarathonTask.Rese" +
+      "rvedState.Timeout\032\277\001\n\007Timeout\022\021\n\tinitiat" +
+      "ed\030\001 \002(\003\022\020\n\010deadline\030\002 \002(\003\022N\n\006reason\030\003 \002" +
+      "(\0162>.mesosphere.marathon.MarathonTask.Re" +
+      "servedState.Timeout.Reason\"?\n\006Reason\022\035\n\031" +
+      "RelaunchEscalationTimeout\020\001\022\026\n\022Reservati" +
+      "onTimeout\020\002\"8\n\004Type\022\007\n\003New\020\001\022\r\n\tSuspende" +
+      "d\020\002\022\013\n\007Garbage\020\003\022\013\n\007Unknown\020\004\"M\n\013Maratho" +
+      "nApp\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!.meso",
+      "sphere.marathon.MarathonTask\"1\n\rContaine" +
+      "rInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007options\030\002 \003(\014\"" +
+      "\332\004\n\025ExtendedContainerInfo\022\'\n\004type\030\001 \002(\0162" +
+      "\031.mesos.ContainerInfo.Type\022,\n\007volumes\030\002 " +
+      "\003(\0132\033.mesosphere.marathon.Volume\022E\n\006dock" +
+      "er\030\003 \001(\01325.mesosphere.marathon.ExtendedC" +
+      "ontainerInfo.DockerInfo\032\242\003\n\nDockerInfo\022\r" +
+      "\n\005image\030\001 \002(\t\022>\n\007network\030\002 \001(\0162\'.mesos.C" +
+      "ontainerInfo.DockerInfo.Network:\004HOST\022X\n" +
+      "\rport_mappings\030\003 \003(\0132A.mesosphere.marath",
+      "on.ExtendedContainerInfo.DockerInfo.Port" +
+      "Mapping\022\031\n\nprivileged\030\004 \001(\010:\005false\022$\n\npa" +
+      "rameters\030\005 \003(\0132\020.mesos.Parameter\022\030\n\020forc" +
+      "e_pull_image\030\006 \001(\010\032\217\001\n\013PortMapping\022\021\n\tho" +
+      "st_port\030\001 \002(\r\022\026\n\016container_port\030\002 \002(\r\022\020\n" +
+      "\010protocol\030\003 \001(\t\022\014\n\004name\030\004 \001(\t\022\034\n\006labels\030" +
+      "\005 \003(\0132\014.mesos.Label\022\027\n\014service_port\030d \001(" +
+      "\r:\0010\"\336\001\n\006Volume\022 \n\004mode\030\003 \002(\0162\022.mesos.Vo" +
+      "lume.Mode\022\026\n\016container_path\030\001 \002(\t\022\021\n\thos" +
+      "t_path\030\002 \001(\t\022\033\n\005image\030\004 \001(\0132\014.mesos.Imag",
+      "e\022D\n\npersistent\030\005 \001(\01320.mesosphere.marat" +
+      "hon.Volume.PersistentVolumeInfo\032$\n\024Persi" +
+      "stentVolumeInfo\022\014\n\004size\030\001 \002(\004\")\n\020EventSu" +
+      "bscribers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016Stor" +
+      "ageVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r" +
+      "\022\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefini" +
+      "tion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023m" +
+      "aximumOverCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDef" +
+      "inition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004" +
+      "apps\030\003 \003(\0132&.mesosphere.marathon.Service",
+      "Definition\0224\n\006groups\030\004 \003(\0132$.mesosphere." +
+      "marathon.GroupDefinition\022\024\n\014dependencies" +
+      "\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002i" +
+      "d\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002" +
+      "(\0132$.mesosphere.marathon.GroupDefinition" +
+      "\0224\n\006target\030\005 \002(\0132$.mesosphere.marathon.G" +
+      "roupDefinition\"\306\001\n\013TaskFailure\022\016\n\006app_id" +
+      "\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037" +
+      "\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007messa" +
+      "ge\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 ",
+      "\002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132" +
+      "\016.mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004name\030" +
+      "\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\nco" +
+      "mpressed\030\004 \001(\010:\005false\"\326\001\n\023ResidencyDefin" +
+      "ition\022(\n relaunchEscalationTimeoutSecond" +
+      "s\030\001 \001(\003\022S\n\020taskLostBehavior\030\002 \001(\01629.meso" +
+      "sphere.marathon.ResidencyDefinition.Task" +
+      "LostBehavior\"@\n\020TaskLostBehavior\022\032\n\026RELA" +
+      "UNCH_AFTER_TIMEOUT\020\000\022\020\n\014WAIT_FOREVER\020\001B\035" +
+      "\n\023mesosphere.marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -28297,13 +29912,25 @@ public final class Protos {
           internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_MarathonTask_descriptor,
-              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "Networks", "ReservationWithVolumes", });
-          internal_static_mesosphere_marathon_MarathonTask_ReservationWithVolumes_descriptor =
+              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "Networks", "Reservation", "ReservedState", });
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor =
             internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_MarathonTask_ReservationWithVolumes_fieldAccessorTable = new
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_ReservationWithVolumes_descriptor,
+              internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor,
               new java.lang.String[] { "LocalVolumeIds", });
+          internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor =
+            internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(1);
+          internal_static_mesosphere_marathon_MarathonTask_ReservedState_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor,
+              new java.lang.String[] { "Type", "Timeout", });
+          internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor =
+            internal_static_mesosphere_marathon_MarathonTask_ReservedState_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonTask_ReservedState_Timeout_descriptor,
+              new java.lang.String[] { "Initiated", "Deadline", "Reason", });
           internal_static_mesosphere_marathon_MarathonApp_descriptor =
             getDescriptor().getMessageTypes().get(7);
           internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -92,27 +92,30 @@ message ResourceRoles {
 
 message MarathonTask {
   message Reservation {
-    repeated string local_volume_ids = 1;
-  }
-  message ReservedState {
-    enum Type {
-      New = 1;
-      Suspended = 2;
-      Garbage = 3;
-      Unknown = 4;
-    }
-    message Timeout {
-      enum Reason {
-        RelaunchEscalationTimeout = 1;
-        ReservationTimeout = 2;
+    message State {
+      enum Type {
+        New = 1;
+        Launched = 2;
+        Suspended = 3;
+        Garbage = 4;
+        Unknown = 5;
       }
+      message Timeout {
+        enum Reason {
+          RelaunchEscalationTimeout = 1;
+          ReservationTimeout = 2;
+        }
 
-      required int64 initiated = 1;
-      required int64 deadline = 2;
-      required Reason reason = 3;
+        required int64 initiated = 1;
+        required int64 deadline = 2;
+        required Reason reason = 3;
+      }
+      required Type type = 1;
+      optional Timeout timeout = 2;
     }
-    required Type type = 1;
-    optional Timeout timeout = 2;
+
+    repeated string local_volume_ids = 1;
+    required State state = 2;
   }
 
   required string id = 1;
@@ -127,7 +130,6 @@ message MarathonTask {
   optional mesos.SlaveID slaveId = 10;
   repeated mesos.NetworkInfo networks = 11;
   optional Reservation reservation = 12; // since 0.16, a list of volumes can be associated with the task ID
-  optional ReservedState reserved_state = 13;
 }
 
 message MarathonApp {

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -91,8 +91,28 @@ message ResourceRoles {
 }
 
 message MarathonTask {
-  message ReservationWithVolumes {
+  message Reservation {
     repeated string local_volume_ids = 1;
+  }
+  message ReservedState {
+    enum Type {
+      New = 1;
+      Suspended = 2;
+      Garbage = 3;
+      Unknown = 4;
+    }
+    message Timeout {
+      enum Reason {
+        RelaunchEscalationTimeout = 1;
+        ReservationTimeout = 2;
+      }
+
+      required int64 initiated = 1;
+      required int64 deadline = 2;
+      required Reason reason = 3;
+    }
+    required Type type = 1;
+    optional Timeout timeout = 2;
   }
 
   required string id = 1;
@@ -106,7 +126,8 @@ message MarathonTask {
   optional mesos.TaskStatus status = 9;
   optional mesos.SlaveID slaveId = 10;
   repeated mesos.NetworkInfo networks = 11;
-  optional ReservationWithVolumes reservation_with_volumes = 12; // since 0.16, a list of volumes can be associated with the task ID
+  optional Reservation reservation = 12; // since 0.16, a list of volumes can be associated with the task ID
+  optional ReservedState reserved_state = 13;
 }
 
 message MarathonApp {

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -2,23 +2,25 @@ package mesosphere.marathon.core.task
 
 import com.fasterxml.uuid.{ EthernetAddress, Generators }
 import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.core.task.Task.Launched
+import mesosphere.marathon.core.task.bus.MarathonTaskStatus
 import mesosphere.marathon.core.task.tracker.impl.TaskSerializer
-import mesosphere.marathon.state.{ PersistentVolume, AppDefinition, PathId, Timestamp }
+import mesosphere.marathon.state.{ AppDefinition, PathId, PersistentVolume, Timestamp }
 import org.apache.mesos.Protos.TaskState
 import org.apache.mesos.Protos.TaskState._
 import org.apache.mesos.{ Protos => MesosProtos }
+import org.slf4j.LoggerFactory
 
-import scala.util.matching.Regex
-
+//scalastyle:off number.of.types
 /**
   * The state for launching a task. This might be a launched task or a reservation for launching a task or both.
   */
-case class Task(
-    taskId: Task.Id,
-    agentInfo: Task.AgentInfo,
-    reservationWithVolumes: Option[Task.ReservationWithVolumes] = None,
-    launched: Option[Task.Launched] = None) {
+sealed trait Task {
+  def taskId: Task.Id
+  def agentInfo: Task.AgentInfo
+  def reservationWithVolumes: Option[Task.ReservationWithVolumes]
+  def launched: Option[Task.Launched]
+
+  def update(update: TaskStateOp): TaskStateChange
 
   def appId: PathId = taskId.appId
 
@@ -49,11 +51,6 @@ case class Task(
     }
   }
 
-  def withAgentInfo(update: Task.AgentInfo => Task.AgentInfo): Task = copy(agentInfo = update(agentInfo))
-
-  def withLaunched(update: Launched => Launched): Task =
-    copy(launched = launched.map(update))
-
   def ipAddresses: Iterable[MesosProtos.NetworkInfo.IPAddress] = launched.map(_.ipAddresses).getOrElse(Iterable.empty)
 
   def effectiveIpAddress(app: AppDefinition): String = {
@@ -67,6 +64,211 @@ case class Task(
 }
 
 object Task {
+  private[this] def newHealthStatus(
+    current: MesosProtos.TaskStatus,
+    update: MesosProtos.TaskStatus): Option[MesosProtos.TaskStatus] = {
+
+    val healthy = update.hasHealthy && (!current.hasHealthy || current.getHealthy != update.getHealthy)
+    val changed = healthy || current.getState != update.getState
+    if (changed) {
+      Some(update)
+    }
+    else {
+      None
+    }
+  }
+
+  /**
+    * A LaunchedEphemeral task is a stateless task that does not consume reserved resources or persistent volumes.
+    */
+  case class LaunchedEphemeral(
+      taskId: Task.Id,
+      agentInfo: AgentInfo,
+      appVersion: Timestamp,
+      status: Status,
+      networking: Networking) extends Task {
+
+    private[this] val log = LoggerFactory.getLogger(getClass)
+
+    override val reservationWithVolumes: Option[ReservationWithVolumes] = None
+
+    override val launched: Option[Launched] = Some(Task.Launched(appVersion, status, networking))
+
+    private[this] def hasStartedRunning: Boolean = status.startedAt.isDefined
+
+    override def update(update: TaskStateOp): TaskStateChange = update match {
+      // case 1: now running
+      case TaskStateOp.MesosUpdate(MarathonTaskStatus.Running(mesosStatus), now) if !hasStartedRunning =>
+        val updated = copy(
+          status = status.copy(
+            startedAt = Some(now),
+            mesosStatus = mesosStatus))
+        TaskStateChange.Update(updated)
+
+      // case 2: terminal
+      case TaskStateOp.MesosUpdate(MarathonTaskStatus.Terminal(_), now) =>
+        TaskStateChange.Expunge
+
+      // case 3: health updated
+      case TaskStateOp.MesosUpdate(taskStatus, now) =>
+        val healthChange = for {
+          current <- status.mesosStatus
+          update <- taskStatus.mesosStatus
+          newStatus <- newHealthStatus(current, update)
+        } yield TaskStateChange.Update(copy(status = status.copy(mesosStatus = Some(newStatus))))
+
+        healthChange.getOrElse{
+          log.debug("Ignoring status update for {}. Status did not change.", taskId)
+          TaskStateChange.NoChange
+        }
+
+      // failure case: Launch
+      case _: TaskStateOp.Launch =>
+        val msg = s"Unable to handle Launch op on LaunchedEphemeral $taskId"
+        log.error(msg, taskId)
+        TaskStateChange.Failure(msg)
+
+      // failure case: Timeout
+      case TaskStateOp.Timeout =>
+        val msg = s"Unable to handle Timeout op on LaunchedEphemeral $taskId"
+        log.error(msg)
+        TaskStateChange.Failure(msg)
+    }
+  }
+
+  /**
+    * A Reserved task carries the information of reserved resources and persistent volumes
+    * and is currently not launched.
+    *
+    * @param taskId The task Id
+    * @param reservation Information about the reserved resources and persistent volumes
+    */
+  case class Reserved(
+      taskId: Task.Id,
+      agentInfo: AgentInfo,
+      state: Reserved.State,
+      reservation: ReservationWithVolumes) extends Task {
+
+    private[this] val log = LoggerFactory.getLogger(getClass)
+
+    override val reservationWithVolumes: Option[ReservationWithVolumes] = Some(reservation)
+
+    override val launched: Option[Launched] = None
+
+    override def update(update: TaskStateOp): TaskStateChange = update match {
+      case TaskStateOp.Launch(appVersion, status, networking) =>
+        TaskStateChange.Update(LaunchedOnReservation(
+          taskId, agentInfo, appVersion, status, networking, reservation))
+
+      case TaskStateOp.Timeout =>
+        TaskStateChange.Expunge
+
+      // failure case: MesosUpdate
+      case _: TaskStateOp.MesosUpdate =>
+        val msg = s"Unable to handle MesosUpdate op on Reserved task $taskId"
+        log.error(msg)
+        TaskStateChange.Failure(msg)
+    }
+  }
+
+  object Reserved {
+
+    sealed trait State {
+      /** Defines when this state should time out and for which reason */
+      def timeout: Option[Timeout]
+    }
+    object State {
+      /** A newly reserved Task */
+      case class New(timeout: Option[Timeout]) extends State
+      /** A ResidentTask that has been running before but terminated and can be relaunched */
+      case class Suspended(timeout: Option[Timeout]) extends State
+      /** A ResidentTask whose reservation and persistent volumes are being destroyed */
+      case class Garbage(timeout: Option[Timeout]) extends State
+      /** An unknown task created because of unknown reservations/persistent volumes */
+      case class Unknown(timeout: Option[Timeout]) extends State
+    }
+
+    /**
+      * A timeout that eventually leads to a state transition
+      * @param initiated When this timeout was setup
+      * @param deadline When this timeout should become effective
+      * @param reason The reason why this timeout was set up
+      */
+    case class Timeout(initiated: Timestamp, deadline: Timestamp, reason: Timeout.Reason)
+
+    object Timeout {
+      sealed trait Reason
+      object Reason {
+        /** A timeout because the task could not be relaunched */
+        case object RelaunchEscalationTimeout extends Reason
+        /** A timeout because we got no ack for reserved resources or persistent volumes */
+        case object ReservationTimeout extends Reason
+      }
+    }
+  }
+
+  case class LaunchedOnReservation(
+      taskId: Task.Id,
+      agentInfo: AgentInfo,
+      appVersion: Timestamp,
+      status: Status,
+      networking: Networking,
+      reservation: ReservationWithVolumes) extends Task {
+
+    private[this] val log = LoggerFactory.getLogger(getClass)
+
+    override lazy val reservationWithVolumes: Option[ReservationWithVolumes] = Some(reservation)
+
+    override lazy val launched: Option[Launched] = Some(Task.Launched(appVersion, status, networking))
+
+    private[this] def hasStartedRunning: Boolean = status.startedAt.isDefined
+
+    override def update(update: TaskStateOp): TaskStateChange = update match {
+      // case 1: now running
+      case TaskStateOp.MesosUpdate(MarathonTaskStatus.Running(mesosStatus), now) if !hasStartedRunning =>
+        val updated = copy(
+          status = status.copy(
+            startedAt = Some(now),
+            mesosStatus = mesosStatus))
+        TaskStateChange.Update(updated)
+
+      // case 2: terminal
+      // FIXME (3221): handle task_lost, kill etc differently and set appropriate timeouts (if any)
+      case TaskStateOp.MesosUpdate(MarathonTaskStatus.Terminal(_), now) =>
+        TaskStateChange.Update(Task.Reserved(
+          taskId = taskId,
+          agentInfo = agentInfo,
+          state = Task.Reserved.State.Suspended(timeout = None),
+          reservation = reservation
+        ))
+
+      // case 3: health updated
+      case TaskStateOp.MesosUpdate(taskStatus, now) =>
+        val healthChange = for {
+          current <- status.mesosStatus
+          update <- taskStatus.mesosStatus
+          newStatus <- newHealthStatus(current, update)
+        } yield TaskStateChange.Update(copy(status = status.copy(mesosStatus = Some(newStatus))))
+
+        healthChange.getOrElse{
+          log.debug("Ignoring status update for {}. Status did not change.", taskId)
+          TaskStateChange.NoChange
+        }
+
+      // failure case: Launch
+      case _: TaskStateOp.Launch =>
+        val msg = s"Unable to handle Launch op on LaunchedOnReservation $taskId}"
+        log.error(msg)
+        TaskStateChange.Failure(msg)
+
+      // failure case: Timeout
+      case TaskStateOp.Timeout =>
+        val msg = s"Unable to handle Timeout op on LaunchedOnReservation $taskId"
+        log.error(msg)
+        TaskStateChange.Failure(msg)
+    }
+  }
+
   def tasksById(tasks: Iterable[Task]): Map[Task.Id, Task] = tasks.iterator.map(task => task.taskId -> task).toMap
 
   case class Id(idString: String) {
@@ -131,12 +333,6 @@ object Task {
       appVersion: Timestamp,
       status: Status,
       networking: Networking) {
-
-    def withStatus(update: Status => Status): Launched = copy(status = update(status))
-
-    def withMesosStatus(mesosStatus: MesosProtos.TaskStatus): Launched = {
-      copy(status = status.copy(mesosStatus = Some(mesosStatus)))
-    }
 
     def hasStartedRunning: Boolean = status.startedAt.isDefined
 

--- a/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
@@ -7,16 +7,14 @@ sealed trait TaskStateOp
 
 object TaskStateOp {
   case class Launch(appVersion: Timestamp, status: Task.Status, networking: Task.Networking) extends TaskStateOp
-  // FIXME (3221): MarathonTaskStatus was introduced for the message bus – is it ok to use it here?
   case class MesosUpdate(status: MarathonTaskStatus, now: Timestamp) extends TaskStateOp
-  case object Timeout extends TaskStateOp
-  //  Garbage?
+  case object ReservationTimeout extends TaskStateOp
 }
 
 sealed trait TaskStateChange
 
 object TaskStateChange {
-  case class Update(task: Task) extends TaskStateChange
+  case class Update(updatedTask: Task) extends TaskStateChange
   case object Expunge extends TaskStateChange
   case object NoChange extends TaskStateChange
   case class Failure(cause: String) extends TaskStateChange

--- a/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
@@ -1,0 +1,23 @@
+package mesosphere.marathon.core.task
+
+import mesosphere.marathon.core.task.bus.MarathonTaskStatus
+import mesosphere.marathon.state.Timestamp
+
+sealed trait TaskStateOp
+
+object TaskStateOp {
+  case class Launch(appVersion: Timestamp, status: Task.Status, networking: Task.Networking) extends TaskStateOp
+  // FIXME (3221): MarathonTaskStatus was introduced for the message bus – is it ok to use it here?
+  case class MesosUpdate(status: MarathonTaskStatus, now: Timestamp) extends TaskStateOp
+  case object Timeout extends TaskStateOp
+  //  Garbage?
+}
+
+sealed trait TaskStateChange
+
+object TaskStateChange {
+  case class Update(task: Task) extends TaskStateChange
+  case object Expunge extends TaskStateChange
+  case object NoChange extends TaskStateChange
+  case class Failure(cause: String) extends TaskStateChange
+}

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
@@ -50,7 +50,9 @@ private[tracker] object TaskOpProcessorImpl {
         case TaskStateChange.Update(updatedTask) => Action.Update(updatedTask)
         case TaskStateChange.Expunge             => Action.Expunge
         case TaskStateChange.NoChange            => Action.Noop
-        case TaskStateChange.Failure(_)          => Action.Noop
+        case TaskStateChange.Failure(cause) =>
+          log.warn(s"Task state update failed for ${task.taskId}. Reason: $cause")
+          Action.Noop
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
@@ -3,13 +3,12 @@ package mesosphere.marathon.core.task.tracker.impl
 import akka.actor.{ ActorRef, Status }
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.base.Clock
-import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.Task.Terminated
+import mesosphere.marathon.core.task.bus.MarathonTaskStatus
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.task.tracker.impl.TaskOpProcessor.Action
 import mesosphere.marathon.core.task.tracker.impl.TaskOpProcessorImpl.StatusUpdateActionResolver
+import mesosphere.marathon.core.task.{ Task, TaskStateChange, TaskStateOp }
 import mesosphere.marathon.state.TaskRepository
-import org.apache.mesos.Protos.TaskState._
 import org.apache.mesos.Protos.TaskStatus
 import org.slf4j.LoggerFactory
 
@@ -34,7 +33,6 @@ private[tracker] object TaskOpProcessorImpl {
       * * a Action.Noop if the task does not have to be changed OR ELSE
       * * an Action.Expunge if the TaskStatus update indicates a terminated task OR ELSE
       * * an Action.Update if the tasks existed and the TaskStatus contains new information OR ELSE
-      * * an Action.Unlaunch if a resident running task is killed
       */
     def resolve(taskId: Task.Id, status: TaskStatus)(
       implicit ec: ExecutionContext): Future[Action] = {
@@ -47,82 +45,12 @@ private[tracker] object TaskOpProcessorImpl {
     }
 
     private[this] def actionForTaskAndStatus(task: Task, statusUpdate: TaskStatus): Action = {
-      //Step 1: if a resident task is terminated, it has to be handled differently
-      resolveForResidentFailed(task, statusUpdate)
-        //Step 2: update existing running task
-        .orElse(resolveForLaunchedTask(task, statusUpdate))
-        //Step 3: nothing of the above: do nothing
-        .getOrElse {
-          log.warn("Got update for task which wasn't launched yet: {}", statusUpdate)
-          Action.Noop
-        }
-    }
-    private[this] def resolveForResidentFailed(task: Task, status: TaskStatus): Option[Action] = {
-      for {
-        _ <- task.reservationWithVolumes
-        _ <- task.launched
-        if Terminated.isTerminated(status.getState)
-      } yield Action.Update(task.copy(launched = None))
-    }
-
-    /**
-      * Calculates the change that needs to performed on this task according to the given task status update
-      */
-    private[this] def resolveForLaunchedTask(task: Task, statusUpdate: TaskStatus): Option[Action] = {
-      task.launched.map { launched =>
-        statusUpdate.getState match {
-          case Terminated(_) => Action.Expunge
-          case TASK_RUNNING if !launched.hasStartedRunning => stagedNowRunning(task, launched, statusUpdate)
-          case _ => updateTaskOnStateChange(task, launched, statusUpdate)
-        }
-      }
-    }
-
-    private[this] def stagedNowRunning(task: Task, currentLaunched: Task.Launched, statusUpdate: TaskStatus): Action = {
-      val now = clock.now()
-      Action.Update(
-        task.copy(launched = Some(
-          currentLaunched.copy(
-            status = currentLaunched.status.copy(
-              startedAt = Some(now),
-              mesosStatus = Some(statusUpdate)
-            )
-          )
-        ))
-      )
-    }
-    private[this] def updateTaskOnStateChange(
-      taskState: Task, currentLaunch: Task.Launched, statusUpdate: TaskStatus): Action = {
-
-      def updatedOnChange(currentStatus: TaskStatus): Option[Task] = {
-        val healthy =
-          statusUpdate.hasHealthy && (!currentStatus.hasHealthy || currentStatus.getHealthy != statusUpdate.getHealthy)
-        val changed = healthy || currentStatus.getState != statusUpdate.getState
-        if (changed) {
-          Some(
-            taskState.copy(
-              launched = Some(
-                currentLaunch.copy(
-                  status = currentLaunch.status.copy(mesosStatus = Some(currentStatus))
-                )
-              )
-            )
-          )
-        }
-        else {
-          log.info("currentStatus {}", currentStatus)
-          log.info("update {}", statusUpdate)
-          None
-        }
-      }
-
-      val maybeUpdated = currentLaunch.status.mesosStatus.flatMap(updatedOnChange(_))
-
-      maybeUpdated match {
-        case Some(updated) => Action.Update(updated)
-        case None =>
-          log.debug(s"Ignoring status update for ${taskState.taskId}. Status did not change.")
-          Action.Noop
+      val change = task.update(TaskStateOp.MesosUpdate(MarathonTaskStatus(statusUpdate), clock.now()))
+      change match {
+        case TaskStateChange.Update(updatedTask) => Action.Update(updatedTask)
+        case TaskStateChange.Expunge             => Action.Expunge
+        case TaskStateChange.NoChange            => Action.Noop
+        case TaskStateChange.Failure(_)          => Action.Noop
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializer.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon.core.task.tracker.impl
 
-import mesosphere.marathon.{ SerializationFailedException, Protos }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.{ LocalVolumeId, ReservationWithVolumes }
 import mesosphere.marathon.state.Timestamp
+import mesosphere.marathon.{ Protos, SerializationFailedException }
 import org.apache.mesos.{ Protos => MesosProtos }
 
 /**
@@ -37,10 +37,10 @@ object TaskSerializer {
       )
     }
 
-    def reservationWithVolume: Option[Task.ReservationWithVolumes] = {
-      if (proto.hasReservationWithVolumes) {
+    def reservation: Option[Task.ReservationWithVolumes] = {
+      if (proto.hasReservation) {
         Some(ReservationWithVolumes(
-          proto.getReservationWithVolumes.getLocalVolumeIdsList.asScala.map {
+          proto.getReservation.getLocalVolumeIdsList.asScala.map {
             case LocalVolumeId(volumeId) => volumeId
             case invalid: String         => throw new SerializationFailedException(s"$invalid is no valid volumeId")
           }))
@@ -50,25 +50,38 @@ object TaskSerializer {
       }
     }
 
+    def reservedState: Option[Task.Reserved.State] = {
+      if (proto.hasReservedState) {
+        Some(ReservedStateSerializer.fromProto(proto.getReservedState))
+      }
+      else None
+    }
+
+    def appVersion = Timestamp(proto.getVersion)
+
+    def taskStatus = Task.Status(
+      stagedAt = Timestamp(proto.getStagedAt),
+      startedAt = if (proto.hasStartedAt) Some(Timestamp(proto.getStartedAt)) else None,
+      mesosStatus = opt(_.hasStatus, _.getStatus)
+    )
+
+    def networking = if (proto.getPortsCount != 0) {
+      Task.HostPorts(proto.getPortsList.iterator().asScala.map(_.intValue()).toVector)
+    }
+    else if (proto.getNetworksCount != 0) {
+      Task.NetworkInfoList(proto.getNetworksList.asScala)
+    }
+    else {
+      Task.NoNetworking
+    }
+
     def launchedTask: Option[Task.Launched] = {
       if (proto.hasStagedAt) {
         Some(
           Task.Launched(
-            appVersion = Timestamp(proto.getVersion),
-            status = Task.Status(
-              stagedAt = Timestamp(proto.getStagedAt),
-              startedAt = if (proto.hasStartedAt) Some(Timestamp(proto.getStartedAt)) else None,
-              mesosStatus = opt(_.hasStatus, _.getStatus)
-            ),
-            networking = if (proto.getPortsCount != 0) {
-              Task.HostPorts(proto.getPortsList.iterator().asScala.map(_.intValue()).toVector)
-            }
-            else if (proto.getNetworksCount != 0) {
-              Task.NetworkInfoList(proto.getNetworksList.asScala)
-            }
-            else {
-              Task.NoNetworking
-            }
+            appVersion = appVersion,
+            status = taskStatus,
+            networking = networking
           )
         )
       }
@@ -77,50 +90,154 @@ object TaskSerializer {
       }
     }
 
-    Task(
+    constructTask(
       taskId = Task.Id(proto.getId),
       agentInfo = agentInfo,
-      reservationWithVolumes = reservationWithVolume,
-      launched = launchedTask
+      reservation,
+      reservedState,
+      launchedTask
     )
   }
 
-  def toProto(taskState: Task): Protos.MarathonTask = {
+  private[this] def constructTask(
+    taskId: Task.Id,
+    agentInfo: Task.AgentInfo,
+    reservationOpt: Option[ReservationWithVolumes],
+    reservedStateOpt: Option[Task.Reserved.State],
+    launchedOpt: Option[Task.Launched]): Task = {
+
+    (taskId, agentInfo, reservationOpt, reservedStateOpt, launchedOpt) match {
+
+      case (_, _, Some(reservation), None, Some(launched)) =>
+        Task.LaunchedOnReservation(
+          taskId, agentInfo, launched.appVersion, launched.status, launched.networking, reservation)
+
+      case (_, _, Some(reservation), Some(reservedState), None) =>
+        Task.Reserved(
+          taskId, agentInfo, reservedState, reservation)
+
+      case (_, _, None, None, Some(launched)) =>
+        Task.LaunchedEphemeral(
+          taskId, agentInfo, launched.appVersion, launched.status, launched.networking)
+
+      case (_, _, _, _, _) =>
+        val msg = s"Unable to deserialize task $taskId, agentInfo=$agentInfo, reservation=$reservationOpt," +
+          s"reservedState=$reservedStateOpt, launched=$launchedOpt"
+        throw new SerializationFailedException(msg)
+    }
+  }
+
+  def toProto(task: Task): Protos.MarathonTask = {
     val builder = Protos.MarathonTask.newBuilder()
 
-    builder.setId(taskState.taskId.idString)
-
-    import taskState.agentInfo
-    builder.setHost(agentInfo.host)
-    agentInfo.agentId.foreach { agentId =>
-      builder.setSlaveId(MesosProtos.SlaveID.newBuilder().setValue(agentId))
+    def setId(taskId: Task.Id): Unit = builder.setId(taskId.idString)
+    def setAgentInfo(agentInfo: Task.AgentInfo): Unit = {
+      builder.setHost(agentInfo.host)
+      agentInfo.agentId.foreach { agentId =>
+        builder.setSlaveId(MesosProtos.SlaveID.newBuilder().setValue(agentId))
+      }
+      builder.addAllAttributes(agentInfo.attributes.asJava)
     }
-    builder.addAllAttributes(agentInfo.attributes.asJava)
-
-    taskState.reservationWithVolumes.foreach {
-      reservation =>
-        builder.setReservationWithVolumes(
-          Protos.MarathonTask.ReservationWithVolumes.newBuilder()
-            .addAllLocalVolumeIds(reservation.volumeIds.map(_.idString).asJava)
-            .build())
+    def setReservation(reservation: Task.ReservationWithVolumes): Unit = {
+      builder.setReservation(
+        Protos.MarathonTask.Reservation.newBuilder()
+          .addAllLocalVolumeIds(reservation.volumeIds.map(_.idString).asJava)
+          .build())
     }
-
-    taskState.launched.foreach { launchedTask =>
-      builder.setVersion(launchedTask.appVersion.toString)
-      builder.setStagedAt(launchedTask.status.stagedAt.toDateTime.getMillis)
-      launchedTask.status.startedAt.foreach(startedAt => builder.setStartedAt(startedAt.toDateTime.getMillis))
-      launchedTask.status.mesosStatus.foreach(status => builder.setStatus(status))
-      launchedTask.networking match {
+    def setReservedState(state: Task.Reserved.State): Unit = {
+      builder.setReservedState(ReservedStateSerializer.toProto(state))
+    }
+    def setLaunched(appVersion: Timestamp, status: Task.Status, networking: Task.Networking): Unit = {
+      builder.setVersion(appVersion.toString)
+      builder.setStagedAt(status.stagedAt.toDateTime.getMillis)
+      status.startedAt.foreach(startedAt => builder.setStartedAt(startedAt.toDateTime.getMillis))
+      status.mesosStatus.foreach(status => builder.setStatus(status))
+      networking match {
         case Task.HostPorts(hostPorts) =>
           builder.addAllPorts(hostPorts.view.map(Integer.valueOf(_)).asJava)
         case Task.NetworkInfoList(networkInfoList) =>
           builder.addAllNetworks(networkInfoList.asJava)
         case Task.NoNetworking => // nothing
       }
+    }
 
+    setId(task.taskId)
+    setAgentInfo(task.agentInfo)
+
+    task match {
+      case launched: Task.LaunchedEphemeral =>
+        setLaunched(launched.appVersion, launched.status, launched.networking)
+
+      case reserved: Task.Reserved =>
+        setReservation(reserved.reservation)
+        setReservedState(reserved.state)
+
+      case launchedOnR: Task.LaunchedOnReservation =>
+        setLaunched(launchedOnR.appVersion, launchedOnR.status, launchedOnR.networking)
+        setReservation(launchedOnR.reservation)
     }
 
     builder.build()
   }
+}
 
+object ReservedStateSerializer {
+
+  object TimeoutSerializer {
+    def fromProto(proto: Protos.MarathonTask.ReservedState.Timeout): Task.Reserved.Timeout = {
+      val reason: Task.Reserved.Timeout.Reason = proto.getReason match {
+        case Protos.MarathonTask.ReservedState.Timeout.Reason.RelaunchEscalationTimeout =>
+          Task.Reserved.Timeout.Reason.RelaunchEscalationTimeout
+        case Protos.MarathonTask.ReservedState.Timeout.Reason.ReservationTimeout =>
+          Task.Reserved.Timeout.Reason.ReservationTimeout
+        case _ => throw new SerializationFailedException(s"Unable to parse ${proto.getReason}")
+      }
+
+      Task.Reserved.Timeout(
+        Timestamp(proto.getInitiated),
+        Timestamp(proto.getDeadline),
+        reason
+      )
+    }
+
+    def toProto(timeout: Task.Reserved.Timeout): Protos.MarathonTask.ReservedState.Timeout = {
+      val reason = timeout.reason match {
+        case Task.Reserved.Timeout.Reason.RelaunchEscalationTimeout =>
+          Protos.MarathonTask.ReservedState.Timeout.Reason.RelaunchEscalationTimeout
+        case Task.Reserved.Timeout.Reason.ReservationTimeout =>
+          Protos.MarathonTask.ReservedState.Timeout.Reason.ReservationTimeout
+      }
+      Protos.MarathonTask.ReservedState.Timeout.newBuilder()
+        .setInitiated(timeout.initiated.toDateTime.getMillis)
+        .setDeadline(timeout.deadline.toDateTime.getMillis)
+        .setReason(reason)
+        .build()
+    }
+  }
+
+  def fromProto(proto: Protos.MarathonTask.ReservedState): Task.Reserved.State = {
+    val timeout = if (proto.hasTimeout) Some(TimeoutSerializer.fromProto(proto.getTimeout)) else None
+    proto.getType match {
+      case Protos.MarathonTask.ReservedState.Type.New => Task.Reserved.State.New(timeout)
+      case Protos.MarathonTask.ReservedState.Type.Suspended => Task.Reserved.State.Suspended(timeout)
+      case Protos.MarathonTask.ReservedState.Type.Garbage => Task.Reserved.State.Garbage(timeout)
+      case Protos.MarathonTask.ReservedState.Type.Unknown => Task.Reserved.State.Unknown(timeout)
+      case _ => throw new SerializationFailedException(s"Unable to parse ${proto.getType}")
+    }
+  }
+
+  def toProto(state: Task.Reserved.State): Protos.MarathonTask.ReservedState = {
+    val builder = Protos.MarathonTask.ReservedState.newBuilder()
+    val stateType = state match {
+      case Task.Reserved.State.New(_)       => Protos.MarathonTask.ReservedState.Type.New
+      case Task.Reserved.State.Suspended(_) => Protos.MarathonTask.ReservedState.Type.Suspended
+      case Task.Reserved.State.Garbage(_)   => Protos.MarathonTask.ReservedState.Type.Garbage
+      case Task.Reserved.State.Unknown(_)   => Protos.MarathonTask.ReservedState.Type.Unknown
+    }
+
+    builder.setType(stateType)
+    state.timeout.foreach { timeout => builder.setTimeout(TimeoutSerializer.toProto(timeout)) }
+
+    builder.build()
+  }
 }

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -11,13 +11,13 @@ import mesosphere.marathon.api.JsonTestHelper
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.launcher.impl.{ TaskLabels, TaskOpFactoryImpl }
 import mesosphere.marathon.core.leadership.LeadershipModule
-import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.Task.{ ReservationWithVolumes, LocalVolumeId }
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
+import mesosphere.marathon.core.task.Task.{ LocalVolumeId, ReservationWithVolumes }
 import mesosphere.marathon.core.task.tracker.impl.TaskSerializer
 import mesosphere.marathon.core.task.tracker.{ TaskTracker, TaskTrackerModule }
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{ PersistentVolumeInfo, PersistentVolume, Volume, Container, Residency, AppDefinition, MarathonStore, MarathonTaskState, PathId, TaskRepository, Timestamp }
+import mesosphere.marathon.state.{ AppDefinition, Container, MarathonStore, MarathonTaskState, PathId, PersistentVolume, PersistentVolumeInfo, Residency, TaskRepository, Timestamp, Volume }
 import mesosphere.mesos.protos.{ FrameworkID, OfferID, Range, RangesResource, Resource, ScalarResource, SlaveID }
 import mesosphere.util.state.PersistentStore
 import mesosphere.util.state.memory.InMemoryStore
@@ -26,12 +26,14 @@ import org.apache.mesos.Protos._
 import org.apache.mesos.{ Protos => Mesos }
 import play.api.libs.json.Json
 
-import scala.util.Random
 import scala.collection.immutable.Seq
+import scala.util.Random
 
 object MarathonTestHelper {
 
   import mesosphere.mesos.protos.Implicits._
+
+  lazy val clock = Clock()
 
   def makeConfig(args: String*): AllConf = {
     val opts = new AllConf(args) {
@@ -165,7 +167,7 @@ object MarathonTestHelper {
 
   def reservedDisk(id: String, size: Double = 4096, role: String = "*",
                    principal: String = "test", containerPath: String = "/container"): Mesos.Resource.Builder = {
-    import Mesos.Resource.{ ReservationInfo, DiskInfo }
+    import Mesos.Resource.{ DiskInfo, ReservationInfo }
     Mesos.Resource.newBuilder()
       .setType(Mesos.Value.Type.SCALAR)
       .setName(Resource.DISK)
@@ -245,22 +247,18 @@ object MarathonTestHelper {
     {
       import scala.collection.JavaConverters._
 
-      Task(
+      Task.LaunchedEphemeral(
         taskId = Task.Id(taskInfo.getTaskId),
         agentInfo = Task.AgentInfo(
           host = offer.getHostname,
           agentId = Some(offer.getSlaveId.getValue),
           attributes = offer.getAttributesList.asScala
         ),
-        launched = Some(
-          Task.Launched(
-            appVersion = version,
-            status = Task.Status(
-              stagedAt = now
-            ),
-            networking = Task.HostPorts(Seq(1, 2, 3))
-          )
-        )
+        appVersion = version,
+        status = Task.Status(
+          stagedAt = now
+        ),
+        networking = Task.HostPorts(Seq(1, 2, 3))
       )
     }
 
@@ -310,7 +308,7 @@ object MarathonTestHelper {
       metrics
     )
 
-    new TaskTrackerModule(Clock(), metrics, defaultConfig(), leadershipModule, taskRepo) {
+    new TaskTrackerModule(clock, metrics, defaultConfig(), leadershipModule, taskRepo) {
       // some tests create only one actor system but create multiple task trackers
       override protected lazy val taskTrackerActorName: String = s"taskTracker_${Random.alphanumeric.take(10).mkString}"
     }
@@ -326,6 +324,7 @@ object MarathonTestHelper {
 
   def dummyTaskBuilder(appId: PathId) = MarathonTask.newBuilder()
     .setId(Task.Id.forApp(appId).idString)
+    .setStagedAt(0)
     .setHost("host.some")
 
   def dummyTaskProto(appId: PathId) = dummyTaskBuilder(appId).build()
@@ -336,12 +335,39 @@ object MarathonTestHelper {
 
   def mininimalTask(appId: PathId): Task = mininimalTask(Task.Id.forApp(appId).idString)
   def mininimalTask(taskId: Task.Id): Task = mininimalTask(taskId.idString)
-  def mininimalTask(taskId: String): Task = {
-    Task(
+  def mininimalTask(taskId: String, now: Timestamp = clock.now()): Task = {
+    Task.LaunchedEphemeral(
       Task.Id(taskId),
       Task.AgentInfo(host = "host.some", agentId = None, attributes = Iterable.empty),
-      reservationWithVolumes = None,
-      launched = None
+      appVersion = now,
+      status = Task.Status(
+        stagedAt = now,
+        startedAt = None,
+        mesosStatus = None
+      ),
+      networking = Task.NoNetworking
+    )
+  }
+
+  def minimalReservedTask(appId: PathId, reservation: ReservationWithVolumes): Task =
+    Task.Reserved(
+      taskId = Task.Id.forApp(appId),
+      Task.AgentInfo(host = "host.some", agentId = None, attributes = Iterable.empty),
+      state = Task.Reserved.State.New(timeout = None),
+      reservation = reservation)
+
+  def mininimalLaunchedTask(taskId: String): Task.LaunchedEphemeral = {
+    val now = Timestamp.now()
+    Task.LaunchedEphemeral(
+      Task.Id(taskId),
+      Task.AgentInfo(host = "host.some", agentId = None, attributes = Iterable.empty),
+      appVersion = now,
+      status = Task.Status(
+        stagedAt = now,
+        startedAt = None,
+        mesosStatus = None
+      ),
+      networking = Task.NoNetworking
     )
   }
 
@@ -352,6 +378,11 @@ object MarathonTestHelper {
   def taskLaunched: Task.Launched = {
     val now = Timestamp.now()
     Task.Launched(now, status = Task.Status(now), networking = Task.NoNetworking)
+  }
+
+  def taskLaunchedOp: TaskStateOp.Launch = {
+    val now = Timestamp.now()
+    TaskStateOp.Launch(now, Task.Status(now), Task.NoNetworking)
   }
 
   def startingTaskForApp(appId: PathId, appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task =
@@ -377,8 +408,22 @@ object MarathonTestHelper {
   def stagedTaskForApp(
     appId: PathId = PathId("/test"), appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task =
     stagedTask(Task.Id.forApp(appId).idString, appVersion = appVersion, stagedAt = stagedAt)
-  def stagedTask(taskId: String, appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task =
-    TaskSerializer.fromProto(stagedTaskProto(taskId, appVersion = appVersion, stagedAt = stagedAt))
+  def stagedTask(
+    taskId: String,
+    appVersion: Timestamp = Timestamp(1),
+    stagedAt: Long = 2,
+    mesosStatus: Option[Mesos.TaskStatus] = None): Task.LaunchedEphemeral =
+    Task.LaunchedEphemeral(
+      Task.Id(taskId),
+      Task.AgentInfo("some.host", Some("agent-1"), Iterable.empty),
+      appVersion,
+      Task.Status(
+        stagedAt = Timestamp(stagedAt),
+        startedAt = None,
+        mesosStatus = Some(statusForState(taskId, Mesos.TaskState.TASK_STAGING))
+      ),
+      Task.NoNetworking
+    )
 
   def stagedTaskProto(appId: PathId): Protos.MarathonTask = stagedTaskProto(Task.Id.forApp(appId).idString)
   def stagedTaskProto(taskId: String, appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Protos.MarathonTask = {
@@ -493,8 +538,23 @@ object MarathonTestHelper {
     )
   }
 
-  def residentReservedTask(appId: PathId, localVolumeIds: LocalVolumeId*) = mininimalTask(appId)
-    .copy(reservationWithVolumes = Some(ReservationWithVolumes(localVolumeIds)))
+  def residentReservedTask(appId: PathId, localVolumeIds: LocalVolumeId*) =
+    minimalReservedTask(appId, ReservationWithVolumes(localVolumeIds))
+
+  def residentLaunchedTask(appId: PathId, localVolumeIds: LocalVolumeId*) = {
+    val now = Timestamp.now()
+    Task.LaunchedOnReservation(
+      taskId = Task.Id.forApp(appId),
+      agentInfo = Task.AgentInfo(host = "host.some", agentId = None, attributes = Iterable.empty),
+      appVersion = now,
+      status = Task.Status(
+        stagedAt = now,
+        startedAt = None,
+        mesosStatus = None
+      ),
+      networking = Task.NoNetworking,
+      reservation = ReservationWithVolumes(localVolumeIds))
+  }
 
   def mesosContainerWithPersistentVolume = Container(
     `type` = Mesos.ContainerInfo.Type.MESOS,
@@ -507,5 +567,44 @@ object MarathonTestHelper {
     ),
     docker = None
   )
+
+  def addNetworking(task: Task, networking: Task.Networking): Task = task match {
+    case launchedEphemeral: Task.LaunchedEphemeral         => launchedEphemeral.copy(networking = networking)
+    case launchedOnReservation: Task.LaunchedOnReservation => launchedOnReservation.copy(networking = networking)
+    case reserved: Task.Reserved                           => throw new scala.RuntimeException("Reserved task cannot have networking")
+  }
+
+  object Implicits {
+    implicit class TaskImprovements(task: Task) {
+      def withAgentInfo(update: Task.AgentInfo => Task.AgentInfo): Task = task match {
+        case launchedEphemeral: Task.LaunchedEphemeral =>
+          launchedEphemeral.copy(agentInfo = update(launchedEphemeral.agentInfo))
+
+        case reserved: Task.Reserved =>
+          reserved.copy(agentInfo = update(reserved.agentInfo))
+
+        case launchedOnReservation: Task.LaunchedOnReservation =>
+          launchedOnReservation.copy(agentInfo = update(launchedOnReservation.agentInfo))
+      }
+
+      def withNetworking(update: Task.Networking): Task = task match {
+        case launchedEphemeral: Task.LaunchedEphemeral         => launchedEphemeral.copy(networking = update)
+        case launchedOnReservation: Task.LaunchedOnReservation => launchedOnReservation.copy(networking = update)
+        case reserved: Task.Reserved                           => throw new scala.RuntimeException("Reserved task cannot have networking")
+      }
+
+      def withStatus(update: Task.Status => Task.Status): Task = task match {
+        case launchedEphemeral: Task.LaunchedEphemeral =>
+          launchedEphemeral.copy(status = update(launchedEphemeral.status))
+
+        case launchedOnReservation: Task.LaunchedOnReservation =>
+          launchedOnReservation.copy(status = update(launchedOnReservation.status))
+
+        case reserved: Task.Reserved =>
+          throw new scala.RuntimeException("Reserved task cannot have a status")
+      }
+
+    }
+  }
 
 }

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -60,6 +60,7 @@ class SchedulerActionsTest extends MarathonActorSupport with MarathonSpec with M
 
     val stagedTask = MarathonTestHelper.stagedTask("task_2")
 
+    import MarathonTestHelper.Implicits._
     val stagedTaskWithSlaveId =
       MarathonTestHelper.stagedTask("task_3")
         .withAgentInfo(_.copy(agentId = Some("slave 1")))

--- a/src/test/scala/mesosphere/marathon/api/v2/AppTasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppTasksResourceTest.scala
@@ -39,6 +39,7 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
   }
 
   test("deleteOne") {
+    import MarathonTestHelper.Implicits._
     val appId = PathId("/my/app")
     val slaveId = SlaveID("some slave ID")
     val task1 = MarathonTestHelper.mininimalTask(appId).withAgentInfo(_.copy(agentId = Some(slaveId.value)))

--- a/src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
@@ -1,9 +1,8 @@
 package mesosphere.marathon.api.v2.json
 
-import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec }
 import mesosphere.marathon.api.JsonTestHelper
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.Task.{ LaunchedOnReservation, NetworkInfoList, NoNetworking, ReservationWithVolumes }
 import mesosphere.marathon.state.Timestamp
 import org.apache.mesos.{ Protos => MesosProtos }
 
@@ -22,22 +21,24 @@ class MarathonTaskFormatTest extends MarathonSpec {
       agentInfo = Task.AgentInfo("agent1.mesos", Some("abcd-1234"), Iterable.empty),
       appVersion = time,
       status = Task.Status(time, None),
-      networking = NoNetworking)
+      networking = Task.NoNetworking)
 
     val taskWithMultipleIPs = new Task.LaunchedEphemeral(
       taskId = Task.Id("/foo/bar"),
       agentInfo = Task.AgentInfo("agent1.mesos", Some("abcd-1234"), Iterable.empty),
       appVersion = time,
       status = Task.Status(time, None),
-      networking = NetworkInfoList(network))
+      networking = Task.NetworkInfoList(network))
 
-    val taskWithLocalVolumes = new LaunchedOnReservation(
+    val taskWithLocalVolumes = new Task.LaunchedOnReservation(
       taskId = Task.Id("/foo/bar"),
       agentInfo = Task.AgentInfo("agent1.mesos", Some("abcd-1234"), Iterable.empty),
       appVersion = time,
       status = Task.Status(time, Some(time)),
-      networking = NoNetworking,
-      reservation = ReservationWithVolumes(Seq(Task.LocalVolumeId.unapply("appid#container#random")).flatten))
+      networking = Task.NoNetworking,
+      reservation = Task.Reservation(
+        Seq(Task.LocalVolumeId.unapply("appid#container#random")).flatten,
+        MarathonTestHelper.taskReservationStateNew))
   }
 
   test("JSON serialization of a Task without IPs") {

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
@@ -16,12 +16,11 @@ class TaskCountsTest extends MarathonSpec with GivenWhenThen with Mockito with M
   }
 
   test("one task without explicit task state is treated as staged task") {
+    val f = new Fixture
     Given("one unstaged task")
-    val oneTaskWithoutTaskState = Seq(
-      MarathonTestHelper.stagedTask("task1").withLaunched(_.withStatus(_.copy(mesosStatus = None)))
-    )
+    val oneTaskWithoutTaskState = f.taskWithoutState
     When("getting counts")
-    val counts = TaskCounts(appTasks = oneTaskWithoutTaskState, healthStatuses = Map.empty)
+    val counts = TaskCounts(appTasks = Seq(oneTaskWithoutTaskState), healthStatuses = Map.empty)
     Then("the task without taskState is counted as staged")
     counts should be(TaskCounts.zero.copy(tasksStaged = 1))
   }
@@ -171,4 +170,19 @@ class TaskCountsTest extends MarathonSpec with GivenWhenThen with Mockito with M
   private[this] val notAliveHealth = Seq(Health(Task.Id("task1"), lastFailure = Some(Timestamp(1))))
   require(notAliveHealth.forall(!_.alive))
   private[this] val mixedHealth = aliveHealth ++ notAliveHealth
+}
+
+class Fixture {
+  val taskWithoutState = Task.LaunchedEphemeral(
+    Task.Id("task1"),
+    Task.AgentInfo("some.host", Some("agent-1"), Iterable.empty),
+    appVersion = Timestamp(0),
+    Task.Status(
+      stagedAt = Timestamp(1),
+      startedAt = None,
+      mesosStatus = None
+    ),
+    Task.NoNetworking
+  )
+
 }

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -86,7 +86,7 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
 
     Then("we get a tasks object in the appInfo")
     appInfo.maybeTasks should not be empty
-    appInfo.maybeTasks.get.map(_.appId.toString) should have size (3)
+    appInfo.maybeTasks.get.map(_.appId.toString) should have size 3
     appInfo.maybeTasks.get.map(_.task.taskId.idString).toSet should be (Set("task1", "task2", "task3"))
 
     appInfo should be(AppInfo(app, maybeTasks = Some(
@@ -235,7 +235,7 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
     Given("one staged and two running tasks in the taskTracker")
     val staged = MarathonTestHelper.stagedTask("task1", stagedAt = (f.clock.now() - 10.seconds).toDateTime.getMillis)
     val running = MarathonTestHelper.runningTask("task2", stagedAt = (f.clock.now() - 11.seconds).toDateTime.getMillis)
-    val running2 = running.copy(taskId = Task.Id("task3"))
+    val running2 = MarathonTestHelper.runningTask("task3", stagedAt = (f.clock.now() - 11.seconds).toDateTime.getMillis)
 
     import scala.concurrent.ExecutionContext.Implicits.global
     val tasks: Set[Task] = Set(staged, running, running2)

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
@@ -363,7 +363,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
   private[this] val app = AppDefinition(id = PathId("/testapp"))
   private[this] val taskId = Task.Id.forApp(app.id)
   private[this] val task = MarathonTestHelper.makeOneCPUTask(taskId.idString).build()
-  private[this] val marathonTask = MarathonTestHelper.mininimalLaunchedTask(task.getTaskId.getValue).copy(
+  private[this] val marathonTask = MarathonTestHelper.mininimalTask(task.getTaskId.getValue).copy(
     appVersion = app.version, status = Task.Status(app.version, None, None), networking = Task.NoNetworking)
 
   private[this] implicit val timeout: Timeout = 3.seconds

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
@@ -363,8 +363,8 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
   private[this] val app = AppDefinition(id = PathId("/testapp"))
   private[this] val taskId = Task.Id.forApp(app.id)
   private[this] val task = MarathonTestHelper.makeOneCPUTask(taskId.idString).build()
-  private[this] val marathonTask = MarathonTestHelper.mininimalTask(task.getTaskId.getValue).copy(
-    launched = Some(Task.Launched(app.version, Task.Status(app.version, None, None), Task.NoNetworking)))
+  private[this] val marathonTask = MarathonTestHelper.mininimalLaunchedTask(task.getTaskId.getValue).copy(
+    appVersion = app.version, status = Task.Status(app.version, None, None), networking = Task.NoNetworking)
 
   private[this] implicit val timeout: Timeout = 3.seconds
   private[this] implicit var actorSystem: ActorSystem = _

--- a/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
@@ -33,6 +33,8 @@ class TaskTest extends FunSuite with Mockito with GivenWhenThen with Matchers {
 
     val host: String = "agent1.mesos"
 
+    import MarathonTestHelper.Implicits._
+
     val taskWithoutIp =
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
@@ -42,31 +44,31 @@ class TaskTest extends FunSuite with Mockito with GivenWhenThen with Matchers {
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
         .withAgentInfo(_.copy(host = host))
-        .withLaunched(_.copy(networking = Task.NetworkInfoList(networkWithOneIp1)))
+        .withNetworking(Task.NetworkInfoList(networkWithOneIp1))
 
     val taskWithMultipleNetworksAndOneIp =
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
         .withAgentInfo(_.copy(host = host))
-        .withLaunched(_.copy(networking = Task.NetworkInfoList(networkWithoutIp, networkWithOneIp1)))
+        .withNetworking(Task.NetworkInfoList(networkWithoutIp, networkWithOneIp1))
 
     val taskWithMultipleNetworkAndNoIp =
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
         .withAgentInfo(_.copy(host = host))
-        .withLaunched(_.copy(networking = Task.NetworkInfoList(networkWithoutIp, networkWithoutIp)))
+        .withNetworking(Task.NetworkInfoList(networkWithoutIp, networkWithoutIp))
 
     val taskWithOneNetworkAndMultipleIPs =
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
         .withAgentInfo(_.copy(host = host))
-        .withLaunched(_.copy(networking = Task.NetworkInfoList(networkWithMultipleIps)))
+        .withNetworking(Task.NetworkInfoList(networkWithMultipleIps))
 
     val taskWithMultipleNetworkAndMultipleIPs =
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
         .withAgentInfo(_.copy(host = host))
-        .withLaunched(_.copy(networking = Task.NetworkInfoList(networkWithOneIp1, networkWithOneIp2)))
+        .withNetworking(Task.NetworkInfoList(networkWithOneIp1, networkWithOneIp2))
   }
 
   test("effectiveIpAddress returns the agent address for MarathonTask instances without their own IP addresses") {

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImplTest.scala
@@ -333,7 +333,7 @@ class TaskOpProcessorImplTest
     val now = Timestamp.now()
     val f = new Fixture
     val appId = PathId("/app")
-    val unlaunched: Task = minimalReservedTask(appId, taskReservation)
+    val unlaunched: Task = minimalReservedTask(appId, newReservation)
     val launched: Task = f.toLaunched(unlaunched, taskLaunchedOp)
     val marathonTask = unlaunched.marathonTask
     val taskId = launched.taskId.mesosTaskId.getValue

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializerTest.scala
@@ -1,9 +1,10 @@
 package mesosphere.marathon.core.task.tracker.impl
 
+import mesosphere.marathon.{ SerializationFailedException, MarathonTestHelper }
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.Task.{ ReservationWithVolumes, LocalVolumeId, Id }
-import mesosphere.marathon.state.{ PathId, Volume, Timestamp }
+import mesosphere.marathon.core.task.Task.LocalVolumeId
+import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.test.Mockito
 import org.apache.mesos.Protos.{ Attribute, TaskStatus }
 import org.apache.mesos.{ Protos => MesosProtos }
@@ -11,21 +12,22 @@ import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 
 class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenWhenThen {
   import scala.collection.JavaConverters._
+  val f = new Fixture
 
   test("minimal marathonTask => Task") {
     Given("a minimal MarathonTask")
-    val marathonTask = MarathonTask.newBuilder().setId("task").setHost(sampleHost).build()
+    val now = MarathonTestHelper.clock.now()
+    val marathonTask = MarathonTask.newBuilder()
+      .setId("task")
+      .setVersion(now.toString)
+      .setStagedAt(now.toDateTime.getMillis)
+      .setHost(f.sampleHost).build()
 
     When("we convert it to task")
     val taskState = TaskSerializer.fromProto(marathonTask)
 
     Then("we get a minimal task State")
-    val expectedState = Task(
-      taskId,
-      Task.AgentInfo(host = sampleHost, agentId = None, attributes = Iterable.empty),
-      reservationWithVolumes = None,
-      launched = None
-    )
+    val expectedState = MarathonTestHelper.mininimalTask(f.taskId.idString, now)
 
     taskState should be(expectedState)
 
@@ -37,14 +39,16 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
   }
 
   test("full marathonTask with no networking => Task") {
+    val f = new Fixture
+
     Given("a MarathonTask with all fields and host ports")
-    val marathonTask = completeTask
+    val marathonTask = f.completeTask
 
     When("we convert it to task")
     val taskState = TaskSerializer.fromProto(marathonTask)
 
     Then("we get the expected task state")
-    val expectedState = fullSampleTaskStateWithoutNetworking
+    val expectedState = f.fullSampleTaskStateWithoutNetworking
 
     taskState should be(expectedState)
 
@@ -56,10 +60,12 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
   }
 
   test("full marathonTask with host ports => Task") {
+    val f = new Fixture
+
     Given("a MarathonTask with all fields and host ports")
     val samplePorts = Iterable(80, 81)
     val marathonTask =
-      completeTask.toBuilder
+      f.completeTask.toBuilder
         .addAllPorts(samplePorts.map(Integer.valueOf(_)).asJava)
         .build()
 
@@ -67,11 +73,8 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
     val taskState = TaskSerializer.fromProto(marathonTask)
 
     Then("we get the expected task state")
-    val expectedState = fullSampleTaskStateWithoutNetworking.copy(
-      launched = fullSampleTaskStateWithoutNetworking.launched.map(
-        _.copy(networking = Task.HostPorts(samplePorts)
-        ))
-    )
+    val expectedState = f.fullSampleTaskStateWithoutNetworking.copy(
+      networking = Task.HostPorts(samplePorts))
 
     taskState should be(expectedState)
 
@@ -83,11 +86,12 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
   }
 
   test("full marathonTask with NetworkInfoList => Task") {
+    val f = new Fixture
+
     Given("a MarathonTask with all fields and host ports")
-    val samplePorts = Iterable(80, 81)
     val marathonTask =
-      completeTask.toBuilder
-        .addAllNetworks(sampleNetworks.asJava)
+      f.completeTask.toBuilder
+        .addAllNetworks(f.sampleNetworks.asJava)
         .build()
 
     When("we convert it to task")
@@ -95,11 +99,8 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
     val taskState = TaskSerializer.fromProto(marathonTask)
 
     Then("we get the expected task state")
-    val expectedState = fullSampleTaskStateWithoutNetworking.copy(
-      launched = fullSampleTaskStateWithoutNetworking.launched.map(
-        _.copy(networking = Task.NetworkInfoList(sampleNetworks)
-        ))
-    )
+    val expectedState = f.fullSampleTaskStateWithoutNetworking.copy(
+      networking = Task.NetworkInfoList(f.sampleNetworks))
 
     taskState should be(expectedState)
 
@@ -110,58 +111,247 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
     marathonTask2 should equal(marathonTask)
   }
 
-  private[this] val appId = PathId.fromSafePath("/test")
-  private[this] val taskId = Task.Id("task")
-  private[this] val sampleHost: String = "somehost"
-  private[this] val sampleAttributes: Iterable[Attribute] = Iterable(attribute("label1", "value1"))
-  private[this] val stagedAtLong: Long = 1
-  private[this] val startedAtLong: Long = 2
-  private[this] val appVersion: Timestamp = Timestamp(3)
-  private[this] val sampleTaskStatus: TaskStatus =
-    MesosProtos.TaskStatus.newBuilder()
-      .setTaskId(MesosProtos.TaskID.newBuilder().setValue(taskId.idString))
-      .setState(MesosProtos.TaskState.TASK_RUNNING)
-      .build()
-  private[this] val sampleSlaveId: MesosProtos.SlaveID.Builder = MesosProtos.SlaveID.newBuilder().setValue("slaveId")
-  private[this] val sampleNetworks: Iterable[MesosProtos.NetworkInfo] =
-    Iterable(
-      MesosProtos.NetworkInfo.newBuilder()
-        .addIpAddresses(MesosProtos.NetworkInfo.IPAddress.newBuilder().setIpAddress("1.2.3.4"))
+  test("Reserved <=> Proto") {
+    val f = new Fixture
+
+    Given("a reserved task")
+    val proto = f.Resident.reservedProto
+
+    When("We convert it to a task")
+    val taskState = TaskSerializer.fromProto(proto)
+
+    Then("We get a correct representation")
+    taskState should equal (f.Resident.reservedState)
+
+    When("We serialize it again")
+    val serialized = TaskSerializer.toProto(taskState)
+
+    Then("We get the original state back")
+    serialized should equal(proto)
+  }
+
+  test("LaunchedOnReservation <=> Proto") {
+    val f = new Fixture
+
+    Given("a LaunchedOnReservation proto")
+    val proto = f.Resident.launchedOnReservationProto
+
+    When("We convert it to a task")
+    val taskState = TaskSerializer.fromProto(proto)
+
+    Then("We get a correct representation")
+    taskState should equal (f.Resident.launchedOnReservationState)
+
+    When("We serialize it again")
+    val serialized = TaskSerializer.toProto(taskState)
+
+    Then("We get the original state back")
+    serialized should equal(proto)
+  }
+
+  test("Failure case: LaunchedOnReservation has ReservedState") {
+    val f = new Fixture
+
+    Given("a LaunchedOnReservation proto with a reservedState")
+    val proto = f.Resident.launchedOnReservationProtoWithReservedState
+
+    When("We convert it to a task")
+    val error = intercept[SerializationFailedException] {
+      TaskSerializer.fromProto(proto)
+    }
+
+    Then("We get a SerializationFailedException")
+    error.message should startWith("Unable to deserialize")
+  }
+
+  test("Failure case: LaunchedEphemeral has ReservedState") {
+    val f = new Fixture
+
+    Given("a LaunchedEphemeral proto with a reservedState")
+    val proto = f.Resident.launchedEphemeralWithReservedState
+
+    When("We convert it to a task")
+    val error = intercept[SerializationFailedException] {
+      TaskSerializer.fromProto(proto)
+    }
+
+    Then("We get a SerializationFailedException")
+    error.message should startWith("Unable to deserialize")
+  }
+
+  test("Failure case: Reserved has no Reservation") {
+    val f = new Fixture
+
+    Given("a Reserved proto missing reservation")
+    val proto = f.Resident.reservedProtoWithoutReservation
+
+    When("We convert it to a task")
+    val error = intercept[SerializationFailedException] {
+      TaskSerializer.fromProto(proto)
+    }
+
+    Then("We get a SerializationFailedException")
+    error.message should startWith("Unable to deserialize")
+  }
+
+  test("Failure case: Reserved has no ReservedState") {
+    val f = new Fixture
+
+    Given("a Reserved proto missing reserved state")
+    val proto = f.Resident.reservedProtoWithoutReservedState
+
+    When("We convert it to a task")
+    val error = intercept[SerializationFailedException] {
+      TaskSerializer.fromProto(proto)
+    }
+
+    Then("We get a SerializationFailedException")
+    error.message should startWith("Unable to deserialize")
+  }
+
+  class Fixture {
+    private[this] val appId = PathId.fromSafePath("/test")
+    val taskId = Task.Id("task")
+    val sampleHost: String = "host.some"
+    private[this] val sampleAttributes: Iterable[Attribute] = Iterable(attribute("label1", "value1"))
+    private[this] val stagedAtLong: Long = 1
+    private[this] val startedAtLong: Long = 2
+    private[this] val appVersion: Timestamp = Timestamp(3)
+    private[this] val sampleTaskStatus: TaskStatus =
+      MesosProtos.TaskStatus.newBuilder()
+        .setTaskId(MesosProtos.TaskID.newBuilder().setValue(taskId.idString))
+        .setState(MesosProtos.TaskState.TASK_RUNNING)
         .build()
-    )
-  private[this] val fullSampleTaskStateWithoutNetworking: Task = Task(
-    taskId,
-    Task.AgentInfo(host = sampleHost, agentId = Some(sampleSlaveId.getValue), attributes = sampleAttributes),
-    reservationWithVolumes = Some(Task.ReservationWithVolumes(Seq(LocalVolumeId(appId, "my-volume", "uuid-123")))),
-    launched = Some(
-      Task.Launched(
+    private[this] val sampleSlaveId: MesosProtos.SlaveID.Builder = MesosProtos.SlaveID.newBuilder().setValue("slaveId")
+    val sampleNetworks: Iterable[MesosProtos.NetworkInfo] =
+      Iterable(
+        MesosProtos.NetworkInfo.newBuilder()
+          .addIpAddresses(MesosProtos.NetworkInfo.IPAddress.newBuilder().setIpAddress("1.2.3.4"))
+          .build()
+      )
+    val fullSampleTaskStateWithoutNetworking: Task.LaunchedOnReservation =
+      Task.LaunchedOnReservation(
+        taskId,
+        Task.AgentInfo(host = sampleHost, agentId = Some(sampleSlaveId.getValue), attributes = sampleAttributes),
         appVersion = appVersion,
         status = Task.Status(
           stagedAt = Timestamp(stagedAtLong),
           startedAt = Some(Timestamp(startedAtLong)),
           mesosStatus = Some(sampleTaskStatus)
         ),
-        networking = Task.NoNetworking
+        networking = Task.NoNetworking,
+        reservation = Task.ReservationWithVolumes(Seq(LocalVolumeId(appId, "my-volume", "uuid-123")))
       )
-    )
-  )
-  private[this] val completeTask =
-    MarathonTask
-      .newBuilder()
-      .setId(taskId.idString)
-      .setHost(sampleHost)
-      .addAllAttributes(sampleAttributes.asJava)
-      .setStagedAt(stagedAtLong)
-      .setStartedAt(startedAtLong)
-      .setVersion(appVersion.toString)
-      .setStatus(sampleTaskStatus)
-      .setSlaveId(sampleSlaveId)
-      .setReservationWithVolumes(MarathonTask.ReservationWithVolumes.newBuilder.addLocalVolumeIds(
-        LocalVolumeId(appId, "my-volume", "uuid-123").idString))
-      .build()
 
-  private[this] def attribute(name: String, textValue: String): MesosProtos.Attribute = {
-    val text = MesosProtos.Value.Text.newBuilder().setValue(textValue)
-    MesosProtos.Attribute.newBuilder().setName(name).setType(MesosProtos.Value.Type.TEXT).setText(text).build()
+    val completeTask =
+      MarathonTask
+        .newBuilder()
+        .setId(taskId.idString)
+        .setHost(sampleHost)
+        .addAllAttributes(sampleAttributes.asJava)
+        .setStagedAt(stagedAtLong)
+        .setStartedAt(startedAtLong)
+        .setVersion(appVersion.toString)
+        .setStatus(sampleTaskStatus)
+        .setSlaveId(sampleSlaveId)
+        .setReservation(MarathonTask.Reservation.newBuilder.addLocalVolumeIds(
+          LocalVolumeId(appId, "my-volume", "uuid-123").idString))
+        .build()
+
+    private[this] def attribute(name: String, textValue: String): MesosProtos.Attribute = {
+      val text = MesosProtos.Value.Text.newBuilder().setValue(textValue)
+      MesosProtos.Attribute.newBuilder().setName(name).setType(MesosProtos.Value.Type.TEXT).setText(text).build()
+    }
+
+    object Resident {
+      import scala.collection.JavaConverters._
+      import scala.concurrent.duration._
+
+      private[this] val appId = PathId("/test")
+      private[this] val taskId = Task.Id("reserved1")
+      private[this] val host = "some.host"
+      private[this] val agentId = "agent-1"
+      private[this] val now = MarathonTestHelper.clock.now()
+      private[this] val containerPath = "containerPath"
+      private[this] val uuid = "uuid"
+      private[this] val attributes = Iterable.empty[MesosProtos.Attribute]
+      private[this] val localVolumeIds = Seq(Task.LocalVolumeId(appId, containerPath, uuid))
+      private[this] val stagedAt = now - 1.minute
+      private[this] val startedAt = now - 55.seconds
+      private[this] val mesosStatus = MarathonTestHelper.statusForState(taskId.idString, MesosProtos.TaskState.TASK_RUNNING)
+      private[this] val status = Task.Status(stagedAt, Some(startedAt), Some(mesosStatus))
+      private[this] val hostPorts = Task.HostPorts(Seq(1, 2, 3))
+
+      def reservedProto = MarathonTask.newBuilder()
+        .setId(taskId.idString)
+        .setHost(host)
+        .setSlaveId(MesosProtos.SlaveID.newBuilder().setValue(agentId))
+        .addAllAttributes(attributes.asJava)
+        .setReservedState(MarathonTask.ReservedState.newBuilder()
+          .setType(MarathonTask.ReservedState.Type.New)
+          .setTimeout(MarathonTask.ReservedState.Timeout.newBuilder()
+            .setInitiated(now.toDateTime.getMillis)
+            .setDeadline((now + 1.minute).toDateTime.getMillis)
+            .setReason(MarathonTask.ReservedState.Timeout.Reason.ReservationTimeout)))
+        .setReservation(MarathonTask.Reservation.newBuilder()
+          .addAllLocalVolumeIds(localVolumeIds.map(_.idString).asJava))
+        .build()
+
+      def reservedState = Task.Reserved(
+        Task.Id(taskId.idString),
+        Task.AgentInfo(host = host, agentId = Some(agentId), attributes),
+        state = Task.Reserved.State.New(Some(Task.Reserved.Timeout(
+          initiated = now, deadline = now + 1.minute, reason = Task.Reserved.Timeout.Reason.ReservationTimeout))),
+        reservation = Task.ReservationWithVolumes(localVolumeIds)
+      )
+
+      def launchedEphemeralProto = MarathonTask.newBuilder()
+        .setId(taskId.idString)
+        .setHost(host)
+        .setSlaveId(MesosProtos.SlaveID.newBuilder().setValue(agentId))
+        .addAllAttributes(attributes.asJava)
+        .setVersion(appVersion.toString)
+        .setStagedAt(stagedAt.toDateTime.getMillis)
+        .setStartedAt(startedAt.toDateTime.getMillis)
+        .setStatus(mesosStatus)
+        .addAllPorts(hostPorts.ports.view.map(Integer.valueOf(_)).asJava)
+        .build()
+
+      def launchedOnReservationProto = launchedEphemeralProto.toBuilder
+        .setReservation(MarathonTask.Reservation.newBuilder()
+          .addAllLocalVolumeIds(localVolumeIds.map(_.idString).asJava))
+        .build()
+
+      def launchedOnReservationState = Task.LaunchedOnReservation(
+        taskId,
+        Task.AgentInfo(host = host, agentId = Some(agentId), attributes),
+        appVersion,
+        status,
+        hostPorts,
+        Task.ReservationWithVolumes(localVolumeIds)
+      )
+
+      def launchedOnReservationProtoWithReservedState = launchedOnReservationProto.toBuilder
+        .setReservedState(MarathonTask.ReservedState.newBuilder()
+          .setType(MarathonTask.ReservedState.Type.New)
+          .setTimeout(MarathonTask.ReservedState.Timeout.newBuilder()
+            .setInitiated(now.toDateTime.getMillis)
+            .setDeadline((now + 1.minute).toDateTime.getMillis)
+            .setReason(MarathonTask.ReservedState.Timeout.Reason.ReservationTimeout)))
+        .build()
+
+      def launchedEphemeralWithReservedState = launchedEphemeralProto.toBuilder
+        .setReservedState(MarathonTask.ReservedState.newBuilder()
+          .setType(MarathonTask.ReservedState.Type.New)
+          .setTimeout(MarathonTask.ReservedState.Timeout.newBuilder()
+            .setInitiated(now.toDateTime.getMillis)
+            .setDeadline((now + 1.minute).toDateTime.getMillis)
+            .setReason(MarathonTask.ReservedState.Timeout.Reason.ReservationTimeout)))
+        .build()
+
+      def reservedProtoWithoutReservation = reservedProto.toBuilder.clearReservation().build()
+
+      def reservedProtoWithoutReservedState = reservedProto.toBuilder.clearReservedState().build()
+    }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -64,7 +64,8 @@ class TaskStatusUpdateProcessorImplTest
     Given("an unknown task")
     import scala.concurrent.ExecutionContext.Implicits.global
     f.taskTracker.task(taskId)(global) returns Future.successful(
-      Some(MarathonTestHelper.minimalReservedTask(taskId.appId, Task.ReservationWithVolumes(Iterable.empty)))
+      Some(MarathonTestHelper.minimalReservedTask(
+        taskId.appId, Task.Reservation(Iterable.empty, MarathonTestHelper.taskReservationStateNew)))
     )
 
     When("we process the updated")

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -64,7 +64,7 @@ class TaskStatusUpdateProcessorImplTest
     Given("an unknown task")
     import scala.concurrent.ExecutionContext.Implicits.global
     f.taskTracker.task(taskId)(global) returns Future.successful(
-      Some(MarathonTestHelper.mininimalTask(taskId.idString))
+      Some(MarathonTestHelper.minimalReservedTask(taskId.appId, Task.ReservationWithVolumes(Iterable.empty)))
     )
 
     When("we process the updated")

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/ContinueOnErrorStepTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/ContinueOnErrorStepTest.scala
@@ -15,7 +15,9 @@ class ContinueOnErrorStepTest extends FunSuite with Matchers with GivenWhenThen 
   test("name uses nested name") {
     object nested extends TaskStatusUpdateStep {
       override def name: String = "nested"
-      override def processUpdate(timestamp: Timestamp, task: Task, mesosStatus: TaskStatus): Future[_] = ???
+      override def processUpdate(timestamp: Timestamp, task: Task, mesosStatus: TaskStatus): Future[_] = {
+        throw new scala.RuntimeException("not implemted")
+      }
     }
 
     ContinueOnErrorStep(nested).name should equal ("continueOnError(nested)")

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImplTest.scala
@@ -138,10 +138,11 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
       .setMessage(taskStatusMessage)
       .build()
 
+  import MarathonTestHelper.Implicits._
   private[this] val stagedMarathonTask =
     MarathonTestHelper.stagedTask(taskId.idString, appVersion = version)
       .withAgentInfo(_.copy(host = host))
-      .withLaunched(_.copy(networking = Task.HostPorts(portsList)))
+      .withNetworking(Task.HostPorts(portsList))
 
   class Fixture {
     val eventStream = new EventStream()

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/UpdateTaskTrackerStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/UpdateTaskTrackerStepImplTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 
 import scala.concurrent.Future
+import MarathonTestHelper.Implicits._
 
 class UpdateTaskTrackerStepImplTest extends FunSuite with Matchers with ScalaFutures with Mockito with GivenWhenThen {
   test("name") {
@@ -87,10 +88,10 @@ class UpdateTaskTrackerStepImplTest extends FunSuite with Matchers with ScalaFut
     MarathonTestHelper
       .stagedTask(taskId.idString, appVersion = version)
       .withAgentInfo(_.copy(host = host))
-      .withLaunched(_.copy(networking = Task.HostPorts(portsList)))
+      .withNetworking(Task.HostPorts(portsList))
 
   private[this] val runningMarathonTask =
-    stagedMarathonTask.withLaunched(_.withStatus(_.copy(startedAt = Some(Timestamp(2)))))
+    stagedMarathonTask.withStatus(_.copy(startedAt = Some(Timestamp(2))))
 
   class Fixture {
     lazy val taskUpdater = mock[TaskUpdater]

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -368,8 +368,9 @@ class HealthCheckTest extends MarathonSpec {
   }
 
   test("getPort") {
+    import MarathonTestHelper.Implicits._
     val check = new HealthCheck(port = Some(1234))
-    val task = MarathonTestHelper.runningTask("test_id").withLaunched(_.copy(networking = Task.HostPorts(4321)))
+    val task = MarathonTestHelper.runningTask("test_id").withNetworking(Task.HostPorts(4321))
 
     assert(check.hostPort(task.launched.get).contains(1234))
   }

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.test.MarathonActorSupport
-import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec, Protos }
+import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
 import org.scalatest.Matchers
 
 import scala.concurrent.duration._
@@ -22,6 +22,8 @@ class HealthCheckWorkerActorTest
     with Matchers {
 
   import HealthCheckWorker._
+  import MarathonTestHelper.Implicits._
+
   import scala.concurrent.ExecutionContext.Implicits.global
 
   test("A TCP health check should correctly resolve the hostname") {
@@ -35,7 +37,7 @@ class HealthCheckWorkerActorTest
     val task =
       MarathonTestHelper.runningTask("test_id")
         .withAgentInfo(_.copy(host = InetAddress.getLocalHost.getCanonicalHostName))
-        .withLaunched(_.copy(networking = Task.HostPorts(socketPort)))
+        .withNetworking(Task.HostPorts(socketPort))
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
     val app = AppDefinition(id = "test_id".toPath)
@@ -60,7 +62,7 @@ class HealthCheckWorkerActorTest
     val task =
       MarathonTestHelper.runningTask("test_id")
         .withAgentInfo(_.copy(host = InetAddress.getLocalHost.getCanonicalHostName))
-        .withLaunched(_.copy(networking = Task.HostPorts(socketPort)))
+        .withNetworking(Task.HostPorts(socketPort))
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
     val app = AppDefinition(id = "test_id".toPath)

--- a/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
@@ -172,7 +172,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
 
     def normalApp = MTH.makeBasicApp()
     def residentApp = MTH.appWithPersistentVolume()
-    def normalLaunchedTask(appId: PathId) = MTH.mininimalLaunchedTask(appId.toString)
+    def normalLaunchedTask(appId: PathId) = MTH.mininimalTask(appId.toString)
     def residentReservedTask(appId: PathId, volumeIds: LocalVolumeId*) = MTH.residentReservedTask(appId, volumeIds: _*)
     def residentLaunchedTask(appId: PathId, volumeIds: LocalVolumeId*) = MTH.residentLaunchedTask(appId, volumeIds: _*)
     def offer = MTH.makeBasicOffer().build()

--- a/src/test/scala/mesosphere/marathon/tasks/TaskTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskTrackerImplTest.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon.tasks
 
 import com.codahale.metrics.MetricRegistry
-import com.google.common.collect.Lists
 import mesosphere.FutureTestSupport._
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.impl.TaskSerializer
@@ -18,7 +17,7 @@ import mesosphere.mesos.protos.TextAttribute
 import mesosphere.util.state.PersistentStore
 import mesosphere.util.state.memory.InMemoryStore
 import org.apache.mesos.Protos
-import org.apache.mesos.Protos.{ TaskID, TaskState, TaskStatus }
+import org.apache.mesos.Protos.{ TaskState, TaskStatus }
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{ reset, spy, times, verify }
 import org.scalatest.concurrent.ScalaFutures
@@ -457,10 +456,11 @@ class TaskTrackerImplTest extends MarathonSpec with Matchers with GivenWhenThen 
   }
 
   def makeSampleTask(appId: PathId) = {
+    import MarathonTestHelper.Implicits._
     MarathonTestHelper
       .stagedTaskForApp(appId)
       .withAgentInfo(_.copy(host = "host", attributes = Iterable(TextAttribute("attr1", "bar"))))
-      .withLaunched(_.copy(networking = Task.HostPorts(Iterable(999))))
+      .withNetworking(Task.HostPorts(Iterable(999)))
   }
 
   def makeTaskStatus(id: Task.Id, state: TaskState = TaskState.TASK_RUNNING) = {

--- a/src/test/scala/mesosphere/mesos/ConstraintsTest.scala
+++ b/src/test/scala/mesosphere/mesos/ConstraintsTest.scala
@@ -1,16 +1,17 @@
 package mesosphere.mesos
 
-import mesosphere.marathon.Protos.{ Constraint, MarathonTask }
-import com.google.common.collect.Lists
+import mesosphere.marathon.MarathonTestHelper.Implicits._
+import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.Protos.Constraint.Operator
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.AppDefinition
-import org.scalatest.{ Matchers, GivenWhenThen }
+import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
+import mesosphere.mesos.protos.{ FrameworkID, OfferID, SlaveID, TextAttribute }
+import org.apache.mesos.Protos.{ Attribute, Offer }
+import org.scalatest.{ GivenWhenThen, Matchers }
+
 import scala.collection.JavaConverters._
 import scala.util.Random
-import mesosphere.mesos.protos.{ FrameworkID, SlaveID, OfferID, TextAttribute }
-import org.apache.mesos.Protos.{ Offer, Attribute }
-import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec }
 
 class ConstraintsTest extends MarathonSpec with GivenWhenThen with Matchers {
 
@@ -446,7 +447,7 @@ class ConstraintsTest extends MarathonSpec with GivenWhenThen with Matchers {
     val attributes = attrs.map { case (name, value) => TextAttribute(name, value): Attribute }
     MarathonTestHelper.stagedTask(id)
       .withAgentInfo(_.copy(attributes = attributes))
-      .withLaunched(_.copy(networking = Task.HostPorts(999)))
+      .withNetworking(Task.HostPorts(999))
   }
 
   def makeOffer(hostname: String, attributes: Iterable[Attribute]) = {
@@ -463,7 +464,7 @@ class ConstraintsTest extends MarathonSpec with GivenWhenThen with Matchers {
     MarathonTestHelper
       .runningTask(id)
       .withAgentInfo(_.copy(host = host))
-      .withLaunched(_.copy(networking = Task.HostPorts(999)))
+      .withNetworking(Task.HostPorts(999))
   }
 
   def makeConstraint(field: String, operator: Operator, value: String) = {

--- a/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
@@ -32,9 +32,7 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
     Given("a resident app with persistent volumes and an offer without persistent volumes")
     val app = f.appWithPersistentVolume()
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    val tasks = Seq(f.makeTask(app.id).copy(
-      reservationWithVolumes = Some(ReservationWithVolumes(Seq(LocalVolumeId(app.id, "persistent-volume", "uuid"))))
-    ))
+    val tasks = Seq(f.makeTask(app.id, ReservationWithVolumes(Seq(LocalVolumeId(app.id, "persistent-volume", "uuid")))))
 
     When("We ask for a volume match")
     val matchOpt = PersistentVolumeMatcher.matchVolumes(offer, app, tasks)
@@ -50,9 +48,7 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
     val app = f.appWithPersistentVolume()
     val localVolumeId = LocalVolumeId(app.id, "persistent-volume", "uuid")
     val offer = f.offerWithVolumes(localVolumeId)
-    val tasks = Seq(f.makeTask(app.id).copy(
-      reservationWithVolumes = Some(ReservationWithVolumes(Seq(localVolumeId)))
-    ))
+    val tasks = Seq(f.makeTask(app.id, ReservationWithVolumes(Seq(localVolumeId))))
 
     When("We ask for a volume match")
     val matchOpt = PersistentVolumeMatcher.matchVolumes(offer, app, tasks)
@@ -74,8 +70,8 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
     val localVolumeId3 = LocalVolumeId(app.id, "persistent-volume", "uuid3")
     val offer = f.offerWithVolumes(localVolumeId1, localVolumeId2, localVolumeId3)
     val tasks = Seq(
-      f.makeTask(app.id).copy(reservationWithVolumes = Some(ReservationWithVolumes(Seq(localVolumeId2)))),
-      f.makeTask(app.id).copy(reservationWithVolumes = Some(ReservationWithVolumes(Seq(localVolumeId3))))
+      f.makeTask(app.id, ReservationWithVolumes(Seq(localVolumeId2))),
+      f.makeTask(app.id, ReservationWithVolumes(Seq(localVolumeId3)))
     )
 
     When("We ask for a volume match")
@@ -95,9 +91,7 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
     val app = f.appWithPersistentVolume()
     val localVolumeId = LocalVolumeId(app.id, "persistent-volume", "uuid")
     val offer = f.offerWithVolumes(localVolumeId)
-    val tasks = Seq(f.makeTask(app.id).copy(
-      reservationWithVolumes = Some(ReservationWithVolumes(Seq(LocalVolumeId(app.id, "other-container", "uuid"))))
-    ))
+    val tasks = Seq(f.makeTask(app.id, ReservationWithVolumes(Seq(LocalVolumeId(app.id, "other-container", "uuid")))))
 
     When("We ask for a volume match")
     val matchOpt = PersistentVolumeMatcher.matchVolumes(offer, app, tasks)
@@ -108,6 +102,7 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
 
   class Fixture {
     def makeTask(appId: PathId) = MarathonTestHelper.mininimalTask(appId)
+    def makeTask(appId: PathId, reservation: ReservationWithVolumes) = MarathonTestHelper.minimalReservedTask(appId, reservation)
     def offerWithVolumes(localVolumeIds: LocalVolumeId*) = MarathonTestHelper.offerWithVolumesOnly(localVolumeIds: _*)
     def appWithPersistentVolume(): AppDefinition = MarathonTestHelper.appWithPersistentVolume()
   }

--- a/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
@@ -1,6 +1,6 @@
 package mesosphere.mesos
 
-import mesosphere.marathon.core.task.Task.{ LocalVolumeId, ReservationWithVolumes }
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{ AppDefinition, PathId }
 import mesosphere.marathon.test.Mockito
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
@@ -32,7 +32,8 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
     Given("a resident app with persistent volumes and an offer without persistent volumes")
     val app = f.appWithPersistentVolume()
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    val tasks = Seq(f.makeTask(app.id, ReservationWithVolumes(Seq(LocalVolumeId(app.id, "persistent-volume", "uuid")))))
+    val tasks = Seq(f.makeTask(app.id,
+      Task.Reservation(Seq(Task.LocalVolumeId(app.id, "persistent-volume", "uuid")), f.taskReservationStateNew)))
 
     When("We ask for a volume match")
     val matchOpt = PersistentVolumeMatcher.matchVolumes(offer, app, tasks)
@@ -46,9 +47,9 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
 
     Given("a resident app with persistent volumes and an offer with matching persistent volumes")
     val app = f.appWithPersistentVolume()
-    val localVolumeId = LocalVolumeId(app.id, "persistent-volume", "uuid")
+    val localVolumeId = Task.LocalVolumeId(app.id, "persistent-volume", "uuid")
     val offer = f.offerWithVolumes(localVolumeId)
-    val tasks = Seq(f.makeTask(app.id, ReservationWithVolumes(Seq(localVolumeId))))
+    val tasks = Seq(f.makeTask(app.id, Task.Reservation(Seq(localVolumeId), f.taskReservationStateNew)))
 
     When("We ask for a volume match")
     val matchOpt = PersistentVolumeMatcher.matchVolumes(offer, app, tasks)
@@ -65,13 +66,13 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
 
     Given("a resident app with 2 tasks and an offer with 3 persistent volumes")
     val app = f.appWithPersistentVolume()
-    val localVolumeId1 = LocalVolumeId(app.id, "persistent-volume", "uuid1")
-    val localVolumeId2 = LocalVolumeId(app.id, "persistent-volume", "uuid2")
-    val localVolumeId3 = LocalVolumeId(app.id, "persistent-volume", "uuid3")
+    val localVolumeId1 = Task.LocalVolumeId(app.id, "persistent-volume", "uuid1")
+    val localVolumeId2 = Task.LocalVolumeId(app.id, "persistent-volume", "uuid2")
+    val localVolumeId3 = Task.LocalVolumeId(app.id, "persistent-volume", "uuid3")
     val offer = f.offerWithVolumes(localVolumeId1, localVolumeId2, localVolumeId3)
     val tasks = Seq(
-      f.makeTask(app.id, ReservationWithVolumes(Seq(localVolumeId2))),
-      f.makeTask(app.id, ReservationWithVolumes(Seq(localVolumeId3)))
+      f.makeTask(app.id, Task.Reservation(Seq(localVolumeId2), f.taskReservationStateNew)),
+      f.makeTask(app.id, Task.Reservation(Seq(localVolumeId3), f.taskReservationStateNew))
     )
 
     When("We ask for a volume match")
@@ -89,9 +90,10 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
 
     Given("a resident app with persistent volumes and an offer with matching persistent volumes")
     val app = f.appWithPersistentVolume()
-    val localVolumeId = LocalVolumeId(app.id, "persistent-volume", "uuid")
+    val localVolumeId = Task.LocalVolumeId(app.id, "persistent-volume", "uuid")
     val offer = f.offerWithVolumes(localVolumeId)
-    val tasks = Seq(f.makeTask(app.id, ReservationWithVolumes(Seq(LocalVolumeId(app.id, "other-container", "uuid")))))
+    val tasks = Seq(f.makeTask(app.id, Task.Reservation(
+      Seq(Task.LocalVolumeId(app.id, "other-container", "uuid")), f.taskReservationStateNew)))
 
     When("We ask for a volume match")
     val matchOpt = PersistentVolumeMatcher.matchVolumes(offer, app, tasks)
@@ -102,8 +104,9 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
 
   class Fixture {
     def makeTask(appId: PathId) = MarathonTestHelper.mininimalTask(appId)
-    def makeTask(appId: PathId, reservation: ReservationWithVolumes) = MarathonTestHelper.minimalReservedTask(appId, reservation)
-    def offerWithVolumes(localVolumeIds: LocalVolumeId*) = MarathonTestHelper.offerWithVolumesOnly(localVolumeIds: _*)
+    def makeTask(appId: PathId, reservation: Task.Reservation) = MarathonTestHelper.minimalReservedTask(appId, reservation)
+    def offerWithVolumes(localVolumeIds: Task.LocalVolumeId*) = MarathonTestHelper.offerWithVolumesOnly(localVolumeIds: _*)
     def appWithPersistentVolume(): AppDefinition = MarathonTestHelper.appWithPersistentVolume()
+    val taskReservationStateNew = MarathonTestHelper.taskReservationStateNew
   }
 }

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1167,10 +1167,11 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
   }
 
   def makeSampleTask(id: PathId, attr: String, attrVal: String) = {
+    import MarathonTestHelper.Implicits._
     MarathonTestHelper
       .stagedTask(taskId = id.toString)
       .withAgentInfo(_.copy(attributes = Iterable(TextAttribute(attr, attrVal))))
-      .withLaunched(_.copy(networking = Task.HostPorts(List(999))))
+      .withNetworking(Task.HostPorts(List(999)))
   }
 
   private def assertTaskInfo(taskInfo: MesosProtos.TaskInfo, taskPorts: Seq[Int], offer: Offer): Unit = {


### PR DESCRIPTION
Goal is to reflect a tasks state so we can apply specific timeouts to certain states

- changed Task to a sealed trait with Reserved, LaunchedOnReservation and LaunchedEphemeral implementations
- task state changes are triggered via TaskStateOps
- resulting TaskStateChange will be used to update tasks in TaskTracker/AppTaskLauncherActor
- reflected changes in proto

Open:
- more tests, especially regarding `Task.update()`
- removal of legacy usages (`.launched`, `.reservationWithVolumes`)