### PR TITLE
WIP: v2 raml for pods

### DIFF
--- a/docs/docs/rest-api/public/api/annotations.raml
+++ b/docs/docs/rest-api/public/api/annotations.raml
@@ -1,0 +1,2 @@
+scalaType: string
+scalaPackage: string

--- a/docs/docs/rest-api/public/api/api.raml
+++ b/docs/docs/rest-api/public/api/api.raml
@@ -17,7 +17,7 @@ traits: !include traits.raml
 
 # considered ofthen used endpoints in alphabetical order
 /v2/apps: !include v2/apps.raml
-/v2/pods: !include v2/pod.raml
+/v2/pods: !include v2/pods.raml
 /v2/deployments: !include v2/deployments.raml
 /v2/groups: !include v2/groups.raml
 /v2/groups/{group_id}: !include v2/groups.raml

--- a/docs/docs/rest-api/public/api/api.raml
+++ b/docs/docs/rest-api/public/api/api.raml
@@ -17,6 +17,7 @@ traits: !include traits.raml
 
 # considered ofthen used endpoints in alphabetical order
 /v2/apps: !include v2/apps.raml
+/v2/pods: !include v2/pod.raml
 /v2/deployments: !include v2/deployments.raml
 /v2/groups: !include v2/groups.raml
 /v2/groups/{group_id}: !include v2/groups.raml
@@ -34,7 +35,3 @@ traits: !include traits.raml
 # no real API endpoints
 /ping: !include general/ping.raml
 /metrics: !include general/metrics.raml
-
-
-
-

--- a/docs/docs/rest-api/public/api/traits.raml
+++ b/docs/docs/rest-api/public/api/traits.raml
@@ -14,6 +14,54 @@
             example: |
               { "message": "Not Authorized to perform this action!" }
 
+- jsonValidator:
+  responses:
+    400:
+      description: Invalid JSON syntax.
+      body:
+        application/json:
+          example: |
+            {"message":"Invalid JSON","details":[{"path":"/id","errors":["error.expected.jsstring"]}]}
+
+- objectValidator:
+    422:
+      description:|
+        Invalid object specification, one or more specification rules have been violated.
+      body:
+        application/json:
+          example: |
+            {
+              "message": "Object is not valid",
+              "details": [
+                {
+                  "path": "/upgradeStrategy/minimumHealthCapacity",
+                  "errors": [
+                    "is greater than 1"
+                  ]
+                }
+              ]
+            }
+
+- objectCreator:
+  responses:
+    409:
+      description:|
+        Duplicate object ID. Another app, group, or pod already exists for the specified ID.
+      body:
+        application/json:
+          example: |
+            {"message":"An app with id [/existing_app] already exists."}
+
+- objectLocator:
+  responses:
+    404:
+      description:|
+        Unknown object ID. No such app, group, or pod exists for the specified ID.
+      body:
+        application/json:
+          example: |
+            {"message":"An app with id [/existing_app] already exists."}
+
 - deployable:
     description:
       Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds.

--- a/docs/docs/rest-api/public/api/traits.raml
+++ b/docs/docs/rest-api/public/api/traits.raml
@@ -1,20 +1,20 @@
 
-- secured:
-    responses:
-      401:
-        description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
-        body:
-          application/json:
-            example: |
-              { "message": "Invalid username or password." }
-      403:
-        description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
-        body:
-          application/json:
-            example: |
-              { "message": "Not Authorized to perform this action!" }
+secured:
+  responses:
+    401:
+      description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+      body:
+        application/json:
+          example: |
+            { "message": "Invalid username or password." }
+    403:
+      description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+      body:
+        application/json:
+          example: |
+            { "message": "Not Authorized to perform this action!" }
 
-- jsonValidator:
+jsonValidator:
   responses:
     400:
       description: Invalid JSON syntax.
@@ -23,9 +23,10 @@
           example: |
             {"message":"Invalid JSON","details":[{"path":"/id","errors":["error.expected.jsstring"]}]}
 
-- objectValidator:
+objectValidator:
+  responses:
     422:
-      description:|
+      description: |
         Invalid object specification, one or more specification rules have been violated.
       body:
         application/json:
@@ -42,59 +43,58 @@
               ]
             }
 
-- objectCreator:
+objectCreator:
   responses:
     409:
-      description:|
+      description: |
         Duplicate object ID. Another app, group, or pod already exists for the specified ID.
       body:
         application/json:
           example: |
             {"message":"An app with id [/existing_app] already exists."}
 
-- objectLocator:
+objectLocator:
   responses:
     404:
-      description:|
+      description: |
         Unknown object ID. No such app, group, or pod exists for the specified ID.
       body:
         application/json:
           example: |
             {"message":"An app with id [/existing_app] already exists."}
 
-- deployable:
-    description:
-      Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds.
-      You can query the deployments endoint to see the status of the deployment.
-    queryParameters:
-      force:
-        required: false
-        description:
-          Only one deployment can be applied to one application at the same time.
-          If the existing deployment should be canceled by this change, you can set force=true.
+deployable:
+  description:
+    Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds.
+    You can query the deployments endoint to see the status of the deployment.
+  queryParameters:
+    force:
+      required: false
+      description:
+        Only one deployment can be applied to one application at the same time.
+        If the existing deployment should be canceled by this change, you can set force=true.
 
-          Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-        type: boolean
-        default: false
-    responses:
-      200:
-        description:
-          A deployment is started which has a unique deployment identifier.
-          The related deployment can be fetched from the /v2/deployments endpoint.
-          If the deployement is gone from the list of deployments, it means that it is finished.
-          As long as the deployment runs, the effect of that change operation is visible only partially.
-        body:
-          application/json:
-            example: !include v2/examples/deployments_result.json
-      409:
-        description:
-          There is an already running deployment, that affects this application.
-          To override this deployment, use the force=true flag
-        body:
-          application/json:
-            example: |
-              {
-               "message":"App is locked by one or more deployments. Override with the option '?force=true'. View details at '/v2/deployments/<DEPLOYMENT_ID>'.",
-               "deployments":[{"id":"97c136bf-5a28-4821-9d94-480d9fbb01c8"}]
-              }
-
+        Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
+      type: boolean
+      default: false
+  responses:
+    200:
+      description:
+        A deployment is started which has a unique deployment identifier.
+        The related deployment can be fetched from the /v2/deployments endpoint.
+        If the deployement is gone from the list of deployments, it means that it is finished.
+        As long as the deployment runs, the effect of that change operation is visible only partially.
+      body:
+        application/json:
+          example: !include v2/examples/deployments_result.json
+    409:
+      description:
+        There is an already running deployment, that affects this application.
+        To override this deployment, use the force=true flag
+      body:
+        application/json:
+          example: |
+            {
+             "message":"App is locked by one or more deployments. Override with the option '?force=true'. View details at '/v2/deployments/<DEPLOYMENT_ID>'.",
+             "deployments":[{"id":"97c136bf-5a28-4821-9d94-480d9fbb01c8"}]
+            }

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -23,7 +23,7 @@ traits: !include ../traits.raml
 
   get:
     is: [ secured ]
-    description:|
+    description: |
       List all the pod-based services in the system.
       TODO(jdef) do we really need this?
     responses:

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -3,3 +3,20 @@ title: v2 pod API
 mediaType: application/json
 types:
   Pod: !include types/pod.raml
+  PathId: !include types/pathId.raml
+/{id}:
+  uriParameters:
+    id:
+      type: PathId
+      description: The path of the pod
+  # TODO: traits.raml needs to be updated... is: [ secured ]
+  get:
+    description:
+      Get the pod at the given id
+    responses:
+      200:
+        body:
+          application/json:
+            type: Pod
+      404:
+        description: No pod found with this `id`

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -2,8 +2,9 @@
 title: v2 pod API
 mediaType: application/json
 types:
-  Pod: !include types/pod.raml
   PathId: !include types/pathId.raml
+  Pod: !include types/pod.raml
+  PodStatus: !include types/pod-status.raml
 traits: !include ../traits.raml
 
 /:
@@ -62,3 +63,23 @@ traits: !include ../traits.raml
         body:
           application/json:
             type: Pod
+
+'/{id}::status':
+  usage: |
+    Implementations should probably generate do-not-cache headers because
+    status should always be live.
+
+  uriParameters:
+    id:
+      type: PathId
+      description: The path of the pod
+
+  get:
+    is: [ secured, objectLocator ]
+    description: |
+      Get the status of the pod with the given id
+    responses:
+      200:
+        body:
+          application/json:
+            type: PodStatus

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -12,6 +12,8 @@ traits: !include ../traits.raml
     is: [ secured, jsonValidator, objectValidator, objectCreator ]
     description: |
       Create and start a new pod-based service.
+      TODO(jdef) would be nice to include link to deployment URI in a Location
+      (or some such) header.
     body:
       application/json:
         type: Pod
@@ -44,12 +46,16 @@ traits: !include ../traits.raml
     is: [ secured, objectLocator, deployable ]
     description: |
       Delete an existing pod-based service.
+      TODO(jdef) would be nice to include link to deployment URI in a Location
+      (or some such) header.
 
   put:
     is: [ secured, jsonValidator, objectValidator, objectLocator, deployable ]
     description: |
       Update an existing pod-based service.
       TODO(jdef) separate error code when update of an immutable field fails?
+      TODO(jdef) would be nice to include link to deployment URI in a Location
+      (or some such) header.
     body:
       application/json:
         type: Pod

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -28,13 +28,27 @@ traits: !include ../traits.raml
     is: [ secured ]
     description: |
       List all the pod-based services in the system.
-      TODO(jdef) do we really need this?
     responses:
       200:
-        description: A list of all pods in the system.
+        description: |
+          Yields a list of all pods in the system.
+          Useful to perform backups of all pods registered with Marathon.
         body:
           application/json:
             type: Pod[]
+
+  put:
+    is: [ secured, jsonValidator, objectValidator, objectCreator ]
+    description: |
+      Create or update each pod in the list.
+      Useful to restore all pods previously backed up via GET /v2/pods.
+      TODO(jdef) this is a stretch goal for the MVP.
+    responses:
+      207:
+        description: |
+          A list of all created/updated pods.
+          TODO(jdef) format for the multi-status response type, see
+          https://tools.ietf.org/html/rfc4918#section-13
 
 /{id}:
   uriParameters:
