### PR TITLE
Apply readiness checks as part of a Deployment

### DIFF
--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/DeploymentsResource_running.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/DeploymentsResource_running.md
@@ -42,7 +42,20 @@ Transfer-Encoding: chunked
         "currentActions": [
           {
               "action": "RestartApplication", 
-              "app": "/test/frontend/app1"
+              "app": "/test/frontend/app1",
+              "readinessChecks": [
+                  {
+                      "lastResponse": {
+                          "body": "{}", 
+                          "contentType": "application/json", 
+                          "status": 500
+                      }, 
+                      "name": "myReadyCheck", 
+                      "ready": false, 
+                      "taskId": "test_frontend_app1.c9de6033"
+                  }
+              ]
+
           }
         ],
         "totalSteps": 9,

--- a/docs/docs/rest-api/public/api/v2/examples/app.json
+++ b/docs/docs/rest-api/public/api/v2/examples/app.json
@@ -73,6 +73,18 @@
       "timeoutSeconds": 20
     }
   ],
+  "readinessChecks": [
+    {
+      "name": "myReadyCheck",
+      "protocol": "HTTP",
+      "path": "/v1/plan"
+      "portName": "http"
+      "interval": 10000,
+      "timeout": 10000,
+      "httpStatusCodesForReady": [ 200 ],
+      "preserveLastResponse": false
+    }
+  ],
   "labels": {
     "owner": "zeus",
     "note": "Away from olympus"
@@ -100,7 +112,7 @@
   ],
   "portDefinitions": [
     {
-      "port": 0
+      "port": 0,
       "protocol": "tcp",
       "name": "http",
       "labels": { "vip": "192.168.0.1:80" }

--- a/docs/docs/rest-api/public/api/v2/examples/deployments.json
+++ b/docs/docs/rest-api/public/api/v2/examples/deployments.json
@@ -22,7 +22,19 @@
     "currentActions": [
       {
         "action": "ScaleApplication",
-        "app": "/foo"
+        "app": "/foo",
+        "readinessChecks": [
+          {
+            "lastResponse": {
+              "body": "{}",
+              "contentType": "application/json",
+              "status": 500
+            },
+            "name": "myReadyCheck",
+            "ready": false,
+            "taskId": "foo.c9de6033"
+          }
+        ]
       }
     ],
     "currentStep": 2,

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -22,6 +22,7 @@ import mesosphere.marathon.api.LeaderInfo
 import mesosphere.marathon.core.launcher.TaskOpFactory
 import mesosphere.marathon.core.launcher.impl.TaskOpFactoryImpl
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.event.http._
 import mesosphere.marathon.event.{ EventModule, HistoryActor }
@@ -191,6 +192,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
     leaderInfo: LeaderInfo,
     storage: StorageProvider,
     @Named(EventModule.busName) eventBus: EventStream,
+    readinessCheckExecutor: ReadinessCheckExecutor,
     taskFailureRepository: TaskFailureRepository): ActorRef = {
     val supervision = OneForOneStrategy() {
       case NonFatal(_) => Restart
@@ -219,6 +221,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, zk: ZooKeeperClient)
           storage,
           healthCheckManager,
           eventBus,
+          readinessCheckExecutor,
           conf
         )
       )

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -296,7 +296,7 @@ class MarathonSchedulerActor private (
                 existingPlan.affectedApplicationIds.intersect(plan.affectedApplicationIds).nonEmpty
               }
               val relatedDeploymentIds: Seq[String] = plans.collect {
-                case DeploymentStepInfo(p, _, _) if intersectsWithNewPlan(p) => p.id
+                case DeploymentStepInfo(p, _, _, _) if intersectsWithNewPlan(p) => p.id
               }
               origSender ! CommandFailed(cmd, AppLockedException(relatedDeploymentIds))
           }

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -12,6 +12,7 @@ import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.leadership.{ LeadershipCoordinator, LeadershipModule }
 import mesosphere.marathon.core.plugin.{ PluginDefinitions, PluginManager }
