### PR TITLE
Fixes #3991 - Use suppressOffers

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActorTest.scala
@@ -186,6 +186,9 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen with Matcher
 
     Then("we cancel the timer")
     Mockito.verify(f.actorRef.underlyingActor.cancellable, Mockito.timeout(1000)).cancel()
+
+    Then("we suppress offers")
+    Mockito.verify(f.driver, Mockito.timeout(1000)).suppressOffers()
     f.verifyNoMoreInteractions()
   }
 


### PR DESCRIPTION
When we don't want any more offers, we ask mesos to suppress
them. This alleviates load on the allocator, and acts as an
infinite duration filter for all agents until the next time
we call `Revive`.