### PR TITLE
cherry-pick: stop using deprecated protobufs for ext vols with docker apps (#4131)

### DIFF
--- a/docs/docs/external-volumes.md
+++ b/docs/docs/external-volumes.md
@@ -124,9 +124,10 @@ In the app definition above:
     
     **Important:** Marathon will not launch apps with external volumes if `upgradeStrategy.minimumHealthCapacity` is greater than 0.5, or if `upgradeStrategy.maximumOverCapacity` does not equal 0.
 
+<a name="docker-extvol"></a>
 ### Using a Docker Container
 
-Below is a sample app definition that uses a Docker container and specifies an external volume:
+Below is a sample app definition that uses a Docker container and specifies first an external volume, second a sandbox-relative host-volume:
 
     {
       "id": "/test-docker",
@@ -150,6 +151,11 @@ Below is a sample app definition that uses a Docker container and specifies an e
               "options": { "dvdi/driver": "rexray" }
             },
             "mode": "RW"
+          },
+          {
+            "hostPath": "var-log",
+            "containerPath": "/var/log/myapp",
+            "mode": "RW"
           }
         ]
       },
@@ -172,15 +178,20 @@ The default implicit volume size is 16 GB. If you are using the Mesos containeri
 
 ### Potential Pitfalls
 
+*   If one or more external volumes are declared for a Marathon app, and the Docker image specification includes one or more `VOLUME` entries, Docker may create anonymous external volumes. This is default Docker behavior with respect to volume management when the `--volume-driver` flag is passed to `docker run`. However, anonymous volumes are not automatically deleted and will accumulate over time unless you manually delete them. Follow these steps to prevent Docker from creating anonymous volumes:
+  *  `docker inspect` the app's Docker image before running the app in Marathon and make a note of the `VOLUME` entries in the specification.
+  *   declare non-external, host-volume mounts in your app's container specification for each `VOLUME` entry that should not map to an anonymous external volume.
+  *   specify a relative `hostPath` for a host-volume to instruct Mesos to create the mount in the task's sandbox (`$MESOS_SANDBOX/$hostPath`); see the sandbox-relative host-volume example [above][12].
+
 *   You can only assign one task per volume. Your storage provider might have other limitations.
 
-*   The volumes you create are not automatically cleaned up. If you delete your cluster, you must go to your storage provider and delete the volumes you no longer need. If you're using EBS, find them by searching by the `container.volumes.external.name` that you set in your Marathon app definition. This name corresponds to an EBS volume `Name` tag.
+*   The volumes you create are not automatically cleaned up. If you delete your cluster, you must go to your storage provider and delete the volumes you no longer need. If you're using EBS, find them by searching by the `container.volumes.external.name` that you set in your Marathon app definition. This name corresponds to an EBS volume `Name` tag. Any anonymous volumes that docker has created on your behalf will have been assigned a UUID for their name.
 
 *   Volumes are namespaced by their storage provider. If you're using EBS, volumes created on the same AWS account share a namespace. Choose unique volume names to avoid conflicts.
 
 *   Docker apps with external volumes on DC/OS installations must use Docker 1.8 or later.
 
-*   If you are using Amazon's EBS, it is possible to create clusters in different availability zones (AZs). If you create a cluster with an external volume in one AZ and destroy it, a new cluster may not have access to that external volume because it could be in a different AZ.
+*   If you are using Amazon's EBS, it is possible to create clusters in different availability zones (AZs). If you create a cluster with an external volume in one AZ and subsequently destroy that cluster, a new cluster may not have access to that external volume because it could be in a different AZ.
 
 *   Launch time might increase for applications that create volumes implicitly. The amount of the increase depends on several factors which include the size and type of the volume. Your storage provider's method of handling volumes can also influence launch time for implicitly created volumes.
 
@@ -197,3 +208,4 @@ The default implicit volume size is 16 GB. If you are using the Mesos containeri
  [9]: https://github.com/emccode/dvdcli#extra-options
  [10]: https://rexray.readthedocs.org/en/v0.3.2/user-guide/schedulers/#docker-containerizer-with-marathon
  [11]: https://github.com/emccode/rexray/blob/master/.docs/user-guide/config.md
+ [12]: #docker-extvol

