### PR TITLE
Initial rev of pods API endpoints

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -1,6 +1,8 @@
 package mesosphere.marathon.api
 
 import java.net.URI
+import java.nio.charset.StandardCharsets
+import javax.servlet.http.HttpServletRequest
 import javax.ws.rs.core.Response
 import javax.ws.rs.core.Response.{ ResponseBuilder, Status }
 
@@ -9,8 +11,7 @@ import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.upgrade.DeploymentPlan
 import play.api.libs.json.Json.JsValueWrapper
-import play.api.libs.json.{ Writes, Json }
-
+import play.api.libs.json.{ Json, Writes }
 import com.wix.accord._
 import mesosphere.marathon.api.v2.Validation._
 
@@ -72,5 +73,16 @@ trait RestResource {
       //scalastyle:on
       case Success => fn(t)
     }
+  }
+
+  def decodeBytes(data: Array[Byte], req: HttpServletRequest): String = {
+    val maybeEncoding = Option(req.getCharacterEncoding())
+    val charset = maybeEncoding match {
+      case Some(charsetName) =>
+        java.nio.charset.Charset.forName(charsetName)
+      case None =>
+        StandardCharsets.UTF_8 // TODO(jdef) should this be configurable somewhere?
+    }
+    new String(data, charset)
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon.api.v2
 
 import java.net.URI
-import java.nio.charset.StandardCharsets
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
@@ -72,7 +71,7 @@ class PodsResource @Inject() (
           .created(new URI(createdPod.id.toString))
           .entity(marshalJson(createdPod.asPodDef))
 
-        deploymentId.foreach(did => builder.header(DEPLOYMENT_ID_HEADER, did))
+        deploymentId.foreach(id => builder.header(DEPLOYMENT_ID_HEADER, id))
         builder.build()
       }
     }(createPodValidator)
@@ -123,7 +122,7 @@ class PodsResource @Inject() (
           .ok(new URI(updatedPod.id.toString))
           .entity(marshalJson(updatedPod.asPodDef))
 
-        deploymentId.foreach(did => builder.header(DEPLOYMENT_ID_HEADER, did))
+        deploymentId.foreach(id => builder.header(DEPLOYMENT_ID_HEADER, id))
         builder.build()
       }
     }(createPodValidator and updatePodValidator)
@@ -146,7 +145,7 @@ class PodsResource @Inject() (
           .ok(new URI(deletedPod.id.toString))
           .entity(marshalJson(deletedPod.asPodDef))
 
-        deploymentId.foreach(did => builder.header(DEPLOYMENT_ID_HEADER, did))
+        deploymentId.foreach(id => builder.header(DEPLOYMENT_ID_HEADER, id))
         builder.build()
       }
     }(PodsValidation.idValidator)
@@ -241,17 +240,6 @@ protected object PodsResourceInternal {
         }.getOrElse(network)
       }
     )
