### PR TITLE
Don't consider lost tasks when evaluating constraints.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/AppTaskLauncherActor.scala
@@ -332,7 +332,11 @@ private class AppTaskLauncherActor(
       sender ! MatchedTasks(offer.getId, Seq.empty)
 
     case ActorOfferMatcher.MatchOffer(deadline, offer) =>
-      val newTaskOpt: Option[CreatedTask] = taskFactory.newTask(app, offer, tasksMap.values)
+      val newTaskOpt: Option[CreatedTask] = taskFactory.newTask(
+        app,
+        offer,
+        tasksMap.values.filterNot(_.getStatus.getState == TaskState.TASK_LOST))
+
       newTaskOpt match {
         case Some(CreatedTask(mesosTask, marathonTask)) =>
           def updateActorState(): Unit = {

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -86,11 +86,11 @@ object TaskStatusUpdateTestHelper {
     )
   )
 
-  def lost(reason: Reason) = TaskStatusUpdateTestHelper(
+  def lost(reason: Reason, maybeMessage: Option[String] = None) = TaskStatusUpdateTestHelper(
     TaskStatusUpdate(
       timestamp = Timestamp.apply(new DateTime(2015, 2, 3, 12, 31, 0, 0)),
       taskId = taskId,
-      status = MarathonTaskStatusTestHelper.lost(reason)
+      status = MarathonTaskStatusTestHelper.lost(reason, maybeMessage)
     )
   )
 


### PR DESCRIPTION
This change should let Marathon start a new task to replace a lost one,
even if an app is pinned to a slave. This could potentially lead to more
than one task running on the same agent, violating a UNIQUE constraint.
Marathon will in that case try to remediate it by killing the new
running/staging task.