### PR TITLE
Resolves #3843 by fixing the upgradeStrategy/residency defaults

### DIFF
--- a/src/main/scala/mesosphere/marathon/LeaderProxyConf.scala
+++ b/src/main/scala/mesosphere/marathon/LeaderProxyConf.scala
@@ -20,6 +20,6 @@ trait LeaderProxyConf extends ScallopConf {
 
   lazy val leaderProxySSLIgnoreHostname = opt[Boolean]("leader_proxy_ssl_ignore_hostname",
     descr = "Do not verify that the hostname of the Marathon leader matches the one in the SSL certificate" +
-            " when proxying API requests to the current leader.",
+      " when proxying API requests to the current leader.",
     default = Some(false))
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -657,7 +657,7 @@ trait AppAndGroupFormats {
           def upgradeStrategyOrDefault: UpgradeStrategy = {
             import UpgradeStrategy.{ forResidentTasks, empty }
             upgradeStrategy.getOrElse {
-              if (residency.isDefined || app.externalVolumes.nonEmpty) forResidentTasks else empty
+              if (residencyOrDefault.isDefined || app.externalVolumes.nonEmpty) forResidentTasks else empty
             }
           }
           def residencyOrDefault: Option[Residency] = {


### PR DESCRIPTION
Background: The `AppAndGroupFormats` didn't consider the possibly applied default `residency` when applying a default for `upgradeStrategy`.

This should be cherry-picked into releases/1.1