### PR TITLE
Backport Leadership fixes

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -204,7 +204,10 @@ class MarathonScheduler @Inject() (
     // Currently, it's pretty hard to disambiguate this error from other causes of framework errors.
     // Watch MESOS-2522 which will add a reason field for framework errors to help with this.
     // For now the frameworkId is removed for all messages.
-    val removeFrameworkId = true
+    val removeFrameworkId = message match {
+      case "Framework has been removed" => true
+      case _: String                    => false
+    }
     suicide(removeFrameworkId)
   }
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -174,7 +174,7 @@ class MarathonSchedulerService @Inject() (
     log.info("Completed run")
   }
 
-  override def triggerShutdown(): Unit = {
+  override def triggerShutdown(): Unit = synchronized {
     log.info("Shutdown triggered")
 
     leader.set(false)
@@ -192,7 +192,7 @@ class MarathonSchedulerService @Inject() (
     super.triggerShutdown()
   }
 
-  def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = {
+  def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = synchronized {
     log.info("Running driver")
 
     // The following block asynchronously runs the driver. Note that driver.run()
@@ -229,7 +229,7 @@ class MarathonSchedulerService @Inject() (
     }
   }
 
-  def stopDriver(): Unit = {
+  def stopDriver(): Unit = synchronized {
     log.info("Stopping driver")
 
     // Stopping the driver will cause the driver run() method to return.
@@ -240,14 +240,14 @@ class MarathonSchedulerService @Inject() (
   //End Service interface
 
   //Begin Leader interface, which is required for CandidateImpl.
-  override def onDefeated(): Unit = {
+  override def onDefeated(): Unit = synchronized {
     log.info("Defeated (Leader Interface)")
 
     // Our leadership has been defeated and thus we call the defeatLeadership() method.
     defeatLeadership()
   }
 
-  override def onElected(abdicateCmd: ExceptionalCommand[JoinException]): Unit = {
+  override def onElected(abdicateCmd: ExceptionalCommand[JoinException]): Unit = synchronized {
     var migrationComplete = false
     try {
       log.info("Elected (Leader Interface)")
@@ -283,7 +283,7 @@ class MarathonSchedulerService @Inject() (
   }
   //End Leader interface
 
-  private def defeatLeadership(): Unit = {
+  private def defeatLeadership(): Unit = synchronized {
     log.info("Defeat leadership")
 
     eventStream.publish(LocalLeadershipEvent.Standby)
@@ -297,7 +297,7 @@ class MarathonSchedulerService @Inject() (
     stopDriver()
   }
 
-  private def electLeadership(abdicateOption: Option[ExceptionalCommand[JoinException]]): Unit = {
+  private def electLeadership(abdicateOption: Option[ExceptionalCommand[JoinException]]): Unit = synchronized {
     log.info("Elect leadership")
 
     // We have been elected as leader. Thus, update leadership and run the driver.
@@ -310,7 +310,7 @@ class MarathonSchedulerService @Inject() (
     schedulePeriodicOperations()
   }
 
-  def abdicateLeadership(): Unit = {
+  def abdicateLeadership(): Unit = synchronized {
     if (leader.get()) {
       log.info("Abdicating")
 
@@ -322,19 +322,19 @@ class MarathonSchedulerService @Inject() (
   var offerLeadershipBackOff = 0.5.seconds
   val maximumOfferLeadershipBackOff = 16.seconds
 
-  private def increaseOfferLeadershipBackOff() {
+  private def increaseOfferLeadershipBackOff(): Unit = synchronized {
     if (offerLeadershipBackOff <= maximumOfferLeadershipBackOff) {
       offerLeadershipBackOff *= 2
       log.info(s"Increasing offerLeadership backoff to $offerLeadershipBackOff")
     }
   }
 
-  private def resetOfferLeadershipBackOff() {
+  private def resetOfferLeadershipBackOff(): Unit = synchronized {
     log.info("Reset offerLeadership backoff")
     offerLeadershipBackOff = 0.5.seconds
   }
 
-  private def offerLeadership(): Unit = {
+  private def offerLeadership(): Unit = synchronized {
     log.info(s"Will offer leadership after $offerLeadershipBackOff backoff")
     after(offerLeadershipBackOff, system.scheduler)(Future {
       candidate.synchronized {
@@ -354,7 +354,7 @@ class MarathonSchedulerService @Inject() (
     })
   }
 
-  private def schedulePeriodicOperations(): Unit = {
+  private def schedulePeriodicOperations(): Unit = synchronized {
 
     timer.schedule(
       new TimerTask {

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -9,7 +9,7 @@ import akka.testkit.{ TestKit, TestProbe }
 import com.codahale.metrics.MetricRegistry
 import com.twitter.common.base.ExceptionalCommand
 import com.twitter.common.zookeeper.Group.JoinException
-import com.twitter.common.zookeeper.{ Candidate, Group }
+import com.twitter.common.zookeeper.{ ZooKeeperClient, Candidate, Group }
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.health.HealthCheckManager
@@ -78,6 +78,7 @@ class MarathonSchedulerServiceTest
   var migration: Migration = _
   var schedulerActor: ActorRef = _
   var events: EventStream = _
+  var zk: ZooKeeperClient = _
 
   before {
     probe = TestProbe()
@@ -93,6 +94,7 @@ class MarathonSchedulerServiceTest
     migration = mock[Migration]
     schedulerActor = probe.ref
     events = new EventStream()
+    zk = mock[ZooKeeperClient]
   }
 
   def driverFactory[T](provide: => SchedulerDriver): SchedulerDriverFactory = {
@@ -118,7 +120,8 @@ class MarathonSchedulerServiceTest
       system,
       migration,
       schedulerActor,
-      events
+      events,
+      zk
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
     }
@@ -148,7 +151,8 @@ class MarathonSchedulerServiceTest
       system,
       migration,
       schedulerActor,
-      events
+      events,
+      zk
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
     }
@@ -178,7 +182,8 @@ class MarathonSchedulerServiceTest
       system,
       migration,
       schedulerActor,
-      events
+      events,
+      zk
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
       override def newTimer() = mockTimer
@@ -216,7 +221,8 @@ class MarathonSchedulerServiceTest
       system,
       migration,
       schedulerActor,
-      events
+      events,
+      zk
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
       override def newTimer() = mockTimer
@@ -246,7 +252,8 @@ class MarathonSchedulerServiceTest
       system,
       migration,
       schedulerActor,
-      events
+      events,
+      zk
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
     }
@@ -283,7 +290,8 @@ class MarathonSchedulerServiceTest
       system,
       migration,
       schedulerActor,
-      events
+      events,
+      zk
     ) {
       override def runDriver(abdicateCmdOption: Option[ExceptionalCommand[JoinException]]): Unit = ()
     }


### PR DESCRIPTION
- AbdicateOnConnectionLoss behavior back ported
- Remove FrameworkId only for specific errors back ported 