### PR TITLE
Remove dependency of HealthCheckManager.add to the AppRepository

### DIFF
--- a/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
@@ -19,9 +19,9 @@ trait HealthCheckManager {
   def list(appId: PathId): Set[HealthCheck]
 
   /**
-    * Adds a health check for the app with the supplied id.
+    * Adds a health check of the supplied app.
     */
-  def add(appId: PathId, version: Timestamp, healthCheck: HealthCheck): Unit
+  def add(appDefinition: AppDefinition, healthCheck: HealthCheck): Unit
 
   /**
     * Adds all health checks for the supplied app.

--- a/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
@@ -109,12 +109,20 @@ class MarathonHealthCheckManagerTest
     }
   }
 
-  test("Add") {
+  test("Add for a known app") {
     val app: AppDefinition = AppDefinition(id = appId)
     appRepository.store(app).futureValue
 
     val healthCheck = HealthCheck()
-    hcManager.add(appId, app.version, healthCheck)
+    hcManager.add(app, healthCheck)
+    assert(hcManager.list(appId).size == 1)
+  }
+
+  test("Add for not-yet-known app") {
+    val app: AppDefinition = AppDefinition(id = appId)
+
+    val healthCheck = HealthCheck()
+    hcManager.add(app, healthCheck)
     assert(hcManager.list(appId).size == 1)
   }
 
@@ -133,7 +141,7 @@ class MarathonHealthCheckManagerTest
     taskCreationHandler.created(TaskStateOp.LaunchEphemeral(marathonTask)).futureValue
     stateOpProcessor.process(update).futureValue
 
-    hcManager.add(appId, app.version, healthCheck)
+    hcManager.add(app, healthCheck)
 
     val status1 = hcManager.status(appId, taskId).futureValue
     assert(status1 == Seq(Health(taskId)))
@@ -164,7 +172,7 @@ class MarathonHealthCheckManagerTest
     val version = app.version
 
     val healthCheck = HealthCheck(protocol = Protocol.COMMAND, gracePeriod = 0.seconds)
-    hcManager.add(appId, version, healthCheck)
+    hcManager.add(app, healthCheck)
 
     val task1 = makeRunningTask(appId, version)
     val task2 = makeRunningTask(appId, version)


### PR DESCRIPTION
This fixes a race of the HelathCheckManager expecting a given AppDefinition in the
AppRepository which is not always true (yet) when an app is launched.

This PR removes the dependency by passing in the known AppDefinition from addForAll,
not only the id and version.