### PR TITLE
Make Framework authentication explicit by using a command line flag

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -120,8 +120,13 @@ The core functionality flags can be also set by environment variable `MARATHON_O
     sessions in milliseconds.
 * <span class="label label-default">v1.1.2</span> `--zk_max_node_size` (Optional. Default: 1 MiB):
     Maximum allowed ZooKeeper node size (in bytes).
+* <span class="label label-default">v1.2.0</span> `--[disable_]mesos_authentication`  (Optional. Default: disabled):
+    If enabled, framework authentication will be used while registering with Mesos with principal and optional secret.
 * `--mesos_authentication_principal` (Optional.): The Mesos principal used for
-    authentication
+    authentication and for resource reservations
+* <span class="label label-default">v1.2.0</span> `--mesos_authentication_secret` (Optional.): The secret to use for authentication.
+    Please also consider using `--mesos_authentication_secret_file` to specify the secret in a file.
+    Only specify `--mesos_authentication_secret_file` or `--mesos_authentication_secret`
 * `--mesos_authentication_secret_file` (Optional.): The path to the Mesos secret
     file containing the authentication secret
 * `--mesos_leader_ui_url` (Optional.): The URL to the Mesos master facade. By default this

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -223,7 +223,7 @@ trait MarathonConf
   lazy val mesosAuthentication = toggle("mesos_authentication",
     default = Some(false),
     noshort = true,
-    descrYes = "Will enforce framework authentication while registering with Mesos with principal and optional secret.",
+    descrYes = "Will use framework authentication while registering with Mesos with principal and optional secret.",
     descrNo = "(Default) will not use framework authentication while registering with Mesos.",
     prefix = "disable_"
   )
@@ -235,7 +235,7 @@ trait MarathonConf
   )
 
   lazy val mesosAuthenticationSecretFile = opt[String]("mesos_authentication_secret_file",
-    descr = "Mesos Authentication Secret written to a file.",
+    descr = "Path to a file containing the Mesos Authentication Secret.",
     noshort = true
   )
   lazy val mesosAuthenticationSecret = opt[String]("mesos_authentication_secret",

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -226,9 +226,14 @@ trait MarathonConf
   )
 
   lazy val mesosAuthenticationSecretFile = opt[String]("mesos_authentication_secret_file",
+    descr = "Mesos Authentication Secret written to a file.",
+    noshort = true
+  )
+  lazy val mesosAuthenticationSecret = opt[String]("mesos_authentication_secret",
     descr = "Mesos Authentication Secret.",
     noshort = true
   )
+  mutuallyExclusive(mesosAuthenticationSecret, mesosAuthenticationSecretFile)
 
   lazy val envVarsPrefix = opt[String]("env_vars_prefix",
     descr = "Prefix to use for environment variables injected automatically into all started tasks.",

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -220,6 +220,15 @@ trait MarathonConf
     noshort = true
   )
 
+  lazy val mesosAuthentication = toggle("mesos_authentication",
+    default = Some(false),
+    noshort = true,
+    descrYes = "Will enforce framework authentication while registering with Mesos with principal and optional secret.",
+    descrNo = "(Default) will not use framework authentication while registering with Mesos.",
+    prefix = "disable_"
+  )
+  dependsOnAll(mesosAuthentication, List(mesosAuthenticationPrincipal))
+
   lazy val mesosAuthenticationPrincipal = opt[String]("mesos_authentication_principal",
     descr = "Mesos Authentication Principal.",
     noshort = true

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
@@ -51,12 +51,14 @@ object MarathonSchedulerDriver {
 
     //set credentials only if principal and secret is set
     val credential: Option[Credential] = {
+      def secretFileContent = config.mesosAuthenticationSecretFile.get.map { secretFile =>
+        ByteString.readFrom(new FileInputStream(secretFile)).toStringUtf8
+      }
       for {
         principal <- config.mesosAuthenticationPrincipal.get
-        secretFile <- config.mesosAuthenticationSecretFile.get
+        secret <- config.mesosAuthenticationSecret.get orElse secretFileContent
       } yield {
-        val secretBytes = ByteString.readFrom(new FileInputStream(secretFile))
-        Credential.newBuilder().setPrincipal(principal).setSecret(secretBytes.toStringUtf8).build()
+        Credential.newBuilder().setPrincipal(principal).setSecret(secret).build()
       }
     }
 

--- a/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
@@ -40,6 +40,29 @@ class MarathonConfTest extends MarathonSpec with Matchers {
     assert(conf.mesosAuthenticationSecretFile.get == Some(secretFile))
   }
 
+  test("Secret can be specified directly") {
+    val conf = MarathonTestHelper.makeConfig(
+      "--master", "127.0.0.1:5050",
+      "--mesos_authentication_principal", principal,
+      "--mesos_authentication_secret", "top secret"
+    )
+    assert(conf.mesosAuthenticationSecretFile.isEmpty)
+    assert(conf.mesosAuthenticationPrincipal.get.contains(principal))
+    assert(conf.mesosAuthenticationSecret.get.contains("top secret"))
+  }
+
+  test("Secret and SecretFile can not be specified at the same time") {
+    Try(MarathonTestHelper.makeConfig(
+      "--master", "127.0.0.1:5050",
+      "--mesos_authentication_principal", principal,
+      "--mesos_authentication_secret", "top secret",
+      "--mesos_authentication_secret_file", secretFile
+    )) match {
+      case Failure(ex) => ex.getMessage should include("There should be only one or zero of the following options: mesos_authentication_secret, mesos_authentication_secret_file")
+      case _           => fail("Should give an error")
+    }
+  }
+
   test("HA mode is enabled by default") {
     val conf = MarathonTestHelper.defaultConfig()
     assert(conf.highlyAvailable())


### PR DESCRIPTION
Only if the flag is set to true, we do framework authentication (default false)
The secret needs to be optional.