@@ -71,7 +85,7 @@ traits: !include ../traits.raml
             type: Pod
 
 '/{id}::status':
-  usage: |
+  description: |
     Implementations should probably generate do-not-cache headers because
     status should always be live.
 

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -1,0 +1,5 @@
+#%RAML 1.0
+title: v2 pod API
+mediaType: application/json
+types:
+  Pod: !include types/pod.raml

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -27,7 +27,7 @@ post:
   delete:
     is: [ secured, objectLocator, deployable ]
     description:|
-      Update an existing pod-based service.
+      Delete an existing pod-based service.
 
   put:
     is: [ secured, jsonValidator, objectValidator, objectLocator, deployable ]

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -4,13 +4,42 @@ mediaType: application/json
 types:
   Pod: !include types/pod.raml
   PathId: !include types/pathId.raml
+
+post:
+  is: [ secured, jsonValidator, objectValidator, objectCreator ]
+  description:|
+    Create and start a new pod-based service.
+  body:
+    application/json:
+      type: Pod
+  responses:
+    201:
+      description: Pod created successfully.
+      body:
+        application/json:
+          type: Pod
+
 /{id}:
   uriParameters:
     id:
       type: PathId
       description: The path of the pod
-  # TODO: traits.raml needs to be updated... is: [ secured ]
+  delete:
+    is: [ secured, objectLocator, deployable ]
+    description:|
+      Update an existing pod-based service.
+
+  put:
+    is: [ secured, jsonValidator, objectValidator, objectLocator, deployable ]
+    usage: TODO(jdef) separate error code when update of an immutable field fails?
+    description:|
+      Update an existing pod-based service.
+    body:
+      application/json:
+        type: Pod
+
   get:
+    is: [ secured, objectLocator ]
     description:
       Get the pod at the given id
     responses:
@@ -18,5 +47,3 @@ types:
         body:
           application/json:
             type: Pod
-      404:
-        description: No pod found with this `id`

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -4,20 +4,22 @@ mediaType: application/json
 types:
   Pod: !include types/pod.raml
   PathId: !include types/pathId.raml
+traits: !include ../traits.raml
 
-post:
-  is: [ secured, jsonValidator, objectValidator, objectCreator ]
-  description:|
-    Create and start a new pod-based service.
-  body:
-    application/json:
-      type: Pod
-  responses:
-    201:
-      description: Pod created successfully.
-      body:
-        application/json:
-          type: Pod
+/:
+  post:
+    is: [ secured, jsonValidator, objectValidator, objectCreator ]
+    description: |
+      Create and start a new pod-based service.
+    body:
+      application/json:
+        type: Pod
+    responses:
+      201:
+        description: Pod created successfully.
+        body:
+          application/json:
+            type: Pod
 
 /{id}:
   uriParameters:
@@ -26,21 +28,21 @@ post:
       description: The path of the pod
   delete:
     is: [ secured, objectLocator, deployable ]
-    description:|
+    description: |
       Delete an existing pod-based service.
 
   put:
     is: [ secured, jsonValidator, objectValidator, objectLocator, deployable ]
-    usage: TODO(jdef) separate error code when update of an immutable field fails?
-    description:|
+    description: |
       Update an existing pod-based service.
+      TODO(jdef) separate error code when update of an immutable field fails?
     body:
       application/json:
         type: Pod
 
   get:
     is: [ secured, objectLocator ]
-    description:
+    description: |
       Get the pod at the given id
     responses:
       200:

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -21,11 +21,24 @@ traits: !include ../traits.raml
           application/json:
             type: Pod
 
+  get:
+    is: [ secured ]
+    description:|
+      List all the pod-based services in the system.
+      TODO(jdef) do we really need this?
+    responses:
+      200:
+        description: A list of all pods in the system.
+        body:
+          application/json:
+            type: Pod[]
+
 /{id}:
   uriParameters:
     id:
       type: PathId
       description: The path of the pod
+
   delete:
     is: [ secured, objectLocator, deployable ]
     description: |

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -1,6 +1,7 @@
 #%RAML 1.0
 title: v2 pod API
 mediaType: application/json
+annotationTypes:  !include ../annotations.raml
 types:
   PathId: !include types/pathId.raml
   Pod: !include types/pod.raml

--- a/docs/docs/rest-api/public/api/v2/schema/Group.json
+++ b/docs/docs/rest-api/public/api/v2/schema/Group.json
@@ -23,6 +23,13 @@
         "$ref": "./AppDefinition.json"
       }
     },
+    "pods" : {
+      "type": "array",
+      "description": "The list of PodDefinitions in this group. See PodDefinition.json for the schema.",
+      "items": {
+        "$ref": "./PodDefinition.json"
+      }
+    },
     "groups": {
       "type": "array",
       "description": "Groups can build a tree. Each group can contain sub-groups. The sub-groups are defined here.",

--- a/docs/docs/rest-api/public/api/v2/types/artifact.raml
+++ b/docs/docs/rest-api/public/api/v2/types/artifact.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): Artifact
 properties:
   uri:
     type: string

--- a/docs/docs/rest-api/public/api/v2/types/artifact.raml
+++ b/docs/docs/rest-api/public/api/v2/types/artifact.raml
@@ -15,7 +15,7 @@ properties:
     type: string
     minLength: 1
     maxLength: 1024
-example:|
+example: |
   {
     "uri": "http://download.me/file.tgz",
     "extract": true,

--- a/docs/docs/rest-api/public/api/v2/types/artifact.raml
+++ b/docs/docs/rest-api/public/api/v2/types/artifact.raml
@@ -1,0 +1,24 @@
+#%RAML 1.0 DataType
+type: object
+properties:
+  uri:
+    type: string
+    minLength: 1
+    maxLength: 1024
+  extract?:
+    type: boolean
+  executable?:
+    type: boolean
+  cache?:
+    type: boolean
+  destPath?:
+    type: string
+    minLength: 1
+    maxLength: 1024
+example:|
+  {
+    "uri": "http://download.me/file.tgz",
+    "extract": true,
+    "executable": true,
+    "cache": false
+  }

--- a/docs/docs/rest-api/public/api/v2/types/constraint.raml
+++ b/docs/docs/rest-api/public/api/v2/types/constraint.raml
@@ -3,5 +3,6 @@ type: object
 properties:
   fieldName: string
   operator:
+    type: string
     enum: [UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER]
   value?: string

--- a/docs/docs/rest-api/public/api/v2/types/constraint.raml
+++ b/docs/docs/rest-api/public/api/v2/types/constraint.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): Constraint
 properties:
   fieldName:
     type: string

--- a/docs/docs/rest-api/public/api/v2/types/constraint.raml
+++ b/docs/docs/rest-api/public/api/v2/types/constraint.raml
@@ -1,7 +1,8 @@
 #%RAML 1.0 DataType
 type: object
 properties:
-  fieldName: string
+  fieldName:
+    type: string
   operator:
     type: string
     enum: [UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER]

--- a/docs/docs/rest-api/public/api/v2/types/constraint.raml
+++ b/docs/docs/rest-api/public/api/v2/types/constraint.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 DataType
+type: object
+properties:
+  fieldName: string
+  operator:
+    enum: [UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER]
+  value?: string

--- a/docs/docs/rest-api/public/api/v2/types/container-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/container-status.raml
@@ -49,7 +49,7 @@ properties:
           description: true if a health check is defined for this endpoint and is passing
   termination?:
     type: object
-    additionalProperies: false
+    additionalProperties: false
     properties:
       exitCode?:
         type: integer

--- a/docs/docs/rest-api/public/api/v2/types/container-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/container-status.raml
@@ -1,0 +1,56 @@
+#%RAML 1.0 DataType
+type: object
+additionalProperties: false
+properties:
+  name:
+    type: !include name.raml
+    description: name of the container specification (within the pod)
+  status:
+    type: string
+    enum: [ STAGING, STABLE, DEGRADED, TERMINAL ]
+    description:|
+      STAGING  - Container has been launched but is not yet running.
+      STABLE   - Container is running and, if health checks were specified, is healthy.
+      DEGRADED - Container is running but is not stable.
+      TERMINAL - Container is in the process of terminating or else has terminated.
+  message?:
+    type: string
+    description:|
+      Human-friendly explanation for the container's current status.
+  containerId?:
+    type: string
+    description:|
+      Unique ID of this container in the cluster.
+      TODO(jdef) Probably represents the Mesos task ID.
+  endpoints?:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: !include name.raml
+          description: name of the endpoint
+        allocatedHostPort?:
+          type: !include port.raml
+        healthy?:
+          type: boolean
+          usage: should only be present if a health check is defined for this endpoint
+          description: true if a health check is defined for this endpoint and is passing
+  termination?:
+    type: object
+    additionalProperies: false
+    properties:
+      exitCode?:
+        type: integer
+      message?:
+        type: string
+        description: Human-explanation for container termination.
+  lastUpdated:
+    type: datetime-only
+    description:|
+      Time that this status was last checked and updated (even if nothing changed)
+  lastChanged:
+    type: datetime-only
+    description:|
+      Time that this status was last modified (some aspect of status did change)

--- a/docs/docs/rest-api/public/api/v2/types/container-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/container-status.raml
@@ -1,11 +1,13 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): ContainerStatus
 additionalProperties: false
 properties:
   name:
     type: !include name.raml
     description: name of the container specification (within the pod)
   status:
+    (scalaType): ContainerState
     type: string
     usage: |
       TODO(jdef) this is not an enum because it reflects Marathon internal state that
@@ -35,6 +37,7 @@ properties:
   endpoints?:
     type: array
     items:
+      (scalaType): ContainerEndpointStatus
       type: object
       additionalProperties: false
       properties:
@@ -48,6 +51,7 @@ properties:
           usage: should only be present if a health check is defined for this endpoint
           description: true if a health check is defined for this endpoint and is passing
   termination?:
+    (scalaType): ContainerTerminationState
     type: object
     additionalProperties: false
     properties:

--- a/docs/docs/rest-api/public/api/v2/types/container-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/container-status.raml
@@ -47,10 +47,10 @@ properties:
         type: string
         description: Human-explanation for container termination.
   lastUpdated:
