### PR TITLE
While taking over leadership, Marathon need to handle fatal errors.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/base/CurrentRuntime.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/CurrentRuntime.scala
@@ -1,0 +1,37 @@
+package mesosphere.marathon.core.base
+
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ ExecutionContext, TimeoutException, Await, Future }
+import scala.util.control.NonFatal
+import scala.concurrent.duration._
+
+object CurrentRuntime {
+
+  private[this] val log = LoggerFactory.getLogger(getClass.getName)
+
+  /**
+    * Exit this process in an async fashion.
+    * First try exit regularly in the given timeout. If this does not exit in time, we halt the system.
+    *
+    * @param exitCode the exit code to signal.
+    * @param waitForExit the time to wait for a normal exit.
+    * @return the Future of this operation.
+    */
+  //scalastyle:off magic.number
+  def asyncExit(exitCode: Int = 9,
+                waitForExit: FiniteDuration = 10.seconds)(implicit ec: ExecutionContext): Future[Unit] = {
+    Future({
+      try {
+        Await.result(Future(sys.exit(exitCode)), waitForExit)
+      }
+      catch {
+        case _: TimeoutException => log.error("Shutdown timeout")
+        case NonFatal(t)         => log.error("Exception while committing suicide", t)
+      }
+
+      log.info("Halting JVM")
+      Runtime.getRuntime.halt(exitCode)
+    })
+  }
+}


### PR DESCRIPTION
Native code handling is a fatal error.
If for example the scheduler driver can not be loaded (native code), those exception were not handled at all. 
The only good reason to handle fatal errors I can think of, is to exit the process.