### PR TITLE
Remove some restrictions from the legacy run-tests.sh

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -134,8 +134,6 @@ DOCKER_OPTIONS=(
     run
     --rm=$CLEANUP_CONTAINERS_ON_EXIT
     --name marathon-itests-$BUILD_ID
-    --memory 4g
-    --memory-swap 6g
     --net host
     -e "BUILD_ID=$BUILD_ID"
     -e "IVY2_DIR=$IVY2_DIR"


### PR DESCRIPTION
We definitely leak Processes and will periodically kill the container