### PR TITLE
WIP: virtual networking for Docker containers

### DIFF
--- a/docs/docs/ports.md
+++ b/docs/docs/ports.md
@@ -10,23 +10,25 @@ If you are running Marathon within a [DC/OS cluster](https://dcos.io/get-started
 
 ## Definitions
 
-*containerPort*: A _container port_ specifies a port within a container. This is only necessary as part of a _port mapping_ when using `BRIDGE` mode networking with a Docker container.
+*containerPort*: A _container port_ specifies a port within a container. This is only necessary as part of a _port mapping_ when using `BRIDGE` or `USER` mode networking with a Docker container.
 
-*hostPort*: A _host port_ specifies a port on the host to bind to. When used with `BRIDGE` mode networking, you specify a _port mapping_ from a _host port_ to a _container port_. In `HOST` networking, requested ports are _host ports_ by default. Note that only _host ports_ are made available to a task through environment variables.
+*hostPort*: A _host port_ specifies a port on the host to bind to. When used with `BRIDGE` or `USER` mode networking, you specify a _port mapping_ from a _host port_ to a _container port_. In `HOST` networking, requested ports are _host ports_ by default. Note that only _host ports_ are made available to a task through environment variables.
 
-*BRIDGE networking*: `BRIDGE` mode networking is used by Docker applications that specify `BRIDGE` mode networking. In this mode, container ports (a port within the container) are mapped to host ports (a port on the host machine). In this mode, applications bind to the specified ports within the container and Docker networking binds to the specified ports on the host.
+*BRIDGE networking*: used by Docker applications that specify `BRIDGE` mode networking. In this mode, container ports (a port within the container) are mapped to host ports (a port on the host machine). In this mode, applications bind to the specified ports within the container and Docker networking binds to the specified ports on the host.
 
-*HOST networking*: `HOST` networking is used by non-Docker Marathon applications and Docker applications that use `HOST` mode networking. In this mode, applications bind directly to one or more ports on the host machine.
+*USER networking*: used by Docker applications that specify `USER` mode networking. In this mode, container ports (a port within the container) are mapped to host ports (a port on the host machine). In this mode, applications bind to the specified ports within the container and Docker networking binds to the specified ports on the host. `USER` network mode is expected to be useful when integrating with "user-defined" Docker networks. In the Mesos world such networks are often made accessible via CNI plugins used in concert with a Mesos CNI network isolator.
 
-*portMapping*: In Docker `BRIDGE` mode, a port mapping is necessary for every port that should be reachable from outside of your container. A port mapping is a tuple containing a host port, container port, service port and protocol. Multiple _port mappings_ may be specified for a Marathon application.
+*HOST networking*: used by non-Docker Marathon applications and Docker applications that use `HOST` mode networking. In this mode, applications bind directly to one or more ports on the host machine.
+
+*portMapping*: In Docker `BRIDGE` mode, a port mapping is necessary for every port that should be reachable from outside of your container. A port mapping is a tuple containing a host port, container port, service port and protocol. Multiple _port mappings_ may be specified for a Marathon application; an unspecified `hostPort` defaults to `0` (meaning that Marathon will assign one at random). In Docker `USER` mode the semantic for `hostPort` slightly changes: `hostPort` is not required for `USER` mode and if left unspecified Marathon WILL NOT automatically allocate one at random. This allows containers to be deployed on `USER` networks that include `containerPort` and discovery information, but do NOT expose those ports on the host network (and by implication would not consume host port resources).
 
 *ports*: The _ports_ array is used to define ports that should be considered as part of a resource offer in `HOST` mode. It is necessary only if no port mappings are specified. Only one of _ports_ and _portDefinitions_ should be defined for an application.
 
 *portDefinitions*: The _portDefinitions_ array is used to define ports that should be considered as part of a resource offer. It is necessary only to define this array if you are using `HOST` networking and no port mappings are specified. This array is meant to replace the _ports_ array, and makes it possible to specify a port name, protocol and labels. Only one of _ports_ and _portDefinitions_ should be defined for an application.
 
-*protocol*: _Protocol_ specifies the internet protocol to use for a port (e.g. `tcp`, `udp` or `udp,tcp` for both). This is only necessary as part of a _port mapping_ when using `BRIDGE` mode networking with a Docker container.
+*protocol*: _Protocol_ specifies the internet protocol to use for a port (e.g. `tcp`, `udp` or `udp,tcp` for both). This is only necessary as part of a _port mapping_ when using `BRIDGE` or `USER` mode networking with a Docker container.
 
-*requirePorts*: _requirePorts_ is a property that specifies whether Marathon should specifically look for specified ports in the resource offers it receives. This ensures that these ports are free and available to be bound to on the Mesos agent. This does not apply to `BRIDGE` mode networking.
+*requirePorts*: _requirePorts_ is a property that specifies whether Marathon should specifically look for specified ports in the resource offers it receives. This ensures that these ports are free and available to be bound to on the Mesos agent. This does not apply to `BRIDGE` or `USER` mode networking.
 
 *servicePort*: A _service port_ is a port used to describe the port that a service should made available at. Marathon does not bind to the service ports specified but will ensure that you cannot have multiple applications that use the same service port running on the same host. Service ports are typically only used by external applications (e.g. HAProxy) to make the application available at the specified port. See [Service Discovery & Load Balancing](service-discovery-load-balancing.html) for more information.
 
@@ -38,7 +40,7 @@ Using the value 0 for any port settings indicates to Marathon that you would lik
 
 Each *host port* value is exposed to the running application instance via environment variables `$PORT0`, `$PORT1`, etc. Each Marathon application is given a single port by default, so `$PORT0` is always available. These variables are available inside a Docker container being run by Marathon too. Additionally, if the port is named `NAME`, it will also be accessible via the environment variable, `$PORT_NAME`.
 
-When using `BRIDGE` mode networking, be sure to bind your application to the `containerPort`s you have specified in your `portMapping`s. However, if you have set `containerPort` to 0 then this will be the same as `hostPort` and you can use the `$PORT` environment variables.
+When using `BRIDGE` or `USER` mode networking, be sure to bind your application to the `containerPort`s you have specified in your `portMapping`s. However, if you have set `containerPort` to 0 then this will be the same as `hostPort` and you can use the `$PORT` environment variables.
 
 ## Example Configuration
 
@@ -170,6 +172,23 @@ You need to specify bridge mode through the `network` property:
       "network": "BRIDGE"
     }
   },
