### PR TITLE
Make deployments aware of apps and pods.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
@@ -28,7 +28,7 @@ class DeploymentsResource @Inject() (
   @GET
   def running(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
     val infos = result(service.listRunningDeployments())
-      .filter(_.plan.affectedApplications.exists(isAuthorized(ViewRunSpec, _)))
+      .filter(_.plan.affectedRunSpecs.exists(isAuthorized(ViewRunSpec, _)))
     ok(infos)
   }
 
@@ -40,7 +40,7 @@ class DeploymentsResource @Inject() (
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
     val plan = result(service.listRunningDeployments()).find(_.plan.id == id).map(_.plan)
     plan.fold(notFound(s"DeploymentPlan $id does not exist")) { deployment =>
-      deployment.affectedApplications.foreach(checkAuthorization(UpdateRunSpec, _))
+      deployment.affectedRunSpecs.foreach(checkAuthorization(UpdateRunSpec, _))
 
       if (force) {
         // do not create a new deployment to return to the previous state

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -499,7 +499,7 @@ trait DeploymentFormats {
   implicit lazy val DeploymentActionWrites: Writes[DeploymentAction] = Writes { action =>
     Json.obj(
       "action" -> action.getClass.getSimpleName,
-      "app" -> action.app.id
+      "app" -> action.runSpec.id
     )
   }
 
@@ -508,13 +508,13 @@ trait DeploymentFormats {
   implicit lazy val DeploymentStepInfoWrites: Writes[DeploymentStepInfo] = Writes { info =>
     def currentAction(action: DeploymentAction): JsObject = Json.obj (
       "action" -> action.getClass.getSimpleName,
-      "app" -> action.app.id,
-      "readinessCheckResults" -> info.readinessChecksByApp(action.app.id)
+      "app" -> action.runSpec.id,
+      "readinessCheckResults" -> info.readinessChecksByApp(action.runSpec.id)
     )
     Json.obj(
       "id" -> info.plan.id,
       "version" -> info.plan.version,
-      "affectedApps" -> info.plan.affectedApplicationIds,
+      "affectedApps" -> info.plan.affectedRunSpecIds,
       "steps" -> info.plan.steps,
       "currentActions" -> info.step.actions.map(currentAction),
       "currentStep" -> info.nr,

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -514,7 +514,8 @@ trait DeploymentFormats {
     Json.obj(
       "id" -> info.plan.id,
       "version" -> info.plan.version,
-      "affectedApps" -> info.plan.affectedRunSpecIds,
+      "affectedApps" -> info.plan.affectedAppIds,
+      "affectedPods" -> info.plan.affectedPodIds,
       "steps" -> info.plan.steps,
       "currentActions" -> info.step.actions.map(currentAction),
       "currentStep" -> info.nr,

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -50,7 +50,7 @@ class AppInfoBaseData(
     allRunningDeploymentsFuture.map { allDeployments =>
       val byApp = Map.empty[PathId, Vector[DeploymentPlan]].withDefaultValue(Vector.empty)
       val deploymentsByAppId = allDeployments.foldLeft(byApp) { (result, deploymentPlan) =>
-        deploymentPlan.affectedApplicationIds.foldLeft(result) { (result, appId) =>
+        deploymentPlan.affectedRunSpecIds.foldLeft(result) { (result, appId) =>
           val newEl = appId -> (result(appId) :+ deploymentPlan)
           result + newEl
         }

--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerActor.scala
@@ -133,8 +133,8 @@ private[impl] class GroupManagerActor(
         _ = validateOrThrow(plan)(DeploymentPlan.deploymentPlanValidator(config))
         _ = log.info(s"Computed new deployment plan:\n$plan")
         _ <- scheduler.deploy(plan, force)
-        // TODO(PODS): Add in createdOrUpdatedPods and deletedPods
-        _ <- groupRepo.storeRoot(plan.target, plan.createdOrUpdatedApps, plan.deletedApps, Nil, Nil)
+        _ <- groupRepo.storeRoot(plan.target, plan.createdOrUpdatedApps,
+          plan.deletedApps, plan.createdOrUpdatedPods, plan.deletedPods)
         _ = log.info(s"Updated groups/apps according to deployment plan ${plan.id}")
       } yield plan
 

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -9,6 +9,7 @@ import mesosphere.marathon.state.AppDefinition.VersionInfo
 
 import scala.concurrent.duration.FiniteDuration
 import scala.collection.immutable.Seq
+import scala.language.implicitConversions
 
 /**
   * A generic spec that specifies something that Marathon is able to launch instances of.
@@ -29,6 +30,14 @@ trait RunnableSpec extends plugin.RunSpec {
   def mem: Double
   def disk: Double
   def gpus: Int
+}
+
+object RunnableSpec {
+
+  //TODO(PODS): Work in progress conversion to make the code compile
+  implicit def runSpecToApp(runnableSpec: RunnableSpec): AppDefinition = {
+    runnableSpec.asInstanceOf[AppDefinition]
+  }
 }
 
 //scalastyle:off

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -35,8 +35,9 @@ trait RunnableSpec extends plugin.RunSpec {
 object RunnableSpec {
 
   //TODO(PODS): Work in progress conversion to make the code compile
-  implicit def runSpecToApp(runnableSpec: RunnableSpec): AppDefinition = {
-    runnableSpec.asInstanceOf[AppDefinition]
+  implicit def runSpecToApp(runnableSpec: RunnableSpec): AppDefinition = runnableSpec match {
+    case app: AppDefinition => app
+    case _ => throw new IllegalArgumentException
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
@@ -2,11 +2,11 @@ package mesosphere.marathon.upgrade
 
 import akka.actor._
 import akka.event.EventStream
+import mesosphere.marathon.core.event.DeploymentStatus
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.core.event.DeploymentStatus
-import mesosphere.marathon.state.AppDefinition
+import mesosphere.marathon.state.RunnableSpec
 import mesosphere.marathon.{ AppStartCanceledException, SchedulerActions }
 import org.apache.mesos.SchedulerDriver
 
@@ -22,22 +22,22 @@ class AppStartActor(
     val instanceTracker: InstanceTracker,
     val eventBus: EventStream,
     val readinessCheckExecutor: ReadinessCheckExecutor,
-    val app: AppDefinition,
+    val run: RunnableSpec,
     val scaleTo: Int,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
   val nrToStart: Int = scaleTo
 
   def initializeStart(): Unit = {
-    scheduler.startApp(driver, app.copy(instances = scaleTo))
+    scheduler.startApp(driver, run.copy(instances = scaleTo))
   }
 
   override def postStop(): Unit = {
     eventBus.unsubscribe(self)
     if (!promise.isCompleted) {
       if (promise.tryFailure(new AppStartCanceledException("The app start has been cancelled"))) {
-        scheduler.stopApp(app).onFailure {
-          case NonFatal(e) => log.error(s"while stopping app ${app.id}", e)
+        scheduler.stopApp(run).onFailure {
+          case NonFatal(e) => log.error(s"while stopping app ${run.id}", e)
         }(context.dispatcher)
       }
     }
@@ -45,7 +45,7 @@ class AppStartActor(
   }
 
   def success(): Unit = {
-    log.info(s"Successfully started $scaleTo instances of ${app.id}")
+    log.info(s"Successfully started $scaleTo instances of ${run.id}")
     promise.success(())
     context.stop(self)
   }
@@ -62,10 +62,10 @@ object AppStartActor {
     taskTracker: InstanceTracker,
     eventBus: EventStream,
     readinessCheckExecutor: ReadinessCheckExecutor,
-    app: AppDefinition,
+    runnableSpec: RunnableSpec,
     scaleTo: Int,
     promise: Promise[Unit]): Props = {
     Props(new AppStartActor(deploymentManager, status, driver, scheduler, launchQueue, taskTracker, eventBus,
-      readinessCheckExecutor, app, scaleTo, promise))
+      readinessCheckExecutor, runnableSpec, scaleTo, promise))
   }
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlan.scala
@@ -83,6 +83,9 @@ final case class DeploymentPlan(
   /** @return all ids of apps which are referenced in any deployment actions */
   lazy val affectedRunSpecIds: Set[PathId] = steps.flatMap(_.actions.map(_.runSpec.id)).toSet
 
+  def affectedAppIds: Set[PathId] = affectedRunSpecs.collect{ case app: AppDefinition => app }.map(_.id)
+  def affectedPodIds: Set[PathId] = affectedRunSpecs.collect{ case pod: PodDefinition => pod }.map(_.id)
+
   def isAffectedBy(other: DeploymentPlan): Boolean =
     // FIXME: check for group change conflicts?
     affectedRunSpecIds.intersect(other.affectedRunSpecIds).nonEmpty

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlanReverter.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlanReverter.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.upgrade
 
-import mesosphere.marathon.state.{ Timestamp, AppDefinition, PathId, Group }
+import mesosphere.marathon.core.pod.PodDefinition
+import mesosphere.marathon.state._
 import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.Seq
@@ -43,15 +44,15 @@ private[upgrade] object DeploymentPlanReverter {
     val groupChanges: Seq[(Option[Group], Option[Group])] =
       changesOnIds(original.transitiveGroups, target.transitiveGroups)(_.id)
 
-    /* a sequence of tuples with the old and the new app definition */
-    val appChanges: Seq[(Option[AppDefinition], Option[AppDefinition])] = {
-      changesOnIds(original.transitiveApps, target.transitiveApps)(_.id)
+    /* a sequence of tuples with the old and the new run definition */
+    val runSpecChanges: Seq[(Option[RunnableSpec], Option[RunnableSpec])] = {
+      changesOnIds(original.transitiveRunSpecs, target.transitiveRunSpecs)(_.id)
         .filter { case (oldOpt, newOpt) => oldOpt != newOpt }
     }
 
-    // We need to revert app changes first so that apps have already been deleted when we check
+    // We need to revert run changes first so that runs have already been deleted when we check
     // a group is empty and can be removed.
-    (revertAppChanges(newVersion, appChanges) _).andThen(revertGroupChanges(newVersion, groupChanges))
+    (revertRunSpecChanges(newVersion, runSpecChanges) _).andThen(revertGroupChanges(newVersion, groupChanges))
   }
 
   /**
@@ -155,24 +156,34 @@ private[upgrade] object DeploymentPlanReverter {
   }
 
   /**
-    * Reverts app additions, changes and removals.
+    * Reverts app and pod additions, changes and removals.
     *
     * The logic is quite simple because during a deployment apps are locked which
     * prevents any concurrent changes.
     */
-  private[this] def revertAppChanges(
-    version: Timestamp, changes: Seq[(Option[AppDefinition], Option[AppDefinition])])(
+  private[this] def revertRunSpecChanges(
+    version: Timestamp, changes: Seq[(Option[RunnableSpec], Option[RunnableSpec])])(
     g: Group): Group = {
 
+    def appOrPodChange(
+      runnableSpec: RunnableSpec,
+      appChange: AppDefinition => Group,
+      podChange: PodDefinition => Group): Group = runnableSpec match {
+      case app: AppDefinition => appChange(app)
+      case pod: PodDefinition => podChange(pod)
+    }
+
     changes.foldLeft(g) {
-      case (result, appUpdate) =>
-        appUpdate match {
-          case (Some(oldApp), _) => //removal or change
-            log.debug("revert to old app definition {}", oldApp.id)
-            result.updateApp(oldApp.id, _ => oldApp, version)
-          case (None, Some(newApp)) =>
-            log.debug("remove app definition {}", newApp.id)
-            result.update(newApp.id.parent, _.removeApplication(newApp.id), version)
+      case (result, runUpdate) =>
+        runUpdate match {
+          case (Some(oldRun), _) => //removal or change
+            log.debug("revert to old app definition {}", oldRun.id)
+            //TODO(PODS): add pod update group logic
+            appOrPodChange(oldRun, app => result.updateApp(app.id, _ => app, version), pod => ???)
+          case (None, Some(newRun)) =>
+            log.debug("remove app definition {}", newRun.id)
+            //TODO(PODS): add pod update group logic
+            appOrPodChange(newRun, a => result.update(a.id.parent, _.removeApplication(a.id), version), pod => ???)
           case (None, None) =>
             log.warn("processing unexpected NOOP in app changes")
             result

--- a/src/main/scala/mesosphere/marathon/upgrade/ReadinessBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/ReadinessBehavior.scala
@@ -1,12 +1,14 @@
 package mesosphere.marathon.upgrade
 
 import akka.actor.{ Actor, ActorLogging, ActorRef }
-import mesosphere.marathon.core.readiness.{ ReadinessCheckExecutor, ReadinessCheckResult }
+import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.pod.PodDefinition
+import mesosphere.marathon.core.readiness.{ ReadinessCheck, ReadinessCheckExecutor, ReadinessCheckResult }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.event.{ DeploymentStatus, HealthStatusChanged, MesosStatusUpdateEvent }
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
+import mesosphere.marathon.state.{ AppDefinition, RunnableSpec, PathId, Timestamp }
 import mesosphere.marathon.upgrade.DeploymentManager.ReadinessCheckUpdate
 import mesosphere.marathon.upgrade.ReadinessBehavior.{ ReadinessCheckSubscriptionKey, ScheduleReadinessCheckFor }
 import rx.lang.scala.Subscription
@@ -22,17 +24,18 @@ import rx.lang.scala.Subscription
 trait ReadinessBehavior { this: Actor with ActorLogging =>
 
   import context.dispatcher
+  import ReadinessBehavior._
 
   //dependencies
-  def app: AppDefinition
+  def run: RunnableSpec
   def readinessCheckExecutor: ReadinessCheckExecutor
   def deploymentManager: ActorRef
   def instanceTracker: InstanceTracker
   def status: DeploymentStatus
 
   //computed values to have stable identifier in pattern matcher
-  val appId: PathId = app.id
-  val version: Timestamp = app.version
+  val runId: PathId = run.id
+  val version: Timestamp = run.version
   val versionString: String = version.toString
 
   //state managed by this behavior
@@ -48,13 +51,13 @@ trait ReadinessBehavior { this: Actor with ActorLogging =>
   /**
     * Indicates, if a given target count has been reached.
     */
-  def taskTargetCountReached(count: Int): Boolean = healthy.size == count && ready.size == count
+  def instanceTargetCountReached(count: Int): Boolean = healthy.size == count && ready.size == count
 
   /**
-    * Actors extending this trait should call this method when they detect that a task is terminated
-    * The task will be removed from subsequent sets and all subscriptions will get canceled.
+    * Actors extending this trait should call this method when they detect that a instance is terminated
+    * The instance will be removed from subsequent sets and all subscriptions will get canceled.
     *
-    * @param taskId the id of the task that has been terminated.
+    * @param taskId the id of the instance that has been terminated.
     */
   def taskTerminated(taskId: Instance.Id): Unit = {
     healthy -= taskId
@@ -74,11 +77,11 @@ trait ReadinessBehavior { this: Actor with ActorLogging =>
   }
 
   /**
-    * Depending on the app definition, this method handles:
-    * - app without health checks and without readiness checks
-    * - app with health checks and without readiness checks
-    * - app without health checks and with readiness checks
-    * - app with health checks and with readiness checks
+    * Depending on the run spec definition, this method handles:
+    * - run spec without health checks and without readiness checks
+    * - run spec with health checks and without readiness checks
+    * - run spec without health checks and with readiness checks
+    * - run spec with health checks and with readiness checks
     *
     * The #taskIsReady function is called, when the task is ready according to the app definition.
     */
@@ -97,25 +100,25 @@ trait ReadinessBehavior { this: Actor with ActorLogging =>
         initiateReadinessCheck(taskId)
       }
       def taskIsRunning(taskFn: Instance.Id => Unit): Receive = {
-        case MesosStatusUpdateEvent(slaveId, taskId, "TASK_RUNNING", _, `appId`, _, _, _, `versionString`, _, _) =>
+        case MesosStatusUpdateEvent(slaveId, taskId, "TASK_RUNNING", _, `runId`, _, _, _, `versionString`, _, _) =>
           taskFn(taskId)
       }
-      taskIsRunning(if (app.readinessChecks.isEmpty) markAsHealthyAndReady else markAsHealthyAndInitiateReadinessCheck)
+      taskIsRunning(if (readinessChecks(run).isEmpty) markAsHealthyAndReady else markAsHealthyAndInitiateReadinessCheck)
     }
 
     def taskHealthBehavior: Receive = {
       def initiateReadinessOnRun: Receive = {
-        case MesosStatusUpdateEvent(_, taskId, "TASK_RUNNING", _, `appId`, _, _, _, `versionString`, _, _) =>
+        case MesosStatusUpdateEvent(_, taskId, "TASK_RUNNING", _, `runId`, _, _, _, `versionString`, _, _) =>
           initiateReadinessCheck(taskId)
       }
       def handleTaskHealthy: Receive = {
-        case HealthStatusChanged(`appId`, taskId, `version`, true, _, _) if !healthy(taskId) =>
-          log.info(s"Task $taskId now healthy for app ${app.id.toString}")
+        case HealthStatusChanged(`runId`, taskId, `version`, true, _, _) if !healthy(taskId) =>
+          log.info(s"Task $taskId now healthy for run spec ${run.id.toString}")
           healthy += taskId
-          if (app.readinessChecks.isEmpty) ready += taskId
+          if (readinessChecks(run).isEmpty) ready += taskId
           taskStatusChanged(taskId)
       }
-      val handleTaskRunning = if (app.readinessChecks.nonEmpty) initiateReadinessOnRun else Actor.emptyBehavior
+      val handleTaskRunning = if (readinessChecks(run).nonEmpty) initiateReadinessOnRun else Actor.emptyBehavior
       handleTaskRunning orElse handleTaskHealthy
     }
 
@@ -134,7 +137,7 @@ trait ReadinessBehavior { this: Actor with ActorLogging =>
     def readinessCheckBehavior: Receive = {
       case ScheduleReadinessCheckFor(task, launched) =>
         log.debug(s"Schedule readiness check for task: ${task.id}")
-        ReadinessCheckExecutor.ReadinessCheckSpec.readinessCheckSpecsForTask(app, task, launched).foreach { spec =>
+        ReadinessCheckExecutor.ReadinessCheckSpec.readinessCheckSpecsForTask(run, task, launched).foreach { spec =>
           val subscriptionName = ReadinessCheckSubscriptionKey(task.id, spec.checkName)
           val subscription = readinessCheckExecutor.execute(spec).subscribe(self ! _)
           subscriptions += subscriptionName -> subscription
@@ -143,9 +146,9 @@ trait ReadinessBehavior { this: Actor with ActorLogging =>
       case result: ReadinessCheckResult =>
         log.info(s"Received readiness check update for task ${result.taskId} with ready: ${result.ready}")
         deploymentManager ! ReadinessCheckUpdate(status.plan.id, result)
-        //TODO(MV): this code assumes only one readiness check per app (validation rules enforce this)
+        //TODO(MV): this code assumes only one readiness check per run spec (validation rules enforce this)
         if (result.ready) {
-          log.info(s"Task ${result.taskId} now ready for app ${app.id.toString}")
+          log.info(s"Task ${result.taskId} now ready for run spec ${run.id.toString}")
           ready += result.taskId
           val subscriptionName = ReadinessCheckSubscriptionKey(result.taskId, result.name)
           subscriptions.get(subscriptionName).foreach(_.unsubscribe())
@@ -154,8 +157,8 @@ trait ReadinessBehavior { this: Actor with ActorLogging =>
         }
     }
 
-    val startBehavior = if (app.healthChecks.nonEmpty) taskHealthBehavior else taskRunBehavior
-    val readinessBehavior = if (app.readinessChecks.nonEmpty) readinessCheckBehavior else Actor.emptyBehavior
+    val startBehavior = if (healthChecks(run).nonEmpty) taskHealthBehavior else taskRunBehavior
+    val readinessBehavior = if (readinessChecks(run).nonEmpty) readinessCheckBehavior else Actor.emptyBehavior
     startBehavior orElse readinessBehavior
   }
 }
@@ -163,4 +166,15 @@ trait ReadinessBehavior { this: Actor with ActorLogging =>
 object ReadinessBehavior {
   case class ReadinessCheckSubscriptionKey(taskId: Instance.Id, readinessCheck: String)
   case class ScheduleReadinessCheckFor(task: Task, launched: Task.Launched)
+
+  def readinessChecks(runSpec: RunnableSpec): Seq[ReadinessCheck] = runSpec match {
+    case app: AppDefinition => app.readinessChecks
+    case _ => Seq.empty[ReadinessCheck]
+  }
+
+  def healthChecks(runSpec: RunnableSpec): Set[HealthCheck] = runSpec match {
+    case app: AppDefinition => app.healthChecks
+    case pod: PodDefinition => Set.empty[HealthCheck] //TODO(PODS) which health checks
+    case _ => Set.empty[HealthCheck]
+  }
 }

--- a/src/main/scala/mesosphere/marathon/upgrade/ResolveArtifactsActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/ResolveArtifactsActor.scala
@@ -5,17 +5,16 @@ import java.net.URL
 import akka.actor.Actor
 import akka.actor.Status.Failure
 import akka.pattern.pipe
-
 import mesosphere.marathon.ResolveArtifactsCanceledException
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.io.{ CancelableDownload, PathFun }
-import mesosphere.marathon.state.AppDefinition
+import mesosphere.marathon.state.RunnableSpec
 import mesosphere.util.Logging
 
 import scala.concurrent.Promise
 
 class ResolveArtifactsActor(
-  app: AppDefinition,
+  runSpec: RunnableSpec,
   url2Path: Map[URL, String],
   promise: Promise[Boolean],
   storage: StorageProvider)

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -26,7 +26,7 @@ trait StartingBehavior extends ReadinessBehavior { this: Actor with ActorLogging
   def initializeStart(): Unit
 
   final override def preStart(): Unit = {
-    if (app.healthChecks.nonEmpty) eventBus.subscribe(self, classOf[MarathonHealthCheckEvent])
+    if (run.healthChecks.nonEmpty) eventBus.subscribe(self, classOf[MarathonHealthCheckEvent])
     eventBus.subscribe(self, classOf[MesosStatusUpdateEvent])
 
     initializeStart()
@@ -38,29 +38,29 @@ trait StartingBehavior extends ReadinessBehavior { this: Actor with ActorLogging
   final override def receive: Receive = readinessBehavior orElse commonBehavior
 
   def commonBehavior: Receive = {
-    case MesosStatusUpdateEvent(_, taskId, StartErrorState(_), _, `appId`, _, _, _, `versionString`, _, _) => // scalastyle:off line.size.limit
-      log.warning(s"New task [$taskId] failed during app ${app.id.toString} scaling, queueing another task")
+    case MesosStatusUpdateEvent(_, taskId, StartErrorState(_), _, `runId`, _, _, _, `versionString`, _, _) => // scalastyle:off line.size.limit
+      log.warning(s"New task [$taskId] failed during app ${run.id.toString} scaling, queueing another task")
       taskTerminated(taskId)
-      launchQueue.add(app)
+      launchQueue.add(run)
 
     case Sync =>
-      val actualSize = launchQueue.get(app.id).map(_.finalTaskCount).getOrElse(instanceTracker.countLaunchedSpecInstancesSync(app.id))
+      val actualSize = launchQueue.get(run.id).map(_.finalTaskCount).getOrElse(instanceTracker.countLaunchedSpecInstancesSync(run.id))
       val tasksToStartNow = Math.max(scaleTo - actualSize, 0)
       if (tasksToStartNow > 0) {
-        log.info(s"Reconciling tasks during app ${app.id.toString} scaling: queuing $tasksToStartNow new tasks")
-        launchQueue.add(app, tasksToStartNow)
+        log.info(s"Reconciling tasks during app ${run.id.toString} scaling: queuing $tasksToStartNow new tasks")
+        launchQueue.add(run, tasksToStartNow)
       }
       context.system.scheduler.scheduleOnce(5.seconds, self, Sync)
   }
 
   override def taskStatusChanged(taskId: Instance.Id): Unit = {
-    log.info(s"New task $taskId changed during app ${app.id.toString} scaling, " +
+    log.info(s"New task $taskId changed during app ${run.id.toString} scaling, " +
       s"${readyTasks.size} ready ${healthyTasks.size} healthy need $nrToStart")
     checkFinished()
   }
 
   def checkFinished(): Unit = {
-    if (taskTargetCountReached(nrToStart)) success()
+    if (instanceTargetCountReached(nrToStart)) success()
   }
 
   def success(): Unit

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -22,17 +22,17 @@ class TaskStartActor(
     val instanceTracker: InstanceTracker,
     val eventBus: EventStream,
     val readinessCheckExecutor: ReadinessCheckExecutor,
-    val app: AppDefinition,
+    val run: AppDefinition,
     val scaleTo: Int,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
   val nrToStart: Int =
-    scaleTo - launchQueue.get(app.id).map(_.finalTaskCount)
-      .getOrElse(instanceTracker.countLaunchedSpecInstancesSync(app.id))
+    scaleTo - launchQueue.get(run.id).map(_.finalTaskCount)
+      .getOrElse(instanceTracker.countLaunchedSpecInstancesSync(run.id))
 
   override def initializeStart(): Unit = {
     if (nrToStart > 0)
-      launchQueue.add(app, nrToStart)
+      launchQueue.add(run, nrToStart)
   }
 
   override def postStop(): Unit = {
@@ -45,7 +45,7 @@ class TaskStartActor(
   }
 
   override def success(): Unit = {
-    log.info(s"Successfully started $nrToStart instances of ${app.id}")
+    log.info(s"Successfully started $nrToStart instances of ${run.id}")
     promise.success(())
     context.stop(self)
   }

--- a/src/test/scala/mesosphere/marathon/state/GroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupTest.scala
@@ -304,7 +304,7 @@ class GroupTest extends FunSpec with GivenWhenThen with Matchers {
       )
       ids should equal (expectedIds)
 
-      current.appsWithNoDependencies should have size 2
+      current.runSpecsWithNoDependencies should have size 2
     }
 
     it("can turn a group with app dependencies into a dependency graph") {
@@ -355,7 +355,7 @@ class GroupTest extends FunSpec with GivenWhenThen with Matchers {
       )
       ids should be(expected)
 
-      current.appsWithNoDependencies should have size 2
+      current.runSpecsWithNoDependencies should have size 2
     }
 
     it("can turn a group without dependencies into a dependency graph") {
@@ -393,7 +393,7 @@ class GroupTest extends FunSpec with GivenWhenThen with Matchers {
       val dependencyGraph = current.dependencyGraph
 
       Then("the dependency graph is correct")
-      current.appsWithNoDependencies should have size 8
+      current.runSpecsWithNoDependencies should have size 8
     }
 
     it("detects a cyclic dependency graph") {

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentPlanTest.scala
@@ -41,7 +41,7 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     )))
 
     When("the group's apps are grouped by the longest outbound path")
-    val partitionedApps = DeploymentPlan.appsGroupedByLongestPath(group)
+    val partitionedApps = DeploymentPlan.runSpecsGroupedByLongestPath(group)
 
     Then("three equivalence classes should be computed")
     partitionedApps should have size (3)
@@ -74,7 +74,7 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     )
 
     When("the group's apps are grouped by the longest outbound path")
-    val partitionedApps = DeploymentPlan.appsGroupedByLongestPath(group)
+    val partitionedApps = DeploymentPlan.runSpecsGroupedByLongestPath(group)
 
     Then("three equivalence classes should be computed")
     partitionedApps should have size (4)
@@ -142,7 +142,7 @@ class DeploymentPlanTest extends MarathonSpec with Matchers with GivenWhenThen w
     val to = Group("/".toPath, groups = Set(Group("/group".toPath, update)))
     val plan = DeploymentPlan(from, to)
 
-    plan.affectedApplicationIds should equal (Set("/app".toPath, "/app2".toPath, "/app3".toPath, "/app4".toPath))
+    plan.affectedRunSpecIds should equal (Set("/app".toPath, "/app2".toPath, "/app3".toPath, "/app4".toPath))
     plan.isAffectedBy(plan) should equal (right = true)
     plan.isAffectedBy(DeploymentPlan(from, from)) should equal (right = false)
   }

--- a/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
@@ -114,7 +114,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
 
     Then("Task readiness checks are performed")
     eventually(taskIsReady should be (false))
-    actor.underlyingActor.taskTargetCountReached(1) should be (false)
+    actor.underlyingActor.instanceTargetCountReached(1) should be (false)
     eventually(actor.underlyingActor.readyTasks should have size 1)
     actor.underlyingActor.healthyTasks should have size 0
 
@@ -191,7 +191,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
           system.eventStream.subscribe(self, classOf[MesosStatusUpdateEvent])
           system.eventStream.subscribe(self, classOf[HealthStatusChanged])
         }
-        override def app: AppDefinition = appDef
+        override def run: AppDefinition = appDef
         override def deploymentManager: ActorRef = deploymentManagerProbe.ref
         override def status: DeploymentStatus = deploymentStatus
         override def readinessCheckExecutor: ReadinessCheckExecutor = executor
@@ -199,7 +199,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
         override def receive: Receive = readinessBehavior orElse {
           case notHandled => throw new RuntimeException(notHandled.toString)
         }
-        override def taskStatusChanged(taskId: Instance.Id): Unit = if (taskTargetCountReached(1)) taskReadyFn(taskId)
+        override def taskStatusChanged(taskId: Instance.Id): Unit = if (instanceTargetCountReached(1)) taskReadyFn(taskId)
       }
       )
     }


### PR DESCRIPTION
Make the DeploymentActions generic to support RunnableSpec.
Rename properties to meet runSpec names.

This is the first step to make deployments aware of pods - mostly to get the types right.
Missing functionality: listen to instance events, handling instances instead of tasks.
Will do this in a separate PR once the events are available.