+import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.bus.{ TaskStatusEmitter, TaskChangeObservables }
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.tracker.{ TaskCreationHandler, TaskStateOpProcessor, TaskTracker }
@@ -91,6 +92,9 @@ class CoreGuiceModule extends AbstractModule {
 
   @Provides @Singleton
   def authenticator(coreModule: CoreModule): Authenticator = coreModule.authModule.authenticator
+
+  @Provides @Singleton
+  def readinessCheckExecutor(coreModule: CoreModule): ReadinessCheckExecutor = coreModule.readinessModule.readinessCheckExecutor //scalastyle:ignore
 
   @Provides @Singleton
   def taskStatusUpdateSteps(

--- a/src/main/scala/mesosphere/marathon/core/CoreModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModule.scala
@@ -5,6 +5,7 @@ import mesosphere.marathon.core.launcher.LauncherModule
 import mesosphere.marathon.core.launchqueue.LaunchQueueModule
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.plugin.PluginModule
+import mesosphere.marathon.core.readiness.ReadinessModule
 import mesosphere.marathon.core.task.bus.TaskBusModule
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.tracker.TaskTrackerModule
@@ -24,4 +25,5 @@ trait CoreModule {
   def appOfferMatcherModule: LaunchQueueModule
   def pluginModule: PluginModule
   def authModule: AuthModule
+  def readinessModule: ReadinessModule
 }

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -151,8 +151,8 @@ case class AppDefinition(
       .addAllLabels(appLabels.asJava)
 
     ipAddress.foreach { ip => builder.setIpAddress(ip.toProto) }
-
     container.foreach { c => builder.setContainer(ContainerSerializer.toProto(c)) }
+    readinessChecks.foreach { r => builder.addReadinessCheckDefinition(ReadinessCheckSerializer.toProto(r)) }
 
     acceptedResourceRoles.foreach { acceptedResourceRoles =>
       val roles = Protos.ResourceRoles.newBuilder()

--- a/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
@@ -3,7 +3,9 @@ package mesosphere.marathon.upgrade
 import akka.actor._
 import akka.event.EventStream
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.event.DeploymentStatus
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.{ AppStartCanceledException, SchedulerActions }
 import org.apache.mesos.SchedulerDriver
@@ -12,11 +14,14 @@ import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
 class AppStartActor(
+    val deploymentManager: ActorRef,
+    val status: DeploymentStatus,
     val driver: SchedulerDriver,
     val scheduler: SchedulerActions,
     val taskQueue: LaunchQueue,
     val taskTracker: TaskTracker,
     val eventBus: EventStream,
+    val readinessCheckExecutor: ReadinessCheckExecutor,
     val app: AppDefinition,
     val scaleTo: Int,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
@@ -36,11 +41,31 @@ class AppStartActor(
         }(context.dispatcher)
       }
     }
+    super.postStop()
   }
 
   def success(): Unit = {
     log.info(s"Successfully started $scaleTo instances of ${app.id}")
     promise.success(())
     context.stop(self)
+  }
+}
+
+object AppStartActor {
+  //scalastyle:off
+  def props(
+    deploymentManager: ActorRef,
+    status: DeploymentStatus,
+    driver: SchedulerDriver,
+    scheduler: SchedulerActions,
+    taskQueue: LaunchQueue,
+    taskTracker: TaskTracker,
+    eventBus: EventStream,
+    readinessCheckExecutor: ReadinessCheckExecutor,
+    app: AppDefinition,
+    scaleTo: Int,
+    promise: Promise[Unit]): Props = {
+    Props(new AppStartActor(deploymentManager, status, driver, scheduler, taskQueue, taskTracker, eventBus,
+      readinessCheckExecutor, app, scaleTo, promise))
   }
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentManager.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentManager.scala
@@ -5,10 +5,12 @@ import akka.actor._
 import akka.event.EventStream
 import mesosphere.marathon.MarathonSchedulerActor.{ RetrieveRunningDeployments, RunningDeployments }
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.readiness.{ ReadinessCheckExecutor, ReadinessCheckResult }
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.io.storage.StorageProvider
-import mesosphere.marathon.state.{ AppRepository, Group, Timestamp }
+import mesosphere.marathon.state.{ PathId, AppRepository, Group, Timestamp }
 import mesosphere.marathon.upgrade.DeploymentActor.Cancel
 import mesosphere.marathon.{ ConcurrentTaskUpgradeException, DeploymentCanceledException, SchedulerActions }
 import org.apache.mesos.SchedulerDriver
@@ -26,6 +28,7 @@ class DeploymentManager(
     storage: StorageProvider,
     healthCheckManager: HealthCheckManager,
     eventBus: EventStream,
+    readinessCheckExecutor: ReadinessCheckExecutor,
     config: UpgradeConfig) extends Actor with ActorLogging {
   import context.dispatcher
   import mesosphere.marathon.upgrade.DeploymentManager._
@@ -97,6 +100,7 @@ class DeploymentManager(
           storage,
           healthCheckManager,
           eventBus,
+          readinessCheckExecutor,
           config
         ),
         plan.id
@@ -104,6 +108,10 @@ class DeploymentManager(
       runningDeployments += plan.id -> DeploymentInfo(ref, plan)
 
     case stepInfo: DeploymentStepInfo => deploymentStatus += stepInfo.plan.id -> stepInfo
+
+    case ReadinessCheckUpdate(id, result) => deploymentStatus.get(id).foreach { info =>
+      deploymentStatus += id -> info.copy(readinessChecks = info.readinessChecks.updated(result.taskId, result))
+    }
 
     case _: PerformDeployment =>
       sender() ! Status.Failure(new ConcurrentTaskUpgradeException("Deployment is already in progress"))
@@ -125,16 +133,26 @@ object DeploymentManager {
   case object CancelAllDeployments
   final case class CancelConflictingDeployments(plan: DeploymentPlan)
 
-  final case class DeploymentStepInfo(plan: DeploymentPlan, step: DeploymentStep, nr: Int)
+  final case class DeploymentStepInfo(plan: DeploymentPlan,
+                                      step: DeploymentStep,
+                                      nr: Int,
+                                      readinessChecks: Map[Task.Id, ReadinessCheckResult] = Map.empty) {
+    lazy val readinessChecksByApp: Map[PathId, Iterable[ReadinessCheckResult]] = {
+      readinessChecks.values.groupBy(_.taskId.appId).withDefaultValue(Iterable.empty)
+    }
+  }
+
   final case class DeploymentFinished(plan: DeploymentPlan)
   final case class DeploymentFailed(plan: DeploymentPlan, reason: Throwable)
   final case class AllDeploymentsCanceled(plans: Seq[DeploymentPlan])
   final case class ConflictingDeploymentsCanceled(id: String, deployments: Seq[DeploymentPlan])
+  final case class ReadinessCheckUpdate(deploymentId: String, result: ReadinessCheckResult)
 
   final case class DeploymentInfo(
     ref: ActorRef,
     plan: DeploymentPlan)
 
+  //scalastyle:off
   def props(
     appRepository: AppRepository,
     taskTracker: TaskTracker,
@@ -143,9 +161,10 @@ object DeploymentManager {
     storage: StorageProvider,
     healthCheckManager: HealthCheckManager,
     eventBus: EventStream,
+    readinessCheckExecutor: ReadinessCheckExecutor,
     config: UpgradeConfig): Props = {
     Props(new DeploymentManager(appRepository, taskTracker, taskQueue,
-      scheduler, storage, healthCheckManager, eventBus, config))
+      scheduler, storage, healthCheckManager, eventBus, readinessCheckExecutor, config))
   }
 
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/ReadinessBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/ReadinessBehavior.scala
@@ -1,0 +1,124 @@
+package mesosphere.marathon.upgrade
+
+import akka.actor.{ ActorLogging, ActorRef, Actor }
+import mesosphere.marathon.core.readiness.{ ReadinessCheckExecutor, ReadinessCheckResult }
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.event.{ DeploymentStatus, HealthStatusChanged, MesosStatusUpdateEvent }
+import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
+import mesosphere.marathon.upgrade.DeploymentManager.ReadinessCheckUpdate
+import mesosphere.marathon.upgrade.ReadinessBehavior.ScheduleReadinessCheckFor
+import rx.lang.scala.Subscription
+
+/**
+  * ReadinessBehavior makes sure all tasks are healthy and ready depending on the app definition.
+  * Listens for TaskStatusUpdate events, HealthCheck events and ReadinessCheck events.
+  * If a task becomes ready, the taskIsReady hook is called.
+  *
+  * Assumptions:
+  *  - the actor is attached to the event stream for HealthStatusChanged and MesosStatusUpdateEvent
+  */
+trait ReadinessBehavior { this: Actor with ActorLogging =>
+
+  import context.dispatcher
+
+  //dependencies
+  def app: AppDefinition
+  def readinessCheckExecutor: ReadinessCheckExecutor
+  def deploymentManager: ActorRef
+  def taskTracker: TaskTracker
+  def status: DeploymentStatus
+
+  //computed values to have stable identifier in pattern matcher
+  val appId: PathId = app.id
+  val version: Timestamp = app.version
+  val versionString: String = version.toString
+
+  //state managed by this behavior
+  var healthy = Set.empty[Task.Id]
+  var ready = Set.empty[Task.Id]
+  var subscriptions = Map.empty[String, Subscription]
+
+  /**
+    * Hook method which is called, whenever a task becomes ready according to the given app definition.
+    * @param taskId the id of the task that has become ready.
+    */
+  def taskIsReady(taskId: Task.Id): Unit
+
+  override def postStop(): Unit = {
+    subscriptions.values.foreach(_.unsubscribe())
+  }
+
+  /**
+    * Depending on the app definition, this method handles:
+    * - app without health checks and without readiness checks
+    * - app with health checks and without readiness checks
+    * - app without health checks and with readiness checks
+    * - app with health checks and with readiness checks
+    *
+    * The #taskIsReady function is called, when the task is ready according to the app definition.
+    */
+  //scalastyle:off cyclomatic.complexity
+  def readinessBehavior: Receive = {
+    def taskIsRunning(taskFn: Task.Id => Unit): Receive = {
+      case MesosStatusUpdateEvent(slaveId, taskId, "TASK_RUNNING", _, `appId`, _, _, _, `versionString`, _, _) =>
+        taskFn(taskId)
+    }
+
+    def taskIsHealthy(taskFn: Task.Id => Unit): Receive = {
+      case HealthStatusChanged(`appId`, taskId, `version`, true, _, _) if !healthy(taskId) => taskFn(taskId)
+    }
+
+    def startedTaskIsReady(taskId: Task.Id): Unit = {
+      log.debug(s"Started task is ready: $taskId")
+      healthy += taskId
+      ready += taskId
+      taskIsReady(taskId)
+    }
+
+    def initiateReadinessCheck(taskId: Task.Id): Unit = {
+      log.debug(s"Initiate readiness check for task: $taskId")
+      healthy += taskId
+      val me = self
+      taskTracker.task(taskId).map { taskOption =>
+        for {
+          task <- taskOption
+          launched <- task.launched
+        } me ! ScheduleReadinessCheckFor(task, launched)
+      }
+    }
+
+    def subscriptionKey(id: Task.Id, name: String) = s"${id.toString}:$name"
+
+    def readinessCheckBehavior: Receive = {
+      case ScheduleReadinessCheckFor(task, launched) =>
+        log.debug(s"Schedule readiness check for task: ${task.taskId}")
+        ReadinessCheckExecutor.ReadinessCheckSpec.readinessCheckSpecsForTask(app, task, launched).foreach { spec =>
+          val subscriptionName = subscriptionKey(task.taskId, spec.checkName)
+          val subscription = readinessCheckExecutor.execute(spec).subscribe(self ! _)
+          subscriptions += subscriptionName -> subscription
+        }
+
+      case result: ReadinessCheckResult =>
+        log.info(s"Received readiness check update for task ${result.taskId} with ready: ${result.ready}")
+        deploymentManager ! ReadinessCheckUpdate(status.plan.id, result)
+        //TODO(MV): this code assumes only one readiness check per app (validation rules enforce this)
+        if (result.ready) {
+          ready += result.taskId
+          val subscriptionName = subscriptionKey(result.taskId, result.name)
+          subscriptions.get(subscriptionName).foreach(_.unsubscribe())
+          subscriptions -= subscriptionName
+          taskIsReady(result.taskId)
+        }
+    }
+
+    val readyFn: Task.Id => Unit = if (app.readinessChecks.isEmpty) startedTaskIsReady else initiateReadinessCheck
+    val startBehavior = if (app.healthChecks.nonEmpty) taskIsHealthy(readyFn) else taskIsRunning(readyFn)
+    val readinessBehavior = if (app.readinessChecks.nonEmpty) readinessCheckBehavior else Actor.emptyBehavior
+    startBehavior orElse readinessBehavior
+  }
+}
+
+object ReadinessBehavior {
+  case class ScheduleReadinessCheckFor(task: Task, launched: Task.Launched)
+}

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -4,14 +4,14 @@ import akka.actor.{ Actor, ActorLogging }
 import akka.event.EventStream
 import mesosphere.marathon.SchedulerActions
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.task.Task.Id
 import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.event.{ HealthStatusChanged, MarathonHealthCheckEvent, MesosStatusUpdateEvent }
-import mesosphere.marathon.state.AppDefinition
+import mesosphere.marathon.event.{ MarathonHealthCheckEvent, MesosStatusUpdateEvent }
 import org.apache.mesos.SchedulerDriver
 
 import scala.concurrent.duration._
 
-trait StartingBehavior { this: Actor with ActorLogging =>
+trait StartingBehavior extends ReadinessBehavior { this: Actor with ActorLogging =>
   import context.dispatcher
   import mesosphere.marathon.upgrade.StartingBehavior._
 
@@ -23,24 +23,11 @@ trait StartingBehavior { this: Actor with ActorLogging =>
   def scheduler: SchedulerActions
   def taskTracker: TaskTracker
 
-  val app: AppDefinition
-  val Version = app.version
-  // FIXME: Don't use a string here!
-  val VersionString = app.version.toString
-  var atLeastOnceHealthyTasks = Set.empty[String]
-  var startedRunningTasks = Set.empty[String]
-  val AppId = app.id
-  val withHealthChecks: Boolean = app.healthChecks.nonEmpty
-
   def initializeStart(): Unit
 
   final override def preStart(): Unit = {
-    if (withHealthChecks) {
-      eventBus.subscribe(self, classOf[MarathonHealthCheckEvent])
-    }
-    else {
-      eventBus.subscribe(self, classOf[MesosStatusUpdateEvent])
-    }
+    if (app.healthChecks.nonEmpty) eventBus.subscribe(self, classOf[MarathonHealthCheckEvent])
+    else eventBus.subscribe(self, classOf[MesosStatusUpdateEvent])
 
     initializeStart()
     checkFinished()
@@ -48,32 +35,13 @@ trait StartingBehavior { this: Actor with ActorLogging =>
     context.system.scheduler.scheduleOnce(5.seconds, self, Sync)
   }
 
-  final override def receive: Receive = {
-    val behavior =
-      if (withHealthChecks) checkForHealthy
-      else checkForRunning
-    behavior orElse commonBehavior: PartialFunction[Any, Unit] // type annotation makes Intellij happy
-  }
-
-  final def checkForHealthy: Receive = {
-    case HealthStatusChanged(AppId, taskId, Version, true, _, _) if !atLeastOnceHealthyTasks(taskId.idString) =>
-      atLeastOnceHealthyTasks += taskId.idString
-      log.info(s"$taskId is now healthy")
-      checkFinished()
-  }
-
-  final def checkForRunning: Receive = {
-    case MesosStatusUpdateEvent(_, taskId, "TASK_RUNNING", _, app.`id`, _, _, _, VersionString, _, _) if !startedRunningTasks(taskId.idString) => // scalastyle:off line.size.limit
-      startedRunningTasks += taskId.idString
-      log.info(s"New task $taskId now running during app ${app.id.toString} scaling, " +
-        s"${nrToStart - startedRunningTasks.size} more to go")
-      checkFinished()
-  }
+  final override def receive: Receive = readinessBehavior orElse commonBehavior
 
   def commonBehavior: Receive = {
-    case MesosStatusUpdateEvent(_, taskId, StartErrorState(_), _, app.`id`, _, _, _, VersionString, _, _) => // scalastyle:off line.size.limit
+    case MesosStatusUpdateEvent(_, taskId, StartErrorState(_), _, `appId`, _, _, _, `versionString`, _, _) => // scalastyle:off line.size.limit
       log.warning(s"New task [$taskId] failed during app ${app.id.toString} scaling, queueing another task")
-      startedRunningTasks -= taskId.idString
+      healthy -= taskId
+      ready -= taskId
       taskQueue.add(app)
 
     case Sync =>
@@ -86,13 +54,14 @@ trait StartingBehavior { this: Actor with ActorLogging =>
       context.system.scheduler.scheduleOnce(5.seconds, self, Sync)
   }
 
+  override def taskIsReady(taskId: Id): Unit = {
+    log.info(s"New task $taskId now ready during app ${app.id.toString} scaling, " +
+      s"${nrToStart - ready.size} more to go")
+    checkFinished()
+  }
+
   def checkFinished(): Unit = {
-    val started =
-      if (withHealthChecks) atLeastOnceHealthyTasks.size
-      else startedRunningTasks.size
-    if (started == nrToStart) {
-      success()
-    }
+    if (ready.size == nrToStart) success()
   }
 
   def success(): Unit

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -1,12 +1,14 @@
 package mesosphere.marathon.upgrade
 
-import akka.actor.{ Actor, ActorLogging, Cancellable }
+import akka.actor._
 import akka.event.EventStream
 import mesosphere.marathon.TaskUpgradeCanceledException
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.Task.Id
 import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.event.{ HealthStatusChanged, MesosStatusUpdateEvent }
+import mesosphere.marathon.event.{ DeploymentStatus, HealthStatusChanged, MesosStatusUpdateEvent }
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.upgrade.TaskReplaceActor._
 import org.apache.mesos.Protos.TaskID
@@ -18,19 +20,18 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 
 class TaskReplaceActor(
-    driver: SchedulerDriver,
-    taskQueue: LaunchQueue,
-    taskTracker: TaskTracker,
-    eventBus: EventStream,
-    app: AppDefinition,
-    promise: Promise[Unit]) extends Actor with ActorLogging {
+    val deploymentManager: ActorRef,
+    val status: DeploymentStatus,
+    val driver: SchedulerDriver,
+    val taskQueue: LaunchQueue,
+    val taskTracker: TaskTracker,
+    val eventBus: EventStream,
+    val readinessCheckExecutor: ReadinessCheckExecutor,
+    val app: AppDefinition,
+    promise: Promise[Unit]) extends Actor with ReadinessBehavior with ActorLogging {
   import context.dispatcher
 
   val tasksToKill = taskTracker.appTasksLaunchedSync(app.id)
-  val appId = app.id
-  val version = app.version
-  val versionString = app.version.toString
-  var healthy = Set.empty[Task.Id]
   var newTasksStarted: Int = 0
   var oldTaskIds = tasksToKill.map(_.taskId).to[SortedSet]
   val toKill = oldTaskIds.to[mutable.Queue]
@@ -39,6 +40,7 @@ class TaskReplaceActor(
   val periodicalRetryKills: Cancellable = context.system.scheduler.schedule(15.seconds, 15.seconds, self, RetryKills)
 
   override def preStart(): Unit = {
+    super.preStart()
     eventBus.subscribe(self, classOf[MesosStatusUpdateEvent])
     eventBus.subscribe(self, classOf[HealthStatusChanged])
 
@@ -62,33 +64,17 @@ class TaskReplaceActor(
       promise.tryFailure(
         new TaskUpgradeCanceledException(
           "The task upgrade has been cancelled"))
+    super.postStop()
   }
 
-  override def receive: Receive = {
-    val behavior =
-      if (app.healthChecks.nonEmpty)
-        healthCheckingBehavior
-      else
-        taskStateBehavior
+  override def receive: Receive = readinessBehavior orElse replaceBehavior
 
-    behavior orElse commonBehavior: PartialFunction[Any, Unit] // type annotation makes Intellij happy
-  }
-
-  def taskStateBehavior: Receive = {
-    case MesosStatusUpdateEvent(slaveId, taskId, "TASK_RUNNING", _, `appId`, _, _, _, `versionString`, _, _) =>
-      handleStartedTask(taskId)
-  }
-
-  def healthCheckingBehavior: Receive = {
-    case HealthStatusChanged(`appId`, taskId, `version`, true, _, _) if !healthy(taskId) =>
-      handleStartedTask(taskId)
-  }
-
-  def commonBehavior: Receive = {
+  def replaceBehavior: Receive = {
     // New task failed to start, restart it
     case MesosStatusUpdateEvent(slaveId, taskId, FailedToStart(_), _, `appId`, _, _, _, `versionString`, _, _) if !oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
       log.error(s"New task $taskId failed on slave $slaveId during app $appId restart")
       healthy -= taskId
+      ready -= taskId
       taskQueue.add(app)
 
     // Old task successfully killed
@@ -104,6 +90,11 @@ class TaskReplaceActor(
     case x: Any => log.debug(s"Received $x")
   }
 
+  override def taskIsReady(taskId: Id): Unit = {
+    killNextOldTask(Some(taskId))
+    checkFinished()
+  }
+
   def reconcileNewTasks(): Unit = {
     val leftCapacity = math.max(0, maxCapacity - oldTaskIds.size - newTasksStarted)
     val tasksNotStartedYet = math.max(0, app.instances - newTasksStarted)
@@ -113,12 +104,6 @@ class TaskReplaceActor(
       taskQueue.add(app, tasksToStartNow)
       newTasksStarted += tasksToStartNow
     }
-  }
-
-  def handleStartedTask(taskId: Task.Id): Unit = {
-    healthy += taskId
-    killNextOldTask(Some(taskId))
-    checkFinished()
   }
 
   def killNextOldTask(maybeNewTaskId: Option[Task.Id] = None): Unit = {
@@ -138,13 +123,14 @@ class TaskReplaceActor(
   }
 
   def checkFinished(): Unit = {
-    if (healthy.size == app.instances && oldTaskIds.isEmpty) {
-      log.info(s"App All new tasks for $appId are healthy and all old tasks have been killed")
+    if (ready.size == app.instances && oldTaskIds.isEmpty) {
+      log.info(s"App All new tasks for $appId are ready and all old tasks have been killed")
       promise.success(())
       context.stop(self)
     }
     else if (log.isDebugEnabled) {
-      log.debug(s"For app: [${app.id}] there are [${healthy.size}] healthy new instances and " +
+      log.debug(s"For app: [${app.id}] there are [${healthy.size}] healthy and " +
+        s"[${ready.size}] ready new instances and " +
         s"[${oldTaskIds.size}] old instances.")
     }
   }
@@ -169,6 +155,21 @@ object TaskReplaceActor {
   val FailedToStart = "^TASK_(ERROR|FAILED|LOST|KILLED)$".r
 
   case object RetryKills
+
+  //scalastyle:off
+  def props(
+    deploymentManager: ActorRef,
+    status: DeploymentStatus,
+    driver: SchedulerDriver,
+    taskQueue: LaunchQueue,
+    taskTracker: TaskTracker,
+    eventBus: EventStream,
+    readinessCheckExecutor: ReadinessCheckExecutor,
+    app: AppDefinition,
+    promise: Promise[Unit]): Props = Props(
+    new TaskReplaceActor(deploymentManager, status, driver, taskQueue, taskTracker, eventBus,
+      readinessCheckExecutor, app, promise)
+  )
 
   /** Encapsulates the logic how to get a Restart going */
   private[upgrade] case class RestartStrategy(nrToKillImmediately: Int, maxCapacity: Int)

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.api.LeaderInfo
 import mesosphere.marathon.core.launcher.impl.LaunchQueueTestHelper
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.event._
@@ -542,6 +543,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
   var deploymentManagerProps: SchedulerActions => Props = _
   var historyActorProps: Props = _
   var conf: UpgradeConfig = _
+  var readinessCheckExecutor: ReadinessCheckExecutor = _
 
   implicit val defaultTimeout: Timeout = 5.seconds
 
@@ -560,6 +562,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     taskFailureEventRepository = mock[TaskFailureRepository]
     leaderInfo = mock[LeaderInfo]
     conf = mock[UpgradeConfig]
+    readinessCheckExecutor = mock[ReadinessCheckExecutor]
 
     deploymentManagerProps = schedulerActions => Props(new DeploymentManager(
       repo,
@@ -569,6 +572,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       storage,
       hcManager,
       system.eventStream,
+      readinessCheckExecutor,
       conf
     ))
     historyActorProps = Props(new HistoryActor(system.eventStream, taskFailureEventRepository))

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -4,6 +4,7 @@ import akka.actor.{ ActorRef, ActorSystem }
 import akka.testkit.{ TestActorRef, TestProbe }
 import akka.util.Timeout
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.event.MesosStatusUpdateEvent
@@ -237,6 +238,7 @@ class DeploymentActorTest
     val storage: StorageProvider = mock[StorageProvider]
     val hcManager: HealthCheckManager = mock[HealthCheckManager]
     val config: UpgradeConfig = mock[UpgradeConfig]
+    val readinessCheckExecutor: ReadinessCheckExecutor = mock[ReadinessCheckExecutor]
     implicit val system = ActorSystem("TestSystem")
     config.killBatchSize returns 100
     config.killBatchCycle returns 10.seconds
@@ -262,6 +264,7 @@ class DeploymentActorTest
         storage,
         hcManager,
         system.eventStream,
+        readinessCheckExecutor,
         config
       )
     )

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.upgrade
 
-import akka.actor.{ ActorRef, Props }
+import akka.actor.ActorRef
 import akka.event.EventStream
 import akka.testkit.TestActor.{ AutoPilot, NoAutoPilot }
 import akka.testkit.{ ImplicitSender, TestActorRef, TestProbe }
@@ -8,6 +8,7 @@ import akka.util.Timeout
 import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
+import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.io.storage.StorageProvider
@@ -35,50 +36,17 @@ class DeploymentManagerTest
     with Mockito
     with ImplicitSender {
 
-  var driver: SchedulerDriver = _
-  var eventBus: EventStream = _
-  var taskQueue: LaunchQueue = _
-  var config: MarathonConf = _
-  var metrics: Metrics = _
-  var taskTracker: TaskTracker = _
-  var scheduler: SchedulerActions = _
-  var appRepo: AppRepository = _
-  var storage: StorageProvider = _
-  var hcManager: HealthCheckManager = _
-
-  before {
-    driver = mock[SchedulerDriver]
-    eventBus = mock[EventStream]
-    taskQueue = mock[LaunchQueue]
-    config = new ScallopConf(Seq("--master", "foo")) with MarathonConf
-    config.afterInit()
-    metrics = new Metrics(new MetricRegistry)
-    taskTracker = MarathonTestHelper.createTaskTracker(
-      AlwaysElectedLeadershipModule.forActorSystem(system), new InMemoryStore, config, metrics
-    )
-    scheduler = mock[SchedulerActions]
-    storage = mock[StorageProvider]
-    appRepo = new AppRepository(
-      new MarathonStore[AppDefinition](new InMemoryStore, metrics, () => AppDefinition(), prefix = "app:"),
-      None,
-      metrics
-    )
-    hcManager = mock[HealthCheckManager]
-  }
-
   test("deploy") {
-    val manager = TestActorRef[DeploymentManager](
-      DeploymentManager.props(appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus, config)
-    )
-
+    val f = new Fixture
+    val manager = f.deploymentManager()
     val app = AppDefinition("app".toRootPath)
 
     val oldGroup = Group("/".toRootPath)
     val newGroup = Group("/".toRootPath, Set(app))
     val plan = DeploymentPlan(oldGroup, newGroup)
 
-    taskQueue.get(app.id) returns None
-    manager ! PerformDeployment(driver, plan)
+    f.taskQueue.get(app.id) returns None
+    manager ! PerformDeployment(f.driver, plan)
 
     awaitCond(
       manager.underlyingActor.runningDeployments.contains(plan.id),
@@ -87,9 +55,8 @@ class DeploymentManagerTest
   }
 
   test("StopActor") {
-    val manager = TestActorRef[DeploymentManager](
-      DeploymentManager.props(appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus, config)
-    )
+    val f = new Fixture
+    val manager = f.deploymentManager()
     val probe = TestProbe()
 
     probe.setAutoPilot(new AutoPilot {
@@ -108,10 +75,8 @@ class DeploymentManagerTest
   }
 
   test("Cancel deployment") {
-    val manager = TestActorRef[DeploymentManager](
-      DeploymentManager.props(appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus, config)
-    )
-
+    val f = new Fixture
+    val manager = f.deploymentManager()
     implicit val timeout = Timeout(1.minute)
 
     val app = AppDefinition("app".toRootPath)
@@ -119,10 +84,37 @@ class DeploymentManagerTest
     val newGroup = Group("/".toRootPath, Set(app))
     val plan = DeploymentPlan(oldGroup, newGroup)
 
-    manager ! PerformDeployment(driver, plan)
+    manager ! PerformDeployment(f.driver, plan)
 
     manager ! CancelDeployment(plan.id)
 
     expectMsgType[DeploymentFailed]
+  }
+
+  class Fixture {
+
+    val driver: SchedulerDriver = mock[SchedulerDriver]
+    val eventBus: EventStream = mock[EventStream]
+    val taskQueue: LaunchQueue = mock[LaunchQueue]
+    val config: MarathonConf = new ScallopConf(Seq("--master", "foo")) with MarathonConf
+    config.afterInit()
+    val metrics: Metrics = new Metrics(new MetricRegistry)
+    val taskTracker: TaskTracker = MarathonTestHelper.createTaskTracker (
+      AlwaysElectedLeadershipModule.forActorSystem(system), new InMemoryStore, config, metrics
+    )
+    val scheduler: SchedulerActions = mock[SchedulerActions]
+    val appRepo: AppRepository = new AppRepository(
+      new MarathonStore[AppDefinition](new InMemoryStore, metrics, () => AppDefinition(), prefix = "app:"),
+      None,
+      metrics
+    )
+    val storage: StorageProvider = mock[StorageProvider]
+    val hcManager: HealthCheckManager = mock[HealthCheckManager]
+    val readinessCheckExecutor: ReadinessCheckExecutor = mock[ReadinessCheckExecutor]
+
+    def deploymentManager(): TestActorRef[DeploymentManager] = TestActorRef (
+      DeploymentManager.props(appRepo, taskTracker, taskQueue, scheduler, storage, hcManager, eventBus, readinessCheckExecutor, config)
+    )
+
   }
 }

--- a/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
@@ -1,0 +1,142 @@
+package mesosphere.marathon.upgrade
+
+import akka.actor.{ ActorLogging, ActorRef, Actor }
+import akka.testkit.{ TestActorRef, TestProbe }
+import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
+import mesosphere.marathon.core.readiness.{ ReadinessCheckResult, ReadinessCheck, ReadinessCheckExecutor }
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.event.{ HealthStatusChanged, MesosStatusUpdateEvent, DeploymentStatus }
+import mesosphere.marathon.health.HealthCheck
+import mesosphere.marathon.state.AppDefinition.VersionInfo
+import mesosphere.marathon.state._
+import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{ Matchers, GivenWhenThen, FunSuite }
+import rx.lang.scala.Observable
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+
+class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen with Matchers with MarathonActorSupport with Eventually {
+
+  test("An app without health checks but readiness checks becomes healthy") {
+    Given ("An app with one instance")
+    val f = new Fixture
+    var taskIsReady = false
+    val appWithReadyCheck = AppDefinition(f.appId,
+      portDefinitions = Seq(PortDefinition(123, "tcp", name = Some("httpApi"))),
+      versionInfo = VersionInfo.OnlyVersion(f.version),
+      readinessChecks = Seq(ReadinessCheck("test")))
+    val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
+
+    When("The task becomes running")
+    system.eventStream.publish(f.taskRunning)
+
+    Then("Task should become ready")
+    eventually(taskIsReady should be (true))
+    actor.stop()
+  }
+
+  test("An app with health checks and readiness checks becomes healthy") {
+    Given ("An app with one instance")
+    val f = new Fixture
+    var taskIsReady = false
+    val appWithReadyCheck = AppDefinition(f.appId,
+      portDefinitions = Seq(PortDefinition(123, "tcp", name = Some("httpApi"))),
+      versionInfo = VersionInfo.OnlyVersion(f.version),
+      healthChecks = Set(HealthCheck()),
+      readinessChecks = Seq(ReadinessCheck("test")))
+    val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
+
+    When("The task becomes healthy")
+    system.eventStream.publish(f.taskIsHealthy)
+
+    Then("Task should become ready")
+    eventually(taskIsReady should be (true))
+    actor.stop()
+  }
+
+  test("An app with health checks but without readiness checks becomes healthy") {
+    Given ("An app with one instance")
+    val f = new Fixture
+    var taskIsReady = false
+    val appWithReadyCheck = AppDefinition(f.appId,
+      portDefinitions = Seq(PortDefinition(123, "tcp", name = Some("httpApi"))),
+      versionInfo = VersionInfo.OnlyVersion(f.version),
+      healthChecks = Set(HealthCheck()))
+    val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
+
+    When("The task becomes healthy")
+    system.eventStream.publish(f.taskIsHealthy)
+
+    Then("Task should become ready")
+    eventually(taskIsReady should be (true))
+    actor.stop()
+  }
+
+  test("An app without health checks and without readiness checks becomes healthy") {
+    Given ("An app with one instance")
+    val f = new Fixture
+    var taskIsReady = false
+    val appWithReadyCheck = AppDefinition(f.appId,
+      versionInfo = VersionInfo.OnlyVersion(f.version))
+    val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
+
+    When("The task becomes running")
+    system.eventStream.publish(f.taskRunning)
+
+    Then("Task should become ready")
+    eventually(taskIsReady should be (true))
+    actor.stop()
+  }
+
+  class Fixture {
+
+    val deploymentManagerProbe = TestProbe()
+    val step = DeploymentStep(Seq.empty)
+    val plan = DeploymentPlan("deploy", Group.empty, Group.empty, Seq(step), Timestamp.now())
+    val deploymentStatus = DeploymentStatus(plan, step)
+    val tracker = mock[TaskTracker]
+    val task = mock[Task]
+    val launched = mock[Task.Launched]
+
+    val appId = PathId("/test")
+    val taskId = Task.Id("app.task")
+    val version = Timestamp.now()
+    val checkIsReady = Seq(ReadinessCheckResult("test", taskId, ready = true, None))
+    val checkIsNotReady = Seq(ReadinessCheckResult("test", taskId, ready = false, None))
+    val taskRunning = MesosStatusUpdateEvent(slaveId = "", taskId = taskId, taskStatus = "TASK_RUNNING",
+      message = "", appId = appId, host = "", ipAddresses = Nil, ports = Nil, version = version.toString)
+    val taskIsHealthy = HealthStatusChanged(appId, taskId, version, alive = true)
+
+    task.taskId returns taskId
+    task.launched returns Some(launched)
+    task.appId returns appId
+    launched.ports returns Seq(1, 2, 3)
+    tracker.task(any)(any) returns Future.successful(Some(task))
+
+    def readinessActor(appDef: AppDefinition, readinessCheckResults: Seq[ReadinessCheckResult], taskReadyFn: Task.Id => Unit) = {
+      val executor = new ReadinessCheckExecutor {
+        override def execute(readinessCheckInfo: ReadinessCheckSpec): Observable[ReadinessCheckResult] = {
+          Observable.from(readinessCheckResults)
+        }
+      }
+      TestActorRef(new Actor with ActorLogging with ReadinessBehavior {
+        override def preStart(): Unit = {
+          system.eventStream.subscribe(self, classOf[MesosStatusUpdateEvent])
+          system.eventStream.subscribe(self, classOf[HealthStatusChanged])
+        }
+        override def app: AppDefinition = appDef
+        override def deploymentManager: ActorRef = deploymentManagerProbe.ref
+        override def status: DeploymentStatus = deploymentStatus
+        override def readinessCheckExecutor: ReadinessCheckExecutor = executor
+        override def taskTracker: TaskTracker = tracker
+        override def receive: Receive = readinessBehavior orElse {
+          case notHandled => throw new RuntimeException(notHandled.toString)
+        }
+        override def taskIsReady(taskId: Task.Id): Unit = taskReadyFn(taskId)
+      }
+      )
+    }
+  }
+}


### PR DESCRIPTION
Fixes #3502 by implementing ReadinessBehavior and add it to StartingBehavior and TaskReplaceActor.
Fixes #3562 by marshalling the readinessCheck results into the deployments output.

