### PR TITLE
Fixes #3699 - external volumes with update strategy

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
@@ -82,8 +82,11 @@ case class AppUpdate(
   }
 
   def empty(appId: PathId): AppDefinition = {
+    def volumes: Iterable[Volume] = container.fold(Seq.empty[Volume])(_.volumes)
+    def externalVolumes: Iterable[ExternalVolume] = volumes.collect { case vol: ExternalVolume => vol }
     val residency = if (persistentVolumes.nonEmpty) Some(Residency.defaultResidency) else None
-    val upgradeStrategy = if (residency.isDefined || isResident) UpgradeStrategy.forResidentTasks
+    val upgradeStrategy = if (residency.isDefined || isResident
+      || externalVolumes.nonEmpty) UpgradeStrategy.forResidentTasks
     else UpgradeStrategy.empty
     apply(AppDefinition(appId, residency = residency, upgradeStrategy = upgradeStrategy))
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -656,7 +656,9 @@ trait AppAndGroupFormats {
             readinessChecks: Seq[ReadinessCheck]) {
           def upgradeStrategyOrDefault: UpgradeStrategy = {
             import UpgradeStrategy.{ forResidentTasks, empty }
-            upgradeStrategy.getOrElse(if (residency.isDefined) forResidentTasks else empty)
+            upgradeStrategy.getOrElse {
+              if (residency.isDefined || app.externalVolumes.nonEmpty) forResidentTasks else empty
+            }
           }
           def residencyOrDefault: Option[Residency] = {
             residency.orElse(if (app.persistentVolumes.nonEmpty) Some(Residency.defaultResidency) else None)

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -299,6 +299,64 @@ class AppUpdateTest extends MarathonSpec {
     assert(updated.readinessChecks == update.readinessChecks.get)
   }
 
+  test("empty app updateStrategy on persistent volumes") {
+    val json =
+      """
+      {
+        "cmd": "sleep 1000",
+        "container": {
+          "type": "MESOS",
+          "volumes": [
+            {
+              "containerPath": "home",
+              "mode": "RW",
+              "persistent": {
+                "size": 100
+                }
+              }]
+        },
+        "residency": {
+          "relaunchEscalationTimeoutSeconds": 10,
+          "taskLostBehavior": "WAIT_FOREVER"
+        }
+      }
+      """
+
+    val update = fromJsonString(json)
+    val strategy = update.empty("foo".toPath).upgradeStrategy
+    assert(strategy.minimumHealthCapacity == 0.5
+      && strategy.maximumOverCapacity == 0)
+  }
+
+  test("empty app residency on persistent volumes") {
+    val json =
+      """
+      {
+        "cmd": "sleep 1000",
+        "container": {
+          "type": "MESOS",
+          "volumes": [
+            {
+              "containerPath": "home",
+              "mode": "RW",
+              "persistent": {
+                "size": 100
+                }
+              }]
+        },
+        "upgradeStrategy": {
+          "minimumHealthCapacity": 0.2,
+          "maximumOverCapacity": 0
+        }
+      }
+      """
+
+    val update = fromJsonString(json)
+    val residency = update.empty("foo".toPath).residency
+    assert(residency.isDefined)
+    assert(residency.forall(_ == Residency.defaultResidency))
+  }
+
   test("empty app updateStrategy") {
     val json =
       """
@@ -355,5 +413,31 @@ class AppUpdateTest extends MarathonSpec {
     val residency = update.empty("foo".toPath).residency
     assert(residency.isDefined)
     assert(residency.forall(_ == Residency.defaultResidency))
+  }
+
+  test("empty app update strategy on external volumes") {
+    val json =
+      """
+      {
+        "cmd": "sleep 1000",
+        "container": {
+          "type": "MESOS",
+          "volumes": [
+            {
+              "containerPath": "/docker_storage",
+              "mode": "RW",
+              "external": {
+                "name": "my-external-volume",
+                "provider": "dvdi",
+                "size": 1234
+                }
+              }]
+        }
+      }
+      """
+
+    val update = fromJsonString(json)
+    val strategy = update.empty("foo".toPath).upgradeStrategy
+    assert(strategy == UpgradeStrategy.forResidentTasks)
   }
 }


### PR DESCRIPTION
According to #3699 defined external volumes should also create a standard update strategy.