### PR TITLE
Make the QueuedTaskInfo a public class

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -12,7 +12,7 @@ object LaunchQueue {
   /**
     * @param runSpec the currently used runSpec
     */
-  protected[marathon] case class QueuedTaskInfo(
+  case class QueuedTaskInfo(
     runSpec: RunSpec,
     inProgress: Boolean,
     tasksLeftToLaunch: Int,


### PR DESCRIPTION
There is no reason to have it package protected and I need to mock this in a derived component.