### PR TITLE
Fixes #4092 Logging with Elasticsearch and Kibana

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -336,3 +336,5 @@ The Web Site flags control the behavior of Marathon's web site, including the us
 * <span class="label label-default">v0.13.0</span> `--[disable_]tracing` (Optional. Default: disabled):
     Enable tracing for all service method calls.
     Log a trace message around the execution of every service method.
+* <span class="label label-default">v1.2.0</span> `--logstash` (Optional. Default: disabled):
+    Report logs over the network in JSON format as defined by the given endpoint in `(udp|tcp|ssl)://<host>:<port>` format.

--- a/project/build.scala
+++ b/project/build.scala
@@ -290,6 +290,7 @@ object Dependencies {
     curatorClient % "compile",
     curatorFramework % "compile",
     java8Compat % "compile",
+    logstash % "compile",
 
     // test
     Test.diffson % "test",
@@ -328,6 +329,7 @@ object Dependency {
     val Graphite = "3.1.2"
     val DataDog = "1.1.5"
     val Logback = "1.1.3"
+    val Logstash = "4.7"
     val WixAccord = "0.5"
     val Curator = "2.10.0"
     val Java8Compat = "0.8.0-RC1"
@@ -371,6 +373,7 @@ object Dependency {
   val marathonApiConsole = "mesosphere.marathon" % "api-console" % V.MarathonApiConsole
   val graphite = "io.dropwizard.metrics" % "metrics-graphite" % V.Graphite
   val datadog = "org.coursera" % "dropwizard-metrics-datadog" % V.DataDog exclude("ch.qos.logback", "logback-classic")
+  val logstash = "net.logstash.logback" % "logstash-logback-encoder" % V.Logstash
   val wixAccord = "com.wix" %% "accord-core" % V.WixAccord
   val curator = "org.apache.curator" % "curator-recipes" % V.Curator
   val curatorClient = "org.apache.curator" % "curator-client" % V.Curator


### PR DESCRIPTION
Added new debug option in command line flags `--logstash`.
User can specify edpoint `<host>[:<port>]` and logs will be formated
with JSON and sent to that endpoint over TCP.