-
-  def decodeBytes(data: Array[Byte], req: HttpServletRequest): String = {
-    val maybeEncoding = Option(req.getCharacterEncoding())
-    val charset = maybeEncoding match {
-      case Some(charsetName) =>
-        java.nio.charset.Charset.forName(charsetName)
-      case None =>
-        StandardCharsets.UTF_8 // TODO(jdef) should this be configurable somewhere?
-    }
-    new String(data, charset)
-  }
 
   def unmarshalJson[T: JsonReader](data: String): T = {
     data.parseJson.convertTo[T]

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -110,6 +110,7 @@ class PodsResource @Inject() (
 
     withValid(unmarshalJson(decodeBytes(body, req))) { podDef =>
 
+      // podDef.id has just been validated, requiring equality for id validates it
       require(id == podDef.id)
       val pod = PodDefinition(withDefaults(podDef, podDefaults)).withCanonizedIds()
 

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -1,14 +1,22 @@
 package mesosphere.marathon.api.v2
 
+import java.net.URI
+import java.nio.charset.StandardCharsets
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.{ Context, MediaType, Response }
 
+import akka.event.EventStream
 import com.codahale.metrics.annotation.Timed
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.api.{ AuthResource, MarathonMediaType, RestResource }
-import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer }
+import mesosphere.marathon.core.base.Clock
+import mesosphere.marathon.core.event._
+import mesosphere.marathon.core.pod.PodDefinition
+import mesosphere.marathon.plugin.auth._
+import mesosphere.marathon.raml.PodDef
+import spray.json._
 
 @Path("v2/pods")
 @Consumes(Array(MediaType.APPLICATION_JSON))
@@ -16,7 +24,10 @@ import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer }
 class PodsResource @Inject() (
     val config: MarathonConf,
     val authenticator: Authenticator,
-    val authorizer: Authorizer) extends RestResource with AuthResource {
+    val authorizer: Authorizer)(
+    implicit
+    val clock: Clock,
+    val eventBus: EventStream) extends RestResource with AuthResource {
 
   /**
     * HEAD is used to determine whether some Marathon variant supports pods.
@@ -30,5 +41,52 @@ class PodsResource @Inject() (
   @Timed
   def capability(@Context req: HttpServletRequest): Response = authenticated(req) { _ =>
     ok()
+  }
+
+  // TODO(jdef) force parameter? probably since this supports deployment; but what does it actually
+  // mean to "force" a create?
+  @POST
+  @Timed
+  def create(
+    body: Array[Byte],
+    @DefaultValue("false")@QueryParam("force") force: Boolean,
+    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+
+    //TODO(jdef) define a validator for PodDef
+    withValid(new String(body, StandardCharsets.UTF_8).parseJson.convertTo[PodDef]) { podDef =>
+
+      val pod = PodDefinition(podDef.copy(
+        networks = podDef.networks.map { network =>
+          config.defaultNetworkName.get.collect {
+            case (defaultName: String) if defaultName.nonEmpty && network.name.isEmpty =>
+              network.copy(name = Some(defaultName))
+          }.getOrElse(network)
+        }
+      )).withCanonizedIds()
+
+      checkAuthorization(CreateRunSpec, pod)
+
+      //def createOrThrow(opt: Option[PodDefinition]) = opt
+      //  .map(_ => throw ConflictingChangeException(s"A pod with id [${pod.id}] already exists."))
+      //  .getOrElse(pod)
+
+      // TODO(jdef) once pods are integrated into groups
+      // val plan = result(groupManager.updateApp(app.id, createOrThrow, pod.version, force))
+
+      // TODO(jdef) get the deployment plan ID and URI, stuff them in headers, and echo the pod back to the client
+      //val appWithDeployments = AppInfo(
+      //  app,
+      //  maybeCounts = Some(TaskCounts.zero),
+      //  maybeTasks = Some(Seq.empty),
+      //  maybeDeployments = Some(Seq(Identifiable(plan.id)))
+      //)
+
+      Events.maybePost(PodCreatedEvent(req.getRemoteAddr, req.getRequestURI, pod))
+
+      Response
+        .created(new URI(pod.id.toString))
+        .entity(pod.asPodDef.toJson.prettyPrint)
+        .build()
+    }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -194,6 +194,7 @@ object PodsResource {
 
     def delete(id: String, force: Boolean): (PodDefinition, Option[String])
 
+    // TODO(jdef) leaky! We need a non-API status return type that converts to PodStatus
     def examine(id: String): PodStatus
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -60,7 +60,7 @@ class PodsResource @Inject() (
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
 
-    withValid(unmarshalJson(decodeBytes(body, req))) { podDef =>
+    withValid(unmarshalJson[PodDef](decodeBytes(body, req))) { podDef =>
 
       val pod = PodDefinition(withDefaults(podDef, podDefaults)).withCanonizedIds()
 
@@ -108,7 +108,7 @@ class PodsResource @Inject() (
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
 
-    withValid(unmarshalJson(decodeBytes(body, req))) { podDef =>
+    withValid(unmarshalJson[PodDef](decodeBytes(body, req))) { podDef =>
 
       // podDef.id has just been validated, requiring equality for id validates it
       require(id == podDef.id)
@@ -251,17 +251,16 @@ protected object PodsResourceInternal {
     new String(data, charset)
   }
 
-  def unmarshalJson(data: String): PodDef =
-    data.parseJson.convertTo[PodDef]
-
-  def marshalJson(p: PodDef): String =
-    p.toJson.prettyPrint
-
-  def marshalJson(p: Iterable[PodDef]): String = {
-    import DefaultJsonProtocol._
-    p.toJson.prettyPrint
+  def unmarshalJson[T : JsonReader](data: String): T = {
+    data.parseJson.convertTo[T]
   }
 
-  def marshalJson(s: PodStatus): String =
-    s.toJson.prettyPrint
+  def marshalJson[T : JsonWriter](t: T): String = {
+    t.toJson.prettyPrint
+  }
+
+  def marshalJson[T : JsonFormat](it: Iterable[T]): String = {
+    import DefaultJsonProtocol._
+    it.toJson.prettyPrint
+  }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{Context, MediaType, Response}
+import javax.ws.rs.core.{ Context, MediaType, Response }
 
 import akka.event.EventStream
 import com.codahale.metrics.annotation.Timed
@@ -13,12 +13,12 @@ import com.wix.accord.Validator
 import com.wix.accord.dsl._
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.api.v2.validation.PodsValidation
-import mesosphere.marathon.api.{AuthResource, MarathonMediaType, RestResource}
+import mesosphere.marathon.api.{ AuthResource, MarathonMediaType, RestResource }
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.raml.{Network, PodDef, PodStatus}
+import mesosphere.marathon.raml.{ Network, PodDef, PodStatus }
 import spray.json._
 
 @Path("v2/pods")
@@ -90,7 +90,7 @@ class PodsResource @Inject() (
 
   @GET @Timed @Path("""{id:.+}""")
   def find(
-    @PathParam("id") id:String,
+    @PathParam("id") id: String,
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
 
     withValid(id) { _ =>
@@ -103,7 +103,7 @@ class PodsResource @Inject() (
 
   @PUT @Timed @Path("""{id:.+}""")
   def update(
-    @PathParam("id") id:String,
+    @PathParam("id") id: String,
     body: Array[Byte],
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
@@ -131,7 +131,7 @@ class PodsResource @Inject() (
 
   @DELETE @Timed @Path("""{id:.+}""")
   def remove(
-    @PathParam("id") id:String,
+    @PathParam("id") id: String,
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
 
@@ -154,7 +154,7 @@ class PodsResource @Inject() (
 
   @GET @Timed @Path("""{id:.+}::status""")
   def examine(
-    @PathParam("id") id:String,
+    @PathParam("id") id: String,
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
 
     withValid(id) { _ =>
@@ -178,7 +178,8 @@ object PodsResource {
     */
   trait System {
 
-    /** Create results in the deployment of a new pod
+    /**
+      * Create results in the deployment of a new pod
       *
       * @param p     is the new pod to deploy
       * @param force TODO(jdef) not sure what this means for create
@@ -252,15 +253,15 @@ protected object PodsResourceInternal {
     new String(data, charset)
   }
 
-  def unmarshalJson[T : JsonReader](data: String): T = {
+  def unmarshalJson[T: JsonReader](data: String): T = {
     data.parseJson.convertTo[T]
   }
 
-  def marshalJson[T : JsonWriter](t: T): String = {
+  def marshalJson[T: JsonWriter](t: T): String = {
     t.toJson.prettyPrint
   }
 
-  def marshalJson[T : JsonFormat](it: Iterable[T]): String = {
+  def marshalJson[T: JsonFormat](it: Iterable[T]): String = {
     import DefaultJsonProtocol._
     it.toJson.prettyPrint
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -11,13 +11,13 @@ import akka.event.EventStream
 import com.codahale.metrics.annotation.Timed
 import com.wix.accord.Validator
 import com.wix.accord.dsl._
-import mesosphere.marathon.{ConflictingChangeException, MarathonConf}
+import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.api.{AuthResource, MarathonMediaType, RestResource}
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.raml.{Network, PodDef}
+import mesosphere.marathon.raml.{Network, PodDef, PodStatus}
 import spray.json._
 
 @Path("v2/pods")
@@ -51,8 +51,7 @@ class PodsResource @Inject() (
 
   // TODO(jdef) force parameter? probably since this supports deployment; but what does it actually
   // mean to "force" a create?
-  @POST
-  @Timed
+  @POST @Timed
   def create(
     body: Array[Byte],
     @DefaultValue("false")@QueryParam("force") force: Boolean,
@@ -64,17 +63,16 @@ class PodsResource @Inject() (
 
       withAuthorization(CreateRunSpec, pod) {
 
-        def createOrThrow(opt: Option[PodDefinition]) = opt
-          .map(_ => throw ConflictingChangeException(s"A pod with id [${pod.id}] already exists."))
-          .getOrElse(pod)
-
         // TODO(jdef) once pods are integrated into groups
+        // def createOrThrow(opt: Option[PodDefinition]) = opt
+        //   .map(_ => throw ConflictingChangeException(s"A pod with id [${pod.id}] already exists."))
+        //   .getOrElse(pod)
         // val plan = result(groupManager.updatePod(app.id, createOrThrow, pod.version, force))
 
         // TODO(jdef) get the deployment plan ID and URI, stuff them in headers, and echo the pod back to the client
         // maybeDeployments = Some(Seq(Identifiable(plan.id)))
 
-        Events.maybePost(PodCreatedEvent(req.getRemoteAddr, req.getRequestURI))
+        Events.maybePost(PodEvent(req.getRemoteAddr, req.getRequestURI, PodEvent.Created))
 
         Response
           .created(new URI(pod.id.toString))
@@ -82,6 +80,88 @@ class PodsResource @Inject() (
           .build()
       }
     }(createPodValidator)
+  }
+
+  @GET @Timed
+  def findAll(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+
+    // TODO(jdef) build a "pod selector" (see AppSelector) that filters on authz for ViewRunSpec
+    val pods: Iterable[PodDefinition] = ???
+    ok(marshalJson(pods.map(_.asPodDef)))
+  }
+
+  @GET @Timed @Path("""{id:.+}""")
+  def find(
+    @PathParam("id") id:String,
+    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+
+    val pod: PodDefinition = ???
+
+    withAuthorization(ViewRunSpec, pod) {
+      ok(marshalJson(pod.asPodDef))
+    }
+  }
+
+  @PUT @Timed @Path("""{id:.+}""")
+  def update(
+    @PathParam("id") id:String,
+    body: Array[Byte],
+    @DefaultValue("false")@QueryParam("force") force: Boolean,
+    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+
+    withValid(unmarshalJson(decodeBytes(body, req))) { podDef =>
+
+      val pod = PodDefinition(withDefaults(podDef, podDefaults)).withCanonizedIds()
+
+      withAuthorization(UpdateRunSpec, pod) {
+
+        val updatedPod: PodDefinition = ???
+
+        Events.maybePost(PodEvent(req.getRemoteAddr, req.getRequestURI, PodEvent.Updated))
+
+        // TODO(jdef) set deployment headers
+
+        Response
+          .ok(new URI(updatedPod.id.toString))
+          .entity(marshalJson(updatedPod.asPodDef))
+          .build()
+      }
+    }(createPodValidator and updatePodValidator)
+  }
+
+  @DELETE @Timed @Path("""{id:.+}""")
+  def remove(
+    @PathParam("id") id:String,
+    @DefaultValue("false")@QueryParam("force") force: Boolean,
+    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+
+    val pod: PodDefinition = ???
+
+    withAuthorization(DeleteRunSpec, pod) {
+
+      val deletedPod: PodDefinition = ???
+
+      // TODO(jdef) set deployment headers
+
+      Events.maybePost(PodEvent(req.getRemoteAddr, req.getRequestURI, PodEvent.Deleted))
+
+      ok(marshalJson(deletedPod.asPodDef))
+    }
+  }
+
+  @GET @Timed @Path("""{id:.+}::status""")
+  def examine(
+    @PathParam("id") id:String,
+    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+
+    val pod: PodDefinition = ???
+
+    withAuthorization(ViewRunSpec, pod) {
+
+      val status: PodStatus = ???
+
+      ok(marshalJson(status))
+    }
   }
 }
 
@@ -92,6 +172,10 @@ object PodsResource {
   val createPodValidator: Validator[PodDef] = validator[PodDef] { pod =>
     pod is valid(PodsValidation.podDefValidator)
     pod.version is empty
+  }
+
+  val updatePodValidator: Validator[PodDef] = validator[PodDef] { pod =>
+    // TODO(jdef) only some fields are mutable, enforce that here
   }
 
   case class Config(defaultNetworkName: Option[String])
@@ -128,4 +212,12 @@ object PodsResource {
 
   def marshalJson(p: PodDef): String =
     p.toJson.prettyPrint
+
+  def marshalJson(p: Iterable[PodDef]): String = {
+    import DefaultJsonProtocol._
+    p.toJson.prettyPrint
+  }
+
+  def marshalJson(s: PodStatus): String =
+    s.toJson.prettyPrint
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
@@ -14,6 +14,7 @@ import scala.reflect.ClassTag
 import scala.util.Try
 import scala.util.matching.Regex
 
+// TODO(jdef) move this into package "validation"
 object Validation {
   def validateOrThrow[T](t: T)(implicit validator: Validator[T]): T = validate(t) match {
     case Success => t

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -525,6 +525,15 @@ trait EventFormats {
 
   implicit lazy val AppTerminatedEventWrites: Writes[AppTerminatedEvent] = Json.writes[AppTerminatedEvent]
 
+  implicit lazy val PodCreatedEventWrites: Writes[PodCreatedEvent] = Writes { event =>
+    Json.obj(
+      "clientIp" -> event.clientIp,
+      "uri" -> event.uri,
+      "eventType" -> event.eventType,
+      "timestamp" -> event.timestamp
+    )
+  }
+
   implicit lazy val ApiPostEventWrites: Writes[ApiPostEvent] = Writes { event =>
     Json.obj(
       "clientIp" -> event.clientIp,
@@ -596,6 +605,7 @@ trait EventFormats {
     case event: SchedulerDisconnectedEvent => Json.toJson(event)
     case event: SchedulerRegisteredEvent => Json.toJson(event)
     case event: SchedulerReregisteredEvent => Json.toJson(event)
+    case event: PodCreatedEvent => Json.toJson(event)
   }
   //scalastyle:on
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -525,7 +525,7 @@ trait EventFormats {
 
   implicit lazy val AppTerminatedEventWrites: Writes[AppTerminatedEvent] = Json.writes[AppTerminatedEvent]
 
-  implicit lazy val PodCreatedEventWrites: Writes[PodCreatedEvent] = Writes { event =>
+  implicit lazy val PodEventWrites: Writes[PodEvent] = Writes { event =>
     Json.obj(
       "clientIp" -> event.clientIp,
       "uri" -> event.uri,
@@ -605,7 +605,7 @@ trait EventFormats {
     case event: SchedulerDisconnectedEvent => Json.toJson(event)
     case event: SchedulerRegisteredEvent => Json.toJson(event)
     case event: SchedulerReregisteredEvent => Json.toJson(event)
-    case event: PodCreatedEvent => Json.toJson(event)
+    case event: PodEvent => Json.toJson(event)
   }
   //scalastyle:on
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -27,8 +27,8 @@ object PodsValidation {
     pod.networks is every(networkValidator)
     // user -- no validation required, passed through to Mesos
     // TODO(jdef) volumes
-    // TODO(jdef) environment
-    // TODO(jdef) labels
+    // TODO(jdef) environment (support pluggable validation for these?)
+    // TODO(jdef) labels (support pluggable validation for these?)
   }
 
   val networkValidator: Validator[Network] = validator[Network] { network =>

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon.api.v2.validation
 
-import com.wix.accord.{Result, Validator}
+import com.wix.accord.{ Result, Validator }
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation
-import mesosphere.marathon.raml.{Network, PodDef}
+import mesosphere.marathon.raml.{ Network, PodDef }
 import mesosphere.marathon.state.PathId
 
 import scala.collection.immutable.Seq
@@ -45,7 +45,8 @@ object PodsValidation {
 
   val namePattern = """^[a-z0-9]([-a-z0-9]*[a-z0-9])?$""".r
   val validName: Validator[String] = validator[String] { name =>
-    name should matchRegexWithFailureMessage(namePattern,
+    name should matchRegexWithFailureMessage(
+      namePattern,
       "must contain only alphanumeric chars or hyphens, and must begin with a letter")
     name.length should be > 0
     name.length should be < 64

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -16,19 +16,21 @@ object PodsValidation {
   import Validation._
 
   val podDefValidator: Validator[PodDef] = validator[PodDef] { pod =>
-    pod.id is valid(new Validator[String] {
-      override def apply(path: String): Result = {
-        val validator = implicitly[Validator[PathId]]
-        val pathId = PathId(path)
-        validator(pathId) and PathId.absolutePathValidator(pathId)
-      }
-    })
+    pod.id is valid(idValidator)
     pod.networks is valid(networksValidator)
     pod.networks is every(networkValidator)
     // user -- no validation required, passed through to Mesos
     // TODO(jdef) volumes
     // TODO(jdef) environment (support pluggable validation for these?)
     // TODO(jdef) labels (support pluggable validation for these?)
+  }
+
+  val idValidator = new Validator[String] {
+    override def apply(path: String): Result = {
+      val validator = implicitly[Validator[PathId]]
+      val pathId = PathId(path)
+      validator(pathId) and PathId.absolutePathValidator(pathId)
+    }
   }
 
   val networkValidator: Validator[Network] = validator[Network] { network =>

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -1,0 +1,50 @@
+package mesosphere.marathon.api.v2.validation
+
+import com.wix.accord.Validator
+import com.wix.accord.dsl._
+import mesosphere.marathon.api.v2.Validation
+import mesosphere.marathon.raml.{Network, PodDef}
+import mesosphere.marathon.state.PathId
+
+import scala.collection.immutable.Seq
+
+/**
+  * Defines implicit validation for PodDef
+  */
+object PodsValidation {
+
+  import Validation._
+
+  val podDefValidator: Validator[PodDef] = validator[PodDef] { pod =>
+    pod.id is absolutePathValidator
+    pod.networks is valid(networksValidator)
+    pod.networks is every(networkValidator)
+    // TODO(jdef) user
+    // TODO(jdef) volumes
+    // TODO(jdef) environment
+    // TODO(jdef) labels
+    // TODO(jdef) version
+  }
+
+  val networkValidator: Validator[Network] = validator[Network] { network =>
+    network.name.each is valid(validName)
+  }
+
+  val networksValidator: Validator[Seq[Network]] = isTrue[Seq[Network]]("Duplicate networks are not allowed") { nets =>
+    val unnamedAtMostOnce = nets.filter(_.name.isEmpty).size < 2
+    val realNamesAtMostOnce: Boolean = !nets.flatMap(_.name).groupBy(name => name).exists(_._2.size > 1)
+    unnamedAtMostOnce && realNamesAtMostOnce
+  }
+
+  val absolutePathValidator = isTrue[String]("Path needs to be absolute") { path =>
+    PathId(path).absolute
+  }
+
+  val namePattern = """^[a-z0-9]([-a-z0-9]*[a-z0-9])?$""".r
+  val validName: Validator[String] = validator[String] { name =>
+    name should matchRegexWithFailureMessage(namePattern,
+      "must contain only alphanumeric chars or hyphens, and must begin with a letter")
+    name.length should be > 0
+    name.length should be < 64
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.core
 
 import javax.inject.Named
 
+import mesosphere.marathon.api.v2.PodsResource
 import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.storage.repository._
 
@@ -144,6 +145,9 @@ class CoreGuiceModule extends AbstractModule {
 
   @Provides @Singleton
   def groupManager(coreModule: CoreModule): GroupManager = coreModule.groupManagerModule.groupManager
+
+  @Provides @Singleton
+  def podSystem(coreModule: CoreModule): PodsResource.System = coreModule.podModule.podSystem
 
   @Provides @Singleton
   def taskStatusUpdateSteps(

--- a/src/main/scala/mesosphere/marathon/core/CoreModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModule.scala
@@ -11,6 +11,7 @@ import mesosphere.marathon.core.launcher.LauncherModule
 import mesosphere.marathon.core.launchqueue.LaunchQueueModule
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.plugin.PluginModule
+import mesosphere.marathon.core.pod.PodModule
 import mesosphere.marathon.core.readiness.ReadinessModule
 import mesosphere.marathon.core.task.bus.TaskBusModule
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
@@ -36,6 +37,7 @@ trait CoreModule {
   def launcherModule: LauncherModule
   def leadershipModule: LeadershipModule
   def pluginModule: PluginModule
+  def podModule: PodModule
   def readinessModule: ReadinessModule
   def storageModule: StorageModule
   def taskBusModule: TaskBusModule

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -4,10 +4,10 @@ import javax.inject.Named
 
 import akka.actor.ActorSystem
 import akka.event.EventStream
-import com.google.inject.{Inject, Provider}
+import com.google.inject.{ Inject, Provider }
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.core.auth.AuthModule
-import mesosphere.marathon.core.base.{ActorsModule, Clock, ShutdownHooks}
+import mesosphere.marathon.core.base.{ ActorsModule, Clock, ShutdownHooks }
 import mesosphere.marathon.core.election._
 import mesosphere.marathon.core.event.EventModule
 import mesosphere.marathon.core.flow.FlowModule
@@ -27,11 +27,11 @@ import mesosphere.marathon.core.task.bus.TaskBusModule
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
 import mesosphere.marathon.core.task.tracker.TaskTrackerModule
-import mesosphere.marathon.core.task.update.{TaskStatusUpdateProcessor, TaskUpdateStep}
+import mesosphere.marathon.core.task.update.{ TaskStatusUpdateProcessor, TaskUpdateStep }
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.storage.StorageModule
-import mesosphere.marathon.{DeploymentService, MarathonConf, MarathonSchedulerDriverHolder, ModuleNames}
+import mesosphere.marathon.{ DeploymentService, MarathonConf, MarathonSchedulerDriverHolder, ModuleNames }
 import mesosphere.util.CapConcurrentExecutions
 
 import scala.concurrent.ExecutionContext

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -4,10 +4,10 @@ import javax.inject.Named
 
 import akka.actor.ActorSystem
 import akka.event.EventStream
-import com.google.inject.{ Inject, Provider }
+import com.google.inject.{Inject, Provider}
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.core.auth.AuthModule
-import mesosphere.marathon.core.base.{ ActorsModule, Clock, ShutdownHooks }
+import mesosphere.marathon.core.base.{ActorsModule, Clock, ShutdownHooks}
 import mesosphere.marathon.core.election._
 import mesosphere.marathon.core.event.EventModule
 import mesosphere.marathon.core.flow.FlowModule
@@ -21,16 +21,17 @@ import mesosphere.marathon.core.matcher.base.util.StopOnFirstMatchingOfferMatche
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerModule
 import mesosphere.marathon.core.matcher.reconcile.OfferMatcherReconciliationModule
 import mesosphere.marathon.core.plugin.PluginModule
+import mesosphere.marathon.core.pod.PodModule
 import mesosphere.marathon.core.readiness.ReadinessModule
 import mesosphere.marathon.core.task.bus.TaskBusModule
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
 import mesosphere.marathon.core.task.tracker.TaskTrackerModule
-import mesosphere.marathon.core.task.update.{ TaskStatusUpdateProcessor, TaskUpdateStep }
+import mesosphere.marathon.core.task.update.{TaskStatusUpdateProcessor, TaskUpdateStep}
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.storage.StorageModule
-import mesosphere.marathon.{ DeploymentService, MarathonConf, MarathonSchedulerDriverHolder, ModuleNames }
+import mesosphere.marathon.{DeploymentService, MarathonConf, MarathonSchedulerDriverHolder, ModuleNames}
 import mesosphere.util.CapConcurrentExecutions
 
 import scala.concurrent.ExecutionContext
@@ -200,6 +201,10 @@ class CoreModuleImpl @Inject() (
     storage,
     eventStream,
     metrics)(actorsModule.materializer)
+
+  // PODS
+
+  override lazy val podModule: PodModule = new PodModule()
 
   // GREEDY INSTANTIATION
   //

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -25,10 +25,10 @@ case class ApiPostEvent(
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
 
 case class PodEvent(
-  clientIp: String,
-  uri: String,
-  podEventType: PodEvent.Kind,
-  timestamp: String = Timestamp.now().toString) extends MarathonEvent {
+    clientIp: String,
+    uri: String,
+    podEventType: PodEvent.Kind,
+    timestamp: String = Timestamp.now().toString) extends MarathonEvent {
   override val eventType = podEventType.label
 }
 

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -24,11 +24,28 @@ case class ApiPostEvent(
   eventType: String = "api_post_event",
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
 
-case class PodCreatedEvent(
+case class PodEvent(
   clientIp: String,
   uri: String,
-  eventType: String = "pod_created_event",
-  timestamp: String = Timestamp.now().toString) extends MarathonEvent
+  podEventType: PodEvent.Kind,
+  timestamp: String = Timestamp.now().toString) extends MarathonEvent {
+  override val eventType = podEventType.label
+}
+
+object PodEvent {
+  sealed trait Kind {
+    val label: String
+  }
+  case object Created extends Kind {
+    val label = "pod_created_event"
+  }
+  case object Updated extends Kind {
+    val label = "pod_updated_event"
+  }
+  case object Deleted extends Kind {
+    val label = "pod_deleted_event"
+  }
+}
 
 // scheduler messages
 sealed trait MarathonSchedulerEvent extends MarathonEvent

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -1,7 +1,9 @@
 package mesosphere.marathon.core.event
 
+import akka.event.EventStream
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep }
 
@@ -21,6 +23,13 @@ case class ApiPostEvent(
   uri: String,
   appDefinition: AppDefinition,
   eventType: String = "api_post_event",
+  timestamp: String = Timestamp.now().toString) extends MarathonEvent
+
+case class PodCreatedEvent(
+  clientIp: String,
+  uri: String,
+  podDefinition: PodDefinition,
+  eventType: String = "pod_created_event",
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
 
 // scheduler messages
@@ -192,3 +201,8 @@ case class MesosFrameworkMessageEvent(
   message: Array[Byte],
   eventType: String = "framework_message_event",
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
+
+case object Events {
+  def maybePost(event: MarathonEvent)(implicit eventBus: EventStream) =
+    eventBus.publish(event)
+}

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -218,6 +218,6 @@ case class MesosFrameworkMessageEvent(
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
 
 case object Events {
-  def maybePost(event: MarathonEvent)(implicit eventBus: EventStream) =
+  def maybePost(event: MarathonEvent)(implicit eventBus: EventStream): Unit =
     eventBus.publish(event)
 }

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -3,7 +3,6 @@ package mesosphere.marathon.core.event
 import akka.event.EventStream
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.health.HealthCheck
-import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep }
 
@@ -28,7 +27,6 @@ case class ApiPostEvent(
 case class PodCreatedEvent(
   clientIp: String,
   uri: String,
-  podDefinition: PodDefinition,
   eventType: String = "pod_created_event",
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
 

--- a/src/main/scala/mesosphere/marathon/core/pod/PodModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodModule.scala
@@ -1,0 +1,11 @@
+package mesosphere.marathon.core.pod
+
+import mesosphere.marathon.api.v2.PodsResource
+
+/**
+  * Created by jdefelice on 8/31/16.
+  */
+class PodModule {
+
+  val podSystem: PodsResource.System = new PodSubsystem()
+}

--- a/src/main/scala/mesosphere/marathon/core/pod/PodSubsystem.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodSubsystem.scala
@@ -1,0 +1,25 @@
+package mesosphere.marathon.core.pod
+
+import mesosphere.marathon.api.v2.PodsResource
+import mesosphere.marathon.raml.PodStatus
+
+class PodSubsystem extends PodsResource.System {
+
+  def create(p: PodDefinition, force: Boolean): (PodDefinition, Option[String]) =
+    throw new NotImplementedError()
+
+  def findAll(s: PodsResource.Selector): Iterable[PodDefinition] =
+    throw new NotImplementedError()
+
+  def find(id: String): PodDefinition =
+    throw new NotImplementedError()
+
+  def update(p: PodDefinition, force: Boolean): (PodDefinition, Option[String]) =
+    throw new NotImplementedError()
+
+  def delete(id: String, force: Boolean): (PodDefinition, Option[String]) =
+    throw new NotImplementedError()
+
+  def examine(id: String): PodStatus =
+    throw new NotImplementedError()
+}

--- a/src/main/scala/mesosphere/marathon/storage/store/ZkStoreSerialization.scala
+++ b/src/main/scala/mesosphere/marathon/storage/store/ZkStoreSerialization.scala
@@ -13,7 +13,6 @@ import mesosphere.marathon.core.storage.store.IdResolver
 import mesosphere.marathon.core.storage.store.impl.zk.{ ZkId, ZkSerialized }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.impl.TaskSerializer
-import mesosphere.marathon.raml.PodDef
 import mesosphere.marathon.state.{ AppDefinition, PathId, TaskFailure }
 import mesosphere.marathon.storage.repository.{ StoredGroup, StoredGroupRepositoryImpl, StoredPlan }
 import mesosphere.util.state.FrameworkId
@@ -49,15 +48,13 @@ trait ZkStoreSerialization {
 
   implicit val podDefMarshaller: Marshaller[PodDefinition, ZkSerialized] =
     Marshaller.opaque { podDef =>
-      import spray.json._
-      ZkSerialized(ByteString(podDef.asPodDef.toJson.compactPrint, "UTF-8"))
+      ZkSerialized(PodDefinition.toByteString(podDef))
     }
 
   implicit val podDefUnmarshaller: Unmarshaller[ZkSerialized, PodDefinition] =
     Unmarshaller.strict {
       case ZkSerialized(byteString) =>
-        import spray.json._
-        PodDefinition(byteString.utf8String.parseJson.convertTo[PodDef])
+        PodDefinition.fromByteString(byteString)
     }
 
   implicit val taskResolver: IdResolver[Task.Id, Task, String, ZkId] =

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -30,6 +30,7 @@ class PodsResourceTest extends MarathonSpec with Matchers with Mockito {
       configArgs: Seq[String] = Seq.empty[String],
       auth: TestAuthFixture = new TestAuthFixture()
     )(implicit
+      podSystem: PodsResource.System = mock[PodsResource.System],
       clock: Clock = ConstantClock(),
       eventBus: EventStream = mock[EventStream]
     ): Fixture = {

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -1,7 +1,11 @@
 package mesosphere.marathon.api.v2
 
+import javax.servlet.http.HttpServletResponse
+
+import akka.event.EventStream
 import mesosphere.marathon._
 import mesosphere.marathon.api.TestAuthFixture
+import mesosphere.marathon.core.base.{Clock, ConstantClock}
 import mesosphere.marathon.test.Mockito
 import org.scalatest.Matchers
 
@@ -10,7 +14,7 @@ class PodsResourceTest extends MarathonSpec with Matchers with Mockito {
   test("Marathon supports pods") {
     val f = Fixture.create()
     val response = f.podsResource.capability(f.auth.request)
-    response.getStatus should be(200)
+    response.getStatus should be(HttpServletResponse.SC_OK)
 
     val body = Option(response.getEntity.asInstanceOf[String])
     body should be(None)
@@ -25,8 +29,10 @@ class PodsResourceTest extends MarathonSpec with Matchers with Mockito {
     def create(
       configArgs: Seq[String] = Seq.empty[String],
       auth: TestAuthFixture = new TestAuthFixture()
+    )(implicit
+      clock: Clock = ConstantClock(),
+      eventBus: EventStream = mock[EventStream]
     ): Fixture = {
-
       val config = AllConf.withTestConfig(configArgs: _*)
       new Fixture(
         new PodsResource(config, auth.auth, auth.auth),


### PR DESCRIPTION
TODO:
- [ ] unit test

Deferred:
- remaining validation
- integration with groups
- integration with deployment

FWIW I really don't like how we bundle in all sorts of crazy functionality into one method. I'd much rather see the API endpoints composed of handlers and decorators. Instead we've guice'd the heck out of it and made each endpoint impl a mini-monolith.