### PR TITLE
Never default servicePorts since they are globally unique!

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -993,7 +993,7 @@ trait AppAndGroupFormats {
       // top-level ports fields are incompatible with IP/CT
       if (runSpec.ipAddress.isEmpty) {
         appJson = appJson ++ Json.obj(
-          "ports" -> runSpec.servicePorts,
+          "ports" -> runSpec.portDefinitions.map(_.port),
           "portDefinitions" -> {
             if (runSpec.servicePorts.nonEmpty) {
               runSpec.portDefinitions.zip(runSpec.servicePorts).map {

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -278,7 +278,7 @@ case class AppDefinition(
 
   val hostPorts: Seq[Option[Int]] = container.flatMap(_.hostPorts).getOrElse(portNumbers.map(Some(_)))
 
-  val servicePorts: Seq[Int] = container.flatMap(_.servicePorts).getOrElse(portNumbers)
+  val servicePorts: Seq[Int] = container.flatMap(_.servicePorts).getOrElse(Nil)
 
   val hasDynamicServicePorts: Boolean = servicePorts.contains(AppDefinition.RandomPortValue)
 

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -253,9 +253,9 @@ object Group {
 
   private def servicePortsDontOverlap: Validator[Group] =
     isTrue("Service ports are unique") { group =>
-      val portGroups = group.transitiveApps
-        .map(apps => apps.servicePorts.filter(_ != AppDefinition.RandomPortValue).toSet)
-      val allPorts = portGroups.fold(Set.empty)(_.union(_))
+      val portGroups: Seq[Seq[Int]] = group.transitiveApps.toSeq
+        .map(apps => apps.servicePorts.filter(_ != AppDefinition.RandomPortValue))
+      val allPorts = portGroups.fold(Set.empty)((a, b) => a.toSet.union(b.toSet))
       portGroups.map(_.size).sum == allPorts.size
     }
 }

--- a/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
@@ -75,7 +75,7 @@ class GroupManagerActorTest extends MockitoSugar with Matchers with MarathonSpec
   test("Assign dynamic app ports") {
     val app1 = AppDefinition("/app1".toPath, container = container(0, 0, 0))
     val app2 = AppDefinition("/app2".toPath, container = container(1, 2, 3))
-    val app3 = AppDefinition("/app3".toPath, container = container(0, 2, 0))
+    val app3 = AppDefinition("/app3".toPath, container = container(0, 4, 0))
     val group = Group(PathId.empty, Map(
       app1.id -> app1,
       app2.id -> app2,

--- a/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
@@ -16,7 +16,10 @@ import mesosphere.util.{ CapConcurrentExecutions, CapConcurrentExecutionsMetrics
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService, MarathonSpec, PortRangeExhaustedException }
 import mesosphere.marathon._
 import mesosphere.marathon.core.group.GroupManager
+import mesosphere.marathon.state.Container.Docker
+import mesosphere.marathon.state.Container.Docker.PortMapping
 import mesosphere.marathon.state._
+import org.apache.mesos.Protos.ContainerInfo
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{ times, verify, when }
 import org.rogach.scallop.ScallopConf
@@ -31,10 +34,29 @@ class GroupManagerActorTest extends MockitoSugar with Matchers with MarathonSpec
 
   val actorId = new AtomicInteger(0)
 
+  def container(servicePorts: Int*): Option[Container] = {
+    Some(
+      Docker.withDefaultPortMappings(Nil, "",
+        network = Some(ContainerInfo.DockerInfo.Network.BRIDGE),
+        portMappings = Option(
+          servicePorts.map(port => PortMapping(servicePort = port)).toVector
+        )
+      )
+    )
+  }
+
+  test("apps without a docker container have no service ports") {
+    val app1 = AppDefinition("/app".toRootPath)
+    val group = Group(PathId.empty, Map(app1.id -> app1))
+    val update = manager(10 to 20).assignDynamicServicePorts(Group.empty, group)
+    update.transitiveApps.filter(_.hasDynamicServicePorts) should be(empty)
+    update.transitiveApps.flatMap(_.servicePorts) should be(empty)
+  }
+
   test("Assign dynamic app ports") {
-    val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-    val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(1, 2, 3))
-    val app3 = AppDefinition("/app3".toPath, portDefinitions = PortDefinitions(0, 2, 0))
+    val app1 = AppDefinition("/app1".toPath, container = container(0, 0, 0))
+    val app2 = AppDefinition("/app2".toPath, container = container(1, 2, 3))
+    val app3 = AppDefinition("/app3".toPath, container = container(0, 2, 0))
     val group = Group(PathId.empty, Map(
       app1.id -> app1,
       app2.id -> app2,
@@ -163,8 +185,8 @@ class GroupManagerActorTest extends MockitoSugar with Matchers with MarathonSpec
 
   //regression for #2743
   test("Reassign dynamic service ports specified in the container") {
-    val app = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 11))
-    val updatedApp = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 0, 11))
+    val app = AppDefinition("/app1".toPath, container = container(10, 11))
+    val updatedApp = AppDefinition("/app1".toPath, container = container(10, 0, 11))
     val from = Group(PathId.empty, Map(app.id -> app))
     val to = Group(PathId.empty, Map(updatedApp.id -> updatedApp))
     val update = manager(10 to 20).assignDynamicServicePorts(from, to)
@@ -192,8 +214,8 @@ class GroupManagerActorTest extends MockitoSugar with Matchers with MarathonSpec
   }
 
   test("Already taken ports will not be used") {
-    val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-    val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(0, 2, 0))
+    val app1 = AppDefinition("/app1".toPath, container = container(0, 0, 0))
+    val app2 = AppDefinition("/app2".toPath, container = container(0, 2, 0))
     val group = Group(PathId.empty, Map(
       app1.id -> app1,
       app2.id -> app2
@@ -206,7 +228,7 @@ class GroupManagerActorTest extends MockitoSugar with Matchers with MarathonSpec
 
   // Regression test for #2868
   test("Don't assign duplicated service ports") {
-    val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 10))
+    val app1 = AppDefinition("/app1".toPath, container = container(0, 10))
     val group = Group(PathId.empty, Map(app1.id -> app1))
     val update = manager(10 to 20).assignDynamicServicePorts(Group.empty, group)
 
@@ -215,10 +237,10 @@ class GroupManagerActorTest extends MockitoSugar with Matchers with MarathonSpec
   }
 
   test("Assign unique service ports also when adding a dynamic service port to an app") {
-    val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 11))
+    val app1 = AppDefinition("/app1".toPath, container = container(10, 11))
     val originalGroup = Group(PathId.empty, Map(app1.id -> app1))
 
-    val updatedApp1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
+    val updatedApp1 = AppDefinition("/app1".toPath, container = container(0, 0, 0))
     val updatedGroup = Group(PathId.empty, Map(updatedApp1.id -> updatedApp1))
     val result = manager(10 to 20).assignDynamicServicePorts(originalGroup, updatedGroup)
 
@@ -227,8 +249,8 @@ class GroupManagerActorTest extends MockitoSugar with Matchers with MarathonSpec
   }
 
   test("If there are not enough ports, a PortExhausted exception is thrown") {
-    val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-    val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(0, 0, 0))
+    val app1 = AppDefinition("/app1".toPath, container = container(0, 0, 0))
+    val app2 = AppDefinition("/app2".toPath, container = container(0, 0, 0))
     val group = Group(PathId.empty, Map(
       app1.id -> app1,
       app2.id -> app2

--- a/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
@@ -53,6 +53,13 @@ class GroupManagerActorTest extends MockitoSugar with Matchers with MarathonSpec
     update.transitiveApps.flatMap(_.servicePorts) should be(empty)
   }
 
+  test("apps with port definitions should keep them") {
+    val app = AppDefinition("/app".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(1)))
+    val group = Group(PathId.empty, Map(app.id -> app))
+    val update = manager(10 to 20).assignDynamicServicePorts(Group.empty, group)
+    update.apps(app.id).portDefinitions should contain theSameElementsAs app.portDefinitions
+  }
+
   test("Assign dynamic app ports") {
     val app1 = AppDefinition("/app1".toPath, container = container(0, 0, 0))
     val app2 = AppDefinition("/app2".toPath, container = container(1, 2, 3))

--- a/src/test/scala/mesosphere/marathon/core/group/impl/GroupValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/GroupValidationTest.scala
@@ -1,0 +1,44 @@
+package mesosphere.marathon.core.group.impl
+
+import mesosphere.UnitTest
+import mesosphere.marathon.state.{ AppDefinition, Container, Group, PathId }
+import mesosphere.marathon.state.Container.Docker
+import mesosphere.marathon.state.Container.Docker.PortMapping
+import org.apache.mesos.Protos.ContainerInfo
+import com.wix.accord._
+
+class GroupValidationTest extends UnitTest {
+  import PathId._
+
+  def container(servicePorts: Int*): Option[Container] = {
+    Some(
+      Docker.withDefaultPortMappings(Nil, "abc",
+        network = Some(ContainerInfo.DockerInfo.Network.BRIDGE),
+        portMappings = Option(
+          servicePorts.map(port => PortMapping(servicePort = port)).toVector
+        )
+      )
+    )
+  }
+
+  implicit private def validator = Group.validRootGroup(None)
+
+  "Groups" when {
+    "validated" should {
+      "fail if service ports overlap" in {
+        val app1 = AppDefinition("/app1".toPath, container = container(1))
+        val app2 = AppDefinition("/app2".toPath, container = container(1))
+        val g = Group(PathId.empty, apps = Map(app1.id -> app1, app2.id -> app2))
+        validate(g) should be('failure)
+      }
+      "succeed if service ports are randomly allocated" in {
+        val app1 = AppDefinition("/app1".toPath, container = container(0))
+        val app2 = AppDefinition("/app2".toPath, container = container(0))
+        val g = Group(PathId.empty, apps = Map(app1.id -> app1, app2.id -> app2))
+        validate(g) should be('success)
+      }
+    }
+    // TODO: needs a lot more coverage: https://github.com/mesosphere/marathon/issues/4198
+  }
+
+}


### PR DESCRIPTION
In order to allocate a service port, you must have Host Networking
and explicitly specify them.