### PR TITLE
Remove an illegal comma from JSON example

### DIFF
--- a/docs/docs/health-checks.md
+++ b/docs/docs/health-checks.md
@@ -26,7 +26,7 @@ checks consecutively, that task is killed.
   "intervalSeconds": 60,
   "timeoutSeconds": 20,
   "maxConsecutiveFailures": 3,
-  "ignoreHttp1xx": false,
+  "ignoreHttp1xx": false
 }
 ```
 


### PR DESCRIPTION
JSON does not allow trailing commas after the last key in an object. Simple fix :)