### PR TITLE
Implement InstanceChangeHandler in former TaskUpdateStepImpls

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -146,7 +146,7 @@ class AppInfoBaseData(
 
       log.debug(s"assembling rich tasks for app [${app.id}]")
 
-      val tasksByIdFuture = tasksByAppFuture.map(_.instancesMap.get(app.id).map(_.instancekMap).getOrElse(Map.empty))
+      val tasksByIdFuture = tasksByAppFuture.map(_.instancesMap.get(app.id).map(_.instanceMap).getOrElse(Map.empty))
       val healthStatusesFutures = healthCheckManager.statuses(app.id)
       for {
         tasksById <- tasksByIdFuture

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -86,7 +86,7 @@ private[health] class HealthCheckActor(
   def dispatchJobs(): Unit = {
     log.debug("Dispatching health check jobs to workers")
     taskTracker.specInstancesSync(app.id).flatMap(Task(_)).foreach { task =>
-        task.launched.foreach { launched =>
+      task.launched.foreach { launched =>
         if (launched.runSpecVersion == app.version && task.isRunning) {
           log.debug("Dispatching health check job for {}", task.id)
           val worker: ActorRef = context.actorOf(workerProps)

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -34,7 +34,7 @@ object Instance {
   def instancesById(tasks: Iterable[Instance]): Map[Instance.Id, Instance] =
     tasks.iterator.map(task => task.id -> task).toMap
 
-  case class InstanceState(status: InstanceStatus, since: Timestamp)
+  case class InstanceState(status: InstanceStatus, since: Timestamp, version: Timestamp)
 
   case class Id(idString: String) extends Ordered[Id] {
     lazy val runSpecId: PathId = Id.runSpecId(idString)

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -11,6 +11,7 @@ trait Instance {
   def state: InstanceState
 
   def isLaunched: Boolean
+  def runSpecVersion: Timestamp
 
   def isReserved: Boolean
   def isCreated: Boolean

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
@@ -22,18 +22,21 @@ trait InstanceChangeHandler {
   * An event notifying of an [[Instance]] change.
   */
 sealed trait InstanceChange {
+  /** The affected [[Instance]] */
+  val instance: Instance
   /** Id of the affected [[Instance]] */
-  def id: Instance.Id
+  val id: Instance.Id = instance.id
   /** Status of the [[Instance]] */
   // TODO(PODS): We might want to transport health information in the status
-  def status: InstanceStatus
+  // TODO(PODS): who carries the version? instance or InstanceStatus?
+  val status: InstanceStatus = instance.state.status
   /** Id of the related [[mesosphere.marathon.state.RunSpec]] */
-  final def runSpecId: PathId = id.runSpecId
+  val runSpecId: PathId = id.runSpecId
 }
 
 /** The given instance has been created. */
-case class InstanceCreated(id: Instance.Id, status: InstanceStatus, instance: Instance) extends InstanceChange
+case class InstanceCreated(instance: Instance) extends InstanceChange
 /** The given instance has been created. */
-case class InstanceUpdated(id: Instance.Id, status: InstanceStatus, instance: Instance) extends InstanceChange
+case class InstanceUpdated(instance: Instance) extends InstanceChange
 /** The given instance has been deleted. */
-case class InstanceDeleted(id: Instance.Id, status: InstanceStatus) extends InstanceChange
+case class InstanceDeleted(instance: Instance) extends InstanceChange

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
@@ -21,7 +21,7 @@ trait InstanceChangeHandler {
 /**
   * An event notifying of an [[Instance]] change.
   */
-sealed trait InstanceChange {
+sealed trait InstanceChange extends Product with Serializable {
   /** The affected [[Instance]] */
   val instance: Instance
   /** Id of the affected [[Instance]] */

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
@@ -28,7 +28,6 @@ sealed trait InstanceChange extends Product with Serializable {
   val id: Instance.Id = instance.id
   /** Status of the [[Instance]] */
   // TODO(PODS): We might want to transport health information in the status
-  // TODO(PODS): who carries the version? instance or InstanceStatus?
   val status: InstanceStatus = instance.state.status
   /** Id of the related [[mesosphere.marathon.state.RunSpec]] */
   val runSpecId: PathId = id.runSpecId

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -1,5 +1,6 @@
 package mesosphere.marathon.core.launchqueue
 
+import mesosphere.marathon.core.instance.update.InstanceChange
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfo
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.state.{ PathId, RunSpec, Timestamp }
@@ -55,6 +56,9 @@ trait LaunchQueue {
   def resetDelay(spec: RunSpec): Unit
 
   /** Notify queue about InstanceUpdate */
-  // TODO(PODS): adjust to instance handling
+  // TODO(PODS): remove function
   def notifyOfTaskUpdate(taskChanged: TaskChanged): Future[Option[QueuedInstanceInfo]]
+
+  /** Notify queue about InstanceUpdate */
+  def notifyOfInstanceUpdate(update: InstanceChange): Future[Option[QueuedInstanceInfo]]
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.core.launchqueue.impl
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
+import mesosphere.marathon.core.instance.update.InstanceChange
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfo
 import mesosphere.marathon.core.launchqueue.{ LaunchQueue, LaunchQueueConfig }
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
@@ -28,6 +29,9 @@ private[launchqueue] class LaunchQueueDelegate(
 
   override def notifyOfTaskUpdate(taskChanged: TaskChanged): Future[Option[QueuedInstanceInfo]] =
     askQueueActorFuture("notifyOfTaskUpdate")(taskChanged).mapTo[Option[QueuedInstanceInfo]]
+
+  override def notifyOfInstanceUpdate(update: InstanceChange): Future[Option[QueuedInstanceInfo]] =
+    askQueueActorFuture("notifyOfInstanceUpdate")(update).mapTo[Option[QueuedInstanceInfo]]
 
   override def count(runSpecId: PathId): Int = get(runSpecId).map(_.instancesLeftToLaunch).getOrElse(0)
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -240,6 +240,7 @@ private class TaskLauncherActor(
       op match {
         // only increment for launch ops, not for reservations:
         case _: InstanceOp.LaunchTask => instancesToLaunch += 1
+        // TODO(PODS): case InstanceOp.LaunchTaskGroup => ...
         case _ => ()
       }
 
@@ -401,6 +402,7 @@ private class TaskLauncherActor(
       instanceOp match {
         // only decrement for launched instances, not for reservations:
         case _: InstanceOp.LaunchTask => instancesToLaunch -= 1
+        // TODO(PODS): case InstanceOp.LaunchTaskGroup => ...
         case _ => ()
       }
 
@@ -462,7 +464,6 @@ private class TaskLauncherActor(
   private[this] object OfferMatcherRegistration {
     private[this] val myselfAsOfferMatcher: OfferMatcher = {
       //set the precedence only, if this app is resident
-      // TODO (pods): how shall we handle residency?
       new ActorOfferMatcher(clock, self, runSpec.residency.map(_ => runSpec.id))
     }
     private[this] var registeredAsMatcher = false

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -63,7 +63,8 @@ sealed trait Task extends Instance {
 
   def status: Task.Status
 
-  override def state: InstanceState = InstanceState(status.taskStatus, status.startedAt.getOrElse(status.stagedAt))
+  override def state: InstanceState = InstanceState(
+    status.taskStatus, status.startedAt.getOrElse(status.stagedAt), version = runSpecVersion)
 
   def launchedMesosId: Option[MesosProtos.TaskID] = launched.map { _ =>
     // it doesn't make sense for an unlaunched task
@@ -125,7 +126,7 @@ object Task {
     case t: Task => t
   }
 
-   /**
+  /**
     * A LaunchedEphemeral task is a stateless task that does not consume reserved resources or persistent volumes.
     */
   case class LaunchedEphemeral(

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -217,6 +217,9 @@ object Task {
 
     override def launched: Option[Launched] = None
 
+    // TODO(PODS): remove when merging with JU's changes
+    override def runSpecVersion: Timestamp = Timestamp.zero
+
     override def update(update: InstanceStateOp): TaskStateChange = update match {
       case TaskStateOp.LaunchOnReservation(_, runSpecVersion, taskStatus, hostPorts) =>
         val updatedTask = LaunchedOnReservation(id, agentInfo, runSpecVersion, taskStatus, hostPorts, reservation)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -53,9 +53,9 @@ object InstanceTracker {
       instancesMap.get(pathId).map(_.instances).getOrElse(Iterable.empty)
     }
 
-    def instanceFor(iid: Instance.Id): Option[Instance] = for {
-      spec <- instancesMap.get(iid.runSpecId)
-      inst <- spec.instancekMap.get(iid)
+    def instanceFor(instanceId: Instance.Id): Option[Instance] = for {
+      spec <- instancesMap.get(instanceId.runSpecId)
+      inst <- spec.instanceMap.get(instanceId)
     } yield inst
 
     def allInstances: Iterable[Instance] = instancesMap.values.view.flatMap(_.instances)
@@ -67,7 +67,7 @@ object InstanceTracker {
         log.info(s"Removed app [$appId] from tracker")
         copy(instancesMap = instancesMap - appId)
       } else {
-        log.debug(s"Updated app [$appId], currently ${updated.instancekMap.size} tasks in total.")
+        log.debug(s"Updated app [$appId], currently ${updated.instanceMap.size} tasks in total.")
         copy(instancesMap = instancesMap + (appId -> updated))
       }
     }
@@ -91,20 +91,20 @@ object InstanceTracker {
   /**
     * Contains only the tasks of the app with the given app ID.
     *
-    * @param specId   The id of the app.
-    * @param instancekMap The tasks of this app by task ID. FIXME: change keys to Task.TaskID
+    * @param specId The id of the app.
+    * @param instanceMap The tasks of this app by task ID. FIXME: change keys to Task.TaskID
     */
-  case class SpecInstances(specId: PathId, instancekMap: Map[Instance.Id, Instance] = Map.empty) {
+  case class SpecInstances(specId: PathId, instanceMap: Map[Instance.Id, Instance] = Map.empty) {
 
-    def isEmpty: Boolean = instancekMap.isEmpty
-    def contains(taskId: Instance.Id): Boolean = instancekMap.contains(taskId)
-    def instances: Iterable[Instance] = instancekMap.values
+    def isEmpty: Boolean = instanceMap.isEmpty
+    def contains(taskId: Instance.Id): Boolean = instanceMap.contains(taskId)
+    def instances: Iterable[Instance] = instanceMap.values
 
     private[tracker] def withInstance(instance: Instance): SpecInstances =
-      copy(instancekMap = instancekMap + (instance.id -> instance))
+      copy(instanceMap = instanceMap + (instance.id -> instance))
 
     private[tracker] def withoutInstance(instanceId: Instance.Id): SpecInstances =
-      copy(instancekMap = instancekMap - instanceId)
+      copy(instanceMap = instanceMap - instanceId)
   }
 
   object SpecInstances {

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyHealthCheckManagerStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyHealthCheckManagerStepImpl.scala
@@ -1,10 +1,12 @@
 package mesosphere.marathon.core.task.update.impl.steps
 
+import akka.Done
 import com.google.inject.{ Inject, Provider }
 import mesosphere.marathon.core.task.TaskStateOp
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.update.TaskUpdateStep
 import mesosphere.marathon.core.health.HealthCheckManager
+import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
 
 import scala.concurrent.Future
 
@@ -12,7 +14,7 @@ import scala.concurrent.Future
   * Notify the health check manager of this update.
   */
 class NotifyHealthCheckManagerStepImpl @Inject() (healthCheckManagerProvider: Provider[HealthCheckManager])
-    extends TaskUpdateStep {
+    extends TaskUpdateStep with InstanceChangeHandler {
   override def name: String = "notifyHealthCheckManager"
 
   lazy val healthCheckManager = healthCheckManagerProvider.get
@@ -31,5 +33,10 @@ class NotifyHealthCheckManagerStepImpl @Inject() (healthCheckManagerProvider: Pr
     }
 
     Future.successful(())
+  }
+
+  override def process(update: InstanceChange): Future[Done] = {
+    // TODO(PODS): how do we transport health status? I guess the Instance status should provide def isHealthy: Boolean
+    Future.successful(Done)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyLaunchQueueStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyLaunchQueueStepImpl.scala
@@ -2,7 +2,9 @@ package mesosphere.marathon.core.task.update.impl.steps
 
 import javax.inject.Inject
 
+import akka.Done
 import com.google.inject.Provider
+import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.update.TaskUpdateStep
@@ -12,12 +14,20 @@ import scala.concurrent.Future
 /**
   * Notify the launch queue of this update.
   */
-class NotifyLaunchQueueStepImpl @Inject() (launchQueueProvider: Provider[LaunchQueue]) extends TaskUpdateStep {
+class NotifyLaunchQueueStepImpl @Inject() (launchQueueProvider: Provider[LaunchQueue])
+    extends TaskUpdateStep with InstanceChangeHandler {
+
   override def name: String = "notifyLaunchQueue"
 
   private[this] lazy val launchQueue = launchQueueProvider.get()
 
   override def processUpdate(taskChanged: TaskChanged): Future[_] = {
     launchQueue.notifyOfTaskUpdate(taskChanged)
+  }
+
+  override def process(update: InstanceChange): Future[Done] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    // the return value is only used in test code, we don't care here
+    launchQueue.notifyOfInstanceUpdate(update).map(_ => Done)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
@@ -1,46 +1,68 @@
 package mesosphere.marathon.core.task.update.impl.steps
 
+import java.time.OffsetDateTime
+
+import akka.Done
 import com.google.inject.{ Inject, Provider }
 import mesosphere.marathon.core.instance.InstanceStatus
+import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.update.TaskUpdateStep
-import mesosphere.marathon.core.task.{ Task, TaskStateOp }
+import mesosphere.marathon.core.task.TaskStateOp
+import mesosphere.marathon.state.PathId
 import mesosphere.marathon.storage.repository.ReadOnlyAppRepository
-import org.apache.mesos.Protos.TaskStatus
 
 import scala.concurrent.Future
 
 class NotifyRateLimiterStepImpl @Inject() (
     launchQueueProvider: Provider[LaunchQueue],
-    appRepositoryProvider: Provider[ReadOnlyAppRepository]) extends TaskUpdateStep {
+    appRepositoryProvider: Provider[ReadOnlyAppRepository]) extends TaskUpdateStep with InstanceChangeHandler {
+
+  import NotifyRateLimiterStep._
 
   private[this] lazy val launchQueue = launchQueueProvider.get()
   private[this] lazy val appRepository = appRepositoryProvider.get()
 
   override def name: String = "notifyRateLimiter"
 
-  override def processUpdate(taskChanged: TaskChanged): Future[_] = {
+  // TODO(PODS): remove this function
+  override def processUpdate(taskChanged: TaskChanged): Future[Done] = {
     // if MesosUpdate and status terminal != killed
     taskChanged.stateOp match {
-      case TaskStateOp.MesosUpdate(task, status: InstanceStatus.Terminal, mesosStatus, _) //
-      if status != InstanceStatus.Killed =>
-        notifyRateLimiter(mesosStatus, task)
-      case _ => Future.successful(())
+      case TaskStateOp.MesosUpdate(task, status: InstanceStatus, mesosStatus, _) if limitWorthy(status) =>
+        task.launched.map { launched =>
+          notifyRateLimiter(task.runSpecId, launched.runSpecVersion.toOffsetDateTime)
+        }.getOrElse(Future.successful(Done))
+
+      case _ => Future.successful(Done)
     }
   }
 
-  private[this] def notifyRateLimiter(status: TaskStatus, task: Task): Future[_] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
-    task.launched.fold(Future.successful(())) { launched =>
-      appRepository.getVersion(task.runSpecId, launched.runSpecVersion.toOffsetDateTime).map { maybeApp =>
-        // It would be nice if we could make sure that the delay gets send
-        // to the AppTaskLauncherActor before we continue but that would require quite some work.
-        //
-        // In production, the worst case would be that we restart one or few tasks without delay –
-        // this is unlikely but possible. It is unlikely that this causes noticeable harm.
-        maybeApp.foreach(launchQueue.addDelay)
-      }
+  override def process(update: InstanceChange): Future[Done] = {
+    if (limitWorthy(update.status)) {
+      notifyRateLimiter(update.runSpecId, update.instance.runSpecVersion.toOffsetDateTime)
+    } else {
+      Future.successful(Done)
     }
   }
+
+  private[this] def notifyRateLimiter(runSpecId: PathId, version: OffsetDateTime): Future[Done] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    appRepository.getVersion(runSpecId, version).map { maybeApp =>
+      // It would be nice if we could make sure that the delay gets send
+      // to the AppTaskLauncherActor before we continue but that would require quite some work.
+      //
+      // In production, the worst case would be that we restart one or few tasks without delay –
+      // this is unlikely but possible. It is unlikely that this causes noticeable harm.
+      maybeApp.foreach(launchQueue.addDelay)
+    }.map(_ => Done)
+  }
+}
+
+private[steps] object NotifyRateLimiterStep {
+  // A set of status that are worth rate limiting the associated runSpec
+  val limitWorthy: Set[InstanceStatus] = Set(
+    InstanceStatus.Dropped, InstanceStatus.Error, InstanceStatus.Failed, InstanceStatus.Gone
+  )
 }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
@@ -2,10 +2,12 @@ package mesosphere.marathon.core.task.update.impl.steps
 
 import javax.inject.Named
 
+import akka.Done
 import akka.actor.ActorRef
 import com.google.inject.{ Inject, Provider }
 import mesosphere.marathon.MarathonSchedulerActor.ScaleApp
 import mesosphere.marathon.core.instance.InstanceStatus
+import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
 import mesosphere.marathon.core.task.{ Task, TaskStateChange, TaskStateOp }
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.update.TaskUpdateStep
@@ -17,12 +19,37 @@ import scala.concurrent.Future
   * Trigger rescale of affected app if a task died or a reserved task timed out.
   */
 class ScaleAppUpdateStepImpl @Inject() (
-    @Named("schedulerActor") schedulerActorProvider: Provider[ActorRef]) extends TaskUpdateStep {
+  @Named("schedulerActor") schedulerActorProvider: Provider[ActorRef])
+    extends TaskUpdateStep with InstanceChangeHandler {
+
   private[this] val log = LoggerFactory.getLogger(getClass)
   private[this] lazy val schedulerActor = schedulerActorProvider.get()
 
   override def name: String = "scaleApp"
 
+  override def process(update: InstanceChange): Future[Done] = {
+    // TODO(PODS): we might want to consider scaling pods in case of status Reserved or Unreachable, which are both
+    // not Terminal. That should be up to a tbd InstanceLostBehavior.-
+    update.status match {
+      case _: InstanceStatus.Terminal =>
+        val runSpecId = update.runSpecId
+        val instanceId = update.id
+        val state = update.status
+        log.info(s"initiating a scale check for runSpec [$runSpecId] due to [$instanceId] $state")
+        // TODO(PODS):
+        //    1) SchedulerActor is awful
+        //    2) yet it handles runSpecs locked due to deployments
+        //    3) if we still use it, we should rename the Message and make the SchedulerActor generic
+        schedulerActor ! ScaleApp(runSpecId)
+
+      case _ =>
+      // nothing
+    }
+
+    Future.successful(Done)
+  }
+
+  // TODO(PODS): remove this function
   override def processUpdate(taskChanged: TaskChanged): Future[_] = {
 
     val terminalOrExpungedTask: Option[Task] = {

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/TaskStatusEmitterPublishStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/TaskStatusEmitterPublishStepImpl.scala
@@ -2,7 +2,9 @@ package mesosphere.marathon.core.task.update.impl.steps
 
 import javax.inject.Inject
 
+import akka.Done
 import com.google.inject.Provider
+import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
 import mesosphere.marathon.core.task.bus.TaskStatusEmitter
 import mesosphere.marathon.core.task.bus.TaskChangeObservables.TaskChanged
 import mesosphere.marathon.core.task.update.TaskUpdateStep
@@ -12,12 +14,21 @@ import scala.concurrent.Future
 /**
   * Forward the update to the taskStatusEmitter.
   */
+// TODO(PODS): is the emitter stuff still in use?
+// afaict the taskStatusObservables are only used in OfferMatcherLaunchTokensActor, which could subscribe
+// to the eventStream, instead
+// then this whole step and related code could be removed.
 class TaskStatusEmitterPublishStepImpl @Inject() (
-    taskStatusEmitterProvider: Provider[TaskStatusEmitter]) extends TaskUpdateStep {
+    taskStatusEmitterProvider: Provider[TaskStatusEmitter]) extends TaskUpdateStep with InstanceChangeHandler {
 
   private[this] lazy val taskStatusEmitter = taskStatusEmitterProvider.get()
 
   override def name: String = "emitUpdate"
+
+  override def process(update: InstanceChange): Future[Done] = {
+    // TODO(PODS): verify that we need this at all
+    Future.successful(Done)
+  }
 
   override def processUpdate(taskChanged: TaskChanged): Future[_] = {
     taskStatusEmitter.publish(taskChanged)

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -70,7 +70,7 @@ class TaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
 
     When("upgrading the app")
     val upgradedApp = f.app.copy(cmd = Some("new command"))
-    launcherRef ! TaskLauncherActor.AddTasks(upgradedApp, 1)
+    launcherRef ! TaskLauncherActor.AddInstances(upgradedApp, 1)
 
     Then("the actor requeries the backoff delay")
     rateLimiterActor.expectMsg(RateLimiterActor.GetDelay(upgradedApp))
@@ -105,7 +105,7 @@ class TaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
 
     When("upgrading the app")
     val upgradedApp = f.app.copy(cmd = Some("new command"))
-    launcherRef ! TaskLauncherActor.AddTasks(upgradedApp, 1)
+    launcherRef ! TaskLauncherActor.AddInstances(upgradedApp, 1)
     rateLimiterActor.expectMsg(RateLimiterActor.GetDelay(upgradedApp))
     rateLimiterActor.reply(RateLimiterActor.DelayUpdate(upgradedApp, clock.now()))
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -82,8 +82,8 @@ class InstanceTrackerImplTest extends MarathonSpec with MarathonActorSupport
     testAppTasks.instancesMap(TEST_APP_NAME / "b").specId should equal(TEST_APP_NAME / "b")
     testAppTasks.instancesMap(TEST_APP_NAME / "a").instances should have size 1
     testAppTasks.instancesMap(TEST_APP_NAME / "b").instances should have size 2
-    testAppTasks.instancesMap(TEST_APP_NAME / "a").instancekMap.keySet should equal(Set(task1.id))
-    testAppTasks.instancesMap(TEST_APP_NAME / "b").instancekMap.keySet should equal(Set(task2.id, task3.id))
+    testAppTasks.instancesMap(TEST_APP_NAME / "a").instanceMap.keySet should equal(Set(task1.id))
+    testAppTasks.instancesMap(TEST_APP_NAME / "b").instanceMap.keySet should equal(Set(task2.id, task3.id))
   }
 
   test("GetTasks") {


### PR DESCRIPTION
added implementation for new `InstanceChange` to the steps that currently propagate `TaskChanged`. Will remove old stuff and rename steps in a follow up PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mesosphere/marathon/4342)
<!-- Reviewable:end -->
