### PR TITLE
Container name in taskId and extended usage in TaskBuilder

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -235,16 +235,7 @@ object Instance {
     // instanceId = $runSpecId.(instance-|marathon-)$uuid
     private val InstanceIdRegex = """^(.+)\.(instance-|marathon-)([^\.]+)$""".r
 
-    // Regular expression to extract relevant information of the mesos executorId
-    // executorId = (instance-|marathon-)$runSpecId.$uuid
-    private val ExecutorIdRegex = """^(instance-|marathon-)(.+)\.([^\.]+)$""".r
-
     private val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
-
-    def apply(executorId: mesos.Protos.ExecutorID): Id = executorId.getValue match {
-      case ExecutorIdRegex(prefix, runSpecId, uuid) => Id(runSpecId + "." + prefix + uuid)
-      case _ => throw new MatchError("unable to extract instanceId from executorId " + executorId.getValue)
-    }
 
     def runSpecId(instanceId: String): PathId = {
       instanceId match {

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -33,7 +33,7 @@ class InstanceOpFactoryHelper(
     launched: Instance.LaunchRequest): InstanceOp.LaunchTaskGroup = {
 
     assume(
-      executorInfo.getExecutorId == launched.instance.instanceId.mesosExecutorId,
+      executorInfo.getExecutorId.getValue == launched.instance.instanceId.executorIdString,
       "marathon pod instance id and mesos executor id must be equal")
 
     def createOperations = Seq(offerOperationFactory.launch(executorInfo, groupInfo))

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -191,7 +191,7 @@ class InstanceOpFactoryImpl(
     new TaskBuilder(spec, (_) => task.taskId, config, Some(appTaskProc)).build(offer, resourceMatch, volumeMatch) map {
       case (taskInfo, ports) =>
         val stateOp = InstanceUpdateOperation.LaunchOnReservation(
-          Instance.Id(taskInfo.getExecutor.getExecutorId),
+          task.taskId.instanceId,
           runSpecVersion = spec.version,
           status = Task.Status(
             stagedAt = clock.now(),

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -63,11 +63,11 @@ class InstanceOpFactoryImpl(
       config.envVarsPrefix.get)
 
     TaskGroupBuilder.build(pod, request.offer, Instance.Id.forRunSpec, builderConfig)(request.instances.toVector).map {
-      case (executorInfo, groupInfo, hostPorts) =>
+      case (executorInfo, groupInfo, hostPorts, instanceId) =>
         val agentInfo = Instance.AgentInfo(request.offer)
         val since = clock.now()
         val instance = Instance(
-          Instance.Id(executorInfo.getExecutorId),
+          instanceId,
           agentInfo = agentInfo,
           state = InstanceState(InstanceStatus.Created, since, pod.version, healthy = None),
           tasksMap = groupInfo.getTasksList.asScala.map { taskInfo =>

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -2,16 +2,17 @@ package mesosphere.marathon.core.task
 
 import java.util.Base64
 
-import com.fasterxml.uuid.{ EthernetAddress, Generators }
+import com.fasterxml.uuid.{EthernetAddress, Generators}
 import mesosphere.marathon.core.instance.InstanceStatus.Terminal
-import mesosphere.marathon.core.instance.{ Instance, InstanceStatus }
-import mesosphere.marathon.core.task.update.{ TaskUpdateEffect, TaskUpdateOperation }
-import mesosphere.marathon.core.task.Task.Reservation.Timeout.Reason.{ RelaunchEscalationTimeout, ReservationTimeout }
-import mesosphere.marathon.state.{ PathId, PersistentVolume, RunSpec, Timestamp }
+import mesosphere.marathon.core.instance.{Instance, InstanceStatus}
+import mesosphere.marathon.core.pod.MesosContainer
+import mesosphere.marathon.core.task.update.{TaskUpdateEffect, TaskUpdateOperation}
+import mesosphere.marathon.core.task.Task.Reservation.Timeout.Reason.{RelaunchEscalationTimeout, ReservationTimeout}
+import mesosphere.marathon.state.{PathId, PersistentVolume, RunSpec, Timestamp}
 import org.apache.mesos
-import org.apache.mesos.Protos.{ TaskState, TaskStatus }
+import org.apache.mesos.Protos.{TaskState, TaskStatus}
 import org.apache.mesos.Protos.TaskState._
-import org.apache.mesos.{ Protos => MesosProtos }
+import org.apache.mesos.{Protos => MesosProtos}
 import org.slf4j.LoggerFactory
 // TODO PODS remove api imports
 import play.api.libs.json._
@@ -155,7 +156,8 @@ object Task {
       Task.Id(taskId)
     }
 
-    def forInstanceId(instanceId: Instance.Id): Id = Id(instanceId.idString + "." + Id.uuidGenerator.generate())
+    def forInstanceId(instanceId: Instance.Id, container: Option[MesosContainer]): Id =
+      Id(instanceId.idString + "." + container.map(c => c.name).getOrElse("container"))
 
     implicit val taskIdFormat = Format(
       Reads.of[String](Reads.minLength[String](3)).map(Task.Id(_)),

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -127,6 +127,7 @@ object Task {
 
     // Regular expression for matching taskIds since instance-era
     private val TaskIdWithInstanceIdRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)[\._]([^_\.]+)$""".r
+
     private val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
 
     def runSpecId(taskId: String): PathId = {
@@ -143,14 +144,6 @@ object Task {
           Instance.Id(runSpecId + "." + prefix + instanceUuid)
         case LegacyTaskIdRegex(runSpecId, uuid) =>
           Instance.Id(s"$runSpecId.${calculateLegacyExecutorId(uuid)}.$uuid")
-        case _ => throw new MatchError(s"taskId $taskId is no valid identifier")
-      }
-    }
-
-    def executorIdString(taskId: String): String = {
-      taskId match {
-        case TaskIdWithInstanceIdRegex(runSpecId, prefix, instanceUuid, uuid) => prefix + runSpecId + "." + instanceUuid
-        case LegacyTaskIdRegex(runSpecId, uuid) => calculateLegacyExecutorId(taskId)
         case _ => throw new MatchError(s"taskId $taskId is no valid identifier")
       }
     }

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -143,7 +143,7 @@ object Task {
         case TaskIdWithInstanceIdRegex(runSpecId, prefix, instanceUuid, uuid) =>
           Instance.Id(runSpecId + "." + prefix + instanceUuid)
         case LegacyTaskIdRegex(runSpecId, uuid) =>
-          Instance.Id(s"$runSpecId.${calculateLegacyExecutorId(uuid)}.$uuid")
+          Instance.Id(runSpecId + "." + calculateLegacyExecutorId(uuid))
         case _ => throw new MatchError(s"taskId $taskId is no valid identifier")
       }
     }
@@ -151,8 +151,7 @@ object Task {
     def apply(mesosTaskId: MesosProtos.TaskID): Id = new Id(mesosTaskId.getValue)
 
     def forRunSpec(id: PathId): Id = {
-      val uuid = uuidGenerator.generate().toString
-      val taskId = id.safePath + "." + calculateLegacyExecutorId(uuid) + ".container"
+      val taskId = id.safePath + "." + uuidGenerator.generate()
       Task.Id(taskId)
     }
 

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -131,7 +131,7 @@ class TaskBuilder(
         builder.setCommand(command.build)
 
       case PathExecutor(path) =>
-        val executorId = Task.Id.calculateLegacyExecutorId(taskId.idString) // Fresh executor
+        val executorId = Task.Id.executorIdString(taskId.idString) // Fresh executor
         val executorPath = s"'$path'" // TODO: Really escape this.
         val cmd = runSpec.cmd.getOrElse(runSpec.args.mkString(" "))
         val shell = s"chmod ug+rx $executorPath && exec $executorPath $cmd"

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -131,7 +131,7 @@ class TaskBuilder(
         builder.setCommand(command.build)
 
       case PathExecutor(path) =>
-        val executorId = taskId.instanceId.executorIdString // Fresh executor
+        val executorId = Task.Id.calculateLegacyExecutorId(taskId.idString)
         val executorPath = s"'$path'" // TODO: Really escape this.
         val cmd = runSpec.cmd.getOrElse(runSpec.args.mkString(" "))
         val shell = s"chmod ug+rx $executorPath && exec $executorPath $cmd"

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -131,7 +131,7 @@ class TaskBuilder(
         builder.setCommand(command.build)
 
       case PathExecutor(path) =>
-        val executorId = Task.Id.executorIdString(taskId.idString) // Fresh executor
+        val executorId = taskId.instanceId.executorIdString // Fresh executor
         val executorPath = s"'$path'" // TODO: Really escape this.
         val cmd = runSpec.cmd.getOrElse(runSpec.args.mkString(" "))
         val shell = s"chmod ug+rx $executorPath && exec $executorPath $cmd"

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -39,7 +39,7 @@ object TaskGroupBuilder {
     offer: mesos.Offer,
     newInstanceId: PathId => Instance.Id,
     config: BuilderConfig
-  )(otherInstances: => Seq[Instance]): Option[(mesos.ExecutorInfo, mesos.TaskGroupInfo, Seq[Option[Int]])] = {
+  )(otherInstances: => Seq[Instance]): Option[(mesos.ExecutorInfo, mesos.TaskGroupInfo, Seq[Option[Int]], Instance.Id)] = {
     val acceptedResourceRoles: Set[String] = {
       val roles = if (podDefinition.acceptedResourceRoles.isEmpty) {
         config.acceptedResourceRoles
@@ -62,8 +62,7 @@ object TaskGroupBuilder {
     newInstanceId: PathId => Instance.Id,
     config: BuilderConfig,
     resourceMatch: ResourceMatcher.ResourceMatch
-  ): Some[(mesos.ExecutorInfo, mesos.TaskGroupInfo, Seq[Option[Int]])] = {
-    // TODO: probably set unique ID for each task
+  ): Some[(mesos.ExecutorInfo, mesos.TaskGroupInfo, Seq[Option[Int]], Instance.Id)] = {
     val instanceId = newInstanceId(podDefinition.id)
 
     val allEndpoints = for {
@@ -90,7 +89,7 @@ object TaskGroupBuilder {
       .map(computeTaskInfo(_, podDefinition, offer, instanceId, portsEnvVars))
       .foreach(taskGroup.addTasks)
 
-    Some((executorInfo.build, taskGroup.build, resourceMatch.hostPorts))
+    Some((executorInfo.build, taskGroup.build, resourceMatch.hostPorts, instanceId))
   }
 
   // The resource match provides us with a list of host ports.

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -1,15 +1,15 @@
 package mesosphere.mesos
 
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.pod.{ContainerNetwork, MesosContainer, PodDefinition}
+import mesosphere.marathon.core.pod.{ ContainerNetwork, MesosContainer, PodDefinition }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.pod.{ ContainerNetwork, MesosContainer, PodDefinition }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.raml
-import mesosphere.marathon.state.{EnvVarString, PathId, Timestamp}
+import mesosphere.marathon.state.{ EnvVarString, PathId, Timestamp }
 import mesosphere.marathon.tasks.PortsMatch
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
-import org.apache.mesos.{Protos => mesos}
+import org.apache.mesos.{ Protos => mesos }
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -164,8 +164,7 @@ object TaskGroupBuilder {
     portMappings: Seq[mesos.NetworkInfo.PortMapping],
     instanceId: Instance.Id,
     frameworkId: mesos.FrameworkID): mesos.ExecutorInfo.Builder = {
-    // TODO: use only an instance id.
-    val executorID = mesos.ExecutorID.newBuilder.setValue(instanceId.idString)
+    val executorID = mesos.ExecutorID.newBuilder.setValue(instanceId.executorIdString)
 
     val executorInfo = mesos.ExecutorInfo.newBuilder
       .setType(mesos.ExecutorInfo.Type.DEFAULT)

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -1,13 +1,15 @@
 package mesosphere.mesos
 
 import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.pod.{ContainerNetwork, MesosContainer, PodDefinition}
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.pod.{ ContainerNetwork, MesosContainer, PodDefinition }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.raml
-import mesosphere.marathon.state.{ EnvVarString, PathId, Timestamp }
+import mesosphere.marathon.state.{EnvVarString, PathId, Timestamp}
 import mesosphere.marathon.tasks.PortsMatch
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
-import org.apache.mesos.{ Protos => mesos }
+import org.apache.mesos.{Protos => mesos}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -123,7 +125,7 @@ object TaskGroupBuilder {
     portsEnvVars: Map[String, String]): mesos.TaskInfo.Builder = {
     val builder = mesos.TaskInfo.newBuilder
       .setName(container.name)
-      .setTaskId(mesos.TaskID.newBuilder.setValue(Task.Id.forInstanceId(instanceId).idString))
+      .setTaskId(mesos.TaskID.newBuilder.setValue(Task.Id.forInstanceId(instanceId, Some(container)).idString))
       .setSlaveId(offer.getSlaveId)
 
     builder.addResources(scalarResource("cpus", container.resources.cpus))

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -53,7 +53,7 @@ class OfferMatcherManagerModuleTest extends FunSuite
       module.globalOfferMatcher.matchOffer(clock.now() + 1.second, offer)
     val matchedTasks: MatchedInstanceOps = Await.result(matchedTasksFuture, 3.seconds)
     assert(matchedTasks.offerId == offer.getId)
-    assert(launchedTaskInfos(matchedTasks) == Seq(makeOneCPUTask(Task.Id(task.getTaskId.getValue + "_1"))))
+    assert(launchedTaskInfos(matchedTasks) == Seq(makeOneCPUTask(Task.Id(task.getTaskId.getValue + "-1"))))
   }
 
   test("deregistering only matcher works") {
@@ -85,8 +85,8 @@ class OfferMatcherManagerModuleTest extends FunSuite
       module.globalOfferMatcher.matchOffer(clock.now() + 1.second, offer)
     val matchedTasks: MatchedInstanceOps = Await.result(matchedTasksFuture, 3.seconds)
     assert(launchedTaskInfos(matchedTasks).toSet == Set(
-      makeOneCPUTask(Task.Id(task1.getTaskId.getValue + "_1")),
-      makeOneCPUTask(Task.Id(task2.getTaskId.getValue + "_1")))
+      makeOneCPUTask(Task.Id(task1.getTaskId.getValue + "-1")),
+      makeOneCPUTask(Task.Id(task2.getTaskId.getValue + "-1")))
     )
   }
 
@@ -120,10 +120,10 @@ class OfferMatcherManagerModuleTest extends FunSuite
       module.globalOfferMatcher.matchOffer(clock.now() + 1.second, offer)
     val matchedTasks: MatchedInstanceOps = Await.result(matchedTasksFuture, 3.seconds)
     assert(launchedTaskInfos(matchedTasks).toSet == Set(
-      makeOneCPUTask(Task.Id(task1.getTaskId.getValue + "_1")),
-      makeOneCPUTask(Task.Id(task1.getTaskId.getValue + "_2")),
-      makeOneCPUTask(Task.Id(task2.getTaskId.getValue + "_1")),
-      makeOneCPUTask(Task.Id(task2.getTaskId.getValue + "_2"))
+      makeOneCPUTask(Task.Id(task1.getTaskId.getValue + "-1")),
+      makeOneCPUTask(Task.Id(task1.getTaskId.getValue + "-2")),
+      makeOneCPUTask(Task.Id(task2.getTaskId.getValue + "-1")),
+      makeOneCPUTask(Task.Id(task2.getTaskId.getValue + "-2"))
     ))
   }
 
@@ -170,7 +170,7 @@ class OfferMatcherManagerModuleTest extends FunSuite
       tasks.map { task =>
         task
           .toBuilder
-          .setTaskId(task.getTaskId.toBuilder.setValue(task.getTaskId.getValue + "_" + processCycle))
+          .setTaskId(task.getTaskId.toBuilder.setValue(task.getTaskId.getValue + "-" + processCycle))
           .build()
       }
     }

--- a/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
@@ -1,0 +1,32 @@
+package mesosphere.marathon.instance
+
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.pod.MesosContainer
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.raml.Resources
+import mesosphere.marathon.state.PathId._
+import org.scalatest.{FunSuite, Matchers}
+
+class InstanceIdTest extends FunSuite with Matchers {
+
+  test("AppIds can be converted to InstanceIds and back to AppIds") {
+    val appId = "/test/foo/bla/rest".toPath
+    val instanceId = Instance.Id.forRunSpec(appId)
+    instanceId.runSpecId should equal(appId)
+  }
+
+  test("InstanceIds can be converted to TaskIds without container name") {
+    val appId = "/test/foo/bla/rest".toPath
+    val instanceId = Instance.Id.forRunSpec(appId)
+    val taskId = Task.Id.forInstanceId(instanceId, None)
+    taskId.idString should be(instanceId.idString + ".container")
+  }
+
+  test("InstanceIds can be converted to TaskIds with container name") {
+    val appId = "/test/foo/bla/rest".toPath
+    val instanceId = Instance.Id.forRunSpec(appId)
+    val container = MesosContainer("firstOne", resources = Resources())
+    val taskId = Task.Id.forInstanceId(instanceId, Some(container))
+    taskId.idString should be(instanceId.idString + ".firstOne")
+  }
+}

--- a/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
@@ -19,7 +19,7 @@ class InstanceIdTest extends FunSuite with Matchers {
   test("InstanceIds can be converted to TaskIds without container name") {
     val appId = "/test/foo/bla/rest".toPath
     val instanceId = Instance.Id.forRunSpec(appId)
-    val taskId = Task.Id.forInstanceId(instanceId, None)
+    val taskId = Task.Id.forInstanceId(instanceId, container = None)
     taskId.idString should be(instanceId.idString + ".container")
   }
 
@@ -43,7 +43,7 @@ class InstanceIdTest extends FunSuite with Matchers {
   test("InstanceIds should be created from (legacy) mesos executorID") {
     val appId = "/test/foo/bla/rest".toPath
     val taskId = Task.Id.forRunSpec(appId)
-    val executorId: mesos.Protos.ExecutorID = mesos.Protos.ExecutorID.newBuilder().setValue(Task.Id.executorIdString(taskId.idString)).build()
+    val executorId: mesos.Protos.ExecutorID = mesos.Protos.ExecutorID.newBuilder().setValue(taskId.instanceId.executorIdString).build()
     val instanceIdFromExecutorId = Instance.Id(executorId)
     executorId.getValue should startWith ("marathon-")
     taskId.instanceId should be (instanceIdFromExecutorId)

--- a/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
@@ -6,7 +6,6 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state.PathId._
 import org.scalatest.{ FunSuite, Matchers }
-import org.apache.mesos
 
 class InstanceIdTest extends FunSuite with Matchers {
 
@@ -29,24 +28,6 @@ class InstanceIdTest extends FunSuite with Matchers {
     val container = MesosContainer("firstOne", resources = Resources())
     val taskId = Task.Id.forInstanceId(instanceId, Some(container))
     taskId.idString should be(instanceId.idString + ".firstOne")
-  }
-
-  test("InstanceIds should be created from (current) mesos executorID") {
-    val appId = "/test/foo/bla/rest".toPath
-    val instanceId = Instance.Id.forRunSpec(appId)
-    val executorId: mesos.Protos.ExecutorID = mesos.Protos.ExecutorID.newBuilder().setValue(instanceId.executorIdString).build()
-    val instanceIdFromExecutorId = Instance.Id(executorId)
-    executorId.getValue should startWith ("instance-")
-    instanceId should be (instanceIdFromExecutorId)
-  }
-
-  test("InstanceIds should be created from (legacy) mesos executorID") {
-    val appId = "/test/foo/bla/rest".toPath
-    val taskId = Task.Id.forRunSpec(appId)
-    val executorId: mesos.Protos.ExecutorID = mesos.Protos.ExecutorID.newBuilder().setValue(taskId.instanceId.executorIdString).build()
-    val instanceIdFromExecutorId = Instance.Id(executorId)
-    executorId.getValue should startWith ("marathon-")
-    taskId.instanceId should be (instanceIdFromExecutorId)
   }
 
   test("InstanceIds should be created by static string") {

--- a/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
@@ -49,4 +49,13 @@ class InstanceIdTest extends FunSuite with Matchers {
     taskId.instanceId should be (instanceIdFromExecutorId)
   }
 
+  test("InstanceIds should be created by static string") {
+    val idString = "app.marathon-task"
+    val instanceId = Instance.Id(idString)
+    instanceId.idString should be(idString)
+    instanceId.runSpecId.safePath should be("app")
+    val taskId = Task.Id(idString + ".app")
+    taskId.instanceId should be(instanceId)
+  }
+
 }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -43,6 +43,6 @@ class TaskIdTest extends FunSuite with Matchers {
   test("TaskIds without specific instanceId should use taskId as instanceId") {
     val taskId = Task.Id(TaskID.newBuilder().setValue("test_foo_bla_rest.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
     taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
-    taskId.instanceId.idString should equal("test_foo_bla_rest.marathon-62d0f03f-79aa-11e6-a1a0-660c139c5e15.62d0f03f-79aa-11e6-a1a0-660c139c5e15")
+    taskId.instanceId.idString should equal("test_foo_bla_rest.marathon-62d0f03f-79aa-11e6-a1a0-660c139c5e15")
   }
 }

--- a/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
@@ -161,7 +161,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
     val tracker = mock[InstanceTracker]
     val appId = PathId("/test")
     val instanceId = Instance.Id.forRunSpec(appId)
-    val taskId = Task.Id.forInstanceId(instanceId, None)
+    val taskId = Task.Id.forInstanceId(instanceId, container = None)
     val launched = mock[Task.Launched]
     val agentInfo = mock[Instance.AgentInfo]
     val task = {

--- a/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
@@ -160,7 +160,8 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
     val deploymentStatus = DeploymentStatus(plan, step)
     val tracker = mock[InstanceTracker]
     val appId = PathId("/test")
-    val taskId = Task.Id("app.task")
+    val instanceId = Instance.Id.forRunSpec(appId)
+    val taskId = Task.Id.forInstanceId(instanceId, None)
     val launched = mock[Task.Launched]
     val agentInfo = mock[Instance.AgentInfo]
     val task = {
@@ -173,7 +174,6 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
       t
     }
 
-    val instanceId = taskId.instanceId
     val version = Timestamp.now()
 
     val instance = Instance(instanceId, agentInfo, InstanceState(Running, version, version, healthy = Some(true)), Map(task.taskId -> task))

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
 import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper, Protos }
-import mesosphere.mesos.protos.{ Resource, TaskID, _ }
+import mesosphere.mesos.protos.{ Resource, _ }
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo
 import org.apache.mesos.{ Protos => MesosProtos }
 import org.joda.time.{ DateTime, DateTimeZone }
@@ -628,7 +628,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
 
     val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
       offer, AppDefinition(
-      id = "testApp".toPath,
+      id = "/testApp".toPath,
       resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
       executor = "//cmd",
       container = Some(Container.MesosDocker(
@@ -665,7 +665,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
 
     val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
       offer, AppDefinition(
-      id = "testApp".toPath,
+      id = "/testApp".toPath,
       resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
       executor = "//cmd",
       container = Some(Container.MesosAppC(
@@ -721,7 +721,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
     val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(
       offer,
       AppDefinition(
-        id = "testApp".toPath,
+        id = "/testApp".toPath,
         args = Seq("a", "b", "c"),
         resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
         executor = "//cmd",
@@ -783,7 +783,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
     networkName: Option[String] = None) = buildIfMatches(
     offer,
     AppDefinition(
-      id = "testApp".toPath,
+      id = "/testApp".toPath,
       args = Seq("a", "b", "c"),
       resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
       portDefinitions = Nil,
@@ -956,7 +956,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
     val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
       offer,
       AppDefinition(
-        id = "testApp".toPath,
+        id = "/testApp".toPath,
         resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
         cmd = Some("foo"),
         executor = "/custom/executor",
@@ -983,7 +983,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
     val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
       offer,
       AppDefinition(
-        id = "testApp".toPath,
+        id = "/testApp".toPath,
         resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
         args = Seq("a", "b", "c"),
         executor = "/custom/executor",
@@ -1014,7 +1014,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
     val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(
       offer,
       AppDefinition(
-        id = "testApp".toPath,
+        id = "/testApp".toPath,
         resources = Resources(cpus = 2.0, mem = 200.0, disk = 2.0),
         executor = "//cmd",
         portDefinitions = PortDefinitions(8080, 8081)
@@ -1053,7 +1053,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
     val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(
       offer,
       AppDefinition(
-        id = "testApp".toPath,
+        id = "/testApp".toPath,
         resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
         executor = "//cmd",
         portDefinitions = PortDefinitions(8080, 8081)
@@ -1086,7 +1086,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
 
     val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
       offer, AppDefinition(
-      id = "testApp".toPath,
+      id = "/testApp".toPath,
       resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
       executor = "//cmd",
       container = Some(Docker(
@@ -1114,7 +1114,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
 
     val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
       offer, AppDefinition(
-      id = "testApp".toPath,
+      id = "/testApp".toPath,
       resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
       executor = "//cmd",
       container = Some(Docker(
@@ -1147,7 +1147,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
 
     val task: Option[(MesosProtos.TaskInfo, _)] = buildIfMatches(
       offer, AppDefinition(
-      id = "testApp".toPath,
+      id = "/testApp".toPath,
       resources = Resources(cpus = 1.0, mem = 64.0, disk = 1.0),
       executor = "//cmd",
       container = Some(Docker(
@@ -1332,9 +1332,9 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
 
   test("TaskContextEnv all fields") {
     val version = VersionInfo.forNewConfig(Timestamp(new DateTime(2015, 2, 3, 12, 30, DateTimeZone.UTC)))
-    val taskId = TaskID("taskId")
+    val runSpecId = PathId("/app")
     val runSpec = AppDefinition(
-      id = PathId("/app"),
+      id = runSpecId,
       versionInfo = version,
       container = Some(Docker(
         image = "myregistry/myimage:version"
@@ -1345,11 +1345,12 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
         "LABEL2" -> "VALUE2"
       )
     )
-    val env = TaskBuilder.taskContextEnv(runSpec = runSpec, Some(Task.Id(taskId)))
+    val taskId = Task.Id.forRunSpec(runSpecId)
+    val env = TaskBuilder.taskContextEnv(runSpec = runSpec, Some(taskId))
 
     assert(
       env == Map(
-        "MESOS_TASK_ID" -> "taskId",
+        "MESOS_TASK_ID" -> taskId.idString,
         "MARATHON_APP_ID" -> "/app",
         "MARATHON_APP_VERSION" -> "2015-02-03T12:30:00.000Z",
         "MARATHON_APP_DOCKER_IMAGE" -> "myregistry/myimage:version",
@@ -1755,7 +1756,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers with InstanceSupport {
     envVarsPrefix: Option[String] = None) = {
     val builder = new TaskBuilder(
       app,
-      s => Task.Id(s.toString),
+      s => Task.Id.forRunSpec(s),
       MarathonTestHelper.defaultConfig(
         mesosRole = mesosRole,
         acceptedResourceRoles = acceptedResourceRoles,

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -23,7 +23,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo",
@@ -33,7 +33,7 @@ class TaskGroupBuilderTest extends UnitTest {
           )
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 
@@ -49,7 +49,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo",
@@ -66,7 +66,7 @@ class TaskGroupBuilderTest extends UnitTest {
           )
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 
@@ -82,7 +82,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo1",
@@ -102,7 +102,7 @@ class TaskGroupBuilderTest extends UnitTest {
           )
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 
@@ -142,7 +142,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo1",
@@ -157,7 +157,7 @@ class TaskGroupBuilderTest extends UnitTest {
           user = Some("user")
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 
@@ -176,7 +176,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo1",
@@ -192,7 +192,7 @@ class TaskGroupBuilderTest extends UnitTest {
           labels = Map("a" -> "a", "b" -> "b")
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 
@@ -231,7 +231,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo1",
@@ -249,7 +249,7 @@ class TaskGroupBuilderTest extends UnitTest {
           labels = Map("a" -> "a")
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 
@@ -269,7 +269,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(task1EnvVars("a") == "a")
       assert(task1EnvVars("b") == "c")
-      assert(task1EnvVars("MARATHON_APP_ID") == "/product")
+      assert(task1EnvVars("MARATHON_APP_ID") == "/product/frontend")
       assert(task1EnvVars("MARATHON_CONTAINER_ID") == "Foo1")
       assert(task1EnvVars("MARATHON_APP_LABELS") == "A")
       assert(task1EnvVars("MARATHON_APP_LABEL_A") == "a")
@@ -285,7 +285,7 @@ class TaskGroupBuilderTest extends UnitTest {
       assert(task2EnvVars("a") == "a")
       assert(task2EnvVars("b") == "b")
       assert(task2EnvVars("c") == "c")
-      assert(task2EnvVars("MARATHON_APP_ID") == "/product")
+      assert(task2EnvVars("MARATHON_APP_ID") == "/product/frontend")
       assert(task2EnvVars("MARATHON_CONTAINER_ID") == "Foo2")
       assert(task2EnvVars("MARATHON_APP_LABELS") == "A B")
       assert(task2EnvVars("MARATHON_APP_LABEL_A") == "a")
@@ -297,7 +297,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo1",
@@ -338,7 +338,7 @@ class TaskGroupBuilderTest extends UnitTest {
           )
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 
@@ -371,7 +371,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo1",
@@ -399,7 +399,7 @@ class TaskGroupBuilderTest extends UnitTest {
           )
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 
@@ -435,7 +435,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo1",
@@ -478,7 +478,7 @@ class TaskGroupBuilderTest extends UnitTest {
           )
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 
@@ -517,7 +517,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo1",
@@ -531,7 +531,7 @@ class TaskGroupBuilderTest extends UnitTest {
           )
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 
@@ -550,7 +550,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       val pod = TaskGroupBuilder.build(
         PodDefinition(
-          id = "product_frontend".toPath,
+          id = "/product/frontend".toPath,
           containers = List(
             MesosContainer(
               name = "Foo1",
@@ -581,7 +581,7 @@ class TaskGroupBuilderTest extends UnitTest {
           )
         ),
         offer,
-        s => Instance.Id(s.toString),
+        s => Instance.Id.forRunSpec(s),
         defaultBuilderConfig
       )(Seq.empty)
 

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -39,7 +39,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (_, taskGroupInfo, _) = pod.get
+      val (_, taskGroupInfo, _, _) = pod.get
 
       assert(taskGroupInfo.getTasksList.asScala.exists(_.getName == "Foo"))
     }
@@ -72,7 +72,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (_, taskGroupInfo, _) = pod.get
+      val (_, taskGroupInfo, _, _) = pod.get
 
       assert(taskGroupInfo.getTasksCount == 3)
     }
@@ -108,7 +108,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (_, taskGroupInfo, _) = pod.get
+      val (_, taskGroupInfo, _, _) = pod.get
 
       assert(taskGroupInfo.getTasksCount == 3)
 
@@ -163,7 +163,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (_, taskGroupInfo, _) = pod.get
+      val (_, taskGroupInfo, _, _) = pod.get
 
       assert(taskGroupInfo.getTasksCount == 2)
 
@@ -198,7 +198,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (executorInfo, taskGroupInfo, _) = pod.get
+      val (executorInfo, taskGroupInfo, _, _) = pod.get
 
       assert(executorInfo.hasLabels)
 
@@ -255,7 +255,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (_, taskGroupInfo, _) = pod.get
+      val (_, taskGroupInfo, _, _) = pod.get
 
       assert(taskGroupInfo.getTasksCount == 2)
 
@@ -344,7 +344,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (_, taskGroupInfo, _) = pod.get
+      val (_, taskGroupInfo, _, _) = pod.get
 
       assert(taskGroupInfo.getTasksCount == 2)
 
@@ -405,7 +405,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (_, taskGroupInfo, _) = pod.get
+      val (_, taskGroupInfo, _, _) = pod.get
 
       assert(taskGroupInfo.getTasksCount == 3)
 
@@ -484,7 +484,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (_, taskGroupInfo, _) = pod.get
+      val (_, taskGroupInfo, _, _) = pod.get
 
       assert(taskGroupInfo.getTasksCount == 3)
 
@@ -537,7 +537,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (_, taskGroupInfo, _) = pod.get
+      val (_, taskGroupInfo, _, _) = pod.get
 
       val task1Artifacts = taskGroupInfo.getTasksList.asScala.find(_.getName == "Foo1").get.getCommand.getUrisList
       assert(task1Artifacts.size == 1)
@@ -587,7 +587,7 @@ class TaskGroupBuilderTest extends UnitTest {
 
       assert(pod.isDefined)
 
-      val (executorInfo, taskGroupInfo, _) = pod.get
+      val (executorInfo, taskGroupInfo, _, _) = pod.get
 
       assert(taskGroupInfo.getTasksCount == 2)
 


### PR DESCRIPTION
Introduced more clear and strict TaskId<>InstanceId handling
Using this in TaskBuilder and TaskGroupBuilder
For PODs the container name will be encoded inside the TaskId
Fixed tests using malformed taskIds or instanceIds

Fixes https://github.com/mesosphere/marathon/issues/4399
Fixes https://github.com/mesosphere/marathon/issues/4398

Should be merged AFTER https://github.com/mesosphere/marathon/pull/4388