### PR TITLE
Add missing commas, breaking the marathon/api-console test

### DIFF
--- a/docs/docs/generated/api.html
+++ b/docs/docs/generated/api.html
@@ -932,8 +932,8 @@
     {
       "name": "myReadyCheck",
       "protocol": "HTTP",
-      "path": "/v1/plan"
-      "portName": "http"
+      "path": "/v1/plan",
+      "portName": "http",
       "interval": 10000,
       "timeout": 10000,
       "httpStatusCodesForReady": [ 200 ],
@@ -1063,8 +1063,8 @@
     {
       "name": "myReadyCheck",
       "protocol": "HTTP",
-      "path": "/v1/plan"
-      "portName": "http"
+      "path": "/v1/plan",
+      "portName": "http",
       "interval": 10000,
       "timeout": 10000,
       "httpStatusCodesForReady": [ 200 ],
@@ -1888,8 +1888,8 @@
     {
       "name": "myReadyCheck",
       "protocol": "HTTP",
-      "path": "/v1/plan"
-      "portName": "http"
+      "path": "/v1/plan",
+      "portName": "http",
       "interval": 10000,
       "timeout": 10000,
       "httpStatusCodesForReady": [ 200 ],
@@ -2134,8 +2134,8 @@
     {
       "name": "myReadyCheck",
       "protocol": "HTTP",
-      "path": "/v1/plan"
-      "portName": "http"
+      "path": "/v1/plan",
+      "portName": "http",
       "interval": 10000,
       "timeout": 10000,
       "httpStatusCodesForReady": [ 200 ],


### PR DESCRIPTION
noticed the issue on v2/apps when POSTing

```
{
  "message": "Invalid JSON",
  "details": "Unexpected character ('\"' (code 34)): was expecting comma to separate OBJECT entries"
}
```