### PR TITLE
Fixes #3544 - Introduce feature flags

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -42,6 +42,9 @@ The core functionality flags can be also set by environment variable `MARATHON_O
     Requires checkpointing enabled on slaves. Allows tasks to continue running
     during mesos-slave restarts and Marathon scheduler failover.  See the
     description of `--failover_timeout`.
+* <span class="label label-default">v0.16.0</span> `--enable_features` (Optional. Default: None):
+    Enable the selected features. Currently only "vips" can be used to enable networking VIP integration in the UI.
+    Example: `--enable_features vips`
 * `--executor` (Optional. Default: "//cmd"): Executor to use when none is
     specified.
 * `--failover_timeout` (Optional. Default: 604800 seconds (1 week)): The

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -42,7 +42,9 @@ class InfoResource @Inject() (
     "reconciliation_interval" -> config.reconciliationInterval.get,
     "mesos_user" -> config.mesosUser.get,
     "leader_proxy_connection_timeout_ms" -> config.leaderProxyConnectionTimeout.get,
-    "leader_proxy_read_timeout_ms" -> config.leaderProxyReadTimeout.get)
+    "leader_proxy_read_timeout_ms" -> config.leaderProxyReadTimeout.get,
+    "features" -> config.features.get
+  )
 
   // ZooKeeper congiurations
   private[this] lazy val zookeeperConfigValues = Json.obj(

--- a/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
@@ -1,9 +1,10 @@
 package mesosphere.marathon
 
+import org.scalatest.Matchers
+
 import scala.util.{ Failure, Try }
 
-class MarathonConfTest extends MarathonSpec {
-
+class MarathonConfTest extends MarathonSpec with Matchers {
   private[this] val principal = "foo"
   private[this] val secretFile = "/bar/baz"
 
@@ -68,7 +69,8 @@ class MarathonConfTest extends MarathonSpec {
     val triedConfig = Try(MarathonTestHelper.makeConfig(
       "--master", "127.0.0.1:5050",
       "--default_accepted_resource_roles", "*,marathon"
-    ))
+    )
+    )
     assert(triedConfig.isFailure)
     triedConfig match {
       case Failure(e) if e.getMessage ==
@@ -111,5 +113,33 @@ class MarathonConfTest extends MarathonSpec {
     )
     assert(conf.defaultAcceptedResourceRolesSet == Set("*", "marathon"))
   }
-}
 
+  test("Features should be empty by default") {
+    val conf = MarathonTestHelper.makeConfig(
+      "--master", "127.0.0.1:5050"
+    )
+
+    conf.features() should be(empty)
+  }
+
+  test("Features should allow vips") {
+    val conf = MarathonTestHelper.makeConfig(
+      "--master", "127.0.0.1:5050",
+      "--enable_features", "vips"
+    )
+
+    conf.features() should be(Set("vips"))
+  }
+
+  test("Features should not allow unknown features") {
+    val confTry = Try(
+      MarathonTestHelper.makeConfig(
+        "--master", "127.0.0.1:5050",
+        "--enable_features", "unknown"
+      )
+    )
+
+    confTry.isFailure should be(true)
+    confTry.failed.get.getMessage should include("Unknown features specified: unknown.")
+  }
+}


### PR DESCRIPTION
Currently, they are simply reexposed in the `/v2/info` endpoint.

/cc @pierlo-upitup @aldipower