### PR TITLE
External Volumes refactorings

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
@@ -89,7 +89,7 @@ object ExternalVolumeInfoSerializer {
   def toProto(info: ExternalVolumeInfo): Protos.Volume.ExternalVolumeInfo = {
     val builder = Protos.Volume.ExternalVolumeInfo.newBuilder()
       .setName(info.name)
-      .setProviderName(info.providerName)
+      .setProviderName(info.provider)
 
     info.size.foreach(builder.setSize)
     info.options.map{

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/providers/Helpers.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/providers/Helpers.scala
@@ -2,25 +2,9 @@ package mesosphere.marathon.core.externalvolume.providers
 
 import com.wix.accord._
 import com.wix.accord.dsl._
-import mesosphere.marathon.core.externalvolume._
 import mesosphere.marathon.state._
 
 import scala.util.Try
-
-protected[externalvolume] abstract class AbstractExternalVolumeProvider(
-    val name: String) extends ExternalVolumeProvider {
-  /**
-    * @return true if volume has a provider name that matches ours exactly
-    */
-  def accepts(volume: ExternalVolume): Boolean = {
-    volume.external.providerName == name
-  }
-
-  def collect(container: Container): Iterable[ExternalVolume] =
-    container.volumes.collect{
-      case vol: ExternalVolume if accepts(vol) => vol
-    }
-}
 
 protected[providers] object OptionSupport {
   import OptionLabelPatterns._

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -223,7 +223,7 @@ object Group {
 
   implicit val validRootGroup: Validator[Group] = new Validator[Group] {
     override def apply(group: Group): Result = {
-      group is VolumesModule.validGroup
+      group is VolumesModule.validRootGroup
       validate(group)(validator =
         validNestedGroup(PathId.empty))
     }

--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -171,13 +171,13 @@ object PersistentVolume {
   *
   * @param size absolute size of the volume (MB)
   * @param name identifies the volume within the context of the storage provider.
-  * @param providerName identifies the storage provider responsible for volume lifecycle operations.
+  * @param provider identifies the storage provider responsible for volume lifecycle operations.
   * @param options contains storage provider-specific configuration configuration
   */
 case class ExternalVolumeInfo(
   size: Option[Long] = None,
   name: String,
-  providerName: String,
+  provider: String,
   options: Map[String, String] = Map.empty[String, String])
 
 object OptionLabelPatterns {
@@ -198,7 +198,7 @@ object ExternalVolumeInfo {
   implicit val validExternalVolumeInfo = validator[ExternalVolumeInfo] { info =>
     info.size.each should be > 0L
     info.name should matchRegex(LabelRegex)
-    info.providerName should matchRegex(LabelRegex)
+    info.provider should matchRegex(LabelRegex)
     info.options is valid(validOptions)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/providers/DVDITest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/providers/DVDITest.scala
@@ -68,7 +68,7 @@ class DVDIProvider_VolumeValidationTest extends MarathonSpec with Matchers with 
   )
   for ((tc, idx) <- ttValidateVolume.zipWithIndex; (v, vidx) <- tc.volumes.zipWithIndex) {
     test(s"validExternalVolume $idx,$vidx") {
-      val result = validate(v)(DVDIProvider.volumeValidation)
+      val result = validate(v)(DVDIProvider.validations.volume)
       assert(result.isSuccess == tc.wantsValid,
         s"test case $idx/$vidx expected ${tc.wantsValid} instead of $result for volume $v")
     }

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -312,12 +312,12 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
           volumes = Seq[Volume](
             ExternalVolume("/container/path", ExternalVolumeInfo(
               name = "namedFoo",
-              providerName = "dvdi",
+              provider = "dvdi",
               options = Map[String, String]("dvdi/driver" -> "bar")
             ), MesosProtos.Volume.Mode.RW),
             ExternalVolume("/container/path2", ExternalVolumeInfo(
               name = "namedEdc",
-              providerName = "dvdi",
+              provider = "dvdi",
               options = Map[String, String]("dvdi/driver" -> "ert")
             ), MesosProtos.Volume.Mode.RO)
           )
@@ -365,13 +365,13 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
           volumes = Seq[Volume](
             ExternalVolume("/container/path", ExternalVolumeInfo(
               name = "namedFoo",
-              providerName = "dvdi",
+              provider = "dvdi",
               options = Map[String, String]("dvdi/driver" -> "bar")
             ), MesosProtos.Volume.Mode.RW),
             ExternalVolume("/container/path2", ExternalVolumeInfo(
               size = Some(2L),
               name = "namedEdc",
-              providerName = "dvdi",
+              provider = "dvdi",
               options = Map[String, String]("dvdi/driver" -> "ert")
             ), MesosProtos.Volume.Mode.RW)
           )


### PR DESCRIPTION
* s/provider/providerName/
* extracted ExternalVolumeValidations, refactored them somewhat but
  they can obviously be simplified a lot further
* made it more obvious what the API of an object is and what
  is implementation
* s/validGroup/validRootGroup/
* filter providers for app validation