### PR TITLE
Accept --no-logger and --no_logger to fix ENV export

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -77,11 +77,11 @@ function load_options_and_log {
   fi
   echo "${cmd[@]}"
 
-  if [[ "${cmd[@]} $@" == *'--no-logger'* ]]
+  if [[ "${cmd[@]} $@" =~ .*--no[_-]logger.* ]]
   then
     local clean_cmd=()
     for i in "${cmd[@]}" "$@"; do
-      if [[ "${i}" != "--no-logger" ]]; then
+      if [[ "${i}" != "--no-logger" ]] && [[ "${i}" != "--no_logger" ]]; then
         clean_cmd+=( "${i}" )
       fi
     done


### PR DESCRIPTION
This updates the start script to accept --no_logger as argument to deactivate the logger in addition to --no-logger (for backwards compatibility).
That way users can `export MARATHON_NO_LOGGER=` to turn off the logger. This didn't work before since bash doesn't allow dashes in variable names.