### PR TITLE
Fixes #3624 | Respect constraints for same version

### DIFF
--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -116,7 +116,7 @@ object ResourceMatcher {
     def portsMatchOpt: Option[PortsMatch] = new PortsMatcher(app, offer, selector).portsMatch
 
     def meetsAllConstraints: Boolean = {
-      lazy val tasks = runningTasks
+      lazy val tasks = runningTasks.filter(_.launched.exists(_.appVersion >= app.versionInfo.lastConfigChangeVersion))
       val badConstraints = app.constraints.filterNot { constraint =>
         Constraints.meetsConstraint(tasks, offer, constraint)
       }

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -2,6 +2,7 @@ package mesosphere.mesos
 
 import com.google.common.collect.Lists
 import com.google.protobuf.TextFormat
+import mesosphere.marathon.state.AppDefinition.VersionInfo.OnlyVersion
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state.Container.Docker.PortMapping
@@ -697,6 +698,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     // and run only one per machine
     val app = MarathonTestHelper.makeBasicApp().copy(
       instances = 10,
+      versionInfo = OnlyVersion(Timestamp(10)),
       constraints = Set(
         Protos.Constraint.newBuilder.setField("rackid").setOperator(Protos.Constraint.Operator.GROUP_BY).setValue("3").build,
         Protos.Constraint.newBuilder.setField("hostname").setOperator(Protos.Constraint.Operator.UNIQUE).build


### PR DESCRIPTION
This PR changes behavior of deploying/scaling application with constraints described in #3624. Currently constraints are matched for all instances of application. This PR introduce matching constraints only with tasks ~~in same version~~ deployed after last configuration change. ~~What does it mean? If application has constraints and it's configuration has changed (e.g. constraint was changed), after deployment we could end up with instances that does not match desired constraints. On the other hand after scaling application we (usually) have instances that match constraints. After my changes, deployments always end up with desired distribution of instances although after scaling, newest instances could not match that constraints, because constraints will be checked across instances with same version.~~