### PR TITLE
cherry-pick 4131 into dcos 1.7x stream

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderToUnifiedMesosVolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderToUnifiedMesosVolumeTest.scala
@@ -60,7 +60,7 @@ class DVDIProviderVolumeToUnifiedMesosVolumeTest extends MarathonSpec with Match
   for ((testParams, idx) <- testParameters.zipWithIndex) {
     test(s"toUnifiedMesosVolume $idx") {
       assertResult(testParams.wantsVol, "generated volume doesn't match expectations") {
-        DVDIProvider.Builders.toUnifiedMesosVolume(testParams.externalVolume)
+        DVDIProvider.Builders.toUnifiedContainerVolume(testParams.externalVolume)
       }
     }
   }

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -307,7 +307,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     assert(portsResource.getRole == "marathon")
   }
 
-  test("build creates task for DOCKER container using named, external [DockerVolume] volumes") {
+  test("build creates task for DOCKER container using relative hostPath") {
     val offer = MarathonTestHelper.makeBasicOffer(
       cpus = 2.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000
     ).build
@@ -325,7 +325,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
           docker = Some(Docker()), // must have this to force docker container serialization
           `type` = MesosProtos.ContainerInfo.Type.DOCKER,
           volumes = Seq[Volume](
-            DockerVolume("/container/path", "namedFoo", MesosProtos.Volume.Mode.RW)
+            DockerVolume("/container/path", "relativeDirName", MesosProtos.Volume.Mode.RW)
           )
         ))
       )
@@ -336,22 +336,22 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     assert(resource("cpus") == ScalarResource("cpus", 1)) // sanity, we DID match the offer, right?
 
     // check protobuf construction, should be a ContainerInfo w/ volumes
-    def vol(name: String): Option[MesosProtos.Volume] = {
+    def vol(path: String): Option[MesosProtos.Volume] = {
       if (taskInfo.hasContainer) {
-        taskInfo.getContainer.getVolumesList.asScala.find(_.getHostPath == name)
+        taskInfo.getContainer.getVolumesList.asScala.find(_.getHostPath == path)
       }
       else None
     }
 
     assert(taskInfo.getContainer.getVolumesList.size > 0, "check that container has volumes declared")
     assert(!taskInfo.getContainer.getDocker.hasVolumeDriver, "docker spec should not define a volume driver")
-    assert(vol("namedFoo").isDefined,
-      s"missing expected volume namedFoo, got instead: ${taskInfo.getContainer.getVolumesList}")
+    assert(
+      vol("relativeDirName").isDefined,
+      s"missing expected volume relativeDirName, got instead: ${taskInfo.getContainer.getVolumesList}")
   }
 
-  // TODO(jdef) test both dockerhostvol and persistent extvol in the same docker container
-
-  test("build creates task for DOCKER container using external [DockerVolume] volumes") {
+  test("build creates task for DOCKER container using host-local and external [DockerVolume] volumes") {
+    import mesosphere.marathon.core.externalvolume.impl.providers.DVDIProviderVolumeToUnifiedMesosVolumeTest._
     val offer = MarathonTestHelper.makeBasicOffer(
       cpus = 2.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000
     ).build
@@ -374,11 +374,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
               provider = "dvdi",
               options = Map[String, String]("dvdi/driver" -> "bar")
             ), MesosProtos.Volume.Mode.RW),
-            ExternalVolume("/container/path2", ExternalVolumeInfo(
-              name = "namedEdc",
-              provider = "dvdi",
-              options = Map[String, String]("dvdi/driver" -> "ert")
-            ), MesosProtos.Volume.Mode.RO)
+            DockerVolume("/container/path", "relativeDirName", MesosProtos.Volume.Mode.RW)
           )
         ))
       )
@@ -396,13 +392,90 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
       else None
     }
 
