### PR TITLE
Fixes #3413 - replaces predicate validation with simpler representation.

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Container.scala
+++ b/src/main/scala/mesosphere/marathon/state/Container.scala
@@ -63,13 +63,11 @@ object Container {
       }
     }
 
-    val uniquePortNames: Validator[Seq[PortMapping]] = new Validator[Seq[PortMapping]] {
-      override def apply(portMappings: Seq[PortMapping]): Result = {
+    val uniquePortNames: Validator[Seq[PortMapping]] =
+      isTrue[Seq[PortMapping]]("Port names must be unique.") { portMappings =>
         val portNames = portMappings.flatMap(_.name)
-        if (portNames.size == portNames.distinct.size) Success
-        else Failure(Set(RuleViolation("portMappings", "Port names must be unique.", None)))
+        portNames.size == portNames.distinct.size
       }
-    }
 
     implicit val dockerValidator = validator[Docker] { docker =>
       docker.image is notEmpty
@@ -106,5 +104,4 @@ object Container {
       }
     }
   }
-
 }

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -233,23 +233,15 @@ object Group {
   }
 
   private def noAppsAndGroupsWithSameName: Validator[Group] =
-    new Validator[Group] {
-      def apply(group: Group) = {
-        val groupIds = group.groups.map(_.id)
-        val clashingIds = group.apps.map(_.id).intersect(groupIds)
-
-        if (clashingIds.isEmpty) Success
-        else Failure(Set(RuleViolation(group,
-          s"Groups and Applications may not have the same identifier: ${clashingIds.mkString(", ")}.", None)))
-      }
+    isTrue(s"Groups and Applications may not have the same identifier.") { group =>
+      val groupIds = group.groups.map(_.id)
+      val clashingIds = group.apps.map(_.id).intersect(groupIds)
+      clashingIds.isEmpty
     }
 
   private def noCyclicDependencies(group: Group): Validator[Set[PathId]] =
-    new Validator[Set[PathId]] {
-      def apply(dependencies: Set[PathId]) = {
-        if (group.hasNonCyclicDependencies) Success
-        else Failure(Set(RuleViolation(group, "Dependency graph has cyclic dependencies.", None)))
-      }
+    isTrue("Dependency graph has cyclic dependencies.") { _ =>
+      group.hasNonCyclicDependencies
     }
 
   private def validPorts: Validator[Group] = {

--- a/src/test/scala/mesosphere/marathon/state/GroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupTest.scala
@@ -217,7 +217,7 @@ class GroupTest extends FunSpec with GivenWhenThen with Matchers {
       val result = validate(changed)
       result.isFailure should be(true)
       ValidationHelper.getAllRuleConstrains(result).head
-        .message should be ("Groups and Applications may not have the same identifier: /some/nested.")
+        .message should be ("Groups and Applications may not have the same identifier.")
     }
 
     it("can marshal and unmarshal from to protos") {


### PR DESCRIPTION
@aquamatthias you had your thoughts on simpler representation of if statements, as we use it quite often in our validation. Where is a nice way by using `BaseValidator[T]` and `ViolationBuilder` in order to achieve that. There is no need for writing `Failure(Set(RuleValidation(v, ..., None)))` and `Success` using this method.

Have a look at a couple of changed files and let me know what you think.