-    type: datetime-only
+    type: datetime
     description: |
       Time that this status was last checked and updated (even if nothing changed)
   lastChanged:
-    type: datetime-only
+    type: datetime
     description: |
       Time that this status was last modified (some aspect of status did change)

--- a/docs/docs/rest-api/public/api/v2/types/container-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/container-status.raml
@@ -11,7 +11,7 @@ properties:
     description: |
       STAGING  - Container has been launched but is not yet running.
       STABLE   - Container is running and, if health checks were specified, is healthy.
-      DEGRADED - Container is running but is not stable.
+      DEGRADED - Container is running but its health check is not passing.
       TERMINAL - Container is in the process of terminating or else has terminated.
   message?:
     type: string

--- a/docs/docs/rest-api/public/api/v2/types/container-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/container-status.raml
@@ -8,18 +8,18 @@ properties:
   status:
     type: string
     enum: [ STAGING, STABLE, DEGRADED, TERMINAL ]
-    description:|
+    description: |
       STAGING  - Container has been launched but is not yet running.
       STABLE   - Container is running and, if health checks were specified, is healthy.
       DEGRADED - Container is running but is not stable.
       TERMINAL - Container is in the process of terminating or else has terminated.
   message?:
     type: string
-    description:|
+    description: |
       Human-friendly explanation for the container's current status.
   containerId?:
     type: string
-    description:|
+    description: |
       Unique ID of this container in the cluster.
       TODO(jdef) Probably represents the Mesos task ID.
   endpoints?:
@@ -48,9 +48,9 @@ properties:
         description: Human-explanation for container termination.
   lastUpdated:
     type: datetime-only
-    description:|
+    description: |
       Time that this status was last checked and updated (even if nothing changed)
   lastChanged:
     type: datetime-only
-    description:|
+    description: |
       Time that this status was last modified (some aspect of status did change)

--- a/docs/docs/rest-api/public/api/v2/types/container-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/container-status.raml
@@ -7,16 +7,26 @@ properties:
     description: name of the container specification (within the pod)
   status:
     type: string
-    enum: [ STAGING, STABLE, DEGRADED, TERMINAL ]
+    usage: |
+      TODO(jdef) this is not an enum because it reflects Marathon internal state that
+      could easily change going forward and I don't want breaking API changes that result
+      from a shifting enum here.
     description: |
-      STAGING  - Container has been launched but is not yet running.
-      STABLE   - Container is running and, if health checks were specified, is healthy.
-      DEGRADED - Container is running but its health check is not passing.
-      TERMINAL - Container is in the process of terminating or else has terminated.
+      Reflects the status of the associated Mesos task.
+  statusSince:
+    type: datetime
+    description: |
+      Time at which the status code was last modified.
   message?:
     type: string
     description: |
       Human-friendly explanation for the container's current status.
+  conditions?:
+    type: array
+    description: |
+      Set of status conditions that apply to this container.
+    items:
+      type: !include status-condition.raml
   containerId?:
     type: string
     description: |

--- a/docs/docs/rest-api/public/api/v2/types/endpoint.raml
+++ b/docs/docs/rest-api/public/api/v2/types/endpoint.raml
@@ -1,0 +1,29 @@
+#%RAML 1.0 DataType
+type: object
+usage:|
+  Endpoints accept connections from outside of a pod.
+  Endpoints may also be advertised outside of a cluster.
+properties:
+  name:
+    type: !include name.raml
+    description: Name of this port.
+  containerPort?:
+    type: !include port.raml
+    description: |
+      The container port that a task's process is actually listening on.
+      Required if the network mode is container
+  hostPort?:
+    type: !include port.raml
+    description: |
+      Mapped port on the host
+      All host ports are allocated from resource offers
+  protocol?:
+    type: string
+    enum: [UDP, TCP]
+    description: The protocol of this port
+  labels:
+    type: array
+    items: !include label.raml
+    description:|
+      Metadata as key/value pair. Possible uses include VIPs,
+      per-network-interface binding

--- a/docs/docs/rest-api/public/api/v2/types/endpoint.raml
+++ b/docs/docs/rest-api/public/api/v2/types/endpoint.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 DataType
 type: object
-description:|
+description: |
   Endpoints accept connections from outside of a pod.
   Endpoints may also be advertised outside of a cluster.
 properties:
@@ -27,6 +27,6 @@ properties:
   labels?:
     type: array
     items: !include label.raml
-    description:|
+    description: |
       Metadata as key/value pair. Possible uses include VIPs,
       per-network-interface binding

--- a/docs/docs/rest-api/public/api/v2/types/endpoint.raml
+++ b/docs/docs/rest-api/public/api/v2/types/endpoint.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): Endpoint
 description: |
   Endpoints accept connections from outside of a pod.
   Endpoints may also be advertised outside of a cluster.

--- a/docs/docs/rest-api/public/api/v2/types/endpoint.raml
+++ b/docs/docs/rest-api/public/api/v2/types/endpoint.raml
@@ -1,12 +1,13 @@
 #%RAML 1.0 DataType
 type: object
-usage:|
+description:|
   Endpoints accept connections from outside of a pod.
   Endpoints may also be advertised outside of a cluster.
 properties:
   name:
     type: !include name.raml
-    description: Name of this port.
+    description: |
+      Name of this port. Should be unique in the context of the pod.
   containerPort?:
     type: !include port.raml
     description: |
@@ -15,13 +16,15 @@ properties:
   hostPort?:
     type: !include port.raml
     description: |
-      Mapped port on the host
-      All host ports are allocated from resource offers
+      Mapped port on the host.
+      All host ports are allocated from resource offers.
+    usage: Specify 0 to tell Marathon to dynamically allocate a host port.
+    minimum: 0
   protocol?:
-    type: string
-    enum: [UDP, TCP]
-    description: The protocol of this port
-  labels:
+    type: !include name.raml
+    description: |
+      The protocol of this port, advertised in Mesos DiscoveryInfo.
+  labels?:
     type: array
     items: !include label.raml
     description:|

--- a/docs/docs/rest-api/public/api/v2/types/environmentVariable.raml
+++ b/docs/docs/rest-api/public/api/v2/types/environmentVariable.raml
@@ -1,0 +1,17 @@
+#%RAML 1.0 DataType
+type: object
+maxProperties: 2
+properties:
+  name:
+    type: string
+    minLength: 1
+    maxLength: 1024
+    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+  value?:
+    type: string
+    description: literal value of the environment variable
+  secret?:
+    type: string
+    description: The name of the secret to refer to. At runtime, the
+      value of the secret will be injected into the value of the variable.
+      Mutually exclusive

--- a/docs/docs/rest-api/public/api/v2/types/environmentVariable.raml
+++ b/docs/docs/rest-api/public/api/v2/types/environmentVariable.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): EnvVar
 maxProperties: 2
 additionalProperties: false
 properties:

--- a/docs/docs/rest-api/public/api/v2/types/environmentVariable.raml
+++ b/docs/docs/rest-api/public/api/v2/types/environmentVariable.raml
@@ -1,6 +1,7 @@
 #%RAML 1.0 DataType
 type: object
 maxProperties: 2
+additionalProperties: false
 properties:
   name:
     type: string

--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): HealthCheck
 usage: Must specify a single type of check, http, tcp, or command
 maxProperties: 1
 minProperties: 1
@@ -18,6 +19,7 @@ properties:
         maxLength: 1024
       scheme?:
         type: string
+        (scalaType): HttpScheme
         enum: [ HTTP, HTTPS ]
         description: The http scheme to use
   tcp?:

--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -9,7 +9,7 @@ properties:
     properties:
       endpoint:
         type: !include name.raml
-        description:|
+        description: |
           The endpoint name to use.
           In "host" mode health checks use the hostPort. In other modes use the containerPort.
       path?:
@@ -25,7 +25,7 @@ properties:
     properties:
       endpoint:
         type: !include name.raml
-        description:|
+        description: |
           The endpoint name to use.
           In "host" mode health checks use the hostPort. In other modes use the containerPort.
   command?:

--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -12,7 +12,6 @@ properties:
         description:|
           The endpoint name to use.
           In "host" mode health checks use the hostPort. In other modes use the containerPort.
-          If an integer is specified then it should match hostPort or containerPort when in "host"
       path?:
         type: string
         minLength: 1
@@ -24,10 +23,10 @@ properties:
   tcp?:
     type: object
     properties:
-      type: !include name.raml
-      description:|
-        The endpoint name to use.
-        In "host" mode health checks use the hostPort. In other modes use the containerPort.
-        If an integer is specified then it should match hostPort or containerPort when in "host"
+      endpoint:
+        type: !include name.raml
+        description:|
+          The endpoint name to use.
+          In "host" mode health checks use the hostPort. In other modes use the containerPort.
   command?:
     type: !include mesosCommand.raml

--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -1,0 +1,33 @@
+#%RAML 1.0 DataType
+type: object
+usage: Must specify a single type of check, http, tcp, or command
+maxProperties: 1
+minProperties: 1
+properties:
+  http?:
+    type: object
+    properties:
+      endpoint:
+        type: !include name.raml
+        description:|
+          The endpoint name to use.
+          In "host" mode health checks use the hostPort. In other modes use the containerPort.
+          If an integer is specified then it should match hostPort or containerPort when in "host"
+      path?:
+        type: string
+        minLength: 1
+        maxLength: 1024
+      scheme?:
+        type: string
+        enum: [ HTTP, HTTPS ]
+        description: The http scheme to use
+  tcp?:
+    type: object
+    properties:
+      type: !include name.raml
+      description:|
+        The endpoint name to use.
+        In "host" mode health checks use the hostPort. In other modes use the containerPort.
+        If an integer is specified then it should match hostPort or containerPort when in "host"
+  command?:
+    type: !include mesosCommand.raml

--- a/docs/docs/rest-api/public/api/v2/types/image.raml
+++ b/docs/docs/rest-api/public/api/v2/types/image.raml
@@ -1,7 +1,9 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): Image
 properties:
   kind:
+    (scalaType): ImageType
     enum: [ DOCKER, APPC ]
   id:
     type: string
@@ -12,4 +14,3 @@ properties:
   forcePull?:
     type: boolean
     description: true if the image should always be pulled
