### PR TITLE
Fix a few blockers in persistence store

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerActor.scala
@@ -132,8 +132,8 @@ private[impl] class GroupManagerActor(
         plan = DeploymentPlan(from, to, resolve, version, toKill)
         _ = validateOrThrow(plan)(DeploymentPlan.deploymentPlanValidator(config))
         _ = log.info(s"Computed new deployment plan:\n$plan")
-        _ <- scheduler.deploy(plan, force)
         _ <- groupRepo.storeRoot(plan.target, plan.createdOrUpdatedApps, plan.deletedApps)
+        _ <- scheduler.deploy(plan, force)
         _ = log.info(s"Updated groups/apps according to deployment plan ${plan.id}")
       } yield plan
 

--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerActor.scala
@@ -132,8 +132,8 @@ private[impl] class GroupManagerActor(
         plan = DeploymentPlan(from, to, resolve, version, toKill)
         _ = validateOrThrow(plan)(DeploymentPlan.deploymentPlanValidator(config))
         _ = log.info(s"Computed new deployment plan:\n$plan")
-        _ <- groupRepo.storeRoot(plan.target, plan.createdOrUpdatedApps, plan.deletedApps)
         _ <- scheduler.deploy(plan, force)
+        _ <- groupRepo.storeRoot(plan.target, plan.createdOrUpdatedApps, plan.deletedApps)
         _ = log.info(s"Updated groups/apps according to deployment plan ${plan.id}")
       } yield plan
 

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -102,6 +102,7 @@ class ZkPersistenceStore(
           ZKStoreEntry.newBuilder().setValue(com.google.protobuf.ByteString.copyFrom(actualVersion.toByteArray))
           .setName(Migration.StorageVersionName)
           .setCompressed(false)
+          .setUuid(com.google.protobuf.ByteString.copyFromUtf8(UUID.randomUUID().toString))
           .build.toByteArray
         )
         await(client.setData(path, data).asTry) match {

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -173,7 +173,7 @@ class Migration(
 
   private def storeCurrentVersion(): Future[Done] = async {
     val legacyStore = await(legacyStoreFuture)
-    persistenceStore.map(_.setStorageVersion(StorageVersions.current)).orElse {
+    val future = persistenceStore.map(_.setStorageVersion(StorageVersions.current)).orElse {
       val bytes = StorageVersions.current.toByteArray
       legacyStore.map { store =>
         store.load(StorageVersionName).flatMap {
@@ -181,7 +181,8 @@ class Migration(
           case None => store.create(StorageVersionName, bytes)
         }
       }
-    }
+    }.getOrElse(Future.successful(Done))
+    await(future)
     Done
   }
 

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
@@ -59,6 +59,8 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen {
       val migrate = migration(persistenceStore = Option(mockedStore))
 
       mockedStore.storageVersion() returns Future.successful(None)
+      mockedStore.setStorageVersion(any) returns Future.successful(Done)
+
       migrate.migrate()
 
       verify(mockedStore).storageVersion()


### PR DESCRIPTION
- Deployment plans can be stored before the groups are.
  Instead, always store the group first.
- ZKPersistenceStore was actually failing to store the StorageVersion
  due to missing a field in the wrapper.
- Migration didn't wait on setting storage version, so the error above
  was hidden.
- StoredGroup fails silently and forever if apps couldn't
  be parsed. Log that and log if any of them are missing (which should
  never happen)