### PR TITLE
Opt in for task killing state (pure signalling in the moment)

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
@@ -5,6 +5,8 @@ import java.io.{ IOException, FileInputStream }
 import com.google.protobuf.ByteString
 import mesosphere.chaos.http.HttpConf
 import org.apache.mesos.Protos.{ Credential, FrameworkInfo, FrameworkID }
+import FrameworkInfo.Capability
+
 import org.apache.mesos.{ MesosSchedulerDriver, SchedulerDriver }
 import org.slf4j.LoggerFactory
 
@@ -66,6 +68,13 @@ object MarathonSchedulerDriver {
 
         credentialBuilder.build()
       }
+
+    // Task Killing Behavior enables a dedicated task update (TASK_KILLING) from mesos before a task is killed.
+    // In Marathon this task update is currently ignored.
+    // It makes sense to enable this feature, to support other tools that parse the mesos state, even if
+    // Marathon does not use it in the moment.
+    // Mesos will implement a custom kill behavior, so this state can be used by Marathon as well.
+    frameworkInfoBuilder.addCapabilities(Capability.newBuilder().setType(Capability.Type.TASK_KILLING_STATE))
 
     val frameworkInfo = frameworkInfoBuilder.build()
 


### PR DESCRIPTION
Service Discovery (minuteman) want to see tasks in killing state.
This is an opt-in feature.
The state itself is already handled (ignored).