### PR TITLE
Fixes #4028 by scheduling the health checks soon after the app deploy…

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
@@ -129,6 +129,9 @@ object HealthCheck {
   val DefaultMaxConsecutiveFailures = 3
   val DefaultIgnoreHttp1xx = false
   val DefaultPort = None
+  // As soon as an application is started (before a task is launched), we start the health checks for this app.
+  // We optimistically set a low value here, for tasks that start really fast
+  val DefaultFirstHealthCheckAfter = 5.seconds
 
   implicit val healthCheck = validator[HealthCheck] { hc =>
     (hc.portIndex.nonEmpty is true) or (hc.port.nonEmpty is true)

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -80,7 +80,7 @@ private[health] class HealthCheckActor(
         healthCheck
       )
       nextScheduledCheck = Some(
-        context.system.scheduler.scheduleOnce(healthCheck.interval) {
+        context.system.scheduler.scheduleOnce(interval.getOrElse(healthCheck.interval)) {
           self ! Tick
         }
       )


### PR DESCRIPTION
…… (#4368)

* Fixes #4028 by scheduling the health checks soon after the app deployment has been created.

* Take the minimum of interval and first health check.