-    

--- a/docs/docs/rest-api/public/api/v2/types/image.raml
+++ b/docs/docs/rest-api/public/api/v2/types/image.raml
@@ -1,0 +1,15 @@
+#%RAML 1.0 DataType
+type: object
+properties:
+  kind:
+    enum: [ DOCKER, APPC ]
+  id:
+    type: string
+    minLength: 1
+    maxLength: 1024
+    description: address/identifier of the file system image
+    example: mesosphere/marathon:1.3.0
+  forcePull?:
+    type: boolean
+    description: true if the image should always be pulled
+    

--- a/docs/docs/rest-api/public/api/v2/types/label.raml
+++ b/docs/docs/rest-api/public/api/v2/types/label.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): Label
 properties:
   name:
     type: string

--- a/docs/docs/rest-api/public/api/v2/types/label.raml
+++ b/docs/docs/rest-api/public/api/v2/types/label.raml
@@ -5,6 +5,8 @@ properties:
     type: string
     minLength: 1
     maxLength: 255
-    pattern: (?!^((MARATHON_)|(DCOS_)|(MESOS_)).*)
+    usage:|
+      Users should avoid inventing labels prefixed with MARATHON_ MESOS_
+      or DCOS_ since those may be defined by Marathon, Mesos, or DC/OS.
   value?:
     type: string

--- a/docs/docs/rest-api/public/api/v2/types/label.raml
+++ b/docs/docs/rest-api/public/api/v2/types/label.raml
@@ -5,7 +5,7 @@ properties:
     type: string
     minLength: 1
     maxLength: 255
-    usage:|
+    usage: |
       Users should avoid inventing labels prefixed with MARATHON_ MESOS_
       or DCOS_ since those may be defined by Marathon, Mesos, or DC/OS.
   value?:

--- a/docs/docs/rest-api/public/api/v2/types/label.raml
+++ b/docs/docs/rest-api/public/api/v2/types/label.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0 DataType
+type: object
+properties:
+  name:
+    type: string
+    minLength: 1
+    maxLength: 255
+    pattern: (?!^((MARATHON_)|(DCOS_)|(MESOS_)).*)
+  value?:
+    type: string

--- a/docs/docs/rest-api/public/api/v2/types/mesosCommand.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosCommand.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0 DataType
+type: object
+usage: specify either `shell` or `argv`, never both
+maxProperties: 1
+properties:
+  shell?:
+    type: string
+    description: command line executed by the default shell, not parsed by marathon
+    minLength: 1
+  argv?:
+    type: string[]
+    description: named executable first, followed by one or more parameters
+    minItems: 1

--- a/docs/docs/rest-api/public/api/v2/types/mesosCommand.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosCommand.raml
@@ -2,6 +2,7 @@
 type: object
 usage: specify either `shell` or `argv`, never both
 maxProperties: 1
+minProperties: 1
 additionalProperties: false
 properties:
   shell?:

--- a/docs/docs/rest-api/public/api/v2/types/mesosCommand.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosCommand.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): MesosCommand
 usage: specify either `shell` or `argv`, never both
 maxProperties: 1
 minProperties: 1

--- a/docs/docs/rest-api/public/api/v2/types/mesosCommand.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosCommand.raml
@@ -2,6 +2,7 @@
 type: object
 usage: specify either `shell` or `argv`, never both
 maxProperties: 1
+additionalProperties: false
 properties:
   shell?:
     type: string

--- a/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
@@ -1,0 +1,2 @@
+#%RAML 1.0 DataType
+type: object

--- a/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
@@ -41,3 +41,9 @@ properties:
     items: !include artifact.raml
     description:
       All artifacts to download before the task runs 
+  labels?:
+    type: array
+    items: !include label.raml
+    description:|
+      Metadata as key/value pair.
+      Useful when passing directives to be interpreted by Mesos modules.

--- a/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
@@ -21,12 +21,12 @@ properties:
   environment?:
     type: array
     items: !include environmentVariable.raml
-    description:|
+    description: |
       Environment variables to set, defined as key/value pairs.
       Variables defined here override those specified in the pod definition.
   user?:
     type: string
-    description:|
+    description: |
       The OS user to use to run the tasks on the agent.
       Values here override a "user" value specified in the pod definition.
   healthCheck?:
@@ -40,10 +40,10 @@ properties:
     type: array
     items: !include artifact.raml
     description:
-      All artifacts to download before the task runs 
+      All artifacts to download before the task runs
   labels?:
     type: array
     items: !include label.raml
-    description:|
+    description: |
       Metadata as key/value pair.
       Useful when passing directives to be interpreted by Mesos modules.

--- a/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
@@ -1,2 +1,33 @@
 #%RAML 1.0 DataType
 type: object
+description: Mesos Container
+properties:
+  name:
+    type: !include name.raml
+    description: The name of this container
+  command?:
+    type: !include mesosCommand.raml
+    description: command line executed by the default shell, not parsed by marathon
+  endpoints?:
+    type: array
+    items: !include endpoint.raml
+    description: The ports needed to run this container
+  image?:
+    type: !include image.raml
+    description: The filesystem image to populate the container with
+  environment?:
+    type: array
+    items: !include environmentVariable.raml
+    description: Environment variables to set, defined as key/value pairs
+  healthCheck?:
+    type: !include healthCheck.raml
+    description: All healthchecks to perform on the container
+  volumeMounts?:
+    type: array
+    items: !include volumeMount.raml
+    description: All volume mounts
+  artifacts?:
+    type: array
+    items: !include artifact.raml
+    description:
+      All artifacts to download before the task runs 

--- a/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
@@ -8,6 +8,9 @@ properties:
   command?:
     type: !include mesosCommand.raml
     description: command line executed by the default shell, not parsed by marathon
+  resources:
+    type: !include resources.raml
+    description: The resources to allocate to the container.
   endpoints?:
     type: array
     items: !include endpoint.raml
@@ -18,7 +21,14 @@ properties:
   environment?:
     type: array
     items: !include environmentVariable.raml
-    description: Environment variables to set, defined as key/value pairs
+    description:|
+      Environment variables to set, defined as key/value pairs.
+      Variables defined here override those specified in the pod definition.
+  user?:
+    type: string
+    description:|
+      The OS user to use to run the tasks on the agent.
+      Values here override a "user" value specified in the pod definition.
   healthCheck?:
     type: !include healthCheck.raml
     description: All healthchecks to perform on the container

--- a/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
@@ -5,9 +5,23 @@ properties:
   name:
     type: !include name.raml
     description: The name of this container
-  command?:
-    type: !include mesosCommand.raml
-    description: command line executed by the default shell, not parsed by marathon
+  exec?:
+    type: object
+    properties:
+      command:
+        type: !include mesosCommand.raml
+        description: |
+          Command specification executed by Mesos, not parsed by Marathon.
+          The presence of `command.shell` implies `overrideEntrypoint=true`.
+      overrideEntrypoint?:
+        type: boolean
+        usage: |
+          Applies only if a container image is specified AND that container image
+          defines a default entrypoint (Docker) or exec (appc) property.
+          It is an error to use `false` here when `command.shell` is set.
+        description: |
+          When true argv[0] will be used as the entrypoint/exec of the container.
+          Otherwise the contents of argv[] are appended as arguments.
   resources:
     type: !include resources.raml
     description: The resources to allocate to the container.

--- a/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): MesosContainer
 description: Mesos Container
 properties:
   name:

--- a/docs/docs/rest-api/public/api/v2/types/name.raml
+++ b/docs/docs/rest-api/public/api/v2/types/name.raml
@@ -1,0 +1,5 @@
+#%RAML 1.0 DataType
+type: string
+pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+maxLength: 63
+minLength: 1

--- a/docs/docs/rest-api/public/api/v2/types/network.raml
+++ b/docs/docs/rest-api/public/api/v2/types/network.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): Network
 properties:
   name?:
     type: !include name.raml
@@ -8,6 +9,7 @@ properties:
       Not for use with `host` mode networking
   mode?:
     type: string
+    (scalaType): NetworkMode
     enum: [container, host]
   labels?:
     type: array

--- a/docs/docs/rest-api/public/api/v2/types/network.raml
+++ b/docs/docs/rest-api/public/api/v2/types/network.raml
@@ -1,0 +1,14 @@
+#%RAML 1.0 DataType
+type: object
+properties:
+  name?:
+    type: !include name.raml
+    description: |
+      Defines the name of the container network to join.
+      Not for use with `host` mode networking
+  mode?:
+    type: string
+    enum: [container, host]
+  labels?:
+    type: array
+    items: !include label.raml

--- a/docs/docs/rest-api/public/api/v2/types/pathId.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pathId.raml
@@ -1,0 +1,4 @@
+#%RAML 1.0 DataType
+type: string
+pattern: ^(\/?((\.{2})|([a-z0-9][a-z0-9\-.]*[a-z0-9]+)|([a-z0-9]*))($|\/))+$
+minLength: 1

--- a/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
@@ -46,3 +46,17 @@ properties:
     description: status for each running container of this instance.
     items:
       type: !include container-status.raml
+  startedAt?:
+    type: datetime-only
+    description: time at which this instance was marked PENDING
+  terminatedAt?:
+    type: datetime-only
+    description: time at which this instance was marked TERMINAL
+  lastUpdated:
+    type: datetime-only
+    description:|
+      Time that this status was last checked and updated (even if nothing changed)
+  lastChanged:
+    type: datetime-only
+    description:|
+      Time that this status was last modified (some aspect of status did change)

--- a/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
@@ -47,16 +47,16 @@ properties:
     items:
       type: !include container-status.raml
   startedAt?:
-    type: datetime-only
+    type: datetime
     description: time at which this instance was marked PENDING
   terminatedAt?:
-    type: datetime-only
+    type: datetime
     description: time at which this instance was marked TERMINAL
   lastUpdated:
-    type: datetime-only
+    type: datetime
     description: |
       Time that this status was last checked and updated (even if nothing changed)
   lastChanged:
-    type: datetime-only
+    type: datetime
     description: |
       Time that this status was last modified (some aspect of status did change)

--- a/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
@@ -42,7 +42,7 @@ properties:
     type: array
     description: |
       Status of the networks to which this instance is attached.
