### PR TITLE
Fixes #3439 - relative paths in dependencies validation.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
@@ -12,9 +12,6 @@ import scala.reflect.ClassTag
 import scala.util.Try
 
 object Validation {
-
-  def validate[T](t: T)(implicit validator: Validator[T]): Result = validator.apply(t)
-
   def validateOrThrow[T](t: T)(implicit validator: Validator[T]): T = validate(t) match {
     case Success    => t
     case f: Failure => throw new ValidationFailedException(t, f)

--- a/src/main/scala/mesosphere/marathon/state/Container.scala
+++ b/src/main/scala/mesosphere/marathon/state/Container.scala
@@ -3,7 +3,6 @@ package mesosphere.marathon.state
 import com.wix.accord.dsl._
 import com.wix.accord._
 import mesosphere.marathon.api.v2.Validation._
-import mesosphere.marathon.api.v2.Validation.validate
 import org.apache.mesos.{ Protos => Mesos }
 import scala.collection.immutable.Seq
 

--- a/src/main/scala/mesosphere/marathon/state/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupManager.scala
@@ -155,7 +155,7 @@ class GroupManager @Singleton @Inject() (
       from <- rootGroup()
       (toUnversioned, resolve) <- resolveStoreUrls(assignDynamicServicePorts(from, change(from)))
       to = GroupVersioningUtil.updateVersionInfoForChangedApps(version, from, toUnversioned)
-      _ = validateOrThrow(to)(Group.validWithConfig(config.maxApps.get))
+      _ = validateOrThrow(to)(Group.validGroupWithConfig(config.maxApps.get))
       plan = DeploymentPlan(from, to, resolve, version, toKill)
       _ = validateOrThrow(plan)
       _ = log.info(s"Computed new deployment plan:\n$plan")

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -1,5 +1,6 @@
 package mesosphere.marathon.state
 
+import mesosphere.marathon.api.v2.Validation.isTrue
 import mesosphere.marathon.plugin
 
 import scala.language.implicitConversions
@@ -101,41 +102,40 @@ object PathId {
   private[this] val ID_PATH_SEGMENT_PATTERN =
     "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$".r
 
-  /**
-    * For external usage. Needed to overwrite the whole description, e.g. id.path -> id.
-    * @return
-    */
-  implicit def pathIdValidator: Validator[PathId] = {
-    new Validator[PathId] {
-      override def apply(pathId: PathId): Result = {
-        validate(pathId.path)(validator = pathId.path.each should matchRegexFully(ID_PATH_SEGMENT_PATTERN.pattern)) and
-          validChild(pathId)
-      }
+  private val validPathChars = new Validator[PathId] {
+    override def apply(pathId: PathId): Result = {
+      validate(pathId.path)(validator = pathId.path.each should matchRegexFully(ID_PATH_SEGMENT_PATTERN.pattern))
     }
   }
 
   /**
-    * Check if path's parent, if it exists, is a valid parent indeed.
-    * @return
+    * For external usage. Needed to overwrite the whole description, e.g. id.path -> id.
     */
-  private def validChild: Validator[PathId] = {
-    new Validator[PathId] {
-      override def apply(pathId: PathId): Result = {
-        if (pathId.parent == "".toPath) Success
-        else if (pathId.parent.absolute) {
-          val p = pathId.canonicalPath(pathId.parent)
-          if (pathId.parent != PathId.empty && p.parent != pathId.parent) Failure(Set(
-            RuleViolation(pathId,
-              s"""Identifier $pathId is not child of ${pathId.parent}.
-                    |Actual parent: ${p.parent}.
-                    |Hint: use relative paths.""".
-                stripMargin, None)
-          )
-          )
-          else Success
-        }
-        else Failure(Set(RuleViolation(pathId.parent, "Path of parent should be absolute.", None)))
-      }
+  implicit val pathIdValidator = validator[PathId] { path =>
+    path is childOf(path.parent)
+    path is validPathChars
+  }
+
+  /**
+    * Validate path with regards to some parent path.
+    * @param base Path of parent.
+    */
+  def validPathWithBase(base: PathId): Validator[PathId] = validator[PathId] { path =>
+    path is childOf(base)
+    path is validPathChars
+  }
+
+  private def childOf(parent: PathId): Validator[PathId] = {
+    isTrue[PathId](s"Identifier is not child of $parent. Hint: use relative paths.") { child =>
+      parent == PathId.empty || !parent.absolute ||
+        (parent.absolute && child.canonicalPath(parent).parent == parent)
     }
+  }
+
+  /**
+    * Needed for AppDefinitionValidatorTest.testSchemaLessStrictForId.
+    */
+  val absolutePathValidator = isTrue[PathId]("Path needs to be absolute") { path =>
+    path.absolute
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -1,8 +1,6 @@
 package mesosphere.marathon.api.v2
 
-import java.util.regex.Pattern
-
-import com.wix.accord.{ Success, Failure }
+import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.api.v2.json.GroupUpdate
@@ -17,7 +15,6 @@ import mesosphere.marathon.api.v2.Validation._
 import play.api.libs.json.{ JsObject, Json }
 
 import scala.collection.immutable.Seq
-import scala.util.matching.Regex
 
 class ModelValidationTest
     extends MarathonSpec
@@ -38,12 +35,12 @@ class ModelValidationTest
       createServicePortApp("/c".toPath, 0)
     ))
 
-    val failedResult = Group.validWithConfig(Some(2)).apply(group)
+    val failedResult = Group.validGroupWithConfig(Some(2)).apply(group)
     failedResult.isFailure should be(true)
     ValidationHelper.getAllRuleConstrains(failedResult)
       .find(v => v.message.contains("This Marathon instance may only handle up to 2 Apps!")) should be ('defined)
 
-    val successfulResult = Group.validWithConfig(Some(10)).apply(group)
+    val successfulResult = Group.validGroupWithConfig(Some(10)).apply(group)
     successfulResult.isSuccess should be(true)
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -15,7 +15,7 @@ import play.api.libs.json.{ JsPath, JsError, Json }
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
-import mesosphere.marathon.api.v2.Validation._
+import com.wix.accord._
 
 import scala.util.Try
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon.api.v2.json
 
 import mesosphere.marathon.state.{ AppDefinition, Timestamp, PathId, Group }
-import mesosphere.marathon.api.v2.Validation._
+import com.wix.accord.validate
 import org.scalatest.{ GivenWhenThen, Matchers, FunSuite }
 import PathId._
 

--- a/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidatorTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.api.validation
 
 import mesosphere.marathon.Protos.HealthCheckDefinition
 import mesosphere.marathon.api.v2.Validation._
+import com.wix.accord.validate
 import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state._
@@ -384,21 +385,21 @@ class AppDefinitionValidatorTest extends MarathonSpec with Matchers with GivenWh
     When("Check if only defining residency without persistent volumes is valid")
     val to1 = from.copy(container = None)
     Then("Should be invalid")
-    AppDefinition.appDefinitionValidator(to1).isSuccess should be(false)
+    AppDefinition.validAppDefinition(to1).isSuccess should be(false)
 
     When("Check if only defining local volumes without residency is valid")
     val to2 = from.copy(residency = None)
     Then("Should be invalid")
-    AppDefinition.appDefinitionValidator(to2).isSuccess should be(false)
+    AppDefinition.validAppDefinition(to2).isSuccess should be(false)
 
     When("Check if defining local volumes and residency is valid")
     Then("Should be valid")
-    AppDefinition.appDefinitionValidator(from).isSuccess should be(true)
+    AppDefinition.validAppDefinition(from).isSuccess should be(true)
 
     When("Check if defining no local volumes and no residency is valid")
     val to3 = from.copy(residency = None, container = None)
     Then("Should be valid")
-    AppDefinition.appDefinitionValidator(to3).isSuccess should be(true)
+    AppDefinition.validAppDefinition(to3).isSuccess should be(true)
   }
 
   class Fixture {

--- a/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon.api.validation
 
 import mesosphere.marathon.MarathonSpec
-import mesosphere.marathon.api.v2.Validation._
+import com.wix.accord.validate
 import mesosphere.marathon.api.v2.json.AppUpdate
 import mesosphere.marathon.state.{ Container, PathId }
 import org.apache.mesos.{ Protos => mesos }

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -1,7 +1,5 @@
 package mesosphere.marathon.health
 
-import akka.actor.Props
-import akka.testkit.TestActorRef
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.api.v2.ValidationHelper
 import mesosphere.marathon.core.task.Task
@@ -10,8 +8,7 @@ import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec, Protos }
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
-
-import mesosphere.marathon.api.v2.Validation._
+import com.wix.accord.validate
 
 class HealthCheckTest extends MarathonSpec {
 

--- a/src/test/scala/mesosphere/marathon/state/GroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupTest.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon.state
 
-import com.wix.accord.Success
-import mesosphere.marathon.api.v2.Validation._
+import com.wix.accord._
 import mesosphere.marathon.api.v2.ValidationHelper
 import mesosphere.marathon.state.AppDefinition.VersionInfo
 import mesosphere.marathon.state.PathId._
@@ -395,6 +394,24 @@ class GroupTest extends FunSpec with GivenWhenThen with Matchers {
 
       Then("All non existing subgroups should be created")
       ids should equal(reference.transitiveGroups.map(_.id))
+    }
+
+    it("relative dependencies should be resolvable") {
+      Given("a group with an app having relative dependency")
+      val group: Group = Group("/".toPath, groups = Set(
+        Group("group".toPath, apps = Set(AppDefinition("app1".toPath, cmd = Some("foo"))),
+          groups = Set(
+            Group("subgroup".toPath, Set(
+              AppDefinition("app2".toPath, cmd = Some("bar"),
+                dependencies = Set("../app1".toPath))))
+          ))
+      ))
+
+      When("group is validated")
+      val result = validate(group)
+
+      Then("result should be a success")
+      result.isSuccess should be(true)
     }
   }
 }


### PR DESCRIPTION
Dependencies have to be checked concerning all transitive IDs. This PR adds required validation.

@aquamatthias I am having troubles passing the integration test [GroupDeployIntegrationTest.scala#L35](https://github.com/mesosphere/marathon/blob/6f26274d4b16c97218c383f2deb7d1e9987cbc35/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala#L35), getting following error:
```Json
{
  "message" : "Object is not valid",
  "details" : [ {
    "path" : "/groups(0)/groups(0)/dependencies(0)",
    "errors" : [ "dependency definition does not exist in group's tree" ]
  } ]
}
```
which means, that the dependency `/test` defined in group `/test2` can not find the created `/test` group. I did try the same constellation through the API and it works fine there. I might come up with a solution tomorrow, but if you have a quick hint, I would not mind as well.