### PR TITLE
Fix pod deployment.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
@@ -36,6 +36,7 @@ private[launcher] class TaskLauncherImpl(
       usedOffersMeter.mark()
       val launchCount = taskOps.count {
         case _: InstanceOp.LaunchTask => true
+        case _: InstanceOp.LaunchTaskGroup => true
         case _ => false
       }
       launchedTasksMeter.mark(launchCount)

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -234,7 +234,7 @@ private class TaskLauncherActor(
       op match {
         // only increment for launch ops, not for reservations:
         case _: InstanceOp.LaunchTask => instancesToLaunch += 1
-        // TODO(PODS): case InstanceOp.LaunchTaskGroup => ...
+        case _: InstanceOp.LaunchTaskGroup => instancesToLaunch += 1
         case _ => ()
       }
 
@@ -366,7 +366,7 @@ private class TaskLauncherActor(
       instanceOp match {
         // only decrement for launched instances, not for reservations:
         case _: InstanceOp.LaunchTask => instancesToLaunch -= 1
-        // TODO(PODS): case InstanceOp.LaunchTaskGroup => ...
+        case _: InstanceOp.LaunchTaskGroup => instancesToLaunch -= 1
         case _ => ()
       }
 

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -35,7 +35,7 @@ case class PodDefinition(
   val resources = Resources(
     cpus = PodDefinition.DefaultExecutorCpus + containers.map(_.resources.cpus).sum,
     mem = PodDefinition.DefaultExecutorMem + containers.map(_.resources.mem).sum,
-    disk = containers.map(_.resources.disk).sum,
+    disk = PodDefinition.DefaultExecutorDisk + containers.map(_.resources.disk).sum,
     gpus = containers.map(_.resources.gpus).sum
   )
 
@@ -108,6 +108,7 @@ object PodDefinition {
 
   val DefaultExecutorCpus: Double = 0.1
   val DefaultExecutorMem: Double = 32.0
+  val DefaultExecutorDisk: Double = 10.0
   val DefaultId = PathId.empty
   val DefaultUser = Option.empty[String]
   val DefaultEnv = Map.empty[String, EnvVarValue]

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -49,7 +49,10 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     instanceTracker.instance(taskId.instanceId).flatMap {
       case Some(instance) =>
         val op = InstanceUpdateOperation.MesosUpdate(instance, status, now)
-        stateOpProcessor.process(op).flatMap(_ => acknowledge(status))
+        stateOpProcessor.process(op).flatMap{ _ =>
+          log.info(s"acking $status status update for {}", instance.instanceId)
+          acknowledge(status)
+        }
 
       case None if killWhenUnknown(status) =>
         killUnknownTaskTimer {

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -49,10 +49,7 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     instanceTracker.instance(taskId.instanceId).flatMap {
       case Some(instance) =>
         val op = InstanceUpdateOperation.MesosUpdate(instance, status, now)
-        stateOpProcessor.process(op).flatMap{ _ =>
-          log.info(s"acking $status status update for {}", instance.instanceId)
-          acknowledge(status)
-        }
+        stateOpProcessor.process(op).flatMap(_ => acknowledge(status))
 
       case None if killWhenUnknown(status) =>
         killUnknownTaskTimer {

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -74,9 +74,9 @@ class PodsResourceTest extends MarathonSpec with Matchers with Mockito {
     withClue(s"response body: ${response.getEntity}") {
       response.getStatus() should be(HttpServletResponse.SC_OK)
 
-      val parsedResponse = Option(response.getEntity.asInstanceOf[ String ]).map(Json.parse)
+      val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
       parsedResponse should not be (None)
-      parsedResponse.map(_.as[ Pod ]) should not be (None) // validate that we DID get back a pod definition
+      parsedResponse.map(_.as[Pod]) should not be (None) // validate that we DID get back a pod definition
 
       response.getMetadata().containsKey(PodsResource.DeploymentHeader) should be(true)
     }
@@ -93,7 +93,7 @@ class PodsResourceTest extends MarathonSpec with Matchers with Mockito {
     withClue(s"response body: ${response.getEntity}") {
       response.getStatus() should be(HttpServletResponse.SC_ACCEPTED)
 
-      val body = Option(response.getEntity.asInstanceOf[ String ])
+      val body = Option(response.getEntity.asInstanceOf[String])
       body should be(None)
 
       response.getMetadata().containsKey(PodsResource.DeploymentHeader) should be(true)
@@ -109,7 +109,7 @@ class PodsResourceTest extends MarathonSpec with Matchers with Mockito {
 
     withClue(s"response body: ${response.getEntity}") {
       response.getStatus() should be(HttpServletResponse.SC_NOT_FOUND)
-      val body = Option(response.getEntity.asInstanceOf[ String ])
+      val body = Option(response.getEntity.asInstanceOf[String])
       body should not be (None)
       body.foreach(_ should include("mypod does not exist"))
     }

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -367,7 +367,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "set container images from an image definition" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 6.1, mem = 1568.0, disk = 10.0).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -391,6 +391,10 @@ class TaskGroupBuilderTest extends UnitTest {
                   kind = raml.ImageType.Appc,
                   id = "alpine"
                 ))
+            ),
+            MesosContainer(
+              name = "Foo3",
+              resources = raml.Resources(cpus = 2.0f, mem = 512.0f)
             )
           )
         ),
@@ -403,7 +407,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val (_, taskGroupInfo, _) = pod.get
 
-      assert(taskGroupInfo.getTasksCount == 2)
+      assert(taskGroupInfo.getTasksCount == 3)
 
       val task1Container = taskGroupInfo
         .getTasksList.asScala.find(_.getName == "Foo1").get.getContainer
@@ -419,6 +423,11 @@ class TaskGroupBuilderTest extends UnitTest {
       assert(task2Container.getType == mesos.ContainerInfo.Type.MESOS)
       assert(task2Container.getMesos.getImage.getType == mesos.Image.Type.APPC)
       assert(task2Container.getMesos.getImage.getAppc.getName == "alpine")
+
+      val task3 = taskGroupInfo
+        .getTasksList.asScala.find(_.getName == "Foo3").get
+
+      assert(!task3.hasContainer)
     }
 
     "create health check definitions" in {

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -19,7 +19,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
   "A TaskGroupBuilder" must {
     "build from a PodDefinition with a single container" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.1, mem = 160.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.1, mem = 160.0, disk = 10.0).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -45,7 +45,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "build from a PodDefinition with multiple containers" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -78,7 +78,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "set container commands from a MesosContainer definition" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 3.1, mem = 416.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 3.1, mem = 416.0, disk = 10.0).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -138,7 +138,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "override pod user values with ones defined in containers" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -172,7 +172,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "set pod labels and container labels" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -227,7 +227,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "set environment variables and make sure that container variables override pod variables" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -293,7 +293,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "create volume mappings between volumes defined for a pod and container mounts" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -367,7 +367,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "set container images from an image definition" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -422,7 +422,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "create health check definitions" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 3.1, mem = 416.0, beginPort = 1200, endPort = 1300).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 3.1, mem = 416.0, disk = 10.0, beginPort = 1200, endPort = 1300).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -504,7 +504,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "support URL artifacts" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.1, mem = 160.0).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 1.1, mem = 160.0, disk = 10.0).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
@@ -537,7 +537,7 @@ class TaskGroupBuilderTest extends UnitTest {
     }
 
     "support networks and port mappings for pods and containers" in {
-      val offer = MarathonTestHelper.makeBasicOffer(cpus = 3.1, mem = 416.0, beginPort = 8000, endPort = 9000).build
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 3.1, mem = 416.0, disk = 10.0, beginPort = 8000, endPort = 9000).build
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(


### PR DESCRIPTION
For pods Mesos no longer sets the framework ID implicitly in
'ExecutorInfo'. Also, disk resources are validated and need to be set.
Because the default executor doesn't use disk resources, they are set to
zero.