### PR TITLE
Fixed tomcat distro uri in deploy example

### DIFF
--- a/examples/Tomcat.json
+++ b/examples/Tomcat.json
@@ -5,7 +5,7 @@
   "cpus": 1.0,
   "instances": 1,
   "uris": [
-    "http://www.us.apache.org/dist/tomcat/tomcat-7/v7.0.68/bin/apache-tomcat-7.0.68.tar.gz",
+    "http://www-us.apache.org/dist/tomcat/tomcat-7/v7.0.69/bin/apache-tomcat-7.0.69.tar.gz",
     "https://gwt-examples.googlecode.com/files/Calendar.war"
   ]
 }


### PR DESCRIPTION
Currently link points to 404 page, therefore this change