### PR TITLE
Updated Mesos to 0.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     echo "deb http://repos.mesosphere.io/debian jessie main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=0.26.0-0.2.145.debian81 sbt && \
+    apt-get install --no-install-recommends -y --force-yes mesos=0.26.2-2.0.60.debian81 sbt && \
     apt-get clean && \
     sbt -Dsbt.log.format=false assembly && \
     mv $(find target -name 'marathon-assembly-*.jar' | sort | tail -1) ./ && \


### PR DESCRIPTION
Mesos suffered from a memory leak ([MESOS-5449](https://issues.apache.org/jira/browse/MESOS-5449)) that could affect large clusters and has been
fixed in 0.26.2.