### PR TITLE
Resolves #3851 allow dynamically reserved resources for normal task matching

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/ReservationLabels.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/ReservationLabels.scala
@@ -3,9 +3,9 @@ package mesosphere.marathon.core.launcher.impl
 import org.apache.mesos.{ Protos => MesosProtos }
 
 /**
-  * Encapsulates information about a reserced resource and its (probably empty) list of reservation labels.
+  * Encapsulates information about a reserved resource and its (probably empty) list of reservation labels.
   */
-case class ReservationSelector(labels: Map[String, String]) {
+case class ReservationLabels(labels: Map[String, String]) {
   lazy val mesosLabels: MesosProtos.Labels = {
     val labelsBuilder = MesosProtos.Labels.newBuilder()
     labels.foreach {
@@ -20,17 +20,17 @@ case class ReservationSelector(labels: Map[String, String]) {
   override def toString: String = labels.map { case (k, v) => s"$k: $v" }.mkString(", ")
 }
 
-object ReservationSelector {
-  def withoutLabels: ReservationSelector = new ReservationSelector(Map.empty)
+object ReservationLabels {
+  def withoutLabels: ReservationLabels = new ReservationLabels(Map.empty)
 
-  def apply(resource: MesosProtos.Resource): ReservationSelector = {
+  def apply(resource: MesosProtos.Resource): ReservationLabels = {
     if (resource.hasReservation && resource.getReservation.hasLabels)
-      ReservationSelector(resource.getReservation.getLabels)
+      ReservationLabels(resource.getReservation.getLabels)
     else
-      ReservationSelector.withoutLabels
+      ReservationLabels.withoutLabels
   }
-  def apply(labels: MesosProtos.Labels): ReservationSelector = {
+  def apply(labels: MesosProtos.Labels): ReservationLabels = {
     import scala.collection.JavaConverters._
-    ReservationSelector(labels.getLabelsList.asScala.iterator.map(l => l.getKey -> l.getValue).toMap)
+    ReservationLabels(labels.getLabelsList.asScala.iterator.map(l => l.getKey -> l.getValue).toMap)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/ReservationSelector.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/ReservationSelector.scala
@@ -2,7 +2,10 @@ package mesosphere.marathon.core.launcher.impl
 
 import org.apache.mesos.{ Protos => MesosProtos }
 
-case class ResourceLabels(labels: Map[String, String]) {
+/**
+  * Encapsulates information about a reserced resource and its (probably empty) list of reservation labels.
+  */
+case class ReservationSelector(labels: Map[String, String]) {
   lazy val mesosLabels: MesosProtos.Labels = {
     val labelsBuilder = MesosProtos.Labels.newBuilder()
     labels.foreach {
@@ -17,17 +20,17 @@ case class ResourceLabels(labels: Map[String, String]) {
   override def toString: String = labels.map { case (k, v) => s"$k: $v" }.mkString(", ")
 }
 
-object ResourceLabels {
-  def empty: ResourceLabels = new ResourceLabels(Map.empty)
+object ReservationSelector {
+  def withoutLabels: ReservationSelector = new ReservationSelector(Map.empty)
 
-  def apply(resource: MesosProtos.Resource): ResourceLabels = {
+  def apply(resource: MesosProtos.Resource): ReservationSelector = {
     if (resource.hasReservation && resource.getReservation.hasLabels)
-      ResourceLabels(resource.getReservation.getLabels)
+      ReservationSelector(resource.getReservation.getLabels)
     else
-      ResourceLabels.empty
+      ReservationSelector.withoutLabels
   }
-  def apply(resource: MesosProtos.Labels): ResourceLabels = {
+  def apply(labels: MesosProtos.Labels): ReservationSelector = {
     import scala.collection.JavaConverters._
-    ResourceLabels(resource.getLabelsList.asScala.iterator.map(l => l.getKey -> l.getValue).toMap)
+    ReservationSelector(labels.getLabelsList.asScala.iterator.map(l => l.getKey -> l.getValue).toMap)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLabels.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLabels.scala
@@ -2,10 +2,7 @@ package mesosphere.marathon.core.launcher.impl
 
 import mesosphere.marathon.core.task.Task
 import mesosphere.util.state.FrameworkId
-import org.apache.mesos.Protos.Label
 import org.apache.mesos.{ Protos => MesosProtos }
-
-import scala.collection.mutable
 
 object TaskLabels {
   private[this] final val FRAMEWORK_ID_LABEL = "marathon_framework_id"
@@ -16,7 +13,7 @@ object TaskLabels {
     * labeled by this framework.
     */
   def taskIdForResource(frameworkId: FrameworkId, resource: MesosProtos.Resource): Option[Task.Id] = {
-    val labels = ResourceLabels(resource)
+    val labels = ReservationSelector(resource)
 
     val maybeMatchingFrameworkId = labels.get(FRAMEWORK_ID_LABEL).filter(_ == frameworkId.id)
     def maybeTaskId = labels.get(TASK_ID_LABEL).map(Task.Id(_))
@@ -24,10 +21,15 @@ object TaskLabels {
     maybeMatchingFrameworkId.flatMap(_ => maybeTaskId)
   }
 
-  def labelsForTask(frameworkId: FrameworkId, task: Task): ResourceLabels = labelsForTask(frameworkId, task.taskId)
-  def labelsForTask(frameworkId: FrameworkId, taskId: Task.Id): ResourceLabels =
-    ResourceLabels(Map(
+  def labelsForTask(frameworkId: FrameworkId, task: Task): ReservationSelector =
+    labelsForTask(frameworkId, task.taskId)
+
+  def labelsForTask(frameworkId: FrameworkId, taskId: Task.Id): ReservationSelector =
+    ReservationSelector(Map(
       FRAMEWORK_ID_LABEL -> frameworkId.id,
       TASK_ID_LABEL -> taskId.idString
     ))
+
+  def labelKeysForTaskReservations: Set[String] = Set(FRAMEWORK_ID_LABEL, TASK_ID_LABEL)
+
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLabels.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLabels.scala
@@ -13,7 +13,7 @@ object TaskLabels {
     * labeled by this framework.
     */
   def taskIdForResource(frameworkId: FrameworkId, resource: MesosProtos.Resource): Option[Task.Id] = {
-    val labels = ReservationSelector(resource)
+    val labels = ReservationLabels(resource)
 
     val maybeMatchingFrameworkId = labels.get(FRAMEWORK_ID_LABEL).filter(_ == frameworkId.id)
     def maybeTaskId = labels.get(TASK_ID_LABEL).map(Task.Id(_))
@@ -21,11 +21,11 @@ object TaskLabels {
     maybeMatchingFrameworkId.flatMap(_ => maybeTaskId)
   }
 
-  def labelsForTask(frameworkId: FrameworkId, task: Task): ReservationSelector =
+  def labelsForTask(frameworkId: FrameworkId, task: Task): ReservationLabels =
     labelsForTask(frameworkId, task.taskId)
 
-  def labelsForTask(frameworkId: FrameworkId, taskId: Task.Id): ReservationSelector =
-    ReservationSelector(Map(
+  def labelsForTask(frameworkId: FrameworkId, taskId: Task.Id): ReservationLabels =
+    ReservationLabels(Map(
       FRAMEWORK_ID_LABEL -> frameworkId.id,
       TASK_ID_LABEL -> taskId.idString
     ))

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
@@ -96,8 +96,8 @@ class TaskOpFactoryImpl @Inject() (
           ResourceMatcher.matchResources(
             offer, app, tasksToConsiderForConstraints.values,
             ResourceSelector(
-              rolesToConsider, reserved = true,
-              requiredLabels = TaskLabels.labelsForTask(request.frameworkId, volumeMatch.task)
+              rolesToConsider,
+              reservation = Some(TaskLabels.labelsForTask(request.frameworkId, volumeMatch.task))
             )
           )
 
@@ -119,7 +119,7 @@ class TaskOpFactoryImpl @Inject() (
       val matchingResourcesForReservation =
         ResourceMatcher.matchResources(
           offer, app, tasks.values,
-          ResourceSelector(rolesToConsider, reserved = false)
+          ResourceSelector(rolesToConsider, reservation = None)
         )
       matchingResourcesForReservation.map { resourceMatch =>
         reserveAndCreateVolumes(request.frameworkId, app, offer, resourceMatch)

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
@@ -92,13 +92,11 @@ class TaskOpFactoryImpl @Inject() (
         val tasksToConsiderForConstraints = tasks - volumeMatch.task.taskId
         // resources are reserved for this role, so we only consider those resources
         val rolesToConsider = config.mesosRole.get.toSet
+        val reservationLabels = TaskLabels.labelsForTask(request.frameworkId, volumeMatch.task).labels
         val matchingReservedResourcesWithoutVolumes =
           ResourceMatcher.matchResources(
             offer, app, tasksToConsiderForConstraints.values,
-            ResourceSelector(
-              rolesToConsider,
-              reservation = Some(TaskLabels.labelsForTask(request.frameworkId, volumeMatch.task))
-            )
+            ResourceSelector.reservedWithLabels(rolesToConsider, reservationLabels)
           )
 
         matchingReservedResourcesWithoutVolumes.flatMap { otherResourcesMatch =>
@@ -112,14 +110,14 @@ class TaskOpFactoryImpl @Inject() (
       val configuredRoles = app.acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet)
       // We can only reserve unreserved resources
       val rolesToConsider = Set(ResourceRole.Unreserved).intersect(configuredRoles)
-      if (configuredRoles.isEmpty) {
-        log.warn(s"Will never match for ${app.id} as the app is configured to only accept $configuredRoles")
+      if (rolesToConsider.isEmpty) {
+        log.warn(s"Will never match for ${app.id}. The app is not configured to accept unreserved resources.")
       }
 
       val matchingResourcesForReservation =
         ResourceMatcher.matchResources(
           offer, app, tasks.values,
-          ResourceSelector(rolesToConsider, reservation = None)
+          ResourceSelector.reservable
         )
       matchingResourcesForReservation.map { resourceMatch =>
         reserveAndCreateVolumes(request.frameworkId, app, offer, resourceMatch)

--- a/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
@@ -30,7 +30,7 @@ case class PortsMatch(hostPortsWithRole: Seq[PortWithRole]) {
 class PortsMatcher(
   app: AppDefinition,
   offer: MesosProtos.Offer,
-  resourceSelector: ResourceSelector = ResourceSelector(Set(ResourceRole.Unreserved), reserved = false),
+  resourceSelector: ResourceSelector = ResourceSelector(Set(ResourceRole.Unreserved), reservation = None),
   random: Random = Random)
     extends Logging {
 

--- a/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
@@ -30,7 +30,7 @@ case class PortsMatch(hostPortsWithRole: Seq[PortWithRole]) {
 class PortsMatcher(
   app: AppDefinition,
   offer: MesosProtos.Offer,
-  resourceSelector: ResourceSelector = ResourceSelector(Set(ResourceRole.Unreserved), reservation = None),
+  resourceSelector: ResourceSelector = ResourceSelector.any(Set(ResourceRole.Unreserved)),
   random: Random = Random)
     extends Logging {
 

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -1,6 +1,6 @@
 package mesosphere.mesos
 
-import mesosphere.marathon.core.launcher.impl.{ ReservationSelector, TaskLabels }
+import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{ AppDefinition, ResourceRole }
 import mesosphere.marathon.tasks.{ PortsMatch, PortsMatcher }
@@ -38,51 +38,79 @@ object ResourceMatcher {
     * accident.
     *
     * @param acceptedRoles contains all Mesos resource roles that are accepted
-    * @param reservation if given, only resources with a ReservationInfo are
-    *                    considered and will only match if their labels match
-    *                    the specified labels.
+    * @param needToReserve if true, only unreserved resources will considered
+    * @param labelMatcher a matcher that checks if the given resource labels
+    *                     are compliant with the expected or not expected labels
     */
-  case class ResourceSelector(acceptedRoles: Set[String], reservation: Option[ReservationSelector] = None) {
+  case class ResourceSelector(
+      acceptedRoles: Set[String],
+      needToReserve: Boolean,
+      labelMatcher: LabelMatcher) {
+
     def apply(resource: Protos.Resource): Boolean = {
+      import ResourceSelector._
       // resources with disks are matched by the VolumeMatcher or not at all
       val noAssociatedDisk = !resource.hasDisk
-      def matchesReservationSelector: Boolean = {
-        val labelMap: Map[String, String] =
-          if (!resource.hasReservation || !resource.getReservation.hasLabels)
-            Map.empty
-          else {
-            import scala.collection.JavaConverters._
-            resource.getReservation.getLabels.getLabelsList.asScala.iterator.map { label =>
-              label.getKey -> label.getValue
-            }.toMap
-          }
+      def matchesLabels: Boolean = labelMatcher.matches(reservationLabels(resource))
 
-        reservation match {
-          // only match if the reservation labels match the expectation
-          case Some(reservationWithLabels) =>
-            reservationWithLabels.labels.forall { case (k, v) => labelMap.get(k).contains(v) }
-
-          // allow dynamic reservations if no known reservation label is set
-          case None =>
-            labelMap.keys.toSet.intersect(TaskLabels.labelKeysForTaskReservations).isEmpty
-        }
-      }
-
-      noAssociatedDisk && acceptedRoles(resource.getRole) && matchesReservationSelector
+      noAssociatedDisk && acceptedRoles(resource.getRole) && matchesLabels
     }
 
     override def toString: String = {
-      val reservedString = if (reservation.nonEmpty) " RESERVED" else ""
+      val reserveString = if (needToReserve) " to reserve" else ""
       val rolesString = acceptedRoles.mkString(", ")
-      val labelStrings = if (reservation.exists(_.labels.nonEmpty)) s" and labels $reservation" else ""
-
-      s"Considering$reservedString resources with roles {$rolesString}$labelStrings"
+      s"Considering resources$reserveString with roles {$rolesString} $labelMatcher"
     }
   }
 
   object ResourceSelector {
-    /** Match unreserved resources for which role == '*' applies (default) */
-    def wildcard: ResourceSelector = ResourceSelector(Set(ResourceRole.Unreserved), reservation = None)
+    /** The reservation labels if the resource is reserved, or an empty Map */
+    private def reservationLabels(resource: Protos.Resource): Map[String, String] =
+      if (!resource.hasReservation || !resource.getReservation.hasLabels)
+        Map.empty
+      else {
+        import scala.collection.JavaConverters._
+        resource.getReservation.getLabels.getLabelsList.asScala.iterator.map { label =>
+          label.getKey -> label.getValue
+        }.toMap
+      }
+
+    /** Match resources with given roles that have at least the given labels */
+    def reservedWithLabels(acceptedRoles: Set[String], labels: Map[String, String]): ResourceSelector = {
+      ResourceSelector(acceptedRoles, needToReserve = false, LabelMatcher.WithReservationLabels(labels))
+    }
+    /** Match resources with given roles that do not have known reservation labels */
+    def reservable: ResourceSelector = {
+      ResourceSelector(Set(ResourceRole.Unreserved), needToReserve = true, LabelMatcher.WithoutReservationLabels)
+    }
+
+    /** Match any resources with given roles that do not have known reservation labels */
+    def any(acceptedRoles: Set[String]): ResourceSelector = {
+      ResourceSelector(acceptedRoles, needToReserve = false, LabelMatcher.WithoutReservationLabels)
+    }
+  }
+
+  private[mesos] sealed trait LabelMatcher {
+    def matches(resourceLabels: Map[String, String]): Boolean
+  }
+
+  private[this] object LabelMatcher {
+    case class WithReservationLabels(labels: Map[String, String]) extends LabelMatcher {
+      override def matches(resourceLabels: Map[String, String]): Boolean =
+        labels.forall { case (k, v) => resourceLabels.get(k).contains(v) }
+
+      override def toString: Role = {
+        val labelsStr = labels.map { case (k, v) => s"$k: $v" }.mkString(", ")
+        s"and labels {$labelsStr}"
+      }
+    }
+
+    case object WithoutReservationLabels extends LabelMatcher {
+      override def matches(resourceLabels: Map[String, String]): Boolean =
+        resourceLabels.keys.toSet.intersect(TaskLabels.labelKeysForTaskReservations).isEmpty
+
+      override def toString: Role = "without resident reservation labels"
+    }
   }
 
   /**
@@ -106,7 +134,8 @@ object ResourceMatcher {
 
     // Local volumes only need to be matched if we are making a reservation for resident tasks --
     // that means if the resources that are matched are still unreserved.
-    val diskMatch = if (selector.reservation.isEmpty && app.diskForPersistentVolumes > 0)
+    def needToReserveDisk = selector.needToReserve && app.diskForPersistentVolumes > 0
+    val diskMatch = if (needToReserveDisk)
       scalarResourceMatch(Resource.DISK, app.disk + app.diskForPersistentVolumes,
         ScalarMatchResult.Scope.IncludingLocalVolumes)
     else

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -80,7 +80,7 @@ class TaskBuilder(app: AppDefinition,
 
     val resourceMatch =
       ResourceMatcher.matchResources(
-        offer, app, runningTasks, ResourceSelector(acceptedResourceRoles, reserved = false))
+        offer, app, runningTasks, ResourceSelector(acceptedResourceRoles, reservation = None))
 
     build(offer, resourceMatch)
   }

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -80,7 +80,7 @@ class TaskBuilder(app: AppDefinition,
 
     val resourceMatch =
       ResourceMatcher.matchResources(
-        offer, app, runningTasks, ResourceSelector(acceptedResourceRoles, reservation = None))
+        offer, app, runningTasks, ResourceSelector.any(acceptedResourceRoles))
 
     build(offer, resourceMatch)
   }

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -9,7 +9,7 @@ import com.github.fge.jsonschema.main.JsonSchemaFactory
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.api.JsonTestHelper
 import mesosphere.marathon.core.base.Clock
-import mesosphere.marathon.core.launcher.impl.{ ResourceLabels, TaskLabels }
+import mesosphere.marathon.core.launcher.impl.{ ReservationSelector, TaskLabels }
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.task.update.TaskUpdateStep
 import mesosphere.marathon.core.task.{ Task, TaskStateOp }
@@ -71,14 +71,14 @@ object MarathonTestHelper {
 
   def makeBasicOffer(cpus: Double = 4.0, mem: Double = 16000, disk: Double = 1.0,
                      beginPort: Int = 31000, endPort: Int = 32000, role: String = ResourceRole.Unreserved,
-                     reservation: Option[ResourceLabels] = None): Offer.Builder = {
+                     reservation: Option[ReservationSelector] = None): Offer.Builder = {
 
     require(role != ResourceRole.Unreserved || reservation.isEmpty, "reserved resources cannot have role *")
 
     def heedReserved(resource: Mesos.Resource): Mesos.Resource = {
       reservation match {
-        case Some(reservationLabels) =>
-          val labels = reservationLabels.mesosLabels
+        case Some(reservationWithLabels) =>
+          val labels = reservationWithLabels.mesosLabels
           val reservation =
             Mesos.Resource.ReservationInfo.newBuilder()
               .setPrincipal("marathon")

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -9,7 +9,7 @@ import com.github.fge.jsonschema.main.JsonSchemaFactory
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.api.JsonTestHelper
 import mesosphere.marathon.core.base.Clock
-import mesosphere.marathon.core.launcher.impl.{ ReservationSelector, TaskLabels }
+import mesosphere.marathon.core.launcher.impl.{ ReservationLabels, TaskLabels }
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.task.update.TaskUpdateStep
 import mesosphere.marathon.core.task.{ Task, TaskStateOp }
@@ -71,7 +71,7 @@ object MarathonTestHelper {
 
   def makeBasicOffer(cpus: Double = 4.0, mem: Double = 16000, disk: Double = 1.0,
                      beginPort: Int = 31000, endPort: Int = 32000, role: String = ResourceRole.Unreserved,
-                     reservation: Option[ReservationSelector] = None): Offer.Builder = {
+                     reservation: Option[ReservationLabels] = None): Offer.Builder = {
 
     require(role != ResourceRole.Unreserved || reservation.isEmpty, "reserved resources cannot have role *")
 

--- a/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
@@ -98,7 +98,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
       .addResources(portsResource)
       .addResources(portsResource2)
       .build
-    val matcher = new PortsMatcher(app, offer, resourceSelector = ResourceSelector(Set(ResourceRole.Unreserved, "marathon"), reserved = false))
+    val matcher = new PortsMatcher(app, offer, resourceSelector = ResourceSelector(Set(ResourceRole.Unreserved, "marathon"), reservation = None))
 
     assert(matcher.portsMatch.isDefined)
     assert(5 == matcher.portsMatch.get.hostPorts.size)
@@ -315,7 +315,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
     )
 
     val offer = MarathonTestHelper.makeBasicOffer(beginPort = 31000, endPort = 31000).addResources(portsResource).build
-    val matcher = new PortsMatcher(app, offer, resourceSelector = ResourceSelector(Set(ResourceRole.Unreserved, "marathon"), reserved = false))
+    val matcher = new PortsMatcher(app, offer, resourceSelector = ResourceSelector(Set(ResourceRole.Unreserved, "marathon"), reservation = None))
 
     assert(matcher.portsMatch.isDefined)
     assert(matcher.portsMatch.get.hostPorts.toSet == Set(31000, 31001))


### PR DESCRIPTION
A normal (non-resident) task can now use dynamically reserved resources as long as these are not labeled with known labels which are used for resident tasks. That way, dynamically reserving resources for role foo and using those is possible like with static reservations.