### PR TITLE
Add killCount and noOp to delete tasks endpoint

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -484,6 +484,18 @@ Kill tasks that belong to the application `appId`.
       <td>If <code>wipe=true</code> is specified and the app uses local persistent volumes, associated dynamic reservations will be unreserved, and persistent volumes will be destroyed. Only possible if <code>scale=false</code> or not specified.
         Default: <code>false</code>.</td>
     </tr>
+    <tr>
+      <td><code>killCount</code></td>
+      <td><code>integer</code></td>
+      <td>The number of tasks to kill. A negative value signifies killing all running tasks.
+        Default: <code>-1</code>.</td>
+    </tr>
+    <tr>
+      <td><code>noOp</code></td>
+      <td><code>boolean</code></td>
+      <td>If <code>noOp=true</code> is specified then the app's tasks aren't actually killed, instead the endpoint responds with a list of tasks that would have been killed.
+        Default: <code>false</code>.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/docs/rest-api/public/api/v2/apps.raml
+++ b/docs/docs/rest-api/public/api/v2/apps.raml
@@ -339,7 +339,7 @@ post:
       is: [ secured, deployable ]
       queryParameters:
         host:
-          description: all tasks of that application on the supplied slave are killed
+          description: all tasks of that application on the supplied slave are killed.
         scale:
           type: boolean
           description: If `scale=true` is specified, then the application is scaled down by the number of killed tasks. Only possible if `wipe=false` or not specified.
@@ -347,7 +347,12 @@ post:
         wipe:
           type: boolean
           description: If `wipe=true` is specified and the app uses local persistent volumes, associated dynamic reservations will be unreserved, and persistent volumes will be destroyed. Only possible if `scale=false` or not specified.
-          default: false
+        killCount:
+          type: integer
+          description: The number of tasks to kill. A negative value signifies killing all running tasks.
+        noOp:
+          type: boolean
+          description: If `noOp=true` is specified then the app's tasks aren't actually killed, instead the endpoint responds with a list of tasks that would have been killed.
       responses:
         200:
           description: If scale=false, all tasks that were killed are returned.

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -128,7 +128,7 @@ class TasksResource @Inject() (
       affectedApps.foreach(checkAuthorization(UpdateRunSpec, _))
 
       val killed = result(Future.sequence(toKill.map {
-        case (appId, tasks) => taskKiller.kill(appId, _ => tasks, wipe)
+        case (appId, tasks) => taskKiller.kill(appId, _ => tasks, wipe, -1)
       })).flatten
       ok(jsonObjString("tasks" -> killed.map(task => EnrichedTask(task.taskId.runSpecId, task, Seq.empty))))
     }

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.core.task.{ TaskStateChange, TaskStateOp, Task }
 import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskTracker }
 import mesosphere.marathon.state.{ AppDefinition, Group, PathId, Timestamp }
 import mesosphere.marathon.upgrade.DeploymentPlan
-import org.mockito.ArgumentCaptor
+import org.mockito.{ ArgumentCaptor, ArgumentMatcher }
 import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
@@ -51,6 +51,7 @@ class TaskKillerTest extends MarathonSpec
     val f = new Fixture
     val appId = PathId("invalid")
     when(f.tracker.hasAppTasksSync(appId)).thenReturn(false)
+    when(f.groupManager.app(appId)).thenReturn(Future.successful(None))
 
     val result = f.taskKiller.killAndScale(appId, (tasks) => Set.empty[Task], force = true)
     result.failed.futureValue shouldEqual UnknownAppException(appId)
@@ -61,10 +62,11 @@ class TaskKillerTest extends MarathonSpec
     val appId = PathId(List("app"))
     val task1 = MarathonTestHelper.runningTaskForApp(appId)
     val task2 = MarathonTestHelper.runningTaskForApp(appId)
-    val tasksToKill = Set(task1, task2)
+    val tasksToKill = List(task1, task2)
 
     when(f.tracker.hasAppTasksSync(appId)).thenReturn(true)
     when(f.groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
+    when(f.groupManager.app(appId)).thenReturn(Future.successful(Some(AppDefinition(appId))))
 
     val groupUpdateCaptor = ArgumentCaptor.forClass(classOf[(Group) => Group])
     val forceCaptor = ArgumentCaptor.forClass(classOf[Boolean])
@@ -84,6 +86,48 @@ class TaskKillerTest extends MarathonSpec
     toKillCaptor.getValue shouldEqual Map(appId -> tasksToKill)
   }
 
