### PR TITLE
GracefulTaskKillIntegrationTest should not be flaky

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
@@ -19,8 +19,9 @@ class GracefulTaskKillIntegrationTest
 
   // this command simulates a 'long terminating' application
   // note: Integration test does not interpret symbolic names (SIGTERM=15), therefore signal 15 is used.
-  val appCommand: String = "trap \"sleep 20\" 15 && sleep 100000"
-  val taskKillGracePeriod = 6.seconds
+  val taskKillGraceDuration = 4
+  val taskKillGracePeriod = taskKillGraceDuration.seconds
+  val appCommand: String = s"""trap \"sleep ${taskKillGraceDuration + 1}\" 15 && sleep 100000"""
 
   test("create a 'long terminating' app with custom taskKillGracePeriod duration") {
     Given("a new 'long terminating' app with taskKillGracePeriod set to 10 seconds")


### PR DESCRIPTION
According to https://github.com/mesosphere/marathon/issues/4109 GracefulTaskKillIntegrationTest looks like to be flaky, therefore I reduced the waiting duration and connected appCommand with timeout.