### PR TITLE
Fix offersWantedSubjects

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.core.matcher.manager.impl.{
   OfferMatcherManagerDelegate
 }
 import mesosphere.marathon.metrics.Metrics
-import rx.lang.scala.subjects.PublishSubject
+import rx.lang.scala.subjects.BehaviorSubject
 import rx.lang.scala.{ Observable, Subject }
 
 import scala.util.Random
@@ -25,7 +25,7 @@ class OfferMatcherManagerModule(
     offerMatcherConfig: OfferMatcherManagerConfig,
     leadershipModule: LeadershipModule) {
 
-  private[this] lazy val offersWanted: Subject[Boolean] = PublishSubject[Boolean]()
+  private[this] lazy val offersWanted: Subject[Boolean] = BehaviorSubject[Boolean](false)
 
   private[this] lazy val offerMatcherManagerMetrics = new OfferMatcherManagerActorMetrics(metrics)
 

--- a/src/main/scala/mesosphere/marathon/core/matcher/reconcile/OfferMatcherReconciliationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/reconcile/OfferMatcherReconciliationModule.scala
@@ -6,11 +6,11 @@ import mesosphere.marathon.core.flow.ReviveOffersConfig
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
-import mesosphere.marathon.core.matcher.reconcile.impl.{ OffersWantedForReconciliationActor, OfferMatcherReconciler }
+import mesosphere.marathon.core.matcher.reconcile.impl.{ OfferMatcherReconciler, OffersWantedForReconciliationActor }
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.state.GroupRepository
+import rx.lang.scala.subjects.BehaviorSubject
 import rx.lang.scala.{ Observable, Observer, Subject }
-import rx.lang.scala.subjects.PublishSubject
 
 class OfferMatcherReconciliationModule(
     reviveOffersConfig: ReviveOffersConfig,
@@ -28,7 +28,7 @@ class OfferMatcherReconciliationModule(
   /** Starts underlying actors etc. */
   def start(): Unit = offersWantedForReconciliationActor
 
-  private[this] lazy val offersWantedSubject: Subject[Boolean] = PublishSubject()
+  private[this] lazy val offersWantedSubject: Subject[Boolean] = BehaviorSubject(false)
   private[this] def offersWantedObserver: Observer[Boolean] = offersWantedSubject
 
   private[this] lazy val offersWantedForReconciliationActor = leadershipModule.startWhenLeader(


### PR DESCRIPTION
Make sure that the offersWantedSubjects always submit a
value on subscription. Otherwise, combineLatest in the
CoreModuleImpl will potentially subscribe after the
offerReconcilerActor emitted its signal.