### PR TITLE
Revert "External volumes docs"

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -101,11 +101,11 @@ layout: default
                     Stateful Applications Using Local Persistent Volumes
                 </a>
             </li>
-            <li>
+            <!-- <li>
                 <a href="{{ site.baseurl }}/docs/external-volumes.html">
-                    Stateful Applications Using External Persistent Volumes
+                    Stateful Applications Using Persistent External Volumes
                 </a>
-            </li>
+            </li> -->
             <li>
                 <a href="{{ site.baseurl }}/docs/task-environment-vars.html">
                     Task Environment Variables

--- a/docs/docs/external-volumes.md
+++ b/docs/docs/external-volumes.md
@@ -7,7 +7,7 @@ title: Stateful Applications Using External Persistent Volumes
 <div class="alert alert-danger" role="alert">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> Adapted in Marathon Version 1.0 <br/>
   External persistent storage functionality is considered beta, so use this feature at your own risk. We might add, change, or delete any functionality described in this document.
-  This functionality is *disabled by default* but may be turned on by including `external_volumes` in the value of the `--enable_features` command-line flag.
+  This functionality is **disabled by default** but may be turned on by including `external_volumes` in the value of the `--enable_features` command-line flag.
 </div>
 
 Marathon applications normally lose their state when they terminate and are relaunched. In some contexts, for instance, if your application uses MySQL, you’ll want your application to preserve its state. You can use an external storage service, such as Amazon's Elastic Block Store (EBS), to create a persistent volume that follows your application instance.
@@ -45,7 +45,7 @@ You specify an external volume in the app definition of your Marathon app. [Lear
     "type": "MESOS",
     "volumes": [
       {
-        "containerPath": "tmp/test-rexray-volume",
+        "containerPath": "/tmp/test-rexray-volume",
         "external": {
           "size": 100,
           "name": "my-test-vol",
@@ -65,9 +65,10 @@ You specify an external volume in the app definition of your Marathon app. [Lear
 
 In the app definition above:
 
-- `containerPath` specifies where the volume is mounted inside the container. For Mesos external volumes, this path must be relative to the container, i.e., the path cannot begin with `/`. For Docker external volumes, this path must be absolute. See [the REX-Ray documentation on data directories](https://rexray.readthedocs.org/en/v0.3.2/user-guide/config/#data-directories) for more information.
+- `containerPath` specifies where the volume is mounted inside the container. See [the REX-Ray documentation on data directories](https://rexray.readthedocs.org/en/v0.3.2/user-guide/config/#data-directories) for more information.
 
-- `name` is the name by which your volume driver looks up your volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is [created implicitly](#implicit-vol). Otherwise, the existing volume is re-used. 
+- `name` is the name by which your volume driver looks up your volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it's created. Otherwise, the existing volume is re-used. **Note:** Implicit volume creation only works when using volumes with a Mesos container and requires that you set `volumes[x].external.size`.
+
 - The `external.options["dvdi/driver"]` option specifies which Docker volume driver to use for storage. If you are running Marathon on DCOS, this value should likely be `rexray`. [Learn more about REX-Ray](https://rexray.readthedocs.org/en/v0.3.2/user-guide/schedulers/).
 
 - You can specify additional options with `container.volumes[x].external.options[optionName]`. The dvdi provider for Mesos containers uses `dvdcli`, which offers the options [documented here](https://github.com/emccode/dvdcli#extra-options). The availability of any given option depends on your volume driver, however.
@@ -77,10 +78,6 @@ In the app definition above:
 - Volume parameters cannot be changed after you create the application.
 
 - **Note:** Marathon will not launch apps with external volumes if  `upgradeStrategy.minimusHealthCapacity` is less than 0.5, or if `upgradeStrategy.maximumOverCapacity` does not equal 0.
-
-<a name="implicit-vol"></a>
-### Implicit Volumes
-The default implicit volume size is 16GB. If you are using the Mesos containerizer, you can modify this default for a particular volume by setting `volumes[x].external.size`. For both the Mesos and Docker containerizers, you can modify the default size for all implicit volumes by [modifying the REX-Ray configuration](https://github.com/emccode/rexray/blob/master/.docs/user-guide/config.md).
 
 ### Using a Docker Container
 
@@ -129,7 +126,7 @@ For more information, refer to the [REX-Ray documentation](https://rexray.readth
 
 - Volumes are namespaced by their storage provider. If you're using EBS, volumes created on the same AWS account share a namespace. Choose unique volume names to avoid conflicts.
 
-- Docker apps do not support external volumes on DCOS installations running Docker older than 1.8.
+- Docker apps do not support external volumes on DCOS installations running Docker older than 1.8. Currently, this means that DCOS Community Edition users cannot create Docker apps with external volumes.
 
 - If you are using Amazon's EBS, it is possible that clusters can be created in different availability zones (AZs). This means that if you create a cluster with an external volume in one AZ and destroy it, a new cluster may not have access to that external volume because it could be in a different AZ.
 


### PR DESCRIPTION
Reverts mesosphere/marathon#3887

I merged this to Master, then @jdef made the point that having this doc accessible before the external volume code arrives in Marathon/Master could be confusing to users. How would you like to handle this?