### PR TITLE
instead of using a CSV-formatted string for multiple protocols, make protocol an array

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/network.raml
+++ b/docs/docs/rest-api/public/api/v2/types/network.raml
@@ -27,9 +27,13 @@ types:
         usage: Specify 0 to tell Marathon to dynamically allocate a host port.
         minimum: 0
       protocol?:
-        type: strings.Name
+        type: array
+        items: strings.Name
+        minItems: 1
         description: |
-          The protocol of this port, advertised in Mesos DiscoveryInfo.
+          The protocol of this port, advertised in Mesos DiscoveryInfo (DI).
+          Specifying more than one protocol here will result in the generation
+          of multiple Port DI entries.
       labels?:
         type: label.KVLabels
         description: |


### PR DESCRIPTION
I noticed that the comments don't include validation-related restrictions (like pattern) in the generated code for protocol

goal: avoid the need for CSV'd protocol values, xref #4284