### PR TITLE
Fixed health check status on restart or mesos leader loss

### DIFF
--- a/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/health/HealthCheckManager.scala
@@ -63,4 +63,9 @@ trait HealthCheckManager {
     * Returns the health status of all tasks of the supplied app.
     */
   def statuses(appId: PathId): Future[Map[Task.Id, Seq[Health]]]
+
+  /**
+    * Updated task status on mesos leader lose or marathon restart
+    */
+  def reconcile(taskStatus: TaskStatus): Unit
 }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -8,6 +8,7 @@ import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.event.{ SchedulerDisconnectedEvent, SchedulerRegisteredEvent, SchedulerReregisteredEvent }
+import mesosphere.marathon.health.HealthCheckManager
 import mesosphere.marathon.state.AppRepository
 import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }
 import mesosphere.util.state.{ FrameworkIdUtil, MesosLeaderInfo, MutableMesosLeaderInfo }
@@ -50,7 +51,8 @@ class MarathonSchedulerTest extends MarathonActorSupport with MarathonSpec with 
       config,
       new SchedulerCallbacks {
         override def disconnected(): Unit = {}
-      }
+      },
+      mock[HealthCheckManager]
     ) {
       override protected def suicide(removeFrameworkId: Boolean): Unit = {
         suicideFn(removeFrameworkId)

--- a/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/health/MarathonHealthCheckManagerTest.scala
@@ -80,7 +80,8 @@ class MarathonHealthCheckManagerTest
       eventStream,
       taskTrackerProvider,
       appRepository,
-      config
+      config,
+      mock[TaskRepository]
     )
   }
 


### PR DESCRIPTION
When mesos master is lost or marathon is restarted, task status is shown as "Unknown". It happens because health check status is not handled correctly when health check is in "reconcile" state.

Prepare steps:

1. run zookeeper with default config:

   ```ini
   tickTime=2000
   initLimit=10
   syncLimit=5
   dataDir=/tmp/zookeeper
   ```
   `$ ./bin/zkServer.sh start-foreground`

2. run mesos master and mesos slaves:
   `$ mesos-master.sh --ip=127.0.0.1 --work-dir=/tmp/wd1 --quorum=2 --port=5050 --zk=zk://localhost:2181/mesos`
   `$ mesos-master.sh --ip=127.0.0.1 --work-dir=/tmp/wd2 --quorum=2 --port=5051 --zk=zk://localhost:2181/mesos`
   `$ mesos-master.sh --ip=127.0.0.1 --work-dir=/tmp/wd3 --quorum=2 --port=5052 --zk=zk://localhost:2181/mesos`

3. run mesos agent:
   `$ mesos-agent.sh --master=zk://localhost:2181/mesos --work_dir=/tmp/wda1 --port=5150`

4. run marathon with parameters
   `--master zk://localhost:2181/mesos --zk zk://localhost:2181/marathon`

5. go to http://localhost:8080 and create application with
   * command: `tail -f /dev/null`
   * health check:
      * protocol: `command`
      * command: `true`

After application is created, it's health status will be "healthy"

Steps to reproduce:
* kill mesos master
* restart marathon

In both cases task status becomes "Unknown" instead of "Healthy"

