### PR TITLE
Updated Mesos to 0.28.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /marathon
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.28.1-2.0.20.debian81 && \
+    apt-get install --no-install-recommends -y --force-yes mesos=0.28.2-2.0.27.debian81 && \
     apt-get clean && \
     eval $(sed s/sbt.version/SBT_VERSION/ </marathon/project/build.properties) && \
     mkdir -p /usr/local/bin && \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -10,7 +10,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
     echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.28.1-2.0.20.debian81 lxc
+    apt-get install --no-install-recommends -y --force-yes mesos=0.28.2-2.0.27.debian81 lxc
 
 # Install sbt manually
 COPY ./project/build.properties /marathon/project/build.properties


### PR DESCRIPTION
Mesos suffered from a memory leak ([MESOS-5449](https://issues.apache.org/jira/browse/MESOS-5449)) that could affect large clusters and has been fixed in 0.28.2.