### PR TITLE
Fix appId detail API method to be click through in the documentation

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -7,7 +7,7 @@ title: REST API
 * [Apps](#apps)
   * [POST /v2/apps](#post-v2-apps): Create and start a new app
   * [GET /v2/apps](#get-v2-apps): List all running apps
-  * [GET /v2/apps/{appId}](#get-v2-apps-appid): List the app `appId`
+  * [GET /v2/apps/{appId}](#get-v2-apps-appid-embed-embed): List the app `appId`
   * [GET /v2/apps/{appId}/versions](#get-v2-apps-appid-versions): List the versions of the application with id `appId`.
   * [GET /v2/apps/{appId}/versions/{version}](#get-v2-apps-appid-versions-version): List the configuration of the application with id `appId` at version `version`.
   * [PUT /v2/apps/{appId}](#put-v2-apps-appid): Update or create an app with id `appId`

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_show.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_show.md
@@ -1,4 +1,4 @@
-#### GET `/v2/apps/{appId}?embed=...`
+#### GET `/v2/apps/{appId}?embed={embed}`
 
 List the application with id `appId`.
 


### PR DESCRIPTION
Steps to reproduce:
- go to https://mesosphere.github.io/marathon/docs/rest-api.html
- click on GET /v2/apps/{appId}
- that leads to https://mesosphere.github.io/marathon/docs/rest-api.html#get-v2-apps-appid

But there is no heading for get-v2-apps-appid (that bug was introduced when introduced when introducing embed parameter in this commit https://github.com/mesosphere/marathon/commit/833ce402fdeae34eaff4bf3bc4329faf6cf17b17)