### PR TITLE
Made `dependencyGraph` be only called from the root group.

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -148,6 +148,7 @@ case class Group(
   }
 
   def dependencyGraph: DirectedGraph[AppDefinition, DefaultEdge] = {
+    require(id.isRoot)
     val graph = new DefaultDirectedGraph[AppDefinition, DefaultEdge](classOf[DefaultEdge])
     for (app <- transitiveApps)
       graph.addVertex(app)
@@ -227,7 +228,7 @@ object Group {
       group.id is validPathWithBase(base)
       group.apps is every(AppDefinition.validNestedAppDefinition(group.id.canonicalPath(base)))
       group is noAppsAndGroupsWithSameName
-      (group.id.isRoot is false) or (group.dependencies is noCyclicDependencies(group))
+      group is conditional[Group](_.id.isRoot)(noCyclicDependencies)
       group.groups is every(valid(validNestedGroup(group.id.canonicalPath(base))))
     }
 
@@ -246,10 +247,8 @@ object Group {
       clashingIds.isEmpty
     }
 
-  private def noCyclicDependencies(group: Group): Validator[Set[PathId]] =
-    isTrue("Dependency graph has cyclic dependencies.") { _ =>
-      group.hasNonCyclicDependencies
-    }
+  private def noCyclicDependencies: Validator[Group] =
+    isTrue("Dependency graph has cyclic dependencies.") { _.hasNonCyclicDependencies }
 
   private def validPorts: Validator[Group] = {
     new Validator[Group] {

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -227,14 +227,14 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       upgradeStrategy = UpgradeStrategy(0.5),
       versionInfo = AppDefinition.VersionInfo.forNewConfig(Timestamp(0))
     )
-    val origGroup = Group(PathId("/foo/bar"), Set(app))
+    val origGroup = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app))))
 
     val appNew = app.copy(
       cmd = Some("cmd new"),
       versionInfo = AppDefinition.VersionInfo.forNewConfig(Timestamp(1000))
     )
 
-    val targetGroup = Group(PathId("/foo/bar"), Set(appNew))
+    val targetGroup = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(appNew))))
 
     val plan = DeploymentPlan("foo", origGroup, targetGroup, Nil, Timestamp.now())
 
@@ -312,7 +312,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       upgradeStrategy = UpgradeStrategy(0.5),
       versionInfo = AppDefinition.VersionInfo.forNewConfig(Timestamp(0))
     )
-    val group = Group(PathId("/foo/bar"), Set(app))
+    val group = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app))))
 
     val plan = DeploymentPlan(Group.empty, group)
 
@@ -348,7 +348,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       upgradeStrategy = UpgradeStrategy(0.5),
       versionInfo = AppDefinition.VersionInfo.forNewConfig(Timestamp(0))
     )
-    val group = Group(PathId("/foo/bar"), Set(app))
+    val group = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app))))
 
     val plan = DeploymentPlan(Group.empty, group)
 
@@ -391,7 +391,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
   test("Forced deployment") {
     val app = AppDefinition(id = PathId("app1"), cmd = Some("cmd"), instances = 2, upgradeStrategy = UpgradeStrategy(0.5))
-    val group = Group(PathId("/foo/bar"), Set(app))
+    val group = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app))))
 
     val plan = DeploymentPlan(Group.empty, group)
 
@@ -418,7 +418,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
   test("Cancellation timeout") {
     val app = AppDefinition(id = PathId("app1"), cmd = Some("cmd"), instances = 2, upgradeStrategy = UpgradeStrategy(0.5))
-    val group = Group(PathId("/foo/bar"), Set(app))
+    val group = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app))))
 
     val plan = DeploymentPlan(Group.empty, group)
 

