### PR TITLE
change word delimiter for `--no-logger`

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -77,11 +77,11 @@ function load_options_and_log {
   fi
   echo "${cmd[@]}"
 
-  if [[ "${cmd[@]} $@" == *'--no-logger'* ]]
+  if [[ "${cmd[@]} $@" == *'--no_logger'* ]]
   then
     local clean_cmd=()
     for i in "${cmd[@]}" "$@"; do
-      if [[ "${i}" != "--no-logger" ]]; then
+      if [[ "${i}" != "--no_logger" ]]; then
         clean_cmd+=( "${i}" )
       fi
     done


### PR DESCRIPTION
I suggest we using `--no_logger` instead of `--no-logger`, so it will be a consistent with other command options.

But this change would render the old scripts still using `--no-logger` useless ...