### PR TITLE
Fixes #3392 and #3477 - Residents Task: Use count from LaunchQueue to determine how many tasks are still needed

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/TaskOpFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/TaskOpFactory.scala
@@ -8,9 +8,28 @@ import org.apache.mesos.{ Protos => Mesos }
 trait TaskOpFactory {
 
   /**
-    * @param tasks a list of tasks for the given app, needed to check constraints and handle resident tasks
     * @return a TaskOp if and only if the offer matches the app.
     */
-  def buildTaskOp(app: AppDefinition, offer: Mesos.Offer, tasks: Iterable[Task]): Option[TaskOp]
+  def buildTaskOp(request: TaskOpFactory.Request): Option[TaskOp]
 
+}
+
+object TaskOpFactory {
+
+  /**
+    * @param app the related app definition
+    * @param offer the offer to match against
+    * @param taskMap a map of running tasks or reservations for the given app,
+    *              needed to check constraints and handle resident tasks
+    */
+  case class Request(app: AppDefinition, offer: Mesos.Offer, taskMap: Map[Task.Id, Task]) {
+    def tasks: Iterable[Task] = taskMap.values
+    def isForResidentApp: Boolean = app.isResident
+  }
+
+  object Request {
+    def apply(app: AppDefinition, offer: Mesos.Offer, tasks: Iterable[Task]): Request = {
+      new Request(app, offer, Task.tasksById(tasks))
+    }
+  }
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/TaskOpFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/TaskOpFactory.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.core.launcher
 
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.Task.Reservation
 import mesosphere.marathon.state.AppDefinition
 import org.apache.mesos.{ Protos => Mesos }
 
@@ -21,15 +22,19 @@ object TaskOpFactory {
     * @param offer the offer to match against
     * @param taskMap a map of running tasks or reservations for the given app,
     *              needed to check constraints and handle resident tasks
+    * @param additionalLaunches the number of additional launches that has been requested
     */
-  case class Request(app: AppDefinition, offer: Mesos.Offer, taskMap: Map[Task.Id, Task]) {
+  case class Request(app: AppDefinition, offer: Mesos.Offer, taskMap: Map[Task.Id, Task], additionalLaunches: Int) {
     def tasks: Iterable[Task] = taskMap.values
+    lazy val reserved: Iterable[Task.Reserved] = tasks.collect { case r: Task.Reserved => r }
+    def hasWaitingReservations: Boolean = reserved.nonEmpty
+    def numberOfWaitingReservations: Int = reserved.size
     def isForResidentApp: Boolean = app.isResident
   }
 
   object Request {
-    def apply(app: AppDefinition, offer: Mesos.Offer, tasks: Iterable[Task]): Request = {
-      new Request(app, offer, Task.tasksById(tasks))
+    def apply(app: AppDefinition, offer: Mesos.Offer, tasks: Iterable[Task], additionalLaunches: Int): Request = {
+      new Request(app, offer, Task.tasksById(tasks), additionalLaunches)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.core.launcher.impl
 import com.google.inject.Inject
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.core.base.Clock
-import mesosphere.marathon.core.launcher.{ TaskOp, TaskOpFactory }
+import mesosphere.marathon.core.launcher.{ TaskOpFactory, TaskOp }
 import mesosphere.marathon.core.task.{ TaskStateChange, TaskStateOp, Task }
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
@@ -26,19 +26,21 @@ class TaskOpFactoryImpl @Inject() (
     new TaskOpFactoryHelper(principalOpt, roleOpt)
   }
 
-  override def buildTaskOp(app: AppDefinition, offer: Mesos.Offer, tasks: Iterable[Task]): Option[TaskOp] = {
+  override def buildTaskOp(request: TaskOpFactory.Request): Option[TaskOp] = {
     log.debug("buildTaskOp")
 
-    if (app.isResident) {
-      inferForResidents(app, offer, tasks)
+    if (request.isForResidentApp) {
+      inferForResidents(request)
     }
     else {
-      inferNormalTaskOp(app, offer, tasks)
+      inferNormalTaskOp(request)
     }
   }
 
-  private[this] def inferNormalTaskOp(app: AppDefinition, offer: Mesos.Offer, tasks: Iterable[Task]): Option[TaskOp] = {
-    new TaskBuilder(app, Task.Id.forApp, config).buildIfMatches(offer, tasks).map {
+  private[this] def inferNormalTaskOp(request: TaskOpFactory.Request): Option[TaskOp] = {
+    val TaskOpFactory.Request(app, offer, tasks) = request
+
+    new TaskBuilder(app, Task.Id.forApp, config).buildIfMatches(offer, tasks.values).map {
       case (taskInfo, ports) =>
         val task = Task.LaunchedEphemeral(
           taskId = Task.Id(taskInfo.getTaskId),
@@ -57,8 +59,10 @@ class TaskOpFactoryImpl @Inject() (
     }
   }
 
-  private[this] def inferForResidents(app: AppDefinition, offer: Mesos.Offer, tasks: Iterable[Task]): Option[TaskOp] = {
-    val (launchedTasks, waitingTasks) = tasks.partition(_.launched.isDefined)
+  private[this] def inferForResidents(request: TaskOpFactory.Request): Option[TaskOp] = {
+    val TaskOpFactory.Request(app, offer, tasks) = request
+
+    val (launchedTasks, waitingTasks) = tasks.values.partition(_.launched.isDefined)
     val needToLaunch = launchedTasks.size < app.instances && waitingTasks.nonEmpty
     val needToReserve = tasks.size < app.instances
 
@@ -89,7 +93,7 @@ class TaskOpFactoryImpl @Inject() (
       maybeVolumeMatch.flatMap { volumeMatch =>
         val matchingReservedResourcesWithoutVolumes =
           ResourceMatcher.matchResources(
-            offer, app, tasks,
+            offer, app, tasks.values,
             ResourceSelector(
               config.mesosRole.get.toSet, reserved = true,
               requiredLabels = TaskLabels.labelsForTask(volumeMatch.task)
@@ -105,7 +109,10 @@ class TaskOpFactoryImpl @Inject() (
 
     def maybeReserveAndCreateVolumes = if (needToReserve) {
       val matchingResourcesForReservation =
-        ResourceMatcher.matchResources(offer, app, tasks, ResourceSelector(acceptedResourceRoles, reserved = false))
+        ResourceMatcher.matchResources(
+          offer, app, tasks.values,
+          ResourceSelector(acceptedResourceRoles, reserved = false)
+        )
       matchingResourcesForReservation.map(resourceMatch => reserveAndCreateVolumes(app, offer, resourceMatch))
     }
     else None

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
@@ -331,7 +331,8 @@ private class AppTaskLauncherActor(
       sender ! MatchedTaskOps(offer.getId, Seq.empty)
 
     case ActorOfferMatcher.MatchOffer(deadline, offer) =>
-      val taskOp: Option[TaskOp] = taskOpFactory.buildTaskOp(app, offer, tasksMap.values)
+      val matchRequest = TaskOpFactory.Request(app, offer, tasksMap)
+      val taskOp: Option[TaskOp] = taskOpFactory.buildTaskOp(matchRequest)
       taskOp match {
         case Some(op) => handleTaskOp(op, offer)
         case None     => sender() ! MatchedTaskOps(offer.getId, Seq.empty)

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
@@ -331,7 +331,7 @@ private class AppTaskLauncherActor(
       sender ! MatchedTaskOps(offer.getId, Seq.empty)
 
     case ActorOfferMatcher.MatchOffer(deadline, offer) =>
-      val matchRequest = TaskOpFactory.Request(app, offer, tasksMap)
+      val matchRequest = TaskOpFactory.Request(app, offer, tasksMap, tasksToLaunch)
       val taskOp: Option[TaskOp] = taskOpFactory.buildTaskOp(matchRequest)
       taskOp match {
         case Some(op) => handleTaskOp(op, offer)

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -127,12 +127,13 @@ class LaunchQueueModuleTest
     }
 
     When("we ask for matching an offer")
-    call(taskOpFactory.buildTaskOp(Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(None)
+    call(taskOpFactory.buildTaskOp(Matchers.any())).thenReturn(None)
     val matchFuture = offerMatcherManager.offerMatchers.head.matchOffer(clock.now() + 3.seconds, offer)
     val matchedTasks = Await.result(matchFuture, 3.seconds)
 
     Then("the offer gets passed to the task factory and respects the answer")
-    verify(taskOpFactory).buildTaskOp(Matchers.eq(app), Matchers.eq(offer), Matchers.argThat(SameAsSeq(Seq.empty)))
+    val request = TaskOpFactory.Request(app, offer, Iterable.empty)
+    verify(taskOpFactory).buildTaskOp(request)
     assert(matchedTasks.offerId == offer.getId)
     assert(matchedTasks.opsWithSource == Seq.empty)
 
@@ -148,7 +149,7 @@ class LaunchQueueModuleTest
 
     Given("An app in the queue")
     call(taskTracker.tasksByAppSync).thenReturn(TaskTracker.TasksByApp.empty)
-    call(taskOpFactory.buildTaskOp(Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Some(launch))
+    call(taskOpFactory.buildTaskOp(Matchers.any())).thenReturn(Some(launch))
     taskQueue.add(app)
     WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
       offerMatcherManager.offerMatchers.size == 1
@@ -159,7 +160,8 @@ class LaunchQueueModuleTest
     val matchedTasks = Await.result(matchFuture, 3.seconds)
 
     Then("the offer gets passed to the task factory and respects the answer")
-    verify(taskOpFactory).buildTaskOp(Matchers.eq(app), Matchers.eq(offer), Matchers.argThat(SameAsSeq(Seq.empty)))
+    val request = TaskOpFactory.Request(app, offer, Iterable.empty)
+    verify(taskOpFactory).buildTaskOp(request)
     assert(matchedTasks.offerId == offer.getId)
     assert(matchedTasks.launchedTaskInfos == Seq(mesosTask))
 

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -132,7 +132,7 @@ class LaunchQueueModuleTest
     val matchedTasks = Await.result(matchFuture, 3.seconds)
 
     Then("the offer gets passed to the task factory and respects the answer")
-    val request = TaskOpFactory.Request(app, offer, Iterable.empty)
+    val request = TaskOpFactory.Request(app, offer, Iterable.empty, additionalLaunches = 1)
     verify(taskOpFactory).buildTaskOp(request)
     assert(matchedTasks.offerId == offer.getId)
     assert(matchedTasks.opsWithSource == Seq.empty)
@@ -160,7 +160,7 @@ class LaunchQueueModuleTest
     val matchedTasks = Await.result(matchFuture, 3.seconds)
 
     Then("the offer gets passed to the task factory and respects the answer")
-    val request = TaskOpFactory.Request(app, offer, Iterable.empty)
+    val request = TaskOpFactory.Request(app, offer, Iterable.empty, additionalLaunches = 1)
     verify(taskOpFactory).buildTaskOp(request)
     assert(matchedTasks.offerId == offer.getId)
     assert(matchedTasks.launchedTaskInfos == Seq(mesosTask))

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -344,7 +344,7 @@ object MarathonTestHelper {
     )
   }
 
-  def minimalReservedTask(appId: PathId, reservation: Task.Reservation): Task =
+  def minimalReservedTask(appId: PathId, reservation: Task.Reservation): Task.Reserved =
     Task.Reserved(
       taskId = Task.Id.forApp(appId),
       Task.AgentInfo(host = "host.some", agentId = None, attributes = Iterable.empty),

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
@@ -122,7 +122,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
   test("Process task launch") {
     Mockito.when(taskTracker.tasksByAppSync).thenReturn(TaskTracker.TasksByApp.empty)
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    Mockito.when(taskOpFactory.buildTaskOp(m.any(), m.any(), m.any())).thenReturn(Some(f.launch(task, marathonTask)))
+    Mockito.when(taskOpFactory.buildTaskOp(m.any())).thenReturn(Some(f.launch(task, marathonTask)))
 
     val launcherRef = createLauncherRef(instances = 1)
     launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -138,13 +138,14 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.tasksLeftToLaunch == 0)
 
     Mockito.verify(taskTracker).tasksByAppSync
-    Mockito.verify(taskOpFactory).buildTaskOp(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
+    val matchRequest = TaskOpFactory.Request(app, offer, Seq.empty)
+    Mockito.verify(taskOpFactory).buildTaskOp(matchRequest)
   }
 
   test("Wait for inflight task launches on stop") {
     Mockito.when(taskTracker.tasksByAppSync).thenReturn(TaskTracker.TasksByApp.empty)
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    Mockito.when(taskOpFactory.buildTaskOp(m.any(), m.any(), m.any())).thenReturn(Some(f.launch(task, marathonTask)))
+    Mockito.when(taskOpFactory.buildTaskOp(m.any())).thenReturn(Some(f.launch(task, marathonTask)))
 
     val launcherRef = createLauncherRef(instances = 1)
     launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -161,13 +162,14 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     testProbe.expectMsgClass(classOf[Terminated])
 
     Mockito.verify(taskTracker).tasksByAppSync
-    Mockito.verify(taskOpFactory).buildTaskOp(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
+    val matchRequest = TaskOpFactory.Request(app, offer, Seq.empty)
+    Mockito.verify(taskOpFactory).buildTaskOp(matchRequest)
   }
 
   test("Process task launch reject") {
     Mockito.when(taskTracker.tasksByAppSync).thenReturn(TaskTracker.TasksByApp.empty)
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    Mockito.when(taskOpFactory.buildTaskOp(m.any(), m.any(), m.any())).thenReturn(Some(f.launch(task, marathonTask)))
+    Mockito.when(taskOpFactory.buildTaskOp(m.any())).thenReturn(Some(f.launch(task, marathonTask)))
 
     val launcherRef = createLauncherRef(instances = 1)
     launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -187,13 +189,14 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.tasksLeftToLaunch == 1)
 
     Mockito.verify(taskTracker).tasksByAppSync
-    Mockito.verify(taskOpFactory).buildTaskOp(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
+    val matchRequest = TaskOpFactory.Request(app, offer, Seq.empty)
+    Mockito.verify(taskOpFactory).buildTaskOp(matchRequest)
   }
 
   test("Process task launch timeout") {
     Mockito.when(taskTracker.tasksByAppSync).thenReturn(TaskTracker.TasksByApp.empty)
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    Mockito.when(taskOpFactory.buildTaskOp(m.any(), m.any(), m.any())).thenReturn(Some(f.launch(task, marathonTask)))
+    Mockito.when(taskOpFactory.buildTaskOp(m.any())).thenReturn(Some(f.launch(task, marathonTask)))
 
     var scheduleCalled = false
     val props = Props(
@@ -228,13 +231,14 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(scheduleCalled)
 
     Mockito.verify(taskTracker).tasksByAppSync
-    Mockito.verify(taskOpFactory).buildTaskOp(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
+    val matchRequest = TaskOpFactory.Request(app, offer, Seq.empty)
+    Mockito.verify(taskOpFactory).buildTaskOp(matchRequest)
   }
 
   test("Process task launch accept") {
     Mockito.when(taskTracker.tasksByAppSync).thenReturn(TaskTracker.TasksByApp.empty)
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    Mockito.when(taskOpFactory.buildTaskOp(m.any(), m.any(), m.any())).thenReturn(Some(f.launch(task, marathonTask)))
+    Mockito.when(taskOpFactory.buildTaskOp(m.any())).thenReturn(Some(f.launch(task, marathonTask)))
 
     val launcherRef = createLauncherRef(instances = 1)
     launcherRef ! RateLimiterActor.DelayUpdate(app, clock.now())
@@ -253,7 +257,8 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.tasksLeftToLaunch == 0)
 
     Mockito.verify(taskTracker).tasksByAppSync
-    Mockito.verify(taskOpFactory).buildTaskOp(m.eq(app), m.eq(offer), m.argThat(SameAsSeq(Seq.empty)))
+    val matchRequest = TaskOpFactory.Request(app, offer, Seq.empty)
+    Mockito.verify(taskOpFactory).buildTaskOp(matchRequest)
   }
 
   for (

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
@@ -138,7 +138,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.tasksLeftToLaunch == 0)
 
     Mockito.verify(taskTracker).tasksByAppSync
-    val matchRequest = TaskOpFactory.Request(app, offer, Seq.empty)
+    val matchRequest = TaskOpFactory.Request(app, offer, Iterable.empty, additionalLaunches = 1)
     Mockito.verify(taskOpFactory).buildTaskOp(matchRequest)
   }
 
@@ -162,7 +162,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     testProbe.expectMsgClass(classOf[Terminated])
 
     Mockito.verify(taskTracker).tasksByAppSync
-    val matchRequest = TaskOpFactory.Request(app, offer, Seq.empty)
+    val matchRequest = TaskOpFactory.Request(app, offer, Iterable.empty, additionalLaunches = 1)
     Mockito.verify(taskOpFactory).buildTaskOp(matchRequest)
   }
 
@@ -189,7 +189,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.tasksLeftToLaunch == 1)
 
     Mockito.verify(taskTracker).tasksByAppSync
-    val matchRequest = TaskOpFactory.Request(app, offer, Seq.empty)
+    val matchRequest = TaskOpFactory.Request(app, offer, Iterable.empty, additionalLaunches = 1)
     Mockito.verify(taskOpFactory).buildTaskOp(matchRequest)
   }
 
@@ -231,7 +231,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(scheduleCalled)
 
     Mockito.verify(taskTracker).tasksByAppSync
-    val matchRequest = TaskOpFactory.Request(app, offer, Seq.empty)
+    val matchRequest = TaskOpFactory.Request(app, offer, Iterable.empty, additionalLaunches = 1)
     Mockito.verify(taskOpFactory).buildTaskOp(matchRequest)
   }
 
@@ -257,7 +257,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     assert(counts.tasksLeftToLaunch == 0)
 
     Mockito.verify(taskTracker).tasksByAppSync
-    val matchRequest = TaskOpFactory.Request(app, offer, Seq.empty)
+    val matchRequest = TaskOpFactory.Request(app, offer, Iterable.empty, additionalLaunches = 1)
     Mockito.verify(taskOpFactory).buildTaskOp(matchRequest)
   }
 

--- a/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
@@ -184,10 +184,10 @@ class ResidentTaskIntegrationTest
     all.map(_.version).forall(_.contains(newVersion)) shouldBe true
 
     And("exactly 5 instances are running")
-    all.count(_.launched) shouldBe 5
+    all.filter(_.launched) should have size(5)
 
     And("no extra task was created")
-    all.size shouldBe 5
+    all should have size(5)
   }
 
   /**

--- a/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
@@ -22,12 +22,13 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
       .setHostname("some_host")
       .setSlaveId(SlaveID("some slave ID"))
       .build()
-    val appDefinition: AppDefinition = AppDefinition(portDefinitions = List())
+    val app: AppDefinition = AppDefinition(portDefinitions = List())
     val runningTasks: Set[Task] = Set(
       MarathonTestHelper.mininimalTask("some task ID")
     )
 
-    val inferredTaskOp = f.taskOpFactory.buildTaskOp(appDefinition, offer, runningTasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val inferredTaskOp = f.taskOpFactory.buildTaskOp(request)
 
     val expectedTask = Task.LaunchedEphemeral(
       taskId = inferredTaskOp.fold(Task.Id("failure"))(_.taskId),
@@ -36,7 +37,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
         agentId = Some(offer.getSlaveId.getValue),
         attributes = List.empty
       ),
-      appVersion = appDefinition.version,
+      appVersion = app.version,
       status = Task.Status(
         stagedAt = f.clock.now()
       ),
@@ -51,10 +52,11 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val f = new Fixture
     val app = f.normalApp
     val offer = f.insufficientOffer
-    val tasks = Nil
+    val runningTasks = Nil
 
     When("We infer the taskOp")
-    val taskOp = f.taskOpFactory.buildTaskOp(app, offer, tasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("None is returned because there are already 2 launched tasks")
     taskOp shouldBe empty
@@ -65,10 +67,11 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val f = new Fixture
     val app = f.normalApp
     val offer = f.offer
-    val tasks = Nil
+    val runningTasks = Nil
 
     When("We infer the taskOp")
-    val taskOp = f.taskOpFactory.buildTaskOp(app, offer, tasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A Launch is inferred")
     taskOp shouldBe a[Some[TaskOp.Launch]]
@@ -79,10 +82,11 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val f = new Fixture
     val app = f.residentApp
     val offer = f.insufficientOffer
-    val tasks = Nil
+    val runningTasks = Nil
 
     When("We infer the taskOp")
-    val taskOp = f.taskOpFactory.buildTaskOp(app, offer, tasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("None is returned")
     taskOp shouldBe empty
@@ -93,10 +97,11 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val f = new Fixture
     val app = f.residentApp
     val offer = f.offer
-    val tasks = Nil
+    val runningTasks = Nil
 
     When("We infer the taskOp")
-    val taskOp = f.taskOpFactory.buildTaskOp(app, offer, tasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A no is returned because there is not enough disk space")
     taskOp shouldBe None
@@ -107,10 +112,11 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val f = new Fixture
     val app = f.residentApp
     val offer = f.offerWithSpaceForLocalVolume
-    val tasks = Nil
+    val runningTasks = Nil
 
     When("We infer the taskOp")
-    val taskOp = f.taskOpFactory.buildTaskOp(app, offer, tasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A ReserveAndCreateVolumes is returned")
     taskOp shouldBe a[Some[TaskOp.ReserveAndCreateVolumes]]
@@ -127,12 +133,13 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val offer = f.offerWithVolumes(
       reservedTask.taskId.idString, localVolumeIdLaunched, localVolumeIdUnwanted, localVolumeIdMatch
     )
-    val tasks = Seq(
+    val runningTasks = Seq(
       f.residentLaunchedTask(app.id, localVolumeIdLaunched),
       reservedTask)
 
     When("We infer the taskOp")
-    val taskOp = f.taskOpFactory.buildTaskOp(app, offer, tasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A Launch is returned")
     taskOp shouldBe a[Some[TaskOp.Launch]]
@@ -153,11 +160,12 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val app = f.residentApp
     val usedVolumeId = LocalVolumeId(app.id, "unwanted-persistent-volume", "uuid1")
     val offeredVolumeId = LocalVolumeId(app.id, "unwanted-persistent-volume", "uuid2")
-    val tasks = Seq(f.residentLaunchedTask(app.id, usedVolumeId))
-    val offer = f.offerWithVolumes(tasks.head.taskId.idString, offeredVolumeId)
+    val runningTasks = Seq(f.residentLaunchedTask(app.id, usedVolumeId))
+    val offer = f.offerWithVolumes(runningTasks.head.taskId.idString, offeredVolumeId)
 
     When("We infer the taskOp")
-    val taskOp = f.taskOpFactory.buildTaskOp(app, offer, tasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A None is returned because there is already a launched Task")
     taskOp shouldBe empty

--- a/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
@@ -27,7 +27,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
       MarathonTestHelper.mininimalTask("some task ID")
     )
 
-    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks, additionalLaunches = 1)
     val inferredTaskOp = f.taskOpFactory.buildTaskOp(request)
 
     val expectedTask = Task.LaunchedEphemeral(
@@ -55,7 +55,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val runningTasks = Nil
 
     When("We infer the taskOp")
-    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks, additionalLaunches = 1)
     val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("None is returned because there are already 2 launched tasks")
@@ -70,7 +70,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val runningTasks = Nil
 
     When("We infer the taskOp")
-    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks, additionalLaunches = 1)
     val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A Launch is inferred")
@@ -85,7 +85,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val runningTasks = Nil
 
     When("We infer the taskOp")
-    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks, additionalLaunches = 1)
     val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("None is returned")
@@ -100,7 +100,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val runningTasks = Nil
 
     When("We infer the taskOp")
-    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks, additionalLaunches = 1)
     val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A no is returned because there is not enough disk space")
@@ -115,7 +115,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val runningTasks = Nil
 
     When("We infer the taskOp")
-    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks, additionalLaunches = 1)
     val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A ReserveAndCreateVolumes is returned")
@@ -138,7 +138,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
       reservedTask)
 
     When("We infer the taskOp")
-    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks, additionalLaunches = 1)
     val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A Launch is returned")
@@ -164,7 +164,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val offer = f.offerWithVolumes(runningTasks.head.taskId.idString, offeredVolumeId)
 
     When("We infer the taskOp")
-    val request = TaskOpFactory.Request(app, offer, runningTasks)
+    val request = TaskOpFactory.Request(app, offer, runningTasks, additionalLaunches = 1)
     val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A None is returned because there is already a launched Task")

--- a/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
@@ -11,22 +11,6 @@ import scala.collection.immutable.Seq
 class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with Mockito with Matchers {
   import scala.collection.JavaConverters._
 
-  test("Non-Resident app results in Match") {
-    val f = new Fixture
-
-    Given("a normal app without residency and an offer without persistent volumes")
-    val app = MarathonTestHelper.makeBasicApp()
-    val offer = MarathonTestHelper.makeBasicOffer().build()
-    val tasks = Seq(f.makeTask(app.id))
-
-    When("We ask for a volume match")
-    val matchOpt = PersistentVolumeMatcher.matchVolumes(offer, app, tasks)
-
-    Then("We receive a VolumeMatch with an empty list")
-    matchOpt should not be empty
-    matchOpt.get.persistentVolumeResources shouldBe empty
-  }
-
   test("Missing volumes result in NO match") {
     val f = new Fixture
 


### PR DESCRIPTION
* combine several parameters into one request object (which will soon be extended)
* use a taskMap in the case class to make comparision cheap and correct