### PR TITLE
Fixes #4387 Replace $ with . in metric name

### DIFF
--- a/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
@@ -61,7 +61,7 @@ class Metrics @Inject() (val registry: MetricRegistry) extends StrictLogging {
   }
 
   def name(prefix: String, clazz: Class[_], method: String): String = {
-    s"$prefix.${className(clazz)}.$method"
+    s"$prefix.${className(clazz)}.$method".replace('$', '.').replaceAll("""\.+""", ".")
   }
 
   def name(prefix: String, in: MethodInvocation): String = {

--- a/src/test/scala/mesosphere/marathon/metrics/MetricsTest.scala
+++ b/src/test/scala/mesosphere/marathon/metrics/MetricsTest.scala
@@ -51,6 +51,14 @@ class MetricsTest
     assert(metrics.className(instance.getClass) == "mesosphere.marathon.metrics.FooBar")
   }
 
+  test("Metrics#name should replace $ with .") {
+    val instance = new Serializable {}
+    assert(instance.getClass.getName.contains('$'))
+
+    assert(metrics.name("test$prefix", instance.getClass, "test$method") ==
+      "test.prefix.mesosphere.marathon.metrics.MetricsTest.anonfun.3.anon.1.test.method")
+  }
+
   test("Metrics caches the class names") {
     val metricsSpy = spy(metrics)
 


### PR DESCRIPTION
Graphite does not support `$` in metric name. This PR replace `$` in class name with `.`