### PR TITLE
container persistence fix

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
@@ -122,7 +122,7 @@ case class AppUpdate(
     backoff = backoff.getOrElse(app.backoff),
     backoffFactor = backoffFactor.getOrElse(app.backoffFactor),
     maxLaunchDelay = maxLaunchDelay.getOrElse(app.maxLaunchDelay),
-    container = app.container,
+    container = container.orElse(app.container),
     healthChecks = healthChecks.getOrElse(app.healthChecks),
     readinessChecks = readinessChecks.getOrElse(app.readinessChecks),
     dependencies = dependencies.map(_.map(_.canonicalPath(app.id))).getOrElse(app.dependencies),

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -924,4 +924,15 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     roundTripped should equal(appDef)
     roundTripped.container.map(_.portMappings) should equal(appDef.container.map(_.portMappings))
   }
+
+  test("container change in AppUpdate should be stored") {
+    val appDef = AppDefinition(container = Some(Docker(portMappings = None)))
+    val appUpdate = AppUpdate(container = Some(Docker(portMappings = Some(Seq(
+      Container.Docker.PortMapping(containerPort = 4000, protocol = "tcp")
+    )))))
+    val roundTrip = appUpdate(appDef)
+    roundTrip.container.get.portMappings should not be None
+    roundTrip.container.get.portMappings.get should have size 1
+    roundTrip.container.get.portMappings.get.head.containerPort should be (4000)
+  }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActorTest.scala
@@ -1,22 +1,22 @@
 package mesosphere.marathon.core.task.termination.impl
 
 import akka.Done
-import akka.actor.{ ActorRef, ActorSystem }
-import akka.testkit.{ ImplicitSender, TestActorRef, TestKit, TestProbe }
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import mesosphere.marathon.MarathonSchedulerDriverHolder
 import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.task.termination.TaskKillConfig
-import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskTracker }
-import mesosphere.marathon.core.task.{ Task, TaskStateOp }
+import mesosphere.marathon.core.task.tracker.{TaskStateOpProcessor, TaskTracker}
+import mesosphere.marathon.core.task.{Task, TaskStateOp}
 import mesosphere.marathon.core.event.MesosStatusUpdateEvent
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.test.Mockito
 import org.apache.mesos
 import org.apache.mesos.SchedulerDriver
 import org.mockito.ArgumentCaptor
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{ Millis, Span }
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, GivenWhenThen, Matchers }
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, GivenWhenThen, Matchers}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -83,6 +83,9 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
   }
 
   test("Kill single known LOST task") {
+    //this parameter is used for futureValue timeouts
+    implicit val patienceConfig = PatienceConfig(Span(10, Seconds))
+
     val f = new Fixture
     val actor = f.createTaskKillActor()
 

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -569,7 +569,7 @@ class AppDeployIntegrationTest
     val deploymentId = extractDeploymentIds(create).head
 
     Then("the deployment gets created")
-    WaitTestSupport.validFor("deployment visible", 1.second)(marathon.listDeploymentsForBaseGroup().value.size == 1)
+    WaitTestSupport.validFor("deployment visible", 5.second)(marathon.listDeploymentsForBaseGroup().value.size == 1)
 
     When("the deployment is rolled back")
     val delete = marathon.deleteDeployment(deploymentId, force = false)

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -638,5 +638,50 @@ class AppDeployIntegrationTest
     maybeContainer1.get.docker shouldBe (empty)
   }
 
+  test("create a simple app with a docker container and update it") {
+    import scala.collection.immutable.Seq
+
+    Given("a new app")
+    val appId = testBasePath / "app"
+
+    val container = Container.Docker(
+      network = Some(org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network.BRIDGE),
+      image = "jdef/helpme",
+      portMappings = Some(Seq(
+        Container.Docker.PortMapping(containerPort = 3000, protocol = "tcp")
+      ))
+    )
+
+    val app = AppDefinition(
+      id = appId,
+      cmd = Some("cmd"),
+      container = Some(container),
+      instances = 0
+    )
+
+    When("The app is deployed")
+    val result = marathon.createAppV2(app)
+
+    Then("The app is created")
+    result.code should be (201) //Created
+    extractDeploymentIds(result) should have size 1
+    waitForEvent("deployment_success")
+
+    val appUpdate = AppUpdate(container = Some(container.copy(portMappings = Some(Seq(
+      Container.Docker.PortMapping(containerPort = 4000, protocol = "tcp")
+    )))))
+    val updateResult = marathon.updateApp(app.id, appUpdate, true)
+
+    And("The app is updated")
+    updateResult.code should be (200)
+
+    Then("The container is updated correctly")
+    val updatedApp = marathon.app(appId)
+    updatedApp.value.app.container should not be None
+    updatedApp.value.app.container.get.portMappings should not be None
+    updatedApp.value.app.container.get.portMappings.get should have size 1
+    updatedApp.value.app.container.get.portMappings.get.head.containerPort should be (4000)
+  }
+
   def healthCheck = HealthCheck(gracePeriod = 20.second, interval = 1.second, maxConsecutiveFailures = 10)
 }

--- a/src/test/scala/mesosphere/util/state/zk/ZKStoreTest.scala
+++ b/src/test/scala/mesosphere/util/state/zk/ZKStoreTest.scala
@@ -16,6 +16,7 @@ import mesosphere.FutureTestSupport._
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import ZKStore._
+import org.scalatest.time.{Seconds, Span}
 
 class ZKStoreTest extends PersistentStoreTest with StartedZookeeper with Matchers {
 
@@ -57,6 +58,9 @@ class ZKStoreTest extends PersistentStoreTest with StartedZookeeper with Matcher
   }
 
   test("Already existing paths are not created") {
+    //this parameter is used for futureValue timeouts
+    implicit val patienceConfig = PatienceConfig(Span(10, Seconds))
+
     val client = persistentStore.client
     val path = client("/some/deeply/nested/path")
     path.exists().asScala.failed.futureValue shouldBe a[NoNodeException]


### PR DESCRIPTION
Currently (releases/1.3 and master legacy storage) it is not possible to edit container settings for an existing app. This PR fixes this behavior.