### PR TITLE
WIP - Fixed handling TASK_LOST status updates

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -137,6 +137,13 @@ The core functionality flags can be also set by environment variable `MARATHON_O
     The timeout for preparing the Marathon instance when elected as leader.
 * <span class="label label-default">v0.14.1</span> `--http_event_callback_slow_consumer_timeout` (Optional. Default: 10 seconds):
     A http event callback consumer is considered slow, if the delivery takes longer than this timeout.
+* <span class="label label-default">v0.15.4</span> `--task_lost_expunge_gc` (Optional. Default: 24 hours):
+    This is the length of time in milliseconds, until a lost task is garbage collected and expunged from the task tracker and task repository.
+* <span class="label label-default">v0.15.4</span> `--task_lost_expunge_initial_delay` (Optional. Default: 5 minutes):
+    This is the length of time, in milliseconds, before Marathon begins to periodically perform task expunge gc operations    
+* <span class="label label-default">v0.15.4</span> `--task_lost_expunge_interval` (Optional. Default: 1 hour):
+    This is the length of time in milliseconds, for lost task gc operations.
+
 ## Tuning Flags for Offer Matching/Launching Tasks
 
 Mesos frequently sends resource offers to Marathon (and all other frameworks). Each offer will represent the

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
@@ -1,6 +1,7 @@
 package mesosphere.mesos.simulation
 
 import java.util
+import java.util.Collections
 
 import akka.actor.{ ActorRef, ActorSystem, Props }
 import com.typesafe.config.{ Config, ConfigFactory }
@@ -53,9 +54,11 @@ class SimulatedDriver(driverProps: Props) extends SchedulerDriver {
   override def declineOffer(offerId: OfferID, filters: Filters): Status = Status.DRIVER_RUNNING
 
   override def launchTasks(offerIds: util.Collection[OfferID], tasks: util.Collection[TaskInfo],
-                           filters: Filters): Status = ???
-  override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo], filters: Filters): Status = ???
-  override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo]): Status = ???
+                           filters: Filters): Status = launchTasks(offerIds, tasks)
+  override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo], filters: Filters): Status =
+    launchTasks(Collections.singleton(offerId), tasks)
+  override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo]): Status =
+    launchTasks(Collections.singleton(offerId), tasks)
   override def requestResources(requests: util.Collection[Request]): Status = ???
   override def sendFrameworkMessage(executorId: ExecutorID, slaveId: SlaveID, data: Array[Byte]): Status = ???
   override def acknowledgeStatusUpdate(ackStatus: TaskStatus): Status = status

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -5,6 +5,7 @@ import mesosphere.marathon.core.launcher.OfferProcessorConfig
 import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerConfig
 import mesosphere.marathon.core.plugin.PluginManagerConfiguration
+import mesosphere.marathon.core.task.jobs.TaskJobsConfig
 import mesosphere.marathon.core.task.tracker.TaskTrackerConfig
 import mesosphere.marathon.core.task.update.TaskStatusUpdateConfig
 import org.rogach.scallop.ScallopConf
@@ -16,7 +17,7 @@ trait MarathonConf
     extends ScallopConf with ZookeeperConf with LeaderProxyConf
     with LaunchTokenConfig with OfferMatcherManagerConfig with OfferProcessorConfig with ReviveOffersConfig
     with MarathonSchedulerServiceConfig with LaunchQueueConfig with PluginManagerConfiguration
-    with TaskStatusUpdateConfig with TaskTrackerConfig {
+    with TaskStatusUpdateConfig with TaskTrackerConfig with TaskJobsConfig {
 
   //scalastyle:off magic.number
 

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -122,7 +122,7 @@ class MarathonScheduler @Inject() (
     // For now the frameworkId is removed based on the error message.
     val removeFrameworkId = message match {
       case "Framework has been removed" => true
-      case unknown: String => false
+      case unknown: String              => false
     }
     suicide(removeFrameworkId)
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -103,10 +103,14 @@ trait Formats
     )(toIpAddress, toTuple)
   }
 
+  implicit lazy val TaskStateFormat: Format[mesos.TaskState] =
+    enumFormat(mesos.TaskState.valueOf, str => s"$str is not a valid TaskState type")
+
   implicit lazy val MarathonTaskWrites: Writes[MarathonTask] = Writes { task =>
     Json.obj(
       "id" -> task.getId,
       "host" -> (if (task.hasHost) task.getHost else JsNull),
+      "state" -> task.getStatus.getState,
       "ipAddresses" -> MarathonTasks.ipAddresses(task),
       "ports" -> task.getPortsList.asScala,
       "startedAt" -> (if (task.getStartedAt != 0) Timestamp(task.getStartedAt) else JsNull),

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -22,9 +22,10 @@ object LaunchQueue {
       tasksLeftToLaunch: Int,
       taskLaunchesInFlight: Int,
       tasksLaunchedOrRunning: Int,
+      tasksLost: Int,
       backOffUntil: Timestamp) {
     def waiting: Boolean = tasksLeftToLaunch != 0 || taskLaunchesInFlight != 0
-    def totalTaskCount: Int = tasksLeftToLaunch + tasksLaunchedOrRunning + taskLaunchesInFlight
+    def totalTaskCount: Int = tasksLeftToLaunch + tasksLaunchedOrRunning + taskLaunchesInFlight - tasksLost
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
@@ -20,7 +20,7 @@ import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
 import mesosphere.marathon.tasks.TaskFactory.CreatedTask
 import mesosphere.marathon.tasks.TaskFactory
-import org.apache.mesos.Protos.{ TaskID, TaskInfo }
+import org.apache.mesos.Protos.{ TaskID, TaskInfo, TaskState }
 
 import scala.concurrent.duration._
 
@@ -320,6 +320,7 @@ private class AppTaskLauncherActor(
       tasksLeftToLaunch = tasksToLaunch,
       taskLaunchesInFlight = inFlightTaskLaunches.size,
       tasksLaunchedOrRunning = tasksMap.size - inFlightTaskLaunches.size,
+      tasksLost = tasksMap.values.count(_.getStatus.getState == TaskState.TASK_LOST),
       backOffUntil.getOrElse(clock.now())
     )
   }

--- a/src/main/scala/mesosphere/marathon/core/task/bus/MesosTaskStatus.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/MesosTaskStatus.scala
@@ -1,0 +1,47 @@
+package mesosphere.marathon.core.task.bus
+
+import mesosphere.marathon.Protos.MarathonTask
+import org.apache.mesos.Protos.TaskState._
+import org.apache.mesos.Protos.TaskStatus
+import org.apache.mesos.Protos.TaskStatus.Reason._
+
+object MesosTaskStatus {
+
+  // If we're disconnected at the time of a TASK_LOST event, we will only get the update during
+  // a reconciliation. In that case, the specific reason will be shadowed by REASON_RECONCILIATION.
+  // Since we don't know the original reason, we need to assume that the task might come back.
+  val MightComeBack: Set[TaskStatus.Reason] = Set(
+    REASON_RECONCILIATION,
+    REASON_SLAVE_DISCONNECTED,
+    REASON_SLAVE_REMOVED
+  )
+
+  val WontComeBack: Set[TaskStatus.Reason] = TaskStatus.Reason.values().toSet.diff(MightComeBack)
+
+  object Terminal {
+    def unapply(taskStatus: TaskStatus): Option[TaskStatus] = taskStatus.getState match {
+      case TASK_LOST if WontComeBack(taskStatus.getReason) => Some(taskStatus)
+      case TASK_ERROR | TASK_FAILED | TASK_KILLED | TASK_FINISHED => Some(taskStatus)
+      case _ => None
+    }
+    def isTerminal(taskStatus: TaskStatus): Boolean = unapply(taskStatus).isDefined
+  }
+
+  object TemporarilyUnreachable {
+    def unapply(task: MarathonTask): Option[MarathonTask] = {
+      if (task.getStatus.getState == TASK_LOST && MightComeBack(task.getStatus.getReason)) Some(task)
+      else None
+    }
+    def unapply(taskStatus: TaskStatus): Option[TaskStatus] = {
+      if (taskStatus.getState == TASK_LOST && MightComeBack(taskStatus.getReason)) Some(taskStatus)
+      else None
+    }
+  }
+
+  object Running {
+    def unapply(taskStatus: TaskStatus): Option[TaskStatus] = taskStatus.getState match {
+      case TASK_RUNNING => Some(taskStatus)
+      case _            => None
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsConfig.scala
@@ -1,0 +1,26 @@
+package mesosphere.marathon.core.task.jobs
+
+import org.rogach.scallop.ScallopConf
+import scala.concurrent.duration._
+
+trait TaskJobsConfig extends ScallopConf {
+  //scalastyle:off magic.number
+
+  private[this] lazy val taskLostExpungeGCValue = opt[Long]("task_lost_expunge_gc",
+    descr = "This is the length of time in milliseconds, until a lost task is garbage collected and expunged " +
+      "from the task tracker and task repository.",
+    default = Some(24 * 60 * 60 * 1000L)) // 24h
+
+  private[this] lazy val taskLostExpungeInitialDelayValue = opt[Long]("task_lost_expunge_initial_delay",
+    descr = "This is the length of time, in milliseconds, before Marathon " +
+      "begins to periodically perform task expunge gc operations",
+    default = Some(5 * 60 * 1000L)) // 5 minutes
+
+  private[this] lazy val taskLostExpungeIntervalValue = opt[Long]("task_lost_expunge_interval",
+    descr = "This is the length of time in milliseconds, for lost task gc operations.",
+    default = Some(1 * 60 * 60 * 1000L)) // 1h
+
+  def taskLostExpungeGC: FiniteDuration = taskLostExpungeGCValue().millis
+  def taskLostExpungeInitialDelay: FiniteDuration = taskLostExpungeInitialDelayValue().millis
+  def taskLostExpungeInterval: FiniteDuration = taskLostExpungeIntervalValue().millis
+}

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
@@ -1,20 +1,30 @@
 package mesosphere.marathon.core.task.jobs
 
+import com.google.inject.Provider
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.leadership.LeadershipModule
-import mesosphere.marathon.core.task.jobs.impl.KillOverdueTasksActor
+import mesosphere.marathon.core.task.jobs.impl.{ ExpungeOverdueLostTasksActor, KillOverdueTasksActor }
 import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerDriverHolder }
 
 /**
   * This module contains periodically running jobs interacting with the task tracker.
   */
 class TaskJobsModule(config: MarathonConf, leadershipModule: LeadershipModule, clock: Clock) {
+
   def killOverdueTasks(
     taskTracker: TaskTracker,
     marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder): Unit = {
     leadershipModule.startWhenLeader(
       KillOverdueTasksActor.props(config, taskTracker, marathonSchedulerDriverHolder, clock),
       "killOverdueStagedTasks")
+  }
+
+  def expungeOverdueLostTasks(taskTracker: TaskTracker, updateProcessor: Provider[TaskStatusUpdateProcessor]): Unit = {
+    leadershipModule.startWhenLeader(
+      ExpungeOverdueLostTasksActor.props(clock, config, taskTracker, updateProcessor),
+      "expungeOverdueLostTasks"
+    )
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
@@ -1,0 +1,82 @@
+package mesosphere.marathon.core.task.jobs.impl
+
+import akka.actor.{ ActorLogging, Props, Cancellable, Actor }
+import akka.pattern.pipe
+import com.google.inject.Provider
+import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.base.Clock
+import mesosphere.marathon.core.task.bus.MesosTaskStatus.TemporarilyUnreachable
+import mesosphere.marathon.core.task.jobs.TaskJobsConfig
+import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.core.task.tracker.TaskTracker.AppTasks
+import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
+import mesosphere.marathon.state.PathId
+import org.apache.mesos.Protos.TaskState
+import org.apache.mesos.{ Protos => mesos }
+import org.joda.time.DateTime
+import scala.concurrent.duration._
+
+class ExpungeOverdueLostTasksActor(
+    clock: Clock,
+    config: TaskJobsConfig,
+    taskTracker: TaskTracker,
+    updateProcessorProvider: Provider[TaskStatusUpdateProcessor]) extends Actor with ActorLogging {
+
+  import ExpungeOverdueLostTasksActor._
+  implicit val ec = context.dispatcher
+
+  var tickTimer: Option[Cancellable] = None
+  lazy val updateProcessor = updateProcessorProvider.get()
+
+  override def preStart(): Unit = {
+    log.info("ExpungeOverdueLostTasksActor has started")
+    tickTimer = Some(context.system.scheduler.schedule(config.taskLostExpungeInitialDelay,
+      config.taskLostExpungeInterval, self, Tick))
+  }
+
+  override def postStop(): Unit = {
+    tickTimer.foreach(_.cancel())
+    log.info("ExpungeOverdueLostTasksActor has stopped")
+  }
+
+  override def receive: Receive = {
+    case Tick                             => taskTracker.tasksByApp() pipeTo self
+    case TaskTracker.TasksByApp(appTasks) => filterLostGCTasks(appTasks).foreach(expungeLostGCTask)
+  }
+
+  def expungeLostGCTask(task: MarathonTask): Unit = {
+    val timestamp = new DateTime(task.getStatus.getTimestamp.toLong * 1000)
+    log.warning(s"Task ${task.getId} is lost since $timestamp and will be expunged.")
+    // To expunge the task from the repository, task tracker etc. and to also inform all listeners
+    // for this change, a TaskStatusUpdate is used, since the current infrastructure relies on that.
+    // TODO: update infrastructure in 1.0 and beyond will not use task status updates.
+    val update = task.getStatus.toBuilder
+      .setState(TaskState.TASK_ERROR)
+      .setReason(mesos.TaskStatus.Reason.REASON_TASK_UNKNOWN)
+      .setTimestamp((clock.now().toDateTime.getMillis / 1000).toDouble)
+      .build()
+    updateProcessor.publish(update, ack = false)
+  }
+
+  def filterLostGCTasks(tasks: Map[PathId, AppTasks]): Iterable[MarathonTask] = {
+    def isTimedOut(task: MarathonTask): Boolean = {
+      val age = clock.now().toDateTime.minus(task.getStatus.getTimestamp.toLong * 1000).getMillis.millis
+      age > config.taskLostExpungeGC
+    }
+    tasks.values.flatMap(_.tasks.filter {
+      case TemporarilyUnreachable(task) if isTimedOut(task) => true
+      case _ => false
+    })
+  }
+}
+
+object ExpungeOverdueLostTasksActor {
+
+  case object Tick
+
+  def props(clock: Clock, config: TaskJobsConfig,
+            taskTracker: TaskTracker, updateProcessor: Provider[TaskStatusUpdateProcessor]): Props = {
+    Props(new ExpungeOverdueLostTasksActor(clock, config, taskTracker, updateProcessor))
+  }
+}
+

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTracker.scala
@@ -29,6 +29,7 @@ trait TaskTracker {
   def tasksByApp()(implicit ec: ExecutionContext): Future[TaskTracker.TasksByApp]
 
   def countAppTasksSync(appId: PathId): Int
+  def countAppTasksSync(appId: PathId, filter: MarathonTask => Boolean): Int
   def countAppTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Int]
 
   def hasAppTasksSync(appId: PathId): Boolean

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerDelegate.scala
@@ -46,6 +46,9 @@ private[tracker] class TaskTrackerDelegate(
   }
 
   override def countAppTasksSync(appId: PathId): Int = tasksByAppSync.appTasks(appId).size
+  override def countAppTasksSync(appId: PathId, filter: MarathonTask => Boolean): Int =
+    tasksByAppSync.appTasks(appId).count(filter)
+
   override def countAppTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Int] =
     tasksByApp().map(_.appTasks(appId).size)
   override def taskSync(appId: PathId, taskId: String): Option[MarathonTask] = tasksByAppSync.task(appId, taskId)

--- a/src/main/scala/mesosphere/marathon/core/task/update/TaskStatusUpdateProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/TaskStatusUpdateProcessor.scala
@@ -5,5 +5,11 @@ import org.apache.mesos.Protos.TaskStatus
 import scala.concurrent.Future
 
 trait TaskStatusUpdateProcessor {
-  def publish(status: TaskStatus): Future[Unit]
+
+  /**
+    * Process a task status update message.
+    * @param status the status to update.
+    * @param ack if this update is coming from Mesos, you want to acknowledge this update.
+    */
+  def publish(status: TaskStatus, ack: Boolean = true): Future[Unit]
 }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/ThrottlingTaskStatusUpdateProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/ThrottlingTaskStatusUpdateProcessor.scala
@@ -20,5 +20,7 @@ private[core] class ThrottlingTaskStatusUpdateProcessor @Inject() (
   @Named(ThrottlingTaskStatusUpdateProcessor.dependencyTag) serializePublish: CapConcurrentExecutions,
   @Named(ThrottlingTaskStatusUpdateProcessor.dependencyTag) wrapped: TaskStatusUpdateProcessor)
     extends TaskStatusUpdateProcessor {
-  override def publish(status: TaskStatus): Future[Unit] = serializePublish(wrapped.publish(status))
+  override def publish(status: TaskStatus, ack: Boolean = true): Future[Unit] = {
+    serializePublish(wrapped.publish(status, ack))
+  }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -37,7 +37,7 @@ class PostToEventStreamStepImpl @Inject() (
     status.getState match {
       case TASK_ERROR | TASK_FAILED | TASK_FINISHED | TASK_KILLED | TASK_LOST =>
         postEvent(timestamp, appId, status, task)
-      case TASK_RUNNING if !task.hasStartedAt => // staged, not running
+      case TASK_RUNNING if task.getStatus.getState != TASK_RUNNING => //do not report subsequent running updates
         postEvent(timestamp, appId, status, task)
 
       case state: TaskState =>

--- a/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
+++ b/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
@@ -95,7 +95,8 @@ object TaskFailure {
   protected[this] def taskState(s: String): mesos.TaskState =
     mesos.TaskState.valueOf(s)
 
-  protected[this] def isFailureState(state: mesos.TaskState): Boolean = {
+  // Note that this will also store taskFailures for TASK_LOST no matter the reason
+  private[this] def isFailureState(state: mesos.TaskState): Boolean = {
     import mesos.TaskState._
     state match {
       case TASK_FAILED | TASK_LOST | TASK_ERROR => true

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -240,10 +240,19 @@ trait MarathonTestHelper {
       .buildPartial()
   }
 
-  private[this] def statusForState(state: MesosProtos.TaskState): MesosProtos.TaskStatus = {
+  def lostTask(id: String, reason: MesosProtos.TaskStatus.Reason): Protos.MarathonTask = {
+    Protos.MarathonTask
+      .newBuilder()
+      .setId(id)
+      .setStatus(statusForState(MesosProtos.TaskState.TASK_LOST))
+      .buildPartial()
+  }
+
+  private[this] def statusForState(state: MesosProtos.TaskState, maybeReason: Option[MesosProtos.TaskStatus.Reason] = None): MesosProtos.TaskStatus = {
     MesosProtos.TaskStatus
       .newBuilder()
       .setState(state)
+      .setReason(maybeReason.getOrElse(MesosProtos.TaskStatus.Reason.REASON_RECONCILIATION))
       .buildPartial()
   }
 

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -2,64 +2,53 @@ package mesosphere.marathon
 
 import akka.testkit.TestProbe
 import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskCount
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.task.tracker.TaskTracker.{ AppTasks, TasksByApp }
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.{ AppDefinition, AppRepository, GroupRepository, PathId }
-import mesosphere.marathon.test.MarathonActorSupport
+import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }
 import mesosphere.mesos.protos
 import mesosphere.mesos.protos.Implicits.{ slaveIDToProto, taskIDToProto }
 import mesosphere.mesos.protos.SlaveID
 import org.apache.mesos.Protos.{ TaskID, TaskState, TaskStatus }
 import org.apache.mesos.SchedulerDriver
-import org.mockito.Mockito.{ times, verify, verifyNoMoreInteractions, when }
-import org.scalatest.Matchers
-import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.scalatest.{ GivenWhenThen, Matchers }
+import org.scalatest.concurrent.{ PatienceConfiguration, ScalaFutures }
+import org.scalatest.time.{ Millis, Span }
 
 import scala.collection.JavaConverters._
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
 
-class SchedulerActionsTest extends MarathonActorSupport with MarathonSpec with Matchers with MockitoSugar {
+class SchedulerActionsTest
+    extends MarathonActorSupport
+    with MarathonSpec
+    with Matchers
+    with Mockito
+    with ScalaFutures
+    with GivenWhenThen {
   import system.dispatcher
 
   test("Reset rate limiter if application is stopped") {
-    val queue = mock[LaunchQueue]
-    val repo = mock[AppRepository]
-    val taskTracker = mock[TaskTracker]
-
-    val scheduler = new SchedulerActions(
-      repo,
-      mock[GroupRepository],
-      mock[HealthCheckManager],
-      taskTracker,
-      queue,
-      system.eventStream,
-      TestProbe().ref,
-      mock[MarathonConf]
-    )
-
+    val f = new Fixture
     val app = AppDefinition(id = PathId("/myapp"))
 
-    when(repo.expunge(app.id)).thenReturn(Future.successful(Seq(true)))
-    when(taskTracker.appTasksSync(app.id)).thenReturn(Set.empty[Protos.MarathonTask])
+    f.repo.expunge(app.id) returns Future.successful(Seq(true))
+    f.taskTracker.appTasksSync(app.id) returns Set.empty[Protos.MarathonTask]
 
-    val res = scheduler.stopApp(mock[SchedulerDriver], app)
+    f.scheduler.stopApp(mock[SchedulerDriver], app).futureValue(1.second)
 
-    Await.ready(res, 1.second)
-
-    verify(queue).purge(app.id)
-    verify(queue).resetDelay(app)
-    verifyNoMoreInteractions(queue)
+    verify(f.queue).purge(app.id)
+    verify(f.queue).resetDelay(app)
+    verifyNoMoreInteractions(f.queue)
   }
 
   test("Task reconciliation sends known running and staged tasks and empty list") {
-    val queue = mock[LaunchQueue]
-    val repo = mock[AppRepository]
-    val taskTracker = mock[TaskTracker]
-    val driver = mock[SchedulerDriver]
-
+    val f = new Fixture
     val runningStatus = TaskStatus.newBuilder
       .setTaskId(TaskID.newBuilder.setValue("task_1"))
       .setState(TaskState.TASK_RUNNING)
@@ -90,62 +79,31 @@ class SchedulerActionsTest extends MarathonActorSupport with MarathonSpec with M
       .setState(TaskState.TASK_STAGING)
       .build()
 
-    val scheduler = new SchedulerActions(
-      repo,
-      mock[GroupRepository],
-      mock[HealthCheckManager],
-      taskTracker,
-      queue,
-      system.eventStream,
-      TestProbe().ref,
-      mock[MarathonConf]
-    )
-
     val app = AppDefinition(id = PathId("/myapp"))
 
     val tasks = Set(runningTask, stagedTask, stagedTaskWithSlaveId)
-    when(taskTracker.tasksByApp()).thenReturn(Future.successful(TasksByApp.of(AppTasks(app.id, tasks))))
-    when(repo.allPathIds()).thenReturn(Future.successful(Seq(app.id)))
+    f.taskTracker.tasksByApp() returns Future.successful(TasksByApp.of(AppTasks(app.id, tasks)))
+    f.repo.allPathIds() returns Future.successful(Seq(app.id))
 
-    Await.result(scheduler.reconcileTasks(driver), 5.seconds)
+    f.scheduler.reconcileTasks(f.driver).futureValue(5.seconds)
 
-    verify(driver).reconcileTasks(Set(runningStatus, stagedStatus, stagedWithSlaveIdStatus).asJava)
-    verify(driver).reconcileTasks(java.util.Arrays.asList())
+    verify(f.driver).reconcileTasks(Set(runningStatus, stagedStatus, stagedWithSlaveIdStatus).asJava)
+    verify(f.driver).reconcileTasks(java.util.Arrays.asList())
   }
 
   test("Task reconciliation only one empty list, when no tasks are present in Marathon") {
-    val queue = mock[LaunchQueue]
-    val repo = mock[AppRepository]
-    val taskTracker = mock[TaskTracker]
-    val driver = mock[SchedulerDriver]
+    val f = new Fixture
 
-    val scheduler = new SchedulerActions(
-      repo,
-      mock[GroupRepository],
-      mock[HealthCheckManager],
-      taskTracker,
-      queue,
-      system.eventStream,
-      TestProbe().ref,
-      mock[MarathonConf]
-    )
+    f.taskTracker.tasksByApp() returns Future.successful(TasksByApp.empty)
+    f.repo.allPathIds() returns Future.successful(Seq())
 
-    val app = AppDefinition(id = PathId("/myapp"))
+    f.scheduler.reconcileTasks(f.driver).futureValue
 
-    when(taskTracker.tasksByApp()).thenReturn(Future.successful(TasksByApp.empty))
-    when(repo.allPathIds()).thenReturn(Future.successful(Seq()))
-
-    Await.result(scheduler.reconcileTasks(driver), 5.seconds)
-
-    verify(driver, times(1)).reconcileTasks(java.util.Arrays.asList())
+    verify(f.driver, times(1)).reconcileTasks(java.util.Arrays.asList())
   }
 
   test("Kill orphaned task") {
-    val queue = mock[LaunchQueue]
-    val repo = mock[AppRepository]
-    val taskTracker = mock[TaskTracker]
-    val driver = mock[SchedulerDriver]
-
+    val f = new Fixture
     val status = TaskStatus.newBuilder
       .setTaskId(TaskID.newBuilder.setValue("task_1"))
       .setState(TaskState.TASK_RUNNING)
@@ -161,6 +119,191 @@ class SchedulerActionsTest extends MarathonActorSupport with MarathonSpec with M
       .setStatus(status)
       .build()
 
+    val app = AppDefinition(id = PathId("/myapp"))
+    val tasksOfApp = AppTasks(app.id, Iterable(task))
+    val orphanedApp = AppDefinition(id = PathId("/orphan"))
+    val tasksOfOrphanedApp = AppTasks(orphanedApp.id, Iterable(orphanedTask))
+
+    f.taskTracker.tasksByApp() returns Future.successful(TasksByApp.of(tasksOfApp, tasksOfOrphanedApp))
+    f.repo.allPathIds() returns Future.successful(Seq(app.id))
+
+    f.scheduler.reconcileTasks(f.driver).futureValue(5.seconds)
+
+    verify(f.driver, times(1)).killTask(protos.TaskID(orphanedTask.getId))
+  }
+
+  test("Scale up correctly in case of lost tasks (active queue)") {
+    val f = new Fixture
+
+    Given("An active queue and lost tasks")
+    val app = MarathonTestHelper.makeBasicApp().copy(instances = 15)
+    val queued = QueuedTaskCount(app,
+      tasksLeftToLaunch = 1,
+      taskLaunchesInFlight = 0,
+      tasksLaunchedOrRunning = 14,
+      tasksLost = 5,
+      backOffUntil = f.clock.now())
+    f.queue.get(app.id) returns Some(queued)
+    f.taskTracker.countAppTasksSync(eq(app.id), any) returns (queued.totalTaskCount - queued.tasksLost)
+
+    When("the app is scaled")
+    f.scheduler.scale(f.driver, app)
+
+    Then("5 tasks should be placed onto the launchQueue")
+    verify(f.queue, times(1)).add(app, 5)
+  }
+
+  test("Scale up correctly in case of lost tasks (inactive queue)") {
+    val f = new Fixture
+
+    Given("An active queue and lost tasks")
+    val app = MarathonTestHelper.makeBasicApp().copy(instances = 15)
+    f.queue.get(app.id) returns None
+    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 10
+
+    When("the app is scaled")
+    f.scheduler.scale(f.driver, app)
+
+    Then("5 tasks should be placed onto the launchQueue")
+    verify(f.queue, times(1)).add(app, 5)
+  }
+
+  // This scenario is the following:
+  // - There's an active queue and Marathon has 10 running + 5 staged tasks
+  // - Marathon receives StatusUpdates for 5 previously LOST tasks
+  // - A scale is initiated and Marathon realizes there are 5 tasks over capacity
+  // => We expect Marathon to kill the 5 staged tasks
+  test("Kill staged tasks in correct order in case lost tasks reappear") {
+    val f = new Fixture
+
+    Given("an active queue, staged tasks and 5 overCapacity")
+    val app = MarathonTestHelper.makeBasicApp().copy(instances = 5)
+    val queued = QueuedTaskCount(app,
+      tasksLeftToLaunch = 0,
+      taskLaunchesInFlight = 0,
+      tasksLaunchedOrRunning = 7,
+      tasksLost = 0,
+      backOffUntil = f.clock.now())
+
+    def stagedTask(id: String, stagedAt: Long) = MarathonTestHelper.stagedTask(id).toBuilder
+      .setStagedAt(stagedAt)
+      .buildPartial()
+
+    val tasks = Seq(
+      MarathonTestHelper.runningTask(s"running-1"),
+      stagedTask("staged-1", 1L),
+      MarathonTestHelper.runningTask(s"running-2"),
+      stagedTask("staged-3", 3L),
+      MarathonTestHelper.runningTask(s"running-3"),
+      stagedTask("staged-2", 2L),
+      MarathonTestHelper.runningTask(s"running-4")
+    )
+
+    f.queue.get(app.id) returns Some(queued)
+    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 7
+    f.taskTracker.appTasksSync(app.id) returns tasks
+    When("the app is scaled")
+    f.scheduler.scale(f.driver, app)
+
+    Then("the queue is purged")
+    verify(f.queue, times(1)).purge(app.id)
+
+    And("the youngest STAGED tasks are killed")
+    verify(f.driver).killTask(protos.TaskID("staged-2"))
+    verify(f.driver).killTask(protos.TaskID("staged-3"))
+    verifyNoMoreInteractions(f.driver)
+  }
+
+  test("Kill running tasks in correct order in case of lost tasks") {
+    val f = new Fixture
+
+    Given("an inactive queue, running tasks and some overCapacity")
+    val app = MarathonTestHelper.makeBasicApp().copy(instances = 5)
+
+    def runningTask(id: String, stagedAt: Long) = MarathonTestHelper.runningTask(id).toBuilder
+      .setStagedAt(stagedAt)
+      .buildPartial()
+
+    val tasks = Seq(
+      runningTask(s"running-3", stagedAt = 3L),
+      runningTask(s"running-7", stagedAt = 7L),
+      runningTask(s"running-1", stagedAt = 1L),
+      runningTask(s"running-4", stagedAt = 4L),
+      runningTask(s"running-5", stagedAt = 5L),
+      runningTask(s"running-6", stagedAt = 6L),
+      runningTask(s"running-2", stagedAt = 2L)
+    )
+
+    f.queue.get(app.id) returns None
+    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 7
+    f.taskTracker.appTasksSync(app.id) returns tasks
+    When("the app is scaled")
+    f.scheduler.scale(f.driver, app)
+
+    Then("the queue is purged")
+    verify(f.queue, times(1)).purge(app.id)
+
+    And("the youngest RUNNING tasks are killed")
+    verify(f.driver).killTask(protos.TaskID("running-6"))
+    verify(f.driver).killTask(protos.TaskID("running-7"))
+    verifyNoMoreInteractions(f.driver)
+  }
+
+  test("Kill staged and running tasks in correct order in case of lost tasks") {
+    val f = new Fixture
+
+    Given("an active queue, running tasks and some overCapacity")
+    val app = MarathonTestHelper.makeBasicApp().copy(instances = 3)
+
+    val queued = QueuedTaskCount(app,
+      tasksLeftToLaunch = 0,
+      taskLaunchesInFlight = 0,
+      tasksLaunchedOrRunning = 5,
+      tasksLost = 0,
+      backOffUntil = f.clock.now())
+
+    def stagedTask(id: String, stagedAt: Long) = MarathonTestHelper.stagedTask(id).toBuilder
+      .setStagedAt(stagedAt)
+      .buildPartial()
+    def runningTask(id: String, stagedAt: Long) = MarathonTestHelper.runningTask(id).toBuilder
+      .setStagedAt(stagedAt)
+      .buildPartial()
+
+    val tasks = Seq(
+      runningTask(s"running-3", stagedAt = 3L),
+      runningTask(s"running-4", stagedAt = 4L),
+      stagedTask("staged-1", 1L),
+      runningTask(s"running-1", stagedAt = 1L),
+      runningTask(s"running-2", stagedAt = 2L)
+    )
+
+    f.queue.get(app.id) returns Some(queued)
+    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 5
+    f.taskTracker.appTasksSync(app.id) returns tasks
+    When("the app is scaled")
+    f.scheduler.scale(f.driver, app)
+
+    Then("the queue is purged")
+    verify(f.queue, times(1)).purge(app.id)
+
+    And("all STAGED tasks plus the youngest RUNNING tasks are killed")
+    verify(f.driver).killTask(protos.TaskID("staged-1"))
+    verify(f.driver).killTask(protos.TaskID("running-4"))
+    verifyNoMoreInteractions(f.driver)
+  }
+
+  import scala.language.implicitConversions
+  implicit def durationToPatienceConfigTimeout(d: FiniteDuration): PatienceConfiguration.Timeout = {
+    PatienceConfiguration.Timeout(Span(d.toMillis, Millis))
+  }
+
+  class Fixture {
+    val queue = mock[LaunchQueue]
+    val repo = mock[AppRepository]
+    val taskTracker = mock[TaskTracker]
+    val driver = mock[SchedulerDriver]
+    val clock = ConstantClock()
+
     val scheduler = new SchedulerActions(
       repo,
       mock[GroupRepository],
@@ -171,17 +314,6 @@ class SchedulerActionsTest extends MarathonActorSupport with MarathonSpec with M
       TestProbe().ref,
       mock[MarathonConf]
     )
-
-    val app = AppDefinition(id = PathId("/myapp"))
-    val tasksOfApp = AppTasks(app.id, Iterable(task))
-    val orphanedApp = AppDefinition(id = PathId("/orphan"))
-    val tasksOfOrphanedApp = AppTasks(orphanedApp.id, Iterable(orphanedTask))
-
-    when(taskTracker.tasksByApp()).thenReturn(Future.successful(TasksByApp.of(tasksOfApp, tasksOfOrphanedApp)))
-    when(repo.allPathIds()).thenReturn(Future.successful(Seq(app.id)))
-
-    Await.result(scheduler.reconcileTasks(driver), 5.seconds)
-
-    verify(driver, times(1)).killTask(protos.TaskID(orphanedTask.getId))
   }
+
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -22,7 +22,7 @@ class QueueResourceTest extends MarathonSpec with Matchers with Mockito with Giv
     val app = AppDefinition(id = "app".toRootPath)
     queue.list returns Seq(
       QueuedTaskCount(
-        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunchedOrRunning = 0, clock.now() + 100.seconds
+        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunchedOrRunning = 0, tasksLost = 0, clock.now() + 100.seconds
       )
     )
 
@@ -46,7 +46,7 @@ class QueueResourceTest extends MarathonSpec with Matchers with Mockito with Giv
     val app = AppDefinition(id = "app".toRootPath)
     queue.list returns Seq(
       QueuedTaskCount(
-        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunchedOrRunning = 0,
+        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunchedOrRunning = 0, tasksLost = 0,
         backOffUntil = clock.now() - 100.seconds
       )
     )
@@ -81,7 +81,7 @@ class QueueResourceTest extends MarathonSpec with Matchers with Mockito with Giv
     val app = AppDefinition(id = "app".toRootPath)
     queue.list returns Seq(
       QueuedTaskCount(
-        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunchedOrRunning = 0,
+        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunchedOrRunning = 0, tasksLost = 0,
         backOffUntil = clock.now() + 100.seconds
       )
     )

--- a/src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
@@ -43,6 +43,7 @@ class MarathonTaskFormatTest extends MarathonSpec {
         |{
         |  "id": "/foo/bar",
         |  "host": "agent1.mesos",
+        |  "state": "TASK_STAGING"
         |  "ipAddresses": [],
         |  "ports": [],
         |  "startedAt": null,
@@ -61,6 +62,7 @@ class MarathonTaskFormatTest extends MarathonSpec {
         |{
         |  "id": "/foo/bar",
         |  "host": "agent1.mesos",
+        |  "state": "TASK_STAGING"
         |  "ipAddresses": [
         |    {
         |      "ipAddress": "123.123.123.123",

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
@@ -9,6 +9,7 @@ object LaunchQueueTestHelper {
     tasksLeftToLaunch = 0,
     taskLaunchesInFlight = 0,
     tasksLaunchedOrRunning = 0,
+    tasksLost = 0,
     backOffUntil = Timestamp(0)
   )
 }

--- a/src/test/scala/mesosphere/marathon/core/task/bus/MarathonTaskStatusTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/MarathonTaskStatusTestHelper.scala
@@ -3,14 +3,20 @@ package mesosphere.marathon.core.task.bus
 import java.util.UUID
 
 import mesosphere.mesos.protos.TaskID
+import org.apache.mesos.Protos.TaskStatus.Reason
 import org.apache.mesos.Protos.{ TaskState, TaskStatus }
 
 object MarathonTaskStatusTestHelper {
-  def mesosStatus(state: TaskState, maybeHealthy: Option[Boolean] = None): TaskStatus = {
+  def mesosStatus(
+    state: TaskState,
+    maybeHealthy: Option[Boolean] = None,
+    maybeReason: Option[Reason] = None): TaskStatus = {
     import mesosphere.mesos.protos.Implicits._
+
     val builder = TaskStatus.newBuilder()
     builder.setTaskId(TaskID(UUID.randomUUID().toString)).setState(state)
     maybeHealthy.foreach(builder.setHealthy)
+    maybeReason.foreach(builder.setReason)
     builder.build()
   }
 
@@ -22,6 +28,6 @@ object MarathonTaskStatusTestHelper {
   val staging = MarathonTaskStatus.Staging(mesosStatus = Some(mesosStatus(TaskState.TASK_STAGING)))
   val finished = MarathonTaskStatus.Finished(mesosStatus = Some(mesosStatus(TaskState.TASK_FINISHED)))
   val error = MarathonTaskStatus.Error(mesosStatus = Some(mesosStatus(TaskState.TASK_ERROR)))
-  val lost = MarathonTaskStatus.Lost(mesosStatus = Some(mesosStatus(TaskState.TASK_LOST)))
+  def lost(reason: Reason) = MarathonTaskStatus(mesosStatus = mesosStatus(TaskState.TASK_LOST, maybeReason = Some(reason)))
   val killed = MarathonTaskStatus.Killed(mesosStatus = Some(mesosStatus(TaskState.TASK_KILLED)))
 }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/StatusUpdateActionResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/StatusUpdateActionResolverTest.scala
@@ -1,14 +1,19 @@
 package mesosphere.marathon.core.task.tracker.impl
 
+import mesosphere.marathon.MarathonTestHelper
+import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.task.bus.{ MesosTaskStatus, TaskStatusUpdateTestHelper }
 import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.core.task.tracker.impl.TaskOpProcessor.Action
 import mesosphere.marathon.core.task.tracker.impl.TaskOpProcessorImpl.StatusUpdateActionResolver
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.Mockito
 import org.apache.mesos.Protos.TaskStatus
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ Matchers, GivenWhenThen, FunSuite }
+import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 
 import scala.concurrent.Future
+import scala.util.Random
 
 /**
   * Some specialized tests for statusUpdate action resolving.
@@ -41,6 +46,42 @@ class StatusUpdateActionResolverTest
 
     And("there are no more interactions")
     f.verifyNoMoreInteractions()
+  }
+
+  for (
+    update <- MesosTaskStatus.MightComeBack.toSeq.map(r => TaskStatusUpdateTestHelper.lost(r))
+  ) {
+    test(s"a TASK_LOST update with ${update.reason} indicating a TemporarilyUnreachable Task is mapped to an update") {
+      val f = new Fixture
+      val task: MarathonTask = MarathonTestHelper.runningTask(update.wrapped.taskId.getValue)
+      val status: TaskStatus = update.taskStatus
+      val action = f.actionResolver.resolveForExistingTask(task, status)
+
+      action shouldEqual Action.Update(task.toBuilder.setStatus(status).build())
+    }
+  }
+
+  for (
+    update <- MesosTaskStatus.WontComeBack.toSeq.map(r => TaskStatusUpdateTestHelper.lost(r))
+  ) {
+    test(s"a TASK_LOST update with ${update.reason} indicating a Task that won't come back is mapped to an expunge") {
+      val f = new Fixture
+      val task: MarathonTask = MarathonTestHelper.runningTask(update.wrapped.taskId.getValue)
+      val status: TaskStatus = update.taskStatus
+      val action = f.actionResolver.resolveForExistingTask(task, status)
+
+      action shouldEqual Action.Expunge
+    }
+  }
+
+  test("a subsequent TASK_LOST update with another reason is mapped to a noop and will not update the timestamp") {
+    val f = new Fixture
+    val update = TaskStatusUpdateTestHelper.lost(TaskStatus.Reason.REASON_SLAVE_DISCONNECTED)
+    val task: MarathonTask = MarathonTestHelper.lostTask(update.wrapped.taskId.getValue, TaskStatus.Reason.REASON_RECONCILIATION)
+    val status: TaskStatus = update.taskStatus
+
+    val action = f.actionResolver.resolveForExistingTask(task, status)
+    action shouldEqual Action.Noop
   }
 
   class Fixture {

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImplTest.scala
@@ -61,7 +61,7 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
   test("ignore running notification of already running task") {
     Given("an existing RUNNING task")
     val f = new Fixture
-    val existingTask = stagedMarathonTask.toBuilder.setStartedAt(100).build()
+    val existingTask = runningMarathonTask
 
     When("we receive a running update")
     val status = runningTaskStatus
@@ -151,6 +151,17 @@ class PostToEventStreamStepImplTest extends FunSuite with Matchers with GivenWhe
       .addAllPorts(portsList.asJava)
       .setVersion(version.toString)
       .build()
+
+  private[this] val runningMarathonTask =
+    MarathonTask
+      .newBuilder()
+      .setId(taskId.getValue)
+      .setStatus(TaskStatus.newBuilder().setState(TaskState.TASK_RUNNING).buildPartial())
+      .setStartedAt(100)
+      .setHost(host)
+      .addAllPorts(portsList.asJava)
+      .setVersion(version.toString)
+      .buildPartial()
 
   class Fixture {
     val eventStream = new EventStream()

--- a/src/test/scala/mesosphere/marathon/integration/TaskLostIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/TaskLostIntegrationTest.scala
@@ -1,0 +1,117 @@
+package mesosphere.marathon.integration
+
+import mesosphere.marathon.integration.setup._
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
+import scala.concurrent.duration._
+
+class TaskLostIntegrationTest extends IntegrationFunSuite with WithMesosCluster with Matchers with GivenWhenThen with BeforeAndAfter {
+
+  before {
+    cleanUp()
+    if (ProcessKeeper.hasProcess(slave2)) stopMesos(slave2)
+    if (ProcessKeeper.hasProcess(master2)) stopMesos(master2)
+    if (!ProcessKeeper.hasProcess(master1)) startMaster(master1)
+    if (!ProcessKeeper.hasProcess(slave1)) startSlave(slave1)
+  }
+
+  test("A task lost with mesos master failover will not kill the task") {
+    Given("a new app")
+    val app = appProxy(testBasePath / "app", "v1", instances = 1, withHealth = false)
+    marathon.createAppV2(app)
+    waitForEvent("deployment_success")
+    val task = waitForTasks(app.id, 1).head
+
+    When("We stop the slave, the task is declared lost")
+    stopMesos(slave1)
+    waitForEventMatching("Task is declared lost") { matchEvent("TASK_LOST", task) }
+
+    And("The task is not removed from the task list")
+    val lost = waitForTasks(app.id, 1).head
+    lost.state should be("TASK_LOST")
+
+    When("We do a Mesos Master failover and start the slave again")
+    startMaster(master2, wipe = false)
+    stopMesos(master1)
+    startSlave(slave1, wipe = false)
+
+    Then("The task reappears as running")
+    waitForEventMatching("Task is declared running again") { matchEvent("TASK_RUNNING", task) }
+  }
+
+  test("A task lost with mesos master failover will start a replacement task") {
+    Given("a new app")
+    val app = appProxy(testBasePath / "app", "v1", instances = 1, withHealth = false)
+    marathon.createAppV2(app)
+    waitForEvent("deployment_success")
+    val task = waitForTasks(app.id, 1).head
+
+    When("We stop the slave, the task is declared lost")
+    stopMesos(slave1)
+    startSlave(slave2, wipe = false)
+    waitForEventMatching("Task is declared lost") { matchEvent("TASK_LOST", task) }
+
+    And("A replacement task is started")
+    waitForEventWith("status_update_event", _.info("taskStatus") == "TASK_RUNNING")
+    val tasks = marathon.tasks(app.id).value
+    tasks should have size 2
+    tasks.groupBy(_.state).keySet should be(Set("TASK_RUNNING", "TASK_LOST"))
+    val replacement = tasks.find(_.state == "TASK_RUNNING").get
+
+    When("We do a Mesos Master failover and start the slave again")
+    startMaster(master2, wipe = false)
+    stopMesos(master1)
+    startSlave(slave1, wipe = false)
+
+    Then("The task reappears as running and the replacement is killed")
+    var isRunning = false
+    var isKilled = false
+    waitForEventMatching("Original task is running and replacement task is killed") { event =>
+      isRunning |= matchEvent("TASK_RUNNING", task)(event)
+      isKilled |= matchEvent("TASK_KILLED", replacement)(event)
+      isRunning && isKilled
+    }
+    waitForTasks(app.id, 1).head should be(task)
+  }
+
+  test("A task lost with mesos master failover will expunge the task after gc timeout") {
+    Given("a new app")
+    val app = appProxy(testBasePath / "app", "v1", instances = 1, withHealth = false)
+    marathon.createAppV2(app)
+    waitForEvent("deployment_success")
+    val task = waitForTasks(app.id, 1).head
+
+    When("We stop the slave, the task is declared lost")
+    stopMesos(slave1)
+    startSlave(slave2, wipe = false)
+    waitForEventMatching("Task is declared lost") { matchEvent("TASK_LOST", task) }
+
+    Then("The task is killed due to GC timeout and a replacement is started")
+    waitForEventMatching("Task is expunged", 60.seconds) { matchEvent("TASK_ERROR", task) }
+    val replacement = waitForTasks(app.id, 1).head
+    replacement should not be task
+  }
+
+  //override to start marathon with a low reconciliation frequency
+  override def startMarathon(port: Int, ignore: String*): Unit = {
+    val args = List(
+      "--master", config.master,
+      "--event_subscriber", "http_callback",
+      "--access_control_allow_origin", "*",
+      "--reconciliation_initial_delay", "5000",
+      "--reconciliation_interval", "5000",
+      "--scale_apps_initial_delay", "5000",
+      "--scale_apps_interval", "5000",
+      "--min_revive_offers_interval", "100",
+      "--task_lost_expunge_gc", "30000",
+      "--task_lost_expunge_initial_delay", "1000",
+      "--task_lost_expunge_interval", "1000"
+    ) ++ extraMarathonParameters
+    super.startMarathon(port, args: _*)
+  }
+
+  def matchEvent(status: String, task: ITEnrichedTask): CallbackEvent => Boolean = { event =>
+    event.info.get("taskStatus").contains(status) &&
+      event.info.get("taskId").contains(task.id)
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonFacade.scala
@@ -30,7 +30,7 @@ case class ITListTasks(tasks: Seq[ITEnrichedTask])
 case class ITDeploymentPlan(version: String, deploymentId: String)
 case class ITHealthCheckResult(taskId: String, firstSuccess: Date, lastSuccess: Date, lastFailure: Date, consecutiveFailures: Int, alive: Boolean)
 case class ITDeploymentResult(version: Timestamp, deploymentId: String)
-case class ITEnrichedTask(appId: String, id: String, host: String, ports: Seq[Int], startedAt: Date, stagedAt: Date, version: String /*, healthCheckResults:Seq[ITHealthCheckResult]*/ )
+case class ITEnrichedTask(appId: String, id: String, host: String, ports: Seq[Int], startedAt: Date, stagedAt: Date, state: String, version: String /*, healthCheckResults:Seq[ITHealthCheckResult]*/ )
 case class ITLeaderResult(leader: String)
 
 case class ITListDeployments(deployments: Seq[ITDeployment])

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -65,9 +65,13 @@ trait SingleMarathonIntegrationTest
     ProcessKeeper.startZooKeeper(port, path, wipeWorkDir)
   }
 
+  protected def startMesos(): Unit = ProcessKeeper.startMesosLocal()
+
+  protected def createConfig(configMap: ConfigMap): IntegrationTestConfig = IntegrationTestConfig(configMap)
+
   override protected def beforeAll(configMap: ConfigMap): Unit = {
     log.info("Setting up local mesos/marathon infrastructure...")
-    configOption = Some(IntegrationTestConfig(configMap))
+    configOption = Some(createConfig(configMap))
     super.beforeAll(configMap)
 
     if (!config.useExternalSetup) {
@@ -76,7 +80,7 @@ trait SingleMarathonIntegrationTest
 
       log.info("Setting up local mesos/marathon infrastructure...")
       startZooKeeperProcess()
-      ProcessKeeper.startMesosLocal()
+      startMesos()
       cleanMarathonState()
 
       val parameters = List(
@@ -130,6 +134,24 @@ trait SingleMarathonIntegrationTest
       if (tasks.size == num) Some(tasks) else None
     }
     WaitTestSupport.waitFor(s"$num tasks to launch", maxWait)(checkTasks)
+  }
+
+  def waitForProcessLogMessage(process: String, maxWait: FiniteDuration = 30.seconds)(messageFn: String => Boolean): String = {
+    var result: Option[String] = None
+    def message(log: String) = {
+      if (messageFn(log)) {
+        result = Some(log)
+        true
+      }
+      else false
+    }
+    try {
+      ProcessKeeper.addCheck(process, message)
+      WaitTestSupport.waitFor(s"Log message in process $process", maxWait)(result)
+    }
+    finally {
+      ProcessKeeper.removeCheck(process)
+    }
   }
 
   def waitForHealthCheck(check: IntegrationHealthCheck, maxWait: FiniteDuration = 30.seconds) = {

--- a/src/test/scala/mesosphere/marathon/integration/setup/WithMesosCluster.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/WithMesosCluster.scala
@@ -1,0 +1,43 @@
+package mesosphere.marathon.integration.setup
+
+import java.io.File
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.{ ConfigMap, Suite }
+
+import scala.collection.concurrent.TrieMap
+
+trait WithMesosCluster extends SingleMarathonIntegrationTest { self: Suite =>
+
+  override protected def createConfig(configMap: ConfigMap): IntegrationTestConfig = {
+    val cfg = super.createConfig(configMap)
+    cfg.copy(master = s"zk://${cfg.zkHostAndPort}/mesos")
+  }
+
+  val mesosWorkDir = "/tmp/marathon-itest-mesos"
+  val master1: String = "master1"
+  val master2: String = "master2"
+  val slave1: String = "slave1"
+  val slave2: String = "slave2"
+
+  private val ports: TrieMap[String, Int] = TrieMap.empty
+  private val portIt = Range(50050, Int.MaxValue).iterator
+  def processPort(name: String): Int = ports.getOrElseUpdate(name, portIt.next())
+
+  def startMaster(name: String, wipe: Boolean = true): Unit = {
+    val masterArgs = Seq("--slave_ping_timeout=1secs", "--max_slave_ping_timeouts=4", "--quorum=1")
+    ProcessKeeper.startMesos(name, s"$mesosWorkDir/$name", Seq("mesos", "master", s"--zk=zk://${config.zkHostAndPort}/mesos", s"--work_dir=$mesosWorkDir/$name", s"--port=${processPort(name)}") ++ masterArgs, "new candidate", wipe)
+  }
+
+  def startSlave(name: String, wipe: Boolean = true): Unit = {
+    ProcessKeeper.startMesos(name, s"$mesosWorkDir/$name", Seq("mesos", "slave", s"--master=zk://${config.zkHostAndPort}/mesos", s"--work_dir=$mesosWorkDir/$name", s"--port=${processPort(name)}"), "registered with master", wipe)
+  }
+
+  def stopMesos(name: String): Unit = ProcessKeeper.stopProcess(name)
+
+  override protected def startMesos(): Unit = {
+    FileUtils.deleteDirectory(new File(mesosWorkDir))
+    startMaster(master1)
+    startSlave(slave1)
+  }
+}


### PR DESCRIPTION
**Fixed:**
- don't expunge the task from state if we have an indication that it might come back. This includes REASON_RECONCILIATION because it effectively shadows the underlying reason in case we only get the update during reconciliation.
- Ignore lost tasks when scaling
- Lost tasks will be listed separately in QueuedTaskCount and are not included in totalTaskCount
- In case we need to kill instances to reach the target instance count, we only consider staged and running tasks and sort both partitions so that staged tasks are killed before running tasks, and newer tasks before older ones.
- Lost tasks will still be stored as taskFailures

**Missing:**
- [x] Check deployment logic/TaskRestartActor
- [x] Garbage collect lost tasks after a configurable timeout
- [x] verify with tests that subsequent TASK_LOST updates do NOT alter the TaskStatus timestamp of the stored task
- [x] complete SchedulerActionsTest