### PR TITLE
Don't run unit tests as part of integration tests.

### DIFF
--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -22,6 +22,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.{ spy, verify, when }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
+import org.scalatest.time.{ Span, Second }
 import org.scalatest.{ BeforeAndAfter, FunSuiteLike, Matchers }
 
 import scala.concurrent.duration._
@@ -92,7 +93,7 @@ class TaskStartActorTest
     when(f.launchQueue.get(app.id)).thenReturn(None)
     val task =
       MarathonTestHelper.startingTaskForApp(app.id, appVersion = Timestamp(1024))
-    f.taskCreationHandler.created(TaskStateOp.LaunchEphemeral(task)).futureValue
+    f.taskCreationHandler.created(TaskStateOp.LaunchEphemeral(task)).isReadyWithin(Span(1, Second))
 
     val ref = f.startActor(app, app.instances, promise)
     watch(ref)
@@ -211,7 +212,7 @@ class TaskStartActorTest
 
     val outdatedTask = MarathonTestHelper.stagedTaskForApp(app.id, appVersion = Timestamp(1024))
     val taskId = outdatedTask.taskId
-    f.taskCreationHandler.created(TaskStateOp.LaunchEphemeral(outdatedTask)).futureValue
+    f.taskCreationHandler.created(TaskStateOp.LaunchEphemeral(outdatedTask)).isReadyWithin(Span(1, Second))
 
     val ref = f.startActor(app, app.instances, promise)
     watch(ref)

--- a/tests/integration/unit-integration-tests.sh
+++ b/tests/integration/unit-integration-tests.sh
@@ -31,7 +31,7 @@ export MARATHON_MAX_TASKS_PER_OFFER="${MARATHON_MAX_TASKS_PER_OFFER-1}"
 
 DOCKER_OPTIONS="run --entrypoint=/bin/bash --rm --name marathon-itests-$BUILD_ID --net host --privileged -e TARGETS_DIR=$TARGETS_DIR -e RUN_DOCKER_INTEGRATION_TESTS=$RUN_DOCKER_INTEGRATION_TESTS -e MARATHON_MAX_TASKS_PER_OFFER=$MARATHON_MAX_TASKS_PER_OFFER -v $WORKSPACE:/marathon -v $TARGET:/marathon/target -v /var/run/docker.sock:/var/run/docker.sock -v /etc/hosts:/etc/hosts -i"
 
-DOCKER_CMD="/usr/local/bin/sbt -Dsbt.log.format=false coverage doc test integration:test scapegoat coverageReport mesos-simulation/integration:test"
+DOCKER_CMD="/usr/local/bin/sbt -Dsbt.log.format=false coverage doc integration:test scapegoat coverageReport mesos-simulation/integration:test"
 
 DOCKER_ARGS="$DOCKER_OPTIONS $TAGGED_IMAGE $DOCKER_CMD"
 


### PR DESCRIPTION
Currently we run the unit tests twice in our ci, as part of the package build
and as part of the integration tests. This should disable the later.