### PR TITLE
Fix portDefinition <-> Health Check Validation

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
@@ -140,7 +140,7 @@ object DockerSerializer {
       volumes = proto.getVolumesList.asScala.map(Volume(_)).to[Seq],
       image = d.getImage,
       network = if (d.hasNetwork) Some(d.getNetwork) else None,
-      portMappings = Some(pms.map(PortMappingSerializer.fromProto).to[Seq]),
+      portMappings = if (pms.nonEmpty) Some(pms.map(PortMappingSerializer.fromProto).to[Seq]) else None,
       privileged = d.getPrivileged,
       parameters = d.getParametersList.asScala.map(Parameter(_)).to[Seq],
       forcePullImage = if (d.hasForcePullImage) d.getForcePullImage else false

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -994,8 +994,14 @@ trait AppAndGroupFormats {
       if (runSpec.ipAddress.isEmpty) {
         appJson = appJson ++ Json.obj(
           "ports" -> runSpec.servicePorts,
-          "portDefinitions" -> runSpec.portDefinitions.zip(runSpec.servicePorts).map {
-            case (portDefinition, servicePort) => portDefinition.copy(port = servicePort)
+          "portDefinitions" -> {
+            if (runSpec.servicePorts.nonEmpty) {
+              runSpec.portDefinitions.zip(runSpec.servicePorts).map {
+                case (portDefinition, servicePort) => portDefinition.copy(port = servicePort)
+              }
+            } else {
+              runSpec.portDefinitions
+            }
           },
           // requirePorts only makes sense when allocating hostPorts, which you can't do in IP/CT mode
           "requirePorts" -> runSpec.requirePorts

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -917,4 +917,11 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       "ssh" -> EnvVarSecretRef("psst")
     )))
   }
+
+  test("container port mappings when empty stays empty") {
+    val appDef = AppDefinition(container = Some(Docker(portMappings = None)))
+    val roundTripped = AppDefinition.fromProto(appDef.toProto)
+    roundTripped should equal(appDef)
+    roundTripped.container.map(_.portMappings) should equal(appDef.container.map(_.portMappings))
+  }
 }


### PR DESCRIPTION
- Critical line: ContainerSerializer.scala line 143.
  If there are no container ports, this _was_ None
  before we serialized, after serializing and deserializing
  the None becomes the empty sequence which is not treated the same
- Change a bunch of "defs" to "vals". There is absolutely no reason
  these need to be computed twice.
- Fix AppDefinition serialization to properly serialize portDefinitions
  if there are no service ports (this was a red-herring suspected
  of being the core bug)