-    item:
+    items:
       type: object
       additionalProperties: false
       properties:

--- a/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): PodInstanceStatus
 additionalProperties: false
 properties:
   id:
@@ -9,10 +10,8 @@ properties:
       TODO(jdef) Probably represents the Mesos executor ID.
   status:
     type: string
-    usage: |
-      TODO(jdef) this is not an enum because it reflects Marathon internal state that
-      could easily change going forward and I don't want breaking API changes that result
-      from a shifting enum here.
+    (scalaType): PodInstanceState
+    enum: [ PENDING, STAGING, STABLE, DEGRADED, TERMINAL ]
     description: |
       Reflects the aggregate status of all containers for this pod instance.
       For example RESERVED, CREATED, STAGING, STARTING, RUNNING, ERROR, FAILED, KILLING.
@@ -44,6 +43,7 @@ properties:
       Status of the networks to which this instance is attached.
     items:
       type: object
+      (scalaType): NetworkStatus
       additionalProperties: false
       properties:
         name?:

--- a/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
@@ -14,7 +14,7 @@ properties:
       PENDING  - Instance is queued for launch.
       STAGING  - Instance has been launched but is not yet running.
       STABLE   - Instance is running and, if health checks were specified, is healthy.
-      DEGRADED - One or more of the instance's containers are not stable.
+      DEGRADED - One or more of the instance's containers has a health check that is not passing.
       TERMINAL - Instance is in the process of shutting down.
   message?:
     type: string

--- a/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
@@ -1,0 +1,48 @@
+#%RAML 1.0 DataType
+type: object
+additionalProperties: false
+properties:
+  id:
+    type: !include name.raml
+    description:|
+      Unique ID of this pod instance in the cluster.
+      TODO(jdef) Probably represents the Mesos executor ID.
+  status:
+    type: string
+    enum: [ PENDING, STAGING, STABLE, DEGRADED, TERMINAL ]
+    description:|
+      PENDING  - Instance is queued for launch.
+      STAGING  - Instance has been launched but is not yet running.
+      STABLE   - Instance is running and, if health checks were specified, is healthy.
+      DEGRADED - One or more of the instance's containers are not stable.
+      TERMINAL - Instance is in the process of shutting down.
+  message?:
+    type: string
+    description:|
+      Human-friendly explanation for reason of the current status.
+  agent?:
+    type: string
+    description: agent that this instance was launched on
+  resources?:
+    type: !include resources.raml
+    description:|
+      Sum of all resources allocated for this pod instance.
+      May include additional, system-allocated resources for the default executor.
+  networks?:
+    type: array
+    description:|
+      Status of the networks to which this instance is attached.
+    item:
+      type: object
+      additionalProperties: false
+      properties:
+        name?:
+          type: !include name.raml
+          description: name of the network
+        addresses?:
+          type: string[]
+  containers?:
+    type: array
+    description: status for each running container of this instance.
+    items:
+      type: !include container-status.raml

--- a/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
@@ -9,17 +9,27 @@ properties:
       TODO(jdef) Probably represents the Mesos executor ID.
   status:
     type: string
-    enum: [ PENDING, STAGING, STABLE, DEGRADED, TERMINAL ]
+    usage: |
+      TODO(jdef) this is not an enum because it reflects Marathon internal state that
+      could easily change going forward and I don't want breaking API changes that result
+      from a shifting enum here.
     description: |
-      PENDING  - Instance is queued for launch.
-      STAGING  - Instance has been launched but is not yet running.
-      STABLE   - Instance is running and, if health checks were specified, is healthy.
-      DEGRADED - One or more of the instance's containers has a health check that is not passing.
-      TERMINAL - Instance is in the process of shutting down.
+      Reflects the aggregate status of all containers for this pod instance.
+      For example RESERVED, CREATED, STAGING, STARTING, RUNNING, ERROR, FAILED, KILLING.
+  statusSince:
+    type: datetime
+    description: |
+      Time at which the status code was last modified.
   message?:
     type: string
     description: |
       Human-friendly explanation for reason of the current status.
+  conditions?:
+    type: array
+    description: |
+      Set of status conditions that apply to this pod instance.
+    items:
+      type: !include status-condition.raml
   agent?:
     type: string
     description: agent that this instance was launched on
@@ -46,12 +56,6 @@ properties:
     description: status for each running container of this instance.
     items:
       type: !include container-status.raml
-  startedAt?:
-    type: datetime
-    description: time at which this instance was marked PENDING
-  terminatedAt?:
-    type: datetime
-    description: time at which this instance was marked TERMINAL
   lastUpdated:
     type: datetime
     description: |

--- a/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-instance-status.raml
@@ -4,13 +4,13 @@ additionalProperties: false
 properties:
   id:
     type: !include name.raml
-    description:|
+    description: |
       Unique ID of this pod instance in the cluster.
       TODO(jdef) Probably represents the Mesos executor ID.
   status:
     type: string
     enum: [ PENDING, STAGING, STABLE, DEGRADED, TERMINAL ]
-    description:|
+    description: |
       PENDING  - Instance is queued for launch.
       STAGING  - Instance has been launched but is not yet running.
       STABLE   - Instance is running and, if health checks were specified, is healthy.
@@ -18,19 +18,19 @@ properties:
       TERMINAL - Instance is in the process of shutting down.
   message?:
     type: string
-    description:|
+    description: |
       Human-friendly explanation for reason of the current status.
   agent?:
     type: string
     description: agent that this instance was launched on
   resources?:
     type: !include resources.raml
-    description:|
+    description: |
       Sum of all resources allocated for this pod instance.
       May include additional, system-allocated resources for the default executor.
   networks?:
     type: array
-    description:|
+    description: |
       Status of the networks to which this instance is attached.
     item:
       type: object
@@ -54,9 +54,9 @@ properties:
     description: time at which this instance was marked TERMINAL
   lastUpdated:
     type: datetime-only
-    description:|
+    description: |
       Time that this status was last checked and updated (even if nothing changed)
   lastChanged:
     type: datetime-only
-    description:|
+    description: |
       Time that this status was last modified (some aspect of status did change)

--- a/docs/docs/rest-api/public/api/v2/types/pod-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-status.raml
@@ -40,18 +40,18 @@ properties:
         instanceID:
           type: string
         startedAt:
-          type: datetime-only
+          type: datetime
         terminatedAt:
-          type: datetime-only
+          type: datetime
         message?:
           type: string
           description: |
             Human-friendly explanation for termination.
   lastUpdated:
-    type: datetime-only
+    type: datetime
     description: |
       Time that this status was last checked and updated (even if nothing changed)
   lastChanged:
-    type: datetime-only
+    type: datetime
     description: |
       Time that this status was last modified (some aspect of status did change)

--- a/docs/docs/rest-api/public/api/v2/types/pod-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-status.raml
@@ -20,6 +20,10 @@ properties:
       DEGRADED - The number of STABLE pod instances is less than the number of desired instances.
       STABLE   - All launched pod instances have started and, if health checks were specified, are all healthy.
       TERMINAL - Marathon is tearing down all of the instances for this pod.
+  statusSince:
+    type: datetime
+    description: |
+      Time at which the status code was last modified.
   message?:
     type: string
     description: |
@@ -50,8 +54,8 @@ properties:
   lastUpdated:
     type: datetime
     description: |
-      Time that this status was last checked and updated (even if nothing changed)
+      Time that this status object was last checked and updated (even if nothing changed)
   lastChanged:
     type: datetime
     description: |
-      Time that this status was last modified (some aspect of status did change)
+      Time that this status object was last modified (some aspect of status did change)

--- a/docs/docs/rest-api/public/api/v2/types/pod-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-status.raml
@@ -1,0 +1,58 @@
+#%RAML 1.0 DataType
+type: object
+description: |
+  A pod allows one to launch a collection co-located (on the same agent) containers
+  that share the same network namespace and that may share the same volumes.
+  Resources are specified on a per-container basis.
+additionalProperties: false
+properties:
+  id:
+    type: !include pathId.raml
+    description:|
+      Fully qualified name of the pod that this status object is describing.
+  spec:
+    type: !include pod.raml
+    description:|
+      The latest version of the pod specification (that has the same pod ID).
+  status:
+    type: string
+    enum: [ DEGRADED, STABLE, TERMINAL ]
+    description:|
+      DEGRADED - The number of stable pod instances is less than the number of target instances.
+      STABLE   - All launched pod instances have started and, if health checks were specified, are all healthy.
+      TERMINAL - Marathon is tearing down all of the instances for this pod.
+  message?:
+    type: string
+    description:|
+      Human-friendly explanation for reason of the current status.
+  instances?:
+    type: array
+    items:
+      type: !include pod-instance-status.raml
+  terminationHistory?:
+    type: array
+    description:|
+      List of most recent instance terminations.
+      TODO(jdef) determine how many items might show up here; current thinking is .. not many
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        instanceID:
+          type: string
+        startedAt:
+          type: datetime-only
+        terminatedAt:
+          type: datetime-only
+        message?:
+          type: string
+          description:|
+            Human-friendly explanation for termination.
+  lastUpdated:
+    type: datetime-only
+    description:|
+      Time that this status was last checked and updated (even if nothing changed)
+  lastChanged:
+    type: datetime-only
+    description:|
+      Time that this status was last modified (some aspect of status did change)

--- a/docs/docs/rest-api/public/api/v2/types/pod-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-status.raml
@@ -17,7 +17,7 @@ properties:
     type: string
     enum: [ DEGRADED, STABLE, TERMINAL ]
     description: |
-      DEGRADED - The number of stable pod instances is less than the number of target instances.
+      DEGRADED - The number of STABLE pod instances is less than the number of desired instances.
       STABLE   - All launched pod instances have started and, if health checks were specified, are all healthy.
       TERMINAL - Marathon is tearing down all of the instances for this pod.
   message?:

--- a/docs/docs/rest-api/public/api/v2/types/pod-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-status.raml
@@ -1,9 +1,8 @@
 #%RAML 1.0 DataType
 type: object
 description: |
-  A pod allows one to launch a collection co-located (on the same agent) containers
-  that share the same network namespace and that may share the same volumes.
-  Resources are specified on a per-container basis.
+  Pod status communicates the lifecycle phase of the pod, current instance and container
+  status, and recent termination status history.
 additionalProperties: false
 properties:
   id:

