### PR TITLE
Pedantic doc fix

### DIFF
--- a/docs/docs/ssl-basic-access-authentication.md
+++ b/docs/docs/ssl-basic-access-authentication.md
@@ -131,7 +131,7 @@ The username cannot contain a colon.*
 $ cd /path/to/marathon
 $ ./bin/start --master zk://localhost:2181/mesos \
                   --zk zk://localhost:2181/marathon \
-        --http_credentials "cptPicard:topSecretPa$$word" \
+        --http_credentials 'cptPicard:topSecretPa$$word' \
        --ssl_keystore_path /path/to/marathon.jks \
    --ssl_keystore_password $MARATHON_JKS_PASSWORD
 ```


### PR DESCRIPTION
Starting marathon with `--http_credentials "cptPicard:topSecretPa$$word"` will replace $$ with the current PID which is likely not the author's intention. Even though it's unlikely users will copy'paste our documentation example 1:1 they should still be correct.
