### PR TITLE
Adjust the KillService to handle instances instead of tasks

### DIFF
--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -55,7 +55,7 @@ class ConcurrentTaskUpgradeException(msg: String) extends TaskUpgradeFailedExcep
 class MissingHealthCheckException(msg: String) extends TaskUpgradeFailedException(msg)
 class AppDeletedException(msg: String) extends TaskUpgradeFailedException(msg)
 class TaskUpgradeCanceledException(msg: String) extends TaskUpgradeFailedException(msg)
-class KillingTasksFailedException(msg: String) extends Exception(msg)
+class KillingInstancesFailedException(msg: String) extends Exception(msg)
 
 /*
  * Deployment specific exceptions

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerConfig
 import mesosphere.marathon.core.plugin.PluginManagerConfiguration
 import mesosphere.marathon.core.task.jobs.TaskJobsConfig
-import mesosphere.marathon.core.task.termination.TaskKillConfig
+import mesosphere.marathon.core.task.termination.KillConfig
 import mesosphere.marathon.core.task.tracker.InstanceTrackerConfig
 import mesosphere.marathon.core.task.update.TaskStatusUpdateConfig
 import mesosphere.marathon.io.storage.StorageProvider
@@ -24,7 +24,7 @@ trait MarathonConf
     extends ScallopConf
     with EventConf with GroupManagerConfig with LaunchQueueConfig with LaunchTokenConfig with LeaderProxyConf
     with MarathonSchedulerServiceConfig with OfferMatcherManagerConfig with OfferProcessorConfig
-    with PluginManagerConfiguration with ReviveOffersConfig with StorageConf with TaskKillConfig
+    with PluginManagerConfiguration with ReviveOffersConfig with StorageConf with KillConfig
     with TaskJobsConfig with TaskStatusUpdateConfig with InstanceTrackerConfig with UpgradeConfig with ZookeeperConf {
 
   lazy val mesosMaster = opt[String](

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -17,7 +17,7 @@ import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.heartbeat._
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
-import mesosphere.marathon.core.task.termination.TaskKillService
+import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.metrics.Metrics
@@ -112,7 +112,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf)
     deploymentRepository: DeploymentRepository,
     healthCheckManager: HealthCheckManager,
     instanceTracker: InstanceTracker,
-    killService: TaskKillService,
+    killService: KillService,
     launchQueue: LaunchQueue,
     driverHolder: MarathonSchedulerDriverHolder,
     electionService: ElectionService,

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.core.event.{ AppTerminatedEvent, DeploymentFailed, De
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.{ Instance, InstanceStatus }
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository._
@@ -41,7 +41,7 @@ class MarathonSchedulerActor private (
   podRepository: ReadOnlyPodRepository,
   deploymentRepository: DeploymentRepository,
   healthCheckManager: HealthCheckManager,
-  killService: TaskKillService,
+  killService: KillService,
   launchQueue: LaunchQueue,
   marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder,
   electionService: ElectionService,
@@ -163,7 +163,7 @@ class MarathonSchedulerActor private (
       @SuppressWarnings(Array("all")) /* async/await */
       def killTasks(): Unit = {
         val res = async { // linter:ignore UnnecessaryElseBranch
-          await(killService.killTasks(tasks, TaskKillReason.KillingTasksViaApi))
+          await(killService.killTasks(tasks, KillReason.KillingTasksViaApi))
           val runSpec = await(schedulerActions.runSpecById(runSpecId))
           runSpec.foreach(schedulerActions.scale)
         }
@@ -343,7 +343,7 @@ object MarathonSchedulerActor {
     podRepository: ReadOnlyPodRepository,
     deploymentRepository: DeploymentRepository,
     healthCheckManager: HealthCheckManager,
-    killService: TaskKillService,
+    killService: KillService,
     launchQueue: LaunchQueue,
     marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder,
     electionService: ElectionService,
@@ -430,7 +430,7 @@ class SchedulerActions(
     launchQueue: LaunchQueue,
     eventBus: EventStream,
     val schedulerActor: ActorRef,
-    val killService: TaskKillService)(implicit ec: ExecutionContext, mat: Materializer) {
+    val killService: KillService)(implicit ec: ExecutionContext, mat: Materializer) {
 
   private[this] val log = LoggerFactory.getLogger(getClass)
 
@@ -450,7 +450,7 @@ class SchedulerActions(
         instance =>
           if (instance.isLaunched) {
             log.info("Killing {}", instance.instanceId)
-            killService.killTask(instance, TaskKillReason.DeletingApp)
+            killService.killTask(instance, KillReason.DeletingApp)
           }
       }
       launchQueue.purge(runSpec.id)
@@ -492,7 +492,7 @@ class SchedulerActions(
           )
           instances.specInstances(unknownId).foreach { orphanTask =>
             log.info(s"Killing ${orphanTask.instanceId}")
-            killService.killTask(orphanTask, TaskKillReason.Orphaned)
+            killService.killTask(orphanTask, KillReason.Orphaned)
           }
         }
 
@@ -554,7 +554,7 @@ class SchedulerActions(
         .take(launchedCount - targetCount)
 
       log.info("Killing tasks {}", toKill.map(_.instanceId))
-      killService.killTasks(toKill, TaskKillReason.ScalingApp)
+      killService.killTasks(toKill, KillReason.ScalingApp)
     } else {
       log.info(s"Already running ${runSpec.instances} instances of ${runSpec.id}. Not scaling.")
     }

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -163,7 +163,7 @@ class MarathonSchedulerActor private (
       @SuppressWarnings(Array("all")) /* async/await */
       def killTasks(): Unit = {
         val res = async { // linter:ignore UnnecessaryElseBranch
-          await(killService.killTasks(tasks, KillReason.KillingTasksViaApi))
+          await(killService.killInstances(tasks, KillReason.KillingTasksViaApi))
           val runSpec = await(schedulerActions.runSpecById(runSpecId))
           runSpec.foreach(schedulerActions.scale)
         }
@@ -450,7 +450,7 @@ class SchedulerActions(
         instance =>
           if (instance.isLaunched) {
             log.info("Killing {}", instance.instanceId)
-            killService.killTask(instance, KillReason.DeletingApp)
+            killService.killInstance(instance, KillReason.DeletingApp)
           }
       }
       launchQueue.purge(runSpec.id)
@@ -492,7 +492,7 @@ class SchedulerActions(
           )
           instances.specInstances(unknownId).foreach { orphanTask =>
             log.info(s"Killing ${orphanTask.instanceId}")
-            killService.killTask(orphanTask, KillReason.Orphaned)
+            killService.killInstance(orphanTask, KillReason.Orphaned)
           }
         }
 
@@ -554,7 +554,7 @@ class SchedulerActions(
         .take(launchedCount - targetCount)
 
       log.info("Killing tasks {}", toKill.map(_.instanceId))
-      killService.killTasks(toKill, KillReason.ScalingApp)
+      killService.killInstances(toKill, KillReason.ScalingApp)
     } else {
       log.info(s"Already running ${runSpec.instances} instances of ${runSpec.id}. Not scaling.")
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -606,6 +606,15 @@ trait EventFormats {
       "eventType" -> change.eventType
     )
   }
+  implicit lazy val UnknownInstanceTerminatedEventWrites: Writes[UnknownInstanceTerminated] = Writes { change =>
+    Json.obj(
+      "instanceId" -> change.id,
+      "runSpecId" -> change.runSpecId,
+      "instanceStatus" -> change.status.toString,
+      "timestamp" -> change.timestamp,
+      "eventType" -> change.eventType
+    )
+  }
 
   def eventToJson(event: MarathonEvent): JsValue = event match {
     case event: AppTerminatedEvent => Json.toJson(event)
@@ -633,6 +642,7 @@ trait EventFormats {
     case event: SchedulerReregisteredEvent => Json.toJson(event)
     case event: InstanceChanged => Json.toJson(event)
     case event: InstanceHealthChanged => Json.toJson(event)
+    case event: UnknownInstanceTerminated => Json.toJson(event)
     case event: PodEvent => Json.toJson(event)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -25,7 +25,7 @@ import mesosphere.marathon.core.plugin.{ PluginDefinitions, PluginManager }
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.bus.{ TaskChangeObservables, TaskStatusEmitter }
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
-import mesosphere.marathon.core.task.termination.TaskKillService
+import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.{ InstanceTracker, TaskStateOpProcessor }
 import mesosphere.marathon.core.task.update.impl.steps._
 import mesosphere.marathon.core.task.update.impl.{ TaskStatusUpdateProcessorImpl, ThrottlingTaskStatusUpdateProcessor }
@@ -56,7 +56,7 @@ class CoreGuiceModule extends AbstractModule {
   def taskTracker(coreModule: CoreModule): InstanceTracker = coreModule.taskTrackerModule.instanceTracker
 
   @Provides @Singleton
-  def taskKillService(coreModule: CoreModule): TaskKillService = coreModule.taskTerminationModule.taskKillService
+  def taskKillService(coreModule: CoreModule): KillService = coreModule.taskTerminationModule.taskKillService
 
   @Provides @Singleton
   def taskCreationHandler(coreModule: CoreModule): InstanceCreationHandler =

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -2,8 +2,9 @@ package mesosphere.marathon.core.event
 
 import akka.event.EventStream
 import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.instance.update.InstanceChange
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.instance.{ InstanceStatus, Instance }
+import mesosphere.marathon.core.instance.{ Instance, InstanceStatus }
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep }
 
@@ -209,6 +210,7 @@ case class MesosStatusUpdateEvent(
   eventType: String = "status_update_event",
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
 
+/** Event indicating a status change for a known instance */
 case class InstanceChanged(
     id: Instance.Id,
     runSpecVersion: Timestamp,
@@ -216,6 +218,21 @@ case class InstanceChanged(
     status: InstanceStatus,
     instance: Instance) extends MarathonEvent {
   override val eventType: String = "instance_changed_event"
+  override val timestamp: String = Timestamp.now().toString
+}
+object InstanceChanged {
+  def apply(instanceChange: InstanceChange): InstanceChanged = {
+    InstanceChanged(instanceChange.id, instanceChange.runSpecVersion,
+      instanceChange.runSpecId, instanceChange.status, instanceChange.instance)
+  }
+}
+
+/** Event indicating an unknown instance is terminal */
+case class UnknownInstanceTerminated(
+    id: Instance.Id,
+    runSpecId: PathId,
+    status: InstanceStatus) extends MarathonEvent {
+  override val eventType: String = "unknown_instance_terminated_event"
   override val timestamp: String = Timestamp.now().toString
 }
 

--- a/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.core.health
 import akka.actor.ActorSystem
 import akka.event.EventStream
 import mesosphere.marathon.core.health.impl.MarathonHealthCheckManager
-import mesosphere.marathon.core.task.termination.TaskKillService
+import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.storage.repository.ReadOnlyAppRepository
 
@@ -12,7 +12,7 @@ import mesosphere.marathon.storage.repository.ReadOnlyAppRepository
   */
 class HealthModule(
     actorSystem: ActorSystem,
-    killService: TaskKillService,
+    killService: KillService,
     eventBus: EventStream,
     taskTracker: InstanceTracker,
     appRepository: ReadOnlyAppRepository) {

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -9,13 +9,13 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 
 import scala.concurrent.duration._
 
 private[health] class HealthCheckActor(
     app: AppDefinition,
-    killService: TaskKillService,
+    killService: KillService,
     healthCheck: HealthCheck,
     taskTracker: InstanceTracker,
     eventBus: EventStream) extends Actor with ActorLogging {
@@ -131,7 +131,7 @@ private[health] class HealthCheckActor(
             timestamp = health.lastFailure.getOrElse(Timestamp.now()).toString
           )
         )
-        killService.killTask(Instance(task), TaskKillReason.FailedHealthChecks)
+        killService.killTask(Instance(task), KillReason.FailedHealthChecks)
       }
     }
   }
@@ -205,7 +205,7 @@ private[health] class HealthCheckActor(
 object HealthCheckActor {
   def props(
     app: AppDefinition,
-    killService: TaskKillService,
+    killService: KillService,
     healthCheck: HealthCheck,
     taskTracker: InstanceTracker,
     eventBus: EventStream): Props = {

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -131,7 +131,7 @@ private[health] class HealthCheckActor(
             timestamp = health.lastFailure.getOrElse(Timestamp.now()).toString
           )
         )
-        killService.killTask(Instance(task), KillReason.FailedHealthChecks)
+        killService.killInstance(Instance(task), KillReason.FailedHealthChecks)
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.health.impl.HealthCheckActor.{ AppHealth, GetAppHealth }
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.termination.TaskKillService
+import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.storage.repository.ReadOnlyAppRepository
@@ -24,7 +24,7 @@ import scala.concurrent.duration._
 
 class MarathonHealthCheckManager(
     actorRefFactory: ActorRefFactory,
-    killService: TaskKillService,
+    killService: KillService,
     eventBus: EventStream,
     taskTracker: InstanceTracker,
     appRepository: ReadOnlyAppRepository) extends HealthCheckManager {

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -207,8 +207,7 @@ object Instance {
     tasks.iterator.map(task => task.instanceId -> task).toMap
 
   // TODO ju remove apply
-  def apply(task: Task): Instance = new Instance(
-    task.taskId.instanceId, task.agentInfo,
+  def apply(task: Task): Instance = new Instance(task.taskId.instanceId, task.agentInfo,
     InstanceState(
       status = task.status.taskStatus,
       since = task.status.startedAt.getOrElse(task.status.stagedAt),

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.core.task.jobs
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.task.jobs.impl.{ ExpungeOverdueLostTasksActor, OverdueTasksActor }
-import mesosphere.marathon.core.task.termination.TaskKillService
+import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.{ TaskReservationTimeoutHandler, TaskStateOpProcessor, InstanceTracker }
 import mesosphere.marathon.MarathonConf
 
@@ -14,7 +14,7 @@ class TaskJobsModule(config: MarathonConf, leadershipModule: LeadershipModule, c
   def handleOverdueTasks(
     taskTracker: InstanceTracker,
     taskReservationTimeoutHandler: TaskReservationTimeoutHandler,
-    killService: TaskKillService): Unit = {
+    killService: KillService): Unit = {
     leadershipModule.startWhenLeader(
       OverdueTasksActor.props(
         config,

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.core.task.jobs.impl
 
 import akka.actor._
 import mesosphere.marathon.core.base.Clock
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.{ InstanceTracker, TaskReservationTimeoutHandler }
 import mesosphere.marathon.state.Timestamp
@@ -22,7 +22,7 @@ private[jobs] object OverdueTasksActor {
     config: MarathonConf,
     taskTracker: InstanceTracker,
     reservationTimeoutHandler: TaskReservationTimeoutHandler,
-    killService: TaskKillService,
+    killService: KillService,
     clock: Clock): Props = {
     Props(new OverdueTasksActor(new Support(config, taskTracker, reservationTimeoutHandler, killService, clock)))
   }
@@ -34,7 +34,7 @@ private[jobs] object OverdueTasksActor {
       config: MarathonConf,
       taskTracker: InstanceTracker,
       reservationTimeoutHandler: TaskReservationTimeoutHandler,
-      killService: TaskKillService,
+      killService: KillService,
       clock: Clock) {
     import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -55,7 +55,7 @@ private[jobs] object OverdueTasksActor {
     private[this] def killOverdueInstances(now: Timestamp, instances: Iterable[Instance]): Unit = {
       overdueTasks(now, instances).foreach { overdueTask =>
         log.info("Killing overdue {}", overdueTask.instanceId)
-        killService.killTask(overdueTask, TaskKillReason.Overdue)
+        killService.killTask(overdueTask, KillReason.Overdue)
       }
     }
 

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
@@ -55,7 +55,7 @@ private[jobs] object OverdueTasksActor {
     private[this] def killOverdueInstances(now: Timestamp, instances: Iterable[Instance]): Unit = {
       overdueTasks(now, instances).foreach { overdueTask =>
         log.info("Killing overdue {}", overdueTask.instanceId)
-        killService.killTask(overdueTask, KillReason.Overdue)
+        killService.killInstance(overdueTask, KillReason.Overdue)
       }
     }
 

--- a/src/main/scala/mesosphere/marathon/core/task/termination/KillConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/KillConfig.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration._
 
 import scala.concurrent.duration.FiniteDuration
 
-trait TaskKillConfig extends ScallopConf {
+trait KillConfig extends ScallopConf {
 
   private[this] lazy val _killChunkSize = opt[Int](
     "kill_chunk_size",
@@ -19,7 +19,7 @@ trait TaskKillConfig extends ScallopConf {
   private[this] lazy val _killRetryTimeout = opt[Long](
     "kill_retry_timeout",
     descr = "INTERNAL TUNING PARAMETER: " +
-      "The timeout after which a task kill will be retried.",
+      "The timeout after which an instance kill will be retried.",
     noshort = true,
     hidden = true,
     default = Some(10.seconds.toMillis)
@@ -28,7 +28,7 @@ trait TaskKillConfig extends ScallopConf {
   private[this] lazy val _killRetryMax = opt[Int](
     "kill_retry_max",
     descr = "INTERNAL TUNING PARAMETER: " +
-      "The maximum number of kill retries before which a task will be forcibly expunged from state.",
+      "The maximum number of kill retries before which an instance will be forcibly expunged from state.",
     noshort = true,
     hidden = true,
     default = Some(5)

--- a/src/main/scala/mesosphere/marathon/core/task/termination/KillReason.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/KillReason.scala
@@ -6,30 +6,30 @@ package mesosphere.marathon.core.task.termination
   * This is not sealed on purpose as there might be different reasons for
   * components build on top of the core.
   */
-trait TaskKillReason
+trait KillReason
 
-object TaskKillReason {
+object KillReason {
   /** The task is killed because the instance count is scaled down */
-  case object ScalingApp extends TaskKillReason
+  case object ScalingApp extends KillReason
 
   /** The task is killed because the app has is being deleted */
-  case object DeletingApp extends TaskKillReason
+  case object DeletingApp extends KillReason
 
   /** The task is killed because of an incoming http request */
-  case object KillingTasksViaApi extends TaskKillReason
+  case object KillingTasksViaApi extends KillReason
 
   /** The task is killed because a new version is being deployed */
-  case object Upgrading extends TaskKillReason
+  case object Upgrading extends KillReason
 
   /** The task is killed because the app no longer exists */
-  case object Orphaned extends TaskKillReason
+  case object Orphaned extends KillReason
 
   /** The task is killed because it didn't turn running within a given time frame */
-  case object Overdue extends TaskKillReason
+  case object Overdue extends KillReason
 
   /** The task is killed because it is unknown */
-  case object Unknown extends TaskKillReason
+  case object Unknown extends KillReason
 
   /** The task is killed because it exceeded the maximum number of consecutive failures */
-  case object FailedHealthChecks extends TaskKillReason
+  case object FailedHealthChecks extends KillReason
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/KillService.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/KillService.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
   * A service that handles killing tasks. This will take care about extra logic for lost tasks,
   * apply a retry strategy and throttle kill requests to Mesos.
   */
-trait TaskKillService {
+trait KillService {
   /**
     * Kill the given tasks and return a future that is completed when all of the tasks
     * have been reported as terminal.
@@ -19,7 +19,7 @@ trait TaskKillService {
     * @param reason the reason why the task shall be killed.
     * @return a future that is completed when all tasks are killed.
     */
-  def killTasks(tasks: Iterable[Instance], reason: TaskKillReason): Future[Done]
+  def killTasks(tasks: Iterable[Instance], reason: KillReason): Future[Done]
 
   /**
     * Kill the given task. The implementation should add the task onto
@@ -29,7 +29,7 @@ trait TaskKillService {
     * @param reason the reason why the task shall be killed.
     * @return a future that is completed when all tasks are killed.
     */
-  def killTask(task: Instance, reason: TaskKillReason): Future[Done]
+  def killTask(task: Instance, reason: KillReason): Future[Done]
 
   /**
     * Kill the given unknown task by ID and do not try to fetch its state
@@ -39,5 +39,5 @@ trait TaskKillService {
     * @param reason the reason why the task shall be killed.
     * @return a future that is completed when all tasks are killed.
     */
-  def killUnknownTask(taskId: Task.Id, reason: TaskKillReason): Future[Done]
+  def killUnknownTask(taskId: Task.Id, reason: KillReason): Future[Done]
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/KillService.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/KillService.scala
@@ -19,7 +19,7 @@ trait KillService {
     * @param reason the reason why the task shall be killed.
     * @return a future that is completed when all tasks are killed.
     */
-  def killTasks(tasks: Iterable[Instance], reason: KillReason): Future[Done]
+  def killInstances(tasks: Iterable[Instance], reason: KillReason): Future[Done]
 
   /**
     * Kill the given task. The implementation should add the task onto
@@ -29,7 +29,7 @@ trait KillService {
     * @param reason the reason why the task shall be killed.
     * @return a future that is completed when all tasks are killed.
     */
-  def killTask(task: Instance, reason: KillReason): Future[Done]
+  def killInstance(task: Instance, reason: KillReason): Future[Done]
 
   /**
     * Kill the given unknown task by ID and do not try to fetch its state

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
@@ -11,10 +11,9 @@ class TaskTerminationModule(
     instanceTrackerModule: InstanceTrackerModule,
     leadershipModule: LeadershipModule,
     driverHolder: MarathonSchedulerDriverHolder,
-    config: TaskKillConfig,
+    config: KillConfig,
     clock: Clock) {
 
-  private[this] lazy val instanceTracker = instanceTrackerModule.instanceTracker
   private[this] lazy val stateOpProcessor = instanceTrackerModule.stateOpProcessor
 
   private[this] lazy val taskKillServiceActorProps: Props =
@@ -23,5 +22,5 @@ class TaskTerminationModule(
   private[this] lazy val taskKillServiceActor: ActorRef =
     leadershipModule.startWhenLeader(taskKillServiceActorProps, "taskKillServiceActor")
 
-  val taskKillService: TaskKillService = new TaskKillServiceDelegate(taskKillServiceActor)
+  val taskKillService: KillService = new TaskKillServiceDelegate(taskKillServiceActor)
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
@@ -4,7 +4,7 @@ import akka.actor.{ ActorRef, Props }
 import mesosphere.marathon.MarathonSchedulerDriverHolder
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.leadership.LeadershipModule
-import mesosphere.marathon.core.task.termination.impl.{ TaskKillServiceActor, TaskKillServiceDelegate }
+import mesosphere.marathon.core.task.termination.impl.{ KillServiceActor, KillServiceDelegate }
 import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
 
 class TaskTerminationModule(
@@ -17,10 +17,10 @@ class TaskTerminationModule(
   private[this] lazy val stateOpProcessor = instanceTrackerModule.stateOpProcessor
 
   private[this] lazy val taskKillServiceActorProps: Props =
-    TaskKillServiceActor.props(driverHolder, stateOpProcessor, config, clock)
+    KillServiceActor.props(driverHolder, stateOpProcessor, config, clock)
 
   private[this] lazy val taskKillServiceActor: ActorRef =
     leadershipModule.startWhenLeader(taskKillServiceActorProps, "taskKillServiceActor")
 
-  val taskKillService: KillService = new TaskKillServiceDelegate(taskKillServiceActor)
+  val taskKillService: KillService = new KillServiceDelegate(taskKillServiceActor)
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/InstanceKillProgressActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/InstanceKillProgressActor.scala
@@ -24,7 +24,7 @@ import scala.util.Try
   * @param promise the promise that shall be completed when all instances have been
   *                reported terminal.
   */
-private[this] class TaskKillProgressActor(
+private[this] class InstanceKillProgressActor(
     ids: Iterable[Instance.Id], promise: Promise[Done]) extends Actor with ActorLogging {
   // TODO: if one of the watched instances is reported terminal before this actor subscribed to the event bus,
   //       it won't receive that event. should we reconcile instances after a certain amount of time?
@@ -79,8 +79,8 @@ private[this] class TaskKillProgressActor(
 
 }
 
-private[impl] object TaskKillProgressActor {
+private[impl] object InstanceKillProgressActor {
   def props(toKill: Iterable[Instance.Id], promise: Promise[Done]): Props = {
-    Props(new TaskKillProgressActor(toKill, promise))
+    Props(new InstanceKillProgressActor(toKill, promise))
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
@@ -14,7 +14,7 @@ private[termination] class KillServiceDelegate(actorRef: ActorRef) extends KillS
   import KillServiceDelegate.log
   import KillServiceActor._
 
-  override def killTasks(instances: Iterable[Instance], reason: KillReason): Future[Done] = {
+  override def killInstances(instances: Iterable[Instance], reason: KillReason): Future[Done] = {
     log.info(
       s"Killing ${instances.size} tasks for reason: $reason (ids: {} ...)",
       instances.take(3).map(_.instanceId).mkString(","))
@@ -25,8 +25,8 @@ private[termination] class KillServiceDelegate(actorRef: ActorRef) extends KillS
     promise.future
   }
 
-  override def killTask(instance: Instance, reason: KillReason): Future[Done] = {
-    killTasks(Seq(instance), reason)
+  override def killInstance(instance: Instance, reason: KillReason): Future[Done] = {
+    killInstances(Seq(instance), reason)
   }
 
   override def killUnknownTask(taskId: Task.Id, reason: KillReason): Future[Done] = {

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
@@ -10,10 +10,9 @@ import org.slf4j.LoggerFactory
 import scala.concurrent.{ Future, Promise }
 import scala.collection.immutable.Seq
 
-// TODO(PODS): adjust the interface to handle instances; rename etc
-private[termination] class TaskKillServiceDelegate(actorRef: ActorRef) extends KillService {
-  import TaskKillServiceDelegate.log
-  import TaskKillServiceActor._
+private[termination] class KillServiceDelegate(actorRef: ActorRef) extends KillService {
+  import KillServiceDelegate.log
+  import KillServiceActor._
 
   override def killTasks(instances: Iterable[Instance], reason: KillReason): Future[Done] = {
     log.info(
@@ -39,6 +38,6 @@ private[termination] class TaskKillServiceDelegate(actorRef: ActorRef) extends K
   }
 }
 
-object TaskKillServiceDelegate {
+object KillServiceDelegate {
   private[impl] val log = LoggerFactory.getLogger(getClass)
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillProgressActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillProgressActor.scala
@@ -2,43 +2,45 @@ package mesosphere.marathon.core.task.termination.impl
 
 import akka.Done
 import akka.actor.{ Actor, ActorLogging, Props }
-import mesosphere.marathon.KillingTasksFailedException
-import mesosphere.marathon.core.event.MesosStatusUpdateEvent
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.KillingInstancesFailedException
+import mesosphere.marathon.core.event.{ InstanceChanged, UnknownInstanceTerminated }
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.Instance.Id
 
 import scala.concurrent.Promise
 import scala.collection.mutable
 import scala.util.Try
 
 /**
-  * This actor watches over a given set of taskIds and completes a promise when
-  * all tasks have been reported terminal (including LOST et al). It also
-  * subscribes to the event bus to listen for interesting mesos task status
-  * updates related to the tasks it watches.
+  * This actor watches over a given set of instanceIds and completes a promise when
+  * all instances have been reported terminal (including LOST et al). It also
+  * subscribes to the event bus to listen for instance change updates related
+  * to the instance it watches.
   *
-  * The actor will stop itself once all watched tasks are terminal; if it is
+  * The actor will stop itself once all watched instances are terminal; if it is
   * stopped in any other way the promise will fail.
   *
-  * @param ids the taskIds that shall be watched.
-  * @param promise the promise that shall be completed when all tasks have been
+  * @param ids the instanceIds that shall be watched.
+  * @param promise the promise that shall be completed when all instances have been
   *                reported terminal.
   */
 private[this] class TaskKillProgressActor(
-    ids: Iterable[Task.Id], promise: Promise[Done]) extends Actor with ActorLogging {
-  // TODO: if one of the watched task is reported terminal before this actor subscribed to the event bus,
-  //       it won't receive that event. should we reconcile tasks after a certain amount of time?
+    ids: Iterable[Instance.Id], promise: Promise[Done]) extends Actor with ActorLogging {
+  // TODO: if one of the watched instances is reported terminal before this actor subscribed to the event bus,
+  //       it won't receive that event. should we reconcile instances after a certain amount of time?
 
-  private[this] val taskIds = mutable.HashSet[Task.Id](ids.toVector: _*)
+  private[this] val instanceIds = mutable.HashSet[Instance.Id](ids.toVector: _*)
   // this should be used for logging to prevent polluting the logs
-  private[this] val name = "TaskKillProgressActor" + self.hashCode()
+  private[this] val name = "InstanceKillProgressActor" + self.hashCode()
 
   override def preStart(): Unit = {
-    if (taskIds.nonEmpty) {
-      context.system.eventStream.subscribe(self, classOf[MesosStatusUpdateEvent])
-      log.info("Starting {} to track kill progress of {} tasks", name, taskIds.size)
+    if (instanceIds.nonEmpty) {
+      context.system.eventStream.subscribe(self, classOf[InstanceChanged])
+      context.system.eventStream.subscribe(self, classOf[UnknownInstanceTerminated])
+      log.info("Starting {} to track kill progress of {} instances", name, instanceIds.size)
     } else {
       promise.tryComplete(Try(Done))
-      log.info("premature aborting of {} - no tasks to watch for", name)
+      log.info("premature aborting of {} - no instances to watch for", name)
       context.stop(self)
     }
   }
@@ -47,30 +49,38 @@ private[this] class TaskKillProgressActor(
     context.system.eventStream.unsubscribe(self)
 
     if (!promise.isCompleted) {
-      // we don't expect to be stopped without all tasks being killed, so the promise should fail:
-      val msg = s"$name was stopped before all tasks are killed. Outstanding: ${taskIds.mkString(",")}"
+      // we don't expect to be stopped without all instances being killed, so the promise should fail:
+      val msg = s"$name was stopped before all instances are killed. Outstanding: ${instanceIds.mkString(",")}"
       log.error(msg)
-      promise.tryFailure(new KillingTasksFailedException(msg))
+      promise.tryFailure(new KillingInstancesFailedException(msg))
     }
   }
 
   override def receive: Receive = {
-    case Terminal(event) if taskIds.contains(event.taskId) =>
-      log.debug("Received terminal update for {}", event.taskId)
-      taskIds.remove(event.taskId)
-      if (taskIds.isEmpty) {
-        log.info("All tasks watched by {} are killed, completing promise", name)
-        val success = promise.tryComplete(Try(Done))
-        if (!success) log.error("Promise has already been completed in {}", name)
-        context.stop(self)
-      } else {
-        log.info("{} still waiting for {} tasks to be killed", name, taskIds.size)
-      }
+    case Terminal(event) if instanceIds.contains(event.id) =>
+      handleTerminal(event.id)
+
+    case UnknownInstanceTerminated(id, _, _) if instanceIds.contains(id) =>
+      handleTerminal(id)
   }
+
+  private[this] def handleTerminal(id: Id): Unit = {
+    log.debug("Received terminal update for {}", id)
+    instanceIds.remove(id)
+    if (instanceIds.isEmpty) {
+      log.info("All instances watched by {} are killed, completing promise", name)
+      val success = promise.tryComplete(Try(Done))
+      if (!success) log.error("Promise has already been completed in {}", name)
+      context.stop(self)
+    } else {
+      log.info("{} still waiting for {} instances to be killed", name, instanceIds.size)
+    }
+  }
+
 }
 
 private[impl] object TaskKillProgressActor {
-  def props(toKill: Iterable[Task.Id], promise: Promise[Done]): Props = {
+  def props(toKill: Iterable[Instance.Id], promise: Promise[Done]): Props = {
     Props(new TaskKillProgressActor(toKill, promise))
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceDelegate.scala
@@ -4,35 +4,34 @@ import akka.Done
 import akka.actor.ActorRef
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ Future, Promise }
+import scala.collection.immutable.Seq
 
 // TODO(PODS): adjust the interface to handle instances; rename etc
-private[termination] class TaskKillServiceDelegate(actorRef: ActorRef) extends TaskKillService {
+private[termination] class TaskKillServiceDelegate(actorRef: ActorRef) extends KillService {
   import TaskKillServiceDelegate.log
   import TaskKillServiceActor._
 
-  override def killTasks(instances: Iterable[Instance], reason: TaskKillReason): Future[Done] = {
+  override def killTasks(instances: Iterable[Instance], reason: KillReason): Future[Done] = {
     log.info(
       s"Killing ${instances.size} tasks for reason: $reason (ids: {} ...)",
       instances.take(3).map(_.instanceId).mkString(","))
 
     val promise = Promise[Done]
-    // TODO(PODS): the messages should transport instances and let the killService decide what to do with them
-    instances.foreach(instance => actorRef ! KillTasks(instance.tasks, promise))
+    instances.foreach(instance => actorRef ! KillInstances(Seq(instance), promise))
 
     promise.future
   }
 
-  override def killTask(task: Instance, reason: TaskKillReason): Future[Done] = {
-    killTasks(Seq(task), reason)
+  override def killTask(instance: Instance, reason: KillReason): Future[Done] = {
+    killTasks(Seq(instance), reason)
   }
 
-  // TODO(PODS): we might want to keep this to kill unknown tasks we receive from Mesos
-  override def killUnknownTask(taskId: Task.Id, reason: TaskKillReason): Future[Done] = {
-    log.info(s"Killing 1 unknown task for reason: $reason (id: {})", taskId)
+  override def killUnknownTask(taskId: Task.Id, reason: KillReason): Future[Done] = {
+    log.info(s"Killing unknown task for reason: $reason (id: {})", taskId)
 
     val promise = Promise[Done]
     actorRef ! KillUnknownTaskById(taskId, promise)

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/Terminal.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/Terminal.scala
@@ -1,18 +1,23 @@
 package mesosphere.marathon.core.task.termination.impl
 
-import mesosphere.marathon.core.event.MesosStatusUpdateEvent
+import mesosphere.marathon.core.event.InstanceChanged
+import mesosphere.marathon.core.instance.InstanceStatus
 
+// TODO(PODS): There are various similar Terminal extractors, Sets and functions – the NEED to be aligned
 private[impl] object Terminal {
 
-  private[this] val terminalStrings = Set(
-    "TASK_ERROR",
-    "TASK_FAILED",
-    "TASK_KILLED",
-    "TASK_FINISHED",
-    "TASK_LOST"
+  private[this] val terminalStatus = Set(
+    InstanceStatus.Error,
+    InstanceStatus.Failed,
+    InstanceStatus.Killed,
+    InstanceStatus.Finished,
+    InstanceStatus.Unreachable,
+    InstanceStatus.Unknown,
+    InstanceStatus.Gone,
+    InstanceStatus.Dropped
   )
 
-  def unapply(event: MesosStatusUpdateEvent): Option[MesosStatusUpdateEvent] = {
-    if (terminalStrings(event.taskStatus)) Some(event) else None
+  def unapply(event: InstanceChanged): Option[InstanceChanged] = {
+    if (terminalStatus(event.status)) Some(event) else None
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -26,8 +26,7 @@ class PostToEventStreamStepImpl @Inject() (eventBus: EventStream, clock: Clock) 
 
     //TODO(PODS): Would it make sense to only publish this event, if the instance state has changed?
     //We now send this event for every task update that changes the instance
-    eventBus.publish(InstanceChanged(update.id, update.runSpecVersion,
-      update.runSpecId, update.status, update.instance))
+    eventBus.publish(InstanceChanged(update))
 
     if (update.lastState.flatMap(_.healthy) != update.instance.state.healthy) {
       eventBus.publish(InstanceHealthChanged(update.id, update.runSpecVersion,

--- a/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
+++ b/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
@@ -115,7 +115,7 @@ object TaskFailure {
       apply(instanceChange)
 
     def apply(instanceChange: InstanceChanged): Option[TaskFailure] = {
-      val InstanceChanged(id, runSpecVersion, runSpecId, status, instance) = instanceChange
+      val InstanceChanged(_, runSpecVersion, runSpecId, status, instance) = instanceChange
 
       val state = taskState(status.toMesosStateName)
       val task = instance.tasks.headOption.getOrElse(throw new RuntimeException("no task in instance"))
@@ -143,10 +143,12 @@ object TaskFailure {
     mesos.TaskState.valueOf(s)
 
   // Note that this will also store taskFailures for TASK_LOST no matter the reason
+  // TODO(PODS): this must be aligned with general state handling
   private[this] def isFailureState(state: mesos.TaskState): Boolean = {
     import mesos.TaskState._
     state match {
-      case TASK_FAILED | TASK_LOST | TASK_ERROR => true
+      case TASK_FAILED | TASK_ERROR |
+        TASK_LOST | TASK_DROPPED | TASK_GONE | TASK_GONE_BY_OPERATOR | TASK_UNKNOWN => true
       case _ => false
     }
   }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -7,7 +7,7 @@ import akka.event.EventStream
 import mesosphere.marathon.SchedulerActions
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.event.{ DeploymentStatus, DeploymentStepFailure, DeploymentStepSuccess }
 import mesosphere.marathon.core.health.HealthCheckManager
@@ -26,7 +26,7 @@ private class DeploymentActor(
     deploymentManager: ActorRef,
     receiver: ActorRef,
     driver: SchedulerDriver,
-    killService: TaskKillService,
+    killService: KillService,
     scheduler: SchedulerActions,
     plan: DeploymentPlan,
     instanceTracker: InstanceTracker,
@@ -131,7 +131,7 @@ private class DeploymentActor(
       runningInstances, toKill, killToMeetConstraints, scaleTo)
 
     def killTasksIfNeeded: Future[Unit] = tasksToKill.fold(Future.successful(())) { tasks =>
-      killService.killTasks(tasks, TaskKillReason.ScalingApp).map(_ => ())
+      killService.killTasks(tasks, KillReason.ScalingApp).map(_ => ())
     }
 
     def startTasksIfNeeded: Future[Unit] = tasksToStart.fold(Future.successful(())) { _ =>
@@ -149,7 +149,7 @@ private class DeploymentActor(
   def stopRunnable(runnableSpec: RunSpec): Future[Unit] = {
     val tasks = instanceTracker.specInstancesLaunchedSync(runnableSpec.id)
     // TODO: the launch queue is purged in stopRunnable, but it would make sense to do that before calling kill(tasks)
-    killService.killTasks(tasks, TaskKillReason.DeletingApp).map(_ => ()).andThen {
+    killService.killTasks(tasks, KillReason.DeletingApp).map(_ => ()).andThen {
       case Success(_) => scheduler.stopRunSpec(runnableSpec)
     }
   }
@@ -184,7 +184,7 @@ object DeploymentActor {
     deploymentManager: ActorRef,
     receiver: ActorRef,
     driver: SchedulerDriver,
-    killService: TaskKillService,
+    killService: KillService,
     scheduler: SchedulerActions,
     plan: DeploymentPlan,
     taskTracker: InstanceTracker,

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -131,7 +131,7 @@ private class DeploymentActor(
       runningInstances, toKill, killToMeetConstraints, scaleTo)
 
     def killTasksIfNeeded: Future[Unit] = tasksToKill.fold(Future.successful(())) { tasks =>
-      killService.killTasks(tasks, KillReason.ScalingApp).map(_ => ())
+      killService.killInstances(tasks, KillReason.ScalingApp).map(_ => ())
     }
 
     def startTasksIfNeeded: Future[Unit] = tasksToStart.fold(Future.successful(())) { _ =>
@@ -149,7 +149,7 @@ private class DeploymentActor(
   def stopRunnable(runnableSpec: RunSpec): Future[Unit] = {
     val tasks = instanceTracker.specInstancesLaunchedSync(runnableSpec.id)
     // TODO: the launch queue is purged in stopRunnable, but it would make sense to do that before calling kill(tasks)
-    killService.killTasks(tasks, KillReason.DeletingApp).map(_ => ()).andThen {
+    killService.killInstances(tasks, KillReason.DeletingApp).map(_ => ()).andThen {
       case Success(_) => scheduler.stopRunSpec(runnableSpec)
     }
   }

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentManager.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentManager.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.{ ReadinessCheckExecutor, ReadinessCheckResult }
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.termination.TaskKillService
+import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state.{ Group, PathId, Timestamp }
@@ -23,7 +23,7 @@ import scala.util.control.NonFatal
 
 class DeploymentManager(
     taskTracker: InstanceTracker,
-    killService: TaskKillService,
+    killService: KillService,
     launchQueue: LaunchQueue,
     scheduler: SchedulerActions,
     storage: StorageProvider,
@@ -151,7 +151,7 @@ object DeploymentManager {
 
   def props(
     taskTracker: InstanceTracker,
-    killService: TaskKillService,
+    killService: KillService,
     launchQueue: LaunchQueue,
     scheduler: SchedulerActions,
     storage: StorageProvider,

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.InstanceStatus.Terminal
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.RunSpec
 import mesosphere.marathon.upgrade.TaskReplaceActor._
@@ -22,7 +22,7 @@ class TaskReplaceActor(
     val deploymentManager: ActorRef,
     val status: DeploymentStatus,
     val driver: SchedulerDriver,
-    val killService: TaskKillService,
+    val killService: KillService,
     val launchQueue: LaunchQueue,
     val instanceTracker: InstanceTracker,
     val eventBus: EventStream,
@@ -111,7 +111,7 @@ class TaskReplaceActor(
       }
 
       outstandingKills += nextOldInstance.instanceId
-      killService.killTask(nextOldInstance, TaskKillReason.Upgrading)
+      killService.killTask(nextOldInstance, KillReason.Upgrading)
     }
   }
 
@@ -136,7 +136,7 @@ object TaskReplaceActor {
     deploymentManager: ActorRef,
     status: DeploymentStatus,
     driver: SchedulerDriver,
-    killService: TaskKillService,
+    killService: KillService,
     launchQueue: LaunchQueue,
     instanceTracker: InstanceTracker,
     eventBus: EventStream,

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -111,7 +111,7 @@ class TaskReplaceActor(
       }
 
       outstandingKills += nextOldInstance.instanceId
-      killService.killTask(nextOldInstance, KillReason.Upgrading)
+      killService.killInstance(nextOldInstance, KillReason.Upgrading)
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -18,7 +18,7 @@ import mesosphere.marathon.core.launcher.impl.LaunchQueueTestHelper
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.core.task.{ Task, TaskKillServiceMock }
+import mesosphere.marathon.core.task.{ Task, KillServiceMock }
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
@@ -504,7 +504,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     val deploymentRepo: DeploymentRepository = mock[DeploymentRepository]
     val hcManager: HealthCheckManager = mock[HealthCheckManager]
     val instanceTracker: InstanceTracker = mock[InstanceTracker]
-    val killService = new TaskKillServiceMock(system)
+    val killService = new KillServiceMock(system)
     val queue: LaunchQueue = mock[LaunchQueue]
     val frameworkIdRepo: FrameworkIdRepository = mock[FrameworkIdRepository]
     val driver: SchedulerDriver = mock[SchedulerDriver]

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -99,7 +99,7 @@ class SchedulerActionsTest
 
     f.scheduler.reconcileTasks(f.driver).futureValue(5.seconds)
 
-    verify(f.killService, times(1)).killTask(orphanedTask, KillReason.Orphaned)
+    verify(f.killService, times(1)).killInstance(orphanedTask, KillReason.Orphaned)
   }
 
   test("Scale up correctly in case of lost tasks (active queue)") {
@@ -181,7 +181,7 @@ class SchedulerActionsTest
     verify(f.queue, times(1)).purge(app.id)
 
     And("the youngest STAGED tasks are killed")
-    verify(f.killService).killTasks(List(staged_3, staged_2), KillReason.ScalingApp)
+    verify(f.killService).killInstances(List(staged_3, staged_2), KillReason.ScalingApp)
     verifyNoMoreInteractions(f.driver)
     verifyNoMoreInteractions(f.killService)
   }
@@ -217,7 +217,7 @@ class SchedulerActionsTest
     verify(f.queue, times(1)).purge(app.id)
 
     And("the youngest RUNNING tasks are killed")
-    verify(f.killService).killTasks(List(running_7, running_6), KillReason.ScalingApp)
+    verify(f.killService).killInstances(List(running_7, running_6), KillReason.ScalingApp)
     verifyNoMoreInteractions(f.driver)
     verifyNoMoreInteractions(f.killService)
   }
@@ -261,7 +261,7 @@ class SchedulerActionsTest
     verify(f.queue, times(1)).purge(app.id)
 
     And("all STAGED tasks plus the youngest RUNNING tasks are killed")
-    verify(f.killService).killTasks(List(staged_1, running_4), KillReason.ScalingApp)
+    verify(f.killService).killInstances(List(staged_1, running_4), KillReason.ScalingApp)
     verifyNoMoreInteractions(f.driver)
     verifyNoMoreInteractions(f.killService)
   }

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfo
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.{ SpecInstances, InstancesBySpec }
 import mesosphere.marathon.state.{ AppDefinition, PathId }
@@ -99,7 +99,7 @@ class SchedulerActionsTest
 
     f.scheduler.reconcileTasks(f.driver).futureValue(5.seconds)
 
-    verify(f.killService, times(1)).killTask(orphanedTask, TaskKillReason.Orphaned)
+    verify(f.killService, times(1)).killTask(orphanedTask, KillReason.Orphaned)
   }
 
   test("Scale up correctly in case of lost tasks (active queue)") {
@@ -181,7 +181,7 @@ class SchedulerActionsTest
     verify(f.queue, times(1)).purge(app.id)
 
     And("the youngest STAGED tasks are killed")
-    verify(f.killService).killTasks(List(staged_3, staged_2), TaskKillReason.ScalingApp)
+    verify(f.killService).killTasks(List(staged_3, staged_2), KillReason.ScalingApp)
     verifyNoMoreInteractions(f.driver)
     verifyNoMoreInteractions(f.killService)
   }
@@ -217,7 +217,7 @@ class SchedulerActionsTest
     verify(f.queue, times(1)).purge(app.id)
 
     And("the youngest RUNNING tasks are killed")
-    verify(f.killService).killTasks(List(running_7, running_6), TaskKillReason.ScalingApp)
+    verify(f.killService).killTasks(List(running_7, running_6), KillReason.ScalingApp)
     verifyNoMoreInteractions(f.driver)
     verifyNoMoreInteractions(f.killService)
   }
@@ -261,7 +261,7 @@ class SchedulerActionsTest
     verify(f.queue, times(1)).purge(app.id)
 
     And("all STAGED tasks plus the youngest RUNNING tasks are killed")
-    verify(f.killService).killTasks(List(staged_1, running_4), TaskKillReason.ScalingApp)
+    verify(f.killService).killTasks(List(staged_1, running_4), KillReason.ScalingApp)
     verifyNoMoreInteractions(f.driver)
     verifyNoMoreInteractions(f.killService)
   }
@@ -277,7 +277,7 @@ class SchedulerActionsTest
     val podRepo: ReadOnlyPodRepository = mock[ReadOnlyPodRepository]
     val taskTracker = mock[InstanceTracker]
     val driver = mock[SchedulerDriver]
-    val killService = mock[TaskKillService]
+    val killService = mock[KillService]
     val clock = ConstantClock()
 
     podRepo.ids() returns Source.empty[PathId]

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
@@ -4,7 +4,7 @@ import akka.actor.{ ActorSystem, Props }
 import akka.testkit._
 import mesosphere.marathon._
 import mesosphere.marathon.core.health.{ Health, HealthCheck, MarathonHttpHealthCheck }
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
@@ -77,7 +77,7 @@ class HealthCheckActorTest
     val actor = f.actor(MarathonHttpHealthCheck(maxConsecutiveFailures = 3, portIndex = Some(0)))
 
     actor.underlyingActor.checkConsecutiveFailures(f.task, Health(f.task.taskId, consecutiveFailures = 3))
-    verify(f.killService).killTask(f.task, TaskKillReason.FailedHealthChecks)
+    verify(f.killService).killTask(f.task, KillReason.FailedHealthChecks)
     verifyNoMoreInteractions(f.tracker, f.driver, f.scheduler)
   }
 
@@ -100,7 +100,7 @@ class HealthCheckActorTest
     val driver = mock[SchedulerDriver]
     holder.driver = Some(driver)
     when(appRepository.getVersion(appId, appVersion.toOffsetDateTime)).thenReturn(Future.successful(Some(app)))
-    val killService: TaskKillService = mock[TaskKillService]
+    val killService: KillService = mock[KillService]
     when(appRepository.getVersion(appId, appVersion.toOffsetDateTime)).thenReturn(Future.successful(Some(app)))
 
     val taskId = "test_task.9876543"

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
@@ -77,7 +77,7 @@ class HealthCheckActorTest
     val actor = f.actor(MarathonHttpHealthCheck(maxConsecutiveFailures = 3, portIndex = Some(0)))
 
     actor.underlyingActor.checkConsecutiveFailures(f.task, Health(f.task.taskId, consecutiveFailures = 3))
-    verify(f.killService).killTask(f.task, KillReason.FailedHealthChecks)
+    verify(f.killService).killInstance(f.task, KillReason.FailedHealthChecks)
     verifyNoMoreInteractions(f.tracker, f.driver, f.scheduler)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -13,7 +13,7 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.leadership.{ AlwaysElectedLeadershipModule, LeadershipModule }
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
-import mesosphere.marathon.core.task.termination.TaskKillService
+import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.{ InstanceCreationHandler, InstanceTracker, TaskStateOpProcessor }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.metrics.Metrics
@@ -74,7 +74,7 @@ class MarathonHealthCheckManagerTest
 
     eventStream = new EventStream(system)
 
-    val killService = mock[TaskKillService]
+    val killService = mock[KillService]
     hcManager = new MarathonHealthCheckManager(
       system,
       killService,

--- a/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
@@ -5,7 +5,7 @@ import akka.actor.ActorSystem
 import mesosphere.marathon.core.event.InstanceChanged
 import mesosphere.marathon.core.instance.{ InstanceStatus, Instance }
 import mesosphere.marathon.core.task.Task.Id
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.test.Mockito
 
@@ -13,21 +13,21 @@ import scala.collection.mutable
 import scala.concurrent.Future
 
 /**
-  * A Mocked TaskKillService that publishes a TASK_KILLED event for each given task and always works successfully
+  * A Mocked KillService that publishes a TASK_KILLED event for each given task and always works successfully
   */
-class TaskKillServiceMock(system: ActorSystem) extends TaskKillService with Mockito {
+class KillServiceMock(system: ActorSystem) extends KillService with Mockito {
 
   var numKilled = 0
   val customStatusUpdates = mutable.Map.empty[Instance.Id, InstanceChanged]
   val killed = mutable.Set.empty[Instance.Id]
 
-  override def killTasks(instances: Iterable[Instance], reason: TaskKillReason): Future[Done] = {
+  override def killTasks(instances: Iterable[Instance], reason: KillReason): Future[Done] = {
     instances.foreach { instance =>
       killTask(instance, reason)
     }
     Future.successful(Done)
   }
-  override def killTask(instance: Instance, reason: TaskKillReason): Future[Done] = {
+  override def killTask(instance: Instance, reason: KillReason): Future[Done] = {
     val id = instance.instanceId
     val runSpecId = id.runSpecId
     //val update = customStatusUpdates.getOrElse(instanceId, MesosStatusUpdateEvent("", instanceId, "TASK_KILLED", "", appId, "", None, Nil, "no-version"))
@@ -38,7 +38,7 @@ class TaskKillServiceMock(system: ActorSystem) extends TaskKillService with Mock
     Future.successful(Done)
   }
 
-  override def killUnknownTask(taskId: Id, reason: TaskKillReason): Future[Done] = {
+  override def killUnknownTask(taskId: Id, reason: KillReason): Future[Done] = {
     val instance = mock[Instance]
     instance.instanceId returns taskId.instanceId
     killTask(instance, reason)

--- a/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
@@ -21,13 +21,13 @@ class KillServiceMock(system: ActorSystem) extends KillService with Mockito {
   val customStatusUpdates = mutable.Map.empty[Instance.Id, InstanceChanged]
   val killed = mutable.Set.empty[Instance.Id]
 
-  override def killTasks(instances: Iterable[Instance], reason: KillReason): Future[Done] = {
+  override def killInstances(instances: Iterable[Instance], reason: KillReason): Future[Done] = {
     instances.foreach { instance =>
-      killTask(instance, reason)
+      killInstance(instance, reason)
     }
     Future.successful(Done)
   }
-  override def killTask(instance: Instance, reason: KillReason): Future[Done] = {
+  override def killInstance(instance: Instance, reason: KillReason): Future[Done] = {
     val id = instance.instanceId
     val runSpecId = id.runSpecId
     //val update = customStatusUpdates.getOrElse(instanceId, MesosStatusUpdateEvent("", instanceId, "TASK_KILLED", "", appId, "", None, Nil, "no-version"))
@@ -41,7 +41,7 @@ class KillServiceMock(system: ActorSystem) extends KillService with Mockito {
   override def killUnknownTask(taskId: Id, reason: KillReason): Future[Done] = {
     val instance = mock[Instance]
     instance.instanceId returns taskId.instanceId
-    killTask(instance, reason)
+    killInstance(instance, reason)
   }
 }
 

--- a/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon
 import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.core.task.tracker.{ InstanceTracker, TaskReservationTimeoutHandler }
 import mesosphere.marathon.core.task.Task
@@ -26,7 +26,7 @@ class OverdueTasksActorTest extends MarathonSpec with GivenWhenThen with maratho
   var taskTracker: InstanceTracker = _
   var taskReservationTimeoutHandler: TaskReservationTimeoutHandler = _
   var driver: SchedulerDriver = _
-  var killService: TaskKillService = _
+  var killService: KillService = _
   var checkActor: ActorRef = _
   val clock = ConstantClock()
 
@@ -35,7 +35,7 @@ class OverdueTasksActorTest extends MarathonSpec with GivenWhenThen with maratho
     taskTracker = mock[InstanceTracker]
     taskReservationTimeoutHandler = mock[TaskReservationTimeoutHandler]
     driver = mock[SchedulerDriver]
-    killService = mock[TaskKillService]
+    killService = mock[KillService]
     val driverHolder = new MarathonSchedulerDriverHolder()
     driverHolder.driver = Some(driver)
     val config = MarathonTestHelper.defaultConfig()
@@ -88,7 +88,7 @@ class OverdueTasksActorTest extends MarathonSpec with GivenWhenThen with maratho
 
     Then("the task kill gets initiated")
     verify(taskTracker, Mockito.timeout(1000)).instancesBySpec()(any[ExecutionContext])
-    verify(killService, Mockito.timeout(1000)).killTask(mockInstance, TaskKillReason.Overdue)
+    verify(killService, Mockito.timeout(1000)).killTask(mockInstance, KillReason.Overdue)
   }
 
   // sounds strange, but this is how it currently works: determineOverdueTasks will consider a missing startedAt to
@@ -151,9 +151,9 @@ class OverdueTasksActorTest extends MarathonSpec with GivenWhenThen with maratho
     verify(taskTracker).instancesBySpec()(any[ExecutionContext])
 
     And("All somehow overdue tasks are killed")
-    verify(killService).killTask(unconfirmedOverdueTask, TaskKillReason.Overdue)
-    verify(killService).killTask(overdueUnstagedTask, TaskKillReason.Overdue)
-    verify(killService).killTask(overdueStagedTask, TaskKillReason.Overdue)
+    verify(killService).killTask(unconfirmedOverdueTask, KillReason.Overdue)
+    verify(killService).killTask(overdueUnstagedTask, KillReason.Overdue)
+    verify(killService).killTask(overdueStagedTask, KillReason.Overdue)
 
     And("but not more")
     verifyNoMoreInteractions(driver)

--- a/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
@@ -88,7 +88,7 @@ class OverdueTasksActorTest extends MarathonSpec with GivenWhenThen with maratho
 
     Then("the task kill gets initiated")
     verify(taskTracker, Mockito.timeout(1000)).instancesBySpec()(any[ExecutionContext])
-    verify(killService, Mockito.timeout(1000)).killTask(mockInstance, KillReason.Overdue)
+    verify(killService, Mockito.timeout(1000)).killInstance(mockInstance, KillReason.Overdue)
   }
 
   // sounds strange, but this is how it currently works: determineOverdueTasks will consider a missing startedAt to
@@ -151,9 +151,9 @@ class OverdueTasksActorTest extends MarathonSpec with GivenWhenThen with maratho
     verify(taskTracker).instancesBySpec()(any[ExecutionContext])
 
     And("All somehow overdue tasks are killed")
-    verify(killService).killTask(unconfirmedOverdueTask, KillReason.Overdue)
-    verify(killService).killTask(overdueUnstagedTask, KillReason.Overdue)
-    verify(killService).killTask(overdueStagedTask, KillReason.Overdue)
+    verify(killService).killInstance(unconfirmedOverdueTask, KillReason.Overdue)
+    verify(killService).killInstance(overdueUnstagedTask, KillReason.Overdue)
+    verify(killService).killInstance(overdueStagedTask, KillReason.Overdue)
 
     And("but not more")
     verifyNoMoreInteractions(driver)

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
+class KillServiceActorTest extends TestKit(ActorSystem("test"))
     with FunSuiteLike
     with BeforeAndAfterAll
     with BeforeAndAfterEach
@@ -37,7 +37,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     with Mockito
     with InstanceConversions {
 
-  import TaskKillServiceActorTest.log
+  import KillServiceActorTest.log
 
   // TODO(PODS): verify this test is still flaky https://github.com/mesosphere/marathon/issues/4202
   test("Kill single known instance") {
@@ -49,7 +49,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill that task")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillInstances(Seq(task), promise)
+    actor ! KillServiceActor.KillInstances(Seq(task), promise)
 
     Then("a kill is issued to the driver")
     verify(f.driver, timeout(500)).killTask(task.taskId.mesosTaskId)
@@ -71,7 +71,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill that taskId")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillUnknownTaskById(taskId, promise)
+    actor ! KillServiceActor.KillUnknownTaskById(taskId, promise)
 
     Then("a kill is issued to the driver")
     verify(f.driver, timeout(500)).killTask(taskId.mesosTaskId)
@@ -93,7 +93,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill that task")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillInstances(Seq(task), promise)
+    actor ! KillServiceActor.KillInstances(Seq(task), promise)
 
     Then("NO kill is issued to the driver because the task is lost")
     noMoreInteractions(f.driver)
@@ -120,7 +120,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill those tasks")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillInstances(Seq(runningTask, lostTask, stagingTask), promise)
+    actor ! KillServiceActor.KillInstances(Seq(runningTask, lostTask, stagingTask), promise)
 
     Then("three kill requests are issued to the driver")
     verify(f.driver, timeout(500)).killTask(runningTask.taskId.mesosTaskId)
@@ -146,7 +146,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill those tasks")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillInstances(emptyList, promise)
+    actor ! KillServiceActor.KillInstances(emptyList, promise)
 
     Then("the promise is eventually completed successfully")
     promise.future.futureValue should be (Done)
@@ -170,9 +170,9 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     val promise3 = Promise[Done]()
 
     When("the service is asked subsequently to kill those tasks")
-    actor ! TaskKillServiceActor.KillInstances(Seq(task1), promise1)
-    actor ! TaskKillServiceActor.KillInstances(Seq(task2), promise2)
-    actor ! TaskKillServiceActor.KillInstances(Seq(task3), promise3)
+    actor ! KillServiceActor.KillInstances(Seq(task1), promise1)
+    actor ! KillServiceActor.KillInstances(Seq(task2), promise2)
+    actor ! KillServiceActor.KillInstances(Seq(task3), promise3)
 
     Then("exactly 3 kills are issued to the driver")
     verify(f.driver, timeout(500)).killTask(task1.taskId.mesosTaskId)
@@ -204,7 +204,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     instances.keys.foreach(println(_))
     When("the service is asked to kill those instances")
     instances.values.foreach { instance =>
-      actor ! TaskKillServiceActor.KillInstances(Seq(instance), Promise[Done]())
+      actor ! KillServiceActor.KillInstances(Seq(instance), Promise[Done]())
     }
 
     Then("5 kills are issued immediately to the driver")
@@ -236,7 +236,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill those tasks")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillInstances(tasks.values, promise)
+    actor ! KillServiceActor.KillInstances(tasks.values, promise)
 
     Then("5 kills are issued immediately to the driver")
     val captor: ArgumentCaptor[mesos.Protos.TaskID] = ArgumentCaptor.forClass(classOf[mesos.Protos.TaskID])
@@ -264,7 +264,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     val promise = Promise[Done]()
 
     When("the service is asked to kill that task")
-    actor ! TaskKillServiceActor.KillInstances(Seq(task), promise)
+    actor ! KillServiceActor.KillInstances(Seq(task), promise)
 
     Then("a kill is issued to the driver")
     verify(f.driver, timeout(500)).killTask(task.taskId.mesosTaskId)
@@ -293,7 +293,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
   }
 
   override protected def afterEach(): Unit = {
-    import TaskKillServiceActorTest._
+    import KillServiceActorTest._
     actor match {
       case Some(actorRef) => system.stop(actorRef)
       case _ =>
@@ -330,8 +330,8 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     val clock = ConstantClock()
 
     def createTaskKillActor(config: KillConfig = defaultConfig): ActorRef = {
-      import TaskKillServiceActorTest._
-      val actorRef: ActorRef = TestActorRef(TaskKillServiceActor.props(driverHolder, stateOpProcessor, config, clock), parent.ref, "KillService")
+      import KillServiceActorTest._
+      val actorRef: ActorRef = TestActorRef(KillServiceActor.props(driverHolder, stateOpProcessor, config, clock), parent.ref, "KillService")
       actor = Some(actorRef)
       actorRef
     }
@@ -357,7 +357,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
   }
 }
 
-object TaskKillServiceActorTest {
+object KillServiceActorTest {
   val log = LoggerFactory.getLogger(getClass)
   var actor: Option[ActorRef] = None
 }

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActorTest.scala
@@ -3,13 +3,15 @@ package mesosphere.marathon.core.task.termination.impl
 import akka.Done
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.testkit.{ ImplicitSender, TestActorRef, TestKit, TestProbe }
-import mesosphere.marathon.{ InstanceConversions, MarathonSchedulerDriverHolder }
+import mesosphere.marathon.{ InstanceConversions, MarathonSchedulerDriverHolder, MarathonTestHelper }
 import mesosphere.marathon.core.base.ConstantClock
-import mesosphere.marathon.core.event.MesosStatusUpdateEvent
-import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
-import mesosphere.marathon.core.task.termination.TaskKillConfig
-import mesosphere.marathon.core.task.tracker.{ InstanceTracker, TaskStateOpProcessor }
-import mesosphere.marathon.core.task.{ MarathonTaskStatus, Task }
+import mesosphere.marathon.core.event.{ InstanceChanged, UnknownInstanceTerminated }
+import mesosphere.marathon.core.instance.{ Instance, InstanceStatus }
+import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceUpdateOperation }
+import mesosphere.marathon.core.task.termination.KillConfig
+import mesosphere.marathon.core.task.tracker.TaskStateOpProcessor
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.test.Mockito
 import org.apache.mesos
@@ -37,7 +39,8 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
   import TaskKillServiceActorTest.log
 
-  ignore("Kill single known task - https://github.com/mesosphere/marathon/issues/4202") {
+  // TODO(PODS): verify this test is still flaky https://github.com/mesosphere/marathon/issues/4202
+  test("Kill single known instance") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
@@ -46,19 +49,19 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill that task")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillTasks(Seq(task), promise)
+    actor ! TaskKillServiceActor.KillInstances(Seq(task), promise)
 
     Then("a kill is issued to the driver")
     verify(f.driver, timeout(500)).killTask(task.taskId.mesosTaskId)
 
     When("a terminal status update is published via the event stream")
-    f.publishStatusUpdate(task.taskId, mesos.Protos.TaskState.TASK_KILLED)
+    f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(task).wrapped)
 
     Then("the promise is eventually completed successfully")
     promise.future.futureValue should be (Done)
   }
 
-  test("Kill unknown task") {
+  test("Kill unknown instance") {
     // TODO
     val f = new Fixture
     val actor = f.createTaskKillActor()
@@ -70,21 +73,18 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     val promise = Promise[Done]()
     actor ! TaskKillServiceActor.KillUnknownTaskById(taskId, promise)
 
-    Then("it will not fetch the task from the taskTracker")
-    noMoreInteractions(f.taskTracker)
-
-    And("a kill is issued to the driver")
+    Then("a kill is issued to the driver")
     verify(f.driver, timeout(500)).killTask(taskId.mesosTaskId)
     noMoreInteractions(f.driver)
 
-    When("a terminal status update is published via the event stream")
-    f.publishStatusUpdate(taskId, mesos.Protos.TaskState.TASK_KILLED)
+    When("an event is published indicating the unknown instance terminal")
+    f.publishUnknownInstanceTerminated(taskId.instanceId)
 
     Then("the promise is eventually completed successfully")
     promise.future.futureValue should be (Done)
   }
 
-  test("Kill single known LOST task") {
+  test("Kill single known LOST instance") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
@@ -93,7 +93,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill that task")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillTasks(Seq(task), promise)
+    actor ! TaskKillServiceActor.KillInstances(Seq(task), promise)
 
     Then("NO kill is issued to the driver because the task is lost")
     noMoreInteractions(f.driver)
@@ -102,13 +102,14 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     verify(f.stateOpProcessor, timeout(500)).process(InstanceUpdateOperation.ForceExpunge(task.taskId))
 
     When("a terminal status update is published via the event stream")
-    f.publishStatusUpdate(task.taskId, mesos.Protos.TaskState.TASK_KILLED)
+    f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(task).wrapped)
 
     Then("the promise is eventually completed successfully")
     promise.future.futureValue should be (Done)
   }
 
-  ignore("kill multiple tasks at once - https://github.com/mesosphere/marathon/issues/4202") {
+  // TODO(PODS): verify this test is still flaky https://github.com/mesosphere/marathon/issues/4202
+  test("kill multiple instances at once") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
@@ -119,21 +120,18 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill those tasks")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillTasks(Seq(runningTask, lostTask, stagingTask), promise)
+    actor ! TaskKillServiceActor.KillInstances(Seq(runningTask, lostTask, stagingTask), promise)
 
-    Then("the task tracker is not queried")
-    noMoreInteractions(f.taskTracker)
-
-    And("three kill requests are issued to the driver")
+    Then("three kill requests are issued to the driver")
     verify(f.driver, timeout(500)).killTask(runningTask.taskId.mesosTaskId)
     verify(f.stateOpProcessor, timeout(500)).process(InstanceUpdateOperation.ForceExpunge(lostTask.taskId))
     verify(f.driver, timeout(500)).killTask(stagingTask.taskId.mesosTaskId)
     noMoreInteractions(f.driver)
 
     And("Eventually terminal status updates are published via the event stream")
-    f.publishStatusUpdate(runningTask.taskId, mesos.Protos.TaskState.TASK_KILLED)
-    f.publishStatusUpdate(lostTask.taskId, mesos.Protos.TaskState.TASK_LOST)
-    f.publishStatusUpdate(stagingTask.taskId, mesos.Protos.TaskState.TASK_LOST)
+    f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(runningTask).wrapped)
+    f.publishInstanceChanged(TaskStatusUpdateTestHelper.unreachable(lostTask).wrapped)
+    f.publishInstanceChanged(TaskStatusUpdateTestHelper.unreachable(stagingTask).wrapped)
 
     Then("the promise is eventually completed successfully")
     promise.future.futureValue should be (Done)
@@ -148,19 +146,17 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill those tasks")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillTasks(emptyList, promise)
+    actor ! TaskKillServiceActor.KillInstances(emptyList, promise)
 
     Then("the promise is eventually completed successfully")
     promise.future.futureValue should be (Done)
 
-    And("the task tracker is not queried")
-    noMoreInteractions(f.taskTracker)
-
-    And("no kill is issued")
+    Then("no kill is issued")
     noMoreInteractions(f.driver)
   }
 
-  ignore("kill multiple tasks subsequently - https://github.com/mesosphere/marathon/issues/4202") {
+  // TODO(PODS): verify this test is still flaky https://github.com/mesosphere/marathon/issues/4202
+  test("kill multiple instances subsequently") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
@@ -174,9 +170,9 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     val promise3 = Promise[Done]()
 
     When("the service is asked subsequently to kill those tasks")
-    actor ! TaskKillServiceActor.KillTasks(Seq(task1), promise1)
-    actor ! TaskKillServiceActor.KillTasks(Seq(task2), promise2)
-    actor ! TaskKillServiceActor.KillTasks(Seq(task3), promise3)
+    actor ! TaskKillServiceActor.KillInstances(Seq(task1), promise1)
+    actor ! TaskKillServiceActor.KillInstances(Seq(task2), promise2)
+    actor ! TaskKillServiceActor.KillInstances(Seq(task3), promise3)
 
     Then("exactly 3 kills are issued to the driver")
     verify(f.driver, timeout(500)).killTask(task1.taskId.mesosTaskId)
@@ -185,9 +181,9 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     noMoreInteractions(f.driver)
 
     And("Eventually terminal status updates are published via the event stream")
-    f.publishStatusUpdate(task1.taskId, mesos.Protos.TaskState.TASK_KILLED)
-    f.publishStatusUpdate(task2.taskId, mesos.Protos.TaskState.TASK_KILLED)
-    f.publishStatusUpdate(task3.taskId, mesos.Protos.TaskState.TASK_KILLED)
+    f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(task1).wrapped)
+    f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(task2).wrapped)
+    f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(task3).wrapped)
 
     Then("the promises are eventually are completed successfully")
     promise1.future.futureValue should be (Done)
@@ -195,19 +191,20 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     promise3.future.futureValue should be (Done)
   }
 
-  test("killing tasks is throttled (single requests)") {
+  test("killing instances is throttled (single requests)") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
-    Given("multiple tasks")
-    val tasks: Map[Task.Id, Task] = (1 to 10).map { index =>
-      val task = f.mockTask(Task.Id.forRunSpec(f.appId), f.now(), mesos.Protos.TaskState.TASK_RUNNING)
-      task.taskId -> task
+    Given("multiple instances")
+    val instances: Map[Instance.Id, Instance] = (1 to 10).map { index =>
+      val instance: Instance = f.mockTask(Task.Id.forRunSpec(f.appId), f.now(), mesos.Protos.TaskState.TASK_RUNNING)
+      instance.instanceId -> instance
     }(collection.breakOut)
 
-    When("the service is asked to kill those tasks")
-    tasks.values.foreach { task =>
-      actor ! TaskKillServiceActor.KillTasks(Seq(task), Promise[Done]())
+    instances.keys.foreach(println(_))
+    When("the service is asked to kill those instances")
+    instances.values.foreach { instance =>
+      actor ! TaskKillServiceActor.KillInstances(Seq(instance), Promise[Done]())
     }
 
     Then("5 kills are issued immediately to the driver")
@@ -215,11 +212,11 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     verify(f.driver, timeout(5000).times(5)).killTask(captor.capture())
     reset(f.driver)
 
-    And("after receiving terminal messages for the requested kills, 5 additional tasks are killed")
+    And("after receiving terminal messages for the requested kills, 5 additional instances are killed")
     captor.getAllValues.asScala.foreach { id =>
       val taskId = Task.Id(id)
-      tasks.get(taskId).foreach { task =>
-        f.publishStatusUpdate(task.taskId, mesos.Protos.TaskState.TASK_KILLED)
+      instances.get(taskId.instanceId).foreach { instance =>
+        f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(instance).wrapped)
       }
     }
 
@@ -227,7 +224,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     noMoreInteractions(f.driver)
   }
 
-  test("killing tasks is throttled (batch request)") {
+  test("killing instances is throttled (batch request)") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
@@ -239,7 +236,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
 
     When("the service is asked to kill those tasks")
     val promise = Promise[Done]()
-    actor ! TaskKillServiceActor.KillTasks(tasks.values, promise)
+    actor ! TaskKillServiceActor.KillInstances(tasks.values, promise)
 
     Then("5 kills are issued immediately to the driver")
     val captor: ArgumentCaptor[mesos.Protos.TaskID] = ArgumentCaptor.forClass(classOf[mesos.Protos.TaskID])
@@ -250,7 +247,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     captor.getAllValues.asScala.foreach { id =>
       val taskId = Task.Id(id)
       tasks.get(taskId).foreach { task =>
-        f.publishStatusUpdate(task.taskId, mesos.Protos.TaskState.TASK_KILLED)
+        f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(task).wrapped)
       }
     }
 
@@ -267,7 +264,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     val promise = Promise[Done]()
 
     When("the service is asked to kill that task")
-    actor ! TaskKillServiceActor.KillTasks(Seq(task), promise)
+    actor ! TaskKillServiceActor.KillInstances(Seq(task), promise)
 
     Then("a kill is issued to the driver")
     verify(f.driver, timeout(500)).killTask(task.taskId.mesosTaskId)
@@ -285,7 +282,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     verify(f.stateOpProcessor, timeout(1000)).process(InstanceUpdateOperation.ForceExpunge(task.taskId))
 
     When("a terminal status update is published via the event stream")
-    f.publishStatusUpdate(task.taskId, mesos.Protos.TaskState.TASK_KILLED)
+    f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(task).wrapped)
 
     Then("the promise is eventually completed successfully")
     promise.future.futureValue should be (Done)
@@ -312,19 +309,18 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     import scala.concurrent.duration._
 
     val appId = PathId("/test")
-    val taskTracker: InstanceTracker = mock[InstanceTracker]
     val driver = mock[SchedulerDriver]
     val driverHolder: MarathonSchedulerDriverHolder = {
       val holder = new MarathonSchedulerDriverHolder
       holder.driver = Some(driver)
       holder
     }
-    val defaultConfig: TaskKillConfig = new TaskKillConfig {
+    val defaultConfig: KillConfig = new KillConfig {
       override lazy val killChunkSize: Int = 5
       override lazy val killRetryTimeout: FiniteDuration = 10.minutes
       override lazy val killRetryMax: Int = 5
     }
-    val retryConfig: TaskKillConfig = new TaskKillConfig {
+    val retryConfig: KillConfig = new KillConfig {
       override lazy val killChunkSize: Int = 5
       override lazy val killRetryTimeout: FiniteDuration = 500.millis
       override lazy val killRetryMax: Int = 1
@@ -333,36 +329,30 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     val parent = TestProbe()
     val clock = ConstantClock()
 
-    def createTaskKillActor(config: TaskKillConfig = defaultConfig): ActorRef = {
+    def createTaskKillActor(config: KillConfig = defaultConfig): ActorRef = {
       import TaskKillServiceActorTest._
-      val actorRef: ActorRef = TestActorRef(TaskKillServiceActor.props(driverHolder, stateOpProcessor, config, clock), parent.ref, "TaskKillService")
+      val actorRef: ActorRef = TestActorRef(TaskKillServiceActor.props(driverHolder, stateOpProcessor, config, clock), parent.ref, "KillService")
       actor = Some(actorRef)
       actorRef
     }
 
     def mockTask(taskId: Task.Id, stagedAt: Timestamp, mesosState: mesos.Protos.TaskState): Task.LaunchedEphemeral = {
-      val status: Task.Status = mock[Task.Status]
-      status.stagedAt returns stagedAt
-      val mesosStatus: mesos.Protos.TaskStatus = mesos.Protos.TaskStatus.newBuilder()
-        .setState(mesosState)
-        .buildPartial()
-      val task = mock[Task.LaunchedEphemeral]
-      task.taskId returns taskId
-      task.status returns status
-      task.mesosStatus returns Some(mesosStatus)
-      status.taskStatus returns MarathonTaskStatus(mesosStatus)
-      task
+      val mesosStatus = MarathonTestHelper.statusForState(taskId.idString, mesosState)
+      MarathonTestHelper.minimalTask(taskId, stagedAt, Some(mesosStatus))
     }
+
     def now(): Timestamp = Timestamp(0)
-    def publishStatusUpdate(taskId: Task.Id, state: mesos.Protos.TaskState): Unit = {
-      val appId = taskId.runSpecId
-      val statusUpdateEvent =
-        MesosStatusUpdateEvent(
-          slaveId = "", taskId = taskId, taskStatus = state.toString, message = "", appId = appId, host = "",
-          ipAddresses = None, ports = Nil, version = "version"
-        )
-      log.info("publish {} on the event stream", statusUpdateEvent)
-      system.eventStream.publish(statusUpdateEvent)
+
+    def publishInstanceChanged(instanceChange: InstanceChange): Unit = {
+      val instanceChangedEvent = InstanceChanged(instanceChange)
+      log.info("publish {} on the event stream", instanceChangedEvent)
+      system.eventStream.publish(instanceChangedEvent)
+    }
+
+    def publishUnknownInstanceTerminated(instanceId: Instance.Id): Unit = {
+      val event = UnknownInstanceTerminated(instanceId, instanceId.runSpecId, InstanceStatus.Killed)
+      log.info("publish {} on the event stream", event)
+      system.eventStream.publish(event)
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
@@ -105,10 +105,11 @@ class InstanceTrackerActorTest
 
     When("staged task gets deleted")
     val probe = TestProbe()
-    val stagedUpdate = TaskStatusUpdateTestHelper.killed(stagedTask).effect
+    val helper = TaskStatusUpdateTestHelper.killed(stagedTask)
+    val stagedUpdate = helper.effect
     val stagedAck = InstanceTrackerActor.Ack(probe.ref, stagedUpdate)
     probe.send(f.taskTrackerActor, InstanceTrackerActor.StateChanged(stagedAck))
-    probe.expectMsg(InstanceUpdateEffect.Expunge(stagedTask))
+    probe.expectMsg(InstanceUpdateEffect.Expunge(helper.wrapped.instance))
 
     Then("it will have set the correct metric counts")
     f.actorMetrics.runningCount.getValue should be(2)

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.codahale.metrics.MetricRegistry
 import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.instance.update.{ InstanceUpdateEffect, InstanceUpdateOperation }
-import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
+import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.core.task.tracker.{ InstanceTracker, TaskStateOpProcessor }
 import mesosphere.marathon.core.task.Task
@@ -75,7 +75,7 @@ class TaskStatusUpdateProcessorImplTest
     verify(f.taskTracker).instance(instanceId)
 
     And("the task kill gets initiated")
-    verify(f.killService).killUnknownTask(taskToUpdate.taskId, TaskKillReason.Unknown)
+    verify(f.killService).killUnknownTask(taskToUpdate.taskId, KillReason.Unknown)
     And("the update has been acknowledged")
     verify(f.schedulerDriver).acknowledgeStatusUpdate(status)
 
@@ -107,7 +107,7 @@ class TaskStatusUpdateProcessorImplTest
     verify(f.taskTracker).instance(task.taskId)
 
     And("the task kill gets initiated")
-    verify(f.killService).killTask(task, TaskKillReason.Unknown)
+    verify(f.killService).killTask(task, KillReason.Unknown)
     And("the update has been acknowledged")
     verify(f.schedulerDriver).acknowledgeStatusUpdate(status)
 
@@ -161,7 +161,7 @@ class TaskStatusUpdateProcessorImplTest
     lazy val taskTracker: InstanceTracker = mock[InstanceTracker]
     lazy val stateOpProcessor: TaskStateOpProcessor = mock[TaskStateOpProcessor]
     lazy val schedulerDriver: SchedulerDriver = mock[SchedulerDriver]
-    lazy val killService: TaskKillService = mock[TaskKillService]
+    lazy val killService: KillService = mock[KillService]
     lazy val marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder = {
       val holder = new MarathonSchedulerDriverHolder
       holder.driver = Some(schedulerDriver)
@@ -174,7 +174,8 @@ class TaskStatusUpdateProcessorImplTest
       taskTracker,
       stateOpProcessor,
       marathonSchedulerDriverHolder,
-      killService
+      killService,
+      eventStream = actorSystem.eventStream
     )
 
     def verifyNoMoreInteractions(): Unit = {

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -107,7 +107,7 @@ class TaskStatusUpdateProcessorImplTest
     verify(f.taskTracker).instance(task.taskId)
 
     And("the task kill gets initiated")
-    verify(f.killService).killTask(task, KillReason.Unknown)
+    verify(f.killService).killInstance(task, KillReason.Unknown)
     And("the update has been acknowledged")
     verify(f.schedulerDriver).acknowledgeStatusUpdate(status)
 

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.core.task.{ Task, TaskKillServiceMock }
+import mesosphere.marathon.core.task.{ Task, KillServiceMock }
 import mesosphere.marathon.core.event.InstanceChanged
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.{ InstanceStatus, Instance }
@@ -215,7 +215,7 @@ class DeploymentActorTest
     val tracker: InstanceTracker = mock[InstanceTracker]
     val queue: LaunchQueue = mock[LaunchQueue]
     val driver: SchedulerDriver = mock[SchedulerDriver]
-    val killService = new TaskKillServiceMock(system)
+    val killService = new KillServiceMock(system)
     val scheduler: SchedulerActions = mock[SchedulerActions]
     val storage: StorageProvider = mock[StorageProvider]
     val hcManager: HealthCheckManager = mock[HealthCheckManager]

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentManagerTest.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
-import mesosphere.marathon.core.task.termination.TaskKillService
+import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.metrics.Metrics
@@ -127,7 +127,7 @@ class DeploymentManagerTest
     val taskTracker: InstanceTracker = MarathonTestHelper.createTaskTracker(
       AlwaysElectedLeadershipModule.forActorSystem(system), new InMemoryStore
     )
-    val taskKillService: TaskKillService = mock[TaskKillService]
+    val taskKillService: KillService = mock[KillService]
     val scheduler: SchedulerActions = mock[SchedulerActions]
     val appRepo: AppRepository = new AppEntityRepository(
       new MarathonStore[AppDefinition](new InMemoryStore, metrics, () => AppDefinition(id = PathId("/test")), prefix = "app:"),

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.instance.InstanceStatus.Running
 import mesosphere.marathon.core.instance.{ InstanceStatus, Instance }
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.{ ReadinessCheck, ReadinessCheckExecutor, ReadinessCheckResult }
-import mesosphere.marathon.core.task.{ Task, TaskKillServiceMock }
+import mesosphere.marathon.core.task.{ Task, KillServiceMock }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, UpgradeStrategy }
@@ -463,7 +463,7 @@ class TaskReplaceActorTest
     val deploymentsManager = TestActorRef[Actor](Props.empty)
     val deploymentStatus = DeploymentStatus(DeploymentPlan.empty, DeploymentStep(Seq.empty))
     private[this] val driver = mock[SchedulerDriver]
-    val killService = new TaskKillServiceMock(system)
+    val killService = new KillServiceMock(system)
     val queue = mock[LaunchQueue]
     val tracker = mock[InstanceTracker]
     val readinessCheckExecutor: ReadinessCheckExecutor = mock[ReadinessCheckExecutor]


### PR DESCRIPTION
Resolves #4394

Note the renamings:
TaskKillProgressActor -> InstanceKillProgressActor
TaskKillServiceActor -> KillServiceActor
TaskKillServiceDelegate -> KillServiceDelegate

unfortunately GH doesn't recognize them although edit/rename actions are in separate commits.