### PR TITLE
introduced Task.Id#instanceId

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -134,7 +134,7 @@ class TasksResource @Inject() (
     }
 
     val tasksByAppId = tasksToAppId
-      .flatMap { case (taskId, appId) => instanceTracker.instancesBySpecSync.instance(Instance.Id(taskId)) }
+      .flatMap { case (taskId, appId) => instanceTracker.instancesBySpecSync.instance(Task.Id(taskId).instanceId) }
       .groupBy { instance => instance.instanceId.runSpecId }
       .map{ case (appId, instances) => appId -> instances }
 

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -211,7 +211,7 @@ class MarathonHealthCheckManager(
     implicit val timeout: Timeout = Timeout(2, SECONDS)
 
     val futureAppVersion: Future[Option[Timestamp]] = for {
-      maybeTaskState <- taskTracker.instance(Instance.Id(taskId))
+      maybeTaskState <- taskTracker.instance(taskId.instanceId)
     } yield maybeTaskState.map(_.runSpecVersion)
 
     futureAppVersion.flatMap {

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -205,7 +205,7 @@ object Instance {
 
   // TODO ju remove apply
   def apply(task: Task): Instance = new Instance(
-    Id(task.taskId), task.agentInfo,
+    task.taskId.instanceId, task.agentInfo,
     InstanceState(
       status = task.status.taskStatus,
       since = task.status.startedAt.getOrElse(task.status.stagedAt),
@@ -232,8 +232,6 @@ object Instance {
     private val InstanceIdRegex = """^(.+)[\._]([^_\.]+)$""".r
 
     def apply(executorId: mesos.Protos.ExecutorID): Id = new Id(executorId.getValue)
-
-    def apply(taskId: Task.Id): Id = new Id(taskId.idString) // TODO PODs replace with proper calculation
 
     def runSpecId(instanceId: String): PathId = { // TODO PODs is this calculated correct?
       instanceId match {

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -227,8 +227,6 @@ object Instance {
       if (this.getClass == that.getClass)
         idString.compare(that.idString)
       else this.compareTo(that)
-
-    def createTaskId(): String = idString + "." + Id.uuidGenerator.generate()
   }
 
   object Id {

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -31,7 +31,7 @@ object InstanceUpdateOperation {
 
   // TODO(PODS): this should work on an instance, not a task
   case class Reserve(task: Task.Reserved) extends InstanceUpdateOperation {
-    override def instanceId: Instance.Id = Instance.Id(task.taskId)
+    override def instanceId: Instance.Id = task.taskId.instanceId
     override def possibleNewState: Option[Instance] = Some(Instance(task))
   }
 

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLabels.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLabels.scala
@@ -23,7 +23,7 @@ object TaskLabels {
   }
 
   def labelsForTask(frameworkId: FrameworkId, task: Task): ReservationLabels =
-    labelsForTask(frameworkId, Instance.Id(task.taskId))
+    labelsForTask(frameworkId, task.taskId.instanceId)
 
   def labelsForTask(frameworkId: FrameworkId, taskId: Instance.Id): ReservationLabels =
     ReservationLabels(Map(

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -123,12 +123,12 @@ object Task {
 
   object Id {
     private val TaskIdRegex = """^(.+)[\._]([^_\.]+)$""".r
-    private val TaskIdWithInstanceIdRegex = """^(.+)\.(.+)[\._]([^_\.]+)$""".r
+    private val TaskIdWithInstanceIdRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)[\._]([^_\.]+)$""".r
     private val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
 
     def runSpecId(taskId: String): PathId = {
       taskId match {
-        case TaskIdWithInstanceIdRegex(runSpecId, instanceId, uuid) => PathId.fromSafePath(runSpecId)
+        case TaskIdWithInstanceIdRegex(runSpecId, prefix, instanceId, uuid) => PathId.fromSafePath(runSpecId)
         case TaskIdRegex(runSpecId, uuid) => PathId.fromSafePath(runSpecId)
         case _ => throw new MatchError(s"taskId $taskId is no valid identifier")
       }
@@ -136,8 +136,8 @@ object Task {
 
     def instanceId(taskId: String): Instance.Id = {
       taskId match {
-        case TaskIdWithInstanceIdRegex(runSpecId, instanceUuid, uuid) =>
-          Instance.Id(runSpecId + "." + instanceUuid)
+        case TaskIdWithInstanceIdRegex(runSpecId, prefix, instanceUuid, uuid) =>
+          Instance.Id(runSpecId + "." + prefix + instanceUuid)
         case TaskIdRegex(runSpecId, uuid) =>
           Instance.Id(s"$runSpecId.instance-$uuid.$uuid")
         case _ => throw new MatchError(s"taskId $taskId is no valid identifier")

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -160,7 +160,7 @@ object Task {
       Writes[Task.Id] { id => JsString(id.idString) }
     )
 
-    def calculateLegacyExecutorId(taskId: String): String = s"instance-$taskId" // TODO ju
+    def calculateLegacyExecutorId(taskId: String): String = s"marathon-$taskId"
   }
 
   case class LocalVolume(id: LocalVolumeId, persistentVolume: PersistentVolume)

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -156,7 +156,7 @@ object Task {
       Task.Id(taskId)
     }
 
-    def forInstanceId(instanceId: Instance.Id): Id = Id(instanceId.createTaskId())
+    def forInstanceId(instanceId: Instance.Id): Id = Id(instanceId.idString + "." + Id.uuidGenerator.generate())
 
     implicit val taskIdFormat = Format(
       Reads.of[String](Reads.minLength[String](3)).map(Task.Id(_)),

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -139,7 +139,7 @@ object Task {
         case TaskIdWithInstanceIdRegex(runSpecId, prefix, instanceUuid, uuid) =>
           Instance.Id(runSpecId + "." + prefix + instanceUuid)
         case TaskIdRegex(runSpecId, uuid) =>
-          Instance.Id(s"$runSpecId.instance-$uuid.$uuid")
+          Instance.Id(s"$runSpecId.${calculateLegacyExecutorId(uuid)}.$uuid")
         case _ => throw new MatchError(s"taskId $taskId is no valid identifier")
       }
     }

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -116,20 +116,31 @@ object Task {
   case class Id(idString: String) extends Ordered[Id] {
     lazy val mesosTaskId: MesosProtos.TaskID = MesosProtos.TaskID.newBuilder().setValue(idString).build()
     lazy val runSpecId: PathId = Id.runSpecId(idString)
-    lazy val instanceId: Instance.Id = Instance.Id(this)
+    lazy val instanceId: Instance.Id = Id.instanceId(idString)
     override def toString: String = s"task [$idString]"
     override def compare(that: Id): Int = idString.compare(that.idString)
   }
 
   object Id {
     private val runSpecDelimiter = "."
-    private val TaskIdRegex = """^(.+)[\._]([^_\.]+)$""".r
+    private val instanceIdDelimiter = "#"
+    private val taskIdExpression = """(.+)[\._]([^_\.]+)"""
+    private val TaskIdRegex = ("^" + taskIdExpression + "$").r
+    private val TaskIdWithInstanceIdRegex = ("^" + """(.+)[#]""" + taskIdExpression + "$").r
     private val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
 
     def runSpecId(taskId: String): PathId = {
       taskId match {
+        case TaskIdWithInstanceIdRegex(instanceId, runSpecId, uuid) => PathId.fromSafePath(runSpecId)
         case TaskIdRegex(runSpecId, uuid) => PathId.fromSafePath(runSpecId)
         case _ => throw new MatchError(s"taskId $taskId is no valid identifier")
+      }
+    }
+
+    def instanceId(taskId: String): Instance.Id = {
+      taskId match {
+        case TaskIdWithInstanceIdRegex(instanceId, runSpecId, uuid) => Instance.Id(instanceId)
+        case _ => Instance.Id(taskId) // TODO PODs is this correct?
       }
     }
 
@@ -138,6 +149,11 @@ object Task {
 
     def forRunSpec(id: PathId): Id = {
       val taskId = id.safePath + runSpecDelimiter + uuidGenerator.generate()
+      Task.Id(taskId)
+    }
+
+    def forRunSpec(id: PathId, instanceId: Instance.Id): Id = {
+      val taskId = instanceId.idString + instanceIdDelimiter + id.safePath + runSpecDelimiter + uuidGenerator.generate()
       Task.Id(taskId)
     }
 

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -122,16 +122,16 @@ object Task {
   }
 
   object Id {
-    private val runSpecDelimiter = "."
-    private val instanceIdDelimiter = "#"
-    private val taskIdExpression = """(.+)[\._]([^_\.]+)"""
-    private val TaskIdRegex = ("^" + taskIdExpression + "$").r
-    private val TaskIdWithInstanceIdRegex = ("^" + """(.+)[#]""" + taskIdExpression + "$").r
+    private val delimiter = "."
+    private val legacyExecutorIdPrefix = "marathon-"
+    private val executorIdPrefix = "instance-"
+    private val TaskIdRegex = """^(.+)[\._]([^_\.]+)$""".r
+    private val TaskIdWithInstanceIdRegex = ("""^(.+)\.""" + executorIdPrefix + """(.+)[\._]([^_\.]+)$""").r
     private val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
 
     def runSpecId(taskId: String): PathId = {
       taskId match {
-        case TaskIdWithInstanceIdRegex(instanceId, runSpecId, uuid) => PathId.fromSafePath(runSpecId)
+        case TaskIdWithInstanceIdRegex(runSpecId, instanceId, uuid) => PathId.fromSafePath(runSpecId)
         case TaskIdRegex(runSpecId, uuid) => PathId.fromSafePath(runSpecId)
         case _ => throw new MatchError(s"taskId $taskId is no valid identifier")
       }
@@ -139,8 +139,8 @@ object Task {
 
     def instanceId(taskId: String): Instance.Id = {
       taskId match {
-        case TaskIdWithInstanceIdRegex(instanceId, runSpecId, uuid) => Instance.Id(instanceId)
-        case _ => Instance.Id(taskId) // TODO PODs is this correct?
+        case TaskIdWithInstanceIdRegex(runSpecId, instanceId, uuid) => Instance.Id(executorIdPrefix + instanceId)
+        case _ => Instance.Id(calculateLegacyExecutorId(taskId))
       }
     }
 
@@ -148,12 +148,12 @@ object Task {
       new Id(mesosTaskId.getValue)
 
     def forRunSpec(id: PathId): Id = {
-      val taskId = id.safePath + runSpecDelimiter + uuidGenerator.generate()
+      val taskId = id.safePath + delimiter + uuidGenerator.generate()
       Task.Id(taskId)
     }
 
     def forRunSpec(id: PathId, instanceId: Instance.Id): Id = {
-      val taskId = instanceId.idString + instanceIdDelimiter + id.safePath + runSpecDelimiter + uuidGenerator.generate()
+      val taskId = instanceId.idString + delimiter + id.safePath + delimiter + uuidGenerator.generate()
       Task.Id(taskId)
     }
 
@@ -161,6 +161,8 @@ object Task {
       Reads.of[String](Reads.minLength[String](3)).map(Task.Id(_)),
       Writes[Task.Id] { id => JsString(id.idString) }
     )
+
+    def calculateLegacyExecutorId(taskId: String): String = s"$legacyExecutorIdPrefix$taskId"
   }
 
   case class LocalVolume(id: LocalVolumeId, persistentVolume: PersistentVolume)

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
@@ -3,7 +3,6 @@ package mesosphere.marathon.core.task.jobs.impl
 import akka.actor.{ Actor, ActorLogging, Cancellable, Props }
 import akka.pattern.pipe
 import mesosphere.marathon.core.base.Clock
-import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.jobs.TaskJobsConfig
@@ -46,7 +45,7 @@ class ExpungeOverdueLostTasksActor(
   def expungeLostGCTask(task: Task): Unit = {
     val timestamp = new DateTime(task.mesosStatus.fold(0L)(_.getTimestamp.toLong * 1000))
     log.warning(s"Task ${task.taskId} is lost since $timestamp and will be expunged.")
-    val stateOp = InstanceUpdateOperation.ForceExpunge(Instance.Id(task.taskId))
+    val stateOp = InstanceUpdateOperation.ForceExpunge(task.taskId.instanceId)
     stateOpProcessor.process(stateOp)
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActor.scala
@@ -9,7 +9,6 @@ import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.{ InstanceTracker, TaskStateOpProcessor }
 import mesosphere.marathon.core.event.MesosStatusUpdateEvent
-import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 
 import scala.collection.mutable
@@ -124,7 +123,7 @@ private[impl] class TaskKillServiceActor(
     if (taskIsLost) {
       log.warning("Expunging lost {} from state because it should be killed", taskId)
       // we will eventually be notified of a taskStatusUpdate after the task has been expunged
-      stateOpProcessor.process(InstanceUpdateOperation.ForceExpunge(Instance.Id(taskId)))
+      stateOpProcessor.process(InstanceUpdateOperation.ForceExpunge(taskId.instanceId))
     } else {
       val knownOrNot = if (maybeTask.isDefined) "known" else "unknown"
       log.warning("Killing {} {}", knownOrNot, taskId)
@@ -149,7 +148,7 @@ private[impl] class TaskKillServiceActor(
     inFlight.foreach {
       case (taskId, taskToKill) if taskToKill.attempts >= config.killRetryMax =>
         log.warning("Expunging {} from state: max retries reached", taskId)
-        stateOpProcessor.process(InstanceUpdateOperation.ForceExpunge(Instance.Id(taskId)))
+        stateOpProcessor.process(InstanceUpdateOperation.ForceExpunge(taskId.instanceId))
 
       case (taskId, taskToKill) if (taskToKill.issued + config.killRetryTimeout) < now =>
         log.warning("No kill ack received for {}, retrying", taskId)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -60,7 +60,7 @@ object InstanceTracker {
 
     // TODO(PODS): the instanceTracker should not expose a def for tasks
     def task(id: Task.Id): Option[Task] = {
-      val instances: Option[Instance] = instance(Instance.Id(id))
+      val instances: Option[Instance] = instance(id.instanceId)
       instances.flatMap(_.tasksMap.get(id))
     }
 

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -46,7 +46,7 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     val now = clock.now()
     val taskId = Task.Id(status.getTaskId)
 
-    instanceTracker.instance(Instance.Id(taskId)).flatMap {
+    instanceTracker.instance(taskId.instanceId).flatMap {
       case Some(instance) =>
         val op = InstanceUpdateOperation.MesosUpdate(instance, status, now)
         stateOpProcessor.process(op).flatMap(_ => acknowledge(status))

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -133,7 +133,7 @@ class TaskBuilder(
         builder.setCommand(command.build)
 
       case PathExecutor(path) =>
-        val executorId = f"marathon-${taskId.idString}" // Fresh executor
+        val executorId = Task.Id.calculateLegacyExecutorId(taskId.idString) // Fresh executor
         val executorPath = s"'$path'" // TODO: Really escape this.
         val cmd = runSpec.cmd.getOrElse(runSpec.args.mkString(" "))
         val shell = s"chmod ug+rx $executorPath && exec $executorPath $cmd"

--- a/src/test/scala/mesosphere/marathon/InstanceConversions.scala
+++ b/src/test/scala/mesosphere/marathon/InstanceConversions.scala
@@ -11,7 +11,7 @@ trait InstanceConversions {
 
   implicit def taskToInstance(task: Task): Instance = Instance(task)
 
-  implicit def taskIdToInstanceId(id: Task.Id): Instance.Id = Instance.Id(id)
+  implicit def taskIdToInstanceId(id: Task.Id): Instance.Id = id.instanceId
 
-  implicit def tasksIdToInstanceIds(ids: Iterable[Task.Id]): Iterable[Instance.Id] = ids.map(id => Instance.Id(id))
+  implicit def tasksIdToInstanceIds(ids: Iterable[Task.Id]): Iterable[Instance.Id] = ids.map(id => id.instanceId)
 }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -76,7 +76,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       expectMsg(5.seconds, TasksReconciled)
 
       awaitAssert({
-        killService.killed should contain (Instance.Id(task.taskId))
+        killService.killed should contain (task.taskId.instanceId)
       }, 5.seconds, 10.millis)
     } finally {
       stopActor(schedulerActor)

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -319,7 +319,7 @@ object MarathonTestHelper extends InstanceConversions {
   }
 
   def emptyInstance(): Instance = Instance(
-    instanceId = Instance.Id(Task.Id.forRunSpec(PathId("/test"))),
+    instanceId = Task.Id.forRunSpec(PathId("/test")).instanceId,
     agentInfo = Instance.AgentInfo("", None, Nil),
     state = InstanceState(InstanceStatus.Created, since = clock.now(), version = clock.now(), healthy = None),
     tasksMap = Map.empty[Task.Id, Task]

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -6,8 +6,9 @@ import mesosphere.marathon._
 import mesosphere.marathon.api.{ TaskKiller, TestAuthFixture }
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, InstanceTracker }
+import mesosphere.marathon.core.task.tracker.{ InstanceTracker, TaskStateOpProcessor }
 import mesosphere.marathon.core.health.HealthCheckManager
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.plugin.auth.Identity
 import mesosphere.marathon.state.PathId.StringPathId
 import mesosphere.marathon.state._
@@ -52,11 +53,11 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     val app2 = "/my/app-2".toRootPath
     val taskId1 = Task.Id.forRunSpec(app1)
     val taskId2 = Task.Id.forRunSpec(app2)
-    val body = s"""{"ids": ["$taskId1", "$taskId2"]}"""
+    val body = s"""{"ids": ["${taskId1.idString}", "${taskId2.idString}"]}"""
     val bodyBytes = body.toCharArray.map(_.toByte)
 
-    val task1 = MarathonTestHelper.stagedTask(taskId1)
-    val task2 = MarathonTestHelper.runningTask(taskId2)
+    val task1: Instance = MarathonTestHelper.stagedTask(taskId1)
+    val task2: Instance = MarathonTestHelper.runningTask(taskId2)
 
     config.zkTimeoutDuration returns 5.seconds
     taskTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(task1, task2)
@@ -87,12 +88,12 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     val app2 = "/my/app-2".toRootPath
     val taskId1 = Task.Id.forRunSpec(app1)
     val taskId2 = Task.Id.forRunSpec(app2)
-    val body = s"""{"ids": ["$taskId1", "$taskId2"]}"""
+    val body = s"""{"ids": ["${taskId1.idString}", "${taskId2.idString}"]}"""
     val bodyBytes = body.toCharArray.map(_.toByte)
     val deploymentPlan = new DeploymentPlan("plan", Group.empty, Group.empty, Seq.empty[DeploymentStep], Timestamp.zero)
 
-    val task1 = MarathonTestHelper.runningTask(taskId1)
-    val task2 = MarathonTestHelper.stagedTask(taskId2)
+    val task1: Instance = MarathonTestHelper.runningTask(taskId1)
+    val task2: Instance = MarathonTestHelper.stagedTask(taskId2)
 
     config.zkTimeoutDuration returns 5.seconds
     taskTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(task1, task2)

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -9,6 +9,7 @@ import com.typesafe.config.ConfigFactory
 import mesosphere.marathon._
 import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.health.{ Health, HealthCheck, MesosCommandHealthCheck }
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.leadership.{ AlwaysElectedLeadershipModule, LeadershipModule }
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
@@ -132,7 +133,7 @@ class MarathonHealthCheckManagerTest
     val taskId = Task.Id.forRunSpec(appId)
 
     val taskStatus = MarathonTestHelper.unhealthyTask(taskId).launched.get.status.mesosStatus.get
-    val marathonTask = MarathonTestHelper.stagedTask(taskId, appVersion = app.version)
+    val marathonTask: Instance = MarathonTestHelper.stagedTask(taskId, appVersion = app.version)
     val update = InstanceUpdateOperation.MesosUpdate(marathonTask, taskStatus, clock.now())
 
     val healthCheck = MesosCommandHealthCheck(gracePeriod = 0.seconds, command = Command("true"))
@@ -320,7 +321,7 @@ class MarathonHealthCheckManagerTest
 
     // Create a task
     val taskId = Task.Id.forRunSpec(appId)
-    val marathonTask = MarathonTestHelper.stagedTask(taskId, appVersion = app.version)
+    val marathonTask: Instance = MarathonTestHelper.stagedTask(taskId, appVersion = app.version)
     taskCreationHandler.created(InstanceUpdateOperation.LaunchEphemeral(marathonTask)).futureValue
 
     // Send an unhealthy update

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLabelsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLabelsTest.scala
@@ -1,6 +1,5 @@
 package mesosphere.marathon.core.launcher.impl
 
-import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.{ InstanceConversions, MarathonTestHelper }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.PathId
@@ -28,7 +27,7 @@ class TaskLabelsTest extends FunSuite with GivenWhenThen with Matchers with Inst
     val taskIds = f.labeledResources.flatMap(TaskLabels.taskIdForResource(f.frameworkId, _))
 
     Then("we get as many taskIds as resources")
-    taskIds should be(Iterable.fill(f.labeledResources.size)(Instance.Id(f.taskId)))
+    taskIds should be(Iterable.fill(f.labeledResources.size)(f.taskId.instanceId))
   }
 
   test("labels with incorrect frameworkId are ignored") {

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -59,7 +59,8 @@ class TaskStatusUpdateProcessorImplTest
 
   test("process update for unknown task active task that's not lost will result in a kill and ack") {
     fOpt = Some(new Fixture)
-    val origUpdate = TaskStatusUpdateTestHelper.running()
+    val taskToUpdate = TaskStatusUpdateTestHelper.defaultTask
+    val origUpdate = TaskStatusUpdateTestHelper.running(taskToUpdate)
     val status = origUpdate.status
     val update = origUpdate
     val instanceId = update.operation.instanceId
@@ -74,7 +75,7 @@ class TaskStatusUpdateProcessorImplTest
     verify(f.taskTracker).instance(instanceId)
 
     And("the task kill gets initiated")
-    verify(f.killService).killUnknownTask(Task.Id(instanceId.idString), TaskKillReason.Unknown)
+    verify(f.killService).killUnknownTask(taskToUpdate.taskId, TaskKillReason.Unknown)
     And("the update has been acknowledged")
     verify(f.schedulerDriver).acknowledgeStatusUpdate(status)
 

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/ContinueOnErrorStepTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/ContinueOnErrorStepTest.scala
@@ -57,7 +57,7 @@ class ContinueOnErrorStepTest extends FunSuite with Matchers with GivenWhenThen 
     f.processUpdate(verify(f.nested, times(1)))
     And("produce an error message in the log")
     logEvents.map(_.toString) should contain (
-      s"[ERROR] while executing step nested for [${f.dummyTask.taskId.idString}], continue with other steps"
+      s"[ERROR] while executing step nested for [${f.dummyTask.taskId.instanceId.idString}], continue with other steps"
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
@@ -34,8 +34,12 @@ class InstanceOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Moc
     val request = InstanceOpFactory.Request(app, offer, runningTasks, additionalLaunches = 1)
     val inferredTaskOp = f.taskOpFactory.buildTaskOp(request)
 
+    assert(inferredTaskOp.isDefined, "instanceOp should be defined")
+    assert(inferredTaskOp.get.stateOp.possibleNewState.isDefined, "instanceOp should have a defined new state")
+    assert(inferredTaskOp.get.stateOp.possibleNewState.get.tasks.size == 1, "new state should have 1 task")
+
     val expectedTask = Task.LaunchedEphemeral(
-      taskId = inferredTaskOp.fold(Task.Id("failure"))(a => Task.Id(a.instanceId.idString)),
+      taskId = inferredTaskOp.get.stateOp.possibleNewState.get.tasks.head.taskId,
       agentInfo = Instance.AgentInfo(
         host = "some_host",
         agentId = Some(offer.getSlaveId.getValue),

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -82,8 +82,8 @@ class InstanceTrackerImplTest extends MarathonSpec with MarathonActorSupport
     testAppTasks.instancesMap(TEST_APP_NAME / "b").specId should equal(TEST_APP_NAME / "b")
     testAppTasks.instancesMap(TEST_APP_NAME / "a").instances should have size 1
     testAppTasks.instancesMap(TEST_APP_NAME / "b").instances should have size 2
-    testAppTasks.instancesMap(TEST_APP_NAME / "a").instanceMap.keySet should equal(Set(Instance.Id(task1.taskId)))
-    testAppTasks.instancesMap(TEST_APP_NAME / "b").instanceMap.keySet should equal(Set(Instance.Id(task2.taskId), Instance.Id(task3.taskId)))
+    testAppTasks.instancesMap(TEST_APP_NAME / "a").instanceMap.keySet should equal(Set(task1.taskId.instanceId))
+    testAppTasks.instancesMap(TEST_APP_NAME / "b").instanceMap.keySet should equal(Set(task2.taskId.instanceId, task3.taskId.instanceId))
   }
 
   test("GetTasks") {
@@ -220,7 +220,7 @@ class InstanceTrackerImplTest extends MarathonSpec with MarathonActorSupport
     // don't call taskTracker.created, but directly running
     val runningTaskStatus = InstanceUpdateOperation.MesosUpdate(sampleTask, makeTaskStatus(sampleTask, TaskState.TASK_RUNNING), clock.now())
     val res = stateOpProcessor.process(runningTaskStatus)
-    res.failed.futureValue.getCause.getMessage should equal(s"${Instance.Id(sampleTask.taskId)} of app [/foo] does not exist")
+    res.failed.futureValue.getCause.getMessage should equal(s"${sampleTask.taskId.instanceId} of app [/foo] does not exist")
 
     shouldNotContainTask(instanceTracker.specInstancesSync(TEST_APP_NAME), sampleTask)
     stateShouldNotContainKey(state, sampleTask.taskId)

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -27,4 +27,16 @@ class TaskIdTest extends FunSuite with Matchers {
     val taskId = Task.Id(TaskID.newBuilder().setValue("app_foo_bar_0-12345678").build)
     taskId.runSpecId should equal("/app/foo/bar".toRootPath)
   }
+
+  test("TaskIds with encoded InstanceIds could be encoded") {
+    val taskId = Task.Id(TaskID.newBuilder().setValue("instance1#test_foo_bla_rest.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
+    taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
+    taskId.instanceId.idString should equal("instance1")
+  }
+
+  test("TaskIds without specific instanceId should use taskId as instanceId") {
+    val taskId = Task.Id(TaskID.newBuilder().setValue("test_foo_bla_rest.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
+    taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
+    taskId.instanceId.idString should equal(taskId.idString)
+  }
 }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -29,14 +29,14 @@ class TaskIdTest extends FunSuite with Matchers {
   }
 
   test("TaskIds with encoded InstanceIds could be encoded") {
-    val taskId = Task.Id(TaskID.newBuilder().setValue("instance1#test_foo_bla_rest.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
+    val taskId = Task.Id(TaskID.newBuilder().setValue("test_foo_bla_rest.instance-instance1.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
     taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
-    taskId.instanceId.idString should equal("instance1")
+    taskId.instanceId.idString should equal("instance-instance1")
   }
 
   test("TaskIds without specific instanceId should use taskId as instanceId") {
     val taskId = Task.Id(TaskID.newBuilder().setValue("test_foo_bla_rest.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
     taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
-    taskId.instanceId.idString should equal(taskId.idString)
+    taskId.instanceId.idString should equal(Task.Id.calculateLegacyExecutorId(taskId.idString))
   }
 }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -43,6 +43,6 @@ class TaskIdTest extends FunSuite with Matchers {
   test("TaskIds without specific instanceId should use taskId as instanceId") {
     val taskId = Task.Id(TaskID.newBuilder().setValue("test_foo_bla_rest.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
     taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
-    taskId.instanceId.idString should equal("test_foo_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15.62d0f03f-79aa-11e6-a1a0-660c139c5e15")
+    taskId.instanceId.idString should equal("test_foo_bla_rest.marathon-62d0f03f-79aa-11e6-a1a0-660c139c5e15.62d0f03f-79aa-11e6-a1a0-660c139c5e15")
   }
 }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -43,6 +43,6 @@ class TaskIdTest extends FunSuite with Matchers {
   test("TaskIds without specific instanceId should use taskId as instanceId") {
     val taskId = Task.Id(TaskID.newBuilder().setValue("test_foo_bla_rest.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
     taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
-    taskId.instanceId.idString should equal(Task.Id.calculateLegacyExecutorId(taskId.idString))
+    taskId.instanceId.idString should equal("test_foo_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15.62d0f03f-79aa-11e6-a1a0-660c139c5e15")
   }
 }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -34,6 +34,12 @@ class TaskIdTest extends FunSuite with Matchers {
     taskId.instanceId.idString should equal("instance-instance1")
   }
 
+  test("TaskIds with encoded InstanceIds could be encoded even with crucial path ids") {
+    val taskId = Task.Id(TaskID.newBuilder().setValue("test_foo.instance-_bla_rest.instance-instance1.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
+    taskId.runSpecId should equal("/test/foo.instance-/bla/rest".toRootPath)
+    taskId.instanceId.idString should equal("instance-instance1")
+  }
+
   test("TaskIds without specific instanceId should use taskId as instanceId") {
     val taskId = Task.Id(TaskID.newBuilder().setValue("test_foo_bla_rest.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
     taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -31,13 +31,13 @@ class TaskIdTest extends FunSuite with Matchers {
   test("TaskIds with encoded InstanceIds could be encoded") {
     val taskId = Task.Id(TaskID.newBuilder().setValue("test_foo_bla_rest.instance-instance1.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
     taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
-    taskId.instanceId.idString should equal("instance-instance1")
+    taskId.instanceId.idString should equal("test_foo_bla_rest.instance-instance1")
   }
 
   test("TaskIds with encoded InstanceIds could be encoded even with crucial path ids") {
     val taskId = Task.Id(TaskID.newBuilder().setValue("test_foo.instance-_bla_rest.instance-instance1.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
     taskId.runSpecId should equal("/test/foo.instance-/bla/rest".toRootPath)
-    taskId.instanceId.idString should equal("instance-instance1")
+    taskId.instanceId.idString should equal("test_foo.instance-_bla_rest.instance-instance1")
   }
 
   test("TaskIds without specific instanceId should use taskId as instanceId") {


### PR DESCRIPTION
Introduced instanceId as calculated value from Task.Id#idString and removed Instande.Id(Task.Id)

Task.Id#forRunSpec(PathId, Instance.Id) should be used by TaskGroupBuilder

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mesosphere/marathon/4364)
<!-- Reviewable:end -->
