### PR TITLE
Resolves #3673 by only considering unreserved resources

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerConfig
 import mesosphere.marathon.core.plugin.PluginManagerConfiguration
 import mesosphere.marathon.core.task.tracker.TaskTrackerConfig
 import mesosphere.marathon.core.task.update.TaskStatusUpdateConfig
+import mesosphere.marathon.state.ResourceRole
 import mesosphere.marathon.upgrade.UpgradeConfig
 import org.rogach.scallop.ScallopConf
 import scala.sys.SystemProperties
@@ -129,8 +130,8 @@ trait MarathonConf
     default = None)
 
   def expectedResourceRoles: Set[String] = mesosRole.get match {
-    case Some(role) => Set(role, "*")
-    case None       => Set("*")
+    case Some(role) => Set(role, ResourceRole.Unreserved)
+    case None       => Set(ResourceRole.Unreserved)
   }
 
   lazy val defaultAcceptedResourceRolesSet = defaultAcceptedResourceRoles.get.getOrElse(expectedResourceRoles)

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
@@ -110,12 +110,12 @@ class TaskOpFactoryImpl @Inject() (
 
     def maybeReserveAndCreateVolumes = if (needToReserve) {
       val configuredRoles = app.acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet)
-      if (configuredRoles != Set(ResourceRole.Unreserved)) {
-        log.warn("Ignoring acceptedResourcesRoles for {}. Only unreserved resources can be reserved", app.id)
+      // We can only reserve unreserved resources
+      val rolesToConsider = Set(ResourceRole.Unreserved).intersect(configuredRoles)
+      if (configuredRoles.isEmpty) {
+        log.warn(s"Will never match for ${app.id} as the app is configured to only accept $configuredRoles")
       }
 
-      // We can only reserve resources that are unreserved, which means they are applicable only for role(*)
-      val rolesToConsider = Set(ResourceRole.Unreserved)
       val matchingResourcesForReservation =
         ResourceMatcher.matchResources(
           offer, app, tasks.values,

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -551,6 +551,7 @@ object AppDefinition {
     appDef must complyWithSingleInstanceLabelRules
     appDef must complyWithReadinessCheckRules
     appDef must complyWithUpgradeStrategyRules
+    (appDef.isResident is false) or (appDef.acceptedResourceRoles is empty)
   } and ExternalVolumes.validApp
 
   /**

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -546,12 +546,12 @@ object AppDefinition {
     appDef.cpus should be >= 0.0
     appDef.instances should be >= 0
     appDef.disk should be >= 0.0
+    appDef must complyWithResourceRoleRules
     appDef must complyWithResidencyRules
     appDef must complyWithMigrationAPI
     appDef must complyWithSingleInstanceLabelRules
     appDef must complyWithReadinessCheckRules
     appDef must complyWithUpgradeStrategyRules
-    (appDef.isResident is false) or (appDef.acceptedResourceRoles is empty)
   } and ExternalVolumes.validApp
 
   /**
@@ -580,6 +580,12 @@ object AppDefinition {
   private val complyWithResidencyRules: Validator[AppDefinition] =
     isTrue("AppDefinition must contain persistent volumes and define residency") { app =>
       !(app.residency.isDefined ^ app.persistentVolumes.nonEmpty)
+    }
+
+  private val complyWithResourceRoleRules: Validator[AppDefinition] =
+    isTrue("""Resident apps may not define acceptedResourceRoles other than "*" (unreserved resources)""") { app =>
+      def hasResidencyCompatibleRoles = app.acceptedResourceRoles.fold(true)(_ == Set(ResourceRole.Unreserved))
+      !app.isResident || hasResidencyCompatibleRoles
     }
 
   private val containsCmdArgsOrContainer: Validator[AppDefinition] =

--- a/src/main/scala/mesosphere/marathon/state/ResourceRole.scala
+++ b/src/main/scala/mesosphere/marathon/state/ResourceRole.scala
@@ -1,0 +1,5 @@
+package mesosphere.marathon.state
+
+object ResourceRole {
+  val Unreserved = "*"
+}

--- a/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.tasks
 
-import mesosphere.marathon.state.{ AppDefinition, Container }
+import mesosphere.marathon.state.{ ResourceRole, AppDefinition, Container }
 import mesosphere.marathon.state.Container.Docker.PortMapping
 import mesosphere.marathon.tasks.PortsMatcher.PortWithRole
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
@@ -30,7 +30,7 @@ case class PortsMatch(hostPortsWithRole: Seq[PortWithRole]) {
 class PortsMatcher(
   app: AppDefinition,
   offer: MesosProtos.Offer,
-  resourceSelector: ResourceSelector = ResourceSelector(Set("*"), reserved = false),
+  resourceSelector: ResourceSelector = ResourceSelector(Set(ResourceRole.Unreserved), reserved = false),
   random: Random = Random)
     extends Logging {
 

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -73,8 +73,9 @@ object ResourceMatcher {
   }
 
   object ResourceSelector {
-    /** Match unreserved resources of role '*' (the default role) */
-    def wildcard: ResourceSelector = ResourceSelector(Set("*"), reserved = false)
+    val NoRole = Set("*")
+    /** Match unreserved resources for which role == '*' applies (default) */
+    def wildcard: ResourceSelector = ResourceSelector(NoRole, reserved = false)
   }
 
   /**

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -2,7 +2,7 @@ package mesosphere.mesos
 
 import mesosphere.marathon.core.launcher.impl.ResourceLabels
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.{ AppDefinition, Container }
+import mesosphere.marathon.state.{ AppDefinition, Container, ResourceRole }
 import mesosphere.marathon.tasks.{ PortsMatch, PortsMatcher }
 import mesosphere.mesos.protos.{ ScalarResource, RangesResource, Resource }
 import org.apache.mesos.Protos
@@ -73,7 +73,7 @@ object ResourceMatcher {
   }
 
   object ResourceSelector {
-    val NoRole = Set("*")
+    val NoRole = Set(ResourceRole.Unreserved)
     /** Match unreserved resources for which role == '*' applies (default) */
     def wildcard: ResourceSelector = ResourceSelector(NoRole, reserved = false)
   }

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -2,9 +2,9 @@ package mesosphere.mesos
 
 import mesosphere.marathon.core.launcher.impl.ResourceLabels
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.{ AppDefinition, Container, ResourceRole }
+import mesosphere.marathon.state.{ AppDefinition, ResourceRole }
 import mesosphere.marathon.tasks.{ PortsMatch, PortsMatcher }
-import mesosphere.mesos.protos.{ ScalarResource, RangesResource, Resource }
+import mesosphere.mesos.protos.Resource
 import org.apache.mesos.Protos
 import org.apache.mesos.Protos.Offer
 import org.slf4j.LoggerFactory
@@ -73,9 +73,8 @@ object ResourceMatcher {
   }
 
   object ResourceSelector {
-    val NoRole = Set(ResourceRole.Unreserved)
     /** Match unreserved resources for which role == '*' applies (default) */
-    def wildcard: ResourceSelector = ResourceSelector(NoRole, reserved = false)
+    def wildcard: ResourceSelector = ResourceSelector(Set(ResourceRole.Unreserved), reserved = false)
   }
 
   /**

--- a/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
@@ -1,5 +1,6 @@
 package mesosphere.marathon
 
+import mesosphere.marathon.state.ResourceRole
 import org.scalatest.Matchers
 
 import scala.util.{ Failure, Try }
@@ -88,7 +89,7 @@ class MarathonConfTest extends MarathonSpec with Matchers {
       "--default_accepted_resource_roles", "*,marathon"
     )
 
-    assert(conf.defaultAcceptedResourceRolesSet == Set("*", "marathon"))
+    assert(conf.defaultAcceptedResourceRolesSet == Set(ResourceRole.Unreserved, "marathon"))
   }
 
   test("--default_accepted_resource_roles *") {
@@ -96,14 +97,14 @@ class MarathonConfTest extends MarathonSpec with Matchers {
       "--master", "127.0.0.1:5050",
       "--default_accepted_resource_roles", "*"
     )
-    assert(conf.defaultAcceptedResourceRolesSet == Set("*"))
+    assert(conf.defaultAcceptedResourceRolesSet == Set(ResourceRole.Unreserved))
   }
 
   test("--default_accepted_resource_roles default without --mesos_role") {
     val conf = MarathonTestHelper.makeConfig(
       "--master", "127.0.0.1:5050"
     )
-    assert(conf.defaultAcceptedResourceRolesSet == Set("*"))
+    assert(conf.defaultAcceptedResourceRolesSet == Set(ResourceRole.Unreserved))
   }
 
   test("--default_accepted_resource_roles default with --mesos_role") {
@@ -111,7 +112,7 @@ class MarathonConfTest extends MarathonSpec with Matchers {
       "--master", "127.0.0.1:5050",
       "--mesos_role", "marathon"
     )
-    assert(conf.defaultAcceptedResourceRolesSet == Set("*", "marathon"))
+    assert(conf.defaultAcceptedResourceRolesSet == Set(ResourceRole.Unreserved, "marathon"))
   }
 
   test("Features should be empty by default") {

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -70,10 +70,10 @@ object MarathonTestHelper {
   val frameworkId: FrameworkId = FrameworkId("").mergeFromProto(frameworkID)
 
   def makeBasicOffer(cpus: Double = 4.0, mem: Double = 16000, disk: Double = 1.0,
-                     beginPort: Int = 31000, endPort: Int = 32000, role: String = "*",
+                     beginPort: Int = 31000, endPort: Int = 32000, role: String = ResourceRole.Unreserved,
                      reservation: Option[ResourceLabels] = None): Offer.Builder = {
 
-    require(role != "*" || reservation.isEmpty, "reserved resources cannot have role *")
+    require(role != ResourceRole.Unreserved || reservation.isEmpty, "reserved resources cannot have role *")
 
     def heedReserved(resource: Mesos.Resource): Mesos.Resource = {
       reservation match {
@@ -117,7 +117,7 @@ object MarathonTestHelper {
   }
 
   def scalarResource(
-    name: String, d: Double, role: String = "*",
+    name: String, d: Double, role: String = ResourceRole.Unreserved,
     reservation: Option[ReservationInfo] = None, disk: Option[DiskInfo] = None): Mesos.Resource = {
 
     val builder = Mesos.Resource
@@ -134,7 +134,7 @@ object MarathonTestHelper {
   }
 
   def portsResource(
-    begin: Long, end: Long, role: String = "*",
+    begin: Long, end: Long, role: String = ResourceRole.Unreserved,
     reservation: Option[ReservationInfo] = None): Mesos.Resource = {
 
     val ranges = Mesos.Value.Ranges.newBuilder()
@@ -165,7 +165,7 @@ object MarathonTestHelper {
       .build()
   }
 
-  def reservedDisk(id: String, size: Double = 4096, role: String = "*",
+  def reservedDisk(id: String, size: Double = 4096, role: String = ResourceRole.Unreserved,
                    principal: String = "test", containerPath: String = "/container"): Mesos.Resource.Builder = {
     import Mesos.Resource.{ DiskInfo, ReservationInfo }
     Mesos.Resource.newBuilder()
@@ -188,7 +188,7 @@ object MarathonTestHelper {
     * @return
     */
   def makeBasicOfferWithManyPortRanges(ranges: Int): Offer.Builder = {
-    val role = "*"
+    val role = ResourceRole.Unreserved
     val cpusResource = ScalarResource(Resource.CPUS, 4.0, role = role)
     val memResource = ScalarResource(Resource.MEM, 16000, role = role)
     val diskResource = ScalarResource(Resource.DISK, 1.0, role = role)
@@ -238,7 +238,7 @@ object MarathonTestHelper {
       .setTaskId(TaskID.newBuilder().setValue(taskId).build())
       .setSlaveId(SlaveID("slave1"))
       .setCommand(CommandInfo.newBuilder().setShell(true).addArguments("true"))
-      .addResources(ScalarResource(Resource.CPUS, 1.0, "*"))
+      .addResources(ScalarResource(Resource.CPUS, 1.0, ResourceRole.Unreserved))
   }
 
   def makeTaskFromTaskInfo(taskInfo: TaskInfo,

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -167,13 +167,13 @@ class AppDefinitionFormatsTest
   test("""FromJSON should parse "acceptedResourceRoles": ["production", "*"] """) {
     val json = Json.parse(""" { "id": "test", "acceptedResourceRoles": ["production", "*"] }""")
     val appDef = json.as[AppDefinition]
-    appDef.acceptedResourceRoles should equal(Some(Set("production", "*")))
+    appDef.acceptedResourceRoles should equal(Some(Set("production", ResourceRole.Unreserved)))
   }
 
   test("""FromJSON should parse "acceptedResourceRoles": ["*"] """) {
     val json = Json.parse(""" { "id": "test", "acceptedResourceRoles": ["*"] }""")
     val appDef = json.as[AppDefinition]
-    appDef.acceptedResourceRoles should equal(Some(Set("*")))
+    appDef.acceptedResourceRoles should equal(Some(Set(ResourceRole.Unreserved)))
   }
 
   test("FromJSON should fail when 'acceptedResourceRoles' is defined but empty") {

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.api.v2.json
 
 import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.state.ResourceRole
 import org.scalatest.Matchers
 import play.api.libs.json.{ JsResultException, Json }
 
@@ -28,13 +29,13 @@ class AppUpdateFormatTest extends MarathonSpec with Matchers {
   test("""FromJSON should parse "acceptedResourceRoles": ["production", "*"] """) {
     val json = Json.parse(""" { "id": "test", "acceptedResourceRoles": ["production", "*"] }""")
     val appUpdate = json.as[AppUpdate]
-    appUpdate.acceptedResourceRoles should equal(Some(Set("production", "*")))
+    appUpdate.acceptedResourceRoles should equal(Some(Set("production", ResourceRole.Unreserved)))
   }
 
   test("""FromJSON should parse "acceptedResourceRoles": ["*"] """) {
     val json = Json.parse(""" { "id": "test", "acceptedResourceRoles": ["*"] }""")
     val appUpdate = json.as[AppUpdate]
-    appUpdate.acceptedResourceRoles should equal(Some(Set("*")))
+    appUpdate.acceptedResourceRoles should equal(Some(Set(ResourceRole.Unreserved)))
   }
 
   test("FromJSON should fail when 'acceptedResourceRoles' is defined but empty") {

--- a/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidatorTest.scala
@@ -160,7 +160,7 @@ class AppDefinitionValidatorTest extends MarathonSpec with Matchers with GivenWh
     val app = AppDefinition(
       id = PathId("/test"),
       cmd = Some("true"),
-      acceptedResourceRoles = Some(Set("*")))
+      acceptedResourceRoles = Some(Set(ResourceRole.Unreserved)))
     assert(validate(app).isSuccess)
     MarathonTestHelper.validateJsonSchema(app)
   }
@@ -169,7 +169,7 @@ class AppDefinitionValidatorTest extends MarathonSpec with Matchers with GivenWh
     val app = AppDefinition(
       id = PathId("/test"),
       cmd = Some("true"),
-      acceptedResourceRoles = Some(Set("*", "production")))
+      acceptedResourceRoles = Some(Set(ResourceRole.Unreserved, "production")))
     assert(validate(app).isSuccess)
     MarathonTestHelper.validateJsonSchema(app)
   }

--- a/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidatorTest.scala
@@ -540,6 +540,23 @@ class AppDefinitionValidatorTest extends MarathonSpec with Matchers with GivenWh
     AppDefinition.validAppDefinition(app).isFailure shouldBe true
   }
 
+  test("Resident app may not define acceptedResourceRoles") {
+    Given("A resident app definition")
+    val f = new Fixture
+    val from = f.validResident
+    AllConf.SuppliedOptionNames = Set("mesos_authentication_principal", "mesos_role", "mesos_authentication_secret_file")
+
+    When("validating with acceptedResourceRoles")
+    val to1 = from.copy(acceptedResourceRoles = Some(Set("foo")))
+    Then("Should be invalid")
+    AppDefinition.validAppDefinition(to1).isSuccess shouldBe false
+
+    When("validating without acceptedResourceRoles")
+    val to2 = from.copy(acceptedResourceRoles = None)
+    Then("Should be valid")
+    AppDefinition.validAppDefinition(to2).isSuccess shouldBe true
+  }
+
   class Fixture {
     def validDockerContainer: Container = Container(
       `type` = mesos.ContainerInfo.Type.DOCKER,

--- a/src/test/scala/mesosphere/marathon/tasks/PortWithRoleCreatePortsResourcesTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortWithRoleCreatePortsResourcesTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.tasks
 
 import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.state.ResourceRole
 import mesosphere.marathon.tasks.PortsMatcher.PortWithRole
 import mesosphere.mesos.protos.{ Resource, RangesResource, Range }
 import scala.collection.immutable.Seq
@@ -13,49 +14,49 @@ class PortWithRoleCreatePortsResourcesTest extends MarathonSpec {
   }
 
   test("create ranges resource for single port preserving role") {
-    val result = PortWithRole.createPortsResources(Seq(PortWithRole("*", 2)))
-    assert(result == Seq(rangesResource(Seq(Range(2, 2)), role = "*")))
+    val result = PortWithRole.createPortsResources(Seq(PortWithRole(ResourceRole.Unreserved, 2)))
+    assert(result == Seq(rangesResource(Seq(Range(2, 2)), role = ResourceRole.Unreserved)))
     val result2 = PortWithRole.createPortsResources(Seq(PortWithRole("marathon", 3)))
     assert(result2 == Seq(rangesResource(Seq(Range(3, 3)), role = "marathon")))
   }
 
   test("one ranges resource for multiple ports of the same role") {
-    val result = PortWithRole.createPortsResources(Seq(PortWithRole("*", 2), PortWithRole("*", 10)))
-    assert(result == Seq(rangesResource(Seq(Range(2, 2), Range(10, 10)), role = "*")))
+    val result = PortWithRole.createPortsResources(Seq(PortWithRole(ResourceRole.Unreserved, 2), PortWithRole(ResourceRole.Unreserved, 10)))
+    assert(result == Seq(rangesResource(Seq(Range(2, 2), Range(10, 10)), role = ResourceRole.Unreserved)))
   }
 
   test("one ranges resource for consecutive multiple ports of the same role") {
     val result = PortWithRole.createPortsResources(Seq(
-      PortWithRole("*", 2), PortWithRole("*", 10),
+      PortWithRole(ResourceRole.Unreserved, 2), PortWithRole(ResourceRole.Unreserved, 10),
       PortWithRole("marathon", 11),
-      PortWithRole("*", 12)
+      PortWithRole(ResourceRole.Unreserved, 12)
     ))
     assert(result == Seq(
-      rangesResource(Seq(Range(2, 2), Range(10, 10)), role = "*"),
+      rangesResource(Seq(Range(2, 2), Range(10, 10)), role = ResourceRole.Unreserved),
       rangesResource(Seq(Range(11, 11)), role = "marathon"),
-      rangesResource(Seq(Range(12, 12)), role = "*")
+      rangesResource(Seq(Range(12, 12)), role = ResourceRole.Unreserved)
     ))
   }
 
   test("combined consecutive ports of same role into one range") {
     val result = PortWithRole.createPortsResources(Seq(
-      PortWithRole("*", 2), PortWithRole("*", 3)
+      PortWithRole(ResourceRole.Unreserved, 2), PortWithRole(ResourceRole.Unreserved, 3)
     ))
     assert(result == Seq(
-      rangesResource(Seq(Range(2, 3)), role = "*")
+      rangesResource(Seq(Range(2, 3)), role = ResourceRole.Unreserved)
     ))
   }
 
   test("complex example") {
     val result = PortWithRole.createPortsResources(Seq(
-      PortWithRole("*", 2), PortWithRole("*", 3), PortWithRole("*", 10),
+      PortWithRole(ResourceRole.Unreserved, 2), PortWithRole(ResourceRole.Unreserved, 3), PortWithRole(ResourceRole.Unreserved, 10),
       PortWithRole("marathon", 11),
-      PortWithRole("*", 12)
+      PortWithRole(ResourceRole.Unreserved, 12)
     ))
     assert(result == Seq(
-      rangesResource(Seq(Range(2, 3), Range(10, 10)), role = "*"),
+      rangesResource(Seq(Range(2, 3), Range(10, 10)), role = ResourceRole.Unreserved),
       rangesResource(Seq(Range(11, 11)), role = "marathon"),
-      rangesResource(Seq(Range(12, 12)), role = "*")
+      rangesResource(Seq(Range(12, 12)), role = ResourceRole.Unreserved)
     ))
   }
 

--- a/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.tasks
 import java.util
 
 import mesosphere.marathon.state.Container.Docker
-import mesosphere.marathon.state.{ AppDefinition, Container, PortDefinitions }
+import mesosphere.marathon.state.{ ResourceRole, AppDefinition, Container, PortDefinitions }
 import mesosphere.marathon.tasks.PortsMatcher.PortWithRole
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
@@ -26,7 +26,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
 
     assert(matcher.portsMatch.isDefined)
     assert(2 == matcher.portsMatch.get.hostPorts.size)
-    assert(matcher.portsMatch.get.resources.map(_.getRole) == Seq("*"))
+    assert(matcher.portsMatch.get.resources.map(_.getRole) == Seq(ResourceRole.Unreserved))
   }
 
   test("get ports from multiple ranges") {
@@ -46,7 +46,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
 
     assert(matcher.portsMatch.isDefined)
     assert(5 == matcher.portsMatch.get.hostPorts.size)
-    assert(matcher.portsMatch.get.resources.map(_.getRole) == Seq("*"))
+    assert(matcher.portsMatch.get.resources.map(_.getRole) == Seq(ResourceRole.Unreserved))
   }
 
   test("get ports from multiple ranges, requirePorts") {
@@ -66,7 +66,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
 
     assert(matcher.portsMatch.isDefined)
     assert(matcher.portsMatch.get.hostPorts == Seq(80, 81, 82, 83, 100))
-    assert(matcher.portsMatch.get.resources.map(_.getRole) == Seq("*"))
+    assert(matcher.portsMatch.get.resources.map(_.getRole) == Seq(ResourceRole.Unreserved))
   }
 
   // #2865 Multiple explicit ports are mixed up in task json
@@ -98,11 +98,11 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
       .addResources(portsResource)
       .addResources(portsResource2)
       .build
-    val matcher = new PortsMatcher(app, offer, resourceSelector = ResourceSelector(Set("*", "marathon"), reserved = false))
+    val matcher = new PortsMatcher(app, offer, resourceSelector = ResourceSelector(Set(ResourceRole.Unreserved, "marathon"), reserved = false))
 
     assert(matcher.portsMatch.isDefined)
     assert(5 == matcher.portsMatch.get.hostPorts.size)
-    assert(matcher.portsMatch.get.resources.map(_.getRole).to[Set] == Set("*", "marathon"))
+    assert(matcher.portsMatch.get.resources.map(_.getRole).to[Set] == Set(ResourceRole.Unreserved, "marathon"))
   }
 
   test("get ports from multiple ranges, ignore ranges with unwanted roles") {
@@ -315,12 +315,12 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
     )
 
     val offer = MarathonTestHelper.makeBasicOffer(beginPort = 31000, endPort = 31000).addResources(portsResource).build
-    val matcher = new PortsMatcher(app, offer, resourceSelector = ResourceSelector(Set("*", "marathon"), reserved = false))
+    val matcher = new PortsMatcher(app, offer, resourceSelector = ResourceSelector(Set(ResourceRole.Unreserved, "marathon"), reserved = false))
 
     assert(matcher.portsMatch.isDefined)
     assert(matcher.portsMatch.get.hostPorts.toSet == Set(31000, 31001))
     assert(matcher.portsMatch.get.hostPortsWithRole.toSet == Set(
-      PortWithRole("*", 31000), PortWithRole("marathon", 31001)
+      PortWithRole(ResourceRole.Unreserved, 31000), PortWithRole("marathon", 31001)
     ))
   }
 }

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -252,7 +252,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     assert(resource("disk") == ScalarResource("disk", 1))
     val portsResource: Resource = resource("ports")
     assert(portsResource.getRanges.getRangeList.asScala.map(range => range.getEnd - range.getBegin + 1).sum == 2)
