### PR TITLE
Moved unique port validation from Group to DeploymentPlan

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -13,7 +13,6 @@ import org.jgrapht.alg.CycleDetector
 import org.jgrapht.graph._
 
 import scala.collection.JavaConversions._
-import scala.collection.mutable
 
 case class Group(
     id: PathId,
@@ -237,7 +236,6 @@ object Group {
     // We do not want a "/value" prefix, therefore we do not create nested validators with validator[Group]
     // but chain the validators directly.
     doesNotExceedMaxApps and
-      validPorts and
       validNestedGroup(PathId.empty) and
       ExternalVolumes.validRootGroup()
   }
@@ -252,53 +250,4 @@ object Group {
   private def noCyclicDependencies: Validator[Group] =
     isTrue("Dependency graph has cyclic dependencies.") { _.hasNonCyclicDependencies }
 
-  private def validPorts: Validator[Group] = {
-    new Validator[Group] {
-      override def apply(group: Group): Result = {
-        // Each service port should be unique across a cluster. We
-        // want to report conflicts if the same service port is used
-        // by multiple apps.
-        // We construct the mapping servicePort <- Set[AppKey]. This
-        // allows us to report any service port that has more than 1
-        // application using the same port.
-
-        // We keep track of the total number of ports to support an
-        // early exit condition.
-        var ports: Int = 0
-        var merged =
-          new mutable.HashMap[Int, mutable.Set[AppDefinition.AppKey]] with mutable.MultiMap[Int, AppDefinition.AppKey]
-
-        // Add each servicePort <- Application to the map.
-        for {
-          app <- group.transitiveApps
-          // We ignore randomly assigned ports identified by `0`.
-          port <- app.servicePorts if port != 0
-        } {
-          ports += 1
-          merged.addBinding(port, app.id)
-        }
-
-        // If the total number of unique ports is equal to the number
-        // of requested ports then we know there are no conflicts.
-        if (merged.size == ports) {
-          Success
-        } else {
-          // Otherwise we find all ports that have more than 1 app
-          // interested in them.
-
-          // We report all the conflicting apps along with which other
-          // apps they conflict with.
-          val violations = for {
-            (port, apps) <- merged if apps.size > 1
-            app <- apps
-          } yield RuleViolation(
-            app,
-            s"Requested service port $port is used by more than 1 app: ${apps.mkString(", ")}",
-            None)
-
-          Failure(violations.toSet)
-        }
-      }
-    }
-  }
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlan.scala
@@ -13,7 +13,7 @@ import mesosphere.util.state.zk.{ CompressionConf, ZKData }
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
-import scala.collection.SortedMap
+import scala.collection.{ SortedMap, mutable }
 import scala.collection.immutable.Seq
 
 sealed trait DeploymentAction {
@@ -321,7 +321,65 @@ object DeploymentPlan {
 
     validator[DeploymentPlan] { plan =>
       plan.createdOrUpdatedApps as "app" is every(valid(AppDefinition.updateIsValid(plan.original)))
-      plan should notBeTooBig
+      plan should notBeTooBig and haveValidPorts
+    }
+  }
+
+  private def haveValidPorts: Validator[DeploymentPlan] = {
+    new Validator[DeploymentPlan] {
+      override def apply(plan: DeploymentPlan): Result = {
+        // Each service port should be unique across a cluster. We
+        // want to report conflicts if the same service port is used
+        // by multiple apps.
+
+        // This validation rule is only applied for newly created or
+        // updated applications (within this deployment plan),
+        // not for all applications.
+
+        // We construct the mapping servicePort <- Set[AppKey]. This
+        // allows us to report any service port that has more than 1
+        // application using the same port.
+
+        // We keep track of the total number of ports to support an
+        // early exit condition.
+
+        val createdOrUpdatedApps = plan.createdOrUpdatedApps.map(app => app.id).toSet
+        var ports: Int = 0
+        val merged =
+          new mutable.HashMap[Int, mutable.Set[AppDefinition.AppKey]] with mutable.MultiMap[Int, AppDefinition.AppKey]
+
+        // Add each servicePort <- Application to the map.
+        for {
+          app <- plan.target.transitiveApps
+          // We ignore randomly assigned ports identified by `0`.
+          port <- app.servicePorts if port != 0
+        } {
+          ports += 1
+          merged.addBinding(port, app.id)
+        }
+
+        // If the total number of unique ports is equal to the number
+        // of requested ports then we know there are no conflicts.
+        if (merged.size == ports) {
+          Success
+        } else {
+          // Otherwise we find all ports that have more than 1 app
+          // interested in them.
+
+          // We report all the conflicting apps along with which other
+          // apps they conflict with.
+          val violations = for {
+            // only yield port as conflict if createdOrUpdatedApps are involved and therefore in the intersection set
+            (port, apps) <- merged if apps.size > 1 && apps.intersect(createdOrUpdatedApps).nonEmpty
+            app <- apps
+          } yield RuleViolation(
+            app,
+            s"Requested service port $port is used by more than 1 app: ${apps.mkString(", ")}",
+            None)
+
+          Failure(violations.toSet)
+        }
+      }
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlan.scala
@@ -377,7 +377,11 @@ object DeploymentPlan {
             s"Requested service port $port is used by more than 1 app: ${apps.mkString(", ")}",
             None)
 
-          Failure(violations.toSet)
+          if (violations.isEmpty) {
+            Success
+          } else {
+            Failure(violations.toSet)
+          }
         }
       }
     }

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActorTest.scala
@@ -304,7 +304,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     }
   }
 