--- a/docs/docs/rest-api/public/api/v2/types/pod-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-status.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): PodStatus
 description: |
   Pod status communicates the lifecycle phase of the pod, current instance and container
   status, and recent termination status history.
@@ -15,6 +16,7 @@ properties:
       The latest version of the pod specification (that has the same pod ID).
   status:
     type: string
+    (scalaType): PodState
     enum: [ DEGRADED, STABLE, TERMINAL ]
     description: |
       DEGRADED - The number of STABLE pod instances is less than the number of desired instances.
@@ -31,6 +33,7 @@ properties:
   instances?:
     type: array
     items:
+      (scalaType): PodInstanceStatus
       type: !include pod-instance-status.raml
   terminationHistory?:
     type: array
@@ -38,6 +41,7 @@ properties:
       List of most recent instance terminations.
       TODO(jdef) determine how many items might show up here; current thinking is .. not many
     items:
+      (scalaType): TerminationHistory
       type: object
       additionalProperties: false
       properties:

--- a/docs/docs/rest-api/public/api/v2/types/pod-status.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod-status.raml
@@ -8,22 +8,22 @@ additionalProperties: false
 properties:
   id:
     type: !include pathId.raml
-    description:|
+    description: |
       Fully qualified name of the pod that this status object is describing.
   spec:
     type: !include pod.raml
-    description:|
+    description: |
       The latest version of the pod specification (that has the same pod ID).
   status:
     type: string
     enum: [ DEGRADED, STABLE, TERMINAL ]
-    description:|
+    description: |
       DEGRADED - The number of stable pod instances is less than the number of target instances.
       STABLE   - All launched pod instances have started and, if health checks were specified, are all healthy.
       TERMINAL - Marathon is tearing down all of the instances for this pod.
   message?:
     type: string
-    description:|
+    description: |
       Human-friendly explanation for reason of the current status.
   instances?:
     type: array
@@ -31,7 +31,7 @@ properties:
       type: !include pod-instance-status.raml
   terminationHistory?:
     type: array
-    description:|
+    description: |
       List of most recent instance terminations.
       TODO(jdef) determine how many items might show up here; current thinking is .. not many
     items:
@@ -46,13 +46,13 @@ properties:
           type: datetime-only
         message?:
           type: string
-          description:|
+          description: |
             Human-friendly explanation for termination.
   lastUpdated:
     type: datetime-only
-    description:|
+    description: |
       Time that this status was last checked and updated (even if nothing changed)
   lastChanged:
     type: datetime-only
-    description:|
+    description: |
       Time that this status was last modified (some aspect of status did change)

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -6,12 +6,13 @@ description: |
   Resources are specified on a per-container basis.
 properties:
   id:
-    type: !include pathId.raml
+    type: string
+    pattern: ^(\/?((\.{2})|([a-z0-9][a-z0-9\-.]*[a-z0-9]+)|([a-z0-9]*))($|\/))+$
+    minLength: 1
     description: |
       Unique identifier for the pod consisting of a series of names separated by slashes.
       Each name must be at least 1 character and may only contain digits (`0-9`), dashes
       (`-`), dots (`.`), and lowercase letters (`a-z`). The name may not begin or end with a dash.
-    required: true
     example: /ops/audit
   labels?:
     type: array

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -10,16 +10,25 @@ properties:
   containers:
     type: array
     items: !include mesosContainer.raml
