### PR TITLE
Resolves #3456 added endpoint for manual deletion of residents

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/ResidentResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/ResidentResource.scala
@@ -1,0 +1,75 @@
+package mesosphere.marathon.api.v2
+
+import javax.inject.Inject
+import javax.servlet.http.HttpServletRequest
+import javax.ws.rs._
+import javax.ws.rs.core.{ Context, MediaType, Response }
+
+import com.codahale.metrics.annotation.Timed
+import mesosphere.marathon.{ BadRequestException, MarathonConf }
+import mesosphere.marathon.api.{ AuthResource, MarathonMediaType, RestResource }
+import mesosphere.marathon.core.appinfo.AppSelector
+import mesosphere.marathon.core.base.Clock
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.core.task.tracker.impl.TaskSerializer
+import mesosphere.marathon.plugin.auth._
+import mesosphere.marathon.state._
+
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+
+@Path("v2/residents")
+@Consumes(Array(MediaType.APPLICATION_JSON))
+@Produces(Array(MarathonMediaType.PREFERRED_APPLICATION_JSON))
+class ResidentResource @Inject() (
+    clock: Clock,
+    taskTracker: TaskTracker,
+    taskRepository: TaskRepository,
+    val config: MarathonConf,
+    val authenticator: Authenticator,
+    val authorizer: Authorizer) extends RestResource with AuthResource {
+
+  @DELETE
+  @Path("""{id:.+}""")
+  @Timed
+  def delete(@PathParam("id") id: String,
+             @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    val taskId = Task.Id(id)
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val response = for {
+      maybeTask <- taskTracker.task(taskId)
+      updated <- setTimeout(maybeTask)
+    } yield ok(jsonObjString("task" -> updated.taskId.idString))
+
+    result(response)
+  }
+
+  private[this] def setTimeout(task: Option[Task]): Future[Task] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    task match {
+      case Some(reserved: Task.Reserved) =>
+        val timeout = Task.Reservation.Timeout(
+          initiated = clock.now(),
+          deadline = clock.now(),
+          reason = Task.Reservation.Timeout.Reason.ReservationTimeout)
+        val updated = reserved.copy(reservation = reserved.reservation.copy(
+          state = Task.Reservation.State.Garbage(Some(timeout))))
+        taskRepository.store(TaskSerializer.toProto(updated)).map(TaskSerializer.fromProto)
+
+      case _ => throw new BadRequestException("Only suspended resident tasks can be deleted")
+    }
+  }
+
+  def allAuthorized(implicit identity: Identity): AppSelector = new AppSelector {
+    override def matches(app: AppDefinition): Boolean = isAuthorized(ViewApp, app)
+  }
+
+  def selectAuthorized(fn: => AppSelector)(implicit identity: Identity): AppSelector = {
+    val authSelector = new AppSelector {
+      override def matches(app: AppDefinition): Boolean = isAuthorized(ViewApp, app)
+    }
+    AppSelector.forall(Seq(authSelector, fn))
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -147,6 +147,9 @@ object Task {
       case TaskStateOp.ReservationTimeout =>
         TaskStateChange.Expunge
 
+      case TaskStateOp.MesosUpdate(MarathonTaskStatus.Lost(_), _) =>
+        TaskStateChange.Expunge
+
       // failure case: MesosUpdate
       case _: TaskStateOp.MesosUpdate =>
         TaskStateChange.Failure("Unable to handle MesosUpdate op on Reserved task")

--- a/src/test/scala/mesosphere/marathon/api/v2/ResidentResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ResidentResourceTest.scala
@@ -1,0 +1,106 @@
+package mesosphere.marathon.api.v2
+
+import mesosphere.marathon.api.TestAuthFixture
+import mesosphere.marathon.core.base.ConstantClock
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.core.task.tracker.impl.TaskSerializer
+import mesosphere.marathon.state.{ PathId, TaskRepository }
+import mesosphere.marathon.test.Mockito
+import mesosphere.marathon.{ BadRequestException, MarathonConf, MarathonSpec, MarathonTestHelper }
+import org.scalatest.{ GivenWhenThen, Matchers }
+import play.api.libs.json.Json
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ResidentResourceTest extends MarathonSpec with Matchers with Mockito with GivenWhenThen {
+
+  test("Deleting an existing reserved task succeeds") {
+    Given("A reserved resident task")
+    val appId = PathId("/test")
+    val task = MarathonTestHelper.residentReservedTask(appId)
+    val expectedUpdate = task.copy(reservation = task.reservation.copy(
+      state = Task.Reservation.State.Garbage(Some(Task.Reservation.Timeout(
+        initiated = clock.now(), deadline = clock.now(), reason = Task.Reservation.Timeout.Reason.ReservationTimeout)))))
+    val expectedUpdateProto = TaskSerializer.toProto(expectedUpdate)
+    taskTracker.task(task.taskId) returns Future.successful(Some(task))
+    taskRepository.store(expectedUpdateProto) returns Future.successful(expectedUpdateProto)
+
+    When("DELETE v2/resident/<id> is called")
+    val response = residentResource.delete(task.taskId.idString, auth.request)
+
+    Then("Return status should be OK")
+    response.getStatus should be(200)
+
+    And("The returned task matched the expected state")
+    response.getEntity shouldEqual Json.obj("task" -> task.taskId.idString).toString()
+
+    And("The task was queried")
+    verify(taskTracker).task(task.taskId)
+
+    And("A timeout was set")
+    verify(taskRepository).store(expectedUpdateProto)
+
+    And("no more interactions")
+    noMoreInteractions(taskTracker, taskRepository)
+  }
+
+  test("Deleting a non-existing task fails") {
+    Given("A no reserved resident task")
+    val taskId = Task.Id("invalid")
+    taskTracker.task(taskId) returns Future.successful(None)
+
+    When("DELETE v2/resident/<id> is called")
+    Then("we get a 400")
+    intercept[BadRequestException] { residentResource.delete(taskId.idString, auth.request) }
+
+    And("The task was queried")
+    verify(taskTracker).task(taskId)
+
+    And("no more interactions")
+    noMoreInteractions(taskTracker, taskRepository)
+  }
+
+  test("Deleting a launched task fails") {
+    Given("A launched task")
+    val appId = PathId("/test")
+    val task = MarathonTestHelper.residentLaunchedTask(appId)
+    taskTracker.task(task.taskId) returns Future.successful(Some(task))
+
+    When("DELETE v2/resident/<id> is called")
+    When("DELETE v2/resident/<id> is called")
+    Then("we get a 400")
+    intercept[BadRequestException] { residentResource.delete(task.taskId.idString, auth.request) }
+
+    And("The task was queried")
+    verify(taskTracker).task(task.taskId)
+
+    And("no more interactions")
+    noMoreInteractions(taskTracker, taskRepository)
+  }
+
+  var clock: ConstantClock = _
+  var residentResource: ResidentResource = _
+  var taskTracker: TaskTracker = _
+  var taskRepository: TaskRepository = _
+  var config: MarathonConf = _
+  var auth: TestAuthFixture = _
+
+  before {
+    clock = ConstantClock()
+    auth = new TestAuthFixture
+    config = MarathonTestHelper.defaultConfig()
+    taskTracker = mock[TaskTracker]
+    taskRepository = mock[TaskRepository]
+    residentResource = new ResidentResource(
+      clock,
+      taskTracker,
+      taskRepository,
+      config,
+      auth.auth,
+      auth.auth
+    )
+  }
+
+}


### PR DESCRIPTION
Resolves #3456

The workflow is as follows:
- user calls http DELETE v2/resident/<taskId>
- if the task is Reserved, a timeout will be set
- the KillOverdueTasksActor will eventually schedule a kill
- We receive a TASK_LOST because the task is not known in Mesos
- The TASK_LOST will be forwarded so that the launchQueue and AppTaskLaunchers are notified and expunge the task