### PR TITLE
Improve Task Kill behavior in deployments by introducing kills in batches

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerConfig
 import mesosphere.marathon.core.plugin.PluginManagerConfiguration
 import mesosphere.marathon.core.task.tracker.TaskTrackerConfig
 import mesosphere.marathon.core.task.update.TaskStatusUpdateConfig
+import mesosphere.marathon.upgrade.UpgradeConfig
 import org.rogach.scallop.ScallopConf
 import scala.sys.SystemProperties
 
@@ -16,7 +17,7 @@ trait MarathonConf
     extends ScallopConf with ZookeeperConf with LeaderProxyConf
     with LaunchTokenConfig with OfferMatcherManagerConfig with OfferProcessorConfig with ReviveOffersConfig
     with MarathonSchedulerServiceConfig with LaunchQueueConfig with PluginManagerConfiguration
-    with TaskStatusUpdateConfig with TaskTrackerConfig {
+    with TaskStatusUpdateConfig with TaskTrackerConfig with UpgradeConfig {
 
   //scalastyle:off magic.number
 

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -218,7 +218,8 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
           schedulerActions,
           storage,
           healthCheckManager,
-          eventBus
+          eventBus,
+          conf
         )
       )
     }
@@ -237,7 +238,8 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
         taskQueue,
         driverHolder,
         leaderInfo,
-        eventBus
+        eventBus,
+        conf
       ).withRouter(RoundRobinPool(nrOfInstances = 1, supervisorStrategy = supervision)),
       "MarathonScheduler")
   }

--- a/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStopActor.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon.upgrade
 
+import akka.actor.Props
 import akka.event.EventStream
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.event.MesosStatusUpdateEvent
 import mesosphere.marathon.state.{ AppDefinition, PathId }
 import org.apache.mesos.SchedulerDriver
 
