### PR TITLE
Add line in doc that we permit regex, but remind users to use .*

### DIFF
--- a/docs/docs/constraints.md
+++ b/docs/docs/constraints.md
@@ -24,6 +24,8 @@ Attribute field supports all operators of Marathon.
 
 Marathon supports text, scalar, range, and set attribute values. For scalars, ranges, and sets Marathon will perform a string comparison on the formatted values. The format matches that of the Mesos attribute formatting. For ranges and sets, the format is `[begin-end,...]` and `{item,...}` respectively. For example, you might have a range formatted as `[100-200]` and a set formatted as `{a,b,c}`.
 
+Regex is also allowed; to match ANY value, use the string `.*`.
+
 ## Operators
 
 ### UNIQUE operator

--- a/docs/docs/constraints.md
+++ b/docs/docs/constraints.md
@@ -24,7 +24,7 @@ Attribute field supports all operators of Marathon.
 
 Marathon supports text, scalar, range, and set attribute values. For scalars, ranges, and sets Marathon will perform a string comparison on the formatted values. The format matches that of the Mesos attribute formatting. For ranges and sets, the format is `[begin-end,...]` and `{item,...}` respectively. For example, you might have a range formatted as `[100-200]` and a set formatted as `{a,b,c}`.
 
-Regex is also allowed; to match ANY value, use the string `.*`.
+Regex is allowed for LIKE and UNLIKE operators; to match ANY value, use the string `.*`.
 
 ## Operators
 


### PR DESCRIPTION
A user noted that the regex value of `*` would produce unexpected results. This doc change advises users of the correct way to match ANY value. Partly fixes #3970 