### PR TITLE
Resolves #3456 added endpoint for manual deletion of residents

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -2,14 +2,16 @@ package mesosphere.marathon.api
 
 import javax.inject.Inject
 
+import com.twitter.util.NonFatal
 import mesosphere.marathon.core.task.{ TaskStateOp, Task }
 import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskTracker }
 import mesosphere.marathon.plugin.auth.{ Identity, UpdateApp, Authenticator, Authorizer }
 import mesosphere.marathon.state._
 import mesosphere.marathon.upgrade.DeploymentPlan
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService, UnknownAppException }
+import org.slf4j.LoggerFactory
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 class TaskKiller @Inject() (
     taskTracker: TaskTracker,
@@ -20,29 +22,44 @@ class TaskKiller @Inject() (
     val authenticator: Authenticator,
     val authorizer: Authorizer) extends AuthResource {
 
+  private[this] val log = LoggerFactory.getLogger(getClass)
+
   def kill(appId: PathId,
            findToKill: (Iterable[Task] => Iterable[Task]),
            wipe: Boolean = false)(implicit identity: Identity): Future[Iterable[Task]] = {
+
     result(groupManager.app(appId)) match {
       case Some(app) =>
         checkAuthorization(UpdateApp, app)
 
         import scala.concurrent.ExecutionContext.Implicits.global
-        taskTracker.appTasks(appId).map { allTasks =>
-          val allFound = findToKill(allTasks)
+        taskTracker.appTasks(appId).flatMap { allTasks =>
+          val foundTasks = findToKill(allTasks)
+          val expungeTasks = if (wipe) expunge(foundTasks) else Future.successful(())
 
-          if (wipe) allFound.foreach { task =>
-            stateOpProcessor.process(TaskStateOp.ForceExpunge(task.taskId))
+          expungeTasks.map { _ =>
+            val launchedTasks = foundTasks.filter(_.launched.isDefined)
+            if (launchedTasks.nonEmpty) {
+              service.killTasks(appId, launchedTasks)
+              foundTasks
+            }
+            else foundTasks
           }
-
-          val launched = allFound.filter(_.launched.isDefined)
-          if (launched.nonEmpty)
-            service.killTasks(appId, launched)
-
-          allFound
         }
 
       case None => Future.failed(UnknownAppException(appId))
+    }
+  }
+
+  private[this] def expunge(tasks: Iterable[Task])(implicit ec: ExecutionContext): Future[Unit] = {
+    tasks.foldLeft(Future.successful(())) { (resultSoFar, nextTask) =>
+      resultSoFar.flatMap { _ =>
+        log.info("Expunging {}", nextTask.taskId)
+        stateOpProcessor.process(TaskStateOp.ForceExpunge(nextTask.taskId)).map(_ => ()).recover {
+          case NonFatal(cause) =>
+            log.info("Failed to expunge {}, got: {}", Array[Object](nextTask.taskId, cause): _*)
+        }
+      }
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
@@ -3,9 +3,9 @@ package mesosphere.marathon.core.task.tracker.impl
 import akka.actor.{ ActorRef, Status }
 import akka.util.Timeout
 import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.task.tracker.{ TaskTracker, TaskTrackerConfig }
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.tracker.impl.TaskOpProcessorImpl.TaskStateOpResolver
-import mesosphere.marathon.core.task.tracker.{ TaskTracker, TaskTrackerConfig }
 import mesosphere.marathon.core.task.{ Task, TaskStateChange, TaskStateOp }
 import mesosphere.marathon.state.TaskRepository
 import org.slf4j.LoggerFactory

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -1,9 +1,8 @@
 package mesosphere.marathon.api
 
 import mesosphere.marathon._
-import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.plugin.auth.{ Identity, Authorizer, Authenticator }
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
+import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskTracker }
 import mesosphere.marathon.state.{ AppDefinition, Group, GroupManager, PathId, Timestamp }
 import mesosphere.marathon.upgrade.DeploymentPlan
 import org.mockito.ArgumentCaptor
@@ -13,6 +12,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfterAll, Matchers }
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -22,68 +22,54 @@ class TaskKillerTest extends MarathonSpec
     with MockitoSugar
     with ScalaFutures {
 
-  var tracker: TaskTracker = _
-  var service: MarathonSchedulerService = _
-  var groupManager: GroupManager = _
-  var taskKiller: TaskKiller = _
-  var config: MarathonConf = _
-  var auth: TestAuthFixture = _
-  implicit var identity: Identity = _
-
-  before {
-    service = mock[MarathonSchedulerService]
-    tracker = mock[TaskTracker]
-    groupManager = mock[GroupManager]
-    config = mock[MarathonConf]
-    auth = new TestAuthFixture
-    identity = auth.identity
-
-    taskKiller = new TaskKiller(tracker, groupManager, service, config, auth.auth, auth.auth)
-
-    when(config.zkTimeoutDuration).thenReturn(1.second)
-  }
+  val auth: TestAuthFixture = new TestAuthFixture
+  implicit val identity = auth.identity
 
   //regression for #3251
   test("No tasks to kill should return with an empty array") {
+    val f = new Fixture
     val appId = PathId("invalid")
-    when(tracker.appTasksLaunchedSync(appId)).thenReturn(Iterable.empty)
-    when(groupManager.app(appId)).thenReturn(Future.successful(Some(AppDefinition(appId))))
+    when(f.tracker.appTasks(appId)).thenReturn(Future.successful(Iterable.empty))
+    when(f.groupManager.app(appId)).thenReturn(Future.successful(Some(AppDefinition(appId))))
 
-    val result = taskKiller.kill(appId, (tasks) => Set.empty[Task]).futureValue
+    val result = f.taskKiller.kill(appId, (tasks) => Set.empty[Task]).futureValue
     result.isEmpty shouldEqual true
   }
 
   test("AppNotFound") {
+    val f = new Fixture
     val appId = PathId("invalid")
-    when(tracker.appTasksLaunchedSync(appId)).thenReturn(Iterable.empty)
-    when(groupManager.app(appId)).thenReturn(Future.successful(None))
+    when(f.tracker.appTasks(appId)).thenReturn(Future.successful(Iterable.empty))
+    when(f.groupManager.app(appId)).thenReturn(Future.successful(None))
 
-    val result = taskKiller.kill(appId, (tasks) => Set.empty[Task])
+    val result = f.taskKiller.kill(appId, (tasks) => Set.empty[Task])
     result.failed.futureValue shouldEqual UnknownAppException(appId)
   }
 
   test("AppNotFound with scaling") {
+    val f = new Fixture
     val appId = PathId("invalid")
-    when(tracker.hasAppTasksSync(appId)).thenReturn(false)
+    when(f.tracker.hasAppTasksSync(appId)).thenReturn(false)
 
-    val result = taskKiller.killAndScale(appId, (tasks) => Set.empty[Task], force = true)
+    val result = f.taskKiller.killAndScale(appId, (tasks) => Set.empty[Task], force = true)
     result.failed.futureValue shouldEqual UnknownAppException(appId)
   }
 
   test("KillRequested with scaling") {
+    val f = new Fixture
     val appId = PathId(List("app"))
     val task1 = MarathonTestHelper.runningTaskForApp(appId)
     val task2 = MarathonTestHelper.runningTaskForApp(appId)
     val tasksToKill = Set(task1, task2)
 
-    when(tracker.hasAppTasksSync(appId)).thenReturn(true)
-    when(groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
+    when(f.tracker.hasAppTasksSync(appId)).thenReturn(true)
+    when(f.groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
 
     val groupUpdateCaptor = ArgumentCaptor.forClass(classOf[(Group) => Group])
     val forceCaptor = ArgumentCaptor.forClass(classOf[Boolean])
     val toKillCaptor = ArgumentCaptor.forClass(classOf[Map[PathId, Iterable[Task]]])
     val expectedDeploymentPlan = DeploymentPlan.empty
-    when(groupManager.update(
+    when(f.groupManager.update(
       any[PathId],
       groupUpdateCaptor.capture(),
       any[Timestamp],
@@ -91,37 +77,39 @@ class TaskKillerTest extends MarathonSpec
       toKillCaptor.capture())
     ).thenReturn(Future.successful(expectedDeploymentPlan))
 
-    val result = taskKiller.killAndScale(appId, (tasks) => tasksToKill, force = true)
+    val result = f.taskKiller.killAndScale(appId, (tasks) => tasksToKill, force = true)
     result.futureValue shouldEqual expectedDeploymentPlan
     forceCaptor.getValue shouldEqual true
     toKillCaptor.getValue shouldEqual Map(appId -> tasksToKill)
   }
 
   test("KillRequested without scaling") {
+    val f = new Fixture
     val appId = PathId(List("my", "app"))
     val tasksToKill = Set(MarathonTestHelper.runningTaskForApp(appId))
-    when(groupManager.app(appId)).thenReturn(Future.successful(Some(AppDefinition(appId))))
-    when(tracker.appTasksLaunchedSync(appId)).thenReturn(tasksToKill)
+    when(f.groupManager.app(appId)).thenReturn(Future.successful(Some(AppDefinition(appId))))
+    when(f.tracker.appTasks(appId)).thenReturn(Future.successful(tasksToKill))
 
-    val result = taskKiller.kill(appId, { tasks =>
+    val result = f.taskKiller.kill(appId, { tasks =>
       tasks should equal(tasksToKill)
       tasksToKill
     })
     result.futureValue shouldEqual tasksToKill
-    verify(service, times(1)).killTasks(appId, tasksToKill)
+    verify(f.service, times(1)).killTasks(appId, tasksToKill)
   }
 
   test("Kill and scale w/o force should fail if there is a deployment") {
+    val f = new Fixture
     val appId = PathId(List("my", "app"))
     val task1 = MarathonTestHelper.runningTaskForApp(appId)
     val task2 = MarathonTestHelper.runningTaskForApp(appId)
     val tasksToKill = Set(task1, task2)
 
-    when(tracker.hasAppTasksSync(appId)).thenReturn(true)
-    when(groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
+    when(f.tracker.hasAppTasksSync(appId)).thenReturn(true)
+    when(f.groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
     val groupUpdateCaptor = ArgumentCaptor.forClass(classOf[(Group) => Group])
     val forceCaptor = ArgumentCaptor.forClass(classOf[Boolean])
-    when(groupManager.update(
+    when(f.groupManager.update(
       any[PathId],
       groupUpdateCaptor.capture(),
       any[Timestamp],
@@ -129,8 +117,42 @@ class TaskKillerTest extends MarathonSpec
       any[Map[PathId, Iterable[Task]]]
     )).thenReturn(Future.failed(AppLockedException()))
 
-    val result = taskKiller.killAndScale(appId, (tasks) => tasksToKill, force = false)
+    val result = f.taskKiller.killAndScale(appId, (tasks) => tasksToKill, force = false)
     forceCaptor.getValue shouldEqual false
     result.failed.futureValue shouldEqual AppLockedException()
   }
+
+  test("kill with wipe will kill running and expunge all") {
+    val f = new Fixture
+    val appId = PathId(List("my", "app"))
+    val runningTask = MarathonTestHelper.runningTaskForApp(appId)
+    val reservedTask = MarathonTestHelper.residentReservedTask(appId)
+    val tasksToKill = Set(runningTask, reservedTask)
+    when(f.groupManager.app(appId)).thenReturn(Future.successful(Some(AppDefinition(appId))))
+    when(f.tracker.appTasks(appId)).thenReturn(Future.successful(tasksToKill))
+
+    val result = f.taskKiller.kill(appId, { tasks =>
+      tasks should equal(tasksToKill)
+      tasksToKill
+    }, wipe = true)
+    result.futureValue shouldEqual tasksToKill
+    // only task1 is killed
+    verify(f.service, times(1)).killTasks(appId, Set(runningTask))
+    // both tasks are expunged from the repo
+    verify(f.stateOpProcessor).process(TaskStateOp.ForceExpunge(runningTask.taskId))
+    verify(f.stateOpProcessor).process(TaskStateOp.ForceExpunge(reservedTask.taskId))
+  }
+
+  class Fixture {
+    val tracker: TaskTracker = mock[TaskTracker]
+    val stateOpProcessor: TaskStateOpProcessor = mock[TaskStateOpProcessor]
+    val service: MarathonSchedulerService = mock[MarathonSchedulerService]
+    val groupManager: GroupManager = mock[GroupManager]
+
+    val config: MarathonConf = mock[MarathonConf]
+    when(config.zkTimeoutDuration).thenReturn(1.second)
+
+    val taskKiller: TaskKiller = new TaskKiller(tracker, stateOpProcessor, groupManager, service, config, auth.auth, auth.auth)
+  }
+
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppTasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppTasksResourceTest.scala
@@ -4,13 +4,13 @@ import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.{ JsonTestHelper, TaskKiller, TestAuthFixture }
 import mesosphere.marathon.core.appinfo.EnrichedTask
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskTracker }
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.plugin.auth.Identity
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{ Group, GroupManager, PathId, Timestamp, _ }
+import mesosphere.marathon.state.{ Group, GroupManager, PathId, _ }
 import mesosphere.marathon.test.Mockito
-import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService, MarathonSpec, MarathonTestHelper }
+import mesosphere.marathon.{ BadRequestException, MarathonConf, MarathonSchedulerService, MarathonSpec, MarathonTestHelper }
 import mesosphere.mesos.protos.SlaveID
 import org.mockito.Matchers.{ eq => equalTo }
 import org.mockito.Mockito._
@@ -28,18 +28,40 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     val toKill = Set(MarathonTestHelper.stagedTaskForApp(PathId(appId)))
 
     config.zkTimeoutDuration returns 5.seconds
-    taskKiller.kill(any, any)(any) returns Future.successful(toKill)
+    taskKiller.kill(any, any, any)(any) returns Future.successful(toKill)
     groupManager.app(appId.toRootPath) returns Future.successful(Some(AppDefinition(appId.toRootPath)))
 
-    val response = appsTaskResource.deleteMany(appId, host, scale = false, force = false, auth.request)
+    val response = appsTaskResource.deleteMany(appId, host, scale = false, force = false, wipe = false, auth.request)
     response.getStatus shouldEqual 200
     JsonTestHelper
       .assertThatJsonString(response.getEntity.asInstanceOf[String])
       .correspondsToJsonOf(Json.obj("tasks" -> toKill))
   }
 
+  test("deleteMany with scale and wipe fails") {
+    val appId = "/my/app"
+    val host = "host"
+
+    val exception = intercept[BadRequestException] {
+      appsTaskResource.deleteMany(appId, host, scale = true, force = false, wipe = true, auth.request)
+    }
+    exception.getMessage shouldEqual "You cannot use scale and wipe at the same time."
+  }
+
+  test("deleteMany with wipe delegates to taskKiller with wipe value") {
+    val appId = "/my/app"
+    val host = "host"
+    taskKiller.kill(any, any, any)(any) returns Future.successful(Iterable.empty[Task])
+
+    val response = appsTaskResource.deleteMany(appId, host, scale = false, force = false, wipe = true, auth.request)
+    response.getStatus shouldEqual 200
+    verify(taskKiller).kill(any, any, eq(true))(any)
+  }
+
   test("deleteOne") {
     import MarathonTestHelper.Implicits._
+
+    import scala.concurrent.ExecutionContext.Implicits.global
     val appId = PathId("/my/app")
     val slaveId = SlaveID("some slave ID")
     val task1 = MarathonTestHelper.mininimalTask(appId).withAgentInfo(_.copy(agentId = Some(slaveId.value)))
@@ -47,18 +69,54 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     val toKill = Set(task1)
 
     config.zkTimeoutDuration returns 5.seconds
-    taskTracker.appTasksSync(appId) returns Set(task1, task2)
-    taskKiller.kill(any, any)(any) returns Future.successful(toKill)
+    taskTracker.appTasks(appId) returns Future.successful(Set(task1, task2))
+    taskKiller.kill(any, any, any)(any) returns Future.successful(toKill)
     groupManager.app(appId) returns Future.successful(Some(AppDefinition(appId)))
 
     val response = appsTaskResource.deleteOne(
-      appId.toString, task1.taskId.idString, scale = false, force = false, auth.request
+      appId.toString, task1.taskId.idString, scale = false, force = false, wipe = false, auth.request
     )
     response.getStatus shouldEqual 200
     JsonTestHelper
       .assertThatJsonString(response.getEntity.asInstanceOf[String])
       .correspondsToJsonOf(Json.obj("task" -> toKill.head))
-    verify(taskKiller).kill(equalTo(appId), any)(any)
+    verify(taskKiller).kill(equalTo(appId), any, any)(any)
+    verifyNoMoreInteractions(taskKiller)
+  }
+
+  test("deleteOne with scale and wipe fails") {
+    val appId = "/my/app"
+    val id = "task-1"
+
+    val exception = intercept[BadRequestException] {
+      appsTaskResource.deleteOne(appId, id, scale = true, force = false, wipe = true, auth.request)
+    }
+    exception.getMessage shouldEqual "You cannot use scale and wipe at the same time."
+  }
+
+  test("deleteOne with wipe delegates to taskKiller with wipe value") {
+    import MarathonTestHelper.Implicits._
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val appId = PathId("/my/app")
+    val slaveId = SlaveID("some slave ID")
+    val task1 = MarathonTestHelper.mininimalTask(appId).withAgentInfo(_.copy(agentId = Some(slaveId.value)))
+    val task2 = MarathonTestHelper.mininimalTask(appId).withAgentInfo(_.copy(agentId = Some(slaveId.value)))
+    val toKill = Set(task1)
+
+    config.zkTimeoutDuration returns 5.seconds
+    taskTracker.appTasks(appId) returns Future.successful(Set(task1, task2))
+    taskKiller.kill(any, any, any)(any) returns Future.successful(toKill)
+    groupManager.app(appId) returns Future.successful(Some(AppDefinition(appId)))
+
+    val response = appsTaskResource.deleteOne(
+      appId.toString, task1.taskId.idString, scale = false, force = false, wipe = true, auth.request
+    )
+    response.getStatus shouldEqual 200
+    JsonTestHelper
+      .assertThatJsonString(response.getEntity.asInstanceOf[String])
+      .correspondsToJsonOf(Json.obj("task" -> toKill.head))
+    verify(taskKiller).kill(equalTo(appId), any, org.mockito.Matchers.eq(true))(any)
     verifyNoMoreInteractions(taskKiller)
   }
 
@@ -105,12 +163,12 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     indexTxt.getStatus should be(auth.NotAuthenticatedStatus)
 
     When(s"One task is deleted")
-    val deleteOne = appsTaskResource.deleteOne("appId", "taskId", false, false, req)
+    val deleteOne = appsTaskResource.deleteOne("appId", "taskId", false, false, false, req)
     Then("we receive a NotAuthenticated response")
     deleteOne.getStatus should be(auth.NotAuthenticatedStatus)
 
     When(s"multiple tasks are deleted")
-    val deleteMany = appsTaskResource.deleteMany("appId", "host", false, false, req)
+    val deleteMany = appsTaskResource.deleteMany("appId", "host", false, false, false, req)
     Then("we receive a NotAuthenticated response")
     deleteMany.getStatus should be(auth.NotAuthenticatedStatus)
   }
@@ -217,7 +275,7 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     groupManager.app("/app".toRootPath) returns Future.successful(Some(AppDefinition("/app".toRootPath)))
 
     When(s"deleteOne is called")
-    val deleteOne = appsTaskResource.deleteOne("app", "taskId", false, false, req)
+    val deleteOne = appsTaskResource.deleteOne("app", "taskId", false, false, false, req)
     Then("we receive a not authorized response")
     deleteOne.getStatus should be(auth.UnauthorizedStatus)
   }
@@ -233,7 +291,7 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     groupManager.app("/app".toRootPath) returns Future.successful(None)
 
     When(s"deleteOne is called")
-    val deleteOne = appsTaskResource.deleteOne("app", "taskId", false, false, req)
+    val deleteOne = appsTaskResource.deleteOne("app", "taskId", false, false, false, req)
     Then("we receive a not authorized response")
     deleteOne.getStatus should be(404)
   }
@@ -249,7 +307,7 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     groupManager.app("/app".toRootPath) returns Future.successful(Some(AppDefinition("/app".toRootPath)))
 
     When(s"deleteMany is called")
-    val deleteMany = appsTaskResource.deleteMany("app", "host", false, false, req)
+    val deleteMany = appsTaskResource.deleteMany("app", "host", false, false, false, req)
     Then("we receive a not authorized response")
     deleteMany.getStatus should be(auth.UnauthorizedStatus)
   }
@@ -265,13 +323,14 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     groupManager.app("/app".toRootPath) returns Future.successful(None)
 
     When(s"deleteMany is called")
-    val deleteMany = appsTaskResource.deleteMany("app", "host", false, false, req)
+    val deleteMany = appsTaskResource.deleteMany("app", "host", false, false, false, req)
     Then("we receive a not authorized response")
     deleteMany.getStatus should be(404)
   }
 
   var service: MarathonSchedulerService = _
   var taskTracker: TaskTracker = _
+  var stateOpProcessor: TaskStateOpProcessor = _
   var taskKiller: TaskKiller = _
   var healthCheckManager: HealthCheckManager = _
   var config: MarathonConf = _
@@ -284,6 +343,7 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
     auth = new TestAuthFixture
     service = mock[MarathonSchedulerService]
     taskTracker = mock[TaskTracker]
+    stateOpProcessor = mock[TaskStateOpProcessor]
     taskKiller = mock[TaskKiller]
     healthCheckManager = mock[HealthCheckManager]
     config = mock[MarathonConf]
@@ -304,7 +364,7 @@ class AppTasksResourceTest extends MarathonSpec with Matchers with GivenWhenThen
   }
 
   private[this] def useRealTaskKiller(): Unit = {
-    taskKiller = new TaskKiller(taskTracker, groupManager, service, config, auth.auth, auth.auth)
+    taskKiller = new TaskKiller(taskTracker, stateOpProcessor, groupManager, service, config, auth.auth, auth.auth)
     appsTaskResource = new AppTasksResource(
       service,
       taskTracker,

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -107,7 +107,7 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     exception.getMessage shouldEqual "You cannot use scale and wipe at the same time."
   }
 
-  // FIXME (3221): breaks – why?
+  // FIXME (3456): breaks – why?
   ignore("killTasks with wipe delegates to taskKiller with wipe value") {
     import scala.concurrent.ExecutionContext.Implicits.global
 


### PR DESCRIPTION
Resolves #3456

Adds `wipe` (default=false) to the tasks deletion endpoints. Either `scale` or `wipe` may be true, never both. In case `wipe=true`, running tasks will be killed, and all given Ids will be expunged from the repo.

That means we will eventually receive `TASK_KILLED` updates, to which the code will react with a `ForceExpunge` TaskStateOp. This way, the expunge will be propagated to all relevant parties even though the task is already removed from the repo.

For later reference: it would be cleaner to mark these tasks as `Garbage` instead of expunging them immediately, and react to `TASK_KILLED` on a `Garbage` task with an Expunge operation. Follow-up subtasks are tracked in #3568 