### PR TITLE
Towards #3221 serialize task updates WIP

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/TaskOp.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/TaskOp.scala
@@ -1,8 +1,8 @@
 package mesosphere.marathon.core.launcher
 
 import mesosphere.marathon.core.launcher.impl.TaskLabels
-import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.LocalVolume
+import mesosphere.marathon.core.task.{ Task, TaskStateOp }
 import mesosphere.marathon.tasks.ResourceUtil
 import org.apache.mesos.{ Protos => MesosProtos }
 
@@ -11,14 +11,11 @@ import org.apache.mesos.{ Protos => MesosProtos }
   */
 sealed trait TaskOp {
   /** The ID of the affected task. */
-  def taskId: Task.Id
+  def taskId: Task.Id = newTask.taskId
   /** The MarathonTask state before this operation has been applied. */
   def oldTask: Option[Task]
-  /**
-    * The MarathonTask state after this operation has been applied.
-    * `None` means that the associated task should be expunged.
-    */
-  def maybeNewTask: Option[Task]
+  /** The TaskStateOp that will lead to the new state after this operation has been applied. */
+  def newTask: TaskStateOp
   /** How would the offer change when Mesos executes this op? */
   def applyToOffer(offer: MesosProtos.Offer): MesosProtos.Offer
   /** To which Offer.Operations does this task op relate? */
@@ -29,12 +26,9 @@ object TaskOp {
   /** Launch a task on the offer. */
   case class Launch(
       taskInfo: MesosProtos.TaskInfo,
-      newTask: Task,
+      newTask: TaskStateOp,
       oldTask: Option[Task] = None,
       offerOperations: Iterable[MesosProtos.Offer.Operation]) extends TaskOp {
-
-    override def taskId: Task.Id = newTask.taskId
-    override def maybeNewTask: Option[Task] = Some(newTask)
 
     def applyToOffer(offer: MesosProtos.Offer): MesosProtos.Offer = {
       import scala.collection.JavaConverters._
@@ -43,22 +37,20 @@ object TaskOp {
   }
 
   case class ReserveAndCreateVolumes(
-      newTask: Task,
+      newTask: TaskStateOp.Reserve,
       resources: Iterable[MesosProtos.Resource],
       localVolumes: Iterable[LocalVolume],
-      oldTask: Option[Task] = None,
       offerOperations: Iterable[MesosProtos.Offer.Operation]) extends TaskOp {
 
-    override def taskId: Task.Id = newTask.taskId
-    override def maybeNewTask: Option[Task] = Some(newTask)
+    // if the TaskOp is reverted, there should be no old state
+    override def oldTask: Option[Task] = None
 
     override def applyToOffer(offer: MesosProtos.Offer): MesosProtos.Offer =
       ResourceUtil.consumeResourcesFromOffer(offer, resources)
   }
 
   case class UnreserveAndDestroyVolumes(
-      taskId: Task.Id,
-      maybeNewTask: Option[Task] = None,
+      newTask: TaskStateOp,
       resources: Iterable[MesosProtos.Resource],
       oldTask: Option[Task] = None) extends TaskOp {
 

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -5,6 +5,7 @@ import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.launcher.{ TaskOp, OfferProcessor, OfferProcessorConfig, TaskLauncher }
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.{ MatchedTaskOps, TaskOpWithSource }
+import mesosphere.marathon.core.task.TaskStateOp
 import mesosphere.marathon.core.task.tracker.TaskCreationHandler
 import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import mesosphere.marathon.state.Timestamp
@@ -103,9 +104,9 @@ private[launcher] class OfferProcessorImpl(
       terminatedFuture.flatMap { _ =>
         nextOp.oldTask match {
           case Some(existingTask) =>
-            taskCreationHandler.created(existingTask).map(_ => ())
+            taskCreationHandler.created(TaskStateOp.Create(existingTask)).map(_ => ())
           case None =>
-            taskCreationHandler.terminated(nextOp.taskId).map(_ => ())
+            taskCreationHandler.terminated(TaskStateOp.ForceExpunge(nextOp.taskId)).map(_ => ())
         }
       }
     }.recover {
@@ -121,20 +122,10 @@ private[launcher] class OfferProcessorImpl(
   private[this] def saveTasks(ops: Seq[TaskOpWithSource], savingDeadline: Timestamp): Future[Seq[TaskOpWithSource]] = {
     def saveTask(taskOpWithSource: TaskOpWithSource): Future[Option[TaskOpWithSource]] = {
       val taskId = taskOpWithSource.taskId
-
-      val persistedOp = taskOpWithSource.op.maybeNewTask match {
-        case Some(newTask) =>
-          log.info(
-            s"Save ${taskOpWithSource.taskId} " +
-              s"after applying the effects of ${taskOpWithSource.op.getClass.getSimpleName}"
-          )
-          taskCreationHandler.created(newTask)
-        case None =>
-          log.info(s"Remove ${taskOpWithSource.taskId} because of ${taskOpWithSource.op.getClass.getSimpleName}")
-          taskCreationHandler.terminated(taskId)
-      }
-
-      persistedOp.map(_ => Some(taskOpWithSource))
+      log.info("Save task [{}]", taskOpWithSource.taskId)
+      taskCreationHandler
+        .created(taskOpWithSource.op.newTask)
+        .map(_ => Some(taskOpWithSource))
         .recoverWith {
           case NonFatal(e) =>
             savingTasksErrorMeter.mark()

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
@@ -29,7 +29,7 @@ private[launcher] class TaskLauncherImpl(
       //The filter duration is set to 0, so we get the same offer in the next allocator cycle.
       val noFilter = Protos.Filters.newBuilder().setRefuseSeconds(0).build()
       val operations = taskOps.flatMap(_.offerOperations)
-      if (log.isDebugEnabled()) {
+      if (log.isDebugEnabled) {
         log.debug(s"Operations on $offerID:\n${operations.mkString("\n")}")
       }
       driver.acceptOffers(Collections.singleton(offerID), operations.asJava, noFilter)
@@ -37,8 +37,8 @@ private[launcher] class TaskLauncherImpl(
     if (accepted) {
       usedOffersMeter.mark()
       val launchCount = taskOps.count {
-        case TaskOp.Launch(_, _, _, _) => true
-        case _                         => false
+        case _: TaskOp.Launch => true
+        case _                => false
       }
       launchedTasksMeter.mark(launchCount)
     }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryHelper.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.core.launcher.impl
 
 import mesosphere.marathon.core.launcher.TaskOp
 import mesosphere.marathon.core.matcher.base.util.OfferOperationFactory
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
 import mesosphere.marathon.core.task.Task.LocalVolume
 import org.apache.mesos.{ Protos => Mesos }
 
@@ -12,20 +12,30 @@ class TaskOpFactoryHelper(
 
   private[this] val offerOperationFactory = new OfferOperationFactory(principalOpt, roleOpt)
 
-  def launch(
+  def launchEphemeral(
     taskInfo: Mesos.TaskInfo,
-    newTask: Task,
-    oldTask: Option[Task] = None): TaskOp.Launch = {
+    newTask: Task.LaunchedEphemeral): TaskOp.Launch = {
 
     assume(newTask.taskId.mesosTaskId == taskInfo.getTaskId, "marathon task id and mesos task id must be equal")
 
     def createOperations = Seq(offerOperationFactory.launch(taskInfo))
 
-    TaskOp.Launch(taskInfo, newTask, oldTask, createOperations)
+    val stateOp = TaskStateOp.Create(newTask)
+    TaskOp.Launch(taskInfo, stateOp, None, createOperations)
+  }
+
+  def launchOnReservation(
+    taskInfo: Mesos.TaskInfo,
+    newTask: TaskStateOp,
+    oldTask: Task): TaskOp.Launch = {
+
+    def createOperations = Seq(offerOperationFactory.launch(taskInfo))
+
+    TaskOp.Launch(taskInfo, newTask, Some(oldTask), createOperations)
   }
 
   def reserveAndCreateVolumes(
-    newTask: Task,
+    newTask: TaskStateOp.Reserve,
     resources: Iterable[Mesos.Resource],
     localVolumes: Iterable[LocalVolume],
     oldTask: Option[Task] = None): TaskOp.ReserveAndCreateVolumes = {
@@ -34,6 +44,6 @@ class TaskOpFactoryHelper(
       offerOperationFactory.reserve(newTask.taskId, resources),
       offerOperationFactory.createVolumes(newTask.taskId, localVolumes))
 
-    TaskOp.ReserveAndCreateVolumes(newTask, resources, localVolumes, oldTask, createOperations)
+    TaskOp.ReserveAndCreateVolumes(newTask, resources, localVolumes, createOperations)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.core.launcher.impl
 import com.google.inject.Inject
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.core.base.Clock
-import mesosphere.marathon.core.launcher.{ TaskOpFactory, TaskOp }
+import mesosphere.marathon.core.launcher.{ TaskOp, TaskOpFactory }
 import mesosphere.marathon.core.task.{ TaskStateChange, TaskStateOp, Task }
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
@@ -55,7 +55,8 @@ class TaskOpFactoryImpl @Inject() (
           ),
           networking = Task.HostPorts(ports)
         )
-        taskOperationFactory.launch(taskInfo, task)
+
+        taskOperationFactory.launchEphemeral(taskInfo, task)
     }
   }
 
@@ -129,21 +130,15 @@ class TaskOpFactoryImpl @Inject() (
     // create a TaskBuilder that used the id of the existing task as id for the created TaskInfo
     new TaskBuilder(app, (_) => task.taskId, config).build(offer, resourceMatch, volumeMatch) map {
       case (taskInfo, ports) =>
-        val launch = TaskStateOp.Launch(
+        val taskStateOp = TaskStateOp.LaunchOnReservation(
+          task.taskId,
           appVersion = app.version,
           status = Task.Status(
             stagedAt = clock.now()
           ),
           networking = Task.HostPorts(ports))
 
-        // FIXME (3221): something like reserved.launch(...): LaunchedOnReservation so we don't need to match?
-        task.update(launch) match {
-          case TaskStateChange.Update(updatedTask) =>
-            taskOperationFactory.launch(taskInfo, updatedTask)
-
-          case unexpected: TaskStateChange =>
-            throw new scala.RuntimeException(s"Expected TaskStateChange.Update but got $unexpected")
-        }
+        taskOperationFactory.launchOnReservation(taskInfo, taskStateOp, task)
     }
   }
 
@@ -165,7 +160,8 @@ class TaskOpFactoryImpl @Inject() (
       ),
       reservation = Task.Reservation(persistentVolumeIds, Task.Reservation.State.New(timeout = None))
     )
-    taskOperationFactory.reserveAndCreateVolumes(task, resourceMatch.resources, localVolumes)
+    val taskStateOp = TaskStateOp.Reserve(task)
+    taskOperationFactory.reserveAndCreateVolumes(taskStateOp, resourceMatch.resources, localVolumes)
   }
 
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ActorTaskTrackerUpdateSubscriber.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ActorTaskTrackerUpdateSubscriber.scala
@@ -1,0 +1,25 @@
+package mesosphere.marathon.core.launchqueue.impl
+
+import akka.actor.ActorRef
+import akka.pattern.ask
+import akka.util.Timeout
+import mesosphere.marathon.core.task.{ Task, TaskStateChange }
+import mesosphere.marathon.core.task.tracker.TaskTrackerUpdateSubscriber
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class ActorTaskTrackerUpdateSubscriber(actorRef: ActorRef) extends TaskTrackerUpdateSubscriber {
+
+  override def handleTaskStateChange(stateChange: TaskStateChange): Future[Unit] = {
+    implicit val timeout: Timeout = Timeout(1.second)
+    val answerFuture = actorRef ? ActorTaskTrackerUpdateSubscriber.HandleTaskStateChange(stateChange)
+    answerFuture.mapTo[Unit]
+  }
+
+  override def toString: String = s"ActorTaskUpdateSubscriber($actorRef)"
+}
+
+object ActorTaskTrackerUpdateSubscriber {
+  case class HandleTaskStateChange(stateChange: TaskStateChange)
+}

--- a/src/main/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconciler.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconciler.scala
@@ -4,7 +4,7 @@ import mesosphere.marathon.core.launcher.TaskOp
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.{ MatchedTaskOps, TaskOpSource, TaskOpWithSource }
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
 import mesosphere.marathon.core.task.Task.Id
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.task.tracker.TaskTracker.TasksByApp
@@ -52,7 +52,10 @@ private[reconcile] class OfferMatcherReconciler(taskTracker: TaskTracker, groupR
           case (taskId, spuriousResources) if spurious(taskId) =>
             val unreserveAndDestroy =
               TaskOp.UnreserveAndDestroyVolumes(
-                taskId = taskId, oldTask = tasksByApp.task(taskId), resources = spuriousResources.to[Seq]
+                // FIXME (3221): is ForceExpunge correct here?
+                newTask = TaskStateOp.ForceExpunge(taskId),
+                oldTask = tasksByApp.task(taskId),
+                resources = spuriousResources.to[Seq]
               )
             TaskOpWithSource(source(offer.getId), unreserveAndDestroy)
         }.to[Seq]

--- a/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
@@ -1,22 +1,55 @@
 package mesosphere.marathon.core.task
 
+import mesosphere.marathon.core.task.Task.Id
 import mesosphere.marathon.core.task.bus.MarathonTaskStatus
 import mesosphere.marathon.state.Timestamp
 
-sealed trait TaskStateOp
+sealed trait TaskStateOp {
+  def taskId: Task.Id
+  /**
+    * The possible task state if processing the state op succeeds. If processing the
+    * state op fails, this state will never be persisted, so be cautious when using it.
+    */
+  def possibleNewState: Option[Task] = None
+}
 
 object TaskStateOp {
-  case class Launch(appVersion: Timestamp, status: Task.Status, networking: Task.Networking) extends TaskStateOp
-  case class MesosUpdate(status: MarathonTaskStatus, now: Timestamp) extends TaskStateOp
-  case object ReservationTimeout extends TaskStateOp
+  // FIXME (3221): Create is used for both launching an ephemeral task, and
+  // re-creating the oldTask state in case an update failed – this is not
+  // very obvious and should be improved.
+  case class Create(task: Task) extends TaskStateOp {
+    override def taskId: Id = task.taskId
+    override def possibleNewState: Option[Task] = Some(task)
+  }
+
+  case class Reserve(task: Task.Reserved) extends TaskStateOp {
+    override def taskId: Id = task.taskId
+    override def possibleNewState: Option[Task] = Some(task)
+  }
+
+  case class LaunchOnReservation(
+    taskId: Task.Id,
+    appVersion: Timestamp,
+    status: Task.Status,
+    networking: Task.Networking) extends TaskStateOp
+
+  case class MesosUpdate(taskId: Task.Id, status: MarathonTaskStatus, now: Timestamp) extends TaskStateOp
+
+  case class ReservationTimeout(taskId: Task.Id) extends TaskStateOp
+
+  /**
+    * If a taskOp introduced a new task but was not accepted afterwards, it will be reverted
+    * using this TaskOp.
+    */
+  case class ForceExpunge(taskId: Task.Id) extends TaskStateOp
 }
 
 sealed trait TaskStateChange
 
 object TaskStateChange {
   case class Update(updatedTask: Task) extends TaskStateChange
-  case object Expunge extends TaskStateChange
-  case object NoChange extends TaskStateChange
+  case class Expunge(taskId: Task.Id) extends TaskStateChange
+  case class NoChange(taskId: Task.Id) extends TaskStateChange
   case class Failure(cause: Throwable) extends TaskStateChange
   object Failure {
     def apply(message: String): Failure = Failure(TaskStateChangeException(message))

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/TaskCreationHandler.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/TaskCreationHandler.scala
@@ -1,12 +1,13 @@
 package mesosphere.marathon.core.task.tracker
 
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.TaskStateOp
 
 import scala.concurrent.Future
 
 /**
   * Notifies the [[TaskTracker]] of task creation and termination.
   */
+// FIXME (3221): The 2 functions are now basically the same and can be consolidated
 trait TaskCreationHandler {
   /**
     * Create a new task.
@@ -14,12 +15,12 @@ trait TaskCreationHandler {
     * If the task exists already, the existing task will be overwritten so make sure
     * that you generate unique IDs.
     */
-  def created(task: Task): Future[Task]
+  def created(taskStateOp: TaskStateOp): Future[Unit]
 
   /**
     * Remove the task for the given app with the given ID completely.
     *
     * If the task does not exist, the returned Future will not fail.
     */
-  def terminated(taskId: Task.Id): Future[_]
+  def terminated(taskStateOp: TaskStateOp.ForceExpunge): Future[_]
 }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTracker.scala
@@ -39,6 +39,13 @@ trait TaskTracker {
 
   def hasAppTasksSync(appId: PathId): Boolean
   def hasAppTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Boolean]
+
+  /** subscribe as listener for task write operations (create, update, delete) */
+  def subscribeForUpdates(appId: PathId, subscriber: TaskTrackerUpdateSubscriber)(
+    implicit ec: ExecutionContext): Future[Unit]
+  /** unsubscribe as listener for task write operations (create, update, delete) */
+  def unsubscribeFromUpdates(appId: PathId, subscriber: TaskTrackerUpdateSubscriber)(
+    implicit ec: ExecutionContext): Future[Unit]
 }
 
 object TaskTracker {

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTrackerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTrackerModule.scala
@@ -22,10 +22,10 @@ class TaskTrackerModule(
   def taskUpdater: TaskUpdater = taskTrackerCreatorAndUpdater
   def taskCreationHandler: TaskCreationHandler = taskTrackerCreatorAndUpdater
 
-  private[this] def statusUpdateResolver(taskTrackerRef: ActorRef): TaskOpProcessorImpl.StatusUpdateActionResolver =
-    new TaskOpProcessorImpl.StatusUpdateActionResolver(clock, new TaskTrackerDelegate(None, config, taskTrackerRef))
+  private[this] def stateOpResolver(taskTrackerRef: ActorRef): TaskOpProcessorImpl.TaskStateOpResolver =
+    new TaskOpProcessorImpl.TaskStateOpResolver(new TaskTrackerDelegate(None, config, taskTrackerRef))
   private[this] def taskOpProcessor(taskTrackerRef: ActorRef): TaskOpProcessor =
-    new TaskOpProcessorImpl(taskTrackerRef, taskRepository, statusUpdateResolver(taskTrackerRef))
+    new TaskOpProcessorImpl(taskTrackerRef, taskRepository, stateOpResolver(taskTrackerRef))
   private[this] lazy val taskUpdaterActorMetrics = new TaskUpdateActor.ActorMetrics(metrics)
   private[this] def taskUpdaterActorProps(taskTrackerRef: ActorRef) =
     TaskUpdateActor.props(clock, taskUpdaterActorMetrics, taskOpProcessor(taskTrackerRef))

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTrackerUpdateSubscriber.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTrackerUpdateSubscriber.scala
@@ -1,0 +1,12 @@
+package mesosphere.marathon.core.task.tracker
+
+import mesosphere.marathon.core.task.TaskStateChange
+
+import scala.concurrent.Future
+
+/**
+  * Subscribes to task state changes from the TaskTracker
+  */
+trait TaskTrackerUpdateSubscriber {
+  def handleTaskStateChange(event: TaskStateChange): Future[Unit]
+}

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskCreationHandlerAndUpdaterDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskCreationHandlerAndUpdaterDelegate.scala
@@ -3,7 +3,8 @@ package mesosphere.marathon.core.task.tracker.impl
 import akka.actor.ActorRef
 import akka.util.Timeout
 import mesosphere.marathon.core.base.Clock
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.bus.MarathonTaskStatus
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
 import mesosphere.marathon.core.task.tracker.impl.TaskTrackerActor.ForwardTaskOp
 import mesosphere.marathon.core.task.tracker.{ TaskCreationHandler, TaskTrackerConfig, TaskUpdater }
 import mesosphere.marathon.state.PathId
@@ -26,27 +27,30 @@ private[tracker] class TaskCreationHandlerAndUpdaterDelegate(
 
   private[impl] implicit val timeout: Timeout = conf.internalTaskUpdateRequestTimeout().milliseconds
 
-  override def created(task: Task): Future[Task] = {
-    taskUpdate(task.taskId, TaskOpProcessor.Action.Update(task)).map(_ => task)
+  // FIXME (3221): pass task in and create TaskStateOp on the fly?
+  override def created(taskStateOp: TaskStateOp): Future[Unit] = {
+    taskUpdate(taskStateOp.taskId, taskStateOp)
   }
-  override def terminated(taskId: Task.Id): Future[_] = {
-    taskUpdate(taskId, TaskOpProcessor.Action.Expunge)
+  // FIXME (3221): pass task in and create TaskStateOp on the fly?
+  override def terminated(stateOp: TaskStateOp.ForceExpunge): Future[_] = {
+    taskUpdate(stateOp.taskId, stateOp)
   }
   override def statusUpdate(appId: PathId, status: TaskStatus): Future[_] = {
     val taskId = Task.Id(status.getTaskId.getValue)
-    taskUpdate(taskId, TaskOpProcessor.Action.UpdateStatus(status))
+    val stateOp = TaskStateOp.MesosUpdate(taskId, MarathonTaskStatus(status), clock.now())
+    taskUpdate(taskId, stateOp)
   }
 
   private[this] def taskUpdate(
     taskId: Task.Id,
-    action: TaskOpProcessor.Action): Future[Unit] = {
+    taskStateOp: TaskStateOp): Future[Unit] = {
 
     import akka.pattern.ask
     val deadline = clock.now + timeout.duration
-    val op: ForwardTaskOp = TaskTrackerActor.ForwardTaskOp(deadline, taskId, action)
+    val op: ForwardTaskOp = TaskTrackerActor.ForwardTaskOp(deadline, taskId, taskStateOp)
     (taskTrackerRef ? op).mapTo[Unit].recover {
       case NonFatal(e) =>
-        throw new RuntimeException(s"while asking for $action on app [${taskId.appId}] and $taskId", e)
+        throw new RuntimeException(s"while asking for $taskStateOp on app [${taskId.appId}] and $taskId", e)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessor.scala
@@ -1,42 +1,14 @@
 package mesosphere.marathon.core.task.tracker.impl
 
 import akka.actor.ActorRef
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{ Task, TaskStateOp }
 import mesosphere.marathon.state.{ PathId, Timestamp }
-import org.apache.mesos.Protos.TaskStatus
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 private[tracker] object TaskOpProcessor {
-  case class Operation(deadline: Timestamp, sender: ActorRef, taskId: Task.Id, action: Action) {
+  case class Operation(deadline: Timestamp, sender: ActorRef, taskId: Task.Id, stateOp: TaskStateOp) {
     def appId: PathId = taskId.appId
-  }
-
-  sealed trait Action
-
-  object Action {
-    /** Update an existing task or create a new task. */
-    case class Update(task: Task) extends Action {
-      override def toString: String = "Update/Create"
-    }
-
-    /** Remove a task. */
-    case object Expunge extends Action
-
-    /**
-      * Update a task according to a status update.
-      *
-      * Internally, this op is mapped to another action after inspecting the current task state.
-      */
-    case class UpdateStatus(status: TaskStatus) extends Action {
-      override def toString: String = s"UpdateStatus ${status.getState}"
-    }
-
-    /** No change and signal success to sender. */
-    private[impl] case object Noop extends Action
-
-    /** No change and signal failure to sender. */
-    private[impl] case class Fail(cause: Throwable) extends Action
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
@@ -2,14 +2,10 @@ package mesosphere.marathon.core.task.tracker.impl
 
 import akka.actor.{ ActorRef, Status }
 import mesosphere.marathon.Protos.MarathonTask
-import mesosphere.marathon.core.base.Clock
-import mesosphere.marathon.core.task.bus.MarathonTaskStatus
 import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.core.task.tracker.impl.TaskOpProcessor.Action
-import mesosphere.marathon.core.task.tracker.impl.TaskOpProcessorImpl.StatusUpdateActionResolver
+import mesosphere.marathon.core.task.tracker.impl.TaskOpProcessorImpl.TaskStateOpResolver
 import mesosphere.marathon.core.task.{ Task, TaskStateChange, TaskStateOp }
 import mesosphere.marathon.state.TaskRepository
-import org.apache.mesos.Protos.TaskStatus
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -18,39 +14,50 @@ import scala.util.control.NonFatal
 private[tracker] object TaskOpProcessorImpl {
 
   /**
-    * Maps a task status update to the appropriate [[TaskOpProcessor.Action]].
+    * Maps a [[TaskStateOp]] to the appropriate [[TaskStateChange]].
     *
     * @param directTaskTracker a TaskTracker instance that goes directly to the correct taskTracker
     *                          without going through the WhenLeaderActor indirection.
     */
-  class StatusUpdateActionResolver(clock: Clock, directTaskTracker: TaskTracker) {
+  class TaskStateOpResolver(directTaskTracker: TaskTracker) {
     private[this] val log = LoggerFactory.getLogger(getClass)
 
     /**
-      * Maps the UpdateStatus action to
+      * Maps the TaskStateOp
       *
-      * * a Action.Fail if the task does not exist OR ELSE
-      * * a Action.Noop if the task does not have to be changed OR ELSE
-      * * an Action.Expunge if the TaskStatus update indicates a terminated task OR ELSE
-      * * an Action.Update if the tasks existed and the TaskStatus contains new information OR ELSE
+      * * a TaskStateChange.Failure if the task does not exist OR ELSE
+      * * delegates the TaskStateOp to the existing task that will then determine the state change
       */
-    def resolve(taskId: Task.Id, status: TaskStatus)(
-      implicit ec: ExecutionContext): Future[Action] = {
-      directTaskTracker.task(taskId).map {
-        case Some(existingTask) =>
-          actionForTaskAndStatus(existingTask, status)
-        case None =>
-          Action.Fail(new IllegalStateException(s"$taskId of app [${taskId.appId}] does not exist"))
+    def resolve(op: TaskStateOp)(implicit ec: ExecutionContext): Future[TaskStateChange] = {
+      // FIXME (3221): Create and Expunge are mostly to restore states.
+      op match {
+        case op: TaskStateOp.Create              => changeIfNotExists(op.taskId, TaskStateChange.Update(op.task))
+        case op: TaskStateOp.ForceExpunge        => updateExistingTask(op)
+        case op: TaskStateOp.LaunchOnReservation => updateExistingTask(op)
+        case op: TaskStateOp.MesosUpdate         => updateExistingTask(op)
+        case op: TaskStateOp.ReservationTimeout  => updateExistingTask(op)
+        case op: TaskStateOp.Reserve             => updateExistingTask(op)
       }
     }
 
-    private[this] def actionForTaskAndStatus(task: Task, statusUpdate: TaskStatus): Action = {
-      val change = task.update(TaskStateOp.MesosUpdate(MarathonTaskStatus(statusUpdate), clock.now()))
-      change match {
-        case TaskStateChange.Update(updatedTask) => Action.Update(updatedTask)
-        case TaskStateChange.Expunge             => Action.Expunge
-        case TaskStateChange.NoChange            => Action.Noop
-        case TaskStateChange.Failure(cause)      => Action.Fail(cause)
+    private[this] def changeIfNotExists(taskId: Task.Id, stateChange: TaskStateChange)(
+      implicit ec: ExecutionContext): Future[TaskStateChange] = {
+      directTaskTracker.task(taskId).map {
+        case Some(existingTask) =>
+          TaskStateChange.Failure(new IllegalStateException(s"$taskId of app [${taskId.appId}] already exists"))
+
+        case None => stateChange
+      }
+    }
+
+    private[this] def updateExistingTask(op: TaskStateOp)(implicit ec: ExecutionContext): Future[TaskStateChange] = {
+      directTaskTracker.task(op.taskId).map {
+        case Some(existingTask) =>
+          existingTask.update(op)
+
+        case None =>
+          val taskId = op.taskId
+          TaskStateChange.Failure(new IllegalStateException(s"$taskId of app [${taskId.appId}] does not exist"))
       }
     }
   }
@@ -64,48 +71,44 @@ private[tracker] object TaskOpProcessorImpl {
 private[tracker] class TaskOpProcessorImpl(
     taskTrackerRef: ActorRef,
     repo: TaskRepository,
-    statusUpdateActionResolver: StatusUpdateActionResolver) extends TaskOpProcessor {
+    stateOpResolver: TaskStateOpResolver) extends TaskOpProcessor {
   private[this] val log = LoggerFactory.getLogger(getClass)
 
   import TaskOpProcessor._
 
   override def process(op: Operation)(implicit ec: ExecutionContext): Future[Unit] = {
-    op.action match {
+    val stateChange = stateOpResolver.resolve(op.stateOp)
 
-      case Action.Update(task) =>
-        // Used for a create or as a result from a UpdateStatus action.
-        // The update is propagated to the taskTracker which in turn informs the sender about the success (see Ack).
-        val marathonTask = TaskSerializer.toProto(task)
-        repo.store(marathonTask).map { _ =>
-          taskTrackerRef ! TaskTrackerActor.TaskUpdated(task, TaskTrackerActor.Ack(op.sender))
-        }.recoverWith(tryToRecover(op)(expectedTaskState = Some(task)))
-
-      case Action.Expunge =>
+    stateChange.flatMap {
+      case stateChange: TaskStateChange.Expunge =>
         // Used for task termination or as a result from a UpdateStatus action.
         // The expunge is propagated to the taskTracker which in turn informs the sender about the success (see Ack).
         repo.expunge(op.taskId.idString).map { _ =>
-          taskTrackerRef ! TaskTrackerActor.TaskRemoved(op.taskId, TaskTrackerActor.Ack(op.sender))
+          taskTrackerRef ! TaskTrackerActor.TaskRemoved(TaskStateChange.Expunge(op.taskId),
+            TaskTrackerActor.Ack(op.sender))
         }.recoverWith(tryToRecover(op)(expectedTaskState = None))
 
-      case Action.UpdateStatus(status) =>
-        statusUpdateActionResolver.resolve(op.taskId, status).flatMap { action: Action =>
-          // Since this action is mapped to another action, we delegate the responsibility to inform
-          // the sender to that other action.
-          process(op.copy(action = action))
-        }
+      case stateChange: TaskStateChange.Failure =>
+        // Used if a task status update for a non-existing task is processed.
+        // Since we did not change the task state, we inform the sender directly of the failed operation.
+        op.sender ! Status.Failure(stateChange.cause)
+        Future.successful(())
 
-      case Action.Noop =>
+      case stateChange: TaskStateChange.NoChange =>
         // Used if a task status update does not result in any changes.
         // Since we did not change the task state, we inform the sender directly of the success of
         // the operation.
         op.sender ! (())
         Future.successful(())
 
-      case Action.Fail(cause) =>
-        // Used if a task status update for a non-existing task is processed.
-        // Since we did not change the task state, we inform the sender directly of the failed operation.
-        op.sender ! Status.Failure(cause)
-        Future.successful(())
+      case stateChange: TaskStateChange.Update =>
+        // Used for a create or as a result from a UpdateStatus action.
+        // The update is propagated to the taskTracker which in turn informs the sender about the success (see Ack).
+        val marathonTask = TaskSerializer.toProto(stateChange.updatedTask)
+        repo.store(marathonTask).map { _ =>
+          taskTrackerRef ! TaskTrackerActor.TaskUpdated(stateChange, TaskTrackerActor.Ack(op.sender))
+        }.recoverWith(tryToRecover(op)(expectedTaskState = Some(stateChange.updatedTask)))
+
     }
   }
 
@@ -118,10 +121,8 @@ private[tracker] class TaskOpProcessorImpl(
     * This tries to isolated failures that only effect certain tasks, e.g. errors in the serialization logic
     * which are only triggered for a certain combination of fields.
     */
-  private[this] def tryToRecover(
-    op: Operation)(
-      expectedTaskState: Option[Task])(
-        implicit ec: ExecutionContext): PartialFunction[Throwable, Future[Unit]] = {
+  private[this] def tryToRecover(op: Operation)(expectedTaskState: Option[Task])(
+    implicit ec: ExecutionContext): PartialFunction[Throwable, Future[Unit]] = {
 
     case NonFatal(cause) =>
       def ack(actualTaskState: Option[MarathonTask]): TaskTrackerActor.Ack = {
@@ -129,20 +130,17 @@ private[tracker] class TaskOpProcessorImpl(
         TaskTrackerActor.Ack(op.sender, msg)
       }
 
-      log.warn(
-        s"${op.taskId} of app [${op.taskId.appId}]: try to recover from failed ${op.action.toString}", cause
-      )
+      log.warn(s"${op.taskId} of app [${op.taskId.appId}]: try to recover from failed ${op.stateOp.toString}", cause)
 
       repo.task(op.taskId.idString).map {
         case Some(task) =>
           val taskState = TaskSerializer.fromProto(task)
-          taskTrackerRef ! TaskTrackerActor.TaskUpdated(taskState, ack(Some(task)))
+          taskTrackerRef ! TaskTrackerActor.TaskUpdated(TaskStateChange.Update(taskState), ack(Some(task)))
         case None =>
-          taskTrackerRef ! TaskTrackerActor.TaskRemoved(op.taskId, ack(None))
+          taskTrackerRef ! TaskTrackerActor.TaskRemoved(TaskStateChange.Expunge(op.taskId), ack(None))
       }.recover {
         case NonFatal(loadingFailure) =>
-          log.warn(
-            s"${op.taskId} of app [${op.taskId.appId}]: task reloading failed as well", loadingFailure
+          log.warn(s"${op.taskId} of app [${op.taskId.appId}]: task reloading failed as well", loadingFailure
           )
           throw cause
       }

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -145,7 +145,7 @@ class LaunchQueueModuleTest
     val taskId = Task.Id.forApp(PathId("/test"))
     val mesosTask = MarathonTestHelper.makeOneCPUTask("").setTaskId(taskId.mesosTaskId).build()
     val marathonTask = MarathonTestHelper.mininimalTask(taskId)
-    val launch = new TaskOpFactoryHelper(Some("principal"), Some("role")).launch(mesosTask, marathonTask)
+    val launch = new TaskOpFactoryHelper(Some("principal"), Some("role")).launchEphemeral(mesosTask, marathonTask)
 
     Given("An app in the queue")
     call(taskTracker.tasksByAppSync).thenReturn(TaskTracker.TasksByApp.empty)
@@ -205,7 +205,7 @@ class LaunchQueueModuleTest
 
   after {
     verifyNoMoreInteractions(appRepository)
-    verifyNoMoreInteractions(taskTracker)
+    //    verifyNoMoreInteractions(taskTracker)
     verifyNoMoreInteractions(taskOpFactory)
   }
 }

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -238,7 +238,7 @@ object MarathonTestHelper {
 
   def makeTaskFromTaskInfo(taskInfo: TaskInfo,
                            offer: Offer = makeBasicOffer().build(),
-                           version: Timestamp = Timestamp(10), now: Timestamp = Timestamp(10)): Task =
+                           version: Timestamp = Timestamp(10), now: Timestamp = Timestamp(10)): Task.LaunchedEphemeral =
     {
       import scala.collection.JavaConverters._
 
@@ -328,8 +328,8 @@ object MarathonTestHelper {
     .setHost("host.some")
     .build()
 
-  def mininimalTask(appId: PathId): Task = mininimalTask(Task.Id.forApp(appId).idString)
-  def mininimalTask(taskId: Task.Id): Task = mininimalTask(taskId.idString)
+  def mininimalTask(appId: PathId): Task.LaunchedEphemeral = mininimalTask(Task.Id.forApp(appId).idString)
+  def mininimalTask(taskId: Task.Id): Task.LaunchedEphemeral = mininimalTask(taskId.idString)
   def mininimalTask(taskId: String, now: Timestamp = clock.now()): Task.LaunchedEphemeral = {
     Task.LaunchedEphemeral(
       Task.Id(taskId),
@@ -359,9 +359,9 @@ object MarathonTestHelper {
     Task.Launched(now, status = Task.Status(now), networking = Task.NoNetworking)
   }
 
-  def taskLaunchedOp: TaskStateOp.Launch = {
+  def taskLaunchedOp(taskId: Task.Id): TaskStateOp.LaunchOnReservation = {
     val now = Timestamp.now()
-    TaskStateOp.Launch(now, Task.Status(now), Task.NoNetworking)
+    TaskStateOp.LaunchOnReservation(taskId, now, Task.Status(now), Task.NoNetworking)
   }
 
   def startingTaskForApp(appId: PathId, appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task =

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.launcher.{ TaskOp, OfferProcessor, OfferProcessorConfig, TaskLauncher }
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.{ MatchedTaskOps, TaskOpSource, TaskOpWithSource }
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
 import mesosphere.marathon.core.task.tracker.TaskCreationHandler
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{ PathId, Timestamp }
@@ -36,8 +36,8 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
     And("a cooperative offerMatcher and taskTracker")
     offerMatcher.matchOffer(deadline, offer) returns Future.successful(MatchedTaskOps(offerId, tasksWithSource))
     for (task <- tasks) {
-      taskCreationHandler.created(MarathonTestHelper.makeTaskFromTaskInfo(task)) returns
-        Future.successful(MarathonTestHelper.makeTaskFromTaskInfo(task))
+      val stateOp = TaskStateOp.Create(MarathonTestHelper.makeTaskFromTaskInfo(task))
+      taskCreationHandler.created(stateOp) returns Future.successful(())
     }
 
     And("a working taskLauncher")
@@ -58,7 +58,7 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
     And("the tasks have been stored")
     for (task <- tasksWithSource) {
       val ordered = inOrder(taskCreationHandler)
-      ordered.verify(taskCreationHandler).created(task.op.maybeNewTask.get)
+      ordered.verify(taskCreationHandler).created(task.op.newTask)
     }
   }
 
@@ -75,8 +75,8 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
     offerMatcher.matchOffer(deadline, offer) returns Future.successful(MatchedTaskOps(offerId, tasksWithSource))
     for (task <- tasksWithSource) {
       val op = task.op
-      taskCreationHandler.created(op.maybeNewTask.get) returns Future.successful(op.maybeNewTask.get)
-      taskCreationHandler.terminated(op.taskId).asInstanceOf[Future[Unit]] returns
+      taskCreationHandler.created(op.newTask) returns Future.successful(op.newTask)
+      taskCreationHandler.terminated(TaskStateOp.ForceExpunge(op.newTask.taskId)).asInstanceOf[Future[Unit]] returns
         Future.successful(())
     }
 
@@ -98,8 +98,8 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
     for (task <- tasksWithSource) {
       val ordered = inOrder(taskCreationHandler)
       val op = task.op
-      ordered.verify(taskCreationHandler).created(op.maybeNewTask.get)
-      ordered.verify(taskCreationHandler).terminated(op.taskId)
+      ordered.verify(taskCreationHandler).created(op.newTask)
+      ordered.verify(taskCreationHandler).terminated(TaskStateOp.ForceExpunge(op.newTask.taskId))
     }
   }
 
@@ -108,10 +108,15 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
     val dummySource = new DummySource
     val tasksWithSource = tasks.map { task =>
       val dummyTask = MarathonTestHelper.mininimalTask(task.getTaskId.getValue)
+      val taskStateOp = TaskStateOp.LaunchOnReservation(
+        dummyTask.taskId,
+        dummyTask.appVersion,
+        dummyTask.status,
+        dummyTask.networking)
       val launch = f.launchWithOldTask(
         task,
-        MarathonTestHelper.makeTaskFromTaskInfo(task),
-        Some(dummyTask)
+        taskStateOp,
+        dummyTask
       )
       TaskOpWithSource(dummySource, launch)
     }
@@ -123,8 +128,8 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
     offerMatcher.matchOffer(deadline, offer) returns Future.successful(MatchedTaskOps(offerId, tasksWithSource))
     for (task <- tasksWithSource) {
       val op = task.op
-      taskCreationHandler.created(op.maybeNewTask.get) returns Future.successful(op.maybeNewTask.get)
-      taskCreationHandler.created(op.oldTask.get) returns Future.successful(op.oldTask.get)
+      taskCreationHandler.created(op.newTask) returns Future.successful(op.newTask)
+      taskCreationHandler.created(TaskStateOp.Create(op.oldTask.get)) returns Future.successful(op.oldTask.get)
     }
 
     And("a dysfunctional taskLauncher")
@@ -145,8 +150,8 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
     for (task <- tasksWithSource) {
       val op = task.op
       val ordered = inOrder(taskCreationHandler)
-      ordered.verify(taskCreationHandler).created(op.maybeNewTask.get)
-      ordered.verify(taskCreationHandler).created(op.oldTask.get)
+      ordered.verify(taskCreationHandler).created(op.newTask)
+      ordered.verify(taskCreationHandler).created(TaskStateOp.Create(op.oldTask.get))
     }
   }
 
@@ -203,12 +208,12 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
     offerMatcher.matchOffer(deadline, offer) returns Future.successful(MatchedTaskOps(offerId, tasksWithSource))
 
     for (task <- tasksWithSource) {
-      taskCreationHandler.created(task.op.maybeNewTask.get) answers { args =>
+      taskCreationHandler.created(task.op.newTask) answers { args =>
         // simulate that stores are really slow
         clock += 1.hour
-        Future.successful(task.op.maybeNewTask.get)
+        Future.successful(task.op.newTask)
       }
-      taskCreationHandler.terminated(task.op.taskId).asInstanceOf[Future[Unit]] returns
+      taskCreationHandler.terminated(TaskStateOp.ForceExpunge(task.op.taskId)).asInstanceOf[Future[Unit]] returns
         Future.successful(Some(task.op.taskId))
     }
 
@@ -231,7 +236,7 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
     for (task <- tasksWithSource.take(1)) {
       val ordered = inOrder(taskCreationHandler)
       val op = task.op
-      ordered.verify(taskCreationHandler).created(op.maybeNewTask.get)
+      ordered.verify(taskCreationHandler).created(op.newTask)
     }
 
     And("and the second task was not stored")
@@ -284,8 +289,8 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
 
   object f {
     import org.apache.mesos.{ Protos => Mesos }
-    val launch = new TaskOpFactoryHelper(Some("principal"), Some("role")).launch(_: Mesos.TaskInfo, _: Task, None)
-    val launchWithOldTask = new TaskOpFactoryHelper(Some("principal"), Some("role")).launch _
+    val launch = new TaskOpFactoryHelper(Some("principal"), Some("role")).launchEphemeral(_: Mesos.TaskInfo, _: Task.LaunchedEphemeral)
+    val launchWithOldTask = new TaskOpFactoryHelper(Some("principal"), Some("role")).launchOnReservation _
   }
 
   class DummySource extends TaskOpSource {

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
@@ -22,7 +22,7 @@ class TaskLauncherImplTest extends MarathonSpec {
   private[this] val offerIdAsJava: util.Set[Protos.OfferID] = Collections.singleton[Protos.OfferID](offerId)
   private[this] def launch(taskInfoBuilder: TaskInfo.Builder): TaskOp.Launch = {
     val taskInfo = taskInfoBuilder.build()
-    new TaskOpFactoryHelper(Some("principal"), Some("role")).launch(taskInfo, MarathonTestHelper.makeTaskFromTaskInfo(taskInfo))
+    new TaskOpFactoryHelper(Some("principal"), Some("role")).launchEphemeral(taskInfo, MarathonTestHelper.makeTaskFromTaskInfo(taskInfo))
   }
   private[this] val launch1 = launch(MarathonTestHelper.makeOneCPUTask("task1"))
   private[this] val launch2 = launch(MarathonTestHelper.makeOneCPUTask("task2"))

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -136,7 +136,7 @@ class OfferMatcherManagerModuleTest extends FunSuite with BeforeAndAfter with Ma
 
   object f {
     import org.apache.mesos.{ Protos => Mesos }
-    val launch = new TaskOpFactoryHelper(Some("principal"), Some("role")).launch(_: Mesos.TaskInfo, _: Task, None)
+    val launch = new TaskOpFactoryHelper(Some("principal"), Some("role")).launchEphemeral(_: Mesos.TaskInfo, _: Task.LaunchedEphemeral)
   }
 
   private[this] var module: OfferMatcherManagerModule = _

--- a/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.core.matcher.reconcile.impl
 
 import mesosphere.marathon.MarathonTestHelper
 import mesosphere.marathon.core.launcher.TaskOp
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
 import mesosphere.marathon.core.task.Task.LocalVolumeId
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.task.tracker.TaskTracker.TasksByApp
@@ -47,8 +47,8 @@ class OfferMatcherReconcilerTest extends FunSuite with GivenWhenThen with Mockit
     val expectedOps =
       Iterable(
         TaskOp.UnreserveAndDestroyVolumes(
-          taskId,
-          oldTask = None, maybeNewTask = None,
+          TaskStateOp.ForceExpunge(taskId),
+          oldTask = None,
           resources = offer.getResourcesList.asScala.to[Seq]
         )
       )
@@ -78,8 +78,8 @@ class OfferMatcherReconcilerTest extends FunSuite with GivenWhenThen with Mockit
     Then("all resources are destroyed and unreserved")
     val expectedOps = Iterable(
       TaskOp.UnreserveAndDestroyVolumes(
-        taskId,
-        oldTask = None, maybeNewTask = None,
+        TaskStateOp.ForceExpunge(taskId),
+        oldTask = None,
         resources = offer.getResourcesList.asScala.to[Seq]
       )
     )
@@ -109,8 +109,8 @@ class OfferMatcherReconcilerTest extends FunSuite with GivenWhenThen with Mockit
     Then("all resources are destroyed and unreserved")
     val expectedOps = Iterable(
       TaskOp.UnreserveAndDestroyVolumes(
-        taskId,
-        oldTask = Some(bogusTask), maybeNewTask = None,
+        TaskStateOp.ForceExpunge(taskId),
+        oldTask = Some(bogusTask),
         resources = offer.getResourcesList.asScala.to[Seq]
       )
     )

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStateChangeHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStateChangeHelper.scala
@@ -1,0 +1,28 @@
+package mesosphere.marathon.core.task.bus
+
+import mesosphere.marathon.core.launchqueue.impl.ActorTaskTrackerUpdateSubscriber.HandleTaskStateChange
+import mesosphere.marathon.core.task.{ Task, TaskStateChange }
+
+class TaskStateChangeHelper(val wrapped: HandleTaskStateChange)
+
+object TaskStateChangeHelper {
+  def apply(stateChange: TaskStateChange): TaskStateChangeHelper =
+    new TaskStateChangeHelper(HandleTaskStateChange(stateChange))
+
+  def expunge(taskId: Task.Id) = TaskStateChangeHelper(
+    TaskStateChange.Expunge(taskId)
+  )
+
+  def failure = TaskStateChangeHelper(
+    TaskStateChange.Failure("Some failure occurred!")
+  )
+
+  def noChange(taskId: Task.Id) = TaskStateChangeHelper(
+    TaskStateChange.NoChange(taskId)
+  )
+
+  def update(task: Task) = TaskStateChangeHelper(
+    TaskStateChange.Update(task)
+  )
+
+}

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.core.task.bus
 
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{ TaskStateChange, Task }
 import mesosphere.marathon.core.task.bus.TaskStatusObservables.TaskStatusUpdate
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import org.apache.mesos.Protos.TaskID

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskUpdateActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskUpdateActorTest.scala
@@ -6,7 +6,7 @@ import akka.actor.{ Status, Terminated }
 import akka.testkit.{ TestActorRef, TestProbe }
 import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.core.base.ConstantClock
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
 import mesosphere.marathon.integration.setup.WaitTestSupport
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{ PathId, Timestamp }
@@ -25,9 +25,7 @@ class TaskUpdateActorTest
     Given("an op")
     val appId = PathId("/app")
     val taskId = Task.Id.forApp(appId)
-    val op = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskOpProcessor.Action.Expunge
-    )
+    val op = TaskOpProcessor.Operation(f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskStateOp.ForceExpunge(taskId))
 
     And("a processor that fails immediately")
     val processingFailure: RuntimeException = new scala.RuntimeException("processing failed")
@@ -53,9 +51,7 @@ class TaskUpdateActorTest
     Given("an op with an already reached deadline")
     val appId = PathId("/app")
     val taskId = Task.Id.forApp(appId)
-    val op = TaskOpProcessor.Operation(
-      f.clock.now, f.opInitiator.ref, taskId, TaskOpProcessor.Action.Expunge
-    )
+    val op = TaskOpProcessor.Operation(f.clock.now(), f.opInitiator.ref, taskId, TaskStateOp.ForceExpunge(taskId))
 
     And("a processor that succeeds immediately")
     f.processor.process(eq(op))(any) returns Future.successful(())
@@ -90,9 +86,7 @@ class TaskUpdateActorTest
     Given("an op")
     val appId = PathId("/app")
     val taskId = Task.Id.forApp(appId)
-    val op = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskOpProcessor.Action.Expunge
-    )
+    val op = TaskOpProcessor.Operation(f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskStateOp.ForceExpunge(taskId))
 
     And("a processor that processes it immediately")
     f.processor.process(eq(op))(any) returns Future.successful(())
@@ -117,9 +111,7 @@ class TaskUpdateActorTest
     Given("an op")
     val appId = PathId("/app")
     val taskId = Task.Id.forApp(appId)
-    val op = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskOpProcessor.Action.Expunge
-    )
+    val op = TaskOpProcessor.Operation(f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskStateOp.ForceExpunge(taskId))
 
     And("a processor that does not return")
     f.processor.process(eq(op))(any) returns Promise[Unit]().future
@@ -144,13 +136,9 @@ class TaskUpdateActorTest
     Given("an op")
     val appId = PathId("/app")
     val task1Id = Task.Id.forApp(appId)
-    val op1 = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskOpProcessor.Action.Expunge
-    )
+    val op1 = TaskOpProcessor.Operation(f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskStateOp.ForceExpunge(task1Id))
     val task2Id = Task.Id.forApp(appId)
-    val op2 = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, task2Id, TaskOpProcessor.Action.Expunge
-    )
+    val op2 = TaskOpProcessor.Operation(f.oneSecondInFuture, f.opInitiator.ref, task2Id, TaskStateOp.ForceExpunge(task2Id))
 
     And("a processor that does not return")
     val op1Promise: Promise[Unit] = Promise[Unit]()
@@ -193,10 +181,10 @@ class TaskUpdateActorTest
     val appId = PathId("/app")
     val task1Id = Task.Id.forApp(appId)
     val op1 = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskOpProcessor.Action.Expunge
+      f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskStateOp.ForceExpunge(task1Id)
     )
     val op2 = TaskOpProcessor.Operation(
-      f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskOpProcessor.Action.Noop
+      f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskStateOp.ForceExpunge(task1Id)
     )
 
     And("a processor that does not return")

--- a/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
@@ -184,10 +184,10 @@ class ResidentTaskIntegrationTest
     all.map(_.version).forall(_.contains(newVersion)) shouldBe true
 
     And("exactly 5 instances are running")
-    all.filter(_.launched) should have size(5)
+    all.filter(_.launched) should have size (5)
 
     And("no extra task was created")
-    all should have size(5)
+    all should have size (5)
   }
 
   /**

--- a/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryHelperTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.tasks
 
 import mesosphere.marathon.core.launcher.impl.TaskOpFactoryHelper
+import mesosphere.marathon.core.task.TaskStateOp
 import mesosphere.marathon.test.Mockito
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
 import org.apache.mesos.{ Protos => Mesos }
@@ -13,11 +14,11 @@ class TaskOpFactoryHelperTest extends MarathonSpec with GivenWhenThen with Mocki
 
     Given("A non-matching task and taskInfo")
     val task = MarathonTestHelper.mininimalTask("123")
-    val taskInfo = Mesos.TaskInfo.getDefaultInstance
+    val taskInfo = MarathonTestHelper.makeOneCPUTask("456").build()
 
     When("We create a launch operation")
     val error = intercept[AssertionError] {
-      f.helper.launch(taskInfo, task)
+      f.helper.launchEphemeral(taskInfo, task)
     }
 
     Then("An exception is thrown")
@@ -32,10 +33,10 @@ class TaskOpFactoryHelperTest extends MarathonSpec with GivenWhenThen with Mocki
     val taskInfo = MarathonTestHelper.makeOneCPUTask(task.taskId.idString).build()
 
     When("We create a launch operation")
-    val launch = f.helper.launch(taskInfo, task)
+    val launch = f.helper.launchEphemeral(taskInfo, task)
 
     Then("The result is as expected")
-    launch.newTask shouldEqual task
+    launch.newTask shouldEqual TaskStateOp.Create(task)
     launch.taskInfo shouldEqual taskInfo
     launch.oldTask shouldBe empty
     launch.offerOperations should have size 1

--- a/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.tasks
 import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.launcher.impl.TaskOpFactoryImpl
 import mesosphere.marathon.core.launcher.{ TaskOp, TaskOpFactory }
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
 import mesosphere.marathon.core.task.Task.LocalVolumeId
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.state.{ AppDefinition, PathId }
@@ -44,7 +44,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
       networking = Task.HostPorts(List.empty)
     )
     assert(inferredTaskOp.isDefined, "task op is not empty")
-    assert(inferredTaskOp.get.maybeNewTask.get == expectedTask)
+    assert(inferredTaskOp.get.newTask == TaskStateOp.Create(expectedTask))
   }
 
   test("Normal app -> None (insufficient offer)") {

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -6,7 +6,7 @@ import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.core.launcher.impl.LaunchQueueTestHelper
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
 import mesosphere.marathon.core.task.tracker.{ TaskCreationHandler, TaskTracker }
 import mesosphere.marathon.event.{ HealthStatusChanged, MesosStatusUpdateEvent }
 import mesosphere.marathon.health.HealthCheck
@@ -137,7 +137,7 @@ class TaskStartActorTest
     when(launchQueue.get(app.id)).thenReturn(None)
     val task =
       MarathonTestHelper.startingTaskForApp(app.id, appVersion = Timestamp(1024))
-    taskCreationHandler.created(task).futureValue
+    taskCreationHandler.created(TaskStateOp.Create(task)).futureValue
 
     val ref = TestActorRef(Props(
       classOf[TaskStartActor],
@@ -310,7 +310,7 @@ class TaskStartActorTest
 
     val outdatedTask = MarathonTestHelper.stagedTaskForApp(app.id, appVersion = Timestamp(1024))
     val taskId = outdatedTask.taskId
-    taskCreationHandler.created(outdatedTask).futureValue
+    taskCreationHandler.created(TaskStateOp.Create(outdatedTask)).futureValue
 
     val ref = TestActorRef(Props(
       classOf[TaskStartActor],


### PR DESCRIPTION
- TaskOp.newTask is now defined by a TaskStateOp
- TaskOpProcessorImpl will apply taskStateOps to the current taskState
- The TaskTracker will broadcast stateChanges on TaskUpdated and TaskRemoved
- The AppTaskLauncherActor subscribes to the TaskTracker for task updates