### PR TITLE
[WIP] AppDefinition -> RunSpec

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -780,12 +780,12 @@ trait AppAndGroupFormats {
     .withDefault(Residency.defaultTaskLostBehaviour)
   ) (Residency(_, _), unlift(Residency.unapply))
 
-  implicit lazy val AppDefinitionWrites: Writes[AppDefinition] = {
+  implicit lazy val AppDefinitionWrites: Writes[RunSpec] = {
     implicit lazy val durationWrites = Writes[FiniteDuration] { d =>
       JsNumber(d.toSeconds)
     }
 
-    Writes[AppDefinition] { app =>
+    Writes[RunSpec] { app =>
       val appJson: JsObject = Json.obj(
         "id" -> app.id.toString,
         "cmd" -> app.cmd,

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -127,7 +127,7 @@ trait Formats
           "startedAt" -> launched.status.startedAt,
           "stagedAt" -> launched.status.stagedAt,
           "ports" -> launched.hostPorts,
-          "version" -> launched.appVersion
+          "version" -> launched.runSpecVersion
         )
       ){
           case (launchedJs, ipAddresses) => launchedJs ++ Json.obj("ipAddresses" -> ipAddresses)

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -108,7 +108,6 @@ class CoreModuleImpl @Inject() (
     maybeOfferReviver,
 
     // external guice dependencies
-    appRepository,
     taskTrackerModule.taskTracker,
     taskOpFactory
   )

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/TaskForStatistics.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/TaskForStatistics.scala
@@ -32,7 +32,7 @@ private[appinfo] object TaskForStatistics {
           (nowTs - startedAt.toDateTime.getMillis) / 1000.0
         }
         new TaskForStatistics(
-          version = launched.appVersion,
+          version = launched.runSpecVersion,
           running = maybeTaskState.contains(TaskState.TASK_RUNNING),
           // Tasks that are staged do not have the taskState set at all, currently.
           // To make this a bit more robust, we also allow it to be set explicitly.

--- a/src/main/scala/mesosphere/marathon/core/launcher/TaskOpFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/TaskOpFactory.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.core.launcher
 
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.Reservation
-import mesosphere.marathon.state.AppDefinition
+import mesosphere.marathon.state.RunSpec
 import mesosphere.util.state.FrameworkId
 import org.apache.mesos.{ Protos => Mesos }
 
@@ -25,7 +25,7 @@ object TaskOpFactory {
     *              needed to check constraints and handle resident tasks
     * @param additionalLaunches the number of additional launches that has been requested
     */
-  case class Request(app: AppDefinition, offer: Mesos.Offer, taskMap: Map[Task.Id, Task], additionalLaunches: Int) {
+  case class Request(app: RunSpec, offer: Mesos.Offer, taskMap: Map[Task.Id, Task], additionalLaunches: Int) {
     def frameworkId: FrameworkId = FrameworkId("").mergeFromProto(offer.getFrameworkId)
     def tasks: Iterable[Task] = taskMap.values
     lazy val reserved: Iterable[Task.Reserved] = tasks.collect { case r: Task.Reserved => r }
@@ -35,7 +35,7 @@ object TaskOpFactory {
   }
 
   object Request {
-    def apply(app: AppDefinition, offer: Mesos.Offer, tasks: Iterable[Task], additionalLaunches: Int): Request = {
+    def apply(app: RunSpec, offer: Mesos.Offer, tasks: Iterable[Task], additionalLaunches: Int): Request = {
       new Request(app, offer, Task.tasksById(tasks), additionalLaunches)
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/launcher/TaskOpFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/TaskOpFactory.scala
@@ -6,11 +6,11 @@ import mesosphere.marathon.state.RunSpec
 import mesosphere.util.state.FrameworkId
 import org.apache.mesos.{ Protos => Mesos }
 
-/** Infers which TaskOps to create for given app definitions and offers. */
+/** Infers which TaskOps to create for given run spec and offers. */
 trait TaskOpFactory {
 
   /**
-    * @return a TaskOp if and only if the offer matches the app.
+    * @return a TaskOp if and only if the offer matches the run spec.
     */
   def buildTaskOp(request: TaskOpFactory.Request): Option[TaskOp]
 
@@ -19,24 +19,24 @@ trait TaskOpFactory {
 object TaskOpFactory {
 
   /**
-    * @param app the related app definition
+    * @param runSpec the related run specification definition
     * @param offer the offer to match against
-    * @param taskMap a map of running tasks or reservations for the given app,
+    * @param taskMap a map of running tasks or reservations for the given run spec,
     *              needed to check constraints and handle resident tasks
     * @param additionalLaunches the number of additional launches that has been requested
     */
-  case class Request(app: RunSpec, offer: Mesos.Offer, taskMap: Map[Task.Id, Task], additionalLaunches: Int) {
+  case class Request(runSpec: RunSpec, offer: Mesos.Offer, taskMap: Map[Task.Id, Task], additionalLaunches: Int) {
     def frameworkId: FrameworkId = FrameworkId("").mergeFromProto(offer.getFrameworkId)
     def tasks: Iterable[Task] = taskMap.values
     lazy val reserved: Iterable[Task.Reserved] = tasks.collect { case r: Task.Reserved => r }
     def hasWaitingReservations: Boolean = reserved.nonEmpty
     def numberOfWaitingReservations: Int = reserved.size
-    def isForResidentApp: Boolean = app.isResident
+    def isForResidentRunSpec: Boolean = runSpec.isResident
   }
 
   object Request {
-    def apply(app: RunSpec, offer: Mesos.Offer, tasks: Iterable[Task], additionalLaunches: Int): Request = {
-      new Request(app, offer, Task.tasksById(tasks), additionalLaunches)
+    def apply(runSpec: RunSpec, offer: Mesos.Offer, tasks: Iterable[Task], additionalLaunches: Int): Request = {
+      new Request(runSpec, offer, Task.tasksById(tasks), additionalLaunches)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -130,7 +130,7 @@ private[launcher] class OfferProcessorImpl(
           case NonFatal(e) =>
             savingTasksErrorMeter.mark()
             taskOpWithSource.reject(s"storage error: $e")
-            log.warn(s"error while storing task $taskId for app [${taskId.appId}]", e)
+            log.warn(s"error while storing task $taskId for app [${taskId.runSpecId}]", e)
             revertTaskOps(Some(taskOpWithSource.op))
         }.map {
           case Some(savedTask) => Some(taskOpWithSource)

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.launcher.{ TaskOp, TaskOpFactory }
 import mesosphere.marathon.core.task.{ Task, TaskStateOp }
-import mesosphere.marathon.state.{ ResourceRole, AppDefinition }
+import mesosphere.marathon.state.{ ResourceRole, RunSpec }
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
 import mesosphere.mesos.{ PersistentVolumeMatcher, ResourceMatcher, TaskBuilder }
 import mesosphere.util.state.FrameworkId
@@ -131,7 +131,7 @@ class TaskOpFactoryImpl @Inject() (
   }
 
   private[this] def launchOnReservation(
-    app: AppDefinition,
+    app: RunSpec,
     offer: Mesos.Offer,
     task: Task.Reserved,
     resourceMatch: Option[ResourceMatcher.ResourceMatch],
@@ -154,7 +154,7 @@ class TaskOpFactoryImpl @Inject() (
 
   private[this] def reserveAndCreateVolumes(
     frameworkId: FrameworkId,
-    app: AppDefinition,
+    app: RunSpec,
     offer: Mesos.Offer,
     resourceMatch: ResourceMatcher.ResourceMatch): TaskOp = {
 

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
@@ -31,7 +31,7 @@ class TaskOpFactoryImpl @Inject() (
   override def buildTaskOp(request: TaskOpFactory.Request): Option[TaskOp] = {
     log.debug("buildTaskOp")
 
-    if (request.isForResidentApp) {
+    if (request.isForResidentRunSpec) {
       inferForResidents(request)
     }
     else {
@@ -40,9 +40,9 @@ class TaskOpFactoryImpl @Inject() (
   }
 
   private[this] def inferNormalTaskOp(request: TaskOpFactory.Request): Option[TaskOp] = {
-    val TaskOpFactory.Request(app, offer, tasks, _) = request
+    val TaskOpFactory.Request(runSpec, offer, tasks, _) = request
 
-    new TaskBuilder(app, Task.Id.forApp, config).buildIfMatches(offer, tasks.values).map {
+    new TaskBuilder(runSpec, Task.Id.forRunSpec, config).buildIfMatches(offer, tasks.values).map {
       case (taskInfo, ports) =>
         val task = Task.LaunchedEphemeral(
           taskId = Task.Id(taskInfo.getTaskId),
@@ -51,7 +51,7 @@ class TaskOpFactoryImpl @Inject() (
             agentId = Some(offer.getSlaveId.getValue),
             attributes = offer.getAttributesList.asScala
           ),
-          appVersion = app.version,
+          runSpecVersion = runSpec.version,
           status = Task.Status(
             stagedAt = clock.now()
           ),
@@ -63,14 +63,14 @@ class TaskOpFactoryImpl @Inject() (
   }
 
   private[this] def inferForResidents(request: TaskOpFactory.Request): Option[TaskOp] = {
-    val TaskOpFactory.Request(app, offer, tasks, additionalLaunches) = request
+    val TaskOpFactory.Request(runSpec, offer, tasks, additionalLaunches) = request
 
     val needToLaunch = additionalLaunches > 0 && request.hasWaitingReservations
     val needToReserve = request.numberOfWaitingReservations < additionalLaunches
 
     /* *
-     * If an offer HAS reservations/volumes that match our app, handling these has precedence
-     * If an offer NAS NO reservations/volumes that match our app, we can reserve if needed
+     * If an offer HAS reservations/volumes that match our run spec, handling these has precedence
+     * If an offer NAS NO reservations/volumes that match our run spec, we can reserve if needed
      *
      * Scenario 1:
      *  We need to launch tasks and receive an offer that HAS matching reservations/volumes
@@ -84,7 +84,7 @@ class TaskOpFactoryImpl @Inject() (
      */
 
     def maybeLaunchOnReservation = if (needToLaunch) {
-      val maybeVolumeMatch = PersistentVolumeMatcher.matchVolumes(offer, app, request.reserved)
+      val maybeVolumeMatch = PersistentVolumeMatcher.matchVolumes(offer, runSpec, request.reserved)
 
       maybeVolumeMatch.flatMap { volumeMatch =>
         // we must not consider the volumeMatch's Reserved task because that would lead to a violation of constraints
@@ -94,7 +94,7 @@ class TaskOpFactoryImpl @Inject() (
         val rolesToConsider = config.mesosRole.get.toSet
         val matchingReservedResourcesWithoutVolumes =
           ResourceMatcher.matchResources(
-            offer, app, tasksToConsiderForConstraints.values,
+            offer, runSpec, tasksToConsiderForConstraints.values,
             ResourceSelector(
               rolesToConsider, reserved = true,
               requiredLabels = TaskLabels.labelsForTask(request.frameworkId, volumeMatch.task)
@@ -102,27 +102,28 @@ class TaskOpFactoryImpl @Inject() (
           )
 
         matchingReservedResourcesWithoutVolumes.flatMap { otherResourcesMatch =>
-          launchOnReservation(app, offer, volumeMatch.task, matchingReservedResourcesWithoutVolumes, maybeVolumeMatch)
+          launchOnReservation(runSpec, offer, volumeMatch.task,
+            matchingReservedResourcesWithoutVolumes, maybeVolumeMatch)
         }
       }
     }
     else None
 
     def maybeReserveAndCreateVolumes = if (needToReserve) {
-      val configuredRoles = app.acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet)
+      val configuredRoles = runSpec.acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet)
       // We can only reserve unreserved resources
       val rolesToConsider = Set(ResourceRole.Unreserved).intersect(configuredRoles)
       if (configuredRoles.isEmpty) {
-        log.warn(s"Will never match for ${app.id} as the app is configured to only accept $configuredRoles")
+        log.warn(s"Will never match for ${runSpec.id} as the run spec is configured to only accept $configuredRoles")
       }
 
       val matchingResourcesForReservation =
         ResourceMatcher.matchResources(
-          offer, app, tasks.values,
+          offer, runSpec, tasks.values,
           ResourceSelector(rolesToConsider, reserved = false)
         )
       matchingResourcesForReservation.map { resourceMatch =>
-        reserveAndCreateVolumes(request.frameworkId, app, offer, resourceMatch)
+        reserveAndCreateVolumes(request.frameworkId, runSpec, offer, resourceMatch)
       }
     }
     else None
@@ -131,18 +132,18 @@ class TaskOpFactoryImpl @Inject() (
   }
 
   private[this] def launchOnReservation(
-    app: RunSpec,
+    runSpec: RunSpec,
     offer: Mesos.Offer,
     task: Task.Reserved,
     resourceMatch: Option[ResourceMatcher.ResourceMatch],
     volumeMatch: Option[PersistentVolumeMatcher.VolumeMatch]): Option[TaskOp] = {
 
     // create a TaskBuilder that used the id of the existing task as id for the created TaskInfo
-    new TaskBuilder(app, (_) => task.taskId, config).build(offer, resourceMatch, volumeMatch) map {
+    new TaskBuilder(runSpec, (_) => task.taskId, config).build(offer, resourceMatch, volumeMatch) map {
       case (taskInfo, ports) =>
         val taskStateOp = TaskStateOp.LaunchOnReservation(
           task.taskId,
-          appVersion = app.version,
+          runSpecVersion = runSpec.version,
           status = Task.Status(
             stagedAt = clock.now()
           ),
@@ -154,12 +155,12 @@ class TaskOpFactoryImpl @Inject() (
 
   private[this] def reserveAndCreateVolumes(
     frameworkId: FrameworkId,
-    app: RunSpec,
+    RunSpec: RunSpec,
     offer: Mesos.Offer,
     resourceMatch: ResourceMatcher.ResourceMatch): TaskOp = {
 
-    val localVolumes: Iterable[Task.LocalVolume] = app.persistentVolumes.map { volume =>
-      Task.LocalVolume(Task.LocalVolumeId(app.id, volume), volume)
+    val localVolumes: Iterable[Task.LocalVolume] = RunSpec.persistentVolumes.map { volume =>
+      Task.LocalVolume(Task.LocalVolumeId(RunSpec.id, volume), volume)
     }
     val persistentVolumeIds = localVolumes.map(_.id)
     val now = clock.now()
@@ -169,7 +170,7 @@ class TaskOpFactoryImpl @Inject() (
       reason = Task.Reservation.Timeout.Reason.ReservationTimeout
     )
     val task = Task.Reserved(
-      taskId = Task.Id.forApp(app.id),
+      taskId = Task.Id.forRunSpec(RunSpec.id),
       agentInfo = Task.AgentInfo(
         host = offer.getHostname,
         agentId = Some(offer.getSlaveId.getValue),

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -10,57 +10,57 @@ import scala.concurrent.Future
 object LaunchQueue {
 
   /**
-    * @param app the currently used app definition
+    * @param runSpec the currently used run specification.
     * @param tasksLeftToLaunch the tasks that still have to be launched
     * @param taskLaunchesInFlight the number of tasks which have been requested to be launched
     *                        but are unconfirmed yet
     * @param tasksLaunched the number of tasks which are running or at least have been confirmed to be launched
     */
   protected[marathon] case class QueuedTaskInfo(
-      app: RunSpec,
+      runSpec: RunSpec,
       tasksLeftToLaunch: Int,
       taskLaunchesInFlight: Int, // FIXME (217): rename to taskOpsInFlight
       tasksLaunched: Int,
       backOffUntil: Timestamp) {
     /**
-      * Indicates if the launch queue tries to launch tasks for this app.
+      * Indicates if the launch queue tries to launch tasks for this spec.
       */
     def inProgress: Boolean = tasksLeftToLaunch != 0 || taskLaunchesInFlight != 0
 
     /**
-      * This is the final number of tasks, the launch queue tries to reach for this app.
+      * This is the final number of tasks, the launch queue tries to reach for this spec.
       */
     def finalTaskCount: Int = tasksLaunched + taskLaunchesInFlight + tasksLeftToLaunch
   }
 }
 
 /**
-  * The LaunchQueue contains requests to launch new tasks for an application.
+  * The LaunchQueue contains requests to launch new tasks for an run spec.
   */
 trait LaunchQueue {
 
   /** Returns all entries of the queue. */
   def list: Seq[QueuedTaskInfo]
-  /** Returns all apps for which queue entries exist. */
-  def listApps: Seq[RunSpec]
+  /** Returns all run specs for which queue entries exist. */
+  def listRunSpecs: Seq[RunSpec]
 
-  /** Request to launch `count` additional tasks conforming to the given app definition. */
-  def add(app: RunSpec, count: Int = 1): Unit
+  /** Request to launch `count` additional tasks conforming to the given run spec. */
+  def add(runSpec: RunSpec, count: Int = 1): Unit
 
-  /** Get information for the given appId. */
-  def get(appId: PathId): Option[QueuedTaskInfo]
+  /** Get information for the given run spec id. */
+  def get(runSpecId: PathId): Option[QueuedTaskInfo]
 
   /** Return how many tasks are still to be launched for this PathId. */
-  def count(appId: PathId): Int
+  def count(runSpecId: PathId): Int
 
   /** Remove all task launch requests for the given PathId from this queue. */
-  def purge(appId: PathId): Unit
+  def purge(runSpecId: PathId): Unit
 
   /** Add delay to the given RunSpec because of a failed task */
-  def addDelay(app: RunSpec): Unit
+  def addDelay(runSpec: RunSpec): Unit
 
   /** Reset the backoff delay for the given RunSpec. */
-  def resetDelay(app: RunSpec): Unit
+  def resetDelay(runSpec: RunSpec): Unit
 
   /** Notify queue about TaskUpdate */
   def notifyOfTaskUpdate(taskChanged: TaskChanged): Future[Option[QueuedTaskInfo]]

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.core.launchqueue
 
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskInfo
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
+import mesosphere.marathon.state.{ RunSpec, PathId, Timestamp }
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
@@ -17,7 +17,7 @@ object LaunchQueue {
     * @param tasksLaunched the number of tasks which are running or at least have been confirmed to be launched
     */
   protected[marathon] case class QueuedTaskInfo(
-      app: AppDefinition,
+      app: RunSpec,
       tasksLeftToLaunch: Int,
       taskLaunchesInFlight: Int, // FIXME (217): rename to taskOpsInFlight
       tasksLaunched: Int,
@@ -42,10 +42,10 @@ trait LaunchQueue {
   /** Returns all entries of the queue. */
   def list: Seq[QueuedTaskInfo]
   /** Returns all apps for which queue entries exist. */
-  def listApps: Seq[AppDefinition]
+  def listApps: Seq[RunSpec]
 
   /** Request to launch `count` additional tasks conforming to the given app definition. */
-  def add(app: AppDefinition, count: Int = 1): Unit
+  def add(app: RunSpec, count: Int = 1): Unit
 
   /** Get information for the given appId. */
   def get(appId: PathId): Option[QueuedTaskInfo]
@@ -56,11 +56,11 @@ trait LaunchQueue {
   /** Remove all task launch requests for the given PathId from this queue. */
   def purge(appId: PathId): Unit
 
-  /** Add delay to the given AppDefinition because of a failed task */
-  def addDelay(app: AppDefinition): Unit
+  /** Add delay to the given RunSpec because of a failed task */
+  def addDelay(app: RunSpec): Unit
 
-  /** Reset the backoff delay for the given AppDefinition. */
-  def resetDelay(app: AppDefinition): Unit
+  /** Reset the backoff delay for the given RunSpec. */
+  def resetDelay(app: RunSpec): Unit
 
   /** Notify queue about TaskUpdate */
   def notifyOfTaskUpdate(taskChanged: TaskChanged): Future[Option[QueuedTaskInfo]]

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -14,10 +14,10 @@ import mesosphere.marathon.core.launchqueue.impl.{
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
 import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.state.{ AppDefinition, AppRepository }
+import mesosphere.marathon.state.{ RunSpec, AppRepository }
 
 /**
-  * Provides a [[LaunchQueue]] implementation which can be used to launch tasks for a given AppDefinition.
+  * Provides a [[LaunchQueue]] implementation which can be used to launch tasks for a given RunSpec.
   */
 class LaunchQueueModule(
     config: LaunchQueueConfig,
@@ -43,7 +43,7 @@ class LaunchQueueModule(
 
   val launchQueue: LaunchQueue = new LaunchQueueDelegate(config, launchQueueActorRef, rateLimiterActor)
 
-  private[this] def appActorProps(app: AppDefinition, count: Int): Props =
+  private[this] def appActorProps(app: RunSpec, count: Int): Props =
     AppTaskLauncherActor.props(
       config,
       subOfferMatcherManager,

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.launcher.TaskOpFactory
 import mesosphere.marathon.core.launchqueue.impl.{
-  AppTaskLauncherActor,
+  RunSpecTaskLauncherActor,
   LaunchQueueActor,
   LaunchQueueDelegate,
   RateLimiter,
@@ -14,7 +14,7 @@ import mesosphere.marathon.core.launchqueue.impl.{
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
 import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.state.{ RunSpec, AppRepository }
+import mesosphere.marathon.state.RunSpec
 
 /**
   * Provides a [[LaunchQueue]] implementation which can be used to launch tasks for a given RunSpec.
@@ -25,31 +25,30 @@ class LaunchQueueModule(
     clock: Clock,
     subOfferMatcherManager: OfferMatcherManager,
     maybeOfferReviver: Option[OfferReviver],
-    appRepository: AppRepository,
     taskTracker: TaskTracker,
     taskOpFactory: TaskOpFactory) {
 
   private[this] val launchQueueActorRef: ActorRef = {
-    val props = LaunchQueueActor.props(config, appActorProps)
+    val props = LaunchQueueActor.props(config, runSpecActorProps)
     leadershipModule.startWhenLeader(props, "launchQueue")
   }
   private[this] val rateLimiter: RateLimiter = new RateLimiter(clock)
 
   private[this] val rateLimiterActor: ActorRef = {
     val props = RateLimiterActor.props(
-      rateLimiter, appRepository, launchQueueActorRef)
+      rateLimiter, launchQueueActorRef)
     leadershipModule.startWhenLeader(props, "rateLimiter")
   }
 
   val launchQueue: LaunchQueue = new LaunchQueueDelegate(config, launchQueueActorRef, rateLimiterActor)
 
-  private[this] def appActorProps(app: RunSpec, count: Int): Props =
-    AppTaskLauncherActor.props(
+  private[this] def runSpecActorProps(runSpec: RunSpec, count: Int): Props =
+    RunSpecTaskLauncherActor.props(
       config,
       subOfferMatcherManager,
       clock,
       taskOpFactory,
       maybeOfferReviver,
       taskTracker,
-      rateLimiterActor)(app, count)
+      rateLimiterActor)(runSpec, count)
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
@@ -17,7 +17,7 @@ import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.task.{ Task, TaskStateChange }
-import mesosphere.marathon.state.{ AppDefinition, Timestamp }
+import mesosphere.marathon.state.{ RunSpec, Timestamp }
 import org.apache.mesos.{ Protos => Mesos }
 
 import scala.concurrent.duration._
@@ -32,7 +32,7 @@ private[launchqueue] object AppTaskLauncherActor {
     maybeOfferReviver: Option[OfferReviver],
     taskTracker: TaskTracker,
     rateLimiterActor: ActorRef)(
-      app: AppDefinition,
+      app: RunSpec,
       initialCount: Int): Props = {
     Props(new AppTaskLauncherActor(
       config,
@@ -50,7 +50,7 @@ private[launchqueue] object AppTaskLauncherActor {
     * Increase the task count of the receiver.
     * The actor responds with a [[QueuedTaskInfo]] message.
     */
-  case class AddTasks(app: AppDefinition, count: Int) extends Requests
+  case class AddTasks(app: RunSpec, count: Int) extends Requests
   /**
     * Get the current count.
     * The actor responds with a [[QueuedTaskInfo]] message.
@@ -82,7 +82,7 @@ private class AppTaskLauncherActor(
     taskTracker: TaskTracker,
     rateLimiterActor: ActorRef,
 
-    private[this] var app: AppDefinition,
+    private[this] var app: RunSpec,
     private[this] var tasksToLaunch: Int) extends Actor with ActorLogging with Stash {
   // scalastyle:on parameter.number
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
@@ -15,7 +15,7 @@ import akka.pattern.{ ask, pipe }
 import akka.util.Timeout
 import mesosphere.marathon.core.launchqueue.{ LaunchQueueConfig, LaunchQueue }
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
-import mesosphere.marathon.state.{ AppDefinition, PathId }
+import mesosphere.marathon.state.{ RunSpec, PathId }
 import LaunchQueue.QueuedTaskInfo
 
 import scala.concurrent.Future
@@ -23,7 +23,7 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 private[launchqueue] object LaunchQueueActor {
-  def props(config: LaunchQueueConfig, appActorProps: (AppDefinition, Int) => Props): Props = {
+  def props(config: LaunchQueueConfig, appActorProps: (RunSpec, Int) => Props): Props = {
     Props(new LaunchQueueActor(config, appActorProps))
   }
 
@@ -37,7 +37,7 @@ private[launchqueue] object LaunchQueueActor {
   */
 private[impl] class LaunchQueueActor(
     launchQueueConfig: LaunchQueueConfig,
-    appActorProps: (AppDefinition, Int) => Props) extends Actor with ActorLogging {
+    appActorProps: (RunSpec, Int) => Props) extends Actor with ActorLogging {
   import LaunchQueueDelegate._
 
   /** Currently active actors by pathId. */
@@ -195,7 +195,7 @@ private[impl] class LaunchQueueActor(
       launchers.get(app.id).foreach(_.forward(msg))
   }
 
-  private[this] def createAppTaskLauncher(app: AppDefinition, initialCount: Int): ActorRef = {
+  private[this] def createAppTaskLauncher(app: RunSpec, initialCount: Int): ActorRef = {
     val actorRef = context.actorOf(appActorProps(app, initialCount), s"$childSerial-${app.id.safePath}")
     childSerial += 1
     launchers += app.id -> actorRef

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
@@ -23,8 +23,8 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 private[launchqueue] object LaunchQueueActor {
-  def props(config: LaunchQueueConfig, appActorProps: (RunSpec, Int) => Props): Props = {
-    Props(new LaunchQueueActor(config, appActorProps))
+  def props(config: LaunchQueueConfig, runSpecActorProps: (RunSpec, Int) => Props): Props = {
+    Props(new LaunchQueueActor(config, runSpecActorProps))
   }
 
   case class FullCount(appId: PathId)
@@ -37,7 +37,7 @@ private[launchqueue] object LaunchQueueActor {
   */
 private[impl] class LaunchQueueActor(
     launchQueueConfig: LaunchQueueConfig,
-    appActorProps: (RunSpec, Int) => Props) extends Actor with ActorLogging {
+    runSpecActorProps: (RunSpec, Int) => Props) extends Actor with ActorLogging {
   import LaunchQueueDelegate._
 
   /** Currently active actors by pathId. */
@@ -81,14 +81,14 @@ private[impl] class LaunchQueueActor(
     * we will replay these messages to ourselves with the correct sender.
     */
   private[this] def receiveHandlePurging: Receive = {
-    case Purge(appId) =>
-      launchers.get(appId) match {
+    case Purge(runSpecId) =>
+      launchers.get(runSpecId) match {
         case Some(actorRef) =>
           val deferredMessages: Vector[DeferredMessage] =
             suspendedLaunchersMessages(actorRef) :+ DeferredMessage(sender(), ConfirmPurge)
           suspendedLaunchersMessages += actorRef -> deferredMessages
-          suspendedLauncherPathIds += appId
-          actorRef ! AppTaskLauncherActor.Stop
+          suspendedLauncherPathIds += runSpecId
+          actorRef ! RunSpecTaskLauncherActor.Stop
         case None => sender() ! (())
       }
 
@@ -102,7 +102,7 @@ private[impl] class LaunchQueueActor(
 
           suspendedLaunchersMessages.get(actorRef) match {
             case None =>
-              log.warning("Got unexpected terminated for app {}: {}", pathId, actorRef)
+              log.warning("Got unexpected terminated for runSpec {}: {}", pathId, actorRef)
             case Some(deferredMessages) =>
               deferredMessages.foreach(msg => self.tell(msg.message, msg.sender))
 
@@ -115,7 +115,7 @@ private[impl] class LaunchQueueActor(
   }
 
   private[this] def receiveTaskUpdateToSuspendedActor: Receive = {
-    case taskChanged: TaskChanged if suspendedLauncherPathIds(taskChanged.appId) =>
+    case taskChanged: TaskChanged if suspendedLauncherPathIds(taskChanged.runSpecId) =>
       // Do not defer. If an AppTaskLauncherActor restarts, it retrieves a new task list.
       // If we defer this, there is a potential deadlock (resolved by timeout):
       //   * AppTaskLauncher waits for in-flight tasks
@@ -147,7 +147,7 @@ private[impl] class LaunchQueueActor(
   private[this] def receiveTaskUpdate: Receive = {
     case taskChanged: TaskChanged =>
       import context.dispatcher
-      launchers.get(taskChanged.appId) match {
+      launchers.get(taskChanged.runSpecId) match {
         case Some(actorRef) =>
           val eventualCount: Future[QueuedTaskInfo] =
             (actorRef ? taskChanged).mapTo[QueuedTaskInfo]
@@ -170,7 +170,7 @@ private[impl] class LaunchQueueActor(
       launchers.get(appId) match {
         case Some(actorRef) =>
           val eventualCount: Future[QueuedTaskInfo] =
-            (actorRef ? AppTaskLauncherActor.GetCount).mapTo[QueuedTaskInfo]
+            (actorRef ? RunSpecTaskLauncherActor.GetCount).mapTo[QueuedTaskInfo]
           eventualCount.map(Some(_)).pipeTo(sender())
         case None => sender() ! None
       }
@@ -181,13 +181,13 @@ private[impl] class LaunchQueueActor(
           import context.dispatcher
           val actorRef = createAppTaskLauncher(app, count)
           val eventualCount: Future[QueuedTaskInfo] =
-            (actorRef ? AppTaskLauncherActor.GetCount).mapTo[QueuedTaskInfo]
+            (actorRef ? RunSpecTaskLauncherActor.GetCount).mapTo[QueuedTaskInfo]
           eventualCount.map(_ => ()).pipeTo(sender())
 
         case Some(actorRef) =>
           import context.dispatcher
           val eventualCount: Future[QueuedTaskInfo] =
-            (actorRef ? AppTaskLauncherActor.AddTasks(app, count)).mapTo[QueuedTaskInfo]
+            (actorRef ? RunSpecTaskLauncherActor.AddTasks(app, count)).mapTo[QueuedTaskInfo]
           eventualCount.map(_ => ()).pipeTo(sender())
       }
 
@@ -196,7 +196,7 @@ private[impl] class LaunchQueueActor(
   }
 
   private[this] def createAppTaskLauncher(app: RunSpec, initialCount: Int): ActorRef = {
-    val actorRef = context.actorOf(appActorProps(app, initialCount), s"$childSerial-${app.id.safePath}")
+    val actorRef = context.actorOf(runSpecActorProps(app, initialCount), s"$childSerial-${app.id.safePath}")
     childSerial += 1
     launchers += app.id -> actorRef
     launcherRefs += actorRef -> app.id

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskInfo
 import mesosphere.marathon.core.launchqueue.{ LaunchQueue, LaunchQueueConfig }
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
-import mesosphere.marathon.state.{ AppDefinition, PathId }
+import mesosphere.marathon.state.{ RunSpec, PathId }
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
@@ -31,7 +31,7 @@ private[launchqueue] class LaunchQueueDelegate(
 
   override def count(appId: PathId): Int = get(appId).map(_.tasksLeftToLaunch).getOrElse(0)
 
-  override def listApps: Seq[AppDefinition] = list.map(_.app)
+  override def listApps: Seq[RunSpec] = list.map(_.app)
 
   override def purge(appId: PathId): Unit = {
     // When purging, we wait for the AppTaskLauncherActor to shut down. This actor will wait for
@@ -40,7 +40,7 @@ private[launchqueue] class LaunchQueueDelegate(
     askQueueActor("purge", timeout = purgeTimeout)(LaunchQueueDelegate.Purge(appId))
   }
 
-  override def add(app: AppDefinition, count: Int): Unit = askQueueActor("add")(LaunchQueueDelegate.Add(app, count))
+  override def add(app: RunSpec, count: Int): Unit = askQueueActor("add")(LaunchQueueDelegate.Add(app, count))
 
   private[this] def askQueueActor[T](
     method: String,
@@ -63,9 +63,9 @@ private[launchqueue] class LaunchQueueDelegate(
     answerFuture
   }
 
-  override def addDelay(app: AppDefinition): Unit = rateLimiterRef ! RateLimiterActor.AddDelay(app)
+  override def addDelay(app: RunSpec): Unit = rateLimiterRef ! RateLimiterActor.AddDelay(app)
 
-  override def resetDelay(app: AppDefinition): Unit = rateLimiterRef ! RateLimiterActor.ResetDelay(app)
+  override def resetDelay(app: RunSpec): Unit = rateLimiterRef ! RateLimiterActor.ResetDelay(app)
 }
 
 private[impl] object LaunchQueueDelegate {
@@ -74,5 +74,5 @@ private[impl] object LaunchQueueDelegate {
   case class Count(appId: PathId) extends Request
   case class Purge(appId: PathId) extends Request
   case object ConfirmPurge extends Request
-  case class Add(app: AppDefinition, count: Int) extends Request
+  case class Add(app: RunSpec, count: Int) extends Request
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActor.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.core.launchqueue.impl.RateLimiterActor.{
   ResetDelay,
   ResetDelayResponse
 }
-import mesosphere.marathon.state.{ AppDefinition, AppRepository, Timestamp }
+import mesosphere.marathon.state.{ RunSpec, AppRepository, Timestamp }
 
 import scala.concurrent.duration._
 
@@ -24,14 +24,14 @@ private[launchqueue] object RateLimiterActor {
       rateLimiter, appRepository, launchQueueRef
     ))
 
-  case class DelayUpdate(app: AppDefinition, delayUntil: Timestamp)
+  case class DelayUpdate(app: RunSpec, delayUntil: Timestamp)
 
-  case class ResetDelay(app: AppDefinition)
+  case class ResetDelay(app: RunSpec)
   case object ResetDelayResponse
 
-  case class GetDelay(appDefinition: AppDefinition)
-  private[impl] case class AddDelay(app: AppDefinition)
-  private[impl] case class DecreaseDelay(app: AppDefinition)
+  case class GetDelay(appDefinition: RunSpec)
+  private[impl] case class AddDelay(app: RunSpec)
+  private[impl] case class DecreaseDelay(app: RunSpec)
 
   private case object CleanupOverdueDelays
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActor.scala
@@ -11,34 +11,32 @@ import mesosphere.marathon.core.launchqueue.impl.RateLimiterActor.{
   ResetDelay,
   ResetDelayResponse
 }
-import mesosphere.marathon.state.{ RunSpec, AppRepository, Timestamp }
+import mesosphere.marathon.state.{ RunSpec, Timestamp }
 
 import scala.concurrent.duration._
 
 private[launchqueue] object RateLimiterActor {
   def props(
     rateLimiter: RateLimiter,
-    appRepository: AppRepository,
     launchQueueRef: ActorRef): Props =
     Props(new RateLimiterActor(
-      rateLimiter, appRepository, launchQueueRef
+      rateLimiter, launchQueueRef
     ))
 
-  case class DelayUpdate(app: RunSpec, delayUntil: Timestamp)
+  case class DelayUpdate(runSpec: RunSpec, delayUntil: Timestamp)
 
-  case class ResetDelay(app: RunSpec)
+  case class ResetDelay(runSpec: RunSpec)
   case object ResetDelayResponse
 
-  case class GetDelay(appDefinition: RunSpec)
-  private[impl] case class AddDelay(app: RunSpec)
-  private[impl] case class DecreaseDelay(app: RunSpec)
+  case class GetDelay(runSpec: RunSpec)
+  private[impl] case class AddDelay(runSpec: RunSpec)
+  private[impl] case class DecreaseDelay(runSpec: RunSpec)
 
   private case object CleanupOverdueDelays
 }
 
 private class RateLimiterActor private (
     rateLimiter: RateLimiter,
-    appRepository: AppRepository,
     launchQueueRef: ActorRef) extends Actor with ActorLogging {
   var cleanup: Cancellable = _
 
@@ -61,25 +59,25 @@ private class RateLimiterActor private (
 
   private[this] def receiveCleanup: Receive = {
     case CleanupOverdueDelays =>
-      // If an app gets removed or updated, the delay should be reset.
+      // If an run spec gets removed or updated, the delay should be reset.
       // Still, we can remove overdue delays before that and also make leaks less likely
       // by calling this periodically.
       rateLimiter.cleanUpOverdueDelays()
   }
 
   private[this] def receiveDelayOps: Receive = {
-    case GetDelay(app) =>
-      sender() ! DelayUpdate(app, rateLimiter.getDelay(app))
+    case GetDelay(runSpec) =>
+      sender() ! DelayUpdate(runSpec, rateLimiter.getDelay(runSpec))
 
-    case AddDelay(app) =>
-      rateLimiter.addDelay(app)
-      launchQueueRef ! DelayUpdate(app, rateLimiter.getDelay(app))
+    case AddDelay(runSpec) =>
+      rateLimiter.addDelay(runSpec)
+      launchQueueRef ! DelayUpdate(runSpec, rateLimiter.getDelay(runSpec))
 
-    case DecreaseDelay(app) => // ignore for now
+    case DecreaseDelay(runSpec) => // ignore for now
 
-    case ResetDelay(app) =>
-      rateLimiter.resetDelay(app)
-      launchQueueRef ! DelayUpdate(app, rateLimiter.getDelay(app))
+    case ResetDelay(runSpec) =>
+      rateLimiter.resetDelay(runSpec)
+      launchQueueRef ! DelayUpdate(runSpec, rateLimiter.getDelay(runSpec))
       sender() ! ResetDelayResponse
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RunSpecTaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RunSpecTaskLauncherActor.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.launcher.{ TaskOp, TaskOpFactory }
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskInfo
 import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
-import mesosphere.marathon.core.launchqueue.impl.AppTaskLauncherActor.RecheckIfBackOffUntilReached
+import mesosphere.marathon.core.launchqueue.impl.RunSpecTaskLauncherActor.RecheckIfBackOffUntilReached
 import mesosphere.marathon.core.matcher.base
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.{ MatchedTaskOps, TaskOpWithSource }
@@ -22,7 +22,7 @@ import org.apache.mesos.{ Protos => Mesos }
 
 import scala.concurrent.duration._
 
-private[launchqueue] object AppTaskLauncherActor {
+private[launchqueue] object RunSpecTaskLauncherActor {
   // scalastyle:off parameter.number
   def props(
     config: LaunchQueueConfig,
@@ -32,15 +32,15 @@ private[launchqueue] object AppTaskLauncherActor {
     maybeOfferReviver: Option[OfferReviver],
     taskTracker: TaskTracker,
     rateLimiterActor: ActorRef)(
-      app: RunSpec,
+      runSpec: RunSpec,
       initialCount: Int): Props = {
-    Props(new AppTaskLauncherActor(
+    Props(new RunSpecTaskLauncherActor(
       config,
       offerMatcherManager,
       clock, taskOpFactory,
       maybeOfferReviver,
       taskTracker, rateLimiterActor,
-      app, initialCount))
+      runSpec, initialCount))
   }
   // scalastyle:on parameter.number
 
@@ -50,7 +50,7 @@ private[launchqueue] object AppTaskLauncherActor {
     * Increase the task count of the receiver.
     * The actor responds with a [[QueuedTaskInfo]] message.
     */
-  case class AddTasks(app: RunSpec, count: Int) extends Requests
+  case class AddTasks(runSpec: RunSpec, count: Int) extends Requests
   /**
     * Get the current count.
     * The actor responds with a [[QueuedTaskInfo]] message.
@@ -73,7 +73,7 @@ private[launchqueue] object AppTaskLauncherActor {
   * Allows processing offers for starting tasks for the given app.
   */
 // scalastyle:off parameter.number
-private class AppTaskLauncherActor(
+private class RunSpecTaskLauncherActor(
     config: LaunchQueueConfig,
     offerMatcherManager: OfferMatcherManager,
     clock: Clock,
@@ -82,7 +82,7 @@ private class AppTaskLauncherActor(
     taskTracker: TaskTracker,
     rateLimiterActor: ActorRef,
 
-    private[this] var app: RunSpec,
+    private[this] var runSpec: RunSpec,
     private[this] var tasksToLaunch: Int) extends Actor with ActorLogging with Stash {
   // scalastyle:on parameter.number
 
@@ -101,11 +101,11 @@ private class AppTaskLauncherActor(
     super.preStart()
 
     log.info("Started appTaskLaunchActor for {} version {} with initial count {}",
-      app.id, app.version, tasksToLaunch)
+      runSpec.id, runSpec.version, tasksToLaunch)
 
-    tasksMap = taskTracker.tasksByAppSync.appTasksMap(app.id).taskMap
+    tasksMap = taskTracker.tasksByAppSync.appTasksMap(runSpec.id).taskMap
 
-    rateLimiterActor ! RateLimiterActor.GetDelay(app)
+    rateLimiterActor ! RateLimiterActor.GetDelay(runSpec)
   }
 
   override def postStop(): Unit = {
@@ -119,17 +119,17 @@ private class AppTaskLauncherActor(
 
     super.postStop()
 
-    log.info("Stopped appTaskLaunchActor for {} version {}", app.id, app.version)
+    log.info("Stopped appTaskLaunchActor for {} version {}", runSpec.id, runSpec.version)
   }
 
   override def receive: Receive = waitForInitialDelay
 
   private[this] def waitForInitialDelay: Receive = LoggingReceive.withLabel("waitingForInitialDelay") {
-    case RateLimiterActor.DelayUpdate(delayApp, delayUntil) if delayApp == app =>
+    case RateLimiterActor.DelayUpdate(delayApp, delayUntil) if delayApp == runSpec =>
       stash()
       unstashAll()
       context.become(active)
-    case msg @ RateLimiterActor.DelayUpdate(delayApp, delayUntil) if delayApp != app =>
+    case msg @ RateLimiterActor.DelayUpdate(delayApp, delayUntil) if delayApp != runSpec =>
       log.warning("Received delay update for other app: {}", msg)
     case message: Any => stash()
   }
@@ -160,9 +160,9 @@ private class AppTaskLauncherActor(
       receiveTaskLaunchNotification(notification)
       waitForInFlightIfNecessary()
 
-    case AppTaskLauncherActor.Stop => // ignore, already stopping
+    case RunSpecTaskLauncherActor.Stop => // ignore, already stopping
 
-    case "waitingForInFlight"      => sender() ! "waitingForInFlight" // for testing
+    case "waitingForInFlight"          => sender() ! "waitingForInFlight" // for testing
   }
 
   private[this] def receiveUnknown: Receive = {
@@ -172,7 +172,7 @@ private class AppTaskLauncherActor(
   }
 
   private[this] def receiveStop: Receive = {
-    case AppTaskLauncherActor.Stop =>
+    case RunSpecTaskLauncherActor.Stop =>
       if (inFlightTaskOperations.nonEmpty) {
         // try to stop gracefully but also schedule timeout
         import context.dispatcher
@@ -200,7 +200,7 @@ private class AppTaskLauncherActor(
     * Receive rate limiter updates.
     */
   private[this] def receiveDelayUpdate: Receive = {
-    case RateLimiterActor.DelayUpdate(delayApp, delayUntil) if delayApp == app =>
+    case RateLimiterActor.DelayUpdate(delayApp, delayUntil) if delayApp == runSpec =>
 
       if (backOffUntil != Some(delayUntil)) {
 
@@ -222,7 +222,7 @@ private class AppTaskLauncherActor(
 
       log.debug("After delay update {}", status)
 
-    case msg @ RateLimiterActor.DelayUpdate(delayApp, delayUntil) if delayApp != app =>
+    case msg @ RateLimiterActor.DelayUpdate(delayApp, delayUntil) if delayApp != runSpec =>
       log.warning("Received delay update for other app: {}", msg)
 
     case RecheckIfBackOffUntilReached => OfferMatcherRegistration.manageOfferMatcherStatus()
@@ -236,7 +236,7 @@ private class AppTaskLauncherActor(
         op.getClass.getSimpleName, op.taskId, reason, status)
       OfferMatcherRegistration.manageOfferMatcherStatus()
 
-    case TaskOpSourceDelegate.TaskOpRejected(op, AppTaskLauncherActor.TASK_OP_REJECTED_TIMEOUT_REASON) =>
+    case TaskOpSourceDelegate.TaskOpRejected(op, RunSpecTaskLauncherActor.TASK_OP_REJECTED_TIMEOUT_REASON) =>
       // This is a message that we scheduled in this actor.
       // When we receive a launch confirmation or rejection, we cancel this timer but
       // there is still a race and we might send ourselves the message nevertheless, so we just
@@ -267,7 +267,7 @@ private class AppTaskLauncherActor(
           // of that node after a task on that node has died.
           //
           // B) If a reservation timed out, already rejected offers might become eligible for creating new reservations.
-          if (app.constraints.nonEmpty || (app.isResident && shouldLaunchTasks)) {
+          if (runSpec.constraints.nonEmpty || (runSpec.isResident && shouldLaunchTasks)) {
             maybeOfferReviver.foreach(_.reviveOffers())
           }
 
@@ -284,21 +284,21 @@ private class AppTaskLauncherActor(
   }
 
   private[this] def receiveGetCurrentCount: Receive = {
-    case AppTaskLauncherActor.GetCount =>
+    case RunSpecTaskLauncherActor.GetCount =>
       replyWithQueuedTaskCount()
   }
 
   private[this] def receiveAddCount: Receive = {
-    case AppTaskLauncherActor.AddTasks(newApp, addCount) =>
-      val configChange = app.isUpgrade(newApp)
-      if (configChange || app.needsRestart(newApp) || app.isOnlyScaleChange(newApp)) {
-        app = newApp
+    case RunSpecTaskLauncherActor.AddTasks(newApp, addCount) =>
+      val configChange = runSpec.isUpgrade(newApp)
+      if (configChange || runSpec.needsRestart(newApp) || runSpec.isOnlyScaleChange(newApp)) {
+        runSpec = newApp
         tasksToLaunch = addCount
 
         if (configChange) {
           log.info(
             "getting new app definition config for '{}', version {} with {} initial tasks",
-            app.id, app.version, addCount
+            runSpec.id, runSpec.version, addCount
           )
 
           suspendMatchingUntilWeGetBackoffDelayUpdate()
@@ -307,7 +307,7 @@ private class AppTaskLauncherActor(
         else {
           log.info(
             "scaling change for '{}', version {} with {} initial tasks",
-            app.id, app.version, addCount
+            runSpec.id, runSpec.version, addCount
           )
         }
       }
@@ -327,13 +327,13 @@ private class AppTaskLauncherActor(
 
     // get new back off delay, don't do anything until we get that.
     backOffUntil = None
-    rateLimiterActor ! RateLimiterActor.GetDelay(app)
+    rateLimiterActor ! RateLimiterActor.GetDelay(runSpec)
     context.become(waitForInitialDelay)
   }
 
   private[this] def replyWithQueuedTaskCount(): Unit = {
     sender() ! QueuedTaskInfo(
-      app,
+      runSpec,
       tasksLeftToLaunch = tasksToLaunch,
       taskLaunchesInFlight = inFlightTaskOperations.size,
       // don't count tasks that are not launched in the tasksMap
@@ -349,7 +349,7 @@ private class AppTaskLauncherActor(
       sender ! MatchedTaskOps(offer.getId, Seq.empty)
 
     case ActorOfferMatcher.MatchOffer(deadline, offer) =>
-      val matchRequest = TaskOpFactory.Request(app, offer, tasksMap, tasksToLaunch)
+      val matchRequest = TaskOpFactory.Request(runSpec, offer, tasksMap, tasksToLaunch)
       val taskOp: Option[TaskOp] = taskOpFactory.buildTaskOp(matchRequest)
       taskOp match {
         case Some(op) => handleTaskOp(op, offer)
@@ -378,7 +378,7 @@ private class AppTaskLauncherActor(
     }
 
     log.info("Request {} for task '{}', version '{}'. {}",
-      taskOp.getClass.getSimpleName, taskOp.taskId.idString, app.version, status)
+      taskOp.getClass.getSimpleName, taskOp.taskId.idString, runSpec.version, status)
 
     updateActorState()
     sender() ! MatchedTaskOps(offer.getId, Seq(TaskOpWithSource(myselfAsLaunchSource, taskOp)))
@@ -386,7 +386,7 @@ private class AppTaskLauncherActor(
 
   private[this] def scheduleTaskOpTimeout(taskOp: TaskOp): Unit = {
     val reject = TaskOpSourceDelegate.TaskOpRejected(
-      taskOp, AppTaskLauncherActor.TASK_OP_REJECTED_TIMEOUT_REASON
+      taskOp, RunSpecTaskLauncherActor.TASK_OP_REJECTED_TIMEOUT_REASON
     )
     val cancellable = scheduleTaskOperationTimeout(context, reject)
     inFlightTaskOperations += taskOp.taskId -> cancellable
@@ -413,7 +413,7 @@ private class AppTaskLauncherActor(
 
     val inFlight = inFlightTaskOperations.size
     val tasksLaunchedOrRunning = tasksMap.values.count(_.launched.isDefined) - inFlight
-    val instanceCountDelta = tasksMap.size + tasksToLaunch - app.instances
+    val instanceCountDelta = tasksMap.size + tasksToLaunch - runSpec.instances
     val matchInstanceStr = if (instanceCountDelta == 0) "" else s"instance count delta $instanceCountDelta."
     s"$tasksToLaunch tasksToLaunch, $inFlight in flight, " +
       s"$tasksLaunchedOrRunning confirmed. $matchInstanceStr $backoffStr"
@@ -423,7 +423,7 @@ private class AppTaskLauncherActor(
   private[this] object OfferMatcherRegistration {
     private[this] val myselfAsOfferMatcher: OfferMatcher = {
       //set the precedence only, if this app is resident
-      new ActorOfferMatcher(clock, self, app.residency.map(_ => app.id))
+      new ActorOfferMatcher(clock, self, runSpec.residency.map(_ => runSpec.id))
     }
     private[this] var registeredAsMatcher = false
 
@@ -432,16 +432,16 @@ private class AppTaskLauncherActor(
       val shouldBeRegistered = shouldLaunchTasks
 
       if (shouldBeRegistered && !registeredAsMatcher) {
-        log.debug("Registering for {}, {}.", app.id, app.version)
+        log.debug("Registering for {}, {}.", runSpec.id, runSpec.version)
         offerMatcherManager.addSubscription(myselfAsOfferMatcher)(context.dispatcher)
         registeredAsMatcher = true
       }
       else if (!shouldBeRegistered && registeredAsMatcher) {
         if (tasksToLaunch > 0) {
-          log.info("Backing off due to task failures. Stop receiving offers for {}, {}", app.id, app.version)
+          log.info("Backing off due to task failures. Stop receiving offers for {}, {}", runSpec.id, runSpec.version)
         }
         else {
-          log.info("No tasks left to launch. Stop receiving offers for {}, {}", app.id, app.version)
+          log.info("No tasks left to launch. Stop receiving offers for {}, {}", runSpec.id, runSpec.version)
         }
         offerMatcherManager.removeSubscription(myselfAsOfferMatcher)(context.dispatcher)
         registeredAsMatcher = false

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
@@ -135,7 +135,7 @@ private[impl] class OfferMatcherManagerActor private (
     val appReservations = offer.getResourcesList.asScala
       .filter(r => r.hasDisk && r.getDisk.hasPersistence && r.getDisk.getPersistence.hasId)
       .map(_.getDisk.getPersistence.getId)
-      .collect { case LocalVolumeId(volumeId) => volumeId.appId }
+      .collect { case LocalVolumeId(volumeId) => volumeId.runSpecId }
       .toSet
     val (reserved, normal) = matchers.toSeq.partition(_.precedenceFor.exists(appReservations))
     //1 give the offer to the matcher waiting for a reservation

--- a/src/main/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconciler.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconciler.scala
@@ -56,7 +56,7 @@ private[reconcile] class OfferMatcherReconciler(taskTracker: TaskTracker, groupR
       else {
         def createTaskOps(tasksByApp: TasksByApp, rootGroup: Group): MatchedTaskOps = {
           def spurious(taskId: Id): Boolean =
-            tasksByApp.task(taskId).isEmpty || rootGroup.app(taskId.appId).isEmpty
+            tasksByApp.task(taskId).isEmpty || rootGroup.app(taskId.runSpecId).isEmpty
 
           val taskOps = resourcesByTaskId.iterator.collect {
             case (taskId, spuriousResources) if spurious(taskId) =>

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheck.scala
@@ -3,11 +3,9 @@ package mesosphere.marathon.core.readiness
 import com.wix.accord.Validator
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation._
-import mesosphere.marathon.state.Container.Docker.PortMapping
-import mesosphere.marathon.state.{ RunSpec, PortDefinition }
+import mesosphere.marathon.state.RunSpec
 import org.apache.http.HttpStatus
 
-import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 case class ReadinessCheck(
@@ -40,12 +38,12 @@ object ReadinessCheck {
     case object HTTPS extends Protocol
   }
 
-  def readinessCheckValidator(app: RunSpec): Validator[ReadinessCheck] =
+  def readinessCheckValidator(runSpec: RunSpec): Validator[ReadinessCheck] =
     validator[ReadinessCheck] { rc =>
       rc.name is notEmpty
       rc.path is notEmpty
       rc.portName is notEmpty
-      rc.portName is oneOf(app.portNames: _*)
+      rc.portName is oneOf(runSpec.portNames: _*)
       rc.timeout.toSeconds should be < rc.interval.toSeconds
       rc.timeout.toSeconds should be > 0L
       rc.httpStatusCodesForReady is notEmpty

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheck.scala
@@ -4,7 +4,7 @@ import com.wix.accord.Validator
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.state.Container.Docker.PortMapping
-import mesosphere.marathon.state.{ AppDefinition, PortDefinition }
+import mesosphere.marathon.state.{ RunSpec, PortDefinition }
 import org.apache.http.HttpStatus
 
 import scala.collection.immutable.Seq
@@ -40,7 +40,7 @@ object ReadinessCheck {
     case object HTTPS extends Protocol
   }
 
-  def readinessCheckValidator(app: AppDefinition): Validator[ReadinessCheck] =
+  def readinessCheckValidator(app: RunSpec): Validator[ReadinessCheck] =
     validator[ReadinessCheck] { rc =>
       rc.name is notEmpty
       rc.path is notEmpty

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.core.readiness
 
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.AppDefinition
+import mesosphere.marathon.state.RunSpec
 import rx.lang.scala.Observable
 
 import scala.collection.immutable.Seq
@@ -35,11 +35,11 @@ object ReadinessCheckExecutor {
       * Returns the readiness checks for the given task.
       */
     def readinessCheckSpecsForTask(
-      app: AppDefinition,
+      app: RunSpec,
       task: Task,
       launched: Task.Launched): Seq[ReadinessCheckExecutor.ReadinessCheckSpec] = {
 
-      require(task.appId == app.id, s"Task appId and AppDefinition appId must match: ${task.appId} != ${app.id}")
+      require(task.appId == app.id, s"Task appId and RunSpec appId must match: ${task.appId} != ${app.id}")
       require(task.launched == Some(launched), "Launched info is not the one contained in the task")
       require(task.effectiveIpAddress(app).isDefined,
         "Task is unreachable: an IP address was requested but not yet assigned")

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
@@ -35,16 +35,16 @@ object ReadinessCheckExecutor {
       * Returns the readiness checks for the given task.
       */
     def readinessCheckSpecsForTask(
-      app: RunSpec,
+      runSpec: RunSpec,
       task: Task,
       launched: Task.Launched): Seq[ReadinessCheckExecutor.ReadinessCheckSpec] = {
 
-      require(task.appId == app.id, s"Task appId and RunSpec appId must match: ${task.appId} != ${app.id}")
+      require(task.runSpecId == runSpec.id, s"Task id and RunSpec id must match: ${task.runSpecId} != ${runSpec.id}")
       require(task.launched == Some(launched), "Launched info is not the one contained in the task")
-      require(task.effectiveIpAddress(app).isDefined,
+      require(task.effectiveIpAddress(runSpec).isDefined,
         "Task is unreachable: an IP address was requested but not yet assigned")
 
-      app.readinessChecks.map { checkDef =>
+      runSpec.readinessChecks.map { checkDef =>
 
         // determining the URL is difficult, everything else is just copying configuration
         val url = {
@@ -53,8 +53,8 @@ object ReadinessCheckExecutor {
             case ReadinessCheck.Protocol.HTTPS => "https"
           }
 
-          val portAssignmentsByName = app.portAssignments(task).getOrElse(
-            throw new IllegalStateException(s"no ports assignments for AppDefinition: [$app] - Task: [$task]")
+          val portAssignmentsByName = runSpec.portAssignments(task).getOrElse(
+            throw new IllegalStateException(s"no ports assignments for RunSpec: [$runSpec] - Task: [$task]")
           ).map(portAssignment => portAssignment.portName -> portAssignment).toMap
 
           val effectivePortAssignment = portAssignmentsByName.getOrElse(

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.core.task
 
 import com.fasterxml.uuid.{ EthernetAddress, Generators }
 import mesosphere.marathon.core.task.bus.MarathonTaskStatus
-import mesosphere.marathon.state.{ AppDefinition, PathId, PersistentVolume, Timestamp }
+import mesosphere.marathon.state.{ RunSpec, PathId, PersistentVolume, Timestamp }
 import org.apache.mesos.Protos.{ TaskState }
 import org.apache.mesos.Protos.TaskState._
 import org.apache.mesos.{ Protos => MesosProtos }
@@ -82,7 +82,7 @@ sealed trait Task {
     }
   }
 
-  def effectiveIpAddress(app: AppDefinition): Option[String] = {
+  def effectiveIpAddress(app: RunSpec): Option[String] = {
     if (app.ipAddress.isDefined)
       launched.flatMap(_.ipAddresses).flatMap(_.headOption).map(_.getIpAddress)
     else

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -59,7 +59,7 @@ sealed trait Task {
   /** update the task based on the given trigger - depending on its state the task will decide what should happen */
   def update(update: TaskStateOp): TaskStateChange
 
-  def appId: PathId = taskId.appId
+  def runSpecId: PathId = taskId.runSpecId
 
   def launchedMesosId: Option[MesosProtos.TaskID] = launched.map { _ =>
     // it doesn't make sense for an unlaunched task
@@ -82,8 +82,8 @@ sealed trait Task {
     }
   }
 
-  def effectiveIpAddress(app: RunSpec): Option[String] = {
-    if (app.ipAddress.isDefined)
+  def effectiveIpAddress(runSpec: RunSpec): Option[String] = {
+    if (runSpec.ipAddress.isDefined)
       launched.flatMap(_.ipAddresses).flatMap(_.headOption).map(_.getIpAddress)
     else
       Some(agentInfo.host)
@@ -97,7 +97,7 @@ object Task {
   case class LaunchedEphemeral(
       taskId: Task.Id,
       agentInfo: AgentInfo,
-      appVersion: Timestamp,
+      runSpecVersion: Timestamp,
       status: Status,
       hostPorts: Seq[Int]) extends Task {
 
@@ -105,7 +105,7 @@ object Task {
 
     override def reservationWithVolumes: Option[Reservation] = None
 
-    override def launched: Option[Launched] = Some(Task.Launched(appVersion, status, hostPorts))
+    override def launched: Option[Launched] = Some(Task.Launched(runSpecVersion, status, hostPorts))
 
     private[this] def hasStartedRunning: Boolean = status.startedAt.isDefined
 
@@ -175,8 +175,8 @@ object Task {
     override def launched: Option[Launched] = None
 
     override def update(update: TaskStateOp): TaskStateChange = update match {
-      case TaskStateOp.LaunchOnReservation(_, appVersion, status, hostPorts) =>
-        val updatedTask = LaunchedOnReservation(taskId, agentInfo, appVersion, status, hostPorts, reservation)
+      case TaskStateOp.LaunchOnReservation(_, runSpecVersion, status, hostPorts) =>
+        val updatedTask = LaunchedOnReservation(taskId, agentInfo, runSpecVersion, status, hostPorts, reservation)
         TaskStateChange.Update(newState = updatedTask, oldState = Some(this))
 
       case _: TaskStateOp.ReservationTimeout =>
@@ -205,7 +205,7 @@ object Task {
   case class LaunchedOnReservation(
       taskId: Task.Id,
       agentInfo: AgentInfo,
-      appVersion: Timestamp,
+      runSpecVersion: Timestamp,
       status: Status,
       hostPorts: Seq[Int],
       reservation: Reservation) extends Task {
@@ -214,7 +214,7 @@ object Task {
 
     override def reservationWithVolumes: Option[Reservation] = Some(reservation)
 
-    override def launched: Option[Launched] = Some(Task.Launched(appVersion, status, hostPorts))
+    override def launched: Option[Launched] = Some(Task.Launched(runSpecVersion, status, hostPorts))
 
     private[this] def hasStartedRunning: Boolean = status.startedAt.isDefined
 
@@ -306,27 +306,27 @@ object Task {
 
   case class Id(idString: String) extends Ordered[Id] {
     lazy val mesosTaskId: MesosProtos.TaskID = MesosProtos.TaskID.newBuilder().setValue(idString).build()
-    lazy val appId: PathId = Id.appId(idString)
+    lazy val runSpecId: PathId = Id.runSpecId(idString)
     override def toString: String = s"task [$idString]"
     override def compare(that: Id): Int = idString.compare(that.idString)
   }
 
   object Id {
-    private val appDelimiter = "."
+    private val runSpecDelimiter = "."
     private val TaskIdRegex = """^(.+)[\._]([^_\.]+)$""".r
     private val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
 
-    def appId(taskId: String): PathId = {
+    def runSpecId(taskId: String): PathId = {
       taskId match {
-        case TaskIdRegex(appId, uuid) => PathId.fromSafePath(appId)
-        case _                        => throw new MatchError(s"taskId $taskId is no valid identifier")
+        case TaskIdRegex(runSpecId, uuid) => PathId.fromSafePath(runSpecId)
+        case _                            => throw new MatchError(s"taskId $taskId is no valid identifier")
       }
     }
 
     def apply(mesosTaskId: MesosProtos.TaskID): Id = new Id(mesosTaskId.getValue)
 
-    def forApp(appId: PathId): Id = {
-      val taskId = appId.safePath + appDelimiter + uuidGenerator.generate()
+    def forRunSpec(id: PathId): Id = {
+      val taskId = id.safePath + runSpecDelimiter + uuidGenerator.generate()
       Task.Id(taskId)
     }
   }
@@ -359,6 +359,7 @@ object Task {
 
     /**
       * A timeout that eventually leads to a state transition
+      *
       * @param initiated When this timeout was setup
       * @param deadline When this timeout should become effective
       * @param reason The reason why this timeout was set up
@@ -379,9 +380,9 @@ object Task {
 
   case class LocalVolume(id: LocalVolumeId, persistentVolume: PersistentVolume)
 
-  case class LocalVolumeId(appId: PathId, containerPath: String, uuid: String) {
+  case class LocalVolumeId(runSpecId: PathId, containerPath: String, uuid: String) {
     import LocalVolumeId._
-    lazy val idString = appId.safePath + delimiter + containerPath + delimiter + uuid
+    lazy val idString = runSpecId.safePath + delimiter + containerPath + delimiter + uuid
 
     override def toString: String = s"LocalVolume [$idString]"
   }
@@ -391,12 +392,12 @@ object Task {
     private val delimiter = "#"
     private val LocalVolumeEncoderRE = s"^([^.]+)[$delimiter]([^.]+)[$delimiter]([^.]+)$$".r
 
-    def apply(appId: PathId, volume: PersistentVolume): LocalVolumeId =
-      LocalVolumeId(appId, volume.containerPath, uuidGenerator.generate().toString)
+    def apply(runSpecId: PathId, volume: PersistentVolume): LocalVolumeId =
+      LocalVolumeId(runSpecId, volume.containerPath, uuidGenerator.generate().toString)
 
     def unapply(id: String): Option[(LocalVolumeId)] = id match {
-      case LocalVolumeEncoderRE(app, path, uuid) => Some(LocalVolumeId(PathId.fromSafePath(app), path, uuid))
-      case _                                     => None
+      case LocalVolumeEncoderRE(runSpec, path, uuid) => Some(LocalVolumeId(PathId.fromSafePath(runSpec), path, uuid))
+      case _                                         => None
     }
   }
 
@@ -406,7 +407,7 @@ object Task {
     * @param hostPorts sequence of ports in the Mesos Agent allocated to the task
     */
   case class Launched(
-      appVersion: Timestamp,
+      runSpecVersion: Timestamp,
       status: Status,
       hostPorts: Seq[Int]) {
 

--- a/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
@@ -36,7 +36,7 @@ object TaskStateOp {
 
   case class LaunchOnReservation(
     taskId: Task.Id,
-    appVersion: Timestamp,
+    runSpecVersion: Timestamp,
     status: Task.Status,
     hostPorts: Seq[Int]) extends TaskStateOp
 

--- a/src/main/scala/mesosphere/marathon/core/task/bus/TaskChangeObservables.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/TaskChangeObservables.scala
@@ -8,7 +8,7 @@ import rx.lang.scala.Observable
 object TaskChangeObservables {
   case class TaskChanged(stateOp: TaskStateOp, stateChange: TaskStateChange) {
     def taskId: Task.Id = stateOp.taskId
-    def appId: PathId = stateOp.taskId.appId
+    def runSpecId: PathId = stateOp.taskId.runSpecId
   }
 }
 
@@ -17,6 +17,6 @@ object TaskChangeObservables {
   */
 trait TaskChangeObservables {
   def forAll: Observable[TaskChanged]
-  def forAppId(appId: PathId): Observable[TaskChanged]
+  def forRunSpecId(appId: PathId): Observable[TaskChanged]
 }
 

--- a/src/main/scala/mesosphere/marathon/core/task/bus/impl/InternalTaskChangeEventStream.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/impl/InternalTaskChangeEventStream.scala
@@ -22,5 +22,5 @@ private[bus] class InternalTaskChangeEventStream
 
   override protected def publish(event: TaskChanged, subscriber: Observer[TaskChanged]): Unit =
     subscriber.onNext(event)
-  override protected def classify(event: TaskChanged): PathId = event.appId
+  override protected def classify(event: TaskChanged): PathId = event.runSpecId
 }

--- a/src/main/scala/mesosphere/marathon/core/task/bus/impl/TaskChangeObservablesImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/impl/TaskChangeObservablesImpl.scala
@@ -8,9 +8,9 @@ import rx.lang.scala.{ Observable, Subscription }
 private[bus] class TaskChangeObservablesImpl(eventStream: InternalTaskChangeEventStream)
     extends TaskChangeObservables {
 
-  override def forAll: Observable[TaskChanged] = forAppId(PathId.empty)
+  override def forAll: Observable[TaskChanged] = forRunSpecId(PathId.empty)
 
-  override def forAppId(appId: PathId): Observable[TaskChanged] = {
+  override def forRunSpecId(appId: PathId): Observable[TaskChanged] = {
     Observable.create { observer =>
       eventStream.subscribe(observer, appId)
       Subscription {

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTracker.scala
@@ -51,7 +51,7 @@ object TaskTracker {
     }
 
     def task(taskId: Task.Id): Option[Task] = for {
-      app <- appTasksMap.get(taskId.appId)
+      app <- appTasksMap.get(taskId.runSpecId)
       task <- app.taskMap.get(taskId)
     } yield task
 
@@ -80,7 +80,7 @@ object TaskTracker {
     def of(apps: TaskTracker.AppTasks*): TasksByApp = of(Map(apps.map(app => app.appId -> app): _*))
 
     def forTasks(tasks: Task*): TasksByApp = of(
-      tasks.groupBy(_.appId).map { case (appId, appTasks) => appId -> AppTasks.forTasks(appId, appTasks) }
+      tasks.groupBy(_.runSpecId).map { case (appId, appTasks) => appId -> AppTasks.forTasks(appId, appTasks) }
     )
 
     def empty: TasksByApp = of(collection.immutable.Map.empty[PathId, TaskTracker.AppTasks])

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskCreationHandlerAndUpdaterDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskCreationHandlerAndUpdaterDelegate.scala
@@ -50,7 +50,7 @@ private[tracker] class TaskCreationHandlerAndUpdaterDelegate(
     val op: ForwardTaskOp = TaskTrackerActor.ForwardTaskOp(deadline, taskId, taskStateOp)
     (taskTrackerRef ? op).mapTo[TaskStateChange].recover {
       case NonFatal(e) =>
-        throw new RuntimeException(s"while asking for $taskStateOp on app [${taskId.appId}] and $taskId", e)
+        throw new RuntimeException(s"while asking for $taskStateOp on app [${taskId.runSpecId}] and $taskId", e)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskLoaderImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskLoaderImpl.scala
@@ -22,7 +22,7 @@ private[tracker] class TaskLoaderImpl(repo: TaskRepository) extends TaskLoader {
     } yield {
       log.info(s"Loaded ${tasks.size} tasks")
       val deserializedTasks = tasks.map(TaskSerializer.fromProto)
-      val tasksByApp = deserializedTasks.groupBy(_.taskId.appId)
+      val tasksByApp = deserializedTasks.groupBy(_.taskId.runSpecId)
       val map = tasksByApp.iterator.map {
         case (appId, appTasks) => appId -> TaskTracker.AppTasks.forTasks(appId, appTasks)
       }.toMap

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessor.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 private[tracker] object TaskOpProcessor {
   case class Operation(deadline: Timestamp, sender: ActorRef, taskId: Task.Id, stateOp: TaskStateOp) {
-    def appId: PathId = taskId.appId
+    def appId: PathId = taskId.runSpecId
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
@@ -47,7 +47,7 @@ private[tracker] object TaskOpProcessorImpl {
       implicit ec: ExecutionContext): Future[TaskStateChange] = {
       directTaskTracker.task(taskId).map {
         case Some(existingTask) =>
-          TaskStateChange.Failure(new IllegalStateException(s"$taskId of app [${taskId.appId}] already exists"))
+          TaskStateChange.Failure(new IllegalStateException(s"$taskId of app [${taskId.runSpecId}] already exists"))
 
         case None => TaskStateChange.Update(newState = updatedTask, oldState = None)
       }
@@ -60,7 +60,7 @@ private[tracker] object TaskOpProcessorImpl {
 
         case None =>
           val taskId = op.taskId
-          TaskStateChange.Failure(new IllegalStateException(s"$taskId of app [${taskId.appId}] does not exist"))
+          TaskStateChange.Failure(new IllegalStateException(s"$taskId of app [${taskId.runSpecId}] does not exist"))
       }
     }
 
@@ -153,7 +153,7 @@ private[tracker] class TaskOpProcessorImpl(
         TaskTrackerActor.Ack(op.sender, msg)
       }
 
-      log.warn(s"${op.taskId} of app [${op.taskId.appId}]: try to recover from failed ${op.stateOp}", cause)
+      log.warn(s"${op.taskId} of app [${op.taskId.runSpecId}]: try to recover from failed ${op.stateOp}", cause)
 
       repo.task(op.taskId.idString).map {
         case Some(taskProto) =>
@@ -168,7 +168,7 @@ private[tracker] class TaskOpProcessorImpl(
           ack(None, stateChange)
       }.recover {
         case NonFatal(loadingFailure) =>
-          log.warn(s"${op.taskId} of app [${op.taskId.appId}]: task reloading failed as well", loadingFailure)
+          log.warn(s"${op.taskId} of app [${op.taskId.runSpecId}]: task reloading failed as well", loadingFailure)
           throw cause
       }
   }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializer.scala
@@ -56,7 +56,7 @@ object TaskSerializer {
       if (proto.hasStagedAt) {
         Some(
           Task.Launched(
-            appVersion = appVersion,
+            runSpecVersion = appVersion,
             status = taskStatus,
             hostPorts = hostPorts
           )
@@ -85,14 +85,14 @@ object TaskSerializer {
 
       case (Some(reservation), Some(launched)) =>
         Task.LaunchedOnReservation(
-          taskId, agentInfo, launched.appVersion, launched.status, launched.hostPorts, reservation)
+          taskId, agentInfo, launched.runSpecVersion, launched.status, launched.hostPorts, reservation)
 
       case (Some(reservation), None) =>
         Task.Reserved(taskId, agentInfo, reservation)
 
       case (None, Some(launched)) =>
         Task.LaunchedEphemeral(
-          taskId, agentInfo, launched.appVersion, launched.status, launched.hostPorts)
+          taskId, agentInfo, launched.runSpecVersion, launched.status, launched.hostPorts)
 
       case (None, None) =>
         val msg = s"Unable to deserialize task $taskId, agentInfo=$agentInfo. It is neither reserved nor launched"
@@ -127,13 +127,13 @@ object TaskSerializer {
 
     task match {
       case launched: Task.LaunchedEphemeral =>
-        setLaunched(launched.appVersion, launched.status, launched.hostPorts)
+        setLaunched(launched.runSpecVersion, launched.status, launched.hostPorts)
 
       case reserved: Task.Reserved =>
         setReservation(reserved.reservation)
 
       case launchedOnR: Task.LaunchedOnReservation =>
-        setLaunched(launchedOnR.appVersion, launchedOnR.status, launchedOnR.hostPorts)
+        setLaunched(launchedOnR.runSpecVersion, launchedOnR.status, launchedOnR.hostPorts)
         setReservation(launchedOnR.reservation)
     }
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActor.scala
@@ -139,10 +139,10 @@ private class TaskTrackerActor(
       case msg @ TaskTrackerActor.StateChanged(change, ack) =>
         change.stateChange match {
           case TaskStateChange.Update(task, _) =>
-            becomeWithUpdatedApp(task.appId)(task.taskId, newTask = Some(task))
+            becomeWithUpdatedApp(task.runSpecId)(task.taskId, newTask = Some(task))
 
           case TaskStateChange.Expunge(task) =>
-            becomeWithUpdatedApp(task.appId)(task.taskId, newTask = None)
+            becomeWithUpdatedApp(task.runSpecId)(task.taskId, newTask = None)
 
           case _: TaskStateChange.NoChange |
             _: TaskStateChange.Failure =>

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyHealthCheckManagerStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyHealthCheckManagerStepImpl.scala
@@ -21,7 +21,7 @@ class NotifyHealthCheckManagerStepImpl @Inject() (healthCheckManager: HealthChec
       case TaskStateOp.MesosUpdate(task, MarathonTaskStatus.WithMesosStatus(mesosStatus), _) =>
         // it only makes sense to handle health check results for launched tasks
         task.launched.foreach { launched =>
-          healthCheckManager.update(mesosStatus, launched.appVersion)
+          healthCheckManager.update(mesosStatus, launched.runSpecVersion)
         }
 
       case _ =>

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
@@ -44,7 +44,7 @@ class NotifyRateLimiterStepImpl @Inject() (
   private[this] def notifyRateLimiter(status: TaskStatus, task: Task): Future[_] = {
     import scala.concurrent.ExecutionContext.Implicits.global
     task.launched.fold(Future.successful(())) { launched =>
-      appRepository.app(task.appId, launched.appVersion).map { maybeApp =>
+      appRepository.app(task.runSpecId, launched.runSpecVersion).map { maybeApp =>
         // It would be nice if we could make sure that the delay gets send
         // to the AppTaskLauncherActor before we continue but that would require quite some work.
         //

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -38,7 +38,7 @@ class PostToEventStreamStepImpl @Inject() (
 
           case state: TaskState =>
             val taskId = task.taskId
-            log.debug(s"Do not post event $state for $taskId of app [${taskId.appId}].")
+            log.debug(s"Do not post event $state for $taskId of app [${taskId.runSpecId}].")
         }
 
       case _ =>
@@ -53,7 +53,7 @@ class PostToEventStreamStepImpl @Inject() (
     task.launched.foreach { launched =>
       log.info(
         "Sending event notification for {} of app [{}]: {}",
-        Array[Object](taskId, taskId.appId, status.getState): _*
+        Array[Object](taskId, taskId.runSpecId, status.getState): _*
       )
       eventBus.publish(
         MesosStatusUpdateEvent(
@@ -61,11 +61,11 @@ class PostToEventStreamStepImpl @Inject() (
           taskId = Task.Id(status.getTaskId),
           taskStatus = status.getState.name,
           message = if (status.hasMessage) status.getMessage else "",
-          appId = taskId.appId,
+          appId = taskId.runSpecId,
           host = task.agentInfo.host,
           ipAddresses = Task.MesosStatus.ipAddresses(status),
           ports = launched.hostPorts,
-          version = launched.appVersion.toString,
+          version = launched.runSpecVersion.toString,
           timestamp = timestamp.toString
         )
       )

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
@@ -37,9 +37,9 @@ class ScaleAppUpdateStepImpl @Inject() (
     }
 
     terminalOrExpungedTask.foreach { task =>
-      log.info(s"initiating a scale check for app [${task.taskId.appId}] after ${task.taskId} terminated")
+      log.info(s"initiating a scale check for app [${task.taskId.runSpecId}] after ${task.taskId} terminated")
       log.info("schedulerActor: {}", schedulerActor)
-      schedulerActor ! ScaleApp(task.taskId.appId)
+      schedulerActor ! ScaleApp(task.taskId.runSpecId)
     }
 
     Future.successful(())

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
@@ -85,7 +85,7 @@ private[health] class HealthCheckActor(
     log.debug("Dispatching health check jobs to workers")
     taskTracker.appTasksSync(app.id).foreach { task =>
       task.launched.foreach { launched =>
-        if (launched.appVersion == app.version && launched.hasStartedRunning) {
+        if (launched.runSpecVersion == app.version && launched.hasStartedRunning) {
           log.debug("Dispatching health check job for {}", task.taskId)
           val worker: ActorRef = context.actorOf(workerProps)
           worker ! HealthCheckJob(app, task, launched, healthCheck)
@@ -109,7 +109,7 @@ private[health] class HealthCheckActor(
         log.info(s"Send kill request for ${task.taskId} on host ${task.agentInfo.host} to driver")
         eventBus.publish(
           UnhealthyTaskKillEvent(
-            appId = task.appId,
+            appId = task.runSpecId,
             taskId = task.taskId,
             version = app.version,
             reason = health.lastFailureCause.getOrElse("unknown"),

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -81,7 +81,7 @@ case class AppDefinition(
 
   residency: Option[Residency] = AppDefinition.DefaultResidency)
 
-    extends plugin.AppDefinition with MarathonState[Protos.ServiceDefinition, AppDefinition] {
+    extends RunSpec with plugin.AppDefinition with MarathonState[Protos.ServiceDefinition, AppDefinition] {
 
   import mesosphere.mesos.protos.Implicits._
 
@@ -293,13 +293,13 @@ case class AppDefinition(
   /**
     * Returns whether this is a scaling change only.
     */
-  def isOnlyScaleChange(to: AppDefinition): Boolean = !isUpgrade(to) && (instances != to.instances)
+  def isOnlyScaleChange(to: RunSpec): Boolean = !isUpgrade(to) && (instances != to.instances)
 
   /**
     * True if the given app definition is a change to the current one in terms of runtime characteristics
     * of all deployed tasks of the current app, otherwise false.
     */
-  def isUpgrade(to: AppDefinition): Boolean = {
+  def isUpgrade(to: RunSpec): Boolean = {
     id == to.id && {
       cmd != to.cmd ||
         args != to.args ||
@@ -340,7 +340,7 @@ case class AppDefinition(
     * This can either be caused by changed configuration (e.g. a new cmd, a new docker image version)
     * or by a forced restart.
     */
-  def needsRestart(to: AppDefinition): Boolean = this.versionInfo != to.versionInfo || isUpgrade(to)
+  def needsRestart(to: RunSpec): Boolean = this.versionInfo != to.versionInfo || isUpgrade(to)
 
   /**
     * Identify other app definitions as the same, if id and version is the same.

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -113,7 +113,7 @@ case class AppDefinition(
   //scalastyle:off method.length
   def toProto: Protos.ServiceDefinition = {
     val commandInfo = TaskBuilder.commandInfo(
-      app = this,
+      runSpec = this,
       taskId = None,
       host = None,
       ports = Seq.empty,

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -1,0 +1,89 @@
+package mesosphere.marathon.state
+
+import mesosphere.marathon.Protos.Constraint
+import mesosphere.marathon.core.readiness.ReadinessCheck
+import mesosphere.marathon.health.HealthCheck
+import mesosphere.marathon.state.AppDefinition.VersionInfo
+import mesosphere.marathon.state.Container.Docker.PortMapping
+
+import scala.concurrent.duration.FiniteDuration
+import scala.collection.immutable.Seq
+
+//scalastyle:off
+trait RunSpec {
+  def id: PathId
+
+  def cmd: Option[String]
+
+  def args: Option[Seq[String]]
+
+  def user: Option[String]
+
+  def env: Map[String, String]
+
+  def instances: Int
+
+  def cpus: Double
+
+  def mem: Double
+
+  def disk: Double
+
+  def executor: String
+
+  def constraints: Set[Constraint]
+
+  def fetch: Seq[FetchUri]
+
+  def storeUrls: Seq[String]
+
+  def portDefinitions: Seq[PortDefinition]
+
+  def requirePorts: Boolean
+
+  def backoff: FiniteDuration
+
+  def backoffFactor: Double
+
+  def maxLaunchDelay: FiniteDuration
+
+  def container: Option[Container]
+
+  def healthChecks: Set[HealthCheck]
+
+  def readinessChecks: Seq[ReadinessCheck]
+
+  def dependencies: Set[PathId]
+
+  def upgradeStrategy: UpgradeStrategy
+
+  def labels: Map[String, String]
+
+  def acceptedResourceRoles: Option[Set[String]]
+
+  def ipAddress: Option[IpAddress]
+
+  def versionInfo: VersionInfo
+
+  def version: Timestamp
+
+  def residency: Option[Residency]
+
+  def isResident: Boolean
+
+  def isUpgrade(to: RunSpec): Boolean
+
+  def needsRestart(to: RunSpec): Boolean
+
+  def isOnlyScaleChange(to: RunSpec): Boolean
+
+  def isSingleInstance: Boolean
+  def volumes: Iterable[Volume]
+  def persistentVolumes: Iterable[PersistentVolume]
+  def externalVolumes: Iterable[ExternalVolume]
+  def diskForPersistentVolumes: Double
+  def portNumbers: Seq[Int]
+  def containerHostPorts: Option[Seq[Int]]
+  def portMappings: Option[Seq[PortMapping]]
+  def servicePorts: Seq[Int]
+}

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.state
 
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.core.readiness.ReadinessCheck
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.state.AppDefinition.VersionInfo
 import mesosphere.marathon.state.Container.Docker.PortMapping
@@ -83,7 +84,9 @@ trait RunSpec {
   def externalVolumes: Iterable[ExternalVolume]
   def diskForPersistentVolumes: Double
   def portNumbers: Seq[Int]
+  def portNames: Seq[String]
   def containerHostPorts: Option[Seq[Int]]
   def portMappings: Option[Seq[PortMapping]]
   def servicePorts: Seq[Int]
+  def portAssignments(task: Task): Option[Seq[PortAssignment]]
 }

--- a/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.tasks
 
-import mesosphere.marathon.state.{ ResourceRole, AppDefinition, Container }
+import mesosphere.marathon.state.{ ResourceRole, RunSpec, Container }
 import mesosphere.marathon.state.Container.Docker.PortMapping
 import mesosphere.marathon.tasks.PortsMatcher.PortWithRole
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
@@ -28,7 +28,7 @@ case class PortsMatch(hostPortsWithRole: Seq[PortWithRole]) {
   * Utility class for checking if the ports resource in an offer matches the requirements of an app.
   */
 class PortsMatcher(
-  app: AppDefinition,
+  app: RunSpec,
   offer: MesosProtos.Offer,
   resourceSelector: ResourceSelector = ResourceSelector(Set(ResourceRole.Unreserved), reserved = false),
   random: Random = Random)

--- a/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
@@ -28,7 +28,7 @@ case class PortsMatch(hostPortsWithRole: Seq[PortWithRole]) {
   * Utility class for checking if the ports resource in an offer matches the requirements of an app.
   */
 class PortsMatcher(
-  app: RunSpec,
+  runSpec: RunSpec,
   offer: MesosProtos.Offer,
   resourceSelector: ResourceSelector = ResourceSelector(Set(ResourceRole.Unreserved), reserved = false),
   random: Random = Random)
@@ -41,25 +41,25 @@ class PortsMatcher(
   private[this] def portsWithRoles: Option[Seq[PortWithRole]] = {
     val portMappings: Option[Seq[Container.Docker.PortMapping]] =
       for {
-        c <- app.container
+        c <- runSpec.container
         d <- c.docker
         pms <- d.portMappings if pms.nonEmpty
       } yield pms
 
-    (app.portNumbers, portMappings) match {
+    (runSpec.portNumbers, portMappings) match {
       case (Nil, None) => // optimization for empty special case
         Some(Seq.empty)
 
-      case (appPortSpec, Some(mappings)) =>
+      case (ports, Some(mappings)) =>
         // We use the mappings from the containers if they are available and ignore any other port specification.
         // We cannot warn about this because we autofill the ports field.
         mappedPortRanges(mappings)
 
-      case (appPorts, None) if app.requirePorts =>
-        findPortsInOffer(appPorts, failLog = true)
+      case (ports, None) if runSpec.requirePorts =>
+        findPortsInOffer(ports, failLog = true)
 
-      case (appPorts, None) =>
-        randomPorts(appPorts.size)
+      case (ports, None) =>
+        randomPorts(ports.size)
     }
   }
 
@@ -76,7 +76,7 @@ class PortsMatcher(
             log.info(
               s"Offer [${offer.getId.getValue}]. $resourceSelector. " +
                 s"Couldn't find host port $port (of ${requiredPorts.mkString(", ")}) " +
-                s"in any offered range for app [${app.id}]")
+                s"in any offered range for run spec [${runSpec.id}]")
           None
         }
       }
@@ -91,7 +91,7 @@ class PortsMatcher(
       shuffledAvailablePorts.map(Some(_))
     } orElse {
       log.info(s"Offer [${offer.getId.getValue}]. $resourceSelector. " +
-        s"Couldn't find $numberOfPorts ports in offer for app [${app.id}]")
+        s"Couldn't find $numberOfPorts ports in offer for run spec [${runSpec.id}]")
       None
     }
   }
@@ -113,7 +113,7 @@ class PortsMatcher(
         case PortMapping(containerPort, hostPort, servicePort, protocol, name, labels) if hostPort == 0 =>
           if (!availablePortsWithoutStaticHostPorts.hasNext) {
             log.info(s"Offer [${offer.getId.getValue}]. $resourceSelector. " +
-              s"Insufficient ports in offer for app [${app.id}]")
+              s"Insufficient ports in offer for run spec [${runSpec.id}]")
             None
           }
           else {
@@ -125,7 +125,7 @@ class PortsMatcher(
               Some(PortWithRole(role, pm.hostPort, reservation))
             case None =>
               log.info(s"Offer [${offer.getId.getValue}]. $resourceSelector. " +
-                s"Cannot find range with host port ${pm.hostPort} for app [${app.id}]")
+                s"Cannot find range with host port ${pm.hostPort} for run spec [${runSpec.id}]")
               None
           }
       }
@@ -217,7 +217,7 @@ object PortsMatcher {
     }
 
     /**
-      * We want to make it less likely that we are reusing the same dynamic port for tasks of different apps.
+      * We want to make it less likely that we are reusing the same dynamic port for tasks of different run specs.
       * This way we allow load balancers to reconfigure before reusing the same ports.
       *
       * Therefore we want to choose dynamic ports randomly from all the offered port ranges.

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentManager.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentManager.scala
@@ -138,7 +138,7 @@ object DeploymentManager {
                                       nr: Int,
                                       readinessChecks: Map[Task.Id, ReadinessCheckResult] = Map.empty) {
     lazy val readinessChecksByApp: Map[PathId, Iterable[ReadinessCheckResult]] = {
-      readinessChecks.values.groupBy(_.taskId.appId).withDefaultValue(Iterable.empty)
+      readinessChecks.values.groupBy(_.taskId.runSpecId).withDefaultValue(Iterable.empty)
     }
   }
 

--- a/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
@@ -1,7 +1,7 @@
 package mesosphere.mesos
 
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.AppDefinition
+import mesosphere.marathon.state.RunSpec
 import org.apache.mesos.{ Protos => Mesos }
 
 import scala.collection.JavaConverters._
@@ -9,7 +9,7 @@ import scala.collection.JavaConverters._
 object PersistentVolumeMatcher {
   def matchVolumes(
     offer: Mesos.Offer,
-    app: AppDefinition,
+    app: RunSpec,
     waitingTasks: Iterable[Task.Reserved]): Option[VolumeMatch] = {
 
     // find all offered persistent volumes

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -2,7 +2,7 @@ package mesosphere.mesos
 
 import mesosphere.marathon.core.launcher.impl.ResourceLabels
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.{ AppDefinition, ResourceRole }
+import mesosphere.marathon.state.{ RunSpec, ResourceRole }
 import mesosphere.marathon.tasks.{ PortsMatch, PortsMatcher }
 import mesosphere.mesos.protos.Resource
 import org.apache.mesos.Protos
@@ -89,7 +89,7 @@ object ResourceMatcher {
     * resources, the disk resources for the local volumes are included since they must become part of
     * the reservation.
     */
-  def matchResources(offer: Offer, app: AppDefinition, runningTasks: => Iterable[Task],
+  def matchResources(offer: Offer, app: RunSpec, runningTasks: => Iterable[Task],
                      selector: ResourceSelector): Option[ResourceMatch] = {
 
     val groupedResources: Map[Role, mutable.Buffer[Protos.Resource]] = offer.getResourcesList.asScala.groupBy(_.getName)

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -17,7 +17,7 @@ import play.api.libs.json.Json
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 
-class TaskBuilder(app: RunSpec,
+class TaskBuilder(runSpec: RunSpec,
                   newTaskId: PathId => Task.Id,
                   config: MarathonConf) {
 
@@ -29,9 +29,9 @@ class TaskBuilder(app: RunSpec,
     volumeMatchOpt: Option[PersistentVolumeMatcher.VolumeMatch] = None): Option[(TaskInfo, Seq[Int])] = {
 
     def logInsufficientResources(): Unit = {
-      val appHostPorts = if (app.requirePorts) app.portNumbers else app.portNumbers.map(_ => 0)
-      val containerHostPorts: Option[Seq[Int]] = app.containerHostPorts
-      val hostPorts = containerHostPorts.getOrElse(appHostPorts)
+      val runSpecHostPorts = if (runSpec.requirePorts) runSpec.portNumbers else runSpec.portNumbers.map(_ => 0)
+      val containerHostPorts: Option[Seq[Int]] = runSpec.containerHostPorts
+      val hostPorts = containerHostPorts.getOrElse(runSpecHostPorts)
       val staticHostPorts = hostPorts.filter(_ != 0)
       val numberDynamicHostPorts = hostPorts.count(_ == 0)
 
@@ -54,8 +54,8 @@ class TaskBuilder(app: RunSpec,
       val portsString = s"ports=($portStrings)"
 
       log.info(
-        s"Offer [${offer.getId.getValue}]. Insufficient resources for [${app.id}] (need cpus=${app.cpus}, " +
-          s"mem=${app.mem}, disk=${app.disk}, $portsString, available in offer: " +
+        s"Offer [${offer.getId.getValue}]. Insufficient resources for [${runSpec.id}] (need cpus=${runSpec.cpus}, " +
+          s"mem=${runSpec.mem}, disk=${runSpec.disk}, $portsString, available in offer: " +
           s"[${TextFormat.shortDebugString(offer)}]"
       )
     }
@@ -72,14 +72,14 @@ class TaskBuilder(app: RunSpec,
   def buildIfMatches(offer: Offer, runningTasks: => Iterable[Task]): Option[(TaskInfo, Seq[Int])] = {
 
     val acceptedResourceRoles: Set[String] = {
-      val roles = app.acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet)
+      val roles = runSpec.acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet)
       if (log.isDebugEnabled) log.debug(s"acceptedResourceRoles $roles")
       roles
     }
 
     val resourceMatch =
       ResourceMatcher.matchResources(
-        offer, app, runningTasks, ResourceSelector(acceptedResourceRoles, reserved = false))
+        offer, runSpec, runningTasks, ResourceSelector(acceptedResourceRoles, reserved = false))
 
     build(offer, resourceMatch)
   }
@@ -91,29 +91,29 @@ class TaskBuilder(app: RunSpec,
     resourceMatch: ResourceMatch,
     volumeMatchOpt: Option[PersistentVolumeMatcher.VolumeMatch]): Some[(TaskInfo, Seq[Int])] = {
 
-    val executor: Executor = if (app.executor == "") {
+    val executor: Executor = if (runSpec.executor == "") {
       config.executor
     }
     else {
-      Executor.dispatch(app.executor)
+      Executor.dispatch(runSpec.executor)
     }
 
     val host: Option[String] = Some(offer.getHostname)
 
-    val labels = app.labels.map {
+    val labels = runSpec.labels.map {
       case (key, value) =>
         Label.newBuilder.setKey(key).setValue(value).build()
     }
 
-    val taskId = newTaskId(app.id)
+    val taskId = newTaskId(runSpec.id)
     val builder = TaskInfo.newBuilder
       // Use a valid hostname to make service discovery easier
-      .setName(app.id.toHostname)
+      .setName(runSpec.id.toHostname)
       .setTaskId(taskId.mesosTaskId)
       .setSlaveId(offer.getSlaveId)
       .addAllResources(resourceMatch.resources.asJava)
 
-    builder.setDiscovery(computeDiscoveryInfo(app, resourceMatch.hostPorts))
+    builder.setDiscovery(computeDiscoveryInfo(runSpec, resourceMatch.hostPorts))
 
     if (labels.nonEmpty)
       builder.setLabels(Labels.newBuilder.addAllLabels(labels.asJava))
@@ -124,7 +124,7 @@ class TaskBuilder(app: RunSpec,
     val envPrefix: Option[String] = config.envVarsPrefix.get
 
     def decorateForExternalVolumes(builder: CommandInfo.Builder) = containerProto.foreach { cp =>
-      app.externalVolumes.foreach {
+      runSpec.externalVolumes.foreach {
         ExternalVolumes.build(cp.getType, builder, _)
       }
     }
@@ -132,14 +132,14 @@ class TaskBuilder(app: RunSpec,
     executor match {
       case CommandExecutor() =>
         containerProto.foreach(builder.setContainer)
-        val command = TaskBuilder.commandInfo(app, Some(taskId), host, resourceMatch.hostPorts, envPrefix)
+        val command = TaskBuilder.commandInfo(runSpec, Some(taskId), host, resourceMatch.hostPorts, envPrefix)
         decorateForExternalVolumes(command)
         builder.setCommand(command.build)
 
       case PathExecutor(path) =>
         val executorId = f"marathon-${taskId.idString}" // Fresh executor
         val executorPath = s"'$path'" // TODO: Really escape this.
-        val cmd = app.cmd orElse app.args.map(_ mkString " ") getOrElse ""
+        val cmd = runSpec.cmd orElse runSpec.args.map(_ mkString " ") getOrElse ""
         val shell = s"chmod ug+rx $executorPath && exec $executorPath $cmd"
 
         val info = ExecutorInfo.newBuilder()
@@ -148,7 +148,7 @@ class TaskBuilder(app: RunSpec,
         containerProto.foreach(info.setContainer)
 
         val command =
-          TaskBuilder.commandInfo(app, Some(taskId), host, resourceMatch.hostPorts, envPrefix).setValue(shell)
+          TaskBuilder.commandInfo(runSpec, Some(taskId), host, resourceMatch.hostPorts, envPrefix).setValue(shell)
         decorateForExternalVolumes(command)
         info.setCommand(command.build)
         builder.setExecutor(info)
@@ -164,7 +164,7 @@ class TaskBuilder(app: RunSpec,
     // Mesos supports at most one health check, and only COMMAND checks
     // are currently implemented in the Mesos health check helper program.
     val mesosHealthChecks: Set[org.apache.mesos.Protos.HealthCheck] =
-      app.healthChecks.collect {
+      runSpec.healthChecks.collect {
         case healthCheck: HealthCheck if healthCheck.protocol == Protocol.COMMAND => healthCheck.toMesos
       }
 
@@ -182,24 +182,24 @@ class TaskBuilder(app: RunSpec,
     Some(builder.build -> resourceMatch.hostPorts)
   }
 
-  protected def computeDiscoveryInfo(app: RunSpec, hostPorts: Seq[Int]): org.apache.mesos.Protos.DiscoveryInfo = {
+  protected def computeDiscoveryInfo(runSpec: RunSpec, hostPorts: Seq[Int]): org.apache.mesos.Protos.DiscoveryInfo = {
     val discoveryInfoBuilder = org.apache.mesos.Protos.DiscoveryInfo.newBuilder
-    discoveryInfoBuilder.setName(app.id.toHostname)
+    discoveryInfoBuilder.setName(runSpec.id.toHostname)
     discoveryInfoBuilder.setVisibility(org.apache.mesos.Protos.DiscoveryInfo.Visibility.FRAMEWORK)
 
-    val portProtos = app.ipAddress match {
+    val portProtos = runSpec.ipAddress match {
       case Some(IpAddress(_, _, DiscoveryInfo(ports))) if ports.nonEmpty => ports.map(_.toProto)
       case _ =>
-        app.portMappings match {
+        runSpec.portMappings match {
           case Some(portMappings) =>
-            // The app uses bridge mode with portMappings, use them to create the Port messages
+            // The run spec uses bridge mode with portMappings, use them to create the Port messages
             portMappings.zip(hostPorts).map {
               case (portMapping, hostPort) => PortMappingSerializer.toMesosPort(portMapping, hostPort)
             }
           case None =>
-            // Serialize app.portDefinitions to protos. The port numbers are the service ports, we need to
+            // Serialize runSpec.portDefinitions to protos. The port numbers are the service ports, we need to
             // overwrite them the port numbers assigned to this particular task.
-            app.portDefinitions.zip(hostPorts).map {
+            runSpec.portDefinitions.zip(hostPorts).map {
               case (portDefinition, hostPort) =>
                 PortDefinitionSerializer.toProto(portDefinition).toBuilder.setNumber(hostPort).build
             }
@@ -214,12 +214,12 @@ class TaskBuilder(app: RunSpec,
   }
 
   protected def computeContainerInfo(ports: Seq[Int]): Option[ContainerInfo] = {
-    if (app.container.isEmpty && app.ipAddress.isEmpty) None
+    if (runSpec.container.isEmpty && runSpec.ipAddress.isEmpty) None
     else {
       val builder = ContainerInfo.newBuilder
 
       // Fill in Docker container details if necessary
-      app.container.foreach { c =>
+      runSpec.container.foreach { c =>
         val portMappings = c.docker.map { d =>
           d.portMappings.map { pms =>
             pms zip ports map {
@@ -254,7 +254,7 @@ class TaskBuilder(app: RunSpec,
       }
 
       // Set NetworkInfo if necessary
-      app.ipAddress.foreach { ipAddress =>
+      runSpec.ipAddress.foreach { ipAddress =>
         val ipAddressLabels = Labels.newBuilder().addAllLabels(ipAddress.labels.map {
           case (key, value) => Label.newBuilder.setKey(key).setValue(value).build()
         }.asJava)
@@ -286,22 +286,22 @@ object TaskBuilder {
   val labelEnvironmentKeyPrefix = "MARATHON_APP_LABEL_"
   val maxVariableLength = maxEnvironmentVarLength - labelEnvironmentKeyPrefix.length
 
-  def commandInfo(app: RunSpec,
+  def commandInfo(runSpec: RunSpec,
                   taskId: Option[Task.Id],
                   host: Option[String],
                   ports: Seq[Int],
                   envPrefix: Option[String]): CommandInfo.Builder = {
-    val containerPorts = for (pms <- app.portMappings) yield pms.map(_.containerPort)
-    val declaredPorts = containerPorts.getOrElse(app.portNumbers)
+    val containerPorts = for (pms <- runSpec.portMappings) yield pms.map(_.containerPort)
+    val declaredPorts = containerPorts.getOrElse(runSpec.portNumbers)
     val envMap: Map[String, String] =
-      taskContextEnv(app, taskId) ++
+      taskContextEnv(runSpec, taskId) ++
         addPrefix(envPrefix, portsEnv(declaredPorts, ports) ++ host.map("HOST" -> _).toMap) ++
-        app.env
+        runSpec.env
 
     val builder = CommandInfo.newBuilder()
       .setEnvironment(environment(envMap))
 
-    app.cmd match {
+    runSpec.cmd match {
       case Some(cmd) if cmd.nonEmpty =>
         builder.setValue(cmd)
       case _ =>
@@ -309,18 +309,18 @@ object TaskBuilder {
     }
 
     // args take precedence over command, if supplied
-    app.args.foreach { argv =>
+    runSpec.args.foreach { argv =>
       builder.setShell(false)
       builder.addAllArguments(argv.asJava)
       //mesos command executor expects cmd and arguments
-      if (app.container.isEmpty) builder.setValue(argv.head)
+      if (runSpec.container.isEmpty) builder.setValue(argv.head)
     }
 
-    if (app.fetch.nonEmpty) {
-      builder.addAllUris(app.fetch.map(_.toProto()).asJava)
+    if (runSpec.fetch.nonEmpty) {
+      builder.addAllUris(runSpec.fetch.map(_.toProto()).asJava)
     }
 
-    app.user.foreach(builder.setUser)
+    runSpec.user.foreach(builder.setUser)
 
     builder
   }
@@ -368,7 +368,7 @@ object TaskBuilder {
     }
   }
 
-  def taskContextEnv(app: RunSpec, taskId: Option[Task.Id]): Map[String, String] = {
+  def taskContextEnv(runSpec: RunSpec, taskId: Option[Task.Id]): Map[String, String] = {
     if (taskId.isEmpty) {
       // This branch is taken during serialization. Do not add environment variables in this case.
       Map.empty
@@ -376,15 +376,15 @@ object TaskBuilder {
     else {
       Seq(
         "MESOS_TASK_ID" -> taskId.map(_.idString),
-        "MARATHON_APP_ID" -> Some(app.id.toString),
-        "MARATHON_APP_VERSION" -> Some(app.version.toString),
-        "MARATHON_APP_DOCKER_IMAGE" -> app.container.flatMap(_.docker.map(_.image)),
-        "MARATHON_APP_RESOURCE_CPUS" -> Some(app.cpus.toString),
-        "MARATHON_APP_RESOURCE_MEM" -> Some(app.mem.toString),
-        "MARATHON_APP_RESOURCE_DISK" -> Some(app.disk.toString)
+        "MARATHON_APP_ID" -> Some(runSpec.id.toString),
+        "MARATHON_APP_VERSION" -> Some(runSpec.version.toString),
+        "MARATHON_APP_DOCKER_IMAGE" -> runSpec.container.flatMap(_.docker.map(_.image)),
+        "MARATHON_APP_RESOURCE_CPUS" -> Some(runSpec.cpus.toString),
+        "MARATHON_APP_RESOURCE_MEM" -> Some(runSpec.mem.toString),
+        "MARATHON_APP_RESOURCE_DISK" -> Some(runSpec.disk.toString)
       ).collect {
           case (key, Some(value)) => key -> value
-        }.toMap ++ labelsToEnvVars(app.labels)
+        }.toMap ++ labelsToEnvVars(runSpec.labels)
     }
   }
 

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -153,12 +153,12 @@ class TaskBuilder(runSpec: RunSpec,
         info.setCommand(command.build)
         builder.setExecutor(info)
 
-      //FIXME: why do we jsonify this?
-      //        import mesosphere.marathon.api.v2.json.Formats._
-      //        val appJson = Json.toJson(app)
-      //        val appJsonString = Json.stringify(appJson)
-      //        val appJsonByteString = ByteString.copyFromUtf8(appJsonString)
-      //        builder.setData(appJsonByteString)
+        //FIXME(MV): why do we jsonify this here?
+        import mesosphere.marathon.api.v2.json.Formats._
+        val runSpecJson = Json.toJson(runSpec)
+        val runSpecJsonString = Json.stringify(runSpecJson)
+        val runSpecJsonByteString = ByteString.copyFromUtf8(runSpecJsonString)
+        builder.setData(runSpecJsonByteString)
     }
 
     // Mesos supports at most one health check, and only COMMAND checks

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -50,7 +50,7 @@ class LaunchQueueModuleTest
 
     Then("we get back the added app")
     list should have size 1
-    list.head.app should equal(app)
+    list.head.runSpec should equal(app)
     list.head.tasksLeftToLaunch should equal(1)
     list.head.tasksLaunched should equal(0)
     list.head.taskLaunchesInFlight should equal(0)
@@ -229,7 +229,7 @@ class LaunchQueueModuleTest
     And("test app gets purged (but not stopped yet because of in-flight tasks)")
     Future { launchQueue.purge(app.id) } (ExecutionContext.Implicits.global)
     WaitTestSupport.waitUntil("purge gets executed", 1.second) {
-      !launchQueue.list.exists(_.app.id == app.id)
+      !launchQueue.list.exists(_.runSpec.id == app.id)
     }
     reset(taskTracker, taskOpFactory)
 
@@ -247,7 +247,7 @@ class LaunchQueueModuleTest
     val app = MarathonTestHelper.makeBasicApp().copy(id = PathId("/app"))
 
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    val taskId = Task.Id.forApp(PathId("/test"))
+    val taskId = Task.Id.forRunSpec(PathId("/test"))
     val mesosTask = MarathonTestHelper.makeOneCPUTask("").setTaskId(taskId.mesosTaskId).build()
     val marathonTask = MarathonTestHelper.runningTask(taskId.idString)
     val launch = new TaskOpFactoryHelper(Some("principal"), Some("role")).launchEphemeral(mesosTask, marathonTask)
@@ -259,7 +259,6 @@ class LaunchQueueModuleTest
     lazy val clock: Clock = Clock()
     lazy val taskBusModule: TaskBusModule = new TaskBusModule()
     lazy val offerMatcherManager: DummyOfferMatcherManager = new DummyOfferMatcherManager()
-    lazy val appRepository: AppRepository = mock[AppRepository]
     lazy val taskTracker: TaskTracker = mock[TaskTracker]
     lazy val taskOpFactory: TaskOpFactory = mock[TaskOpFactory]
     lazy val config = MarathonTestHelper.defaultConfig()
@@ -269,7 +268,6 @@ class LaunchQueueModuleTest
       clock,
       subOfferMatcherManager = offerMatcherManager,
       maybeOfferReviver = None,
-      appRepository,
       taskTracker,
       taskOpFactory
     )
@@ -277,7 +275,6 @@ class LaunchQueueModuleTest
     def launchQueue = module.launchQueue
 
     def verifyNoMoreInteractions(): Unit = {
-      noMoreInteractions(appRepository)
       noMoreInteractions(taskTracker)
       noMoreInteractions(taskOpFactory)
     }

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -252,7 +252,7 @@ object MarathonTestHelper {
           agentId = Some(offer.getSlaveId.getValue),
           attributes = offer.getAttributesList.asScala
         ),
-        appVersion = version,
+        runSpecVersion = version,
         status = Task.Status(
           stagedAt = now
         ),
@@ -321,13 +321,13 @@ object MarathonTestHelper {
     createTaskTrackerModule(leadershipModule, store, config, metrics).taskTracker
   }
 
-  def mininimalTask(appId: PathId): Task.LaunchedEphemeral = mininimalTask(Task.Id.forApp(appId).idString)
+  def mininimalTask(appId: PathId): Task.LaunchedEphemeral = mininimalTask(Task.Id.forRunSpec(appId).idString)
   def mininimalTask(taskId: Task.Id): Task.LaunchedEphemeral = mininimalTask(taskId.idString)
   def mininimalTask(taskId: String, now: Timestamp = clock.now()): Task.LaunchedEphemeral = {
     Task.LaunchedEphemeral(
       Task.Id(taskId),
       Task.AgentInfo(host = "host.some", agentId = None, attributes = Iterable.empty),
-      appVersion = now,
+      runSpecVersion = now,
       status = Task.Status(
         stagedAt = now,
         startedAt = None,
@@ -339,7 +339,7 @@ object MarathonTestHelper {
 
   def minimalReservedTask(appId: PathId, reservation: Task.Reservation): Task.Reserved =
     Task.Reserved(
-      taskId = Task.Id.forApp(appId),
+      taskId = Task.Id.forRunSpec(appId),
       Task.AgentInfo(host = "host.some", agentId = None, attributes = Iterable.empty),
       reservation = reservation)
 
@@ -354,12 +354,12 @@ object MarathonTestHelper {
 
   def taskLaunchedOp(taskId: Task.Id): TaskStateOp.LaunchOnReservation = {
     val now = Timestamp.now()
-    TaskStateOp.LaunchOnReservation(taskId = taskId, appVersion = now, status = Task.Status(now), hostPorts = Seq.empty)
+    TaskStateOp.LaunchOnReservation(taskId = taskId, runSpecVersion = now, status = Task.Status(now), hostPorts = Seq.empty)
   }
 
   def startingTaskForApp(appId: PathId, appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task.LaunchedEphemeral =
     startingTask(
-      Task.Id.forApp(appId).idString,
+      Task.Id.forRunSpec(appId).idString,
       appVersion = appVersion,
       stagedAt = stagedAt
     )
@@ -367,7 +367,7 @@ object MarathonTestHelper {
     Task.LaunchedEphemeral(
       taskId = Task.Id(taskId),
       agentInfo = Task.AgentInfo("some.host", Some("agent-1"), Iterable.empty),
-      appVersion = appVersion,
+      runSpecVersion = appVersion,
       status = Task.Status(
         stagedAt = Timestamp(stagedAt),
         startedAt = None,
@@ -378,7 +378,7 @@ object MarathonTestHelper {
 
   def stagedTaskForApp(
     appId: PathId = PathId("/test"), appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task.LaunchedEphemeral =
-    stagedTask(Task.Id.forApp(appId).idString, appVersion = appVersion, stagedAt = stagedAt)
+    stagedTask(Task.Id.forRunSpec(appId).idString, appVersion = appVersion, stagedAt = stagedAt)
   def stagedTask(
     taskId: String,
     appVersion: Timestamp = Timestamp(1),
@@ -387,7 +387,7 @@ object MarathonTestHelper {
     Task.LaunchedEphemeral(
       taskId = Task.Id(taskId),
       agentInfo = Task.AgentInfo("some.host", Some("agent-1"), Iterable.empty),
-      appVersion = appVersion,
+      runSpecVersion = appVersion,
       status = Task.Status(
         stagedAt = Timestamp(stagedAt),
         startedAt = None,
@@ -401,7 +401,7 @@ object MarathonTestHelper {
                         stagedAt: Long = 2,
                         startedAt: Long = 3): Task.LaunchedEphemeral =
     runningTask(
-      Task.Id.forApp(appId).idString,
+      Task.Id.forRunSpec(appId).idString,
       appVersion = appVersion,
       stagedAt = stagedAt,
       startedAt = startedAt
@@ -423,7 +423,7 @@ object MarathonTestHelper {
 
   }
 
-  def healthyTask(appId: PathId): Task.LaunchedEphemeral = healthyTask(Task.Id.forApp(appId).idString)
+  def healthyTask(appId: PathId): Task.LaunchedEphemeral = healthyTask(Task.Id.forRunSpec(appId).idString)
   def healthyTask(taskId: String): Task.LaunchedEphemeral = {
     import Implicits._
     runningTask(taskId).withStatus { status =>
@@ -431,7 +431,7 @@ object MarathonTestHelper {
     }
   }
 
-  def unhealthyTask(appId: PathId): Task.LaunchedEphemeral = unhealthyTask(Task.Id.forApp(appId).idString)
+  def unhealthyTask(appId: PathId): Task.LaunchedEphemeral = unhealthyTask(Task.Id.forRunSpec(appId).idString)
   def unhealthyTask(taskId: String): Task.LaunchedEphemeral = {
     import Implicits._
     runningTask(taskId).withStatus { status =>
@@ -498,9 +498,9 @@ object MarathonTestHelper {
   def residentLaunchedTask(appId: PathId, localVolumeIds: Task.LocalVolumeId*) = {
     val now = Timestamp.now()
     Task.LaunchedOnReservation(
-      taskId = Task.Id.forApp(appId),
+      taskId = Task.Id.forRunSpec(appId),
       agentInfo = Task.AgentInfo(host = "host.some", agentId = None, attributes = Iterable.empty),
-      appVersion = now,
+      runSpecVersion = now,
       status = Task.Status(
         stagedAt = now,
         startedAt = None,

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -25,8 +25,8 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     Given("two apps and 1 task each")
     val app1 = "/my/app-1".toRootPath
     val app2 = "/my/app-2".toRootPath
-    val taskId1 = Task.Id.forApp(app1).idString
-    val taskId2 = Task.Id.forApp(app2).idString
+    val taskId1 = Task.Id.forRunSpec(app1).idString
+    val taskId2 = Task.Id.forRunSpec(app2).idString
     val body = s"""{"ids": ["$taskId1", "$taskId2"]}"""
     val bodyBytes = body.toCharArray.map(_.toByte)
 
@@ -60,8 +60,8 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     Given("two apps and 1 task each")
     val app1 = "/my/app-1".toRootPath
     val app2 = "/my/app-2".toRootPath
-    val taskId1 = Task.Id.forApp(app1).idString
-    val taskId2 = Task.Id.forApp(app2).idString
+    val taskId1 = Task.Id.forRunSpec(app1).idString
+    val taskId2 = Task.Id.forRunSpec(app2).idString
     val body = s"""{"ids": ["$taskId1", "$taskId2"]}"""
     val bodyBytes = body.toCharArray.map(_.toByte)
     val deploymentPlan = new DeploymentPlan("plan", Group.empty, Group.empty, Seq.empty[DeploymentStep], Timestamp.zero)
@@ -94,7 +94,7 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
   test("killTasks with scale and wipe fails") {
     Given("a request")
     val app1 = "/my/app-1".toRootPath
-    val taskId1 = Task.Id.forApp(app1).idString
+    val taskId1 = Task.Id.forRunSpec(app1).idString
     val body = s"""{"ids": ["$taskId1"]}"""
     val bodyBytes = body.toCharArray.map(_.toByte)
 
@@ -113,7 +113,7 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
 
     Given("a task that shall be killed")
     val app1 = "/my/app-1".toRootPath
-    val taskId1 = Task.Id.forApp(app1).idString
+    val taskId1 = Task.Id.forRunSpec(app1).idString
     val body = s"""{"ids": ["$taskId1"]}"""
     val bodyBytes = body.toCharArray.map(_.toByte)
     val task1 = MarathonTestHelper.runningTask(taskId1)
@@ -141,9 +141,9 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     auth.authenticated = false
     val req = auth.request
     val appId = "/my/app".toRootPath
-    val taskId1 = Task.Id.forApp(appId).idString
-    val taskId2 = Task.Id.forApp(appId).idString
-    val taskId3 = Task.Id.forApp(appId).idString
+    val taskId1 = Task.Id.forRunSpec(appId).idString
+    val taskId2 = Task.Id.forRunSpec(appId).idString
+    val taskId3 = Task.Id.forRunSpec(appId).idString
     val body = s"""{"ids": ["$taskId1", "$taskId2", "$taskId3"]}""".getBytes
 
     Given("the app exists")
@@ -160,9 +160,9 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     auth.authenticated = false
     val req = auth.request
     val appId = "/my/app".toRootPath
-    val taskId1 = Task.Id.forApp(appId).idString
-    val taskId2 = Task.Id.forApp(appId).idString
-    val taskId3 = Task.Id.forApp(appId).idString
+    val taskId1 = Task.Id.forRunSpec(appId).idString
+    val taskId2 = Task.Id.forRunSpec(appId).idString
+    val taskId3 = Task.Id.forRunSpec(appId).idString
     val body = s"""{"ids": ["$taskId1", "$taskId2", "$taskId3"]}""".getBytes
 
     Given("the app does not exist")
@@ -196,9 +196,9 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     auth.authorized = false
     val req = auth.request
     val appId = "/my/app".toRootPath
-    val taskId1 = Task.Id.forApp(appId).idString
-    val taskId2 = Task.Id.forApp(appId).idString
-    val taskId3 = Task.Id.forApp(appId).idString
+    val taskId1 = Task.Id.forRunSpec(appId).idString
+    val taskId2 = Task.Id.forRunSpec(appId).idString
+    val taskId3 = Task.Id.forRunSpec(appId).idString
     val body = s"""{"ids": ["$taskId1", "$taskId2", "$taskId3"]}""".getBytes
 
     taskKiller = new TaskKiller(taskTracker, stateOpProcessor, groupManager, service, config, auth.auth, auth.auth)
@@ -226,7 +226,7 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
   test("killTasks fails for invalid taskId") {
     Given("a valid and an invalid taskId")
     val app1 = "/my/app-1".toRootPath
-    val taskId1 = Task.Id.forApp(app1).idString
+    val taskId1 = Task.Id.forRunSpec(app1).idString
     val body = s"""{"ids": ["$taskId1", "invalidTaskId"]}"""
     val bodyBytes = body.toCharArray.map(_.toByte)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
@@ -23,7 +23,7 @@ class MarathonTaskFormatTest extends MarathonSpec {
     val taskWithoutIp = new Task.LaunchedEphemeral(
       taskId = Task.Id("/foo/bar"),
       agentInfo = Task.AgentInfo("agent1.mesos", Some("abcd-1234"), Iterable.empty),
-      appVersion = time,
+      runSpecVersion = time,
       status = Task.Status(time, None),
       hostPorts = Seq.empty)
 
@@ -31,7 +31,7 @@ class MarathonTaskFormatTest extends MarathonSpec {
     val taskWithMultipleIPs = new Task.LaunchedEphemeral(
       taskId = Task.Id("/foo/bar"),
       agentInfo = Task.AgentInfo("agent1.mesos", Some("abcd-1234"), Iterable.empty),
-      appVersion = time,
+      runSpecVersion = time,
       status = Task.Status(
         stagedAt = time,
         startedAt = None,
@@ -49,7 +49,7 @@ class MarathonTaskFormatTest extends MarathonSpec {
     val taskWithLocalVolumes = new Task.LaunchedOnReservation(
       taskId = Task.Id("/foo/bar"),
       agentInfo = Task.AgentInfo("agent1.mesos", Some("abcd-1234"), Iterable.empty),
-      appVersion = time,
+      runSpecVersion = time,
       status = Task.Status(time, Some(time)),
       hostPorts = Seq.empty,
       reservation = Task.Reservation(

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
@@ -178,7 +178,7 @@ class Fixture {
   val taskWithoutState = Task.LaunchedEphemeral(
     taskId = Task.Id("task1"),
     agentInfo = Task.AgentInfo("some.host", Some("agent-1"), Iterable.empty),
-    appVersion = Timestamp(0),
+    runSpecVersion = Timestamp(0),
     status = Task.Status(
       stagedAt = Timestamp(1),
       startedAt = None,

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -198,7 +198,7 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
     Given("One related and one unrelated deployment")
     val emptyGroup = Group.empty
     val deployment = DeploymentPlan(emptyGroup, emptyGroup.copy(apps = Set(app)))
-    val taskId: Task.Id = Task.Id.forApp(app.id)
+    val taskId: Task.Id = Task.Id.forRunSpec(app.id)
     val result = ReadinessCheckResult("foo", taskId, ready = false, None)
     f.marathonSchedulerService.listRunningDeployments() returns Future.successful(Seq[DeploymentStepInfo](
       DeploymentStepInfo(deployment, DeploymentStep(Seq.empty), 1, Map(taskId -> result))

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.state.{ PathId, Timestamp, AppDefinition }
 
 object LaunchQueueTestHelper {
   val zeroCounts = LaunchQueue.QueuedTaskInfo(
-    app = AppDefinition(PathId("/thisisignored")),
+    runSpec = AppDefinition(PathId("/thisisignored")),
     tasksLeftToLaunch = 0,
     taskLaunchesInFlight = 0,
     tasksLaunched = 0,

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -21,8 +21,8 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
   private[this] val offer = MarathonTestHelper.makeBasicOffer().build()
   private[this] val offerId = offer.getId
   private val appId: PathId = PathId("/testapp")
-  private[this] val taskInfo1 = MarathonTestHelper.makeOneCPUTask(Task.Id.forApp(appId).idString).build()
-  private[this] val taskInfo2 = MarathonTestHelper.makeOneCPUTask(Task.Id.forApp(appId).idString).build()
+  private[this] val taskInfo1 = MarathonTestHelper.makeOneCPUTask(Task.Id.forRunSpec(appId).idString).build()
+  private[this] val taskInfo2 = MarathonTestHelper.makeOneCPUTask(Task.Id.forRunSpec(appId).idString).build()
   private[this] val tasks = Seq(taskInfo1, taskInfo2)
 
   test("match successful, launch tasks successful") {
@@ -111,7 +111,7 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
       val dummyTask = MarathonTestHelper.residentReservedTask(appId)
       val taskStateOp = TaskStateOp.LaunchOnReservation(
         taskId = dummyTask.taskId,
-        appVersion = clock.now(),
+        runSpecVersion = clock.now(),
         status = Task.Status(clock.now()),
         hostPorts = Seq.empty)
       val launch = f.launchWithOldTask(

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLabelsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLabelsTest.scala
@@ -45,7 +45,7 @@ class TaskLabelsTest extends FunSuite with GivenWhenThen with Matchers {
     import scala.collection.JavaConverters._
 
     val appId = PathId("/test")
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val frameworkId = MarathonTestHelper.frameworkId
     val otherFrameworkId = FrameworkId("very other different framework id")
 

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActorTest.scala
@@ -51,7 +51,6 @@ class RateLimiterActorTest extends MarathonSpec {
   private[this] var clock: ConstantClock = _
   private[this] var rateLimiter: RateLimiter = _
   private[this] var taskTracker: TaskTracker = _
-  private[this] var appRepository: AppRepository = _
   private[this] var updateReceiver: TestProbe = _
   private[this] var limiterRef: ActorRef = _
 
@@ -60,9 +59,8 @@ class RateLimiterActorTest extends MarathonSpec {
     clock = ConstantClock()
     rateLimiter = Mockito.spy(new RateLimiter(clock))
     taskTracker = mock[TaskTracker]
-    appRepository = mock[AppRepository]
     updateReceiver = TestProbe()
-    val props = RateLimiterActor.props(rateLimiter, appRepository, updateReceiver.ref)
+    val props = RateLimiterActor.props(rateLimiter, updateReceiver.ref)
     limiterRef = actorSystem.actorOf(props, "limiter")
   }
 

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
@@ -32,7 +32,7 @@ class OfferOperationFactoryTest extends MarathonSpec with GivenWhenThen with Moc
 
     When("We create a reserve operation")
     val error = intercept[WrongConfigurationException] {
-      factory.reserve(f.frameworkId, Task.Id.forApp(PathId("/test")), Seq(Mesos.Resource.getDefaultInstance))
+      factory.reserve(f.frameworkId, Task.Id.forRunSpec(PathId("/test")), Seq(Mesos.Resource.getDefaultInstance))
     }
 
     Then("A meaningful exception is thrown")

--- a/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
@@ -31,7 +31,7 @@ class OfferMatcherReconcilerTest extends FunSuite with GivenWhenThen with Mockit
     val f = new Fixture
     Given("an offer with volume")
     val appId = PathId("/test")
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
     val offer = MarathonTestHelper.offerWithVolumes(taskId.idString, localVolumeIdLaunched)
 
@@ -62,7 +62,7 @@ class OfferMatcherReconcilerTest extends FunSuite with GivenWhenThen with Mockit
     val f = new Fixture
     Given("an offer with volume")
     val appId = PathId("/test")
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
     val offer = MarathonTestHelper.offerWithVolumes(taskId.idString, localVolumeIdLaunched)
 
@@ -93,7 +93,7 @@ class OfferMatcherReconcilerTest extends FunSuite with GivenWhenThen with Mockit
     val f = new Fixture
     Given("an offer with volume")
     val appId = PathId("/test")
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
     val offer = MarathonTestHelper.offerWithVolumes(taskId.idString, localVolumeIdLaunched)
 
@@ -124,7 +124,7 @@ class OfferMatcherReconcilerTest extends FunSuite with GivenWhenThen with Mockit
     val f = new Fixture
     Given("an offer with volume")
     val appId = PathId("/test")
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
     val offer = MarathonTestHelper.offerWithVolumes(taskId.idString, localVolumeIdLaunched)
 

--- a/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckResultTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckResultTest.scala
@@ -69,7 +69,7 @@ class ReadinessCheckResultTest extends FunSuite with GivenWhenThen with Matchers
   }
   class Fixture {
     val check = ReadinessCheckSpec(
-      taskId = Task.Id.forApp(PathId("/test")),
+      taskId = Task.Id.forRunSpec(PathId("/test")),
       checkName = "testCheck",
       url = "http://sample.url:123",
       interval = 3.seconds,

--- a/src/test/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImplTest.scala
@@ -117,7 +117,7 @@ class ReadinessCheckExecutorImplTest
 
   class Fixture {
     lazy val check = ReadinessCheckSpec(
-      taskId = Task.Id.forApp(PathId("/test")),
+      taskId = Task.Id.forRunSpec(PathId("/test")),
       checkName = "testCheck",
       url = "http://sample.url:123",
       interval = 3.seconds,

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -24,7 +24,7 @@ object TaskStatusUpdateTestHelper {
     new TaskStatusUpdateTestHelper(taskChanged)
 
   private def newTaskID(appId: String) = {
-    Task.Id.forApp(PathId(appId))
+    Task.Id.forRunSpec(PathId(appId))
   }
 
   val taskId = newTaskID("/app")

--- a/src/test/scala/mesosphere/marathon/core/task/bus/impl/TaskStatusModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/impl/TaskStatusModuleTest.scala
@@ -36,7 +36,7 @@ class TaskStatusModuleTest extends FunSuite with BeforeAndAfter {
 
   test("observable forAppId includes only app status updates") {
     var received = List.empty[TaskChanged]
-    module.taskStatusObservables.forAppId(PathId("/a/a")).foreach(received :+= _)
+    module.taskStatusObservables.forRunSpecId(PathId("/a/a")).foreach(received :+= _)
     val aa: TaskChanged = TaskStatusUpdateTestHelper.running(taskForApp("/a/a")).wrapped
     val ab: TaskChanged = TaskStatusUpdateTestHelper.running(taskForApp("/a/b")).wrapped
     module.taskStatusEmitter.publish(aa)
@@ -46,14 +46,14 @@ class TaskStatusModuleTest extends FunSuite with BeforeAndAfter {
 
   test("observable forAppId unsubscribe works") {
     var received = List.empty[TaskChanged]
-    val subscription = module.taskStatusObservables.forAppId(PathId("/a/a")).subscribe(received :+= _)
+    val subscription = module.taskStatusObservables.forRunSpecId(PathId("/a/a")).subscribe(received :+= _)
     subscription.unsubscribe()
     val aa: TaskChanged = TaskStatusUpdateTestHelper.running(taskForApp("/a/a")).wrapped
     module.taskStatusEmitter.publish(aa)
     assert(received == List.empty)
   }
 
-  private[this] def taskForApp(appId: String) = MarathonTestHelper.stagedTask(Task.Id.forApp(PathId(appId)).idString)
+  private[this] def taskForApp(appId: String) = MarathonTestHelper.stagedTask(Task.Id.forRunSpec(PathId(appId)).idString)
 
 }
 

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializerTest.scala
@@ -193,7 +193,7 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
       Task.LaunchedOnReservation(
         taskId,
         Task.AgentInfo(host = sampleHost, agentId = Some(sampleSlaveId.getValue), attributes = sampleAttributes),
-        appVersion = appVersion,
+        runSpecVersion = appVersion,
         status = Task.Status(
           stagedAt = Timestamp(stagedAtLong),
           startedAt = Some(Timestamp(startedAtLong)),

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskStateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskStateOpResolverTest.scala
@@ -48,7 +48,7 @@ class TaskStateOpResolverTest
     When("A LaunchOnReservation is scheduled with that taskId")
     val stateChange = f.stateOpResolver.resolve(TaskStateOp.LaunchOnReservation(
       taskId = f.notExistingTaskId,
-      appVersion = Timestamp(0),
+      runSpecVersion = Timestamp(0),
       status = Task.Status(Timestamp(0)),
       hostPorts = Seq.empty)).futureValue
 
@@ -159,7 +159,7 @@ class TaskStateOpResolverTest
     val appId = PathId("/app")
     val existingTask = MarathonTestHelper.mininimalTask(appId)
     val existingReservedTask = MarathonTestHelper.residentReservedTask(appId)
-    val notExistingTaskId = Task.Id.forApp(appId)
+    val notExistingTaskId = Task.Id.forRunSpec(appId)
 
     def verifyNoMoreInteractions(): Unit = {
       noMoreInteractions(taskTracker)

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActorTest.scala
@@ -170,7 +170,7 @@ class TaskTrackerActorTest
 
     When("a new staged task gets added")
     val probe = TestProbe()
-    val newStagedTask = MarathonTestHelper.stagedTask(Task.Id.forApp(appId).toString)
+    val newStagedTask = MarathonTestHelper.stagedTask(Task.Id.forRunSpec(appId).toString)
     val update = TaskStatusUpdateTestHelper.taskLaunchFor(newStagedTask).wrapped
 
     val ack = TaskTrackerActor.Ack(probe.ref, update.stateChange)

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskUpdateActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskUpdateActorTest.scala
@@ -24,7 +24,7 @@ class TaskUpdateActorTest
 
     Given("an op")
     val appId = PathId("/app")
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val op = TaskOpProcessor.Operation(f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskStateOp.ForceExpunge(taskId))
 
     And("a processor that fails immediately")
@@ -50,7 +50,7 @@ class TaskUpdateActorTest
 
     Given("an op with an already reached deadline")
     val appId = PathId("/app")
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val op = TaskOpProcessor.Operation(f.clock.now(), f.opInitiator.ref, taskId, TaskStateOp.ForceExpunge(taskId))
 
     And("a processor that succeeds immediately")
@@ -85,7 +85,7 @@ class TaskUpdateActorTest
 
     Given("an op")
     val appId = PathId("/app")
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val op = TaskOpProcessor.Operation(f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskStateOp.ForceExpunge(taskId))
 
     And("a processor that processes it immediately")
@@ -110,7 +110,7 @@ class TaskUpdateActorTest
 
     Given("an op")
     val appId = PathId("/app")
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val op = TaskOpProcessor.Operation(f.oneSecondInFuture, f.opInitiator.ref, taskId, TaskStateOp.ForceExpunge(taskId))
 
     And("a processor that does not return")
@@ -135,9 +135,9 @@ class TaskUpdateActorTest
 
     Given("an op")
     val appId = PathId("/app")
-    val task1Id = Task.Id.forApp(appId)
+    val task1Id = Task.Id.forRunSpec(appId)
     val op1 = TaskOpProcessor.Operation(f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskStateOp.ForceExpunge(task1Id))
-    val task2Id = Task.Id.forApp(appId)
+    val task2Id = Task.Id.forRunSpec(appId)
     val op2 = TaskOpProcessor.Operation(f.oneSecondInFuture, f.opInitiator.ref, task2Id, TaskStateOp.ForceExpunge(task2Id))
 
     And("a processor that does not return")
@@ -179,7 +179,7 @@ class TaskUpdateActorTest
 
     Given("an op")
     val appId = PathId("/app")
-    val task1Id = Task.Id.forApp(appId)
+    val task1Id = Task.Id.forRunSpec(appId)
     val op1 = TaskOpProcessor.Operation(
       f.oneSecondInFuture, f.opInitiator.ref, task1Id, TaskStateOp.ForceExpunge(task1Id)
     )

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -55,7 +55,7 @@ class TaskStatusUpdateProcessorImplTest
     import scala.concurrent.ExecutionContext.Implicits.global
     f.taskTracker.task(taskId)(global) returns Future.successful(
       Some(MarathonTestHelper.minimalReservedTask(
-        taskId.appId, Task.Reservation(Iterable.empty, MarathonTestHelper.taskReservationStateNew)))
+        taskId.runSpecId, Task.Reservation(Iterable.empty, MarathonTestHelper.taskReservationStateNew)))
     )
 
     When("we process the updated")
@@ -101,7 +101,7 @@ class TaskStatusUpdateProcessorImplTest
   test("update for unknown task (TASK_KILLING) will get only acknowledged") {
     fOpt = Some(new Fixture)
 
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val task = MarathonTestHelper.runningTask(taskId.idString)
     val origUpdate = TaskStatusUpdateTestHelper.killing(task)
     val status = origUpdate.status
@@ -127,7 +127,7 @@ class TaskStatusUpdateProcessorImplTest
   test("TASK_KILLING is processed like a normal StatusUpdate") {
     fOpt = Some(new Fixture)
 
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
     val task = MarathonTestHelper.runningTask(taskId.idString)
     val origUpdate = TaskStatusUpdateTestHelper.killing(task)
     val status = origUpdate.status

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImplTest.scala
@@ -116,7 +116,7 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
 
   private[this] val slaveId = SlaveID.newBuilder().setValue("slave1")
   private[this] val appId = PathId("/test")
-  private[this] val taskId = Task.Id.forApp(appId)
+  private[this] val taskId = Task.Id.forRunSpec(appId)
   private[this] val host = "some.host.local"
   private[this] val ipAddress = MarathonTestHelper.mesosIpAddress("127.0.0.1")
   private[this] val portsList = Seq(10, 11, 12)

--- a/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
@@ -85,7 +85,7 @@ class MarathonHealthCheckManagerTest
   }
 
   def makeRunningTask(appId: PathId, version: Timestamp) = {
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
 
     val taskStatus = MarathonTestHelper.runningTask(taskId.idString).launched.get.status.mesosStatus.get
     val marathonTask = MarathonTestHelper.stagedTask(taskId.idString, appVersion = version)
@@ -130,7 +130,7 @@ class MarathonHealthCheckManagerTest
     val app: AppDefinition = AppDefinition(id = appId)
     appRepository.store(app).futureValue
 
-    val taskId = Task.Id.forApp(appId)
+    val taskId = Task.Id.forRunSpec(appId)
 
     val taskStatus = MarathonTestHelper.unhealthyTask(taskId.idString).launched.get.status.mesosStatus.get
     val marathonTask = MarathonTestHelper.stagedTask(taskId.idString, appVersion = app.version)

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -9,22 +9,22 @@ class TaskIdTest extends FunSuite with Matchers {
 
   test("AppIds can be converted to TaskIds and back to AppIds") {
     val appId = "/test/foo/bla/rest".toPath
-    val taskId = Task.Id.forApp(appId)
-    taskId.appId should equal(appId)
+    val taskId = Task.Id.forRunSpec(appId)
+    taskId.runSpecId should equal(appId)
   }
 
   test("Old TaskIds can be converted") {
     val taskId = Task.Id(TaskID.newBuilder().setValue("app_682ebe64-0771-11e4-b05d-e0f84720c54e").build)
-    taskId.appId should equal("app".toRootPath)
+    taskId.runSpecId should equal("app".toRootPath)
   }
 
   test("Old TaskIds can be converted even if they have dots in them") {
     val taskId = Task.Id(TaskID.newBuilder().setValue("app.foo.bar_682ebe64-0771-11e4-b05d-e0f84720c54e").build)
-    taskId.appId should equal("app.foo.bar".toRootPath)
+    taskId.runSpecId should equal("app.foo.bar".toRootPath)
   }
 
   test("Old TaskIds can be converted even if they have underscores in them") {
     val taskId = Task.Id(TaskID.newBuilder().setValue("app_foo_bar_0-12345678").build)
-    taskId.appId should equal("/app/foo/bar".toRootPath)
+    taskId.runSpecId should equal("/app/foo/bar".toRootPath)
   }
 }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
@@ -39,7 +39,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
         agentId = Some(offer.getSlaveId.getValue),
         attributes = List.empty
       ),
-      appVersion = app.version,
+      runSpecVersion = app.version,
       status = Task.Status(
         stagedAt = f.clock.now()
       ),

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -72,7 +72,7 @@ class DeploymentActorTest
         println(invocation.getArguments.toSeq)
         for (i <- 0 until invocation.getArguments()(1).asInstanceOf[Int])
           system.eventStream.publish(MesosStatusUpdateEvent(
-            slaveId = "", taskId = Task.Id.forApp(app2New.id), taskStatus = "TASK_RUNNING", message = "",
+            slaveId = "", taskId = Task.Id.forRunSpec(app2New.id), taskStatus = "TASK_RUNNING", message = "",
             appId = app2.id, host = "", ipAddresses = None, ports = Nil, version = app2New.version.toString)
           )
         true

--- a/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
@@ -166,7 +166,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
     agentInfo.host returns "some.host"
     task.taskId returns taskId
     task.launched returns Some(launched)
-    task.appId returns appId
+    task.runSpecId returns appId
     task.effectiveIpAddress(any) returns Some("some.host")
     task.agentInfo returns agentInfo
     launched.hostPorts returns Seq(1, 2, 3)

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -197,12 +197,12 @@ class TaskStartActorTest
 
     verify(f.launchQueue, Mockito.timeout(3000)).add(app, app.instances)
 
-    system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id.forApp(app.id), "TASK_FAILED", "", app.id, "", None, Nil, app.version.toString))
+    system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id.forRunSpec(app.id), "TASK_FAILED", "", app.id, "", None, Nil, app.version.toString))
 
     verify(f.launchQueue, Mockito.timeout(3000)).add(app, 1)
 
     for (i <- 0 until app.instances)
-      system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id.forApp(app.id), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString))
+      system.eventStream.publish(MesosStatusUpdateEvent("", Task.Id.forRunSpec(app.id), "TASK_RUNNING", "", app.id, "", None, Nil, app.version.toString))
 
     Await.result(promise.future, 3.seconds) should be(())
 
@@ -237,7 +237,7 @@ class TaskStartActorTest
       ipAddresses = None, ports = Nil,
       // The version does not match the app.version so that it is filtered in StartingBehavior.
       // does that make sense?
-      version = outdatedTask.launched.get.appVersion.toString
+      version = outdatedTask.launched.get.runSpecVersion.toString
     ))
 
     // sync will reschedule task

--- a/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
@@ -58,7 +58,7 @@ class PersistentVolumeMatcherTest extends MarathonSpec with GivenWhenThen with M
       f.makeTask(app.id, Task.Reservation(Seq(localVolumeId2), f.taskReservationStateNew)),
       f.makeTask(app.id, Task.Reservation(Seq(localVolumeId3), f.taskReservationStateNew))
     )
-    val unknownTaskId = Task.Id.forApp(app.id)
+    val unknownTaskId = Task.Id.forRunSpec(app.id)
     val offer =
       f.offerWithVolumes(unknownTaskId, localVolumeId1)
         .toBuilder

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1042,22 +1042,22 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
 
   test("TaskContextEnv empty when no taskId given") {
     val version = AppDefinition.VersionInfo.forNewConfig(Timestamp(new DateTime(2015, 2, 3, 12, 30, DateTimeZone.UTC)))
-    val app = AppDefinition(
+    val runSpec = AppDefinition(
       id = PathId("/app"),
       versionInfo = version
     )
-    val env = TaskBuilder.taskContextEnv(app = app, taskId = None)
+    val env = TaskBuilder.taskContextEnv(runSpec = runSpec, taskId = None)
 
     assert(env == Map.empty)
   }
 
   test("TaskContextEnv minimal") {
     val version = AppDefinition.VersionInfo.forNewConfig(Timestamp(new DateTime(2015, 2, 3, 12, 30, DateTimeZone.UTC)))
-    val app = AppDefinition(
+    val runSpec = AppDefinition(
       id = PathId("/app"),
       versionInfo = version
     )
-    val env = TaskBuilder.taskContextEnv(app = app, taskId = Some(Task.Id("taskId")))
+    val env = TaskBuilder.taskContextEnv(runSpec = runSpec, taskId = Some(Task.Id("taskId")))
 
     assert(
       env == Map(
@@ -1075,7 +1075,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
   test("TaskContextEnv all fields") {
     val version = AppDefinition.VersionInfo.forNewConfig(Timestamp(new DateTime(2015, 2, 3, 12, 30, DateTimeZone.UTC)))
     val taskId = TaskID("taskId")
-    val app = AppDefinition(
+    val runSpec = AppDefinition(
       id = PathId("/app"),
       versionInfo = version,
       container = Some(Container(
@@ -1091,7 +1091,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
         "LABEL2" -> "VALUE2"
       )
     )
-    val env = TaskBuilder.taskContextEnv(app = app, Some(Task.Id(taskId)))
+    val env = TaskBuilder.taskContextEnv(runSpec = runSpec, Some(Task.Id(taskId)))
 
     assert(
       env == Map(
@@ -1115,7 +1115,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     val longLabel = "longlabel" * TaskBuilder.maxVariableLength
     var longValue = "longvalue" * TaskBuilder.maxEnvironmentVarLength
 
-    val app = AppDefinition(
+    val runSpec = AppDefinition(
       labels = Map(
         "label" -> "VALUE1",
         "label-with-invalid-chars" -> "VALUE2",
@@ -1125,7 +1125,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
       )
     )
 
-    val env = TaskBuilder.taskContextEnv(app = app, Some(Task.Id("taskId")))
+    val env = TaskBuilder.taskContextEnv(runSpec = runSpec, Some(Task.Id("taskId")))
       .filterKeys(_.startsWith("MARATHON_APP_LABEL"))
 
     assert(
@@ -1141,7 +1141,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
   test("AppContextEnvironment") {
     val command =
       TaskBuilder.commandInfo(
-        app = AppDefinition(
+        runSpec = AppDefinition(
           id = "/test".toPath,
           portDefinitions = PortDefinitions(8080, 8081),
           container = Some(Container(
@@ -1171,7 +1171,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
 
     val command =
       TaskBuilder.commandInfo(
-        app = AppDefinition(
+        runSpec = AppDefinition(
           id = "/test".toPath,
           portDefinitions = PortDefinitions(8080, 8081),
           env = Map(
@@ -1202,7 +1202,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
   test("PortsEnvWithOnlyPorts") {
     val command =
       TaskBuilder.commandInfo(
-        app = AppDefinition(
+        runSpec = AppDefinition(
           portDefinitions = PortDefinitions(8080, 8081)
         ),
         taskId = Some(Task.Id("task-123")),
@@ -1272,7 +1272,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
   test("PortsEnvWithOnlyMappings") {
     val command =
       TaskBuilder.commandInfo(
-        app = AppDefinition(
+        runSpec = AppDefinition(
           container = Some(Container(
             docker = Some(Docker(
               network = Some(DockerInfo.Network.BRIDGE),
@@ -1298,7 +1298,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
   test("PortsEnvWithBothPortsAndMappings") {
     val command =
       TaskBuilder.commandInfo(
-        app = AppDefinition(
+        runSpec = AppDefinition(
           portDefinitions = PortDefinitions(22, 23),
           container = Some(Container(
             docker = Some(Docker(
@@ -1327,7 +1327,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
 
   test("TaskWillCopyFetchIntoCommand") {
     val command = TaskBuilder.commandInfo(
-      app = AppDefinition(
+      runSpec = AppDefinition(
         fetch = Seq(
           FetchUri(uri = "http://www.example.com", extract = false, cache = true, executable = false),
           FetchUri(uri = "http://www.example2.com", extract = true, cache = true, executable = true)


### PR DESCRIPTION
Proposal to use a trait in the core launcher module instead of an AppDefinition:
- RunSpec from AppDefinition created
- All occurrences of AppDefinition replaced by RunSpec (1. commit)
- All properties names appXXX renamed to runSpecXXX (3.commit)