--- a/src/test/scala/mesosphere/marathon/state/GroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupTest.scala
@@ -386,14 +386,15 @@ class GroupTest extends FunSpec with GivenWhenThen with Matchers {
 
     it("detects a cyclic dependency graph") {
       Given("a group with cyclic dependencies")
-      val current: Group = Group("/test".toPath, groups = Set(
-        Group("/test/database".toPath, groups = Set(
-          Group("/test/database/mongo".toPath, Set(AppDefinition("/test/database/mongo/m1".toPath, dependencies = Set("/test/service".toPath))))
-        )),
-        Group("/test/service".toPath, groups = Set(
-          Group("/test/service/service1".toPath, Set(AppDefinition("/test/service/service1/srv1".toPath, dependencies = Set("/test/database".toPath))))
-        ))
-      ))
+      val current: Group = Group.empty.copy(groups = Set(
+        Group("/test".toPath, groups = Set(
+          Group("/test/database".toPath, groups = Set(
+            Group("/test/database/mongo".toPath, Set(AppDefinition("/test/database/mongo/m1".toPath, dependencies = Set("/test/service".toPath))))
+          )),
+          Group("/test/service".toPath, groups = Set(
+            Group("/test/service/service1".toPath, Set(AppDefinition("/test/service/service1/srv1".toPath, dependencies = Set("/test/database".toPath))))
+          ))
+        ))))
 
       Then("the cycle is detected")
       current.hasNonCyclicDependencies should equal(false)

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -41,13 +41,13 @@ class DeploymentActorTest
     val app2 = AppDefinition(id = PathId("/app2"), cmd = Some("cmd"), instances = 1)
     val app3 = AppDefinition(id = PathId("/app3"), cmd = Some("cmd"), instances = 1)
     val app4 = AppDefinition(id = PathId("/app4"), cmd = Some("cmd"))
-    val origGroup = Group(PathId("/foo/bar"), Set(app1, app2, app4))
+    val origGroup = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app1, app2, app4))))
 
     val version2 = AppDefinition.VersionInfo.forNewConfig(Timestamp(1000))
     val app1New = app1.copy(instances = 1, versionInfo = version2)
     val app2New = app2.copy(instances = 2, cmd = Some("otherCmd"), versionInfo = version2)
 
-    val targetGroup = Group(PathId("/foo/bar"), Set(app1New, app2New, app3))
+    val targetGroup = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app1New, app2New, app3))))
 
     // setting started at to 0 to make sure this survives
     val task1_1 = MarathonTestHelper.runningTask("task1_1", appVersion = app1.version, startedAt = 0)
@@ -117,12 +117,12 @@ class DeploymentActorTest
     val managerProbe = TestProbe()
     val receiverProbe = TestProbe()
     val app = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 2)
-    val origGroup = Group(PathId("/foo/bar"), Set(app))
+    val origGroup = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app))))
 
     val version2 = AppDefinition.VersionInfo.forNewConfig(Timestamp(1000))
     val appNew = app.copy(cmd = Some("cmd new"), versionInfo = version2)
 
-    val targetGroup = Group(PathId("/foo/bar"), Set(appNew))
+    val targetGroup = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(appNew))))
 
     val task1_1 = MarathonTestHelper.runningTask("task1_1", appVersion = app.version, startedAt = 0)
     val task1_2 = MarathonTestHelper.runningTask("task1_2", appVersion = app.version, startedAt = 1000)
@@ -169,11 +169,11 @@ class DeploymentActorTest
     val receiverProbe = TestProbe()
 
     val app = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 0)
-    val origGroup = Group(PathId("/foo/bar"), Set(app))
+    val origGroup = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app))))
 
     val version2 = AppDefinition.VersionInfo.forNewConfig(Timestamp(1000))
     val appNew = app.copy(cmd = Some("cmd new"), versionInfo = version2)
-    val targetGroup = Group(PathId("/foo/bar"), Set(appNew))
+    val targetGroup = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(appNew))))
 
     val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
@@ -193,12 +193,12 @@ class DeploymentActorTest
     val managerProbe = TestProbe()
     val receiverProbe = TestProbe()
     val app1 = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 3)
-    val origGroup = Group(PathId("/foo/bar"), Set(app1))
+    val origGroup = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app1))))
 
     val version2 = AppDefinition.VersionInfo.forNewConfig(Timestamp(1000))
     val app1New = app1.copy(instances = 2, versionInfo = version2)
 
-    val targetGroup = Group(PathId("/foo/bar"), Set(app1New))
+    val targetGroup = Group(PathId("/"), groups = Set(Group(PathId("/foo/bar"), Set(app1New))))
 
     val task1_1 = MarathonTestHelper.runningTask("task1_1", appVersion = app1.version, startedAt = 0)
     val task1_2 = MarathonTestHelper.runningTask("task1_2", appVersion = app1.version, startedAt = 500)


### PR DESCRIPTION
There are a couple of goals met with this PR.

(1) As of today, `Group.dependencyGraph` is computed 2600 times when I deploy 50 independent apps all under the root group. This patch makes `Group.dependencyGraph` as a `lazy val`, which reduces this to 100 invocations.

(2) In order for us to store a __single__ dependency graph that we update as things change, we need to ensure that `Group.dependencyGraph` is only ever called on the root group.

(3) This patch makes (2) become true, by fixing the following validation check:
```
(group.id.isRoot is false) or (group.dependencies is noCyclicDependencies(group))
```
Because the `or` is not a `||`, the expression on the right is always evaluated as we recurse down the `Group` tree. This causes the dependency graph of all group subtrees to be computed. This didn't help with my benchmark since I was deploying independent apps all under the root group, but it's critical invariant for us to achieve in order to get to (2).