### PR TITLE
allow mesos container to run without cmd and args

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -637,11 +637,18 @@ object AppDefinition extends GeneralPurposeCombinators {
     }
 
   private val containsCmdArgsOrContainer: Validator[AppDefinition] =
-    isTrue("AppDefinition must either contain one of 'cmd' or 'args', and/or a non-Mesos 'container'.") { app =>
+    isTrue("AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.") { app =>
       val cmd = app.cmd.nonEmpty
       val args = app.args.nonEmpty
-      val container = app.container.exists(!_.isInstanceOf[Container.Mesos])
-      (cmd ^ args) || (!(cmd || args) && container)
+      val container = app.container.exists(
+        _ match {
+          case _: MesosDocker => true
+          case _: MesosAppC => true
+          case _: Container.Docker => true
+          case _ => false
+        }
+      )
+      (cmd ^ args) || (!(cmd && args) && container)
     }
 
   private val complyWithMigrationAPI: Validator[AppDefinition] =

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -6,8 +6,8 @@ import com.wix.accord._
 import com.wix.accord.combinators.GeneralPurposeCombinators
 import com.wix.accord.dsl._
 import mesosphere.marathon.Protos.Constraint
-import mesosphere.marathon.core.health.MesosCommandHealthCheck
-import mesosphere.marathon.state.Container.Docker
+import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
+import mesosphere.marathon.state.Container.{ Docker, MesosAppC, MesosDocker }
 // scalastyle:off
 import mesosphere.marathon.api.serialization.{ ContainerSerializer, EnvVarRefSerializer, PortDefinitionSerializer, ResidencySerializer, SecretsSerializer }
 // scalastyle:on

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -6,7 +6,7 @@ import com.wix.accord._
 import com.wix.accord.combinators.GeneralPurposeCombinators
 import com.wix.accord.dsl._
 import mesosphere.marathon.Protos.Constraint
-import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
+import mesosphere.marathon.core.health.MesosCommandHealthCheck
 import mesosphere.marathon.state.Container.{ Docker, MesosAppC, MesosDocker }
 // scalastyle:off
 import mesosphere.marathon.api.serialization.{ ContainerSerializer, EnvVarRefSerializer, PortDefinitionSerializer, ResidencySerializer, SecretsSerializer }

--- a/src/test/scala/mesosphere/marathon/api/MarathonExceptionMapperTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/MarathonExceptionMapperTest.scala
@@ -85,6 +85,6 @@ class MarathonExceptionMapperTest extends MarathonSpec with GivenWhenThen with M
     val firstError = errors.head
     (firstError \ "path").as[String] should be("/")
     val errorMsgs = (firstError \ "errors").as[Seq[String]]
-    errorMsgs.head should be("AppDefinition must either contain one of 'cmd' or 'args', and/or a non-Mesos 'container'.")
+    errorMsgs.head should be("AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.")
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -276,7 +276,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     shouldViolate(
       app,
       "/",
-      "AppDefinition must either contain one of 'cmd' or 'args', and/or a non-Mesos 'container'."
+      "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'."
     )
     MarathonTestHelper.validateJsonSchema(app, false)
 
@@ -284,7 +284,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     shouldNotViolate(
       app,
       "/",
-      "AppDefinition must either contain one of 'cmd' or 'args', and/or a non-Mesos 'container'."
+      "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'."
     )
     MarathonTestHelper.validateJsonSchema(app)
 

--- a/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
@@ -224,6 +224,15 @@ class RunSpecValidatorTest extends MarathonSpec with Matchers with GivenWhenThen
     MarathonTestHelper.validateJsonSchema(app)
   }
 
+  test("mesos container only") {
+    val f = new Fixture
+    val app = AppDefinition(
+      id = PathId("/test"),
+      container = Some(f.validMesosDockerContainer))
+    assert(validate(app).isSuccess)
+    MarathonTestHelper.validateJsonSchema(app)
+  }
+
   test("mesos container and cmd") {
     val f = new Fixture
     val app = AppDefinition(

--- a/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
@@ -204,7 +204,7 @@ class RunSpecValidatorTest extends MarathonSpec with Matchers with GivenWhenThen
     MarathonTestHelper.validateJsonSchema(app)
   }
 
-  test("container and cmd") {
+  test("docker container and cmd") {
     val f = new Fixture
     val app = AppDefinition(
       id = PathId("/test"),
@@ -214,12 +214,32 @@ class RunSpecValidatorTest extends MarathonSpec with Matchers with GivenWhenThen
     MarathonTestHelper.validateJsonSchema(app)
   }
 
-  test("container and args") {
+  test("docker container and args") {
     val f = new Fixture
     val app = AppDefinition(
       id = PathId("/test"),
       args = Some("test" :: Nil),
       container = Some(f.validDockerContainer))
+    assert(validate(app).isSuccess)
+    MarathonTestHelper.validateJsonSchema(app)
+  }
+
+  test("mesos container and cmd") {
+    val f = new Fixture
+    val app = AppDefinition(
+      id = PathId("/test"),
+      cmd = Some("true"),
+      container = Some(f.validMesosDockerContainer))
+    assert(validate(app).isSuccess)
+    MarathonTestHelper.validateJsonSchema(app)
+  }
+
+  test("mesos container and args") {
+    val f = new Fixture
+    val app = AppDefinition(
+      id = PathId("/test"),
+      args = Some("test" :: Nil),
+      container = Some(f.validMesosDockerContainer))
     assert(validate(app).isSuccess)
     MarathonTestHelper.validateJsonSchema(app)
   }
@@ -699,6 +719,11 @@ class RunSpecValidatorTest extends MarathonSpec with Matchers with GivenWhenThen
 
     def validMesosContainer: Container.Mesos = Container.Mesos(
       volumes = Nil
+    )
+
+    def validMesosDockerContainer: Container.MesosDocker = Container.MesosDocker(
+      volumes = Nil,
+      image = "foo/bar:latest"
     )
 
     // scalastyle:off magic.number


### PR DESCRIPTION
The docker/runtime isolator grab cmd or args from docker image if not available in app definition.

The  originally PR is #4187 from @vixns.
I rebased it on top of master.