### PR TITLE
Move `metrics/*.scala` from `java` package folder to `scala` package folder

### DIFF
--- a/src/main/scala/mesosphere/marathon/metrics/MetricPrefixes.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/MetricPrefixes.scala
@@ -1,5 +1,8 @@
 package mesosphere.marathon.metrics
 
+/**
+  * Created by nate on 6/11/16.
+  */
 object MetricPrefixes {
   /**
    * Metrics relating to our API.

--- a/src/main/scala/mesosphere/marathon/metrics/MetricPrefixes.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/MetricPrefixes.scala
@@ -1,8 +1,5 @@
 package mesosphere.marathon.metrics
 
-/**
-  * Created by nate on 6/11/16.
-  */
 object MetricPrefixes {
   /**
    * Metrics relating to our API.

--- a/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import com.codahale.metrics.{Gauge, MetricRegistry}
 import com.google.inject.Inject
-import mesosphere.marathon.metrics.Metrics.{ Histogram, Meter, Timer, Counter }
+import mesosphere.marathon.metrics.Metrics.{Counter, Histogram, Meter, Timer}
 import org.aopalliance.intercept.MethodInvocation
 
 import scala.collection.concurrent.TrieMap

--- a/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
@@ -3,9 +3,9 @@ package mesosphere.marathon.metrics
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.codahale.metrics.{Gauge, MetricRegistry}
+import com.codahale.metrics.{ Gauge, MetricRegistry }
 import com.google.inject.Inject
-import mesosphere.marathon.metrics.Metrics.{Counter, Histogram, Meter, Timer}
+import mesosphere.marathon.metrics.Metrics.{ Counter, Histogram, Meter, Timer }
 import org.aopalliance.intercept.MethodInvocation
 
 import scala.collection.concurrent.TrieMap

--- a/src/test/scala/mesosphere/marathon/core/election/impl/ElectionServiceBaseTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/election/impl/ElectionServiceBaseTest.scala
@@ -7,14 +7,13 @@ import com.codahale.metrics.MetricRegistry
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.core.base.ShutdownHooks
 import mesosphere.marathon.event.LocalLeadershipEvent
-import mesosphere.marathon.{MarathonTestHelper, MarathonSpec, MarathonConf}
+import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec, MarathonConf }
 import mesosphere.marathon.core.election.{ ElectionCandidate, ElectionService }
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.test.MarathonActorSupport
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.Mockito
-import org.rogach.scallop.ScallopOption
 import org.scalatest.{ GivenWhenThen, BeforeAndAfterAll, Matchers }
 
 import scala.concurrent.duration._

--- a/src/test/scala/mesosphere/mesos/ConstraintsTest.scala
+++ b/src/test/scala/mesosphere/mesos/ConstraintsTest.scala
@@ -5,11 +5,11 @@ import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.Protos.Constraint.Operator
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.AppDefinition
-import mesosphere.marathon.{MarathonSpec, MarathonTestHelper}
-import mesosphere.mesos.protos.{FrameworkID, OfferID, SlaveID, TextAttribute}
+import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
+import mesosphere.mesos.protos.{ FrameworkID, OfferID, SlaveID, TextAttribute }
 import org.apache.mesos.Protos
-import org.apache.mesos.Protos.{Attribute, Offer}
-import org.scalatest.{GivenWhenThen, Matchers}
+import org.apache.mesos.Protos.{ Attribute, Offer }
+import org.scalatest.{ GivenWhenThen, Matchers }
 
 import scala.collection.immutable.Seq
 import scala.collection.JavaConverters._
@@ -557,7 +557,7 @@ class ConstraintsTest extends MarathonSpec with GivenWhenThen with Matchers {
       makeOffer("foohost", Set(makeScalarAttribute("jdk", 7))), // slave attributes
       jdk7ConstraintCluster)
     assert(clusterVersionMet, "Should meet cluster-version constraints.")
-    
+
     val likeNoAttributeNotMet = Constraints.meetsConstraint(
       freshRack, // list of tasks register in the cluster
       makeOffer("foohost", Set()), // no slave attribute
@@ -653,7 +653,7 @@ class ConstraintsTest extends MarathonSpec with GivenWhenThen with Matchers {
       makeOffer("foohost", Set(makeSetAttribute("gpu", List("0", "1")))), // slave attributes
       jdk7ConstraintClusterSet)
     assert(clusterSetVersionMet, "Should meet cluster-set-version constraints.")
-    
+
     val likeSetNoAttributeNotMet = Constraints.meetsConstraint(
       freshRack, // list of tasks register in the cluster
       makeOffer("foohost", Set()), // no slave attribute


### PR DESCRIPTION
The files `Metrics.scala` and `MetricsPrefixes.scala` were misplaced in the `src/main/java/mesosphere/marathon/metrics` package folder. This commit puts them in `src/main/scala/mesosphere/marathon/metrics`.

Also made some minor adjustments to whitespace in the import statements of `ElectionServiceBaseTest.scala` and `ConstraintsTest.scala` so that it is consistent with the style of the rest of the codebase.