### PR TITLE
Allow  for tcp,udp ports in portMappings

### DIFF
--- a/docs/docs/ports.md
+++ b/docs/docs/ports.md
@@ -22,7 +22,7 @@ Port configuration for applications in Marathon can be confusing and there is [a
 
 *portDefinitions*: The _portDefinitionss_ array is used to define ports that should be considered as part of a resource offer. It is necessary only to define this array if you are using `HOST` networking and no port mappings are specified. This array is meant to replace the _ports_ array, and makes it possible to specify a port name, protocol and labels. Only one of _ports_ and _portDefinitions_ should be defined at the same time.
 
-*protocol*: _Protocol_ specifies the internet protocol to use for a port (e.g. `tcp` or `udp`). This is only necessary as part of a _port mapping_ when using `BRIDGE` mode networking with a Docker container.
+*protocol*: _Protocol_ specifies the internet protocol to use for a port (e.g. `tcp`, `udp` or `udp,tcp` for both). This is only necessary as part of a _port mapping_ when using `BRIDGE` mode networking with a Docker container.
 
 *requirePorts*: _requirePorts_ is a property that specifies whether Marathon should specifically look for specified ports in the resource offers it receives. This ensures that these ports are free and available to be bound to on the Mesos agent. This does not apply to `BRIDGE` mode networking.
 

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -144,8 +144,8 @@
                   },
                   "protocol": {
                     "type": "string",
-                    "enum": ["tcp", "udp"],
-                    "description": "Protocol of the port (one of ['tcp', 'udp']). Defaults to 'tcp'."
+                    "enum": ["tcp", "udp", "udp,tcp"],
+                    "description": "Protocol of the port (one of ['tcp', 'udp'] or 'udp,tcp' for both). Defaults to 'tcp'."
                   },
                   "servicePort": {
                     "type": "integer",

--- a/src/main/scala/mesosphere/marathon/state/Container.scala
+++ b/src/main/scala/mesosphere/marathon/state/Container.scala
@@ -40,22 +40,12 @@ object Container {
       *                      interpreted by external applications such as firewalls.
       */
     case class PortMapping(
-        containerPort: Int = 0,
-        hostPort: Int = 0,
-        servicePort: Int = 0,
-        protocol: String = "tcp",
-        name: Option[String] = None,
-        labels: Map[String, String] = Map.empty[String, String]) {
-
-      require(
-        protocol.split(',').forall(p => p == "tcp" || p == "udp"),
-        "protocol can only be 'tcp', 'udp' or 'udp,tcp'"
-      )
-      require(
-        protocol.split(',').toSet.size == protocol.split(',').toList.length,
-        "protocol cannot contain duplicates"
-      )
-    }
+      containerPort: Int = 0,
+      hostPort: Int = 0,
+      servicePort: Int = 0,
+      protocol: String = "tcp",
+      name: Option[String] = None,
+      labels: Map[String, String] = Map.empty[String, String])
 
     object PortMapping {
       val TCP = "tcp"

--- a/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
@@ -9,6 +9,7 @@ import mesosphere.marathon.api.serialization.{
   DockerSerializer,
   ContainerSerializer
 }
+import com.wix.accord._
 import org.scalatest.Matchers
 import org.apache.mesos.{ Protos => mesos }
 import play.api.libs.json.Json
@@ -91,6 +92,29 @@ class ContainerTest extends MarathonSpec with Matchers {
       )
     )
 
+    lazy val container5 = Container(
+      `type` = mesos.ContainerInfo.Type.DOCKER,
+      volumes = Nil,
+      docker = Some(
+        Container.Docker(
+          image = "group/image",
+          network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
+          portMappings = Some(Seq(
+            Container.Docker.PortMapping(
+              containerPort = 8080,
+              hostPort = 32001,
+              servicePort = 9000,
+              protocol = "tcp,udp"),
+            Container.Docker.PortMapping(
+              containerPort = 8081,
+              hostPort = 32002,
+              servicePort = 9001,
+              protocol = "udp,tcp")
+          ))
+        )
+      )
+    )
+
     lazy val mesosContainerWithPersistentVolume = Container(
       `type` = mesos.ContainerInfo.Type.MESOS,
       volumes = Seq[Volume](
@@ -153,6 +177,8 @@ class ContainerTest extends MarathonSpec with Matchers {
     assert(proto3.getDocker.hasForcePullImage)
     assert(f.container3.docker.get.forcePullImage == proto3.getDocker.getForcePullImage)
 
+    val proto5 = ContainerSerializer.toProto(f.container5)
+    assert(proto5.getDocker.getPortMappingsCount == 2)
   }
 
   test("ToMesos") {
@@ -197,6 +223,14 @@ class ContainerTest extends MarathonSpec with Matchers {
     )
     assert(proto3.getDocker.hasForcePullImage)
     assert(f.container3.docker.get.forcePullImage == proto3.getDocker.getForcePullImage)
+
+    val proto5 = ContainerSerializer.toMesos(f.container5)
+    assert(proto5.getDocker.getPortMappingsCount == 4)
+    val pms5 = proto5.getDocker.getPortMappingsList.asScala
+    assert(pms5.groupBy(_.getHostPort).contains(32001))
+    assert(pms5.groupBy(_.getHostPort).contains(32002))
+    assert(pms5.groupBy(_.getHostPort)(32001).map(_.getProtocol).toSet == Set("tcp", "udp"))
+    assert(pms5.groupBy(_.getHostPort)(32002).map(_.getProtocol).toSet == Set("tcp", "udp"))
   }
 
   test("ConstructFromProto") {
@@ -269,6 +303,7 @@ class ContainerTest extends MarathonSpec with Matchers {
     val f = fixture()
     assert (readResult3 == f.container)
   }
+
   test("Reading JSON with portMappings") {
     val json4 =
       """
@@ -289,6 +324,44 @@ class ContainerTest extends MarathonSpec with Matchers {
     val readResult4 = fromJson(json4)
     val f = fixture()
     assert(readResult4 == f.container2)
+  }
+
+  test("Reading JSON with multi-protocol portMappings") {
+    val json5 =
+      """
+      {
+        "type": "DOCKER",
+        "docker": {
+          "image": "group/image",
+          "network": "BRIDGE",
+          "portMappings": [
+            { "containerPort": 8080, "hostPort": 32001, "servicePort": 9000, "protocol": "tcp,udp" },
+            { "containerPort": 8081, "hostPort": 32002, "servicePort": 9001, "protocol": "udp,tcp" }
+          ]
+        }
+      }
+      """
+
+    val readResult5 = fromJson(json5)
+    val f = fixture()
+    assert(readResult5 == f.container5)
+  }
+
+  test("Reading JSON with non-unique multi-protocol portMappings") {
+    val json =
+      """
+      {
+        "type": "DOCKER",
+        "docker": {
+          "image": "group/image",
+          "network": "BRIDGE",
+          "portMappings": [
+            { "containerPort": 8080, "hostPort": 32001, "servicePort": 9000, "protocol": "tcp,udp,udp" }
+          ]
+        }
+      }
+      """
+    assert(validate(fromJson(json)).isFailure)
   }
 
   test("SerializationRoundTrip with privileged, networking and parameters") {

--- a/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
@@ -326,6 +326,23 @@ class ContainerTest extends MarathonSpec with Matchers {
     assert(readResult4 == f.container2)
   }
 
+  test("Reading JSON with invalid-protocol portMappings") {
+    val json =
+      """
+      {
+        "type": "DOCKER",
+        "docker": {
+          "image": "group/image",
+          "network": "BRIDGE",
+          "portMappings": [
+            { "containerPort": 8080, "hostPort": 32001, "servicePort": 9000, "protocol": "http" }
+          ]
+        }
+      }
+      """
+    assert(validate(fromJson(json)).isFailure)
+  }
+
   test("Reading JSON with multi-protocol portMappings") {
     val json5 =
       """


### PR DESCRIPTION
- allow `tcp,udp` and `udp,tcp` as protocol for Docker portMappings
- only reserve one port resource from an offer, but unfold the portMapping into `tcp` and `udp` in portMapping.toMesos, resulting in two Docker `-p` port mappings.

Fixes #929.

Example `marathon.json`:

```json
{
	"id": "/kdc",
	"instances": 1,
	"cpus": 1,
	"mem": 128,
	"env": {
		"PRINCIPAL_hdfs": "hdfs@LOCAL:secret",
		"PRINCIPAL_tester": "tester@LOCAL:secret",
		"KEYTAB_hdfs": "hdfs@LOCAL:hdfs.keytab",
		"KEYTAB_tester": "tester@LOCAL:tester.keytab"
	},
	"container": {
		"type": "DOCKER",
		"docker": {
			"image": "sttts/test-kdc:latest",
			"network": "BRIDGE",
			"forcePullImage": true,
			"portMappings": [
				{ "containerPort": 88, "hostPort": 0, "protocol": "udp,tcp" }
			]
		}
	}
}
```

leading to:

<img width="1193" alt="bildschirmfoto 2016-03-21 um 15 10 28" src="https://cloud.githubusercontent.com/assets/730123/13921235/3223e8dc-ef77-11e5-9264-426c8703bf50.png">