@@ -15,14 +15,21 @@ class AppStopActor(
     val taskTracker: TaskTracker,
     val eventBus: EventStream,
     app: AppDefinition,
+    val config: UpgradeConfig,
     val promise: Promise[Unit]) extends StoppingBehavior {
 
   override var idsToKill: mutable.Set[Task.Id] = taskTracker.appTasksLaunchedSync(app.id).map(_.taskId).to[mutable.Set]
 
-  def appId: PathId = app.id
+  override def appId: PathId = app.id
 
-  def initializeStop(): Unit = {
-    eventBus.subscribe(self, classOf[MesosStatusUpdateEvent])
-    for (id <- idsToKill) driver.killTask(id.mesosTaskId)
-  }
+}
+
+object AppStopActor {
+  def props(
+    driver: SchedulerDriver,
+    taskTracker: TaskTracker,
+    eventBus: EventStream,
+    app: AppDefinition,
+    config: UpgradeConfig,
+    promise: Promise[Unit]): Props = Props(new AppStopActor(driver, taskTracker, eventBus, app, config, promise))
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentManager.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentManager.scala
@@ -25,7 +25,8 @@ class DeploymentManager(
     scheduler: SchedulerActions,
     storage: StorageProvider,
     healthCheckManager: HealthCheckManager,
-    eventBus: EventStream) extends Actor with ActorLogging {
+    eventBus: EventStream,
+    config: UpgradeConfig) extends Actor with ActorLogging {
   import context.dispatcher
   import mesosphere.marathon.upgrade.DeploymentManager._
 
@@ -95,7 +96,8 @@ class DeploymentManager(
           taskQueue,
           storage,
           healthCheckManager,
-          eventBus
+          eventBus,
+          config
         ),
         plan.id
       )
@@ -132,4 +134,18 @@ object DeploymentManager {
   final case class DeploymentInfo(
     ref: ActorRef,
     plan: DeploymentPlan)
+
+  def props(
+    appRepository: AppRepository,
+    taskTracker: TaskTracker,
+    taskQueue: LaunchQueue,
+    scheduler: SchedulerActions,
+    storage: StorageProvider,
+    healthCheckManager: HealthCheckManager,
+    eventBus: EventStream,
+    config: UpgradeConfig): Props = {
+    Props(new DeploymentManager(appRepository, taskTracker, taskQueue,
+      scheduler, storage, healthCheckManager, eventBus, config))
+  }
+
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StoppingBehavior.scala
@@ -7,34 +7,39 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.event.MesosStatusUpdateEvent
 import mesosphere.marathon.state.PathId
-import mesosphere.marathon.upgrade.StoppingBehavior.SynchronizeTasks
-import org.apache.mesos.{ Protos, SchedulerDriver }
+import mesosphere.marathon.upgrade.StoppingBehavior.KillNextBatch
+import org.apache.mesos.SchedulerDriver
 
 import scala.collection.mutable
 import scala.concurrent.Promise
-import scala.concurrent.duration._
+import scala.math.min
 
 trait StoppingBehavior extends Actor with ActorLogging {
   import context.dispatcher
 
+  def config: UpgradeConfig
   def driver: SchedulerDriver
   def eventBus: EventStream
   def promise: Promise[Unit]
   def taskTracker: TaskTracker
   def appId: PathId
   var idsToKill: mutable.Set[Task.Id]
+  var batchKill: mutable.Queue[Task.Id] = _
   var periodicalCheck: Cancellable = _
-
-  def initializeStop(): Unit
 
   final override def preStart(): Unit = {
     eventBus.subscribe(self, classOf[MesosStatusUpdateEvent])
-    initializeStop()
-    scheduleSynchronization()
+    periodicalCheck = context.system.scheduler.schedule(
+      config.killBatchCycle, config.killBatchCycle, self, KillNextBatch)
+    //initiate first batch
+    batchKill = idsToKill.to[mutable.Queue]
+    killNextTasks(config.killBatchSize)
+    //check if there is anything to do
     checkFinished()
   }
 
   final override def postStop(): Unit = {
+    periodicalCheck.cancel()
     eventBus.unsubscribe(self)
     if (!promise.isCompleted)
       promise.tryFailure(
@@ -48,34 +53,40 @@ trait StoppingBehavior extends Actor with ActorLogging {
     case MesosStatusUpdateEvent(_, taskId, taskFinished(_), _, _, _, _, _, _, _, _) if idsToKill(taskId) =>
       idsToKill.remove(taskId)
       log.info(s"Task $taskId has been killed. Waiting for ${idsToKill.size} more tasks to be killed.")
+      killNextTasks(1) //since one kill is processed, initiate another one
       checkFinished()
 
-    case SynchronizeTasks =>
-      val trackerIds = taskTracker.appTasksLaunchedSync(appId).map(_.taskId).toSet
-      idsToKill = idsToKill.filter(trackerIds)
-
-      idsToKill.foreach { id =>
-        driver.killTask(id.mesosTaskId)
-      }
-
-      scheduleSynchronization()
-      checkFinished()
+    case KillNextBatch =>
+      if (batchKill.isEmpty && idsToKill.nonEmpty) synchronizeTasks()
+      killNextTasks(config.killBatchSize)
 
     case x: MesosStatusUpdateEvent => log.debug(s"Received $x")
+  }
+
+  def killNextTasks(toKill: Int): Unit = {
+    if (batchKill.nonEmpty) {
+      val tasksToKill = (0 until min(toKill, batchKill.size)).map { _ => batchKill.dequeue().mesosTaskId }
+      log.info(s"Killing ${tasksToKill.size} instances from ${idsToKill.size}")
+      tasksToKill.foreach(driver.killTask)
+    }
+  }
+
+  def synchronizeTasks(): Unit = {
+    val trackerIds = taskTracker.appTasksLaunchedSync(appId).map(_.taskId).toSet
+    idsToKill = idsToKill.filter(trackerIds)
+    log.info(s"Synchronize tasks: ${idsToKill.size} instances to kill")
+    batchKill = idsToKill.to[mutable.Queue]
+    checkFinished()
   }
 
   def checkFinished(): Unit =
     if (idsToKill.isEmpty) {
       log.info("Successfully killed all the tasks")
       promise.success(())
-      periodicalCheck.cancel()
       context.stop(self)
     }
-
-  def scheduleSynchronization(): Unit =
-    periodicalCheck = context.system.scheduler.scheduleOnce(5.seconds, self, SynchronizeTasks)
 }
 
 object StoppingBehavior {
-  case object SynchronizeTasks
+  case object KillNextBatch
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskKillActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskKillActor.scala
@@ -16,16 +16,11 @@ class TaskKillActor(
     val taskTracker: TaskTracker,
     val eventBus: EventStream,
     tasksToKill: Iterable[Task.Id],
+    val config: UpgradeConfig,
     val promise: Promise[Unit]) extends StoppingBehavior {
 
   override var idsToKill = tasksToKill.to[mutable.Set]
 
-  def initializeStop(): Unit = {
-    log.info(s"Killing ${tasksToKill.size} instances")
-    for (taskId <- tasksToKill) {
-      driver.killTask(taskId.mesosTaskId)
-    }
-  }
 }
 
 object TaskKillActor {
@@ -35,7 +30,8 @@ object TaskKillActor {
     taskTracker: TaskTracker,
     eventBus: EventStream,
     tasksToKill: Iterable[Task.Id],
+    config: UpgradeConfig,
     promise: Promise[Unit]): Props = {
-    Props(new TaskKillActor(driver, appId, taskTracker, eventBus, tasksToKill, promise))
+    Props(new TaskKillActor(driver, appId, taskTracker, eventBus, tasksToKill, config, promise))
   }
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/UpgradeConfig.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/UpgradeConfig.scala
@@ -1,0 +1,36 @@
+package mesosphere.marathon.upgrade
+
+import org.rogach.scallop.ScallopConf
+import scala.concurrent.duration._
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Config parameters for the upgrade module.
+  */
+trait UpgradeConfig extends ScallopConf {
+  //scalastyle:off magic.number
+
+  lazy val killsPerBatch = opt[Int]("killsPerBatch",
+    descr = "INTERNAL TUNING PARAMETER: " +
+      "The number of kills that can be issued in one batch size.",
+    noshort = true,
+    hidden = true,
+    default = Some(100)
+  )
+
+  /**
+    * Defines the duration of one batch cycle
+    */
+  lazy val killBatchDuration = opt[Long]("killBatchDuration",
+    descr = "INTERNAL TUNING PARAMETER: " +
+      "The duration of one batch cycle in milliseconds.",
+    noshort = true,
+    hidden = true,
+    default = Some(10000L) //10 seconds
+  )
+
+  def killBatchCycle: FiniteDuration = killBatchDuration().millis
+  def killBatchSize: Int = killsPerBatch()
+
+}

--- a/src/test/scala/mesosphere/marathon/test/Mockito.scala
+++ b/src/test/scala/mesosphere/marathon/test/Mockito.scala
@@ -15,6 +15,7 @@ trait Mockito extends MockitoSugar {
   def any[T] = org.mockito.Matchers.any[T]
   def anyBoolean = org.mockito.Matchers.anyBoolean
   def anyString = org.mockito.Matchers.anyString
+  def same[T](value: T) = org.mockito.Matchers.same(value)
   def verify[T](t: T, mode: VerificationMode = times(1)) = M.verify(t, mode)
   def times(num: Int) = M.times(num)
   def timeout(millis: Int) = M.timeout(millis)

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
@@ -6,13 +6,12 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.event.{ AppTerminatedEvent, HistoryActor, MesosStatusUpdateEvent }
 import mesosphere.marathon.state.{ AppDefinition, PathId, TaskFailure, TaskFailureRepository }
-import mesosphere.marathon.test.MarathonActorSupport
-import mesosphere.marathon.upgrade.StoppingBehavior.SynchronizeTasks
+import mesosphere.marathon.test.{ Mockito, MarathonActorSupport }
+import mesosphere.marathon.upgrade.StoppingBehavior.KillNextBatch
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper, TaskUpgradeCanceledException }
 import org.apache.mesos.SchedulerDriver
-import org.mockito.Matchers.any
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.concurrent.Eventually
 import org.scalatest.{ BeforeAndAfterAll, Matchers }
 
 import scala.concurrent.duration._
@@ -23,45 +22,20 @@ class AppStopActorTest
     with MarathonSpec
     with Matchers
     with BeforeAndAfterAll
-    with MockitoSugar {
-
-  var driver: SchedulerDriver = _
-  var taskTracker: TaskTracker = _
-  var taskFailureRepository: TaskFailureRepository = _
-
-  before {
-    driver = mock[SchedulerDriver]
-    taskTracker = mock[TaskTracker]
-    taskFailureRepository = mock[TaskFailureRepository]
-  }
+    with Mockito
+    with Eventually {
 
   test("Stop App") {
+    val f = new Fixture
     val app = AppDefinition(id = PathId("app"), instances = 2)
     val promise = Promise[Unit]()
     val tasks = Set(MarathonTestHelper.runningTask("task_a"), MarathonTestHelper.runningTask("task_b"))
 
-    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(tasks)
+    when(f.taskTracker.appTasksLaunchedSync(app.id)).thenReturn(tasks)
 
-    val ref = TestActorRef[AppStopActor](
-      Props(
-        new AppStopActor(
-          driver,
-          taskTracker,
-          system.eventStream,
-          app,
-          promise
-        ))
-    )
+    val ref = f.stopActor(app, promise)
     watch(ref)
-
-    val historyRef = TestActorRef[HistoryActor](
-      Props(
-        new HistoryActor(
-          system.eventStream,
-          taskFailureRepository
-        )
-      )
-    )
+    val historyRef = f.historyActor()
 
     val statusUpdateEventA =
       MesosStatusUpdateEvent(
@@ -86,60 +60,44 @@ class AppStopActorTest
 
     Await.result(promise.future, 5.seconds)
 
-    verify(driver, times(2)).killTask(any())
+    verify(f.driver, times(2)).killTask(any)
 
     system.eventStream.publish(AppTerminatedEvent(app.id))
 
     expectTerminated(ref)
 
     watch(historyRef)
-    verify(taskFailureRepository, times(1)).store(app.id, taskFailureA)
-    verify(taskFailureRepository, times(1)).store(app.id, taskFailureB)
+    verify(f.taskFailureRepository, times(1)).store(app.id, taskFailureA)
+    verify(f.taskFailureRepository, times(1)).store(app.id, taskFailureB)
 
-    verify(taskFailureRepository, times(1)).expunge(app.id)
+    verify(f.taskFailureRepository, times(1)).expunge(app.id)
   }
 
   test("Stop App without running tasks") {
+    val f = new Fixture
     val app = AppDefinition(id = PathId("app"), instances = 2)
     val promise = Promise[Unit]()
 
-    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable.empty[Task])
+    when(f.taskTracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable.empty[Task])
 
-    val ref = TestActorRef[AppStopActor](
-      Props(
-        new AppStopActor(
-          driver,
-          taskTracker,
-          system.eventStream,
-          app,
-          promise
-        ))
-    )
+    val ref = f.stopActor(app, promise)
     watch(ref)
 
     Await.result(promise.future, 5.seconds)
 
-    verify(driver, times(0)).killTask(any())
+    verify(f.driver, times(0)).killTask(any)
     expectTerminated(ref)
   }
 
   test("Failed") {
+    val f = new Fixture
     val app = AppDefinition(id = PathId("app"), instances = 2)
     val promise = Promise[Unit]()
     val tasks = Set(MarathonTestHelper.runningTask("task_a"), MarathonTestHelper.runningTask("task_b"))
 
-    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(tasks)
+    when(f.taskTracker.appTasksLaunchedSync(app.id)).thenReturn(tasks)
 
-    val ref = TestActorRef[AppStopActor](
-      Props(
-        new AppStopActor(
-          driver,
-          taskTracker,
-          system.eventStream,
-          app,
-          promise
-        ))
-    )
+    val ref = f.stopActor(app, promise)
     watch(ref)
 
     ref.stop()
@@ -148,38 +106,126 @@ class AppStopActorTest
       Await.result(promise.future, 5.seconds)
     }
 
-    verify(driver, times(2)).killTask(any())
+    verify(f.driver, times(2)).killTask(any)
     expectTerminated(ref)
   }
 
   test("Task synchronization") {
+    val f = new Fixture
     val app = AppDefinition(id = PathId("app"), instances = 2)
     val promise = Promise[Unit]()
     val tasks = Set(MarathonTestHelper.runningTask("task_a"), MarathonTestHelper.runningTask("task_b"))
 
-    when(taskTracker.appTasksLaunchedSync(app.id))
+    when(f.taskTracker.appTasksLaunchedSync(app.id))
       .thenReturn(tasks)
       .thenReturn(Iterable.empty[Task])
 
-    val ref = TestActorRef[AppStopActor](
-      Props(
-        classOf[AppStopActor],
-        driver,
-        taskTracker,
-        system.eventStream,
-        app,
-        promise
-      )
-    )
+    val ref = f.stopActor(app, promise)
     watch(ref)
 
     ref.underlyingActor.periodicalCheck.cancel()
 
-    ref ! SynchronizeTasks
+    ref ! KillNextBatch
 
     Await.result(promise.future, 10.seconds) should be(())
 
-    verify(driver, times(2)).killTask(any())
+    verify(f.driver, times(2)).killTask(any)
     expectTerminated(ref)
+  }
+
+  test("Kill is performed in batches") {
+    //Given: one app with 20 tasks
+    val f = new Fixture
+    val app = AppDefinition(id = PathId("app"), instances = 20)
+    val promise = Promise[Unit]()
+    val tasks = (0 until 20).map { a => MarathonTestHelper.runningTask(s"task_$a") }
+
+    //When: the App is stopped
+    f.taskTracker.appTasksLaunchedSync(app.id) returns tasks
+    val ref = f.stopActor(app, promise)
+    watch(ref)
+    ref.underlyingActor.periodicalCheck.cancel()
+
+    //Then: the first batch is executed directly after creation
+    ref.underlyingActor.idsToKill should have size 20
+    eventually { ref.underlyingActor.batchKill should have size 10 }
+
+    //And: the next batch will kill 10 tasks
+    ref ! KillNextBatch
+    eventually { ref.underlyingActor.batchKill should have size 0 }
+
+    //And: all tasks are erased from the task tracker, so the future completes
+    f.taskTracker.appTasksLaunchedSync(app.id) returns Iterable.empty
+    ref ! KillNextBatch
+    Await.result(promise.future, 10.seconds) should be(())
+
+    //And: we make sure 20 kill commands are issued
+    verify(f.driver, times(20)).killTask(any)
+    expectTerminated(ref)
+  }
+
+  test("Kill in batches - retry if kill is not acknowledged") {
+    //Given: one app with 20 tasks
+    val f = new Fixture
+    val app = AppDefinition(id = PathId("app"), instances = 20)
+    val promise = Promise[Unit]()
+    val tasks = (0 until 20).map { a => MarathonTestHelper.runningTask(s"task_$a") }
+
+    //When: the App is stopped
+    f.taskTracker.appTasksLaunchedSync(app.id) returns tasks
+    val ref = f.stopActor(app, promise)
+    watch(ref)
+    ref.underlyingActor.periodicalCheck.cancel()
+
+    //Then: the first batch is executed directly after creation
+    ref.underlyingActor.idsToKill should have size 20
+    eventually { ref.underlyingActor.batchKill should have size 10 }
+
+    //And: the next batch is triggered
+    ref ! KillNextBatch
+    eventually { ref.underlyingActor.batchKill should have size 0 }
+
+    //And: the next batch will trigger a synchronization
+    ref ! KillNextBatch
+    eventually { ref.underlyingActor.batchKill should have size 10 }
+
+    //And: all tasks are erased from the task tracker
+    ref ! KillNextBatch
+    f.taskTracker.appTasksLaunchedSync(app.id) returns Iterable.empty
+    ref ! KillNextBatch
+    Await.result(promise.future, 10.seconds) should be(())
+
+    //And: every task kill is issued twice: 20 tasks -> 40 kills
+    verify(f.driver, times(40)).killTask(any)
+    expectTerminated(ref)
+  }
+
+  class Fixture {
+    val driver: SchedulerDriver = mock[SchedulerDriver]
+    val taskTracker: TaskTracker = mock[TaskTracker]
+    val taskFailureRepository: TaskFailureRepository = mock[TaskFailureRepository]
+    val config: UpgradeConfig = mock[UpgradeConfig]
+    config.killBatchSize returns 10
+    config.killBatchCycle returns 10.seconds
+
+    def stopActor(app: AppDefinition, promise: Promise[Unit]) = TestActorRef[AppStopActor](
+      AppStopActor.props(
+        driver,
+        taskTracker,
+        system.eventStream,
+        app,
+        config,
+        promise
+      )
+    )
+
+    def historyActor() = TestActorRef[HistoryActor](
+      Props(
+        new HistoryActor(
+          system.eventStream,
+          taskFailureRepository
+        )
+      )
+    )
   }
 }

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.upgrade
 
-import akka.actor.ActorSystem
+import akka.actor.{ ActorRef, ActorSystem }
 import akka.testkit.{ TestActorRef, TestProbe }
 import akka.util.Timeout
 import mesosphere.marathon.core.launchqueue.LaunchQueue
@@ -10,15 +10,14 @@ import mesosphere.marathon.event.MesosStatusUpdateEvent
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state._
+import mesosphere.marathon.test.Mockito
 import mesosphere.marathon.upgrade.DeploymentManager.{ DeploymentFinished, DeploymentStepInfo }
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper, SchedulerActions }
 import org.apache.mesos.Protos.Status
 import org.apache.mesos.SchedulerDriver
-import org.mockito.Matchers.{ any, same }
-import org.mockito.Mockito.{ times, verify, verifyNoMoreInteractions, when }
+import org.mockito.Mockito.{ verifyNoMoreInteractions, when }
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfterAll, Matchers }
 
 import scala.concurrent.Future
@@ -28,28 +27,13 @@ class DeploymentActorTest
     extends MarathonSpec
     with Matchers
     with BeforeAndAfterAll
-    with MockitoSugar {
-
-  var tracker: TaskTracker = _
-  var queue: LaunchQueue = _
-  var driver: SchedulerDriver = _
-  var scheduler: SchedulerActions = _
-  var storage: StorageProvider = _
-  var hcManager: HealthCheckManager = _
+    with Mockito {
 
   implicit val defaultTimeout: Timeout = 5.seconds
 
-  before {
-    driver = mock[SchedulerDriver]
-    tracker = mock[TaskTracker]
-    queue = mock[LaunchQueue]
-    scheduler = mock[SchedulerActions]
-    storage = mock[StorageProvider]
-    hcManager = mock[HealthCheckManager]
-  }
-
   test("Deploy") {
-    implicit val system = ActorSystem("TestSystem")
+    val f = new Fixture
+    implicit val system = f.system
     val managerProbe = TestProbe()
     val receiverProbe = TestProbe()
     val app1 = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 2)
@@ -73,30 +57,16 @@ class DeploymentActorTest
 
     val plan = DeploymentPlan(origGroup, targetGroup)
 
-    when(tracker.appTasksLaunchedSync(app1.id)).thenReturn(Set(task1_1, task1_2))
-    when(tracker.appTasksLaunchedSync(app2.id)).thenReturn(Set(task2_1))
-    when(tracker.appTasksLaunchedSync(app3.id)).thenReturn(Set(task3_1))
-    when(tracker.appTasksLaunchedSync(app4.id)).thenReturn(Set(task4_1))
+    when(f.tracker.appTasksLaunchedSync(app1.id)).thenReturn(Set(task1_1, task1_2))
+    when(f.tracker.appTasksLaunchedSync(app2.id)).thenReturn(Set(task2_1))
+    when(f.tracker.appTasksLaunchedSync(app3.id)).thenReturn(Set(task3_1))
+    when(f.tracker.appTasksLaunchedSync(app4.id)).thenReturn(Set(task4_1))
 
-    when(driver.killTask(task1_2.taskId.mesosTaskId)).thenAnswer(new Answer[Status] {
-      def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent(
-          slaveId = "", taskId = Task.Id("task1_2"), taskStatus = "TASK_KILLED", message = "", appId = app1.id, host = "",
-          ipAddresses = Nil, ports = Nil, version = app1New.version.toString))
-        Status.DRIVER_RUNNING
-      }
-    })
+    f.driverKillSendsStatusKilledFor(app1, task1_2)
+    f.driverKillSendsStatusKilledFor(app2, task2_1)
+    f.driverKillSendsStatusKilledFor(app4, task4_1)
 
-    when(driver.killTask(task2_1.taskId.mesosTaskId)).thenAnswer(new Answer[Status] {
-      def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent(
-          slaveId = "", taskId = Task.Id("task2_1"), taskStatus = "TASK_KILLED", message = "", appId = app2.id, host = "",
-          ipAddresses = Nil, ports = Nil, version = app2.version.toString))
-        Status.DRIVER_RUNNING
-      }
-    })
-
-    when(queue.add(same(app2New), any[Int])).thenAnswer(new Answer[Boolean] {
+    when(f.queue.add(same(app2New), any[Int])).thenAnswer(new Answer[Boolean] {
       def answer(invocation: InvocationOnMock): Boolean = {
         println(invocation.getArguments.toSeq)
         for (i <- 0 until invocation.getArguments()(1).asInstanceOf[Int])
@@ -108,14 +78,14 @@ class DeploymentActorTest
       }
     })
 
-    when(scheduler.startApp(driver, app3)).thenAnswer(new Answer[Future[Unit]] {
+    when(f.scheduler.startApp(f.driver, app3)).thenAnswer(new Answer[Future[Unit]] {
       def answer(invocation: InvocationOnMock): Future[Unit] = {
         // system.eventStream.publish(MesosStatusUpdateEvent("", "task3_1", "TASK_RUNNING", "", app3.id, "", "", Nil, app3.version.toString))
         Future.successful(())
       }
     })
 
-    when(scheduler.scale(driver, app3)).thenAnswer(new Answer[Future[Unit]] {
+    when(f.scheduler.scale(f.driver, app3)).thenAnswer(new Answer[Future[Unit]] {
       def answer(invocation: InvocationOnMock): Future[Unit] = {
         system.eventStream.publish(MesosStatusUpdateEvent(
           slaveId = "", taskId = Task.Id("task3_1"), taskStatus = "TASK_RUNNING", message = "", appId = app3.id, host = "",
@@ -124,41 +94,17 @@ class DeploymentActorTest
       }
     })
 
-    when(driver.killTask(task4_1.taskId.mesosTaskId)).thenAnswer(new Answer[Status] {
-      def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent(
-          slaveId = "", taskId = Task.Id("task4_1"), taskStatus = "TASK_FINISHED", message = "", appId = app4.id,
-          host = "", ipAddresses = Nil, ports = Nil, version = app4.version.toString
-        ))
-        Status.DRIVER_RUNNING
-      }
-    })
-
     try {
-      TestActorRef(
-        DeploymentActor.props(
-          managerProbe.ref,
-          receiverProbe.ref,
-          driver,
-          scheduler,
-          plan,
-          tracker,
-          queue,
-          storage,
-          hcManager,
-          system.eventStream
-        )
-      )
-
+      f.deploymentActor(managerProbe.ref, receiverProbe.ref, plan)
       plan.steps.zipWithIndex.foreach {
         case (step, num) => managerProbe.expectMsg(5.seconds, DeploymentStepInfo(plan, step, num + 1))
       }
 
       managerProbe.expectMsg(5.seconds, DeploymentFinished(plan))
 
-      verify(scheduler).startApp(driver, app3.copy(instances = 0))
-      verify(driver, times(1)).killTask(task1_2.taskId.mesosTaskId)
-      verify(scheduler).stopApp(driver, app4.copy(instances = 0))
+      verify(f.scheduler).startApp(f.driver, app3.copy(instances = 0))
+      verify(f.driver, times(1)).killTask(task1_2.taskId.mesosTaskId)
+      verify(f.scheduler).stopApp(f.driver, app4.copy(instances = 0))
     }
     finally {
       system.shutdown()
@@ -166,7 +112,8 @@ class DeploymentActorTest
   }
 
   test("Restart app") {
-    implicit val system = ActorSystem("TestSystem")
+    val f = new Fixture
+    implicit val system = f.system
     val managerProbe = TestProbe()
     val receiverProbe = TestProbe()
     val app = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 2)
@@ -180,68 +127,45 @@ class DeploymentActorTest
     val task1_1 = MarathonTestHelper.runningTask("task1_1", appVersion = app.version, startedAt = 0)
     val task1_2 = MarathonTestHelper.runningTask("task1_2", appVersion = app.version, startedAt = 1000)
 
-    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Set(task1_1, task1_2))
+    when(f.tracker.appTasksLaunchedSync(app.id)).thenReturn(Set(task1_1, task1_2))
 
     val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
-    when(driver.killTask(task1_1.taskId.mesosTaskId)).thenAnswer(new Answer[Status] {
-      def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id("task1_1"), "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString))
-        Status.DRIVER_RUNNING
-      }
-    })
-
-    when(driver.killTask(task1_2.taskId.mesosTaskId)).thenAnswer(new Answer[Status] {
-      def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id("task1_2"), "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString))
-        Status.DRIVER_RUNNING
-      }
-    })
+    f.driverKillSendsStatusKilledFor(app, task1_1)
+    f.driverKillSendsStatusKilledFor(app, task1_2)
 
     val taskIDs = Iterator.from(3)
 
-    when(queue.count(appNew.id)).thenAnswer(new Answer[Int] {
+    when(f.queue.count(appNew.id)).thenAnswer(new Answer[Int] {
       override def answer(p1: InvocationOnMock): Int = appNew.instances
     })
 
-    when(queue.add(same(appNew), any[Int])).thenAnswer(new Answer[Boolean] {
+    when(f.queue.add(same(appNew), any[Int])).thenAnswer(new Answer[Boolean] {
       def answer(invocation: InvocationOnMock): Boolean = {
         for (i <- 0 until invocation.getArguments()(1).asInstanceOf[Int])
-          system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id(s"task1_${taskIDs.next()}"),
+          f.system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id(s"task1_${taskIDs.next()}"),
             "TASK_RUNNING", "", app.id, "", Nil, Nil, appNew.version.toString))
         true
       }
     })
 
     try {
-      TestActorRef(
-        DeploymentActor.props(
-          managerProbe.ref,
-          receiverProbe.ref,
-          driver,
-          scheduler,
-          plan,
-          tracker,
-          queue,
-          storage,
-          hcManager,
-          system.eventStream
-        )
-      )
 
+      f.deploymentActor(managerProbe.ref, receiverProbe.ref, plan)
       receiverProbe.expectMsg(DeploymentFinished(plan))
 
-      verify(driver).killTask(task1_1.taskId.mesosTaskId)
-      verify(driver).killTask(task1_2.taskId.mesosTaskId)
-      verify(queue).add(appNew, 2)
+      verify(f.driver).killTask(task1_1.taskId.mesosTaskId)
+      verify(f.driver).killTask(task1_2.taskId.mesosTaskId)
+      verify(f.queue).add(appNew, 2)
     }
     finally {
-      system.shutdown()
+      f.system.shutdown()
     }
   }
 
   test("Restart suspended app") {
-    implicit val system = ActorSystem("TestSystem")
+    val f = new Fixture
+    implicit val system = f.system
     val managerProbe = TestProbe()
     val receiverProbe = TestProbe()
 
@@ -254,33 +178,20 @@ class DeploymentActorTest
 
     val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
-    when(tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable.empty[Task])
+    when(f.tracker.appTasksLaunchedSync(app.id)).thenReturn(Iterable.empty[Task])
 
     try {
-      TestActorRef(
-        DeploymentActor.props(
-          managerProbe.ref,
-          receiverProbe.ref,
-          driver,
-          scheduler,
-          plan,
-          tracker,
-          queue,
-          storage,
-          hcManager,
-          system.eventStream
-        )
-      )
-
+      f.deploymentActor(managerProbe.ref, receiverProbe.ref, plan)
       receiverProbe.expectMsg(DeploymentFinished(plan))
     }
     finally {
-      system.shutdown()
+      f.system.shutdown()
     }
   }
 
   test("Scale with tasksToKill") {
-    implicit val system = ActorSystem("TestSystem")
+    val f = new Fixture
+    implicit val system = f.system
     val managerProbe = TestProbe()
     val receiverProbe = TestProbe()
     val app1 = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 3)
@@ -297,30 +208,12 @@ class DeploymentActorTest
 
     val plan = DeploymentPlan(original = origGroup, target = targetGroup, toKill = Map(app1.id -> Set(task1_2)))
 
-    when(tracker.appTasksLaunchedSync(app1.id)).thenReturn(Set(task1_1, task1_2, task1_3))
+    when(f.tracker.appTasksLaunchedSync(app1.id)).thenReturn(Set(task1_1, task1_2, task1_3))
 
-    when(driver.killTask(task1_2.taskId.mesosTaskId)).thenAnswer(new Answer[Status] {
-      def answer(invocation: InvocationOnMock): Status = {
-        system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id("task1_2"), "TASK_KILLED", "", app1.id, "", Nil, Nil, app1New.version.toString))
-        Status.DRIVER_RUNNING
-      }
-    })
+    f.driverKillSendsStatusKilledFor(app1, task1_2)
 
     try {
-      TestActorRef(
-        DeploymentActor.props(
-          managerProbe.ref,
-          receiverProbe.ref,
-          driver,
-          scheduler,
-          plan,
-          tracker,
-          queue,
-          storage,
-          hcManager,
-          system.eventStream
-        )
-      )
+      f.deploymentActor(managerProbe.ref, receiverProbe.ref, plan)
 
       plan.steps.zipWithIndex.foreach {
         case (step, num) => managerProbe.expectMsg(5.seconds, DeploymentStepInfo(plan, step, num + 1))
@@ -328,11 +221,50 @@ class DeploymentActorTest
 
       managerProbe.expectMsg(5.seconds, DeploymentFinished(plan))
 
-      verify(driver, times(1)).killTask(task1_2.taskId.mesosTaskId)
-      verifyNoMoreInteractions(driver)
+      verify(f.driver, times(1)).killTask(task1_2.taskId.mesosTaskId)
+      verifyNoMoreInteractions(f.driver)
     }
     finally {
-      system.shutdown()
+      f.system.shutdown()
     }
+  }
+
+  class Fixture {
+    val tracker: TaskTracker = mock[TaskTracker]
+    val queue: LaunchQueue = mock[LaunchQueue]
+    val driver: SchedulerDriver = mock[SchedulerDriver]
+    val scheduler: SchedulerActions = mock[SchedulerActions]
+    val storage: StorageProvider = mock[StorageProvider]
+    val hcManager: HealthCheckManager = mock[HealthCheckManager]
+    val config: UpgradeConfig = mock[UpgradeConfig]
+    implicit val system = ActorSystem("TestSystem")
+    config.killBatchSize returns 100
+    config.killBatchCycle returns 10.seconds
+
+    def driverKillSendsStatusKilledFor(app: AppDefinition, task: Task): Unit = {
+      driver.killTask(task.taskId.mesosTaskId) answers { args =>
+        system.eventStream.publish(MesosStatusUpdateEvent(
+          slaveId = "", taskId = task.taskId, taskStatus = "TASK_KILLED", message = "", appId = app.id, host = "",
+          ipAddresses = Nil, ports = Nil, version = app.version.toString))
+        Status.DRIVER_RUNNING
+      }
+    }
+
+    def deploymentActor(manager: ActorRef, receiver: ActorRef, plan: DeploymentPlan) = TestActorRef(
+      DeploymentActor.props(
+        manager,
+        receiver,
+        driver,
+        scheduler,
+        plan,
+        tracker,
+        queue,
+        storage,
+        hcManager,
+        system.eventStream,
+        config
+      )
+    )
+
   }
 }

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
@@ -68,8 +68,7 @@ class DeploymentManagerTest
 
   test("deploy") {
     val manager = TestActorRef[DeploymentManager](
-      Props(classOf[DeploymentManager],
-        appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus)
+      DeploymentManager.props(appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus, config)
     )
 
     val app = AppDefinition("app".toRootPath)
@@ -89,8 +88,7 @@ class DeploymentManagerTest
 
   test("StopActor") {
     val manager = TestActorRef[DeploymentManager](
-      Props(classOf[DeploymentManager],
-        appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus)
+      DeploymentManager.props(appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus, config)
     )
     val probe = TestProbe()
 
@@ -111,8 +109,7 @@ class DeploymentManagerTest
 
   test("Cancel deployment") {
     val manager = TestActorRef[DeploymentManager](
-      Props(classOf[DeploymentManager],
-        appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus)
+      DeploymentManager.props(appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus, config)
     )
 
     implicit val timeout = Timeout(1.minute)

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
@@ -6,12 +6,11 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.event.MesosStatusUpdateEvent
 import mesosphere.marathon.state.{ AppDefinition, PathId }
-import mesosphere.marathon.test.MarathonActorSupport
-import mesosphere.marathon.upgrade.StoppingBehavior.SynchronizeTasks
+import mesosphere.marathon.test.{ Mockito, MarathonActorSupport }
+import mesosphere.marathon.upgrade.StoppingBehavior.KillNextBatch
 import mesosphere.marathon.{ MarathonTestHelper, TaskUpgradeCanceledException }
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, FunSuiteLike, Matchers }
 
 import scala.collection.mutable
@@ -24,60 +23,55 @@ class TaskKillActorTest
     with Matchers
     with BeforeAndAfterAll
     with BeforeAndAfter
-    with MockitoSugar {
-
-  var taskTracker: TaskTracker = _
-  var driver: SchedulerDriver = _
-
-  before {
-    taskTracker = mock[TaskTracker]
-    driver = mock[SchedulerDriver]
-  }
+    with Mockito {
 
   test("Kill tasks") {
+    val f = new Fixture
     val taskA = MarathonTestHelper.runningTask("taskA_id")
     val taskB = MarathonTestHelper.runningTask("taskB_id")
 
     val tasks = Iterable(taskA, taskB)
     val promise = Promise[Unit]()
 
-    val ref = TestActorRef(Props(new TaskKillActor(driver, PathId("/test"), taskTracker, system.eventStream, tasks.map(_.taskId), promise)))
-
+    f.taskTracker.appTasksLaunchedSync(any) returns tasks
+    val ref = f.killActor(PathId("/test"), tasks.map(_.taskId), promise)
     watch(ref)
 
     system.eventStream.publish(MesosStatusUpdateEvent("", taskA.taskId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
     system.eventStream.publish(MesosStatusUpdateEvent("", taskB.taskId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
 
     Await.result(promise.future, 5.seconds) should be(())
-    verify(driver).killTask(taskA.taskId.mesosTaskId)
-    verify(driver).killTask(taskB.taskId.mesosTaskId)
+    verify(f.driver).killTask(taskA.taskId.mesosTaskId)
+    verify(f.driver).killTask(taskB.taskId.mesosTaskId)
 
     expectTerminated(ref)
   }
 
   test("Kill tasks with empty task list") {
+    val f = new Fixture
     val tasks = Iterable.empty[Task]
     val promise = Promise[Unit]()
 
-    val ref = TestActorRef(Props(new TaskKillActor(driver, PathId("/test"), taskTracker, system.eventStream, tasks.map(_.taskId), promise)))
-
+    f.taskTracker.appTasksLaunchedSync(any) returns Iterable.empty
+    val ref = f.killActor(PathId("/test"), tasks.map(_.taskId), promise)
     watch(ref)
 
     Await.result(promise.future, 5.seconds) should be(())
 
-    verifyZeroInteractions(driver)
+    verifyZeroInteractions(f.driver)
     expectTerminated(ref)
   }
 
   test("Cancelled") {
+    val f = new Fixture
     val taskA = MarathonTestHelper.runningTask("taskA_id")
     val taskB = MarathonTestHelper.runningTask("taskB_id")
 
     val tasks = Iterable(taskA, taskB)
     val promise = Promise[Unit]()
 
-    val ref = system.actorOf(Props(new TaskKillActor(driver, PathId("/test"), taskTracker, system.eventStream, tasks.map(_.taskId), promise)))
-
+    f.taskTracker.appTasksLaunchedSync(any) returns tasks
+    val ref = f.killActor(PathId("/test"), tasks.map(_.taskId), promise)
     watch(ref)
 
     system.stop(ref)
@@ -90,20 +84,21 @@ class TaskKillActorTest
   }
 
   test("Task synchronization") {
+    val f = new Fixture
     val app = AppDefinition(id = PathId("/app"), instances = 2)
     val promise = Promise[Unit]()
     val taskA = MarathonTestHelper.runningTask("taskA_id")
     val taskB = MarathonTestHelper.runningTask("taskB_id")
     val tasks = mutable.Iterable(taskA, taskB)
 
-    when(taskTracker.appTasksLaunchedSync(app.id)).thenReturn(mutable.Iterable.empty[Task])
-
-    val ref = TestActorRef[TaskKillActor](Props(new TaskKillActor(driver, app.id, taskTracker, system.eventStream, tasks.map(_.taskId), promise)))
+    f.taskTracker.appTasksLaunchedSync(any) returns tasks
+    val ref = f.killActor(app.id, tasks.map(_.taskId), promise)
     watch(ref)
 
     ref.underlyingActor.periodicalCheck.cancel()
 
-    ref ! SynchronizeTasks
+    f.taskTracker.appTasksLaunchedSync(any) returns Iterable.empty
+    ref ! KillNextBatch
 
     Await.result(promise.future, 5.seconds) should be(())
 
@@ -111,6 +106,7 @@ class TaskKillActorTest
   }
 
   test("Send kill again after synchronization with task tracker") {
+    val f = new Fixture
     val taskA = MarathonTestHelper.runningTask("taskA_id")
     val taskB = MarathonTestHelper.runningTask("taskB_id")
     val appId = PathId("/test")
@@ -118,23 +114,34 @@ class TaskKillActorTest
     val tasks = Iterable(taskA, taskB)
     val promise = Promise[Unit]()
 
-    val ref = TestActorRef[TaskKillActor](Props(new TaskKillActor(driver, appId, taskTracker, system.eventStream, tasks.map(_.taskId), promise)))
-
-    when(taskTracker.appTasksLaunchedSync(appId)).thenReturn(Iterable(taskA, taskB))
-
+    f.taskTracker.appTasksLaunchedSync(any) returns tasks
+    val ref = f.killActor(appId, tasks.map(_.taskId), promise)
     watch(ref)
 
     ref.underlyingActor.periodicalCheck.cancel()
-
-    ref ! SynchronizeTasks
+    ref ! KillNextBatch
 
     system.eventStream.publish(MesosStatusUpdateEvent("", taskA.taskId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
     system.eventStream.publish(MesosStatusUpdateEvent("", taskB.taskId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
 
     Await.result(promise.future, 5.seconds) should be(())
-    verify(driver, times(2)).killTask(taskA.launchedMesosId.get)
-    verify(driver, times(2)).killTask(taskB.launchedMesosId.get)
+    verify(f.driver, times(2)).killTask(taskA.launchedMesosId.get)
+    verify(f.driver, times(2)).killTask(taskB.launchedMesosId.get)
 
     expectTerminated(ref)
+  }
+
+  class Fixture {
+    val conf = mock[UpgradeConfig]
+    val taskTracker: TaskTracker = mock[TaskTracker]
+    val driver: SchedulerDriver = mock[SchedulerDriver]
+    val config: UpgradeConfig = mock[UpgradeConfig]
+
+    config.killBatchCycle returns 30.seconds
+    config.killBatchSize returns 100
+
+    def killActor(appId: PathId, tasks: Iterable[Task.Id], promise: Promise[Unit]) = {
+      TestActorRef[TaskKillActor](TaskKillActor.props(driver, appId, taskTracker, system.eventStream, tasks, config, promise))
+    }
   }
 }


### PR DESCRIPTION
The limit and cycle can be controlled via internal configuration parameters.
Introduces a config, that is passed to the deployment actors.
Adapted tests to meet the new configuration parameter.
Adapted tests to align with the new logic.
Additional tests added for the new functionality.