### PR TITLE
Rework health checks/readiness checks effective ip:port resolution

### DIFF
--- a/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheck.scala
@@ -5,7 +5,7 @@ import com.wix.accord.dsl._
 import mesosphere.marathon.Protos
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.{ Command, MarathonState, Timestamp }
+import mesosphere.marathon.state._
 import org.apache.mesos.{ Protos => MesosProtos }
 
 import scala.concurrent.duration._
@@ -106,8 +106,11 @@ case class HealthCheck(
       .build
   }
 
-  def hostPort(launched: Task.Launched): Option[Int] = {
-    def portViaIndex: Option[Int] = portIndex.flatMap(launched.hostPorts.lift(_))
+  def effectivePort(app: AppDefinition, task: Task): Option[Int] = {
+    def portViaIndex: Option[Int] = portIndex.flatMap { portIndex =>
+      app.portAssignments(task).flatMap(_.lift(portIndex)).map(_.effectivePort)
+    }
+
     port.orElse(portViaIndex)
   }
 

--- a/src/main/scala/mesosphere/marathon/health/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckWorkerActor.scala
@@ -45,7 +45,7 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
     app: AppDefinition, task: Task, launched: Task.Launched, check: HealthCheck): Future[Option[HealthResult]] =
     task.effectiveIpAddress(app) match {
       case Some(host) =>
-        check.hostPort(launched) match {
+        check.effectivePort(app, task) match {
           case None => Future.successful {
             Some(
               Unhealthy(task.taskId,
@@ -58,8 +58,7 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
             case HTTPS => https(task, launched, check, host, port)
             case COMMAND =>
               Future.failed {
-                val message = s"COMMAND health checks can only be performed " +
-                  "by the Mesos executor."
+                val message = "COMMAND health checks can only be performed by the Mesos executor."
                 log.warning(message)
                 new UnsupportedOperationException(message)
               }

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -16,6 +16,8 @@ import mesosphere.marathon.core.task.update.TaskUpdateStep
 import mesosphere.marathon.core.task.{ Task, TaskStateOp }
 import mesosphere.marathon.core.task.tracker.{ TaskTracker, TaskTrackerModule }
 import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.state.Container.Docker
+import mesosphere.marathon.state.Container.Docker.PortMapping
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.mesos.protos.{ FrameworkID, OfferID, Range, RangesResource, Resource, ScalarResource, SlaveID }
@@ -564,6 +566,20 @@ object MarathonTestHelper {
       def withNoPortDefinitions(): AppDefinition = app.withPortDefinitions(Seq.empty)
 
       def withIpAddress(ipAddress: IpAddress): AppDefinition = app.copy(ipAddress = Some(ipAddress))
+
+      def withDockerNetwork(network: Mesos.ContainerInfo.DockerInfo.Network): AppDefinition = {
+        val container = app.container.getOrElse(Container())
+        val docker = container.docker.getOrElse(Docker(image = "busybox")).copy(network = Some(network))
+
+        app.copy(container = Some(container.copy(docker = Some(docker))))
+      }
+
+      def withPortMapings(portMappings: Seq[PortMapping]): AppDefinition = {
+        val container = app.container.getOrElse(Container())
+        val docker = container.docker.getOrElse(Docker(image = "busybox")).copy(portMappings = Some(portMappings))
+
+        app.copy(container = Some(container.copy(docker = Some(docker))))
+      }
     }
 
     implicit class TaskImprovements(task: Task) {

--- a/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/HealthCheckTest.scala
@@ -2,8 +2,8 @@ package mesosphere.marathon.health
 
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.api.v2.ValidationHelper
-import mesosphere.marathon.state.Command
-import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec, Protos }
+import mesosphere.marathon.state.{ Command, PortDefinition }
+import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper, Protos }
 import play.api.libs.json.Json
 
 import scala.collection.immutable.Seq
@@ -364,11 +364,21 @@ class HealthCheckTest extends MarathonSpec {
     ))
   }
 
-  test("getPort") {
+  test("effectivePort with a hard-coded port") {
     import MarathonTestHelper.Implicits._
     val check = new HealthCheck(port = Some(1234))
+    val app = MarathonTestHelper.makeBasicApp().withPortDefinitions(Seq(PortDefinition(0)))
     val task = MarathonTestHelper.runningTask("test_id").withHostPorts(Seq(4321))
 
-    assert(check.hostPort(task.launched.get).contains(1234))
+    assert(check.effectivePort(app, task).contains(1234))
+  }
+
+  test("effectivePort with a port index") {
+    import MarathonTestHelper.Implicits._
+    val check = new HealthCheck(portIndex = Some(0))
+    val app = MarathonTestHelper.makeBasicApp().withPortDefinitions(Seq(PortDefinition(0)))
+    val task = MarathonTestHelper.runningTask("test_id").withHostPorts(Seq(4321))
+
+    assert(check.effectivePort(app, task).contains(4321))
   }
 }

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
@@ -28,14 +28,9 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
     val portAssignments = app.portAssignments(task)
 
     Then("The right port assignment is returned")
-    portAssignments should equal(
-      Some(
-        Seq(
-          PortAssignment(
-            portName = Some("http"),
-            effectiveIpAddress = "192.168.0.1",
-            effectivePort = 1)
-        )))
+    portAssignments should equal(Some(Seq(
+      PortAssignment(portName = Some("http"), effectiveIpAddress = "192.168.0.1", effectivePort = 1)
+    )))
   }
 
   test("portAssignments with IP-per-task defining ports, but a task which doesn't have an IP address yet") {
@@ -84,37 +79,27 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
     app.portAssignments(task) should be(None)
   }
 
-  test("portAssignments with port mappings") {
-    Given("An app requesting one port through port definitions")
-    val app = MarathonTestHelper.makeBasicApp().copy(
-      container = Some(Container(
-        docker = Some(Docker(
-          image = "mesosphere/marathon",
-          network = Some(Protos.ContainerInfo.DockerInfo.Network.BRIDGE),
-          portMappings = Some(Seq(
-            Docker.PortMapping(containerPort = 80, hostPort = Some(0), servicePort = 0, protocol = "tcp",
-              name = Some("http"))
-          ))
-        ))
-      )),
-      portDefinitions = Seq.empty)
+  test("portAssignments without IP-per-task and Docker BRIDGE mode with a port mapping") {
+    Given("An app without IP-per-task, using BRIDGE networking with one port mapping requesting a dynamic port")
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withDockerNetwork(Protos.ContainerInfo.DockerInfo.Network.BRIDGE)
+      .withPortMapings(Seq(
+        Docker.PortMapping(containerPort = 80, hostPort = Some(0), servicePort = 0, protocol = "tcp",
+          name = Some("http"))
+      ))
 
-    Given("A task with a host port")
+    Given("A task without an IP and with a host port")
     val task = MarathonTestHelper.mininimalTask(app.id).withHostPorts(Seq(1))
 
     Then("The right port assignment is returned")
     val portAssignments = app.portAssignments(task)
-    portAssignments should be(
-      Some(
-        Seq(
-          PortAssignment(
-            portName = Some("http"),
-            effectiveIpAddress = task.agentInfo.host,
-            effectivePort = 1)
-        )))
+    portAssignments should be(Some(Seq(
+      PortAssignment(portName = Some("http"), effectiveIpAddress = task.agentInfo.host, effectivePort = 1)
+    )))
   }
 
-  test("portAssignments with bridge network and no port mappings") {
+  test("portAssignments without IP-per-task using Docker BRIDGE network and no port mappings") {
     Given("An app using bridge network with no port mappings nor ports")
     val app = MarathonTestHelper.makeBasicApp().copy(
       container = Some(Container(
@@ -132,6 +117,107 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
     app.portAssignments(task).value should be(empty)
   }
 
+  test("portAssignments with IP-per-task using Docker USER networking and a port mapping NOT requesting a host port") {
+    Given("An app using IP-per-task, USER networking and with a port mapping requesting no ports")
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withIpAddress(IpAddress.empty)
+      .withDockerNetwork(Protos.ContainerInfo.DockerInfo.Network.USER)
+      .withPortMapings(Seq(
+        Docker.PortMapping(containerPort = 80, hostPort = None, servicePort = 0, protocol = "tcp", name = Some("http"))
+      ))
+
+    Given("A task with an IP and without a host port")
+    val task = MarathonTestHelper.mininimalTask(app.id)
+      .withHostPorts(Seq.empty)
+      .withNetworkInfos(
+        Seq(MarathonTestHelper.networkInfoWithIPAddress(MarathonTestHelper.mesosIpAddress("192.168.0.1")))
+      )
+
+    Then("The right port assignment is returned")
+    val portAssignments = app.portAssignments(task)
+    portAssignments should be(Some(Seq(
+      PortAssignment(portName = Some("http"), effectiveIpAddress = "192.168.0.1", effectivePort = 80)
+    )))
+  }
+
+  test("portAssignments with IP-per-task Docker USER networking and a port mapping requesting a host port") {
+    Given("An app using IP-per-task, USER networking and with a port mapping requesting one host port")
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withIpAddress(IpAddress.empty)
+      .withDockerNetwork(Protos.ContainerInfo.DockerInfo.Network.USER)
+      .withPortMapings(Seq(
+        Docker.PortMapping(containerPort = 80, hostPort = Some(0), servicePort = 0, protocol = "tcp",
+          name = Some("http"))
+      ))
+
+    Given("A task with IP-per-task and a host port")
+    val task = MarathonTestHelper.mininimalTask(app.id)
+      .withHostPorts(Seq(30000))
+      .withNetworkInfos(
+        Seq(MarathonTestHelper.networkInfoWithIPAddress(MarathonTestHelper.mesosIpAddress("192.168.0.1")))
+      )
+
+    Then("The right port assignment is returned")
+    val portAssignments = app.portAssignments(task)
+    portAssignments should be(Some(Seq(
+      PortAssignment(portName = Some("http"), effectiveIpAddress = "192.168.0.1", effectivePort = 80)
+    )))
+  }
+
+  test("portAssignments with IP-per-task Docker, USER networking, and a mix of port mappings") {
+    Given("An app using IP-per-task, USER networking and a mix of port mappings")
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withIpAddress(IpAddress.empty)
+      .withDockerNetwork(Protos.ContainerInfo.DockerInfo.Network.USER)
+      .withPortMapings(Seq(
+        Docker.PortMapping(containerPort = 80, hostPort = None, servicePort = 0, protocol = "tcp", name = Some("http")),
+        Docker.PortMapping(containerPort = 443, hostPort = Some(0), servicePort = 0, protocol = "tcp",
+          name = Some("https"))
+      ))
+
+    Given("A task with IP-per-task and a host port")
+    val task = MarathonTestHelper.mininimalTask(app.id)
+      .withHostPorts(Seq(30000))
+      .withNetworkInfos(
+        Seq(MarathonTestHelper.networkInfoWithIPAddress(MarathonTestHelper.mesosIpAddress("192.168.0.1")))
+      )
+
+    Then("The right port assignment is returned")
+    val portAssignments = app.portAssignments(task)
+    portAssignments should be(Some(Seq(
+      PortAssignment(portName = Some("http"), effectiveIpAddress = "192.168.0.1", effectivePort = 80),
+      PortAssignment(portName = Some("https"), effectiveIpAddress = "192.168.0.1", effectivePort = 443)
+    )))
+  }
+
+  test("portAssignments without IP-per-task, with Docker USER networking and a mix of port mappings") {
+    Given("An app not using IP-per-task, with Docker USER networking and a mix of port mappings")
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withDockerNetwork(Protos.ContainerInfo.DockerInfo.Network.USER)
+      .withPortMapings(Seq(
+        Docker.PortMapping(containerPort = 80, hostPort = None, servicePort = 0, protocol = "tcp",
+          name = Some("http")),
+        Docker.PortMapping(containerPort = 443, hostPort = Some(0), servicePort = 0, protocol = "tcp",
+          name = Some("https"))
+      ))
+
+    Given("A task with a host port")
+    val task = MarathonTestHelper.mininimalTask(app.id).withHostPorts(Seq(30000))
+
+    Then("The right port assignment is returned")
+    val portAssignments = app.portAssignments(task)
+    portAssignments should be(Some(Seq(
+      // If there's no IP-per-task and no host port is required, fall back to the container port
+      PortAssignment(portName = Some("http"), effectiveIpAddress = task.agentInfo.host, effectivePort = 80),
+      // If there's no IP-per-task and a host port is required, use that host port
+      PortAssignment(portName = Some("https"), effectiveIpAddress = task.agentInfo.host, effectivePort = 30000)
+    )))
+  }
+
   test("portAssignments with port definitions") {
     Given("An app with port definitions")
     val app = MarathonTestHelper.makeBasicApp()
@@ -142,14 +228,9 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
 
     Then("The right port assignment is returned")
     val portAssignments = app.portAssignments(task)
-    portAssignments should be(
-      Some(
-        Seq(
-          PortAssignment(
-            portName = Some("http"),
-            effectiveIpAddress = task.agentInfo.host,
-            effectivePort = 1)
-        )))
+    portAssignments should be(Some(Seq(
+      PortAssignment(portName = Some("http"), effectiveIpAddress = task.agentInfo.host, effectivePort = 1)
+    )))
   }
 
   test("portAssignments with absolutely no ports") {


### PR DESCRIPTION
- If IP-per-Task is used, then use the task's IP address. If port mappings are
  defined used the container ports, otherwise the discovery ports.
- If IP-per-Task is not used, then use the Mesos Agent IP address. If a host
  port is requested, use it, otherwise use the container port.

cc/ @sargun