### PR TITLE
Correctly pass in the password when using new zookeeper storage.

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -260,7 +260,7 @@ object CuratorZk {
       zkPath = conf.zooKeeperStatePath,
       zkAcls = conf.zkDefaultCreationACL,
       username = conf.zkUsername,
-      password = conf.zkUsername,
+      password = conf.zkPassword,
       enableCompression = conf.zooKeeperCompressionEnabled(),
       retryConfig = RetryConfig(),
       maxConcurrent = conf.zkMaxConcurrency(),

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.state.DiscoveryInfo.Port
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import play.api.data.validation.ValidationError
-import play.api.libs.json.{JsError, JsPath, Json}
+import play.api.libs.json.{ JsError, JsPath, Json }
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
@@ -19,7 +19,7 @@ import org.scalatest.Matchers
 
 import scala.util.Try
 
-class AppUpdateTest extends MarathonSpec with Matchers  {
+class AppUpdateTest extends MarathonSpec with Matchers {
   import Formats._
   import mesosphere.marathon.integration.setup.V2TestFormats._
 

--- a/src/test/scala/mesosphere/marathon/storage/repository/legacy/store/ZKStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/legacy/store/ZKStoreTest.scala
@@ -17,7 +17,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import org.scalatest.time.{Seconds, Span}
+import org.scalatest.time.{ Seconds, Span }
 
 class ZKStoreTest extends PersistentStoreTest with ZookeeperServerTest with Matchers with ScalaFutures {
   import ZKStore._

--- a/src/test/scala/mesosphere/util/state/PersistentStoreTest.scala
+++ b/src/test/scala/mesosphere/util/state/PersistentStoreTest.scala
@@ -3,8 +3,8 @@ package mesosphere.util.state
 import mesosphere.FutureTestSupport._
 import mesosphere.marathon.StoreCommandFailedException
 import mesosphere.marathon.integration.setup.IntegrationFunSuite
-import mesosphere.marathon.storage.repository.legacy.store.{PersistentEntity, PersistentStore, PersistentStoreManagement}
-import org.scalatest.{BeforeAndAfter, Matchers}
+import mesosphere.marathon.storage.repository.legacy.store.{ PersistentEntity, PersistentStore, PersistentStoreManagement }
+import org.scalatest.{ BeforeAndAfter, Matchers }
 
 /**
   * Common  tests for all persistent stores.


### PR DESCRIPTION
I was wondering why some tests had thousands of "NoAuth" lines...