### PR TITLE
allow health-checks to be performed directly against specified ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/run-tests-config.sh
+.ensime*
 .idea
 *.iml
 docker-volumes

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -639,7 +639,7 @@ object AppDefinition {
     isTrue("Health check port indices must address an element of the ports array or container port mappings.") { hc =>
       hc.protocol == Protocol.COMMAND || (hc.portIndex match {
         case Some(idx) => hostPortsIndices contains idx
-        case None      => hostPortsIndices.length == 1 && hostPortsIndices.head == 0
+        case None      => hc.port.nonEmpty || (hostPortsIndices.length == 1 && hostPortsIndices.head == 0)
       })
     }
 

--- a/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidatorTest.scala
@@ -550,6 +550,31 @@ class AppDefinitionValidatorTest extends MarathonSpec with Matchers with GivenWh
     AppDefinition.validAppDefinition(to3).isSuccess shouldBe true
   }
 
+  test("health check validation should allow port specifications without port indices") {
+    Given("A docker app with no portDefinitions and HTTP health checks")
+
+    val app1 = AppDefinition(
+      container = Some(
+        Container(docker = Some(
+          Container.Docker(
+            "group/image",
+            network = Some(mesos.ContainerInfo.DockerInfo.Network.HOST)
+          )))
+      ),
+      portDefinitions = List.empty,
+      healthChecks = Set(
+        HealthCheck(
+          path = Some("/"),
+          protocol = Protos.HealthCheckDefinition.Protocol.HTTP,
+          port = Some(8000),
+          portIndex = None
+        )
+      )
+    )
+    Then("validation succeeds")
+    AppDefinition.validAppDefinition(app1).isSuccess shouldBe true
+  }
+
   test("cassandraWithoutResidency") {
     import Formats._
 


### PR DESCRIPTION
When using a macvlan IP, or a vlan such a weave, it is possible for Docker containers to be assigned an IP address which is reachable from Marathon. When creating app definitions via the Marathon API, it's possible to specify the `ipAddress` setting, which informs Marathon that an IP Address will be allocated for the container. However, it was not possible to enable HTTP health-checks directly against said container's IP address because of validation restrictions.

This change addresses that issue.

https://github.com/mesosphere/marathon/issues/3591