### PR TITLE
Towards #3502 - Define ReadinessCheckExecutor

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -14,6 +14,7 @@ import mesosphere.marathon.core.matcher.base.util.StopOnFirstMatchingOfferMatche
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerModule
 import mesosphere.marathon.core.matcher.reconcile.OfferMatcherReconciliationModule
 import mesosphere.marathon.core.plugin.PluginModule
+import mesosphere.marathon.core.readiness.ReadinessModule
 import mesosphere.marathon.core.task.bus.TaskBusModule
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.tracker.TaskTrackerModule
@@ -60,6 +61,9 @@ class CoreModuleImpl @Inject() (
   override lazy val taskTrackerModule =
     new TaskTrackerModule(clock, metrics, marathonConf, leadershipModule, taskRepository, taskStatusUpdateSteps)
   override lazy val taskJobsModule = new TaskJobsModule(marathonConf, leadershipModule, clock)
+
+  // READINESS CHECKS
+  lazy val readinessModule = new ReadinessModule()
 
   // OFFER MATCHING AND LAUNCHING TASKS
 

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
@@ -62,8 +62,9 @@ object ReadinessCheckExecutor {
               checkDef.portName,
               throw new IllegalArgumentException(s"no port definition for port name '${checkDef.portName}' was found")
             )
-            val fixedPort = app.portDefinitions(portIndex).fixedHostPort
-            fixedPort.getOrElse(launched.ports(portIndex))
+
+            if (app.hasFixedHostPorts) app.portDefinitions(portIndex).port
+            else launched.ports(portIndex)
           }
 
           s"$schema://$host:$port${checkDef.path}"

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
@@ -1,0 +1,84 @@
+package mesosphere.marathon.core.readiness
+
+import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.state.AppDefinition
+import rx.lang.scala.Observable
+
+import scala.collection.immutable.Seq
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Poll readiness of the given endpoint until we receive readiness confirmation.
+  * Intermediate results are returned as part of the Observable.
+  */
+trait ReadinessCheckExecutor {
+  def execute(readinessCheckInfo: ReadinessCheckSpec): Observable[ReadinessCheckResult]
+}
+
+object ReadinessCheckExecutor {
+  /**
+    * A self-contained description which contains all information necessary to perform
+    * a readiness check.
+    */
+  case class ReadinessCheckSpec(
+    taskId: Task.Id,
+    checkName: String,
+    url: String,
+    interval: FiniteDuration = ReadinessCheck.DefaultInterval,
+    timeout: FiniteDuration = ReadinessCheck.DefaultTimeout,
+    httpStatusCodesForReady: Set[Int] = ReadinessCheck.DefaultHttpStatusCodesForReady,
+    preserveLastResponse: Boolean = ReadinessCheck.DefaultPreserveLastResponse)
+
+  object ReadinessCheckSpec {
+    /**
+      * Returns the readiness checks for the given task.
+      */
+    def readinessCheckSpecsForTask(
+      app: AppDefinition,
+      task: Task,
+      launched: Task.Launched): Seq[ReadinessCheckExecutor.ReadinessCheckSpec] = {
+
+      require(task.appId == app.id, s"Task appId and AppDefinition appId must match: ${task.appId} != ${app.id}")
+      require(task.launched == Some(launched), "Launched info is not the one contained in the task")
+
+      val portIndexByName = app.portDefinitions.iterator.zipWithIndex.flatMap {
+        case (portDef, idx) => portDef.name.map(_ -> idx)
+      }.toMap
+
+      app.readinessChecks.map { checkDef =>
+
+        // determining the URL is difficult, everything else is just copying configuration
+        val url = {
+          val schema = checkDef.protocol match {
+            case ReadinessCheck.Protocol.HTTP  => "http"
+            case ReadinessCheck.Protocol.HTTPS => "https"
+          }
+          val host = task.effectiveIpAddress(app)
+          val port = {
+            // Launched.ports and and app.portDefinitions have the same number
+            // of entries and correspond to each one-on-one.
+            val portIndex = portIndexByName.getOrElse(
+              checkDef.portName,
+              throw new IllegalArgumentException(s"no port definition for port name '${checkDef.portName}' was found")
+            )
+            val fixedPort = app.portDefinitions(portIndex).fixedHostPort
+            fixedPort.getOrElse(launched.ports(portIndex))
+          }
+
+          s"$schema://$host:$port${checkDef.path}"
+        }
+
+        ReadinessCheckSpec(
+          taskId = task.taskId,
+          checkName = checkDef.name,
+          url = url,
+          interval = checkDef.interval,
+          timeout = checkDef.timeout,
+          httpStatusCodesForReady = checkDef.httpStatusCodesForReady,
+          preserveLastResponse = checkDef.preserveLastResponse
+        )
+      }
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessModule.scala
@@ -1,0 +1,17 @@
+package mesosphere.marathon.core.readiness
+
+import mesosphere.marathon.core.readiness.impl.DummyReadinessCheckExecutor
+
+/**
+  * Exposes everything necessary to execute readiness checks on tasks.
+  *
+  * A task might not be ready:
+  *
+  * * because it needs to run a migration (which potentially can be controlled using the DCOS Migration API)
+  * * it needs to warm up its caches
+  * * it needs to load some data
+  * * ...
+  */
+class ReadinessModule {
+  lazy val readinessCheckExecutor: ReadinessCheckExecutor = new DummyReadinessCheckExecutor()
+}

--- a/src/main/scala/mesosphere/marathon/core/readiness/impl/DummyReadinessCheckExecutor.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/impl/DummyReadinessCheckExecutor.scala
@@ -1,0 +1,38 @@
+package mesosphere.marathon.core.readiness.impl
+
+import mesosphere.marathon.core.readiness.{ HttpResponse, ReadinessCheckResult, ReadinessCheckExecutor }
+import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
+import rx.lang.scala.Observable
+
+/**
+  * A stop-gap dummy implementation to allow testing.
+  */
+private[readiness] class DummyReadinessCheckExecutor extends ReadinessCheckExecutor {
+  override def execute(readinessCheckInfo: ReadinessCheckSpec): Observable[ReadinessCheckResult] = {
+    // dummy results
+    def resultForIndex(idx: Int): ReadinessCheckResult = {
+      val ready = idx >= 3
+
+      ReadinessCheckResult(
+        readinessCheckInfo.checkName,
+        readinessCheckInfo.taskId,
+        ready = ready,
+        httpResponse = Some(
+          HttpResponse(
+            status = if (ready)
+              readinessCheckInfo.httpStatusCodesForReady.head
+            else
+              (500 to 599).find(!readinessCheckInfo.httpStatusCodesForReady(_)).getOrElse(???),
+            mediaType = "application/json",
+            body = "{}".getBytes
+          )
+        )
+      )
+    }
+
+    Observable
+      .interval(readinessCheckInfo.interval)
+      .zipWithIndex.map { case (_, idx) => resultForIndex(idx) }
+      .takeUntil(_.ready)
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -383,7 +383,7 @@ object Task {
 
     def hasStartedRunning: Boolean = status.startedAt.isDefined
 
-    def ports: Iterable[Int] = networking.ports
+    def ports: Seq[Int] = networking.ports
 
     def ipAddresses: Iterable[MesosProtos.NetworkInfo.IPAddress] = networking match {
       case list: NetworkInfoList => list.addresses
@@ -414,13 +414,13 @@ object Task {
 
   /** Info on how to reach the task in the network. */
   sealed trait Networking {
-    def ports: Iterable[Int]
+    def ports: Seq[Int]
   }
 
   /** The task is reachable via host ports which are bound to [[AgentInfo#host]]. */
-  case class HostPorts(ports: Iterable[Int]) extends Networking
+  case class HostPorts(ports: Seq[Int]) extends Networking
   object HostPorts {
-    def apply(ports: Int*): HostPorts = HostPorts(ports)
+    def forPorts(ports: Int*): HostPorts = new HostPorts(ports)
   }
 
   /**
@@ -430,14 +430,14 @@ object Task {
   case class NetworkInfoList(networkInfoList: Iterable[MesosProtos.NetworkInfo]) extends Networking {
     import scala.collection.JavaConverters._
     def addresses: Iterable[MesosProtos.NetworkInfo.IPAddress] = networkInfoList.flatMap(_.getIpAddressesList.asScala)
-    override def ports: Iterable[Int] = Iterable.empty
+    override def ports: Seq[Int] = Seq.empty
   }
   object NetworkInfoList {
     def apply(networkInfoList: MesosProtos.NetworkInfo*): NetworkInfoList = NetworkInfoList(networkInfoList)
   }
 
   case object NoNetworking extends Networking {
-    override def ports: Iterable[Int] = Iterable.empty
+    override def ports: Seq[Int] = Seq.empty
   }
 
   object Terminated {

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -69,7 +69,7 @@ class PostToEventStreamStepImpl @Inject() (
           },
           ports = launched.networking match {
             case Task.HostPorts(ports) => ports
-            case _                     => Iterable.empty
+            case _                     => Seq.empty
           },
           version = launched.appVersion.toString,
           timestamp = timestamp.toString

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -1,14 +1,14 @@
 package mesosphere.marathon.state
 
 import com.wix.accord._
-import mesosphere.marathon.Protos
+import com.wix.accord.dsl._
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
-import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.serialization.{ ContainerSerializer, PortDefinitionSerializer, ResidencySerializer }
+import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.core.readiness.ReadinessCheck
 import mesosphere.marathon.health.HealthCheck
-import mesosphere.marathon.plugin
+import mesosphere.marathon.{ Protos, plugin }
 import mesosphere.marathon.state.AppDefinition.VersionInfo
 import mesosphere.marathon.state.AppDefinition.VersionInfo.{ FullVersionInfo, OnlyVersion }
 import mesosphere.marathon.state.Container.Docker.PortMapping
@@ -20,8 +20,6 @@ import org.apache.mesos.{ Protos => mesos }
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
-
-import com.wix.accord.dsl._
 
 case class AppDefinition(
 

--- a/src/main/scala/mesosphere/marathon/state/PortDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/PortDefinition.scala
@@ -9,9 +9,7 @@ import scala.collection.immutable.Seq
 case class PortDefinition(port: Int,
                           protocol: String = "tcp",
                           name: Option[String] = None,
-                          labels: Map[String, String] = Map.empty[String, String]) {
-  def fixedHostPort: Option[Int] = if (port != AppDefinition.RandomPortValue) Some(port) else None
-}
+                          labels: Map[String, String] = Map.empty[String, String])
 
 object PortDefinition {
   implicit val portDefinitionValidator = validator[PortDefinition] { portDefinition =>

--- a/src/main/scala/mesosphere/marathon/state/PortDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/PortDefinition.scala
@@ -9,7 +9,9 @@ import scala.collection.immutable.Seq
 case class PortDefinition(port: Int,
                           protocol: String = "tcp",
                           name: Option[String] = None,
-                          labels: Map[String, String] = Map.empty[String, String])
+                          labels: Map[String, String] = Map.empty[String, String]) {
+  def fixedHostPort: Option[Int] = if (port != AppDefinition.RandomPortValue) Some(port) else None
+}
 
 object PortDefinition {
   implicit val portDefinitionValidator = validator[PortDefinition] { portDefinition =>

--- a/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckSpecTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckSpecTest.scala
@@ -111,6 +111,7 @@ class ReadinessCheckSpecTest extends FunSuite with Matchers with GivenWhenThen {
     val appWithOneReadinessCheckWithFixedPort = AppDefinition(
       id = appId,
       readinessChecks = Seq(ReadinessCheckTestHelper.defaultHttp),
+      requirePorts = true,
       portDefinitions = Seq(
         PortDefinition(
           port = 8080,
@@ -127,11 +128,11 @@ class ReadinessCheckSpecTest extends FunSuite with Matchers with GivenWhenThen {
       ),
       portDefinitions = Seq(
         PortDefinition(
-          port = AppDefinition.RandomPortValue,
+          port = 1, // service ports, ignore
           name = Some(ReadinessCheckTestHelper.alternativeHttps.portName)
         ),
         PortDefinition(
-          port = AppDefinition.RandomPortValue,
+          port = 2, // service ports, ignore
           name = Some(ReadinessCheckTestHelper.defaultHttp.portName)
         )
       )

--- a/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckSpecTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckSpecTest.scala
@@ -1,0 +1,142 @@
+package mesosphere.marathon.core.readiness
+
+import mesosphere.marathon.MarathonTestHelper
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.state.{ PortDefinition, PathId, AppDefinition }
+import org.scalatest.{ GivenWhenThen, Matchers, FunSuite }
+import scala.collection.immutable.Seq
+
+class ReadinessCheckSpecTest extends FunSuite with Matchers with GivenWhenThen {
+  import MarathonTestHelper.Implicits._
+
+  test("readiness check specs for one task with dynamic ports and one readiness check") {
+    val f = new Fixture
+
+    Given("an app with a readiness check and a randomly assigned port")
+    val app = f.appWithOneReadinessCheck
+    And("a task with two host port")
+    val task = f.taskWithPorts
+
+    When("calculating the ReadinessCheckSpec")
+    val specs = ReadinessCheckExecutor.ReadinessCheckSpec.readinessCheckSpecsForTask(app, task, task.launched.get)
+
+    Then("we get one spec")
+    specs should have size 1
+    val spec = specs.head
+    And("it has the correct url")
+    spec.url should equal("http://host.some:80/")
+    And("the rest of the fields are correct, too")
+    spec should equal(
+      ReadinessCheckExecutor.ReadinessCheckSpec(
+        url = "http://host.some:80/",
+        taskId = task.taskId,
+        checkName = app.readinessChecks.head.name,
+        interval = app.readinessChecks.head.interval,
+        timeout = app.readinessChecks.head.timeout,
+        httpStatusCodesForReady = app.readinessChecks.head.httpStatusCodesForReady,
+        preserveLastResponse = app.readinessChecks.head.preserveLastResponse
+      )
+    )
+  }
+
+  test("readiness check specs for one task with fixed ports and one readiness check") {
+    val f = new Fixture
+
+    Given("an app with a readiness check and a fixed port assignment")
+    val app = f.appWithOneReadinessCheckWithFixedPort
+    And("a task with two host port")
+    val task = f.taskWithPorts
+
+    When("calculating the ReadinessCheckSpec")
+    val specs = ReadinessCheckExecutor.ReadinessCheckSpec.readinessCheckSpecsForTask(app, task, task.launched.get)
+
+    Then("we get one spec")
+    specs should have size 1
+    val spec = specs.head
+    And("it has the correct url")
+    spec.url should equal("http://host.some:8080/")
+    And("the rest of the fields are correct, too")
+    spec should equal(
+      ReadinessCheckExecutor.ReadinessCheckSpec(
+        url = "http://host.some:8080/",
+        taskId = task.taskId,
+        checkName = app.readinessChecks.head.name,
+        interval = app.readinessChecks.head.interval,
+        timeout = app.readinessChecks.head.timeout,
+        httpStatusCodesForReady = app.readinessChecks.head.httpStatusCodesForReady,
+        preserveLastResponse = app.readinessChecks.head.preserveLastResponse
+      )
+    )
+  }
+
+  test("multiple readiness check specs") {
+    val f = new Fixture
+
+    Given("an app with two readiness checks and randomly assigned ports")
+    val app = f.appWithMultipleReadinessChecks
+    And("a task with two host port")
+    val task = f.taskWithPorts
+
+    When("calculating the ReadinessCheckSpec")
+    val specs = ReadinessCheckExecutor.ReadinessCheckSpec.readinessCheckSpecsForTask(app, task, task.launched.get)
+
+    Then("we get two specs in the right order")
+    specs should have size 2
+    val specDefaultHttp = specs.head
+    val specAlternative = specs(1)
+    specDefaultHttp.checkName should equal(app.readinessChecks.head.name)
+    specAlternative.checkName should equal(app.readinessChecks(1).name)
+
+    And("the default http spec has the right url")
+    specDefaultHttp.url should equal("http://host.some:81/")
+
+    And("the alternative https spec has the right url")
+    specAlternative.url should equal("https://host.some:80/v1/plan")
+  }
+
+  class Fixture {
+    val appId: PathId = PathId("/test")
+
+    val appWithOneReadinessCheck = AppDefinition(
+      id = appId,
+      readinessChecks = Seq(ReadinessCheckTestHelper.defaultHttp),
+      portDefinitions = Seq(
+        PortDefinition(
+          port = AppDefinition.RandomPortValue,
+          name = Some("httpApi")
+        )
+      )
+    )
+
+    val appWithOneReadinessCheckWithFixedPort = AppDefinition(
+      id = appId,
+      readinessChecks = Seq(ReadinessCheckTestHelper.defaultHttp),
+      portDefinitions = Seq(
+        PortDefinition(
+          port = 8080,
+          name = Some(ReadinessCheckTestHelper.defaultHttp.portName)
+        )
+      )
+    )
+
+    val appWithMultipleReadinessChecks = AppDefinition(
+      id = appId,
+      readinessChecks = Seq(
+        ReadinessCheckTestHelper.defaultHttp,
+        ReadinessCheckTestHelper.alternativeHttps
+      ),
+      portDefinitions = Seq(
+        PortDefinition(
+          port = AppDefinition.RandomPortValue,
+          name = Some(ReadinessCheckTestHelper.alternativeHttps.portName)
+        ),
+        PortDefinition(
+          port = AppDefinition.RandomPortValue,
+          name = Some(ReadinessCheckTestHelper.defaultHttp.portName)
+        )
+      )
+    )
+
+    val taskWithPorts = MarathonTestHelper.runningTaskForApp(appId).withNetworking(Task.HostPorts.forPorts(80, 81))
+  }
+}

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializerTest.scala
@@ -63,7 +63,7 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
     val f = new Fixture
 
     Given("a MarathonTask with all fields and host ports")
-    val samplePorts = Iterable(80, 81)
+    val samplePorts = Seq(80, 81)
     val marathonTask =
       f.completeTask.toBuilder
         .addAllPorts(samplePorts.map(Integer.valueOf(_)).asJava)

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -367,7 +367,7 @@ class HealthCheckTest extends MarathonSpec {
   test("getPort") {
     import MarathonTestHelper.Implicits._
     val check = new HealthCheck(port = Some(1234))
-    val task = MarathonTestHelper.runningTask("test_id").withNetworking(Task.HostPorts(4321))
+    val task = MarathonTestHelper.runningTask("test_id").withNetworking(Task.HostPorts.forPorts(4321))
 
     assert(check.hostPort(task.launched.get).contains(1234))
   }

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
@@ -37,7 +37,7 @@ class HealthCheckWorkerActorTest
     val task =
       MarathonTestHelper.runningTask("test_id")
         .withAgentInfo(_.copy(host = InetAddress.getLocalHost.getCanonicalHostName))
-        .withNetworking(Task.HostPorts(socketPort))
+        .withNetworking(Task.HostPorts.forPorts(socketPort))
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
     val app = AppDefinition(id = "test_id".toPath)
@@ -62,7 +62,7 @@ class HealthCheckWorkerActorTest
     val task =
       MarathonTestHelper.runningTask("test_id")
         .withAgentInfo(_.copy(host = InetAddress.getLocalHost.getCanonicalHostName))
-        .withNetworking(Task.HostPorts(socketPort))
+        .withNetworking(Task.HostPorts.forPorts(socketPort))
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
     val app = AppDefinition(id = "test_id".toPath)

--- a/src/test/scala/mesosphere/marathon/tasks/TaskTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskTrackerImplTest.scala
@@ -473,7 +473,7 @@ class TaskTrackerImplTest extends MarathonSpec with Matchers with GivenWhenThen 
     MarathonTestHelper
       .stagedTaskForApp(appId)
       .withAgentInfo(_.copy(host = "host", attributes = Iterable(TextAttribute("attr1", "bar"))))
-      .withNetworking(Task.HostPorts(Iterable(999)))
+      .withNetworking(Task.HostPorts.forPorts(999))
   }
 
   def makeTaskStatus(task: Task, state: TaskState = TaskState.TASK_RUNNING) = {

--- a/src/test/scala/mesosphere/mesos/ConstraintsTest.scala
+++ b/src/test/scala/mesosphere/mesos/ConstraintsTest.scala
@@ -447,7 +447,7 @@ class ConstraintsTest extends MarathonSpec with GivenWhenThen with Matchers {
     val attributes = attrs.map { case (name, value) => TextAttribute(name, value): Attribute }
     MarathonTestHelper.stagedTask(id)
       .withAgentInfo(_.copy(attributes = attributes))
-      .withNetworking(Task.HostPorts(999))
+      .withNetworking(Task.HostPorts.forPorts(999))
   }
 
   def makeOffer(hostname: String, attributes: Iterable[Attribute]) = {
@@ -464,7 +464,7 @@ class ConstraintsTest extends MarathonSpec with GivenWhenThen with Matchers {
     MarathonTestHelper
       .runningTask(id)
       .withAgentInfo(_.copy(host = host))
-      .withNetworking(Task.HostPorts(999))
+      .withNetworking(Task.HostPorts.forPorts(999))
   }
 
   def makeConstraint(field: String, operator: Operator, value: String) = {


### PR DESCRIPTION
* Also make Task.(host)Ports a Seq since their order is important
* Implement deriving the target of readiness checks
* Provide a dummy implementation such that integration is already possible