### PR TITLE
Scala friendly wrapper around Apache Curator

### DIFF
--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/DriverActor.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/DriverActor.scala
@@ -168,8 +168,7 @@ class DriverActor(schedulerProps: Props) extends Actor {
     case ReconcileTask(taskStatuses) =>
       if (taskStatuses.isEmpty) {
         tasks.values.foreach(scheduler ! _)
-      }
-      else {
+      } else {
         taskStatuses.iterator.map(_.getTaskId.getValue).map(tasks).foreach(scheduler ! _)
       }
   }
@@ -193,14 +192,12 @@ class DriverActor(schedulerProps: Props) extends Actor {
         tasksToLaunch.map(_.getTaskId).foreach {
           scheduleStatusChange(toState = TaskState.TASK_RUNNING, afterDuration = 5.seconds)
         }
-      }
-      else {
+      } else {
         tasksToLaunch.map(_.getTaskId).foreach {
           scheduleStatusChange(toState = TaskState.TASK_FAILED, afterDuration = 5.seconds)
         }
       }
-    }
-    else {
+    } else {
       log.debug("simulating lost launch")
     }
   }
@@ -215,12 +212,10 @@ class DriverActor(schedulerProps: Props) extends Actor {
       }
       log.debug(s"${tasks.size} tasks")
       scheduler ! status
-    }
-    else {
+    } else {
       if (status.getState == TaskState.TASK_LOST) {
         scheduler ! status
-      }
-      else {
+      } else {
         log.debug(s"${status.getTaskId.getValue} does not exist anymore")
       }
     }

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/FindDeterioratedMetrics.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/FindDeterioratedMetrics.scala
@@ -59,8 +59,7 @@ object FindDeterioratedMetrics {
         printSlope(deteriorated)
         throw new IllegalStateException(s"Sample is deteriorated according to deterioration factor")
       }