--- a/project/build.scala
+++ b/project/build.scala
@@ -115,7 +115,7 @@ object MarathonBuild extends Build {
     scalacOptions in Compile ++= Seq(
       "-encoding", "UTF-8",
       "-target:jvm-1.8",
-      "-deprecation:false", // FIXME (gkleiman): reenable deprecation after Mesos 1.0.0-rc2 deprecations are handled
+      "-deprecation",
       "-feature",
       "-unchecked",
       "-Xlog-reflective-calls",
@@ -124,6 +124,9 @@ object MarathonBuild extends Build {
       "-Xfatal-warnings",
       "-Yno-adapted-args",
       "-Ywarn-numeric-widen"
+    ),
+    scalacOptions in Test ++= Seq(
+      "-deprecation:false" // TODO(jdef) remove this once deprecated mesos-1.0 APIs are actually removed
     ),
     javacOptions in Compile ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-Xlint:unchecked", "-Xlint:deprecation"),
     resolvers ++= Seq(

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderToUnifiedMesosVolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderToUnifiedMesosVolumeTest.scala
@@ -60,7 +60,7 @@ class DVDIProviderVolumeToUnifiedMesosVolumeTest extends MarathonSpec with Match
   for ((testParams, idx) <- testParameters.zipWithIndex) {
     test(s"toUnifiedMesosVolume $idx") {
       assertResult(testParams.wantsVol, "generated volume doesn't match expectations") {
-        DVDIProvider.Builders.toUnifiedMesosVolume(testParams.externalVolume)
+        DVDIProvider.Builders.toUnifiedContainerVolume(testParams.externalVolume)
       }
     }
   }

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -277,7 +277,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     assert(portsResource.getRole == "marathon")
   }
 
-  test("build creates task for DOCKER container using named, external [DockerVolume] volumes") {
+  test("build creates task for DOCKER container using relative hostPath") {
     val offer = MarathonTestHelper.makeBasicOffer(
       cpus = 2.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000
     ).build
@@ -295,7 +295,56 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
           docker = Some(Docker()), // must have this to force docker container serialization
           `type` = MesosProtos.ContainerInfo.Type.DOCKER,
           volumes = Seq[Volume](
-            DockerVolume("/container/path", "namedFoo", MesosProtos.Volume.Mode.RW)
+            DockerVolume("/container/path", "relativeDirName", MesosProtos.Volume.Mode.RW)
+          )
+        ))
+      )
+    )
+
+    val Some((taskInfo, _)) = task
+    def resource(name: String): Resource = taskInfo.getResourcesList.asScala.find(_.getName == name).get
+    assert(resource("cpus") == ScalarResource("cpus", 1)) // sanity, we DID match the offer, right?
+
+    // check protobuf construction, should be a ContainerInfo w/ volumes
+    def vol(path: String): Option[MesosProtos.Volume] = {
+      if (taskInfo.hasContainer) {
+        taskInfo.getContainer.getVolumesList.asScala.find(_.getHostPath == path)
+      }
+      else None
+    }
+
+    assert(taskInfo.getContainer.getVolumesList.size > 0, "check that container has volumes declared")
+    assert(!taskInfo.getContainer.getDocker.hasVolumeDriver, "docker spec should not define a volume driver")
+    assert(
+      vol("relativeDirName").isDefined,
+      s"missing expected volume relativeDirName, got instead: ${taskInfo.getContainer.getVolumesList}")
+  }
+
+  test("build creates task for DOCKER container using host-local and external [DockerVolume] volumes") {
+    import mesosphere.marathon.core.externalvolume.impl.providers.DVDIProviderVolumeToUnifiedMesosVolumeTest._
+    val offer = MarathonTestHelper.makeBasicOffer(
+      cpus = 2.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000
+    ).build
+
+    val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
+      offer,
+      AppDefinition(
+        id = "/product/frontend".toPath,
+        cmd = Some("foo"),
+        cpus = 1.0,
+        mem = 32.0,
+        executor = "//cmd",
+        portDefinitions = Nil,
+        container = Some(Container(
+          `type` = MesosProtos.ContainerInfo.Type.DOCKER,
+          docker = Some(Docker()), // must have this to force docker container serialization
+          volumes = Seq[Volume](
+            ExternalVolume("/container/path", ExternalVolumeInfo(
+              name = "namedFoo",
+              provider = "dvdi",
+              options = Map[String, String]("dvdi/driver" -> "bar")
+            ), MesosProtos.Volume.Mode.RW),
+            DockerVolume("/container/path", "relativeDirName", MesosProtos.Volume.Mode.RW)
           )
         ))
       )
@@ -313,15 +362,29 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
       else None
     }
 
-    assert(taskInfo.getContainer.getVolumesList.size > 0, "check that container has volumes declared")
+    assert(taskInfo.getContainer.getVolumesList.size == 2, "check that container has volumes declared")
     assert(!taskInfo.getContainer.getDocker.hasVolumeDriver, "docker spec should not define a volume driver")
-    assert(vol("namedFoo").isDefined,
-      s"missing expected volume namedFoo, got instead: ${taskInfo.getContainer.getVolumesList}")
+
+    assert(
+      taskInfo.getContainer.getVolumesList.size == 2,
+      s"check that container has 2 volumes declared, got instead ${taskInfo.getExecutor.getContainer.getVolumesList}")
+
+    val vol1 = volumeWith(
+      containerPath("/container/path"),
+      mode(MesosProtos.Volume.Mode.RW),
+      volumeRef("bar", "namedFoo")
+    )
+
+    val got1 = taskInfo.getContainer.getVolumes(0)
+    assert(vol1.equals(got1), s"expected volume $vol1, got instead: $got1")
+
+    assert(
+      vol("relativeDirName").isDefined,
+      s"missing expected volume relativeDirName, got instead: ${taskInfo.getContainer.getVolumesList}")
   }
 
