### PR TITLE
Fixes #3423 | Report kills due to failed healthcheck.

### DIFF
--- a/docs/docs/event-bus.md
+++ b/docs/docs/event-bus.md
@@ -191,6 +191,19 @@ Fired when a new http callback subscriber is added or removed:
 }
 ```
 
+``` json
+{
+  "appId":"/my-app",
+  "taskId":"my-app_0-1396592784349",
+  "version":"2016-03-16T13:05:00.590Z",
+  "reason":"500 Internal Server Error",
+  "host":"localhost",
+  "slaveId":"4fb620fa-ba8d-4eb0-8ae3-f2912aaf015c-S0",
+  "eventType":"unhealthy_task_kill_event",
+  "timestamp":"2016-03-21T09:15:10.764Z"
+}
+```
+
 ### Deployments
 
 ```json

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
@@ -305,6 +305,7 @@ If a task fails more than `maxConsecutiveFailures`
 health checks consecutively, that task is killed causing Marathon to start
 more instances. These restarts are modulated like any other failing app
 by `backoffSeconds`, `backoffFactor` and `maxLaunchDelaySeconds`.
+The kill of the unhealthy task is signalled via `unhealthy_task_kill_event` event.
 
 ###### Health Check Options
 

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -367,6 +367,7 @@ trait EventFormats {
 
   implicit lazy val SubscribeWrites: Writes[Subscribe] = Json.writes[Subscribe]
   implicit lazy val UnsubscribeWrites: Writes[Unsubscribe] = Json.writes[Unsubscribe]
+  implicit lazy val UnhealthyTaskKillEventWrites: Writes[UnhealthyTaskKillEvent] = Json.writes[UnhealthyTaskKillEvent]
   implicit lazy val EventStreamAttachedWrites: Writes[EventStreamAttached] = Json.writes[EventStreamAttached]
   implicit lazy val EventStreamDetachedWrites: Writes[EventStreamDetached] = Json.writes[EventStreamDetached]
   implicit lazy val AddHealthCheckWrites: Writes[AddHealthCheck] = Json.writes[AddHealthCheck]
@@ -402,6 +403,7 @@ trait EventFormats {
     case event: RemoveHealthCheck          => Json.toJson(event)
     case event: FailedHealthCheck          => Json.toJson(event)
     case event: HealthStatusChanged        => Json.toJson(event)
+    case event: UnhealthyTaskKillEvent     => Json.toJson(event)
     case event: GroupChangeSuccess         => Json.toJson(event)
     case event: GroupChangeFailed          => Json.toJson(event)
     case event: DeploymentSuccess          => Json.toJson(event)
@@ -441,6 +443,7 @@ trait HealthCheckFormats {
       "firstSuccess" -> health.firstSuccess,
       "lastFailure" -> health.lastFailure,
       "lastSuccess" -> health.lastSuccess,
+      "lastFailureCause" -> (if (health.lastFailureCause.isDefined) health.lastFailureCause.get else JsNull),
       "taskId" -> health.taskId
     )
   }

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -152,6 +152,16 @@ case class HealthStatusChanged(
   timestamp: String = Timestamp.now().toString)
     extends MarathonHealthCheckEvent
 
+case class UnhealthyTaskKillEvent(
+  appId: PathId,
+  taskId: Task.Id,
+  version: Timestamp,
+  reason: String,
+  host: String,
+  slaveId: Option[String],
+  eventType: String = "unhealthy_task_kill_event",
+  timestamp: String = Timestamp.now().toString) extends MarathonHealthCheckEvent
+
 // upgrade messages
 
 sealed trait UpgradeEvent extends MarathonEvent

--- a/src/main/scala/mesosphere/marathon/event/HistoryActor.scala
+++ b/src/main/scala/mesosphere/marathon/event/HistoryActor.scala
@@ -9,10 +9,15 @@ class HistoryActor(eventBus: EventStream, taskFailureRepository: TaskFailureRepo
 
   override def preStart(): Unit = {
     eventBus.subscribe(self, classOf[MesosStatusUpdateEvent])
+    eventBus.subscribe(self, classOf[UnhealthyTaskKillEvent])
     eventBus.subscribe(self, classOf[AppTerminatedEvent])
   }
 
   def receive: Receive = {
+
+    case TaskFailure.FromUnhealthyTaskKillEvent(taskFailure) =>
+      taskFailureRepository.store(taskFailure.appId, taskFailure)
+
     case TaskFailure.FromMesosStatusUpdateEvent(taskFailure) =>
       taskFailureRepository.store(taskFailure.appId, taskFailure)
 

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
@@ -108,6 +108,17 @@ class HealthCheckActor(
       // kill the task
       marathonSchedulerDriverHolder.driver.foreach { driver =>
         log.info(s"Send kill request for ${task.taskId} on host ${task.agentInfo.host} to driver")
+        eventBus.publish(
+          UnhealthyTaskKillEvent(
+            appId = task.appId,
+            taskId = task.taskId,
+            version = app.version,
+            reason = health.lastFailureCause.getOrElse("unknown"),
+            host = task.agentInfo.host,
+            slaveId = task.agentInfo.agentId,
+            timestamp = health.lastFailure.getOrElse(Timestamp.now()).toString
+          )
+        )
         driver.killTask(task.taskId.mesosTaskId)
       }
     }


### PR DESCRIPTION
Health check kills are published as an event and stored as task failure.
They appear in UI showing cause of last failed health check and host
just as normal Mesos task failures.

![screenshot from 2016-03-16 16 05 55](https://cloud.githubusercontent.com/assets/1616386/13819171/dec0ee56-eb98-11e5-8583-5d3d93dd5488.png)