-    }
-    else {
+    } else {
       println(
         """Usage:
           | FindDeterioratedMetrics <file_base> <file_sample> <deterioration_factor>"

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/Metric.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/Metric.scala
@@ -22,47 +22,50 @@ case class Counter(name: String, count: Int) extends Metric {
   override def mean: Double = count.toDouble
 }
 
-case class Histogram(name: String,
-                     count: Int,
-                     max: Double,
-                     mean: Double,
-                     min: Double,
-                     p50: Double,
-                     p75: Double,
-                     p95: Double,
-                     p98: Double,
-                     p99: Double,
-                     p999: Double,
-                     stddev: Double) extends Metric
+case class Histogram(
+  name: String,
+  count: Int,
+  max: Double,
+  mean: Double,
+  min: Double,
+  p50: Double,
+  p75: Double,
+  p95: Double,
+  p98: Double,
+  p99: Double,
+  p999: Double,
+  stddev: Double) extends Metric
 
-case class Meter(name: String,
-                 count: Int,
-                 m15_rate: Double,
-                 m1_rate: Double,
-                 m5_rate: Double,
-                 mean_rate: Double,
-                 units: String) extends Metric {
+case class Meter(
+    name: String,
+    count: Int,
+    m15_rate: Double,
+    m1_rate: Double,
+    m5_rate: Double,
+    mean_rate: Double,
+    units: String) extends Metric {
   override def mean: Double = mean_rate
 }
 
-case class Timer(name: String,
-                 count: Int,
-                 max: Double,
-                 mean: Double,
-                 min: Double,
-                 p50: Double,
-                 p75: Double,
-                 p95: Double,
-                 p98: Double,
-                 p99: Double,
-                 p999: Double,
-                 stddev: Double,
-                 m15_rate: Double,
-                 m1_rate: Double,
-                 m5_rate: Double,
-                 mean_rate: Double,
-                 duration_units: String,
-                 rate_units: String) extends Metric
+case class Timer(
+  name: String,
+  count: Int,
+  max: Double,
+  mean: Double,
+  min: Double,
+  p50: Double,
+  p75: Double,
+  p95: Double,
+  p98: Double,
+  p99: Double,
+  p999: Double,
+  stddev: Double,
+  m15_rate: Double,
+  m1_rate: Double,
+  m5_rate: Double,
+  mean_rate: Double,
+  duration_units: String,
+  rate_units: String) extends Metric
 
 case class MetricsSample(
     version: String,

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
@@ -127,8 +127,7 @@ class SingleAppScalingTest
 
       if (instances == 0) {
         Some(())
-      }
-      else {
+      } else {
         // slow down
         Thread.sleep(1000)
         None

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.11

--- a/project/build.scala
+++ b/project/build.scala
@@ -85,12 +85,12 @@ object MarathonBuild extends Build {
 
   lazy val integrationTestSettings = inConfig(IntegrationTest)(Defaults.testTasks) ++
     Seq(
-      testOptions in IntegrationTest := Seq(formattingTestArg, Tests.Argument("-n", "integration"))
+      testOptions in IntegrationTest := Seq(formattingTestArg, Tests.Argument("-n", "mesosphere.marathon.IntegrationTest"))
     )
 
   lazy val testSettings = Seq(
-    testOptions in Test := Seq(formattingTestArg, Tests.Argument("-l", "integration")),
     parallelExecution in Test := false,
+    testOptions in Test := Seq(formattingTestArg, Tests.Argument("-l", "mesosphere.marathon.IntegrationTest")),
     fork in Test := true
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,18 +1,18 @@
-resolvers += Classpaths.typesafeReleases
+resolvers += Resolver.typesafeRepo("releases")
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
@@ -20,10 +20,13 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
 resolvers += "Era7 maven releases" at "http://releases.era7.com.s3.amazonaws.com"
 
-addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.10.1")
+addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.14.0")
 
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
+

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -16,8 +16,6 @@ import com.twitter.zk.{ AuthInfo, NativeConnector, ZkClient }
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.election.ElectionService
-import mesosphere.marathon.core.launcher.TaskOpFactory
-import mesosphere.marathon.core.launcher.impl.TaskOpFactoryImpl
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.TaskTracker
@@ -36,8 +34,8 @@ import mesosphere.util.{ CapConcurrentExecutions, CapConcurrentExecutionsMetrics
 import org.apache.mesos.state.ZooKeeperState
 import org.slf4j.LoggerFactory
 
-import scala.collection.immutable.Seq
 import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
 import scala.concurrent.Await
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
@@ -93,7 +91,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf)
   def provideMesosLeaderInfo(): MesosLeaderInfo = {
     conf.mesosLeaderUiUrl.get match {
       case someUrl @ Some(_) => ConstMesosLeaderInfo(someUrl)
-      case None              => new MutableMesosLeaderInfo
+      case None => new MutableMesosLeaderInfo
     }
   }
 
@@ -115,10 +113,11 @@ class MarathonModule(conf: MarathonConf, http: HttpConf)
   @Named(ModuleNames.HTTP_EVENT_STREAM)
   @Provides
   @Singleton
-  def provideHttpEventStreamActor(system: ActorSystem,
-                                  electionService: ElectionService,
-                                  @Named(EventModule.busName) eventBus: EventStream,
-                                  metrics: HttpEventStreamActorMetrics): ActorRef = {
+  def provideHttpEventStreamActor(
+    system: ActorSystem,
+    electionService: ElectionService,
+    @Named(EventModule.busName) eventBus: EventStream,
+    metrics: HttpEventStreamActorMetrics): ActorRef = {
     val outstanding = conf.eventStreamMaxOutstandingMessages.get.getOrElse(50)
     def handleStreamProps(handle: HttpEventStreamHandle): Props =
       Props(new HttpEventStreamHandleActor(handle, eventBus, outstanding))
@@ -135,7 +134,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf)
 
       val authInfo = (conf.zkUsername, conf.zkPassword) match {
         case (Some(user), Some(pass)) => Some(AuthInfo.digest(user, pass))
-        case _                        => None
+        case _ => None
       }
 
       val connector = NativeConnector(conf.zkHosts, None, sessionTimeout, new JavaTimer(isDaemon = true), authInfo)
@@ -156,9 +155,9 @@ class MarathonModule(conf: MarathonConf, http: HttpConf)
       new MesosStateStore(state, conf.zkTimeoutDuration)
     }
     conf.internalStoreBackend.get match {
-      case Some("zk")              => directZK()
-      case Some("mesos_zk")        => mesosZK()
-      case Some("mem")             => new InMemoryStore()
+      case Some("zk") => directZK()
+      case Some("mesos_zk") => mesosZK()
+      case Some("mem") => new InMemoryStore()
       case backend: Option[String] => throw new IllegalArgumentException(s"Storage backend $backend not known!")
     }
   }

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -15,9 +15,8 @@ import mesosphere.marathon.event.{ AppTerminatedEvent, DeploymentFailed, Deploym
 import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state._
 import mesosphere.marathon.upgrade.DeploymentManager._
-import mesosphere.marathon.upgrade.{ UpgradeConfig, DeploymentManager, DeploymentPlan, TaskKillActor }
-import mesosphere.mesos.protos
-import org.apache.mesos.Protos.{ Status, TaskState, TaskID }
+import mesosphere.marathon.upgrade.{ DeploymentManager, DeploymentPlan, TaskKillActor, UpgradeConfig }
+import org.apache.mesos.Protos.{ Status, TaskID, TaskState }
 import org.apache.mesos.SchedulerDriver
 import org.slf4j.LoggerFactory
 
@@ -74,7 +73,7 @@ class MarathonSchedulerActor private (
       log.info("Starting scheduler actor")
       deploymentRepository.all() onComplete {
         case Success(deployments) => self ! RecoverDeployments(deployments)
-        case Failure(_)           => self ! RecoverDeployments(Nil)
+        case Failure(_) => self ! RecoverDeployments(Nil)
       }
 
     case RecoverDeployments(deployments) =>
@@ -93,7 +92,7 @@ class MarathonSchedulerActor private (
     // FIXME: When we get this while recovering deployments, we become active anyway
     // and drop this message.
 
-    case _                            => stash()
+    case _ => stash()
   }
 
   //TODO: fix style issue and enable this scalastyle check
@@ -189,7 +188,7 @@ class MarathonSchedulerActor private (
       lockedApps --= plan.affectedApplicationIds
       deploymentFailed(plan, reason)
 
-    case AppScaled(id)         => lockedApps -= id
+    case AppScaled(id) => lockedApps -= id
 
     case TasksKilled(appId, _) => lockedApps -= appId
 
@@ -238,8 +237,7 @@ class MarathonSchedulerActor private (
       unstashAll()
       context.become(started)
       true
-    }
-    else {
+    } else {
       false
     }
   }
@@ -256,8 +254,7 @@ class MarathonSchedulerActor private (
     if (conflicts.isEmpty) {
       lockedApps ++= appIds
       Try(f)
-    }
-    else {
+    } else {
       Failure(new LockingFailedException("Failed to acquire locks."))
     }
   }
@@ -326,8 +323,7 @@ class MarathonSchedulerActor private (
     eventBus.publish(DeploymentFailed(plan.id, plan))
     if (reason.isInstanceOf[DeploymentCanceledException]) {
       deploymentRepository.expunge(plan.id).map(_ => ())
-    }
-    else {
+    } else {
       Future.successful(())
     }
   }
@@ -463,7 +459,7 @@ class SchedulerActions(
   def scaleApps(): Future[Unit] = {
     appRepository.allPathIds().map(_.toSet).andThen {
       case Success(appIds) => for (appId <- appIds) schedulerActor ! ScaleApp(appId)
-      case Failure(t)      => log.warn("Failed to get task names", t)
+      case Failure(t) => log.warn("Failed to get task names", t)
     }.map(_ => ())
   }
 
@@ -547,12 +543,10 @@ class SchedulerActions(
       if (toQueue > 0) {
         log.info(s"Queueing $toQueue new tasks for ${app.id} ($queuedOrRunning queued or running)")
         launchQueue.add(app, toQueue)
-      }
-      else {
+      } else {
         log.info(s"Already queued or started $queuedOrRunning tasks for ${app.id}. Not scaling.")
       }
-    }
-    else if (targetCount < launchedCount) {
+    } else if (targetCount < launchedCount) {
       log.info(s"Scaling ${app.id} from $launchedCount down to $targetCount instances")
       launchQueue.purge(app.id)
 
@@ -563,8 +557,7 @@ class SchedulerActions(
       val taskIds: Iterable[TaskID] = toKill.flatMap(_.launchedMesosId)
       log.info(s"Killing tasks: ${taskIds.map(_.getValue)}")
       taskIds.foreach(driver.killTask)
-    }
-    else {
+    } else {
       log.info(s"Already running ${app.instances} instances of ${app.id}. Not scaling.")
     }
   }
@@ -572,7 +565,7 @@ class SchedulerActions(
   def scale(driver: SchedulerDriver, appId: PathId): Future[Unit] = {
     currentAppVersion(appId).map {
       case Some(app) => scale(driver, app)
-      case _         => log.warn(s"App $appId does not exist. Not scaling.")
+      case _ => log.warn(s"App $appId does not exist. Not scaling.")
     }
   }
 
@@ -585,7 +578,7 @@ private[this] object SchedulerActions {
 
     def opt[T](a: Option[T], b: Option[T], default: Boolean)(fn: (T, T) => Boolean): Boolean = (a, b) match {
       case (Some(av), Some(bv)) => fn(av, bv)
-      case _                    => default
+      case _ => default
     }
     opt(a.mesosStatus, b.mesosStatus, a.mesosStatus.isDefined) { (aStatus, bStatus) =>
       runningOrStaged(bStatus.getState) compareTo runningOrStaged(aStatus.getState) match {

--- a/src/main/scala/mesosphere/marathon/api/AuthResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/AuthResource.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.api
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs.core.Response
 
-import mesosphere.marathon.{ UnknownGroupException, UnknownAppException, AccessDeniedException }
+import mesosphere.marathon.AccessDeniedException
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.plugin.http.HttpResponse
 
@@ -20,8 +20,7 @@ trait AuthResource extends RestResource {
     maybeIdentity.map { identity =>
       try {
         fn(identity)
-      }
-      catch {
+      } catch {
         case e: AccessDeniedException => withResponseFacade(authorizer.handleNotAuthorized(identity, _))
       }
     }.getOrElse {
@@ -29,18 +28,20 @@ trait AuthResource extends RestResource {
     }
   }
 
-  def checkAuthorization[T](action: AuthorizedAction[T],
-                            maybeResource: Option[T],
-                            ifNotExists: Exception)(implicit identity: Identity): Unit = {
+  def checkAuthorization[T](
+    action: AuthorizedAction[T],
+    maybeResource: Option[T],
+    ifNotExists: Exception)(implicit identity: Identity): Unit = {
     maybeResource match {
       case Some(resource) => checkAuthorization(action, resource)
-      case None           => throw ifNotExists
+      case None => throw ifNotExists
     }
   }
 
-  def withAuthorization[A, B >: A](action: AuthorizedAction[B],
-                                   maybeResource: Option[A],
-                                   ifNotExists: Response)(fn: A => Response)(implicit identity: Identity): Response =
+  def withAuthorization[A, B >: A](
+    action: AuthorizedAction[B],
+    maybeResource: Option[A],
+    ifNotExists: Response)(fn: A => Response)(implicit identity: Identity): Response =
     {
       maybeResource match {
         case Some(resource) =>
@@ -50,8 +51,9 @@ trait AuthResource extends RestResource {
       }
     }
 
-  def withAuthorization[A, B >: A](action: AuthorizedAction[B],
-                                   resource: A)(fn: => Response)(implicit identity: Identity): Response = {
+  def withAuthorization[A, B >: A](
+    action: AuthorizedAction[B],
+    resource: A)(fn: => Response)(implicit identity: Identity): Response = {
     checkAuthorization(action, resource)
     fn
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -10,23 +10,25 @@ import mesosphere.marathon.api.{ AuthResource, MarathonMediaType }
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, ViewRunSpec }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ GroupManager, Timestamp }
-import mesosphere.marathon.{ UnknownAppException, MarathonConf, MarathonSchedulerService }
+import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService }
 import org.slf4j.LoggerFactory
 
 @Produces(Array(MarathonMediaType.PREFERRED_APPLICATION_JSON))
 @Consumes(Array(MediaType.APPLICATION_JSON))
-class AppVersionsResource(service: MarathonSchedulerService,
-                          groupManager: GroupManager,
-                          val authenticator: Authenticator,
-                          val authorizer: Authorizer,
-                          val config: MarathonConf) extends AuthResource {
+class AppVersionsResource(
+    service: MarathonSchedulerService,
+    groupManager: GroupManager,
+    val authenticator: Authenticator,
+    val authorizer: Authorizer,
+    val config: MarathonConf) extends AuthResource {
 
   val log = LoggerFactory.getLogger(getClass.getName)
 
   @GET
   @Timed
-  def index(@PathParam("appId") appId: String,
-            @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+  def index(
+    @PathParam("appId") appId: String,
+    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
     val id = appId.toRootPath
     withAuthorization(ViewRunSpec, result(groupManager.app(id)), unknownApp(id)) { _ =>
       ok(jsonObjString("versions" -> service.listAppVersions(id).toSeq))
@@ -36,9 +38,10 @@ class AppVersionsResource(service: MarathonSchedulerService,
   @GET
   @Timed
   @Path("{version}")
-  def show(@PathParam("appId") appId: String,
-           @PathParam("version") version: String,
-           @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+  def show(
+    @PathParam("appId") appId: String,
+    @PathParam("version") version: String,
+    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
     val id = appId.toRootPath
     val timestamp = Timestamp(version)
     withAuthorization(ViewRunSpec, service.getApp(id, timestamp), unknownApp(id, Some(timestamp))) { app =>

--- a/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
@@ -9,12 +9,13 @@ import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.{ MarathonMediaType, RequestFacade, ResponseFacade, RestResource }
 import mesosphere.marathon.core.plugin.PluginDefinitions
-import mesosphere.marathon.plugin.http.{ HttpRequest, HttpRequestHandler, HttpResponse }
+import mesosphere.marathon.plugin.http.HttpRequestHandler
 
 @Path("v2/plugins")
-class PluginsResource @Inject() (val config: MarathonConf,
-                                 requestHandlers: Seq[HttpRequestHandler],
-                                 definitions: PluginDefinitions) extends RestResource {
+class PluginsResource @Inject() (
+    val config: MarathonConf,
+    requestHandlers: Seq[HttpRequestHandler],
+    definitions: PluginDefinitions) extends RestResource {
 
   val pluginIdToHandler = definitions.plugins
     .filter(_.plugin == classOf[HttpRequestHandler].getName)
@@ -27,33 +28,38 @@ class PluginsResource @Inject() (val config: MarathonConf,
 
   @GET
   @Path("""{pluginId}/{path:.+}""")
-  def get(@PathParam("pluginId") pluginId: String,
-          @PathParam("path") path: String,
-          @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
+  def get(
+    @PathParam("pluginId") pluginId: String,
+    @PathParam("path") path: String,
+    @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
 
   @HEAD
   @Path("""{pluginId}/{path:.+}""")
-  def head(@PathParam("pluginId") pluginId: String,
-           @PathParam("path") path: String,
-           @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
+  def head(
+    @PathParam("pluginId") pluginId: String,
+    @PathParam("path") path: String,
+    @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
 
   @PUT
   @Path("""{pluginId}/{path:.+}""")
-  def put(@PathParam("pluginId") pluginId: String,
-          @PathParam("path") path: String,
-          @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
+  def put(
+    @PathParam("pluginId") pluginId: String,
+    @PathParam("path") path: String,
+    @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
 
   @POST
   @Path("""{pluginId}/{path:.+}""")
-  def post(@PathParam("pluginId") pluginId: String,
-           @PathParam("path") path: String,
-           @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
+  def post(
+    @PathParam("pluginId") pluginId: String,
+    @PathParam("path") path: String,
+    @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
 
   @DELETE
   @Path("""{pluginId}/{path:.+}""")
-  def delete(@PathParam("pluginId") pluginId: String,
-             @PathParam("path") path: String,
-             @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
+  def delete(
+    @PathParam("pluginId") pluginId: String,
+    @PathParam("path") path: String,
+    @Context req: HttpServletRequest): Response = handleRequest(pluginId, path, req)
 
   private[this] def handleRequest(pluginId: String, path: String, req: HttpServletRequest): Response = {
     pluginIdToHandler.get(pluginId).map { handler =>

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -6,7 +6,7 @@ import javax.ws.rs._
 import javax.ws.rs.core.{ Context, MediaType, Response }
 
 import com.codahale.metrics.annotation.Timed
-import mesosphere.marathon.{ UnknownAppException, MarathonConf }
+import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.api.v2.json.Formats
 import mesosphere.marathon.api.{ AuthResource, MarathonMediaType }
 import mesosphere.marathon.core.base.Clock
@@ -49,8 +49,9 @@ class QueueResource @Inject() (
 
   @DELETE
   @Path("""{appId:.+}/delay""")
-  def resetDelay(@PathParam("appId") id: String,
-                 @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+  def resetDelay(
+    @PathParam("appId") id: String,
+    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
     val appId = id.toRootPath
     val maybeApp = launchQueue.list.find(_.runSpec.id == appId).map(_.runSpec)
     withAuthorization(UpdateRunSpec, maybeApp, notFound(s"Application $appId not found in tasks queue.")) { app =>

--- a/src/main/scala/mesosphere/marathon/core/appinfo/TaskCounts.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/TaskCounts.scala
@@ -4,7 +4,6 @@ import mesosphere.marathon.core.appinfo.impl.TaskForStatistics
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.health.Health
 import mesosphere.marathon.state.Timestamp
-import org.apache.mesos.{ Protos => mesos }
 
 /**
   * @param tasksStaged snapshot of the number of staged tasks

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/TaskForStatistics.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/TaskForStatistics.scala
@@ -5,8 +5,6 @@ import mesosphere.marathon.health.Health
 import mesosphere.marathon.state.Timestamp
 import org.apache.mesos.Protos.TaskState
 
-import scala.collection.mutable
-
 /** Precalculated task infos for internal calculations. */
 private[appinfo] class TaskForStatistics(
   val version: Timestamp,

--- a/src/main/scala/mesosphere/marathon/core/base/ActorsModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/ActorsModule.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.core.base
 import akka.actor.{ ActorRefFactory, ActorSystem }
 import org.slf4j.LoggerFactory
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 /**
@@ -15,7 +16,6 @@ class ActorsModule(shutdownHooks: ShutdownHooks, actorSystem: ActorSystem = Acto
 
   shutdownHooks.onShutdown {
     log.info("Shutting down actor system {}", actorSystem)
-    actorSystem.shutdown()
-    actorSystem.awaitTermination(10.seconds)
+    Await.result(actorSystem.terminate(), 10.seconds)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/election/impl/CuratorElectionService.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/impl/CuratorElectionService.scala
@@ -42,8 +42,7 @@ class CuratorElectionService(
         val participant = l.getLeader
         if (participant.isLeader) Some(participant.getId) else None
       }
-    }
-    catch {
+    } catch {
       case NonFatal(e) =>
         log.error("error while getting current leader", e)
         None
@@ -166,8 +165,7 @@ class CuratorElectionService(
           creatingParentsIfNeeded().
           withMode(CreateMode.EPHEMERAL).
           forPath(path, hostPort.getBytes("UTF-8"))
-      }
-      catch {
+      } catch {
         case e: Exception =>
           log.error(s"Exception while creating tombstone for twitter commons leader election: ${e.getMessage}")
           abdicateLeadership(error = true)
@@ -183,9 +181,8 @@ class CuratorElectionService(
               log.info("Deleting existing tombstone for old twitter commons leader election")
               client.delete().guaranteed().withVersion(tombstone.getVersion).forPath(path)
             }
-          }
-          catch {
-            case _: KeeperException.NoNodeException     =>
+          } catch {
+            case _: KeeperException.NoNodeException =>
             case _: KeeperException.BadVersionException =>
           }
       }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -8,7 +8,6 @@ import mesosphere.marathon.core.launcher.{ TaskOp, TaskOpFactory }
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskInfo
 import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
 import mesosphere.marathon.core.launchqueue.impl.TaskLauncherActor.RecheckIfBackOffUntilReached
-import mesosphere.marathon.core.matcher.base
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.{ MatchedTaskOps, TaskOpWithSource }
 import mesosphere.marathon.core.matcher.base.util.TaskOpSourceDelegate.TaskOpNotification
@@ -32,8 +31,8 @@ private[launchqueue] object TaskLauncherActor {
     maybeOfferReviver: Option[OfferReviver],
     taskTracker: TaskTracker,
     rateLimiterActor: ActorRef)(
-      runSpec: RunSpec,
-      initialCount: Int): Props = {
+    runSpec: RunSpec,
+    initialCount: Int): Props = {
     Props(new TaskLauncherActor(
       config,
       offerMatcherManager,
@@ -100,7 +99,8 @@ private class TaskLauncherActor(
   override def preStart(): Unit = {
     super.preStart()
 
-    log.info("Started taskLaunchActor for {} version {} with initial count {}",
+    log.info(
+      "Started taskLaunchActor for {} version {} with initial count {}",
       runSpec.id, runSpec.version, tasksToLaunch)
 
     tasksMap = taskTracker.tasksByAppSync.appTasksMap(runSpec.id).taskMap
@@ -163,7 +163,7 @@ private class TaskLauncherActor(
 
     case TaskLauncherActor.Stop => // ignore, already stopping
 
-    case "waitingForInFlight"   => sender() ! "waitingForInFlight" // for testing
+    case "waitingForInFlight" => sender() ! "waitingForInFlight" // for testing
   }
 
   private[this] def receiveUnknown: Receive = {
@@ -186,8 +186,7 @@ private class TaskLauncherActor(
   private[this] def waitForInFlightIfNecessary(): Unit = {
     if (inFlightTaskOperations.isEmpty) {
       context.stop(self)
-    }
-    else {
+    } else {
       val taskIds = inFlightTaskOperations.keys.take(3).mkString(", ")
       log.info(
         s"Stopping but still waiting for ${inFlightTaskOperations.size} in-flight messages, " +
@@ -232,13 +231,14 @@ private class TaskLauncherActor(
   private[this] def receiveTaskLaunchNotification: Receive = {
     case TaskOpSourceDelegate.TaskOpRejected(op, reason) if inFlight(op) =>
       removeTask(op.taskId)
-      log.info("Task op '{}' for {} was REJECTED, reason '{}', rescheduling. {}",
+      log.info(
+        "Task op '{}' for {} was REJECTED, reason '{}', rescheduling. {}",
         op.getClass.getSimpleName, op.taskId, reason, status)
 
       op match {
         // only increment for launch ops, not for reservations:
         case _: TaskOp.Launch => tasksToLaunch += 1
-        case _                => ()
+        case _ => ()
       }
 
       OfferMatcherRegistration.manageOfferMatcherStatus()
@@ -310,15 +310,13 @@ private class TaskLauncherActor(
 
           suspendMatchingUntilWeGetBackoffDelayUpdate()
 
-        }
-        else {
+        } else {
           log.info(
             "scaling change for '{}', version {} with {} initial tasks",
             runSpec.id, runSpec.version, addCount
           )
         }
-      }
-      else {
+      } else {
         tasksToLaunch += addCount
       }
 
@@ -363,7 +361,7 @@ private class TaskLauncherActor(
       val taskOp: Option[TaskOp] = taskOpFactory.buildTaskOp(matchRequest)
       taskOp match {
         case Some(op) => handleTaskOp(op, offer)
-        case None     => sender() ! MatchedTaskOps(offer.getId, Seq.empty)
+        case None => sender() ! MatchedTaskOps(offer.getId, Seq.empty)
       }
   }
 
@@ -373,7 +371,7 @@ private class TaskLauncherActor(
       taskOp match {
         // only decrement for launched tasks, not for reservations:
         case _: TaskOp.Launch => tasksToLaunch -= 1
-        case _                => ()
+        case _ => ()
       }
 
       // We will receive the updated task once it's been persisted. Before that,
@@ -387,7 +385,8 @@ private class TaskLauncherActor(
       OfferMatcherRegistration.manageOfferMatcherStatus()
     }
 
-    log.info("Request {} for task '{}', version '{}'. {}",
+    log.info(
+      "Request {} for task '{}', version '{}'. {}",
       taskOp.getClass.getSimpleName, taskOp.taskId.idString, runSpec.version, status)
 
     updateActorState()
@@ -418,7 +417,7 @@ private class TaskLauncherActor(
   private[this] def status: String = {
     val backoffStr = backOffUntil match {
       case Some(until) if until > clock.now() => s"currently waiting for backoff($until)"
-      case _                                  => "not backing off"
+      case _ => "not backing off"
     }
 
     val inFlight = inFlightTaskOperations.size
@@ -445,12 +444,10 @@ private class TaskLauncherActor(
         log.debug("Registering for {}, {}.", runSpec.id, runSpec.version)
         offerMatcherManager.addSubscription(myselfAsOfferMatcher)(context.dispatcher)
         registeredAsMatcher = true
-      }
-      else if (!shouldBeRegistered && registeredAsMatcher) {
+      } else if (!shouldBeRegistered && registeredAsMatcher) {
         if (tasksToLaunch > 0) {
           log.info("Backing off due to task failures. Stop receiving offers for {}, {}", runSpec.id, runSpec.version)
-        }
-        else {
+        } else {
           log.info("No tasks left to launch. Stop receiving offers for {}, {}", runSpec.id, runSpec.version)
         }
         offerMatcherManager.removeSubscription(myselfAsOfferMatcher)(context.dispatcher)

--- a/src/main/scala/mesosphere/marathon/core/leadership/impl/LeadershipCoordinatorActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/leadership/impl/LeadershipCoordinatorActor.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.core.leadership.impl
 import akka.actor.{ Actor, ActorLogging, ActorRef, Props, Stash, Status, Terminated }
 import akka.event.LoggingReceive
 import mesosphere.marathon.core.leadership.PreparationMessages
-import mesosphere.marathon.core.leadership.impl.WhenLeaderActor.{ Stopped, Stop }
+import mesosphere.marathon.core.leadership.impl.WhenLeaderActor.Stop
 
 private[leadership] object LeadershipCoordinatorActor {
   def props(whenLeaderActors: Set[ActorRef]): Props = {
@@ -46,8 +46,7 @@ private class LeadershipCoordinatorActor(var whenLeaderActors: Set[ActorRef])
         ackStartRef ! PreparationMessages.Prepared(self)
       }
       active
-    }
-    else {
+    } else {
       LoggingReceive.withLabel("preparingForStart") {
         case PreparationMessages.PrepareForStart =>
           context.become(preparingForStart(ackStartRefs + sender(), whenLeaderActorsWithoutAck))

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheck.scala
@@ -22,6 +22,7 @@ case class ReadinessCheck(
   preserveLastResponse: Boolean = ReadinessCheck.DefaultPreserveLastResponse)
 
 object ReadinessCheck {
+  import scala.language.implicitConversions
 
   val DefaultName = "readinessCheck"
   val DefaultProtocol = Protocol.HTTP
@@ -38,7 +39,7 @@ object ReadinessCheck {
     case object HTTPS extends Protocol
   }
 
-  def readinessCheckValidator(runSpec: RunSpec): Validator[ReadinessCheck] =
+  implicit def readinessCheckValidator(runSpec: RunSpec): Validator[ReadinessCheck] =
     validator[ReadinessCheck] { rc =>
       rc.name is notEmpty
       rc.path is notEmpty

--- a/src/main/scala/mesosphere/marathon/core/task/bus/impl/TaskChangeObservablesImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/bus/impl/TaskChangeObservablesImpl.scala
@@ -11,11 +11,9 @@ private[bus] class TaskChangeObservablesImpl(eventStream: InternalTaskChangeEven
   override def forAll: Observable[TaskChanged] = forRunSpecId(PathId.empty)
 
   override def forRunSpecId(appId: PathId): Observable[TaskChanged] = {
-    Observable.create { observer =>
+    Observable { observer =>
+      observer.add(Subscription(eventStream.unsubscribe(observer, appId)))
       eventStream.subscribe(observer, appId)
-      Subscription {
-        eventStream.unsubscribe(observer, appId)
-      }
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/event/http/HttpEventModule.scala
+++ b/src/main/scala/mesosphere/marathon/event/http/HttpEventModule.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.event.http
 
-import java.util.concurrent.{ TimeUnit, Executors }
+import java.util.concurrent.TimeUnit
 
 import akka.actor.{ ActorRef, ActorSystem, Props }
 import akka.pattern.ask
@@ -17,25 +17,27 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 trait HttpEventConfiguration extends ScallopConf {
 
-  lazy val httpEventEndpoints = opt[String]("http_endpoints",
+  lazy val httpEventEndpoints = opt[String](
+    "http_endpoints",
     descr = "The URLs of the event endpoints added to the current list of subscribers on startup. " +
       "You can manage this list during runtime by using the /v2/eventSubscriptions API endpoint.",
     required = false,
     validate = { parseHttpEventEndpoints(_).forall(urlIsValid(_).isSuccess) },
     noshort = true).map(parseHttpEventEndpoints)
 
-  lazy val httpEventCallbackSlowConsumerTimeout = opt[Long]("http_event_callback_slow_consumer_timeout",
+  lazy val httpEventCallbackSlowConsumerTimeout = opt[Long](
+    "http_event_callback_slow_consumer_timeout",
     descr = "A http event callback consumer is considered slow, if the delivery takes longer than this timeout (ms)",
     required = false,
     noshort = true,
     default = Some(10.seconds.toMillis)
   )
 
-  lazy val httpEventRequestTimeout = opt[Long]("http_event_request_timeout",
+  lazy val httpEventRequestTimeout = opt[Long](
+    "http_event_request_timeout",
     descr = "A http event request timeout (ms)",
     required = false,
     noshort = true,
@@ -63,18 +65,20 @@ class HttpEventModule(httpEventConfiguration: HttpEventConfiguration) extends Ab
 
   @Provides
   @Named(HttpEventModule.StatusUpdateActor)
-  def provideStatusUpdateActor(system: ActorSystem,
-                               @Named(HttpEventModule.SubscribersKeeperActor) subscribersKeeper: ActorRef,
-                               metrics: HttpEventActor.HttpEventActorMetrics,
-                               clock: Clock): ActorRef = {
+  def provideStatusUpdateActor(
+    system: ActorSystem,
+    @Named(HttpEventModule.SubscribersKeeperActor) subscribersKeeper: ActorRef,
+    metrics: HttpEventActor.HttpEventActorMetrics,
+    clock: Clock): ActorRef = {
     system.actorOf(Props(new HttpEventActor(httpEventConfiguration, subscribersKeeper, metrics, clock)))
   }
 
   @Provides
   @Named(HttpEventModule.SubscribersKeeperActor)
-  def provideSubscribersKeeperActor(conf: HttpEventConfiguration,
-                                    system: ActorSystem,
-                                    @Named(STORE_EVENT_SUBSCRIBERS) store: EntityStore[EventSubscribers]): ActorRef = {
+  def provideSubscribersKeeperActor(
+    conf: HttpEventConfiguration,
+    system: ActorSystem,
+    @Named(STORE_EVENT_SUBSCRIBERS) store: EntityStore[EventSubscribers]): ActorRef = {
     implicit val timeout = conf.eventRequestTimeout
     val local_ip = java.net.InetAddress.getLocalHost.getHostAddress
 

--- a/src/main/scala/mesosphere/marathon/health/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/health/MarathonHealthCheckManager.scala
@@ -20,8 +20,8 @@ import org.apache.mesos.Protos.TaskStatus
 import scala.collection.immutable.{ Map, Seq }
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
 
 class MarathonHealthCheckManager @Inject() (
     system: ActorSystem,
@@ -94,8 +94,7 @@ class MarathonHealthCheckManager @Inject() (
       val currentHealthChecksForApp = ahcs(appId)
       val newHealthChecksForApp = if (newHealthChecksForVersion.isEmpty) {
         currentHealthChecksForApp - appVersion
-      }
-      else {
+      } else {
         currentHealthChecksForApp + (appVersion -> newHealthChecksForVersion)
       }
 
@@ -168,8 +167,7 @@ class MarathonHealthCheckManager @Inject() (
           val healthy = taskStatus.getHealthy
           log.info(s"Received status for $taskId with version [$version] and healthy [$healthy]")
           Some(if (healthy) Healthy(taskId, version) else Unhealthy(taskId, version, ""))
-        }
-        else {
+        } else {
           log.debug(s"Ignoring status for $taskId with no health information")
           None
         }
@@ -226,7 +224,7 @@ class MarathonHealthCheckManager @Inject() (
           appTasks.iterator.map { task =>
             groupedHealth.get(task.taskId) match {
               case Some(xs) => task.taskId -> xs.toSeq
-              case None     => task.taskId -> Nil
+              case None => task.taskId -> Nil
             }
           }.toMap
         }

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -7,13 +7,9 @@ import com.wix.accord.combinators.GeneralPurposeCombinators
 import com.wix.accord.dsl._
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
-import mesosphere.marathon.api.serialization.{
-  ContainerSerializer,
-  EnvVarRefSerializer,
-  PortDefinitionSerializer,
-  ResidencySerializer,
-  SecretsSerializer
-}
+// scalastyle:off
+import mesosphere.marathon.api.serialization.{ ContainerSerializer, EnvVarRefSerializer, PortDefinitionSerializer, ResidencySerializer, SecretsSerializer }
+// scalastyle:on
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.core.externalvolume.ExternalVolumes
 import mesosphere.marathon.core.plugin.PluginManager
@@ -23,11 +19,9 @@ import mesosphere.marathon.health.HealthCheck
 import mesosphere.marathon.plugin.validation.RunSpecValidator
 import mesosphere.marathon.state.AppDefinition.VersionInfo.{ FullVersionInfo, OnlyVersion }
 import mesosphere.marathon.state.AppDefinition.{ Labels, VersionInfo }
-import mesosphere.marathon.state.Container.Docker.PortMapping
 import mesosphere.marathon.{ Features, Protos, plugin }
 import mesosphere.mesos.TaskBuilder
 import mesosphere.mesos.protos.{ Resource, ScalarResource }
-import org.apache.mesos.Protos.ContainerInfo.DockerInfo
 import org.apache.mesos.{ Protos => mesos }
 
 import scala.collection.JavaConverters._
@@ -100,7 +94,8 @@ case class AppDefinition(
 
   import mesosphere.mesos.protos.Implicits._
 
-  require(ipAddress.isEmpty || portDefinitions.isEmpty,
+  require(
+    ipAddress.isEmpty || portDefinitions.isEmpty,
     s"IP address ($ipAddress) and ports ($portDefinitions) are not allowed at the same time")
 
   lazy val portNumbers: Seq[Int] = portDefinitions.map(_.port)
@@ -355,7 +350,7 @@ case class AppDefinition(
   override def equals(obj: Any): Boolean = {
     obj match {
       case that: AppDefinition => (that eq this) || (that.id == id && that.version == version)
-      case _                   => false
+      case _ => false
     }
   }
 
@@ -673,29 +668,26 @@ object AppDefinition extends GeneralPurposeCombinators {
     override def apply(c: Constraint): Result = {
       if (!c.hasField || !c.hasOperator) {
         Failure(Set(RuleViolation(c, "Missing field and operator", None)))
-      }
-      else {
+      } else {
         c.getOperator match {
           case UNIQUE =>
             if (c.hasValue && c.getValue.nonEmpty) {
               Failure(Set(RuleViolation(c, "Value specified but not used", None)))
-            }
-            else {
+            } else {
               Success
             }
           case CLUSTER =>
             if (c.hasValue && c.getValue.nonEmpty) {
               Success
-            }
-            else {
+            } else {
               Failure(Set(RuleViolation(c, "Missing value", None)))
             }
           case GROUP_BY =>
             if (!c.hasValue || (c.hasValue && c.getValue.nonEmpty && Try(c.getValue.toInt).isSuccess)) {
               Success
-            }
-            else {
-              Failure(Set(RuleViolation(c,
+            } else {
+              Failure(Set(RuleViolation(
+                c,
                 "Value was specified but is not a number",
                 Some("GROUP_BY may either have no value or an integer value"))))
             }
@@ -705,20 +697,20 @@ object AppDefinition extends GeneralPurposeCombinators {
                 case util.Success(_) =>
                   Success
                 case util.Failure(e) =>
-                  Failure(Set(RuleViolation(c,
+                  Failure(Set(RuleViolation(
+                    c,
                     s"'${c.getValue}' is not a valid regular expression",
                     Some(s"${c.getValue}\n${e.getMessage}"))))
               }
-            }
-            else {
+            } else {
               Failure(Set(RuleViolation(c, "A regular expression value must be provided", None)))
             }
           case MAX_PER =>
             if (c.hasValue && c.getValue.nonEmpty && Try(c.getValue.toInt).isSuccess) {
               Success
-            }
-            else {
-              Failure(Set(RuleViolation(c,
+            } else {
+              Failure(Set(RuleViolation(
+                c,
                 "Value was specified but is not a number",
                 Some("MAX_PER may have an integer value"))))
             }
@@ -734,7 +726,7 @@ object AppDefinition extends GeneralPurposeCombinators {
     isTrue("Health check port indices must address an element of the ports array or container port mappings.") { hc =>
       hc.protocol == Protocol.COMMAND || (hc.portIndex match {
         case Some(idx) => hostPortsIndices contains idx
-        case None      => hc.port.nonEmpty || (hostPortsIndices.length == 1 && hostPortsIndices.head == 0)
+        case None => hc.port.nonEmpty || (hostPortsIndices.length == 1 && hostPortsIndices.head == 0)
       })
     }
 

--- a/src/main/scala/mesosphere/marathon/state/EntityStoreCache.scala
+++ b/src/main/scala/mesosphere/marathon/state/EntityStoreCache.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.state
 
-import mesosphere.marathon.{ PrePostDriverCallback, MarathonSchedulerService }
+import mesosphere.marathon.PrePostDriverCallback
 import org.slf4j.LoggerFactory
 
 import scala.collection.concurrent.TrieMap
@@ -32,11 +32,10 @@ class EntityStoreCache[T <: MarathonState[_, T]](store: EntityStore[T])
       Future.successful{
         cache.get(key) match {
           case Some(t) => t
-          case _       => None
+          case _ => None
         }
       }
-    }
-    else {
+    } else {
       //if we need to fetch a versioned entry, try if this is the latest version we have in the cache
       //otherwise let the underlying store fetch that entry.
       val id = idFromVersionKey(key)
@@ -78,7 +77,7 @@ class EntityStoreCache[T <: MarathonState[_, T]](store: EntityStore[T])
     def preloadEntry(nextName: String): Future[Unit] = {
       store.fetch(nextName).map {
         case Some(t) => cache.update(nextName, Some(t))
-        case None    => log.warn(s"Expected to find entry $nextName in store $store")
+        case None => log.warn(s"Expected to find entry $nextName in store $store")
       }
     }
 
@@ -117,7 +116,7 @@ class EntityStoreCache[T <: MarathonState[_, T]](store: EntityStore[T])
   private[this] def directOrCached[R](direct: => R)(cached: TrieMap[String, Option[T]] => R): R = {
     cacheOpt match {
       case Some(cache) => cached(cache)
-      case None        => direct
+      case None => direct
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/EnvVarValue.scala
+++ b/src/main/scala/mesosphere/marathon/state/EnvVarValue.scala
@@ -8,7 +8,7 @@ sealed trait EnvVarValue extends plugin.EnvVarValue {
   val valueValidator = new Validator[EnvVarValue] {
     override def apply(v: EnvVarValue) =
       v match {
-        case s: EnvVarString    => validate(s)(EnvVarString.valueValidator)
+        case s: EnvVarString => validate(s)(EnvVarString.valueValidator)
         case r: EnvVarSecretRef => validate(r)(EnvVarSecretRef.valueValidator)
       }
   }
@@ -25,8 +25,6 @@ case class EnvVarSecretRef(secret: String) extends EnvVarRef with plugin.EnvVarS
 }
 
 object EnvVarValue {
-  import scala.language.implicitConversions
-
   def apply(m: Map[String, String]): Map[String, EnvVarValue] =
     m.map { case (k, v) => k -> v.toEnvVar }
 

--- a/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
+++ b/src/main/scala/mesosphere/marathon/state/MarathonStore.scala
@@ -1,10 +1,10 @@
 package mesosphere.marathon.state
 
 import mesosphere.marathon.StoreCommandFailedException
-import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
-import mesosphere.util.{ LockManager, ThreadPoolContext }
-import mesosphere.util.state.PersistentStore
 import mesosphere.marathon.metrics.Metrics.Histogram
+import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
+import mesosphere.util.LockManager
+import mesosphere.util.state.PersistentStore
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -1,12 +1,9 @@
 package mesosphere.marathon.state
 
+import com.wix.accord._
+import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation.isTrue
 import mesosphere.marathon.plugin
-
-import scala.language.implicitConversions
-
-import com.wix.accord.dsl._
-import com.wix.accord._
 
 case class PathId(path: List[String], absolute: Boolean = true) extends Ordered[PathId] with plugin.PathId {
 
@@ -21,8 +18,8 @@ case class PathId(path: List[String], absolute: Boolean = true) extends Ordered[
   def isRoot: Boolean = path.isEmpty
 
   def parent: PathId = path match {
-    case Nil          => this
-    case head :: Nil  => PathId(Nil, absolute)
+    case Nil => this
+    case head :: Nil => PathId(Nil, absolute)
     case head :: rest => PathId(path.reverse.tail.reverse, absolute)
   }
 
@@ -51,10 +48,10 @@ case class PathId(path: List[String], absolute: Boolean = true) extends Ordered[
   def canonicalPath(base: PathId = PathId(Nil, absolute = true)): PathId = {
     require(base.absolute, "Base path is not absolute, canonical path can not be computed!")
     def in(remaining: List[String], result: List[String] = Nil): List[String] = remaining match {
-      case head :: tail if head == "."  => in(tail, result)
+      case head :: tail if head == "." => in(tail, result)
       case head :: tail if head == ".." => in(tail, if (result.nonEmpty) result.tail else Nil)
-      case head :: tail                 => in(tail, head :: result)
-      case Nil                          => result.reverse
+      case head :: tail => in(tail, head :: result)
+      case Nil => result.reverse
     }
     if (absolute) PathId(in(path)) else PathId(in(base.path ::: path))
   }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlan.scala
@@ -3,13 +3,12 @@ package mesosphere.marathon.upgrade
 import java.net.URL
 import java.util.UUID
 
-import com.wix.accord.dsl._
 import com.wix.accord._
-import mesosphere.marathon.Protos.ZKStoreEntry
-import mesosphere.marathon.{ MarathonConf, Protos }
+import com.wix.accord.dsl._
+import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state._
-import mesosphere.marathon.api.v2.Validation._
+import mesosphere.marathon.{ MarathonConf, Protos }
 import mesosphere.util.state.zk.{ CompressionConf, ZKData }
 import org.slf4j.LoggerFactory
 
@@ -25,9 +24,10 @@ sealed trait DeploymentAction {
 final case class StartApplication(app: AppDefinition, scaleTo: Int) extends DeploymentAction
 
 // application is started, but the instance count should be changed
-final case class ScaleApplication(app: AppDefinition,
-                                  scaleTo: Int,
-                                  sentencedToDeath: Option[Iterable[Task]] = None) extends DeploymentAction
+final case class ScaleApplication(
+  app: AppDefinition,
+  scaleTo: Int,
+  sentencedToDeath: Option[Iterable[Task]] = None) extends DeploymentAction
 
 // application is started, but shall be completely stopped
 final case class StopApplication(app: AppDefinition) extends DeploymentAction
@@ -100,12 +100,12 @@ final case class DeploymentPlan(
     }
     def actionString(a: DeploymentAction): String = a match {
       case StartApplication(app, scale) => s"Start(${appString(app)}, instances=$scale)"
-      case StopApplication(app)         => s"Stop(${appString(app)})"
+      case StopApplication(app) => s"Stop(${appString(app)})"
       case ScaleApplication(app, scale, toKill) =>
         val killTasksString =
           toKill.filter(_.nonEmpty).map(", killTasks=" + _.map(_.taskId.idString).mkString(",")).getOrElse("")
         s"Scale(${appString(app)}, instances=$scale$killTasksString)"
-      case RestartApplication(app)     => s"Restart(${appString(app)})"
+      case RestartApplication(app) => s"Restart(${appString(app)})"
       case ResolveArtifacts(app, urls) => s"Resolve(${appString(app)}, $urls})"
     }
     val stepString =
@@ -115,8 +115,7 @@ final case class DeploymentPlan(
           .zipWithIndex
           .map { case (stepsString, index) => s"step ${index + 1}:\n$stepsString" }
           .mkString("\n", "\n", "")
-      }
-      else " NO STEPS"
+      } else " NO STEPS"
     s"DeploymentPlan $version$stepString\n"
   }
 
@@ -205,7 +204,7 @@ object DeploymentPlan {
     * from the topology of the target group's dependency graph.
     */
   def dependencyOrderedSteps(original: Group, target: Group,
-                             toKill: Map[PathId, Iterable[Task]]): Seq[DeploymentStep] = {
+    toKill: Map[PathId, Iterable[Task]]): Seq[DeploymentStep] = {
     val originalApps: Map[PathId, AppDefinition] =
       original.transitiveApps.map(app => app.id -> app).toMap
 

--- a/src/main/scala/mesosphere/util/state/memory/InMemoryStore.scala
+++ b/src/main/scala/mesosphere/util/state/memory/InMemoryStore.scala
@@ -1,7 +1,6 @@
 package mesosphere.util.state.memory
 
 import mesosphere.marathon.StoreCommandFailedException
-import mesosphere.util.ThreadPoolContext
 import mesosphere.util.state.{ PersistentEntity, PersistentStore }
 
 import scala.collection.concurrent.TrieMap
@@ -42,7 +41,7 @@ class InMemoryStore(implicit val ec: ExecutionContext = ExecutionContext.Implici
   override def delete(key: ID): Future[Boolean] = {
     entities.get(key) match {
       case Some(value) => Future.successful(entities.remove(key).isDefined)
-      case None        => Future.successful(false)
+      case None => Future.successful(false)
     }
   }
 

--- a/src/main/scala/mesosphere/util/state/mesos/MesosStateStore.scala
+++ b/src/main/scala/mesosphere/util/state/mesos/MesosStateStore.scala
@@ -2,14 +2,13 @@ package mesosphere.util.state.mesos
 
 import mesosphere.marathon.StoreCommandFailedException
 import mesosphere.util.BackToTheFuture.Timeout
-import mesosphere.util.ThreadPoolContext
 import mesosphere.util.state.{ PersistentEntity, PersistentStore }
 import org.apache.mesos.state.{ State, Variable }
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
-import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
 
 class MesosStateStore(state: State, timeout: Duration) extends PersistentStore {
@@ -52,7 +51,7 @@ class MesosStateStore(state: State, timeout: Duration) extends PersistentStore {
       .flatMap { variable =>
         futureToFuture(state.expunge(variable))
           .map{
-            case java.lang.Boolean.TRUE  => true
+            case java.lang.Boolean.TRUE => true
             case java.lang.Boolean.FALSE => false
           }
       }
@@ -83,7 +82,7 @@ class MesosStateStore(state: State, timeout: Duration) extends PersistentStore {
   private[this] def throwOnNull[T](t: T): T = {
     Option(t) match {
       case Some(value) => value
-      case None        => throw new StoreCommandFailedException("Null returned from state store!")
+      case None => throw new StoreCommandFailedException("Null returned from state store!")
     }
   }
 

--- a/src/main/scala/mesosphere/util/state/zk/RichCuratorFramework.scala
+++ b/src/main/scala/mesosphere/util/state/zk/RichCuratorFramework.scala
@@ -1,0 +1,127 @@
+package mesosphere.util.state.zk
+
+import akka.Done
+import akka.util.ByteString
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.api.{ BackgroundPathable, Backgroundable, Pathable }
+import org.apache.zookeeper.CreateMode
+import org.apache.zookeeper.data.{ ACL, Stat }
+
+import scala.collection.JavaConversions._
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+/**
+  * Extensions to CuratorFramework that give a more friendly API to scala (everything executes in the background
+  * and returns futures instead of the blocking form).
+  *
+  * While an implicit conversion is provided, the compiler doesn't appear to be able to resolve it automatically
+  * if named parameters are given. Instead, it is advisable to create it explicitly.
+  *
+  * @param client The underlying Curator client.
+  */
+class RichCuratorFramework(val client: CuratorFramework) extends AnyVal {
+  // scalastyle:off maxParameters
+  def create(
+    path: String,
+    data: Option[ByteString] = None,
+    compress: Boolean = false,
+    `protected`: Boolean = false,
+    acls: Seq[ACL] = Nil,
+    createMode: CreateMode = CreateMode.PERSISTENT,
+    creatingParentsIfNeeded: Boolean = false,
+    creatingParentContainersIfNeeded: Boolean = false): Future[String] =
+    build(client.create(), ZkFuture.create) { builder =>
+      if (compress) builder.compressed()
+      if (`protected`) builder.withProtection()
+      if (creatingParentsIfNeeded) builder.creatingParentsIfNeeded()
+      if (creatingParentContainersIfNeeded) builder.creatingParentContainersIfNeeded()
+      if (acls.nonEmpty) builder.withACL(acls)
+      builder.withMode(createMode)
+      data.fold(builder.forPath(path)) { bytes =>
+        builder.forPath(path, bytes.toArray)
+      }
+    }
+
+  // scalastyle:on
+
+  def delete(
+    path: String,
+    version: Option[Int] = None,
+    quietly: Boolean = false,
+    guaranteed: Boolean = false,
+    deletingChildrenIfNeeded: Boolean = false): Future[String] =
+    build(client.delete(), ZkFuture.delete) { builder =>
+      if (deletingChildrenIfNeeded) builder.deletingChildrenIfNeeded()
+      if (guaranteed) builder.guaranteed()
+      if (deletingChildrenIfNeeded) builder.deletingChildrenIfNeeded()
+      version.foreach(builder.withVersion)
+      builder.forPath(path)
+    }
+
+  def exists(
+    path: String,
+    creatingParentContainersIfNeeded: Boolean = false): Future[ExistsResult] =
+    build(client.checkExists(), ZkFuture.exists) { builder =>
+      if (creatingParentContainersIfNeeded) builder.creatingParentContainersIfNeeded()
+      builder.forPath(path)
+    }
+
+  def data(
+    path: String,
+    decompressed: Boolean = false): Future[GetData] =
+    build(client.getData, ZkFuture.data) { builder =>
+      if (decompressed) builder.decompressed()
+      builder.forPath(path)
+    }
+
+  def setData(
+    path: String,
+    data: ByteString,
+    compressed: Boolean = false,
+    version: Option[Int] = None): Future[SetData] =
+    build(client.setData(), ZkFuture.setData) { builder =>
+      version.foreach(builder.withVersion)
+      if (compressed) builder.compressed()
+      builder.forPath(path, data.toArray)
+    }
+
+  def children(path: String): Future[Children] =
+    build(client.getChildren, ZkFuture.children) { builder =>
+      builder.forPath(path)
+    }
+
+  def sync(path: String): Future[Option[Stat]] =
+    build(client.sync(), ZkFuture.sync) { builder =>
+      builder.forPath(path)
+    }
+
+  def acl(path: String): Future[Seq[ACL]] =
+    build(client.getACL, ZkFuture.acl) { builder =>
+      builder.forPath(path)
+    }
+
+  def setAcl(path: String, acls: Seq[ACL],
+    version: Option[Int] = None): Future[Done] = {
+    val builder = client.setACL()
+    // sadly, the builder doesn't export BackgroundPathable, but the impl is.
+    build(builder.asInstanceOf[BackgroundPathable[_]], ZkFuture.setAcl) { _ =>
+      version.foreach(builder.withVersion)
+      builder.withACL(acls)
+      // it doesn't export Pathable either?
+      builder.asInstanceOf[Pathable[_]].forPath(path)
+    }
+  }
+
+  private def build[A <: Backgroundable[_], B](builder: A, future: ZkFuture[B])(f: A => Unit): Future[B] = {
+    try {
+      builder.inBackground(future)
+      f(builder)
+      future
+    } catch {
+      case NonFatal(e) =>
+        future.fail(e)
+    }
+  }
+}

--- a/src/main/scala/mesosphere/util/state/zk/ZkFuture.scala
+++ b/src/main/scala/mesosphere/util/state/zk/ZkFuture.scala
@@ -1,0 +1,140 @@
+package mesosphere.util.state.zk
+
+import akka.Done
+import akka.util.ByteString
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.api.CuratorEventType._
+import org.apache.curator.framework.api.{ BackgroundCallback, CuratorEvent }
+import org.apache.zookeeper.KeeperException
+import org.apache.zookeeper.data.{ ACL, Stat }
+
+import scala.collection.JavaConversions._
+import scala.collection.immutable.Seq
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ CanAwait, ExecutionContext, Future, Promise, TimeoutException }
+import scala.util.{ Failure, Success, Try }
+
+private[zk] abstract class ZkFuture[T] extends Future[T] with BackgroundCallback {
+  private val promise = Promise[T]()
+  override def onComplete[U](f: (Try[T]) => U)(implicit executor: ExecutionContext): Unit =
+    promise.future.onComplete(f)
+
+  override def isCompleted: Boolean = promise.isCompleted
+
+  override def value: Option[Try[T]] = promise.future.value
+
+  override def processResult(client: CuratorFramework, event: CuratorEvent): Unit = {
+    import KeeperException.Code._
+    val resultCode = KeeperException.Code.get(event.getResultCode)
+    if (resultCode != OK) {
+      promise.failure(KeeperException.create(resultCode))
+    } else {
+      promise.complete(processEvent(event))
+    }
+  }
+
+  @scala.throws[Exception](classOf[Exception])
+  override def result(atMost: Duration)(implicit permit: CanAwait): T = promise.future.result(atMost)
+
+  @scala.throws[InterruptedException](classOf[InterruptedException])
+  @scala.throws[TimeoutException](classOf[TimeoutException])
+  override def ready(atMost: Duration)(implicit permit: CanAwait): this.type = {
+    promise.future.ready(atMost)
+    this
+  }
+
+  def fail(e: Throwable): Future[T] = {
+    promise.tryFailure(e)
+    this
+  }
+
+  protected def processEvent(event: CuratorEvent): Try[T]
+}
+
+private class CreateOrDeleteFuture extends ZkFuture[String] {
+  override protected def processEvent(event: CuratorEvent): Try[String] = event.getType match {
+    case CREATE | DELETE =>
+      Success(event.getPath)
+    case _ =>
+      Failure(new IllegalArgumentException(s"${event.getType} is not a CREATE or DELETE operation"))
+  }
+}
+
+case class ExistsResult(path: String, stat: Stat)
+private class ExistsFuture extends ZkFuture[ExistsResult] {
+  override protected def processEvent(event: CuratorEvent): Try[ExistsResult] = event.getType match {
+    case EXISTS =>
+      Success(ExistsResult(event.getPath, event.getStat))
+    case _ =>
+      Failure(new IllegalArgumentException(s"${event.getType} is not an EXISTS operation"))
+  }
+}
+
+case class GetData(path: String, stat: Stat, data: ByteString)
+private class GetDataFuture extends ZkFuture[GetData] {
+  override protected def processEvent(event: CuratorEvent): Try[GetData] = event.getType match {
+    case GET_DATA =>
+      Success(GetData(event.getPath, event.getStat, ByteString(event.getData)))
+    case _ =>
+      Failure(new IllegalArgumentException(s"${event.getType} is not a GET_DATA operation"))
+  }
+}
+
+case class SetData(path: String, stat: Stat)
+private class SetDataFuture extends ZkFuture[SetData] {
+  override protected def processEvent(event: CuratorEvent): Try[SetData] = event.getType match {
+    case SET_DATA =>
+      Success(SetData(event.getPath, event.getStat))
+    case _ =>
+      Failure(new IllegalArgumentException(s"${event.getType} is not a SET_DATA operation"))
+  }
+}
+
+case class Children(path: String, stat: Stat, children: Seq[String])
+private class ChildrenFuture extends ZkFuture[Children] {
+  override protected def processEvent(event: CuratorEvent): Try[Children] = event.getType match {
+    case CHILDREN =>
+      Success(Children(event.getPath, event.getStat, event.getChildren.toVector))
+    case _ =>
+      Failure(new IllegalArgumentException(s"${event.getType} is not a CHILDREN operation"))
+  }
+}
+
+private class SyncFuture extends ZkFuture[Option[Stat]] {
+  override protected def processEvent(event: CuratorEvent): Try[Option[Stat]] = event.getType match {
+    case SYNC =>
+      Success(Option(event.getStat))
+    case _ =>
+      Failure(new IllegalArgumentException(s"${event.getType} is not a SYNC operation"))
+  }
+}
+
+private class GetAclFuture extends ZkFuture[Seq[ACL]] {
+  override protected def processEvent(event: CuratorEvent): Try[Seq[ACL]] = event.getType match {
+    case GET_ACL =>
+      Success(event.getACLList.toVector)
+    case _ =>
+      Failure(new IllegalArgumentException(s"${event.getType} is not a GET_ACL operation"))
+  }
+}
+
+private class SetAclFuture extends ZkFuture[Done] {
+  override protected def processEvent(event: CuratorEvent): Try[Done] = event.getType match {
+    case SET_ACL =>
+      Success(Done)
+    case _ =>
+      Failure(new IllegalArgumentException(s"${event.getType} is not a SET_ACL operation"))
+  }
+}
+
+private[zk] object ZkFuture {
+  def create: ZkFuture[String] = new CreateOrDeleteFuture
+  def delete: ZkFuture[String] = new CreateOrDeleteFuture
+  def exists: ZkFuture[ExistsResult] = new ExistsFuture
+  def data: ZkFuture[GetData] = new GetDataFuture
+  def setData: ZkFuture[SetData] = new SetDataFuture
+  def children: ZkFuture[Children] = new ChildrenFuture
+  def sync: ZkFuture[Option[Stat]] = new SyncFuture
+  def acl: ZkFuture[Seq[ACL]] = new GetAclFuture
+  def setAcl: ZkFuture[Done] = new SetAclFuture
+}

--- a/src/main/scala/mesosphere/util/state/zk/package.scala
+++ b/src/main/scala/mesosphere/util/state/zk/package.scala
@@ -1,0 +1,8 @@
+package mesosphere.util.state
+
+import scala.language.implicitConversions
+import org.apache.curator.framework.CuratorFramework
+
+package object zk {
+  implicit def toRichCurator(client: CuratorFramework): RichCuratorFramework = new RichCuratorFramework(client)
+}

--- a/src/test/java/mesosphere/marathon/IntegrationTest.java
+++ b/src/test/java/mesosphere/marathon/IntegrationTest.java
@@ -1,0 +1,14 @@
+package mesosphere.marathon;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@org.scalatest.TagAnnotation
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface IntegrationTest {
+}

--- a/src/test/scala/mesosphere/FutureTestSupport.scala
+++ b/src/test/scala/mesosphere/FutureTestSupport.scala
@@ -1,12 +1,12 @@
 package mesosphere
 
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{ JavaFutures, ScalaFutures }
 import org.scalatest.time.{ Seconds, Span }
 
 /**
   * ScalaFutures from scalatest with a different default configuration.
   */
-trait FutureTestSupport extends ScalaFutures {
+trait FutureTestSupport extends ScalaFutures with JavaFutures {
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(3, Seconds))
 }
 

--- a/src/test/scala/mesosphere/UnitTest.scala
+++ b/src/test/scala/mesosphere/UnitTest.scala
@@ -1,0 +1,34 @@
+package mesosphere
+
+import akka.actor.ActorSystem
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, BeforeAndAfterEach, Matchers, OptionValues, TryValues, WordSpec, WordSpecLike }
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+/**
+  * Base trait for newer unit tests using WordSpec style with common matching/before/after and Option/Try/Future
+  * helpers all mixed in.
+  */
+trait UnitTestLike extends WordSpecLike
+  with FutureTestSupport
+  with Matchers
+  with BeforeAndAfter
+  with BeforeAndAfterEach
+  with OptionValues
+  with TryValues
+
+trait UnitTest extends WordSpec with UnitTestLike
+
+trait AkkaUnitTestLike extends UnitTestLike with BeforeAndAfterAll {
+  protected def config: Config = ConfigFactory.load
+  implicit val system = ActorSystem(suiteName, config)
+
+  abstract override def afterAll {
+    Await.result(system.terminate(), Duration.Inf)
+    super.afterAll
+  }
+}
+
+trait AkkaUnitTest extends WordSpec with AkkaUnitTestLike

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -11,14 +11,14 @@ import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.task.{ Task, TaskStateChange, TaskStateOp }
 import mesosphere.marathon.integration.setup.WaitTestSupport
-import mesosphere.marathon.state.{ AppRepository, PathId }
+import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.{ MarathonShutdownHookSupport, Mockito }
 import org.mockito.Matchers
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers => ScalaTestMatchers }
 
-import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Future }
 
 class LaunchQueueModuleTest
     extends MarathonSpec

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -42,8 +42,6 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     with ImplicitSender
     with test.Mockito {
 
-  import scala.concurrent.ExecutionContext.Implicits.global
-
   test("RecoversDeploymentsAndReconcilesHealthChecksOnStart") {
     val app = AppDefinition(id = "test-app".toPath, instances = 1)
     when(groupRepo.rootGroup()).thenReturn(Future.successful(Some(Group.apply(PathId.empty, apps = Set(app)))))
@@ -53,8 +51,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
       awaitAssert(verify(hcManager).reconcileWith(app.id), 5.seconds, 10.millis)
       verify(deploymentRepo, times(1)).all()
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -79,8 +76,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       awaitAssert({
         verify(driver).killTask(TaskID("task_a"))
       }, 5.seconds, 10.millis)
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -103,8 +99,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       schedulerActor ! ScaleApps
 
       awaitAssert(verify(queue).add(app, 1), 5.seconds, 10.millis)
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -127,8 +122,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       awaitAssert(verify(queue).add(app, 1), 5.seconds, 10.millis)
 
       expectMsg(5.seconds, AppScaled(app.id))
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -179,8 +173,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
       // KillTasks does no longer scale
       verify(repo, times(0)).store(any[AppDefinition])
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -220,8 +213,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       expectMsg(5.seconds, TasksKilled(app.id, Set(taskA.taskId)))
 
       awaitAssert(verify(queue).add(app, 1), 5.seconds, 10.millis)
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -259,8 +251,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       answer.id should be(plan.id)
 
       system.eventStream.unsubscribe(probe.ref)
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -308,8 +299,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       Mockito.verify(queue, timeout(1000)).resetDelay(app.copy(instances = 0))
 
       system.eventStream.unsubscribe(probe.ref)
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -345,8 +335,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
       answer.cmd should equal(Deploy(plan))
       answer.reason.isInstanceOf[AppLockedException] should be(true)
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -395,8 +384,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       val answer = expectMsgType[CommandFailed]
       answer.cmd should equal(Deploy(plan))
       answer.reason.isInstanceOf[AppLockedException] should be(true)
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -423,8 +411,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
       val answer = expectMsgType[DeploymentStarted]
 
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -469,8 +456,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
       answer.reason.isInstanceOf[TimeoutException] should be(true)
       answer.reason.getMessage should be
-    }
-    finally {
+    } finally {
       stopActor(schedulerActor)
     }
   }
@@ -571,7 +557,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     ))
     historyActorProps = Props(new HistoryActor(system.eventStream, taskFailureEventRepository))
     schedulerActions = ref => new SchedulerActions(
-      repo, groupRepo, hcManager, taskTracker, queue, new EventStream(), ref, mock[MarathonConf])(system.dispatcher)
+      repo, groupRepo, hcManager, taskTracker, queue, new EventStream(system), ref, mock[MarathonConf])(system.dispatcher)
 
     when(deploymentRepo.store(any)).thenAnswer(new Answer[Future[DeploymentPlan]] {
       override def answer(p1: InvocationOnMock): Future[DeploymentPlan] = {

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -3,7 +3,6 @@ package mesosphere.marathon
 import java.util.{ Timer, TimerTask }
 
 import akka.actor.ActorRef
-import akka.event.EventStream
 import akka.testkit.TestProbe
 import com.codahale.metrics.MetricRegistry
 import mesosphere.chaos.http.HttpConf
@@ -17,7 +16,7 @@ import mesosphere.marathon.state.{ AppRepository, MarathonStore, Migration }
 import mesosphere.marathon.test.MarathonActorSupport
 import mesosphere.util.state.memory.InMemoryStore
 import mesosphere.util.state.{ FrameworkId, FrameworkIdUtil }
-import org.apache.mesos.{ Protos => mesos, SchedulerDriver }
+import org.apache.mesos.{ SchedulerDriver, Protos => mesos }
 import org.mockito.Matchers.{ any, eq => mockEq }
 import org.mockito.Mockito
 import org.mockito.Mockito.{ times, verify, when }
@@ -260,8 +259,7 @@ class MarathonSchedulerServiceTest
 
     try {
       schedulerService.startLeadership()
-    }
-    catch {
+    } catch {
       case _: TimeoutException =>
         schedulerService.stopLeadership()
     }
@@ -293,8 +291,7 @@ class MarathonSchedulerServiceTest
 
     try {
       schedulerService.startLeadership()
-    }
-    catch {
+    } catch {
       case e: Exception => schedulerService.stopLeadership()
     }
 

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -9,13 +9,11 @@ import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.event.{ SchedulerDisconnectedEvent, SchedulerRegisteredEvent, SchedulerReregisteredEvent }
 import mesosphere.marathon.state.AppRepository
-import mesosphere.marathon.test.{ Mockito, MarathonActorSupport }
+import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }
 import mesosphere.util.state.{ FrameworkIdUtil, MesosLeaderInfo, MutableMesosLeaderInfo }
 import org.apache.mesos.Protos._
 import org.apache.mesos.SchedulerDriver
-import org.scalatest.{ Matchers, GivenWhenThen, BeforeAndAfterAll }
-
-import scala.concurrent.Future
+import org.scalatest.{ BeforeAndAfterAll, GivenWhenThen, Matchers }
 
 class MarathonSchedulerTest extends MarathonActorSupport with MarathonSpec with BeforeAndAfterAll with Mockito with Matchers with GivenWhenThen {
 
@@ -84,8 +82,7 @@ class MarathonSchedulerTest extends MarathonActorSupport with MarathonSpec with 
       assert(msg.master == masterInfo.getHostname)
       assert(msg.eventType == "scheduler_registered_event")
       assert(mesosLeaderInfo.currentLeaderUrl.get == "http://some_host:5050/")
-    }
-    finally {
+    } finally {
       eventBus.unsubscribe(probe.ref)
     }
   }
@@ -109,8 +106,7 @@ class MarathonSchedulerTest extends MarathonActorSupport with MarathonSpec with 
       assert(msg.master == masterInfo.getHostname)
       assert(msg.eventType == "scheduler_reregistered_event")
       assert(mesosLeaderInfo.currentLeaderUrl.get == "http://some_host:5050/")
-    }
-    finally {
+    } finally {
       eventBus.unsubscribe(probe.ref)
     }
   }
@@ -127,8 +123,7 @@ class MarathonSchedulerTest extends MarathonActorSupport with MarathonSpec with 
       val msg = probe.expectMsgType[SchedulerDisconnectedEvent]
 
       assert(msg.eventType == "scheduler_disconnected_event")
-    }
-    finally {
+    } finally {
       eventBus.unsubscribe(probe.ref)
     }
   }

--- a/src/test/scala/mesosphere/marathon/MarathonSpec.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSpec.scala
@@ -1,8 +1,6 @@
 package mesosphere.marathon
 
-import org.scalatest.{ FunSuiteLike, BeforeAndAfter }
+import org.scalatest.{ BeforeAndAfter, FunSuiteLike, OptionValues }
 import org.scalatest.mock.MockitoSugar
 
-trait MarathonSpec extends FunSuiteLike with BeforeAndAfter with MockitoSugar {
-
-}
+trait MarathonSpec extends FunSuiteLike with BeforeAndAfter with MockitoSugar with OptionValues

--- a/src/test/scala/mesosphere/marathon/api/JsonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/api/JsonTestHelper.scala
@@ -1,8 +1,8 @@
 package mesosphere.marathon.api
 
-import gnieh.diffson.{ Operation, JsonDiff, Add, Copy }
-import org.scalatest.{ Matchers, Assertions }
-import play.api.libs.json.{ JsArray, JsObject, JsNull, JsValue, Format, Json, Writes }
+import gnieh.diffson.playJson._
+import org.scalatest.{ Assertions, Matchers }
+import play.api.libs.json.{ Format, JsArray, JsNull, JsObject, JsValue, Json, Writes }
 
 import scala.collection.Map
 
@@ -28,7 +28,7 @@ object JsonTestHelper extends Assertions with Matchers {
     case JsObject(fields) =>
       val withoutNullValues: Map[String, JsValue] = fields.filter {
         case (_, JsNull) => false
-        case _           => true
+        case _ => true
       }
       val filterSubValues = withoutNullValues.mapValues {
         case v => removeNullFieldValues(v)
@@ -43,11 +43,11 @@ object JsonTestHelper extends Assertions with Matchers {
   case class AssertThatJsonString(actual: String) {
     private[this] def isAddition(op: Operation): Boolean = op match {
       case _: Add | _: Copy => true
-      case _: Operation     => false
+      case _: Operation => false
     }
 
     def containsEverythingInJsonString(expected: String): Unit = {
-      val diff = JsonDiff.diff(expected, actual)
+      val diff = JsonDiff.diff(expected, actual, remember = false)
       require(diff.ops.forall(isAddition), s"unexpected differences in actual json:\n$actual\nexpected:\n$expected\n${diff.ops.filter(!isAddition(_))}")
     }
 
@@ -56,7 +56,7 @@ object JsonTestHelper extends Assertions with Matchers {
     }
 
     def correspondsToJsonString(expected: String): Unit = {
-      val diff = JsonDiff.diff(expected, actual)
+      val diff = JsonDiff.diff(expected, actual, remember = false)
       require(diff.ops.isEmpty, s"unexpected differences in actual json:\n$actual\nexpected:\n$expected\n$diff")
     }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
@@ -5,10 +5,10 @@ import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.event.EventConfiguration
 import mesosphere.marathon.event.http.HttpEventConfiguration
-import mesosphere.marathon.{ LeaderProxyConf, MarathonConf, MarathonSchedulerService, MarathonSpec }
 import mesosphere.marathon.test.Mockito
+import mesosphere.marathon.{ LeaderProxyConf, MarathonConf, MarathonSchedulerService, MarathonSpec }
 import mesosphere.util.state.MesosLeaderInfo
-import org.scalatest.{ GivenWhenThen, Matchers, FunSuite }
+import org.scalatest.{ GivenWhenThen, Matchers }
 
 class InfoResourceTest extends MarathonSpec with Matchers with Mockito with GivenWhenThen {
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionAppInfoTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionAppInfoTest.scala
@@ -5,11 +5,12 @@ import mesosphere.marathon.api.JsonTestHelper
 import mesosphere.marathon.core.appinfo.{ AppInfo, TaskCounts }
 import mesosphere.marathon.core.readiness.{ HttpResponse, ReadinessCheckResult }
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.{ AppDefinition, Timestamp, TaskFailure, Identifiable, PathId }
-import org.scalatest.GivenWhenThen
-import play.api.libs.json.{ Writes, JsObject, Json }
-import scala.collection.immutable.Seq
+import mesosphere.marathon.state.{ AppDefinition, Identifiable, PathId, TaskFailure, Timestamp }
 import org.apache.mesos.{ Protos => mesos }
+import org.scalatest.GivenWhenThen
+import play.api.libs.json.{ JsObject, Json }
+
+import scala.collection.immutable.Seq
 
 class AppDefinitionAppInfoTest extends MarathonSpec with GivenWhenThen {
   import Formats._

--- a/src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/MarathonTaskFormatTest.scala
@@ -66,7 +66,7 @@ class MarathonTaskFormatTest extends MarathonSpec {
         |{
         |  "id": "/foo/bar",
         |  "host": "agent1.mesos",
-        |  "state": "TASK_STAGING"
+        |  "state": "TASK_STAGING",
         |  "ports": [],
         |  "startedAt": null,
         |  "stagedAt": "1970-01-01T00:00:01.024Z",
@@ -84,7 +84,7 @@ class MarathonTaskFormatTest extends MarathonSpec {
         |{
         |  "id": "/foo/bar",
         |  "host": "agent1.mesos",
-        |  "state": "TASK_STAGING"
+        |  "state": "TASK_STAGING",
         |  "ipAddresses": [
         |    {
         |      "ipAddress": "123.123.123.123",

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskLifeTimeTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskLifeTimeTest.scala
@@ -1,10 +1,10 @@
 package mesosphere.marathon.core.appinfo
 
-import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.test.Mockito
-import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec, Protos }
 import mesosphere.marathon.core.base.ConstantClock
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.Timestamp
+import mesosphere.marathon.test.Mockito
+import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
 import org.scalatest.{ GivenWhenThen, Matchers }
 
 class TaskLifeTimeTest extends MarathonSpec with Mockito with GivenWhenThen with Matchers {

--- a/src/test/scala/mesosphere/marathon/core/election/impl/ElectionServiceBaseTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/election/impl/ElectionServiceBaseTest.scala
@@ -36,7 +36,7 @@ class ElectionServiceBaseTest
     )
     val httpConfig: HttpConf = mock[HttpConf]
     val electionService: ElectionService = mock[ElectionService]
-    val events: EventStream = new EventStream()
+    val events: EventStream = new EventStream(system)
     val candidate: ElectionCandidate = mock[ElectionCandidate]
     val metrics: Metrics = new Metrics(new MetricRegistry)
     val backoff: Backoff = new ExponentialBackoff(0.01.seconds, 0.1.seconds)

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderToUnifiedMesosVolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderToUnifiedMesosVolumeTest.scala
@@ -1,13 +1,13 @@
 package mesosphere.marathon.core.externalvolume.impl.providers
 
 import mesosphere.marathon.MarathonSpec
-import mesosphere.marathon.state.{ ExternalVolumeInfo, ExternalVolume }
-import org.apache.mesos.Protos.{ Volume, Parameter, Parameters }
+import mesosphere.marathon.state.{ ExternalVolume, ExternalVolumeInfo }
+import org.apache.mesos.Protos.{ Parameter, Parameters, Volume }
 import org.scalatest.Matchers
+
 import scala.collection.JavaConverters._
 
 class DVDIProviderVolumeToUnifiedMesosVolumeTest extends MarathonSpec with Matchers {
-  import org.apache.mesos.Protos.Environment
   import DVDIProviderVolumeToUnifiedMesosVolumeTest._
 
   case class TestParameters(
@@ -93,14 +93,12 @@ object DVDIProviderVolumeToUnifiedMesosVolumeTest {
       val oldDriver: Option[String] = {
         if (v.hasSource && v.getSource.hasDockerVolume && v.getSource.getDockerVolume.hasDriver) {
           Some(v.getSource.getDockerVolume.getDriver)
-        }
-        else None
+        } else None
       }
       val oldName: Option[String] = {
         if (v.hasSource && v.getSource.hasDockerVolume && v.getSource.getDockerVolume.hasName) {
           Some(v.getSource.getDockerVolume.getName)
-        }
-        else None
+        } else None
       }
       val sb: Volume.Source.Builder =
         if (v.hasSource) v.getSource.toBuilder
@@ -126,8 +124,7 @@ object DVDIProviderVolumeToUnifiedMesosVolumeTest {
           Map[String, String](v.getSource.getDockerVolume.getDriverOptions.getParameterList().asScala.map { p =>
             p.getKey() -> p.getValue()
           }.toList: _*)
-        }
-        else Map.empty[String, String]
+        } else Map.empty[String, String]
       }
       val sb: Volume.Source.Builder =
         if (v.hasSource) v.getSource.toBuilder

--- a/src/test/scala/mesosphere/marathon/core/flow/impl/OfferMatcherLaunchTokensActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/flow/impl/OfferMatcherLaunchTokensActorTest.scala
@@ -11,6 +11,9 @@ import org.mockito.Mockito
 import rx.lang.scala.Subject
 import rx.lang.scala.subjects.PublishSubject
 
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
 class OfferMatcherLaunchTokensActorTest extends MarathonSpec {
   test("initially setup tokens") {
     Mockito.verify(taskStatusObservables).forAll
@@ -71,7 +74,6 @@ class OfferMatcherLaunchTokensActorTest extends MarathonSpec {
     Mockito.verifyNoMoreInteractions(taskStatusObservables)
     Mockito.verifyNoMoreInteractions(offerMatcherManager)
 
-    actorSystem.shutdown()
-    actorSystem.awaitTermination()
+    Await.result(actorSystem.terminate(), Duration.Inf)
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActorTest.scala
@@ -9,10 +9,11 @@ import mesosphere.marathon.event.{ SchedulerRegisteredEvent, SchedulerReregister
 import mesosphere.marathon.{ MarathonSchedulerDriverHolder, MarathonSpec }
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito
-import org.scalatest.{ Matchers, GivenWhenThen }
+import org.scalatest.{ GivenWhenThen, Matchers }
 import rx.lang.scala.Subject
 import rx.lang.scala.subjects.PublishSubject
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen with Matchers {
@@ -301,14 +302,14 @@ class ReviveOffersActorTest extends MarathonSpec with GivenWhenThen with Matcher
   }
 
   after {
-    actorSystem.shutdown()
-    actorSystem.awaitTermination()
+    Await.result(actorSystem.terminate(), Duration.Inf)
   }
 
   class Fixture(val repetitions: Int = 1) {
     lazy val conf: ReviveOffersConfig = {
       new ReviveOffersConfig {
-        override lazy val reviveOffersRepetitions = opt[Int]("revive_offers_repetitions",
+        override lazy val reviveOffersRepetitions = opt[Int](
+          "revive_offers_repetitions",
           descr = "Repeat every reviveOffer request this many times, delayed by the --min_revive_offers_interval.",
           default = Some(repetitions))
         verify()

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActorTest.scala
@@ -7,7 +7,7 @@ import akka.util.Timeout
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.state.{ AppDefinition, AppRepository, PathId }
+import mesosphere.marathon.state.{ AppDefinition, PathId }
 import org.mockito.Mockito
 
 import scala.concurrent.Await
@@ -65,7 +65,6 @@ class RateLimiterActorTest extends MarathonSpec {
   }
 
   after {
-    actorSystem.shutdown()
-    actorSystem.awaitTermination()
+    Await.result(actorSystem.terminate(), Duration.Inf)
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -466,9 +466,6 @@ class TaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     // Mockito.verifyNoMoreInteractions(offerMatcherManager)
     Mockito.verifyNoMoreInteractions(taskOpFactory)
     //    Mockito.verifyNoMoreInteractions(taskTracker)
-
-    actorSystem.shutdown()
-    actorSystem.awaitTermination()
-
+    Await.result(actorSystem.terminate(), Duration.Inf)
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/leadership/impl/LeadershipCoordinatorActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/leadership/impl/LeadershipCoordinatorActorTest.scala
@@ -1,9 +1,11 @@
 package mesosphere.marathon.core.leadership.impl
 
-import akka.actor.{ Status, PoisonPill, ActorSystem, Actor, Props }
+import akka.actor.{ ActorSystem, PoisonPill, Status }
 import akka.testkit.{ TestActorRef, TestProbe }
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.core.leadership.PreparationMessages
+
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class LeadershipCoordinatorActorTest extends MarathonSpec {
@@ -135,8 +137,6 @@ class LeadershipCoordinatorActorTest extends MarathonSpec {
 
   after {
     coordinatorRef.stop()
-
-    actorSystem.shutdown()
-    actorSystem.awaitTermination()
+    Await.result(actorSystem.terminate(), Duration.Inf)
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/leadership/impl/WhenLeaderActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/leadership/impl/WhenLeaderActorTest.scala
@@ -5,6 +5,9 @@ import akka.testkit.{ TestActorRef, TestProbe }
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.core.leadership.PreparationMessages
 
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
 class WhenLeaderActorTest extends MarathonSpec {
   test("when suspended, respond to all unknown messages with failures") {
     val ref = whenLeaderRef()
@@ -97,7 +100,6 @@ class WhenLeaderActorTest extends MarathonSpec {
   }
 
   after {
-    actorSystem.shutdown()
-    actorSystem.awaitTermination()
+    Await.result(actorSystem.terminate(), Duration.Inf)
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImplTest.scala
@@ -1,22 +1,14 @@
 package mesosphere.marathon.core.readiness.impl
 
-import mesosphere.marathon.core.readiness.{ ReadinessCheckResult, HttpResponse }
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
+import mesosphere.marathon.core.readiness.{ HttpResponse, ReadinessCheckResult }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.MarathonActorSupport
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 import rx.lang.scala.Observable
-import spray.http.{
-  HttpResponse => SprayHttpResponse,
-  MediaTypes,
-  MediaType,
-  ContentType,
-  HttpHeaders,
-  HttpEntity,
-  StatusCodes
-}
+import spray.http.{ ContentType, HttpEntity, HttpHeaders, MediaTypes, StatusCodes, HttpResponse => SprayHttpResponse }
 
 import scala.concurrent.Future
 import scala.concurrent.duration.{ FiniteDuration, _ }

--- a/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
@@ -4,21 +4,20 @@ import akka.actor._
 import akka.testkit.TestProbe
 import mesosphere.marathon
 import mesosphere.marathon.core.base.ConstantClock
-import mesosphere.marathon.core.task.{ TaskStateOp, Task }
-import mesosphere.marathon.core.task.tracker.{ TaskReservationTimeoutHandler, TaskTracker }
 import mesosphere.marathon.core.task.tracker.TaskTracker.TasksByApp
+import mesosphere.marathon.core.task.tracker.{ TaskReservationTimeoutHandler, TaskTracker }
+import mesosphere.marathon.core.task.{ Task, TaskStateOp }
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.{ MarathonSchedulerDriverHolder, MarathonSpec, MarathonTestHelper }
 import mesosphere.mesos.protos.TaskID
-import org.apache.mesos.Protos.{ TaskState, TaskStatus }
-import org.apache.mesos.{ Protos => MesosProtos, SchedulerDriver }
+import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito
 import org.mockito.Mockito._
 import org.scalatest.GivenWhenThen
 import org.scalatest.concurrent.ScalaFutures
 
-import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
+import scala.concurrent.{ Await, ExecutionContext, Future }
 
 class OverdueTasksActorTest extends MarathonSpec with GivenWhenThen with marathon.test.Mockito with ScalaFutures {
   implicit var actorSystem: ActorSystem = _
@@ -52,9 +51,7 @@ class OverdueTasksActorTest extends MarathonSpec with GivenWhenThen with maratho
 
     waitForActorProcessingAllAndDying()
 
-    actorSystem.shutdown()
-    actorSystem.awaitTermination()
-
+    Await.result(actorSystem.terminate(), Duration.Inf)
     noMoreInteractions(taskTracker)
     noMoreInteractions(driver)
     noMoreInteractions(taskReservationTimeoutHandler)

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskStateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskStateOpResolverTest.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon.core.task.tracker.impl
 
 import mesosphere.marathon.MarathonTestHelper
-import mesosphere.marathon.core.task.bus.{ MarathonTaskStatus, MarathonTaskStatusTestHelper, MesosTaskStatus, TaskStatusUpdateTestHelper }
+import mesosphere.marathon.core.task.bus.{ MarathonTaskStatusTestHelper, MesosTaskStatus, TaskStatusUpdateTestHelper }
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.task.tracker.impl.TaskOpProcessorImpl.TaskStateOpResolver
 import mesosphere.marathon.core.task.{ Task, TaskStateChange, TaskStateOp }

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -15,7 +15,8 @@ import org.apache.mesos.SchedulerDriver
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ GivenWhenThen, Matchers }
 
-import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future }
 
 class TaskStatusUpdateProcessorImplTest
     extends MarathonSpec with Mockito with ScalaFutures with GivenWhenThen with Matchers {
@@ -194,8 +195,7 @@ class TaskStatusUpdateProcessorImplTest
     }
 
     def shutdown(): Unit = {
-      actorSystem.shutdown()
-      actorSystem.awaitTermination()
+      Await.result(actorSystem.terminate(), Duration.Inf)
       fOpt = None
     }
   }

--- a/src/test/scala/mesosphere/marathon/event/http/HttpEventActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/http/HttpEventActorTest.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import com.codahale.metrics.MetricRegistry
 import com.typesafe.config.ConfigFactory
 import mesosphere.marathon.MarathonSpec
-import mesosphere.marathon.core.base.{ ConstantClock, Clock }
+import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.event.EventStreamAttached
 import mesosphere.marathon.event.http.HttpEventActor.EventNotificationLimit
 import mesosphere.marathon.event.http.SubscribersKeeperActor.GetSubscribers
@@ -16,8 +16,8 @@ import mesosphere.marathon.test.Mockito
 import org.scalatest.{ GivenWhenThen, Matchers }
 import spray.http.{ HttpRequest, HttpResponse, StatusCode }
 
-import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
+import scala.concurrent.{ Await, ExecutionContext, Future }
 
 class HttpEventActorTest extends MarathonSpec with Mockito with GivenWhenThen with Matchers {
 
@@ -104,7 +104,8 @@ class HttpEventActorTest extends MarathonSpec with Mockito with GivenWhenThen wi
   implicit var system: ActorSystem = _
 
   before {
-    system = ActorSystem("test-system",
+    system = ActorSystem(
+      "test-system",
       ConfigFactory.parseString("""akka.loggers = ["akka.testkit.TestEventListener"]""")
     )
     clock = ConstantClock()
@@ -120,8 +121,7 @@ class HttpEventActorTest extends MarathonSpec with Mockito with GivenWhenThen wi
   }
 
   after {
-    system.shutdown()
-    system.awaitTermination()
+    Await.result(system.terminate(), Duration.Inf)
   }
 
   class NoHttpEventActor(subscribers: Set[String])

--- a/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamActorTest.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.event.http
 
-import akka.actor.{ Terminated, ActorSystem, Props }
+import akka.actor.{ Props, Terminated }
 import akka.event.EventStream
 import akka.testkit._
 import com.codahale.metrics.MetricRegistry
@@ -10,9 +10,10 @@ import mesosphere.marathon.event.LocalLeadershipEvent
 import mesosphere.marathon.event.http.HttpEventStreamActor.{ HttpEventStreamConnectionClosed, HttpEventStreamConnectionOpen }
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.test.MarathonActorSupport
-import org.mockito.Mockito.{ when => call, verify, verifyNoMoreInteractions }
+import org.mockito.Mockito.{ verify, verifyNoMoreInteractions, when => call }
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
+
 import scala.concurrent.duration._
 
 class HttpEventStreamActorTest extends MarathonActorSupport

--- a/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamHandleActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/event/http/HttpEventStreamHandleActorTest.scala
@@ -3,9 +3,9 @@ package mesosphere.marathon.event.http
 import java.io.EOFException
 import java.util.concurrent.CountDownLatch
 
-import akka.actor.{ ActorSystem, Props }
+import akka.actor.Props
 import akka.event.EventStream
-import akka.testkit.{ EventFilter, ImplicitSender, TestActorRef, TestKit }
+import akka.testkit.{ EventFilter, ImplicitSender, TestActorRef }
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.event.{ EventStreamAttached, EventStreamDetached, Subscribe }
 import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckWorkerActorTest.scala
@@ -5,7 +5,6 @@ import java.net.{ InetAddress, ServerSocket }
 import akka.actor.Props
 import akka.testkit.{ ImplicitSender, TestActorRef }
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
-import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.test.MarathonActorSupport

--- a/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
@@ -66,7 +66,7 @@ class MarathonHealthCheckManagerTest
       None,
       metrics)
 
-    eventStream = new EventStream()
+    eventStream = new EventStream(system)
 
     val schedulerDriverHolderProvider = new Provider[MarathonSchedulerDriverHolder] {
       override def get(): MarathonSchedulerDriverHolder = new MarathonSchedulerDriverHolder

--- a/src/test/scala/mesosphere/marathon/integration/ForwardToLeaderIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ForwardToLeaderIntegrationTest.scala
@@ -1,14 +1,16 @@
 package mesosphere.marathon.integration
 
 import java.net.URL
-import javax.net.ssl.HttpsURLConnection
 
 import akka.actor.ActorSystem
-import mesosphere.marathon.api.{ LeaderProxyFilter, JavaUrlConnectionRequestForwarder }
+import mesosphere.marathon.api.{ JavaUrlConnectionRequestForwarder, LeaderProxyFilter }
 import mesosphere.marathon.integration.setup._
+import mesosphere.marathon.io.IO
 import org.apache.commons.httpclient.HttpStatus
 import org.scalatest.BeforeAndAfter
-import mesosphere.marathon.io.IO
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 /**
   * Tests forwarding requests.
@@ -24,8 +26,7 @@ class ForwardToLeaderIntegrationTest extends IntegrationFunSuite with BeforeAndA
   }
 
   after {
-    actorSystem.shutdown()
-    actorSystem.awaitTermination()
+    Await.result(actorSystem.terminate(), Duration.Inf)
     ProcessKeeper.shutdown()
   }
 

--- a/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
@@ -5,7 +5,6 @@ import mesosphere.marathon.integration.setup.{ IntegrationFunSuite, IntegrationH
 import mesosphere.marathon.state.{ AppDefinition, PathId, UpgradeStrategy }
 import org.apache.http.HttpStatus
 import org.scalatest._
-import play.api.libs.json.JsObject
 import spray.http.DateTime
 
 import scala.concurrent.duration._
@@ -326,7 +325,8 @@ class GroupDeployIntegrationTest
       val db = appProxy("/test/db".toTestPath, version, 1)
       val service = appProxy("/test/service".toTestPath, version, 1, dependencies = Set(db.id))
       val frontend = appProxy("/test/frontend1".toTestPath, version, 1, dependencies = Set(service.id))
-      (GroupUpdate("/test".toTestPath, Set(db, service, frontend)),
+      (
+        GroupUpdate("/test".toTestPath, Set(db, service, frontend)),
         appProxyCheck(db.id, version, state = initialState).withHealthAction(storeFirst),
         appProxyCheck(service.id, version, state = initialState).withHealthAction(storeFirst),
         appProxyCheck(frontend.id, version, state = initialState).withHealthAction(storeFirst))

--- a/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
@@ -1,15 +1,14 @@
 package mesosphere.marathon.integration
 
-import mesosphere.marathon.Features
-import mesosphere.marathon.integration.facades.{ ITLeaderResult, MarathonFacade }
+import mesosphere.marathon.integration.facades.MarathonFacade
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.state.PathId
 import org.apache.zookeeper.data.Stat
-import org.apache.zookeeper.{ ZooKeeper, WatchedEvent, Watcher }
+import org.apache.zookeeper.{ WatchedEvent, Watcher, ZooKeeper }
 import org.scalatest.{ GivenWhenThen, Matchers }
 
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
 import scala.util.Try
 
 class LeaderIntegrationTest extends IntegrationFunSuite
@@ -105,8 +104,7 @@ class LeaderIntegrationTest extends IntegrationFunSuite
         val apiLeader: String = marathon.leader().value.leader
         val tombstoneData = zooKeeper.getData(config.zkPath + "/leader/member_-00000000", false, stat.get)
         new String(tombstoneData, "UTF-8") should equal(apiLeader)
-      }
-      finally {
+      } finally {
         zooKeeper.close()
       }
     }

--- a/src/test/scala/mesosphere/marathon/integration/ZooKeeperTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ZooKeeperTest.scala
@@ -2,11 +2,10 @@ package mesosphere.marathon.integration
 
 import java.util
 
-import mesosphere.marathon.integration.facades.MarathonFacade
 import mesosphere.marathon.integration.setup._
 import org.apache.zookeeper.ZooDefs.Perms
-import org.apache.zookeeper.data.{ Id, ACL }
-import org.apache.zookeeper.{ ZooDefs, WatchedEvent, Watcher, ZooKeeper }
+import org.apache.zookeeper.data.{ ACL, Id }
+import org.apache.zookeeper.{ WatchedEvent, Watcher, ZooDefs, ZooKeeper }
 import org.scalatest.{ ConfigMap, GivenWhenThen, Matchers }
 
 import scala.concurrent.duration._

--- a/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
@@ -7,7 +7,7 @@ import javax.ws.rs.{ GET, Path }
 import akka.actor.ActorRef
 import com.google.common.util.concurrent.Service
 import com.google.inject._
-import mesosphere.chaos.http.{ HttpConf, HttpModule, HttpService, RestModule }
+import mesosphere.chaos.http.{ HttpConf, HttpModule, HttpService }
 import mesosphere.chaos.metrics.MetricsModule
 import mesosphere.marathon.api._
 import mesosphere.marathon.core.election.{ ElectionCandidate, ElectionService }

--- a/src/test/scala/mesosphere/marathon/integration/setup/IntegrationFunSuite.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/IntegrationFunSuite.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
   * Integration tests need a special set up and can take a long time.
   * So it is not desirable, that these kind of tests run every time all the unit tests run.
   */
-object IntegrationTag extends Tag("integration")
+object IntegrationTag extends Tag("mesosphere.marathon.IntegrationTest")
 
 /**
   * Convenience trait, which will mark all test cases as integration tests.

--- a/src/test/scala/mesosphere/marathon/integration/setup/IntegrationTestConfig.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/IntegrationTestConfig.scala
@@ -3,9 +3,8 @@ package mesosphere.marathon.integration.setup
 import java.io.File
 
 import mesosphere.marathon.state.PathId
+import mesosphere.util.PortAllocator
 import org.scalatest.ConfigMap
-
-import scala.util.Try
 
 /**
   * Configuration used in integration test.
@@ -71,7 +70,7 @@ case class IntegrationTestConfig(
   def zkHostAndPort: String = s"127.0.0.1:$zkPort"
   def zkPath: String = "/marathon-itest"
   def zk: String = zkCredentials match {
-    case None               => s"zk://$zkHostAndPort$zkPath"
+    case None => s"zk://$zkHostAndPort$zkPath"
     case Some(userPassword) => s"zk://$userPassword@$zkHostAndPort$zkPath"
   }
 
@@ -111,20 +110,19 @@ object IntegrationTestConfig {
     def unusedForExternalSetup(block: => String): String = {
       if (useExternalSetup) {
         "UNUSED FOR EXTERNAL SETUP"
-      }
-      else {
+      } else {
         block
       }
     }
 
     val zkHost = string("zkHost", unusedForExternalSetup("localhost"))
-    val zkPort = int("zkPort", 2183 + (math.random * 100).toInt)
+    val zkPort = int("zkPort", PortAllocator.ephemeralPort())
     val zkCredentials = config.getOptional[String]("zkCredentials")
     val master = string("master", unusedForExternalSetup("127.0.0.1:5050"))
     val mesosLib = string("mesosLib", unusedForExternalSetup(defaultMesosLibConfig))
-    val httpPort = int("httpPort", 11211 + (math.random * 100).toInt)
+    val httpPort = int("httpPort", PortAllocator.ephemeralPort())
     val marathonHost = string("marathonHost", "localhost")
-    val marathonBasePort = int("marathonPort", 8080 + (math.random * 100).toInt)
+    val marathonBasePort = int("marathonPort", PortAllocator.ephemeralPort())
     val clusterSize = int("clusterSize", 3)
     val marathonPorts = 0.to(clusterSize - 1).map(_ + marathonBasePort)
     val marathonGroup = PathId(string("marathonGroup", "/marathon_integration_test"))

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -4,18 +4,19 @@ import java.io.File
 import java.util
 
 import mesosphere.marathon.health.HealthCheck
-import mesosphere.marathon.integration.facades.{ MesosFacade, ITEnrichedTask, ITDeploymentResult, MarathonFacade }
-import mesosphere.marathon.state.{ DockerVolume, AppDefinition, Container, PathId }
+import mesosphere.marathon.integration.facades.{ ITDeploymentResult, ITEnrichedTask, MarathonFacade, MesosFacade }
+import mesosphere.marathon.state.{ AppDefinition, Container, DockerVolume, PathId }
 import org.apache.commons.io.FileUtils
 import org.apache.mesos.Protos
 import org.apache.zookeeper.ZooDefs.Perms
-import org.apache.zookeeper.data.{ Id, ACL }
+import org.apache.zookeeper.data.{ ACL, Id }
 import org.apache.zookeeper._
 import org.scalatest.{ BeforeAndAfterAllConfigMap, ConfigMap, Suite }
 import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 
 import scala.collection.JavaConverters._
+import scala.concurrent.Await
 import scala.concurrent.duration.{ FiniteDuration, _ }
 import scala.util.Try
 
@@ -131,8 +132,7 @@ trait SingleMarathonIntegrationTest
 
       waitForCleanSlateInMesos()
       log.info("Setting up local mesos/marathon infrastructure: done.")
-    }
-    else {
+    } else {
       log.info("Using already running Marathon at {}", config.marathonUrl)
     }
 
@@ -147,8 +147,7 @@ trait SingleMarathonIntegrationTest
     ExternalMarathonIntegrationTest.healthChecks.clear()
     ProcessKeeper.shutdown()
     ProcessKeeper.stopJavaProcesses("mesosphere.marathon.integration.setup.AppMock")
-    system.shutdown()
-    system.awaitTermination()
+    Await.result(system.terminate(), Duration.Inf)
     log.info("Cleaning up local mesos/marathon structure: done.")
   }
 
@@ -180,14 +179,12 @@ trait SingleMarathonIntegrationTest
       if (messageFn(log)) {
         result = Some(log)
         true
-      }
-      else false
+      } else false
     }
     try {
       ProcessKeeper.addCheck(process, message)
       WaitTestSupport.waitFor(s"Log message in process $process", maxWait)(result)
-    }
-    finally {
+    } finally {
       ProcessKeeper.removeCheck(process)
     }
   }
@@ -211,7 +208,8 @@ trait SingleMarathonIntegrationTest
     val file = File.createTempFile("appProxy", ".sh")
     file.deleteOnExit()
 
-    FileUtils.write(file,
+    FileUtils.write(
+      file,
       s"""#!/bin/sh
           |set -x
           |exec $appProxyMainInvocationImpl $$*""".stripMargin)

--- a/src/test/scala/mesosphere/marathon/integration/setup/SprayHttpResponse.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SprayHttpResponse.scala
@@ -2,7 +2,6 @@ package mesosphere.marathon.integration.setup
 
 import play.api.libs.json.{ JsError, JsSuccess, Json, Reads }
 import spray.http.HttpResponse
-import spray.httpx.PlayJsonSupport
 
 import scala.reflect.ClassTag
 

--- a/src/test/scala/mesosphere/marathon/integration/setup/StartedZookeeper.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/StartedZookeeper.scala
@@ -3,14 +3,14 @@ package mesosphere.marathon.integration.setup
 import java.io.File
 
 import org.apache.commons.io.FileUtils
-import org.scalatest.{ BeforeAndAfterAllConfigMap, ConfigMap }
+import org.scalatest.{ BeforeAndAfterAllConfigMap, ConfigMap, Suite }
 
-trait StartedZookeeper extends BeforeAndAfterAllConfigMap { self: IntegrationFunSuite =>
+trait StartedZookeeper extends BeforeAndAfterAllConfigMap { self: Suite =>
 
   private var configOption: Option[IntegrationTestConfig] = None
   def config: IntegrationTestConfig = configOption.get
 
-  override protected def beforeAll(configMap: ConfigMap): Unit = {
+  abstract override protected def beforeAll(configMap: ConfigMap): Unit = {
     super.beforeAll(configMap)
     configOption = Some(IntegrationTestConfig(configMap))
     if (!config.useExternalSetup) {
@@ -19,7 +19,7 @@ trait StartedZookeeper extends BeforeAndAfterAllConfigMap { self: IntegrationFun
     }
   }
 
-  override protected def afterAll(configMap: ConfigMap): Unit = {
+  abstract override protected def afterAll(configMap: ConfigMap): Unit = {
     super.afterAll(configMap)
     ProcessKeeper.shutdown()
   }

--- a/src/test/scala/mesosphere/marathon/integration/setup/V2TestFormats.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/V2TestFormats.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.integration.setup
 
-import mesosphere.marathon.api.v2.json.{ AppUpdate, AppUpdate$ }
+import mesosphere.marathon.api.v2.json.AppUpdate
 import mesosphere.marathon.event._
 import mesosphere.marathon.event.http.EventSubscribers
 import mesosphere.marathon.state.{ Group, Timestamp }
@@ -19,7 +19,7 @@ object V2TestFormats {
         original = (js \ "original").as[Group],
         target = (js \ "target").as[Group],
         version = (js \ "version").as[Timestamp]).copy(id = (js \ "id").as[String]
-        )
+      )
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/state/AppRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppRepositoryTest.scala
@@ -9,7 +9,6 @@ import org.mockito.Mockito._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
-import scala.language.postfixOps
 
 class AppRepositoryTest extends MarathonSpec {
   var metrics: Metrics = _

--- a/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
@@ -1,22 +1,20 @@
 package mesosphere.marathon.state
 
 import com.codahale.metrics.MetricRegistry
+import mesosphere.FutureTestSupport._
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.{ MarathonConf, MarathonSpec, StoreCommandFailedException }
-import mesosphere.util.ThreadPoolContext
 import mesosphere.util.state.memory.InMemoryStore
 import mesosphere.util.state.{ PersistentEntity, PersistentStore }
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.rogach.scallop.ScallopConf
 import org.scalatest.Matchers
-import mesosphere.FutureTestSupport._
 
 import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class MarathonStoreTest extends MarathonSpec with Matchers {
   var metrics: Metrics = _
@@ -158,7 +156,7 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
     def populate(key: String, value: Array[Byte]) = {
       state.load(key).futureValue match {
         case Some(ent) => state.update(ent.withNewContent(value)).futureValue
-        case None      => state.create(key, value).futureValue
+        case None => state.create(key, value).futureValue
       }
     }
 

--- a/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
@@ -6,9 +6,8 @@ import java.util.concurrent.TimeUnit
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.tasks.PortsMatcher.{ PortRange, PortWithRole }
 import org.slf4j.LoggerFactory
-import scala.collection.immutable.Seq
-import org.apache.mesos.Protos
 
+import scala.collection.immutable.Seq
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Random
 

--- a/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskOpFactoryImplTest.scala
@@ -76,7 +76,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A Launch is inferred")
-    taskOp shouldBe a[Some[TaskOp.Launch]]
+    taskOp.value shouldBe a[TaskOp.Launch]
   }
 
   test("Resident app -> None (insufficient offer)") {
@@ -121,7 +121,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A ReserveAndCreateVolumes is returned")
-    taskOp shouldBe a[Some[TaskOp.ReserveAndCreateVolumes]]
+    taskOp.value shouldBe a[TaskOp.ReserveAndCreateVolumes]
   }
 
   test("Resident app -> Launch succeeds") {
@@ -144,7 +144,7 @@ class TaskOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Mockito
     val taskOp = f.taskOpFactory.buildTaskOp(request)
 
     Then("A Launch is returned")
-    taskOp shouldBe a[Some[TaskOp.Launch]]
+    taskOp.value shouldBe a[TaskOp.Launch]
 
     And("the taskInfo contains the correct persistent volume")
     import scala.collection.JavaConverters._

--- a/src/test/scala/mesosphere/marathon/test/CaptureEvents.scala
+++ b/src/test/scala/mesosphere/marathon/test/CaptureEvents.scala
@@ -7,6 +7,8 @@ import akka.testkit.TestProbe
 import mesosphere.marathon.event.MarathonEvent
 
 import scala.collection.immutable.Seq
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 class CaptureEvents(eventStream: EventStream) {
   /**
@@ -31,15 +33,13 @@ class CaptureEvents(eventStream: EventStream) {
 
     try {
       block
-    }
-    finally {
+    } finally {
       eventStream.unsubscribe(captureEventsActor)
       captureEventsActor ! PoisonPill
       val probe = TestProbe()
       probe.watch(captureEventsActor)
       probe.expectMsgClass(classOf[Terminated])
-      actorSystem.shutdown()
-      actorSystem.awaitTermination()
+      Await.result(actorSystem.terminate(), Duration.Inf)
     }
 
     capture

--- a/src/test/scala/mesosphere/marathon/test/MarathonActorSupport.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonActorSupport.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon.test
 
 import akka.actor.ActorSystem
-import akka.testkit.{ TestKitBase, TestKit }
+import akka.testkit.{ TestKit, TestKitBase }
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfter, Suite }
+import org.scalatest.{ BeforeAndAfterAll, Suite }
 import org.slf4j.LoggerFactory
 
 /**

--- a/src/test/scala/mesosphere/marathon/test/Mockito.scala
+++ b/src/test/scala/mesosphere/marathon/test/Mockito.scala
@@ -18,7 +18,7 @@ trait Mockito extends MockitoSugar {
   def same[T](value: T) = org.mockito.Matchers.same(value)
   def verify[T](t: T, mode: VerificationMode = times(1)) = M.verify(t, mode)
   def times(num: Int) = M.times(num)
-  def timeout(millis: Int) = M.timeout(millis)
+  def timeout(millis: Int) = M.timeout(millis.toLong)
   def atLeastOnce = M.atLeastOnce()
   def atLeast(num: Int) = M.atLeast(num)
   def atMost(num: Int) = M.atMost(num)

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -21,7 +21,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{ BeforeAndAfterAll, Matchers }
 
-import scala.concurrent.Future
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 class DeploymentActorTest
@@ -106,9 +106,8 @@ class DeploymentActorTest
       verify(f.scheduler).startApp(f.driver, app3.copy(instances = 0))
       verify(f.driver, times(1)).killTask(task1_2.taskId.mesosTaskId)
       verify(f.scheduler).stopApp(f.driver, app4.copy(instances = 0))
-    }
-    finally {
-      system.shutdown()
+    } finally {
+      Await.result(system.terminate(), Duration.Inf)
     }
   }
 
@@ -158,9 +157,8 @@ class DeploymentActorTest
       verify(f.driver).killTask(task1_1.taskId.mesosTaskId)
       verify(f.driver).killTask(task1_2.taskId.mesosTaskId)
       verify(f.queue).add(appNew, 2)
-    }
-    finally {
-      f.system.shutdown()
+    } finally {
+      Await.result(system.terminate(), Duration.Inf)
     }
   }
 
@@ -184,9 +182,8 @@ class DeploymentActorTest
     try {
       f.deploymentActor(managerProbe.ref, receiverProbe.ref, plan)
       receiverProbe.expectMsg(DeploymentFinished(plan))
-    }
-    finally {
-      f.system.shutdown()
+    } finally {
+      Await.result(system.terminate(), Duration.Inf)
     }
   }
 
@@ -224,9 +221,8 @@ class DeploymentActorTest
 
       verify(f.driver, times(1)).killTask(task1_2.taskId.mesosTaskId)
       verifyNoMoreInteractions(f.driver)
-    }
-    finally {
-      f.system.shutdown()
+    } finally {
+      Await.result(system.terminate(), Duration.Inf)
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanRevertTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanRevertTest.scala
@@ -1,11 +1,9 @@
 package mesosphere.marathon.upgrade
 
 import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import org.scalatest.{ GivenWhenThen, Matchers }
-import mesosphere.marathon.state.PathId._
-
-import scala.collection.SortedSet
 
 class DeploymentPlanRevertTest extends MarathonSpec with Matchers with GivenWhenThen {
   private def normalizeVersions(group: Group): Group = {
@@ -445,52 +443,52 @@ class DeploymentPlanRevertTest extends MarathonSpec with Matchers with GivenWhen
   testWithConcurrentChange(
     original
   )(
-      // revert first
-      addApp("/changeme/some/a"),
-      // concurrent deployments
-      addApp("/changeme/some/b/a"),
-      addApp("/changeme/some/b/b"),
-      addApp("/changeme/some/b/c")
-    ) {
-        // expected outcome after revert
-        Group(
-          PathId.empty,
-          groups = Set(
-            Group("othergroup1".toRootPath),
-            Group("othergroup2".toRootPath),
-            Group("othergroup3".toRootPath),
-            {
-              val id = "changeme".toRootPath
-              Group(
-                id,
-                dependencies = Set(
-                  "othergroup1".toRootPath,
-                  "othergroup2".toRootPath
-                ),
-                apps = Set(
-                  AppDefinition(id / "app1"),
-                  AppDefinition(id / "app2")
-                ),
-                groups = Set(
-                  Group(
-                    id / "some",
-                    groups = Set(
-                      Group(
-                        id / "some" / "b",
-                        apps = Set(
-                          AppDefinition(id / "some" / "b" / "a"),
-                          AppDefinition(id / "some" / "b" / "b"),
-                          AppDefinition(id / "some" / "b" / "c")
-                        )
+    // revert first
+    addApp("/changeme/some/a"),
+    // concurrent deployments
+    addApp("/changeme/some/b/a"),
+    addApp("/changeme/some/b/b"),
+    addApp("/changeme/some/b/c")
+  ) {
+      // expected outcome after revert
+      Group(
+        PathId.empty,
+        groups = Set(
+          Group("othergroup1".toRootPath),
+          Group("othergroup2".toRootPath),
+          Group("othergroup3".toRootPath),
+          {
+            val id = "changeme".toRootPath
+            Group(
+              id,
+              dependencies = Set(
+                "othergroup1".toRootPath,
+                "othergroup2".toRootPath
+              ),
+              apps = Set(
+                AppDefinition(id / "app1"),
+                AppDefinition(id / "app2")
+              ),
+              groups = Set(
+                Group(
+                  id / "some",
+                  groups = Set(
+                    Group(
+                      id / "some" / "b",
+                      apps = Set(
+                        AppDefinition(id / "some" / "b" / "a"),
+                        AppDefinition(id / "some" / "b" / "b"),
+                        AppDefinition(id / "some" / "b" / "c")
                       )
                     )
                   )
                 )
               )
-            }
-          )
+            )
+          }
         )
-      }
+      )
+    }
 
   case class Deployment(name: String, change: Group => Group)
 

--- a/src/test/scala/mesosphere/marathon/upgrade/ScalingPropositionTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ScalingPropositionTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.upgrade
 
 import mesosphere.marathon.MarathonTestHelper
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.Timestamp
 import org.scalatest.{ FunSuite, Matchers }
 
 class ScalingPropositionTest extends FunSuite with Matchers {

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskKillActorTest.scala
@@ -1,12 +1,11 @@
 package mesosphere.marathon.upgrade
 
-import akka.actor.Props
 import akka.testkit.TestActorRef
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.event.MesosStatusUpdateEvent
 import mesosphere.marathon.state.{ AppDefinition, PathId }
-import mesosphere.marathon.test.{ Mockito, MarathonActorSupport }
+import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }
 import mesosphere.marathon.upgrade.StoppingBehavior.KillNextBatch
 import mesosphere.marathon.{ MarathonTestHelper, TaskUpgradeCanceledException }
 import org.apache.mesos.SchedulerDriver

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -3,7 +3,7 @@ package mesosphere.mesos
 import mesosphere.marathon.MarathonTestHelper.Implicits._
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.Protos.Constraint.Operator
-import mesosphere.marathon.core.launcher.impl.{ ReservationLabels, TaskLabels }
+import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.AppDefinition.VersionInfo.{ FullVersionInfo, OnlyVersion }
 import mesosphere.marathon.state.PathId._
@@ -11,11 +11,12 @@ import mesosphere.marathon.state.{ AppDefinition, Container, PortDefinitions, Re
 import mesosphere.marathon.tasks.PortsMatcher
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
+import mesosphere.mesos.protos.Implicits._
 import mesosphere.mesos.protos.{ Resource, TextAttribute }
+import mesosphere.util.state.FrameworkId
 import org.apache.mesos.Protos.{ Attribute, ContainerInfo }
 import org.scalatest.Matchers
-import mesosphere.mesos.protos.Implicits._
-import mesosphere.util.state.FrameworkId
+
 import scala.collection.immutable.Seq
 
 class ResourceMatcherTest extends MarathonSpec with Matchers {

--- a/src/test/scala/mesosphere/util/PortAllocator.scala
+++ b/src/test/scala/mesosphere/util/PortAllocator.scala
@@ -1,0 +1,12 @@
+package mesosphere.util
+
+import java.net.ServerSocket
+
+object PortAllocator {
+  def ephemeralPort(): Int = {
+    val socket = new ServerSocket(0)
+    val port = socket.getLocalPort
+    socket.close()
+    port
+  }
+}

--- a/src/test/scala/mesosphere/util/PromiseActorTest.scala
+++ b/src/test/scala/mesosphere/util/PromiseActorTest.scala
@@ -1,12 +1,13 @@
 package mesosphere.util
 
-import akka.testkit.{ TestProbe, TestActorRef, TestKit }
-import akka.actor.{ Status, Props, ActorSystem }
+import akka.actor.{ Props, Status }
+import akka.testkit.{ TestActorRef, TestProbe }
 import mesosphere.marathon.MarathonSpec
 import mesosphere.marathon.test.MarathonActorSupport
-import org.scalatest.{ Matchers, BeforeAndAfterAll }
-import scala.concurrent.{ Future, Await, Promise }
+import org.scalatest.{ BeforeAndAfterAll, Matchers }
+
 import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future, Promise }
 
 class PromiseActorTest
     extends MarathonActorSupport

--- a/src/test/scala/mesosphere/util/state/zk/RichCuratorFrameworkTest.scala
+++ b/src/test/scala/mesosphere/util/state/zk/RichCuratorFrameworkTest.scala
@@ -1,0 +1,132 @@
+package mesosphere.util.state.zk
+
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+import akka.util.ByteString
+import mesosphere.UnitTest
+import mesosphere.marathon.IntegrationTest
+import mesosphere.marathon.integration.setup.StartedZookeeper
+import mesosphere.util.PortAllocator
+import org.apache.curator.framework.CuratorFrameworkFactory
+import org.apache.curator.{ RetryPolicy, RetrySleeper }
+import org.apache.zookeeper.{ KeeperException, ZooDefs }
+import org.apache.zookeeper.ZooDefs.Perms
+import org.apache.zookeeper.data.{ ACL, Id }
+import org.apache.zookeeper.server.auth.DigestAuthenticationProvider
+import org.scalatest.ConfigMap
+
+import scala.collection.immutable.Seq
+import scala.collection.JavaConversions._
+import scala.util.{ Random, Try }
+
+@IntegrationTest
+class RichCuratorFrameworkTest extends UnitTest with StartedZookeeper {
+  // scalastyle:off magic.number
+  val root = Random.alphanumeric.take(10).mkString
+  val user = new Id("digest", DigestAuthenticationProvider.generateDigest("super:secret"))
+  // scalastyle:on
+  lazy val (client, richClient) = {
+    val client = CuratorFrameworkFactory.newClient(config.zkHostAndPort, new RetryPolicy {
+      override def allowRetry(retryCount: Int, elapsedTimeMs: Long, sleeper: RetrySleeper): Boolean = false
+    })
+    client.start()
+    client.getZookeeperClient.getZooKeeper.addAuthInfo(user.getScheme, user.getId.getBytes(StandardCharsets.UTF_8))
+    Try(client.create().forPath(s"/$root"))
+    val chroot = client.usingNamespace(root)
+    (chroot, new RichCuratorFramework(chroot))
+  }
+
+  override protected def beforeAll(configMap: ConfigMap): Unit = {
+    super.beforeAll(configMap + ("zkPort" -> PortAllocator.ephemeralPort().toString))
+  }
+
+  after {
+    client.getChildren.forPath("/").map { child =>
+      client.delete().deletingChildrenIfNeeded().forPath(s"/$child")
+    }
+  }
+
+  "RichCuratorFramework" should {
+    "be able to create a simple node" in {
+      richClient.create("/1").futureValue should equal(s"/1")
+      val childrenData = client.children("/").futureValue
+      childrenData.children should contain only ("1")
+      childrenData.path should equal("/")
+      childrenData.stat.getVersion should equal(0)
+      childrenData.stat.getEphemeralOwner should equal(0)
+      childrenData.stat.getNumChildren should equal(1)
+    }
+    "be able to create a simple node with data" in {
+      richClient.create("/2", data = Some(ByteString("abc"))).futureValue should equal(s"/2")
+      client.data("/2").futureValue.data should equal(ByteString("abc"))
+      val childrenData = client.children("/").futureValue
+      childrenData.children should contain only ("2")
+      childrenData.path should equal("/")
+      childrenData.stat.getVersion should equal(0)
+      childrenData.stat.getEphemeralOwner should equal(0)
+      childrenData.stat.getNumChildren should equal(1)
+    }
+    "be able to create a tree with data" in {
+      richClient.create(
+        "/3/4/5/6",
+        data = Some(ByteString("def")),
+        creatingParentContainersIfNeeded = true).futureValue should equal("/3/4/5/6")
+      richClient.data("/3/4/5/6").futureValue.data should equal(ByteString("def"))
+    }
+    "fail when creating a nested node when the parent doesn't exist and createParent isn't enabled" in {
+      val failure = richClient.create("/4/5/6").failed.futureValue
+      failure shouldBe a[KeeperException.NoNodeException]
+    }
+    "fail when creating a node with an invalid name" in {
+      val failure = richClient.create(UUID.randomUUID.toString).failed.futureValue
+      failure shouldBe a[IllegalArgumentException]
+    }
+    "be able to delete a node" in {
+      richClient.create("/4").futureValue
+      richClient.delete("/4").futureValue should equal("/4")
+      richClient.children("/").futureValue.children should be('empty)
+    }
+    "be able to delete a tree of nodes" in {
+      richClient.create("/4/5/6", creatingParentsIfNeeded = true).futureValue
+      richClient.delete("/4", deletingChildrenIfNeeded = true).futureValue should equal("/4")
+      richClient.children("/").futureValue.children should be('empty)
+    }
+    "be able to check for the existence of a node" in {
+      richClient.create("/5").futureValue
+      val exists = richClient.exists("/5").futureValue
+      exists.path should equal("/5")
+      exists.stat.getVersion should equal(0)
+    }
+    "be able to check for the existence of a node in a nested path" in {
+      richClient.create("/5/6/7", creatingParentsIfNeeded = true).futureValue
+      val exists = richClient.exists("/5/6/7").futureValue
+      exists.path should equal("/5/6/7")
+      exists.stat.getVersion should equal(0)
+    }
+    "be able to set data on an existing node" in {
+      richClient.create("/5/6/7", creatingParentsIfNeeded = true).futureValue
+      val result = richClient.setData("/5/6/7", ByteString("abc")).futureValue
+      result.path should equal("/5/6/7")
+      result.stat.getVersion should equal(1)
+      result.stat.getDataLength should equal(ByteString("abc").toArray.length)
+      richClient.data("/5/6/7").futureValue.data should equal(ByteString("abc"))
+    }
+    "be able to sync" in {
+      richClient.create("/sync").futureValue
+      richClient.sync("/sync").futureValue should be('empty)
+    }
+    "be able to get an ACL" in {
+      val acl = new ACL(Perms.ALL, user)
+      val readAcl = ZooDefs.Ids.READ_ACL_UNSAFE.toIndexedSeq
+      richClient.create("/acl", acls = acl +: readAcl).futureValue
+      richClient.acl("/acl").futureValue should equal(acl +: readAcl)
+    }
+    "be able to set an ACL" in {
+      val acls = Seq(new ACL(Perms.ALL, user))
+      richClient.create("/acl", acls = ZooDefs.Ids.OPEN_ACL_UNSAFE.toIndexedSeq).futureValue
+      richClient.setAcl("/acl", acls).futureValue
+      richClient.acl("/acl").futureValue should equal(acls)
+    }
+  }
+}


### PR DESCRIPTION
- Future based version of the curator client.
- UnitTest/WordSpec mixin with common classes
  available.
- PortAllocator which should be used to allocate ports
  for testing and once adopted, it should give
  us the ability to run a lot of tests in parallel.
- Add annotation to tag classes as IntegrationTests.