-  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(2000, Millis)))
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(3000, Millis)))
 
   class Fixture {
     import scala.concurrent.duration._

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActorTest.scala
@@ -304,7 +304,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     }
   }
 
-  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(3000, Millis)))
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(4000, Millis)))
 
   class Fixture {
     import scala.concurrent.duration._

--- a/src/test/scala/mesosphere/marathon/state/GroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupTest.scala
@@ -5,9 +5,6 @@ import mesosphere.marathon.api.v2.ValidationHelper
 import mesosphere.marathon.state.AppDefinition.VersionInfo
 import mesosphere.marathon.state.PathId._
 import org.scalatest.{ FunSpec, GivenWhenThen, Matchers }
-import mesosphere.marathon.MarathonTestHelper
-import mesosphere.marathon.state.Container.Docker.PortMapping
-import org.apache.mesos.Protos
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
@@ -236,27 +233,6 @@ class GroupTest extends FunSpec with GivenWhenThen with Matchers {
       result.isFailure should be(true)
       ValidationHelper.getAllRuleConstrains(result).head
         .message should be ("Groups and Applications may not have the same identifier.")
-    }
-
-    it("validates that there are no service ports conflicts") {
-      import MarathonTestHelper.Implicits._
-
-      Given("a group with duplicated service ports")
-      val appFoo = AppDefinition(id = "/foo/app".toRootPath).withPortMappings(
-        Seq(PortMapping(hostPort = Some(0), containerPort = 0, servicePort = 123))
-      ).withDockerNetwork(Protos.ContainerInfo.DockerInfo.Network.BRIDGE)
-      val groupFoo = Group(id = "/foo".toRootPath, apps = Map(appFoo.id -> appFoo))
-
-      val appBar = appFoo.copy(id = "/bar/app".toRootPath)
-      val groupBar = Group(id = "/bar".toRootPath, apps = Map(appBar.id -> appBar))
-
-      val root = Group.empty.copy(groups = Set(groupFoo, groupBar))
-
-      When("validating the root group")
-      val result = validate(root)(Group.validRootGroup(maxApps = None))
-
-      Then("the validation returns an errror")
-      ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
     }
 
     it("can marshal and unmarshal from to protos") {

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
@@ -449,23 +449,21 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
                                                                              |See: http://zookeeper.apache.org/doc/r3.3.1/zookeeperAdmin.html#Unsafe+Options""".stripMargin)
   }
 
-  test("Deployment plan validates that there are no service ports conflicts") {
+  test("Deployment plan validates that there are no service ports conflicts - one application involved, other not") {
     import MarathonTestHelper.Implicits._
 
     Given("a deployment with duplicated service ports")
     val f = new Fixture()
-    val appFoo = AppDefinition(id = "/foo/app".toRootPath).withPortMappings(
+    val appFoo = AppDefinition(id = "/foo".toRootPath).withPortMappings(
       Seq(PortMapping(hostPort = Some(0), containerPort = 0, servicePort = 123))
     ).withDockerNetwork(mesos.ContainerInfo.DockerInfo.Network.BRIDGE)
-    val groupFoo = Group(id = "/foo".toRootPath, apps = Map(appFoo.id -> appFoo))
 
-    val appBar = appFoo.copy(id = "/bar/app".toRootPath)
-    val groupBar = Group(id = "/bar".toRootPath, apps = Map(appBar.id -> appBar))
+    val appBar = appFoo.copy(id = "/bar".toRootPath)
 
-    val root = Group.empty.copy(groups = Set(groupFoo, groupBar))
+    val group = Group(id = "/foo".toRootPath, apps = Map(appFoo.id -> appFoo, appBar.id -> appBar))
 
     val steps = Seq(DeploymentStep(Seq(StartApplication(appBar, 1))))
-    val deploymentPlan = DeploymentPlan(UUID.randomUUID().toString, root, root, steps, Timestamp.now())
+    val deploymentPlan = DeploymentPlan(UUID.randomUUID().toString, group, group, steps, Timestamp.now())
 
     When("validating the deployment plan")
     val result = validate(deploymentPlan)(f.validator)
@@ -475,22 +473,72 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
   }
 
-  test("Deployment plan validates that there are no service ports conflicts only in created or updated apps") {
+  test("Deployment plan validates that there are no service ports conflicts - no application involved") {
     import MarathonTestHelper.Implicits._
 
     Given("a deployment with duplicated service ports")
     val f = new Fixture()
-    val appFoo = AppDefinition(id = "/foo/app".toRootPath).withPortMappings(
+    val appFoo = AppDefinition(id = "/foo".toRootPath).withPortMappings(
       Seq(PortMapping(hostPort = Some(0), containerPort = 0, servicePort = 123))
     ).withDockerNetwork(mesos.ContainerInfo.DockerInfo.Network.BRIDGE)
-    val groupFoo = Group(id = "/foo".toRootPath, apps = Map(appFoo.id -> appFoo))
 
-    val appBar = appFoo.copy(id = "/bar/app".toRootPath)
-    val groupBar = Group(id = "/bar".toRootPath, apps = Map(appBar.id -> appBar))
+    val appBar = appFoo.copy(id = "/bar".toRootPath)
 
-    val root = Group.empty.copy(groups = Set(groupFoo, groupBar))
+    val group = Group(id = "/foo".toRootPath, apps = Map(appFoo.id -> appFoo, appBar.id -> appBar))
 
-    val deploymentPlan = DeploymentPlan(UUID.randomUUID().toString, root, root, Seq.empty, Timestamp.now())
+    val deploymentPlan = DeploymentPlan(UUID.randomUUID().toString, group, group, Seq.empty, Timestamp.now())
+
+    When("validating the deployment plan")
+    val result = validate(deploymentPlan)(f.validator)
+
+    Then("the validation returns no error, altthough a validation error exists (but not in created or udpated apps)")
+    result should be (Success)
+    ValidationHelper.getAllRuleConstrains(result) should have size 0
+  }
+
+  test("Deployment plan validates that there are no service ports conflicts - both application involved") {
+    import MarathonTestHelper.Implicits._
+
+    Given("a deployment with duplicated service ports")
+    val f = new Fixture()
+    val appFoo = AppDefinition(id = "/foo".toRootPath).withPortMappings(
+      Seq(PortMapping(hostPort = Some(0), containerPort = 0, servicePort = 123))
+    ).withDockerNetwork(mesos.ContainerInfo.DockerInfo.Network.BRIDGE)
+
+    val appBar = appFoo.copy(id = "/bar".toRootPath)
+
+    val group = Group(id = "/foo".toRootPath, apps = Map(appFoo.id -> appFoo, appBar.id -> appBar))
+
+    val steps = Seq(DeploymentStep(Seq(StartApplication(appBar, 1), StartApplication(appFoo, 1))))
+    val deploymentPlan = DeploymentPlan(UUID.randomUUID().toString, group, group, steps, Timestamp.now())
+
+    When("validating the deployment plan")
+    val result = validate(deploymentPlan)(f.validator)
+
+    Then("the validation returns an error")
+    result shouldBe a [Failure]
+    ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
+  }
+
+  test("Deployment plan validates that there are no service ports conflicts - one application involved, two conflicting not") {
+    import MarathonTestHelper.Implicits._
+
+    Given("a deployment with duplicated service ports")
+    val f = new Fixture()
+    val appFoo = AppDefinition(id = "/foo".toRootPath).withPortMappings(
+      Seq(PortMapping(hostPort = Some(0), containerPort = 0, servicePort = 123))
+    ).withDockerNetwork(mesos.ContainerInfo.DockerInfo.Network.BRIDGE)
+
+    val appFoo2 = appFoo.copy(id = "/foo2".toRootPath)
+
+    val appBar = appFoo.copy(id = "/bar".toRootPath).withPortMappings(
+      Seq(PortMapping(hostPort = Some(0), containerPort = 0, servicePort = 124))
+    )
+
+    val group = Group(id = "/foo".toRootPath, apps = Map(appFoo.id -> appFoo, appBar.id -> appBar, appFoo2.id -> appFoo2))
+
+    val steps = Seq(DeploymentStep(Seq(StartApplication(appBar, 1))))
+    val deploymentPlan = DeploymentPlan(UUID.randomUUID().toString, group, group, steps, Timestamp.now())
 
     When("validating the deployment plan")
     val result = validate(deploymentPlan)(f.validator)

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
@@ -471,6 +471,7 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     val result = validate(deploymentPlan)(f.validator)
 
     Then("the validation returns an error")
+    result shouldBe a [Failure]
     ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
   }
 
@@ -495,6 +496,7 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     val result = validate(deploymentPlan)(f.validator)
 
     Then("the validation returns no error, altthough a validation error exists (but not in created or udpated apps)")
+    result should be (Success)
     ValidationHelper.getAllRuleConstrains(result) should have size 0
   }
 

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
@@ -471,9 +471,10 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     Then("the validation returns an error")
     result shouldBe a [Failure]
     ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
+    ValidationHelper.getAllRuleConstrains(result).head.message should include ("/foo, /bar")
   }
 
-  test("Deployment plan validates that there are no service ports conflicts - no application involved") {
+  test("Deployment plan validates that there are no service ports conflicts - no conflicting application involved") {
     import MarathonTestHelper.Implicits._
 
     Given("a deployment with duplicated service ports")
@@ -496,7 +497,7 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     ValidationHelper.getAllRuleConstrains(result) should have size 0
   }
 
-  test("Deployment plan validates that there are no service ports conflicts - both application involved") {
+  test("Deployment plan validates that there are no service ports conflicts - both conflicting applications involved") {
     import MarathonTestHelper.Implicits._
 
     Given("a deployment with duplicated service ports")
@@ -518,9 +519,10 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     Then("the validation returns an error")
     result shouldBe a [Failure]
     ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
+    ValidationHelper.getAllRuleConstrains(result).head.message should include ("/foo, /bar")
   }
 
-  test("Deployment plan validates that there are no service ports conflicts - one application involved, two conflicting not") {
+  test("Deployment plan validates that there are no service ports conflicts - one non conflicting application involved, two conflicting not") {
     import MarathonTestHelper.Implicits._
 
     Given("a deployment with duplicated service ports")
@@ -546,6 +548,33 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     Then("the validation returns no error, altthough a validation error exists (but not in created or udpated apps)")
     result should be (Success)
     ValidationHelper.getAllRuleConstrains(result) should have size 0
+  }
+
+  test("Deployment plan validates that there are no service ports conflicts - one conflicting application involved, two conflicting not") {
+    import MarathonTestHelper.Implicits._
+
+    Given("a deployment with duplicated service ports")
+    val f = new Fixture()
+    val appFoo = AppDefinition(id = "/foo".toRootPath).withPortMappings(
+      Seq(PortMapping(hostPort = Some(0), containerPort = 0, servicePort = 123))
+    ).withDockerNetwork(mesos.ContainerInfo.DockerInfo.Network.BRIDGE)
+
+    val appFoo2 = appFoo.copy(id = "/foo2".toRootPath)
+
+    val appBar = appFoo.copy(id = "/bar".toRootPath)
+
+    val group = Group(id = "/foo".toRootPath, apps = Map(appFoo.id -> appFoo, appBar.id -> appBar, appFoo2.id -> appFoo2))
+
+    val steps = Seq(DeploymentStep(Seq(StartApplication(appBar, 1))))
+    val deploymentPlan = DeploymentPlan(UUID.randomUUID().toString, group, group, steps, Timestamp.now())
+
+    When("validating the deployment plan")
+    val result = validate(deploymentPlan)(f.validator)
+
+    Then("the validation returns no error, altthough a validation error exists (but not in created or udpated apps)")
+    result shouldBe a [Failure]
+    ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
+    ValidationHelper.getAllRuleConstrains(result).head.message should include ("/foo, /foo2, /bar")
   }
 
   class Fixture {

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
@@ -1,5 +1,7 @@
 package mesosphere.marathon.upgrade
 
+import java.util.UUID
+
 import mesosphere.marathon.api.v2.ValidationHelper
 import mesosphere.marathon.state.AppDefinition.VersionInfo
 import mesosphere.marathon.state.AppDefinition.VersionInfo.FullVersionInfo
@@ -10,6 +12,7 @@ import mesosphere.marathon.test.Mockito
 import org.apache.mesos.{ Protos => mesos }
 import org.scalatest.{ GivenWhenThen, Matchers }
 import com.wix.accord._
+import mesosphere.marathon.state.Container.Docker.PortMapping
 
 import scala.collection.immutable.Seq
 
@@ -444,6 +447,55 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
                                                                              |You can adjust this value via --zk_max_node_size, but make sure this value is compatible with
                                                                              |your ZooKeeper ensemble!
                                                                              |See: http://zookeeper.apache.org/doc/r3.3.1/zookeeperAdmin.html#Unsafe+Options""".stripMargin)
+  }
+
+  test("Deployment plan validates that there are no service ports conflicts") {
+    import MarathonTestHelper.Implicits._
+
+    Given("a deployment with duplicated service ports")
+    val f = new Fixture()
+    val appFoo = AppDefinition(id = "/foo/app".toRootPath).withPortMappings(
+      Seq(PortMapping(hostPort = Some(0), containerPort = 0, servicePort = 123))
+    ).withDockerNetwork(mesos.ContainerInfo.DockerInfo.Network.BRIDGE)
+    val groupFoo = Group(id = "/foo".toRootPath, apps = Map(appFoo.id -> appFoo))
+
+    val appBar = appFoo.copy(id = "/bar/app".toRootPath)
+    val groupBar = Group(id = "/bar".toRootPath, apps = Map(appBar.id -> appBar))
+
+    val root = Group.empty.copy(groups = Set(groupFoo, groupBar))
+
+    val steps = Seq(DeploymentStep(Seq(StartApplication(appBar, 1))))
+    val deploymentPlan = DeploymentPlan(UUID.randomUUID().toString, root, root, steps, Timestamp.now())
+
+    When("validating the deployment plan")
+    val result = validate(deploymentPlan)(f.validator)
+
+    Then("the validation returns an error")
+    ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
+  }
+
+  test("Deployment plan validates that there are no service ports conflicts only in created or updated apps") {
+    import MarathonTestHelper.Implicits._
+
+    Given("a deployment with duplicated service ports")
+    val f = new Fixture()
+    val appFoo = AppDefinition(id = "/foo/app".toRootPath).withPortMappings(
+      Seq(PortMapping(hostPort = Some(0), containerPort = 0, servicePort = 123))
+    ).withDockerNetwork(mesos.ContainerInfo.DockerInfo.Network.BRIDGE)
+    val groupFoo = Group(id = "/foo".toRootPath, apps = Map(appFoo.id -> appFoo))
+
+    val appBar = appFoo.copy(id = "/bar/app".toRootPath)
+    val groupBar = Group(id = "/bar".toRootPath, apps = Map(appBar.id -> appBar))
+
+    val root = Group.empty.copy(groups = Set(groupFoo, groupBar))
+
+    val deploymentPlan = DeploymentPlan(UUID.randomUUID().toString, root, root, Seq.empty, Timestamp.now())
+
+    When("validating the deployment plan")
+    val result = validate(deploymentPlan)(f.validator)
+
+    Then("the validation returns no error, altthough a validation error exists (but not in created or udpated apps)")
+    ValidationHelper.getAllRuleConstrains(result) should have size 0
   }
 
   class Fixture {

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
@@ -469,7 +469,7 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     val result = validate(deploymentPlan)(f.validator)
 
     Then("the validation returns an error")
-    result shouldBe a [Failure]
+    result shouldBe a[Failure]
     ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
     ValidationHelper.getAllRuleConstrains(result).head.message should include ("/foo, /bar")
   }
@@ -517,7 +517,7 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     val result = validate(deploymentPlan)(f.validator)
 
     Then("the validation returns an error")
-    result shouldBe a [Failure]
+    result shouldBe a[Failure]
     ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
     ValidationHelper.getAllRuleConstrains(result).head.message should include ("/foo, /bar")
   }
@@ -572,7 +572,7 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     val result = validate(deploymentPlan)(f.validator)
 
     Then("the validation returns no error, altthough a validation error exists (but not in created or udpated apps)")
-    result shouldBe a [Failure]
+    result shouldBe a[Failure]
     ValidationHelper.getAllRuleConstrains(result).head.message should include ("used by more than 1 app")
     ValidationHelper.getAllRuleConstrains(result).head.message should include ("/foo, /foo2, /bar")
   }


### PR DESCRIPTION
Like we discussed today:
Moved unique port validation from Group to DeploymentPlan, like requested in https://github.com/mesosphere/marathon/issues/4167