### PR TITLE
We need Mesos 1.0 for the docker image to work.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ COPY . /marathon
 WORKDIR /marathon
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
-    echo "deb http://repos.mesosphere.com/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.28.2-2.0.27.debian81 && \
+    apt-get install --no-install-recommends -y --force-yes mesos=1.0.0-1.0.52.rc1.debian81 && \
     apt-get clean && \
     eval $(sed s/sbt.version/SBT_VERSION/ </marathon/project/build.properties) && \
     mkdir -p /usr/local/bin && \


### PR DESCRIPTION
Since there will be no release soon, we need to cut the RC against a Mesos RC.