### PR TITLE
Fixes #4480 Race Condition in GroupManager with new Persistence Store

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerActor.scala
@@ -129,6 +129,7 @@ private[impl] class GroupManagerActor(
         plan = DeploymentPlan(from, to, resolve, version, toKill)
         _ = validateOrThrow(plan)(DeploymentPlan.deploymentPlanValidator(config))
         _ = log.info(s"Computed new deployment plan:\n$plan")
+        _ <- groupRepo.storeRootVersion(plan.target, plan.createdOrUpdatedApps)
         _ <- scheduler.deploy(plan, force)
         _ <- groupRepo.storeRoot(plan.target, plan.createdOrUpdatedApps, plan.deletedApps)
         _ = log.info(s"Updated groups/apps according to deployment plan ${plan.id}")

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -637,14 +637,12 @@ object AppDefinition extends GeneralPurposeCombinators {
     isTrue("AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.") { app =>
       val cmd = app.cmd.nonEmpty
       val args = app.args.nonEmpty
-      val container = app.container.exists(
-        _ match {
-          case _: MesosDocker => true
-          case _: MesosAppC => true
-          case _: Container.Docker => true
-          case _ => false
-        }
-      )
+      val container = app.container.exists {
+        case _: MesosDocker => true
+        case _: MesosAppC => true
+        case _: Container.Docker => true
+        case _ => false
+      }
       (cmd ^ args) || (!(cmd && args) && container)
     }
 

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -247,7 +247,6 @@ class StoredGroupRepositoryImpl[K, C, S](
           await(preStore(storedGroup))
         case _ =>
       }
-      val promise = Promise[Group]()
 
       val storeAppFutures = updatedApps.map(appRepository.store)
       val storedApps = await(Future.sequence(storeAppFutures).asTry)
@@ -257,7 +256,6 @@ class StoredGroupRepositoryImpl[K, C, S](
           val storedRoot = await(storedRepo.storeVersion(storedGroup).asTry)
           storedRoot match {
             case Success(_) =>
-              promise.success(group)
               Done
             case Failure(ex) =>
               logger.error(s"Unable to store updated group $group", ex)

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -238,6 +238,37 @@ class StoredGroupRepositoryImpl[K, C, S](
       }
     }
 
+  @SuppressWarnings(Array("all")) // async/await
+  override def storeRootVersion(group: Group, updatedApps: Seq[AppDefinition]): Future[Done] =
+    async { // linter:ignore UnnecessaryElseBranch
+      val storedGroup = StoredGroup(group)
+      beforeStore match {
+        case Some(preStore) =>
+          await(preStore(storedGroup))
+        case _ =>
+      }
+      val promise = Promise[Group]()
+
+      val storeAppFutures = updatedApps.map(appRepository.store)
+      val storedApps = await(Future.sequence(storeAppFutures).asTry)
+
+      storedApps match {
+        case Success(_) =>
+          val storedRoot = await(storedRepo.storeVersion(storedGroup).asTry)
+          storedRoot match {
+            case Success(_) =>
+              promise.success(group)
+              Done
+            case Failure(ex) =>
+              logger.error(s"Unable to store updated group $group", ex)
+              throw ex
+          }
+        case Failure(ex) =>
+          logger.error(s"Unable to store updated apps ${updatedApps.map(_.id).mkString}", ex)
+          throw ex
+      }
+    }
+
   private[storage] def lazyRootVersion(version: OffsetDateTime): Future[Option[StoredGroup]] = {
     storedRepo.getVersion(RootId, version)
   }

--- a/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
@@ -42,6 +42,8 @@ trait GroupRepository {
     * update the apps or the root, but deletion errors are ignored.
     */
   def storeRoot(group: Group, updatedApps: Seq[AppDefinition], deletedApps: Seq[PathId]): Future[Done]
+
+  def storeRootVersion(group: Group, updatedApps: Seq[AppDefinition]): Future[Done]
 }
 
 object GroupRepository {

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/LegacyEntityRepository.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/LegacyEntityRepository.scala
@@ -245,6 +245,7 @@ class GroupEntityRepository(
     }
   }
 
+  @SuppressWarnings(Array("all")) // async/await
   override def storeRootVersion(group: Group, updatedApps: Seq[AppDefinition]): Future[Done] = {
     async { // linter:ignore UnnecessaryElseBranch
       val storeAppsFutures = updatedApps.map(appRepository.store)

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/LegacyEntityRepository.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/LegacyEntityRepository.scala
@@ -244,6 +244,14 @@ class GroupEntityRepository(
       await(store(group))
     }
   }
+
+  override def storeRootVersion(group: Group, updatedApps: Seq[AppDefinition]): Future[Done] = {
+    async { // linter:ignore UnnecessaryElseBranch
+      val storeAppsFutures = updatedApps.map(appRepository.store)
+      await(Future.sequence(storeAppsFutures))
+      await(storeVersion(group))
+    }
+  }
 }
 
 object GroupEntityRepository {

--- a/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
@@ -291,11 +291,13 @@ class GroupManagerActorTest extends Mockito with Matchers with MarathonSpec {
 
     val groupWithVersionInfo = Group(PathId.empty, Map(
       appWithVersionInfo.id -> appWithVersionInfo)).copy(version = Timestamp(1))
+    when(f.groupRepo.storeRootVersion(any, any)).thenReturn(Future.successful(Done))
     when(f.groupRepo.storeRoot(any, any, any)).thenReturn(Future.successful(Done))
 
     Await.result(f.manager ? update(group.id, _ => group, version = Timestamp(1)), 3.seconds)
 
     verify(f.groupRepo).storeRoot(groupWithVersionInfo, Seq(appWithVersionInfo), Nil)
+    verify(f.groupRepo).storeRootVersion(groupWithVersionInfo, Seq(appWithVersionInfo))
   }
 
   test("Expunge removed apps from appRepo") {
@@ -307,11 +309,13 @@ class GroupManagerActorTest extends Mockito with Matchers with MarathonSpec {
     when(f.groupRepo.root()).thenReturn(Future.successful(group))
     when(f.scheduler.deploy(any, any)).thenReturn(Future.successful(()))
     when(f.appRepo.delete(any)).thenReturn(Future.successful(Done))
+    when(f.groupRepo.storeRootVersion(any, any)).thenReturn(Future.successful(Done))
     when(f.groupRepo.storeRoot(any, any, any)).thenReturn(Future.successful(Done))
 
     Await.result(f.manager ? update(group.id, _ => groupEmpty, version = Timestamp(1)), 3.seconds)
 
     verify(f.groupRepo).storeRoot(groupEmpty, Nil, Seq(app.id))
+    verify(f.groupRepo).storeRootVersion(groupEmpty, Nil)
     verify(f.appRepo, atMost(1)).delete(app.id)
     verify(f.appRepo, atMost(1)).deleteCurrent(app.id)
   }


### PR DESCRIPTION
There were situations where groups would be referenced by deployment
plans, but the group was not yet stored. Ensure that roots are always
available for any plan by storing the root version first.