### PR TITLE
Soften validation for PortValidations to allow `tcp,udp`

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/serialization/PortDefinitionSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/PortDefinitionSerializer.scala
@@ -6,18 +6,20 @@ import org.apache.mesos
 import scala.collection.JavaConverters._
 
 object PortDefinitionSerializer {
-  def toProto(portDefinition: PortDefinition): mesos.Protos.Port = {
-    val builder = mesos.Protos.Port.newBuilder
-      .setNumber(portDefinition.port)
-      .setProtocol(portDefinition.protocol)
+  def toProto(portDefinition: PortDefinition): Seq[mesos.Protos.Port] = {
+    portDefinition.protocol.split(',').map { protocol =>
+      val builder = mesos.Protos.Port.newBuilder
+        .setNumber(portDefinition.port)
+        .setProtocol(protocol)
 
-    portDefinition.name.foreach(builder.setName)
+      portDefinition.name.foreach(builder.setName)
 
-    if (portDefinition.labels.nonEmpty) {
-      builder.setLabels(LabelsSerializer.toMesosLabelsBuilder(portDefinition.labels))
+      if (portDefinition.labels.nonEmpty) {
+        builder.setLabels(LabelsSerializer.toMesosLabelsBuilder(portDefinition.labels))
+      }
+
+      builder.build
     }
-
-    builder.build
   }
 
   def fromProto(proto: mesos.Protos.Port): PortDefinition = {

--- a/src/main/scala/mesosphere/marathon/api/serialization/PortDefinitionSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/PortDefinitionSerializer.scala
@@ -6,8 +6,17 @@ import org.apache.mesos
 import scala.collection.JavaConverters._
 
 object PortDefinitionSerializer {
-  def toProto(portDefinition: PortDefinition): Seq[mesos.Protos.Port] = {
-    portDefinition.protocol.split(',').map { protocol =>
+  def toProto(portDefinition: PortDefinition): mesos.Protos.Port = toProto(portDefinition, split = false).head
+
+  def toMesosProto(portDefinition: PortDefinition): Seq[mesos.Protos.Port] = toProto(portDefinition, split = true)
+
+  private def toProto(portDefinition: PortDefinition, split: Boolean): Seq[mesos.Protos.Port] = {
+    val protocols: Seq[String] = if (split) {
+      portDefinition.protocol.split(',')
+    } else {
+      Seq(portDefinition.protocol)
+    }
+    protocols.map { protocol =>
       val builder = mesos.Protos.Port.newBuilder
         .setNumber(portDefinition.port)
         .setProtocol(protocol)

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -137,7 +137,7 @@ case class AppDefinition(
       .setId(id.toString)
       .setCmd(commandInfo)
       .setInstances(instances)
-      .addAllPortDefinitions(portDefinitions.flatMap(PortDefinitionSerializer.toProto).asJava)
+      .addAllPortDefinitions(portDefinitions.map(PortDefinitionSerializer.toProto).asJava)
       .setRequirePorts(requirePorts)
       .setBackoff(backoff.toMillis)
       .setBackoffFactor(backoffFactor)

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -137,7 +137,7 @@ case class AppDefinition(
       .setId(id.toString)
       .setCmd(commandInfo)
       .setInstances(instances)
-      .addAllPortDefinitions(portDefinitions.map(PortDefinitionSerializer.toProto).asJava)
+      .addAllPortDefinitions(portDefinitions.flatMap(PortDefinitionSerializer.toProto).asJava)
       .setRequirePorts(requirePorts)
       .setBackoff(backoff.toMillis)
       .setBackoffFactor(backoffFactor)

--- a/src/main/scala/mesosphere/marathon/state/PortDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/PortDefinition.scala
@@ -14,7 +14,7 @@ case class PortDefinition(
 
 object PortDefinition {
   implicit val portDefinitionValidator = validator[PortDefinition] { portDefinition =>
-    portDefinition.protocol is oneOf(DiscoveryInfo.Port.AllowedProtocols)
+    portDefinition.protocol.split(',').toIterable is every(oneOf(DiscoveryInfo.Port.AllowedProtocols))
     portDefinition.port should be >= 0
     portDefinition.name is optional(matchRegexFully(PortAssignment.PortNamePattern))
   }

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -195,8 +195,8 @@ class TaskBuilder(
             // overwrite them the port numbers assigned to this particular task.
             runSpec.portDefinitions.zip(hostPorts).collect {
               case (portDefinition, Some(hostPort)) =>
-                PortDefinitionSerializer.toProto(portDefinition).toBuilder.setNumber(hostPort).build
-            }
+                PortDefinitionSerializer.toProto(portDefinition).map(_.toBuilder.setNumber(hostPort).build)
+            }.flatten
         }
     }
 

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -195,7 +195,7 @@ class TaskBuilder(
             // overwrite them the port numbers assigned to this particular task.
             runSpec.portDefinitions.zip(hostPorts).collect {
               case (portDefinition, Some(hostPort)) =>
-                PortDefinitionSerializer.toProto(portDefinition).map(_.toBuilder.setNumber(hostPort).build)
+                PortDefinitionSerializer.toMesosProto(portDefinition).map(_.toBuilder.setNumber(hostPort).build)
             }.flatten
         }
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -100,7 +100,6 @@ class ModelValidationTest
     result.isSuccess should be(true)
   }
 
-
   private def createServicePortApp(id: PathId, servicePort: Int) =
     AppDefinition(
       id,

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -91,6 +91,16 @@ class ModelValidationTest
     }
   }
 
+  test("PortDefinition should be allowed to contain tcp and udp as protocol.") {
+    val validApp = AppDefinition("/test/app".toPath, cmd = Some("foo"), portDefinitions = Seq(PortDefinition(port = 80, protocol = "tcp,udp")))
+
+    val group = Group("/test".toPath, apps = Map(validApp.id -> validApp))
+
+    val result = validate(group)(Group.validRootGroup(maxApps = None, Set()))
+    result.isSuccess should be(true)
+  }
+
+
   private def createServicePortApp(id: PathId, servicePort: Int) =
     AppDefinition(
       id,

--- a/src/test/scala/mesosphere/marathon/state/PortDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/PortDefinitionTest.scala
@@ -8,6 +8,10 @@ class PortDefinitionTest extends FunSuiteLike with Matchers {
     validate(Fixture.validPortDefinition) should be(Success)
   }
 
+  test("portDefinition with tcp and udp should be valid") {
+    validate(Fixture.tcpUdpPortDefinition) should be(Success)
+  }
+
   test("valid portDefinition with no name should be valid") {
     validate(Fixture.validPortDefinition.copy(name = None)) should be(Success)
   }
@@ -28,6 +32,12 @@ class PortDefinitionTest extends FunSuiteLike with Matchers {
     val validPortDefinition = PortDefinition(
       port = 80,
       protocol = "tcp",
+      name = Some("http-port"),
+      labels = Map("foo" -> "bar"))
+
+    val tcpUdpPortDefinition= PortDefinition(
+      port = 80,
+      protocol = "udp,tcp",
       name = Some("http-port"),
       labels = Map("foo" -> "bar"))
   }

--- a/src/test/scala/mesosphere/marathon/state/PortDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/PortDefinitionTest.scala
@@ -35,7 +35,7 @@ class PortDefinitionTest extends FunSuiteLike with Matchers {
       name = Some("http-port"),
       labels = Map("foo" -> "bar"))
 
-    val tcpUdpPortDefinition= PortDefinition(
+    val tcpUdpPortDefinition = PortDefinition(
       port = 80,
       protocol = "udp,tcp",
       name = Some("http-port"),

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -7,12 +7,12 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state.Container.Docker.PortMapping
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{AppDefinition, Container, PathId, Timestamp, _}
-import mesosphere.marathon.{MarathonSpec, MarathonTestHelper, Protos}
-import mesosphere.mesos.protos.{Resource, TaskID, _}
+import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
+import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper, Protos }
+import mesosphere.mesos.protos.{ Resource, TaskID, _ }
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo
-import org.apache.mesos.{Protos => MesosProtos}
-import org.joda.time.{DateTime, DateTimeZone}
+import org.apache.mesos.{ Protos => MesosProtos }
+import org.joda.time.{ DateTime, DateTimeZone }
 import org.scalatest.Matchers
 
 import scala.collection.JavaConverters._

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1,17 +1,18 @@
 package mesosphere.mesos
 
 import com.google.protobuf.TextFormat
+import mesosphere.marathon.api.serialization.PortDefinitionSerializer
 import mesosphere.marathon.state.AppDefinition.VersionInfo.OnlyVersion
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state.Container.Docker.PortMapping
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
-import mesosphere.marathon.{ MarathonTestHelper, MarathonSpec, Protos }
-import mesosphere.mesos.protos.{ Resource, TaskID, _ }
+import mesosphere.marathon.state.{AppDefinition, Container, PathId, Timestamp, _}
+import mesosphere.marathon.{MarathonSpec, MarathonTestHelper, Protos}
+import mesosphere.mesos.protos.{Resource, TaskID, _}
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo
-import org.apache.mesos.{ Protos => MesosProtos }
-import org.joda.time.{ DateTime, DateTimeZone }
+import org.apache.mesos.{Protos => MesosProtos}
+import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.Matchers
 
 import scala.collection.JavaConverters._
@@ -125,6 +126,15 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
 
     TextFormat.shortDebugString(discoveryInfo) should equal(TextFormat.shortDebugString(discoveryInfoProto))
     discoveryInfo should equal(discoveryInfoProto)
+  }
+
+  test("PortDefinition to proto (zk, mesos) with tcp, udp protocol") {
+    val portDefinition = PortDefinition(port = 80, protocol = "tcp,udp")
+
+    // used for mesos communication, should return two ports
+    PortDefinitionSerializer.toMesosProto(portDefinition).size should be (2)
+    // used for zk communication, should return only one port with "tcp,udp" as protocol name
+    PortDefinitionSerializer.toProto(portDefinition).getProtocol should be ("tcp,udp")
   }
 
   test("BuildIfMatches with port name, different protocol and labels") {


### PR DESCRIPTION
Fixes #4283 

@aquamatthias: Can`t find the place in code where `PortDefinitions` are mapped to `ServiceInfo`. Can you give me a hint?