### PR TITLE
Fixes #3698 - External Volumes: DVDI

### DIFF
--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -197,6 +197,29 @@
                 },
                 "type": "object"
               },
+              "external": {
+                "additionalProperties": false,
+                "properties": {
+                  "size": {
+                    "type": "integer",
+                    "description": "The size of the external volume in MiB",
+                    "minimum": 0
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the volume"
+                  },
+                  "provider": {
+                    "type": "string",
+                    "description": "The name of the volume provider"
+                  },
+                  "options": {
+                    "type": "object",
+                    "description": "Provider-specific volume configuration options"
+                  }
+                },
+                "type": "object"
+              },
               "mode": {
                 "type": "string",
                 "description": "Possible values are RO for ReadOnly and RW for Read/Write",

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -22535,7 +22535,7 @@ public final class Protos {
      * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
      *
      * <pre>
-     * Defines a Persistent Volume. In this case hostPath must not be set
+     * Defines a Persistent Volume; implies no hostPath or external.
      * </pre>
      */
     boolean hasPersistent();
@@ -22543,7 +22543,7 @@ public final class Protos {
      * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
      *
      * <pre>
-     * Defines a Persistent Volume. In this case hostPath must not be set
+     * Defines a Persistent Volume; implies no hostPath or external.
      * </pre>
      */
     mesosphere.marathon.Protos.Volume.PersistentVolumeInfo getPersistent();
@@ -22551,10 +22551,36 @@ public final class Protos {
      * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
      *
      * <pre>
-     * Defines a Persistent Volume. In this case hostPath must not be set
+     * Defines a Persistent Volume; implies no hostPath or external.
      * </pre>
      */
     mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder getPersistentOrBuilder();
+
+    // optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;
+    /**
+     * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+     *
+     * <pre>
+     * Defines an External Volume; implies no hostPath or persistent.
+     * </pre>
+     */
+    boolean hasExternal();
+    /**
+     * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+     *
+     * <pre>
+     * Defines an External Volume; implies no hostPath or persistent.
+     * </pre>
+     */
+    mesosphere.marathon.Protos.Volume.ExternalVolumeInfo getExternal();
+    /**
+     * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+     *
+     * <pre>
+     * Defines an External Volume; implies no hostPath or persistent.
+     * </pre>
+     */
+    mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder getExternalOrBuilder();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.Volume}
@@ -22658,6 +22684,19 @@ public final class Protos {
                 persistent_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000010;
+              break;
+            }
+            case 50: {
+              mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000020) == 0x00000020)) {
+                subBuilder = external_.toBuilder();
+              }
+              external_ = input.readMessage(mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(external_);
+                external_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000020;
               break;
             }
           }
@@ -23111,6 +23150,1112 @@ public final class Protos {
       // @@protoc_insertion_point(class_scope:mesosphere.marathon.Volume.PersistentVolumeInfo)
     }
 
