### PR TITLE
Fixes #4028: First health check is scheduled immediately after the task was launched.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
@@ -46,8 +46,8 @@ case class HealthCheck(
 
     path foreach builder.setPath
 
-    portIndex foreach { p => builder.setPortIndex(p.toInt) }
-    port foreach { p => builder.setPort(p.toInt) }
+    portIndex foreach { p => builder.setPortIndex(p) }
+    port foreach { p => builder.setPort(p) }
 
     builder.build
   }
@@ -123,6 +123,7 @@ object HealthCheck {
   val DefaultPortIndex = None
   val DefaultCommand = None
   // Dockers can take a long time to download, so default to a fairly long wait.
+  val DefaultFirstHealthCheckTime = 1.seconds
   val DefaultGracePeriod = 5.minutes
   val DefaultInterval = 1.minute
   val DefaultTimeout = 20.seconds


### PR DESCRIPTION
First health check is now applied DefaultFirstHealthCheckTime (1s by default) after the task was successfully launched. scheduler.schedule(...) is used instead of scheduler.scheduleOnce(...) which simplifies code a bit.

- a few minor scalastyle complains also fixed