-  // TODO(jdef) test both dockerhostvol and persistent extvol in the same docker container
-
   test("build creates task for DOCKER container using external [DockerVolume] volumes") {
+    import mesosphere.marathon.core.externalvolume.impl.providers.DVDIProviderVolumeToUnifiedMesosVolumeTest._
     val offer = MarathonTestHelper.makeBasicOffer(
       cpus = 2.0, mem = 128.0, disk = 2000.0, beginPort = 31000, endPort = 32000
     ).build
@@ -347,7 +410,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
             ExternalVolume("/container/path2", ExternalVolumeInfo(
               name = "namedEdc",
               provider = "dvdi",
-              options = Map[String, String]("dvdi/driver" -> "ert")
+              options = Map[String, String]("dvdi/driver" -> "ert", "dvdi/boo" -> "baa")
             ), MesosProtos.Volume.Mode.RO)
           )
         ))
@@ -358,21 +421,31 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     def resource(name: String): Resource = taskInfo.getResourcesList.asScala.find(_.getName == name).get
     assert(resource("cpus") == ScalarResource("cpus", 1)) // sanity, we DID match the offer, right?
 
-    // check protobuf construction, should be a ContainerInfo w/ volumes
-    def vol(name: String): Option[MesosProtos.Volume] = {
-      if (taskInfo.hasContainer) {
-        taskInfo.getContainer.getVolumesList.asScala.find(_.getHostPath == name)
-      }
-      else None
-    }
+    assert(taskInfo.getContainer.getVolumesList.size == 2, "check that container has volumes declared")
+    assert(!taskInfo.getContainer.getDocker.hasVolumeDriver, "docker spec should not define a volume driver")
 
-    assert(taskInfo.getContainer.getVolumesList.size > 0, "check that container has volumes declared")
-    assert(taskInfo.getContainer.getDocker.hasVolumeDriver, "docker spec should define a volume driver")
-    assert(taskInfo.getContainer.getDocker.getVolumeDriver == "ert", "docker spec should choose ert driver")
-    assert(vol("namedFoo").isDefined,
-      s"missing expected volume namedFoo, got instead: ${taskInfo.getContainer.getVolumesList}")
-    assert(vol("namedEdc").isDefined,
-      s"missing expected volume namedFoo, got instead: ${taskInfo.getContainer.getVolumesList}")
+    // check protobuf construction, should be a ContainerInfo w/ no volumes, w/ envvar
+    assert(
+      taskInfo.getContainer.getVolumesList.size == 2,
+      s"check that container has 2 volumes declared, got instead ${taskInfo.getExecutor.getContainer.getVolumesList}")
+
+    val vol1 = volumeWith(
+      containerPath("/container/path"),
+      mode(MesosProtos.Volume.Mode.RW),
+      volumeRef("bar", "namedFoo")
+    )
+
+    val got1 = taskInfo.getContainer.getVolumes(0)
+    assert(vol1.equals(got1), s"expected volume $vol1, got instead: $got1")
+
+    val vol2 = volumeWith(
+      containerPath("/container/path2"),
+      mode(MesosProtos.Volume.Mode.RO),
+      volumeRef("ert", "namedEdc"),
+      options(Map("boo" -> "baa"))
+    )
+    val got2 = taskInfo.getContainer.getVolumes(1)
+    assert(vol2.equals(got2), s"expected volume $vol2, got instead: $got2")
   }
 
   test("build creates task for MESOS container using named, external [ExternalVolume] volumes") {
@@ -412,18 +485,6 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     val Some((taskInfo, _)) = task
     def resource(name: String): Resource = taskInfo.getResourcesList.asScala.find(_.getName == name).get
     assert(resource("cpus") == ScalarResource("cpus", 1)) // sanity, we DID match the offer, right?
-
-    def hasEnv(name: String, value: String): Boolean =
-      taskInfo.getExecutor.getCommand.hasEnvironment &&
-        taskInfo.getExecutor.getCommand.getEnvironment.getVariablesList.asScala.find{ ev =>
-          ev.getName == name && ev.getValue == value
-        }.isDefined
-
-    def missingEnv(name: String): Boolean =
-      taskInfo.getExecutor.getCommand.hasEnvironment &&
-        taskInfo.getExecutor.getCommand.getEnvironment.getVariablesList.asScala.find{ ev =>
-          ev.getName == name
-        }.isEmpty
 
     taskInfo.hasContainer should be (false)
     taskInfo.hasCommand should be (false)


### PR DESCRIPTION
* generate external vol protos using the unified container protobufs for apps using docker engine
* update external volume docs w/ notes re: docker-created anonymous volumes and how to prevent them
* only disable deprecation warnings for Test, re-enable for Compile
* Update external-volumes.md

Conflicts:
	src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
	src/test/scala/mesosphere/mesos/TaskBuilderTest.scala