+    public interface ExternalVolumeInfoOrBuilder
+        extends com.google.protobuf.MessageOrBuilder {
+
+      // optional uint64 size = 1;
+      /**
+       * <code>optional uint64 size = 1;</code>
+       */
+      boolean hasSize();
+      /**
+       * <code>optional uint64 size = 1;</code>
+       */
+      long getSize();
+
+      // required string name = 2;
+      /**
+       * <code>required string name = 2;</code>
+       */
+      boolean hasName();
+      /**
+       * <code>required string name = 2;</code>
+       */
+      java.lang.String getName();
+      /**
+       * <code>required string name = 2;</code>
+       */
+      com.google.protobuf.ByteString
+          getNameBytes();
+
+      // required string provider = 3;
+      /**
+       * <code>required string provider = 3;</code>
+       */
+      boolean hasProvider();
+      /**
+       * <code>required string provider = 3;</code>
+       */
+      java.lang.String getProvider();
+      /**
+       * <code>required string provider = 3;</code>
+       */
+      com.google.protobuf.ByteString
+          getProviderBytes();
+
+      // repeated .mesos.Label options = 4;
+      /**
+       * <code>repeated .mesos.Label options = 4;</code>
+       */
+      java.util.List<org.apache.mesos.Protos.Label> 
+          getOptionsList();
+      /**
+       * <code>repeated .mesos.Label options = 4;</code>
+       */
+      org.apache.mesos.Protos.Label getOptions(int index);
+      /**
+       * <code>repeated .mesos.Label options = 4;</code>
+       */
+      int getOptionsCount();
+      /**
+       * <code>repeated .mesos.Label options = 4;</code>
+       */
+      java.util.List<? extends org.apache.mesos.Protos.LabelOrBuilder> 
+          getOptionsOrBuilderList();
+      /**
+       * <code>repeated .mesos.Label options = 4;</code>
+       */
+      org.apache.mesos.Protos.LabelOrBuilder getOptionsOrBuilder(
+          int index);
+    }
+    /**
+     * Protobuf type {@code mesosphere.marathon.Volume.ExternalVolumeInfo}
+     *
+     * <pre>
+     * Defining properties of external volumes
+     * </pre>
+     */
+    public static final class ExternalVolumeInfo extends
+        com.google.protobuf.GeneratedMessage
+        implements ExternalVolumeInfoOrBuilder {
+      // Use ExternalVolumeInfo.newBuilder() to construct.
+      private ExternalVolumeInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+        super(builder);
+        this.unknownFields = builder.getUnknownFields();
+      }
+      private ExternalVolumeInfo(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+      private static final ExternalVolumeInfo defaultInstance;
+      public static ExternalVolumeInfo getDefaultInstance() {
+        return defaultInstance;
+      }
+
+      public ExternalVolumeInfo getDefaultInstanceForType() {
+        return defaultInstance;
+      }
+
+      private final com.google.protobuf.UnknownFieldSet unknownFields;
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+          getUnknownFields() {
+        return this.unknownFields;
+      }
+      private ExternalVolumeInfo(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        initFields();
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(input, unknownFields,
+                                       extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+              case 8: {
+                bitField0_ |= 0x00000001;
+                size_ = input.readUInt64();
+                break;
+              }
+              case 18: {
+                bitField0_ |= 0x00000002;
+                name_ = input.readBytes();
+                break;
+              }
+              case 26: {
+                bitField0_ |= 0x00000004;
+                provider_ = input.readBytes();
+                break;
+              }
+              case 34: {
+                if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+                  options_ = new java.util.ArrayList<org.apache.mesos.Protos.Label>();
+                  mutable_bitField0_ |= 0x00000008;
+                }
+                options_.add(input.readMessage(org.apache.mesos.Protos.Label.PARSER, extensionRegistry));
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e.getMessage()).setUnfinishedMessage(this);
+        } finally {
+          if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+            options_ = java.util.Collections.unmodifiableList(options_);
+          }
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.class, mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder.class);
+      }
+
+      public static com.google.protobuf.Parser<ExternalVolumeInfo> PARSER =
+          new com.google.protobuf.AbstractParser<ExternalVolumeInfo>() {
+        public ExternalVolumeInfo parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new ExternalVolumeInfo(input, extensionRegistry);
+        }
+      };
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<ExternalVolumeInfo> getParserForType() {
+        return PARSER;
+      }
+
+      private int bitField0_;
+      // optional uint64 size = 1;
+      public static final int SIZE_FIELD_NUMBER = 1;
+      private long size_;
+      /**
+       * <code>optional uint64 size = 1;</code>
+       */
+      public boolean hasSize() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional uint64 size = 1;</code>
+       */
+      public long getSize() {
+        return size_;
+      }
+
+      // required string name = 2;
+      public static final int NAME_FIELD_NUMBER = 2;
+      private java.lang.Object name_;
+      /**
+       * <code>required string name = 2;</code>
+       */
+      public boolean hasName() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>required string name = 2;</code>
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = 
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            name_ = s;
+          }
+          return s;
+        }
+      }
+      /**
+       * <code>required string name = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof java.lang.String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+
+      // required string provider = 3;
+      public static final int PROVIDER_FIELD_NUMBER = 3;
+      private java.lang.Object provider_;
+      /**
+       * <code>required string provider = 3;</code>
+       */
+      public boolean hasProvider() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>required string provider = 3;</code>
+       */
+      public java.lang.String getProvider() {
+        java.lang.Object ref = provider_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = 
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            provider_ = s;
+          }
+          return s;
+        }
+      }
+      /**
+       * <code>required string provider = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getProviderBytes() {
+        java.lang.Object ref = provider_;
+        if (ref instanceof java.lang.String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          provider_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+
+      // repeated .mesos.Label options = 4;
+      public static final int OPTIONS_FIELD_NUMBER = 4;
+      private java.util.List<org.apache.mesos.Protos.Label> options_;
+      /**
+       * <code>repeated .mesos.Label options = 4;</code>
+       */
+      public java.util.List<org.apache.mesos.Protos.Label> getOptionsList() {
+        return options_;
+      }
+      /**
+       * <code>repeated .mesos.Label options = 4;</code>
+       */
+      public java.util.List<? extends org.apache.mesos.Protos.LabelOrBuilder> 
+          getOptionsOrBuilderList() {
+        return options_;
+      }
+      /**
+       * <code>repeated .mesos.Label options = 4;</code>
+       */
+      public int getOptionsCount() {
+        return options_.size();
+      }
+      /**
+       * <code>repeated .mesos.Label options = 4;</code>
+       */
+      public org.apache.mesos.Protos.Label getOptions(int index) {
+        return options_.get(index);
+      }
+      /**
+       * <code>repeated .mesos.Label options = 4;</code>
+       */
+      public org.apache.mesos.Protos.LabelOrBuilder getOptionsOrBuilder(
+          int index) {
+        return options_.get(index);
+      }
+
+      private void initFields() {
+        size_ = 0L;
+        name_ = "";
+        provider_ = "";
+        options_ = java.util.Collections.emptyList();
+      }
+      private byte memoizedIsInitialized = -1;
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized != -1) return isInitialized == 1;
+
+        if (!hasName()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        if (!hasProvider()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        for (int i = 0; i < getOptionsCount(); i++) {
+          if (!getOptions(i).isInitialized()) {
+            memoizedIsInitialized = 0;
+            return false;
+          }
+        }
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        getSerializedSize();
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          output.writeUInt64(1, size_);
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          output.writeBytes(2, getNameBytes());
+        }
+        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          output.writeBytes(3, getProviderBytes());
+        }
+        for (int i = 0; i < options_.size(); i++) {
+          output.writeMessage(4, options_.get(i));
+        }
+        getUnknownFields().writeTo(output);
+      }
+
+      private int memoizedSerializedSize = -1;
+      public int getSerializedSize() {
+        int size = memoizedSerializedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeUInt64Size(1, size_);
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeBytesSize(2, getNameBytes());
+        }
+        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeBytesSize(3, getProviderBytes());
+        }
+        for (int i = 0; i < options_.size(); i++) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(4, options_.get(i));
+        }
+        size += getUnknownFields().getSerializedSize();
+        memoizedSerializedSize = size;
+        return size;
+      }
+
+      private static final long serialVersionUID = 0L;
+      @java.lang.Override
+      protected java.lang.Object writeReplace()
+          throws java.io.ObjectStreamException {
+        return super.writeReplace();
+      }
+
+      public static mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input);
+      }
+      public static mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input, extensionRegistry);
+      }
+      public static mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return PARSER.parseDelimitedFrom(input);
+      }
+      public static mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      }
+      public static mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input);
+      }
+      public static mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return PARSER.parseFrom(input, extensionRegistry);
+      }
+
+      public static Builder newBuilder() { return Builder.create(); }
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder(mesosphere.marathon.Protos.Volume.ExternalVolumeInfo prototype) {
+        return newBuilder().mergeFrom(prototype);
+      }
+      public Builder toBuilder() { return newBuilder(this); }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mesosphere.marathon.Volume.ExternalVolumeInfo}
+       *
+       * <pre>
+       * Defining properties of external volumes
+       * </pre>
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessage.Builder<Builder>
+         implements mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor;
+        }
+
+        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.class, mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder.class);
+        }
+
+        // Construct using mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+            getOptionsFieldBuilder();
+          }
+        }
+        private static Builder create() {
+          return new Builder();
+        }
+
+        public Builder clear() {
+          super.clear();
+          size_ = 0L;
+          bitField0_ = (bitField0_ & ~0x00000001);
+          name_ = "";
+          bitField0_ = (bitField0_ & ~0x00000002);
+          provider_ = "";
+          bitField0_ = (bitField0_ & ~0x00000004);
+          if (optionsBuilder_ == null) {
+            options_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000008);
+          } else {
+            optionsBuilder_.clear();
+          }
+          return this;
+        }
+
+        public Builder clone() {
+          return create().mergeFrom(buildPartial());
+        }
+
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor;
+        }
+
+        public mesosphere.marathon.Protos.Volume.ExternalVolumeInfo getDefaultInstanceForType() {
+          return mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.getDefaultInstance();
+        }
+
+        public mesosphere.marathon.Protos.Volume.ExternalVolumeInfo build() {
+          mesosphere.marathon.Protos.Volume.ExternalVolumeInfo result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        public mesosphere.marathon.Protos.Volume.ExternalVolumeInfo buildPartial() {
+          mesosphere.marathon.Protos.Volume.ExternalVolumeInfo result = new mesosphere.marathon.Protos.Volume.ExternalVolumeInfo(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          result.size_ = size_;
+          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+            to_bitField0_ |= 0x00000002;
+          }
+          result.name_ = name_;
+          if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+            to_bitField0_ |= 0x00000004;
+          }
+          result.provider_ = provider_;
+          if (optionsBuilder_ == null) {
+            if (((bitField0_ & 0x00000008) == 0x00000008)) {
+              options_ = java.util.Collections.unmodifiableList(options_);
+              bitField0_ = (bitField0_ & ~0x00000008);
+            }
+            result.options_ = options_;
+          } else {
+            result.options_ = optionsBuilder_.build();
+          }
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof mesosphere.marathon.Protos.Volume.ExternalVolumeInfo) {
+            return mergeFrom((mesosphere.marathon.Protos.Volume.ExternalVolumeInfo)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(mesosphere.marathon.Protos.Volume.ExternalVolumeInfo other) {
+          if (other == mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.getDefaultInstance()) return this;
+          if (other.hasSize()) {
+            setSize(other.getSize());
+          }
+          if (other.hasName()) {
+            bitField0_ |= 0x00000002;
+            name_ = other.name_;
+            onChanged();
+          }
+          if (other.hasProvider()) {
+            bitField0_ |= 0x00000004;
+            provider_ = other.provider_;
+            onChanged();
+          }
+          if (optionsBuilder_ == null) {
+            if (!other.options_.isEmpty()) {
+              if (options_.isEmpty()) {
+                options_ = other.options_;
+                bitField0_ = (bitField0_ & ~0x00000008);
+              } else {
+                ensureOptionsIsMutable();
+                options_.addAll(other.options_);
+              }
+              onChanged();
+            }
+          } else {
+            if (!other.options_.isEmpty()) {
+              if (optionsBuilder_.isEmpty()) {
+                optionsBuilder_.dispose();
+                optionsBuilder_ = null;
+                options_ = other.options_;
+                bitField0_ = (bitField0_ & ~0x00000008);
+                optionsBuilder_ = 
+                  com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                     getOptionsFieldBuilder() : null;
+              } else {
+                optionsBuilder_.addAllMessages(other.options_);
+              }
+            }
+          }
+          this.mergeUnknownFields(other.getUnknownFields());
+          return this;
+        }
+
+        public final boolean isInitialized() {
+          if (!hasName()) {
+            
+            return false;
+          }
+          if (!hasProvider()) {
+            
+            return false;
+          }
+          for (int i = 0; i < getOptionsCount(); i++) {
+            if (!getOptions(i).isInitialized()) {
+              
+              return false;
+            }
+          }
+          return true;
+        }
+
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          mesosphere.marathon.Protos.Volume.ExternalVolumeInfo parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (mesosphere.marathon.Protos.Volume.ExternalVolumeInfo) e.getUnfinishedMessage();
+            throw e;
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        // optional uint64 size = 1;
+        private long size_ ;
+        /**
+         * <code>optional uint64 size = 1;</code>
+         */
+        public boolean hasSize() {
+          return ((bitField0_ & 0x00000001) == 0x00000001);
+        }
+        /**
+         * <code>optional uint64 size = 1;</code>
+         */
+        public long getSize() {
+          return size_;
+        }
+        /**
+         * <code>optional uint64 size = 1;</code>
+         */
+        public Builder setSize(long value) {
+          bitField0_ |= 0x00000001;
+          size_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>optional uint64 size = 1;</code>
+         */
+        public Builder clearSize() {
+          bitField0_ = (bitField0_ & ~0x00000001);
+          size_ = 0L;
+          onChanged();
+          return this;
+        }
+
+        // required string name = 2;
+        private java.lang.Object name_ = "";
+        /**
+         * <code>required string name = 2;</code>
+         */
+        public boolean hasName() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <code>required string name = 2;</code>
+         */
+        public java.lang.String getName() {
+          java.lang.Object ref = name_;
+          if (!(ref instanceof java.lang.String)) {
+            java.lang.String s = ((com.google.protobuf.ByteString) ref)
+                .toStringUtf8();
+            name_ = s;
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         * <code>required string name = 2;</code>
+         */
+        public com.google.protobuf.ByteString
+            getNameBytes() {
+          java.lang.Object ref = name_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b = 
+                com.google.protobuf.ByteString.copyFromUtf8(
+                    (java.lang.String) ref);
+            name_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <code>required string name = 2;</code>
+         */
+        public Builder setName(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+          name_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>required string name = 2;</code>
+         */
+        public Builder clearName() {
+          bitField0_ = (bitField0_ & ~0x00000002);
+          name_ = getDefaultInstance().getName();
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>required string name = 2;</code>
+         */
+        public Builder setNameBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+          name_ = value;
+          onChanged();
+          return this;
+        }
+
+        // required string provider = 3;
+        private java.lang.Object provider_ = "";
+        /**
+         * <code>required string provider = 3;</code>
+         */
+        public boolean hasProvider() {
+          return ((bitField0_ & 0x00000004) == 0x00000004);
+        }
+        /**
+         * <code>required string provider = 3;</code>
+         */
+        public java.lang.String getProvider() {
+          java.lang.Object ref = provider_;
+          if (!(ref instanceof java.lang.String)) {
+            java.lang.String s = ((com.google.protobuf.ByteString) ref)
+                .toStringUtf8();
+            provider_ = s;
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         * <code>required string provider = 3;</code>
+         */
+        public com.google.protobuf.ByteString
+            getProviderBytes() {
+          java.lang.Object ref = provider_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b = 
+                com.google.protobuf.ByteString.copyFromUtf8(
+                    (java.lang.String) ref);
+            provider_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <code>required string provider = 3;</code>
+         */
+        public Builder setProvider(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+          provider_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>required string provider = 3;</code>
+         */
+        public Builder clearProvider() {
+          bitField0_ = (bitField0_ & ~0x00000004);
+          provider_ = getDefaultInstance().getProvider();
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>required string provider = 3;</code>
+         */
+        public Builder setProviderBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+          provider_ = value;
+          onChanged();
+          return this;
+        }
+
+        // repeated .mesos.Label options = 4;
+        private java.util.List<org.apache.mesos.Protos.Label> options_ =
+          java.util.Collections.emptyList();
+        private void ensureOptionsIsMutable() {
+          if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+            options_ = new java.util.ArrayList<org.apache.mesos.Protos.Label>(options_);
+            bitField0_ |= 0x00000008;
+           }
+        }
+
+        private com.google.protobuf.RepeatedFieldBuilder<
+            org.apache.mesos.Protos.Label, org.apache.mesos.Protos.Label.Builder, org.apache.mesos.Protos.LabelOrBuilder> optionsBuilder_;
+
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public java.util.List<org.apache.mesos.Protos.Label> getOptionsList() {
+          if (optionsBuilder_ == null) {
+            return java.util.Collections.unmodifiableList(options_);
+          } else {
+            return optionsBuilder_.getMessageList();
+          }
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public int getOptionsCount() {
+          if (optionsBuilder_ == null) {
+            return options_.size();
+          } else {
+            return optionsBuilder_.getCount();
+          }
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public org.apache.mesos.Protos.Label getOptions(int index) {
+          if (optionsBuilder_ == null) {
+            return options_.get(index);
+          } else {
+            return optionsBuilder_.getMessage(index);
+          }
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public Builder setOptions(
+            int index, org.apache.mesos.Protos.Label value) {
+          if (optionsBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensureOptionsIsMutable();
+            options_.set(index, value);
+            onChanged();
+          } else {
+            optionsBuilder_.setMessage(index, value);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public Builder setOptions(
+            int index, org.apache.mesos.Protos.Label.Builder builderForValue) {
+          if (optionsBuilder_ == null) {
+            ensureOptionsIsMutable();
+            options_.set(index, builderForValue.build());
+            onChanged();
+          } else {
+            optionsBuilder_.setMessage(index, builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public Builder addOptions(org.apache.mesos.Protos.Label value) {
+          if (optionsBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensureOptionsIsMutable();
+            options_.add(value);
+            onChanged();
+          } else {
+            optionsBuilder_.addMessage(value);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public Builder addOptions(
+            int index, org.apache.mesos.Protos.Label value) {
+          if (optionsBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensureOptionsIsMutable();
+            options_.add(index, value);
+            onChanged();
+          } else {
+            optionsBuilder_.addMessage(index, value);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public Builder addOptions(
+            org.apache.mesos.Protos.Label.Builder builderForValue) {
+          if (optionsBuilder_ == null) {
+            ensureOptionsIsMutable();
+            options_.add(builderForValue.build());
+            onChanged();
+          } else {
+            optionsBuilder_.addMessage(builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public Builder addOptions(
+            int index, org.apache.mesos.Protos.Label.Builder builderForValue) {
+          if (optionsBuilder_ == null) {
+            ensureOptionsIsMutable();
+            options_.add(index, builderForValue.build());
+            onChanged();
+          } else {
+            optionsBuilder_.addMessage(index, builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public Builder addAllOptions(
+            java.lang.Iterable<? extends org.apache.mesos.Protos.Label> values) {
+          if (optionsBuilder_ == null) {
+            ensureOptionsIsMutable();
+            super.addAll(values, options_);
+            onChanged();
+          } else {
+            optionsBuilder_.addAllMessages(values);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public Builder clearOptions() {
+          if (optionsBuilder_ == null) {
+            options_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000008);
+            onChanged();
+          } else {
+            optionsBuilder_.clear();
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public Builder removeOptions(int index) {
+          if (optionsBuilder_ == null) {
+            ensureOptionsIsMutable();
+            options_.remove(index);
+            onChanged();
+          } else {
+            optionsBuilder_.remove(index);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public org.apache.mesos.Protos.Label.Builder getOptionsBuilder(
+            int index) {
+          return getOptionsFieldBuilder().getBuilder(index);
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public org.apache.mesos.Protos.LabelOrBuilder getOptionsOrBuilder(
+            int index) {
+          if (optionsBuilder_ == null) {
+            return options_.get(index);  } else {
+            return optionsBuilder_.getMessageOrBuilder(index);
+          }
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public java.util.List<? extends org.apache.mesos.Protos.LabelOrBuilder> 
+             getOptionsOrBuilderList() {
+          if (optionsBuilder_ != null) {
+            return optionsBuilder_.getMessageOrBuilderList();
+          } else {
+            return java.util.Collections.unmodifiableList(options_);
+          }
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public org.apache.mesos.Protos.Label.Builder addOptionsBuilder() {
+          return getOptionsFieldBuilder().addBuilder(
+              org.apache.mesos.Protos.Label.getDefaultInstance());
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public org.apache.mesos.Protos.Label.Builder addOptionsBuilder(
+            int index) {
+          return getOptionsFieldBuilder().addBuilder(
+              index, org.apache.mesos.Protos.Label.getDefaultInstance());
+        }
+        /**
+         * <code>repeated .mesos.Label options = 4;</code>
+         */
+        public java.util.List<org.apache.mesos.Protos.Label.Builder> 
+             getOptionsBuilderList() {
+          return getOptionsFieldBuilder().getBuilderList();
+        }
+        private com.google.protobuf.RepeatedFieldBuilder<
+            org.apache.mesos.Protos.Label, org.apache.mesos.Protos.Label.Builder, org.apache.mesos.Protos.LabelOrBuilder> 
+            getOptionsFieldBuilder() {
+          if (optionsBuilder_ == null) {
+            optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+                org.apache.mesos.Protos.Label, org.apache.mesos.Protos.Label.Builder, org.apache.mesos.Protos.LabelOrBuilder>(
+                    options_,
+                    ((bitField0_ & 0x00000008) == 0x00000008),
+                    getParentForChildren(),
+                    isClean());
+            options_ = null;
+          }
+          return optionsBuilder_;
+        }
+
+        // @@protoc_insertion_point(builder_scope:mesosphere.marathon.Volume.ExternalVolumeInfo)
+      }
+
+      static {
+        defaultInstance = new ExternalVolumeInfo(true);
+        defaultInstance.initFields();
+      }
+
+      // @@protoc_insertion_point(class_scope:mesosphere.marathon.Volume.ExternalVolumeInfo)
+    }
+
     private int bitField0_;
     // required .mesos.Volume.Mode mode = 3;
     public static final int MODE_FIELD_NUMBER = 3;
@@ -23294,7 +24439,7 @@ public final class Protos {
      * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
      *
      * <pre>
-     * Defines a Persistent Volume. In this case hostPath must not be set
+     * Defines a Persistent Volume; implies no hostPath or external.
      * </pre>
      */
     public boolean hasPersistent() {
@@ -23304,7 +24449,7 @@ public final class Protos {
      * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
      *
      * <pre>
-     * Defines a Persistent Volume. In this case hostPath must not be set
+     * Defines a Persistent Volume; implies no hostPath or external.
      * </pre>
      */
     public mesosphere.marathon.Protos.Volume.PersistentVolumeInfo getPersistent() {
@@ -23314,11 +24459,45 @@ public final class Protos {
      * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
      *
      * <pre>
-     * Defines a Persistent Volume. In this case hostPath must not be set
+     * Defines a Persistent Volume; implies no hostPath or external.
      * </pre>
      */
     public mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder getPersistentOrBuilder() {
       return persistent_;
+    }
+
+    // optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;
+    public static final int EXTERNAL_FIELD_NUMBER = 6;
+    private mesosphere.marathon.Protos.Volume.ExternalVolumeInfo external_;
+    /**
+     * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+     *
+     * <pre>
+     * Defines an External Volume; implies no hostPath or persistent.
+     * </pre>
+     */
+    public boolean hasExternal() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+     *
+     * <pre>
+     * Defines an External Volume; implies no hostPath or persistent.
+     * </pre>
+     */
+    public mesosphere.marathon.Protos.Volume.ExternalVolumeInfo getExternal() {
+      return external_;
+    }
+    /**
+     * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+     *
+     * <pre>
+     * Defines an External Volume; implies no hostPath or persistent.
+     * </pre>
+     */
+    public mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder getExternalOrBuilder() {
+      return external_;
     }
 
     private void initFields() {
@@ -23327,6 +24506,7 @@ public final class Protos {
       hostPath_ = "";
       image_ = org.apache.mesos.Protos.Image.getDefaultInstance();
       persistent_ = mesosphere.marathon.Protos.Volume.PersistentVolumeInfo.getDefaultInstance();
+      external_ = mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -23353,6 +24533,12 @@ public final class Protos {
           return false;
         }
       }
+      if (hasExternal()) {
+        if (!getExternal().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
       memoizedIsInitialized = 1;
       return true;
     }
@@ -23374,6 +24560,9 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeMessage(5, persistent_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeMessage(6, external_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -23403,6 +24592,10 @@ public final class Protos {
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(5, persistent_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(6, external_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -23520,6 +24713,7 @@ public final class Protos {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
           getImageFieldBuilder();
           getPersistentFieldBuilder();
+          getExternalFieldBuilder();
         }
       }
       private static Builder create() {
@@ -23546,6 +24740,12 @@ public final class Protos {
           persistentBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000010);
+        if (externalBuilder_ == null) {
+          external_ = mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.getDefaultInstance();
+        } else {
+          externalBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -23602,6 +24802,14 @@ public final class Protos {
         } else {
           result.persistent_ = persistentBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        if (externalBuilder_ == null) {
+          result.external_ = external_;
+        } else {
+          result.external_ = externalBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -23637,6 +24845,9 @@ public final class Protos {
         if (other.hasPersistent()) {
           mergePersistent(other.getPersistent());
         }
+        if (other.hasExternal()) {
+          mergeExternal(other.getExternal());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -23658,6 +24869,12 @@ public final class Protos {
         }
         if (hasPersistent()) {
           if (!getPersistent().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasExternal()) {
+          if (!getExternal().isInitialized()) {
             
             return false;
           }
@@ -24110,7 +25327,7 @@ public final class Protos {
        * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
        *
        * <pre>
-       * Defines a Persistent Volume. In this case hostPath must not be set
+       * Defines a Persistent Volume; implies no hostPath or external.
        * </pre>
        */
       public boolean hasPersistent() {
@@ -24120,7 +25337,7 @@ public final class Protos {
        * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
        *
        * <pre>
-       * Defines a Persistent Volume. In this case hostPath must not be set
+       * Defines a Persistent Volume; implies no hostPath or external.
        * </pre>
        */
       public mesosphere.marathon.Protos.Volume.PersistentVolumeInfo getPersistent() {
@@ -24134,7 +25351,7 @@ public final class Protos {
        * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
        *
        * <pre>
-       * Defines a Persistent Volume. In this case hostPath must not be set
+       * Defines a Persistent Volume; implies no hostPath or external.
        * </pre>
        */
       public Builder setPersistent(mesosphere.marathon.Protos.Volume.PersistentVolumeInfo value) {
@@ -24154,7 +25371,7 @@ public final class Protos {
        * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
        *
        * <pre>
-       * Defines a Persistent Volume. In this case hostPath must not be set
+       * Defines a Persistent Volume; implies no hostPath or external.
        * </pre>
        */
       public Builder setPersistent(
@@ -24172,7 +25389,7 @@ public final class Protos {
        * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
        *
        * <pre>
-       * Defines a Persistent Volume. In this case hostPath must not be set
+       * Defines a Persistent Volume; implies no hostPath or external.
        * </pre>
        */
       public Builder mergePersistent(mesosphere.marathon.Protos.Volume.PersistentVolumeInfo value) {
@@ -24195,7 +25412,7 @@ public final class Protos {
        * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
        *
        * <pre>
-       * Defines a Persistent Volume. In this case hostPath must not be set
+       * Defines a Persistent Volume; implies no hostPath or external.
        * </pre>
        */
       public Builder clearPersistent() {
@@ -24212,7 +25429,7 @@ public final class Protos {
        * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
        *
        * <pre>
-       * Defines a Persistent Volume. In this case hostPath must not be set
+       * Defines a Persistent Volume; implies no hostPath or external.
        * </pre>
        */
       public mesosphere.marathon.Protos.Volume.PersistentVolumeInfo.Builder getPersistentBuilder() {
@@ -24224,7 +25441,7 @@ public final class Protos {
        * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
        *
        * <pre>
-       * Defines a Persistent Volume. In this case hostPath must not be set
+       * Defines a Persistent Volume; implies no hostPath or external.
        * </pre>
        */
       public mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder getPersistentOrBuilder() {
@@ -24238,7 +25455,7 @@ public final class Protos {
        * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
        *
        * <pre>
-       * Defines a Persistent Volume. In this case hostPath must not be set
+       * Defines a Persistent Volume; implies no hostPath or external.
        * </pre>
        */
       private com.google.protobuf.SingleFieldBuilder<
@@ -24253,6 +25470,159 @@ public final class Protos {
           persistent_ = null;
         }
         return persistentBuilder_;
+      }
+
+      // optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;
+      private mesosphere.marathon.Protos.Volume.ExternalVolumeInfo external_ = mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          mesosphere.marathon.Protos.Volume.ExternalVolumeInfo, mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder> externalBuilder_;
+      /**
+       * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+       *
+       * <pre>
+       * Defines an External Volume; implies no hostPath or persistent.
+       * </pre>
+       */
+      public boolean hasExternal() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+       *
+       * <pre>
+       * Defines an External Volume; implies no hostPath or persistent.
+       * </pre>
+       */
+      public mesosphere.marathon.Protos.Volume.ExternalVolumeInfo getExternal() {
+        if (externalBuilder_ == null) {
+          return external_;
+        } else {
+          return externalBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+       *
+       * <pre>
+       * Defines an External Volume; implies no hostPath or persistent.
+       * </pre>
+       */
+      public Builder setExternal(mesosphere.marathon.Protos.Volume.ExternalVolumeInfo value) {
+        if (externalBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          external_ = value;
+          onChanged();
+        } else {
+          externalBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+       *
+       * <pre>
+       * Defines an External Volume; implies no hostPath or persistent.
+       * </pre>
+       */
+      public Builder setExternal(
+          mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder builderForValue) {
+        if (externalBuilder_ == null) {
+          external_ = builderForValue.build();
+          onChanged();
+        } else {
+          externalBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+       *
+       * <pre>
+       * Defines an External Volume; implies no hostPath or persistent.
+       * </pre>
+       */
+      public Builder mergeExternal(mesosphere.marathon.Protos.Volume.ExternalVolumeInfo value) {
+        if (externalBuilder_ == null) {
+          if (((bitField0_ & 0x00000020) == 0x00000020) &&
+              external_ != mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.getDefaultInstance()) {
+            external_ =
+              mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.newBuilder(external_).mergeFrom(value).buildPartial();
+          } else {
+            external_ = value;
+          }
+          onChanged();
+        } else {
+          externalBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000020;
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+       *
+       * <pre>
+       * Defines an External Volume; implies no hostPath or persistent.
+       * </pre>
+       */
+      public Builder clearExternal() {
+        if (externalBuilder_ == null) {
+          external_ = mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.getDefaultInstance();
+          onChanged();
+        } else {
+          externalBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000020);
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+       *
+       * <pre>
+       * Defines an External Volume; implies no hostPath or persistent.
+       * </pre>
+       */
+      public mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder getExternalBuilder() {
+        bitField0_ |= 0x00000020;
+        onChanged();
+        return getExternalFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+       *
+       * <pre>
+       * Defines an External Volume; implies no hostPath or persistent.
+       * </pre>
+       */
+      public mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder getExternalOrBuilder() {
+        if (externalBuilder_ != null) {
+          return externalBuilder_.getMessageOrBuilder();
+        } else {
+          return external_;
+        }
+      }
+      /**
+       * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
+       *
+       * <pre>
+       * Defines an External Volume; implies no hostPath or persistent.
+       * </pre>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          mesosphere.marathon.Protos.Volume.ExternalVolumeInfo, mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder> 
+          getExternalFieldBuilder() {
+        if (externalBuilder_ == null) {
+          externalBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              mesosphere.marathon.Protos.Volume.ExternalVolumeInfo, mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder>(
+                  external_,
+                  getParentForChildren(),
+                  isClean());
+          external_ = null;
+        }
+        return externalBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:mesosphere.marathon.Volume)
@@ -31559,6 +32929,11 @@ public final class Protos {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_EventSubscribers_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -31704,39 +33079,43 @@ public final class Protos {
       "rt\030\001 \002(\r\022\026\n\016container_port\030\002 \002(\r\022\020\n\010prot" +
       "ocol\030\003 \001(\t\022\014\n\004name\030\004 \001(\t\022\034\n\006labels\030\005 \003(\013" +
       "2\014.mesos.Label\022\027\n\014service_port\030d \001(\r:\0010\"" +
-      "\336\001\n\006Volume\022 \n\004mode\030\003 \002(\0162\022.mesos.Volume." +
+      "\203\003\n\006Volume\022 \n\004mode\030\003 \002(\0162\022.mesos.Volume." +
       "Mode\022\026\n\016container_path\030\001 \002(\t\022\021\n\thost_pat" +
       "h\030\002 \001(\t\022\033\n\005image\030\004 \001(\0132\014.mesos.Image\022D\n\n",
       "persistent\030\005 \001(\01320.mesosphere.marathon.V" +
-      "olume.PersistentVolumeInfo\032$\n\024Persistent" +
-      "VolumeInfo\022\014\n\004size\030\001 \002(\004\")\n\020EventSubscri" +
-      "bers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016StorageVe" +
-      "rsion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005p" +
-      "atch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefinition\022" +
-      "\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023maximu" +
-      "mOverCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDefiniti" +
-      "on\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004apps\030" +
-      "\003 \003(\0132&.mesosphere.marathon.ServiceDefin",
-      "ition\0224\n\006groups\030\004 \003(\0132$.mesosphere.marat" +
-      "hon.GroupDefinition\022\024\n\014dependencies\030\005 \003(" +
-      "\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002id\030\001 \002" +
-      "(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002(\0132$." +
-      "mesosphere.marathon.GroupDefinition\0224\n\006t" +
-      "arget\030\005 \002(\0132$.mesosphere.marathon.GroupD" +
-      "efinition\"\306\001\n\013TaskFailure\022\016\n\006app_id\030\001 \002(" +
-      "\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037\n\005sta" +
-      "te\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007message\030\004 " +
-      "\001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021",
-      "\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016.mes" +
-      "os.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004name\030\001 \002(\t" +
-      "\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\ncompres" +
-      "sed\030\004 \001(\010:\005false\"\326\001\n\023ResidencyDefinition" +
-      "\022(\n relaunchEscalationTimeoutSeconds\030\001 \001" +
-      "(\003\022S\n\020taskLostBehavior\030\002 \001(\01629.mesospher" +
-      "e.marathon.ResidencyDefinition.TaskLostB" +
-      "ehavior\"@\n\020TaskLostBehavior\022\032\n\026RELAUNCH_" +
-      "AFTER_TIMEOUT\020\000\022\020\n\014WAIT_FOREVER\020\001B\035\n\023mes" +
-      "osphere.marathonB\006Protos"
+      "olume.PersistentVolumeInfo\022@\n\010external\030\006" +
+      " \001(\0132..mesosphere.marathon.Volume.Extern" +
+      "alVolumeInfo\032$\n\024PersistentVolumeInfo\022\014\n\004" +
+      "size\030\001 \002(\004\032a\n\022ExternalVolumeInfo\022\014\n\004size" +
+      "\030\001 \001(\004\022\014\n\004name\030\002 \002(\t\022\020\n\010provider\030\003 \002(\t\022\035" +
+      "\n\007options\030\004 \003(\0132\014.mesos.Label\")\n\020EventSu" +
+      "bscribers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016Stor" +
+      "ageVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r" +
+      "\022\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefini",
+      "tion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023m" +
+      "aximumOverCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDef" +
+      "inition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n\004" +
+      "apps\030\003 \003(\0132&.mesosphere.marathon.Service" +
+      "Definition\0224\n\006groups\030\004 \003(\0132$.mesosphere." +
+      "marathon.GroupDefinition\022\024\n\014dependencies" +
+      "\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002i" +
+      "d\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 \002" +
+      "(\0132$.mesosphere.marathon.GroupDefinition" +
+      "\0224\n\006target\030\005 \002(\0132$.mesosphere.marathon.G",
+      "roupDefinition\"\306\001\n\013TaskFailure\022\016\n\006app_id" +
+      "\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022\037" +
+      "\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007messa" +
+      "ge\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006 " +
+      "\002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\0132" +
+      "\016.mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004name\030" +
+      "\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\nco" +
+      "mpressed\030\004 \001(\010:\005false\"\326\001\n\023ResidencyDefin" +
+      "ition\022(\n relaunchEscalationTimeoutSecond" +
+      "s\030\001 \001(\003\022S\n\020taskLostBehavior\030\002 \001(\01629.meso",
+      "sphere.marathon.ResidencyDefinition.Task" +
+      "LostBehavior\"@\n\020TaskLostBehavior\022\032\n\026RELA" +
+      "UNCH_AFTER_TIMEOUT\020\000\022\020\n\014WAIT_FOREVER\020\001B\035" +
+      "\n\023mesosphere.marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -31844,13 +33223,19 @@ public final class Protos {
           internal_static_mesosphere_marathon_Volume_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_Volume_descriptor,
-              new java.lang.String[] { "Mode", "ContainerPath", "HostPath", "Image", "Persistent", });
+              new java.lang.String[] { "Mode", "ContainerPath", "HostPath", "Image", "Persistent", "External", });
           internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor =
             internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(0);
           internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor,
               new java.lang.String[] { "Size", });
+          internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor =
+            internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(1);
+          internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor,
+              new java.lang.String[] { "Size", "Name", "Provider", "Options", });
           internal_static_mesosphere_marathon_EventSubscribers_descriptor =
             getDescriptor().getMessageTypes().get(12);
           internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -211,6 +211,14 @@ message Volume {
     required uint64 size = 1;
   }
 
+  // Defining properties of external volumes
+  message ExternalVolumeInfo {
+    optional uint64 size = 1;
+    required string name = 2;
+    required string provider = 3;
+    repeated mesos.Label options = 4;
+  }
+
   required mesos.Volume.Mode mode = 3;
 
   // Path pointing to a directory or file in the container. If the
@@ -230,8 +238,11 @@ message Volume {
   // filesystem which will be provisioned by Mesos.
   optional mesos.Image image = 4;
 
-  // Defines a Persistent Volume. In this case hostPath must not be set
+  // Defines a Persistent Volume; implies no hostPath or external.
   optional PersistentVolumeInfo persistent = 5;
+
+  // Defines an External Volume; implies no hostPath or persistent.
+  optional ExternalVolumeInfo external = 6;
 }
 
 message EventSubscribers {

--- a/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.api.serialization
 
 import mesosphere.marathon.Protos
+import mesosphere.marathon.core.externalvolume.ExternalVolumes
 import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state.Container.Docker.PortMapping
 import mesosphere.marathon.state._
@@ -28,25 +29,36 @@ object ContainerSerializer {
   }
 
   def toMesos(container: Container): mesos.Protos.ContainerInfo = {
-    // we can only serialize DockerVolumes into a Mesos Protobuf.
-    // PersistentVolumes and ExternalVolumes are handled differently
-    val serializedVolumes = container.volumes.collect { case dv: DockerVolume => VolumeSerializer.toMesos(dv) }
-    val builder = mesos.Protos.ContainerInfo.newBuilder
-      .setType(container.`type`)
-      .addAllVolumes(serializedVolumes.asJava)
+    val builder = mesos.Protos.ContainerInfo.newBuilder.setType(container.`type`)
+
+    // first set container.docker because the external volume provider might depend on it
+    // to set further values.
     container.docker.foreach { d => builder.setDocker(DockerSerializer.toMesos(d)) }
+
+    container.volumes.foreach {
+      case pv: PersistentVolume => // PersistentVolumes are handled differently
+      case ev: ExternalVolume   => ExternalVolumes.build(builder, ev) // this also adds the volume
+      case dv: DockerVolume     => builder.addVolumes(VolumeSerializer.toMesos(dv))
+    }
+
     builder.build
   }
 }
 
 object VolumeSerializer {
-
   def toProto(volume: Volume): Protos.Volume = volume match {
     case p: PersistentVolume =>
       Protos.Volume.newBuilder()
         .setContainerPath(p.containerPath)
         .setPersistent(PersistentVolumeInfoSerializer.toProto(p.persistent))
         .setMode(p.mode)
+        .build()
+
+    case e: ExternalVolume =>
+      Protos.Volume.newBuilder()
+        .setContainerPath(e.containerPath)
+        .setExternal(ExternalVolumeInfoSerializer.toProto(e.external))
+        .setMode(e.mode)
         .build()
 
     case d: DockerVolume =>
@@ -71,6 +83,21 @@ object PersistentVolumeInfoSerializer {
     Protos.Volume.PersistentVolumeInfo.newBuilder()
       .setSize(info.size)
       .build()
+}
+
+object ExternalVolumeInfoSerializer {
+  def toProto(info: ExternalVolumeInfo): Protos.Volume.ExternalVolumeInfo = {
+    val builder = Protos.Volume.ExternalVolumeInfo.newBuilder()
+      .setName(info.name)
+      .setProvider(info.provider)
+
+    info.size.foreach(builder.setSize)
+    info.options.map{
+      case (key, value) => mesos.Protos.Label.newBuilder().setKey(key).setValue(value).build
+    }.foreach(builder.addOptions)
+
+    builder.build
+  }
 }
 
 object DockerSerializer {

--- a/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
@@ -24,6 +24,18 @@ object Validation {
     }
   }
 
+  def definedAnd[T](implicit validator: Validator[T]): Validator[Option[T]] = {
+    new Validator[Option[T]] {
+      override def apply(option: Option[T]): Result = option.map(validator).getOrElse(
+        Failure(Set(RuleViolation(None, "not defined", None)))
+      )
+    }
+  }
+
+  def conditional[T](b: T => Boolean)(implicit validator: Validator[T]): Validator[T] = new Validator[T] {
+    override def apply(t: T): Result = if (!b(t)) Success else validator(t)
+  }
+
   implicit def every[T](implicit validator: Validator[T]): Validator[Iterable[T]] = {
     new Validator[Iterable[T]] {
       override def apply(seq: Iterable[T]): Result = {

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -243,12 +243,20 @@ trait ContainerFormats {
 
   implicit lazy val PersistentVolumeInfoFormat: Format[PersistentVolumeInfo] = Json.format[PersistentVolumeInfo]
 
+  implicit lazy val ExternalVolumeInfoFormat: Format[ExternalVolumeInfo] = (
+    (__ \ "size").formatNullable[Long] ~
+    (__ \ "name").format[String] ~
+    (__ \ "provider").format[String] ~
+    (__ \ "options").formatNullable[Map[String, String]].withDefault(Map.empty[String, String])
+  )(ExternalVolumeInfo(_, _, _, _), unlift(ExternalVolumeInfo.unapply))
+
   implicit lazy val VolumeFormat: Format[Volume] = (
     (__ \ "containerPath").format[String] ~
     (__ \ "hostPath").formatNullable[String] ~
     (__ \ "mode").format[mesos.Volume.Mode] ~
-    (__ \ "persistent").formatNullable[PersistentVolumeInfo]
-  )(Volume(_, _, _, _), unlift(Volume.unapply))
+    (__ \ "persistent").formatNullable[PersistentVolumeInfo] ~
+    (__ \ "external").formatNullable[ExternalVolumeInfo]
+  )(Volume(_, _, _, _, _), unlift(Volume.unapply))
 
   implicit lazy val ContainerTypeFormat: Format[mesos.ContainerInfo.Type] =
     enumFormat(mesos.ContainerInfo.Type.valueOf, str => s"$str is not a valid container type")

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/ExternalVolumes.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/ExternalVolumes.scala
@@ -1,0 +1,74 @@
+package mesosphere.marathon.core.externalvolume
+
+import com.wix.accord._
+import mesosphere.marathon.core.externalvolume.impl._
+import mesosphere.marathon.state._
+import org.apache.mesos.Protos.{ ContainerInfo, CommandInfo }
+
+/**
+  * Validations for external volumes on different levels.
+  */
+trait ExternalVolumeValidations {
+  def rootGroup: Validator[Group]
+  def app: Validator[AppDefinition]
+  def volume: Validator[ExternalVolume]
+}
+
+/**
+  * ExternalVolumeProvider is an interface implemented by external storage volume providers
+  */
+trait ExternalVolumeProvider {
+  def name: String
+
+  def validations: ExternalVolumeValidations
+
+  /** build adds v to the given builder **/
+  def build(builder: ContainerInfo.Builder, v: ExternalVolume): Unit
+  /** build adds ev to the given builder **/
+  def build(containerType: ContainerInfo.Type, builder: CommandInfo.Builder, ev: ExternalVolume): Unit
+}
+
+trait ExternalVolumeProviderRegistry {
+  /**
+    * @return the ExternalVolumeProvider interface registered for the given name
+    */
+  def get(name: String): Option[ExternalVolumeProvider]
+
+  def all: Iterable[ExternalVolumeProvider]
+}
+
+/**
+  * API facade for callers interested in storage volumes
+  */
+object ExternalVolumes {
+  private[this] lazy val providers: ExternalVolumeProviderRegistry = StaticExternalVolumeProviderRegistry
+
+  def build(builder: ContainerInfo.Builder, v: ExternalVolume): Unit = {
+    providers.get(v.external.provider).foreach { _.build(builder, v) }
+  }
+
+  def build(containerType: ContainerInfo.Type, builder: CommandInfo.Builder, v: ExternalVolume): Unit = {
+    providers.get(v.external.provider).foreach { _.build(containerType, builder, v) }
+  }
+
+  def validExternalVolume: Validator[ExternalVolume] = new Validator[ExternalVolume] {
+    def apply(ev: ExternalVolume) = providers.get(ev.external.provider) match {
+      case Some(p) => p.validations.volume(ev)
+      case None    => Failure(Set(RuleViolation(None, "is unknown provider", Some("external/provider"))))
+    }
+  }
+
+  /** @return a validator that checks the validity of a container given the related volume providers */
+  def validApp(): Validator[AppDefinition] = new Validator[AppDefinition] {
+    def apply(app: AppDefinition) = {
+      val appProviders = app.externalVolumes.iterator.flatMap(ev => providers.get(ev.external.provider)).toSet
+      appProviders.map(_.validations.app).map(validate(app)(_)).fold(Success)(_ and _)
+    }
+  }
+
+  /** @return a validator that checks the validity of a group given the related volume providers */
+  def validRootGroup(): Validator[Group] = new Validator[Group] {
+    def apply(grp: Group) =
+      providers.all.map(_.validations.rootGroup).map(validate(grp)(_)).fold(Success)(_ and _)
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/impl/StaticExternalVolumeProviderRegistry.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/impl/StaticExternalVolumeProviderRegistry.scala
@@ -1,0 +1,21 @@
+package mesosphere.marathon.core.externalvolume.impl
+
+import mesosphere.marathon.core.externalvolume._
+import mesosphere.marathon.core.externalvolume.impl.providers.DVDIProvider
+
+/**
+  * StaticExternalVolumeProviderRegistry is a fixed, precomputed storage provider registry
+  */
+protected[externalvolume] object StaticExternalVolumeProviderRegistry extends ExternalVolumeProviderRegistry {
+  def make(prov: ExternalVolumeProvider*): Map[String, ExternalVolumeProvider] =
+    prov.map(p => p.name -> p).toMap
+
+  val registry = make(
+    // list supported providers here; all MUST provide a non-empty "name" trait
+    DVDIProvider
+  )
+
+  override def get(name: String): Option[ExternalVolumeProvider] = registry.get(name)
+
+  override def all: Iterable[ExternalVolumeProvider] = registry.values
+}

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
@@ -1,0 +1,264 @@
+package mesosphere.marathon.core.externalvolume.impl.providers
+
+import com.wix.accord._
+import com.wix.accord.dsl._
+import mesosphere.marathon.core.externalvolume.{ ExternalVolumeValidations, ExternalVolumeProvider }
+import mesosphere.marathon.state._
+import org.apache.mesos.Protos.Volume.Mode
+import org.apache.mesos.Protos.{ Volume => MesosVolume, CommandInfo, ContainerInfo, Environment }
+
+import OptionSupport._
+import scala.collection.JavaConverters._
+
+/**
+  * DVDIProvider (Docker Volume Driver Interface provider) handles external volumes allocated
+  * by a specific docker volume driver plugin. This works for both docker and mesos containerizers,
+  * albeit with some limitations:
+  *   - only a single volume driver per container is allowed when using the docker containerizer
+  *   - docker containerizer requires that referenced volumes be created prior to application launch
+  *   - mesos containerizer only supports volumes mounted in RW mode
+  */
+protected[externalvolume] case object DVDIProvider extends ExternalVolumeProvider {
+  override val name: String = "dvdi"
+
+  override def validations: ExternalVolumeValidations = DVDIProviderValidations
+
+  override def build(builder: ContainerInfo.Builder, ev: ExternalVolume): Unit = {
+    def toMesosVolume(volume: ExternalVolume): MesosVolume =
+      MesosVolume.newBuilder
+        .setContainerPath(volume.containerPath)
+        .setHostPath(volume.external.name)
+        .setMode(volume.mode)
+        .build
+
+    // special behavior for docker vs. mesos containers
+    // - docker containerizer: serialize volumes into mesos proto
+    // - docker containerizer: specify "volumeDriver" for the container
+    if (builder.getType == ContainerInfo.Type.DOCKER && builder.hasDocker) {
+      val driverName = ev.external.options(driverOption)
+      builder.setDocker(builder.getDocker.toBuilder.setVolumeDriver(driverName).build)
+      builder.addVolumes(toMesosVolume(ev))
+    }
+  }
+
+  override def build(containerType: ContainerInfo.Type, builder: CommandInfo.Builder, ev: ExternalVolume): Unit = {
+    // special behavior for docker vs. mesos containers
+    // - mesos containerizer: serialize volumes into envvar sets
+    if (containerType == ContainerInfo.Type.MESOS) {
+      val env = if (builder.hasEnvironment) builder.getEnvironment.toBuilder else Environment.newBuilder
+      val toAdd = volumeToEnv(ev, env.getVariablesList.asScala)
+      env.addAllVariables(toAdd.asJava)
+      builder.setEnvironment(env.build)
+    }
+  }
+
+  val driverOption = "dvdi/driver"
+  val dvdiVolumeContainerPath = "DVDI_VOLUME_CONTAINERPATH"
+  val dvdiVolumeName = "DVDI_VOLUME_NAME"
+  val dvdiVolumeDriver = "DVDI_VOLUME_DRIVER"
+  val dvdiVolumeOpts = "DVDI_VOLUME_OPTS"
+
+  private[providers] def volumeToEnv(
+    vol: ExternalVolume,
+    i: Iterable[Environment.Variable]): Iterable[Environment.Variable] = {
+
+    import OptionLabelPatterns._
+
+    val suffix = {
+      val offset = i.filter(_.getName.startsWith(dvdiVolumeName)).map{ s =>
+        val ss = s.getName.substring(dvdiVolumeName.length)
+        if (ss.length > 0) ss.toInt else 0
+      }.foldLeft(-1)((z, i) => if (i > z) i else z)
+
+      if (offset >= 0) (offset + 1).toString else ""
+    }
+
+    def mkVar(name: String, value: String): Environment.Variable =
+      Environment.Variable.newBuilder.setName(name).setValue(value).build
+
+    val vars = Seq[Environment.Variable](
+      mkVar(dvdiVolumeContainerPath + suffix, vol.containerPath),
+      mkVar(dvdiVolumeName + suffix, vol.external.name),
+      mkVar(dvdiVolumeDriver + suffix, vol.external.options(driverOption))
+    )
+
+    val optsVar = {
+      val prefix: String = name + OptionNamespaceSeparator
+      // don't let the user override these
+      val ignore = Set(driverOption)
+      // external.size trumps any user-specified dvdi/size option
+      val opts = vol.external.options ++ Map[String, String](
+        vol.external.size.map(prefix + "size" -> _.toString).toList: _*
+      )
+
+      // forward all dvdi/* options to the dvdcli driver, stripping the dvdi/ prefix
+      // and trimming the values
+      opts.filterKeys{ k =>
+        k.startsWith(prefix) && !ignore.contains(k.toLowerCase)
+      }.map{
+        case (k, v) => k.substring(prefix.length) + "=" + v.trim()
+      }.mkString(",")
+    }
+
+    if (optsVar.isEmpty) vars
+    else { vars :+ mkVar(dvdiVolumeOpts + suffix, optsVar) }
+  }
+}
+
+private[externalvolume] object DVDIProviderValidations extends ExternalVolumeValidations {
+  import mesosphere.marathon.api.v2.Validation._
+  import DVDIProvider._
+  import ViolationBuilder._
+
+  // group-level validation for DVDI volumes: the same volume name may only be referenced by a single
+  // task instance across the entire cluster.
+  override lazy val rootGroup = new Validator[Group] {
+    override def apply(g: Group): Result = {
+      val appsByVolume = g.transitiveApps.flatMap { app =>
+        app.externalVolumes.flatMap{ vol => nameOf(vol.external).map(_ -> app.id) }
+      }.groupBy[String](_._1).mapValues(_.map(_._2))
+
+      val groupViolations = g.apps.flatMap { app =>
+        val ruleViolations = app.externalVolumes.flatMap{ vol => nameOf(vol.external) }.flatMap{ name =>
+          for {
+            otherApp <- appsByVolume(name)
+            if otherApp != app.id // do not compare to self
+          } yield RuleViolation(app.id,
+            s"Requested volume $name conflicts with a volume in app $otherApp", None)
+        }
+        if (ruleViolations.isEmpty) None
+        else Some(GroupViolation(app, "app contains conflicting volumes", None, ruleViolations.toSet))
+      }
+      if (groupViolations.isEmpty) Success
+      else Failure(groupViolations.toSet)
+    }
+  }
+
+  override lazy val app = validator[AppDefinition] { app =>
+    //app should haveOnlyOneProvider // TODO(jdef) see comments on validator decl below
+    app should haveUniqueExternalVolumeNames
+    app should haveOnlyOneReplica
+    app.container is valid(optional(validContainer))
+    app.upgradeStrategy is valid(validUpgradeStrategy)
+  }
+
+  override lazy val volume = validator[ExternalVolume] { v =>
+    v.external.name is notEmpty
+    v.external.provider is equalTo(name)
+    v.external.options.get(driverOption) as s"external/options($driverOption)" is definedAnd(validLabel)
+    v.external.options is valid(
+      conditional[Map[String, String]](_.get(driverOption).contains("rexray"))(validRexRayOptions))
+  }
+
+  /**
+    * @return true if volume has a provider name that matches ours exactly
+    */
+  private[this] def accepts(volume: ExternalVolume): Boolean = {
+    volume.external.provider == name
+  }
+
+  private[this] def optionalOption(opts: Map[String, String], v: Validator[String]): Validator[String] =
+    new Validator[String] {
+      override def apply(optionName: String): Result = {
+        validate(opts.get(optionName))(optional(v)) match {
+          case Success     => Success
+          // we do this to get sane error messages
+          case Failure(vs) => Failure(vs.map(_.withDescription(optionName)))
+        }
+      }
+    }
+
+  private[this] lazy val validRexRayOptions: Validator[Map[String, String]] = validator[Map[String, String]] { opts =>
+    // there's probaby a better way to do this; this worked and didn't require me to duplicate option keys
+    "dvdi/volumetype" as "" is valid(optionalOption(opts, validLabel))
+    "dvdi/newfstype" as "" is valid(optionalOption(opts, validLabel))
+    "dvdi/iops" as "" is valid(optionalOption(opts, validNaturalNumber))
+    "dvdi/overwritefs" as "" is valid(optionalOption(opts, validBoolean))
+  }
+
+  private[this] def nameOf(vol: ExternalVolumeInfo): Option[String] = {
+    Some(vol.provider + "::" + vol.name)
+  }
+
+  private[this] case object haveOnlyOneReplica extends Validator[AppDefinition] {
+    override def apply(app: AppDefinition): Result =
+      if (app.externalVolumes.nonEmpty && app.instances > 1)
+        Failure(Set(RuleViolation(app.id,
+          s"Number of instances is limited to 1 when declaring DVDI volumes in app ${app.id}", None
+        )))
+      else Success
+  }
+
+  private[this] case object haveUniqueExternalVolumeNames extends Validator[AppDefinition] {
+    override def apply(app: AppDefinition): Result = {
+      val conflicts = volumeNameCounts(app).filter(_._2 > 1).keys
+      if (conflicts.isEmpty) Success
+      else Failure(conflicts.toSet[String].map { e =>
+        RuleViolation(app.id, s"Requested DVDI volume '$e' is declared more than once within app ${app.id}", None)
+      })
+    }
+  }
+
+  // for now this matches the validation for resident tasks, but probably won't be as
+  // restrictive in the future.
+  private[this] lazy val validUpgradeStrategy = validator[UpgradeStrategy] { strategy =>
+    strategy.minimumHealthCapacity should be <= 0.5
+    strategy.maximumOverCapacity should equalTo(0.0)
+  }
+
+  /** @return a count of volume references-by-name within an app spec */
+  private[this] def volumeNameCounts(app: AppDefinition): Map[String, Int] =
+    app.externalVolumes.flatMap{ v => nameOf(v.external) }.groupBy(identity).mapValues(_.size)
+
+  private[this] lazy val validMesosVolume = validator[ExternalVolume] { v =>
+    v.mode is equalTo(Mode.RW)
+  }
+
+  private[this] lazy val validMesosContainer = validator[Container] { ct =>
+    ct.volumes is every(valid(ifDVDIVolume(validMesosVolume)))
+  }
+
+  /*
+  // TODO(jdef) Unclear where this requirement came from. Seems super-useful to mix and match
+  // volumes from different providers within the same app (we only have 1 right now anyway, but
+  // the limitation imposed by this validator doesn't make sense to me).
+  private[this] case object haveOnlyOneProvider extends Validator[AppDefinition] {
+    override def apply(app: AppDefinition): Result = {
+      val uniqueProviderNames = app.externalVolumes.iterator.map(_.external.provider).toSet
+      val n = uniqueProviderNames.size
+      if (n <= 1) Success
+      else Failure(Set(RuleViolation(n, "one external volume provider per app", None)))
+    }
+  }
+  */
+
+  private[this] case object haveOnlyDriverOption extends Validator[ExternalVolume] {
+    override def apply(v: ExternalVolume): Result =
+      if (v.external.options.filterKeys(_ != driverOption).isEmpty) Success
+      else Failure(Set(RuleViolation(v.external.options, "only contains driver", Some("external.options"))))
+  }
+
+  private[this] lazy val haveNoSize: Validator[ExternalVolume] = new NullSafeValidator(
+    test = _.external.size.isEmpty,
+    failure = v => RuleViolation(v.external.size, "must be undefined for DOCKER container", Some("external/size"))
+  )
+
+  private[this] def ifDVDIVolume(vtor: Validator[ExternalVolume]): Validator[Volume] = new Validator[Volume] {
+    override def apply(v: Volume): Result = v match {
+      case ev: ExternalVolume if accepts(ev) => validate(ev)(vtor)
+      case _                                 => Success
+    }
+  }
+
+  private[this] lazy val validDockerContainer = validator[Container] { ct =>
+    ct.volumes is every(valid(ifDVDIVolume(haveOnlyDriverOption)))
+    ct.volumes is every(valid(ifDVDIVolume(haveNoSize)))
+  }
+
+  private[this] case object validContainer extends Validator[Container] {
+    override def apply(ct: Container): Result = ct.`type` match {
+      case ContainerInfo.Type.MESOS  => validate(ct)(validMesosContainer)
+      case ContainerInfo.Type.DOCKER => validate(ct)(validDockerContainer)
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/Helpers.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/Helpers.scala
@@ -1,0 +1,32 @@
+package mesosphere.marathon.core.externalvolume.impl.providers
+
+import com.wix.accord._
+import com.wix.accord.dsl._
+import mesosphere.marathon.state._
+
+import scala.util.Try
+
+protected[providers] object OptionSupport {
+  import OptionLabelPatterns._
+
+  /** a validator to enforce that values conform to expectations of "labels" */
+  lazy val validLabel: Validator[String] = validator[String] { v =>
+    v should matchRegex(LabelRegex)
+  }
+
+  /** a validator to enforce that values parse to natural (whole, positive) numbers */
+  lazy val validNaturalNumber: Validator[String] = new Validator[String] {
+    override def apply(v: String): Result = {
+      import scala.util.Try
+      val parsed: Try[Long] = Try(v.toLong)
+      if (parsed.isSuccess && parsed.get > 0) Success
+      else Failure(Set(RuleViolation(v, s"Expected a valid, positive integer instead of $v", None)))
+    }
+  }
+
+  /** a validator to enforce that values parse to booleans */
+  import mesosphere.marathon.api.v2.Validation.isTrue
+  lazy val validBoolean: Validator[String] = isTrue[String](s"Expected a valid boolean")(s =>
+    Try(s.toBoolean).getOrElse(false)
+  )
+}

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.plugin.{ Group => IGroup }
 import mesosphere.marathon.Protos.GroupDefinition
 import mesosphere.marathon.state.Group._
 import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.core.externalvolume.ExternalVolumes
 import org.jgrapht.DirectedGraph
 import org.jgrapht.alg.CycleDetector
 import org.jgrapht.graph._
@@ -222,6 +223,7 @@ object Group {
 
   implicit val validRootGroup: Validator[Group] = new Validator[Group] {
     override def apply(group: Group): Result = {
+      group is ExternalVolumes.validRootGroup
       validate(group)(validator =
         validNestedGroup(PathId.empty))
     }
@@ -277,4 +279,3 @@ object Group {
     }
   }
 }
-

--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -4,8 +4,11 @@ import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.Protos
+import mesosphere.marathon.api.v2.Validation.oneOf
+import mesosphere.marathon.core.externalvolume.ExternalVolumes
 import org.apache.mesos.Protos.Volume.Mode
 import org.apache.mesos.{ Protos => Mesos }
+import scala.collection.JavaConverters._
 
 sealed trait Volume {
   def containerPath: String
@@ -17,68 +20,81 @@ object Volume {
     containerPath: String,
     hostPath: Option[String],
     mode: Mesos.Volume.Mode,
-    persistent: Option[PersistentVolumeInfo]): Volume =
+    persistent: Option[PersistentVolumeInfo],
+    external: Option[ExternalVolumeInfo]): Volume = {
+
     persistent match {
       case Some(persistentVolumeInfo) =>
+        if (hostPath.isDefined) throw new IllegalArgumentException("hostPath may not be set with persistent")
+        if (external.isDefined) throw new IllegalArgumentException("external may not be set with persistent")
         PersistentVolume(
           containerPath = containerPath,
           persistent = persistentVolumeInfo,
           mode = mode
         )
       case None =>
-        DockerVolume(
-          containerPath = containerPath,
-          hostPath = hostPath.getOrElse(""),
-          mode = mode
-        )
-    }
-
-  def apply(proto: Protos.Volume): Volume = {
-    val persistent: Option[PersistentVolumeInfo] =
-      if (proto.hasPersistent) Some(PersistentVolumeInfo(proto.getPersistent.getSize)) else None
-
-    persistent match {
-      case Some(persistentVolumeInfo) =>
-        PersistentVolume(
-          containerPath = proto.getContainerPath,
-          persistent = persistentVolumeInfo,
-          mode = proto.getMode
-        )
-      case None =>
-        DockerVolume(
-          containerPath = proto.getContainerPath,
-          hostPath = proto.getHostPath,
-          mode = proto.getMode
-        )
+        external match {
+          case Some(externalVolumeInfo) =>
+            if (hostPath.isDefined) throw new IllegalArgumentException("hostPath may not be set with persistent")
+            ExternalVolume(
+              containerPath = containerPath,
+              external = external.get,
+              mode = mode
+            )
+          case None =>
+            DockerVolume(
+              containerPath = containerPath,
+              hostPath = hostPath.getOrElse(""),
+              mode = mode
+            )
+        }
     }
   }
 
-  def apply(proto: Mesos.Volume): Volume =
-    DockerVolume(
-      containerPath = proto.getContainerPath,
-      hostPath = proto.getHostPath,
-      mode = proto.getMode
-    )
+  def apply(proto: Protos.Volume): Volume = {
+    if (proto.hasPersistent)
+      PersistentVolume(
+        containerPath = proto.getContainerPath,
+        persistent = PersistentVolumeInfo.fromProto(proto.getPersistent),
+        mode = proto.getMode
+      )
+    else if (proto.hasExternal)
+      ExternalVolume(
+        containerPath = proto.getContainerPath,
+        external = ExternalVolumeInfo.fromProto(proto.getExternal),
+        mode = proto.getMode
+      )
+    else
+      DockerVolume(
+        containerPath = proto.getContainerPath,
+        hostPath = proto.getHostPath,
+        mode = proto.getMode
+      )
+  }
 
-  def unapply(volume: Volume): Option[(String, Option[String], Mesos.Volume.Mode, Option[PersistentVolumeInfo])] =
+  type TupleV = (String, Option[String], Mesos.Volume.Mode, Option[PersistentVolumeInfo], Option[ExternalVolumeInfo])
+  def unapply(volume: Volume): Option[TupleV] =
     volume match {
       case persistentVolume: PersistentVolume =>
-        Some((persistentVolume.containerPath, None, persistentVolume.mode, Some(persistentVolume.persistent)))
+        Some((persistentVolume.containerPath, None, persistentVolume.mode, Some(persistentVolume.persistent), None))
+      case ev: ExternalVolume =>
+        Some((ev.containerPath, None, ev.mode, None, Some(ev.external)))
       case dockerVolume: DockerVolume =>
-        Some((dockerVolume.containerPath, Some(dockerVolume.hostPath), dockerVolume.mode, None))
+        Some((dockerVolume.containerPath, Some(dockerVolume.hostPath), dockerVolume.mode, None, None))
     }
 
   implicit val validVolume: Validator[Volume] = new Validator[Volume] {
     override def apply(volume: Volume): Result = volume match {
       case pv: PersistentVolume => validate(pv)(PersistentVolume.validPersistentVolume)
       case dv: DockerVolume     => validate(dv)(DockerVolume.validDockerVolume)
+      case ev: ExternalVolume   => validate(ev)(ExternalVolume.validExternalVolume)
     }
   }
 }
 
 /**
   * A volume mapping either from host to container or vice versa.
-  * Both paths can either refer to a directory or a file.  Paths must be
+  * Both paths can either refer to a directory or a file. Paths must be
   * absolute.
   */
 case class DockerVolume(
@@ -88,7 +104,6 @@ case class DockerVolume(
     extends Volume
 
 object DockerVolume {
-
   implicit val validDockerVolume = validator[DockerVolume] { vol =>
     vol.containerPath is notEmpty
     vol.hostPath is notEmpty
@@ -99,6 +114,9 @@ object DockerVolume {
 case class PersistentVolumeInfo(size: Long)
 
 object PersistentVolumeInfo {
+  def fromProto(pvi: Protos.Volume.PersistentVolumeInfo): PersistentVolumeInfo =
+    new PersistentVolumeInfo(pvi.getSize)
+
   implicit val validPersistentVolumeInfo = validator[PersistentVolumeInfo] { info =>
     info.size should be > 0L
   }
@@ -122,4 +140,83 @@ object PersistentVolume {
     vol.persistent is valid
     vol.mode is equalTo(Mode.RW)
   }
+}
+
+/**
+  * ExternalVolumeInfo captures the specification for a volume that survives task restarts.
+  *
+  * `name` is the *unique name* of the storage volume. names should be treated as case insensitive labels
+  * derived from an alpha-numeric character range [a-z0-9]. while there is no prescribed length limit for
+  * volume names it has been observed that some storage provider implementations may refuse names greater
+  * than 31 characters. YMMV. Although `name` is optional, some storage providers may require it.
+  *
+  * `name` uniqueness:
+  *  <li> A volume name MUST be unique within the scope of a volume provider.
+  *  <li> A fully-qualified volume name is expected to be unique across the cluster and may formed, for example,
+  *       by concatenating the volume provider name with the volume name. E.g “dvdi.volume123”
+  *
+  * `provider` is optional; if specified it indicates which storage provider will implement volume
+  * lifecycle management operations for the external volume. if unspecified, “agent” is assumed.
+  * the provider names “dcos”, “agent”, and "docker" are currently reserved. The contents of provider
+  * values are restricted to the alpha-numeric character range [a-z0-9].
+  *
+  * `options` contains provider-specific volume options. some items may be required in order for a volume
+  * driver to function properly. Given a storage provider named “dvdi” all options specific to that
+  * provider MUST be namespaced with a “dvdi/” prefix.
+  *
+  * future DCOS-specific options will be prefixed with “dcos/”. an example of a DCOS option might be
+  * “dcos/label”, a user-assigned, human-friendly label that appears in a UI.
+  *
+  * @param size absolute size of the volume (MB)
+  * @param name identifies the volume within the context of the storage provider.
+  * @param provider identifies the storage provider responsible for volume lifecycle operations.
+  * @param options contains storage provider-specific configuration configuration
+  */
+case class ExternalVolumeInfo(
+  size: Option[Long] = None,
+  name: String,
+  provider: String,
+  options: Map[String, String] = Map.empty[String, String])
+
+object OptionLabelPatterns {
+  val OptionNamespaceSeparator = "/"
+  val OptionNamePattern = "[A-Za-z0-9](?:[-A-Za-z0-9\\._:]*[A-Za-z0-9])?"
+  val LabelPattern = "[a-z0-9](?:[-a-z0-9]*[a-z0-9])?"
+  val LabelRegex = "^" + LabelPattern + "$"
+  val OptionKeyRegex = "^" + LabelPattern + OptionNamespaceSeparator + OptionNamePattern + "$"
+}
+
+object ExternalVolumeInfo {
+  import OptionLabelPatterns._
+
+  implicit val validOptions = validator[Map[String, String]] {
+    option => option.keys.each should matchRegex(OptionKeyRegex)
+  }
+
+  implicit val validExternalVolumeInfo = validator[ExternalVolumeInfo] { info =>
+    info.size.each should be > 0L
+    info.name should matchRegex(LabelRegex)
+    info.provider should matchRegex(LabelRegex)
+    info.options is valid(validOptions)
+  }
+
+  def fromProto(evi: Protos.Volume.ExternalVolumeInfo): ExternalVolumeInfo =
+    ExternalVolumeInfo(
+      if (evi.hasSize) Some(evi.getSize) else None,
+      evi.getName,
+      evi.getProvider,
+      evi.getOptionsList.asScala.map { p => p.getKey -> p.getValue }.toMap
+    )
+}
+
+case class ExternalVolume(
+  containerPath: String,
+  external: ExternalVolumeInfo,
+  mode: Mesos.Volume.Mode) extends Volume
+
+object ExternalVolume {
+  val validExternalVolume = validator[ExternalVolume] { ev =>
+    ev.containerPath is notEmpty
+    ev.external is valid(ExternalVolumeInfo.validExternalVolumeInfo)
+  } and ExternalVolumes.validExternalVolume
 }

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -2,7 +2,7 @@ package mesosphere.mesos
 
 import mesosphere.marathon.core.launcher.impl.ResourceLabels
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.AppDefinition
+import mesosphere.marathon.state.{ AppDefinition, Container }
 import mesosphere.marathon.tasks.{ PortsMatch, PortsMatcher }
 import mesosphere.mesos.protos.{ ScalarResource, RangesResource, Resource }
 import org.apache.mesos.Protos
@@ -98,12 +98,11 @@ object ResourceMatcher {
 
     // Local volumes only need to be matched if we are making a reservation for resident tasks --
     // that means if the resources that are matched are still unreserved.
-    val diskMatch = if (!selector.reserved && app.diskForVolumes > 0) {
-      scalarResourceMatch(Resource.DISK, app.disk + app.diskForVolumes, ScalarMatchResult.Scope.IncludingLocalVolumes)
-    }
-    else {
+    val diskMatch = if (!selector.reserved && app.diskForPersistentVolumes > 0)
+      scalarResourceMatch(Resource.DISK, app.disk + app.diskForPersistentVolumes,
+        ScalarMatchResult.Scope.IncludingLocalVolumes)
+    else
       scalarResourceMatch(Resource.DISK, app.disk, ScalarMatchResult.Scope.ExcludingLocalVolumes)
-    }
 
     val scalarMatchResults = Iterable(
       scalarResourceMatch(Resource.CPUS, app.cpus, ScalarMatchResult.Scope.NoneDisk),

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDITest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDITest.scala
@@ -1,0 +1,182 @@
+package mesosphere.marathon.core.externalvolume.impl.providers
+
+import com.wix.accord._
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.core.externalvolume.ExternalVolumeProvider
+import mesosphere.marathon.state._
+import org.apache.mesos.Protos.Volume.Mode
+import org.scalatest.Matchers
+
+sealed trait TCHelpers {
+  val EVI = ExternalVolumeInfo.apply _
+  val EV = ExternalVolume.apply _
+}
+
+class DVDIProviderVolumeValidationTest extends MarathonSpec with Matchers with TCHelpers {
+  case class TC(volumes: Iterable[ExternalVolume], wantsValid: Boolean)
+  // validation concerns are split at different levels:
+  // - between state/Volume and providers/*
+  //     > containerPath, in particular, in enforced in state/Volume and not at the
+  //       provider-level
+  // - between validateVolume, validateApp, validateGroup
+  val ttValidateVolume = Seq[TC](
+    TC(
+      // various combinations of INVALID external persistent volume parameters
+      Seq[ExternalVolume](
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driverNam" -> "rexray", "dvdi/volumetype" -> "io1")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "rexray", "dvdi/volumetype" -> "io1 ")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "rexray", "dvdi/newfstype" -> " xfs")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "rexray", "dvdi/newfstype" -> "")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "rexray", "dvdi/iops" -> "0")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "rexray", "dvdi/iops" -> "b")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "rexray", "dvdi/overwritefs" -> "b")), Mode.RO),
+
+        EV("", EVI(None, "f", "qaz", Map("dvdi/driver" -> "bar")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map("dvdi/driver" -> "")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map("driver" -> "bar")), Mode.RO),
+        EV("", EVI(None, "f", "", Map("dvdi/driver" -> "bar")), Mode.RO),
+        EV("", EVI(None, "", "dvdi", Map("dvdi/driver" -> "bar")), Mode.RO),
+        EV("", EVI(None, "f", "", Map.empty[String, String]), Mode.RO),
+        EV("", EVI(Some(1L), "", "", Map.empty[String, String]), Mode.RO)
+      ), false
+    ),
+    TC(
+      // various combinations of VALID external persistent volume parameters
+      Seq[ExternalVolume](
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "bar", "dvdi/volumetype" -> "io1")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "bar", "dvdi/newfstype" -> "xfs")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "bar", "dvdi/iops" -> "1")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "bar", "dvdi/overwritefs" -> "true")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map(
+          "dvdi/driver" -> "bar", "dvdi/overwritefs" -> "false")), Mode.RO),
+        EV("", EVI(Some(1L), "f", "dvdi", Map("dvdi/driver" -> "bar", "a" -> "b")), Mode.RO),
+        EV("", EVI(Some(1L), "f", "dvdi", Map("dvdi/driver" -> "bar")), Mode.RO),
+        EV("", EVI(None, "f", "dvdi", Map("dvdi/driver" -> "bar")), Mode.RO)
+      ), true
+    )
+  )
+  for ((tc, idx) <- ttValidateVolume.zipWithIndex; (v, vidx) <- tc.volumes.zipWithIndex) {
+    test(s"validExternalVolume $idx,$vidx") {
+      val result = validate(v)(DVDIProvider.validations.volume)
+      assert(result.isSuccess == tc.wantsValid,
+        s"test case $idx/$vidx expected ${tc.wantsValid} instead of $result for volume $v")
+    }
+  }
+}
+
+//def volumeToEnv(v: ExternalVolume, i: Iterable[Environment.Variable]): Iterable[Environment.Variable]
+class DVDIProvider_VolumeToEnvTest extends MarathonSpec with Matchers with TCHelpers {
+  import org.apache.mesos.Protos.Environment
+  case class TC(pv: ExternalVolume, env: Seq[Environment.Variable], wantsEnv: Seq[Environment.Variable])
+
+  def mkVar(name: String, value: String): Environment.Variable =
+    Environment.Variable.newBuilder.setName(name).setValue(value).build
+
+  val ttVolumeToEnv = Seq[TC](
+    TC(
+      EV("/path", EVI(None, "foo", "dvdi", Map("dvdi/driver" -> "bar")), Mode.RO),
+      Seq[Environment.Variable](),
+      Seq[Environment.Variable](
+        mkVar("DVDI_VOLUME_CONTAINERPATH", "/path"),
+        mkVar("DVDI_VOLUME_NAME", "foo"),
+        mkVar("DVDI_VOLUME_DRIVER", "bar")
+      )
+    ),
+    TC(
+      EV("/path", EVI(Some(1L), "foo", "dvdi", Map("dvdi/driver" -> "bar")), Mode.RO),
+      Seq[Environment.Variable](),
+      Seq[Environment.Variable](
+        mkVar("DVDI_VOLUME_CONTAINERPATH", "/path"),
+        mkVar("DVDI_VOLUME_NAME", "foo"),
+        mkVar("DVDI_VOLUME_DRIVER", "bar"),
+        mkVar("DVDI_VOLUME_OPTS", "size=1")
+      )
+    ),
+    TC(
+      EV("/path", EVI(Some(1L), "foo", "dvdi", Map(
+        "dvdi/driver" -> "bar",
+        "dvdi/size" -> "2"
+      )), Mode.RO),
+      Seq[Environment.Variable](),
+      Seq[Environment.Variable](
+        mkVar("DVDI_VOLUME_CONTAINERPATH", "/path"),
+        mkVar("DVDI_VOLUME_NAME", "foo"),
+        mkVar("DVDI_VOLUME_DRIVER", "bar"),
+        mkVar("DVDI_VOLUME_OPTS", "size=1")
+      )
+    ),
+    TC(
+      EV("/path", EVI(None, "foo", "dvdi", Map(
+        "dvdi/driver" -> "bar",
+        "dvdi/size" -> "abc"
+      )), Mode.RO),
+      Seq[Environment.Variable](),
+      Seq[Environment.Variable](
+        mkVar("DVDI_VOLUME_CONTAINERPATH", "/path"),
+        mkVar("DVDI_VOLUME_NAME", "foo"),
+        mkVar("DVDI_VOLUME_DRIVER", "bar"),
+        mkVar("DVDI_VOLUME_OPTS", "size=abc")
+      )
+    ),
+    TC(
+      EV("/path", EVI(None, "foo", "dvdi", Map("dvdi/driver" -> "bar")), Mode.RO),
+      Seq[Environment.Variable](
+        mkVar("DVDI_VOLUME_CONTAINERPATH0", "/tmp"),
+        mkVar("DVDI_VOLUME_NAME0", "qaz"),
+        mkVar("DVDI_VOLUME_DRIVER0", "wsx")
+      ),
+      Seq[Environment.Variable](
+        mkVar("DVDI_VOLUME_CONTAINERPATH1", "/path"),
+        mkVar("DVDI_VOLUME_NAME1", "foo"),
+        mkVar("DVDI_VOLUME_DRIVER1", "bar")
+      )
+    ),
+    TC(
+      EV("/path", EVI(None, "foo", "dvdi", Map("dvdi/driver" -> "bar")), Mode.RO),
+      Seq[Environment.Variable](
+        mkVar("DVDI_VOLUME_CONTAINERPATH", "/tmp"),
+        mkVar("DVDI_VOLUME_NAME", "qaz"),
+        mkVar("DVDI_VOLUME_DRIVER", "wsx")
+      ),
+      Seq[Environment.Variable](
+        mkVar("DVDI_VOLUME_CONTAINERPATH1", "/path"),
+        mkVar("DVDI_VOLUME_NAME1", "foo"),
+        mkVar("DVDI_VOLUME_DRIVER1", "bar")
+      )
+    ),
+    TC(
+      EV("/path", EVI(None, "foo", "dvdi", Map("dvdi/driver" -> "bar")), Mode.RO),
+      Seq[Environment.Variable](
+        mkVar("DVDI_VOLUME_CONTAINERPATH", "/tmp"),
+        mkVar("DVDI_VOLUME_NAME", "qaz"),
+        mkVar("DVDI_VOLUME_DRIVER", "wsx"),
+        mkVar("DVDI_VOLUME_CONTAINERPATH1", "/var"),
+        mkVar("DVDI_VOLUME_NAME1", "edc"),
+        mkVar("DVDI_VOLUME_DRIVER1", "rfv")
+      ),
+      Seq[Environment.Variable](
+        mkVar("DVDI_VOLUME_CONTAINERPATH2", "/path"),
+        mkVar("DVDI_VOLUME_NAME2", "foo"),
+        mkVar("DVDI_VOLUME_DRIVER2", "bar")
+      )
+    ) // TC
+  )
+  for ((tc, idx) <- ttVolumeToEnv.zipWithIndex) {
+    test(s"volumeToEnv $idx") {
+      assertResult(tc.wantsEnv, "generated environment vars don't match expectations") {
+        DVDIProvider.volumeToEnv(tc.pv, tc.env)
+      }
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
@@ -184,9 +184,9 @@ class ContainerTest extends MarathonSpec with Matchers {
   test("ToMesos") {
     val f = fixture()
     val proto = ContainerSerializer.toMesos(f.container)
+
     assert(mesos.ContainerInfo.Type.DOCKER == proto.getType)
     assert("group/image" == proto.getDocker.getImage)
-    assert(f.container.volumes == proto.getVolumesList.asScala.map(Volume(_)))
     assert(proto.getDocker.hasForcePullImage)
     assert(f.container.docker.get.forcePullImage == proto.getDocker.getForcePullImage)
 


### PR DESCRIPTION
Based on https://github.com/mesosphere/marathon/pull/3525, squashed and rebased.

TODO:

* [x] "providerName" to "provider" in the protobufs
* [ ] docs in #3607 
  - upgradeStrategy requirements should be doc'd
  - prohibited chars for option values (as enforced by EMC mesos isolator)
* [x] restructuring to impl/providers, etc as per @kolloch
  - left top-level traits in top-level package because it doesn't make sense to expose lower level interfaces in a higher level package
* [x] wrap complex validators with `valid(...)` to get proper error messages 
* [x] use `container.volumes is every(valid(someValidator))` to get `volume(x)` indices in failure msg