### PR TITLE
Add --leader_proxy_ssl_ignore_hostname option

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -279,6 +279,9 @@ The Web Site flags control the behavior of Marathon's web site, including the us
 * `--ssl_keystore_password` (Optional. Default: None): Password for the keystore
     supplied with the `ssl_keystore_path` option. Required if `ssl_keystore_path` is supplied.
     May also be specified with the `MESOSPHERE_KEYSTORE_PASS` environment variable.
+* `--leader_proxy_ssl_ignore_hostname` (Optional. Default: false): Do not
+    verify that the hostname of the Marathon leader matches the one in the SSL
+    certificate when proxying API requests to the current leader.
 *  <span class="label label-default">v0.10.0</span> `--http_max_concurrent_requests` (Optional.): the maximum number of
     concurrent HTTP requests, that is allowed concurrently before requests get answered directly with a
     HTTP 503 Service Temporarily Unavailable.

--- a/docs/docs/ssl-basic-access-authentication.md
+++ b/docs/docs/ssl-basic-access-authentication.md
@@ -31,6 +31,8 @@ the `--https_port`
 $ curl https://localhost:8443/v2/apps
 ```
 
+Note that by default when a request is proxied to the leading Marathon instance, the hostname of the leader is checked against the certificate. If you don't provide proper CN values in the certificates, proxying will fail. In this case, you can skip the hostname check by passing `--leader_proxy_ssl_ignore_hostname` to Marathon.
+
 ### Generating a keystore with an SSL key and certificate
 
 If you do not already have a Java keystore, follow the steps below to create one.

--- a/src/main/scala/mesosphere/marathon/LeaderProxyConf.scala
+++ b/src/main/scala/mesosphere/marathon/LeaderProxyConf.scala
@@ -18,4 +18,8 @@ trait LeaderProxyConf extends ScallopConf {
     descr = "Maximum time, in milliseconds, for reading from the current Marathon leader.",
     default = Some(10000)) // 10 seconds
 
+  lazy val leaderProxySSLIgnoreHostname = opt[Boolean]("leader_proxy_ssl_ignore_hostname",
+    descr = "Do not verify that the hostname of the Marathon leader matches the one in the SSL certificate" +
+            " when proxying API requests to the current leader.",
+    default = Some(false))
 }


### PR DESCRIPTION
When proxying by default the certificate CN attribute is matched against the leader hostname. If they differ, the proxying fails. The `--leader_proxy_ssl_ignore_hostname` disables this check.