### PR TITLE
Fixes #4100 - Use output_file option in FetchUri

### DIFF
--- a/docs/docs/rest-api/public/api/v2/examples/app.json
+++ b/docs/docs/rest-api/public/api/v2/examples/app.json
@@ -123,7 +123,7 @@
   },
   "fetch": [
     { "uri": "https://foo.com/setup.py" },
-    { "uri": "https://foo.com/archive.zip", "executable": false, "extract": true, "cache": true }
+    { "uri": "https://foo.com/archive.zip", "executable": false, "extract": true, "cache": true, "outputFile": "newname.zip" }
   ],
   "user": "root",
   "secrets": {

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -300,6 +300,10 @@
           "cache": {
             "type": "boolean",
             "description": "Cache fetched artifact if supported by Mesos fetcher module"
+          },
+          "outputFile": {
+            "type": "string",
+            "description": "Rename fetched artifact with the given name"
           }
         },
         "required": [ "uri" ]

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -563,8 +563,9 @@ trait FetchUriFormats {
       (__ \ "uri").format[String] ~
       (__ \ "extract").formatNullable[Boolean].withDefault(true) ~
       (__ \ "executable").formatNullable[Boolean].withDefault(false) ~
-      (__ \ "cache").formatNullable[Boolean].withDefault(false)
-    )(FetchUri(_, _, _, _), unlift(FetchUri.unapply))
+      (__ \ "cache").formatNullable[Boolean].withDefault(false) ~
+      (__ \ "outputFile").formatNullable[String]
+    )(FetchUri(_, _, _, _, _), unlift(FetchUri.unapply))
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/state/FetchUri.scala
+++ b/src/main/scala/mesosphere/marathon/state/FetchUri.scala
@@ -10,15 +10,18 @@ case class FetchUri(
     uri: String,
     extract: Boolean = true,
     executable: Boolean = false,
-    cache: Boolean = false) {
+    cache: Boolean = false,
+    outputFile: Option[String] = None) {
 
-  def toProto(): mesos.CommandInfo.URI =
-    mesos.CommandInfo.URI.newBuilder()
+  def toProto(): mesos.CommandInfo.URI = {
+    val builder = mesos.CommandInfo.URI.newBuilder()
       .setValue(uri)
       .setExecutable(executable)
       .setExtract(extract)
       .setCache(cache)
-      .build()
+    outputFile.foreach{ name => builder.setOutputFile(name) }
+    builder.build()
+  }
 }
 
 object FetchUri {
@@ -30,7 +33,8 @@ object FetchUri {
       uri = uri.getValue,
       executable = uri.getExecutable,
       extract = uri.getExtract,
-      cache = uri.getCache
+      cache = uri.getCache,
+      outputFile = if (uri.hasOutputFile) Some(uri.getOutputFile) else None
     )
 
   def isExtract(uri: String): Boolean = {

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -607,8 +607,10 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       id = "app-with-fetch".toPath,
       cmd = Some("brew update"),
       fetch = Seq(
-        new FetchUri(uri = "http://example.com/file1", executable = false, extract = true, cache = true),
-        new FetchUri(uri = "http://example.com/file2", executable = true, extract = false, cache = false)
+        new FetchUri(uri = "http://example.com/file1", executable = false, extract = true, cache = true,
+          outputFile = None),
+        new FetchUri(uri = "http://example.com/file2", executable = true, extract = false, cache = false,
+          outputFile = None)
       )
     )
 
@@ -662,8 +664,10 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       id = "app-with-fetch".toPath,
       cmd = Some("brew update"),
       fetch = Seq(
-        new FetchUri(uri = "http://example.com/file1", executable = false, extract = true, cache = true),
-        new FetchUri(uri = "http://example.com/file2", executable = true, extract = false, cache = false)
+        new FetchUri(uri = "http://example.com/file1", executable = false, extract = true, cache = true,
+          outputFile = None),
+        new FetchUri(uri = "http://example.com/file2", executable = true, extract = false, cache = false,
+          outputFile = None)
       )
     )
 


### PR DESCRIPTION
mesos.proto defines URI message type with output_file option.
Make FetchUri use this option in order to be able to define the name of
 files we want to add to the mesos task.