### PR TITLE
Fixes #3664 - default upgradeStrategy and residency for persistent volumes

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -216,7 +216,7 @@ class AppsResource @Inject() (
                              appUpdate: AppUpdate,
                              newVersion: Timestamp)(implicit identity: Identity): AppDefinition = {
     def createApp(): AppDefinition = {
-      val app = validateOrThrow(appUpdate(AppDefinition(appId)))
+      val app = validateOrThrow(appUpdate.empty(appId))
       checkAuthorization(CreateApp, app)
     }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -298,4 +298,62 @@ class AppUpdateTest extends MarathonSpec {
 
     assert(updated.readinessChecks == update.readinessChecks.get)
   }
+
+  test("empty app updateStrategy") {
+    val json =
+      """
+      {
+        "cmd": "sleep 1000",
+        "container": {
+          "type": "MESOS",
+          "volumes": [
+            {
+              "containerPath": "home",
+              "mode": "RW",
+              "persistent": {
+                "size": 100
+                }
+              }]
+        },
+        "residency": {
+          "relaunchEscalationTimeoutSeconds": 10,
+          "taskLostBehavior": "WAIT_FOREVER"
+        }
+      }
+      """
+
+    val update = fromJsonString(json)
+    val strategy = update.empty("foo".toPath).upgradeStrategy
+    assert(strategy.minimumHealthCapacity == 0.5
+      && strategy.maximumOverCapacity == 0)
+  }
+
+  test("empty app residency") {
+    val json =
+      """
+      {
+        "cmd": "sleep 1000",
+        "container": {
+          "type": "MESOS",
+          "volumes": [
+            {
+              "containerPath": "home",
+              "mode": "RW",
+              "persistent": {
+                "size": 100
+                }
+              }]
+        },
+        "upgradeStrategy": {
+          "minimumHealthCapacity": 0.2,
+          "maximumOverCapacity": 0
+        }
+      }
+      """
+
+    val update = fromJsonString(json)
+    val residency = update.empty("foo".toPath).residency
+    assert(residency.isDefined)
+    assert(residency.forall(_ == Residency.defaultResidency))
+  }
 }


### PR DESCRIPTION
As described in #3664 a PUT on a non-existing resident app would cause a validation error due to missing upgradeStrategy and residency. 