### PR TITLE
Let a TaskStateChange.Expunge carry the updated mesosState

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -121,7 +121,8 @@ object Task {
 
       // case 2: terminal
       case TaskStateOp.MesosUpdate(_, MarathonTaskStatus.Terminal(_), now) =>
-        TaskStateChange.Expunge(this)
+        val updated = copy(status = status.copy(mesosStatus = mesosStatus))
+        TaskStateChange.Expunge(updated)
 
       // case 3: health or state updated
       case TaskStateOp.MesosUpdate(_, taskStatus, now) =>


### PR DESCRIPTION
In case of state change triggered by a terminal Mesos status update, the Expunge should contain the task with updated Mesos TaskStatus

This helps deriving the actual state of the task when looking at the combination of StateChangeOp and TaskStateChange. 