### PR TITLE
Log events and deployment id in integration tests.

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonCallbackTestSupport.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonCallbackTestSupport.scala
@@ -69,6 +69,7 @@ trait MarathonCallbackTestSupport extends ExternalMarathonIntegrationTest {
   }
 
   def waitForStatusUpdates(kinds: String*) = kinds.foreach { kind =>
+    log.info(s"Wait for status update event with kind: $kind")
     waitForEventWith("status_update_event", _.taskStatus == kind)
   }
 

--- a/src/test/scala/mesosphere/marathon/util/TimeoutTest.scala
+++ b/src/test/scala/mesosphere/marathon/util/TimeoutTest.scala
@@ -16,7 +16,7 @@ class TimeoutTest extends AkkaUnitTest {
         failure shouldBe a[IllegalArgumentException]
       }
       "fail with a timeout exception if the method took too long" in {
-        val failure = Timeout(1.nano)(Future(Thread.sleep(50))).failed.futureValue
+        val failure = Timeout(1.milli)(Future(Thread.sleep(50))).failed.futureValue
         failure shouldBe a[TimeoutException]
       }
     }

--- a/src/test/scala/mesosphere/marathon/util/TimeoutTest.scala
+++ b/src/test/scala/mesosphere/marathon/util/TimeoutTest.scala
@@ -29,7 +29,7 @@ class TimeoutTest extends AkkaUnitTest {
         failure shouldBe a[IllegalArgumentException]
       }
       "fail with a timeout if the method took too long" in {
-        val failure = Timeout.blocking(1.nano)(Thread.sleep(50)).failed.futureValue
+        val failure = Timeout.blocking(1.milli)(Thread.sleep(50)).failed.futureValue
         failure shouldBe a[TimeoutException]
       }
     }


### PR DESCRIPTION
Get a little more insight into errors such as `java.lang.AssertionError: Waiting for event status_update_event to arrive took longer than 30 seconds. Give up.`.

This closes #4339.