### PR TITLE
Fixed a typo in Dockerfile when adding Mesosphere repos.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ COPY . /marathon
 WORKDIR /marathon
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
-    echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee /etc/apt/sources.list.d/mesosphere.list && \
-    echo "deb http://repos.mesosphere.com/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
     apt-get install --no-install-recommends -y --force-yes mesos=1.0.0-1.0.59.rc1.debian81 && \
     apt-get clean && \


### PR DESCRIPTION
It was overwriting the testing repo and so `apt` couldn't find any Mesos RC packages.