### PR TITLE
Add necessary properties for health checks + send health events

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -31,6 +31,39 @@ types:
       http?: HttpHealthCheck
       tcp?: TcpHealthCheck
       command?: CommandHealthCheck
+      gracePeriodSeconds?:
+        type: integer
+        format: int64
+        description: |
+          Health check failures are ignored within this number of seconds of
+          the task being started or until the task becomes healthy for the
+          first time.
+        minimum: 0
+        default: 300
+      intervalSeconds?:
+        type: integer
+        format: int32
+        description: Interval between the hralth checks
+        minimum: 0
+        default: 60
+      maxConsecutiveFailures?:
+        type: integer
+        format: int32
+        description: Number of consecutive failures until the task will be killed
+        minimum: 0
+        default: 3
+      timeoutSeconds?:
+        type: integer
+        format: int32
+        description: Amount of time to wait for the health check to complete.
+        minimum: 0
+        default: 20
+      delaySeconds?:
+        type: integer
+        format: int32
+        description: Amount of time to wait until starting the health checks.
+        minimum: 0
+        default: 2
     usage: Must specify a single type of check, http, tcp, or command
   AppHealthCheckProtocol:
     type: string

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -225,7 +225,7 @@ case class InstanceHealthChanged(
     id: Instance.Id,
     runSpecVersion: Timestamp,
     runSpecId: PathId,
-    healthy: Boolean) extends MarathonEvent {
+    healthy: Option[Boolean]) extends MarathonEvent {
   override val eventType: String = "instance_health_changed_event"
   override val timestamp: String = Timestamp.now().toString
 }