-    assert(portsResource.getRole == "*")
+    assert(portsResource.getRole == ResourceRole.Unreserved)
   }
 
   // #1583 Do not pass zero disk resource shares to Mesos
@@ -292,7 +292,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
         portDefinitions = PortDefinitions(8080, 8081)
       ),
       mesosRole = Some("marathon"),
-      acceptedResourceRoles = Some(Set("*", "marathon"))
+      acceptedResourceRoles = Some(Set(ResourceRole.Unreserved, "marathon"))
     )
 
     val Some((taskInfo, _)) = task
@@ -547,7 +547,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     assert(cmd.getArgumentsList.asScala == Seq("a", "b", "c"))
 
     for (r <- taskInfo.getResourcesList.asScala) {
-      assert("*" == r.getRole)
+      assert(ResourceRole.Unreserved == r.getRole)
     }
 
     // TODO test for resources etc.
@@ -787,9 +787,9 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
 
   test("BuildIfMatchesWithRole") {
     val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = "marathon")
-      .addResources(ScalarResource("cpus", 1, "*"))
-      .addResources(ScalarResource("mem", 128, "*"))
-      .addResources(ScalarResource("disk", 1000, "*"))
+      .addResources(ScalarResource("cpus", 1, ResourceRole.Unreserved))
+      .addResources(ScalarResource("mem", 128, ResourceRole.Unreserved))
+      .addResources(ScalarResource("disk", 1000, ResourceRole.Unreserved))
       .addResources(ScalarResource("cpus", 2, "marathon"))
       .addResources(ScalarResource("mem", 256, "marathon"))
       .addResources(ScalarResource("disk", 2000, "marathon"))
