### PR TITLE
more Pods API tweaks

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
+++ b/docs/docs/rest-api/public/api/v2/types/mesosContainer.raml
@@ -7,7 +7,6 @@ uses:
   mesosCommand: mesosCommand.raml
   network: network.raml
   resources: resources.raml
-  secrets: secrets.raml
   strings: stringTypes.raml
   volumes: volumes.raml
 types:
@@ -42,6 +41,16 @@ types:
         description: |
           When true argv[0] will be used as the entrypoint/exec of the container.
           Otherwise the contents of argv[] are appended as arguments.
+  Lifecycle:
+    type: object
+    properties:
+      killGracePeriodSeconds?:
+        type: number
+        description: |
+          After a SIGTERM is sent to a container instance, Mesos will wait this number of seconds
+          before issuing a SIGKILL.
+        format: double
+        minimum: 0
   MesosContainer:
     type: object
     description: Mesos Container
@@ -60,7 +69,6 @@ types:
         type: Image
         description: The filesystem image to populate the container with
       environment?: env.EnvVars
-      secrets?: secrets.Secrets
       user?:
         type: string
         description: |
@@ -81,3 +89,5 @@ types:
         description: |
           Metadata as key/value pair.
           Useful when passing directives to be interpreted by Mesos modules.
+      lifecycle?:
+        type: Lifecycle

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -50,6 +50,7 @@ trait RunSpec extends plugin.RunSpec {
   val readinessChecks: Seq[ReadinessCheck]
   val upgradeStrategy: UpgradeStrategy
   def portAssignments(task: Task): Seq[PortAssignment]
+  // TODO(PODS)- should be set per-container instance
   val taskKillGracePeriod = Option.empty[FiniteDuration]
   def withInstances(instances: Int): RunSpec
   def isUpgrade(to: RunSpec): Boolean


### PR DESCRIPTION
* remove secrets from container API (only need them at the top level, not per-CT)
* add lifecycle/kill-grace-period to container spec