### PR TITLE
Revert "ext vols should more strictly validate containerPath"

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -130,7 +130,8 @@ case class PersistentVolume(
 
 object PersistentVolume {
   import org.apache.mesos.Protos.Volume.Mode
-  import PathPatterns._
+
+  val NoSlashesPattern = """^[^/]*$""".r
 
   implicit val validPersistentVolume = validator[PersistentVolume] { vol =>
     vol.containerPath is notEmpty
@@ -139,10 +140,6 @@ object PersistentVolume {
     vol.persistent is valid
     vol.mode is equalTo(Mode.RW)
   }
-}
-
-object PathPatterns {
-  val NoSlashesPattern = """^[^/]*$""".r
 }
 
 /**
@@ -218,13 +215,9 @@ case class ExternalVolume(
   mode: Mesos.Volume.Mode) extends Volume
 
 object ExternalVolume {
-  import PathPatterns._
-
   val validExternalVolume = validator[ExternalVolume] { ev =>
     ev is featureEnabled(Features.EXTERNAL_VOLUMES)
     ev.containerPath is notEmpty
-    ev.containerPath is notOneOf(".", "..")
-    ev.containerPath should matchRegexFully(NoSlashesPattern)
     ev.external is valid(ExternalVolumeInfo.validExternalVolumeInfo)
   } and ExternalVolumes.validExternalVolume
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -269,7 +269,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("MESOS",
       """
         |    "volumes": [{
-        |      "containerPath": "var",
+        |      "containerPath": "/var",
         |      "external": {
         |        "size": 10,
         |        "name": "foo",
@@ -292,7 +292,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
       createAppWithVolumes("MESOS",
         """
           |    "volumes": [{
-          |      "containerPath": "var",
+          |      "containerPath": "/var",
           |      "external": {
           |        "size": 10
           |      },
@@ -307,34 +307,12 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     e.getMessage should include("/container/volumes(0)/external/name")
   }
 
-  test("Creating an app with an external volume w/ an absolute containerPath should fail validation") {
-    Given("An app with a named, non-'agent' volume provider")
-    val response = createAppWithVolumes("MESOS",
-      """
-        |    "volumes": [{
-        |      "containerPath": "/var",
-        |      "external": {
-        |        "size": 10,
-        |        "provider": "dvdi",
-        |        "name": "namedfoo",
-        |        "options": {"dvdi/driver": "bar"}
-        |      },
-        |      "mode": "RW"
-        |    }]
-      """.stripMargin
-    )
-
-    Then("The return code indicates failure")
-    response.getStatus should be(422)
-    response.getEntity.toString should include("/container/volumes(0)/containerPath")
-  }
-
   test("Creating an app with an external volume and MESOS containerizer should pass validation") {
     Given("An app with a named, non-'agent' volume provider")
     val response = createAppWithVolumes("MESOS",
       """
         |    "volumes": [{
-        |      "containerPath": "var",
+        |      "containerPath": "/var",
         |      "external": {
         |        "size": 10,
         |        "provider": "dvdi",
@@ -355,7 +333,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("MESOS",
       """
         |    "volumes": [{
-        |      "containerPath": "var",
+        |      "containerPath": "/var",
         |      "external": {
         |        "size": 10,
         |        "provider": "dvdi",
@@ -377,7 +355,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("DOCKER",
       """
         |    "volumes": [{
-        |      "containerPath": "var",
+        |      "containerPath": "/var",
         |      "external": {
         |        "provider": "dvdi",
         |        "name": "namedfoo",
@@ -397,7 +375,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("DOCKER",
       """
         |    "volumes": [{
-        |      "containerPath": "var",
+        |      "containerPath": "/var",
         |      "external": {
         |        "provider": "dvdi",
         |        "name": "namedfoo",
@@ -419,7 +397,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("DOCKER",
       """
         |    "volumes": [{
-        |      "containerPath": "var",
+        |      "containerPath": "/var",
         |      "external": {
         |        "provider": "dvdi",
         |        "name": "namedfoo",
@@ -446,7 +424,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("DOCKER",
       """
         |    "volumes": [{
-        |      "containerPath": "var",
+        |      "containerPath": "/var",
         |      "external": {
         |        "provider": "dvdi",
         |        "name": "namedfoo",
@@ -472,7 +450,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("DOCKER",
       """
         |    "volumes": [{
-        |      "containerPath": "var",
+        |      "containerPath": "/var",
         |      "external": {
         |        "provider": "dvdi",
         |        "name": "namedfoo",
@@ -481,7 +459,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
         |      "mode": "RW"
         |    },{
         |      "hostPath": "namedfoo",
-        |      "containerPath": "ert",
+        |      "containerPath": "/ert",
         |      "mode": "RW"
         |    }]
       """.stripMargin


### PR DESCRIPTION
Reverts mesosphere/marathon#3886

This commit breaks external volumes for docker containerizer since Docker itself only supports absolute paths and the docker containerizer impl doesn't supply a sandbox prefix for relative `containerPath` specs.