### PR TITLE
Fix GPU validation if 'container' isn't set.

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -7,7 +7,7 @@ import com.wix.accord.combinators.GeneralPurposeCombinators
 import com.wix.accord.dsl._
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
-import mesosphere.marathon.state.Container.{ Mesos, MesosAppC, MesosDocker }
+import mesosphere.marathon.state.Container.Docker
 // scalastyle:off
 import mesosphere.marathon.api.serialization.{ ContainerSerializer, EnvVarRefSerializer, PortDefinitionSerializer, ResidencySerializer, SecretsSerializer }
 // scalastyle:on
@@ -660,13 +660,9 @@ object AppDefinition extends GeneralPurposeCombinators {
   private def complyWithGpuRules(enabledFeatures: Set[String]): Validator[AppDefinition] =
     conditional[AppDefinition](_.gpus > 0) {
       isTrue[AppDefinition]("GPU resources only work with the Mesos containerizer") { app =>
-        app.container.exists{
-          _ match {
-            case _: MesosDocker => true
-            case _: MesosAppC => true
-            case _: Mesos => true
-            case _ => false
-          }
+        app.container match {
+          case Some(_: Docker) => false
+          case _ => true
         }
       } and featureEnabled(enabledFeatures, Features.GPU_RESOURCES)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -427,6 +427,13 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     )
 
     shouldNotViolate(app, "/", "GPU resources only work with the Mesos containerizer")
+
+    app = correct.copy(
+      gpus = 1,
+      container = None
+    )
+
+    shouldNotViolate(app, "/", "GPU resources only work with the Mesos containerizer")
   }
 
   test("SerializationRoundtrip empty") {


### PR DESCRIPTION
GPU validation would fail if `container` isn't set in an app definition. Because in that case the Mesos Containerizer will be used, the validation shouldn't fail.