### PR TITLE
change documentation from v0.16.0 -> v1.0.0

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -42,7 +42,7 @@ The core functionality flags can be also set by environment variable `MARATHON_O
     Requires checkpointing enabled on slaves. Allows tasks to continue running
     during mesos-slave restarts and Marathon scheduler failover.  See the
     description of `--failover_timeout`.
-* <span class="label label-default">v0.16.0</span> `--enable_features` (Optional. Default: None):
+* <span class="label label-default">v1.0.0</span> `--enable_features` (Optional. Default: None):
     Enable the selected features. Options to use:
     - "vips" can be used to enable the networking VIP integration UI.
     - "task_killing" can be used to enable the TASK_KILLING state in Mesos (0.28 or later)

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
@@ -142,7 +142,7 @@ The number of CPU`s this application needs per instance. This number does not ha
 The amount of memory in MB that is needed for the application per instance.
 
 ##### ports (Array of Integers)
-Since <span class="label label-default">v0.16.0</span>: __Deprecated__ . Use portDefinitions instead.
+Since <span class="label label-default">v1.0.0</span>: __Deprecated__ . Use portDefinitions instead.
 
 An array of required port resources on the host.
 
@@ -170,7 +170,7 @@ as well, see [Rethink ports API](https://github.com/mesosphere/marathon/issues/6
 
 ##### portsDefinitions (Array of Objects)
 
-Since <span class="label label-default">v0.16.0</span>:
+Since <span class="label label-default">v1.0.0</span>:
 
 An array of required port resources on the host.
 


### PR DESCRIPTION
Documentation says v0.16.0 which was bumped to v1.0.0