-    assert(taskInfo.getContainer.getVolumesList.size > 0, "check that container has volumes declared")
-    assert(taskInfo.getContainer.getDocker.hasVolumeDriver, "docker spec should define a volume driver")
-    assert(taskInfo.getContainer.getDocker.getVolumeDriver == "ert", "docker spec should choose ert driver")
-    assert(vol("namedFoo").isDefined,
-      s"missing expected volume namedFoo, got instead: ${taskInfo.getContainer.getVolumesList}")
-    assert(vol("namedEdc").isDefined,
-      s"missing expected volume namedFoo, got instead: ${taskInfo.getContainer.getVolumesList}")
+    assert(taskInfo.getContainer.getVolumesList.size == 2, "check that container has volumes declared")
+    assert(!taskInfo.getContainer.getDocker.hasVolumeDriver, "docker spec should not define a volume driver")
+
+    assert(
+      taskInfo.getContainer.getVolumesList.size == 2,
+      s"check that container has 2 volumes declared, got instead ${taskInfo.getExecutor.getContainer.getVolumesList}")
+
+    val vol1 = volumeWith(
+      containerPath("/container/path"),
+      mode(MesosProtos.Volume.Mode.RW),
+      volumeRef("bar", "namedFoo")
+    )
+
+    val got1 = taskInfo.getContainer.getVolumes(0)
+    assert(vol1.equals(got1), s"expected volume $vol1, got instead: $got1")
+
+    assert(
+      vol("relativeDirName").isDefined,
+      s"missing expected volume relativeDirName, got instead: ${taskInfo.getContainer.getVolumesList}")
+  }
+
+  test("build creates task for DOCKER container using external [DockerVolume] volumes") {
+    import mesosphere.marathon.core.externalvolume.impl.providers.DVDIProviderVolumeToUnifiedMesosVolumeTest._
+    val offer = MarathonTestHelper.makeBasicOffer(
+      cpus = 2.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000
+    ).build
+
+    val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
+      offer,
+      AppDefinition(
+        id = "/product/frontend".toPath,
+        cmd = Some("foo"),
+        cpus = 1.0,
+        mem = 32.0,
+        executor = "//cmd",
+        portDefinitions = Nil,
+        container = Some(Container(
+          `type` = MesosProtos.ContainerInfo.Type.DOCKER,
+          docker = Some(Docker()), // must have this to force docker container serialization
+          volumes = Seq[Volume](
+            ExternalVolume("/container/path", ExternalVolumeInfo(
+              name = "namedFoo",
+              provider = "dvdi",
+              options = Map[String, String]("dvdi/driver" -> "bar")
+            ), MesosProtos.Volume.Mode.RW),
+            ExternalVolume("/container/path2", ExternalVolumeInfo(
+              name = "namedEdc",
+              provider = "dvdi",
+              options = Map[String, String]("dvdi/driver" -> "ert", "dvdi/boo" -> "baa")
+            ), MesosProtos.Volume.Mode.RO)
+          )
+        ))
+      )
+    )
+
+    val Some((taskInfo, _)) = task
+    def resource(name: String): Resource = taskInfo.getResourcesList.asScala.find(_.getName == name).get
+    assert(resource("cpus") == ScalarResource("cpus", 1)) // sanity, we DID match the offer, right?
+
+    assert(taskInfo.getContainer.getVolumesList.size == 2, "check that container has volumes declared")
+    assert(!taskInfo.getContainer.getDocker.hasVolumeDriver, "docker spec should not define a volume driver")
+
+    // check protobuf construction, should be a ContainerInfo w/ no volumes, w/ envvar
+    assert(
+      taskInfo.getContainer.getVolumesList.size == 2,
+      s"check that container has 2 volumes declared, got instead ${taskInfo.getExecutor.getContainer.getVolumesList}")
+
+    val vol1 = volumeWith(
+      containerPath("/container/path"),
+      mode(MesosProtos.Volume.Mode.RW),
+      volumeRef("bar", "namedFoo")
+    )
+
+    val got1 = taskInfo.getContainer.getVolumes(0)
+    assert(vol1.equals(got1), s"expected volume $vol1, got instead: $got1")
+
+    val vol2 = volumeWith(
+      containerPath("/container/path2"),
+      mode(MesosProtos.Volume.Mode.RO),
+      volumeRef("ert", "namedEdc"),
+      options(Map("boo" -> "baa"))
+    )
+    val got2 = taskInfo.getContainer.getVolumes(1)
+    assert(vol2.equals(got2), s"expected volume $vol2, got instead: $got2")
   }
 
   test("build creates task for MESOS container using named, external [ExternalVolume] volumes") {
@@ -442,18 +515,6 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     val Some((taskInfo, _)) = task
     def resource(name: String): Resource = taskInfo.getResourcesList.asScala.find(_.getName == name).get
     assert(resource("cpus") == ScalarResource("cpus", 1)) // sanity, we DID match the offer, right?
-
-    def hasEnv(name: String, value: String): Boolean =
-      taskInfo.getExecutor.getCommand.hasEnvironment &&
-        taskInfo.getExecutor.getCommand.getEnvironment.getVariablesList.asScala.find{ ev =>
-          ev.getName == name && ev.getValue == value
-        }.isDefined
-
-    def missingEnv(name: String): Boolean =
-      taskInfo.getExecutor.getCommand.hasEnvironment &&
-        taskInfo.getExecutor.getCommand.getEnvironment.getVariablesList.asScala.find{ ev =>
-          ev.getName == name
-        }.isEmpty
 
     taskInfo.hasContainer should be (false)
     taskInfo.hasCommand should be (false)


### PR DESCRIPTION
generate external vol protos using the unified container protobufs for apps using docker engine

Conflicts:
	src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
	src/test/scala/mesosphere/mesos/TaskBuilderTest.scala