### PR TITLE
Fix TaskBuilderTest: Test would fail when

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -127,8 +127,8 @@ trait Formats
           "version" -> launched.appVersion
         )
       ){
-        case (launchedJs, ipAddresses) => launchedJs ++ Json.obj("ipAddresses" -> ipAddresses)
-      }
+          case (launchedJs, ipAddresses) => launchedJs ++ Json.obj("ipAddresses" -> ipAddresses)
+        }
     }.getOrElse(base)
 
     val reservation = task.reservationWithVolumes.map { reservation =>


### PR DESCRIPTION
port range was randomly chosen as [32000-31000] in 1/1000 cases.