### PR TITLE
split containerPath validation for external vols between mesos and docker containerizer

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -130,16 +130,21 @@ case class PersistentVolume(
 
 object PersistentVolume {
   import org.apache.mesos.Protos.Volume.Mode
-
-  val NoSlashesPattern = """^[^/]*$""".r
+  import PathPatterns._
 
   implicit val validPersistentVolume = validator[PersistentVolume] { vol =>
     vol.containerPath is notEmpty
-    vol.containerPath is notOneOf(".", "..")
+    vol.containerPath is notOneOf(DotPaths: _*)
     vol.containerPath should matchRegexFully(NoSlashesPattern)
     vol.persistent is valid
     vol.mode is equalTo(Mode.RW)
   }
+}
+
+object PathPatterns {
+  lazy val NoSlashesPattern = """^[^/]*$""".r
+  lazy val AbsolutePathPattern = """^/[^/].*$""".r
+  lazy val DotPaths = Seq[String](".", "..")
 }
 
 /**

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -250,7 +250,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("MESOS",
       """
         |    "volumes": [{
-        |      "containerPath": "/var",
+        |      "containerPath": "var",
         |      "persistent_WRONG_FIELD_NAME": {
         |        "size": 10
         |      },
@@ -269,7 +269,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("MESOS",
       """
         |    "volumes": [{
-        |      "containerPath": "/var",
+        |      "containerPath": "var",
         |      "external": {
         |        "size": 10,
         |        "name": "foo",
@@ -292,7 +292,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
       createAppWithVolumes("MESOS",
         """
           |    "volumes": [{
-          |      "containerPath": "/var",
+          |      "containerPath": "var",
           |      "external": {
           |        "size": 10
           |      },
@@ -307,12 +307,34 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     e.getMessage should include("/container/volumes(0)/external/name")
   }
 
-  test("Creating an app with an external volume and MESOS containerizer should pass validation") {
+  test("Creating an app with an external volume w/ MESOS and absolute containerPath should fail validation") {
     Given("An app with a named, non-'agent' volume provider")
     val response = createAppWithVolumes("MESOS",
       """
         |    "volumes": [{
         |      "containerPath": "/var",
+        |      "external": {
+        |        "size": 10,
+        |        "provider": "dvdi",
+        |        "name": "namedfoo",
+        |        "options": {"dvdi/driver": "bar"}
+        |      },
+        |      "mode": "RW"
+        |    }]
+      """.stripMargin
+    )
+
+    Then("The return code indicates create failure")
+    response.getStatus should be(422)
+    response.getEntity.toString should include("/container/volumes(0)/containerPath")
+  }
+
+  test("Creating an app with an external volume and MESOS containerizer should pass validation") {
+    Given("An app with a named, non-'agent' volume provider")
+    val response = createAppWithVolumes("MESOS",
+      """
+        |    "volumes": [{
+        |      "containerPath": "var",
         |      "external": {
         |        "size": 10,
         |        "provider": "dvdi",
@@ -333,7 +355,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val response = createAppWithVolumes("MESOS",
       """
         |    "volumes": [{
-        |      "containerPath": "/var",
+        |      "containerPath": "var",
         |      "external": {
         |        "size": 10,
         |        "provider": "dvdi",
@@ -348,6 +370,27 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     Then("The return code indicates validation error")
     response.getStatus should be(422)
     response.getEntity.toString should include("/container/volumes(0)/external/options(\\\"dvdi/iops\\\")")
+  }
+
+  test("Creating an app with an external volume w/ relative containerPath DOCKER containerizer should fail validation") {
+    Given("An app with a named, non-'agent' volume provider")
+    val response = createAppWithVolumes("DOCKER",
+      """
+        |    "volumes": [{
+        |      "containerPath": "var",
+        |      "external": {
+        |        "provider": "dvdi",
+        |        "name": "namedfoo",
+        |        "options": {"dvdi/driver": "bar"}
+        |      },
+        |      "mode": "RW"
+        |    }]
+      """.stripMargin
+    )
+
+    Then("The return code indicates create failed")
+    response.getStatus should be(422)
+    response.getEntity.toString should include("/container/volumes(0)/containerPath")
   }
 
   test("Creating an app with an external volume and DOCKER containerizer should pass validation") {


### PR DESCRIPTION
* Mesos containerizer requires relative `containerPath`
* Docker containerizer requires absolute `containerPath`
* Not having these changes allows Marathon to launch invalid tasks that will consistently **fail** with confusing error messages (bad user experience).