-  resources: !include resources.raml
-  acceptedResourceRoles?:
-    type: string[]
-    displayName: A list of resource roles. Marathon considers only resource offers with roles in this list for launching tasks of this app. If you do not specify this, Marathon considers all resource offers with roles that have been configured by the `--default_accepted_resource_roles` command line flag. If no `--default_accepted_resource_roles` was given on startup, Marathon considers all resource offers. To register Marathon for a role, you need to specify the `--mesos_role` command line flag on startup. If you want to assign all resources of a slave to a role, you can use the `--default_role` argument when starting up the slave. If you need a more fine-grained configuration, you can use the `--resources` argument to specify resource shares per role. See [the Mesos attribute and resources documentation](http://mesos.apache.org/documentation/latest/attributes-resources/) for details
-    example: public-facing
+  resources:
+    type: !include resources.raml
+    description: The resources to allocate to the pod
+  instances:
+    type: integer
+    description: The number of instances of this pod to start.
+    minimum: 0
+  maxInstances?:
+    type: integer
+    description:|
+      The maximum number of instances of this pod that should
+      be running at a given time.
+    minimum: 0
   constraints?:
     type: array
     items: !include constraint.raml
-    description: Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER
-    example: hostname:UNIQUE
+    description:|
+      Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER
+    example: [hostname:UNIQUE]
   user?:
     type: string
     description: The user to use to run the tasks on the agent
@@ -27,11 +36,40 @@ properties:
     type: datetime-only
     description: The version of the definition, immutable
   versionInfo?: !include versionInfo.raml
-  env:
+  env?:
     type: array
     items: !include environmentVariable.raml
     displayName: environment
-    description: Environment Variables to set
+    description:|
+      Environment Variables to set at the pod level.
+      Individual containers may override them
     example: |
       [ { "name" : "MASTER_URI", "value": "http://master.local" },
         { "name" : "MASTER_PASSWORD", "secret": "/master/secret1" } ]
+  volumes?:
+    type: array
+    items: !include volumes.raml
+    description: Volumes defined on a pod level that are mounted into containers
+  networks?:
+    type: array
+    items: !include network.raml
+    description:|
+      Network settings are defined on a pod level. All containers
+      share the same network stack. At this time, only one stack is supported.
+  acceptedResourceRoles?:
+    type: string[]
+    example: [public-facing]
+    description: |
+      A list of resource roles.
+      Marathon considers only resource offers with roles in this list for
+      launching tasks of this app. If you do not specify this,
+      Marathon considers all resource offers with roles that have been
+      configured by the `--default_accepted_resource_roles` command line flag.
+      If no `--default_accepted_resource_roles` was given on startup,
+      Marathon considers all resource offers. To register Marathon for a role,
+      you need to specify the `--mesos_role` command line flag on startup.
+      If you want to assign all resources of a slave to a role,
+      you can use the `--default_role` argument when starting up the slave.
+      If you need a more fine-grained configuration, you can use the
+      `--resources` argument to specify resource shares per role.
+      See [the Mesos attribute and resources documentation](http://mesos.apache.org/documentation/latest/attributes-resources/) for details

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -1,0 +1,37 @@
+#%RAML 1.0 DataType
+type: object
+description: How much disk space is needed for this application. This number does not have to be an integer, but can be a fraction.
+properties:
+  id:
+    type: !include pathId.raml
+    description: Unique identifier for the pod consisting of a series of names separated by slashes. Each name must be at least 1 character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The name may not begin or end with a dash.
+    required: true
+    example: /ops/audit
+  containers:
+    type: array
+    items: !include mesosContainer.raml
+  resources: !include resources.raml
+  acceptedResourceRoles?:
+    type: string[]
+    displayName: A list of resource roles. Marathon considers only resource offers with roles in this list for launching tasks of this app. If you do not specify this, Marathon considers all resource offers with roles that have been configured by the `--default_accepted_resource_roles` command line flag. If no `--default_accepted_resource_roles` was given on startup, Marathon considers all resource offers. To register Marathon for a role, you need to specify the `--mesos_role` command line flag on startup. If you want to assign all resources of a slave to a role, you can use the `--default_role` argument when starting up the slave. If you need a more fine-grained configuration, you can use the `--resources` argument to specify resource shares per role. See [the Mesos attribute and resources documentation](http://mesos.apache.org/documentation/latest/attributes-resources/) for details
+    example: public-facing
+  constraints?:
+    type: array
+    items: !include constraint.raml
+    description: Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER
+    example: hostname:UNIQUE
+  user?:
+    type: string
+    description: The user to use to run the tasks on the agent
+  version?:
+    type: datetime-only
+    description: The version of the definition, immutable
+  versionInfo?: !include versionInfo.raml
+  env:
+    type: array
+    items: !include environmentVariable.raml
+    displayName: environment
+    description: Environment Variables to set
+    example: |
+      [ { "name" : "MASTER_URI", "value": "http://master.local" },
+        { "name" : "MASTER_PASSWORD", "secret": "/master/secret1" } ]

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -1,18 +1,21 @@
 #%RAML 1.0 DataType
 type: object
-description: How much disk space is needed for this application. This number does not have to be an integer, but can be a fraction.
+description:|
+  A pod allows one to launch a collection co-located (on the same agent) containers
+  that share the same network namespace and that may share the same volumes.
+  Resources are specified on a per-container basis.
 properties:
   id:
     type: !include pathId.raml
-    description: Unique identifier for the pod consisting of a series of names separated by slashes. Each name must be at least 1 character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The name may not begin or end with a dash.
+    description:|
+      Unique identifier for the pod consisting of a series of names separated by slashes.
+      Each name must be at least 1 character and may only contain digits (`0-9`), dashes
+      (`-`), dots (`.`), and lowercase letters (`a-z`). The name may not begin or end with a dash.
     required: true
     example: /ops/audit
   containers:
     type: array
     items: !include mesosContainer.raml
-  resources:
-    type: !include resources.raml
-    description: The resources to allocate to the pod
   instances:
     type: integer
     description: The number of instances of this pod to start.
@@ -31,15 +34,17 @@ properties:
     example: [hostname:UNIQUE]
   user?:
     type: string
-    description: The user to use to run the tasks on the agent
+    description:|
+      The OS user to use to run the tasks on the agent.
+      May be overridden by a container.
   version?:
     type: datetime-only
     description: The version of the definition, immutable
-  versionInfo?: !include versionInfo.raml
-  env?:
+  versionInfo?:
+    type: !include versionInfo.raml
+  environment?:
     type: array
     items: !include environmentVariable.raml
-    displayName: environment
     description:|
       Environment Variables to set at the pod level.
       Individual containers may override them
@@ -48,7 +53,7 @@ properties:
         { "name" : "MASTER_PASSWORD", "secret": "/master/secret1" } ]
   volumes?:
     type: array
-    items: !include volumes.raml
+    items: !include volume.raml
     description: Volumes defined on a pod level that are mounted into containers
   networks?:
     type: array

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -13,35 +13,20 @@ properties:
       (`-`), dots (`.`), and lowercase letters (`a-z`). The name may not begin or end with a dash.
     required: true
     example: /ops/audit
-  containers:
+  labels?:
     type: array
-    items: !include mesosContainer.raml
-  instances:
-    type: integer
-    description: The number of instances of this pod to start.
-    minimum: 0
-  maxInstances?:
-    type: integer
+    items: !include label.raml
     description:|
-      The maximum number of instances of this pod that should
-      be running at a given time.
-    minimum: 0
-  constraints?:
-    type: array
-    items: !include constraint.raml
-    description:|
-      Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER
-    example: [hostname:UNIQUE]
+      Metadata as key/value pair.
+      Useful when passing directives to be interpreted by Mesos modules.
+  version?:
+    type: datetime-only
+    description: The version of the definition, immutable
   user?:
     type: string
     description:|
       The OS user to use to run the tasks on the agent.
       May be overridden by a container.
-  version?:
-    type: datetime-only
-    description: The version of the definition, immutable
-  versionInfo?:
-    type: !include versionInfo.raml
   environment?:
     type: array
     items: !include environmentVariable.raml
@@ -51,6 +36,9 @@ properties:
     example: |
       [ { "name" : "MASTER_URI", "value": "http://master.local" },
         { "name" : "MASTER_PASSWORD", "secret": "/master/secret1" } ]
+  containers:
+    type: array
+    items: !include mesosContainer.raml
   volumes?:
     type: array
     items: !include volume.raml
@@ -59,22 +47,95 @@ properties:
     type: array
     items: !include network.raml
     description:|
-      Network settings are defined on a pod level. All containers
-      share the same network stack. At this time, only one stack is supported.
-  acceptedResourceRoles?:
-    type: string[]
-    example: [public-facing]
-    description: |
-      A list of resource roles.
-      Marathon considers only resource offers with roles in this list for
-      launching tasks of this app. If you do not specify this,
-      Marathon considers all resource offers with roles that have been
-      configured by the `--default_accepted_resource_roles` command line flag.
-      If no `--default_accepted_resource_roles` was given on startup,
-      Marathon considers all resource offers. To register Marathon for a role,
-      you need to specify the `--mesos_role` command line flag on startup.
-      If you want to assign all resources of a slave to a role,
-      you can use the `--default_role` argument when starting up the slave.
-      If you need a more fine-grained configuration, you can use the
-      `--resources` argument to specify resource shares per role.
-      See [the Mesos attribute and resources documentation](http://mesos.apache.org/documentation/latest/attributes-resources/) for details
+      Network settings are defined on a pod level. All containers share the same network stack.
+      At this time, only one stack is supported.
+  scaling?:
+    type: object
+    minProperties: 1
+    maxProperties: 1
+    additionalProperties: false
+    properties:
+      fixed?:
+        type: object
+        properties:
+          instances:
+            type: integer
+            description: The number of instances of this pod to start.
+            minimum: 0
+          maxInstances?:
+            type: integer
+            description:|
+              The maximum number of instances of this pod that should
+              be running at a given time.
+            minimum: 0
+  scheduling?:
+    type: object
+    properties:
+      backoffStrategy?:
+        type: object
+        description:|
+          Configures exponential backoff behavior when launching potentially sick apps.
+          This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves.
+          The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds.
+          This applies also to tasks that are killed due to failing too many health checks.
+        properties:
+          backoff?:
+            type: number
+            description: Configures exponential backoff behavior when launching potentially sick apps. 
+            minimum: 0
+          backoffFactor?:
+            type: number
+            description: Configures exponential backoff behavior when launching potentially sick apps. 
+            minimum: 0
+          maxLaunchDelay?: 
+            type: number
+            description: Amount of time (seconds) until a pod is reported running
+            minimum: 0
+      upgradeStrategy?:
+        type: object
+        description:|
+          During an upgrade all instances of an application get replaced by a new version.
+          The upgradeStrategy controls how Marathon stops old versions and launches new versions.
+        properties:
+          minimumHealthCapacity?:
+            type: number
+            description:|
+              A number between 0and 1 that is multiplied with the instance count.
+              This is the minimum number of healthy nodes that do not sacrifice overall application purpose.
+              Marathon will make sure, during the upgrade process, that at any point of time this number of healthy instances are up.
+            default: 1
+            minimum: 0
+            maxumum: 1
+          maximumOverCapacity?:
+            type: number
+            description:|
+              A number between 0 and 1 which is multiplied with the instance count.
+              This is the maximum number of additional instances launched at any point of time during the upgrade process.
+            default: 1
+            minimum: 0
+            maxumum: 1
+      placement?:
+        type: object
+        properties:
+          constraints?:
+            type: array
+            items: !include constraint.raml
+            description:|
+              Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER
+          acceptedResourceRoles?:
+            type: string[]
+            example: [public-facing]
+            description: |
+              A list of resource roles.
+              Marathon considers only resource offers with roles in this list for
+              launching tasks of this app. If you do not specify this,
+              Marathon considers all resource offers with roles that have been
+              configured by the `--default_accepted_resource_roles` command line flag.
+              If no `--default_accepted_resource_roles` was given on startup,
+              Marathon considers all resource offers. To register Marathon for a role,
+              you need to specify the `--mesos_role` command line flag on startup.
+              If you want to assign all resources of a slave to a role,
+              you can use the `--default_role` argument when starting up the slave.
+              If you need a more fine-grained configuration, you can use the
+              `--resources` argument to specify resource shares per role.
+              See [the Mesos attribute and resources documentation](http://mesos.apache.org/documentation/latest/attributes-resources/) for details

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): PodDef
 description: |
   A pod allows one to launch a collection co-located (on the same agent) containers
   that share the same network namespace and that may share the same volumes.
@@ -55,6 +56,7 @@ properties:
     minProperties: 1
     maxProperties: 1
     additionalProperties: false
+    (scalaType): PodScalingPolicy
     properties:
       fixed?:
         type: object
@@ -71,9 +73,11 @@ properties:
             minimum: 0
   scheduling?:
     type: object
+    (scalaType): PodSchedulingPolicy
     properties:
       backoffStrategy?:
         type: object
+        (scalaType): PodSchedulingBackoffStrategy
         description: |
           Configures exponential backoff behavior when launching potentially sick apps.
           This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves.
@@ -94,6 +98,7 @@ properties:
             minimum: 0
       upgradeStrategy?:
         type: object
+        (scalaType): PodSchedulingUpgradeStrategy
         description: |
           During an upgrade all instances of an application get replaced by a new version.
           The upgradeStrategy controls how Marathon stops old versions and launches new versions.
@@ -117,6 +122,7 @@ properties:
             maximum: 1
       placement?:
         type: object
+        (scalaType): PodSchedulingPlacementPolicy
         properties:
           constraints?:
             type: array

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -1,13 +1,13 @@
 #%RAML 1.0 DataType
 type: object
-description:|
+description: |
   A pod allows one to launch a collection co-located (on the same agent) containers
   that share the same network namespace and that may share the same volumes.
   Resources are specified on a per-container basis.
 properties:
   id:
     type: !include pathId.raml
-    description:|
+    description: |
       Unique identifier for the pod consisting of a series of names separated by slashes.
       Each name must be at least 1 character and may only contain digits (`0-9`), dashes
       (`-`), dots (`.`), and lowercase letters (`a-z`). The name may not begin or end with a dash.
@@ -16,7 +16,7 @@ properties:
   labels?:
     type: array
     items: !include label.raml
-    description:|
+    description: |
       Metadata as key/value pair.
       Useful when passing directives to be interpreted by Mesos modules.
   version?:
@@ -24,13 +24,13 @@ properties:
     description: The version of the definition, immutable
   user?:
     type: string
-    description:|
+    description: |
       The OS user to use to run the tasks on the agent.
       May be overridden by a container.
   environment?:
     type: array
     items: !include environmentVariable.raml
-    description:|
+    description: |
       Environment Variables to set at the pod level.
       Individual containers may override them
     example: |
@@ -46,7 +46,7 @@ properties:
   networks?:
     type: array
     items: !include network.raml
-    description:|
+    description: |
       Network settings are defined on a pod level. All containers share the same network stack.
       At this time, only one stack is supported.
   scaling?:
@@ -64,7 +64,7 @@ properties:
             minimum: 0
           maxInstances?:
             type: integer
-            description:|
+            description: |
               The maximum number of instances of this pod that should
               be running at a given time.
             minimum: 0
@@ -73,7 +73,7 @@ properties:
     properties:
       backoffStrategy?:
         type: object
-        description:|
+        description: |
           Configures exponential backoff behavior when launching potentially sick apps.
           This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves.
           The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds.
@@ -81,46 +81,46 @@ properties:
         properties:
           backoff?:
             type: number
-            description: Configures exponential backoff behavior when launching potentially sick apps. 
+            description: Configures exponential backoff behavior when launching potentially sick apps.
             minimum: 0
           backoffFactor?:
             type: number
-            description: Configures exponential backoff behavior when launching potentially sick apps. 
+            description: Configures exponential backoff behavior when launching potentially sick apps.
             minimum: 0
-          maxLaunchDelay?: 
+          maxLaunchDelay?:
             type: number
             description: Amount of time (seconds) until a pod is reported running
             minimum: 0
       upgradeStrategy?:
         type: object
-        description:|
+        description: |
           During an upgrade all instances of an application get replaced by a new version.
           The upgradeStrategy controls how Marathon stops old versions and launches new versions.
         properties:
           minimumHealthCapacity?:
             type: number
-            description:|
+            description: |
               A number between 0and 1 that is multiplied with the instance count.
               This is the minimum number of healthy nodes that do not sacrifice overall application purpose.
               Marathon will make sure, during the upgrade process, that at any point of time this number of healthy instances are up.
             default: 1
             minimum: 0
-            maxumum: 1
+            maximum: 1
           maximumOverCapacity?:
             type: number
-            description:|
+            description: |
               A number between 0 and 1 which is multiplied with the instance count.
               This is the maximum number of additional instances launched at any point of time during the upgrade process.
             default: 1
             minimum: 0
-            maxumum: 1
+            maximum: 1
       placement?:
         type: object
         properties:
           constraints?:
             type: array
             items: !include constraint.raml
-            description:|
+            description: |
               Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER
           acceptedResourceRoles?:
             type: string[]

--- a/docs/docs/rest-api/public/api/v2/types/port.raml
+++ b/docs/docs/rest-api/public/api/v2/types/port.raml
@@ -1,0 +1,4 @@
+#%RAML 1.0 DataType
+type: integer
+minimum: 1
+maximum: 65535

--- a/docs/docs/rest-api/public/api/v2/types/resources.raml
+++ b/docs/docs/rest-api/public/api/v2/types/resources.raml
@@ -1,0 +1,30 @@
+#%RAML 1.0 DataType
+type: object
+description: Resource Allocations
+properties:
+  cpus:
+    displayName: cpu shares
+    description: The number of CPU shares this pod needs per instance. This number does not have to be integer, but can be a fraction.
+    type: number
+    minimum: 0
+    format: float
+    example: 0.1
+  mem:
+    displayName: memory shares
+    type: number
+    minimum: 0
+    description: The amount of memory in MB that is needed for the pod instance
+    example: 512
+  disk?:
+    displayName: disk space
+    type: number
+    minimum: 0
+    format: float
+    description: How much disk space is needed for this application. This number does not have to be an integer, but can be a fraction.
+    example: 0.2
+  gpus?:
+    displayName: gpu shares
+    type: integer
+    minimum: 0
+    description: The amount of GPU cores that are needed for the pod
+    example: 1

--- a/docs/docs/rest-api/public/api/v2/types/resources.raml
+++ b/docs/docs/rest-api/public/api/v2/types/resources.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): Resources
 description: Resource Allocations
 properties:
   cpus:

--- a/docs/docs/rest-api/public/api/v2/types/resources.raml
+++ b/docs/docs/rest-api/public/api/v2/types/resources.raml
@@ -6,19 +6,20 @@ properties:
     displayName: cpu shares
     description: The number of CPU shares this pod needs per instance. This number does not have to be integer, but can be a fraction.
     type: number
-    minimum: 0
+    minimum: 0.001
     format: float
     example: 0.1
   mem:
     displayName: memory shares
     type: number
-    minimum: 0
+    minimum: 0.001
+    format: float
     description: The amount of memory in MB that is needed for the pod instance
     example: 512
   disk?:
     displayName: disk space
     type: number
-    minimum: 0
+    minimum: 0.001
     format: float
     description: How much disk space is needed for this application. This number does not have to be an integer, but can be a fraction.
     example: 0.2

--- a/docs/docs/rest-api/public/api/v2/types/status-condition.raml
+++ b/docs/docs/rest-api/public/api/v2/types/status-condition.raml
@@ -1,0 +1,23 @@
+#%RAML 1.0 DataType
+type: object
+additionalProperties: false
+properties:
+  name:
+    type: !include name.raml
+    description: |
+      Human and machine-readable name of this condition.
+      For example "healthy", "disk-full".
+  lastChanged:
+    type: datetime
+    description: last time the value field was changed for this condition
+  lastUpdated:
+    type: datetime
+    description: last time this condition was updated (value may not have changed)
+  value:
+    type: string
+    description: the state of the condition. may be boolean or some enumeration-derived value
+    maxLength: 64
+  reason?:
+    type: string
+    description: |
+      a machine-readable value that systems use to reason about the state of the condition

--- a/docs/docs/rest-api/public/api/v2/types/versionInfo.raml
+++ b/docs/docs/rest-api/public/api/v2/types/versionInfo.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): VersionInfo
 description: Detailed version information
 properties:
   lastScalingAt:

--- a/docs/docs/rest-api/public/api/v2/types/versionInfo.raml
+++ b/docs/docs/rest-api/public/api/v2/types/versionInfo.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0 DataType
+type: object
+description: Detailed version information
+properties:
+  lastScalingAt:
+    type: datetime-only
+    description: Contains the timestamp of the last change to this pod which was not simply a scaling or restarting configuration
+  lastConfigChangeAt:
+    type: datetime-only
+    description: Contains the timestamp of the last change including changes like scaling or restarting.

--- a/docs/docs/rest-api/public/api/v2/types/volume.raml
+++ b/docs/docs/rest-api/public/api/v2/types/volume.raml
@@ -1,0 +1,14 @@
+#%RAML 1.0 DataType
+type: object
+properties:
+  name:
+    type: !include name.raml
+    description: The name of the volume to reference.
+  host?:
+    type: string
+    description: |
+      Absolute path of the file or directory on the agent, or else the relative
+      path of the directory in the executor's sandbox.
+      Host volumes are useful for mapping directories that exist on the agent apriori,
+      or within the executor sandbox. No resources (Mesos or otherwise) are allocated for
+      these types of volumes.

--- a/docs/docs/rest-api/public/api/v2/types/volume.raml
+++ b/docs/docs/rest-api/public/api/v2/types/volume.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): Volume
 properties:
   name:
     type: !include name.raml

