### PR TITLE
Alauda is powered by Marathon

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ To develop on the web UI look into the instructions of the [Marathon UI](https:/
 Across all installations Marathon is managing applications on more than 100,000 nodes world-wide. These are some of the companies using it:
 
 * [Adform](http://site.adform.com/)
+* [Alauda](http://www.alauda.cn/)
 * [Allegro](http://allegro.tech)
 * [AllUnite](https://allunite.com/)
 * [Argus Cyber Security](http://argus-sec.com/)


### PR DESCRIPTION
Alauda build public CaaS on top of mesos and marathon in multiple datacenters around the world running tens of thousands of apps in each datacenter.