### PR TITLE
WIP - cherry-picking TASK_LOST changes from 0.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /marathon
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.28.0-2.0.16.debian81 && \
+    apt-get install --no-install-recommends -y --force-yes mesos=0.28.1-2.0.20.debian81 && \
     apt-get clean && \
     eval $(sed s/sbt.version/SBT_VERSION/ </marathon/project/build.properties) && \
     mkdir -p /usr/local/bin && \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -10,7 +10,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
     echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.28.0-2.0.16.debian81 lxc
+    apt-get install --no-install-recommends -y --force-yes mesos=0.28.1-2.0.20.debian81 lxc
 
 # Install sbt manually
 COPY ./project/build.properties /marathon/project/build.properties

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -143,6 +143,12 @@ The core functionality flags can be also set by environment variable `MARATHON_O
     The timeout for preparing the Marathon instance when elected as leader.
 * <span class="label label-default">v0.14.1</span> `--http_event_callback_slow_consumer_timeout` (Optional. Default: 10 seconds):
     A http event callback consumer is considered slow, if the delivery takes longer than this timeout.
+* <span class="label label-default">v0.15.4</span> `--task_lost_expunge_gc` (Optional. Default: 24 hours):
+    This is the length of time in milliseconds, until a lost task is garbage collected and expunged from the task tracker and task repository.
+* <span class="label label-default">v0.15.4</span> `--task_lost_expunge_initial_delay` (Optional. Default: 5 minutes):
+    This is the length of time, in milliseconds, before Marathon begins to periodically perform task expunge gc operations    
+* <span class="label label-default">v0.15.4</span> `--task_lost_expunge_interval` (Optional. Default: 1 hour):
+    This is the length of time in milliseconds, for lost task gc operations.
 
 ## Tuning Flags for Offer Matching/Launching Tasks
 

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
@@ -1,6 +1,7 @@
 package mesosphere.mesos.simulation
 
 import java.util
+import java.util.Collections
 
 import akka.actor.{ ActorRef, ActorSystem, Props }
 import com.typesafe.config.{ Config, ConfigFactory }
@@ -58,9 +59,11 @@ class SimulatedDriver(driverProps: Props) extends SchedulerDriver {
   override def declineOffer(offerId: OfferID, filters: Filters): Status = Status.DRIVER_RUNNING
 
   override def launchTasks(offerIds: util.Collection[OfferID], tasks: util.Collection[TaskInfo],
-                           filters: Filters): Status = ???
-  override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo], filters: Filters): Status = ???
-  override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo]): Status = ???
+                           filters: Filters): Status = launchTasks(offerIds, tasks)
+  override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo], filters: Filters): Status =
+    launchTasks(Collections.singleton(offerId), tasks)
+  override def launchTasks(offerId: OfferID, tasks: util.Collection[TaskInfo]): Status =
+    launchTasks(Collections.singleton(offerId), tasks)
   override def requestResources(requests: util.Collection[Request]): Status = ???
   override def sendFrameworkMessage(executorId: ExecutorID, slaveId: SlaveID, data: Array[Byte]): Status = ???
   override def acknowledgeStatusUpdate(ackStatus: TaskStatus): Status = status

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -5,6 +5,7 @@ import mesosphere.marathon.core.launcher.OfferProcessorConfig
 import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerConfig
 import mesosphere.marathon.core.plugin.PluginManagerConfiguration
+import mesosphere.marathon.core.task.jobs.TaskJobsConfig
 import mesosphere.marathon.core.task.tracker.TaskTrackerConfig
 import mesosphere.marathon.core.task.update.TaskStatusUpdateConfig
 import mesosphere.marathon.state.ResourceRole
@@ -18,7 +19,7 @@ trait MarathonConf
     extends ScallopConf with ZookeeperConf with LeaderProxyConf
     with LaunchTokenConfig with OfferMatcherManagerConfig with OfferProcessorConfig with ReviveOffersConfig
     with MarathonSchedulerServiceConfig with LaunchQueueConfig with PluginManagerConfiguration
-    with TaskStatusUpdateConfig with TaskTrackerConfig with UpgradeConfig {
+    with TaskStatusUpdateConfig with TaskTrackerConfig with UpgradeConfig with TaskJobsConfig {
 
   //scalastyle:off magic.number
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -17,7 +17,7 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.upgrade.DeploymentManager._
 import mesosphere.marathon.upgrade.{ UpgradeConfig, DeploymentManager, DeploymentPlan, TaskKillActor }
 import mesosphere.mesos.protos
-import org.apache.mesos.Protos.{ Status, TaskID }
+import org.apache.mesos.Protos.{ Status, TaskState, TaskID }
 import org.apache.mesos.SchedulerDriver
 import org.slf4j.LoggerFactory
 
@@ -516,8 +516,13 @@ class SchedulerActions(
   /**
     * Make sure the app is running the correct number of instances
     */
+  // FIXME: extract computation into a function that can be easily tested
   def scale(driver: SchedulerDriver, app: AppDefinition): Unit = {
-    val launchedCount = taskTracker.countLaunchedAppTasksSync(app.id)
+    import SchedulerActions._
+
+    // FIXME (merge): there are now 2 filters ...
+    val launchedCount = taskTracker.countLaunchedAppTasksSync(app.id,
+      _.mesosStatus.fold(false)(_.getState != TaskState.TASK_LOST))
     val targetCount = app.instances
 
     if (targetCount > launchedCount) {
@@ -538,7 +543,10 @@ class SchedulerActions(
       log.info(s"Scaling ${app.id} from $launchedCount down to $targetCount instances")
       launchQueue.purge(app.id)
 
-      val toKill = taskTracker.appTasksLaunchedSync(app.id).take(launchedCount - targetCount)
+      val toKill = taskTracker.appTasksSync(app.id).toSeq
+        .filter(t => t.mesosStatus.fold(false)(status => runningOrStaged.get(status.getState).nonEmpty))
+        .sortWith(sortByStateAndTime)
+        .take(launchedCount - targetCount)
       val taskIds: Iterable[TaskID] = toKill.flatMap(_.launchedMesosId)
       log.info(s"Killing tasks: ${taskIds.map(_.getValue)}")
       for (taskId <- taskIds) {
@@ -559,4 +567,28 @@ class SchedulerActions(
 
   def currentAppVersion(appId: PathId): Future[Option[AppDefinition]] =
     appRepository.currentVersion(appId)
+}
+
+private[this] object SchedulerActions {
+  def sortByStateAndTime(a: Task, b: Task): Boolean = {
+
+    def opt[T](a: Option[T], b: Option[T], default: Boolean)(fn: (T, T) => Boolean): Boolean = (a, b) match {
+      case (Some(av), Some(bv)) => fn(av, bv)
+      case _                    => default
+    }
+    opt(a.mesosStatus, b.mesosStatus, a.mesosStatus.isDefined) { (aStatus, bStatus) =>
+      runningOrStaged(bStatus.getState) compareTo runningOrStaged(aStatus.getState) match {
+        case 0 => opt(a.launched, b.launched, a.launched.isDefined) { (aLaunched, bLaunched) =>
+          (aLaunched.status.stagedAt compareTo bLaunched.status.stagedAt) > 0
+        }
+        case value: Int => value > 0
+      }
+    }
+
+  }
+
+  val runningOrStaged = Map(
+    TaskState.TASK_STAGING -> 1,
+    TaskState.TASK_STARTING -> 2,
+    TaskState.TASK_RUNNING -> 3)
 }

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -520,9 +520,8 @@ class SchedulerActions(
   def scale(driver: SchedulerDriver, app: AppDefinition): Unit = {
     import SchedulerActions._
 
-    // FIXME (merge): there are now 2 filters ...
-    val launchedCount = taskTracker.countLaunchedAppTasksSync(app.id,
-      _.mesosStatus.fold(false)(_.getState != TaskState.TASK_LOST))
+    def launchedNotLost(t: Task) = t.launched.isDefined && t.mesosStatus.fold(false)(_.getState != TaskState.TASK_LOST)
+    val launchedCount = taskTracker.countAppTasksSync(app.id, launchedNotLost)
     val targetCount = app.instances
 
     if (targetCount > launchedCount) {

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -113,12 +113,15 @@ trait Formats
       "persistenceId" -> id.idString
     )
   }
+  implicit lazy val TaskStateFormat: Format[mesos.TaskState] =
+    enumFormat(mesos.TaskState.valueOf, str => s"$str is not a valid TaskState type")
 
   implicit lazy val TaskWrites: Writes[Task] = Writes { task =>
     val base = Json.obj(
       "id" -> task.taskId,
       "slaveId" -> task.agentInfo.agentId,
-      "host" -> task.agentInfo.host
+      "host" -> task.agentInfo.host,
+      "state" -> task.mesosStatus.fold(mesos.TaskState.TASK_STAGING)(_.getState)
     )
 
     val launched = task.launched.map { launched =>

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon.core
 
 import akka.actor.ActorSystem
-import com.google.inject.Inject
+import com.google.inject.{ Provider, Inject }
 import com.twitter.common.zookeeper.ZooKeeperClient
 import mesosphere.marathon.api.LeaderInfo
 import mesosphere.marathon.core.auth.AuthModule
@@ -19,6 +19,7 @@ import mesosphere.marathon.core.task.bus.TaskBusModule
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.tracker.TaskTrackerModule
 import mesosphere.marathon.core.task.update.TaskUpdateStep
+import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{ GroupRepository, AppRepository, TaskRepository }
 import mesosphere.marathon.{ LeadershipAbdication, MarathonConf, MarathonSchedulerDriverHolder }
@@ -44,6 +45,7 @@ class CoreModuleImpl @Inject() (
     taskRepository: TaskRepository,
     taskOpFactory: TaskOpFactory,
     leaderInfo: LeaderInfo,
+    taskStatusUpdateProcessor: Provider[TaskStatusUpdateProcessor],
     clock: Clock,
     taskStatusUpdateSteps: Seq[TaskUpdateStep]) extends CoreModule {
 
@@ -153,6 +155,7 @@ class CoreModuleImpl @Inject() (
     taskTrackerModule.taskReservationTimeoutHandler,
     marathonSchedulerDriverHolder
   )
+  taskJobsModule.expungeOverdueLostTasks(taskTrackerModule.taskTracker, taskTrackerModule.stateOpProcessor)
   maybeOfferReviver
   offerMatcherManagerModule
   launcherModule

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -21,6 +21,7 @@ object LaunchQueue {
       tasksLeftToLaunch: Int,
       taskLaunchesInFlight: Int, // FIXME (217): rename to taskOpsInFlight
       tasksLaunched: Int,
+      tasksLost: Int,
       backOffUntil: Timestamp) {
     /**
       * Indicates if the launch queue tries to launch tasks for this app.
@@ -30,7 +31,7 @@ object LaunchQueue {
     /**
       * This is the final number of tasks, the launch queue tries to reach for this app.
       */
-    def finalTaskCount: Int = tasksLaunched + taskLaunchesInFlight + tasksLeftToLaunch
+    def finalTaskCount: Int = tasksLaunched + taskLaunchesInFlight + tasksLeftToLaunch - tasksLost
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
@@ -337,6 +337,7 @@ private class AppTaskLauncherActor(
       taskLaunchesInFlight = inFlightTaskOperations.size,
       // don't count tasks that are not launched in the tasksMap
       tasksLaunched = tasksMap.values.count(_.launched.isDefined) - inFlightTaskOperations.size,
+      tasksLost = tasksMap.values.count(_.mesosStatus.fold(false)(_.getState == Mesos.TaskState.TASK_LOST)),
       backOffUntil.getOrElse(clock.now())
     )
   }

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -38,7 +38,6 @@ sealed trait Task {
     taskId.mesosTaskId
   }
 
-  // FIXME (merge): remove this accessor and add a universal Status to all tasks that includes unconfirmed states
   def mesosStatus: Option[MesosProtos.TaskStatus] = {
     launched.flatMap(_.status.mesosStatus).orElse {
       launchedMesosId.map { mesosId =>

--- a/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/TaskStateOp.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.core.task
 
 import mesosphere.marathon.core.task.Task.Id
+import mesosphere.marathon.core.task.TaskStateChange.{ Expunge, Update }
 import mesosphere.marathon.core.task.bus.MarathonTaskStatus
 import mesosphere.marathon.state.Timestamp
 
@@ -59,6 +60,14 @@ object TaskStateChange {
   case class Failure(cause: Throwable) extends TaskStateChange
   object Failure {
     def apply(message: String): Failure = Failure(TaskStateChangeException(message))
+  }
+}
+
+object EffectiveTaskStateChange {
+  def unapply(stateChange: TaskStateChange): Option[Task] = stateChange match {
+    case Update(newState, _) => Some(newState)
+    case Expunge(oldState)   => Some(oldState)
+    case _                   => None
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/task/bus/MarathonTaskStatus.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/MarathonTaskStatus.scala
@@ -7,9 +7,11 @@ sealed trait MarathonTaskStatus {
   def mesosStatus: Option[TaskStatus]
 }
 
+// FIXME (merge): Merge MarathonTaskStatus and MesosTaskStatus
 object MarathonTaskStatus {
+  import org.apache.mesos.Protos.TaskState._
+
   def apply(mesosStatus: TaskStatus): MarathonTaskStatus = {
-    import org.apache.mesos.Protos.TaskState._
     val constructor: Option[TaskStatus] => MarathonTaskStatus = mesosStatus.getState match {
       case TASK_STAGING  => Staging
       case TASK_STARTING => Starting
@@ -29,12 +31,20 @@ object MarathonTaskStatus {
   case class Running(mesosStatus: Option[TaskStatus]) extends MarathonTaskStatus
   case class Killing(mesosStatus: Option[TaskStatus]) extends MarathonTaskStatus
 
+  // Note that we need to distinguish between TemporarilyUnreachable tasks and really lost tasks that won't come back
+  // tl;dr: don't use Lost
+  case class Lost(mesosStatus: Option[TaskStatus]) extends MarathonTaskStatus
+
   sealed trait Terminal extends MarathonTaskStatus {
     override def terminal: Boolean = true
     def killed: Boolean = false
   }
   object Terminal {
     def unapply(terminal: Terminal): Option[Terminal] = Some(terminal)
+    def unapply(status: MarathonTaskStatus): Option[MarathonTaskStatus] = status.mesosStatus match {
+      case Some(MesosTaskStatus.Terminal(_)) => Some(status)
+      case _                                 => None
+    }
   }
 
   object WithMesosStatus {
@@ -46,6 +56,5 @@ object MarathonTaskStatus {
   case class Killed(mesosStatus: Option[TaskStatus]) extends Terminal {
     override def killed: Boolean = true
   }
-  case class Lost(mesosStatus: Option[TaskStatus]) extends Terminal
   case class Error(mesosStatus: Option[TaskStatus]) extends Terminal
 }

--- a/src/main/scala/mesosphere/marathon/core/task/bus/MesosTaskStatus.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/MesosTaskStatus.scala
@@ -29,13 +29,16 @@ object MesosTaskStatus {
   }
 
   object TemporarilyUnreachable {
-    def unapply(task: Task): Option[Task] = task.mesosStatus match {
-      case (Some(status)) if status.getState == TASK_LOST && MightComeBack(status.getReason) => Some(task)
-      case _ => None
+    def isUnreachable(task: Task): Boolean = task.mesosStatus.fold(false)(isUnreachable)
+    def isUnreachable(taskStatus: TaskStatus): Boolean = {
+      taskStatus.getState == TASK_LOST && MightComeBack(taskStatus.getReason)
+    }
+
+    def unapply(task: Task): Option[Task] = {
+      if (isUnreachable(task)) Some(task) else None
     }
     def unapply(taskStatus: TaskStatus): Option[TaskStatus] = {
-      if (taskStatus.getState == TASK_LOST && MightComeBack(taskStatus.getReason)) Some(taskStatus)
-      else None
+      if (isUnreachable(taskStatus)) Some(taskStatus) else None
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/bus/MesosTaskStatus.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/MesosTaskStatus.scala
@@ -1,0 +1,48 @@
+package mesosphere.marathon.core.task.bus
+
+import mesosphere.marathon.Protos.MarathonTask
+import mesosphere.marathon.core.task.Task
+import org.apache.mesos.Protos.TaskState._
+import org.apache.mesos.Protos.TaskStatus
+import org.apache.mesos.Protos.TaskStatus.Reason._
+
+object MesosTaskStatus {
+
+  // If we're disconnected at the time of a TASK_LOST event, we will only get the update during
+  // a reconciliation. In that case, the specific reason will be shadowed by REASON_RECONCILIATION.
+  // Since we don't know the original reason, we need to assume that the task might come back.
+  val MightComeBack: Set[TaskStatus.Reason] = Set(
+    REASON_RECONCILIATION,
+    REASON_SLAVE_DISCONNECTED,
+    REASON_SLAVE_REMOVED
+  )
+
+  val WontComeBack: Set[TaskStatus.Reason] = TaskStatus.Reason.values().toSet.diff(MightComeBack)
+
+  object Terminal {
+    def unapply(taskStatus: TaskStatus): Option[TaskStatus] = taskStatus.getState match {
+      case TASK_LOST if WontComeBack(taskStatus.getReason) => Some(taskStatus)
+      case TASK_ERROR | TASK_FAILED | TASK_KILLED | TASK_FINISHED => Some(taskStatus)
+      case _ => None
+    }
+    def isTerminal(taskStatus: TaskStatus): Boolean = unapply(taskStatus).isDefined
+  }
+
+  object TemporarilyUnreachable {
+    def unapply(task: Task): Option[Task] = task.mesosStatus match {
+      case (Some(status)) if status.getState == TASK_LOST && MightComeBack(status.getReason) => Some(task)
+      case _ => None
+    }
+    def unapply(taskStatus: TaskStatus): Option[TaskStatus] = {
+      if (taskStatus.getState == TASK_LOST && MightComeBack(taskStatus.getReason)) Some(taskStatus)
+      else None
+    }
+  }
+
+  object Running {
+    def unapply(taskStatus: TaskStatus): Option[TaskStatus] = taskStatus.getState match {
+      case TASK_RUNNING => Some(taskStatus)
+      case _            => None
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/task/bus/MesosTaskStatus.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/MesosTaskStatus.scala
@@ -1,6 +1,5 @@
 package mesosphere.marathon.core.task.bus
 
-import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.task.Task
 import org.apache.mesos.Protos.TaskState._
 import org.apache.mesos.Protos.TaskStatus

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsConfig.scala
@@ -1,0 +1,26 @@
+package mesosphere.marathon.core.task.jobs
+
+import org.rogach.scallop.ScallopConf
+import scala.concurrent.duration._
+
+trait TaskJobsConfig extends ScallopConf {
+  //scalastyle:off magic.number
+
+  private[this] lazy val taskLostExpungeGCValue = opt[Long]("task_lost_expunge_gc",
+    descr = "This is the length of time in milliseconds, until a lost task is garbage collected and expunged " +
+      "from the task tracker and task repository.",
+    default = Some(24 * 60 * 60 * 1000L)) // 24h
+
+  private[this] lazy val taskLostExpungeInitialDelayValue = opt[Long]("task_lost_expunge_initial_delay",
+    descr = "This is the length of time, in milliseconds, before Marathon " +
+      "begins to periodically perform task expunge gc operations",
+    default = Some(5 * 60 * 1000L)) // 5 minutes
+
+  private[this] lazy val taskLostExpungeIntervalValue = opt[Long]("task_lost_expunge_interval",
+    descr = "This is the length of time in milliseconds, for lost task gc operations.",
+    default = Some(1 * 60 * 60 * 1000L)) // 1h
+
+  def taskLostExpungeGC: FiniteDuration = taskLostExpungeGCValue().millis
+  def taskLostExpungeInitialDelay: FiniteDuration = taskLostExpungeInitialDelayValue().millis
+  def taskLostExpungeInterval: FiniteDuration = taskLostExpungeIntervalValue().millis
+}

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
@@ -2,8 +2,8 @@ package mesosphere.marathon.core.task.jobs
 
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.leadership.LeadershipModule
-import mesosphere.marathon.core.task.jobs.impl.OverdueTasksActor
-import mesosphere.marathon.core.task.tracker.{ TaskReservationTimeoutHandler, TaskTracker }
+import mesosphere.marathon.core.task.jobs.impl.{ ExpungeOverdueLostTasksActor, OverdueTasksActor }
+import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskReservationTimeoutHandler, TaskTracker }
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerDriverHolder }
 
 /**
@@ -23,5 +23,12 @@ class TaskJobsModule(config: MarathonConf, leadershipModule: LeadershipModule, c
         clock
       ),
       "killOverdueStagedTasks")
+  }
+
+  def expungeOverdueLostTasks(taskTracker: TaskTracker, stateOpProcessor: TaskStateOpProcessor): Unit = {
+    leadershipModule.startWhenLeader(
+      ExpungeOverdueLostTasksActor.props(clock, config, taskTracker, stateOpProcessor),
+      "expungeOverdueLostTasks"
+    )
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
@@ -1,0 +1,71 @@
+package mesosphere.marathon.core.task.jobs.impl
+
+import akka.actor.{ ActorLogging, Props, Cancellable, Actor }
+import akka.pattern.pipe
+import mesosphere.marathon.core.base.Clock
+import mesosphere.marathon.core.task.{ TaskStateOp, Task }
+import mesosphere.marathon.core.task.bus.MesosTaskStatus.TemporarilyUnreachable
+import mesosphere.marathon.core.task.jobs.TaskJobsConfig
+import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskTracker }
+import mesosphere.marathon.core.task.tracker.TaskTracker.AppTasks
+import mesosphere.marathon.state.PathId
+import org.joda.time.DateTime
+import scala.concurrent.duration._
+
+class ExpungeOverdueLostTasksActor(
+    clock: Clock,
+    config: TaskJobsConfig,
+    taskTracker: TaskTracker,
+    stateOpProcessor: TaskStateOpProcessor) extends Actor with ActorLogging {
+
+  import ExpungeOverdueLostTasksActor._
+  implicit val ec = context.dispatcher
+
+  var tickTimer: Option[Cancellable] = None
+
+  override def preStart(): Unit = {
+    log.info("ExpungeOverdueLostTasksActor has started")
+    tickTimer = Some(context.system.scheduler.schedule(config.taskLostExpungeInitialDelay,
+      config.taskLostExpungeInterval, self, Tick))
+  }
+
+  override def postStop(): Unit = {
+    tickTimer.foreach(_.cancel())
+    log.info("ExpungeOverdueLostTasksActor has stopped")
+  }
+
+  override def receive: Receive = {
+    case Tick                             => taskTracker.tasksByApp() pipeTo self
+    case TaskTracker.TasksByApp(appTasks) => filterLostGCTasks(appTasks).foreach(expungeLostGCTask)
+  }
+
+  def expungeLostGCTask(task: Task): Unit = {
+    val timestamp = new DateTime(task.mesosStatus.fold(0L)(_.getTimestamp.toLong * 1000))
+    log.warning(s"Task ${task.taskId} is lost since $timestamp and will be expunged.")
+    val stateOp = TaskStateOp.ForceExpunge(task.taskId)
+    stateOpProcessor.process(stateOp)
+  }
+
+  def filterLostGCTasks(tasks: Map[PathId, AppTasks]): Iterable[Task] = {
+    def isTimedOut(task: Task): Boolean = {
+      task.mesosStatus.fold(false) { status =>
+        val age = clock.now().toDateTime.minus(status.getTimestamp.toLong * 1000).getMillis.millis
+        age > config.taskLostExpungeGC
+      }
+    }
+    tasks.values.flatMap(_.tasks.filter {
+      case TemporarilyUnreachable(task) if isTimedOut(task) => true
+      case _ => false
+    })
+  }
+}
+
+object ExpungeOverdueLostTasksActor {
+
+  case object Tick
+
+  def props(clock: Clock, config: TaskJobsConfig,
+            taskTracker: TaskTracker, stateOpProcessor: TaskStateOpProcessor): Props = {
+    Props(new ExpungeOverdueLostTasksActor(clock, config, taskTracker, stateOpProcessor))
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/TaskTracker.scala
@@ -33,7 +33,9 @@ trait TaskTracker {
   def tasksByApp()(implicit ec: ExecutionContext): Future[TaskTracker.TasksByApp]
 
   def countLaunchedAppTasksSync(appId: PathId): Int
+  def countLaunchedAppTasksSync(appId: PathId, filter: Task => Boolean): Int
   def countAppTasksSync(appId: PathId): Int
+  def countAppTasksSync(appId: PathId, filter: Task => Boolean): Int
   def countAppTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Int]
 
   def hasAppTasksSync(appId: PathId): Boolean

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerDelegate.scala
@@ -48,7 +48,13 @@ private[tracker] class TaskTrackerDelegate(
 
   override def countLaunchedAppTasksSync(appId: PathId): Int =
     tasksByAppSync.appTasks(appId).count(_.launched.isDefined)
+  override def countLaunchedAppTasksSync(appId: PathId, filter: Task => Boolean): Int =
+    tasksByAppSync.appTasks(appId).count { t =>
+      t.launched.isDefined && filter(t)
+    }
   override def countAppTasksSync(appId: PathId): Int = tasksByAppSync.marathonAppTasks(appId).size
+  override def countAppTasksSync(appId: PathId, filter: Task => Boolean): Int =
+    tasksByAppSync.appTasks(appId).count(filter)
   override def countAppTasks(appId: PathId)(implicit ec: ExecutionContext): Future[Int] =
     tasksByApp().map(_.marathonAppTasks(appId).size)
   override def marathonTaskSync(taskId: Task.Id): Option[MarathonTask] =

--- a/src/main/scala/mesosphere/marathon/core/task/update/TaskStatusUpdateProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/TaskStatusUpdateProcessor.scala
@@ -9,7 +9,6 @@ trait TaskStatusUpdateProcessor {
   /**
     * Process a task status update message.
     * @param status the status to update.
-    * @param ack if this update is coming from Mesos, you want to acknowledge this update.
     */
-  def publish(status: TaskStatus, ack: Boolean = true): Future[Unit]
+  def publish(status: TaskStatus): Future[Unit]
 }

--- a/src/main/scala/mesosphere/marathon/core/task/update/TaskStatusUpdateProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/TaskStatusUpdateProcessor.scala
@@ -5,5 +5,11 @@ import org.apache.mesos.Protos.TaskStatus
 import scala.concurrent.Future
 
 trait TaskStatusUpdateProcessor {
-  def publish(status: TaskStatus): Future[Unit]
+
+  /**
+    * Process a task status update message.
+    * @param status the status to update.
+    * @param ack if this update is coming from Mesos, you want to acknowledge this update.
+    */
+  def publish(status: TaskStatus, ack: Boolean = true): Future[Unit]
 }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -29,7 +29,7 @@ class TaskStatusUpdateProcessorImpl @Inject() (
 
   private[this] val log = LoggerFactory.getLogger(getClass)
 
-  private[this] val publishFutureTimer: Timer =
+  private[this] val publishTimer: Timer =
     metrics.timer(metrics.name(MetricPrefixes.SERVICE, getClass, "publishFuture"))
 
   private[this] val killUnknownTaskTimer: Timer =
@@ -37,7 +37,7 @@ class TaskStatusUpdateProcessorImpl @Inject() (
 
   log.info("Started status update processor")
 
-  override def publish(status: MesosProtos.TaskStatus): Future[Unit] = publishFutureTimer.timeFuture {
+  override def publish(status: MesosProtos.TaskStatus, ack: Boolean = true): Future[Unit] = publishTimer.timeFuture {
     import TaskStatusUpdateProcessorImpl._
 
     val now = clock.now()
@@ -46,25 +46,25 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     taskTracker.task(taskId).flatMap {
       case Some(task) if task.launched.isDefined =>
         val taskStateOp = TaskStateOp.MesosUpdate(task, MarathonTaskStatus(status), now)
-        stateOpProcessor.process(taskStateOp).flatMap(_ => acknowledge(status))
+        stateOpProcessor.process(taskStateOp).flatMap(_ => acknowledge(status, ack))
 
       case maybeTask: Option[Task] if killWhenUnknownOrNotLaunched(status) =>
         killUnknownTaskTimer {
           val taskStr = taskKnownOrNotStr(maybeTask)
           log.warn(s"Kill $taskStr $taskId")
           killTask(taskId.mesosTaskId)
-          acknowledge(status)
+          acknowledge(status, ack)
         }
 
       case maybeTask: Option[Task] =>
         val taskStr = taskKnownOrNotStr(maybeTask)
         log.info(s"Ignoring ${status.getState} update for $taskStr $taskId")
-        acknowledge(status)
+        acknowledge(status, ack)
     }
   }
 
-  private[this] def acknowledge(taskStatus: MesosProtos.TaskStatus): Future[Unit] = {
-    driverHolder.driver.foreach(_.acknowledgeStatusUpdate(taskStatus))
+  private[this] def acknowledge(taskStatus: MesosProtos.TaskStatus, ack: Boolean = true): Future[Unit] = {
+    if (ack) driverHolder.driver.foreach(_.acknowledgeStatusUpdate(taskStatus))
     Future.successful(())
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/ThrottlingTaskStatusUpdateProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/ThrottlingTaskStatusUpdateProcessor.scala
@@ -20,7 +20,7 @@ private[core] class ThrottlingTaskStatusUpdateProcessor @Inject() (
   @Named(ThrottlingTaskStatusUpdateProcessor.dependencyTag) serializePublish: CapConcurrentExecutions,
   @Named(ThrottlingTaskStatusUpdateProcessor.dependencyTag) wrapped: TaskStatusUpdateProcessor)
     extends TaskStatusUpdateProcessor {
-  override def publish(status: TaskStatus, ack: Boolean = true): Future[Unit] = {
-    serializePublish(wrapped.publish(status, ack))
+  override def publish(status: TaskStatus): Future[Unit] = {
+    serializePublish(wrapped.publish(status))
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/ThrottlingTaskStatusUpdateProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/ThrottlingTaskStatusUpdateProcessor.scala
@@ -20,5 +20,7 @@ private[core] class ThrottlingTaskStatusUpdateProcessor @Inject() (
   @Named(ThrottlingTaskStatusUpdateProcessor.dependencyTag) serializePublish: CapConcurrentExecutions,
   @Named(ThrottlingTaskStatusUpdateProcessor.dependencyTag) wrapped: TaskStatusUpdateProcessor)
     extends TaskStatusUpdateProcessor {
-  override def publish(status: TaskStatus): Future[Unit] = serializePublish(wrapped.publish(status))
+  override def publish(status: TaskStatus, ack: Boolean = true): Future[Unit] = {
+    serializePublish(wrapped.publish(status, ack))
+  }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -29,7 +29,6 @@ class PostToEventStreamStepImpl @Inject() (
   override def processUpdate(taskChanged: TaskChanged): Future[_] = {
     import TaskStateOp.MesosUpdate
 
-    // FIXME (merge): it should be clear which task state (old or new) to post
     taskChanged match {
       // case 1: Mesos status update => update or expunge
       // In this case, we post the OLD state - when terminated, a persistent task no longer has a launched

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -4,14 +4,14 @@ import javax.inject.Named
 
 import akka.event.EventStream
 import com.google.inject.Inject
-import mesosphere.marathon.core.task.Task.Terminated
-import mesosphere.marathon.core.task.bus.MarathonTaskStatus
+import mesosphere.marathon.core.base.Clock
+import mesosphere.marathon.core.task.bus.MarathonTaskStatus.WithMesosStatus
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.update.TaskUpdateStep
-import mesosphere.marathon.core.task.{ Task, TaskStateOp }
+import mesosphere.marathon.core.task.{ EffectiveTaskStateChange, Task, TaskStateOp }
 import mesosphere.marathon.event.{ EventModule, MesosStatusUpdateEvent }
 import mesosphere.marathon.state.Timestamp
-import org.apache.mesos.Protos.{ TaskState, TaskStatus }
+import org.apache.mesos.Protos.TaskStatus
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
@@ -20,37 +20,41 @@ import scala.concurrent.Future
   * Post this update to the internal event stream.
   */
 class PostToEventStreamStepImpl @Inject() (
-    @Named(EventModule.busName) eventBus: EventStream) extends TaskUpdateStep {
+    @Named(EventModule.busName) eventBus: EventStream, clock: Clock) extends TaskUpdateStep {
+
   private[this] val log = LoggerFactory.getLogger(getClass)
 
   override def name: String = "postTaskStatusEvent"
 
   override def processUpdate(taskChanged: TaskChanged): Future[_] = {
-    taskChanged.stateOp match {
-      case TaskStateOp.MesosUpdate(task, MarathonTaskStatus.WithMesosStatus(mesosStatus), timestamp) =>
-        mesosStatus.getState match {
-          case Terminated(_) =>
-            postEvent(timestamp, mesosStatus, task)
-          case TaskState.TASK_RUNNING if task.launched.exists(!_.hasStartedRunning) => // staged, not running
-            postEvent(timestamp, mesosStatus, task)
-          case TaskState.TASK_KILLING if task.launched.isDefined =>
-            postEvent(timestamp, mesosStatus, task)
+    import TaskStateOp.MesosUpdate
 
-          case state: TaskState =>
-            val taskId = task.taskId
-            log.debug(s"Do not post event $state for $taskId of app [${taskId.appId}].")
-        }
+    // FIXME (merge): it should be clear which task state (old or new) to post
+    taskChanged match {
+      // case 1: Mesos status update => update or expunge
+      // In this case, we post the OLD state - when terminated, a persistent task no longer has a launched
+      case TaskChanged(MesosUpdate(task, WithMesosStatus(status), now), EffectiveTaskStateChange(_)) =>
+        postEvent(clock.now(), Some(status), task)
+
+      // case 2: Any TaskStateOp => update or expunge
+      // In this case, we post the NEW state
+      case TaskChanged(_, EffectiveTaskStateChange(task)) =>
+        postEvent(clock.now(), task.mesosStatus, task)
 
       case _ =>
-      // ignore
+        log.debug("Ignoring noop for {}", taskChanged.taskId)
     }
 
     Future.successful(())
   }
 
-  private[this] def postEvent(timestamp: Timestamp, status: TaskStatus, task: Task): Unit = {
+  private[this] def postEvent(timestamp: Timestamp, maybeStatus: Option[TaskStatus], task: Task): Unit = {
     val taskId = task.taskId
-    task.launched.foreach { launched =>
+
+    for {
+      launched <- task.launched
+      status <- maybeStatus
+    } {
       log.info(
         "Sending event notification for {} of app [{}]: {}",
         Array[Object](taskId, taskId.appId, status.getState): _*

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
@@ -9,6 +9,7 @@ import mesosphere.marathon.core.task.{ Task, TaskStateChange, TaskStateOp }
 import mesosphere.marathon.core.task.bus.MarathonTaskStatus
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.update.TaskUpdateStep
+import org.apache.mesos.Protos.{ TaskStatus, TaskState }
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
@@ -29,15 +30,24 @@ class ScaleAppUpdateStepImpl @Inject() (
       (taskChanged.stateOp, taskChanged.stateChange) match {
         // stateOp is a terminal MesosUpdate
         case (TaskStateOp.MesosUpdate(task, MarathonTaskStatus.Terminal(_), _), _) => Some(task)
+
+        // A Lost task that might come back wouldN#t be included in Terminal(_)
+        case (TaskStateOp.MesosUpdate(task, MarathonTaskStatus.Lost(_), _), _) => Some(task)
+
         // stateChange is an expunge (probably because we expunged a timeout reservation)
         case (_, TaskStateChange.Expunge(task)) => Some(task)
+
         // no ScaleApp needed
         case _ => None
       }
     }
 
     terminalOrExpungedTask.foreach { task =>
-      log.info(s"initiating a scale check for app [${task.taskId.appId}] after ${task.taskId} terminated")
+      val appId = task.taskId.appId
+      val taskId = task.taskId
+      val state = task.mesosStatus.fold(TaskState.TASK_STAGING)(_.getState)
+      val reason = task.mesosStatus.fold("")(status => if (status.hasReason) status.getReason.toString else "")
+      log.info(s"initiating a scale check for app [$appId] due to [$taskId] $state $reason")
       log.info("schedulerActor: {}", schedulerActor)
       schedulerActor ! ScaleApp(task.taskId.appId)
     }

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckActor.scala
@@ -4,6 +4,7 @@ import akka.actor.{ Actor, ActorLogging, ActorRef, Cancellable, Props }
 import akka.event.EventStream
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.bus.MesosTaskStatus.TemporarilyUnreachable
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.event._
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
@@ -82,10 +83,12 @@ private[health] class HealthCheckActor(
     }
 
   def dispatchJobs(): Unit = {
+    import TemporarilyUnreachable.isUnreachable
+
     log.debug("Dispatching health check jobs to workers")
     taskTracker.appTasksSync(app.id).foreach { task =>
       task.launched.foreach { launched =>
-        if (launched.appVersion == app.version && launched.hasStartedRunning) {
+        if (launched.appVersion == app.version && launched.hasStartedRunning && !isUnreachable(task)) {
           log.debug("Dispatching health check job for {}", task.taskId)
           val worker: ActorRef = context.actorOf(workerProps)
           worker ! HealthCheckJob(app, task, launched, healthCheck)
@@ -104,21 +107,27 @@ private[health] class HealthCheckActor(
         s"Detected unhealthy ${task.taskId} of app [${app.id}] version [${app.version}] on host ${task.agentInfo.host}"
       )
 
-      // kill the task
-      marathonSchedulerDriverHolder.driver.foreach { driver =>
-        log.info(s"Send kill request for ${task.taskId} on host ${task.agentInfo.host} to driver")
-        eventBus.publish(
-          UnhealthyTaskKillEvent(
-            appId = task.appId,
-            taskId = task.taskId,
-            version = app.version,
-            reason = health.lastFailureCause.getOrElse("unknown"),
-            host = task.agentInfo.host,
-            slaveId = task.agentInfo.agentId,
-            timestamp = health.lastFailure.getOrElse(Timestamp.now()).toString
-          )
-        )
-        driver.killTask(task.taskId.mesosTaskId)
+      // kill the task, if it is reachable
+      task match {
+        case TemporarilyUnreachable(_) =>
+          val id = task.taskId
+          log.warning(s"Task $id on host ${task.agentInfo.host} is temporarily unreachable. Performing no kill.")
+        case _ =>
+          marathonSchedulerDriverHolder.driver.foreach { driver =>
+            log.warning(s"Send kill request for ${task.taskId} on host ${task.agentInfo.host} to driver")
+            eventBus.publish(
+              UnhealthyTaskKillEvent(
+                appId = task.appId,
+                taskId = task.taskId,
+                version = app.version,
+                reason = health.lastFailureCause.getOrElse("unknown"),
+                host = task.agentInfo.host,
+                slaveId = task.agentInfo.agentId,
+                timestamp = health.lastFailure.getOrElse(Timestamp.now()).toString
+              )
+            )
+            driver.killTask(task.taskId.mesosTaskId)
+          }
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
+++ b/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
@@ -116,7 +116,8 @@ object TaskFailure {
   protected[this] def taskState(s: String): mesos.TaskState =
     mesos.TaskState.valueOf(s)
 
-  protected[this] def isFailureState(state: mesos.TaskState): Boolean = {
+  // Note that this will also store taskFailures for TASK_LOST no matter the reason
+  private[this] def isFailureState(state: mesos.TaskState): Boolean = {
     import mesos.TaskState._
     state match {
       case TASK_FAILED | TASK_LOST | TASK_ERROR => true

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -133,7 +133,7 @@ class SchedulerActionsTest
     Given("An active queue and lost tasks")
     val app = MarathonTestHelper.makeBasicApp().copy(instances = 15)
     f.queue.get(app.id) returns None
-    f.taskTracker.countLaunchedAppTasksSync(eq(app.id), any) returns 10
+    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 10
 
     When("the app is scaled")
     f.scheduler.scale(f.driver, app)
@@ -172,7 +172,7 @@ class SchedulerActionsTest
     )
 
     f.queue.get(app.id) returns Some(queued)
-    f.taskTracker.countLaunchedAppTasksSync(eq(app.id), any) returns 7
+    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 7
     f.taskTracker.appTasksSync(app.id) returns tasks
     When("the app is scaled")
     f.scheduler.scale(f.driver, app)
@@ -205,7 +205,7 @@ class SchedulerActionsTest
     )
 
     f.queue.get(app.id) returns None
-    f.taskTracker.countLaunchedAppTasksSync(eq(app.id), any) returns 7
+    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 7
     f.taskTracker.appTasksSync(app.id) returns tasks
     When("the app is scaled")
     f.scheduler.scale(f.driver, app)
@@ -244,7 +244,7 @@ class SchedulerActionsTest
     )
 
     f.queue.get(app.id) returns Some(queued)
-    f.taskTracker.countLaunchedAppTasksSync(eq(app.id), any) returns 5
+    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 5
     f.taskTracker.appTasksSync(app.id) returns tasks
     When("the app is scaled")
     f.scheduler.scale(f.driver, app)

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -1,63 +1,54 @@
 package mesosphere.marathon
 
 import akka.testkit.TestProbe
+import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskInfo
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.task.tracker.TaskTracker.{ AppTasks, TasksByApp }
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.{ AppDefinition, AppRepository, GroupRepository, PathId }
-import mesosphere.marathon.test.{ Mockito, MarathonActorSupport }
+import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }
+import mesosphere.mesos.protos
+import mesosphere.mesos.protos.Implicits.taskIDToProto
+import org.apache.mesos.Protos.{ TaskID, TaskState, TaskStatus }
 import org.apache.mesos.SchedulerDriver
-import org.mockito.Mockito.{ times, verify, verifyNoMoreInteractions, when }
-import org.scalatest.Matchers
-import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.scalatest.{ GivenWhenThen, Matchers }
+import org.scalatest.concurrent.{ PatienceConfiguration, ScalaFutures }
+import org.scalatest.time.{ Millis, Span }
 
 import scala.collection.JavaConverters._
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
 
-class SchedulerActionsTest extends MarathonActorSupport with MarathonSpec with Matchers with Mockito {
+class SchedulerActionsTest
+    extends MarathonActorSupport
+    with MarathonSpec
+    with Matchers
+    with Mockito
+    with ScalaFutures
+    with GivenWhenThen {
   import system.dispatcher
 
   test("Reset rate limiter if application is stopped") {
-    val queue = mock[LaunchQueue]
-    val repo = mock[AppRepository]
-    val taskTracker = mock[TaskTracker]
-
-    val scheduler = new SchedulerActions(
-      repo,
-      mock[GroupRepository],
-      mock[HealthCheckManager],
-      taskTracker,
-      queue,
-      system.eventStream,
-      TestProbe().ref,
-      mock[MarathonConf]
-    )
-
+    val f = new Fixture
     val app = AppDefinition(id = PathId("/myapp"))
 
-    when(repo.expunge(app.id)).thenReturn(Future.successful(Seq(true)))
-    when(taskTracker.appTasks(eq(app.id))(any)).thenReturn(Future.successful(Iterable.empty[Task]))
+    f.repo.expunge(app.id) returns Future.successful(Seq(true))
+    f.taskTracker.appTasks(eq(app.id))(any) returns Future.successful(Iterable.empty[Task])
 
-    val res = scheduler.stopApp(mock[SchedulerDriver], app)
+    f.scheduler.stopApp(mock[SchedulerDriver], app).futureValue(1.second)
 
-    Await.ready(res, 1.second)
-
-    verify(queue).purge(app.id)
-    verify(queue).resetDelay(app)
-    verifyNoMoreInteractions(queue)
+    verify(f.queue).purge(app.id)
+    verify(f.queue).resetDelay(app)
+    verifyNoMoreInteractions(f.queue)
   }
 
   test("Task reconciliation sends known running and staged tasks and empty list") {
-    val queue = mock[LaunchQueue]
-    val repo = mock[AppRepository]
-    val taskTracker = mock[TaskTracker]
-    val driver = mock[SchedulerDriver]
-
+    val f = new Fixture
     val runningTask = MarathonTestHelper.runningTask("task_1")
-
     val stagedTask = MarathonTestHelper.stagedTask("task_2")
 
     import MarathonTestHelper.Implicits._
@@ -65,91 +56,230 @@ class SchedulerActionsTest extends MarathonActorSupport with MarathonSpec with M
       MarathonTestHelper.stagedTask("task_3")
         .withAgentInfo(_.copy(agentId = Some("slave 1")))
 
-    val scheduler = new SchedulerActions(
-      repo,
-      mock[GroupRepository],
-      mock[HealthCheckManager],
-      taskTracker,
-      queue,
-      system.eventStream,
-      TestProbe().ref,
-      mock[MarathonConf]
-    )
-
     val app = AppDefinition(id = PathId("/myapp"))
 
     val tasks = Set(runningTask, stagedTask, stagedTaskWithSlaveId)
-    when(taskTracker.tasksByApp()).thenReturn(Future.successful(TasksByApp.of(AppTasks.forTasks(app.id, tasks))))
-    when(repo.allPathIds()).thenReturn(Future.successful(Seq(app.id)))
+    f.taskTracker.tasksByApp() returns Future.successful(TasksByApp.of(AppTasks.forTasks(app.id, tasks)))
+    f.repo.allPathIds() returns Future.successful(Seq(app.id))
 
-    Await.result(scheduler.reconcileTasks(driver), 5.seconds)
+    f.scheduler.reconcileTasks(f.driver).futureValue(5.seconds)
 
-    verify(driver).reconcileTasks(Set(
+    verify(f.driver).reconcileTasks(Set(
       runningTask,
       stagedTask,
       stagedTaskWithSlaveId
     ).flatMap(_.launched.flatMap(_.status.mesosStatus)).asJava)
-    verify(driver).reconcileTasks(java.util.Arrays.asList())
+    verify(f.driver).reconcileTasks(java.util.Arrays.asList())
   }
 
   test("Task reconciliation only one empty list, when no tasks are present in Marathon") {
-    val queue = mock[LaunchQueue]
-    val repo = mock[AppRepository]
-    val taskTracker = mock[TaskTracker]
-    val driver = mock[SchedulerDriver]
+    val f = new Fixture
 
-    val scheduler = new SchedulerActions(
-      repo,
-      mock[GroupRepository],
-      mock[HealthCheckManager],
-      taskTracker,
-      queue,
-      system.eventStream,
-      TestProbe().ref,
-      mock[MarathonConf]
-    )
+    f.taskTracker.tasksByApp() returns Future.successful(TasksByApp.empty)
+    f.repo.allPathIds() returns Future.successful(Seq())
 
-    val app = AppDefinition(id = PathId("/myapp"))
+    f.scheduler.reconcileTasks(f.driver).futureValue
 
-    when(taskTracker.tasksByApp()).thenReturn(Future.successful(TasksByApp.empty))
-    when(repo.allPathIds()).thenReturn(Future.successful(Seq()))
-
-    Await.result(scheduler.reconcileTasks(driver), 5.seconds)
-
-    verify(driver, times(1)).reconcileTasks(java.util.Arrays.asList())
+    verify(f.driver, times(1)).reconcileTasks(java.util.Arrays.asList())
   }
 
   test("Kill orphaned task") {
-    val queue = mock[LaunchQueue]
-    val repo = mock[AppRepository]
-    val taskTracker = mock[TaskTracker]
-    val driver = mock[SchedulerDriver]
+    val f = new Fixture
+    val status = TaskStatus.newBuilder
+      .setTaskId(TaskID.newBuilder.setValue("task_1"))
+      .setState(TaskState.TASK_RUNNING)
+      .build()
 
     val task = MarathonTestHelper.runningTask("task_1")
-
     val orphanedTask = MarathonTestHelper.runningTask("orphaned task")
-
-    val scheduler = new SchedulerActions(
-      repo,
-      mock[GroupRepository],
-      mock[HealthCheckManager],
-      taskTracker,
-      queue,
-      system.eventStream,
-      TestProbe().ref,
-      mock[MarathonConf]
-    )
 
     val app = AppDefinition(id = PathId("/myapp"))
     val tasksOfApp = AppTasks.forTasks(app.id, Iterable(task))
     val orphanedApp = AppDefinition(id = PathId("/orphan"))
     val tasksOfOrphanedApp = AppTasks.forTasks(orphanedApp.id, Iterable(orphanedTask))
 
-    when(taskTracker.tasksByApp()).thenReturn(Future.successful(TasksByApp.of(tasksOfApp, tasksOfOrphanedApp)))
-    when(repo.allPathIds()).thenReturn(Future.successful(Seq(app.id)))
+    f.taskTracker.tasksByApp() returns Future.successful(TasksByApp.of(tasksOfApp, tasksOfOrphanedApp))
+    f.repo.allPathIds() returns Future.successful(Seq(app.id))
 
-    Await.result(scheduler.reconcileTasks(driver), 5.seconds)
+    f.scheduler.reconcileTasks(f.driver).futureValue(5.seconds)
 
-    verify(driver, times(1)).killTask(orphanedTask.launchedMesosId.get)
+    verify(f.driver, times(1)).killTask(protos.TaskID(orphanedTask.taskId.idString))
   }
+
+  test("Scale up correctly in case of lost tasks (active queue)") {
+    val f = new Fixture
+
+    Given("An active queue and lost tasks")
+    val app = MarathonTestHelper.makeBasicApp().copy(instances = 15)
+    val queued = QueuedTaskInfo(app,
+      tasksLeftToLaunch = 1,
+      taskLaunchesInFlight = 0,
+      tasksLaunched = 14,
+      tasksLost = 5,
+      backOffUntil = f.clock.now())
+    f.queue.get(app.id) returns Some(queued)
+    f.taskTracker.countAppTasksSync(eq(app.id), any) returns (queued.finalTaskCount - queued.tasksLost)
+
+    When("the app is scaled")
+    f.scheduler.scale(f.driver, app)
+
+    Then("5 tasks should be placed onto the launchQueue")
+    verify(f.queue, times(1)).add(app, 5)
+  }
+
+  test("Scale up correctly in case of lost tasks (inactive queue)") {
+    val f = new Fixture
+
+    Given("An active queue and lost tasks")
+    val app = MarathonTestHelper.makeBasicApp().copy(instances = 15)
+    f.queue.get(app.id) returns None
+    f.taskTracker.countLaunchedAppTasksSync(eq(app.id), any) returns 10
+
+    When("the app is scaled")
+    f.scheduler.scale(f.driver, app)
+
+    Then("5 tasks should be placed onto the launchQueue")
+    verify(f.queue, times(1)).add(app, 5)
+  }
+
+  // This scenario is the following:
+  // - There's an active queue and Marathon has 10 running + 5 staged tasks
+  // - Marathon receives StatusUpdates for 5 previously LOST tasks
+  // - A scale is initiated and Marathon realizes there are 5 tasks over capacity
+  // => We expect Marathon to kill the 5 staged tasks
+  test("Kill staged tasks in correct order in case lost tasks reappear") {
+    val f = new Fixture
+
+    Given("an active queue, staged tasks and 5 overCapacity")
+    val app = MarathonTestHelper.makeBasicApp().copy(instances = 5)
+    val queued = QueuedTaskInfo(app,
+      tasksLeftToLaunch = 0,
+      taskLaunchesInFlight = 0,
+      tasksLaunched = 7,
+      tasksLost = 0,
+      backOffUntil = f.clock.now())
+
+    def stagedTask(id: String, stagedAt: Long) = MarathonTestHelper.stagedTask(id, stagedAt = stagedAt)
+
+    val tasks = Seq(
+      MarathonTestHelper.runningTask(s"running-1"),
+      stagedTask("staged-1", 1L),
+      MarathonTestHelper.runningTask(s"running-2"),
+      stagedTask("staged-3", 3L),
+      MarathonTestHelper.runningTask(s"running-3"),
+      stagedTask("staged-2", 2L),
+      MarathonTestHelper.runningTask(s"running-4")
+    )
+
+    f.queue.get(app.id) returns Some(queued)
+    f.taskTracker.countLaunchedAppTasksSync(eq(app.id), any) returns 7
+    f.taskTracker.appTasksSync(app.id) returns tasks
+    When("the app is scaled")
+    f.scheduler.scale(f.driver, app)
+
+    Then("the queue is purged")
+    verify(f.queue, times(1)).purge(app.id)
+
+    And("the youngest STAGED tasks are killed")
+    verify(f.driver).killTask(protos.TaskID("staged-2"))
+    verify(f.driver).killTask(protos.TaskID("staged-3"))
+    verifyNoMoreInteractions(f.driver)
+  }
+
+  test("Kill running tasks in correct order in case of lost tasks") {
+    val f = new Fixture
+
+    Given("an inactive queue, running tasks and some overCapacity")
+    val app = MarathonTestHelper.makeBasicApp().copy(instances = 5)
+
+    def runningTask(id: String, stagedAt: Long) = MarathonTestHelper.runningTask(id, stagedAt = stagedAt)
+
+    val tasks = Seq(
+      runningTask(s"running-3", stagedAt = 3L),
+      runningTask(s"running-7", stagedAt = 7L),
+      runningTask(s"running-1", stagedAt = 1L),
+      runningTask(s"running-4", stagedAt = 4L),
+      runningTask(s"running-5", stagedAt = 5L),
+      runningTask(s"running-6", stagedAt = 6L),
+      runningTask(s"running-2", stagedAt = 2L)
+    )
+
+    f.queue.get(app.id) returns None
+    f.taskTracker.countLaunchedAppTasksSync(eq(app.id), any) returns 7
+    f.taskTracker.appTasksSync(app.id) returns tasks
+    When("the app is scaled")
+    f.scheduler.scale(f.driver, app)
+
+    Then("the queue is purged")
+    verify(f.queue, times(1)).purge(app.id)
+
+    And("the youngest RUNNING tasks are killed")
+    verify(f.driver).killTask(protos.TaskID("running-6"))
+    verify(f.driver).killTask(protos.TaskID("running-7"))
+    verifyNoMoreInteractions(f.driver)
+  }
+
+  test("Kill staged and running tasks in correct order in case of lost tasks") {
+    val f = new Fixture
+
+    Given("an active queue, running tasks and some overCapacity")
+    val app = MarathonTestHelper.makeBasicApp().copy(instances = 3)
+
+    val queued = QueuedTaskInfo(app,
+      tasksLeftToLaunch = 0,
+      taskLaunchesInFlight = 0,
+      tasksLaunched = 5,
+      tasksLost = 0,
+      backOffUntil = f.clock.now())
+
+    def stagedTask(id: String, stagedAt: Long) = MarathonTestHelper.stagedTask(id, stagedAt = stagedAt)
+    def runningTask(id: String, stagedAt: Long) = MarathonTestHelper.runningTask(id, stagedAt = stagedAt)
+
+    val tasks = Seq(
+      runningTask(s"running-3", stagedAt = 3L),
+      runningTask(s"running-4", stagedAt = 4L),
+      stagedTask("staged-1", 1L),
+      runningTask(s"running-1", stagedAt = 1L),
+      runningTask(s"running-2", stagedAt = 2L)
+    )
+
+    f.queue.get(app.id) returns Some(queued)
+    f.taskTracker.countLaunchedAppTasksSync(eq(app.id), any) returns 5
+    f.taskTracker.appTasksSync(app.id) returns tasks
+    When("the app is scaled")
+    f.scheduler.scale(f.driver, app)
+
+    Then("the queue is purged")
+    verify(f.queue, times(1)).purge(app.id)
+
+    And("all STAGED tasks plus the youngest RUNNING tasks are killed")
+    verify(f.driver).killTask(protos.TaskID("staged-1"))
+    verify(f.driver).killTask(protos.TaskID("running-4"))
+    verifyNoMoreInteractions(f.driver)
+  }
+
+  import scala.language.implicitConversions
+  implicit def durationToPatienceConfigTimeout(d: FiniteDuration): PatienceConfiguration.Timeout = {
+    PatienceConfiguration.Timeout(Span(d.toMillis, Millis))
+  }
+
+  class Fixture {
+    val queue = mock[LaunchQueue]
+    val repo = mock[AppRepository]
+    val taskTracker = mock[TaskTracker]
+    val driver = mock[SchedulerDriver]
+    val clock = ConstantClock()
+
+    val scheduler = new SchedulerActions(
+      repo,
+      mock[GroupRepository],
+      mock[HealthCheckManager],
+      taskTracker,
+      queue,
+      system.eventStream,
+      TestProbe().ref,
+      mock[MarathonConf]
+    )
+  }
+
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -22,7 +22,7 @@ class QueueResourceTest extends MarathonSpec with Matchers with Mockito with Giv
     val app = AppDefinition(id = "app".toRootPath)
     queue.list returns Seq(
       QueuedTaskInfo(
-        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunched = 0, clock.now() + 100.seconds
+        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunched = 0, tasksLost = 0, clock.now() + 100.seconds
       )
     )
 
@@ -46,7 +46,7 @@ class QueueResourceTest extends MarathonSpec with Matchers with Mockito with Giv
     val app = AppDefinition(id = "app".toRootPath)
     queue.list returns Seq(
       QueuedTaskInfo(
-        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunched = 0,
+        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunched = 0, tasksLost = 0,
         backOffUntil = clock.now() - 100.seconds
       )
     )
@@ -81,7 +81,7 @@ class QueueResourceTest extends MarathonSpec with Matchers with Mockito with Giv
     val app = AppDefinition(id = "app".toRootPath)
     queue.list returns Seq(
       QueuedTaskInfo(
-        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunched = 0,
+        app, tasksLeftToLaunch = 23, taskLaunchesInFlight = 0, tasksLaunched = 0, tasksLost = 0,
         backOffUntil = clock.now() + 100.seconds
       )
     )
@@ -118,7 +118,7 @@ class QueueResourceTest extends MarathonSpec with Matchers with Mockito with Giv
 
     When(s"one delay is reset")
     val appId = "appId".toRootPath
-    val taskCount = LaunchQueue.QueuedTaskInfo(AppDefinition(appId), 0, 0, 0, Timestamp.now())
+    val taskCount = LaunchQueue.QueuedTaskInfo(AppDefinition(appId), 0, 0, 0, 0, Timestamp.now())
     queue.list returns Seq(taskCount)
 
     val resetDelay = queueResource.resetDelay("appId", req)

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
@@ -9,6 +9,7 @@ object LaunchQueueTestHelper {
     tasksLeftToLaunch = 0,
     taskLaunchesInFlight = 0,
     tasksLaunched = 0,
+    tasksLost = 0,
     backOffUntil = Timestamp(0)
   )
 }

--- a/src/test/scala/mesosphere/marathon/core/task/bus/MarathonTaskStatusTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/MarathonTaskStatusTestHelper.scala
@@ -3,14 +3,20 @@ package mesosphere.marathon.core.task.bus
 import java.util.UUID
 
 import mesosphere.mesos.protos.TaskID
+import org.apache.mesos.Protos.TaskStatus.Reason
 import org.apache.mesos.Protos.{ TaskState, TaskStatus }
 
 object MarathonTaskStatusTestHelper {
-  def mesosStatus(state: TaskState, maybeHealthy: Option[Boolean] = None): TaskStatus = {
+  def mesosStatus(
+    state: TaskState,
+    maybeHealthy: Option[Boolean] = None,
+    maybeReason: Option[Reason] = None): TaskStatus = {
     import mesosphere.mesos.protos.Implicits._
+
     val builder = TaskStatus.newBuilder()
     builder.setTaskId(TaskID(UUID.randomUUID().toString)).setState(state)
     maybeHealthy.foreach(builder.setHealthy)
+    maybeReason.foreach(builder.setReason)
     builder.build()
   }
 
@@ -23,6 +29,6 @@ object MarathonTaskStatusTestHelper {
   val staging = MarathonTaskStatus.Staging(mesosStatus = Some(mesosStatus(TaskState.TASK_STAGING)))
   val finished = MarathonTaskStatus.Finished(mesosStatus = Some(mesosStatus(TaskState.TASK_FINISHED)))
   val error = MarathonTaskStatus.Error(mesosStatus = Some(mesosStatus(TaskState.TASK_ERROR)))
-  val lost = MarathonTaskStatus.Lost(mesosStatus = Some(mesosStatus(TaskState.TASK_LOST)))
+  def lost(reason: Reason) = MarathonTaskStatus(mesosStatus = mesosStatus(TaskState.TASK_LOST, maybeReason = Some(reason)))
   val killed = MarathonTaskStatus.Killed(mesosStatus = Some(mesosStatus(TaskState.TASK_KILLED)))
 }

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -4,8 +4,10 @@ import mesosphere.marathon.MarathonTestHelper
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.{ Task, TaskStateChange, TaskStateOp }
 import mesosphere.marathon.state.{ PathId, Timestamp }
-import org.apache.mesos.Protos.{ TaskStatus, TaskState }
+import org.apache.mesos.Protos.TaskStatus.Reason
+import org.apache.mesos.Protos.{ TaskState, TaskStatus }
 import org.joda.time.DateTime
+import org.slf4j.LoggerFactory
 
 class TaskStatusUpdateTestHelper(val wrapped: TaskChanged) {
   def simpleName = wrapped.stateOp match {
@@ -17,9 +19,12 @@ class TaskStatusUpdateTestHelper(val wrapped: TaskChanged) {
     case TaskStateOp.MesosUpdate(_, MarathonTaskStatus.WithMesosStatus(mesosStatus), _) => mesosStatus
     case _ => throw new scala.RuntimeException("the wrapped stateOp os no MesosUpdate!")
   }
+  def reason: String = if (status.hasReason) status.getReason.toString else "no reason"
+
 }
 
 object TaskStatusUpdateTestHelper {
+  val log = LoggerFactory.getLogger(getClass)
   def apply(taskChanged: TaskChanged): TaskStatusUpdateTestHelper =
     new TaskStatusUpdateTestHelper(taskChanged)
 
@@ -50,29 +55,44 @@ object TaskStatusUpdateTestHelper {
         TaskStateChange.Expunge(task)))
   }
 
-  def makeTaskStatus(task: Task, state: TaskState, maybeHealth: Option[Boolean] = None) = {
+  def makeMesosTaskStatus(taskId: Task.Id, state: TaskState, maybeHealth: Option[Boolean] = None, maybeReason: Option[TaskStatus.Reason] = None) = {
     val mesosStatus = TaskStatus.newBuilder
-      .setTaskId(task.taskId.mesosTaskId)
+      .setTaskId(taskId.mesosTaskId)
       .setState(state)
     maybeHealth.foreach(mesosStatus.setHealthy)
-    MarathonTaskStatus(mesosStatus.build())
+    maybeReason.foreach(mesosStatus.setReason)
+    mesosStatus.build()
+  }
+  def makeTaskStatus(taskId: Task.Id, state: TaskState, maybeHealth: Option[Boolean] = None, maybeReason: Option[TaskStatus.Reason] = None) = {
+    val mesosStatus = makeMesosTaskStatus(taskId, state, maybeHealth, maybeReason)
+    MarathonTaskStatus(mesosStatus)
   }
 
-  def running(task: Task = defaultTask) = taskUpdateFor(task, makeTaskStatus(task, TaskState.TASK_RUNNING))
+  def running(task: Task = defaultTask) = taskUpdateFor(task, makeTaskStatus(task.taskId, TaskState.TASK_RUNNING))
 
-  def runningHealthy(task: Task = defaultTask) = taskUpdateFor(task, makeTaskStatus(task, TaskState.TASK_RUNNING, maybeHealth = Some(true)))
+  def runningHealthy(task: Task = defaultTask) = taskUpdateFor(task, makeTaskStatus(task.taskId, TaskState.TASK_RUNNING, maybeHealth = Some(true)))
 
-  def runningUnhealthy(task: Task = defaultTask) = taskUpdateFor(task, makeTaskStatus(task, TaskState.TASK_RUNNING, maybeHealth = Some(false)))
+  def runningUnhealthy(task: Task = defaultTask) = taskUpdateFor(task, makeTaskStatus(task.taskId, TaskState.TASK_RUNNING, maybeHealth = Some(false)))
 
-  def staging(task: Task = defaultTask) = taskUpdateFor(task, makeTaskStatus(task, TaskState.TASK_STAGING))
+  def staging(task: Task = defaultTask) = taskUpdateFor(task, makeTaskStatus(task.taskId, TaskState.TASK_STAGING))
 
-  def finished(task: Task = defaultTask) = taskExpungeFor(task, makeTaskStatus(task, TaskState.TASK_FINISHED))
+  def finished(task: Task = defaultTask) = taskExpungeFor(task, makeTaskStatus(task.taskId, TaskState.TASK_FINISHED))
 
-  def lost(task: Task = defaultTask) = taskExpungeFor(task, makeTaskStatus(task, TaskState.TASK_LOST))
+  def lost(reason: Reason, task: Task = defaultTask) = {
+    val taskStatus = makeTaskStatus(task.taskId, TaskState.TASK_LOST, maybeReason = Some(reason))
 
-  def killed(task: Task = defaultTask) = taskExpungeFor(task, makeTaskStatus(task, TaskState.TASK_KILLED))
+    taskStatus match {
+      case MarathonTaskStatus.Terminal(status) =>
+        taskExpungeFor(task, taskStatus)
 
-  def killing(task: Task = defaultTask) = taskUpdateFor(task, makeTaskStatus(task, TaskState.TASK_KILLING))
+      case _ =>
+        taskUpdateFor(task, taskStatus)
+    }
+  }
 
-  def error(task: Task = defaultTask) = taskExpungeFor(task, makeTaskStatus(task, TaskState.TASK_ERROR))
+  def killed(task: Task = defaultTask) = taskExpungeFor(task, makeTaskStatus(task.taskId, TaskState.TASK_KILLED))
+
+  def killing(task: Task = defaultTask) = taskUpdateFor(task, makeTaskStatus(task.taskId, TaskState.TASK_KILLING))
+
+  def error(task: Task = defaultTask) = taskExpungeFor(task, makeTaskStatus(task.taskId, TaskState.TASK_ERROR))
 }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskStateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskStateOpResolverTest.scala
@@ -1,12 +1,13 @@
 package mesosphere.marathon.core.task.tracker.impl
 
 import mesosphere.marathon.MarathonTestHelper
-import mesosphere.marathon.core.task.bus.MarathonTaskStatusTestHelper
-import mesosphere.marathon.core.task.{ TaskStateChange, TaskStateOp, Task }
+import mesosphere.marathon.core.task.bus.{ MarathonTaskStatus, MarathonTaskStatusTestHelper, MesosTaskStatus, TaskStatusUpdateTestHelper }
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.task.tracker.impl.TaskOpProcessorImpl.TaskStateOpResolver
-import mesosphere.marathon.state.{ Timestamp, PathId }
+import mesosphere.marathon.core.task.{ Task, TaskStateChange, TaskStateOp }
+import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.test.Mockito
+import org.apache.mesos
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 
@@ -80,6 +81,83 @@ class TaskStateOpResolverTest
     And("the result is a Failure")
     stateChange shouldBe a[TaskStateChange.Failure]
 
+    And("there are no more interactions")
+    f.verifyNoMoreInteractions()
+  }
+
+  for (
+    reason <- MesosTaskStatus.MightComeBack
+  ) {
+    test(s"a TASK_LOST update with $reason indicating a TemporarilyUnreachable task is mapped to an update") {
+      val f = new Fixture
+
+      Given("an existing task")
+      f.taskTracker.task(f.existingTask.taskId) returns Future.successful(Some(f.existingTask))
+
+      When("A TASK_LOST update is received with a reason indicating it might come back")
+      val stateOp = TaskStatusUpdateTestHelper.lost(reason, f.existingTask).wrapped.stateOp
+      val stateChange = f.stateOpResolver.resolve(stateOp).futureValue
+
+      Then("taskTracker.task is called")
+      verify(f.taskTracker).task(f.existingTask.taskId)
+
+      And("the result is an Update")
+      stateChange shouldBe a[TaskStateChange.Update]
+
+      And("the new state should have the correct status")
+      val update: TaskStateChange.Update = stateChange.asInstanceOf[TaskStateChange.Update]
+      update.newState.mesosStatus should not be empty
+      update.newState.mesosStatus.get.getState shouldEqual mesos.Protos.TaskState.TASK_LOST
+
+      And("there are no more interactions")
+      f.verifyNoMoreInteractions()
+    }
+  }
+
+  for (
+    reason <- MesosTaskStatus.WontComeBack
+  ) {
+    test(s"a TASK_LOST update with $reason indicating a task won't come back is mapped to an expunge") {
+      val f = new Fixture
+
+      Given("an existing task")
+      f.taskTracker.task(f.existingTask.taskId) returns Future.successful(Some(f.existingTask))
+
+      When("A TASK_LOST update is received with a reason indicating it won't come back")
+      val stateOp: TaskStateOp.MesosUpdate = TaskStatusUpdateTestHelper.lost(reason, f.existingTask).wrapped.stateOp.asInstanceOf[TaskStateOp.MesosUpdate]
+      val stateChange = f.stateOpResolver.resolve(stateOp).futureValue
+
+      Then("taskTracker.task is called")
+      verify(f.taskTracker).task(f.existingTask.taskId)
+
+      And("the result is an Expunge")
+      stateChange shouldBe a[TaskStateChange.Expunge]
+      val expectedState = f.existingTask.copy(
+        status = f.existingTask.status.copy(
+          mesosStatus = stateOp.status.mesosStatus))
+      stateChange shouldEqual TaskStateChange.Expunge(expectedState)
+
+      And("there are no more interactions")
+      f.verifyNoMoreInteractions()
+    }
+  }
+
+  test("a subsequent TASK_LOST update with another reason is mapped to a noop and will not update the timestamp") {
+    val f = new Fixture
+
+    Given("an existing lost task")
+    f.taskTracker.task(f.existingLostTask.taskId) returns Future.successful(Some(f.existingLostTask))
+
+    When("A subsequent TASK_LOST update is received")
+    val reason = mesos.Protos.TaskStatus.Reason.REASON_SLAVE_DISCONNECTED
+    val stateOp: TaskStateOp.MesosUpdate = TaskStatusUpdateTestHelper.lost(reason, f.existingLostTask).wrapped.stateOp.asInstanceOf[TaskStateOp.MesosUpdate]
+    val stateChange = f.stateOpResolver.resolve(stateOp).futureValue
+
+    Then("taskTracker.task is called")
+    verify(f.taskTracker).task(f.existingLostTask.taskId)
+
+    And("the result is an noop")
+    stateChange shouldBe a[TaskStateChange.NoChange]
     And("there are no more interactions")
     f.verifyNoMoreInteractions()
   }
@@ -160,6 +238,7 @@ class TaskStateOpResolverTest
     val existingTask = MarathonTestHelper.mininimalTask(appId)
     val existingReservedTask = MarathonTestHelper.residentReservedTask(appId)
     val notExistingTaskId = Task.Id.forApp(appId)
+    val existingLostTask = MarathonTestHelper.mininimalLostTask(appId)
 
     def verifyNoMoreInteractions(): Unit = {
       noMoreInteractions(taskTracker)

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActorTest.scala
@@ -105,7 +105,7 @@ class TaskTrackerActorTest
 
     When("staged task gets deleted")
     val probe = TestProbe()
-    val stagedUpdate = TaskStatusUpdateTestHelper.lost(stagedTaskState).wrapped
+    val stagedUpdate = TaskStatusUpdateTestHelper.killed(stagedTaskState).wrapped
     val stagedAck = TaskTrackerActor.Ack(probe.ref, stagedUpdate.stateChange)
     probe.send(f.taskTrackerActor, TaskTrackerActor.StateChanged(stagedUpdate, stagedAck))
     probe.expectMsg(TaskStateChange.Expunge(stagedTaskState))
@@ -115,7 +115,7 @@ class TaskTrackerActorTest
     f.actorMetrics.stagedCount.getValue should be(0)
 
     When("running task gets deleted")
-    val runningUpdate = TaskStatusUpdateTestHelper.lost(runningTask1State).wrapped
+    val runningUpdate = TaskStatusUpdateTestHelper.killed(runningTask1State).wrapped
     val runningAck = TaskTrackerActor.Ack(probe.ref, stagedUpdate.stateChange)
     probe.send(f.taskTrackerActor, TaskTrackerActor.StateChanged(runningUpdate, runningAck))
     probe.expectMsg(())

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.Mockito
 import mesosphere.marathon.{ MarathonSchedulerDriverHolder, MarathonSpec, MarathonTestHelper }
+import org.apache.mesos.Protos.TaskStatus
 import org.apache.mesos.SchedulerDriver
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ GivenWhenThen, Matchers }
@@ -76,7 +77,7 @@ class TaskStatusUpdateProcessorImplTest
   test("update for unknown task (TASK_LOST) will get only acknowledged") {
     fOpt = Some(new Fixture)
 
-    val origUpdate = TaskStatusUpdateTestHelper.lost()
+    val origUpdate = TaskStatusUpdateTestHelper.lost(TaskStatus.Reason.REASON_RECONCILIATION)
     val status = origUpdate.status
     val update = origUpdate
     val taskId = update.wrapped.stateOp.taskId

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -101,8 +101,9 @@ class AppDeployIntegrationTest
     deployment2.code should be (200) //Created
 
     And("the task eventually fails AGAIN")
-    val events2 = waitForEvents("status_update_event", "status_update_event")()
+    val events2 = waitForEvents("status_update_event", "status_update_event", "status_update_event")()
     val statuses2 = events2.values.flatMap(_.map(_.info("taskStatus")))
+    statuses2 should contain("TASK_STAGING")
     statuses2 should contain("TASK_RUNNING")
     statuses2 should contain("TASK_FAILED")
   }
@@ -124,8 +125,9 @@ class AppDeployIntegrationTest
     result.code should be(201) //Created
 
     And("the task eventually fails")
-    val events = waitForEvents("status_update_event", "status_update_event")()
+    val events = waitForEvents("status_update_event", "status_update_event", "status_update_event")()
     val statuses = events.values.flatMap(_.map(_.info("taskStatus")))
+    statuses should contain("TASK_STAGING")
     statuses should contain("TASK_RUNNING")
     statuses should contain("TASK_FAILED")
 

--- a/src/test/scala/mesosphere/marathon/integration/TaskLostIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/TaskLostIntegrationTest.scala
@@ -1,0 +1,122 @@
+package mesosphere.marathon.integration
+
+import mesosphere.marathon.integration.facades.ITEnrichedTask
+import mesosphere.marathon.integration.setup._
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
+
+import scala.concurrent.duration._
+
+class TaskLostIntegrationTest extends IntegrationFunSuite with WithMesosCluster with Matchers with GivenWhenThen with BeforeAndAfter {
+
+  before {
+    cleanUp()
+    if (ProcessKeeper.hasProcess(slave2)) stopMesos(slave2)
+    if (ProcessKeeper.hasProcess(master2)) stopMesos(master2)
+    if (!ProcessKeeper.hasProcess(master1)) startMaster(master1)
+    if (!ProcessKeeper.hasProcess(slave1)) startSlave(slave1)
+  }
+
+  test("A task lost with mesos master failover will not kill the task") {
+    Given("a new app")
+    val app = appProxy(testBasePath / "app", "v1", instances = 1, withHealth = false)
+    marathon.createAppV2(app)
+    waitForEvent("deployment_success")
+    val task = waitForTasks(app.id, 1).head
+
+    When("We stop the slave, the task is declared lost")
+    stopMesos(slave1)
+    waitForEventMatching("Task is declared lost") { matchEvent("TASK_LOST", task) }
+
+    And("The task is not removed from the task list")
+    val lost = waitForTasks(app.id, 1).head
+    lost.state should be("TASK_LOST")
+
+    When("We do a Mesos Master failover and start the slave again")
+    startMaster(master2, wipe = false)
+    stopMesos(master1)
+    startSlave(slave1, wipe = false)
+
+    Then("The task reappears as running")
+    waitForEventMatching("Task is declared running again") { matchEvent("TASK_RUNNING", task) }
+  }
+
+  test("A task lost with mesos master failover will start a replacement task") {
+    Given("a new app")
+    val app = appProxy(testBasePath / "app", "v1", instances = 1, withHealth = false)
+    marathon.createAppV2(app)
+    waitForEvent("deployment_success")
+    val task = waitForTasks(app.id, 1).head
+
+    When("We stop the slave, the task is declared lost")
+    stopMesos(slave1)
+    startSlave(slave2, wipe = false)
+    waitForEventMatching("Task is declared lost") { matchEvent("TASK_LOST", task) }
+
+    And("A replacement task is started")
+    waitForEventWith("status_update_event", _.info("taskStatus") == "TASK_RUNNING")
+    val tasks = marathon.tasks(app.id).value
+    tasks should have size 2
+    tasks.groupBy(_.state).keySet should be(Set("TASK_RUNNING", "TASK_LOST"))
+    val replacement = tasks.find(_.state == "TASK_RUNNING").get
+
+    When("We do a Mesos Master failover and start the slave again")
+    startMaster(master2, wipe = false)
+    stopMesos(master1)
+    startSlave(slave1, wipe = false)
+
+    Then("The task reappears as running and the replacement is killed")
+    var isRunning = false
+    var isKilled = false
+    waitForEventMatching("Original task is running and replacement task is killed") { event =>
+      isRunning |= matchEvent("TASK_RUNNING", task)(event)
+      isKilled |= matchEvent("TASK_KILLED", replacement)(event)
+      isRunning && isKilled
+    }
+    waitForTasks(app.id, 1).head should be(task)
+  }
+
+  test("A task lost with mesos master failover will expunge the task after gc timeout") {
+    Given("a new app")
+    val app = appProxy(testBasePath / "app", "v1", instances = 1, withHealth = false)
+    marathon.createAppV2(app)
+    waitForEvent("deployment_success")
+    val task = waitForTasks(app.id, 1).head
+
+    When("We stop the slave, the task is declared lost")
+    stopMesos(slave1)
+    startSlave(slave2, wipe = false)
+    waitForEventMatching("Task is declared lost") { matchEvent("TASK_LOST", task) }
+
+    Then("The task is killed due to GC timeout and a replacement is started")
+    val marathonName = ProcessKeeper.processNames.find(_.startsWith("marathon")).getOrElse(fail("no Marathon process found"))
+    waitForProcessLogMessage(marathonName, maxWait = 1.minute) { line =>
+      line.contains(task.id) && line.contains("will be expunged")
+    }
+    val replacement = waitForTasks(app.id, 1).head
+    replacement should not be task
+  }
+
+  //override to start marathon with a low reconciliation frequency
+  override def startMarathon(port: Int, ignore: String*): Unit = {
+    val args = List(
+      "--master", config.master,
+      "--event_subscriber", "http_callback",
+      "--access_control_allow_origin", "*",
+      "--reconciliation_initial_delay", "5000",
+      "--reconciliation_interval", "5000",
+      "--scale_apps_initial_delay", "5000",
+      "--scale_apps_interval", "5000",
+      "--min_revive_offers_interval", "100",
+      "--task_lost_expunge_gc", "30000",
+      "--task_lost_expunge_initial_delay", "1000",
+      "--task_lost_expunge_interval", "1000"
+    ) ++ extraMarathonParameters
+    super.startMarathon(port, args: _*)
+  }
+
+  def matchEvent(status: String, task: ITEnrichedTask): CallbackEvent => Boolean = { event =>
+    event.info.get("taskStatus").contains(status) &&
+      event.info.get("taskId").contains(task.id)
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -40,6 +40,7 @@ case class ITEnrichedTask(
     ipAddresses: Option[Seq[IpAddress]],
     startedAt: Option[Date],
     stagedAt: Option[Date],
+    state: String,
     version: Option[String]) {
 
   def launched: Boolean = startedAt.nonEmpty
@@ -95,8 +96,9 @@ class MarathonFacade(url: String, baseGroup: PathId, waitTime: Duration = 30.sec
     (__ \ "ipAddresses").formatNullable[Seq[IpAddress]] ~
     (__ \ "startedAt").formatNullable[Date] ~
     (__ \ "stagedAt").formatNullable[Date] ~
+    (__ \ "state").format[String] ~
     (__ \ "version").formatNullable[String]
-  )(ITEnrichedTask(_, _, _, _, _, _, _, _), unlift(ITEnrichedTask.unapply))
+  )(ITEnrichedTask(_, _, _, _, _, _, _, _, _), unlift(ITEnrichedTask.unapply))
 
   def isInBaseGroup(pathId: PathId): Boolean = {
     pathId.path.startsWith(baseGroup.path)

--- a/src/test/scala/mesosphere/marathon/integration/setup/ProcessKeeper.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ProcessKeeper.scala
@@ -59,8 +59,16 @@ object ProcessKeeper {
     FileUtils.deleteDirectory(mesosWorkDirFile)
     FileUtils.forceMkdir(mesosWorkDirFile)
 
-    val credentialsPath = write(mesosWorkDirFile, fileName = "credentials", content = "principal1 secret1")
-    val aclsPath = write(mesosWorkDirFile, fileName = "acls.json", content =
+    val mesosEnv = setupMesosEnv(mesosWorkDirFile, mesosWorkDirForMesos)
+    startProcess(
+      "mesos",
+      Process(Seq("mesos-local", "--ip=127.0.0.1"), cwd = None, mesosEnv: _*),
+      upWhen = _.toLowerCase.contains("registered with master"))
+  }
+
+  def setupMesosEnv(workDirFile: File, workDir: String, containerizers: String = "docker,mesos") = {
+    val credentialsPath = write(workDirFile, fileName = "credentials", content = "principal1 secret1")
+    val aclsPath = write(workDirFile, fileName = "acls.json", content =
       """
         |{
         |  "run_tasks": [{
@@ -84,18 +92,25 @@ object ProcessKeeper {
         |}
       """.stripMargin)
 
-    log.info(s">>> credentialsPath = $credentialsPath")
-    val mesosEnv = Seq(
-      ENV_MESOS_WORK_DIR -> mesosWorkDirForMesos,
+    Seq(
+      ENV_MESOS_WORK_DIR -> workDir,
       "MESOS_LAUNCHER" -> "posix",
-      "MESOS_CONTAINERIZERS" -> "docker,mesos",
+      "MESOS_CONTAINERIZERS" -> containerizers,
       "MESOS_ROLES" -> "public,foo",
       "MESOS_ACLS" -> s"file://$aclsPath",
       "MESOS_CREDENTIALS" -> s"file://$credentialsPath")
+  }
+
+  def startMesos(processName: String, workDir: String, args: Seq[String], startMessage: String, wipe: Boolean): Process = {
+    val workDirFile: File = new File(workDir)
+    if (wipe) FileUtils.deleteDirectory(workDirFile)
+    FileUtils.forceMkdir(workDirFile)
+
+    val mesosEnv = setupMesosEnv(workDirFile, workDir, containerizers = "mesos")
     startProcess(
-      "mesos",
-      Process(Seq("mesos-local", "--ip=127.0.0.1"), cwd = None, mesosEnv: _*),
-      upWhen = _.toLowerCase.contains("registered with master"))
+      processName,
+      Process(args, cwd = None, mesosEnv: _*),
+      upWhen = _.toLowerCase.contains(startMessage))
   }
 
   def startMarathon(cwd: File, env: Map[String, String], arguments: List[String],
@@ -163,6 +178,7 @@ object ProcessKeeper {
     val logger = new ProcessLogger {
       def checkUp(out: String) = {
         log.info(s"$name: $out")
+        checkLogFunctions.get(name).foreach(fn => fn.apply(out))
         if (!up.isCompleted && upWhen(out)) up.trySuccess(ProcessIsUp)
       }
       override def buffer[T](f: => T): T = f
@@ -229,29 +245,34 @@ object ProcessKeeper {
   def stopProcess(name: String): Unit = {
     import mesosphere.util.ThreadPoolContext.ioContext
     log.info(s"Stop Process $name")
-    val process = processes(name)
-    def killProcess: Int = {
-      // Unfortunately, there seem to be race conditions in Process.exitValue.
-      // Thus this ugly workaround.
-      Await.result(Future {
-        scala.concurrent.blocking {
-          Try(process.destroy())
-          process.exitValue()
-        }
-      }, 5.seconds)
+    processes.get(name).foreach { process =>
+      def killProcess: Int = {
+        // Unfortunately, there seem to be race conditions in Process.exitValue.
+        // Thus this ugly workaround.
+        Await.result(Future {
+          scala.concurrent.blocking {
+            Try(process.destroy())
+            process.exitValue()
+          }
+        }, 5.seconds)
+      }
+      //retry on fail
+      Try(killProcess) recover { case _ => killProcess } match {
+        case Success(value)       => processes -= name
+        case Failure(NonFatal(e)) => log.error("giving up waiting for processes to finish", e)
+      }
+      log.info(s"Stop Process $name: Done")
     }
-    //retry on fail
-    Try(killProcess) recover { case _ => killProcess } match {
-      case Success(value)       => processes -= name
-      case Failure(NonFatal(e)) => log.error("giving up waiting for processes to finish", e)
-    }
-    log.info(s"Stop Process $name: Done")
   }
 
   def stopAllProcesses(): Unit = {
     processes.keys.toSeq.reverse.foreach(stopProcess)
     processes = ListMap.empty
   }
+
+  def hasProcess(name: String): Boolean = processes.contains(name)
+
+  def processNames: Set[String] = processes.keySet
 
   def startService(service: Service): Unit = {
     services ::= service
@@ -268,6 +289,14 @@ object ProcessKeeper {
     }
     services = Nil
   }
+
+  /**
+    * Check log functions are used to analyze the output of the process.
+    * See SingleMarathonIntegrationTest.waitForProcessLogMessage
+    */
+  var checkLogFunctions: Map[String, String => Boolean] = Map.empty
+  def addCheck(process: String, fn: String => Boolean): Unit = checkLogFunctions += process -> fn
+  def removeCheck(process: String) = checkLogFunctions -= process
 
   def shutdown(): Unit = {
     log.info(s"Cleaning up Processes $processes and Services $services")

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -76,9 +76,13 @@ trait SingleMarathonIntegrationTest
     ProcessKeeper.startZooKeeper(port, path, wipeWorkDir)
   }
 
+  protected def startMesos(): Unit = ProcessKeeper.startMesosLocal()
+
+  protected def createConfig(configMap: ConfigMap): IntegrationTestConfig = IntegrationTestConfig(configMap)
+
   override protected def beforeAll(configMap: ConfigMap): Unit = {
     log.info("Setting up local mesos/marathon infrastructure...")
-    configOption = Some(IntegrationTestConfig(configMap))
+    configOption = Some(createConfig(configMap))
     super.beforeAll(configMap)
 
     if (!config.useExternalSetup) {
@@ -87,7 +91,7 @@ trait SingleMarathonIntegrationTest
 
       log.info("Setting up local mesos/marathon infrastructure...")
       startZooKeeperProcess()
-      ProcessKeeper.startMesosLocal()
+      startMesos()
       cleanMarathonState()
 
       startMarathon(config.marathonBasePort, marathonParameters: _*)
@@ -135,6 +139,24 @@ trait SingleMarathonIntegrationTest
       if (tasks.size == num) Some(tasks) else None
     }
     WaitTestSupport.waitFor(s"$num tasks to launch", maxWait)(checkTasks)
+  }
+
+  def waitForProcessLogMessage(process: String, maxWait: FiniteDuration = 30.seconds)(messageFn: String => Boolean): String = {
+    var result: Option[String] = None
+    def message(log: String) = {
+      if (messageFn(log)) {
+        result = Some(log)
+        true
+      }
+      else false
+    }
+    try {
+      ProcessKeeper.addCheck(process, message)
+      WaitTestSupport.waitFor(s"Log message in process $process", maxWait)(result)
+    }
+    finally {
+      ProcessKeeper.removeCheck(process)
+    }
   }
 
   def waitForHealthCheck(check: IntegrationHealthCheck, maxWait: FiniteDuration = 30.seconds) = {

--- a/src/test/scala/mesosphere/marathon/integration/setup/WithMesosCluster.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/WithMesosCluster.scala
@@ -1,0 +1,57 @@
+package mesosphere.marathon.integration.setup
+
+import java.io.File
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.{ ConfigMap, Suite }
+import org.slf4j.LoggerFactory
+
+import scala.collection.concurrent.TrieMap
+
+trait WithMesosCluster extends SingleMarathonIntegrationTest { self: Suite =>
+  import WithMesosCluster.log
+
+  override protected def createConfig(configMap: ConfigMap): IntegrationTestConfig = {
+    val cfg = super.createConfig(configMap)
+    cfg.copy(master = s"zk://${cfg.zkHostAndPort}/mesos")
+  }
+
+  val mesosWorkDir = "/tmp/marathon-itest-mesos"
+  val master1: String = "master1"
+  val master2: String = "master2"
+  val slave1: String = "slave1"
+  val slave2: String = "slave2"
+
+  private val ports: TrieMap[String, Int] = TrieMap.empty
+  private val portIt = Range(50050, Int.MaxValue).iterator
+  def processPort(name: String): Int = ports.getOrElseUpdate(name, portIt.next())
+
+  /**
+    * TODO: implement me if we need this for mesos cluster support
+    */
+  override def waitForCleanSlateInMesos(): Boolean = {
+    log.warn("Will NOT wait for clean Mesos slate; mesos cluster support is not yet implemented.")
+    true
+  }
+
+  def startMaster(name: String, wipe: Boolean = true): Unit = {
+    val masterArgs = Seq("--slave_ping_timeout=1secs", "--max_slave_ping_timeouts=4", "--quorum=1")
+    ProcessKeeper.startMesos(name, s"$mesosWorkDir/$name", Seq("mesos", "master", s"--zk=zk://${config.zkHostAndPort}/mesos", s"--work_dir=$mesosWorkDir/$name", s"--port=${processPort(name)}") ++ masterArgs, "new candidate", wipe)
+  }
+
+  def startSlave(name: String, wipe: Boolean = true): Unit = {
+    ProcessKeeper.startMesos(name, s"$mesosWorkDir/$name", Seq("mesos", "slave", "--no-systemd_enable_support", s"--master=zk://${config.zkHostAndPort}/mesos", s"--work_dir=$mesosWorkDir/$name", s"--port=${processPort(name)}"), "registered with master", wipe)
+  }
+
+  def stopMesos(name: String): Unit = ProcessKeeper.stopProcess(name)
+
+  override protected def startMesos(): Unit = {
+    FileUtils.deleteDirectory(new File(mesosWorkDir))
+    startMaster(master1)
+    startSlave(slave1)
+  }
+}
+
+object WithMesosCluster {
+  val log = LoggerFactory.getLogger(getClass)
+}


### PR DESCRIPTION
…timeout.

The lost task is killed after a configurable timeout.

Conflicts:
	docs/docs/command-line-flags.md
	src/main/scala/mesosphere/marathon/MarathonConf.scala
	src/main/scala/mesosphere/marathon/MarathonScheduler.scala
	src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
	src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
	src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
	src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
	src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
	src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
	src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskOpProcessorImpl.scala
	src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerDelegate.scala
	src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
	src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
	src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
	src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
	src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
	src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
	src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
	src/test/scala/mesosphere/marathon/core/launcher/impl/LaunchQueueTestHelper.scala
	src/test/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActorTest.scala
	src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
	src/test/scala/mesosphere/marathon/core/task/tracker/impl/StatusUpdateActionResolverTest.scala
	src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
	src/test/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImplTest.scala
	src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala