### PR TITLE
Protection for create/PUT with persistent volumes and for user-specified residency/upgradeOptions

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
@@ -92,10 +92,12 @@ case class AppUpdate(
   def empty(appId: PathId): AppDefinition = {
     def volumes: Iterable[Volume] = container.fold(Seq.empty[Volume])(_.volumes)
     def externalVolumes: Iterable[ExternalVolume] = volumes.collect { case vol: ExternalVolume => vol }
-    val residency = if (persistentVolumes.nonEmpty) Some(Residency.defaultResidency) else None
-    val upgradeStrategy = if (residency.isDefined || isResident
-      || externalVolumes.nonEmpty) UpgradeStrategy.forResidentTasks
-    else UpgradeStrategy.empty
+    val defaultResidency = if (persistentVolumes.nonEmpty) Some(Residency.defaultResidency) else None
+    val residency = this.residency.orElse(defaultResidency)
+    val defaultUpgradeStrategy =
+      if (residency.isDefined || isResident || externalVolumes.nonEmpty) UpgradeStrategy.forResidentTasks
+      else UpgradeStrategy.empty
+    val upgradeStrategy = this.upgradeStrategy.getOrElse(defaultUpgradeStrategy)
     apply(AppDefinition(appId, residency = residency, upgradeStrategy = upgradeStrategy))
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -406,6 +406,112 @@ class AppUpdateTest extends MarathonSpec with Matchers {
       && strategy.maximumOverCapacity == 0)
   }
 
+  test("empty app persists container") {
+    val json =
+      """
+        {
+          "id": "/payload-id",
+          "args": [],
+          "container": {
+            "type": "DOCKER",
+            "volumes": [
+              {
+                "containerPath": "data",
+                "mode": "RW",
+                "persistent": {
+                  "size": 100
+                }
+              }
+            ],
+            "docker": {
+              "image": "anImage"
+            }
+          },
+          "residency": {
+            "taskLostBehavior": "WAIT_FOREVER",
+            "relaunchEscalationTimeoutSeconds": 3600
+          }
+        }
+      """
+
+    val update = fromJsonString(json)
+    val create = update.empty("/put-path-id".toPath)
+    assert(update.container.isDefined)
+    assert(update.container == create.container)
+  }
+
+  test("empty app persists existing residency") {
+    val json =
+      """
+        {
+          "id": "/app",
+          "args": [],
+          "container": {
+            "type": "DOCKER",
+            "volumes": [
+              {
+                "containerPath": "data",
+                "mode": "RW",
+                "persistent": {
+                  "size": 100
+                }
+              }
+            ],
+            "docker": {
+              "image": "anImage"
+            }
+          },
+          "residency": {
+            "taskLostBehavior": "WAIT_FOREVER",
+            "relaunchEscalationTimeoutSeconds": 1234
+          }
+        }
+      """
+
+    val update = fromJsonString(json)
+    val create = update.empty("/app".toPath)
+    assert(update.residency.isDefined)
+    assert(update.residency == create.residency)
+  }
+
+  test("empty app persists existing upgradeStrategy") {
+    val json =
+      """
+        {
+          "id": "/app",
+          "args": [],
+          "container": {
+            "type": "DOCKER",
+            "volumes": [
+              {
+                "containerPath": "data",
+                "mode": "RW",
+                "persistent": {
+                  "size": 100
+                }
+              }
+            ],
+            "docker": {
+              "image": "anImage"
+            }
+          },
+          "residency": {
+            "taskLostBehavior": "WAIT_FOREVER",
+            "relaunchEscalationTimeoutSeconds": 1234
+          },
+          "upgradeStrategy": {
+            "minimumHealthCapacity": 0.1,
+            "maximumOverCapacity": 0.0
+          }
+        }
+      """
+
+    val update = fromJsonString(json)
+    val create = update.empty("/app".toPath)
+    assert(update.upgradeStrategy.isDefined)
+    assert(update.upgradeStrategy.get == create.upgradeStrategy)
+  }
+
   test("empty app residency") {
     val json =
       """


### PR DESCRIPTION
I encountered an issue in DCOS 1.8.1/Marathon 1.3.0-RC4 where apps with persistent volumes could not be created via 
`PUT /v2/apps/:appId`
but they could be created via
`POST /v2/apps`
In debugging the issue, I tracked it down to `.container` attributes not being persisted on `AppUpdate.empty`, resulting in an intermediate `AppDefinition` for creation that wouldn't pass validation. 

Similarly, payload `.residency` or `.upgradeStrategy` were not persisted, so that user-specific entries were overwritten by defaults on a Create via PUT.

After creating documenting/protecting tests and resolving the issues, I discovered that the container issue was handled in #4185 (since merged and released in 1.3.0-RC5/DCOS 1.8.2, thanks much!), though `.upgradeStrategy` and `.residency` are still not addressed. 

This PR contains tests to help protect the behavior in the future and to persist `.residency` and `.upgradeStrategy`.

