### PR TITLE
Update some libraries to the latest patches

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -315,7 +315,7 @@ object Dependency {
     val Guava = "19.0"
     // FIXME (gkleiman): reenable deprecation checks after Mesos 1.0.0-rc2 deprecations are handled
     val MesosUtils = "1.0.0"
-    val Akka = "2.4.7"
+    val Akka = "2.4.8"
     val AsyncAwait = "0.9.6-RC2"
     val Spray = "1.3.3"
     val TwitterCommons = "0.0.76"
@@ -338,12 +338,12 @@ object Dependency {
     val Logback = "1.1.3"
     val Logstash = "4.7"
     val WixAccord = "0.5"
-    val Curator = "2.10.0"
+    val Curator = "2.11.0"
     val Java8Compat = "0.8.0-RC1"
 
     // test deps versions
     val Mockito = "1.10.19"
-    val ScalaTest = "2.2.6"
+    val ScalaTest = "3.0.0"
     val JUnit = "4.12"
     val ScalaMeter = "0.7"
   }

--- a/src/test/scala/mesosphere/marathon/MarathonSpec.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSpec.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon
 
 import org.scalatest.{ BeforeAndAfter, FunSuiteLike, OptionValues }
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 trait MarathonSpec extends FunSuiteLike with BeforeAndAfter with MockitoSugar with OptionValues

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -10,7 +10,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfterAll, Matchers }
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActorTest.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.core.event.impl.stream.HttpEventStreamActor._
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.test._
 import org.mockito.Mockito.{ when => call, _ }
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
 
 import scala.concurrent.duration._

--- a/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
@@ -21,7 +21,7 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.{ times, verify, when }
 import org.rogach.scallop.ScallopConf
 import org.scalatest.Matchers
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._

--- a/src/test/scala/mesosphere/marathon/core/history/impl/HistoryActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/history/impl/HistoryActorTest.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.test.MarathonActorSupport
 import org.apache.mesos.Protos.{ NetworkInfo, TaskState }
 import org.mockito.Matchers.any
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfterAll, Matchers }
 
 import scala.collection.immutable.Seq

--- a/src/test/scala/mesosphere/marathon/integration/setup/IntegrationFunSuite.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/IntegrationFunSuite.scala
@@ -5,6 +5,7 @@ import java.io.File
 import akka.actor.ActorSystem
 import mesosphere.marathon.state.PathId
 import org.joda.time.DateTime
+import org.scalactic.source.Position
 import org.scalatest._
 
 import scala.collection.mutable
@@ -21,7 +22,8 @@ object IntegrationTag extends Tag("mesosphere.marathon.IntegrationTest")
   * Convenience trait, which will mark all test cases as integration tests.
   */
 trait IntegrationFunSuite extends FunSuite {
-  override protected def test(testName: String, testTags: Tag*)(testFun: => Unit): Unit = {
+
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
     super.test(testName, IntegrationTag +: testTags: _*)(testFun)
   }
 }

--- a/src/test/scala/mesosphere/marathon/metrics/MetricsTest.scala
+++ b/src/test/scala/mesosphere/marathon/metrics/MetricsTest.scala
@@ -12,7 +12,7 @@ import org.aopalliance.intercept.{ MethodInvocation, MethodInterceptor }
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class FooBar {
   def dummy(): Unit = {}

--- a/src/test/scala/mesosphere/marathon/test/Mockito.scala
+++ b/src/test/scala/mesosphere/marathon/test/Mockito.scala
@@ -4,7 +4,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.{ Answer, OngoingStubbing }
 import org.mockito.verification.VerificationMode
 import org.mockito.{ Mockito => M }
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 /**
   * ScalaTest mockito support is quite limited and ugly.

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -16,7 +16,7 @@ import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfterAll, FunSuiteLike, Matchers }
 
 import scala.concurrent.duration._

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -20,7 +20,7 @@ import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito
 import org.mockito.Mockito.{ spy, verify, when }
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfter, FunSuiteLike, Matchers }
 
 import scala.concurrent.duration._


### PR DESCRIPTION
- Akka 2.4.8 has some Http/Stream Improvements
- Curator 2.11 has some good fixes.
- ScalaTest 3.0 is out
  - Only fixed deprecations so far. The release notes
    look really interesting.