--- a/docs/docs/rest-api/public/api/v2/types/volumeMount.raml
+++ b/docs/docs/rest-api/public/api/v2/types/volumeMount.raml
@@ -1,62 +1,11 @@
 #%RAML 1.0 DataType
 type: object
-maxProperties: 2
-minProperties: 2
 properties:
   name:
     type: !include name.raml
     description: The name of the volume to reference.
-  host?:
+  mountPath:
     type: string
-    description: |
-      Absolute path of the file or directory on the agent, or else the relative
-      path of the directory in the executor's sandbox
-
-      Host volumes are useful for mapping directories that exist on the agent apriori,
-      or within the executor sandbox. No resources (Mesos or otherwise) are allocated for
-      these types of volumes.
-  request?:
-    type: object
-    description: |
-      Volume requests would be used, for example, with persistent and external volumes.
-    properties:
-      provider:
-        type: string
-        enum: [external, resident]
-        description: |
-          the system providing the volume; `resident` will request a persistent volume
-        example: external
-      providerName?:
-        type: !include name.raml
-        usage: required for `external` providers
-        example: dvdi
-      shareMode:
-        type: string
-        enum: [ READ_ONE_WRITE_ONE ]
-        description: Possible future values are READ_ALL_WRITE_ONE and READ_ALL_WRITE_ALL
-        default: READ_ONE_WRITE_ONE
-      volumeName?:
-        type: !include name.raml
-      volumeOptions?:
-        type: object
-        description: key-value pairs, provider and marathon specific options
-        properties:
-          category?:
-            type: !include name.raml
-            usage: could be the name of a volume provider, or something like marathon
-          name?:
-            type: string
-            pattern: ^[A-Za-z0-9](?:[-A-za-z0-9\._:]*[A-Za-z0-9])?$
-            minLength: 1
-            maxLength: 128
-          value?:
-            type: string
-            maxLength: 1024
-          resource?:
-            type: integer
-            description: Disk size in MB
-            minimum: 1
-          labels?:
-            type: array
-            items: !include label.raml
-            
+    description: The path inside the container at which the volume is mounted.
+  readOnly?:
+    type: boolean

--- a/docs/docs/rest-api/public/api/v2/types/volumeMount.raml
+++ b/docs/docs/rest-api/public/api/v2/types/volumeMount.raml
@@ -1,0 +1,62 @@
+#%RAML 1.0 DataType
+type: object
+maxProperties: 2
+minProperties: 2
+properties:
+  name:
+    type: !include name.raml
+    description: The name of the volume to reference.
+  host?:
+    type: string
+    description: |
+      Absolute path of the file or directory on the agent, or else the relative
+      path of the directory in the executor's sandbox
+
+      Host volumes are useful for mapping directories that exist on the agent apriori,
+      or within the executor sandbox. No resources (Mesos or otherwise) are allocated for
+      these types of volumes.
+  request?:
+    type: object
+    description: |
+      Volume requests would be used, for example, with persistent and external volumes.
+    properties:
+      provider:
+        type: string
+        enum: [external, resident]
+        description: |
+          the system providing the volume; `resident` will request a persistent volume
+        example: external
+      providerName?:
+        type: !include name.raml
+        usage: required for `external` providers
+        example: dvdi
+      shareMode:
+        type: string
+        enum: [ READ_ONE_WRITE_ONE ]
+        description: Possible future values are READ_ALL_WRITE_ONE and READ_ALL_WRITE_ALL
+        default: READ_ONE_WRITE_ONE
+      volumeName?:
+        type: !include name.raml
+      volumeOptions?:
+        type: object
+        description: key-value pairs, provider and marathon specific options
+        properties:
+          category?:
+            type: !include name.raml
+            usage: could be the name of a volume provider, or something like marathon
+          name?:
+            type: string
+            pattern: ^[A-Za-z0-9](?:[-A-za-z0-9\._:]*[A-Za-z0-9])?$
+            minLength: 1
+            maxLength: 128
+          value?:
+            type: string
+            maxLength: 1024
+          resource?:
+            type: integer
+            description: Disk size in MB
+            minimum: 1
+          labels?:
+            type: array
+            items: !include label.raml
+            

--- a/docs/docs/rest-api/public/api/v2/types/volumeMount.raml
+++ b/docs/docs/rest-api/public/api/v2/types/volumeMount.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0 DataType
 type: object
+(scalaType): VolumeMount
 properties:
   name:
     type: !include name.raml


### PR DESCRIPTION
Purely an API sketch still.
The new stuff is all RAML 1.0

TODO:
- [ ] add pods to v2 groups API (will report PodStatus objects, not Pod)
- [ ] strip out the `additionalProperties: false` from most things (as per @jasongilanfarr)
- [x] align command spec w/ how mesos deals with `entrypoint` in UNICON docker isolator

References:
- docker isolator CommandInfo decoder table
  - https://github.com/apache/mesos/blob/6f2a452d4876b2073ad552df88aa6e49f3e36a34/src/slave/containerizer/mesos/isolators/docker/runtime.cpp#L255
- appc isolator CommandInfo decoder table
  - https://github.com/apache/mesos/blob/6f2a452d4876b2073ad552df88aa6e49f3e36a34/src/slave/containerizer/mesos/isolators/appc/runtime.cpp#L203