### PR TITLE
Updated Mesos to 0.28.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /marathon
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.28.0-2.0.16.debian81 && \
+    apt-get install --no-install-recommends -y --force-yes mesos=0.28.2-2.0.27.debian81 && \
     apt-get clean && \
     eval $(sed s/sbt.version/SBT_VERSION/ </marathon/project/build.properties) && \
     mkdir -p /usr/local/bin && \


### PR DESCRIPTION
Mesos suffered from a memory leak ([MESOS-5449](https://issues.apache.org/jira/browse/MESOS-5449)) that could affect large clusters
and has been fixed in 0.28.2.