+```
+
+#### Enabling User Mode
+
+You need to specify user mode through the `network` property:
+
+```json
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "my-image:1.0",
+      "network": "USER"
+    }
+  },
+  "ipAddress": {
+    "networkName": "someUserNetwork"
+  }
 ```
 
 #### Specifying Ports

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
@@ -170,7 +170,7 @@ The port array currently serves multiple roles:
   for details.
 
 Since this is confusing, we recommend to configure ports assignment for Docker
-containers for `BRIDGE` networking in `container.docker.portMappings` instead, see
+containers for `BRIDGE` and `USER` networking in `container.docker.portMappings` instead, see
 [Docker Containers doc page]({{ site.baseurl }}/docs/native-docker.html#bridged-networking-mode)).
 
 Alternatively or if you use the Mesos Containerizer, pass zeros as port values to generate one or more arbitrary
@@ -197,7 +197,7 @@ The portDefinitions array currently serves multiple roles:
   See [Service Discovery Load Balancing doc page]({{ site.baseurl }}/docs/service-discovery-load-balancing.html)
   for details.
 
-Since this is confusing, we recommend to configure ports assignment for Docker containers for `BRIDGE` networking in
+Since this is confusing, we recommend to configure ports assignment for Docker containers for `BRIDGE` and `USER` networking in
 `container.docker.portMappings` instead, see [Docker Containers doc page]({{ site.baseurl }}/docs/native-docker.html#bridged-networking-mode)).
 
 Alternatively or if you use the Mesos Containerizer, pass zeros as port values to generate one or more arbitrary

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -90,8 +90,8 @@
             },
             "network": {
               "type": "string",
-              "description": "The networking mode, this container should operate in. One of BRIDGED|HOST|NONE",
-              "enum": ["BRIDGE", "HOST", "NONE"]
+              "description": "The networking mode, this container should operate in. One of BRIDGE|HOST|NONE|USER",
+              "enum": ["BRIDGE", "HOST", "NONE", "USER"]
             },
             "parameters": {
               "type": "array",
@@ -121,13 +121,13 @@
                 "properties": {
                   "containerPort": {
                     "type": "integer",
-                    "description": "Refers to the port the application listens to inside of the container. It is optional and now defaults to 0, in which case Marathon assigns the container port the same value as the assigned hostPort. This is especially useful for apps that advertise the port they are listening on to the outside world for P2P communication. Without containerPort: 0 they would erroneously advertise their private container port which is usually not the same as the externally visible host port.",
+                    "description": "Refers to the port the application listens to inside of the container. It is optional and defaults to 0. For each containerPort with a value of 0 Marathon assigns the containerPort the same value as the assigned hostPort. This is especially useful for apps that advertise the port they are listening on to the outside world for P2P communication. Without containerPort: 0 they would erroneously advertise their private container port which is usually not the same as the externally visible host port.",
                     "maximum": 65535,
                     "minimum": 0
                   },
                   "hostPort": {
                     "type": "integer",
-                    "description": "Retains the traditional meaning in Marathon, which is a random port from the range included in the Mesos resource offer. The resulting host ports for each task are exposed via the task details in the REST API and the Marathon web UI. hostPort is optional and defaults to 0.",
+                    "description": "Retains the traditional meaning in Marathon, which is a random port from the range included in the Mesos resource offer. The resulting host ports for each task are exposed via the task details in the REST API and the Marathon web UI. hostPort is optional. In BRIDGE mode it defaults to 0 if left unspecified. In USER mode an unspecified hostPort does not allocate a port from a Mesos offer.",
                     "maximum": 65535,
                     "minimum": 0
                   },

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -8,10 +8,10 @@ public final class Protos {
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
   }
-  public interface ConstraintOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Constraint)
-      com.google.protobuf.MessageOrBuilder {
+  public interface ConstraintOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required string field = 1;
     /**
      * <code>required string field = 1;</code>
      */
@@ -26,6 +26,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getFieldBytes();
 
+    // required .mesosphere.marathon.Constraint.Operator operator = 2;
     /**
      * <code>required .mesosphere.marathon.Constraint.Operator operator = 2;</code>
      */
@@ -35,6 +36,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.Constraint.Operator getOperator();
 
+    // optional string value = 3;
     /**
      * <code>optional string value = 3;</code>
      */
@@ -53,9 +55,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.Constraint}
    */
   public static final class Constraint extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.Constraint)
-      ConstraintOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements ConstraintOrBuilder {
     // Use Constraint.newBuilder() to construct.
     private Constraint(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -102,9 +103,8 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              field_ = bs;
+              field_ = input.readBytes();
               break;
             }
             case 16: {
@@ -119,9 +119,8 @@ public final class Protos {
               break;
             }
             case 26: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000004;
-              value_ = bs;
+              value_ = input.readBytes();
               break;
             }
           }
@@ -332,6 +331,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required string field = 1;
     public static final int FIELD_FIELD_NUMBER = 1;
     private java.lang.Object field_;
     /**
@@ -374,6 +374,7 @@ public final class Protos {
       }
     }
 
+    // required .mesosphere.marathon.Constraint.Operator operator = 2;
     public static final int OPERATOR_FIELD_NUMBER = 2;
     private mesosphere.marathon.Protos.Constraint.Operator operator_;
     /**
@@ -389,6 +390,7 @@ public final class Protos {
       return operator_;
     }
 
+    // optional string value = 3;
     public static final int VALUE_FIELD_NUMBER = 3;
     private java.lang.Object value_;
     /**
@@ -439,8 +441,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasField()) {
         memoizedIsInitialized = 0;
@@ -569,9 +570,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.Constraint}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Constraint)
-        mesosphere.marathon.Protos.ConstraintOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.ConstraintOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Constraint_descriptor;
@@ -714,6 +714,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required string field = 1;
       private java.lang.Object field_ = "";
       /**
        * <code>required string field = 1;</code>
@@ -727,12 +728,9 @@ public final class Protos {
       public java.lang.String getField() {
         java.lang.Object ref = field_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            field_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          field_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -790,6 +788,7 @@ public final class Protos {
         return this;
       }
 
+      // required .mesosphere.marathon.Constraint.Operator operator = 2;
       private mesosphere.marathon.Protos.Constraint.Operator operator_ = mesosphere.marathon.Protos.Constraint.Operator.UNIQUE;
       /**
        * <code>required .mesosphere.marathon.Constraint.Operator operator = 2;</code>
@@ -825,6 +824,7 @@ public final class Protos {
         return this;
       }
 
+      // optional string value = 3;
       private java.lang.Object value_ = "";
       /**
        * <code>optional string value = 3;</code>
@@ -838,12 +838,9 @@ public final class Protos {
       public java.lang.String getValue() {
         java.lang.Object ref = value_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            value_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          value_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -912,10 +909,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.Constraint)
   }
 
-  public interface HealthCheckDefinitionOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.HealthCheckDefinition)
-      com.google.protobuf.MessageOrBuilder {
+  public interface HealthCheckDefinitionOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;
     /**
      * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
      */
@@ -925,6 +922,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.HealthCheckDefinition.Protocol getProtocol();
 
+    // optional uint32 portIndex = 2;
     /**
      * <code>optional uint32 portIndex = 2;</code>
      */
@@ -934,6 +932,7 @@ public final class Protos {
      */
     int getPortIndex();
 
+    // optional uint32 gracePeriodSeconds = 3 [default = 15];
     /**
      * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
      */
@@ -943,6 +942,7 @@ public final class Protos {
      */
     int getGracePeriodSeconds();
 
+    // optional uint32 intervalSeconds = 4 [default = 10];
     /**
      * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
      */
@@ -952,6 +952,7 @@ public final class Protos {
      */
     int getIntervalSeconds();
 
+    // optional uint32 timeoutSeconds = 5 [default = 20];
     /**
      * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
      */
@@ -961,6 +962,7 @@ public final class Protos {
      */
     int getTimeoutSeconds();
 
+    // optional string path = 6 [default = "/"];
     /**
      * <code>optional string path = 6 [default = "/"];</code>
      *
@@ -987,6 +989,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getPathBytes();
 
+    // optional uint32 maxConsecutiveFailures = 7 [default = 3];
     /**
      * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
      */
@@ -996,6 +999,7 @@ public final class Protos {
      */
     int getMaxConsecutiveFailures();
 
+    // optional .mesos.CommandInfo command = 8;
     /**
      * <code>optional .mesos.CommandInfo command = 8;</code>
      */
@@ -1009,6 +1013,7 @@ public final class Protos {
      */
     org.apache.mesos.Protos.CommandInfoOrBuilder getCommandOrBuilder();
 
+    // optional bool ignoreHttp1xx = 9 [default = false];
     /**
      * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
      */
@@ -1018,6 +1023,7 @@ public final class Protos {
      */
     boolean getIgnoreHttp1Xx();
 
+    // optional uint32 port = 10;
     /**
      * <code>optional uint32 port = 10;</code>
      */
@@ -1031,9 +1037,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
    */
   public static final class HealthCheckDefinition extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.HealthCheckDefinition)
-      HealthCheckDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements HealthCheckDefinitionOrBuilder {
     // Use HealthCheckDefinition.newBuilder() to construct.
     private HealthCheckDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -1111,9 +1116,8 @@ public final class Protos {
               break;
             }
             case 50: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000020;
-              path_ = bs;
+              path_ = input.readBytes();
               break;
             }
             case 56: {
@@ -1284,6 +1288,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;
     public static final int PROTOCOL_FIELD_NUMBER = 1;
     private mesosphere.marathon.Protos.HealthCheckDefinition.Protocol protocol_;
     /**
@@ -1299,6 +1304,7 @@ public final class Protos {
       return protocol_;
     }
 
+    // optional uint32 portIndex = 2;
     public static final int PORTINDEX_FIELD_NUMBER = 2;
     private int portIndex_;
     /**
@@ -1314,6 +1320,7 @@ public final class Protos {
       return portIndex_;
     }
 
+    // optional uint32 gracePeriodSeconds = 3 [default = 15];
     public static final int GRACEPERIODSECONDS_FIELD_NUMBER = 3;
     private int gracePeriodSeconds_;
     /**
@@ -1329,6 +1336,7 @@ public final class Protos {
       return gracePeriodSeconds_;
     }
 
+    // optional uint32 intervalSeconds = 4 [default = 10];
     public static final int INTERVALSECONDS_FIELD_NUMBER = 4;
     private int intervalSeconds_;
     /**
@@ -1344,6 +1352,7 @@ public final class Protos {
       return intervalSeconds_;
     }
 
+    // optional uint32 timeoutSeconds = 5 [default = 20];
     public static final int TIMEOUTSECONDS_FIELD_NUMBER = 5;
     private int timeoutSeconds_;
     /**
@@ -1359,6 +1368,7 @@ public final class Protos {
       return timeoutSeconds_;
     }
 
+    // optional string path = 6 [default = "/"];
     public static final int PATH_FIELD_NUMBER = 6;
     private java.lang.Object path_;
     /**
@@ -1413,6 +1423,7 @@ public final class Protos {
       }
     }
 
+    // optional uint32 maxConsecutiveFailures = 7 [default = 3];
     public static final int MAXCONSECUTIVEFAILURES_FIELD_NUMBER = 7;
     private int maxConsecutiveFailures_;
     /**
@@ -1428,6 +1439,7 @@ public final class Protos {
       return maxConsecutiveFailures_;
     }
 
+    // optional .mesos.CommandInfo command = 8;
     public static final int COMMAND_FIELD_NUMBER = 8;
     private org.apache.mesos.Protos.CommandInfo command_;
     /**
@@ -1449,6 +1461,7 @@ public final class Protos {
       return command_;
     }
 
+    // optional bool ignoreHttp1xx = 9 [default = false];
     public static final int IGNOREHTTP1XX_FIELD_NUMBER = 9;
     private boolean ignoreHttp1Xx_;
     /**
@@ -1464,6 +1477,7 @@ public final class Protos {
       return ignoreHttp1Xx_;
     }
 
+    // optional uint32 port = 10;
     public static final int PORT_FIELD_NUMBER = 10;
     private int port_;
     /**
@@ -1494,8 +1508,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasProtocol()) {
         memoizedIsInitialized = 0;
@@ -1675,9 +1688,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.HealthCheckDefinition)
-        mesosphere.marathon.Protos.HealthCheckDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.HealthCheckDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor;
@@ -1892,6 +1904,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;
       private mesosphere.marathon.Protos.HealthCheckDefinition.Protocol protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
       /**
        * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
@@ -1927,6 +1940,7 @@ public final class Protos {
         return this;
       }
 
+      // optional uint32 portIndex = 2;
       private int portIndex_ ;
       /**
        * <code>optional uint32 portIndex = 2;</code>
@@ -1959,6 +1973,7 @@ public final class Protos {
         return this;
       }
 
+      // optional uint32 gracePeriodSeconds = 3 [default = 15];
       private int gracePeriodSeconds_ = 15;
       /**
        * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
@@ -1991,6 +2006,7 @@ public final class Protos {
         return this;
       }
 
+      // optional uint32 intervalSeconds = 4 [default = 10];
       private int intervalSeconds_ = 10;
       /**
        * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
@@ -2023,6 +2039,7 @@ public final class Protos {
         return this;
       }
 
+      // optional uint32 timeoutSeconds = 5 [default = 20];
       private int timeoutSeconds_ = 20;
       /**
        * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
@@ -2055,6 +2072,7 @@ public final class Protos {
         return this;
       }
 
+      // optional string path = 6 [default = "/"];
       private java.lang.Object path_ = "/";
       /**
        * <code>optional string path = 6 [default = "/"];</code>
@@ -2076,12 +2094,9 @@ public final class Protos {
       public java.lang.String getPath() {
         java.lang.Object ref = path_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            path_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          path_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -2155,6 +2170,7 @@ public final class Protos {
         return this;
       }
 
+      // optional uint32 maxConsecutiveFailures = 7 [default = 3];
       private int maxConsecutiveFailures_ = 3;
       /**
        * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
@@ -2187,6 +2203,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesos.CommandInfo command = 8;
       private org.apache.mesos.Protos.CommandInfo command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder> commandBuilder_;
@@ -2295,7 +2312,7 @@ public final class Protos {
         if (commandBuilder_ == null) {
           commandBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder>(
-                  getCommand(),
+                  command_,
                   getParentForChildren(),
                   isClean());
           command_ = null;
@@ -2303,6 +2320,7 @@ public final class Protos {
         return commandBuilder_;
       }
 
+      // optional bool ignoreHttp1xx = 9 [default = false];
       private boolean ignoreHttp1Xx_ ;
       /**
        * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
@@ -2335,6 +2353,7 @@ public final class Protos {
         return this;
       }
 
+      // optional uint32 port = 10;
       private int port_ ;
       /**
        * <code>optional uint32 port = 10;</code>
@@ -2378,10 +2397,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.HealthCheckDefinition)
   }
 
-  public interface ReadinessCheckDefinitionOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ReadinessCheckDefinition)
-      com.google.protobuf.MessageOrBuilder {
+  public interface ReadinessCheckDefinitionOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // optional string name = 1;
     /**
      * <code>optional string name = 1;</code>
      */
@@ -2396,6 +2415,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getNameBytes();
 
+    // optional .mesosphere.marathon.ReadinessCheckDefinition.Protocol protocol = 2;
     /**
      * <code>optional .mesosphere.marathon.ReadinessCheckDefinition.Protocol protocol = 2;</code>
      */
@@ -2405,6 +2425,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ReadinessCheckDefinition.Protocol getProtocol();
 
+    // optional string path = 3;
     /**
      * <code>optional string path = 3;</code>
      */
@@ -2419,6 +2440,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getPathBytes();
 
+    // optional string portName = 4;
     /**
      * <code>optional string portName = 4;</code>
      */
@@ -2433,6 +2455,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getPortNameBytes();
 
+    // optional uint64 intervalMillis = 5;
     /**
      * <code>optional uint64 intervalMillis = 5;</code>
      */
@@ -2442,6 +2465,7 @@ public final class Protos {
      */
     long getIntervalMillis();
 
+    // optional uint64 timeoutMillis = 6;
     /**
      * <code>optional uint64 timeoutMillis = 6;</code>
      */
@@ -2451,6 +2475,7 @@ public final class Protos {
      */
     long getTimeoutMillis();
 
+    // repeated uint32 httpStatusCodeForReady = 7;
     /**
      * <code>repeated uint32 httpStatusCodeForReady = 7;</code>
      */
@@ -2464,6 +2489,7 @@ public final class Protos {
      */
     int getHttpStatusCodeForReady(int index);
 
+    // optional bool preserveLastResponse = 8;
     /**
      * <code>optional bool preserveLastResponse = 8;</code>
      */
@@ -2477,9 +2503,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ReadinessCheckDefinition}
    */
   public static final class ReadinessCheckDefinition extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ReadinessCheckDefinition)
-      ReadinessCheckDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements ReadinessCheckDefinitionOrBuilder {
     // Use ReadinessCheckDefinition.newBuilder() to construct.
     private ReadinessCheckDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -2526,9 +2551,8 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              name_ = bs;
+              name_ = input.readBytes();
               break;
             }
             case 16: {
@@ -2543,15 +2567,13 @@ public final class Protos {
               break;
             }
             case 26: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000004;
-              path_ = bs;
+              path_ = input.readBytes();
               break;
             }
             case 34: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
-              portName_ = bs;
+              portName_ = input.readBytes();
               break;
             }
             case 40: {
@@ -2715,6 +2737,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // optional string name = 1;
     public static final int NAME_FIELD_NUMBER = 1;
     private java.lang.Object name_;
     /**
@@ -2757,6 +2780,7 @@ public final class Protos {
       }
     }
 
+    // optional .mesosphere.marathon.ReadinessCheckDefinition.Protocol protocol = 2;
     public static final int PROTOCOL_FIELD_NUMBER = 2;
     private mesosphere.marathon.Protos.ReadinessCheckDefinition.Protocol protocol_;
     /**
@@ -2772,6 +2796,7 @@ public final class Protos {
       return protocol_;
     }
 
+    // optional string path = 3;
     public static final int PATH_FIELD_NUMBER = 3;
     private java.lang.Object path_;
     /**
@@ -2814,6 +2839,7 @@ public final class Protos {
       }
     }
 
+    // optional string portName = 4;
     public static final int PORTNAME_FIELD_NUMBER = 4;
     private java.lang.Object portName_;
     /**
@@ -2856,6 +2882,7 @@ public final class Protos {
       }
     }
 
+    // optional uint64 intervalMillis = 5;
     public static final int INTERVALMILLIS_FIELD_NUMBER = 5;
     private long intervalMillis_;
     /**
@@ -2871,6 +2898,7 @@ public final class Protos {
       return intervalMillis_;
     }
 
+    // optional uint64 timeoutMillis = 6;
     public static final int TIMEOUTMILLIS_FIELD_NUMBER = 6;
     private long timeoutMillis_;
     /**
@@ -2886,6 +2914,7 @@ public final class Protos {
       return timeoutMillis_;
     }
 
+    // repeated uint32 httpStatusCodeForReady = 7;
     public static final int HTTPSTATUSCODEFORREADY_FIELD_NUMBER = 7;
     private java.util.List<java.lang.Integer> httpStatusCodeForReady_;
     /**
@@ -2908,6 +2937,7 @@ public final class Protos {
       return httpStatusCodeForReady_.get(index);
     }
 
+    // optional bool preserveLastResponse = 8;
     public static final int PRESERVELASTRESPONSE_FIELD_NUMBER = 8;
     private boolean preserveLastResponse_;
     /**
@@ -2936,8 +2966,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       memoizedIsInitialized = 1;
       return true;
@@ -3098,9 +3127,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ReadinessCheckDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ReadinessCheckDefinition)
-        mesosphere.marathon.Protos.ReadinessCheckDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.ReadinessCheckDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor;
@@ -3290,6 +3318,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // optional string name = 1;
       private java.lang.Object name_ = "";
       /**
        * <code>optional string name = 1;</code>
@@ -3303,12 +3332,9 @@ public final class Protos {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            name_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          name_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -3366,6 +3392,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesosphere.marathon.ReadinessCheckDefinition.Protocol protocol = 2;
       private mesosphere.marathon.Protos.ReadinessCheckDefinition.Protocol protocol_ = mesosphere.marathon.Protos.ReadinessCheckDefinition.Protocol.HTTP;
       /**
        * <code>optional .mesosphere.marathon.ReadinessCheckDefinition.Protocol protocol = 2;</code>
@@ -3401,6 +3428,7 @@ public final class Protos {
         return this;
       }
 
+      // optional string path = 3;
       private java.lang.Object path_ = "";
       /**
        * <code>optional string path = 3;</code>
@@ -3414,12 +3442,9 @@ public final class Protos {
       public java.lang.String getPath() {
         java.lang.Object ref = path_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            path_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          path_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -3477,6 +3502,7 @@ public final class Protos {
         return this;
       }
 
+      // optional string portName = 4;
       private java.lang.Object portName_ = "";
       /**
        * <code>optional string portName = 4;</code>
@@ -3490,12 +3516,9 @@ public final class Protos {
       public java.lang.String getPortName() {
         java.lang.Object ref = portName_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            portName_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          portName_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -3553,6 +3576,7 @@ public final class Protos {
         return this;
       }
 
+      // optional uint64 intervalMillis = 5;
       private long intervalMillis_ ;
       /**
        * <code>optional uint64 intervalMillis = 5;</code>
@@ -3585,6 +3609,7 @@ public final class Protos {
         return this;
       }
 
+      // optional uint64 timeoutMillis = 6;
       private long timeoutMillis_ ;
       /**
        * <code>optional uint64 timeoutMillis = 6;</code>
@@ -3617,6 +3642,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated uint32 httpStatusCodeForReady = 7;
       private java.util.List<java.lang.Integer> httpStatusCodeForReady_ = java.util.Collections.emptyList();
       private void ensureHttpStatusCodeForReadyIsMutable() {
         if (!((bitField0_ & 0x00000040) == 0x00000040)) {
@@ -3668,8 +3694,7 @@ public final class Protos {
       public Builder addAllHttpStatusCodeForReady(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureHttpStatusCodeForReadyIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, httpStatusCodeForReady_);
+        super.addAll(values, httpStatusCodeForReady_);
         onChanged();
         return this;
       }
@@ -3683,6 +3708,7 @@ public final class Protos {
         return this;
       }
 
+      // optional bool preserveLastResponse = 8;
       private boolean preserveLastResponse_ ;
       /**
        * <code>optional bool preserveLastResponse = 8;</code>
@@ -3726,15 +3752,15 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ReadinessCheckDefinition)
   }
 
-  public interface IpAddressOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.IpAddress)
-      com.google.protobuf.MessageOrBuilder {
+  public interface IpAddressOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // repeated string groups = 1;
     /**
      * <code>repeated string groups = 1;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getGroupsList();
+    java.util.List<java.lang.String>
+    getGroupsList();
     /**
      * <code>repeated string groups = 1;</code>
      */
@@ -3749,6 +3775,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getGroupsBytes(int index);
 
+    // repeated .mesos.Label labels = 2;
     /**
      * <code>repeated .mesos.Label labels = 2;</code>
      */
@@ -3773,6 +3800,7 @@ public final class Protos {
     org.apache.mesos.Protos.LabelOrBuilder getLabelsOrBuilder(
         int index);
 
+    // optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;
     /**
      * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
      */
@@ -3786,6 +3814,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.DiscoveryInfoOrBuilder getDiscoveryInfoOrBuilder();
 
+    // optional string networkName = 4;
     /**
      * <code>optional string networkName = 4;</code>
      */
@@ -3804,9 +3833,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.IpAddress}
    */
   public static final class IpAddress extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.IpAddress)
-      IpAddressOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements IpAddressOrBuilder {
     // Use IpAddress.newBuilder() to construct.
     private IpAddress(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -3853,12 +3881,11 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 groups_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000001;
               }
-              groups_.add(bs);
+              groups_.add(input.readBytes());
               break;
             }
             case 18: {
@@ -3883,9 +3910,8 @@ public final class Protos {
               break;
             }
             case 34: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              networkName_ = bs;
+              networkName_ = input.readBytes();
               break;
             }
           }
@@ -3897,7 +3923,7 @@ public final class Protos {
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          groups_ = groups_.getUnmodifiableView();
+          groups_ = new com.google.protobuf.UnmodifiableLazyStringList(groups_);
         }
         if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
           labels_ = java.util.Collections.unmodifiableList(labels_);
@@ -3934,12 +3960,13 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // repeated string groups = 1;
     public static final int GROUPS_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList groups_;
     /**
      * <code>repeated string groups = 1;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getGroupsList() {
       return groups_;
     }
@@ -3963,6 +3990,7 @@ public final class Protos {
       return groups_.getByteString(index);
     }
 
+    // repeated .mesos.Label labels = 2;
     public static final int LABELS_FIELD_NUMBER = 2;
     private java.util.List<org.apache.mesos.Protos.Label> labels_;
     /**
@@ -3998,6 +4026,7 @@ public final class Protos {
       return labels_.get(index);
     }
 
+    // optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;
     public static final int DISCOVERYINFO_FIELD_NUMBER = 3;
     private mesosphere.marathon.Protos.DiscoveryInfo discoveryInfo_;
     /**
@@ -4019,6 +4048,7 @@ public final class Protos {
       return discoveryInfo_;
     }
 
+    // optional string networkName = 4;
     public static final int NETWORKNAME_FIELD_NUMBER = 4;
     private java.lang.Object networkName_;
     /**
@@ -4070,8 +4100,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getLabelsCount(); i++) {
         if (!getLabels(i).isInitialized()) {
@@ -4216,9 +4245,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.IpAddress}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.IpAddress)
-        mesosphere.marathon.Protos.IpAddressOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.IpAddressOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_IpAddress_descriptor;
@@ -4298,7 +4326,8 @@ public final class Protos {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          groups_ = groups_.getUnmodifiableView();
+          groups_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              groups_);
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.groups_ = groups_;
@@ -4422,6 +4451,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // repeated string groups = 1;
       private com.google.protobuf.LazyStringList groups_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureGroupsIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4432,9 +4462,9 @@ public final class Protos {
       /**
        * <code>repeated string groups = 1;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getGroupsList() {
-        return groups_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(groups_);
       }
       /**
        * <code>repeated string groups = 1;</code>
@@ -4487,8 +4517,7 @@ public final class Protos {
       public Builder addAllGroups(
           java.lang.Iterable<java.lang.String> values) {
         ensureGroupsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, groups_);
+        super.addAll(values, groups_);
         onChanged();
         return this;
       }
@@ -4515,6 +4544,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated .mesos.Label labels = 2;
       private java.util.List<org.apache.mesos.Protos.Label> labels_ =
         java.util.Collections.emptyList();
       private void ensureLabelsIsMutable() {
@@ -4656,8 +4686,7 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Label> values) {
         if (labelsBuilder_ == null) {
           ensureLabelsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, labels_);
+          super.addAll(values, labels_);
           onChanged();
         } else {
           labelsBuilder_.addAllMessages(values);
@@ -4755,6 +4784,7 @@ public final class Protos {
         return labelsBuilder_;
       }
 
+      // optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;
       private mesosphere.marathon.Protos.DiscoveryInfo discoveryInfo_ = mesosphere.marathon.Protos.DiscoveryInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.DiscoveryInfo, mesosphere.marathon.Protos.DiscoveryInfo.Builder, mesosphere.marathon.Protos.DiscoveryInfoOrBuilder> discoveryInfoBuilder_;
@@ -4863,7 +4893,7 @@ public final class Protos {
         if (discoveryInfoBuilder_ == null) {
           discoveryInfoBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.DiscoveryInfo, mesosphere.marathon.Protos.DiscoveryInfo.Builder, mesosphere.marathon.Protos.DiscoveryInfoOrBuilder>(
-                  getDiscoveryInfo(),
+                  discoveryInfo_,
                   getParentForChildren(),
                   isClean());
           discoveryInfo_ = null;
@@ -4871,6 +4901,7 @@ public final class Protos {
         return discoveryInfoBuilder_;
       }
 
+      // optional string networkName = 4;
       private java.lang.Object networkName_ = "";
       /**
        * <code>optional string networkName = 4;</code>
@@ -4884,12 +4915,9 @@ public final class Protos {
       public java.lang.String getNetworkName() {
         java.lang.Object ref = networkName_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            networkName_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          networkName_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -4958,10 +4986,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.IpAddress)
   }
 
-  public interface DiscoveryInfoOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.DiscoveryInfo)
-      com.google.protobuf.MessageOrBuilder {
+  public interface DiscoveryInfoOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // repeated .mesos.Port ports = 1;
     /**
      * <code>repeated .mesos.Port ports = 1;</code>
      */
@@ -4990,9 +5018,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.DiscoveryInfo}
    */
   public static final class DiscoveryInfo extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.DiscoveryInfo)
-      DiscoveryInfoOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements DiscoveryInfoOrBuilder {
     // Use DiscoveryInfo.newBuilder() to construct.
     private DiscoveryInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -5088,6 +5115,7 @@ public final class Protos {
       return PARSER;
     }
 
+    // repeated .mesos.Port ports = 1;
     public static final int PORTS_FIELD_NUMBER = 1;
     private java.util.List<org.apache.mesos.Protos.Port> ports_;
     /**
@@ -5129,8 +5157,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getPortsCount(); i++) {
         if (!getPorts(i).isInitialized()) {
@@ -5243,9 +5270,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.DiscoveryInfo}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.DiscoveryInfo)
-        mesosphere.marathon.Protos.DiscoveryInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.DiscoveryInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_DiscoveryInfo_descriptor;
@@ -5395,6 +5421,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // repeated .mesos.Port ports = 1;
       private java.util.List<org.apache.mesos.Protos.Port> ports_ =
         java.util.Collections.emptyList();
       private void ensurePortsIsMutable() {
@@ -5536,8 +5563,7 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Port> values) {
         if (portsBuilder_ == null) {
           ensurePortsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, ports_);
+          super.addAll(values, ports_);
           onChanged();
         } else {
           portsBuilder_.addAllMessages(values);
@@ -5646,10 +5672,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.DiscoveryInfo)
   }
 
-  public interface ServiceDefinitionOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ServiceDefinition)
-      com.google.protobuf.MessageOrBuilder {
+  public interface ServiceDefinitionOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required string id = 1;
     /**
      * <code>required string id = 1;</code>
      */
@@ -5664,6 +5690,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getIdBytes();
 
+    // required .mesos.CommandInfo cmd = 2;
     /**
      * <code>required .mesos.CommandInfo cmd = 2;</code>
      */
@@ -5677,6 +5704,7 @@ public final class Protos {
      */
     org.apache.mesos.Protos.CommandInfoOrBuilder getCmdOrBuilder();
 
+    // required uint32 instances = 3;
     /**
      * <code>required uint32 instances = 3;</code>
      */
@@ -5686,6 +5714,7 @@ public final class Protos {
      */
     int getInstances();
 
+    // repeated .mesos.Resource resources = 4;
     /**
      * <code>repeated .mesos.Resource resources = 4;</code>
      */
@@ -5710,6 +5739,7 @@ public final class Protos {
     org.apache.mesos.Protos.ResourceOrBuilder getResourcesOrBuilder(
         int index);
 
+    // optional string description = 5;
     /**
      * <code>optional string description = 5;</code>
      */
@@ -5724,6 +5754,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getDescriptionBytes();
 
+    // repeated uint32 ports = 6;
     /**
      * <code>repeated uint32 ports = 6;</code>
      */
@@ -5737,6 +5768,7 @@ public final class Protos {
      */
     int getPorts(int index);
 
+    // repeated .mesosphere.marathon.Constraint constraints = 7;
     /**
      * <code>repeated .mesosphere.marathon.Constraint constraints = 7;</code>
      */
@@ -5761,6 +5793,7 @@ public final class Protos {
     mesosphere.marathon.Protos.ConstraintOrBuilder getConstraintsOrBuilder(
         int index);
 
+    // required string executor = 8 [default = ""];
     /**
      * <code>required string executor = 8 [default = ""];</code>
      */
@@ -5775,6 +5808,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getExecutorBytes();
 
+    // optional .mesosphere.marathon.ContainerInfo OBSOLETE_container = 10;
     /**
      * <code>optional .mesosphere.marathon.ContainerInfo OBSOLETE_container = 10;</code>
      *
@@ -5800,6 +5834,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ContainerInfoOrBuilder getOBSOLETEContainerOrBuilder();
 
+    // optional string version = 11 [default = "1970-01-01T00:00:00.000Z"];
     /**
      * <code>optional string version = 11 [default = "1970-01-01T00:00:00.000Z"];</code>
      *
@@ -5826,6 +5861,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getVersionBytes();
 
+    // repeated .mesosphere.marathon.HealthCheckDefinition healthChecks = 12;
     /**
      * <code>repeated .mesosphere.marathon.HealthCheckDefinition healthChecks = 12;</code>
      */
@@ -5850,6 +5886,7 @@ public final class Protos {
     mesosphere.marathon.Protos.HealthCheckDefinitionOrBuilder getHealthChecksOrBuilder(
         int index);
 
+    // optional int64 backoff = 13 [default = 1000];
     /**
      * <code>optional int64 backoff = 13 [default = 1000];</code>
      *
@@ -5867,6 +5904,7 @@ public final class Protos {
      */
     long getBackoff();
 
+    // optional double backoffFactor = 14 [default = 1.15];
     /**
      * <code>optional double backoffFactor = 14 [default = 1.15];</code>
      */
@@ -5876,6 +5914,7 @@ public final class Protos {
      */
     double getBackoffFactor();
 
+    // optional .mesosphere.marathon.UpgradeStrategyDefinition upgradeStrategy = 15;
     /**
      * <code>optional .mesosphere.marathon.UpgradeStrategyDefinition upgradeStrategy = 15;</code>
      */
@@ -5889,11 +5928,12 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.UpgradeStrategyDefinitionOrBuilder getUpgradeStrategyOrBuilder();
 
+    // repeated string dependencies = 16;
     /**
      * <code>repeated string dependencies = 16;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getDependenciesList();
+    java.util.List<java.lang.String>
+    getDependenciesList();
     /**
      * <code>repeated string dependencies = 16;</code>
      */
@@ -5908,11 +5948,12 @@ public final class Protos {
     com.google.protobuf.ByteString
         getDependenciesBytes(int index);
 
+    // repeated string storeUrls = 17;
     /**
      * <code>repeated string storeUrls = 17;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getStoreUrlsList();
+    java.util.List<java.lang.String>
+    getStoreUrlsList();
     /**
      * <code>repeated string storeUrls = 17;</code>
      */
@@ -5927,6 +5968,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getStoreUrlsBytes(int index);
 
+    // optional bool require_ports = 18 [default = false];
     /**
      * <code>optional bool require_ports = 18 [default = false];</code>
      */
@@ -5936,6 +5978,7 @@ public final class Protos {
      */
     boolean getRequirePorts();
 
+    // optional .mesosphere.marathon.ExtendedContainerInfo container = 19;
     /**
      * <code>optional .mesosphere.marathon.ExtendedContainerInfo container = 19;</code>
      */
@@ -5949,6 +5992,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ExtendedContainerInfoOrBuilder getContainerOrBuilder();
 
+    // repeated .mesos.Parameter labels = 20;
     /**
      * <code>repeated .mesos.Parameter labels = 20;</code>
      */
@@ -5973,6 +6017,7 @@ public final class Protos {
     org.apache.mesos.Protos.ParameterOrBuilder getLabelsOrBuilder(
         int index);
 
+    // optional int64 maxLaunchDelay = 21 [default = 3600000];
     /**
      * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
      *
@@ -5990,6 +6035,7 @@ public final class Protos {
      */
     long getMaxLaunchDelay();
 
+    // optional .mesosphere.marathon.ResourceRoles acceptedResourceRoles = 22;
     /**
      * <code>optional .mesosphere.marathon.ResourceRoles acceptedResourceRoles = 22;</code>
      */
@@ -6003,6 +6049,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ResourceRolesOrBuilder getAcceptedResourceRolesOrBuilder();
 
+    // optional int64 last_scaling_at = 23;
     /**
      * <code>optional int64 last_scaling_at = 23;</code>
      */
@@ -6012,6 +6059,7 @@ public final class Protos {
      */
     long getLastScalingAt();
 
+    // optional int64 last_config_change_at = 24;
     /**
      * <code>optional int64 last_config_change_at = 24;</code>
      */
@@ -6021,6 +6069,7 @@ public final class Protos {
      */
     long getLastConfigChangeAt();
 
+    // optional .mesosphere.marathon.IpAddress ipAddress = 25;
     /**
      * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
      */
@@ -6034,6 +6083,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.IpAddressOrBuilder getIpAddressOrBuilder();
 
+    // optional .mesosphere.marathon.ResidencyDefinition residency = 26;
     /**
      * <code>optional .mesosphere.marathon.ResidencyDefinition residency = 26;</code>
      */
@@ -6047,6 +6097,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ResidencyDefinitionOrBuilder getResidencyOrBuilder();
 
+    // repeated .mesos.Port portDefinitions = 27;
     /**
      * <code>repeated .mesos.Port portDefinitions = 27;</code>
      */
@@ -6071,6 +6122,7 @@ public final class Protos {
     org.apache.mesos.Protos.PortOrBuilder getPortDefinitionsOrBuilder(
         int index);
 
+    // repeated .mesosphere.marathon.ReadinessCheckDefinition readinessCheckDefinition = 28;
     /**
      * <code>repeated .mesosphere.marathon.ReadinessCheckDefinition readinessCheckDefinition = 28;</code>
      */
@@ -6095,6 +6147,7 @@ public final class Protos {
     mesosphere.marathon.Protos.ReadinessCheckDefinitionOrBuilder getReadinessCheckDefinitionOrBuilder(
         int index);
 
+    // repeated .mesosphere.marathon.Secret secrets = 29;
     /**
      * <code>repeated .mesosphere.marathon.Secret secrets = 29;</code>
      */
@@ -6119,6 +6172,7 @@ public final class Protos {
     mesosphere.marathon.Protos.SecretOrBuilder getSecretsOrBuilder(
         int index);
 
+    // repeated .mesosphere.marathon.EnvVarReference envVarReferences = 30;
     /**
      * <code>repeated .mesosphere.marathon.EnvVarReference envVarReferences = 30;</code>
      */
@@ -6143,6 +6197,7 @@ public final class Protos {
     mesosphere.marathon.Protos.EnvVarReferenceOrBuilder getEnvVarReferencesOrBuilder(
         int index);
 
+    // optional int64 taskKillGracePeriod = 31;
     /**
      * <code>optional int64 taskKillGracePeriod = 31;</code>
      *
@@ -6164,9 +6219,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ServiceDefinition}
    */
   public static final class ServiceDefinition extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ServiceDefinition)
-      ServiceDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements ServiceDefinitionOrBuilder {
     // Use ServiceDefinition.newBuilder() to construct.
     private ServiceDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -6213,9 +6267,8 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = bs;
+              id_ = input.readBytes();
               break;
             }
             case 18: {
@@ -6245,9 +6298,8 @@ public final class Protos {
               break;
             }
             case 42: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
-              description_ = bs;
+              description_ = input.readBytes();
               break;
             }
             case 48: {
@@ -6280,9 +6332,8 @@ public final class Protos {
               break;
             }
             case 66: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000010;
-              executor_ = bs;
+              executor_ = input.readBytes();
               break;
             }
             case 82: {
@@ -6299,9 +6350,8 @@ public final class Protos {
               break;
             }
             case 90: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000040;
-              version_ = bs;
+              version_ = input.readBytes();
               break;
             }
             case 98: {
@@ -6336,21 +6386,19 @@ public final class Protos {
               break;
             }
             case 130: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
                 dependencies_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00004000;
               }
-              dependencies_.add(bs);
+              dependencies_.add(input.readBytes());
               break;
             }
             case 138: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00008000) == 0x00008000)) {
                 storeUrls_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00008000;
               }
-              storeUrls_.add(bs);
+              storeUrls_.add(input.readBytes());
               break;
             }
             case 144: {
@@ -6491,10 +6539,10 @@ public final class Protos {
           healthChecks_ = java.util.Collections.unmodifiableList(healthChecks_);
         }
         if (((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
-          dependencies_ = dependencies_.getUnmodifiableView();
+          dependencies_ = new com.google.protobuf.UnmodifiableLazyStringList(dependencies_);
         }
         if (((mutable_bitField0_ & 0x00008000) == 0x00008000)) {
-          storeUrls_ = storeUrls_.getUnmodifiableView();
+          storeUrls_ = new com.google.protobuf.UnmodifiableLazyStringList(storeUrls_);
         }
         if (((mutable_bitField0_ & 0x00040000) == 0x00040000)) {
           labels_ = java.util.Collections.unmodifiableList(labels_);
@@ -6543,6 +6591,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -6585,6 +6634,7 @@ public final class Protos {
       }
     }
 
+    // required .mesos.CommandInfo cmd = 2;
     public static final int CMD_FIELD_NUMBER = 2;
     private org.apache.mesos.Protos.CommandInfo cmd_;
     /**
@@ -6606,6 +6656,7 @@ public final class Protos {
       return cmd_;
     }
 
+    // required uint32 instances = 3;
     public static final int INSTANCES_FIELD_NUMBER = 3;
     private int instances_;
     /**
@@ -6621,6 +6672,7 @@ public final class Protos {
       return instances_;
     }
 
+    // repeated .mesos.Resource resources = 4;
     public static final int RESOURCES_FIELD_NUMBER = 4;
     private java.util.List<org.apache.mesos.Protos.Resource> resources_;
     /**
@@ -6656,6 +6708,7 @@ public final class Protos {
       return resources_.get(index);
     }
 
+    // optional string description = 5;
     public static final int DESCRIPTION_FIELD_NUMBER = 5;
     private java.lang.Object description_;
     /**
@@ -6698,6 +6751,7 @@ public final class Protos {
       }
     }
 
+    // repeated uint32 ports = 6;
     public static final int PORTS_FIELD_NUMBER = 6;
     private java.util.List<java.lang.Integer> ports_;
     /**
@@ -6720,6 +6774,7 @@ public final class Protos {
       return ports_.get(index);
     }
 
+    // repeated .mesosphere.marathon.Constraint constraints = 7;
     public static final int CONSTRAINTS_FIELD_NUMBER = 7;
     private java.util.List<mesosphere.marathon.Protos.Constraint> constraints_;
     /**
@@ -6755,6 +6810,7 @@ public final class Protos {
       return constraints_.get(index);
     }
 
+    // required string executor = 8 [default = ""];
     public static final int EXECUTOR_FIELD_NUMBER = 8;
     private java.lang.Object executor_;
     /**
@@ -6797,6 +6853,7 @@ public final class Protos {
       }
     }
 
+    // optional .mesosphere.marathon.ContainerInfo OBSOLETE_container = 10;
     public static final int OBSOLETE_CONTAINER_FIELD_NUMBER = 10;
     private mesosphere.marathon.Protos.ContainerInfo oBSOLETEContainer_;
     /**
@@ -6830,6 +6887,7 @@ public final class Protos {
       return oBSOLETEContainer_;
     }
 
+    // optional string version = 11 [default = "1970-01-01T00:00:00.000Z"];
     public static final int VERSION_FIELD_NUMBER = 11;
     private java.lang.Object version_;
     /**
@@ -6884,6 +6942,7 @@ public final class Protos {
       }
     }
 
+    // repeated .mesosphere.marathon.HealthCheckDefinition healthChecks = 12;
     public static final int HEALTHCHECKS_FIELD_NUMBER = 12;
     private java.util.List<mesosphere.marathon.Protos.HealthCheckDefinition> healthChecks_;
     /**
@@ -6919,6 +6978,7 @@ public final class Protos {
       return healthChecks_.get(index);
     }
 
+    // optional int64 backoff = 13 [default = 1000];
     public static final int BACKOFF_FIELD_NUMBER = 13;
     private long backoff_;
     /**
@@ -6942,6 +7002,7 @@ public final class Protos {
       return backoff_;
     }
 
+    // optional double backoffFactor = 14 [default = 1.15];
     public static final int BACKOFFFACTOR_FIELD_NUMBER = 14;
     private double backoffFactor_;
     /**
@@ -6957,6 +7018,7 @@ public final class Protos {
       return backoffFactor_;
     }
 
+    // optional .mesosphere.marathon.UpgradeStrategyDefinition upgradeStrategy = 15;
     public static final int UPGRADESTRATEGY_FIELD_NUMBER = 15;
     private mesosphere.marathon.Protos.UpgradeStrategyDefinition upgradeStrategy_;
     /**
@@ -6978,12 +7040,13 @@ public final class Protos {
       return upgradeStrategy_;
     }
 
+    // repeated string dependencies = 16;
     public static final int DEPENDENCIES_FIELD_NUMBER = 16;
     private com.google.protobuf.LazyStringList dependencies_;
     /**
      * <code>repeated string dependencies = 16;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getDependenciesList() {
       return dependencies_;
     }
@@ -7007,12 +7070,13 @@ public final class Protos {
       return dependencies_.getByteString(index);
     }
 
+    // repeated string storeUrls = 17;
     public static final int STOREURLS_FIELD_NUMBER = 17;
     private com.google.protobuf.LazyStringList storeUrls_;
     /**
      * <code>repeated string storeUrls = 17;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getStoreUrlsList() {
       return storeUrls_;
     }
@@ -7036,6 +7100,7 @@ public final class Protos {
       return storeUrls_.getByteString(index);
     }
 
+    // optional bool require_ports = 18 [default = false];
     public static final int REQUIRE_PORTS_FIELD_NUMBER = 18;
     private boolean requirePorts_;
     /**
@@ -7051,6 +7116,7 @@ public final class Protos {
       return requirePorts_;
     }
 
+    // optional .mesosphere.marathon.ExtendedContainerInfo container = 19;
     public static final int CONTAINER_FIELD_NUMBER = 19;
     private mesosphere.marathon.Protos.ExtendedContainerInfo container_;
     /**
@@ -7072,6 +7138,7 @@ public final class Protos {
       return container_;
     }
 
+    // repeated .mesos.Parameter labels = 20;
     public static final int LABELS_FIELD_NUMBER = 20;
     private java.util.List<org.apache.mesos.Protos.Parameter> labels_;
     /**
@@ -7107,6 +7174,7 @@ public final class Protos {
       return labels_.get(index);
     }
 
+    // optional int64 maxLaunchDelay = 21 [default = 3600000];
     public static final int MAXLAUNCHDELAY_FIELD_NUMBER = 21;
     private long maxLaunchDelay_;
     /**
@@ -7130,6 +7198,7 @@ public final class Protos {
       return maxLaunchDelay_;
     }
 
+    // optional .mesosphere.marathon.ResourceRoles acceptedResourceRoles = 22;
     public static final int ACCEPTEDRESOURCEROLES_FIELD_NUMBER = 22;
     private mesosphere.marathon.Protos.ResourceRoles acceptedResourceRoles_;
     /**
@@ -7151,6 +7220,7 @@ public final class Protos {
       return acceptedResourceRoles_;
     }
 
+    // optional int64 last_scaling_at = 23;
     public static final int LAST_SCALING_AT_FIELD_NUMBER = 23;
     private long lastScalingAt_;
     /**
@@ -7166,6 +7236,7 @@ public final class Protos {
       return lastScalingAt_;
     }
 
+    // optional int64 last_config_change_at = 24;
     public static final int LAST_CONFIG_CHANGE_AT_FIELD_NUMBER = 24;
     private long lastConfigChangeAt_;
     /**
@@ -7181,6 +7252,7 @@ public final class Protos {
       return lastConfigChangeAt_;
     }
 
+    // optional .mesosphere.marathon.IpAddress ipAddress = 25;
     public static final int IPADDRESS_FIELD_NUMBER = 25;
     private mesosphere.marathon.Protos.IpAddress ipAddress_;
     /**
@@ -7202,6 +7274,7 @@ public final class Protos {
       return ipAddress_;
     }
 
+    // optional .mesosphere.marathon.ResidencyDefinition residency = 26;
     public static final int RESIDENCY_FIELD_NUMBER = 26;
     private mesosphere.marathon.Protos.ResidencyDefinition residency_;
     /**
@@ -7223,6 +7296,7 @@ public final class Protos {
       return residency_;
     }
 
+    // repeated .mesos.Port portDefinitions = 27;
     public static final int PORTDEFINITIONS_FIELD_NUMBER = 27;
     private java.util.List<org.apache.mesos.Protos.Port> portDefinitions_;
     /**
@@ -7258,6 +7332,7 @@ public final class Protos {
       return portDefinitions_.get(index);
     }
 
+    // repeated .mesosphere.marathon.ReadinessCheckDefinition readinessCheckDefinition = 28;
     public static final int READINESSCHECKDEFINITION_FIELD_NUMBER = 28;
     private java.util.List<mesosphere.marathon.Protos.ReadinessCheckDefinition> readinessCheckDefinition_;
     /**
@@ -7293,6 +7368,7 @@ public final class Protos {
       return readinessCheckDefinition_.get(index);
     }
 
+    // repeated .mesosphere.marathon.Secret secrets = 29;
     public static final int SECRETS_FIELD_NUMBER = 29;
     private java.util.List<mesosphere.marathon.Protos.Secret> secrets_;
     /**
@@ -7328,6 +7404,7 @@ public final class Protos {
       return secrets_.get(index);
     }
 
+    // repeated .mesosphere.marathon.EnvVarReference envVarReferences = 30;
     public static final int ENVVARREFERENCES_FIELD_NUMBER = 30;
     private java.util.List<mesosphere.marathon.Protos.EnvVarReference> envVarReferences_;
     /**
@@ -7363,6 +7440,7 @@ public final class Protos {
       return envVarReferences_.get(index);
     }
 
+    // optional int64 taskKillGracePeriod = 31;
     public static final int TASKKILLGRACEPERIOD_FIELD_NUMBER = 31;
     private long taskKillGracePeriod_;
     /**
@@ -7421,8 +7499,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasId()) {
         memoizedIsInitialized = 0;
@@ -7833,9 +7910,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ServiceDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ServiceDefinition)
-        mesosphere.marathon.Protos.ServiceDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.ServiceDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ServiceDefinition_descriptor;
@@ -8116,12 +8192,14 @@ public final class Protos {
           result.upgradeStrategy_ = upgradeStrategyBuilder_.build();
         }
         if (((bitField0_ & 0x00004000) == 0x00004000)) {
-          dependencies_ = dependencies_.getUnmodifiableView();
+          dependencies_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              dependencies_);
           bitField0_ = (bitField0_ & ~0x00004000);
         }
         result.dependencies_ = dependencies_;
         if (((bitField0_ & 0x00008000) == 0x00008000)) {
-          storeUrls_ = storeUrls_.getUnmodifiableView();
+          storeUrls_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              storeUrls_);
           bitField0_ = (bitField0_ & ~0x00008000);
         }
         result.storeUrls_ = storeUrls_;
@@ -8654,6 +8732,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>required string id = 1;</code>
@@ -8667,12 +8746,9 @@ public final class Protos {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            id_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          id_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -8730,6 +8806,7 @@ public final class Protos {
         return this;
       }
 
+      // required .mesos.CommandInfo cmd = 2;
       private org.apache.mesos.Protos.CommandInfo cmd_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder> cmdBuilder_;
@@ -8838,7 +8915,7 @@ public final class Protos {
         if (cmdBuilder_ == null) {
           cmdBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder>(
-                  getCmd(),
+                  cmd_,
                   getParentForChildren(),
                   isClean());
           cmd_ = null;
@@ -8846,6 +8923,7 @@ public final class Protos {
         return cmdBuilder_;
       }
 
+      // required uint32 instances = 3;
       private int instances_ ;
       /**
        * <code>required uint32 instances = 3;</code>
@@ -8878,6 +8956,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated .mesos.Resource resources = 4;
       private java.util.List<org.apache.mesos.Protos.Resource> resources_ =
         java.util.Collections.emptyList();
       private void ensureResourcesIsMutable() {
@@ -9019,8 +9098,7 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Resource> values) {
         if (resourcesBuilder_ == null) {
           ensureResourcesIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, resources_);
+          super.addAll(values, resources_);
           onChanged();
         } else {
           resourcesBuilder_.addAllMessages(values);
@@ -9118,6 +9196,7 @@ public final class Protos {
         return resourcesBuilder_;
       }
 
+      // optional string description = 5;
       private java.lang.Object description_ = "";
       /**
        * <code>optional string description = 5;</code>
@@ -9131,12 +9210,9 @@ public final class Protos {
       public java.lang.String getDescription() {
         java.lang.Object ref = description_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            description_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          description_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -9194,6 +9270,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated uint32 ports = 6;
       private java.util.List<java.lang.Integer> ports_ = java.util.Collections.emptyList();
       private void ensurePortsIsMutable() {
         if (!((bitField0_ & 0x00000020) == 0x00000020)) {
@@ -9245,8 +9322,7 @@ public final class Protos {
       public Builder addAllPorts(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensurePortsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, ports_);
+        super.addAll(values, ports_);
         onChanged();
         return this;
       }
@@ -9260,6 +9336,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated .mesosphere.marathon.Constraint constraints = 7;
       private java.util.List<mesosphere.marathon.Protos.Constraint> constraints_ =
         java.util.Collections.emptyList();
       private void ensureConstraintsIsMutable() {
@@ -9401,8 +9478,7 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.Constraint> values) {
         if (constraintsBuilder_ == null) {
           ensureConstraintsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, constraints_);
+          super.addAll(values, constraints_);
           onChanged();
         } else {
           constraintsBuilder_.addAllMessages(values);
@@ -9500,6 +9576,7 @@ public final class Protos {
         return constraintsBuilder_;
       }
 
+      // required string executor = 8 [default = ""];
       private java.lang.Object executor_ = "";
       /**
        * <code>required string executor = 8 [default = ""];</code>
@@ -9513,12 +9590,9 @@ public final class Protos {
       public java.lang.String getExecutor() {
         java.lang.Object ref = executor_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            executor_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          executor_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -9576,6 +9650,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesosphere.marathon.ContainerInfo OBSOLETE_container = 10;
       private mesosphere.marathon.Protos.ContainerInfo oBSOLETEContainer_ = mesosphere.marathon.Protos.ContainerInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ContainerInfo, mesosphere.marathon.Protos.ContainerInfo.Builder, mesosphere.marathon.Protos.ContainerInfoOrBuilder> oBSOLETEContainerBuilder_;
@@ -9720,7 +9795,7 @@ public final class Protos {
         if (oBSOLETEContainerBuilder_ == null) {
           oBSOLETEContainerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ContainerInfo, mesosphere.marathon.Protos.ContainerInfo.Builder, mesosphere.marathon.Protos.ContainerInfoOrBuilder>(
-                  getOBSOLETEContainer(),
+                  oBSOLETEContainer_,
                   getParentForChildren(),
                   isClean());
           oBSOLETEContainer_ = null;
@@ -9728,6 +9803,7 @@ public final class Protos {
         return oBSOLETEContainerBuilder_;
       }
 
+      // optional string version = 11 [default = "1970-01-01T00:00:00.000Z"];
       private java.lang.Object version_ = "1970-01-01T00:00:00.000Z";
       /**
        * <code>optional string version = 11 [default = "1970-01-01T00:00:00.000Z"];</code>
@@ -9749,12 +9825,9 @@ public final class Protos {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            version_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          version_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -9828,6 +9901,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated .mesosphere.marathon.HealthCheckDefinition healthChecks = 12;
       private java.util.List<mesosphere.marathon.Protos.HealthCheckDefinition> healthChecks_ =
         java.util.Collections.emptyList();
       private void ensureHealthChecksIsMutable() {
@@ -9969,8 +10043,7 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.HealthCheckDefinition> values) {
         if (healthChecksBuilder_ == null) {
           ensureHealthChecksIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, healthChecks_);
+          super.addAll(values, healthChecks_);
           onChanged();
         } else {
           healthChecksBuilder_.addAllMessages(values);
@@ -10068,6 +10141,7 @@ public final class Protos {
         return healthChecksBuilder_;
       }
 
+      // optional int64 backoff = 13 [default = 1000];
       private long backoff_ = 1000L;
       /**
        * <code>optional int64 backoff = 13 [default = 1000];</code>
@@ -10116,6 +10190,7 @@ public final class Protos {
         return this;
       }
 
+      // optional double backoffFactor = 14 [default = 1.15];
       private double backoffFactor_ = 1.15D;
       /**
        * <code>optional double backoffFactor = 14 [default = 1.15];</code>
@@ -10148,6 +10223,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesosphere.marathon.UpgradeStrategyDefinition upgradeStrategy = 15;
       private mesosphere.marathon.Protos.UpgradeStrategyDefinition upgradeStrategy_ = mesosphere.marathon.Protos.UpgradeStrategyDefinition.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.UpgradeStrategyDefinition, mesosphere.marathon.Protos.UpgradeStrategyDefinition.Builder, mesosphere.marathon.Protos.UpgradeStrategyDefinitionOrBuilder> upgradeStrategyBuilder_;
@@ -10256,7 +10332,7 @@ public final class Protos {
         if (upgradeStrategyBuilder_ == null) {
           upgradeStrategyBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.UpgradeStrategyDefinition, mesosphere.marathon.Protos.UpgradeStrategyDefinition.Builder, mesosphere.marathon.Protos.UpgradeStrategyDefinitionOrBuilder>(
-                  getUpgradeStrategy(),
+                  upgradeStrategy_,
                   getParentForChildren(),
                   isClean());
           upgradeStrategy_ = null;
@@ -10264,6 +10340,7 @@ public final class Protos {
         return upgradeStrategyBuilder_;
       }
 
+      // repeated string dependencies = 16;
       private com.google.protobuf.LazyStringList dependencies_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureDependenciesIsMutable() {
         if (!((bitField0_ & 0x00004000) == 0x00004000)) {
@@ -10274,9 +10351,9 @@ public final class Protos {
       /**
        * <code>repeated string dependencies = 16;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getDependenciesList() {
-        return dependencies_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(dependencies_);
       }
       /**
        * <code>repeated string dependencies = 16;</code>
@@ -10329,8 +10406,7 @@ public final class Protos {
       public Builder addAllDependencies(
           java.lang.Iterable<java.lang.String> values) {
         ensureDependenciesIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, dependencies_);
+        super.addAll(values, dependencies_);
         onChanged();
         return this;
       }
@@ -10357,6 +10433,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated string storeUrls = 17;
       private com.google.protobuf.LazyStringList storeUrls_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureStoreUrlsIsMutable() {
         if (!((bitField0_ & 0x00008000) == 0x00008000)) {
@@ -10367,9 +10444,9 @@ public final class Protos {
       /**
        * <code>repeated string storeUrls = 17;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getStoreUrlsList() {
-        return storeUrls_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(storeUrls_);
       }
       /**
        * <code>repeated string storeUrls = 17;</code>
@@ -10422,8 +10499,7 @@ public final class Protos {
       public Builder addAllStoreUrls(
           java.lang.Iterable<java.lang.String> values) {
         ensureStoreUrlsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, storeUrls_);
+        super.addAll(values, storeUrls_);
         onChanged();
         return this;
       }
@@ -10450,6 +10526,7 @@ public final class Protos {
         return this;
       }
 
+      // optional bool require_ports = 18 [default = false];
       private boolean requirePorts_ ;
       /**
        * <code>optional bool require_ports = 18 [default = false];</code>
@@ -10482,6 +10559,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesosphere.marathon.ExtendedContainerInfo container = 19;
       private mesosphere.marathon.Protos.ExtendedContainerInfo container_ = mesosphere.marathon.Protos.ExtendedContainerInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ExtendedContainerInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfoOrBuilder> containerBuilder_;
@@ -10590,7 +10668,7 @@ public final class Protos {
         if (containerBuilder_ == null) {
           containerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ExtendedContainerInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfoOrBuilder>(
-                  getContainer(),
+                  container_,
                   getParentForChildren(),
                   isClean());
           container_ = null;
@@ -10598,6 +10676,7 @@ public final class Protos {
         return containerBuilder_;
       }
 
+      // repeated .mesos.Parameter labels = 20;
       private java.util.List<org.apache.mesos.Protos.Parameter> labels_ =
         java.util.Collections.emptyList();
       private void ensureLabelsIsMutable() {
@@ -10739,8 +10818,7 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Parameter> values) {
         if (labelsBuilder_ == null) {
           ensureLabelsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, labels_);
+          super.addAll(values, labels_);
           onChanged();
         } else {
           labelsBuilder_.addAllMessages(values);
@@ -10838,6 +10916,7 @@ public final class Protos {
         return labelsBuilder_;
       }
 
+      // optional int64 maxLaunchDelay = 21 [default = 3600000];
       private long maxLaunchDelay_ = 3600000L;
       /**
        * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
@@ -10886,6 +10965,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesosphere.marathon.ResourceRoles acceptedResourceRoles = 22;
       private mesosphere.marathon.Protos.ResourceRoles acceptedResourceRoles_ = mesosphere.marathon.Protos.ResourceRoles.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ResourceRoles, mesosphere.marathon.Protos.ResourceRoles.Builder, mesosphere.marathon.Protos.ResourceRolesOrBuilder> acceptedResourceRolesBuilder_;
@@ -10994,7 +11074,7 @@ public final class Protos {
         if (acceptedResourceRolesBuilder_ == null) {
           acceptedResourceRolesBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ResourceRoles, mesosphere.marathon.Protos.ResourceRoles.Builder, mesosphere.marathon.Protos.ResourceRolesOrBuilder>(
-                  getAcceptedResourceRoles(),
+                  acceptedResourceRoles_,
                   getParentForChildren(),
                   isClean());
           acceptedResourceRoles_ = null;
@@ -11002,6 +11082,7 @@ public final class Protos {
         return acceptedResourceRolesBuilder_;
       }
 
+      // optional int64 last_scaling_at = 23;
       private long lastScalingAt_ ;
       /**
        * <code>optional int64 last_scaling_at = 23;</code>
@@ -11034,6 +11115,7 @@ public final class Protos {
         return this;
       }
 
+      // optional int64 last_config_change_at = 24;
       private long lastConfigChangeAt_ ;
       /**
        * <code>optional int64 last_config_change_at = 24;</code>
@@ -11066,6 +11148,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesosphere.marathon.IpAddress ipAddress = 25;
       private mesosphere.marathon.Protos.IpAddress ipAddress_ = mesosphere.marathon.Protos.IpAddress.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.IpAddress, mesosphere.marathon.Protos.IpAddress.Builder, mesosphere.marathon.Protos.IpAddressOrBuilder> ipAddressBuilder_;
@@ -11174,7 +11257,7 @@ public final class Protos {
         if (ipAddressBuilder_ == null) {
           ipAddressBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.IpAddress, mesosphere.marathon.Protos.IpAddress.Builder, mesosphere.marathon.Protos.IpAddressOrBuilder>(
-                  getIpAddress(),
+                  ipAddress_,
                   getParentForChildren(),
                   isClean());
           ipAddress_ = null;
@@ -11182,6 +11265,7 @@ public final class Protos {
         return ipAddressBuilder_;
       }
 
+      // optional .mesosphere.marathon.ResidencyDefinition residency = 26;
       private mesosphere.marathon.Protos.ResidencyDefinition residency_ = mesosphere.marathon.Protos.ResidencyDefinition.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ResidencyDefinition, mesosphere.marathon.Protos.ResidencyDefinition.Builder, mesosphere.marathon.Protos.ResidencyDefinitionOrBuilder> residencyBuilder_;
@@ -11290,7 +11374,7 @@ public final class Protos {
         if (residencyBuilder_ == null) {
           residencyBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ResidencyDefinition, mesosphere.marathon.Protos.ResidencyDefinition.Builder, mesosphere.marathon.Protos.ResidencyDefinitionOrBuilder>(
-                  getResidency(),
+                  residency_,
                   getParentForChildren(),
                   isClean());
           residency_ = null;
@@ -11298,6 +11382,7 @@ public final class Protos {
         return residencyBuilder_;
       }
 
+      // repeated .mesos.Port portDefinitions = 27;
       private java.util.List<org.apache.mesos.Protos.Port> portDefinitions_ =
         java.util.Collections.emptyList();
       private void ensurePortDefinitionsIsMutable() {
@@ -11439,8 +11524,7 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Port> values) {
         if (portDefinitionsBuilder_ == null) {
           ensurePortDefinitionsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, portDefinitions_);
+          super.addAll(values, portDefinitions_);
           onChanged();
         } else {
           portDefinitionsBuilder_.addAllMessages(values);
@@ -11538,6 +11622,7 @@ public final class Protos {
         return portDefinitionsBuilder_;
       }
 
+      // repeated .mesosphere.marathon.ReadinessCheckDefinition readinessCheckDefinition = 28;
       private java.util.List<mesosphere.marathon.Protos.ReadinessCheckDefinition> readinessCheckDefinition_ =
         java.util.Collections.emptyList();
       private void ensureReadinessCheckDefinitionIsMutable() {
@@ -11679,8 +11764,7 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.ReadinessCheckDefinition> values) {
         if (readinessCheckDefinitionBuilder_ == null) {
           ensureReadinessCheckDefinitionIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, readinessCheckDefinition_);
+          super.addAll(values, readinessCheckDefinition_);
           onChanged();
         } else {
           readinessCheckDefinitionBuilder_.addAllMessages(values);
@@ -11778,6 +11862,7 @@ public final class Protos {
         return readinessCheckDefinitionBuilder_;
       }
 
+      // repeated .mesosphere.marathon.Secret secrets = 29;
       private java.util.List<mesosphere.marathon.Protos.Secret> secrets_ =
         java.util.Collections.emptyList();
       private void ensureSecretsIsMutable() {
@@ -11919,8 +12004,7 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.Secret> values) {
         if (secretsBuilder_ == null) {
           ensureSecretsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, secrets_);
+          super.addAll(values, secrets_);
           onChanged();
         } else {
           secretsBuilder_.addAllMessages(values);
@@ -12018,6 +12102,7 @@ public final class Protos {
         return secretsBuilder_;
       }
 
+      // repeated .mesosphere.marathon.EnvVarReference envVarReferences = 30;
       private java.util.List<mesosphere.marathon.Protos.EnvVarReference> envVarReferences_ =
         java.util.Collections.emptyList();
       private void ensureEnvVarReferencesIsMutable() {
@@ -12159,8 +12244,7 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.EnvVarReference> values) {
         if (envVarReferencesBuilder_ == null) {
           ensureEnvVarReferencesIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, envVarReferences_);
+          super.addAll(values, envVarReferences_);
           onChanged();
         } else {
           envVarReferencesBuilder_.addAllMessages(values);
@@ -12258,6 +12342,7 @@ public final class Protos {
         return envVarReferencesBuilder_;
       }
 
+      // optional int64 taskKillGracePeriod = 31;
       private long taskKillGracePeriod_ ;
       /**
        * <code>optional int64 taskKillGracePeriod = 31;</code>
@@ -12317,15 +12402,15 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ServiceDefinition)
   }
 
-  public interface ResourceRolesOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ResourceRoles)
-      com.google.protobuf.MessageOrBuilder {
+  public interface ResourceRolesOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // repeated string role = 1;
     /**
      * <code>repeated string role = 1;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getRoleList();
+    java.util.List<java.lang.String>
+    getRoleList();
     /**
      * <code>repeated string role = 1;</code>
      */
@@ -12344,9 +12429,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ResourceRoles}
    */
   public static final class ResourceRoles extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ResourceRoles)
-      ResourceRolesOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements ResourceRolesOrBuilder {
     // Use ResourceRoles.newBuilder() to construct.
     private ResourceRoles(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -12393,12 +12477,11 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 role_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000001;
               }
-              role_.add(bs);
+              role_.add(input.readBytes());
               break;
             }
           }
@@ -12410,7 +12493,7 @@ public final class Protos {
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          role_ = role_.getUnmodifiableView();
+          role_ = new com.google.protobuf.UnmodifiableLazyStringList(role_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -12443,12 +12526,13 @@ public final class Protos {
       return PARSER;
     }
 
+    // repeated string role = 1;
     public static final int ROLE_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList role_;
     /**
      * <code>repeated string role = 1;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getRoleList() {
       return role_;
     }
@@ -12478,8 +12562,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       memoizedIsInitialized = 1;
       return true;
@@ -12591,9 +12674,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ResourceRoles}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ResourceRoles)
-        mesosphere.marathon.Protos.ResourceRolesOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.ResourceRolesOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ResourceRoles_descriptor;
@@ -12656,7 +12738,8 @@ public final class Protos {
         mesosphere.marathon.Protos.ResourceRoles result = new mesosphere.marathon.Protos.ResourceRoles(this);
         int from_bitField0_ = bitField0_;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          role_ = role_.getUnmodifiableView();
+          role_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              role_);
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.role_ = role_;
@@ -12712,6 +12795,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // repeated string role = 1;
       private com.google.protobuf.LazyStringList role_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureRoleIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -12722,9 +12806,9 @@ public final class Protos {
       /**
        * <code>repeated string role = 1;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getRoleList() {
-        return role_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(role_);
       }
       /**
        * <code>repeated string role = 1;</code>
@@ -12777,8 +12861,7 @@ public final class Protos {
       public Builder addAllRole(
           java.lang.Iterable<java.lang.String> values) {
         ensureRoleIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, role_);
+        super.addAll(values, role_);
         onChanged();
         return this;
       }
@@ -12816,10 +12899,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ResourceRoles)
   }
 
-  public interface MarathonTaskOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.MarathonTask)
-      com.google.protobuf.MessageOrBuilder {
+  public interface MarathonTaskOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required string id = 1;
     /**
      * <code>required string id = 1;</code>
      */
@@ -12834,6 +12917,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getIdBytes();
 
+    // optional string host = 2;
     /**
      * <code>optional string host = 2;</code>
      */
@@ -12848,6 +12932,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getHostBytes();
 
+    // repeated uint32 ports = 3;
     /**
      * <code>repeated uint32 ports = 3;</code>
      */
@@ -12861,6 +12946,7 @@ public final class Protos {
      */
     int getPorts(int index);
 
+    // repeated .mesos.Attribute attributes = 4;
     /**
      * <code>repeated .mesos.Attribute attributes = 4;</code>
      */
@@ -12885,6 +12971,7 @@ public final class Protos {
     org.apache.mesos.Protos.AttributeOrBuilder getAttributesOrBuilder(
         int index);
 
+    // optional int64 staged_at = 5;
     /**
      * <code>optional int64 staged_at = 5;</code>
      */
@@ -12894,6 +12981,7 @@ public final class Protos {
      */
     long getStagedAt();
 
+    // optional int64 started_at = 6;
     /**
      * <code>optional int64 started_at = 6;</code>
      */
@@ -12903,6 +12991,7 @@ public final class Protos {
      */
     long getStartedAt();
 
+    // repeated .mesos.TaskStatus OBSOLETE_statuses = 7;
     /**
      * <code>repeated .mesos.TaskStatus OBSOLETE_statuses = 7;</code>
      */
@@ -12927,6 +13016,7 @@ public final class Protos {
     org.apache.mesos.Protos.TaskStatusOrBuilder getOBSOLETEStatusesOrBuilder(
         int index);
 
+    // optional string version = 8 [default = "1970-01-01T00:00:00.000Z"];
     /**
      * <code>optional string version = 8 [default = "1970-01-01T00:00:00.000Z"];</code>
      *
@@ -12953,6 +13043,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getVersionBytes();
 
+    // optional .mesos.TaskStatus status = 9;
     /**
      * <code>optional .mesos.TaskStatus status = 9;</code>
      */
@@ -12966,6 +13057,7 @@ public final class Protos {
      */
     org.apache.mesos.Protos.TaskStatusOrBuilder getStatusOrBuilder();
 
+    // optional .mesos.SlaveID slaveId = 10;
     /**
      * <code>optional .mesos.SlaveID slaveId = 10;</code>
      */
@@ -12979,6 +13071,7 @@ public final class Protos {
      */
     org.apache.mesos.Protos.SlaveIDOrBuilder getSlaveIdOrBuilder();
 
+    // repeated .mesos.NetworkInfo OBSOLETE_networks = 11;
     /**
      * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
      *
@@ -13023,6 +13116,7 @@ public final class Protos {
     org.apache.mesos.Protos.NetworkInfoOrBuilder getOBSOLETENetworksOrBuilder(
         int index);
 
+    // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
     /**
      * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
      *
@@ -13052,9 +13146,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.MarathonTask}
    */
   public static final class MarathonTask extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.MarathonTask)
-      MarathonTaskOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements MarathonTaskOrBuilder {
     // Use MarathonTask.newBuilder() to construct.
     private MarathonTask(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -13101,15 +13194,13 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = bs;
+              id_ = input.readBytes();
               break;
             }
             case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              host_ = bs;
+              host_ = input.readBytes();
               break;
             }
             case 24: {
@@ -13160,9 +13251,8 @@ public final class Protos {
               break;
             }
             case 66: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000010;
-              version_ = bs;
+              version_ = input.readBytes();
               break;
             }
             case 74: {
@@ -13263,15 +13353,15 @@ public final class Protos {
       return PARSER;
     }
 
-    public interface ReservationOrBuilder extends
-        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.MarathonTask.Reservation)
-        com.google.protobuf.MessageOrBuilder {
+    public interface ReservationOrBuilder
+        extends com.google.protobuf.MessageOrBuilder {
 
+      // repeated string local_volume_ids = 1;
       /**
        * <code>repeated string local_volume_ids = 1;</code>
        */
-      com.google.protobuf.ProtocolStringList
-          getLocalVolumeIdsList();
+      java.util.List<java.lang.String>
+      getLocalVolumeIdsList();
       /**
        * <code>repeated string local_volume_ids = 1;</code>
        */
@@ -13286,6 +13376,7 @@ public final class Protos {
       com.google.protobuf.ByteString
           getLocalVolumeIdsBytes(int index);
 
+      // required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;
       /**
        * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
        */
@@ -13303,9 +13394,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation}
      */
     public static final class Reservation extends
-        com.google.protobuf.GeneratedMessage implements
-        // @@protoc_insertion_point(message_implements:mesosphere.marathon.MarathonTask.Reservation)
-        ReservationOrBuilder {
+        com.google.protobuf.GeneratedMessage
+        implements ReservationOrBuilder {
       // Use Reservation.newBuilder() to construct.
       private Reservation(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -13352,12 +13442,11 @@ public final class Protos {
                 break;
               }
               case 10: {
-                com.google.protobuf.ByteString bs = input.readBytes();
                 if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                   localVolumeIds_ = new com.google.protobuf.LazyStringArrayList();
                   mutable_bitField0_ |= 0x00000001;
                 }
-                localVolumeIds_.add(bs);
+                localVolumeIds_.add(input.readBytes());
                 break;
               }
               case 18: {
@@ -13382,7 +13471,7 @@ public final class Protos {
               e.getMessage()).setUnfinishedMessage(this);
         } finally {
           if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-            localVolumeIds_ = localVolumeIds_.getUnmodifiableView();
+            localVolumeIds_ = new com.google.protobuf.UnmodifiableLazyStringList(localVolumeIds_);
           }
           this.unknownFields = unknownFields.build();
           makeExtensionsImmutable();
@@ -13415,10 +13504,10 @@ public final class Protos {
         return PARSER;
       }
 
-      public interface StateOrBuilder extends
-          // @@protoc_insertion_point(interface_extends:mesosphere.marathon.MarathonTask.Reservation.State)
-          com.google.protobuf.MessageOrBuilder {
+      public interface StateOrBuilder
+          extends com.google.protobuf.MessageOrBuilder {
 
+        // required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;
         /**
          * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
          */
@@ -13428,6 +13517,7 @@ public final class Protos {
          */
         mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type getType();
 
+        // optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;
         /**
          * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
          */
@@ -13445,9 +13535,8 @@ public final class Protos {
        * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State}
        */
       public static final class State extends
-          com.google.protobuf.GeneratedMessage implements
-          // @@protoc_insertion_point(message_implements:mesosphere.marathon.MarathonTask.Reservation.State)
-          StateOrBuilder {
+          com.google.protobuf.GeneratedMessage
+          implements StateOrBuilder {
         // Use State.newBuilder() to construct.
         private State(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
           super(builder);
@@ -13665,10 +13754,10 @@ public final class Protos {
           // @@protoc_insertion_point(enum_scope:mesosphere.marathon.MarathonTask.Reservation.State.Type)
         }
 
-        public interface TimeoutOrBuilder extends
-            // @@protoc_insertion_point(interface_extends:mesosphere.marathon.MarathonTask.Reservation.State.Timeout)
-            com.google.protobuf.MessageOrBuilder {
+        public interface TimeoutOrBuilder
+            extends com.google.protobuf.MessageOrBuilder {
 
+          // required int64 initiated = 1;
           /**
            * <code>required int64 initiated = 1;</code>
            */
@@ -13678,6 +13767,7 @@ public final class Protos {
            */
           long getInitiated();
 
+          // required int64 deadline = 2;
           /**
            * <code>required int64 deadline = 2;</code>
            */
@@ -13687,6 +13777,7 @@ public final class Protos {
            */
           long getDeadline();
 
+          // required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;
           /**
            * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
            */
@@ -13700,9 +13791,8 @@ public final class Protos {
          * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State.Timeout}
          */
         public static final class Timeout extends
-            com.google.protobuf.GeneratedMessage implements
-            // @@protoc_insertion_point(message_implements:mesosphere.marathon.MarathonTask.Reservation.State.Timeout)
-            TimeoutOrBuilder {
+            com.google.protobuf.GeneratedMessage
+            implements TimeoutOrBuilder {
           // Use Timeout.newBuilder() to construct.
           private Timeout(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
             super(builder);
@@ -13891,6 +13981,7 @@ public final class Protos {
           }
 
           private int bitField0_;
+          // required int64 initiated = 1;
           public static final int INITIATED_FIELD_NUMBER = 1;
           private long initiated_;
           /**
@@ -13906,6 +13997,7 @@ public final class Protos {
             return initiated_;
           }
 
+          // required int64 deadline = 2;
           public static final int DEADLINE_FIELD_NUMBER = 2;
           private long deadline_;
           /**
@@ -13921,6 +14013,7 @@ public final class Protos {
             return deadline_;
           }
 
+          // required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;
           public static final int REASON_FIELD_NUMBER = 3;
           private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason reason_;
           /**
@@ -13944,8 +14037,7 @@ public final class Protos {
           private byte memoizedIsInitialized = -1;
           public final boolean isInitialized() {
             byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1) return true;
-            if (isInitialized == 0) return false;
+            if (isInitialized != -1) return isInitialized == 1;
 
             if (!hasInitiated()) {
               memoizedIsInitialized = 0;
@@ -14078,9 +14170,8 @@ public final class Protos {
            * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State.Timeout}
            */
           public static final class Builder extends
-              com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-              // @@protoc_insertion_point(builder_implements:mesosphere.marathon.MarathonTask.Reservation.State.Timeout)
-              mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder {
+              com.google.protobuf.GeneratedMessage.Builder<Builder>
+             implements mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder {
             public static final com.google.protobuf.Descriptors.Descriptor
                 getDescriptor() {
               return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor;
@@ -14223,6 +14314,7 @@ public final class Protos {
             }
             private int bitField0_;
 
+            // required int64 initiated = 1;
             private long initiated_ ;
             /**
              * <code>required int64 initiated = 1;</code>
@@ -14255,6 +14347,7 @@ public final class Protos {
               return this;
             }
 
+            // required int64 deadline = 2;
             private long deadline_ ;
             /**
              * <code>required int64 deadline = 2;</code>
@@ -14287,6 +14380,7 @@ public final class Protos {
               return this;
             }
 
+            // required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;
             private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason reason_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason.RelaunchEscalationTimeout;
             /**
              * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
@@ -14334,6 +14428,7 @@ public final class Protos {
         }
 
         private int bitField0_;
+        // required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;
         public static final int TYPE_FIELD_NUMBER = 1;
         private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type type_;
         /**
@@ -14349,6 +14444,7 @@ public final class Protos {
           return type_;
         }
 
+        // optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;
         public static final int TIMEOUT_FIELD_NUMBER = 2;
         private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout timeout_;
         /**
@@ -14377,8 +14473,7 @@ public final class Protos {
         private byte memoizedIsInitialized = -1;
         public final boolean isInitialized() {
           byte isInitialized = memoizedIsInitialized;
-          if (isInitialized == 1) return true;
-          if (isInitialized == 0) return false;
+          if (isInitialized != -1) return isInitialized == 1;
 
           if (!hasType()) {
             memoizedIsInitialized = 0;
@@ -14502,9 +14597,8 @@ public final class Protos {
          * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State}
          */
         public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-            // @@protoc_insertion_point(builder_implements:mesosphere.marathon.MarathonTask.Reservation.State)
-            mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder {
+            com.google.protobuf.GeneratedMessage.Builder<Builder>
+           implements mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder {
           public static final com.google.protobuf.Descriptors.Descriptor
               getDescriptor() {
             return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor;
@@ -14645,6 +14739,7 @@ public final class Protos {
           }
           private int bitField0_;
 
+          // required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;
           private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type type_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type.New;
           /**
            * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
@@ -14680,6 +14775,7 @@ public final class Protos {
             return this;
           }
 
+          // optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;
           private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout timeout_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.getDefaultInstance();
           private com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder> timeoutBuilder_;
@@ -14788,7 +14884,7 @@ public final class Protos {
             if (timeoutBuilder_ == null) {
               timeoutBuilder_ = new com.google.protobuf.SingleFieldBuilder<
                   mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder>(
-                      getTimeout(),
+                      timeout_,
                       getParentForChildren(),
                       isClean());
               timeout_ = null;
@@ -14808,12 +14904,13 @@ public final class Protos {
       }
 
       private int bitField0_;
+      // repeated string local_volume_ids = 1;
       public static final int LOCAL_VOLUME_IDS_FIELD_NUMBER = 1;
       private com.google.protobuf.LazyStringList localVolumeIds_;
       /**
        * <code>repeated string local_volume_ids = 1;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getLocalVolumeIdsList() {
         return localVolumeIds_;
       }
@@ -14837,6 +14934,7 @@ public final class Protos {
         return localVolumeIds_.getByteString(index);
       }
 
+      // required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;
       public static final int STATE_FIELD_NUMBER = 2;
       private mesosphere.marathon.Protos.MarathonTask.Reservation.State state_;
       /**
@@ -14865,8 +14963,7 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized == 1) return true;
-        if (isInitialized == 0) return false;
+        if (isInitialized != -1) return isInitialized == 1;
 
         if (!hasState()) {
           memoizedIsInitialized = 0;
@@ -14993,9 +15090,8 @@ public final class Protos {
        * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation}
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.MarathonTask.Reservation)
-          mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder>
+         implements mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor;
@@ -15066,7 +15162,8 @@ public final class Protos {
           int from_bitField0_ = bitField0_;
           int to_bitField0_ = 0;
           if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            localVolumeIds_ = localVolumeIds_.getUnmodifiableView();
+            localVolumeIds_ = new com.google.protobuf.UnmodifiableLazyStringList(
+                localVolumeIds_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
           result.localVolumeIds_ = localVolumeIds_;
@@ -15142,6 +15239,7 @@ public final class Protos {
         }
         private int bitField0_;
 
+        // repeated string local_volume_ids = 1;
         private com.google.protobuf.LazyStringList localVolumeIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         private void ensureLocalVolumeIdsIsMutable() {
           if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -15152,9 +15250,9 @@ public final class Protos {
         /**
          * <code>repeated string local_volume_ids = 1;</code>
          */
-        public com.google.protobuf.ProtocolStringList
+        public java.util.List<java.lang.String>
             getLocalVolumeIdsList() {
-          return localVolumeIds_.getUnmodifiableView();
+          return java.util.Collections.unmodifiableList(localVolumeIds_);
         }
         /**
          * <code>repeated string local_volume_ids = 1;</code>
@@ -15207,8 +15305,7 @@ public final class Protos {
         public Builder addAllLocalVolumeIds(
             java.lang.Iterable<java.lang.String> values) {
           ensureLocalVolumeIdsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, localVolumeIds_);
+          super.addAll(values, localVolumeIds_);
           onChanged();
           return this;
         }
@@ -15235,6 +15332,7 @@ public final class Protos {
           return this;
         }
 
+        // required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;
         private mesosphere.marathon.Protos.MarathonTask.Reservation.State state_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.getDefaultInstance();
         private com.google.protobuf.SingleFieldBuilder<
             mesosphere.marathon.Protos.MarathonTask.Reservation.State, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder> stateBuilder_;
@@ -15343,7 +15441,7 @@ public final class Protos {
           if (stateBuilder_ == null) {
             stateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
                 mesosphere.marathon.Protos.MarathonTask.Reservation.State, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder>(
-                    getState(),
+                    state_,
                     getParentForChildren(),
                     isClean());
             state_ = null;
@@ -15363,6 +15461,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -15405,6 +15504,7 @@ public final class Protos {
       }
     }
 
+    // optional string host = 2;
     public static final int HOST_FIELD_NUMBER = 2;
     private java.lang.Object host_;
     /**
@@ -15447,6 +15547,7 @@ public final class Protos {
       }
     }
 
+    // repeated uint32 ports = 3;
     public static final int PORTS_FIELD_NUMBER = 3;
     private java.util.List<java.lang.Integer> ports_;
     /**
@@ -15469,6 +15570,7 @@ public final class Protos {
       return ports_.get(index);
     }
 
+    // repeated .mesos.Attribute attributes = 4;
     public static final int ATTRIBUTES_FIELD_NUMBER = 4;
     private java.util.List<org.apache.mesos.Protos.Attribute> attributes_;
     /**
@@ -15504,6 +15606,7 @@ public final class Protos {
       return attributes_.get(index);
     }
 
+    // optional int64 staged_at = 5;
     public static final int STAGED_AT_FIELD_NUMBER = 5;
     private long stagedAt_;
     /**
@@ -15519,6 +15622,7 @@ public final class Protos {
       return stagedAt_;
     }
 
+    // optional int64 started_at = 6;
     public static final int STARTED_AT_FIELD_NUMBER = 6;
     private long startedAt_;
     /**
@@ -15534,6 +15638,7 @@ public final class Protos {
       return startedAt_;
     }
 
+    // repeated .mesos.TaskStatus OBSOLETE_statuses = 7;
     public static final int OBSOLETE_STATUSES_FIELD_NUMBER = 7;
     private java.util.List<org.apache.mesos.Protos.TaskStatus> oBSOLETEStatuses_;
     /**
@@ -15569,6 +15674,7 @@ public final class Protos {
       return oBSOLETEStatuses_.get(index);
     }
 
+    // optional string version = 8 [default = "1970-01-01T00:00:00.000Z"];
     public static final int VERSION_FIELD_NUMBER = 8;
     private java.lang.Object version_;
     /**
@@ -15623,6 +15729,7 @@ public final class Protos {
       }
     }
 
+    // optional .mesos.TaskStatus status = 9;
     public static final int STATUS_FIELD_NUMBER = 9;
     private org.apache.mesos.Protos.TaskStatus status_;
     /**
@@ -15644,6 +15751,7 @@ public final class Protos {
       return status_;
     }
 
+    // optional .mesos.SlaveID slaveId = 10;
     public static final int SLAVEID_FIELD_NUMBER = 10;
     private org.apache.mesos.Protos.SlaveID slaveId_;
     /**
@@ -15665,6 +15773,7 @@ public final class Protos {
       return slaveId_;
     }
 
+    // repeated .mesos.NetworkInfo OBSOLETE_networks = 11;
     public static final int OBSOLETE_NETWORKS_FIELD_NUMBER = 11;
     private java.util.List<org.apache.mesos.Protos.NetworkInfo> oBSOLETENetworks_;
     /**
@@ -15720,6 +15829,7 @@ public final class Protos {
       return oBSOLETENetworks_.get(index);
     }
 
+    // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
     public static final int RESERVATION_FIELD_NUMBER = 12;
     private mesosphere.marathon.Protos.MarathonTask.Reservation reservation_;
     /**
@@ -15770,8 +15880,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasId()) {
         memoizedIsInitialized = 0;
@@ -16000,9 +16109,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.MarathonTask}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.MarathonTask)
-        mesosphere.marathon.Protos.MarathonTaskOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.MarathonTaskOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_descriptor;
@@ -16394,6 +16502,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>required string id = 1;</code>
@@ -16407,12 +16516,9 @@ public final class Protos {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            id_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          id_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -16470,6 +16576,7 @@ public final class Protos {
         return this;
       }
 
+      // optional string host = 2;
       private java.lang.Object host_ = "";
       /**
        * <code>optional string host = 2;</code>
@@ -16483,12 +16590,9 @@ public final class Protos {
       public java.lang.String getHost() {
         java.lang.Object ref = host_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            host_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          host_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -16546,6 +16650,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated uint32 ports = 3;
       private java.util.List<java.lang.Integer> ports_ = java.util.Collections.emptyList();
       private void ensurePortsIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
@@ -16597,8 +16702,7 @@ public final class Protos {
       public Builder addAllPorts(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensurePortsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, ports_);
+        super.addAll(values, ports_);
         onChanged();
         return this;
       }
@@ -16612,6 +16716,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated .mesos.Attribute attributes = 4;
       private java.util.List<org.apache.mesos.Protos.Attribute> attributes_ =
         java.util.Collections.emptyList();
       private void ensureAttributesIsMutable() {
@@ -16753,8 +16858,7 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Attribute> values) {
         if (attributesBuilder_ == null) {
           ensureAttributesIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, attributes_);
+          super.addAll(values, attributes_);
           onChanged();
         } else {
           attributesBuilder_.addAllMessages(values);
@@ -16852,6 +16956,7 @@ public final class Protos {
         return attributesBuilder_;
       }
 
+      // optional int64 staged_at = 5;
       private long stagedAt_ ;
       /**
        * <code>optional int64 staged_at = 5;</code>
@@ -16884,6 +16989,7 @@ public final class Protos {
         return this;
       }
 
+      // optional int64 started_at = 6;
       private long startedAt_ ;
       /**
        * <code>optional int64 started_at = 6;</code>
@@ -16916,6 +17022,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated .mesos.TaskStatus OBSOLETE_statuses = 7;
       private java.util.List<org.apache.mesos.Protos.TaskStatus> oBSOLETEStatuses_ =
         java.util.Collections.emptyList();
       private void ensureOBSOLETEStatusesIsMutable() {
@@ -17057,8 +17164,7 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.TaskStatus> values) {
         if (oBSOLETEStatusesBuilder_ == null) {
           ensureOBSOLETEStatusesIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, oBSOLETEStatuses_);
+          super.addAll(values, oBSOLETEStatuses_);
           onChanged();
         } else {
           oBSOLETEStatusesBuilder_.addAllMessages(values);
@@ -17156,6 +17262,7 @@ public final class Protos {
         return oBSOLETEStatusesBuilder_;
       }
 
+      // optional string version = 8 [default = "1970-01-01T00:00:00.000Z"];
       private java.lang.Object version_ = "1970-01-01T00:00:00.000Z";
       /**
        * <code>optional string version = 8 [default = "1970-01-01T00:00:00.000Z"];</code>
@@ -17177,12 +17284,9 @@ public final class Protos {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            version_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          version_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -17256,6 +17360,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesos.TaskStatus status = 9;
       private org.apache.mesos.Protos.TaskStatus status_ = org.apache.mesos.Protos.TaskStatus.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.TaskStatus, org.apache.mesos.Protos.TaskStatus.Builder, org.apache.mesos.Protos.TaskStatusOrBuilder> statusBuilder_;
@@ -17364,7 +17469,7 @@ public final class Protos {
         if (statusBuilder_ == null) {
           statusBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.TaskStatus, org.apache.mesos.Protos.TaskStatus.Builder, org.apache.mesos.Protos.TaskStatusOrBuilder>(
-                  getStatus(),
+                  status_,
                   getParentForChildren(),
                   isClean());
           status_ = null;
@@ -17372,6 +17477,7 @@ public final class Protos {
         return statusBuilder_;
       }
 
+      // optional .mesos.SlaveID slaveId = 10;
       private org.apache.mesos.Protos.SlaveID slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder> slaveIdBuilder_;
@@ -17480,7 +17586,7 @@ public final class Protos {
         if (slaveIdBuilder_ == null) {
           slaveIdBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder>(
-                  getSlaveId(),
+                  slaveId_,
                   getParentForChildren(),
                   isClean());
           slaveId_ = null;
@@ -17488,6 +17594,7 @@ public final class Protos {
         return slaveIdBuilder_;
       }
 
+      // repeated .mesos.NetworkInfo OBSOLETE_networks = 11;
       private java.util.List<org.apache.mesos.Protos.NetworkInfo> oBSOLETENetworks_ =
         java.util.Collections.emptyList();
       private void ensureOBSOLETENetworksIsMutable() {
@@ -17669,8 +17776,7 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.NetworkInfo> values) {
         if (oBSOLETENetworksBuilder_ == null) {
           ensureOBSOLETENetworksIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, oBSOLETENetworks_);
+          super.addAll(values, oBSOLETENetworks_);
           onChanged();
         } else {
           oBSOLETENetworksBuilder_.addAllMessages(values);
@@ -17800,6 +17906,7 @@ public final class Protos {
         return oBSOLETENetworksBuilder_;
       }
 
+      // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
       private mesosphere.marathon.Protos.MarathonTask.Reservation reservation_ = mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.MarathonTask.Reservation, mesosphere.marathon.Protos.MarathonTask.Reservation.Builder, mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder> reservationBuilder_;
@@ -17944,7 +18051,7 @@ public final class Protos {
         if (reservationBuilder_ == null) {
           reservationBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.MarathonTask.Reservation, mesosphere.marathon.Protos.MarathonTask.Reservation.Builder, mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder>(
-                  getReservation(),
+                  reservation_,
                   getParentForChildren(),
                   isClean());
           reservation_ = null;
@@ -17963,10 +18070,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask)
   }
 
-  public interface MarathonAppOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.MarathonApp)
-      com.google.protobuf.MessageOrBuilder {
+  public interface MarathonAppOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // optional string name = 1;
     /**
      * <code>optional string name = 1;</code>
      */
@@ -17981,6 +18088,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getNameBytes();
 
+    // repeated .mesosphere.marathon.MarathonTask tasks = 2;
     /**
      * <code>repeated .mesosphere.marathon.MarathonTask tasks = 2;</code>
      */
@@ -18009,9 +18117,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.MarathonApp}
    */
   public static final class MarathonApp extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.MarathonApp)
-      MarathonAppOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements MarathonAppOrBuilder {
     // Use MarathonApp.newBuilder() to construct.
     private MarathonApp(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -18058,9 +18165,8 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              name_ = bs;
+              name_ = input.readBytes();
               break;
             }
             case 18: {
@@ -18114,6 +18220,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // optional string name = 1;
     public static final int NAME_FIELD_NUMBER = 1;
     private java.lang.Object name_;
     /**
@@ -18156,6 +18263,7 @@ public final class Protos {
       }
     }
 
+    // repeated .mesosphere.marathon.MarathonTask tasks = 2;
     public static final int TASKS_FIELD_NUMBER = 2;
     private java.util.List<mesosphere.marathon.Protos.MarathonTask> tasks_;
     /**
@@ -18198,8 +18306,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       for (int i = 0; i < getTasksCount(); i++) {
         if (!getTasks(i).isInitialized()) {
@@ -18319,9 +18426,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.MarathonApp}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.MarathonApp)
-        mesosphere.marathon.Protos.MarathonAppOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.MarathonAppOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonApp_descriptor;
@@ -18484,6 +18590,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // optional string name = 1;
       private java.lang.Object name_ = "";
       /**
        * <code>optional string name = 1;</code>
@@ -18497,12 +18604,9 @@ public final class Protos {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            name_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          name_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -18560,6 +18664,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated .mesosphere.marathon.MarathonTask tasks = 2;
       private java.util.List<mesosphere.marathon.Protos.MarathonTask> tasks_ =
         java.util.Collections.emptyList();
       private void ensureTasksIsMutable() {
@@ -18701,8 +18806,7 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.MarathonTask> values) {
         if (tasksBuilder_ == null) {
           ensureTasksIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, tasks_);
+          super.addAll(values, tasks_);
           onChanged();
         } else {
           tasksBuilder_.addAllMessages(values);
@@ -18811,10 +18915,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonApp)
   }
 
-  public interface ContainerInfoOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ContainerInfo)
-      com.google.protobuf.MessageOrBuilder {
+  public interface ContainerInfoOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required bytes image = 1 [default = ""];
     /**
      * <code>required bytes image = 1 [default = ""];</code>
      */
@@ -18824,6 +18928,7 @@ public final class Protos {
      */
     com.google.protobuf.ByteString getImage();
 
+    // repeated bytes options = 2;
     /**
      * <code>repeated bytes options = 2;</code>
      */
@@ -18841,9 +18946,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ContainerInfo}
    */
   public static final class ContainerInfo extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ContainerInfo)
-      ContainerInfoOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements ContainerInfoOrBuilder {
     // Use ContainerInfo.newBuilder() to construct.
     private ContainerInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -18945,6 +19049,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required bytes image = 1 [default = ""];
     public static final int IMAGE_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString image_;
     /**
@@ -18960,6 +19065,7 @@ public final class Protos {
       return image_;
     }
 
+    // repeated bytes options = 2;
     public static final int OPTIONS_FIELD_NUMBER = 2;
     private java.util.List<com.google.protobuf.ByteString> options_;
     /**
@@ -18989,8 +19095,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasImage()) {
         memoizedIsInitialized = 0;
@@ -19113,9 +19218,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ContainerInfo}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ContainerInfo)
-        mesosphere.marathon.Protos.ContainerInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.ContainerInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ContainerInfo_descriptor;
@@ -19249,6 +19353,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required bytes image = 1 [default = ""];
       private com.google.protobuf.ByteString image_ = com.google.protobuf.Internal.bytesDefaultValue("");
       /**
        * <code>required bytes image = 1 [default = ""];</code>
@@ -19284,6 +19389,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated bytes options = 2;
       private java.util.List<com.google.protobuf.ByteString> options_ = java.util.Collections.emptyList();
       private void ensureOptionsIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
@@ -19341,8 +19447,7 @@ public final class Protos {
       public Builder addAllOptions(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensureOptionsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, options_);
+        super.addAll(values, options_);
         onChanged();
         return this;
       }
@@ -19367,10 +19472,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ContainerInfo)
   }
 
-  public interface ExtendedContainerInfoOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ExtendedContainerInfo)
-      com.google.protobuf.MessageOrBuilder {
+  public interface ExtendedContainerInfoOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required .mesos.ContainerInfo.Type type = 1;
     /**
      * <code>required .mesos.ContainerInfo.Type type = 1;</code>
      */
@@ -19380,6 +19485,7 @@ public final class Protos {
      */
     org.apache.mesos.Protos.ContainerInfo.Type getType();
 
+    // repeated .mesosphere.marathon.Volume volumes = 2;
     /**
      * <code>repeated .mesosphere.marathon.Volume volumes = 2;</code>
      */
@@ -19404,6 +19510,7 @@ public final class Protos {
     mesosphere.marathon.Protos.VolumeOrBuilder getVolumesOrBuilder(
         int index);
 
+    // optional .mesosphere.marathon.ExtendedContainerInfo.DockerInfo docker = 3;
     /**
      * <code>optional .mesosphere.marathon.ExtendedContainerInfo.DockerInfo docker = 3;</code>
      */
@@ -19426,9 +19533,8 @@ public final class Protos {
    * </pre>
    */
   public static final class ExtendedContainerInfo extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ExtendedContainerInfo)
-      ExtendedContainerInfoOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements ExtendedContainerInfoOrBuilder {
     // Use ExtendedContainerInfo.newBuilder() to construct.
     private ExtendedContainerInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -19548,10 +19654,10 @@ public final class Protos {
       return PARSER;
     }
 
-    public interface DockerInfoOrBuilder extends
-        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ExtendedContainerInfo.DockerInfo)
-        com.google.protobuf.MessageOrBuilder {
+    public interface DockerInfoOrBuilder
+        extends com.google.protobuf.MessageOrBuilder {
 
+      // required string image = 1;
       /**
        * <code>required string image = 1;</code>
        */
@@ -19566,6 +19672,7 @@ public final class Protos {
       com.google.protobuf.ByteString
           getImageBytes();
 
+      // optional .mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];
       /**
        * <code>optional .mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];</code>
        */
@@ -19575,6 +19682,7 @@ public final class Protos {
        */
       org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network getNetwork();
 
+      // repeated .mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping port_mappings = 3;
       /**
        * <code>repeated .mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping port_mappings = 3;</code>
        */
@@ -19599,6 +19707,7 @@ public final class Protos {
       mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMappingOrBuilder getPortMappingsOrBuilder(
           int index);
 
+      // optional bool privileged = 4 [default = false];
       /**
        * <code>optional bool privileged = 4 [default = false];</code>
        */
@@ -19608,6 +19717,7 @@ public final class Protos {
        */
       boolean getPrivileged();
 
+      // repeated .mesos.Parameter parameters = 5;
       /**
        * <code>repeated .mesos.Parameter parameters = 5;</code>
        *
@@ -19667,6 +19777,7 @@ public final class Protos {
       org.apache.mesos.Protos.ParameterOrBuilder getParametersOrBuilder(
           int index);
 
+      // optional bool force_pull_image = 6;
       /**
        * <code>optional bool force_pull_image = 6;</code>
        *
@@ -19692,9 +19803,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ExtendedContainerInfo.DockerInfo}
      */
     public static final class DockerInfo extends
-        com.google.protobuf.GeneratedMessage implements
-        // @@protoc_insertion_point(message_implements:mesosphere.marathon.ExtendedContainerInfo.DockerInfo)
-        DockerInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage
+        implements DockerInfoOrBuilder {
       // Use DockerInfo.newBuilder() to construct.
       private DockerInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -19741,9 +19851,8 @@ public final class Protos {
                 break;
               }
               case 10: {
-                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
-                image_ = bs;
+                image_ = input.readBytes();
                 break;
               }
               case 16: {
@@ -19828,19 +19937,20 @@ public final class Protos {
         return PARSER;
       }
 
-      public interface PortMappingOrBuilder extends
-          // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping)
-          com.google.protobuf.MessageOrBuilder {
+      public interface PortMappingOrBuilder
+          extends com.google.protobuf.MessageOrBuilder {
 
+        // optional uint32 host_port = 1;
         /**
-         * <code>required uint32 host_port = 1;</code>
+         * <code>optional uint32 host_port = 1;</code>
          */
         boolean hasHostPort();
         /**
-         * <code>required uint32 host_port = 1;</code>
+         * <code>optional uint32 host_port = 1;</code>
          */
         int getHostPort();
 
+        // required uint32 container_port = 2;
         /**
          * <code>required uint32 container_port = 2;</code>
          */
@@ -19850,6 +19960,7 @@ public final class Protos {
          */
         int getContainerPort();
 
+        // optional string protocol = 3;
         /**
          * <code>optional string protocol = 3;</code>
          */
@@ -19864,6 +19975,7 @@ public final class Protos {
         com.google.protobuf.ByteString
             getProtocolBytes();
 
+        // optional string name = 4;
         /**
          * <code>optional string name = 4;</code>
          */
@@ -19878,6 +19990,7 @@ public final class Protos {
         com.google.protobuf.ByteString
             getNameBytes();
 
+        // repeated .mesos.Label labels = 5;
         /**
          * <code>repeated .mesos.Label labels = 5;</code>
          */
@@ -19902,6 +20015,7 @@ public final class Protos {
         org.apache.mesos.Protos.LabelOrBuilder getLabelsOrBuilder(
             int index);
 
+        // optional uint32 service_port = 100 [default = 0];
         /**
          * <code>optional uint32 service_port = 100 [default = 0];</code>
          */
@@ -19915,9 +20029,8 @@ public final class Protos {
        * Protobuf type {@code mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping}
        */
       public static final class PortMapping extends
-          com.google.protobuf.GeneratedMessage implements
-          // @@protoc_insertion_point(message_implements:mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping)
-          PortMappingOrBuilder {
+          com.google.protobuf.GeneratedMessage
+          implements PortMappingOrBuilder {
         // Use PortMapping.newBuilder() to construct.
         private PortMapping(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
           super(builder);
@@ -19974,15 +20087,13 @@ public final class Protos {
                   break;
                 }
                 case 26: {
-                  com.google.protobuf.ByteString bs = input.readBytes();
                   bitField0_ |= 0x00000004;
-                  protocol_ = bs;
+                  protocol_ = input.readBytes();
                   break;
                 }
                 case 34: {
-                  com.google.protobuf.ByteString bs = input.readBytes();
                   bitField0_ |= 0x00000008;
-                  name_ = bs;
+                  name_ = input.readBytes();
                   break;
                 }
                 case 42: {
@@ -20041,21 +20152,23 @@ public final class Protos {
         }
 
         private int bitField0_;
+        // optional uint32 host_port = 1;
         public static final int HOST_PORT_FIELD_NUMBER = 1;
         private int hostPort_;
         /**
-         * <code>required uint32 host_port = 1;</code>
+         * <code>optional uint32 host_port = 1;</code>
          */
         public boolean hasHostPort() {
           return ((bitField0_ & 0x00000001) == 0x00000001);
         }
         /**
-         * <code>required uint32 host_port = 1;</code>
+         * <code>optional uint32 host_port = 1;</code>
          */
         public int getHostPort() {
           return hostPort_;
         }
 
+        // required uint32 container_port = 2;
         public static final int CONTAINER_PORT_FIELD_NUMBER = 2;
         private int containerPort_;
         /**
@@ -20071,6 +20184,7 @@ public final class Protos {
           return containerPort_;
         }
 
+        // optional string protocol = 3;
         public static final int PROTOCOL_FIELD_NUMBER = 3;
         private java.lang.Object protocol_;
         /**
@@ -20113,6 +20227,7 @@ public final class Protos {
           }
         }
 
+        // optional string name = 4;
         public static final int NAME_FIELD_NUMBER = 4;
         private java.lang.Object name_;
         /**
@@ -20155,6 +20270,7 @@ public final class Protos {
           }
         }
 
+        // repeated .mesos.Label labels = 5;
         public static final int LABELS_FIELD_NUMBER = 5;
         private java.util.List<org.apache.mesos.Protos.Label> labels_;
         /**
@@ -20190,6 +20306,7 @@ public final class Protos {
           return labels_.get(index);
         }
 
+        // optional uint32 service_port = 100 [default = 0];
         public static final int SERVICE_PORT_FIELD_NUMBER = 100;
         private int servicePort_;
         /**
@@ -20216,13 +20333,8 @@ public final class Protos {
         private byte memoizedIsInitialized = -1;
         public final boolean isInitialized() {
           byte isInitialized = memoizedIsInitialized;
-          if (isInitialized == 1) return true;
-          if (isInitialized == 0) return false;
+          if (isInitialized != -1) return isInitialized == 1;
 
-          if (!hasHostPort()) {
-            memoizedIsInitialized = 0;
-            return false;
-          }
           if (!hasContainerPort()) {
             memoizedIsInitialized = 0;
             return false;
@@ -20373,9 +20485,8 @@ public final class Protos {
          * Protobuf type {@code mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping}
          */
         public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-            // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping)
-            mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMappingOrBuilder {
+            com.google.protobuf.GeneratedMessage.Builder<Builder>
+           implements mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMappingOrBuilder {
           public static final com.google.protobuf.Descriptors.Descriptor
               getDescriptor() {
             return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor;
@@ -20548,10 +20659,6 @@ public final class Protos {
           }
 
           public final boolean isInitialized() {
-            if (!hasHostPort()) {
-              
-              return false;
-            }
             if (!hasContainerPort()) {
               
               return false;
@@ -20584,21 +20691,22 @@ public final class Protos {
           }
           private int bitField0_;
 
+          // optional uint32 host_port = 1;
           private int hostPort_ ;
           /**
-           * <code>required uint32 host_port = 1;</code>
+           * <code>optional uint32 host_port = 1;</code>
            */
           public boolean hasHostPort() {
             return ((bitField0_ & 0x00000001) == 0x00000001);
           }
           /**
-           * <code>required uint32 host_port = 1;</code>
+           * <code>optional uint32 host_port = 1;</code>
            */
           public int getHostPort() {
             return hostPort_;
           }
           /**
-           * <code>required uint32 host_port = 1;</code>
+           * <code>optional uint32 host_port = 1;</code>
            */
           public Builder setHostPort(int value) {
             bitField0_ |= 0x00000001;
@@ -20607,7 +20715,7 @@ public final class Protos {
             return this;
           }
           /**
-           * <code>required uint32 host_port = 1;</code>
+           * <code>optional uint32 host_port = 1;</code>
            */
           public Builder clearHostPort() {
             bitField0_ = (bitField0_ & ~0x00000001);
@@ -20616,6 +20724,7 @@ public final class Protos {
             return this;
           }
 
+          // required uint32 container_port = 2;
           private int containerPort_ ;
           /**
            * <code>required uint32 container_port = 2;</code>
@@ -20648,6 +20757,7 @@ public final class Protos {
             return this;
           }
 
+          // optional string protocol = 3;
           private java.lang.Object protocol_ = "";
           /**
            * <code>optional string protocol = 3;</code>
@@ -20661,12 +20771,9 @@ public final class Protos {
           public java.lang.String getProtocol() {
             java.lang.Object ref = protocol_;
             if (!(ref instanceof java.lang.String)) {
-              com.google.protobuf.ByteString bs =
-                  (com.google.protobuf.ByteString) ref;
-              java.lang.String s = bs.toStringUtf8();
-              if (bs.isValidUtf8()) {
-                protocol_ = s;
-              }
+              java.lang.String s = ((com.google.protobuf.ByteString) ref)
+                  .toStringUtf8();
+              protocol_ = s;
               return s;
             } else {
               return (java.lang.String) ref;
@@ -20724,6 +20831,7 @@ public final class Protos {
             return this;
           }
 
+          // optional string name = 4;
           private java.lang.Object name_ = "";
           /**
            * <code>optional string name = 4;</code>
@@ -20737,12 +20845,9 @@ public final class Protos {
           public java.lang.String getName() {
             java.lang.Object ref = name_;
             if (!(ref instanceof java.lang.String)) {
-              com.google.protobuf.ByteString bs =
-                  (com.google.protobuf.ByteString) ref;
-              java.lang.String s = bs.toStringUtf8();
-              if (bs.isValidUtf8()) {
-                name_ = s;
-              }
+              java.lang.String s = ((com.google.protobuf.ByteString) ref)
+                  .toStringUtf8();
+              name_ = s;
               return s;
             } else {
               return (java.lang.String) ref;
@@ -20800,6 +20905,7 @@ public final class Protos {
             return this;
           }
 
+          // repeated .mesos.Label labels = 5;
           private java.util.List<org.apache.mesos.Protos.Label> labels_ =
             java.util.Collections.emptyList();
           private void ensureLabelsIsMutable() {
@@ -20941,8 +21047,7 @@ public final class Protos {
               java.lang.Iterable<? extends org.apache.mesos.Protos.Label> values) {
             if (labelsBuilder_ == null) {
               ensureLabelsIsMutable();
-              com.google.protobuf.AbstractMessageLite.Builder.addAll(
-                  values, labels_);
+              super.addAll(values, labels_);
               onChanged();
             } else {
               labelsBuilder_.addAllMessages(values);
@@ -21040,6 +21145,7 @@ public final class Protos {
             return labelsBuilder_;
           }
 
+          // optional uint32 service_port = 100 [default = 0];
           private int servicePort_ ;
           /**
            * <code>optional uint32 service_port = 100 [default = 0];</code>
@@ -21084,6 +21190,7 @@ public final class Protos {
       }
 
       private int bitField0_;
+      // required string image = 1;
       public static final int IMAGE_FIELD_NUMBER = 1;
       private java.lang.Object image_;
       /**
@@ -21126,6 +21233,7 @@ public final class Protos {
         }
       }
 
+      // optional .mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];
       public static final int NETWORK_FIELD_NUMBER = 2;
       private org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network network_;
       /**
@@ -21141,6 +21249,7 @@ public final class Protos {
         return network_;
       }
 
+      // repeated .mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping port_mappings = 3;
       public static final int PORT_MAPPINGS_FIELD_NUMBER = 3;
       private java.util.List<mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMapping> portMappings_;
       /**
@@ -21176,6 +21285,7 @@ public final class Protos {
         return portMappings_.get(index);
       }
 
+      // optional bool privileged = 4 [default = false];
       public static final int PRIVILEGED_FIELD_NUMBER = 4;
       private boolean privileged_;
       /**
@@ -21191,6 +21301,7 @@ public final class Protos {
         return privileged_;
       }
 
+      // repeated .mesos.Parameter parameters = 5;
       public static final int PARAMETERS_FIELD_NUMBER = 5;
       private java.util.List<org.apache.mesos.Protos.Parameter> parameters_;
       /**
@@ -21261,6 +21372,7 @@ public final class Protos {
         return parameters_.get(index);
       }
 
+      // optional bool force_pull_image = 6;
       public static final int FORCE_PULL_IMAGE_FIELD_NUMBER = 6;
       private boolean forcePullImage_;
       /**
@@ -21299,8 +21411,7 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized == 1) return true;
-        if (isInitialized == 0) return false;
+        if (isInitialized != -1) return isInitialized == 1;
 
         if (!hasImage()) {
           memoizedIsInitialized = 0;
@@ -21458,9 +21569,8 @@ public final class Protos {
        * Protobuf type {@code mesosphere.marathon.ExtendedContainerInfo.DockerInfo}
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ExtendedContainerInfo.DockerInfo)
-          mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfoOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder>
+         implements mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfoOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor;
@@ -21702,6 +21812,7 @@ public final class Protos {
         }
         private int bitField0_;
 
+        // required string image = 1;
         private java.lang.Object image_ = "";
         /**
          * <code>required string image = 1;</code>
@@ -21715,12 +21826,9 @@ public final class Protos {
         public java.lang.String getImage() {
           java.lang.Object ref = image_;
           if (!(ref instanceof java.lang.String)) {
-            com.google.protobuf.ByteString bs =
-                (com.google.protobuf.ByteString) ref;
-            java.lang.String s = bs.toStringUtf8();
-            if (bs.isValidUtf8()) {
-              image_ = s;
-            }
+            java.lang.String s = ((com.google.protobuf.ByteString) ref)
+                .toStringUtf8();
+            image_ = s;
             return s;
           } else {
             return (java.lang.String) ref;
@@ -21778,6 +21886,7 @@ public final class Protos {
           return this;
         }
 
+        // optional .mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];
         private org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network network_ = org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network.HOST;
         /**
          * <code>optional .mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];</code>
@@ -21813,6 +21922,7 @@ public final class Protos {
           return this;
         }
 
+        // repeated .mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping port_mappings = 3;
         private java.util.List<mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMapping> portMappings_ =
           java.util.Collections.emptyList();
         private void ensurePortMappingsIsMutable() {
@@ -21954,8 +22064,7 @@ public final class Protos {
             java.lang.Iterable<? extends mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMapping> values) {
           if (portMappingsBuilder_ == null) {
             ensurePortMappingsIsMutable();
-            com.google.protobuf.AbstractMessageLite.Builder.addAll(
-                values, portMappings_);
+            super.addAll(values, portMappings_);
             onChanged();
           } else {
             portMappingsBuilder_.addAllMessages(values);
@@ -22053,6 +22162,7 @@ public final class Protos {
           return portMappingsBuilder_;
         }
 
+        // optional bool privileged = 4 [default = false];
         private boolean privileged_ ;
         /**
          * <code>optional bool privileged = 4 [default = false];</code>
@@ -22085,6 +22195,7 @@ public final class Protos {
           return this;
         }
 
+        // repeated .mesos.Parameter parameters = 5;
         private java.util.List<org.apache.mesos.Protos.Parameter> parameters_ =
           java.util.Collections.emptyList();
         private void ensureParametersIsMutable() {
@@ -22296,8 +22407,7 @@ public final class Protos {
             java.lang.Iterable<? extends org.apache.mesos.Protos.Parameter> values) {
           if (parametersBuilder_ == null) {
             ensureParametersIsMutable();
-            com.google.protobuf.AbstractMessageLite.Builder.addAll(
-                values, parameters_);
+            super.addAll(values, parameters_);
             onChanged();
           } else {
             parametersBuilder_.addAllMessages(values);
@@ -22451,6 +22561,7 @@ public final class Protos {
           return parametersBuilder_;
         }
 
+        // optional bool force_pull_image = 6;
         private boolean forcePullImage_ ;
         /**
          * <code>optional bool force_pull_image = 6;</code>
@@ -22519,6 +22630,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required .mesos.ContainerInfo.Type type = 1;
     public static final int TYPE_FIELD_NUMBER = 1;
     private org.apache.mesos.Protos.ContainerInfo.Type type_;
     /**
@@ -22534,6 +22646,7 @@ public final class Protos {
       return type_;
     }
 
+    // repeated .mesosphere.marathon.Volume volumes = 2;
     public static final int VOLUMES_FIELD_NUMBER = 2;
     private java.util.List<mesosphere.marathon.Protos.Volume> volumes_;
     /**
@@ -22569,6 +22682,7 @@ public final class Protos {
       return volumes_.get(index);
     }
 
+    // optional .mesosphere.marathon.ExtendedContainerInfo.DockerInfo docker = 3;
     public static final int DOCKER_FIELD_NUMBER = 3;
     private mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo docker_;
     /**
@@ -22598,8 +22712,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasType()) {
         memoizedIsInitialized = 0;
@@ -22741,9 +22854,8 @@ public final class Protos {
      * </pre>
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ExtendedContainerInfo)
-        mesosphere.marathon.Protos.ExtendedContainerInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.ExtendedContainerInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor;
@@ -22932,6 +23044,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required .mesos.ContainerInfo.Type type = 1;
       private org.apache.mesos.Protos.ContainerInfo.Type type_ = org.apache.mesos.Protos.ContainerInfo.Type.DOCKER;
       /**
        * <code>required .mesos.ContainerInfo.Type type = 1;</code>
@@ -22967,6 +23080,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated .mesosphere.marathon.Volume volumes = 2;
       private java.util.List<mesosphere.marathon.Protos.Volume> volumes_ =
         java.util.Collections.emptyList();
       private void ensureVolumesIsMutable() {
@@ -23108,8 +23222,7 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.Volume> values) {
         if (volumesBuilder_ == null) {
           ensureVolumesIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, volumes_);
+          super.addAll(values, volumes_);
           onChanged();
         } else {
           volumesBuilder_.addAllMessages(values);
@@ -23207,6 +23320,7 @@ public final class Protos {
         return volumesBuilder_;
       }
 
+      // optional .mesosphere.marathon.ExtendedContainerInfo.DockerInfo docker = 3;
       private mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo docker_ = mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfoOrBuilder> dockerBuilder_;
@@ -23315,7 +23429,7 @@ public final class Protos {
         if (dockerBuilder_ == null) {
           dockerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfoOrBuilder>(
-                  getDocker(),
+                  docker_,
                   getParentForChildren(),
                   isClean());
           docker_ = null;
@@ -23334,10 +23448,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ExtendedContainerInfo)
   }
 
-  public interface VolumeOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Volume)
-      com.google.protobuf.MessageOrBuilder {
+  public interface VolumeOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required .mesos.Volume.Mode mode = 3;
     /**
      * <code>required .mesos.Volume.Mode mode = 3;</code>
      */
@@ -23347,6 +23461,7 @@ public final class Protos {
      */
     org.apache.mesos.Protos.Volume.Mode getMode();
 
+    // required string container_path = 1;
     /**
      * <code>required string container_path = 1;</code>
      *
@@ -23382,6 +23497,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getContainerPathBytes();
 
+    // optional string host_path = 2;
     /**
      * <code>optional string host_path = 2;</code>
      *
@@ -23411,6 +23527,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getHostPathBytes();
 
+    // optional .mesos.Image image = 4;
     /**
      * <code>optional .mesos.Image image = 4;</code>
      *
@@ -23439,6 +23556,7 @@ public final class Protos {
      */
     org.apache.mesos.Protos.ImageOrBuilder getImageOrBuilder();
 
+    // optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;
     /**
      * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
      *
@@ -23464,6 +23582,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder getPersistentOrBuilder();
 
+    // optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;
     /**
      * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
      *
@@ -23499,9 +23618,8 @@ public final class Protos {
    * </pre>
    */
   public static final class Volume extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.Volume)
-      VolumeOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements VolumeOrBuilder {
     // Use Volume.newBuilder() to construct.
     private Volume(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -23548,15 +23666,13 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              containerPath_ = bs;
+              containerPath_ = input.readBytes();
               break;
             }
             case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000004;
-              hostPath_ = bs;
+              hostPath_ = input.readBytes();
               break;
             }
             case 24: {
@@ -23648,10 +23764,10 @@ public final class Protos {
       return PARSER;
     }
 
-    public interface PersistentVolumeInfoOrBuilder extends
-        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Volume.PersistentVolumeInfo)
-        com.google.protobuf.MessageOrBuilder {
+    public interface PersistentVolumeInfoOrBuilder
+        extends com.google.protobuf.MessageOrBuilder {
 
+      // required uint64 size = 1;
       /**
        * <code>required uint64 size = 1;</code>
        */
@@ -23669,9 +23785,8 @@ public final class Protos {
      * </pre>
      */
     public static final class PersistentVolumeInfo extends
-        com.google.protobuf.GeneratedMessage implements
-        // @@protoc_insertion_point(message_implements:mesosphere.marathon.Volume.PersistentVolumeInfo)
-        PersistentVolumeInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage
+        implements PersistentVolumeInfoOrBuilder {
       // Use PersistentVolumeInfo.newBuilder() to construct.
       private PersistentVolumeInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -23762,6 +23877,7 @@ public final class Protos {
       }
 
       private int bitField0_;
+      // required uint64 size = 1;
       public static final int SIZE_FIELD_NUMBER = 1;
       private long size_;
       /**
@@ -23783,8 +23899,7 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized == 1) return true;
-        if (isInitialized == 0) return false;
+        if (isInitialized != -1) return isInitialized == 1;
 
         if (!hasSize()) {
           memoizedIsInitialized = 0;
@@ -23899,9 +24014,8 @@ public final class Protos {
        * </pre>
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Volume.PersistentVolumeInfo)
-          mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder>
+         implements mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor;
@@ -24018,6 +24132,7 @@ public final class Protos {
         }
         private int bitField0_;
 
+        // required uint64 size = 1;
         private long size_ ;
         /**
          * <code>required uint64 size = 1;</code>
@@ -24061,10 +24176,10 @@ public final class Protos {
       // @@protoc_insertion_point(class_scope:mesosphere.marathon.Volume.PersistentVolumeInfo)
     }
 
-    public interface ExternalVolumeInfoOrBuilder extends
-        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Volume.ExternalVolumeInfo)
-        com.google.protobuf.MessageOrBuilder {
+    public interface ExternalVolumeInfoOrBuilder
+        extends com.google.protobuf.MessageOrBuilder {
 
+      // optional uint64 size = 1;
       /**
        * <code>optional uint64 size = 1;</code>
        */
@@ -24074,6 +24189,7 @@ public final class Protos {
        */
       long getSize();
 
+      // required string name = 2;
       /**
        * <code>required string name = 2;</code>
        */
@@ -24088,6 +24204,7 @@ public final class Protos {
       com.google.protobuf.ByteString
           getNameBytes();
 
+      // required string provider = 3;
       /**
        * <code>required string provider = 3;</code>
        */
@@ -24102,6 +24219,7 @@ public final class Protos {
       com.google.protobuf.ByteString
           getProviderBytes();
 
+      // repeated .mesos.Label options = 4;
       /**
        * <code>repeated .mesos.Label options = 4;</code>
        */
@@ -24134,9 +24252,8 @@ public final class Protos {
      * </pre>
      */
     public static final class ExternalVolumeInfo extends
-        com.google.protobuf.GeneratedMessage implements
-        // @@protoc_insertion_point(message_implements:mesosphere.marathon.Volume.ExternalVolumeInfo)
-        ExternalVolumeInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage
+        implements ExternalVolumeInfoOrBuilder {
       // Use ExternalVolumeInfo.newBuilder() to construct.
       private ExternalVolumeInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -24188,15 +24305,13 @@ public final class Protos {
                 break;
               }
               case 18: {
-                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000002;
-                name_ = bs;
+                name_ = input.readBytes();
                 break;
               }
               case 26: {
-                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000004;
-                provider_ = bs;
+                provider_ = input.readBytes();
                 break;
               }
               case 34: {
@@ -24250,6 +24365,7 @@ public final class Protos {
       }
 
       private int bitField0_;
+      // optional uint64 size = 1;
       public static final int SIZE_FIELD_NUMBER = 1;
       private long size_;
       /**
@@ -24265,6 +24381,7 @@ public final class Protos {
         return size_;
       }
 
+      // required string name = 2;
       public static final int NAME_FIELD_NUMBER = 2;
       private java.lang.Object name_;
       /**
@@ -24307,6 +24424,7 @@ public final class Protos {
         }
       }
 
+      // required string provider = 3;
       public static final int PROVIDER_FIELD_NUMBER = 3;
       private java.lang.Object provider_;
       /**
@@ -24349,6 +24467,7 @@ public final class Protos {
         }
       }
 
+      // repeated .mesos.Label options = 4;
       public static final int OPTIONS_FIELD_NUMBER = 4;
       private java.util.List<org.apache.mesos.Protos.Label> options_;
       /**
@@ -24393,8 +24512,7 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized == 1) return true;
-        if (isInitialized == 0) return false;
+        if (isInitialized != -1) return isInitialized == 1;
 
         if (!hasName()) {
           memoizedIsInitialized = 0;
@@ -24540,9 +24658,8 @@ public final class Protos {
        * </pre>
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Volume.ExternalVolumeInfo)
-          mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder>
+         implements mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor;
@@ -24733,6 +24850,7 @@ public final class Protos {
         }
         private int bitField0_;
 
+        // optional uint64 size = 1;
         private long size_ ;
         /**
          * <code>optional uint64 size = 1;</code>
@@ -24765,6 +24883,7 @@ public final class Protos {
           return this;
         }
 
+        // required string name = 2;
         private java.lang.Object name_ = "";
         /**
          * <code>required string name = 2;</code>
@@ -24778,12 +24897,9 @@ public final class Protos {
         public java.lang.String getName() {
           java.lang.Object ref = name_;
           if (!(ref instanceof java.lang.String)) {
-            com.google.protobuf.ByteString bs =
-                (com.google.protobuf.ByteString) ref;
-            java.lang.String s = bs.toStringUtf8();
-            if (bs.isValidUtf8()) {
-              name_ = s;
-            }
+            java.lang.String s = ((com.google.protobuf.ByteString) ref)
+                .toStringUtf8();
+            name_ = s;
             return s;
           } else {
             return (java.lang.String) ref;
@@ -24841,6 +24957,7 @@ public final class Protos {
           return this;
         }
 
+        // required string provider = 3;
         private java.lang.Object provider_ = "";
         /**
          * <code>required string provider = 3;</code>
@@ -24854,12 +24971,9 @@ public final class Protos {
         public java.lang.String getProvider() {
           java.lang.Object ref = provider_;
           if (!(ref instanceof java.lang.String)) {
-            com.google.protobuf.ByteString bs =
-                (com.google.protobuf.ByteString) ref;
-            java.lang.String s = bs.toStringUtf8();
-            if (bs.isValidUtf8()) {
-              provider_ = s;
-            }
+            java.lang.String s = ((com.google.protobuf.ByteString) ref)
+                .toStringUtf8();
+            provider_ = s;
             return s;
           } else {
             return (java.lang.String) ref;
@@ -24917,6 +25031,7 @@ public final class Protos {
           return this;
         }
 
+        // repeated .mesos.Label options = 4;
         private java.util.List<org.apache.mesos.Protos.Label> options_ =
           java.util.Collections.emptyList();
         private void ensureOptionsIsMutable() {
@@ -25058,8 +25173,7 @@ public final class Protos {
             java.lang.Iterable<? extends org.apache.mesos.Protos.Label> values) {
           if (optionsBuilder_ == null) {
             ensureOptionsIsMutable();
-            com.google.protobuf.AbstractMessageLite.Builder.addAll(
-                values, options_);
+            super.addAll(values, options_);
             onChanged();
           } else {
             optionsBuilder_.addAllMessages(values);
@@ -25169,6 +25283,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required .mesos.Volume.Mode mode = 3;
     public static final int MODE_FIELD_NUMBER = 3;
     private org.apache.mesos.Protos.Volume.Mode mode_;
     /**
@@ -25184,6 +25299,7 @@ public final class Protos {
       return mode_;
     }
 
+    // required string container_path = 1;
     public static final int CONTAINER_PATH_FIELD_NUMBER = 1;
     private java.lang.Object containerPath_;
     /**
@@ -25247,6 +25363,7 @@ public final class Protos {
       }
     }
 
+    // optional string host_path = 2;
     public static final int HOST_PATH_FIELD_NUMBER = 2;
     private java.lang.Object hostPath_;
     /**
@@ -25304,6 +25421,7 @@ public final class Protos {
       }
     }
 
+    // optional .mesos.Image image = 4;
     public static final int IMAGE_FIELD_NUMBER = 4;
     private org.apache.mesos.Protos.Image image_;
     /**
@@ -25340,6 +25458,7 @@ public final class Protos {
       return image_;
     }
 
+    // optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;
     public static final int PERSISTENT_FIELD_NUMBER = 5;
     private mesosphere.marathon.Protos.Volume.PersistentVolumeInfo persistent_;
     /**
@@ -25373,6 +25492,7 @@ public final class Protos {
       return persistent_;
     }
 
+    // optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;
     public static final int EXTERNAL_FIELD_NUMBER = 6;
     private mesosphere.marathon.Protos.Volume.ExternalVolumeInfo external_;
     /**
@@ -25417,8 +25537,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasMode()) {
         memoizedIsInitialized = 0;
@@ -25592,9 +25711,8 @@ public final class Protos {
      * </pre>
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Volume)
-        mesosphere.marathon.Protos.VolumeOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.VolumeOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_descriptor;
@@ -25809,6 +25927,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required .mesos.Volume.Mode mode = 3;
       private org.apache.mesos.Protos.Volume.Mode mode_ = org.apache.mesos.Protos.Volume.Mode.RW;
       /**
        * <code>required .mesos.Volume.Mode mode = 3;</code>
@@ -25844,6 +25963,7 @@ public final class Protos {
         return this;
       }
 
+      // required string container_path = 1;
       private java.lang.Object containerPath_ = "";
       /**
        * <code>required string container_path = 1;</code>
@@ -25871,12 +25991,9 @@ public final class Protos {
       public java.lang.String getContainerPath() {
         java.lang.Object ref = containerPath_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            containerPath_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          containerPath_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -25962,6 +26079,7 @@ public final class Protos {
         return this;
       }
 
+      // optional string host_path = 2;
       private java.lang.Object hostPath_ = "";
       /**
        * <code>optional string host_path = 2;</code>
@@ -25985,12 +26103,9 @@ public final class Protos {
       public java.lang.String getHostPath() {
         java.lang.Object ref = hostPath_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            hostPath_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          hostPath_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -26068,6 +26183,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesos.Image image = 4;
       private org.apache.mesos.Protos.Image image_ = org.apache.mesos.Protos.Image.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.Image, org.apache.mesos.Protos.Image.Builder, org.apache.mesos.Protos.ImageOrBuilder> imageBuilder_;
@@ -26221,7 +26337,7 @@ public final class Protos {
         if (imageBuilder_ == null) {
           imageBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.Image, org.apache.mesos.Protos.Image.Builder, org.apache.mesos.Protos.ImageOrBuilder>(
-                  getImage(),
+                  image_,
                   getParentForChildren(),
                   isClean());
           image_ = null;
@@ -26229,6 +26345,7 @@ public final class Protos {
         return imageBuilder_;
       }
 
+      // optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;
       private mesosphere.marathon.Protos.Volume.PersistentVolumeInfo persistent_ = mesosphere.marathon.Protos.Volume.PersistentVolumeInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.Volume.PersistentVolumeInfo, mesosphere.marathon.Protos.Volume.PersistentVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder> persistentBuilder_;
@@ -26373,7 +26490,7 @@ public final class Protos {
         if (persistentBuilder_ == null) {
           persistentBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.Volume.PersistentVolumeInfo, mesosphere.marathon.Protos.Volume.PersistentVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder>(
-                  getPersistent(),
+                  persistent_,
                   getParentForChildren(),
                   isClean());
           persistent_ = null;
@@ -26381,6 +26498,7 @@ public final class Protos {
         return persistentBuilder_;
       }
 
+      // optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;
       private mesosphere.marathon.Protos.Volume.ExternalVolumeInfo external_ = mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.Volume.ExternalVolumeInfo, mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder> externalBuilder_;
@@ -26525,7 +26643,7 @@ public final class Protos {
         if (externalBuilder_ == null) {
           externalBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.Volume.ExternalVolumeInfo, mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder>(
-                  getExternal(),
+                  external_,
                   getParentForChildren(),
                   isClean());
           external_ = null;
@@ -26544,15 +26662,15 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.Volume)
   }
 
-  public interface EventSubscribersOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.EventSubscribers)
-      com.google.protobuf.MessageOrBuilder {
+  public interface EventSubscribersOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // repeated string callback_urls = 1;
     /**
      * <code>repeated string callback_urls = 1;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getCallbackUrlsList();
+    java.util.List<java.lang.String>
+    getCallbackUrlsList();
     /**
      * <code>repeated string callback_urls = 1;</code>
      */
@@ -26571,9 +26689,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.EventSubscribers}
    */
   public static final class EventSubscribers extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.EventSubscribers)
-      EventSubscribersOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements EventSubscribersOrBuilder {
     // Use EventSubscribers.newBuilder() to construct.
     private EventSubscribers(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -26620,12 +26737,11 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 callbackUrls_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000001;
               }
-              callbackUrls_.add(bs);
+              callbackUrls_.add(input.readBytes());
               break;
             }
           }
@@ -26637,7 +26753,7 @@ public final class Protos {
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          callbackUrls_ = callbackUrls_.getUnmodifiableView();
+          callbackUrls_ = new com.google.protobuf.UnmodifiableLazyStringList(callbackUrls_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -26670,12 +26786,13 @@ public final class Protos {
       return PARSER;
     }
 
+    // repeated string callback_urls = 1;
     public static final int CALLBACK_URLS_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList callbackUrls_;
     /**
      * <code>repeated string callback_urls = 1;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getCallbackUrlsList() {
       return callbackUrls_;
     }
@@ -26705,8 +26822,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       memoizedIsInitialized = 1;
       return true;
@@ -26818,9 +26934,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.EventSubscribers}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.EventSubscribers)
-        mesosphere.marathon.Protos.EventSubscribersOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.EventSubscribersOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_EventSubscribers_descriptor;
@@ -26883,7 +26998,8 @@ public final class Protos {
         mesosphere.marathon.Protos.EventSubscribers result = new mesosphere.marathon.Protos.EventSubscribers(this);
         int from_bitField0_ = bitField0_;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          callbackUrls_ = callbackUrls_.getUnmodifiableView();
+          callbackUrls_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              callbackUrls_);
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.callbackUrls_ = callbackUrls_;
@@ -26939,6 +27055,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // repeated string callback_urls = 1;
       private com.google.protobuf.LazyStringList callbackUrls_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureCallbackUrlsIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -26949,9 +27066,9 @@ public final class Protos {
       /**
        * <code>repeated string callback_urls = 1;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getCallbackUrlsList() {
-        return callbackUrls_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(callbackUrls_);
       }
       /**
        * <code>repeated string callback_urls = 1;</code>
@@ -27004,8 +27121,7 @@ public final class Protos {
       public Builder addAllCallbackUrls(
           java.lang.Iterable<java.lang.String> values) {
         ensureCallbackUrlsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, callbackUrls_);
+        super.addAll(values, callbackUrls_);
         onChanged();
         return this;
       }
@@ -27043,10 +27159,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.EventSubscribers)
   }
 
-  public interface StorageVersionOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.StorageVersion)
-      com.google.protobuf.MessageOrBuilder {
+  public interface StorageVersionOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required uint32 major = 1;
     /**
      * <code>required uint32 major = 1;</code>
      */
@@ -27056,6 +27172,7 @@ public final class Protos {
      */
     int getMajor();
 
+    // required uint32 minor = 2;
     /**
      * <code>required uint32 minor = 2;</code>
      */
@@ -27065,6 +27182,7 @@ public final class Protos {
      */
     int getMinor();
 
+    // required uint32 patch = 3;
     /**
      * <code>required uint32 patch = 3;</code>
      */
@@ -27078,9 +27196,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.StorageVersion}
    */
   public static final class StorageVersion extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.StorageVersion)
-      StorageVersionOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements StorageVersionOrBuilder {
     // Use StorageVersion.newBuilder() to construct.
     private StorageVersion(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -27181,6 +27298,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required uint32 major = 1;
     public static final int MAJOR_FIELD_NUMBER = 1;
     private int major_;
     /**
@@ -27196,6 +27314,7 @@ public final class Protos {
       return major_;
     }
 
+    // required uint32 minor = 2;
     public static final int MINOR_FIELD_NUMBER = 2;
     private int minor_;
     /**
@@ -27211,6 +27330,7 @@ public final class Protos {
       return minor_;
     }
 
+    // required uint32 patch = 3;
     public static final int PATCH_FIELD_NUMBER = 3;
     private int patch_;
     /**
@@ -27234,8 +27354,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasMajor()) {
         memoizedIsInitialized = 0;
@@ -27368,9 +27487,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.StorageVersion}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.StorageVersion)
-        mesosphere.marathon.Protos.StorageVersionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.StorageVersionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_StorageVersion_descriptor;
@@ -27513,6 +27631,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required uint32 major = 1;
       private int major_ ;
       /**
        * <code>required uint32 major = 1;</code>
@@ -27545,6 +27664,7 @@ public final class Protos {
         return this;
       }
 
+      // required uint32 minor = 2;
       private int minor_ ;
       /**
        * <code>required uint32 minor = 2;</code>
@@ -27577,6 +27697,7 @@ public final class Protos {
         return this;
       }
 
+      // required uint32 patch = 3;
       private int patch_ ;
       /**
        * <code>required uint32 patch = 3;</code>
@@ -27620,10 +27741,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.StorageVersion)
   }
 
-  public interface UpgradeStrategyDefinitionOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.UpgradeStrategyDefinition)
-      com.google.protobuf.MessageOrBuilder {
+  public interface UpgradeStrategyDefinitionOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required double minimumHealthCapacity = 1;
     /**
      * <code>required double minimumHealthCapacity = 1;</code>
      */
@@ -27633,6 +27754,7 @@ public final class Protos {
      */
     double getMinimumHealthCapacity();
 
+    // optional double maximumOverCapacity = 2 [default = 1];
     /**
      * <code>optional double maximumOverCapacity = 2 [default = 1];</code>
      */
@@ -27646,9 +27768,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.UpgradeStrategyDefinition}
    */
   public static final class UpgradeStrategyDefinition extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.UpgradeStrategyDefinition)
-      UpgradeStrategyDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements UpgradeStrategyDefinitionOrBuilder {
     // Use UpgradeStrategyDefinition.newBuilder() to construct.
     private UpgradeStrategyDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -27744,6 +27865,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required double minimumHealthCapacity = 1;
     public static final int MINIMUMHEALTHCAPACITY_FIELD_NUMBER = 1;
     private double minimumHealthCapacity_;
     /**
@@ -27759,6 +27881,7 @@ public final class Protos {
       return minimumHealthCapacity_;
     }
 
+    // optional double maximumOverCapacity = 2 [default = 1];
     public static final int MAXIMUMOVERCAPACITY_FIELD_NUMBER = 2;
     private double maximumOverCapacity_;
     /**
@@ -27781,8 +27904,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasMinimumHealthCapacity()) {
         memoizedIsInitialized = 0;
@@ -27900,9 +28022,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.UpgradeStrategyDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.UpgradeStrategyDefinition)
-        mesosphere.marathon.Protos.UpgradeStrategyDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.UpgradeStrategyDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor;
@@ -28028,6 +28149,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required double minimumHealthCapacity = 1;
       private double minimumHealthCapacity_ ;
       /**
        * <code>required double minimumHealthCapacity = 1;</code>
@@ -28060,6 +28182,7 @@ public final class Protos {
         return this;
       }
 
+      // optional double maximumOverCapacity = 2 [default = 1];
       private double maximumOverCapacity_ = 1D;
       /**
        * <code>optional double maximumOverCapacity = 2 [default = 1];</code>
@@ -28103,10 +28226,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.UpgradeStrategyDefinition)
   }
 
-  public interface GroupDefinitionOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.GroupDefinition)
-      com.google.protobuf.MessageOrBuilder {
+  public interface GroupDefinitionOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required string id = 1;
     /**
      * <code>required string id = 1;</code>
      */
@@ -28121,6 +28244,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getIdBytes();
 
+    // required string version = 2;
     /**
      * <code>required string version = 2;</code>
      */
@@ -28135,6 +28259,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getVersionBytes();
 
+    // repeated .mesosphere.marathon.ServiceDefinition apps = 3;
     /**
      * <code>repeated .mesosphere.marathon.ServiceDefinition apps = 3;</code>
      */
@@ -28159,6 +28284,7 @@ public final class Protos {
     mesosphere.marathon.Protos.ServiceDefinitionOrBuilder getAppsOrBuilder(
         int index);
 
+    // repeated .mesosphere.marathon.GroupDefinition groups = 4;
     /**
      * <code>repeated .mesosphere.marathon.GroupDefinition groups = 4;</code>
      */
@@ -28183,11 +28309,12 @@ public final class Protos {
     mesosphere.marathon.Protos.GroupDefinitionOrBuilder getGroupsOrBuilder(
         int index);
 
+    // repeated string dependencies = 5;
     /**
      * <code>repeated string dependencies = 5;</code>
      */
-    com.google.protobuf.ProtocolStringList
-        getDependenciesList();
+    java.util.List<java.lang.String>
+    getDependenciesList();
     /**
      * <code>repeated string dependencies = 5;</code>
      */
@@ -28206,9 +28333,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.GroupDefinition}
    */
   public static final class GroupDefinition extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.GroupDefinition)
-      GroupDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements GroupDefinitionOrBuilder {
     // Use GroupDefinition.newBuilder() to construct.
     private GroupDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -28255,15 +28381,13 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = bs;
+              id_ = input.readBytes();
               break;
             }
             case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              version_ = bs;
+              version_ = input.readBytes();
               break;
             }
             case 26: {
@@ -28283,12 +28407,11 @@ public final class Protos {
               break;
             }
             case 42: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
                 dependencies_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000010;
               }
-              dependencies_.add(bs);
+              dependencies_.add(input.readBytes());
               break;
             }
           }
@@ -28306,7 +28429,7 @@ public final class Protos {
           groups_ = java.util.Collections.unmodifiableList(groups_);
         }
         if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-          dependencies_ = dependencies_.getUnmodifiableView();
+          dependencies_ = new com.google.protobuf.UnmodifiableLazyStringList(dependencies_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -28340,6 +28463,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -28382,6 +28506,7 @@ public final class Protos {
       }
     }
 
+    // required string version = 2;
     public static final int VERSION_FIELD_NUMBER = 2;
     private java.lang.Object version_;
     /**
@@ -28424,6 +28549,7 @@ public final class Protos {
       }
     }
 
+    // repeated .mesosphere.marathon.ServiceDefinition apps = 3;
     public static final int APPS_FIELD_NUMBER = 3;
     private java.util.List<mesosphere.marathon.Protos.ServiceDefinition> apps_;
     /**
@@ -28459,6 +28585,7 @@ public final class Protos {
       return apps_.get(index);
     }
 
+    // repeated .mesosphere.marathon.GroupDefinition groups = 4;
     public static final int GROUPS_FIELD_NUMBER = 4;
     private java.util.List<mesosphere.marathon.Protos.GroupDefinition> groups_;
     /**
@@ -28494,12 +28621,13 @@ public final class Protos {
       return groups_.get(index);
     }
 
+    // repeated string dependencies = 5;
     public static final int DEPENDENCIES_FIELD_NUMBER = 5;
     private com.google.protobuf.LazyStringList dependencies_;
     /**
      * <code>repeated string dependencies = 5;</code>
      */
-    public com.google.protobuf.ProtocolStringList
+    public java.util.List<java.lang.String>
         getDependenciesList() {
       return dependencies_;
     }
@@ -28533,8 +28661,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasId()) {
         memoizedIsInitialized = 0;
@@ -28694,9 +28821,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.GroupDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.GroupDefinition)
-        mesosphere.marathon.Protos.GroupDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.GroupDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_GroupDefinition_descriptor;
@@ -28804,7 +28930,8 @@ public final class Protos {
           result.groups_ = groupsBuilder_.build();
         }
         if (((bitField0_ & 0x00000010) == 0x00000010)) {
-          dependencies_ = dependencies_.getUnmodifiableView();
+          dependencies_ = new com.google.protobuf.UnmodifiableLazyStringList(
+              dependencies_);
           bitField0_ = (bitField0_ & ~0x00000010);
         }
         result.dependencies_ = dependencies_;
@@ -28943,6 +29070,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>required string id = 1;</code>
@@ -28956,12 +29084,9 @@ public final class Protos {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            id_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          id_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -29019,6 +29144,7 @@ public final class Protos {
         return this;
       }
 
+      // required string version = 2;
       private java.lang.Object version_ = "";
       /**
        * <code>required string version = 2;</code>
@@ -29032,12 +29158,9 @@ public final class Protos {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            version_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          version_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -29095,6 +29218,7 @@ public final class Protos {
         return this;
       }
 
+      // repeated .mesosphere.marathon.ServiceDefinition apps = 3;
       private java.util.List<mesosphere.marathon.Protos.ServiceDefinition> apps_ =
         java.util.Collections.emptyList();
       private void ensureAppsIsMutable() {
@@ -29236,8 +29360,7 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.ServiceDefinition> values) {
         if (appsBuilder_ == null) {
           ensureAppsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, apps_);
+          super.addAll(values, apps_);
           onChanged();
         } else {
           appsBuilder_.addAllMessages(values);
@@ -29335,6 +29458,7 @@ public final class Protos {
         return appsBuilder_;
       }
 
+      // repeated .mesosphere.marathon.GroupDefinition groups = 4;
       private java.util.List<mesosphere.marathon.Protos.GroupDefinition> groups_ =
         java.util.Collections.emptyList();
       private void ensureGroupsIsMutable() {
@@ -29476,8 +29600,7 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.GroupDefinition> values) {
         if (groupsBuilder_ == null) {
           ensureGroupsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, groups_);
+          super.addAll(values, groups_);
           onChanged();
         } else {
           groupsBuilder_.addAllMessages(values);
@@ -29575,6 +29698,7 @@ public final class Protos {
         return groupsBuilder_;
       }
 
+      // repeated string dependencies = 5;
       private com.google.protobuf.LazyStringList dependencies_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureDependenciesIsMutable() {
         if (!((bitField0_ & 0x00000010) == 0x00000010)) {
@@ -29585,9 +29709,9 @@ public final class Protos {
       /**
        * <code>repeated string dependencies = 5;</code>
        */
-      public com.google.protobuf.ProtocolStringList
+      public java.util.List<java.lang.String>
           getDependenciesList() {
-        return dependencies_.getUnmodifiableView();
+        return java.util.Collections.unmodifiableList(dependencies_);
       }
       /**
        * <code>repeated string dependencies = 5;</code>
@@ -29640,8 +29764,7 @@ public final class Protos {
       public Builder addAllDependencies(
           java.lang.Iterable<java.lang.String> values) {
         ensureDependenciesIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, dependencies_);
+        super.addAll(values, dependencies_);
         onChanged();
         return this;
       }
@@ -29679,10 +29802,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.GroupDefinition)
   }
 
-  public interface DeploymentPlanDefinitionOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.DeploymentPlanDefinition)
-      com.google.protobuf.MessageOrBuilder {
+  public interface DeploymentPlanDefinitionOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required string id = 1;
     /**
      * <code>required string id = 1;</code>
      */
@@ -29697,6 +29820,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getIdBytes();
 
+    // required string version = 2;
     /**
      * <code>required string version = 2;</code>
      */
@@ -29711,6 +29835,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getVersionBytes();
 
+    // required .mesosphere.marathon.GroupDefinition original = 4;
     /**
      * <code>required .mesosphere.marathon.GroupDefinition original = 4;</code>
      */
@@ -29724,6 +29849,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.GroupDefinitionOrBuilder getOriginalOrBuilder();
 
+    // required .mesosphere.marathon.GroupDefinition target = 5;
     /**
      * <code>required .mesosphere.marathon.GroupDefinition target = 5;</code>
      */
@@ -29741,9 +29867,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.DeploymentPlanDefinition}
    */
   public static final class DeploymentPlanDefinition extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.DeploymentPlanDefinition)
-      DeploymentPlanDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements DeploymentPlanDefinitionOrBuilder {
     // Use DeploymentPlanDefinition.newBuilder() to construct.
     private DeploymentPlanDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -29790,15 +29915,13 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = bs;
+              id_ = input.readBytes();
               break;
             }
             case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              version_ = bs;
+              version_ = input.readBytes();
               break;
             }
             case 34: {
@@ -29867,6 +29990,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -29909,6 +30033,7 @@ public final class Protos {
       }
     }
 
+    // required string version = 2;
     public static final int VERSION_FIELD_NUMBER = 2;
     private java.lang.Object version_;
     /**
@@ -29951,6 +30076,7 @@ public final class Protos {
       }
     }
 
+    // required .mesosphere.marathon.GroupDefinition original = 4;
     public static final int ORIGINAL_FIELD_NUMBER = 4;
     private mesosphere.marathon.Protos.GroupDefinition original_;
     /**
@@ -29972,6 +30098,7 @@ public final class Protos {
       return original_;
     }
 
+    // required .mesosphere.marathon.GroupDefinition target = 5;
     public static final int TARGET_FIELD_NUMBER = 5;
     private mesosphere.marathon.Protos.GroupDefinition target_;
     /**
@@ -30002,8 +30129,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasId()) {
         memoizedIsInitialized = 0;
@@ -30155,9 +30281,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.DeploymentPlanDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.DeploymentPlanDefinition)
-        mesosphere.marathon.Protos.DeploymentPlanDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.DeploymentPlanDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor;
@@ -30343,6 +30468,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>required string id = 1;</code>
@@ -30356,12 +30482,9 @@ public final class Protos {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            id_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          id_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -30419,6 +30542,7 @@ public final class Protos {
         return this;
       }
 
+      // required string version = 2;
       private java.lang.Object version_ = "";
       /**
        * <code>required string version = 2;</code>
@@ -30432,12 +30556,9 @@ public final class Protos {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            version_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          version_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -30495,6 +30616,7 @@ public final class Protos {
         return this;
       }
 
+      // required .mesosphere.marathon.GroupDefinition original = 4;
       private mesosphere.marathon.Protos.GroupDefinition original_ = mesosphere.marathon.Protos.GroupDefinition.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.GroupDefinition, mesosphere.marathon.Protos.GroupDefinition.Builder, mesosphere.marathon.Protos.GroupDefinitionOrBuilder> originalBuilder_;
@@ -30603,7 +30725,7 @@ public final class Protos {
         if (originalBuilder_ == null) {
           originalBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.GroupDefinition, mesosphere.marathon.Protos.GroupDefinition.Builder, mesosphere.marathon.Protos.GroupDefinitionOrBuilder>(
-                  getOriginal(),
+                  original_,
                   getParentForChildren(),
                   isClean());
           original_ = null;
@@ -30611,6 +30733,7 @@ public final class Protos {
         return originalBuilder_;
       }
 
+      // required .mesosphere.marathon.GroupDefinition target = 5;
       private mesosphere.marathon.Protos.GroupDefinition target_ = mesosphere.marathon.Protos.GroupDefinition.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.GroupDefinition, mesosphere.marathon.Protos.GroupDefinition.Builder, mesosphere.marathon.Protos.GroupDefinitionOrBuilder> targetBuilder_;
@@ -30719,7 +30842,7 @@ public final class Protos {
         if (targetBuilder_ == null) {
           targetBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.GroupDefinition, mesosphere.marathon.Protos.GroupDefinition.Builder, mesosphere.marathon.Protos.GroupDefinitionOrBuilder>(
-                  getTarget(),
+                  target_,
                   getParentForChildren(),
                   isClean());
           target_ = null;
@@ -30738,10 +30861,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.DeploymentPlanDefinition)
   }
 
-  public interface TaskFailureOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.TaskFailure)
-      com.google.protobuf.MessageOrBuilder {
+  public interface TaskFailureOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required string app_id = 1;
     /**
      * <code>required string app_id = 1;</code>
      */
@@ -30756,6 +30879,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getAppIdBytes();
 
+    // required .mesos.TaskID task_id = 2;
     /**
      * <code>required .mesos.TaskID task_id = 2;</code>
      */
@@ -30769,6 +30893,7 @@ public final class Protos {
      */
     org.apache.mesos.Protos.TaskIDOrBuilder getTaskIdOrBuilder();
 
+    // required .mesos.TaskState state = 3;
     /**
      * <code>required .mesos.TaskState state = 3;</code>
      */
@@ -30778,6 +30903,7 @@ public final class Protos {
      */
     org.apache.mesos.Protos.TaskState getState();
 
+    // optional string message = 4 [default = ""];
     /**
      * <code>optional string message = 4 [default = ""];</code>
      */
@@ -30792,6 +30918,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getMessageBytes();
 
+    // optional string host = 5 [default = ""];
     /**
      * <code>optional string host = 5 [default = ""];</code>
      */
@@ -30806,6 +30933,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getHostBytes();
 
+    // required string version = 6;
     /**
      * <code>required string version = 6;</code>
      */
@@ -30820,6 +30948,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getVersionBytes();
 
+    // required string timestamp = 7;
     /**
      * <code>required string timestamp = 7;</code>
      */
@@ -30834,6 +30963,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getTimestampBytes();
 
+    // optional .mesos.SlaveID slaveId = 8;
     /**
      * <code>optional .mesos.SlaveID slaveId = 8;</code>
      */
@@ -30851,9 +30981,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.TaskFailure}
    */
   public static final class TaskFailure extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.TaskFailure)
-      TaskFailureOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements TaskFailureOrBuilder {
     // Use TaskFailure.newBuilder() to construct.
     private TaskFailure(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -30900,9 +31029,8 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              appId_ = bs;
+              appId_ = input.readBytes();
               break;
             }
             case 18: {
@@ -30930,27 +31058,23 @@ public final class Protos {
               break;
             }
             case 34: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
-              message_ = bs;
+              message_ = input.readBytes();
               break;
             }
             case 42: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000010;
-              host_ = bs;
+              host_ = input.readBytes();
               break;
             }
             case 50: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000020;
-              version_ = bs;
+              version_ = input.readBytes();
               break;
             }
             case 58: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000040;
-              timestamp_ = bs;
+              timestamp_ = input.readBytes();
               break;
             }
             case 66: {
@@ -31006,6 +31130,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required string app_id = 1;
     public static final int APP_ID_FIELD_NUMBER = 1;
     private java.lang.Object appId_;
     /**
@@ -31048,6 +31173,7 @@ public final class Protos {
       }
     }
 
+    // required .mesos.TaskID task_id = 2;
     public static final int TASK_ID_FIELD_NUMBER = 2;
     private org.apache.mesos.Protos.TaskID taskId_;
     /**
@@ -31069,6 +31195,7 @@ public final class Protos {
       return taskId_;
     }
 
+    // required .mesos.TaskState state = 3;
     public static final int STATE_FIELD_NUMBER = 3;
     private org.apache.mesos.Protos.TaskState state_;
     /**
@@ -31084,6 +31211,7 @@ public final class Protos {
       return state_;
     }
 
+    // optional string message = 4 [default = ""];
     public static final int MESSAGE_FIELD_NUMBER = 4;
     private java.lang.Object message_;
     /**
@@ -31126,6 +31254,7 @@ public final class Protos {
       }
     }
 
+    // optional string host = 5 [default = ""];
     public static final int HOST_FIELD_NUMBER = 5;
     private java.lang.Object host_;
     /**
@@ -31168,6 +31297,7 @@ public final class Protos {
       }
     }
 
+    // required string version = 6;
     public static final int VERSION_FIELD_NUMBER = 6;
     private java.lang.Object version_;
     /**
@@ -31210,6 +31340,7 @@ public final class Protos {
       }
     }
 
+    // required string timestamp = 7;
     public static final int TIMESTAMP_FIELD_NUMBER = 7;
     private java.lang.Object timestamp_;
     /**
@@ -31252,6 +31383,7 @@ public final class Protos {
       }
     }
 
+    // optional .mesos.SlaveID slaveId = 8;
     public static final int SLAVEID_FIELD_NUMBER = 8;
     private org.apache.mesos.Protos.SlaveID slaveId_;
     /**
@@ -31286,8 +31418,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasAppId()) {
         memoizedIsInitialized = 0;
@@ -31473,9 +31604,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.TaskFailure}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.TaskFailure)
-        mesosphere.marathon.Protos.TaskFailureOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.TaskFailureOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_TaskFailure_descriptor;
@@ -31709,6 +31839,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required string app_id = 1;
       private java.lang.Object appId_ = "";
       /**
        * <code>required string app_id = 1;</code>
@@ -31722,12 +31853,9 @@ public final class Protos {
       public java.lang.String getAppId() {
         java.lang.Object ref = appId_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            appId_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          appId_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -31785,6 +31913,7 @@ public final class Protos {
         return this;
       }
 
+      // required .mesos.TaskID task_id = 2;
       private org.apache.mesos.Protos.TaskID taskId_ = org.apache.mesos.Protos.TaskID.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.TaskID, org.apache.mesos.Protos.TaskID.Builder, org.apache.mesos.Protos.TaskIDOrBuilder> taskIdBuilder_;
@@ -31893,7 +32022,7 @@ public final class Protos {
         if (taskIdBuilder_ == null) {
           taskIdBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.TaskID, org.apache.mesos.Protos.TaskID.Builder, org.apache.mesos.Protos.TaskIDOrBuilder>(
-                  getTaskId(),
+                  taskId_,
                   getParentForChildren(),
                   isClean());
           taskId_ = null;
@@ -31901,6 +32030,7 @@ public final class Protos {
         return taskIdBuilder_;
       }
 
+      // required .mesos.TaskState state = 3;
       private org.apache.mesos.Protos.TaskState state_ = org.apache.mesos.Protos.TaskState.TASK_STAGING;
       /**
        * <code>required .mesos.TaskState state = 3;</code>
@@ -31936,6 +32066,7 @@ public final class Protos {
         return this;
       }
 
+      // optional string message = 4 [default = ""];
       private java.lang.Object message_ = "";
       /**
        * <code>optional string message = 4 [default = ""];</code>
@@ -31949,12 +32080,9 @@ public final class Protos {
       public java.lang.String getMessage() {
         java.lang.Object ref = message_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            message_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          message_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -32012,6 +32140,7 @@ public final class Protos {
         return this;
       }
 
+      // optional string host = 5 [default = ""];
       private java.lang.Object host_ = "";
       /**
        * <code>optional string host = 5 [default = ""];</code>
@@ -32025,12 +32154,9 @@ public final class Protos {
       public java.lang.String getHost() {
         java.lang.Object ref = host_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            host_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          host_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -32088,6 +32214,7 @@ public final class Protos {
         return this;
       }
 
+      // required string version = 6;
       private java.lang.Object version_ = "";
       /**
        * <code>required string version = 6;</code>
@@ -32101,12 +32228,9 @@ public final class Protos {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            version_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          version_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -32164,6 +32288,7 @@ public final class Protos {
         return this;
       }
 
+      // required string timestamp = 7;
       private java.lang.Object timestamp_ = "";
       /**
        * <code>required string timestamp = 7;</code>
@@ -32177,12 +32302,9 @@ public final class Protos {
       public java.lang.String getTimestamp() {
         java.lang.Object ref = timestamp_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            timestamp_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          timestamp_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -32240,6 +32362,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesos.SlaveID slaveId = 8;
       private org.apache.mesos.Protos.SlaveID slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder> slaveIdBuilder_;
@@ -32348,7 +32471,7 @@ public final class Protos {
         if (slaveIdBuilder_ == null) {
           slaveIdBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder>(
-                  getSlaveId(),
+                  slaveId_,
                   getParentForChildren(),
                   isClean());
           slaveId_ = null;
@@ -32367,10 +32490,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.TaskFailure)
   }
 
-  public interface ZKStoreEntryOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ZKStoreEntry)
-      com.google.protobuf.MessageOrBuilder {
+  public interface ZKStoreEntryOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required string name = 1;
     /**
      * <code>required string name = 1;</code>
      */
@@ -32385,6 +32508,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getNameBytes();
 
+    // required bytes uuid = 2;
     /**
      * <code>required bytes uuid = 2;</code>
      */
@@ -32394,6 +32518,7 @@ public final class Protos {
      */
     com.google.protobuf.ByteString getUuid();
 
+    // required bytes value = 3;
     /**
      * <code>required bytes value = 3;</code>
      */
@@ -32403,6 +32528,7 @@ public final class Protos {
      */
     com.google.protobuf.ByteString getValue();
 
+    // optional bool compressed = 4 [default = false];
     /**
      * <code>optional bool compressed = 4 [default = false];</code>
      *
@@ -32435,9 +32561,8 @@ public final class Protos {
    * </pre>
    */
   public static final class ZKStoreEntry extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ZKStoreEntry)
-      ZKStoreEntryOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements ZKStoreEntryOrBuilder {
     // Use ZKStoreEntry.newBuilder() to construct.
     private ZKStoreEntry(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -32484,9 +32609,8 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              name_ = bs;
+              name_ = input.readBytes();
               break;
             }
             case 18: {
@@ -32544,6 +32668,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required string name = 1;
     public static final int NAME_FIELD_NUMBER = 1;
     private java.lang.Object name_;
     /**
@@ -32586,6 +32711,7 @@ public final class Protos {
       }
     }
 
+    // required bytes uuid = 2;
     public static final int UUID_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString uuid_;
     /**
@@ -32601,6 +32727,7 @@ public final class Protos {
       return uuid_;
     }
 
+    // required bytes value = 3;
     public static final int VALUE_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString value_;
     /**
@@ -32616,6 +32743,7 @@ public final class Protos {
       return value_;
     }
 
+    // optional bool compressed = 4 [default = false];
     public static final int COMPRESSED_FIELD_NUMBER = 4;
     private boolean compressed_;
     /**
@@ -32652,8 +32780,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasName()) {
         memoizedIsInitialized = 0;
@@ -32800,9 +32927,8 @@ public final class Protos {
      * </pre>
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ZKStoreEntry)
-        mesosphere.marathon.Protos.ZKStoreEntryOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.ZKStoreEntryOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ZKStoreEntry_descriptor;
@@ -32956,6 +33082,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required string name = 1;
       private java.lang.Object name_ = "";
       /**
        * <code>required string name = 1;</code>
@@ -32969,12 +33096,9 @@ public final class Protos {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            name_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          name_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -33032,6 +33156,7 @@ public final class Protos {
         return this;
       }
 
+      // required bytes uuid = 2;
       private com.google.protobuf.ByteString uuid_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes uuid = 2;</code>
@@ -33067,6 +33192,7 @@ public final class Protos {
         return this;
       }
 
+      // required bytes value = 3;
       private com.google.protobuf.ByteString value_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes value = 3;</code>
@@ -33102,6 +33228,7 @@ public final class Protos {
         return this;
       }
 
+      // optional bool compressed = 4 [default = false];
       private boolean compressed_ ;
       /**
        * <code>optional bool compressed = 4 [default = false];</code>
@@ -33169,10 +33296,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ZKStoreEntry)
   }
 
-  public interface ResidencyDefinitionOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ResidencyDefinition)
-      com.google.protobuf.MessageOrBuilder {
+  public interface ResidencyDefinitionOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // optional int64 relaunchEscalationTimeoutSeconds = 1;
     /**
      * <code>optional int64 relaunchEscalationTimeoutSeconds = 1;</code>
      */
@@ -33182,6 +33309,7 @@ public final class Protos {
      */
     long getRelaunchEscalationTimeoutSeconds();
 
+    // optional .mesosphere.marathon.ResidencyDefinition.TaskLostBehavior taskLostBehavior = 2;
     /**
      * <code>optional .mesosphere.marathon.ResidencyDefinition.TaskLostBehavior taskLostBehavior = 2;</code>
      */
@@ -33195,9 +33323,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ResidencyDefinition}
    */
   public static final class ResidencyDefinition extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ResidencyDefinition)
-      ResidencyDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements ResidencyDefinitionOrBuilder {
     // Use ResidencyDefinition.newBuilder() to construct.
     private ResidencyDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -33381,6 +33508,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // optional int64 relaunchEscalationTimeoutSeconds = 1;
     public static final int RELAUNCHESCALATIONTIMEOUTSECONDS_FIELD_NUMBER = 1;
     private long relaunchEscalationTimeoutSeconds_;
     /**
@@ -33396,6 +33524,7 @@ public final class Protos {
       return relaunchEscalationTimeoutSeconds_;
     }
 
+    // optional .mesosphere.marathon.ResidencyDefinition.TaskLostBehavior taskLostBehavior = 2;
     public static final int TASKLOSTBEHAVIOR_FIELD_NUMBER = 2;
     private mesosphere.marathon.Protos.ResidencyDefinition.TaskLostBehavior taskLostBehavior_;
     /**
@@ -33418,8 +33547,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       memoizedIsInitialized = 1;
       return true;
@@ -33533,9 +33661,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ResidencyDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ResidencyDefinition)
-        mesosphere.marathon.Protos.ResidencyDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.ResidencyDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ResidencyDefinition_descriptor;
@@ -33657,6 +33784,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // optional int64 relaunchEscalationTimeoutSeconds = 1;
       private long relaunchEscalationTimeoutSeconds_ ;
       /**
        * <code>optional int64 relaunchEscalationTimeoutSeconds = 1;</code>
@@ -33689,6 +33817,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesosphere.marathon.ResidencyDefinition.TaskLostBehavior taskLostBehavior = 2;
       private mesosphere.marathon.Protos.ResidencyDefinition.TaskLostBehavior taskLostBehavior_ = mesosphere.marathon.Protos.ResidencyDefinition.TaskLostBehavior.RELAUNCH_AFTER_TIMEOUT;
       /**
        * <code>optional .mesosphere.marathon.ResidencyDefinition.TaskLostBehavior taskLostBehavior = 2;</code>
@@ -33735,10 +33864,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ResidencyDefinition)
   }
 
-  public interface SecretOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Secret)
-      com.google.protobuf.MessageOrBuilder {
+  public interface SecretOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required string id = 1;
     /**
      * <code>required string id = 1;</code>
      */
@@ -33753,6 +33882,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getIdBytes();
 
+    // required string source = 2;
     /**
      * <code>required string source = 2;</code>
      */
@@ -33771,9 +33901,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.Secret}
    */
   public static final class Secret extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.Secret)
-      SecretOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements SecretOrBuilder {
     // Use Secret.newBuilder() to construct.
     private Secret(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -33820,15 +33949,13 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = bs;
+              id_ = input.readBytes();
               break;
             }
             case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              source_ = bs;
+              source_ = input.readBytes();
               break;
             }
           }
@@ -33871,6 +33998,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -33913,6 +34041,7 @@ public final class Protos {
       }
     }
 
+    // required string source = 2;
     public static final int SOURCE_FIELD_NUMBER = 2;
     private java.lang.Object source_;
     /**
@@ -33962,8 +34091,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasId()) {
         memoizedIsInitialized = 0;
@@ -34085,9 +34213,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.Secret}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Secret)
-        mesosphere.marathon.Protos.SecretOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.SecretOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Secret_descriptor;
@@ -34221,6 +34348,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>required string id = 1;</code>
@@ -34234,12 +34362,9 @@ public final class Protos {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            id_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          id_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -34297,6 +34422,7 @@ public final class Protos {
         return this;
       }
 
+      // required string source = 2;
       private java.lang.Object source_ = "";
       /**
        * <code>required string source = 2;</code>
@@ -34310,12 +34436,9 @@ public final class Protos {
       public java.lang.String getSource() {
         java.lang.Object ref = source_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            source_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          source_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -34384,10 +34507,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.Secret)
   }
 
-  public interface EnvVarReferenceOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.EnvVarReference)
-      com.google.protobuf.MessageOrBuilder {
+  public interface EnvVarReferenceOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required .mesosphere.marathon.EnvVarReference.Type type = 1;
     /**
      * <code>required .mesosphere.marathon.EnvVarReference.Type type = 1;</code>
      */
@@ -34397,6 +34520,7 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.EnvVarReference.Type getType();
 
+    // required string name = 2;
     /**
      * <code>required string name = 2;</code>
      */
@@ -34411,6 +34535,7 @@ public final class Protos {
     com.google.protobuf.ByteString
         getNameBytes();
 
+    // optional .mesosphere.marathon.EnvVarSecretRef secretRef = 3;
     /**
      * <code>optional .mesosphere.marathon.EnvVarSecretRef secretRef = 3;</code>
      */
@@ -34428,9 +34553,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.EnvVarReference}
    */
   public static final class EnvVarReference extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.EnvVarReference)
-      EnvVarReferenceOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements EnvVarReferenceOrBuilder {
     // Use EnvVarReference.newBuilder() to construct.
     private EnvVarReference(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -34488,9 +34612,8 @@ public final class Protos {
               break;
             }
             case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              name_ = bs;
+              name_ = input.readBytes();
               break;
             }
             case 26: {
@@ -34628,6 +34751,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required .mesosphere.marathon.EnvVarReference.Type type = 1;
     public static final int TYPE_FIELD_NUMBER = 1;
     private mesosphere.marathon.Protos.EnvVarReference.Type type_;
     /**
@@ -34643,6 +34767,7 @@ public final class Protos {
       return type_;
     }
 
+    // required string name = 2;
     public static final int NAME_FIELD_NUMBER = 2;
     private java.lang.Object name_;
     /**
@@ -34685,6 +34810,7 @@ public final class Protos {
       }
     }
 
+    // optional .mesosphere.marathon.EnvVarSecretRef secretRef = 3;
     public static final int SECRETREF_FIELD_NUMBER = 3;
     private mesosphere.marathon.Protos.EnvVarSecretRef secretRef_;
     /**
@@ -34714,8 +34840,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasType()) {
         memoizedIsInitialized = 0;
@@ -34850,9 +34975,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.EnvVarReference}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.EnvVarReference)
-        mesosphere.marathon.Protos.EnvVarReferenceOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.EnvVarReferenceOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_EnvVarReference_descriptor;
@@ -35008,6 +35132,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required .mesosphere.marathon.EnvVarReference.Type type = 1;
       private mesosphere.marathon.Protos.EnvVarReference.Type type_ = mesosphere.marathon.Protos.EnvVarReference.Type.UNKNOWN;
       /**
        * <code>required .mesosphere.marathon.EnvVarReference.Type type = 1;</code>
@@ -35043,6 +35168,7 @@ public final class Protos {
         return this;
       }
 
+      // required string name = 2;
       private java.lang.Object name_ = "";
       /**
        * <code>required string name = 2;</code>
@@ -35056,12 +35182,9 @@ public final class Protos {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            name_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          name_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -35119,6 +35242,7 @@ public final class Protos {
         return this;
       }
 
+      // optional .mesosphere.marathon.EnvVarSecretRef secretRef = 3;
       private mesosphere.marathon.Protos.EnvVarSecretRef secretRef_ = mesosphere.marathon.Protos.EnvVarSecretRef.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.EnvVarSecretRef, mesosphere.marathon.Protos.EnvVarSecretRef.Builder, mesosphere.marathon.Protos.EnvVarSecretRefOrBuilder> secretRefBuilder_;
@@ -35227,7 +35351,7 @@ public final class Protos {
         if (secretRefBuilder_ == null) {
           secretRefBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.EnvVarSecretRef, mesosphere.marathon.Protos.EnvVarSecretRef.Builder, mesosphere.marathon.Protos.EnvVarSecretRefOrBuilder>(
-                  getSecretRef(),
+                  secretRef_,
                   getParentForChildren(),
                   isClean());
           secretRef_ = null;
@@ -35246,10 +35370,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.EnvVarReference)
   }
 
-  public interface EnvVarSecretRefOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.EnvVarSecretRef)
-      com.google.protobuf.MessageOrBuilder {
+  public interface EnvVarSecretRefOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
 
+    // required string secretId = 1;
     /**
      * <code>required string secretId = 1;</code>
      */
@@ -35268,9 +35392,8 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.EnvVarSecretRef}
    */
   public static final class EnvVarSecretRef extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:mesosphere.marathon.EnvVarSecretRef)
-      EnvVarSecretRefOrBuilder {
+      com.google.protobuf.GeneratedMessage
+      implements EnvVarSecretRefOrBuilder {
     // Use EnvVarSecretRef.newBuilder() to construct.
     private EnvVarSecretRef(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -35317,9 +35440,8 @@ public final class Protos {
               break;
             }
             case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              secretId_ = bs;
+              secretId_ = input.readBytes();
               break;
             }
           }
@@ -35362,6 +35484,7 @@ public final class Protos {
     }
 
     private int bitField0_;
+    // required string secretId = 1;
     public static final int SECRETID_FIELD_NUMBER = 1;
     private java.lang.Object secretId_;
     /**
@@ -35410,8 +35533,7 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
+      if (isInitialized != -1) return isInitialized == 1;
 
       if (!hasSecretId()) {
         memoizedIsInitialized = 0;
@@ -35522,9 +35644,8 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.EnvVarSecretRef}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.EnvVarSecretRef)
-        mesosphere.marathon.Protos.EnvVarSecretRefOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.EnvVarSecretRefOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor;
@@ -35643,6 +35764,7 @@ public final class Protos {
       }
       private int bitField0_;
 
+      // required string secretId = 1;
       private java.lang.Object secretId_ = "";
       /**
        * <code>required string secretId = 1;</code>
@@ -35656,12 +35778,9 @@ public final class Protos {
       public java.lang.String getSecretId() {
         java.lang.Object ref = secretId_;
         if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            secretId_ = s;
-          }
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          secretId_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
@@ -35730,152 +35849,152 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.EnvVarSecretRef)
   }
 
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Constraint_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Constraint_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ReadinessCheckDefinition_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_IpAddress_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_DiscoveryInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ServiceDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ResourceRoles_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ResourceRoles_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonTask_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonApp_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ContainerInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ContainerInfo_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ExtendedContainerInfo_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Volume_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Volume_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_EventSubscribers_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_StorageVersion_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_StorageVersion_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_GroupDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_DeploymentPlanDefinition_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_TaskFailure_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_TaskFailure_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ZKStoreEntry_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ResidencyDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ResidencyDefinition_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Secret_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Secret_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_EnvVarReference_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_EnvVarReference_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -35987,7 +36106,7 @@ public final class Protos {
       "Info.PortMapping\022\031\n\nprivileged\030\004 \001(\010:\005fa" +
       "lse\022$\n\nparameters\030\005 \003(\0132\020.mesos.Paramete" +
       "r\022\030\n\020force_pull_image\030\006 \001(\010\032\217\001\n\013PortMapp" +
-      "ing\022\021\n\thost_port\030\001 \002(\r\022\026\n\016container_port" +
+      "ing\022\021\n\thost_port\030\001 \001(\r\022\026\n\016container_port" +
       "\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\014\n\004name\030\004 \001(\t\022\034",
       "\n\006labels\030\005 \003(\0132\014.mesos.Label\022\027\n\014service_" +
       "port\030d \001(\r:\0010\"\203\003\n\006Volume\022 \n\004mode\030\003 \002(\0162\022" +
@@ -36036,199 +36155,198 @@ public final class Protos {
       "re.marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
+      new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
+        public com.google.protobuf.ExtensionRegistry assignDescriptors(
+            com.google.protobuf.Descriptors.FileDescriptor root) {
+          descriptor = root;
+          internal_static_mesosphere_marathon_Constraint_descriptor =
+            getDescriptor().getMessageTypes().get(0);
+          internal_static_mesosphere_marathon_Constraint_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Constraint_descriptor,
+              new java.lang.String[] { "Field", "Operator", "Value", });
+          internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(1);
+          internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
+              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "Port", });
+          internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(2);
+          internal_static_mesosphere_marathon_ReadinessCheckDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor,
+              new java.lang.String[] { "Name", "Protocol", "Path", "PortName", "IntervalMillis", "TimeoutMillis", "HttpStatusCodeForReady", "PreserveLastResponse", });
+          internal_static_mesosphere_marathon_IpAddress_descriptor =
+            getDescriptor().getMessageTypes().get(3);
+          internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_IpAddress_descriptor,
+              new java.lang.String[] { "Groups", "Labels", "DiscoveryInfo", "NetworkName", });
+          internal_static_mesosphere_marathon_DiscoveryInfo_descriptor =
+            getDescriptor().getMessageTypes().get(4);
+          internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_DiscoveryInfo_descriptor,
+              new java.lang.String[] { "Ports", });
+          internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(5);
+          internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ServiceDefinition_descriptor,
+              new java.lang.String[] { "Id", "Cmd", "Instances", "Resources", "Description", "Ports", "Constraints", "Executor", "OBSOLETEContainer", "Version", "HealthChecks", "Backoff", "BackoffFactor", "UpgradeStrategy", "Dependencies", "StoreUrls", "RequirePorts", "Container", "Labels", "MaxLaunchDelay", "AcceptedResourceRoles", "LastScalingAt", "LastConfigChangeAt", "IpAddress", "Residency", "PortDefinitions", "ReadinessCheckDefinition", "Secrets", "EnvVarReferences", "TaskKillGracePeriod", });
+          internal_static_mesosphere_marathon_ResourceRoles_descriptor =
+            getDescriptor().getMessageTypes().get(6);
+          internal_static_mesosphere_marathon_ResourceRoles_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ResourceRoles_descriptor,
+              new java.lang.String[] { "Role", });
+          internal_static_mesosphere_marathon_MarathonTask_descriptor =
+            getDescriptor().getMessageTypes().get(7);
+          internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonTask_descriptor,
+              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "OBSOLETENetworks", "Reservation", });
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor =
+            internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor,
+              new java.lang.String[] { "LocalVolumeIds", "State", });
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor =
+            internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor,
+              new java.lang.String[] { "Type", "Timeout", });
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor =
+            internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor,
+              new java.lang.String[] { "Initiated", "Deadline", "Reason", });
+          internal_static_mesosphere_marathon_MarathonApp_descriptor =
+            getDescriptor().getMessageTypes().get(8);
+          internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonApp_descriptor,
+              new java.lang.String[] { "Name", "Tasks", });
+          internal_static_mesosphere_marathon_ContainerInfo_descriptor =
+            getDescriptor().getMessageTypes().get(9);
+          internal_static_mesosphere_marathon_ContainerInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ContainerInfo_descriptor,
+              new java.lang.String[] { "Image", "Options", });
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor =
+            getDescriptor().getMessageTypes().get(10);
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor,
+              new java.lang.String[] { "Type", "Volumes", "Docker", });
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor =
+            internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor,
+              new java.lang.String[] { "Image", "Network", "PortMappings", "Privileged", "Parameters", "ForcePullImage", });
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor =
+            internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor,
+              new java.lang.String[] { "HostPort", "ContainerPort", "Protocol", "Name", "Labels", "ServicePort", });
+          internal_static_mesosphere_marathon_Volume_descriptor =
+            getDescriptor().getMessageTypes().get(11);
+          internal_static_mesosphere_marathon_Volume_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Volume_descriptor,
+              new java.lang.String[] { "Mode", "ContainerPath", "HostPath", "Image", "Persistent", "External", });
+          internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor =
+            internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor,
+              new java.lang.String[] { "Size", });
+          internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor =
+            internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(1);
+          internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor,
+              new java.lang.String[] { "Size", "Name", "Provider", "Options", });
+          internal_static_mesosphere_marathon_EventSubscribers_descriptor =
+            getDescriptor().getMessageTypes().get(12);
+          internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_EventSubscribers_descriptor,
+              new java.lang.String[] { "CallbackUrls", });
+          internal_static_mesosphere_marathon_StorageVersion_descriptor =
+            getDescriptor().getMessageTypes().get(13);
+          internal_static_mesosphere_marathon_StorageVersion_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_StorageVersion_descriptor,
+              new java.lang.String[] { "Major", "Minor", "Patch", });
+          internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(14);
+          internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor,
+              new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", });
+          internal_static_mesosphere_marathon_GroupDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(15);
+          internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_GroupDefinition_descriptor,
+              new java.lang.String[] { "Id", "Version", "Apps", "Groups", "Dependencies", });
+          internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(16);
+          internal_static_mesosphere_marathon_DeploymentPlanDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor,
+              new java.lang.String[] { "Id", "Version", "Original", "Target", });
+          internal_static_mesosphere_marathon_TaskFailure_descriptor =
+            getDescriptor().getMessageTypes().get(17);
+          internal_static_mesosphere_marathon_TaskFailure_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_TaskFailure_descriptor,
+              new java.lang.String[] { "AppId", "TaskId", "State", "Message", "Host", "Version", "Timestamp", "SlaveId", });
+          internal_static_mesosphere_marathon_ZKStoreEntry_descriptor =
+            getDescriptor().getMessageTypes().get(18);
+          internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ZKStoreEntry_descriptor,
+              new java.lang.String[] { "Name", "Uuid", "Value", "Compressed", });
+          internal_static_mesosphere_marathon_ResidencyDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(19);
+          internal_static_mesosphere_marathon_ResidencyDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ResidencyDefinition_descriptor,
+              new java.lang.String[] { "RelaunchEscalationTimeoutSeconds", "TaskLostBehavior", });
+          internal_static_mesosphere_marathon_Secret_descriptor =
+            getDescriptor().getMessageTypes().get(20);
+          internal_static_mesosphere_marathon_Secret_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Secret_descriptor,
+              new java.lang.String[] { "Id", "Source", });
+          internal_static_mesosphere_marathon_EnvVarReference_descriptor =
+            getDescriptor().getMessageTypes().get(21);
+          internal_static_mesosphere_marathon_EnvVarReference_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_EnvVarReference_descriptor,
+              new java.lang.String[] { "Type", "Name", "SecretRef", });
+          internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor =
+            getDescriptor().getMessageTypes().get(22);
+          internal_static_mesosphere_marathon_EnvVarSecretRef_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor,
+              new java.lang.String[] { "SecretId", });
+          return null;
+        }
+      };
     com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           org.apache.mesos.Protos.getDescriptor(),
         }, assigner);
-    internal_static_mesosphere_marathon_Constraint_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_mesosphere_marathon_Constraint_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_Constraint_descriptor,
-        new java.lang.String[] { "Field", "Operator", "Value", });
-    internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
-        new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "Port", });
-    internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_mesosphere_marathon_ReadinessCheckDefinition_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor,
-        new java.lang.String[] { "Name", "Protocol", "Path", "PortName", "IntervalMillis", "TimeoutMillis", "HttpStatusCodeForReady", "PreserveLastResponse", });
-    internal_static_mesosphere_marathon_IpAddress_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_IpAddress_descriptor,
-        new java.lang.String[] { "Groups", "Labels", "DiscoveryInfo", "NetworkName", });
-    internal_static_mesosphere_marathon_DiscoveryInfo_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_DiscoveryInfo_descriptor,
-        new java.lang.String[] { "Ports", });
-    internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_ServiceDefinition_descriptor,
-        new java.lang.String[] { "Id", "Cmd", "Instances", "Resources", "Description", "Ports", "Constraints", "Executor", "OBSOLETEContainer", "Version", "HealthChecks", "Backoff", "BackoffFactor", "UpgradeStrategy", "Dependencies", "StoreUrls", "RequirePorts", "Container", "Labels", "MaxLaunchDelay", "AcceptedResourceRoles", "LastScalingAt", "LastConfigChangeAt", "IpAddress", "Residency", "PortDefinitions", "ReadinessCheckDefinition", "Secrets", "EnvVarReferences", "TaskKillGracePeriod", });
-    internal_static_mesosphere_marathon_ResourceRoles_descriptor =
-      getDescriptor().getMessageTypes().get(6);
-    internal_static_mesosphere_marathon_ResourceRoles_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_ResourceRoles_descriptor,
-        new java.lang.String[] { "Role", });
-    internal_static_mesosphere_marathon_MarathonTask_descriptor =
-      getDescriptor().getMessageTypes().get(7);
-    internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_MarathonTask_descriptor,
-        new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "OBSOLETENetworks", "Reservation", });
-    internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor =
-      internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(0);
-    internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor,
-        new java.lang.String[] { "LocalVolumeIds", "State", });
-    internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor =
-      internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor.getNestedTypes().get(0);
-    internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor,
-        new java.lang.String[] { "Type", "Timeout", });
-    internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor =
-      internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor.getNestedTypes().get(0);
-    internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor,
-        new java.lang.String[] { "Initiated", "Deadline", "Reason", });
-    internal_static_mesosphere_marathon_MarathonApp_descriptor =
-      getDescriptor().getMessageTypes().get(8);
-    internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_MarathonApp_descriptor,
-        new java.lang.String[] { "Name", "Tasks", });
-    internal_static_mesosphere_marathon_ContainerInfo_descriptor =
-      getDescriptor().getMessageTypes().get(9);
-    internal_static_mesosphere_marathon_ContainerInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_ContainerInfo_descriptor,
-        new java.lang.String[] { "Image", "Options", });
-    internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor =
-      getDescriptor().getMessageTypes().get(10);
-    internal_static_mesosphere_marathon_ExtendedContainerInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor,
-        new java.lang.String[] { "Type", "Volumes", "Docker", });
-    internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor =
-      internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(0);
-    internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor,
-        new java.lang.String[] { "Image", "Network", "PortMappings", "Privileged", "Parameters", "ForcePullImage", });
-    internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor =
-      internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor.getNestedTypes().get(0);
-    internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor,
-        new java.lang.String[] { "HostPort", "ContainerPort", "Protocol", "Name", "Labels", "ServicePort", });
-    internal_static_mesosphere_marathon_Volume_descriptor =
-      getDescriptor().getMessageTypes().get(11);
-    internal_static_mesosphere_marathon_Volume_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_Volume_descriptor,
-        new java.lang.String[] { "Mode", "ContainerPath", "HostPath", "Image", "Persistent", "External", });
-    internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor =
-      internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(0);
-    internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor,
-        new java.lang.String[] { "Size", });
-    internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor =
-      internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(1);
-    internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor,
-        new java.lang.String[] { "Size", "Name", "Provider", "Options", });
-    internal_static_mesosphere_marathon_EventSubscribers_descriptor =
-      getDescriptor().getMessageTypes().get(12);
-    internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_EventSubscribers_descriptor,
-        new java.lang.String[] { "CallbackUrls", });
-    internal_static_mesosphere_marathon_StorageVersion_descriptor =
-      getDescriptor().getMessageTypes().get(13);
-    internal_static_mesosphere_marathon_StorageVersion_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_StorageVersion_descriptor,
-        new java.lang.String[] { "Major", "Minor", "Patch", });
-    internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor =
-      getDescriptor().getMessageTypes().get(14);
-    internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor,
-        new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", });
-    internal_static_mesosphere_marathon_GroupDefinition_descriptor =
-      getDescriptor().getMessageTypes().get(15);
-    internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_GroupDefinition_descriptor,
-        new java.lang.String[] { "Id", "Version", "Apps", "Groups", "Dependencies", });
-    internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor =
-      getDescriptor().getMessageTypes().get(16);
-    internal_static_mesosphere_marathon_DeploymentPlanDefinition_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor,
-        new java.lang.String[] { "Id", "Version", "Original", "Target", });
-    internal_static_mesosphere_marathon_TaskFailure_descriptor =
-      getDescriptor().getMessageTypes().get(17);
-    internal_static_mesosphere_marathon_TaskFailure_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_TaskFailure_descriptor,
-        new java.lang.String[] { "AppId", "TaskId", "State", "Message", "Host", "Version", "Timestamp", "SlaveId", });
-    internal_static_mesosphere_marathon_ZKStoreEntry_descriptor =
-      getDescriptor().getMessageTypes().get(18);
-    internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_ZKStoreEntry_descriptor,
-        new java.lang.String[] { "Name", "Uuid", "Value", "Compressed", });
-    internal_static_mesosphere_marathon_ResidencyDefinition_descriptor =
-      getDescriptor().getMessageTypes().get(19);
-    internal_static_mesosphere_marathon_ResidencyDefinition_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_ResidencyDefinition_descriptor,
-        new java.lang.String[] { "RelaunchEscalationTimeoutSeconds", "TaskLostBehavior", });
-    internal_static_mesosphere_marathon_Secret_descriptor =
-      getDescriptor().getMessageTypes().get(20);
-    internal_static_mesosphere_marathon_Secret_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_Secret_descriptor,
-        new java.lang.String[] { "Id", "Source", });
-    internal_static_mesosphere_marathon_EnvVarReference_descriptor =
-      getDescriptor().getMessageTypes().get(21);
-    internal_static_mesosphere_marathon_EnvVarReference_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_EnvVarReference_descriptor,
-        new java.lang.String[] { "Type", "Name", "SecretRef", });
-    internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor =
-      getDescriptor().getMessageTypes().get(22);
-    internal_static_mesosphere_marathon_EnvVarSecretRef_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor,
-        new java.lang.String[] { "SecretId", });
-    org.apache.mesos.Protos.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -177,7 +177,7 @@ message ExtendedContainerInfo {
     optional mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];
 
     message PortMapping {
-      required uint32 host_port = 1;
+      optional uint32 host_port = 1;
       required uint32 container_port = 2;
       optional string protocol = 3;
       optional string name = 4;

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -853,16 +853,7 @@ trait AppAndGroupFormats {
       // top-level ports fields are incompatible with IP/CT
       if (runSpec.ipAddress.isEmpty) {
         appJson = appJson ++ Json.obj(
-          // the ports field was written incorrectly in old code if a container was specified
-          // it should contain the service ports
-          //
-          // "ports" -> runSpec.servicePorts, -- can't specify both this and portDefinitions and be valid,
-          // so I'm removing it. it's been deprecated for a while, users will have to deal.
-          //
-          // TODO(jdef) honestly, it's still very confusing even without IP/CT mode if you're
-          // using BRIDGE networking because portMappings stuff bubbles up to the top-level
-          // ports fields here -- which results in serialized JSON that's invalid according to
-          // our own validation funcs.
+          "ports" -> runSpec.servicePorts,
           "portDefinitions" -> runSpec.portDefinitions.zip(runSpec.servicePorts).map {
             case (portDefinition, servicePort) => portDefinition.copy(port = servicePort)
           },

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskOpFactoryImpl.scala
@@ -60,7 +60,7 @@ class TaskOpFactoryImpl(
           status = Task.Status(
             stagedAt = clock.now()
           ),
-          hostPorts = ports
+          hostPorts = ports.flatten
         )
 
         taskOperationFactory.launchEphemeral(taskInfo, task)
@@ -150,7 +150,7 @@ class TaskOpFactoryImpl(
           status = Task.Status(
             stagedAt = clock.now()
           ),
-          hostPorts = ports)
+          hostPorts = ports.flatten)
 
         taskOperationFactory.launchOnReservation(taskInfo, taskStateOp, task)
     }

--- a/src/main/scala/mesosphere/marathon/state/DiscoveryInfo.scala
+++ b/src/main/scala/mesosphere/marathon/state/DiscoveryInfo.scala
@@ -10,6 +10,9 @@ case class DiscoveryInfo(ports: Seq[DiscoveryInfo.Port] = Seq.empty) {
       .addAllPorts(ports.map(_.toProto).asJava)
       .build
   }
+
+  def isEmpty: Boolean = DiscoveryInfo.empty.equals(this)
+  def nonEmpty: Boolean = !isEmpty
 }
 
 object DiscoveryInfo {

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -254,11 +254,11 @@ object Group {
     new Validator[Group] {
       override def apply(group: Group): Result = {
         val groupViolations = group.apps.flatMap { app =>
-          val ruleViolations = app.containerServicePorts.toSeq.flatMap { servicePorts =>
+          val ruleViolations = app.container.flatMap(_.servicePorts).toSeq.flatMap { servicePorts =>
             for {
               existingApp <- group.transitiveApps.toList
               if existingApp.id != app.id // in case of an update, do not compare the app against itself
-              existingServicePort <- existingApp.portMappings.toList.flatten.map(_.servicePort)
+              existingServicePort <- existingApp.container.flatMap(_.portMappings).toList.flatten.map(_.servicePort)
               if existingServicePort != 0 // ignore zero ports, which will be chosen at random
               if servicePorts contains existingServicePort
             } yield RuleViolation(app.id,

--- a/src/main/scala/mesosphere/marathon/state/PortAssignment.scala
+++ b/src/main/scala/mesosphere/marathon/state/PortAssignment.scala
@@ -2,11 +2,10 @@ package mesosphere.marathon.state
 
 /**
   * @param portName name of the port
-  * @param portIndex index of the port, used for example to define health checks
   * @param effectiveIpAddress ip address on which the port can be reached (can be an agent's IP or an IP-per-Task)
   * @param effectivePort resolved non-dynamic port. The task is reachable under effectiveIpAddress:effectivePort.
   */
-case class PortAssignment(portName: Option[String], portIndex: Int, effectiveIpAddress: String, effectivePort: Int)
+case class PortAssignment(portName: Option[String], effectiveIpAddress: String, effectivePort: Int)
 
 object PortAssignment {
   /**

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -6,7 +6,6 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.plugin
 import mesosphere.marathon.state.AppDefinition.VersionInfo
-import mesosphere.marathon.state.Container.Docker.PortMapping
 
 import scala.concurrent.duration.FiniteDuration
 import scala.collection.immutable.Seq
@@ -90,8 +89,6 @@ trait RunSpec extends plugin.RunSpec {
   def diskForPersistentVolumes: Double
   def portNumbers: Seq[Int]
   def portNames: Seq[String]
-  def containerHostPorts: Option[Seq[Int]]
-  def portMappings: Option[Seq[PortMapping]]
   def servicePorts: Seq[Int]
   def portAssignments(task: Task): Option[Seq[PortAssignment]]
 }

--- a/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.tasks
 
 import mesosphere.marathon.state.{ ResourceRole, RunSpec, Container }
 import mesosphere.marathon.state.Container.Docker.PortMapping
-import mesosphere.marathon.tasks.PortsMatcher.PortWithRole
+import mesosphere.marathon.tasks.PortsMatcher.{ Request, RequestNone, PortWithRole }
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
 import mesosphere.mesos.protos
 import mesosphere.mesos.protos.{ RangesResource, Resource }
@@ -14,14 +14,16 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.util.Random
 
-case class PortsMatch(hostPortsWithRole: Seq[PortWithRole]) {
+case class PortsMatch(hostPortsWithRole: Seq[Option[PortWithRole]]) {
   /**
     * The resulting port resources which should be consumed from the offer. If no matching port ranges could
     * be generated from the offer, return `None`.
     */
-  lazy val resources: Seq[MesosProtos.Resource] = PortWithRole.createPortsResources(hostPortsWithRole)
+  lazy val resources: Seq[MesosProtos.Resource] = PortWithRole.createPortsResources(hostPortsWithRole.flatten)
 
-  def hostPorts: Seq[Int] = hostPortsWithRole.map(_.port)
+  def hostPorts: Seq[Option[Int]] = hostPortsWithRole.map(_.map {
+    case PortWithRole(_, port, _) => port
+  })
 }
 
 /**
@@ -38,7 +40,7 @@ class PortsMatcher(
 
   lazy val portsMatch: Option[PortsMatch] = portsWithRoles.map(PortsMatch(_))
 
-  private[this] def portsWithRoles: Option[Seq[PortWithRole]] = {
+  private[this] def portsWithRoles: Option[Seq[Option[PortWithRole]]] = {
     val portMappings: Option[Seq[Container.Docker.PortMapping]] =
       for {
         c <- runSpec.container
@@ -66,7 +68,7 @@ class PortsMatcher(
   /**
     * Try to find supplied ports in offer. Returns `None` if not all ports were found.
     */
-  private[this] def findPortsInOffer(requiredPorts: Seq[Int], failLog: Boolean): Option[Seq[PortWithRole]] = {
+  private[this] def findPortsInOffer(requiredPorts: Seq[Int], failLog: Boolean): Option[Seq[Option[PortWithRole]]] = {
     takeEnoughPortsOrNone(expectedSize = requiredPorts.size) {
       requiredPorts.iterator.map { (port: Int) =>
         offeredPortRanges.find(_.contains(port)).map { offeredRange =>
@@ -86,7 +88,7 @@ class PortsMatcher(
   /**
     * Choose random ports from offer.
     */
-  private[this] def randomPorts(numberOfPorts: Int): Option[Seq[PortWithRole]] = {
+  private[this] def randomPorts(numberOfPorts: Int): Option[Seq[Option[PortWithRole]]] = {
     takeEnoughPortsOrNone(expectedSize = numberOfPorts) {
       shuffledAvailablePorts.map(Some(_))
     } orElse {
@@ -100,17 +102,19 @@ class PortsMatcher(
     * Try to find all non-zero host ports in offer and use random ports from the offer for dynamic host ports (=0).
     * Return `None` if not all host ports could be assigned this way.
     */
-  private[this] def mappedPortRanges(mappings: Seq[PortMapping]): Option[Seq[PortWithRole]] = {
+  private[this] def mappedPortRanges(mappings: Seq[PortMapping]): Option[Seq[Option[PortWithRole]]] = {
     takeEnoughPortsOrNone(expectedSize = mappings.size) {
       // non-dynamic hostPorts from port mappings
-      val hostPortsFromMappings: Set[Int] = mappings.iterator.map(_.hostPort).filter(_ != 0).toSet
+      val hostPortsFromMappings: Set[Int] = mappings.collect {
+        case PortMapping(_, Some(hostPort), _, _, _, _) if hostPort != 0 => hostPort
+      }.toSet
 
       // available ports without the ports that have been preset in the port mappings
       val availablePortsWithoutStaticHostPorts: Iterator[PortWithRole] =
         shuffledAvailablePorts.filter(portWithRole => !hostPortsFromMappings(portWithRole.port))
 
       mappings.iterator.map {
-        case PortMapping(containerPort, hostPort, servicePort, protocol, name, labels) if hostPort == 0 =>
+        case PortMapping(containerPort, Some(hostPort), servicePort, protocol, name, labels) if hostPort == 0 =>
           if (!availablePortsWithoutStaticHostPorts.hasNext) {
             log.info(s"Offer [${offer.getId.getValue}]. $resourceSelector. " +
               s"Insufficient ports in offer for run spec [${runSpec.id}]")
@@ -119,15 +123,21 @@ class PortsMatcher(
           else {
             Option(availablePortsWithoutStaticHostPorts.next())
           }
-        case pm: PortMapping =>
-          offeredPortRanges.find(_.contains(pm.hostPort)) match {
+        case PortMapping(_, Some(hostPort), _, _, _, _) =>
+          offeredPortRanges.find(_.contains(hostPort)) match {
             case Some(PortRange(role, _, _, reservation)) =>
-              Some(PortWithRole(role, pm.hostPort, reservation))
+              Some(PortWithRole(role, hostPort, reservation))
             case None =>
               log.info(s"Offer [${offer.getId.getValue}]. $resourceSelector. " +
-                s"Cannot find range with host port ${pm.hostPort} for run spec [${runSpec.id}]")
+                s"Cannot find range with host port ${hostPort} for run spec [${runSpec.id}]")
               None
           }
+        case PortMapping(_, None, _, _, _, _) =>
+          // None has special meaning in this context: it stops the allocation process. this is a problem
+          // if there's an optional host port in the middle of some mappings list. so instead of None we
+          // generate Some(RequestNone) to indicate that we're not requesting a host port, but there may
+          // still be host ports to allocate so don't stop iterating through the list.
+          Some(RequestNone)
       }
     }
   }
@@ -135,9 +145,15 @@ class PortsMatcher(
   /**
     * Takes `expectedSize` ports from the given iterator if possible. Stops when encountering the first `None` port.
     */
-  private[this] def takeEnoughPortsOrNone[T](expectedSize: Int)(ports: Iterator[Option[T]]): Option[Seq[T]] = {
+  private[this] def takeEnoughPortsOrNone[T <: Request](
+    expectedSize: Int)(ports: Iterator[Option[T]]): Option[Seq[Option[PortWithRole]]] = {
     val allocatedPorts = ports.takeWhile(_.isDefined).take(expectedSize).flatten.toVector
-    if (allocatedPorts.size == expectedSize) Some(allocatedPorts) else None
+    if (allocatedPorts.size == expectedSize)
+      Some(allocatedPorts.map(_ match {
+        case RequestNone      => None
+        case pr: PortWithRole => Some(pr)
+      }))
+    else None
   }
 
   private[this] lazy val offeredPortRanges: Seq[PortRange] = {
@@ -156,7 +172,16 @@ class PortsMatcher(
 
 object PortsMatcher {
 
-  case class PortWithRole(role: String, port: Int, reservation: Option[MesosProtos.Resource.ReservationInfo] = None) {
+  // Request represents some particular type of port resource request.
+  // If there is no such request for a port, then use RequestNone.
+  protected[tasks] sealed trait Request
+
+  protected[tasks] case object RequestNone extends Request
+
+  case class PortWithRole(
+      role: String,
+      port: Int,
+      reservation: Option[MesosProtos.Resource.ReservationInfo] = None) extends Request {
     def toRange: protos.Range = {
       protos.Range(port.toLong, port.toLong)
     }

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -23,7 +23,7 @@ object ResourceMatcher {
     * A successful match result of the [[ResourceMatcher]].matchResources method.
     */
   case class ResourceMatch(scalarMatches: Iterable[ScalarMatch], portsMatch: PortsMatch) {
-    lazy val hostPorts: Seq[Int] = portsMatch.hostPorts
+    lazy val hostPorts: Seq[Option[Int]] = portsMatch.hostPorts
 
     def scalarMatch(name: String): Option[ScalarMatch] = scalarMatches.find(_.resourceName == name)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -319,7 +319,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
           ))
         ))
       )),
-      portDefinitions = Nil
+      portDefinitions = Seq.empty
     )
     val (body, plan) = prepareApp(app)
 
@@ -356,9 +356,15 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
           ))
         ))
       )),
-      portDefinitions = Nil
+      portDefinitions = Seq.empty
     )
-    val (body, plan) = prepareApp(app)
+
+    val group = Group(PathId("/"), Set(app))
+    val plan = DeploymentPlan(group, group)
+    val body = Json.stringify(Json.toJson(app).as[JsObject] - "ports").getBytes("UTF-8")
+    groupManager.updateApp(any, any, any, any, any) returns Future.successful(plan)
+    groupManager.rootGroup() returns Future.successful(group)
+    groupManager.app(app.id) returns Future.successful(Some(app))
 
     When("The create request is made")
     clock += 5.seconds
@@ -406,7 +412,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
           ))
         ))
       )),
-      portDefinitions = Nil
+      portDefinitions = Seq.empty
     )
     val (body, plan) = prepareApp(app)
 
@@ -438,7 +444,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
           image = "jdef/helpme"
         ))
       )),
-      portDefinitions = Nil
+      portDefinitions = Seq.empty
     )
     val (body, plan) = prepareApp(app)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -114,7 +114,7 @@ class ModelValidationTest
         docker = Some(Docker(
           image = "demothing",
           network = Some(Network.BRIDGE),
-          portMappings = Some(Seq(PortMapping(2000, servicePort = servicePort)))
+          portMappings = Some(Seq(PortMapping(2000, Some(0), servicePort = servicePort)))
         ))
       ))
     )

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -62,7 +62,6 @@ class AppDefinitionFormatsTest
     (r1 \ "uris").as[Seq[String]] should equal (DefaultUris)
     (r1 \ "fetch").as[Seq[FetchUri]] should equal (DefaultFetch)
     (r1 \ "storeUrls").as[Seq[String]] should equal (DefaultStoreUrls)
-    (r1 \ "ports").as[Seq[Long]] should equal (DefaultPortDefinitions.map(_.port))
     (r1 \ "portDefinitions").as[Seq[PortDefinition]] should equal (DefaultPortDefinitions)
     (r1 \ "requirePorts").as[Boolean] should equal (DefaultRequirePorts)
     (r1 \ "backoffSeconds").as[Long] should equal (DefaultBackoff.toSeconds)

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
@@ -33,7 +33,6 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
         Seq(
           PortAssignment(
             portName = Some("http"),
-            portIndex = 0,
             effectiveIpAddress = "192.168.0.1",
             effectivePort = 1)
         )))
@@ -93,7 +92,7 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
           image = "mesosphere/marathon",
           network = Some(Protos.ContainerInfo.DockerInfo.Network.BRIDGE),
           portMappings = Some(Seq(
-            Docker.PortMapping(containerPort = 80, hostPort = 0, servicePort = 0, protocol = "tcp",
+            Docker.PortMapping(containerPort = 80, hostPort = Some(0), servicePort = 0, protocol = "tcp",
               name = Some("http"))
           ))
         ))
@@ -110,7 +109,6 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
         Seq(
           PortAssignment(
             portName = Some("http"),
-            portIndex = 0,
             effectiveIpAddress = task.agentInfo.host,
             effectivePort = 1)
         )))
@@ -149,7 +147,6 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
         Seq(
           PortAssignment(
             portName = Some("http"),
-            portIndex = 0,
             effectiveIpAddress = task.agentInfo.host,
             effectivePort = 1)
         )))

--- a/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
@@ -42,14 +42,14 @@ class ContainerTest extends MarathonSpec with Matchers {
           portMappings = Some(Seq(
             Container.Docker.PortMapping(
               containerPort = 8080,
-              hostPort = 32001,
+              hostPort = Some(32001),
               servicePort = 9000,
               protocol = Container.Docker.PortMapping.TCP,
               name = Some("http"),
               labels = Map("foo" -> "bar")),
             Container.Docker.PortMapping(
               containerPort = 8081,
-              hostPort = 32002,
+              hostPort = Some(32002),
               servicePort = 9001,
               protocol = Container.Docker.PortMapping.UDP)
           )
@@ -102,12 +102,12 @@ class ContainerTest extends MarathonSpec with Matchers {
           portMappings = Some(Seq(
             Container.Docker.PortMapping(
               containerPort = 8080,
-              hostPort = 32001,
+              hostPort = Some(32001),
               servicePort = 9000,
               protocol = "tcp,udp"),
             Container.Docker.PortMapping(
               containerPort = 8081,
-              hostPort = 32002,
+              hostPort = Some(32002),
               servicePort = 9001,
               protocol = "udp,tcp")
           ))

--- a/src/test/scala/mesosphere/marathon/state/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupManagerTest.scala
@@ -76,9 +76,9 @@ class GroupManagerTest extends MarathonActorSupport with MockitoSugar with Match
         image = "busybox",
         network = Some(Network.BRIDGE),
         portMappings = Some(Seq(
-          PortMapping(containerPort = 8080, hostPort = 0, servicePort = 0, protocol = "tcp"),
-          PortMapping (containerPort = 9000, hostPort = 10555, servicePort = 10555, protocol = "udp"),
-          PortMapping(containerPort = 9001, hostPort = 0, servicePort = 0, protocol = "tcp")
+          PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 0, protocol = "tcp"),
+          PortMapping (containerPort = 9000, hostPort = Some(10555), servicePort = 10555, protocol = "udp"),
+          PortMapping(containerPort = 9001, hostPort = Some(0), servicePort = 0, protocol = "tcp")
         ))
       ))
     )
@@ -108,8 +108,8 @@ class GroupManagerTest extends MarathonActorSupport with MockitoSugar with Match
         image = "busybox",
         network = Some(Network.BRIDGE),
         portMappings = Some(Seq(
-          PortMapping(containerPort = 8080, hostPort = 0, servicePort = 80, protocol = "tcp"),
-          PortMapping (containerPort = 9000, hostPort = 10555, servicePort = 81, protocol = "udp")
+          PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 80, protocol = "tcp"),
+          PortMapping (containerPort = 9000, hostPort = Some(10555), servicePort = 81, protocol = "udp")
         ))
       ))
     )

--- a/src/test/scala/mesosphere/marathon/state/PortMappingTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/PortMappingTest.scala
@@ -24,13 +24,21 @@ class PortMappingTest extends FunSuiteLike with Matchers {
   }
 
   test("portMapping with invalid port is invalid") {
-    validate(Fixture.validPortMapping.copy(hostPort = -1)).isFailure should be(true)
+    validate(Fixture.validPortMapping.copy(hostPort = Some(-1))).isFailure should be(true)
     validate(Fixture.validPortMapping.copy(containerPort = -1)).isFailure should be(true)
+  }
+
+  test("portMapping without hostport may be valid") {
+    validate(Fixture.validPortMapping.copy(hostPort = None)) should be (Success)
+  }
+
+  test("portMapping with zero hostport is valid") {
+    validate(Fixture.validPortMapping.copy(hostPort = Some(0))) should be (Success)
   }
 
   object Fixture {
     val validPortMapping = PortMapping(
-      hostPort = 80,
+      hostPort = Some(80),
       containerPort = 80,
       protocol = "tcp",
       name = Some("http-port"),

--- a/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
@@ -66,7 +66,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
     val matcher = new PortsMatcher(app, offer, f.wildcardResourceSelector)
 
     assert(matcher.portsMatch.isDefined)
-    assert(matcher.portsMatch.get.hostPorts == Seq(80, 81, 82, 83, 100))
+    assert(matcher.portsMatch.get.hostPorts.flatten == Seq(80, 81, 82, 83, 100))
     assert(matcher.portsMatch.get.resources.map(_.getRole) == Seq(ResourceRole.Unreserved))
   }
 
@@ -78,7 +78,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
     val matcher = new PortsMatcher(app, offer, f.wildcardResourceSelector)
 
     assert(matcher.portsMatch.isDefined)
-    assert(matcher.portsMatch.get.hostPorts == Seq(100, 80))
+    assert(matcher.portsMatch.get.hostPorts.flatten == Seq(100, 80))
   }
 
   test("get ports from multiple resources, preserving role") {
@@ -157,7 +157,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
       Container(
         docker = Some(new Docker(
           portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = 0)
+            new Docker.PortMapping(containerPort = 1, hostPort = Some(0))
           ))
         ))
       )
@@ -174,7 +174,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
       Container(
         docker = Some(new Docker(
           portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = 0)
+            new Docker.PortMapping(containerPort = 1, hostPort = Some(0))
           ))
         ))
       )
@@ -184,7 +184,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
     val matcher = new PortsMatcher(app, offer)
 
     assert(matcher.portsMatch.isDefined)
-    assert(matcher.portsMatch.get.hostPorts == Seq(31000))
+    assert(matcher.portsMatch.get.hostPorts.flatten == Seq(31000))
   }
 
   test("randomly satisfy dynamic mapped port from container") {
@@ -192,7 +192,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
       Container(
         docker = Some(new Docker(
           portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = 0)
+            new Docker.PortMapping(containerPort = 1, hostPort = Some(0))
           ))
         ))
       )
@@ -227,7 +227,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
       Container(
         docker = Some(new Docker(
           portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = 8080)
+            new Docker.PortMapping(containerPort = 1, hostPort = Some(8080))
           ))
         ))
       )
@@ -244,7 +244,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
       Container(
         docker = Some(new Docker(
           portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = 31200)
+            new Docker.PortMapping(containerPort = 1, hostPort = Some(31200))
           ))
         ))
       )
@@ -254,7 +254,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
     val matcher = new PortsMatcher(app, offer)
 
     assert(matcher.portsMatch.isDefined)
-    assert(matcher.portsMatch.get.hostPorts == Seq(31200))
+    assert(matcher.portsMatch.get.hostPorts.flatten == Seq(31200))
   }
 
   test("do not satisfy fixed mapped port from container with resource offer of incorrect role") {
@@ -262,7 +262,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
       Container(
         docker = Some(new Docker(
           portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = 31200)
+            new Docker.PortMapping(containerPort = 1, hostPort = Some(31200))
           ))
         ))
       )
@@ -285,8 +285,8 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
       Container(
         docker = Some(new Docker(
           portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = 0),
-            new Docker.PortMapping(containerPort = 1, hostPort = 31000)
+            new Docker.PortMapping(containerPort = 1, hostPort = Some(0)),
+            new Docker.PortMapping(containerPort = 1, hostPort = Some(31000))
           ))
         ))
       )
@@ -296,7 +296,7 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
     val matcher = new PortsMatcher(app, offer)
 
     assert(matcher.portsMatch.isDefined)
-    assert(matcher.portsMatch.get.hostPorts == Seq(31001, 31000))
+    assert(matcher.portsMatch.get.hostPorts.flatten == Seq(31001, 31000))
   }
 
   test("satisfy fixed and dynamic mapped port from container from ranges with different roles") {
@@ -304,8 +304,8 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
       Container(
         docker = Some(new Docker(
           portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = 0),
-            new Docker.PortMapping(containerPort = 1, hostPort = 31000)
+            new Docker.PortMapping(containerPort = 1, hostPort = Some(0)),
+            new Docker.PortMapping(containerPort = 1, hostPort = Some(31000))
           ))
         ))
       )
@@ -321,9 +321,9 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
     val matcher = new PortsMatcher(app, offer, resourceSelector = ResourceSelector.any(Set(ResourceRole.Unreserved, "marathon")))
 
     assert(matcher.portsMatch.isDefined)
-    assert(matcher.portsMatch.get.hostPorts.toSet == Set(31000, 31001))
+    assert(matcher.portsMatch.get.hostPorts.flatten.toSet == Set(31000, 31001))
     assert(matcher.portsMatch.get.hostPortsWithRole.toSet == Set(
-      PortWithRole(ResourceRole.Unreserved, 31000), PortWithRole("marathon", 31001)
+      Some(PortWithRole(ResourceRole.Unreserved, 31000)), Some(PortWithRole("marathon", 31001))
     ))
   }
 }

--- a/src/test/scala/mesosphere/mesos/ResourceMatchTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatchTest.scala
@@ -20,7 +20,7 @@ class ResourceMatchTest
           scope = ScalarMatchResult.Scope.NoneDisk
         )
       ),
-      portsMatch = PortsMatch(Seq(PortsMatcher.PortWithRole("role2", 80, reservation = Some(portReservation))))
+      portsMatch = PortsMatch(Seq(Some(PortsMatcher.PortWithRole("role2", 80, reservation = Some(portReservation)))))
     )
 
     When("converting it to resources")


### PR DESCRIPTION
- docker.portMappings.hostPort is optional
- support for USER network mode in Marathon scala API
- add USER as a valid networking mode to docker.network JSON schema
- portMappings require hostPort in docker BRIDGE network mode
- move container portMappings, hostPorts, servicePorts from AppDefinition to Container
- marathon serialization proto tests for docker networking
- disallow ipaddress/discoveryInfo for docker containers using BRIDGE/USER networking
- updated docs for USER mode and portMapping
- generate PORT{x} and PORT_{y} variables more consistently
- removed unused portIndex from PortAssignment

Conflicts:
	src/main/java/mesosphere/marathon/Protos.java
	src/main/scala/mesosphere/mesos/TaskBuilder.scala
	src/test/scala/mesosphere/mesos/TaskBuilderTest.scala