### PR TITLE
ext vols should more strictly validate containerPath

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -130,8 +130,7 @@ case class PersistentVolume(
 
 object PersistentVolume {
   import org.apache.mesos.Protos.Volume.Mode
-
-  val NoSlashesPattern = """^[^/]*$""".r
+  import PathPatterns._
 
   implicit val validPersistentVolume = validator[PersistentVolume] { vol =>
     vol.containerPath is notEmpty
@@ -140,6 +139,10 @@ object PersistentVolume {
     vol.persistent is valid
     vol.mode is equalTo(Mode.RW)
   }
+}
+
+object PathPatterns {
+  val NoSlashesPattern = """^[^/]*$""".r
 }
 
 /**
@@ -215,9 +218,13 @@ case class ExternalVolume(
   mode: Mesos.Volume.Mode) extends Volume
 
 object ExternalVolume {
+  import PathPatterns._
+
   val validExternalVolume = validator[ExternalVolume] { ev =>
     ev is featureEnabled(Features.EXTERNAL_VOLUMES)
     ev.containerPath is notEmpty
+    ev.containerPath is notOneOf(".", "..")
+    ev.containerPath should matchRegexFully(NoSlashesPattern)
     ev.external is valid(ExternalVolumeInfo.validExternalVolumeInfo)
   } and ExternalVolumes.validExternalVolume
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -269,7 +269,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("MESOS",
       """
         |    "volumes": [{
-        |      "containerPath": "/var",
+        |      "containerPath": "var",
         |      "external": {
         |        "size": 10,
         |        "name": "foo",
@@ -292,7 +292,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
       createAppWithVolumes("MESOS",
         """
           |    "volumes": [{
-          |      "containerPath": "/var",
+          |      "containerPath": "var",
           |      "external": {
           |        "size": 10
           |      },
@@ -307,12 +307,34 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     e.getMessage should include("/container/volumes(0)/external/name")
   }
 
-  test("Creating an app with an external volume and MESOS containerizer should pass validation") {
+  test("Creating an app with an external volume w/ an absolute containerPath should fail validation") {
     Given("An app with a named, non-'agent' volume provider")
     val response = createAppWithVolumes("MESOS",
       """
         |    "volumes": [{
         |      "containerPath": "/var",
+        |      "external": {
+        |        "size": 10,
+        |        "provider": "dvdi",
+        |        "name": "namedfoo",
+        |        "options": {"dvdi/driver": "bar"}
+        |      },
+        |      "mode": "RW"
+        |    }]
+      """.stripMargin
+    )
+
+    Then("The return code indicates failure")
+    response.getStatus should be(422)
+    response.getEntity.toString should include("/container/volumes(0)/containerPath")
+  }
+
+  test("Creating an app with an external volume and MESOS containerizer should pass validation") {
+    Given("An app with a named, non-'agent' volume provider")
+    val response = createAppWithVolumes("MESOS",
+      """
+        |    "volumes": [{
+        |      "containerPath": "var",
         |      "external": {
         |        "size": 10,
         |        "provider": "dvdi",
@@ -333,7 +355,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("MESOS",
       """
         |    "volumes": [{
-        |      "containerPath": "/var",
+        |      "containerPath": "var",
         |      "external": {
         |        "size": 10,
         |        "provider": "dvdi",
@@ -355,7 +377,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("DOCKER",
       """
         |    "volumes": [{
-        |      "containerPath": "/var",
+        |      "containerPath": "var",
         |      "external": {
         |        "provider": "dvdi",
         |        "name": "namedfoo",
@@ -375,7 +397,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("DOCKER",
       """
         |    "volumes": [{
-        |      "containerPath": "/var",
+        |      "containerPath": "var",
         |      "external": {
         |        "provider": "dvdi",
         |        "name": "namedfoo",
@@ -397,7 +419,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("DOCKER",
       """
         |    "volumes": [{
-        |      "containerPath": "/var",
+        |      "containerPath": "var",
         |      "external": {
         |        "provider": "dvdi",
         |        "name": "namedfoo",
@@ -424,7 +446,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("DOCKER",
       """
         |    "volumes": [{
-        |      "containerPath": "/var",
+        |      "containerPath": "var",
         |      "external": {
         |        "provider": "dvdi",
         |        "name": "namedfoo",
@@ -450,7 +472,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("DOCKER",
       """
         |    "volumes": [{
-        |      "containerPath": "/var",
+        |      "containerPath": "var",
         |      "external": {
         |        "provider": "dvdi",
         |        "name": "namedfoo",
@@ -459,7 +481,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
         |      "mode": "RW"
         |    },{
         |      "hostPath": "namedfoo",
-        |      "containerPath": "/ert",
+        |      "containerPath": "ert",
         |      "mode": "RW"
         |    }]
       """.stripMargin


### PR DESCRIPTION
without this change, tasks with `/abs/container/paths` launch and immediately fail: "Failed to launch container: Absolute container path does not exist; Container destroyed while preparing isolators"