### PR TITLE
Fix TaskKillerTest

### DIFF
--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -7,9 +7,9 @@ import mesosphere.marathon.core.instance.update.{ InstanceUpdateEffect, Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.{ InstanceTracker, TaskStateOpProcessor }
 import mesosphere.marathon.state.{ AppDefinition, Group, PathId, Timestamp }
+import mesosphere.marathon.test.Mockito
 import mesosphere.marathon.upgrade.DeploymentPlan
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
@@ -24,6 +24,7 @@ class TaskKillerTest extends MarathonSpec
     with BeforeAndAfterAll
     with GivenWhenThen
     with MockitoSugar
+    with Mockito
     with ScalaFutures
     with InstanceConversions {
 
@@ -176,8 +177,8 @@ class TaskKillerTest extends MarathonSpec
     result.futureValue shouldEqual instancesToKill
     // only task1 is killed
     verify(f.service, times(1)).killTasks(appId, launchedInstances)
-    // both tasks are expunged from the repo
-    verify(f.stateOpProcessor).process(InstanceUpdateOperation.ForceExpunge(runningInstance.instanceId))
+    // all found instances are expunged and the launched instance is expunged again
+    verify(f.stateOpProcessor, times(2)).process(InstanceUpdateOperation.ForceExpunge(runningInstance.instanceId))
     verify(f.stateOpProcessor).process(InstanceUpdateOperation.ForceExpunge(reservedInstance.instanceId))
   }
 

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -177,8 +177,8 @@ class TaskKillerTest extends MarathonSpec
     result.futureValue shouldEqual instancesToKill
     // only task1 is killed
     verify(f.service, times(1)).killTasks(appId, launchedInstances)
-    // all found instances are expunged and the launched instance is expunged again
-    verify(f.stateOpProcessor, times(2)).process(expungeRunning)
+    // all found instances are expunged and the launched instance is eventually expunged again
+    verify(f.stateOpProcessor, atLeastOnce).process(expungeRunning)
     verify(f.stateOpProcessor).process(expungeReserved)
   }
 


### PR DESCRIPTION
`kill with wipe will kill running and expunge all` turned out shaky e.g. [here](https://jenkins.mesosphere.com/service/jenkins/job/public-marathon-unit-integration-tests-pulls/1215/). The underlying problem is that, if `TaskKiller` is called with `wipe=true`, it will explicitly expunge all found instances, **and** call `KillService.killInstances` with all launched instances:

````
if (wipe) expunge(foundTasks)
val launchedTasks = foundTasks.filter(_.isLaunched)
if (launchedTasks.nonEmpty) await(service.killTasks(appId, launchedTasks))
```

With the given test setup, this will effectively process two Expunge operations for the running instance, and one for the reserved one. The test only verified 2 ops, and eventually both were for the same instance which let the test fail.