### PR TITLE
allow 100% minimum health capacity setting for resident tasks (#4138)

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/UpgradeStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/state/UpgradeStrategy.scala
@@ -27,7 +27,7 @@ object UpgradeStrategy {
   }
 
   lazy val validForResidentTasks: Validator[UpgradeStrategy] = validator[UpgradeStrategy] { strategy =>
-    strategy.minimumHealthCapacity should be <= 0.5
+    strategy.minimumHealthCapacity is between(0.0, 1.0)
     strategy.maximumOverCapacity should be == 0.0
   }
 


### PR DESCRIPTION
When push comes to shove, Marathon will allow one instance to be unhealthy vs. having an extra resident task or having a deployment get stuck.

Fixes https://github.com/mesosphere/marathon/issues/3901

Cherry-picking from releases/1.2