### PR TITLE
Makes headers case-insensitive again

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/RequestFacade.scala
+++ b/src/main/scala/mesosphere/marathon/api/RequestFacade.scala
@@ -10,11 +10,12 @@ class RequestFacade(request: HttpServletRequest, path: String) extends HttpReque
   def this(request: HttpServletRequest) = this(request, request.getRequestURI)
   // Jersey will not allow calls to the request object from another thread
   // To circumvent that, we have to copy all data during creation
-  val headers = request.getHeaderNames.asScala.map(header => header -> request.getHeaders(header).asScala.toSeq).toMap
+  val headers = request.getHeaderNames.asScala.map(header =>
+    header.toLowerCase -> request.getHeaders(header).asScala.toSeq).toMap
   val cookies = request.getCookies
   val params = request.getParameterMap
   val remoteAddr = request.getRemoteAddr
-  override def header(name: String): Seq[String] = headers.getOrElse(name, Seq.empty)
+  override def header(name: String): Seq[String] = headers.getOrElse(name.toLowerCase, Seq.empty)
   override def requestPath: String = path
   override def cookie(name: String): Option[String] = cookies.find(_.getName == name).map(_.getValue)
   override def queryParam(name: String): Seq[String] = params.asScala.get(name).map(_.toSeq).getOrElse(Seq.empty)


### PR DESCRIPTION
The Jersey thread restriction circumvention changes the behavior on Servlets, making headers case sensitive. This enforces lower casing when mapping the original headers and accessing them.