@@ -827,10 +827,10 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
   }
 
   test("BuildIfMatchesWithRole2") {
-    val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = "*")
-      .addResources(ScalarResource("cpus", 1, "*"))
-      .addResources(ScalarResource("mem", 128, "*"))
-      .addResources(ScalarResource("disk", 1000, "*"))
+    val offer = MarathonTestHelper.makeBasicOfferWithRole(cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved)
+      .addResources(ScalarResource("cpus", 1, ResourceRole.Unreserved))
+      .addResources(ScalarResource("mem", 128, ResourceRole.Unreserved))
+      .addResources(ScalarResource("disk", 1000, ResourceRole.Unreserved))
       .addResources(ScalarResource("cpus", 2, "marathon"))
       .addResources(ScalarResource("mem", 256, "marathon"))
       .addResources(ScalarResource("disk", 2000, "marathon"))
@@ -860,7 +860,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
 
     // In this case, the first roles are sufficient so we'll use those first.
     for (r <- taskInfo.getResourcesList.asScala) {
-      assert("*" == r.getRole)
+      assert(ResourceRole.Unreserved == r.getRole)
     }
 
     // TODO test for resources etc.
@@ -868,7 +868,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
 
   test("PortMappingsWithZeroContainerPort") {
     val offer = MarathonTestHelper.makeBasicOfferWithRole(
-      cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31000, role = "*"
+      cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 31000, role = ResourceRole.Unreserved
     )
       .addResources(RangesResource(Resource.PORTS, Seq(protos.Range(33000, 34000)), "marathon"))
       .build
@@ -1445,7 +1445,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     assert(exposesSecondPort)
 
     for (r <- taskInfo.getResourcesList.asScala) {
-      assert("*" == r.getRole)
+      assert(ResourceRole.Unreserved == r.getRole)
     }
 
     assert(taskInfo.hasDiscovery)


### PR DESCRIPTION
for reserve/create operations.

Resources that are already associated with a role (are already reserved) cannot be reserved again. Marathon will now only consider unreserved resources when trying to reserve them for resident tasks. As a result, it makes no sense to define acceptedResourceRoles for resident apps, which is now prevented using a validator.