### PR TITLE
Fixes #3575 - Get NetworkInfo from Mesos task updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -75,6 +75,7 @@ It is possible to make Marathon let Mesos use the `TASK_KILLING` state introduce
 - #3402 - Race conditions in HttpEventActor
 - #3423 - Report kills due to failed healthcheck.
 - #3439 - Relative paths in dependencies should be resolvable.
+- #3575 - Container IP not correctly displayed
 
 ## Changes from 0.15.2 to 0.15.3
 

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -10320,29 +10320,49 @@ public final class Protos {
      */
     org.apache.mesos.Protos.SlaveIDOrBuilder getSlaveIdOrBuilder();
 
-    // repeated .mesos.NetworkInfo networks = 11;
+    // repeated .mesos.NetworkInfo OBSOLETE_networks = 11;
     /**
-     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+     *
+     * <pre>
+     * status already contained this, so this field was redundant
+     * </pre>
      */
     java.util.List<org.apache.mesos.Protos.NetworkInfo> 
-        getNetworksList();
+        getOBSOLETENetworksList();
     /**
-     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+     *
+     * <pre>
+     * status already contained this, so this field was redundant
+     * </pre>
      */
-    org.apache.mesos.Protos.NetworkInfo getNetworks(int index);
+    org.apache.mesos.Protos.NetworkInfo getOBSOLETENetworks(int index);
     /**
-     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+     *
+     * <pre>
+     * status already contained this, so this field was redundant
+     * </pre>
      */
-    int getNetworksCount();
+    int getOBSOLETENetworksCount();
     /**
-     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+     *
+     * <pre>
+     * status already contained this, so this field was redundant
+     * </pre>
      */
     java.util.List<? extends org.apache.mesos.Protos.NetworkInfoOrBuilder> 
-        getNetworksOrBuilderList();
+        getOBSOLETENetworksOrBuilderList();
     /**
-     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+     *
+     * <pre>
+     * status already contained this, so this field was redundant
+     * </pre>
      */
-    org.apache.mesos.Protos.NetworkInfoOrBuilder getNetworksOrBuilder(
+    org.apache.mesos.Protos.NetworkInfoOrBuilder getOBSOLETENetworksOrBuilder(
         int index);
 
     // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
@@ -10512,10 +10532,10 @@ public final class Protos {
             }
             case 90: {
               if (!((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
-                networks_ = new java.util.ArrayList<org.apache.mesos.Protos.NetworkInfo>();
+                oBSOLETENetworks_ = new java.util.ArrayList<org.apache.mesos.Protos.NetworkInfo>();
                 mutable_bitField0_ |= 0x00000400;
               }
-              networks_.add(input.readMessage(org.apache.mesos.Protos.NetworkInfo.PARSER, extensionRegistry));
+              oBSOLETENetworks_.add(input.readMessage(org.apache.mesos.Protos.NetworkInfo.PARSER, extensionRegistry));
               break;
             }
             case 98: {
@@ -10549,7 +10569,7 @@ public final class Protos {
           oBSOLETEStatuses_ = java.util.Collections.unmodifiableList(oBSOLETEStatuses_);
         }
         if (((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
-          networks_ = java.util.Collections.unmodifiableList(networks_);
+          oBSOLETENetworks_ = java.util.Collections.unmodifiableList(oBSOLETENetworks_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -13002,40 +13022,60 @@ public final class Protos {
       return slaveId_;
     }
 
-    // repeated .mesos.NetworkInfo networks = 11;
-    public static final int NETWORKS_FIELD_NUMBER = 11;
-    private java.util.List<org.apache.mesos.Protos.NetworkInfo> networks_;
+    // repeated .mesos.NetworkInfo OBSOLETE_networks = 11;
+    public static final int OBSOLETE_NETWORKS_FIELD_NUMBER = 11;
+    private java.util.List<org.apache.mesos.Protos.NetworkInfo> oBSOLETENetworks_;
     /**
-     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+     *
+     * <pre>
+     * status already contained this, so this field was redundant
+     * </pre>
      */
-    public java.util.List<org.apache.mesos.Protos.NetworkInfo> getNetworksList() {
-      return networks_;
+    public java.util.List<org.apache.mesos.Protos.NetworkInfo> getOBSOLETENetworksList() {
+      return oBSOLETENetworks_;
     }
     /**
-     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+     *
+     * <pre>
+     * status already contained this, so this field was redundant
+     * </pre>
      */
     public java.util.List<? extends org.apache.mesos.Protos.NetworkInfoOrBuilder> 
-        getNetworksOrBuilderList() {
-      return networks_;
+        getOBSOLETENetworksOrBuilderList() {
+      return oBSOLETENetworks_;
     }
     /**
-     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+     *
+     * <pre>
+     * status already contained this, so this field was redundant
+     * </pre>
      */
-    public int getNetworksCount() {
-      return networks_.size();
+    public int getOBSOLETENetworksCount() {
+      return oBSOLETENetworks_.size();
     }
     /**
-     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+     *
+     * <pre>
+     * status already contained this, so this field was redundant
+     * </pre>
      */
-    public org.apache.mesos.Protos.NetworkInfo getNetworks(int index) {
-      return networks_.get(index);
+    public org.apache.mesos.Protos.NetworkInfo getOBSOLETENetworks(int index) {
+      return oBSOLETENetworks_.get(index);
     }
     /**
-     * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+     * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+     *
+     * <pre>
+     * status already contained this, so this field was redundant
+     * </pre>
      */
-    public org.apache.mesos.Protos.NetworkInfoOrBuilder getNetworksOrBuilder(
+    public org.apache.mesos.Protos.NetworkInfoOrBuilder getOBSOLETENetworksOrBuilder(
         int index) {
-      return networks_.get(index);
+      return oBSOLETENetworks_.get(index);
     }
 
     // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
@@ -13083,7 +13123,7 @@ public final class Protos {
       version_ = "1970-01-01T00:00:00.000Z";
       status_ = org.apache.mesos.Protos.TaskStatus.getDefaultInstance();
       slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
-      networks_ = java.util.Collections.emptyList();
+      oBSOLETENetworks_ = java.util.Collections.emptyList();
       reservation_ = mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
@@ -13119,8 +13159,8 @@ public final class Protos {
           return false;
         }
       }
-      for (int i = 0; i < getNetworksCount(); i++) {
-        if (!getNetworks(i).isInitialized()) {
+      for (int i = 0; i < getOBSOLETENetworksCount(); i++) {
+        if (!getOBSOLETENetworks(i).isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -13168,8 +13208,8 @@ public final class Protos {
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         output.writeMessage(10, slaveId_);
       }
-      for (int i = 0; i < networks_.size(); i++) {
-        output.writeMessage(11, networks_.get(i));
+      for (int i = 0; i < oBSOLETENetworks_.size(); i++) {
+        output.writeMessage(11, oBSOLETENetworks_.get(i));
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         output.writeMessage(12, reservation_);
@@ -13228,9 +13268,9 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(10, slaveId_);
       }
-      for (int i = 0; i < networks_.size(); i++) {
+      for (int i = 0; i < oBSOLETENetworks_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(11, networks_.get(i));
+          .computeMessageSize(11, oBSOLETENetworks_.get(i));
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += com.google.protobuf.CodedOutputStream
@@ -13348,7 +13388,7 @@ public final class Protos {
           getOBSOLETEStatusesFieldBuilder();
           getStatusFieldBuilder();
           getSlaveIdFieldBuilder();
-          getNetworksFieldBuilder();
+          getOBSOLETENetworksFieldBuilder();
           getReservationFieldBuilder();
         }
       }
@@ -13394,11 +13434,11 @@ public final class Protos {
           slaveIdBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000200);
-        if (networksBuilder_ == null) {
-          networks_ = java.util.Collections.emptyList();
+        if (oBSOLETENetworksBuilder_ == null) {
+          oBSOLETENetworks_ = java.util.Collections.emptyList();
           bitField0_ = (bitField0_ & ~0x00000400);
         } else {
-          networksBuilder_.clear();
+          oBSOLETENetworksBuilder_.clear();
         }
         if (reservationBuilder_ == null) {
           reservation_ = mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance();
@@ -13493,14 +13533,14 @@ public final class Protos {
         } else {
           result.slaveId_ = slaveIdBuilder_.build();
         }
-        if (networksBuilder_ == null) {
+        if (oBSOLETENetworksBuilder_ == null) {
           if (((bitField0_ & 0x00000400) == 0x00000400)) {
-            networks_ = java.util.Collections.unmodifiableList(networks_);
+            oBSOLETENetworks_ = java.util.Collections.unmodifiableList(oBSOLETENetworks_);
             bitField0_ = (bitField0_ & ~0x00000400);
           }
-          result.networks_ = networks_;
+          result.oBSOLETENetworks_ = oBSOLETENetworks_;
         } else {
-          result.networks_ = networksBuilder_.build();
+          result.oBSOLETENetworks_ = oBSOLETENetworksBuilder_.build();
         }
         if (((from_bitField0_ & 0x00000800) == 0x00000800)) {
           to_bitField0_ |= 0x00000080;
@@ -13615,29 +13655,29 @@ public final class Protos {
         if (other.hasSlaveId()) {
           mergeSlaveId(other.getSlaveId());
         }
-        if (networksBuilder_ == null) {
-          if (!other.networks_.isEmpty()) {
-            if (networks_.isEmpty()) {
-              networks_ = other.networks_;
+        if (oBSOLETENetworksBuilder_ == null) {
+          if (!other.oBSOLETENetworks_.isEmpty()) {
+            if (oBSOLETENetworks_.isEmpty()) {
+              oBSOLETENetworks_ = other.oBSOLETENetworks_;
               bitField0_ = (bitField0_ & ~0x00000400);
             } else {
-              ensureNetworksIsMutable();
-              networks_.addAll(other.networks_);
+              ensureOBSOLETENetworksIsMutable();
+              oBSOLETENetworks_.addAll(other.oBSOLETENetworks_);
             }
             onChanged();
           }
         } else {
-          if (!other.networks_.isEmpty()) {
-            if (networksBuilder_.isEmpty()) {
-              networksBuilder_.dispose();
-              networksBuilder_ = null;
-              networks_ = other.networks_;
+          if (!other.oBSOLETENetworks_.isEmpty()) {
+            if (oBSOLETENetworksBuilder_.isEmpty()) {
+              oBSOLETENetworksBuilder_.dispose();
+              oBSOLETENetworksBuilder_ = null;
+              oBSOLETENetworks_ = other.oBSOLETENetworks_;
               bitField0_ = (bitField0_ & ~0x00000400);
-              networksBuilder_ = 
+              oBSOLETENetworksBuilder_ = 
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
-                   getNetworksFieldBuilder() : null;
+                   getOBSOLETENetworksFieldBuilder() : null;
             } else {
-              networksBuilder_.addAllMessages(other.networks_);
+              oBSOLETENetworksBuilder_.addAllMessages(other.oBSOLETENetworks_);
             }
           }
         }
@@ -13677,8 +13717,8 @@ public final class Protos {
             return false;
           }
         }
-        for (int i = 0; i < getNetworksCount(); i++) {
-          if (!getNetworks(i).isInitialized()) {
+        for (int i = 0; i < getOBSOLETENetworksCount(); i++) {
+          if (!getOBSOLETENetworks(i).isInitialized()) {
             
             return false;
           }
@@ -14803,244 +14843,316 @@ public final class Protos {
         return slaveIdBuilder_;
       }
 
-      // repeated .mesos.NetworkInfo networks = 11;
-      private java.util.List<org.apache.mesos.Protos.NetworkInfo> networks_ =
+      // repeated .mesos.NetworkInfo OBSOLETE_networks = 11;
+      private java.util.List<org.apache.mesos.Protos.NetworkInfo> oBSOLETENetworks_ =
         java.util.Collections.emptyList();
-      private void ensureNetworksIsMutable() {
+      private void ensureOBSOLETENetworksIsMutable() {
         if (!((bitField0_ & 0x00000400) == 0x00000400)) {
-          networks_ = new java.util.ArrayList<org.apache.mesos.Protos.NetworkInfo>(networks_);
+          oBSOLETENetworks_ = new java.util.ArrayList<org.apache.mesos.Protos.NetworkInfo>(oBSOLETENetworks_);
           bitField0_ |= 0x00000400;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilder<
-          org.apache.mesos.Protos.NetworkInfo, org.apache.mesos.Protos.NetworkInfo.Builder, org.apache.mesos.Protos.NetworkInfoOrBuilder> networksBuilder_;
+          org.apache.mesos.Protos.NetworkInfo, org.apache.mesos.Protos.NetworkInfo.Builder, org.apache.mesos.Protos.NetworkInfoOrBuilder> oBSOLETENetworksBuilder_;
 
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public java.util.List<org.apache.mesos.Protos.NetworkInfo> getNetworksList() {
-        if (networksBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(networks_);
+      public java.util.List<org.apache.mesos.Protos.NetworkInfo> getOBSOLETENetworksList() {
+        if (oBSOLETENetworksBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(oBSOLETENetworks_);
         } else {
-          return networksBuilder_.getMessageList();
+          return oBSOLETENetworksBuilder_.getMessageList();
         }
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public int getNetworksCount() {
-        if (networksBuilder_ == null) {
-          return networks_.size();
+      public int getOBSOLETENetworksCount() {
+        if (oBSOLETENetworksBuilder_ == null) {
+          return oBSOLETENetworks_.size();
         } else {
-          return networksBuilder_.getCount();
+          return oBSOLETENetworksBuilder_.getCount();
         }
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public org.apache.mesos.Protos.NetworkInfo getNetworks(int index) {
-        if (networksBuilder_ == null) {
-          return networks_.get(index);
+      public org.apache.mesos.Protos.NetworkInfo getOBSOLETENetworks(int index) {
+        if (oBSOLETENetworksBuilder_ == null) {
+          return oBSOLETENetworks_.get(index);
         } else {
-          return networksBuilder_.getMessage(index);
+          return oBSOLETENetworksBuilder_.getMessage(index);
         }
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public Builder setNetworks(
+      public Builder setOBSOLETENetworks(
           int index, org.apache.mesos.Protos.NetworkInfo value) {
-        if (networksBuilder_ == null) {
+        if (oBSOLETENetworksBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureNetworksIsMutable();
-          networks_.set(index, value);
+          ensureOBSOLETENetworksIsMutable();
+          oBSOLETENetworks_.set(index, value);
           onChanged();
         } else {
-          networksBuilder_.setMessage(index, value);
+          oBSOLETENetworksBuilder_.setMessage(index, value);
         }
         return this;
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public Builder setNetworks(
+      public Builder setOBSOLETENetworks(
           int index, org.apache.mesos.Protos.NetworkInfo.Builder builderForValue) {
-        if (networksBuilder_ == null) {
-          ensureNetworksIsMutable();
-          networks_.set(index, builderForValue.build());
+        if (oBSOLETENetworksBuilder_ == null) {
+          ensureOBSOLETENetworksIsMutable();
+          oBSOLETENetworks_.set(index, builderForValue.build());
           onChanged();
         } else {
-          networksBuilder_.setMessage(index, builderForValue.build());
+          oBSOLETENetworksBuilder_.setMessage(index, builderForValue.build());
         }
         return this;
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public Builder addNetworks(org.apache.mesos.Protos.NetworkInfo value) {
-        if (networksBuilder_ == null) {
+      public Builder addOBSOLETENetworks(org.apache.mesos.Protos.NetworkInfo value) {
+        if (oBSOLETENetworksBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureNetworksIsMutable();
-          networks_.add(value);
+          ensureOBSOLETENetworksIsMutable();
+          oBSOLETENetworks_.add(value);
           onChanged();
         } else {
-          networksBuilder_.addMessage(value);
+          oBSOLETENetworksBuilder_.addMessage(value);
         }
         return this;
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public Builder addNetworks(
+      public Builder addOBSOLETENetworks(
           int index, org.apache.mesos.Protos.NetworkInfo value) {
-        if (networksBuilder_ == null) {
+        if (oBSOLETENetworksBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureNetworksIsMutable();
-          networks_.add(index, value);
+          ensureOBSOLETENetworksIsMutable();
+          oBSOLETENetworks_.add(index, value);
           onChanged();
         } else {
-          networksBuilder_.addMessage(index, value);
+          oBSOLETENetworksBuilder_.addMessage(index, value);
         }
         return this;
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public Builder addNetworks(
+      public Builder addOBSOLETENetworks(
           org.apache.mesos.Protos.NetworkInfo.Builder builderForValue) {
-        if (networksBuilder_ == null) {
-          ensureNetworksIsMutable();
-          networks_.add(builderForValue.build());
+        if (oBSOLETENetworksBuilder_ == null) {
+          ensureOBSOLETENetworksIsMutable();
+          oBSOLETENetworks_.add(builderForValue.build());
           onChanged();
         } else {
-          networksBuilder_.addMessage(builderForValue.build());
+          oBSOLETENetworksBuilder_.addMessage(builderForValue.build());
         }
         return this;
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public Builder addNetworks(
+      public Builder addOBSOLETENetworks(
           int index, org.apache.mesos.Protos.NetworkInfo.Builder builderForValue) {
-        if (networksBuilder_ == null) {
-          ensureNetworksIsMutable();
-          networks_.add(index, builderForValue.build());
+        if (oBSOLETENetworksBuilder_ == null) {
+          ensureOBSOLETENetworksIsMutable();
+          oBSOLETENetworks_.add(index, builderForValue.build());
           onChanged();
         } else {
-          networksBuilder_.addMessage(index, builderForValue.build());
+          oBSOLETENetworksBuilder_.addMessage(index, builderForValue.build());
         }
         return this;
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public Builder addAllNetworks(
+      public Builder addAllOBSOLETENetworks(
           java.lang.Iterable<? extends org.apache.mesos.Protos.NetworkInfo> values) {
-        if (networksBuilder_ == null) {
-          ensureNetworksIsMutable();
-          super.addAll(values, networks_);
+        if (oBSOLETENetworksBuilder_ == null) {
+          ensureOBSOLETENetworksIsMutable();
+          super.addAll(values, oBSOLETENetworks_);
           onChanged();
         } else {
-          networksBuilder_.addAllMessages(values);
+          oBSOLETENetworksBuilder_.addAllMessages(values);
         }
         return this;
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public Builder clearNetworks() {
-        if (networksBuilder_ == null) {
-          networks_ = java.util.Collections.emptyList();
+      public Builder clearOBSOLETENetworks() {
+        if (oBSOLETENetworksBuilder_ == null) {
+          oBSOLETENetworks_ = java.util.Collections.emptyList();
           bitField0_ = (bitField0_ & ~0x00000400);
           onChanged();
         } else {
-          networksBuilder_.clear();
+          oBSOLETENetworksBuilder_.clear();
         }
         return this;
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public Builder removeNetworks(int index) {
-        if (networksBuilder_ == null) {
-          ensureNetworksIsMutable();
-          networks_.remove(index);
+      public Builder removeOBSOLETENetworks(int index) {
+        if (oBSOLETENetworksBuilder_ == null) {
+          ensureOBSOLETENetworksIsMutable();
+          oBSOLETENetworks_.remove(index);
           onChanged();
         } else {
-          networksBuilder_.remove(index);
+          oBSOLETENetworksBuilder_.remove(index);
         }
         return this;
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public org.apache.mesos.Protos.NetworkInfo.Builder getNetworksBuilder(
+      public org.apache.mesos.Protos.NetworkInfo.Builder getOBSOLETENetworksBuilder(
           int index) {
-        return getNetworksFieldBuilder().getBuilder(index);
+        return getOBSOLETENetworksFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public org.apache.mesos.Protos.NetworkInfoOrBuilder getNetworksOrBuilder(
+      public org.apache.mesos.Protos.NetworkInfoOrBuilder getOBSOLETENetworksOrBuilder(
           int index) {
-        if (networksBuilder_ == null) {
-          return networks_.get(index);  } else {
-          return networksBuilder_.getMessageOrBuilder(index);
+        if (oBSOLETENetworksBuilder_ == null) {
+          return oBSOLETENetworks_.get(index);  } else {
+          return oBSOLETENetworksBuilder_.getMessageOrBuilder(index);
         }
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
       public java.util.List<? extends org.apache.mesos.Protos.NetworkInfoOrBuilder> 
-           getNetworksOrBuilderList() {
-        if (networksBuilder_ != null) {
-          return networksBuilder_.getMessageOrBuilderList();
+           getOBSOLETENetworksOrBuilderList() {
+        if (oBSOLETENetworksBuilder_ != null) {
+          return oBSOLETENetworksBuilder_.getMessageOrBuilderList();
         } else {
-          return java.util.Collections.unmodifiableList(networks_);
+          return java.util.Collections.unmodifiableList(oBSOLETENetworks_);
         }
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public org.apache.mesos.Protos.NetworkInfo.Builder addNetworksBuilder() {
-        return getNetworksFieldBuilder().addBuilder(
+      public org.apache.mesos.Protos.NetworkInfo.Builder addOBSOLETENetworksBuilder() {
+        return getOBSOLETENetworksFieldBuilder().addBuilder(
             org.apache.mesos.Protos.NetworkInfo.getDefaultInstance());
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
-      public org.apache.mesos.Protos.NetworkInfo.Builder addNetworksBuilder(
+      public org.apache.mesos.Protos.NetworkInfo.Builder addOBSOLETENetworksBuilder(
           int index) {
-        return getNetworksFieldBuilder().addBuilder(
+        return getOBSOLETENetworksFieldBuilder().addBuilder(
             index, org.apache.mesos.Protos.NetworkInfo.getDefaultInstance());
       }
       /**
-       * <code>repeated .mesos.NetworkInfo networks = 11;</code>
+       * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
+       *
+       * <pre>
+       * status already contained this, so this field was redundant
+       * </pre>
        */
       public java.util.List<org.apache.mesos.Protos.NetworkInfo.Builder> 
-           getNetworksBuilderList() {
-        return getNetworksFieldBuilder().getBuilderList();
+           getOBSOLETENetworksBuilderList() {
+        return getOBSOLETENetworksFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilder<
           org.apache.mesos.Protos.NetworkInfo, org.apache.mesos.Protos.NetworkInfo.Builder, org.apache.mesos.Protos.NetworkInfoOrBuilder> 
-          getNetworksFieldBuilder() {
-        if (networksBuilder_ == null) {
-          networksBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+          getOBSOLETENetworksFieldBuilder() {
+        if (oBSOLETENetworksBuilder_ == null) {
+          oBSOLETENetworksBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
               org.apache.mesos.Protos.NetworkInfo, org.apache.mesos.Protos.NetworkInfo.Builder, org.apache.mesos.Protos.NetworkInfoOrBuilder>(
-                  networks_,
+                  oBSOLETENetworks_,
                   ((bitField0_ & 0x00000400) == 0x00000400),
                   getParentForChildren(),
                   isClean());
-          networks_ = null;
+          oBSOLETENetworks_ = null;
         }
-        return networksBuilder_;
+        return oBSOLETENetworksBuilder_;
       }
 
       // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
@@ -29818,82 +29930,82 @@ public final class Protos {
       "athon.IpAddress\022;\n\tresidency\030\032 \001(\0132(.mes" +
       "osphere.marathon.ResidencyDefinition\022$\n\017" +
       "portDefinitions\030\033 \003(\0132\013.mesos.Port\"\035\n\rRe" +
-      "sourceRoles\022\014\n\004role\030\001 \003(\t\"\247\007\n\014MarathonTa" +
+      "sourceRoles\022\014\n\004role\030\001 \003(\t\"\260\007\n\014MarathonTa" +
       "sk\022\n\n\002id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 " +
       "\003(\r\022$\n\nattributes\030\004 \003(\0132\020.mesos.Attribut" +
       "e\022\021\n\tstaged_at\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003" +
       "\022,\n\021OBSOLETE_statuses\030\007 \003(\0132\021.mesos.Task",
       "Status\022)\n\007version\030\010 \001(\t:\0301970-01-01T00:0" +
       "0:00.000Z\022!\n\006status\030\t \001(\0132\021.mesos.TaskSt" +
-      "atus\022\037\n\007slaveId\030\n \001(\0132\016.mesos.SlaveID\022$\n" +
-      "\010networks\030\013 \003(\0132\022.mesos.NetworkInfo\022B\n\013r" +
-      "eservation\030\014 \001(\0132-.mesosphere.marathon.M" +
-      "arathonTask.Reservation\032\231\004\n\013Reservation\022" +
-      "\030\n\020local_volume_ids\030\001 \003(\t\022B\n\005state\030\002 \002(\013" +
-      "23.mesosphere.marathon.MarathonTask.Rese" +
-      "rvation.State\032\253\003\n\005State\022F\n\004type\030\001 \002(\01628." +
-      "mesosphere.marathon.MarathonTask.Reserva",
-      "tion.State.Type\022L\n\007timeout\030\002 \001(\0132;.mesos" +
-      "phere.marathon.MarathonTask.Reservation." +
-      "State.Timeout\032\303\001\n\007Timeout\022\021\n\tinitiated\030\001" +
-      " \002(\003\022\020\n\010deadline\030\002 \002(\003\022R\n\006reason\030\003 \002(\0162B" +
-      ".mesosphere.marathon.MarathonTask.Reserv" +
-      "ation.State.Timeout.Reason\"?\n\006Reason\022\035\n\031" +
-      "RelaunchEscalationTimeout\020\001\022\026\n\022Reservati" +
-      "onTimeout\020\002\"F\n\004Type\022\007\n\003New\020\001\022\014\n\010Launched" +
-      "\020\002\022\r\n\tSuspended\020\003\022\013\n\007Garbage\020\004\022\013\n\007Unknow" +
-      "n\020\005\"M\n\013MarathonApp\022\014\n\004name\030\001 \001(\t\0220\n\005task",
-      "s\030\002 \003(\0132!.mesosphere.marathon.MarathonTa" +
-      "sk\"1\n\rContainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007" +
-      "options\030\002 \003(\014\"\332\004\n\025ExtendedContainerInfo\022" +
-      "\'\n\004type\030\001 \002(\0162\031.mesos.ContainerInfo.Type" +
-      "\022,\n\007volumes\030\002 \003(\0132\033.mesosphere.marathon." +
-      "Volume\022E\n\006docker\030\003 \001(\01325.mesosphere.mara" +
-      "thon.ExtendedContainerInfo.DockerInfo\032\242\003" +
-      "\n\nDockerInfo\022\r\n\005image\030\001 \002(\t\022>\n\007network\030\002" +
-      " \001(\0162\'.mesos.ContainerInfo.DockerInfo.Ne" +
-      "twork:\004HOST\022X\n\rport_mappings\030\003 \003(\0132A.mes",
-      "osphere.marathon.ExtendedContainerInfo.D" +
-      "ockerInfo.PortMapping\022\031\n\nprivileged\030\004 \001(" +
-      "\010:\005false\022$\n\nparameters\030\005 \003(\0132\020.mesos.Par" +
-      "ameter\022\030\n\020force_pull_image\030\006 \001(\010\032\217\001\n\013Por" +
-      "tMapping\022\021\n\thost_port\030\001 \002(\r\022\026\n\016container" +
-      "_port\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\014\n\004name\030\004 " +
-      "\001(\t\022\034\n\006labels\030\005 \003(\0132\014.mesos.Label\022\027\n\014ser" +
-      "vice_port\030d \001(\r:\0010\"\336\001\n\006Volume\022 \n\004mode\030\003 " +
-      "\002(\0162\022.mesos.Volume.Mode\022\026\n\016container_pat" +
-      "h\030\001 \002(\t\022\021\n\thost_path\030\002 \001(\t\022\033\n\005image\030\004 \001(",
-      "\0132\014.mesos.Image\022D\n\npersistent\030\005 \001(\01320.me" +
-      "sosphere.marathon.Volume.PersistentVolum" +
-      "eInfo\032$\n\024PersistentVolumeInfo\022\014\n\004size\030\001 " +
-      "\002(\004\")\n\020EventSubscribers\022\025\n\rcallback_urls" +
-      "\030\001 \003(\t\"=\n\016StorageVersion\022\r\n\005major\030\001 \002(\r\022" +
-      "\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z\n\031Upgrade" +
-      "StrategyDefinition\022\035\n\025minimumHealthCapac" +
-      "ity\030\001 \002(\001\022\036\n\023maximumOverCapacity\030\002 \001(\001:\001" +
-      "1\"\260\001\n\017GroupDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007ver" +
-      "sion\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.mesosphere.ma",
-      "rathon.ServiceDefinition\0224\n\006groups\030\004 \003(\013" +
-      "2$.mesosphere.marathon.GroupDefinition\022\024" +
-      "\n\014dependencies\030\005 \003(\t\"\245\001\n\030DeploymentPlanD" +
-      "efinition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226" +
-      "\n\010original\030\004 \002(\0132$.mesosphere.marathon.G" +
-      "roupDefinition\0224\n\006target\030\005 \002(\0132$.mesosph" +
-      "ere.marathon.GroupDefinition\"\306\001\n\013TaskFai" +
-      "lure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r." +
-      "mesos.TaskID\022\037\n\005state\030\003 \002(\0162\020.mesos.Task" +
-      "State\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000",
-      "\022\017\n\007version\030\006 \002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007" +
-      "slaveId\030\010 \001(\0132\016.mesos.SlaveID\"T\n\014ZKStore" +
-      "Entry\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005val" +
-      "ue\030\003 \002(\014\022\031\n\ncompressed\030\004 \001(\010:\005false\"\326\001\n\023" +
-      "ResidencyDefinition\022(\n relaunchEscalatio" +
-      "nTimeoutSeconds\030\001 \001(\003\022S\n\020taskLostBehavio" +
-      "r\030\002 \001(\01629.mesosphere.marathon.ResidencyD" +
-      "efinition.TaskLostBehavior\"@\n\020TaskLostBe" +
-      "havior\022\032\n\026RELAUNCH_AFTER_TIMEOUT\020\000\022\020\n\014WA" +
-      "IT_FOREVER\020\001B\035\n\023mesosphere.marathonB\006Pro",
-      "tos"
+      "atus\022\037\n\007slaveId\030\n \001(\0132\016.mesos.SlaveID\022-\n" +
+      "\021OBSOLETE_networks\030\013 \003(\0132\022.mesos.Network" +
+      "Info\022B\n\013reservation\030\014 \001(\0132-.mesosphere.m" +
+      "arathon.MarathonTask.Reservation\032\231\004\n\013Res" +
+      "ervation\022\030\n\020local_volume_ids\030\001 \003(\t\022B\n\005st" +
+      "ate\030\002 \002(\01323.mesosphere.marathon.Marathon" +
+      "Task.Reservation.State\032\253\003\n\005State\022F\n\004type" +
+      "\030\001 \002(\01628.mesosphere.marathon.MarathonTas",
+      "k.Reservation.State.Type\022L\n\007timeout\030\002 \001(" +
+      "\0132;.mesosphere.marathon.MarathonTask.Res" +
+      "ervation.State.Timeout\032\303\001\n\007Timeout\022\021\n\tin" +
+      "itiated\030\001 \002(\003\022\020\n\010deadline\030\002 \002(\003\022R\n\006reaso" +
+      "n\030\003 \002(\0162B.mesosphere.marathon.MarathonTa" +
+      "sk.Reservation.State.Timeout.Reason\"?\n\006R" +
+      "eason\022\035\n\031RelaunchEscalationTimeout\020\001\022\026\n\022" +
+      "ReservationTimeout\020\002\"F\n\004Type\022\007\n\003New\020\001\022\014\n" +
+      "\010Launched\020\002\022\r\n\tSuspended\020\003\022\013\n\007Garbage\020\004\022" +
+      "\013\n\007Unknown\020\005\"M\n\013MarathonApp\022\014\n\004name\030\001 \001(",
+      "\t\0220\n\005tasks\030\002 \003(\0132!.mesosphere.marathon.M" +
+      "arathonTask\"1\n\rContainerInfo\022\017\n\005image\030\001 " +
+      "\002(\014:\000\022\017\n\007options\030\002 \003(\014\"\332\004\n\025ExtendedConta" +
+      "inerInfo\022\'\n\004type\030\001 \002(\0162\031.mesos.Container" +
+      "Info.Type\022,\n\007volumes\030\002 \003(\0132\033.mesosphere." +
+      "marathon.Volume\022E\n\006docker\030\003 \001(\01325.mesosp" +
+      "here.marathon.ExtendedContainerInfo.Dock" +
+      "erInfo\032\242\003\n\nDockerInfo\022\r\n\005image\030\001 \002(\t\022>\n\007" +
+      "network\030\002 \001(\0162\'.mesos.ContainerInfo.Dock" +
+      "erInfo.Network:\004HOST\022X\n\rport_mappings\030\003 ",
+      "\003(\0132A.mesosphere.marathon.ExtendedContai" +
+      "nerInfo.DockerInfo.PortMapping\022\031\n\nprivil" +
+      "eged\030\004 \001(\010:\005false\022$\n\nparameters\030\005 \003(\0132\020." +
+      "mesos.Parameter\022\030\n\020force_pull_image\030\006 \001(" +
+      "\010\032\217\001\n\013PortMapping\022\021\n\thost_port\030\001 \002(\r\022\026\n\016" +
+      "container_port\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\014" +
+      "\n\004name\030\004 \001(\t\022\034\n\006labels\030\005 \003(\0132\014.mesos.Lab" +
+      "el\022\027\n\014service_port\030d \001(\r:\0010\"\336\001\n\006Volume\022 " +
+      "\n\004mode\030\003 \002(\0162\022.mesos.Volume.Mode\022\026\n\016cont" +
+      "ainer_path\030\001 \002(\t\022\021\n\thost_path\030\002 \001(\t\022\033\n\005i",
+      "mage\030\004 \001(\0132\014.mesos.Image\022D\n\npersistent\030\005" +
+      " \001(\01320.mesosphere.marathon.Volume.Persis" +
+      "tentVolumeInfo\032$\n\024PersistentVolumeInfo\022\014" +
+      "\n\004size\030\001 \002(\004\")\n\020EventSubscribers\022\025\n\rcall" +
+      "back_urls\030\001 \003(\t\"=\n\016StorageVersion\022\r\n\005maj" +
+      "or\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z" +
+      "\n\031UpgradeStrategyDefinition\022\035\n\025minimumHe" +
+      "althCapacity\030\001 \002(\001\022\036\n\023maximumOverCapacit" +
+      "y\030\002 \001(\001:\0011\"\260\001\n\017GroupDefinition\022\n\n\002id\030\001 \002" +
+      "(\t\022\017\n\007version\030\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.meso",
+      "sphere.marathon.ServiceDefinition\0224\n\006gro" +
+      "ups\030\004 \003(\0132$.mesosphere.marathon.GroupDef" +
+      "inition\022\024\n\014dependencies\030\005 \003(\t\"\245\001\n\030Deploy" +
+      "mentPlanDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007versio" +
+      "n\030\002 \002(\t\0226\n\010original\030\004 \002(\0132$.mesosphere.m" +
+      "arathon.GroupDefinition\0224\n\006target\030\005 \002(\0132" +
+      "$.mesosphere.marathon.GroupDefinition\"\306\001" +
+      "\n\013TaskFailure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id" +
+      "\030\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003 \002(\0162\020.m" +
+      "esos.TaskState\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004hos",
+      "t\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\ttimestamp\030" +
+      "\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016.mesos.SlaveID\"T" +
+      "\n\014ZKStoreEntry\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002" +
+      "(\014\022\r\n\005value\030\003 \002(\014\022\031\n\ncompressed\030\004 \001(\010:\005f" +
+      "alse\"\326\001\n\023ResidencyDefinition\022(\n relaunch" +
+      "EscalationTimeoutSeconds\030\001 \001(\003\022S\n\020taskLo" +
+      "stBehavior\030\002 \001(\01629.mesosphere.marathon.R" +
+      "esidencyDefinition.TaskLostBehavior\"@\n\020T" +
+      "askLostBehavior\022\032\n\026RELAUNCH_AFTER_TIMEOU" +
+      "T\020\000\022\020\n\014WAIT_FOREVER\020\001B\035\n\023mesosphere.mara",
+      "thonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -29941,7 +30053,7 @@ public final class Protos {
           internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_MarathonTask_descriptor,
-              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "Networks", "Reservation", });
+              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "OBSOLETENetworks", "Reservation", });
           internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor =
             internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(0);
           internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -128,7 +128,7 @@ message MarathonTask {
   optional string version = 8 [default = "1970-01-01T00:00:00.000Z"]; // since 0.7.0
   optional mesos.TaskStatus status = 9;
   optional mesos.SlaveID slaveId = 10;
-  repeated mesos.NetworkInfo networks = 11;
+  repeated mesos.NetworkInfo OBSOLETE_networks = 11; // status already contained this, so this field was redundant
   optional Reservation reservation = 12; // since 0.16, a list of volumes can be associated with the task ID
 }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -50,8 +50,8 @@ class TasksResource @Inject() (
 
     val taskList = taskTracker.tasksByAppSync
 
-    val tasks = taskList.appTasksMap.values.view.flatMap { app =>
-      app.tasks.view.map(t => app.appId -> t)
+    val tasks = taskList.appTasksMap.values.view.flatMap { appTasks =>
+      appTasks.tasks.view.map(t => appTasks.appId -> t)
     }
 
     val appIds = taskList.allAppIdsWithTasks
@@ -60,7 +60,7 @@ class TasksResource @Inject() (
 
     val appToPorts = appIdsToApps.map {
       case (appId, app) => appId -> app.map(_.servicePorts).getOrElse(Nil)
-    }.toMap
+    }
 
     val health = appIds.flatMap { appId =>
       result(healthCheckManager.statuses(appId))

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -119,13 +119,16 @@ trait Formats
     )
 
     val launched = task.launched.map { launched =>
-      base ++ Json.obj (
-        "startedAt" -> launched.status.startedAt,
-        "stagedAt" -> launched.status.stagedAt,
-        "ports" -> launched.ports,
-        "ipAddresses" -> launched.ipAddresses,
-        "version" -> launched.appVersion
-      )
+      launched.ipAddresses.foldLeft(
+        base ++ Json.obj (
+          "startedAt" -> launched.status.startedAt,
+          "stagedAt" -> launched.status.stagedAt,
+          "ports" -> launched.hostPorts,
+          "version" -> launched.appVersion
+        )
+      ){
+        case (launchedJs, ipAddresses) => launchedJs ++ Json.obj("ipAddresses" -> ipAddresses)
+      }
     }.getOrElse(base)
 
     val reservation = task.reservationWithVolumes.map { reservation =>

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
@@ -55,7 +55,7 @@ class TaskOpFactoryImpl @Inject() (
           status = Task.Status(
             stagedAt = clock.now()
           ),
-          networking = Task.HostPorts(ports)
+          hostPorts = ports
         )
 
         taskOperationFactory.launchEphemeral(taskInfo, task)
@@ -140,7 +140,7 @@ class TaskOpFactoryImpl @Inject() (
           status = Task.Status(
             stagedAt = clock.now()
           ),
-          networking = Task.HostPorts(ports))
+          hostPorts = ports)
 
         taskOperationFactory.launchOnReservation(taskInfo, taskStateOp, task)
     }

--- a/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
@@ -4,6 +4,8 @@ import mesosphere.marathon.core.task.Task.Id
 import mesosphere.marathon.core.task.bus.MarathonTaskStatus
 import mesosphere.marathon.state.Timestamp
 
+import scala.collection.immutable.Seq
+
 sealed trait TaskStateOp {
   def taskId: Task.Id
   /**
@@ -36,7 +38,7 @@ object TaskStateOp {
     taskId: Task.Id,
     appVersion: Timestamp,
     status: Task.Status,
-    networking: Task.Networking) extends TaskStateOp
+    hostPorts: Seq[Int]) extends TaskStateOp
 
   case class MesosUpdate(task: Task, status: MarathonTaskStatus, now: Timestamp) extends TaskStateOp {
     override def taskId: Id = task.taskId

--- a/src/main/scala/mesosphere/marathon/core/task/bus/MarathonTaskStatus.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/MarathonTaskStatus.scala
@@ -4,11 +4,7 @@ import org.apache.mesos.Protos.TaskStatus
 
 sealed trait MarathonTaskStatus {
   def terminal: Boolean = false
-
   def mesosStatus: Option[TaskStatus]
-  def mesosHealth: Option[Boolean] = mesosStatus.flatMap { status =>
-    if (status.hasHealthy) Some(status.getHealthy) else None
-  }
 }
 
 object MarathonTaskStatus {

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -63,14 +63,8 @@ class PostToEventStreamStepImpl @Inject() (
           message = if (status.hasMessage) status.getMessage else "",
           appId = taskId.appId,
           host = task.agentInfo.host,
-          ipAddresses = launched.networking match {
-            case networkInfoList: Task.NetworkInfoList => networkInfoList.addresses.to[Seq]
-            case _                                     => Seq.empty
-          },
-          ports = launched.networking match {
-            case Task.HostPorts(ports) => ports
-            case _                     => Iterable.empty
-          },
+          ipAddresses = Task.MesosStatus.ipAddresses(status),
+          ports = launched.hostPorts,
           version = launched.appVersion.toString,
           timestamp = timestamp.toString
         )

--- a/src/main/scala/mesosphere/marathon/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/event/Events.scala
@@ -12,6 +12,8 @@ import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep }
 import org.rogach.scallop.ScallopConf
 import org.slf4j.LoggerFactory
 
+import scala.collection.immutable.Seq
+
 //scalastyle:off number.of.types
 
 trait EventSubscriber[C <: ScallopConf, M <: AbstractModule] {
@@ -223,8 +225,8 @@ case class MesosStatusUpdateEvent(
   message: String,
   appId: PathId,
   host: String,
-  ipAddresses: Seq[org.apache.mesos.Protos.NetworkInfo.IPAddress],
-  ports: Iterable[Int],
+  ipAddresses: Option[Seq[org.apache.mesos.Protos.NetworkInfo.IPAddress]],
+  ports: Seq[Int],
   version: String,
   eventType: String = "status_update_event",
   timestamp: String = Timestamp.now().toString) extends MarathonEvent

--- a/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
@@ -107,7 +107,7 @@ case class HealthCheck(
   }
 
   def hostPort(launched: Task.Launched): Option[Int] = {
-    def portViaIndex: Option[Int] = portIndex.flatMap(launched.ports.toVector.lift(_))
+    def portViaIndex: Option[Int] = portIndex.flatMap(launched.hostPorts.lift(_))
     port.orElse(portViaIndex)
   }
 

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -156,7 +156,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       message = "",
       appId = app.id,
       host = "",
-      ipAddresses = Nil,
+      ipAddresses = None,
       ports = Nil,
       version = app.version.toString
     )
@@ -206,7 +206,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     val statusUpdateEvent = MesosStatusUpdateEvent(
       slaveId = "", taskId = taskA.taskId, taskStatus = "TASK_KILLED", message = "", appId = app.id,
-      host = "", ipAddresses = Nil, ports = Nil, version = "",
+      host = "", ipAddresses = None, ports = Nil, version = "",
       timestamp = app.version.toString
     )
 
@@ -293,7 +293,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
         system.eventStream.publish(
           MesosStatusUpdateEvent(
             slaveId = "", taskId = taskA.taskId, taskStatus = "TASK_KILLED", message = "", appId = app.id, host = "",
-            ipAddresses = Nil, ports = Nil, version = app.version.toString
+            ipAddresses = None, ports = Nil, version = app.version.toString
           )
         )
         Status.DRIVER_RUNNING

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
@@ -7,6 +7,8 @@ import mesosphere.marathon.test.Mockito
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
 import org.scalatest.{ GivenWhenThen, Matchers }
 
+import scala.collection.immutable.Seq
+
 class TaskCountsTest extends MarathonSpec with GivenWhenThen with Mockito with Matchers {
   test("count no tasks") {
     When("getting counts for no tasks")
@@ -174,15 +176,15 @@ class TaskCountsTest extends MarathonSpec with GivenWhenThen with Mockito with M
 
 class Fixture {
   val taskWithoutState = Task.LaunchedEphemeral(
-    Task.Id("task1"),
-    Task.AgentInfo("some.host", Some("agent-1"), Iterable.empty),
+    taskId = Task.Id("task1"),
+    agentInfo = Task.AgentInfo("some.host", Some("agent-1"), Iterable.empty),
     appVersion = Timestamp(0),
-    Task.Status(
+    status = Task.Status(
       stagedAt = Timestamp(1),
       startedAt = None,
       mesosStatus = None
     ),
-    Task.NoNetworking
+    hostPorts = Seq.empty
   )
 
 }

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -13,6 +13,7 @@ import mesosphere.marathon.test.Mockito
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
 import org.scalatest.GivenWhenThen
 
+import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 
@@ -112,7 +113,7 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
         taskId = dummyTask.taskId,
         appVersion = clock.now(),
         status = Task.Status(clock.now()),
-        networking = Task.NoNetworking)
+        hostPorts = Seq.empty)
       val launch = f.launchWithOldTask(
         task,
         taskStateOp,

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
@@ -23,6 +23,7 @@ import org.mockito
 import org.mockito.Mockito
 import org.scalatest.GivenWhenThen
 
+import scala.collection.immutable.Seq
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -370,7 +371,7 @@ class AppTaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     val taskId = Task.Id.forApp(app.id)
     val task = MarathonTestHelper.makeOneCPUTask(taskId.idString).build()
     val marathonTask = MarathonTestHelper.mininimalTask(task.getTaskId.getValue).copy(
-      appVersion = app.version, status = Task.Status(app.version, None, None), networking = Task.NoNetworking)
+      appVersion = app.version, status = Task.Status(app.version, None, None), hostPorts = Seq.empty)
   }
 
   private[this] implicit val timeout: Timeout = 3.seconds

--- a/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
@@ -7,6 +7,7 @@ import org.apache.mesos.{ Protos => MesosProtos }
 import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 
 import scala.collection.immutable.Seq
+import org.scalatest.OptionValues._
 
 class TaskTest extends FunSuite with Mockito with GivenWhenThen with Matchers {
   import scala.collection.JavaConverters._
@@ -44,87 +45,81 @@ class TaskTest extends FunSuite with Mockito with GivenWhenThen with Matchers {
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
         .withAgentInfo(_.copy(host = host))
-        .withNetworking(Task.NetworkInfoList(networkWithOneIp1))
+        .withNetworkInfos(Seq(networkWithOneIp1))
 
     val taskWithMultipleNetworksAndOneIp =
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
         .withAgentInfo(_.copy(host = host))
-        .withNetworking(Task.NetworkInfoList(networkWithoutIp, networkWithOneIp1))
+        .withNetworkInfos(Seq(networkWithoutIp, networkWithOneIp1))
 
     val taskWithMultipleNetworkAndNoIp =
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
         .withAgentInfo(_.copy(host = host))
-        .withNetworking(Task.NetworkInfoList(networkWithoutIp, networkWithoutIp))
+        .withNetworkInfos(Seq(networkWithoutIp, networkWithoutIp))
 
     val taskWithOneNetworkAndMultipleIPs =
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
         .withAgentInfo(_.copy(host = host))
-        .withNetworking(Task.NetworkInfoList(networkWithMultipleIps))
+        .withNetworkInfos(Seq(networkWithMultipleIps))
 
     val taskWithMultipleNetworkAndMultipleIPs =
       MarathonTestHelper
         .runningTaskForApp(appWithoutIpAddress.id)
         .withAgentInfo(_.copy(host = host))
-        .withNetworking(Task.NetworkInfoList(networkWithOneIp1, networkWithOneIp2))
-  }
-
-  test("effectiveIpAddress returns the agent address for MarathonTask instances without their own IP addresses") {
-    val f = new Fixture
-    f.taskWithoutIp.effectiveIpAddress(f.appWithIpAddress) should equal (f.host)
-    f.taskWithoutIp.effectiveIpAddress(f.appWithoutIpAddress) should equal (f.host)
+        .withNetworkInfos(Seq(networkWithOneIp1, networkWithOneIp2))
   }
 
   test("effectiveIpAddress returns the container ip for MarathonTask instances with one NetworkInfo (if the app requests an IP)") {
     val f = new Fixture
-    f.taskWithOneIp.effectiveIpAddress(f.appWithIpAddress) should equal(f.ipString1)
+    f.taskWithOneIp.effectiveIpAddress(f.appWithIpAddress).value should equal(f.ipString1)
   }
 
   test("effectiveIpAddress returns the first container ip for for MarathonTask instances with multiple NetworkInfos (if the app requests an IP)") {
     val f = new Fixture
-    f.taskWithMultipleNetworksAndOneIp.effectiveIpAddress(f.appWithIpAddress) should equal (f.ipString1)
+    f.taskWithMultipleNetworksAndOneIp.effectiveIpAddress(f.appWithIpAddress).value should equal (f.ipString1)
   }
 
-  test("effectiveIpAddress falls back to the agent IP") {
+  test("effectiveIpAddress returns None if there is no ip") {
     val f = new Fixture
-    f.taskWithMultipleNetworkAndNoIp.effectiveIpAddress(f.appWithIpAddress) should equal (f.host)
+    f.taskWithMultipleNetworkAndNoIp.effectiveIpAddress(f.appWithIpAddress) should be (None)
   }
 
   test("effectiveIpAddress returns the agent ip for MarathonTask instances with one NetworkInfo (if the app does NOT request an IP)") {
     val f = new Fixture
-    f.taskWithOneIp.effectiveIpAddress(f.appWithoutIpAddress) should equal(f.host)
+    f.taskWithOneIp.effectiveIpAddress(f.appWithoutIpAddress).value should equal(f.host)
   }
 
-  test("ipAddresses returns an empty list for MarathonTask instances with no IPs") {
+  test("ipAddresses returns None for MarathonTask instances with no IPs") {
     val f = new Fixture
-    f.taskWithoutIp.ipAddresses should be (empty)
+    f.taskWithoutIp.launched.value.ipAddresses should be (None)
   }
 
   test("ipAddresses returns an empty list for MarathonTask instances with no IPs and multiple NetworkInfos") {
     val f = new Fixture
-    f.taskWithMultipleNetworkAndNoIp.ipAddresses should be (empty)
+    f.taskWithMultipleNetworkAndNoIp.launched.value.ipAddresses.value should be (empty)
   }
 
   test("ipAddresses returns all IPs for MarathonTask instances with multiple IPs") {
     val f = new Fixture
-    f.taskWithMultipleNetworkAndMultipleIPs.ipAddresses should equal(Seq(f.ipAddress1, f.ipAddress2))
+    f.taskWithMultipleNetworkAndMultipleIPs.launched.value.ipAddresses.value should equal(Seq(f.ipAddress1, f.ipAddress2))
   }
 
   test("ipAddresses returns all IPs for MarathonTask instances with multiple IPs and multiple NetworkInfos") {
     val f = new Fixture
-    f.taskWithMultipleNetworkAndMultipleIPs.ipAddresses should equal(Seq(f.ipAddress1, f.ipAddress2))
+    f.taskWithMultipleNetworkAndMultipleIPs.launched.value.ipAddresses.value should equal(Seq(f.ipAddress1, f.ipAddress2))
   }
 
   test("ipAddresses returns one IP for MarathonTask instances with one IP and one NetworkInfo") {
     val f = new Fixture
-    f.taskWithOneIp.ipAddresses should equal(Seq(f.ipAddress1))
+    f.taskWithOneIp.launched.value.ipAddresses.value should equal(Seq(f.ipAddress1))
   }
 
   test("ipAddresses returns one IP for MarathonTask instances with one IP and multiple NetworkInfo") {
     val f = new Fixture
-    f.taskWithMultipleNetworksAndOneIp.ipAddresses should equal(Seq(f.ipAddress1))
+    f.taskWithMultipleNetworksAndOneIp.launched.value.ipAddresses.value should equal(Seq(f.ipAddress1))
   }
 
 }

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -31,11 +31,16 @@ object TaskStatusUpdateTestHelper {
   lazy val defaultTask = MarathonTestHelper.stagedTask(taskId.idString)
   lazy val defaultTimestamp = Timestamp.apply(new DateTime(2015, 2, 3, 12, 30, 0, 0))
 
+  def taskLaunchFor(task: Task, timestamp: Timestamp = defaultTimestamp) = {
+    val taskStateOp = TaskStateOp.LaunchEphemeral(task)
+    val taskStateChange = task.update(taskStateOp)
+    TaskStatusUpdateTestHelper(TaskChanged(taskStateOp, taskStateChange))
+  }
+
   def taskUpdateFor(task: Task, taskStatus: MarathonTaskStatus, timestamp: Timestamp = defaultTimestamp) = {
-    TaskStatusUpdateTestHelper(
-      TaskChanged(
-        TaskStateOp.MesosUpdate(task, taskStatus, timestamp),
-        TaskStateChange.Update(task, None)))
+    val taskStateOp = TaskStateOp.MesosUpdate(task, taskStatus, timestamp)
+    val taskStateChange = task.update(taskStateOp)
+    TaskStatusUpdateTestHelper(TaskChanged(taskStateOp, taskStateChange))
   }
 
   def taskExpungeFor(task: Task, taskStatus: MarathonTaskStatus, timestamp: Timestamp = defaultTimestamp) = {

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImplTest.scala
@@ -21,6 +21,7 @@ import org.apache.mesos.SchedulerDriver
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ GivenWhenThen, Matchers }
 
+import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
@@ -402,7 +403,7 @@ class TaskOpProcessorImplTest
     def stateOpLaunch(task: Task) = TaskStateOp.LaunchEphemeral(task)
     def stateOpUpdate(task: Task, status: MarathonTaskStatus, now: Timestamp = now) = TaskStateOp.MesosUpdate(task, status, now)
     def stateOpExpunge(task: Task) = TaskStateOp.ForceExpunge(task.taskId)
-    def stateOpLaunchOnReservation(task: Task, status: Task.Status) = TaskStateOp.LaunchOnReservation(task.taskId, now, status, Task.NoNetworking)
+    def stateOpLaunchOnReservation(task: Task, status: Task.Status) = TaskStateOp.LaunchOnReservation(task.taskId, now, status, Seq.empty)
     def stateOpReservationTimeout(task: Task) = TaskStateOp.ReservationTimeout(task.taskId)
     def stateOpReserve(task: Task) = TaskStateOp.Reserve(task.asInstanceOf[Task.Reserved])
 

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskStateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskStateOpResolverTest.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon.test.Mockito
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 
+import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
 /**
@@ -49,7 +50,7 @@ class TaskStateOpResolverTest
       taskId = f.notExistingTaskId,
       appVersion = Timestamp(0),
       status = Task.Status(Timestamp(0)),
-      networking = Task.NoNetworking)).futureValue
+      hostPorts = Seq.empty)).futureValue
 
     Then("taskTracker.task is called")
     verify(f.taskTracker).task(f.notExistingTaskId)

--- a/src/test/scala/mesosphere/marathon/event/HistoryActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/HistoryActorTest.scala
@@ -13,6 +13,8 @@ import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfterAll, Matchers }
 
+import scala.collection.immutable.Seq
+
 class HistoryActorTest
     extends MarathonActorSupport
     with MarathonSpec
@@ -103,7 +105,7 @@ class HistoryActorTest
       message = "message",
       appId = "appId".toPath,
       host = "host",
-      ipAddresses = Seq(ipAddress),
+      ipAddresses = Some(Seq(ipAddress)),
       ports = Nil,
       version = Timestamp.now().toString
     )

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -2,11 +2,11 @@ package mesosphere.marathon.health
 
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.api.v2.ValidationHelper
-import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.Command
 import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec, Protos }
 import play.api.libs.json.Json
 
+import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import com.wix.accord.validate
 
@@ -367,7 +367,7 @@ class HealthCheckTest extends MarathonSpec {
   test("getPort") {
     import MarathonTestHelper.Implicits._
     val check = new HealthCheck(port = Some(1234))
-    val task = MarathonTestHelper.runningTask("test_id").withNetworking(Task.HostPorts(4321))
+    val task = MarathonTestHelper.runningTask("test_id").withHostPorts(Seq(4321))
 
     assert(check.hostPort(task.launched.get).contains(1234))
   }

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
@@ -12,6 +12,7 @@ import mesosphere.marathon.test.MarathonActorSupport
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
 import org.scalatest.Matchers
 
+import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 
@@ -37,7 +38,7 @@ class HealthCheckWorkerActorTest
     val task =
       MarathonTestHelper.runningTask("test_id")
         .withAgentInfo(_.copy(host = InetAddress.getLocalHost.getCanonicalHostName))
-        .withNetworking(Task.HostPorts(socketPort))
+        .withHostPorts(Seq(socketPort))
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
     val app = AppDefinition(id = "test_id".toPath)
@@ -62,7 +63,7 @@ class HealthCheckWorkerActorTest
     val task =
       MarathonTestHelper.runningTask("test_id")
         .withAgentInfo(_.copy(host = InetAddress.getLocalHost.getCanonicalHostName))
-        .withNetworking(Task.HostPorts(socketPort))
+        .withHostPorts(Seq(socketPort))
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
     val app = AppDefinition(id = "test_id".toPath)

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.Protos.Constraint.Operator
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.api.v2.json.AppUpdate
 import mesosphere.marathon.health.HealthCheck
-import mesosphere.marathon.integration.facades.{ ITDeployment, ITQueueItem, MarathonFacade }
+import mesosphere.marathon.integration.facades.{ ITEnrichedTask, ITDeployment, ITQueueItem, MarathonFacade }
 import MarathonFacade._
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.state._
@@ -256,9 +256,12 @@ class AppDeployIntegrationTest
     apps.code should be(200)
     apps.value should have size 1
 
-    val tasks = marathon.tasks(appId)
-    tasks.code should be(200)
-    tasks.value should have size 2
+    val tasksResult: RestResult[List[ITEnrichedTask]] = marathon.tasks(appId)
+    tasksResult.code should be(200)
+
+    val tasks = tasksResult.value
+    tasks should have size 2
+    tasks.foreach(_.ipAddresses.get should not be empty)
   }
 
   test("an unhealthy app fails to deploy") {

--- a/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.api.v2.json.{ AppUpdate, GroupUpdate }
 import mesosphere.marathon.event.http.EventSubscribers
 import mesosphere.marathon.event.{ Subscribe, Unsubscribe }
 import mesosphere.marathon.integration.setup.{ RestResult, SprayHttpResponse }
-import mesosphere.marathon.state.{ AppDefinition, Group, PathId, Timestamp }
+import mesosphere.marathon.state._
 import org.slf4j.LoggerFactory
 import play.api.libs.functional.syntax._
 import play.api.libs.json.JsArray
@@ -37,6 +37,7 @@ case class ITEnrichedTask(
     id: String,
     host: String,
     ports: Option[Seq[Int]],
+    ipAddresses: Option[Seq[IpAddress]],
     startedAt: Option[Date],
     stagedAt: Option[Date],
     version: Option[String]) {
@@ -91,10 +92,11 @@ class MarathonFacade(url: String, baseGroup: PathId, waitTime: Duration = 30.sec
     (__ \ "id").format[String] ~
     (__ \ "host").format[String] ~
     (__ \ "ports").formatNullable[Seq[Int]] ~
+    (__ \ "ipAddresses").formatNullable[Seq[IpAddress]] ~
     (__ \ "startedAt").formatNullable[Date] ~
     (__ \ "stagedAt").formatNullable[Date] ~
     (__ \ "version").formatNullable[String]
-  )(ITEnrichedTask(_, _, _, _, _, _, _), unlift(ITEnrichedTask.unapply))
+  )(ITEnrichedTask(_, _, _, _, _, _, _, _), unlift(ITEnrichedTask.unapply))
 
   def isInBaseGroup(pathId: PathId): Boolean = {
     pathId.path.startsWith(baseGroup.path)

--- a/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
@@ -13,6 +13,8 @@ import mesosphere.mesos.protos.Implicits.slaveIDToProto
 import mesosphere.mesos.protos.SlaveID
 import org.scalatest.{ GivenWhenThen, Matchers }
 
+import scala.collection.immutable.Seq
+
 class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito with Matchers {
 
   test("Copy SlaveID from Offer to Task") {
@@ -41,7 +43,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
       status = Task.Status(
         stagedAt = f.clock.now()
       ),
-      networking = Task.HostPorts(List.empty)
+      hostPorts = Seq.empty
     )
     assert(inferredTaskOp.isDefined, "task op is not empty")
     assert(inferredTaskOp.get.stateOp == TaskStateOp.LaunchEphemeral(expectedTask))

--- a/src/test/scala/mesosphere/marathon/tasks/TaskTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskTrackerImplTest.scala
@@ -24,9 +24,8 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.{ reset, spy, times, verify }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ GivenWhenThen, Matchers }
-import org.slf4j.LoggerFactory
 
-import scala.collection._
+import scala.collection.immutable.Seq
 
 class TaskTrackerImplTest extends MarathonSpec with Matchers with GivenWhenThen with MarathonShutdownHookSupport {
 
@@ -473,7 +472,7 @@ class TaskTrackerImplTest extends MarathonSpec with Matchers with GivenWhenThen 
     MarathonTestHelper
       .stagedTaskForApp(appId)
       .withAgentInfo(_.copy(host = "host", attributes = Iterable(TextAttribute("attr1", "bar"))))
-      .withNetworking(Task.HostPorts(Iterable(999)))
+      .withHostPorts(Seq(999))
   }
 
   def makeTaskStatus(task: Task, state: TaskState = TaskState.TASK_RUNNING) = {
@@ -487,7 +486,7 @@ class TaskTrackerImplTest extends MarathonSpec with Matchers with GivenWhenThen 
   def containsTask(tasks: Iterable[Task], task: Task) =
     tasks.exists(t => t.taskId == task.taskId
       && t.agentInfo.host == task.agentInfo.host
-      && t.launched.map(_.networking) == task.launched.map(_.networking))
+      && t.launched.map(_.hostPorts) == task.launched.map(_.hostPorts))
   def shouldContainTask(tasks: Iterable[Task], task: Task) =
     assert(containsTask(tasks, task), s"Should contain ${task.taskId}")
   def shouldNotContainTask(tasks: Iterable[Task], task: Task) =

--- a/src/test/scala/mesosphere/marathon/test/CaptureEvents.scala
+++ b/src/test/scala/mesosphere/marathon/test/CaptureEvents.scala
@@ -6,6 +6,8 @@ import akka.event.EventStream
 import akka.testkit.TestProbe
 import mesosphere.marathon.event.MarathonEvent
 
+import scala.collection.immutable.Seq
+
 class CaptureEvents(eventStream: EventStream) {
   /**
     * Captures the events send to the EventStream while the block is executing.

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -60,13 +60,13 @@ class AppStartActorTest
       MesosStatusUpdateEvent(
         slaveId = "", taskId = Task.Id("task_a"),
         taskStatus = "TASK_RUNNING", message = "", appId = app
-          .id, host = "", ipAddresses = Nil, ports = Nil, version = app.version.toString
+          .id, host = "", ipAddresses = None, ports = Nil, version = app.version.toString
       )
     )
     system.eventStream.publish(
       MesosStatusUpdateEvent(
         slaveId = "", taskId = Task.Id("task_b"), taskStatus = "TASK_RUNNING", message = "", appId = app.id, host = "",
-        ipAddresses = Nil, ports = Nil, version = app.version.toString
+        ipAddresses = None, ports = Nil, version = app.version.toString
       )
     )
 

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStopActorTest.scala
@@ -40,13 +40,13 @@ class AppStopActorTest
     val statusUpdateEventA =
       MesosStatusUpdateEvent(
         slaveId = "", taskId = Task.Id("task_a"), taskStatus = "TASK_FAILED", message = "", appId = app.id, host = "",
-        ipAddresses = Nil, ports = Nil, version = app.version.toString
+        ipAddresses = None, ports = Nil, version = app.version.toString
       )
 
     val statusUpdateEventB =
       MesosStatusUpdateEvent(
         slaveId = "", taskId = Task.Id("task_b"), taskStatus = "TASK_LOST", message = "", appId = app.id, host = "",
-        ipAddresses = Nil, ports = Nil, version = app.version.toString
+        ipAddresses = None, ports = Nil, version = app.version.toString
       )
 
     val Some(taskFailureA) =

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -72,7 +72,7 @@ class DeploymentActorTest
         for (i <- 0 until invocation.getArguments()(1).asInstanceOf[Int])
           system.eventStream.publish(MesosStatusUpdateEvent(
             slaveId = "", taskId = Task.Id.forApp(app2New.id), taskStatus = "TASK_RUNNING", message = "",
-            appId = app2.id, host = "", ipAddresses = Nil, ports = Nil, version = app2New.version.toString)
+            appId = app2.id, host = "", ipAddresses = None, ports = Nil, version = app2New.version.toString)
           )
         true
       }
@@ -89,7 +89,7 @@ class DeploymentActorTest
       def answer(invocation: InvocationOnMock): Future[Unit] = {
         system.eventStream.publish(MesosStatusUpdateEvent(
           slaveId = "", taskId = Task.Id("task3_1"), taskStatus = "TASK_RUNNING", message = "", appId = app3.id, host = "",
-          ipAddresses = Nil, ports = Nil, version = app3.version.toString))
+          ipAddresses = None, ports = Nil, version = app3.version.toString))
         Future.successful(())
       }
     })
@@ -144,7 +144,7 @@ class DeploymentActorTest
       def answer(invocation: InvocationOnMock): Boolean = {
         for (i <- 0 until invocation.getArguments()(1).asInstanceOf[Int])
           f.system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id(s"task1_${taskIDs.next()}"),
-            "TASK_RUNNING", "", app.id, "", Nil, Nil, appNew.version.toString))
+            "TASK_RUNNING", "", app.id, "", None, Nil, appNew.version.toString))
         true
       }
     })
@@ -245,7 +245,7 @@ class DeploymentActorTest
       driver.killTask(task.taskId.mesosTaskId) answers { args =>
         system.eventStream.publish(MesosStatusUpdateEvent(
           slaveId = "", taskId = task.taskId, taskStatus = "TASK_KILLED", message = "", appId = app.id, host = "",
-          ipAddresses = Nil, ports = Nil, version = app.version.toString))
+          ipAddresses = None, ports = Nil, version = app.version.toString))
         Status.DRIVER_RUNNING
       }
     }

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
@@ -37,8 +37,8 @@ class TaskKillActorTest
     val ref = f.killActor(PathId("/test"), tasks.map(_.taskId), promise)
     watch(ref)
 
-    system.eventStream.publish(MesosStatusUpdateEvent("", taskA.taskId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
-    system.eventStream.publish(MesosStatusUpdateEvent("", taskB.taskId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
+    system.eventStream.publish(MesosStatusUpdateEvent("", taskA.taskId, "TASK_KILLED", "", PathId.empty, "", None, Nil, ""))
+    system.eventStream.publish(MesosStatusUpdateEvent("", taskB.taskId, "TASK_KILLED", "", PathId.empty, "", None, Nil, ""))
 
     Await.result(promise.future, 5.seconds) should be(())
     verify(f.driver).killTask(taskA.taskId.mesosTaskId)
@@ -121,8 +121,8 @@ class TaskKillActorTest
     ref.underlyingActor.periodicalCheck.cancel()
     ref ! KillNextBatch
 
-    system.eventStream.publish(MesosStatusUpdateEvent("", taskA.taskId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
-    system.eventStream.publish(MesosStatusUpdateEvent("", taskB.taskId, "TASK_KILLED", "", PathId.empty, "", Nil, Nil, ""))
+    system.eventStream.publish(MesosStatusUpdateEvent("", taskA.taskId, "TASK_KILLED", "", PathId.empty, "", None, Nil, ""))
+    system.eventStream.publish(MesosStatusUpdateEvent("", taskB.taskId, "TASK_KILLED", "", PathId.empty, "", None, Nil, ""))
 
     Await.result(promise.future, 5.seconds) should be(())
     verify(f.driver, times(2)).killTask(taskA.launchedMesosId.get)

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -46,7 +46,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID]
-        val update = MesosStatusUpdateEvent("", Task.Id(taskId), "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", Task.Id(taskId), "TASK_KILLED", "", app.id, "", None, Nil, app.version.toString)
         system.eventStream.publish(update)
         Status.DRIVER_RUNNING
       }
@@ -66,7 +66,7 @@ class TaskReplaceActorTest
     watch(ref)
 
     for (i <- 0 until app.instances)
-      ref ! MesosStatusUpdateEvent("", Task.Id(s"task_$i"), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString)
+      ref ! MesosStatusUpdateEvent("", Task.Id(s"task_$i"), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString)
 
     Await.result(promise.future, 5.seconds)
     verify(queue).resetDelay(app)
@@ -93,7 +93,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID]
-        val update = MesosStatusUpdateEvent("", Task.Id(taskId), "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", Task.Id(taskId), "TASK_KILLED", "", app.id, "", None, Nil, app.version.toString)
         system.eventStream.publish(update)
         Status.DRIVER_RUNNING
       }
@@ -136,7 +136,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID]
-        val update = MesosStatusUpdateEvent("", Task.Id(taskId), "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", Task.Id(taskId), "TASK_KILLED", "", app.id, "", None, Nil, app.version.toString)
         system.eventStream.publish(update)
         Status.DRIVER_RUNNING
       }
@@ -158,8 +158,8 @@ class TaskReplaceActorTest
     eventually { verify(driver, times(2)).killTask(_) }
     eventually { app: AppDefinition => verify(queue, times(2)).add(app) }
 
-    ref ! MesosStatusUpdateEvent("", Task.Id("task_1"), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString)
-    ref ! MesosStatusUpdateEvent("", Task.Id("task_2"), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString)
+    ref ! MesosStatusUpdateEvent("", Task.Id("task_1"), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString)
+    ref ! MesosStatusUpdateEvent("", Task.Id("task_2"), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString)
 
     Await.result(promise.future, 5.seconds)
 
@@ -190,7 +190,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       override def answer(invocation: InvocationOnMock): Status = {
         val taskId = invocation.getArguments()(0).asInstanceOf[TaskID]
-        val update = MesosStatusUpdateEvent("", Task.Id(taskId), "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", Task.Id(taskId), "TASK_KILLED", "", app.id, "", None, Nil, app.version.toString)
         system.eventStream.publish(update)
 
         oldTaskCount -= 1
@@ -260,7 +260,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = Task.Id(invocation.getArguments()(0).asInstanceOf[TaskID])
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", None, Nil, app.version.toString)
         system.eventStream.publish(update)
 
         oldTaskCount -= 1
@@ -334,7 +334,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = Task.Id(invocation.getArguments()(0).asInstanceOf[TaskID])
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", None, Nil, app.version.toString)
         system.eventStream.publish(update)
 
         oldTaskCount -= 1
@@ -406,7 +406,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = Task.Id(invocation.getArguments()(0).asInstanceOf[TaskID])
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", None, Nil, app.version.toString)
         system.eventStream.publish(update)
 
         oldTaskCount -= 1
@@ -479,7 +479,7 @@ class TaskReplaceActorTest
     when(driver.killTask(any[TaskID])).thenAnswer(new Answer[Status] {
       def answer(invocation: InvocationOnMock): Status = {
         val taskId = Task.Id(invocation.getArguments()(0).asInstanceOf[TaskID])
-        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
+        val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", None, Nil, app.version.toString)
         system.eventStream.publish(update)
 
         oldTaskCount -= 1
@@ -584,7 +584,7 @@ class TaskReplaceActorTest
           firstKillForTaskB = false
         }
         else {
-          val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString)
+          val update = MesosStatusUpdateEvent("", taskId, "TASK_KILLED", "", app.id, "", None, Nil, app.version.toString)
           system.eventStream.publish(update)
         }
         Status.DRIVER_RUNNING
@@ -608,7 +608,7 @@ class TaskReplaceActorTest
     ref ! RetryKills
 
     for (i <- 0 until app.instances)
-      ref ! MesosStatusUpdateEvent("", Task.Id(s"task_$i"), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString)
+      ref ! MesosStatusUpdateEvent("", Task.Id(s"task_$i"), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString)
 
     Await.result(promise.future, 5.seconds)
     verify(queue).resetDelay(app)
@@ -642,7 +642,7 @@ class TaskReplaceActorTest
     watch(ref)
 
     for (i <- 0 until app.instances)
-      ref.receive(MesosStatusUpdateEvent("", Task.Id(s"task_$i"), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
+      ref.receive(MesosStatusUpdateEvent("", Task.Id(s"task_$i"), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString))
 
     verify(queue, Mockito.timeout(1000)).resetDelay(app)
     verify(driver, Mockito.timeout(1000)).killTask(taskA.launchedMesosId.get)
@@ -651,7 +651,7 @@ class TaskReplaceActorTest
     promise.isCompleted should be(false)
 
     for (oldTask <- Iterable(taskA, taskB))
-      ref.receive(MesosStatusUpdateEvent("", oldTask.taskId, "TASK_KILLED", "", app.id, "", Nil, Nil, app.version.toString))
+      ref.receive(MesosStatusUpdateEvent("", oldTask.taskId, "TASK_KILLED", "", app.id, "", None, Nil, app.version.toString))
 
     Await.result(promise.future, 0.second)
   }

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -81,7 +81,7 @@ class TaskStartActorTest
       verify(launchQueue, Mockito.timeout(3000)).add(app, app.instances)
 
       for (i <- 0 until app.instances)
-        system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id(s"task-$i"), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
+        system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id(s"task-$i"), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString))
 
       Await.result(promise.future, 3.seconds) should be(())
 
@@ -122,7 +122,7 @@ class TaskStartActorTest
       for (i <- 0 until (app.instances - 1))
         system
           .eventStream
-          .publish(MesosStatusUpdateEvent("", Task.Id(s"task-$i"), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
+          .publish(MesosStatusUpdateEvent("", Task.Id(s"task-$i"), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString))
 
       Await.result(promise.future, 3.seconds) should be(())
 
@@ -155,7 +155,7 @@ class TaskStartActorTest
     verify(launchQueue, Mockito.timeout(3000)).add(app, app.instances - 1)
 
     for (i <- 0 until (app.instances - 1))
-      system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id(s"task-$i"), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
+      system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id(s"task-$i"), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString))
 
     Await.result(promise.future, 3.seconds) should be(())
 
@@ -291,12 +291,12 @@ class TaskStartActorTest
 
     verify(launchQueue, Mockito.timeout(3000)).add(app, app.instances)
 
-    system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id.forApp(app.id), "TASK_FAILED", "", app.id, "", Nil, Nil, app.version.toString))
+    system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id.forApp(app.id), "TASK_FAILED", "", app.id, "", None, Nil, app.version.toString))
 
     verify(launchQueue, Mockito.timeout(3000)).add(app, 1)
 
     for (i <- 0 until app.instances)
-      system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id.forApp(app.id), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
+      system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id.forApp(app.id), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString))
 
     Await.result(promise.future, 3.seconds) should be(())
 
@@ -337,7 +337,7 @@ class TaskStartActorTest
     when(launchQueue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLeftToLaunch = 4)))
     system.eventStream.publish(MesosStatusUpdateEvent(
       slaveId = "", taskId = taskId, taskStatus = "TASK_ERROR", message = "", appId = app.id, host = "",
-      ipAddresses = Nil, ports = Nil,
+      ipAddresses = None, ports = Nil,
       // The version does not match the app.version so that it is filtered in StartingBehavior.
       // does that make sense?
       version = outdatedTask.launched.get.appVersion.toString
@@ -355,7 +355,7 @@ class TaskStartActorTest
     when(launchQueue.get(app.id)).thenReturn(Some(LaunchQueueTestHelper.zeroCounts.copy(tasksLeftToLaunch = app.instances)))
     when(taskTracker.countLaunchedAppTasksSync(app.id)).thenReturn(4)
     List(0, 1, 2, 3) foreach { i =>
-      system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id(s"task-$i"), "TASK_RUNNING", "", app.id, "", Nil, Nil, app.version.toString))
+      system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id(s"task-$i"), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString))
     }
 
     // it finished early

--- a/src/test/scala/mesosphere/mesos/ConstraintsTest.scala
+++ b/src/test/scala/mesosphere/mesos/ConstraintsTest.scala
@@ -10,6 +10,7 @@ import mesosphere.mesos.protos.{ FrameworkID, OfferID, SlaveID, TextAttribute }
 import org.apache.mesos.Protos.{ Attribute, Offer }
 import org.scalatest.{ GivenWhenThen, Matchers }
 
+import scala.collection.immutable.Seq
 import scala.collection.JavaConverters._
 import scala.util.Random
 
@@ -447,7 +448,7 @@ class ConstraintsTest extends MarathonSpec with GivenWhenThen with Matchers {
     val attributes = attrs.map { case (name, value) => TextAttribute(name, value): Attribute }
     MarathonTestHelper.stagedTask(id)
       .withAgentInfo(_.copy(attributes = attributes))
-      .withNetworking(Task.HostPorts(999))
+      .withHostPorts(Seq(999))
   }
 
   def makeOffer(hostname: String, attributes: Iterable[Attribute]) = {
@@ -464,7 +465,7 @@ class ConstraintsTest extends MarathonSpec with GivenWhenThen with Matchers {
     MarathonTestHelper
       .runningTask(id)
       .withAgentInfo(_.copy(host = host))
-      .withNetworking(Task.HostPorts(999))
+      .withHostPorts(Seq(999))
   }
 
   def makeConstraint(field: String, operator: Operator, value: String) = {

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1171,7 +1171,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     MarathonTestHelper
       .stagedTask(taskId = id.toString)
       .withAgentInfo(_.copy(attributes = Iterable(TextAttribute(attr, attrVal))))
-      .withNetworking(Task.HostPorts(List(999)))
+      .withHostPorts(Seq(999))
   }
 
   private def assertTaskInfo(taskInfo: MesosProtos.TaskInfo, taskPorts: Seq[Int], offer: Offer): Unit = {


### PR DESCRIPTION
**NOTE**: IP-per-Task is also broken in Marathon v0.15.x. We might need to backport this commit.

- Recent versions of Mesos send the NetworkInfo messages for all tasks,
  even if no ip address was requested.
- The NetworkInfo messages are wrapped inside of the ContainerStatus message.
- Marathon should always store the NetworkInfo messages and expose the
  IpAddresses through the tasks API. Clients (including the UI) can then decide
  if they want to use the agent info or one of the ip addresses.

Changes in order to always return the IpAddreses:

- Refactored the Task.Networking traits. It is now a case class that stores both
  host ports and NetworkInfo messages.
- Changed Task.update in order to always extract the NetworkInfo messages from
  the update messages and store them using new Task.Networking case class.