### PR TITLE
WIP: Fix reservations on role != "*"

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactory.scala
@@ -44,8 +44,8 @@ class OfferOperationFactory(
   def reserve(frameworkId: FrameworkId, taskId: Task.Id, resources: Iterable[Mesos.Resource]): Mesos.Offer.Operation = {
     import scala.collection.JavaConverters._
     val reservedResources = resources.map { resource =>
-      Mesos.Resource.newBuilder(resource)
-        .setRole(role)
+      resource
+        .toBuilder
         .setReservation(
           ReservationInfo.newBuilder()
             .setPrincipal(principal)


### PR DESCRIPTION
No tests and I am getting the following Mesos error with this:

```
I0405 18:01:16.250953  5329 master.cpp:5525] Successfully authenticated principal 'marathon' at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:16.256309  5325 master.cpp:2231] Received SUBSCRIBE call for framework 'marathon' at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:16.256340  5325 master.cpp:1750] Authorizing framework principal 'marathon' to receive offers for role 'public'
I0405 18:01:16.256379  5325 master.cpp:2302] Subscribing framework marathon with checkpointing enabled and capabilities [  ]
I0405 18:01:16.256536  5325 hierarchical.cpp:265] Added framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001
I0405 18:01:16.256772  5325 master.cpp:5324] Sending 1 offers to framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:16.262729  5325 master.cpp:3641] Processing DECLINE call for offers: [ 34541e67-00d4-4677-9b4c-e0e11ee62e6c-O1 ] for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:21.983050  5322 master.cpp:3720] Processing REVIVE call for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:21.983151  5322 hierarchical.cpp:988] Removed offer filters for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001
I0405 18:01:21.983383  5322 master.cpp:5324] Sending 1 offers to framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:22.098059  5328 master.cpp:3104] Processing ACCEPT call for offers: [ 34541e67-00d4-4677-9b4c-e0e11ee62e6c-O2 ] on slave 34541e67-00d4-4677-9b4c-e0e11ee62e6c-S0 at slave(1)@192.168.99.10:5051 (master) for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:22.098130  5328 master.cpp:2820] Authorizing principal 'marathon' to reserve resources 'cpus(public, marathon, {marathon_framework_id: 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001, marathon_task_id: resident1.a40d1ae5-fb47-11e5-a731-6a881b8b3958}):0.1; mem(public, marathon, {marathon_framework_id: 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001, marathon_task_id: resident1.a40d1ae5-fb47-11e5-a731-6a881b8b3958}):32; disk(public, marathon, {marathon_framework_id: 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001, marathon_task_id: resident1.a40d1ae5-fb47-11e5-a731-6a881b8b3958}):100; ports(public, marathon, {marathon_framework_id: 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001, marathon_task_id: resident1.a40d1ae5-fb47-11e5-a731-6a881b8b3958}):[31790-31790]'
I0405 18:01:22.098204  5328 master.cpp:2892] Authorizing principal 'marathon' to create volumes
E0405 18:01:22.098497  5328 master.cpp:1819] Dropping RESERVE offer operation from framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489: Invalid RESERVE Operation: cpus(public):8; mem(public):5078; disk(public):52830; ports(public):[31000-32000] does not contain cpus(*):0.1
E0405 18:01:22.098769  5328 master.cpp:1819] Dropping CREATE offer operation from framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489: Invalid CREATE Operation: Insufficient disk resources
I0405 18:01:22.432237  5328 master.cpp:5324] Sending 1 offers to framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:22.435340  5326 master.cpp:3641] Processing DECLINE call for offers: [ 34541e67-00d4-4677-9b4c-e0e11ee62e6c-O3 ] for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:27.001921  5328 master.cpp:3720] Processing REVIVE call for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:27.001998  5328 hierarchical.cpp:988] Removed offer filters for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001
I0405 18:01:27.002159  5328 master.cpp:5324] Sending 1 offers to framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:27.005242  5327 master.cpp:3641] Processing DECLINE call for offers: [ 34541e67-00d4-4677-9b4c-e0e11ee62e6c-O4 ] for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:28.954627  5328 http.cpp:312] HTTP GET for /master/state from 192.168.99.1:54371 with User-Agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.110 Safari/537.36'
I0405 18:01:31.248471  5329 master.cpp:4997] Performing implicit task state reconciliation for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:32.019223  5323 master.cpp:3720] Processing REVIVE call for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:32.019307  5323 hierarchical.cpp:988] Removed offer filters for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001
I0405 18:01:32.019518  5323 master.cpp:5324] Sending 1 offers to framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
I0405 18:01:32.022567  5327 master.cpp:3641] Processing DECLINE call for offers: [ 34541e67-00d4-4677-9b4c-e0e11ee62e6c-O5 ] for framework 34541e67-00d4-4677-9b4c-e0e11ee62e6c-0001 (marathon) at scheduler-ce03681f-a103-4101-8f93-09d347432a1f@172.18.8.82:54489
```

This looks like a Mesos error to me but I'll check a bit more on that tomorrow.