### PR TITLE
Ensure no new connections are accepted prior to closing out handlers

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActor.scala
@@ -93,8 +93,8 @@ class HttpEventStreamActor(
   private[this] def handleLeadership: Receive = {
     case LocalLeadershipEvent.Standby =>
       log.info("Now standing by. Closing existing handles and rejecting new.")
-      streamHandleActors.keys.foreach(removeHandler)
       context.become(standby)
+      streamHandleActors.keys.foreach(removeHandler)
 
     case LocalLeadershipEvent.ElectedAsLeader =>
       log.info("Became active. Accepting event streaming requests.")


### PR DESCRIPTION
Digging through the logs of a marathon instance I had, I found that the server still accepted connections to the event stream after having abdicated leadership.

The abdication seems to be due to a lost ZK connection, though this is not relevant to the experienced issue.

Sequence of events is: 

- 2016-09-01T01:42:43.241274 - Marathon reports it is closing connections and will no longer accept new ones
- 2016-09-01T01:42:43.243984 - Marathon accepts a new connection to the event bus
- 2016-09-01T01:42:43.244183 - Marathon accepts another new connection to the event bus

At no state prior to the acceptance of connections does "Became active. Accepting event streaming requests." become logged. 

The state that I hope to achieve with this PR is that an abdicating Marathon leader first closes itself off to new connections, and then removes existing handles. I suspect that as these new connections happen during the abdication process, that they do not receive proper bookkeeping to ensure they continue to receive events from the event bus.

```2016-09-01T01:42:43.236911+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,231] INFO Abdicating (mesosphere.marathon.MarathonSchedulerService$$EnhancerByGuice$$a8de78d5:marathon-akka.actor.default-dispatcher-15)
2016-09-01T01:42:43.237225+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,231] INFO Defeat leadership (mesosphere.marathon.MarathonSchedulerService$$EnhancerByGuice$$a8de78d5:marathon-akka.actor.default-dispatcher-15)
2016-09-01T01:42:43.237440+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,232] WARN ZooKeeper connection has been dropped. Abdicate Leadership: WatchedEvent state:Disconnected type:None path:null (mesosphere.marathon.core.leadership.impl.AbdicateOnConnectionLossActor:marathon-akka.actor.default-dispatcher-8)
2016-09-01T01:42:43.237661+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,233] INFO All actors suspended:
2016-09-01T01:42:43.237931+00:00 ip-10-90-29-238 marathon[13463]: * Actor[akka://marathon/user/rateLimiter#-1772258812]
2016-09-01T01:42:43.238159+00:00 ip-10-90-29-238 marathon[13463]: * Actor[akka://marathon/user/offersWantedForReconciliation#1064204870]
2016-09-01T01:42:43.238357+00:00 ip-10-90-29-238 marathon[13463]: * Actor[akka://marathon/user/taskTracker#390691799]
2016-09-01T01:42:43.238571+00:00 ip-10-90-29-238 marathon[13463]: * Actor[akka://marathon/user/offerMatcherManager#1185534699]
2016-09-01T01:42:43.238771+00:00 ip-10-90-29-238 marathon[13463]: * Actor[akka://marathon/user/expungeOverdueLostTasks#1453147665]
2016-09-01T01:42:43.238991+00:00 ip-10-90-29-238 marathon[13463]: * Actor[akka://marathon/user/launchQueue#-35303881]
2016-09-01T01:42:43.239221+00:00 ip-10-90-29-238 marathon[13463]: * Actor[akka://marathon/user/reviveOffersWhenWanted#713980817]
2016-09-01T01:42:43.239427+00:00 ip-10-90-29-238 marathon[13463]: * Actor[akka://marathon/user/AbdicateOnConnectionLoss#-2098804840]
2016-09-01T01:42:43.239628+00:00 ip-10-90-29-238 marathon[13463]: * Actor[akka://marathon/user/offerMatcherLaunchTokens#1494091835]
2016-09-01T01:42:43.239851+00:00 ip-10-90-29-238 marathon[13463]: * Actor[akka://marathon/user/killOverdueStagedTasks#557085080] (mesosphere.marathon.core.leadership.impl.LeadershipCoordinatorActor:marathon-akka.actor.default-dispatcher-8)
2016-09-01T01:42:43.240106+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,234] INFO ExpungeOverdueLostTasksActor has stopped (mesosphere.marathon.core.task.jobs.impl.ExpungeOverdueLostTasksActor:marathon-akka.actor.default-dispatcher-8)
2016-09-01T01:42:43.241274+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,234] INFO Now standing by. Closing existing handles and rejecting new. (mesosphere.marathon.event.http.HttpEventStreamActor:marathon-akka.actor.default-dispatcher-9)
2016-09-01T01:42:43.241484+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,234] INFO Removed EventStream Handle as event listener: HttpEventSSEHandle(18e4444a-df68-4b37-be77-c6c79fe18e25 on 10.90.27.185). Current nr of listeners: 1 (mesosphere.marathon.event.http.HttpEventStreamActor:marathon-akka.actor.default-dispatcher-9)
2016-09-01T01:42:43.241687+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,234] INFO Removed EventStream Handle as event listener: HttpEventSSEHandle(3d80cbe9-5a8f-473e-b081-6e468966bbcf on 10.90.37.187). Current nr of listeners: 0 (mesosphere.marathon.event.http.HttpEventStreamActor:marathon-akka.actor.default-dispatcher-9)
2016-09-01T01:42:43.241957+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,234] INFO Suspending scheduler actor (mesosphere.marathon.MarathonSchedulerActor:marathon-akka.actor.default-dispatcher-6)
2016-09-01T01:42:43.242187+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 2016-09-01T01:42:43.242390+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,234] INFO Stop actor HttpEventSSEHandle(3d80cbe9-5a8f-473e-b081-6e468966bbcf on 10.90.37.187) (mesosphere.marathon.event.http.HttpEventStreamHandleActor:marathon-akka.actor.default-dispatcher-7)
2016-09-01T01:42:43.242797+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,235] INFO POSTing to all endpoints. (mesosphere.marathon.event.http.HttpEventActor:marathon-akka.actor.default-dispatcher-7)
2016-09-01T01:42:43.243016+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,235] INFO POSTing to all endpoints. (mesosphere.marathon.event.http.HttpEventActor:marathon-akka.actor.default-dispatcher-7)
2016-09-01T01:42:43.243984+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,236] INFO 10.90.37.187 - redacted2 [30/Aug/2016:17:49:51 +0000] "GET //mesos-master.redacted.io:8080/v2/events HTTP/1.1" 200 433356 "-" "Go-http-client/1.1" 11477169 (mesosphere.chaos.http.ChaosRequestLog$$EnhancerByGuice$$c42d4d3b:marathon-akka.actor.default-dispatcher-6)
2016-09-01T01:42:43.244183+00:00 ip-10-90-29-238 marathon[13463]: [2016-09-01 01:42:43,236] INFO 10.90.27.185 - redacted2 [31/Aug/2016:16:02:06 +0000] "GET //mesos-master.redacted.io:8080/v2/events HTTP/1.1" 200 313875 "-" "Go-http-client/1.1" 3483634 (mesosphere.chaos.http.ChaosRequestLog$$EnhancerByGuice$$c42d4d3b:marathon-akka.actor.default-dispatcher-9)```