### PR TITLE
Restructured the Container class towards UC

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
@@ -119,7 +119,7 @@ case class AppUpdate(
     backoff = backoff.getOrElse(app.backoff),
     backoffFactor = backoffFactor.getOrElse(app.backoffFactor),
     maxLaunchDelay = maxLaunchDelay.getOrElse(app.maxLaunchDelay),
-    container = container.filterNot(_ == Container.Empty).orElse(app.container),
+    container = app.container,
     healthChecks = healthChecks.getOrElse(app.healthChecks),
     readinessChecks = readinessChecks.getOrElse(app.readinessChecks),
     dependencies = dependencies.map(_.map(_.canonicalPath(app.id))).getOrElse(app.dependencies),

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
@@ -187,14 +187,14 @@ private[impl] object DVDIProviderValidations extends ExternalVolumeValidations {
 
       def ifDVDIVolume(vtor: Validator[ExternalVolume]): Validator[ExternalVolume] = conditional(matchesProvider)(vtor)
 
-      def volumeValidator(`type`: ContainerInfo.Type) = `type` match {
-        case ContainerInfo.Type.MESOS => validMesosVolume
-        case ContainerInfo.Type.DOCKER => validDockerVolume
+      def volumeValidator(container: Container) = container match {
+        case _: Container.Mesos => validMesosVolume
+        case _: Container.Docker => validDockerVolume
       }
 
       validator[Container] { ct =>
         ct.volumes.collect { case ev: ExternalVolume => ev } as "volumes" is
-          every(ifDVDIVolume(volumeValidator(ct.`type`)))
+          every(ifDVDIVolume(volumeValidator(ct)))
       }
     }
 

--- a/src/main/scala/mesosphere/marathon/state/Container.scala
+++ b/src/main/scala/mesosphere/marathon/state/Container.scala
@@ -3,74 +3,50 @@ package mesosphere.marathon.state
 import com.wix.accord.dsl._
 import com.wix.accord._
 import mesosphere.marathon.api.v2.Validation._
-import org.apache.mesos.{ Protos => Mesos }
+
+import org.apache.mesos.Protos.ContainerInfo
+
 import scala.collection.immutable.Seq
 
-// TODO: trait Container and specializations?
-// Current implementation with type defaulting to DOCKER and docker to NONE makes no sense
-case class Container(
-    `type`: Mesos.ContainerInfo.Type = Mesos.ContainerInfo.Type.DOCKER,
-    volumes: Seq[Volume] = Nil,
-    docker: Option[Container.Docker] = None) {
+trait Container {
+  val volumes: Seq[Volume]
 
-  import Container._
+  def docker(): Option[Container.Docker] = {
+    this match {
+      case docker: Container.Docker => Some(docker)
+      case _ => None
+    }
+  }
 
-  def portMappings: Option[Seq[Docker.PortMapping]] = {
-    import Mesos.ContainerInfo.DockerInfo.Network
+  def getPortMappings: Option[Seq[Container.Docker.PortMapping]] = {
     for {
       d <- docker
-      n <- d.network if n == Network.BRIDGE || n == Network.USER
+      n <- d.network if n == ContainerInfo.DockerInfo.Network.BRIDGE || n == ContainerInfo.DockerInfo.Network.USER
       pms <- d.portMappings
     } yield pms
   }
 
   def hostPorts: Option[Seq[Option[Int]]] =
-    for (pms <- portMappings) yield pms.map(_.hostPort)
+    for (pms <- getPortMappings) yield pms.map(_.hostPort)
 
   def servicePorts: Option[Seq[Int]] =
-    for (pms <- portMappings) yield pms.map(_.servicePort)
+    for (pms <- getPortMappings) yield pms.map(_.servicePort)
 }
 
 object Container {
 
-  object Empty extends Container
+  case class Mesos(volumes: Seq[Volume] = Seq.empty) extends Container
 
-  /**
-    * Docker-specific container parameters.
-    */
   case class Docker(
+    volumes: Seq[Volume] = Seq.empty,
     image: String = "",
-    network: Option[Mesos.ContainerInfo.DockerInfo.Network] = None,
+    network: Option[ContainerInfo.DockerInfo.Network] = None,
     portMappings: Option[Seq[Docker.PortMapping]] = None,
     privileged: Boolean = false,
     parameters: Seq[Parameter] = Nil,
-    forcePullImage: Boolean = false)
+    forcePullImage: Boolean = false) extends Container
 
   object Docker {
-
-    def withDefaultPortMappings(
-      image: String = "",
-      network: Option[Mesos.ContainerInfo.DockerInfo.Network] = None,
-      portMappings: Option[Seq[Docker.PortMapping]] = None,
-      privileged: Boolean = false,
-      parameters: Seq[Parameter] = Nil,
-      forcePullImage: Boolean = false): Docker = Docker(
-      image = image,
-      network = network,
-      portMappings = network match {
-        case Some(networkMode) if networkMode == Mesos.ContainerInfo.DockerInfo.Network.BRIDGE =>
-          portMappings.map(_.map { m =>
-            m match {
-              // backwards compat: when in BRIDGE mode, missing host ports default to zero
-              case PortMapping(x, None, y, z, w, a) => PortMapping(x, Some(PortMapping.HostPortDefault), y, z, w, a)
-              case _ => m
-            }
-          })
-        case _ => portMappings
-      },
-      privileged = privileged,
-      parameters = parameters,
-      forcePullImage = forcePullImage)
 
     /**
       * @param containerPort The container port to expose
@@ -93,8 +69,6 @@ object Container {
       val TCP = "tcp"
       val UDP = "udp"
 
-      val HostPortDefault = AppDefinition.RandomPortValue // HostPortDefault only applies when in BRIDGE mode
-
       implicit val uniqueProtocols: Validator[Iterable[String]] =
         isTrue[Iterable[String]]("protocols must be unique.") { protocols =>
           protocols.size == protocols.toSet.size
@@ -108,54 +82,150 @@ object Container {
         portMapping.name is optional(matchRegexFully(PortAssignment.PortNamePattern))
       }
 
-      def networkHostPortValidator(d: Docker): Validator[PortMapping] =
+      def networkHostPortValidator(docker: Docker): Validator[PortMapping] =
         isTrue[PortMapping]("hostPort is required for BRIDGE mode.") { pm =>
-          d.network match {
-            case Some(Mesos.ContainerInfo.DockerInfo.Network.BRIDGE) => pm.hostPort.isDefined
+          docker.network match {
+            case Some(ContainerInfo.DockerInfo.Network.BRIDGE) => pm.hostPort.isDefined
             case _ => true
           }
         }
-    }
 
-    object PortMappings {
-      val portMappingsValidator: Validator[Seq[PortMapping]] = validator[Seq[PortMapping]] { portMappings =>
+      val portMappingsValidator = validator[Seq[PortMapping]] { portMappings =>
         portMappings is every(valid)
         portMappings is elementsAreUniqueByOptional(_.name, "Port names must be unique.")
       }
 
-      def validForDocker(d: Docker): Validator[Seq[PortMapping]] = validator[Seq[PortMapping]] { pm =>
-        pm is every(valid (PortMapping.networkHostPortValidator(d)))
+      def validForDocker(docker: Docker): Validator[Seq[PortMapping]] = validator[Seq[PortMapping]] { pm =>
+        pm is every(valid(PortMapping.networkHostPortValidator(docker)))
       }
     }
 
-    implicit val dockerValidator = validator[Docker] { docker =>
-      docker.image is notEmpty
-      docker.portMappings is optional(PortMappings.portMappingsValidator and PortMappings.validForDocker(docker))
+    val validDockerContainer: Validator[Container.Docker] = validator[Container.Docker] { docker =>
+      docker.portMappings is optional(PortMapping.portMappingsValidator and PortMapping.validForDocker(docker))
     }
   }
 
-  // We need validation based on the container type, but don't have dedicated classes. Therefore this approach manually
-  // delegates validation to the matching validator
   implicit val validContainer: Validator[Container] = {
     val validGeneralContainer = validator[Container] { container =>
       container.volumes is every(valid)
     }
 
-    val validDockerContainer: Validator[Container] = validator[Container] { container =>
-      container.docker is notEmpty
-      container.docker.each is valid
-    }
-
-    val validMesosContainer: Validator[Container] = validator[Container] { container =>
-      container.docker is empty
-    }
-
     new Validator[Container] {
-      override def apply(c: Container): Result = c.`type` match {
-        case Mesos.ContainerInfo.Type.MESOS => validate(c)(validMesosContainer)
-        case Mesos.ContainerInfo.Type.DOCKER => validate(c)(validDockerContainer)
-        case _ => Failure(Set(RuleViolation(c.`type`, "unknown", None)))
+      override def apply(container: Container): Result = container match {
+        case _: Mesos => Success
+        case docker: Docker => validate(docker)(Docker.validDockerContainer)
       }
     } and validGeneralContainer
   }
+
+  /**
+    * An intermediate structure that parallels the external JSON API for containers.
+    * This allows for validation of all JSON input combinations,
+    * before they have been reduced to a single outcome of type Container
+    * which would cover up too many possible error conditions.
+    * Furthrmore, we can provide trivial Formats implementation via apply/unapply.
+    */
+  case class Mask(
+      `type`: ContainerInfo.Type,
+      volumes: Seq[Volume] = Nil,
+      docker: Option[Mask.Docker]) {
+
+    def toContainer(): Container = {
+      // When writing tests against this validation,
+      // note that paths begin at the container level (not the app level)
+      // and thus do not contain the prefix "/container".
+      validateOrThrow(this)
+
+      docker match {
+        case Some(d) =>
+          Container.Docker(
+            volumes,
+            d.image,
+            d.network,
+            d.portMappings,
+            d.privileged,
+            d.parameters,
+            d.forcePullImage
+          )
+        case _ =>
+          Container.Mesos(volumes)
+      }
+    }
+  }
+
+  object Mask {
+
+    def fromContainer(container: Container): Mask = {
+      container match {
+        case m: Container.Mesos =>
+          Mask(ContainerInfo.Type.MESOS, m.volumes, None)
+        case d: Container.Docker =>
+          Mask(ContainerInfo.Type.DOCKER, d.volumes, Some(Mask.Docker(
+            d.image,
+            d.network,
+            d.portMappings,
+            d.privileged,
+            d.parameters,
+            d.forcePullImage
+          )))
+      }
+    }
+
+    case class Docker(
+      image: String = "",
+      network: Option[ContainerInfo.DockerInfo.Network] = None,
+      portMappings: Option[Seq[Container.Docker.PortMapping]] = None,
+      privileged: Boolean = false,
+      parameters: Seq[Parameter] = Nil,
+      forcePullImage: Boolean = false)
+
+    object Docker {
+      import Container.Docker.PortMapping
+
+      val HostPortDefault = AppDefinition.RandomPortValue // HostPortDefault only applies when in BRIDGE mode
+
+      def withDefaultPortMappings(
+        image: String = "",
+        network: Option[ContainerInfo.DockerInfo.Network] = None,
+        portMappings: Option[Seq[Container.Docker.PortMapping]] = None,
+        privileged: Boolean = false,
+        parameters: Seq[Parameter] = Nil,
+        forcePullImage: Boolean = false): Docker = Docker(
+        image = image,
+        network = network,
+        portMappings = network match {
+          case Some(networkMode) if networkMode == ContainerInfo.DockerInfo.Network.BRIDGE =>
+            portMappings.map(_.map { m =>
+              m match {
+                // backwards compat: when in BRIDGE mode, missing host ports default to zero
+                case PortMapping(x, None, y, z, w, a) => PortMapping(x, Some(HostPortDefault), y, z, w, a)
+                case _ => m
+              }
+            })
+          case _ => portMappings
+        },
+        privileged = privileged,
+        parameters = parameters,
+        forcePullImage = forcePullImage)
+    }
+
+    implicit val validContainerMask: Validator[Container.Mask] = {
+      val validDockerContainerMask: Validator[Container.Mask] = validator[Container.Mask] { mask =>
+        mask.docker is notEmpty
+      }
+
+      val validMesosContainerMask: Validator[Container.Mask] = validator[Container.Mask] { mask =>
+        mask.docker is empty
+      }
+
+      new Validator[Container.Mask] {
+        override def apply(mask: Container.Mask): Result = mask.`type` match {
+          case ContainerInfo.Type.MESOS => validate(mask)(validMesosContainerMask)
+          case ContainerInfo.Type.DOCKER => validate(mask)(validDockerContainerMask)
+          case _ => Failure(Set(RuleViolation(mask.`type`, "unknown", None)))
+        }
+      }
+    }
+  }
 }
+

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -259,7 +259,8 @@ object Group {
             for {
               existingApp <- group.transitiveApps.toList
               if existingApp.id != app.id // in case of an update, do not compare the app against itself
-              existingServicePort <- existingApp.container.flatMap(_.portMappings).toList.flatten.map(_.servicePort)
+              existingServicePort <- existingApp.container.flatMap(_.getPortMappings)
+                .toList.flatten.map(_.servicePort)
               if existingServicePort != 0 // ignore zero ports, which will be chosen at random
               if servicePorts contains existingServicePort
             } yield RuleViolation(

--- a/src/main/scala/mesosphere/marathon/state/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/state/GroupManager.scala
@@ -256,9 +256,7 @@ class GroupManager @Inject() (
             portMapping.copy(servicePort = servicePort)
         }
 
-        c.copy(
-          docker = Some(d.copy(portMappings = Some(portMappings)))
-        )
+        d.copy(portMappings = Some(portMappings))
       }
 
       app.copy(

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -535,16 +535,14 @@ object MarathonTestHelper {
       reservation = Task.Reservation(localVolumeIds, Task.Reservation.State.Launched))
   }
 
-  def mesosContainerWithPersistentVolume = Container(
-    `type` = Mesos.ContainerInfo.Type.MESOS,
+  def mesosContainerWithPersistentVolume = Container.Mesos(
     volumes = Seq[mesosphere.marathon.state.Volume](
       PersistentVolume(
         containerPath = "persistent-volume",
         persistent = PersistentVolumeInfo(10), // must match persistentVolumeResources
         mode = Mesos.Volume.Mode.RW
       )
-    ),
-    docker = None
+    )
   )
 
   def mesosIpAddress(ipAddress: String) = {
@@ -569,17 +567,19 @@ object MarathonTestHelper {
       def withIpAddress(ipAddress: IpAddress): AppDefinition = app.copy(ipAddress = Some(ipAddress))
 
       def withDockerNetwork(network: Mesos.ContainerInfo.DockerInfo.Network): AppDefinition = {
-        val container = app.container.getOrElse(Container())
-        val docker = container.docker.getOrElse(Docker(image = "busybox")).copy(network = Some(network))
+        val docker = app.container.getOrElse(Container.Mesos()) match {
+          case docker: Docker => docker
+          case _ => Docker(image = "busybox")
+        }
 
-        app.copy(container = Some(container.copy(docker = Some(docker))))
+        app.copy(container = Some(docker.copy(network = Some(network))))
       }
 
       def withPortMapings(portMappings: Seq[PortMapping]): AppDefinition = {
-        val container = app.container.getOrElse(Container())
+        val container = app.container.getOrElse(Container.Mesos())
         val docker = container.docker.getOrElse(Docker(image = "busybox")).copy(portMappings = Some(portMappings))
 
-        app.copy(container = Some(container.copy(docker = Some(docker))))
+        app.copy(container = Some(docker))
       }
     }
 

--- a/src/test/scala/mesosphere/marathon/api/MarathonExceptionMapperTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/MarathonExceptionMapperTest.scala
@@ -87,6 +87,6 @@ class MarathonExceptionMapperTest extends MarathonSpec with GivenWhenThen with M
     val firstError = errors.head
     (firstError \ "path").as[String] should be("/")
     val errorMsgs = (firstError \ "errors").as[Seq[String]]
-    errorMsgs.head should be("AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.")
+    errorMsgs.head should be("AppDefinition must either contain one of 'cmd' or 'args', and/or a non-Mesos 'container'.")
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -144,9 +144,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
       cmd = Some("cmd"),
       ipAddress = Some(IpAddress(networkName = Some("foo"))),
       portDefinitions = Seq.empty[PortDefinition],
-      container = Some(Container(
-        `type` = Mesos.ContainerInfo.Type.MESOS
-      ))
+      container = Some(Container.Mesos())
     )
     val (body, plan) = prepareApp(app)
 
@@ -304,16 +302,14 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
       id = PathId("/app"),
       cmd = Some("cmd"),
       ipAddress = Some(IpAddress(networkName = Some("foo"))),
-      container = Some(Container(
-        `type` = Mesos.ContainerInfo.Type.DOCKER,
-        docker = Some(Container.Docker(
-          network = Some(Mesos.ContainerInfo.DockerInfo.Network.USER),
-          image = "jdef/helpme",
-          portMappings = Some(Seq(
-            Container.Docker.PortMapping(containerPort = 0, protocol = "tcp")
-          ))
+      container = Some(Container.Docker(
+        network = Some(Mesos.ContainerInfo.DockerInfo.Network.USER),
+        image = "jdef/helpme",
+        portMappings = Some(Seq(
+          Container.Docker.PortMapping(containerPort = 0, protocol = "tcp")
+        )
         ))
-      )),
+      ),
       portDefinitions = Seq.empty
     )
     val (body, plan) = prepareApp(app)
@@ -341,16 +337,14 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val app = AppDefinition(
       id = PathId("/app"),
       cmd = Some("cmd"),
-      container = Some(Container(
-        `type` = Mesos.ContainerInfo.Type.DOCKER,
-        docker = Some(Container.Docker(
-          network = Some(Mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
-          image = "jdef/helpme",
-          portMappings = Some(Seq(
-            Container.Docker.PortMapping(containerPort = 0, protocol = "tcp")
-          ))
+      container = Some(Container.Docker(
+        network = Some(Mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
+        image = "jdef/helpme",
+        portMappings = Some(Seq(
+          Container.Docker.PortMapping(containerPort = 0, protocol = "tcp")
         ))
-      )),
+      )
+      ),
       portDefinitions = Seq.empty
     )
 
@@ -373,11 +367,11 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     val expected = AppInfo(
       app.copy(
         versionInfo = AppDefinition.VersionInfo.OnlyVersion(clock.now()),
-        container = Some(app.container.get.copy(docker = Some(app.container.get.docker.get.copy(
+        container = Some(app.container.get.asInstanceOf[Container.Docker].copy(
           portMappings = Some(Seq(
             Container.Docker.PortMapping(containerPort = 0, hostPort = Some(0), protocol = "tcp")
           ))
-        ))))
+        ))
       ),
       maybeTasks = Some(immutable.Seq.empty),
       maybeCounts = Some(TaskCounts.zero),
@@ -397,16 +391,14 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
           DiscoveryInfo.Port(number = 1, name = "bob", protocol = "tcp")
         ))
       )),
-      container = Some(Container(
-        `type` = Mesos.ContainerInfo.Type.DOCKER,
-        docker = Some(Container.Docker(
-          network = Some(Mesos.ContainerInfo.DockerInfo.Network.USER),
-          image = "jdef/helpme",
-          portMappings = Some(Seq(
-            Container.Docker.PortMapping(containerPort = 0, protocol = "tcp")
-          ))
+      container = Some(Container.Docker(
+        network = Some(Mesos.ContainerInfo.DockerInfo.Network.USER),
+        image = "jdef/helpme",
+        portMappings = Some(Seq(
+          Container.Docker.PortMapping(containerPort = 0, protocol = "tcp")
         ))
-      )),
+      )
+      ),
       portDefinitions = Seq.empty
     )
     val (body, plan) = prepareApp(app)
@@ -432,13 +424,11 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
           DiscoveryInfo.Port(number = 1, name = "bob", protocol = "tcp")
         ))
       )),
-      container = Some(Container(
-        `type` = Mesos.ContainerInfo.Type.DOCKER,
-        docker = Some(Container.Docker(
-          network = Some(Mesos.ContainerInfo.DockerInfo.Network.HOST),
-          image = "jdef/helpme"
-        ))
-      )),
+      container = Some(Container.Docker(
+        network = Some(Mesos.ContainerInfo.DockerInfo.Network.HOST),
+        image = "jdef/helpme"
+      )
+      ),
       portDefinitions = Seq.empty
     )
     val (body, plan) = prepareApp(app)
@@ -665,7 +655,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
 
     Then("The return code indicates a validation error for container.docker")
     response.getStatus should be(422)
-    response.getEntity.toString should include("/container/docker")
+    response.getEntity.toString should include("/docker")
     response.getEntity.toString should include("must not be empty")
   }
 
@@ -1016,7 +1006,7 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
 
     Then("The return code indicates a validation error for container.docker")
     response.getStatus should be(422)
-    response.getEntity.toString should include("/container/docker")
+    response.getEntity.toString should include("/docker")
     response.getEntity.toString should include("must be empty")
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -110,12 +110,10 @@ class ModelValidationTest
   private def createServicePortApp(id: PathId, servicePort: Int) =
     AppDefinition(
       id,
-      container = Some(Container(
-        docker = Some(Docker(
-          image = "demothing",
-          network = Some(Network.BRIDGE),
-          portMappings = Some(Seq(PortMapping(2000, Some(0), servicePort = servicePort)))
-        ))
+      container = Some(Docker(
+        image = "demothing",
+        network = Some(Network.BRIDGE),
+        portMappings = Some(Seq(PortMapping(2000, Some(0), servicePort = servicePort)))
       ))
     )
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -274,7 +274,8 @@ class AppDefinitionFormatsTest
 
     appDef.ipAddress.isDefined && appDef.ipAddress.get.networkName.isDefined should equal(true)
     appDef.ipAddress.get.networkName should equal(Some("foo"))
-    appDef.container.map(_.`type`.toString) should equal (Some("MESOS"))
+    appDef.container.isDefined
+    appDef.container.get shouldBe a[Container.Mesos]
   }
 
   test("FromJSON should parse ipAddress.networkName with DOCKER container w/o port mappings") {
@@ -295,7 +296,8 @@ class AppDefinitionFormatsTest
 
     appDef.ipAddress.isDefined && appDef.ipAddress.get.networkName.isDefined should equal(true)
     appDef.ipAddress.get.networkName should equal(Some("foo"))
-    appDef.container.map(_.`type`.toString) should equal (Some("DOCKER"))
+    appDef.container.isDefined
+    appDef.container.get shouldBe a[Container.Docker]
     appDef.container.flatMap(_.docker.flatMap(_.network.map(_.toString))) should equal (Some("USER"))
   }
 
@@ -320,7 +322,8 @@ class AppDefinitionFormatsTest
 
     appDef.ipAddress.isDefined && appDef.ipAddress.get.networkName.isDefined should equal(true)
     appDef.ipAddress.get.networkName should equal(Some("foo"))
-    appDef.container.map(_.`type`.toString) should equal (Some("DOCKER"))
+    appDef.container.isDefined
+    appDef.container.get shouldBe a[Container.Docker]
     appDef.container.flatMap(_.docker.flatMap(_.network.map(_.toString))) should equal (Some("USER"))
     appDef.container.flatMap(_.docker.flatMap(_.portMappings)) should equal (Some(Seq(
       Container.Docker.PortMapping(containerPort = 123, servicePort = 80, name = Some("foobar"))

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -107,21 +107,19 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     app = AppDefinition(
       id = "test".toPath,
       cmd = Some("true"),
-      container = Some(Container(
-        docker = Some(Docker(
-          image = "mesosphere/marathon",
-          network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
-          portMappings = Some(Seq(
-            Docker.PortMapping(8080, Some(0), 0, "tcp", Some("foo")),
-            Docker.PortMapping(8081, Some(0), 0, "tcp", Some("foo"))
-          ))
+      container = Some(Docker(
+        image = "mesosphere/marathon",
+        network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
+        portMappings = Some(Seq(
+          Docker.PortMapping(8080, Some(0), 0, "tcp", Some("foo")),
+          Docker.PortMapping(8081, Some(0), 0, "tcp", Some("foo"))
         ))
       )),
       portDefinitions = Nil
     )
     shouldViolate(
       app,
-      "/container/docker/portMappings",
+      "/container/portMappings",
       "Port names must be unique."
     )
 
@@ -142,64 +140,75 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     val correct = AppDefinition(id = "test".toPath)
 
     app = correct.copy(
-      container = Some(Container(
-        docker = Some(Docker(
-          image = "mesosphere/marathon",
-          network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
-          portMappings = Some(Seq(
-            Docker.PortMapping(8080, Some(0), 0, "tcp", Some("foo")),
-            Docker.PortMapping(8081, Some(0), 0, "tcp", Some("bar"))
-          ))
+      container = Some(Docker(
+        image = "mesosphere/marathon",
+        portMappings = Some(Seq(
+          Docker.PortMapping(8080, Some(0), 0, "tcp", Some("foo")),
+          Docker.PortMapping(8081, Some(0), 0, "tcp", Some("bar"))
         ))
       )),
       portDefinitions = Nil)
     shouldNotViolate(
       app,
-      "/container/docker/portMappings",
+      "/container/portMappings",
       "Port names must be unique."
     )
 
     app = correct.copy(
-      container = Some(app.container.get.copy(docker = Some(app.container.get.docker.get.copy(
+      container = Some(app.container.get.asInstanceOf[Docker].copy(
+        network = Some(mesos.ContainerInfo.DockerInfo.Network.USER),
         portMappings = Some(Seq(
-          Docker.PortMapping(8080, None, 0, "tcp", Some("foo")),
-          Docker.PortMapping(8081, None, 0, "tcp", Some("bar"))
+          Docker.PortMapping(8080, None, 0, "tcp", Some("foo"))
         ))
-      )))),
+      )),
       portDefinitions = Nil)
-    shouldViolate(
+    shouldNotViolate(
       app,
-      "/container/docker/portMappings(0)",
+      "/container/portMappings(0)",
       "hostPort is required for BRIDGE mode."
     )
 
     app = correct.copy(
-      container = Some(app.container.get.copy(docker = Some(app.container.get.docker.get.copy(
+      container = Some(app.container.get.asInstanceOf[Docker].copy(
+        network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
+        portMappings = Some(Seq(
+          Docker.PortMapping(8080, None, 0, "tcp", Some("foo"))
+        ))
+      )),
+      portDefinitions = Nil)
+    shouldViolate(
+      app,
+      "/container/portMappings(0)",
+      "hostPort is required for BRIDGE mode."
+    )
+
+    app = correct.copy(
+      container = Some(app.container.get.asInstanceOf[Docker].copy(
         network = Some(mesos.ContainerInfo.DockerInfo.Network.USER),
         portMappings = Some(Seq(
           Docker.PortMapping(8080, Some(0), 0, "tcp", Some("foo")),
           Docker.PortMapping(8081, Some(0), 0, "tcp", Some("bar"))
         ))
-      )))),
+      )),
       portDefinitions = Nil)
     shouldNotViolate(
       app,
-      "/container/docker/portMappings",
+      "/container/portMappings",
       "Port names must be unique."
     )
 
     // unique port names for USER mode
     app = correct.copy(
-      container = Some(app.container.get.copy(docker = Some(app.container.get.docker.get.copy(
+      container = Some(app.container.get.asInstanceOf[Docker].copy(
         portMappings = Some(Seq(
           Docker.PortMapping(8080, Some(0), 0, "tcp", Some("foo")),
           Docker.PortMapping(8081, Some(0), 0, "tcp", Some("foo"))
         ))
-      )))),
+      )),
       portDefinitions = Nil)
     shouldViolate(
       app,
-      "/container/docker/portMappings",
+      "/container/portMappings",
       "Port names must be unique."
     )
 
@@ -267,7 +276,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     shouldViolate(
       app,
       "/",
-      "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'."
+      "AppDefinition must either contain one of 'cmd' or 'args', and/or a non-Mesos 'container'."
     )
     MarathonTestHelper.validateJsonSchema(app, false)
 
@@ -275,7 +284,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     shouldNotViolate(
       app,
       "/",
-      "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'."
+      "AppDefinition must either contain one of 'cmd' or 'args', and/or a non-Mesos 'container'."
     )
     MarathonTestHelper.validateJsonSchema(app)
 
@@ -312,13 +321,11 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     MarathonTestHelper.validateJsonSchema(app, false)
 
     app = correct.copy(
-      container = Some(Container(
-        docker = Some(Docker(
-          network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
-          portMappings = Some(Seq(
-            Docker.PortMapping(8080, Some(0), 0, "tcp"),
-            Docker.PortMapping(8081, Some(0), 0, "tcp")
-          ))
+      container = Some(Docker(
+        network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
+        portMappings = Some(Seq(
+          Docker.PortMapping(8080, Some(0), 0, "tcp"),
+          Docker.PortMapping(8081, Some(0), 0, "tcp")
         ))
       )),
       portDefinitions = Nil,
@@ -332,11 +339,9 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     MarathonTestHelper.validateJsonSchema(app, false) // missing image
 
     app = correct.copy(
-      container = Some(Container(
-        docker = Some(Docker(
-          network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
-          portMappings = None
-        ))
+      container = Some(Docker(
+        network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
+        portMappings = None
       )),
       portDefinitions = Nil,
       healthChecks = Set(HealthCheck(protocol = Protocol.COMMAND))
@@ -451,9 +456,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       backoff = 5.seconds,
       backoffFactor = 1.5,
       maxLaunchDelay = 3.minutes,
-      container = Some(
-        Container(docker = Some(Container.Docker("group/image")))
-      ),
+      container = Some(Docker(image = "group/image")),
       healthChecks = Set(HealthCheck(portIndex = Some(0))),
       dependencies = Set(PathId("/prod/product/backend")),
       upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.75)
@@ -514,17 +517,11 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       id = PathId("/prod/product/frontend/my-app"),
       cmd = Some("sleep 30"),
       portDefinitions = Seq.empty,
-      container = Some(
-        Container(
-          docker = Some(
-            Docker(
-              portMappings = Some(
-                Seq(Docker.PortMapping())
-              )
-            )
-          )
+      container = Some(Docker(
+        portMappings = Some(
+          Seq(Docker.PortMapping())
         )
-      ),
+      )),
       healthChecks = Set(HealthCheck())
     )
 
@@ -542,15 +539,9 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       id = PathId("/prod/product/frontend/my-app"),
       cmd = Some("sleep 30"),
       portDefinitions = Seq.empty,
-      container = Some(
-        Container(
-          docker = Some(
-            Docker(
-              portMappings = Some(Seq.empty)
-            )
-          )
-        )
-      ),
+      container = Some(Docker(
+        portMappings = Some(Seq.empty)
+      )),
       healthChecks = Set(HealthCheck())
     )
 
@@ -568,13 +559,11 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     val app4 = AppDefinition(
       id = "bridged-webapp".toPath,
       cmd = Some("python3 -m http.server 8080"),
-      container = Some(Container(
-        docker = Some(Docker(
-          image = "python:3",
-          network = Some(Network.BRIDGE),
-          portMappings = Some(Seq(
-            PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 9000, protocol = "tcp")
-          ))
+      container = Some(Docker(
+        image = "python:3",
+        network = Some(Network.BRIDGE),
+        portMappings = Some(Seq(
+          PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 9000, protocol = "tcp")
         ))
       ))
     )

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -9,7 +9,6 @@ import mesosphere.marathon.state.Container._
 import mesosphere.marathon.state.DiscoveryInfo.Port
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
-import org.apache.mesos.{ Protos => mesos }
 import play.api.data.validation.ValidationError
 import play.api.libs.json.{ JsPath, JsError, Json }
 
@@ -89,7 +88,7 @@ class AppUpdateTest extends MarathonSpec {
   }
 
   test("SerializationRoundtrip for empty definition") {
-    val update0 = AppUpdate(container = Some(Container.Empty))
+    val update0 = AppUpdate(container = Some(Container.Mesos()))
     JsonTestHelper.assertSerializationRoundtripWorks(update0)
   }
 
@@ -109,13 +108,10 @@ class AppUpdateTest extends MarathonSpec {
       backoff = Some(2.seconds),
       backoffFactor = Some(1.2),
       maxLaunchDelay = Some(1.minutes),
-      container = Some(
-        Container(
-          `type` = mesos.ContainerInfo.Type.DOCKER,
-          volumes = Nil,
-          docker = Some(Docker(image = "docker:///group/image"))
-        )
-      ),
+      container = Some(Docker(
+        volumes = Nil,
+        image = "docker:///group/image"
+      )),
       healthChecks = Some(Set[HealthCheck]()),
       taskKillGracePeriod = Some(2.seconds),
       dependencies = Some(Set[PathId]()),

--- a/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
@@ -3,9 +3,11 @@ package mesosphere.marathon.api.validation
 import mesosphere.marathon.MarathonSpec
 import com.wix.accord.validate
 import mesosphere.marathon.api.v2.json.AppUpdate
+import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state.{ Container, PathId }
-import org.apache.mesos.{ Protos => mesos }
 import org.scalatest.Matchers
+
+import scala.collection.immutable.Seq
 
 class AppUpdateValidatorTest extends MarathonSpec with Matchers {
 
@@ -18,10 +20,10 @@ class AppUpdateValidatorTest extends MarathonSpec with Matchers {
   }
 
   class Fixture {
-    def invalidDockerContainer: Container = Container(
-      `type` = mesos.ContainerInfo.Type.DOCKER,
-      volumes = Nil,
-      docker = None
+    def invalidDockerContainer: Container = Container.Docker(
+      portMappings = Some(Seq(
+        Docker.PortMapping(-1, Some(-1), -1, "tcp") // Invalid (negative) port numbers
+      ))
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
@@ -78,8 +78,7 @@ class DVDIProviderRootGroupValidationTest extends FunSuite with Matchers with Gi
         cmd = Some("sleep 123"),
         upgradeStrategy = UpgradeStrategy.forResidentTasks,
         container = Some(
-          Container(
-            `type` = MesosProtos.ContainerInfo.Type.MESOS,
+          Container.Mesos(
             volumes = Seq(
               ExternalVolume(
                 containerPath = "ignoreme",

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
-import org.apache.mesos.{ Protos => MesosProtos }
 
 class AppDeployIntegrationTest
     extends IntegrationFunSuite
@@ -594,13 +593,11 @@ class AppDeployIntegrationTest
       id = appId,
       cmd = Some("sleep 1"),
       instances = 0,
-      container = Some(Container(
-        `type` = MesosProtos.ContainerInfo.Type.MESOS
-      ))
+      container = Some(Container.Mesos())
     )
 
     app.container should not be empty
-    app.container.get.`type` should equal(MesosProtos.ContainerInfo.Type.MESOS)
+    app.container.get shouldBe a[Container.Mesos]
 
     When("The request is sent")
     val result = marathon.createAppV2(app)
@@ -617,7 +614,7 @@ class AppDeployIntegrationTest
 
     Then("The container should still be of type MESOS")
     maybeContainer1 should not be empty
-    maybeContainer1.get.`type` should equal(MesosProtos.ContainerInfo.Type.MESOS)
+    app.container.get shouldBe a[Container.Mesos]
 
     And("container.docker should not be set")
     maybeContainer1.get.docker shouldBe (empty)
@@ -635,7 +632,7 @@ class AppDeployIntegrationTest
 
     Then("The container should still be of type MESOS")
     maybeContainer2 should not be empty
-    maybeContainer2.get.`type` should equal(MesosProtos.ContainerInfo.Type.MESOS)
+    app.container.get shouldBe a[Container.Mesos]
 
     And("container.docker should not be set")
     maybeContainer1.get.docker shouldBe (empty)

--- a/src/test/scala/mesosphere/marathon/integration/NetworkPartitionIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/NetworkPartitionIntegrationTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.integration
 
 import mesosphere.marathon.integration.facades.ITEnrichedTask
 import mesosphere.marathon.integration.setup._
-import org.scalatest.{BeforeAndAfter, GivenWhenThen, Matchers}
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
 
 /**
   * Integration test to simulate the issues discovered a verizon where a network partition caused Marathon to be

--- a/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
@@ -300,8 +300,7 @@ class ResidentTaskIntegrationTest
           Residency.defaultTaskLostBehaviour
         )),
         constraints = constraints,
-        container = Some(Container(
-          `type` = Mesos.ContainerInfo.Type.MESOS,
+        container = Some(Container.Mesos(
           volumes = Seq(persistentVolume)
         )),
         cmd = Some(cmd),

--- a/src/test/scala/mesosphere/marathon/integration/setup/DockerAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/DockerAppIntegrationTest.scala
@@ -23,13 +23,7 @@ class DockerAppIntegrationTest
       val app = AppDefinition(
         id = testBasePath / "dockerapp",
         cmd = Some("sleep 600"),
-        container = Some(
-          Container(
-            docker = Some(
-              mesosphere.marathon.state.Container.Docker(
-                image = "busybox"
-              )))
-        ),
+        container = Some(Container.Docker(image = "busybox")),
         cpus = 0.2,
         mem = 16.0,
         instances = 1

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -227,21 +227,17 @@ trait SingleMarathonIntegrationTest
     AppDefinition(
       id = appId,
       cmd = cmd,
-      container = Some(
-        new Container(
-          docker = Some(new mesosphere.marathon.state.Container.Docker(
-            image = s"""marathon-buildbase:${sys.env.getOrElse("BUILD_ID", "test")}""",
-            network = Some(Protos.ContainerInfo.DockerInfo.Network.HOST)
-          )),
-          volumes = collection.immutable.Seq(
-            new DockerVolume(hostPath = env.getOrElse("IVY2_DIR", "/root/.ivy2"), containerPath = "/root/.ivy2", mode = Protos.Volume.Mode.RO),
-            new DockerVolume(hostPath = env.getOrElse("SBT_DIR", "/root/.sbt"), containerPath = "/root/.sbt", mode = Protos.Volume.Mode.RO),
-            new DockerVolume(hostPath = env.getOrElse("SBT_DIR", "/root/.sbt"), containerPath = "/root/.sbt", mode = Protos.Volume.Mode.RO),
-            new DockerVolume(hostPath = s"""$targetDirs/main""", containerPath = "/marathon/target", mode = Protos.Volume.Mode.RO),
-            new DockerVolume(hostPath = s"""$targetDirs/project""", containerPath = "/marathon/project/target", mode = Protos.Volume.Mode.RO)
-          )
+      container = Some(Container.Docker(
+        image = s"""marathon-buildbase:${sys.env.getOrElse("BUILD_ID", "test")}""",
+        network = Some(Protos.ContainerInfo.DockerInfo.Network.HOST),
+        volumes = collection.immutable.Seq(
+          new DockerVolume(hostPath = env.getOrElse("IVY2_DIR", "/root/.ivy2"), containerPath = "/root/.ivy2", mode = Protos.Volume.Mode.RO),
+          new DockerVolume(hostPath = env.getOrElse("SBT_DIR", "/root/.sbt"), containerPath = "/root/.sbt", mode = Protos.Volume.Mode.RO),
+          new DockerVolume(hostPath = env.getOrElse("SBT_DIR", "/root/.sbt"), containerPath = "/root/.sbt", mode = Protos.Volume.Mode.RO),
+          new DockerVolume(hostPath = s"""$targetDirs/main""", containerPath = "/marathon/target", mode = Protos.Volume.Mode.RO),
+          new DockerVolume(hostPath = s"""$targetDirs/project""", containerPath = "/marathon/project/target", mode = Protos.Volume.Mode.RO)
         )
-      ),
+      )),
       instances = instances,
       cpus = 0.5,
       mem = 128.0,

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
@@ -102,13 +102,13 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
   test("portAssignments without IP-per-task using Docker BRIDGE network and no port mappings") {
     Given("An app using bridge network with no port mappings nor ports")
     val app = MarathonTestHelper.makeBasicApp().copy(
-      container = Some(Container(
-        docker = Some(Docker(
-          image = "mesosphere/marathon",
-          network = Some(Protos.ContainerInfo.DockerInfo.Network.BRIDGE),
-          portMappings = Some(Seq.empty))))
-      ),
-      portDefinitions = Seq.empty)
+      container = Some(Container.Docker(
+        image = "mesosphere/marathon",
+        network = Some(Protos.ContainerInfo.DockerInfo.Network.BRIDGE),
+        portMappings = Some(Seq.empty)
+      )),
+      portDefinitions = Seq.empty
+    )
 
     Given("A task with a port")
     val task = MarathonTestHelper.mininimalTask(app.id)

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionTest.scala
@@ -47,9 +47,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       id = "play".toPath,
       cmd = None,
       args = Some(Seq("a", "b", "c")),
-      container = Some(
-        Container(docker = Some(Container.Docker("group/image")))
-      ),
+      container = Some(Container.Docker(image = "group/image")),
       cpus = 4.0,
       mem = 256.0,
       instances = 5,
@@ -148,16 +146,13 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
           networkName = Some("blahze")
         )
       ),
-      container = Some(Container(
-        `type` = mesos.ContainerInfo.Type.DOCKER,
-        docker = Some(Container.Docker(
-          image = "jdef/foo",
-          network = Some(mesos.ContainerInfo.DockerInfo.Network.USER),
-          portMappings = Some(Seq(
-            Container.Docker.PortMapping(hostPort = None),
-            Container.Docker.PortMapping(hostPort = Some(123)),
-            Container.Docker.PortMapping(containerPort = 1, hostPort = Some(234), protocol = "udp")
-          ))
+      container = Some(Container.Docker(
+        image = "jdef/foo",
+        network = Some(mesos.ContainerInfo.DockerInfo.Network.USER),
+        portMappings = Some(Seq(
+          Container.Docker.PortMapping(hostPort = None),
+          Container.Docker.PortMapping(hostPort = Some(123)),
+          Container.Docker.PortMapping(containerPort = 1, hostPort = Some(234), protocol = "udp")
         ))
       ))
     )
@@ -175,16 +170,13 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       id = "app-with-ip-address".toPath,
       cmd = Some("sleep 30"),
       portDefinitions = Nil,
-      container = Some(Container(
-        `type` = mesos.ContainerInfo.Type.DOCKER,
-        docker = Some(Container.Docker(
-          image = "jdef/foo",
-          network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
-          portMappings = Some(Seq(
-            Container.Docker.PortMapping(hostPort = Some(0)),
-            Container.Docker.PortMapping(hostPort = Some(123)),
-            Container.Docker.PortMapping(containerPort = 1, hostPort = Some(234), protocol = "udp")
-          ))
+      container = Some(Container.Docker(
+        image = "jdef/foo",
+        network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
+        portMappings = Some(Seq(
+          Container.Docker.PortMapping(hostPort = Some(0)),
+          Container.Docker.PortMapping(hostPort = Some(123)),
+          Container.Docker.PortMapping(containerPort = 1, hostPort = Some(234), protocol = "udp")
         ))
       ))
     )

--- a/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/ContainerTest.scala
@@ -26,105 +26,81 @@ class ContainerTest extends MarathonSpec with Matchers {
       DockerVolume("/etc/b", "/var/data/b", mesos.Volume.Mode.RW)
     )
 
-    lazy val container = Container(
-      `type` = mesos.ContainerInfo.Type.DOCKER,
+    lazy val container: Container = Container.Docker(
       volumes = volumes,
-      docker = Some(Container.Docker(image = "group/image"))
+      image = "group/image"
     )
 
-    lazy val container2 = Container(
-      `type` = mesos.ContainerInfo.Type.DOCKER,
+    lazy val container2: Container = Container.Docker(
       volumes = Nil,
-      docker = Some(
-        Container.Docker(
-          image = "group/image",
-          network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
-          portMappings = Some(Seq(
-            Container.Docker.PortMapping(
-              containerPort = 8080,
-              hostPort = Some(32001),
-              servicePort = 9000,
-              protocol = Container.Docker.PortMapping.TCP,
-              name = Some("http"),
-              labels = Map("foo" -> "bar")),
-            Container.Docker.PortMapping(
-              containerPort = 8081,
-              hostPort = Some(32002),
-              servicePort = 9001,
-              protocol = Container.Docker.PortMapping.UDP)
-          )
-          )
-        )
+      image = "group/image",
+      network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
+      portMappings = Some(Seq(
+        Container.Docker.PortMapping(
+          containerPort = 8080,
+          hostPort = Some(32001),
+          servicePort = 9000,
+          protocol = Container.Docker.PortMapping.TCP,
+          name = Some("http"),
+          labels = Map("foo" -> "bar")),
+        Container.Docker.PortMapping(
+          containerPort = 8081,
+          hostPort = Some(32002),
+          servicePort = 9001,
+          protocol = Container.Docker.PortMapping.UDP)
+      ))
+    )
+
+    lazy val container3: Container = Container.Docker(
+      volumes = Nil,
+      image = "group/image",
+      network = Some(mesos.ContainerInfo.DockerInfo.Network.NONE),
+      privileged = true,
+      parameters = Seq(
+        Parameter("abc", "123"),
+        Parameter("def", "456")
       )
     )
 
-    lazy val container3 = Container(
-      `type` = mesos.ContainerInfo.Type.DOCKER,
+    lazy val container4: Container = Container.Docker(
       volumes = Nil,
-      docker = Some(
-        Container.Docker(
-          image = "group/image",
-          network = Some(mesos.ContainerInfo.DockerInfo.Network.NONE),
-          privileged = true,
-          parameters = Seq(
-            Parameter("abc", "123"),
-            Parameter("def", "456")
-          )
-        )
-      )
+      image = "group/image",
+      network = Some(mesos.ContainerInfo.DockerInfo.Network.NONE),
+      privileged = true,
+      parameters = Seq(
+        Parameter("abc", "123"),
+        Parameter("def", "456"),
+        Parameter("def", "789")
+      ),
+      forcePullImage = true
     )
 
-    lazy val container4 = Container(
-      `type` = mesos.ContainerInfo.Type.DOCKER,
+    lazy val container5: Container = Container.Docker(
       volumes = Nil,
-      docker = Some(
-        Container.Docker(
-          image = "group/image",
-          network = Some(mesos.ContainerInfo.DockerInfo.Network.NONE),
-          privileged = true,
-          parameters = Seq(
-            Parameter("abc", "123"),
-            Parameter("def", "456"),
-            Parameter("def", "789")
-          ),
-          forcePullImage = true
-        )
-      )
+      image = "group/image",
+      network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
+      portMappings = Some(Seq(
+        Container.Docker.PortMapping(
+          containerPort = 8080,
+          hostPort = Some(32001),
+          servicePort = 9000,
+          protocol = "tcp,udp"),
+        Container.Docker.PortMapping(
+          containerPort = 8081,
+          hostPort = Some(32002),
+          servicePort = 9001,
+          protocol = "udp,tcp")
+      ))
     )
 
-    lazy val container5 = Container(
-      `type` = mesos.ContainerInfo.Type.DOCKER,
-      volumes = Nil,
-      docker = Some(
-        Container.Docker(
-          image = "group/image",
-          network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE),
-          portMappings = Some(Seq(
-            Container.Docker.PortMapping(
-              containerPort = 8080,
-              hostPort = Some(32001),
-              servicePort = 9000,
-              protocol = "tcp,udp"),
-            Container.Docker.PortMapping(
-              containerPort = 8081,
-              hostPort = Some(32002),
-              servicePort = 9001,
-              protocol = "udp,tcp")
-          ))
-        )
-      )
-    )
-
-    lazy val mesosContainerWithPersistentVolume = Container(
-      `type` = mesos.ContainerInfo.Type.MESOS,
+    lazy val mesosContainerWithPersistentVolume: Container = Container.Mesos(
       volumes = Seq[Volume](
         PersistentVolume(
           containerPath = "/local/container/",
           persistent = PersistentVolumeInfo(1024),
           mode = mesos.Volume.Mode.RW
         )
-      ),
-      docker = None
+      )
     )
 
     lazy val mesosContainerWithPersistentVolumeJsonStr =
@@ -263,7 +239,7 @@ class ContainerTest extends MarathonSpec with Matchers {
   }
 
   test("SerializationRoundtrip empty") {
-    val container1 = Container(`type` = mesos.ContainerInfo.Type.DOCKER)
+    val container1: Container = Container.Docker()
     JsonTestHelper.assertSerializationRoundtripWorks(container1)
   }
 

--- a/src/test/scala/mesosphere/marathon/state/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupManagerTest.scala
@@ -72,16 +72,14 @@ class GroupManagerTest extends MarathonActorSupport with MockitoSugar with Match
     import Container.Docker
     import Docker.PortMapping
     import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network
-    val container = Container(
-      docker = Some(Docker(
-        image = "busybox",
-        network = Some(Network.BRIDGE),
-        portMappings = Some(Seq(
-          PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 0, protocol = "tcp"),
-          PortMapping(containerPort = 9000, hostPort = Some(10555), servicePort = 10555, protocol = "udp"),
-          PortMapping(containerPort = 9001, hostPort = Some(31337), servicePort = 0, protocol = "udp"),
-          PortMapping(containerPort = 9002, hostPort = Some(0), servicePort = 0, protocol = "tcp")
-        ))
+    val container = Docker(
+      image = "busybox",
+      network = Some(Network.BRIDGE),
+      portMappings = Some(Seq(
+        PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 0, protocol = "tcp"),
+        PortMapping(containerPort = 9000, hostPort = Some(10555), servicePort = 10555, protocol = "udp"),
+        PortMapping(containerPort = 9001, hostPort = Some(31337), servicePort = 0, protocol = "udp"),
+        PortMapping(containerPort = 9002, hostPort = Some(0), servicePort = 0, protocol = "tcp")
       ))
     )
     val group = Group(PathId.empty, Set(
@@ -100,22 +98,18 @@ class GroupManagerTest extends MarathonActorSupport with MockitoSugar with Match
     import Container.Docker
     import Docker.PortMapping
     import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network
-    val c1 = Some(Container(
-      docker = Some(Docker(
-        image = "busybox",
-        network = Some(Network.USER),
-        portMappings = Some(Seq(
-          PortMapping(containerPort = 8080)
-        ))
+    val c1 = Some(Docker(
+      image = "busybox",
+      network = Some(Network.USER),
+      portMappings = Some(Seq(
+        PortMapping(containerPort = 8080)
       ))
     ))
-    val c2 = Some(Container(
-      docker = Some(Docker(
-        image = "busybox",
-        network = Some(Network.USER),
-        portMappings = Some(Seq(
-          PortMapping(containerPort = 8081)
-        ))
+    val c2 = Some(Docker(
+      image = "busybox",
+      network = Some(Network.USER),
+      portMappings = Some(Seq(
+        PortMapping(containerPort = 8081)
       ))
     ))
     val group = Group(PathId.empty, Set(
@@ -133,23 +127,19 @@ class GroupManagerTest extends MarathonActorSupport with MockitoSugar with Match
     import Container.Docker
     import Docker.PortMapping
     import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network
-    val bridgeModeContainer = Some(Container(
-      docker = Some(Docker(
-        image = "busybox",
-        network = Some(Network.BRIDGE),
-        portMappings = Some(Seq(
-          PortMapping(containerPort = 8080, hostPort = Some(0))
-        ))
+    val bridgeModeContainer = Some(Docker(
+      image = "busybox",
+      network = Some(Network.BRIDGE),
+      portMappings = Some(Seq(
+        PortMapping(containerPort = 8080, hostPort = Some(0))
       ))
     ))
-    val userModeContainer = Some(Container(
-      docker = Some(Docker(
-        image = "busybox",
-        network = Some(Network.USER),
-        portMappings = Some(Seq(
-          PortMapping(containerPort = 8081),
-          PortMapping(containerPort = 8082, hostPort = Some(0))
-        ))
+    val userModeContainer = Some(Docker(
+      image = "busybox",
+      network = Some(Network.USER),
+      portMappings = Some(Seq(
+        PortMapping(containerPort = 8081),
+        PortMapping(containerPort = 8082, hostPort = Some(0))
       ))
     ))
     val fromGroup = Group(PathId.empty, Set(
@@ -176,13 +166,11 @@ class GroupManagerTest extends MarathonActorSupport with MockitoSugar with Match
     import Container.Docker
     import Docker.PortMapping
     import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network
-    val c1 = Some(Container(
-      docker = Some(Docker(
-        image = "busybox",
-        network = Some(Network.USER),
-        portMappings = Some(Seq(
-          PortMapping()
-        ))
+    val c1 = Some(Docker(
+      image = "busybox",
+      network = Some(Network.USER),
+      portMappings = Some(Seq(
+        PortMapping()
       ))
     ))
     val group = Group(PathId.empty, Set(
@@ -208,14 +196,12 @@ class GroupManagerTest extends MarathonActorSupport with MockitoSugar with Match
     import Container.Docker
     import Docker.PortMapping
     import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network
-    val container = Container(
-      docker = Some(Docker(
-        image = "busybox",
-        network = Some(Network.BRIDGE),
-        portMappings = Some(Seq(
-          PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 80, protocol = "tcp"),
-          PortMapping (containerPort = 9000, hostPort = Some(10555), servicePort = 81, protocol = "udp")
-        ))
+    val container = Docker(
+      image = "busybox",
+      network = Some(Network.BRIDGE),
+      portMappings = Some(Seq(
+        PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 80, protocol = "tcp"),
+        PortMapping (containerPort = 9000, hostPort = Some(10555), servicePort = 81, protocol = "udp")
       ))
     )
     val group = Group(PathId.empty, Set(
@@ -275,13 +261,7 @@ class GroupManagerTest extends MarathonActorSupport with MockitoSugar with Match
   }
 
   test("Retain the original container definition if port mappings are missing") {
-    import Container.Docker
-
-    val container = Container(
-      docker = Some(Docker(
-        image = "busybox"
-      ))
-    )
+    val container = Container.Docker(image = "busybox")
 
     val group = Group(PathId.empty, Set(
       AppDefinition(

--- a/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortsMatcherTest.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.tasks
 import java.util
 
 import mesosphere.marathon.state.Container.Docker
-import mesosphere.marathon.state.{ ResourceRole, AppDefinition, Container, PortDefinitions }
+import mesosphere.marathon.state.{ ResourceRole, AppDefinition, PortDefinitions }
 import mesosphere.marathon.tasks.PortsMatcher.PortWithRole
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
@@ -153,15 +153,11 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
   }
 
   test("fail if dynamic mapped port from container cannot be satisfied") {
-    val app = AppDefinition(container = Some(
-      Container(
-        docker = Some(new Docker(
-          portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = Some(0))
-          ))
-        ))
-      )
-    ))
+    val app = AppDefinition(container = Some(Docker(
+      portMappings = Some(Seq(
+        new Docker.PortMapping(containerPort = 1, hostPort = Some(0))
+      ))
+    )))
 
     val offer = MarathonTestHelper.makeBasicOffer(beginPort = 0, endPort = -1).build
     val matcher = new PortsMatcher(app, offer)
@@ -170,15 +166,11 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
   }
 
   test("satisfy dynamic mapped port from container") {
-    val app = AppDefinition(container = Some(
-      Container(
-        docker = Some(new Docker(
-          portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = Some(0))
-          ))
-        ))
-      )
-    ))
+    val app = AppDefinition(container = Some(Docker(
+      portMappings = Some(Seq(
+        new Docker.PortMapping(containerPort = 1, hostPort = Some(0))
+      ))
+    )))
 
     val offer = MarathonTestHelper.makeBasicOffer(beginPort = 31000, endPort = 31000).build
     val matcher = new PortsMatcher(app, offer)
@@ -188,15 +180,11 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
   }
 
   test("randomly satisfy dynamic mapped port from container") {
-    val app = AppDefinition(container = Some(
-      Container(
-        docker = Some(new Docker(
-          portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = Some(0))
-          ))
-        ))
-      )
-    ))
+    val app = AppDefinition(container = Some(Docker(
+      portMappings = Some(Seq(
+        new Docker.PortMapping(containerPort = 1, hostPort = Some(0))
+      ))
+    )))
 
     val offer = MarathonTestHelper.makeBasicOffer(beginPort = 31000, endPort = 32000).build
     val rand = new Random(new util.Random(0))
@@ -223,15 +211,11 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
   }
 
   test("fail if fixed mapped port from container cannot be satisfied") {
-    val app = AppDefinition(container = Some(
-      Container(
-        docker = Some(new Docker(
-          portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = Some(8080))
-          ))
-        ))
-      )
-    ))
+    val app = AppDefinition(container = Some(Docker(
+      portMappings = Some(Seq(
+        new Docker.PortMapping(containerPort = 1, hostPort = Some(8080))
+      ))
+    )))
 
     val offer = MarathonTestHelper.makeBasicOffer(beginPort = 31000, endPort = 32000).build
     val matcher = new PortsMatcher(app, offer)
@@ -240,15 +224,11 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
   }
 
   test("satisfy fixed mapped port from container") {
-    val app = AppDefinition(container = Some(
-      Container(
-        docker = Some(new Docker(
-          portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = Some(31200))
-          ))
-        ))
-      )
-    ))
+    val app = AppDefinition(container = Some(Docker(
+      portMappings = Some(Seq(
+        new Docker.PortMapping(containerPort = 1, hostPort = Some(31200))
+      ))
+    )))
 
     val offer = MarathonTestHelper.makeBasicOffer(beginPort = 31000, endPort = 32000).build
     val matcher = new PortsMatcher(app, offer)
@@ -258,15 +238,11 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
   }
 
   test("do not satisfy fixed mapped port from container with resource offer of incorrect role") {
-    val app = AppDefinition(container = Some(
-      Container(
-        docker = Some(new Docker(
-          portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = Some(31200))
-          ))
-        ))
-      )
-    ))
+    val app = AppDefinition(container = Some(Docker(
+      portMappings = Some(Seq(
+        new Docker.PortMapping(containerPort = 1, hostPort = Some(31200))
+      ))
+    )))
 
     val portsResource = RangesResource(
       Resource.PORTS,
@@ -281,16 +257,12 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
   }
 
   test("satisfy fixed and dynamic mapped port from container from one offered range") {
-    val app = AppDefinition(container = Some(
-      Container(
-        docker = Some(new Docker(
-          portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = Some(0)),
-            new Docker.PortMapping(containerPort = 1, hostPort = Some(31000))
-          ))
-        ))
-      )
-    ))
+    val app = AppDefinition(container = Some(Docker(
+      portMappings = Some(Seq(
+        new Docker.PortMapping(containerPort = 1, hostPort = Some(0)),
+        new Docker.PortMapping(containerPort = 1, hostPort = Some(31000))
+      ))
+    )))
 
     val offer = MarathonTestHelper.makeBasicOffer(beginPort = 31000, endPort = 31001).build
     val matcher = new PortsMatcher(app, offer)
@@ -300,16 +272,12 @@ class PortsMatcherTest extends MarathonSpec with Matchers {
   }
 
   test("satisfy fixed and dynamic mapped port from container from ranges with different roles") {
-    val app = AppDefinition(container = Some(
-      Container(
-        docker = Some(new Docker(
-          portMappings = Some(Seq(
-            new Docker.PortMapping(containerPort = 1, hostPort = Some(0)),
-            new Docker.PortMapping(containerPort = 1, hostPort = Some(31000))
-          ))
-        ))
-      )
-    ))
+    val app = AppDefinition(container = Some(Docker(
+      portMappings = Some(Seq(
+        new Docker.PortMapping(containerPort = 1, hostPort = Some(0)),
+        new Docker.PortMapping(containerPort = 1, hostPort = Some(31000))
+      ))
+    )))
 
     val portsResource = RangesResource(
       Resource.PORTS,

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
@@ -443,7 +443,7 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     def residentApp(id: String, volumes: Seq[PersistentVolume]): AppDefinition = {
       AppDefinition(
         id = PathId(id),
-        container = Some(Container(mesos.ContainerInfo.Type.MESOS, volumes)),
+        container = Some(Container.Mesos(volumes)),
         residency = Some(Residency(123, Protos.ResidencyDefinition.TaskLostBehavior.RELAUNCH_AFTER_TIMEOUT))
       )
     }

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -79,14 +79,12 @@ class ResourceMatcherTest extends MarathonSpec with Matchers {
       mem = 128.0,
       disk = 0.0,
       portDefinitions = Nil,
-      container = Some(Container(
-        docker = Some(Container.Docker(
-          image = "foo/bar",
-          network = Some(ContainerInfo.DockerInfo.Network.BRIDGE),
-          portMappings = Some(Seq(
-            Container.Docker.PortMapping(31001, Some(0), 0, "tcp", Some("qax")),
-            Container.Docker.PortMapping(31002, Some(0), 0, "tcp", Some("qab"))
-          ))
+      container = Some(Container.Docker(
+        image = "foo/bar",
+        network = Some(ContainerInfo.DockerInfo.Network.BRIDGE),
+        portMappings = Some(Seq(
+          Container.Docker.PortMapping(31001, Some(0), 0, "tcp", Some("qax")),
+          Container.Docker.PortMapping(31002, Some(0), 0, "tcp", Some("qab"))
         ))
       ))
     )
@@ -111,15 +109,13 @@ class ResourceMatcherTest extends MarathonSpec with Matchers {
       mem = 128.0,
       disk = 0.0,
       portDefinitions = Nil,
-      container = Some(Container(
-        docker = Some(Container.Docker(
-          image = "foo/bar",
-          network = Some(ContainerInfo.DockerInfo.Network.USER),
-          portMappings = Some(Seq(
-            Container.Docker.PortMapping(0, Some(0), 0, "tcp", Some("yas")),
-            Container.Docker.PortMapping(31001, None, 0, "tcp", Some("qax")),
-            Container.Docker.PortMapping(31002, Some(0), 0, "tcp", Some("qab"))
-          ))
+      container = Some(Container.Docker(
+        image = "foo/bar",
+        network = Some(ContainerInfo.DockerInfo.Network.USER),
+        portMappings = Some(Seq(
+          Container.Docker.PortMapping(0, Some(0), 0, "tcp", Some("yas")),
+          Container.Docker.PortMapping(31001, None, 0, "tcp", Some("qax")),
+          Container.Docker.PortMapping(31002, Some(0), 0, "tcp", Some("qab"))
         ))
       ))
     )

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -129,28 +129,28 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
         mem = 64.0,
         disk = 1.0,
         executor = "//cmd",
-        container = Some(Container(
-          docker = Some(Docker(
-            network = Some(DockerInfo.Network.BRIDGE),
-            portMappings = Some(Seq(
-              PortMapping(
-                containerPort = 8080,
-                hostPort = Some(0),
-                servicePort = 9000,
-                protocol = "tcp",
-                name = Some("http"),
-                labels = Map("VIP" -> "127.0.0.1:8080")),
-              PortMapping(
-                containerPort = 8081,
-                hostPort = Some(0),
-                servicePort = 9001,
-                protocol = "udp",
-                name = Some("admin"),
-                labels = Map("VIP" -> "127.0.0.1:8081"))
-            ))
+        container = Some(Docker(
+          network = Some(DockerInfo.Network.BRIDGE),
+          portMappings = Some(Seq(
+            PortMapping(
+              containerPort = 8080,
+              hostPort = Some(0),
+              servicePort = 9000,
+              protocol = "tcp",
+              name = Some("http"),
+              labels = Map("VIP" -> "127.0.0.1:8080")
+            ),
+            PortMapping(
+              containerPort = 8081,
+              hostPort = Some(0),
+              servicePort = 9001,
+              protocol = "udp",
+              name = Some("admin"),
+              labels = Map("VIP" -> "127.0.0.1:8081")
+            )
           ))
-        )))
-    )
+        ))
+      ))
 
     assert(task.isDefined)
 
@@ -291,9 +291,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
         mem = 32.0,
         executor = "//cmd",
         portDefinitions = Nil,
-        container = Some(Container(
-          docker = Some(Docker()), // must have this to force docker container serialization
-          `type` = MesosProtos.ContainerInfo.Type.DOCKER,
+        container = Some(Docker(
           volumes = Seq[Volume](
             DockerVolume("/container/path", "namedFoo", MesosProtos.Volume.Mode.RW)
           )
@@ -335,9 +333,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
         mem = 32.0,
         executor = "//cmd",
         portDefinitions = Nil,
-        container = Some(Container(
-          `type` = MesosProtos.ContainerInfo.Type.DOCKER,
-          docker = Some(Docker()), // must have this to force docker container serialization
+        container = Some(Docker(
           volumes = Seq[Volume](
             ExternalVolume("/container/path", ExternalVolumeInfo(
               name = "namedFoo",
@@ -391,8 +387,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
         mem = 32.0,
         executor = "/qazwsx",
         portDefinitions = Nil,
-        container = Some(Container(
-          `type` = MesosProtos.ContainerInfo.Type.MESOS,
+        container = Some(Container.Mesos(
           volumes = Seq[Volume](
             ExternalVolume("/container/path", ExternalVolumeInfo(
               name = "namedFoo",
@@ -878,12 +873,10 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
       mem = 64.0,
       disk = 1.0,
       executor = "//cmd",
-      container = Some(Container(
-        docker = Some(Docker(
-          network = Some(DockerInfo.Network.BRIDGE),
-          portMappings = Some(Seq(
-            PortMapping(containerPort = 0, hostPort = Some(0), servicePort = 9000, protocol = "tcp")
-          ))
+      container = Some(Docker(
+        network = Some(DockerInfo.Network.BRIDGE),
+        portMappings = Some(Seq(
+          PortMapping(containerPort = 0, hostPort = Some(0), servicePort = 9000, protocol = "tcp")
         ))
       ))
     )
@@ -910,12 +903,10 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
       mem = 64.0,
       disk = 1.0,
       executor = "//cmd",
-      container = Some(Container(
-        docker = Some(Docker(
-          network = Some(DockerInfo.Network.USER),
-          portMappings = Some(Seq(
-            PortMapping()
-          ))
+      container = Some(Docker(
+        network = Some(DockerInfo.Network.USER),
+        portMappings = Some(Seq(
+          PortMapping()
         ))
       )),
       portDefinitions = Seq.empty,
@@ -947,14 +938,12 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
       mem = 64.0,
       disk = 1.0,
       executor = "//cmd",
-      container = Some(Container(
-        docker = Some(Docker(
-          network = Some(DockerInfo.Network.USER),
-          portMappings = Some(Seq(
-            PortMapping(containerPort = 0, hostPort = Some(31000), servicePort = 9000, protocol = "tcp"),
-            PortMapping(containerPort = 0, hostPort = None, servicePort = 9001, protocol = "tcp"),
-            PortMapping(containerPort = 0, hostPort = Some(31005), servicePort = 9002, protocol = "tcp")
-          ))
+      container = Some(Docker(
+        network = Some(DockerInfo.Network.USER),
+        portMappings = Some(Seq(
+          PortMapping(containerPort = 0, hostPort = Some(31000), servicePort = 9000, protocol = "tcp"),
+          PortMapping(containerPort = 0, hostPort = None, servicePort = 9001, protocol = "tcp"),
+          PortMapping(containerPort = 0, hostPort = Some(31005), servicePort = 9002, protocol = "tcp")
         ))
       ))
     )
@@ -1182,10 +1171,8 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     val runSpec = AppDefinition(
       id = PathId("/app"),
       versionInfo = version,
-      container = Some(Container(
-        docker = Some(Docker(
-          image = "myregistry/myimage:version"
-        ))
+      container = Some(Docker(
+        image = "myregistry/myimage:version"
       )),
       cpus = 10.0,
       mem = 256.0,
@@ -1248,12 +1235,9 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
         runSpec = AppDefinition(
           id = "/test".toPath,
           portDefinitions = PortDefinitions(8080, 8081),
-          container = Some(Container(
-            docker = Some(Docker(
-              image = "myregistry/myimage:version"
-            ))
-          )
-          )
+          container = Some(Docker(
+            image = "myregistry/myimage:version"
+          ))
         ),
         taskId = Some(Task.Id("task-123")),
         host = Some("host.mega.corp"),
@@ -1377,13 +1361,11 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     val command =
       TaskBuilder.commandInfo(
         runSpec = AppDefinition(
-          container = Some(Container(
-            docker = Some(Docker(
-              network = Some(DockerInfo.Network.BRIDGE),
-              portMappings = Some(Seq(
-                PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 9000, protocol = "tcp", name = Some("http")),
-                PortMapping(containerPort = 8081, hostPort = Some(0), servicePort = 9000, protocol = "tcp", name = Some("jabber"))
-              ))
+          container = Some(Docker(
+            network = Some(DockerInfo.Network.BRIDGE),
+            portMappings = Some(Seq(
+              PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 9000, protocol = "tcp", name = Some("http")),
+              PortMapping(containerPort = 8081, hostPort = Some(0), servicePort = 9000, protocol = "tcp", name = Some("jabber"))
             ))
           ))
         ),
@@ -1406,13 +1388,11 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
       TaskBuilder.commandInfo(
         runSpec = AppDefinition(
           portDefinitions = PortDefinitions(22, 23),
-          container = Some(Container(
-            docker = Some(Docker(
-              network = Some(DockerInfo.Network.BRIDGE),
-              portMappings = Some(Seq(
-                PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 9000, protocol = "tcp"),
-                PortMapping(containerPort = 8081, hostPort = Some(0), servicePort = 9000, protocol = "tcp")
-              ))
+          container = Some(Docker(
+            network = Some(DockerInfo.Network.BRIDGE),
+            portMappings = Some(Seq(
+              PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 9000, protocol = "tcp"),
+              PortMapping(containerPort = 8081, hostPort = Some(0), servicePort = 9000, protocol = "tcp")
             ))
           ))
         ),
@@ -1498,20 +1478,17 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
       AppDefinition(
         id = "/product/frontend".toPath,
         cmd = Some("foo"),
-        container = Some(Container(
-          `type` = MesosProtos.ContainerInfo.Type.DOCKER,
-          docker = Some(Container.Docker(
-            image = "jdef/foo",
-            network = Some(MesosProtos.ContainerInfo.DockerInfo.Network.USER),
-            portMappings = Some(Seq(
-              // order is important here since it impacts the specific assertions that follow
-              Container.Docker.PortMapping(containerPort = 0, hostPort = None),
-              Container.Docker.PortMapping(containerPort = 100, hostPort = Some(0)),
-              Container.Docker.PortMapping(containerPort = 200, hostPort = Some(25002)),
-              Container.Docker.PortMapping(containerPort = 0, hostPort = Some(25001)),
-              Container.Docker.PortMapping(containerPort = 400, hostPort = None),
-              Container.Docker.PortMapping(containerPort = 0, hostPort = Some(0))
-            ))
+        container = Some(Docker(
+          image = "jdef/foo",
+          network = Some(MesosProtos.ContainerInfo.DockerInfo.Network.USER),
+          portMappings = Some(Seq(
+            // order is important here since it impacts the specific assertions that follow
+            Container.Docker.PortMapping(containerPort = 0, hostPort = None),
+            Container.Docker.PortMapping(containerPort = 100, hostPort = Some(0)),
+            Container.Docker.PortMapping(containerPort = 200, hostPort = Some(25002)),
+            Container.Docker.PortMapping(containerPort = 0, hostPort = Some(25001)),
+            Container.Docker.PortMapping(containerPort = 400, hostPort = None),
+            Container.Docker.PortMapping(containerPort = 0, hostPort = Some(0))
           ))
         )),
         ipAddress = Some(IpAddress(networkName = Some("vnet"))),


### PR DESCRIPTION
Restructured the Container class in anticipation of Universal Containerizer support.

In the course of this, changed all occurences of "{Protos => Mesos}"
to "{Protos => mesos}" for uniformity across the project.

(rebased to mesosphere/marathon - does not compile yet - Scala compiler crashes)