### PR TITLE
introduce env var `NO_LOGGER` to disable syslog output

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -75,6 +75,9 @@ function load_options_and_log {
       cmd+=( --master "$(cat /etc/mesos/zk)" )
     fi
   fi
+  
+  env | grep ^NO_LOGGER > /dev/null && cmd+=( --no-logger )
+  
   echo "${cmd[@]}"
 
   if [[ "${cmd[@]} $@" == *'--no-logger'* ]]


### PR DESCRIPTION
Another approach for issue #3621.