### PR TITLE
Add explicit close to connection

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActor.scala
@@ -112,6 +112,7 @@ class HttpEventStreamActor(
       context.unwatch(actor)
       context.stop(actor)
       streamHandleActors -= handle
+      Try(handle.close())
       metrics.numberOfStreams.setValue(streamHandleActors.size)
       log.info(s"Removed EventStream Handle as event listener: $handle. " +
         s"Current nr of listeners: ${streamHandleActors.size}")


### PR DESCRIPTION
In #4159 , we seem to be experiencing cases where connections to marathon essentially become stale, potentially due to leadership changes. I have to admit that I am not particularly well versed in scala or akka, but I suspect that it is because the actor servicing the connection is stopped but the underlying connection itself is left open in these cases.