--- a/src/main/scala/mesosphere/marathon/core/flow/impl/OfferMatcherLaunchTokensActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/impl/OfferMatcherLaunchTokensActor.scala
@@ -49,8 +49,7 @@ private class OfferMatcherLaunchTokensActor(
   }
 
   override def receive: Receive = {
-    // TODO(PODS): NOT checking for health breaks the "DO NOT refill on running UNhealthy task" test case
-    case InstanceUpdated(instance) if instance.isRunning && instance.state.healthy.fold(true)(_ == true) =>
+    case InstanceUpdated(instance, _) if instance.isRunning && instance.state.healthy.fold(true)(_ == true) =>
       offerMatcherManager.addLaunchTokens(1)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -191,13 +191,11 @@ private[health] class HealthCheckActor(
       instanceHealth += (taskId -> newHealth)
 
       if (health.alive != newHealth.alive && result.publishEvent) {
-        eventBus.publish(
-          HealthStatusChanged(
-            appId = app.id,
-            taskId = taskId,
-            version = result.version,
-            alive = newHealth.alive)
-        )
+        eventBus.publish(HealthStatusChanged(app.id, taskId, result.version, alive = newHealth.alive))
+        // We moved to InstanceHealthChanged Events everywhere
+        // Since we perform marathon based health checks only for apps, (every task is an instance)
+        // every health result is translated to an instance health changed event
+        eventBus.publish(InstanceHealthChanged(taskId.instanceId, result.version, app.id, Some(newHealth.alive)))
       }
 
     case result: HealthResult =>

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
@@ -1,8 +1,9 @@
 package mesosphere.marathon.core.instance.update
 
 import akka.Done
+import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.core.instance.{ Instance, InstanceStatus }
-import mesosphere.marathon.state.{ Timestamp, PathId }
+import mesosphere.marathon.state.{ PathId, Timestamp }
 
 import scala.concurrent.Future
 
@@ -33,9 +34,10 @@ sealed trait InstanceChange extends Product with Serializable {
   val status: InstanceStatus = instance.state.status
   /** Id of the related [[mesosphere.marathon.state.RunSpec]] */
   val runSpecId: PathId = id.runSpecId
+  def lastState: Option[InstanceState]
 }
 
 /** The given instance has been created or updated. */
-case class InstanceUpdated(instance: Instance) extends InstanceChange
+case class InstanceUpdated(instance: Instance, lastState: Option[InstanceState]) extends InstanceChange
 /** The given instance has been deleted. */
-case class InstanceDeleted(instance: Instance) extends InstanceChange
+case class InstanceDeleted(instance: Instance, lastState: Option[InstanceState]) extends InstanceChange

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -149,13 +149,13 @@ private class InstanceTrackerActor(
 
       case msg @ InstanceTrackerActor.StateChanged(ack) =>
         val maybeChange: Option[InstanceChange] = ack.effect match {
-          case InstanceUpdateEffect.Update(instance, _) =>
+          case InstanceUpdateEffect.Update(instance, oldState) =>
             becomeWithUpdatedApp(instance.runSpecId)(instance.instanceId, newInstance = Some(instance))
-            Some(InstanceUpdated(instance))
+            Some(InstanceUpdated(instance, lastState = oldState.map(_.state)))
 
           case InstanceUpdateEffect.Expunge(instance) =>
             becomeWithUpdatedApp(instance.runSpecId)(instance.instanceId, newInstance = None)
-            Some(InstanceDeleted(instance))
+            Some(InstanceDeleted(instance, lastState = None))
 
           case InstanceUpdateEffect.Noop(_) |
             InstanceUpdateEffect.Failure(_) =>

--- a/src/main/scala/mesosphere/marathon/upgrade/ReadinessBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/ReadinessBehavior.scala
@@ -108,7 +108,7 @@ trait ReadinessBehavior { this: Actor with ActorLogging =>
         case InstanceChanged(_, `version`, `pathId`, Running, instance) => initiateReadinessCheck(instance)
       }
       def handleInstanceHealthy: Receive = {
-        case InstanceHealthChanged(id, `version`, `pathId`, true) if !healthy(id) =>
+        case InstanceHealthChanged(id, `version`, `pathId`, Some(true)) if !healthy(id) =>
           log.info(s"Instance $id now healthy for run spec ${runSpec.id}")
           healthy += id
           if (runSpec.readinessChecks.isEmpty) ready += id

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -323,6 +323,11 @@ object TaskGroupBuilder {
     healthCheck: raml.HealthCheck,
     endpoints: Seq[raml.Endpoint]): mesos.HealthCheck.Builder = {
     val builder = mesos.HealthCheck.newBuilder
+    builder.setDelaySeconds(healthCheck.delaySeconds.toDouble)
+    builder.setGracePeriodSeconds(healthCheck.gracePeriodSeconds.toDouble)
+    builder.setIntervalSeconds(healthCheck.intervalSeconds.toDouble)
+    builder.setConsecutiveFailures(healthCheck.maxConsecutiveFailures)
+    builder.setTimeoutSeconds(healthCheck.timeoutSeconds.toDouble)
 
     healthCheck.command.foreach { command =>
       builder.setType(mesos.HealthCheck.Type.COMMAND)

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -24,8 +24,8 @@ class TaskStatusUpdateTestHelper(val operation: InstanceUpdateOperation, val eff
   }
   def reason: String = if (status.hasReason) status.getReason.toString else "no reason"
   def wrapped: InstanceChange = effect match {
-    case InstanceUpdateEffect.Update(instance, _) => InstanceUpdated(instance)
-    case InstanceUpdateEffect.Expunge(instance) => InstanceDeleted(instance)
+    case InstanceUpdateEffect.Update(instance, old) => InstanceUpdated(instance, old.map(_.state))
+    case InstanceUpdateEffect.Expunge(instance) => InstanceDeleted(instance, None)
     case _ => throw new scala.RuntimeException("The wrapped effect does not result in an InstanceChange")
   }
 }

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -126,7 +126,7 @@ class AppStartActorTest
     }
 
     def healthChanged(app: AppDefinition, healthy: Boolean): InstanceHealthChanged = {
-      InstanceHealthChanged(Instance.Id.forRunSpec(app.id), app.version, app.id, healthy = healthy)
+      InstanceHealthChanged(Instance.Id.forRunSpec(app.id), app.version, app.id, healthy = Some(healthy))
     }
 
     def startActor(app: AppDefinition, scaleTo: Int, promise: Promise[Unit]): TestActorRef[AppStartActor] =

--- a/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
@@ -181,7 +181,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
     val checkIsReady = Seq(ReadinessCheckResult("test", taskId, ready = true, None))
     val checkIsNotReady = Seq(ReadinessCheckResult("test", taskId, ready = false, None))
     val instanceRunning = InstanceChanged(instanceId, version, appId, Running, instance)
-    val instanceIsHealthy = InstanceHealthChanged(instanceId, version, appId, healthy = true)
+    val instanceIsHealthy = InstanceHealthChanged(instanceId, version, appId, healthy = Some(true))
 
     agentInfo.host returns "some.host"
     launched.hostPorts returns Seq(1, 2, 3)

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -441,7 +441,7 @@ class TaskReplaceActorTest
     val newInstanceId = newTaskId.instanceId
 
     //unhealthy
-    ref ! InstanceHealthChanged(newInstanceId, app.version, app.id, healthy = false)
+    ref ! InstanceHealthChanged(newInstanceId, app.version, app.id, healthy = Some(false))
     eventually { f.killService.numKilled should be(0) }
 
     //unready
@@ -449,7 +449,7 @@ class TaskReplaceActorTest
     eventually { f.killService.numKilled should be(0) }
 
     //healthy
-    ref ! InstanceHealthChanged(newInstanceId, app.version, app.id, healthy = true)
+    ref ! InstanceHealthChanged(newInstanceId, app.version, app.id, healthy = Some(true))
     eventually { f.killService.numKilled should be(0) }
 
     //ready
@@ -480,7 +480,7 @@ class TaskReplaceActorTest
     }
 
     def healthChanged(app: AppDefinition, healthy: Boolean): InstanceHealthChanged = {
-      InstanceHealthChanged(Instance.Id.forRunSpec(app.id), app.version, app.id, healthy = healthy)
+      InstanceHealthChanged(Instance.Id.forRunSpec(app.id), app.version, app.id, healthy = Some(healthy))
     }
     def replaceActor(app: AppDefinition, promise: Promise[Unit]): TestActorRef[TaskReplaceActor] = TestActorRef(
       TaskReplaceActor.props(deploymentsManager, deploymentStatus, driver, killService, queue,

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -277,7 +277,7 @@ class TaskStartActorTest
     }
 
     def healthChange(app: AppDefinition, id: Instance.Id, healthy: Boolean): InstanceHealthChanged = {
-      InstanceHealthChanged(id, app.version, app.id, healthy)
+      InstanceHealthChanged(id, app.version, app.id, Some(healthy))
     }
 
     def startActor(app: AppDefinition, scaleTo: Int, promise: Promise[Unit]): TestActorRef[TaskStartActor] = TestActorRef(TaskStartActor.props(


### PR DESCRIPTION
Divided into 2 commits:
1) add properties to raml and set in TaskGroupBuilder
2) Send InstanceHealthChanged Events in PostToEventStream(Mesos based) and HealthCheckActor (Marathon based)