+  test("KillRequested with killCount") {
+    val f = new Fixture
+    val appId = PathId(List("app"))
+    val task1 = MarathonTestHelper.runningTaskForApp(appId)
+    val task2 = MarathonTestHelper.runningTaskForApp(appId)
+    val tasksToKill = List(task1, task2)
+
+    when(f.tracker.hasAppTasksSync(appId)).thenReturn(true)
+    when(f.groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
+    when(f.groupManager.app(appId)).thenReturn(Future.successful(Some(AppDefinition(appId))))
+
+    val expectedDeploymentPlan = DeploymentPlan.empty
+    val toKillCaptor = ArgumentCaptor.forClass(classOf[Map[PathId, Iterable[Task]]])
+    when(f.groupManager.update(
+      any[PathId],
+      any(classOf[Group => Group]),
+      any[Timestamp],
+      any[Boolean],
+      toKillCaptor.capture()
+    )).thenReturn(Future.successful(expectedDeploymentPlan))
+
+    val result = f.taskKiller.killAndScale(appId, (tasks) => tasksToKill, force = true, killCount = 1)
+    result.futureValue shouldEqual expectedDeploymentPlan
+    toKillCaptor.getValue.size shouldEqual 1
+    tasksToKill contains toKillCaptor.getValue.values.take(1)
+  }
+
+  class IterableEquals[A](var original: Iterable[A]) extends ArgumentMatcher[Iterable[A]] {
+    override def matches(other: scala.Any): Boolean = {
+      other match {
+        case iterable: Iterable[A] =>
+          iterable should contain theSameElementsAs original
+          true
+        case _ => false
+      }
+    }
+  }
+
+  def iterableEquals[A](original: Iterable[A]): Iterable[A] = {
+    org.mockito.Matchers.argThat(new IterableEquals(original))
+  }
+
   test("KillRequested without scaling") {
     val f = new Fixture
     val appId = PathId(List("my", "app"))
@@ -92,11 +136,11 @@ class TaskKillerTest extends MarathonSpec
     when(f.tracker.appTasks(appId)).thenReturn(Future.successful(tasksToKill))
 
     val result = f.taskKiller.kill(appId, { tasks =>
-      tasks should equal(tasksToKill)
+      tasks should contain theSameElementsAs tasksToKill
       tasksToKill
     })
-    result.futureValue shouldEqual tasksToKill
-    verify(f.service, times(1)).killTasks(appId, tasksToKill)
+    result.futureValue should contain theSameElementsAs tasksToKill
+    verify(f.service, times(1)).killTasks(org.mockito.Matchers.eq(appId), iterableEquals(tasksToKill))
   }
 
   test("Kill and scale w/o force should fail if there is a deployment") {
@@ -108,6 +152,7 @@ class TaskKillerTest extends MarathonSpec
 
     when(f.tracker.hasAppTasksSync(appId)).thenReturn(true)
     when(f.groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
+    when(f.groupManager.app(appId)).thenReturn(Future.successful(Some(AppDefinition(appId))))
     val groupUpdateCaptor = ArgumentCaptor.forClass(classOf[(Group) => Group])
     val forceCaptor = ArgumentCaptor.forClass(classOf[Boolean])
     when(f.groupManager.update(
@@ -143,12 +188,27 @@ class TaskKillerTest extends MarathonSpec
       tasks should equal(tasksToKill)
       tasksToKill
     }, wipe = true)
-    result.futureValue shouldEqual tasksToKill
+    result.futureValue should contain theSameElementsAs tasksToKill
     // only task1 is killed
-    verify(f.service, times(1)).killTasks(appId, launchedTasks)
+    verify(f.service, times(1)).killTasks(org.mockito.Matchers.eq(appId), iterableEquals(launchedTasks))
     // both tasks are expunged from the repo
     verify(f.stateOpProcessor).process(TaskStateOp.ForceExpunge(runningTask.taskId))
     verify(f.stateOpProcessor).process(TaskStateOp.ForceExpunge(reservedTask.taskId))
+  }
+
+  test("kill with killCount will only kill one task") {
+    val f = new Fixture
+    val appId = PathId(List("my", "app"))
+    val tasks = List(MarathonTestHelper.runningTaskForApp(appId), MarathonTestHelper.runningTaskForApp(appId))
+
+    when(f.groupManager.app(appId)).thenReturn(Future.successful(Some(AppDefinition(appId))))
+    when(f.tracker.appTasks(appId)).thenReturn(Future.successful(tasks))
+    when(f.service.killTasks(appId, tasks)).thenReturn(tasks)
+
+    val result = f.taskKiller.kill(appId, tasks => tasks, killCount = 1)
+    result.futureValue.size == 1
+
+    verify(f.service, times(1)).killTasks(org.mockito.Matchers.eq(appId), any[Iterable[Task]])
   }
 
   class Fixture {

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -60,7 +60,7 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
 
     config.zkTimeoutDuration returns 5.seconds
     taskTracker.tasksByAppSync returns TaskTracker.TasksByApp.forTasks(task1, task2)
-    taskKiller.kill(any, any, any)(any) returns Future.successful(Iterable.empty[Task])
+    taskKiller.kill(any, any, any, any)(any) returns Future.successful(Iterable.empty[Task])
     groupManager.app(app1) returns Future.successful(Some(AppDefinition(app1)))
     groupManager.app(app2) returns Future.successful(Some(AppDefinition(app2)))
 
@@ -74,8 +74,8 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     response.getEntity shouldEqual """{"tasks":[]}"""
 
     And("Both tasks should be requested to be killed")
-    verify(taskKiller).kill(eq(app1), any, any)(any)
-    verify(taskKiller).kill(eq(app2), any, any)(any)
+    verify(taskKiller).kill(eq(app1), any, any, any)(any)
+    verify(taskKiller).kill(eq(app2), any, any, any)(any)
 
     And("nothing else should be called on the TaskKiller")
     noMoreInteractions(taskKiller)


### PR DESCRIPTION
# Motivation

At Yelp, for [PaaSTA](https://github.com/Yelp/paasta), we would like to be able to predict Marathon's actions during a scale down event. This gives us a chance to decide if we're really sure about killing an instance/scaling down. This noOp flag allows us to get a preview of Marathon's plan during these events.

Ideally it'd be possible to hit up `PUT /v2/apps/{app_id}` with some sort of noOp flag to probe Marathon's deploy plans for any arbitrary change but that's a far more complicated code diff, so I opted for this simpler approach.
## Implementation

This is my first time dabbing into Scala, so I apologize if I'm doing anything horribly wrong. All feedback is much appreciated. I checked the project with scalastyle and as far as I can tell I didn't any new style violations.

I added two basic tests following the pattern for the rest of AppTaskResourceTest.scala file and some tests had to be changed a little because of the type change to be just a generic `Iterable[Task]` instead of some specific collection. I'll add some github comments to mark some of the more interesting testing changes.
