### PR TITLE
[Don't merge] Only for discussion – residency with instances

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.core.event
 import akka.event.EventStream
 import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.core.instance.update.InstanceChange
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{ MarathonTaskStatus, Task }
 import mesosphere.marathon.core.instance.{ Instance, InstanceStatus }
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep }
@@ -222,8 +222,9 @@ case class InstanceChanged(
 }
 object InstanceChanged {
   def apply(instanceChange: InstanceChange): InstanceChanged = {
+    val status: InstanceStatus = instanceChange.trigger.map(MarathonTaskStatus(_)).getOrElse(instanceChange.status)
     InstanceChanged(instanceChange.id, instanceChange.runSpecVersion,
-      instanceChange.runSpecId, instanceChange.status, instanceChange.instance)
+      instanceChange.runSpecId, status, instanceChange.instance)
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/flow/impl/OfferMatcherLaunchTokensActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/impl/OfferMatcherLaunchTokensActor.scala
@@ -49,7 +49,7 @@ private class OfferMatcherLaunchTokensActor(
   }
 
   override def receive: Receive = {
-    case InstanceUpdated(instance, _) if instance.isRunning && instance.state.healthy.fold(true)(_ == true) =>
+    case InstanceUpdated(instance, _, _) if instance.isRunning && instance.state.healthy.fold(true)(_ == true) =>
       offerMatcherManager.addLaunchTokens(1)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon.core.instance
 
 import java.util.Base64
 
-import com.fasterxml.uuid.{EthernetAddress, Generators}
+import com.fasterxml.uuid.{ EthernetAddress, Generators }
 import mesosphere.marathon.Protos
 import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
@@ -12,12 +12,12 @@ import mesosphere.marathon.core.task.update.TaskUpdateOperation
 import mesosphere.marathon.core.task.update.TaskUpdateEffect
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.raml._
-import mesosphere.marathon.state.{MarathonState, PathId, RunSpec, Timestamp}
+import mesosphere.marathon.state.{ MarathonState, PathId, RunSpec, Timestamp }
 import mesosphere.mesos.Placed
 import org.apache._
 import org.apache.mesos.Protos.Attribute
-import play.api.libs.json.{Reads, Writes}
-import org.slf4j.{Logger, LoggerFactory}
+import play.api.libs.json.{ Reads, Writes }
+import org.slf4j.{ Logger, LoggerFactory }
 
 // TODO PODs remove api import
 import play.api.libs.json.{ Format, JsResult, JsString, JsValue, Json }

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
@@ -3,7 +3,9 @@ package mesosphere.marathon.core.instance.update
 import akka.Done
 import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.core.instance.{ Instance, InstanceStatus }
+import mesosphere.marathon.core.task.MarathonTaskStatus
 import mesosphere.marathon.state.{ PathId, Timestamp }
+import org.apache.mesos
 
 import scala.concurrent.Future
 
@@ -31,13 +33,21 @@ sealed trait InstanceChange extends Product with Serializable {
   /** version of the related run spec */
   val runSpecVersion: Timestamp = instance.runSpecVersion
   /** Status of the [[Instance]] */
-  val status: InstanceStatus = instance.state.status
+  val status: InstanceStatus = trigger.map(MarathonTaskStatus(_)).getOrElse(instance.state.status)
   /** Id of the related [[mesosphere.marathon.state.RunSpec]] */
   val runSpecId: PathId = id.runSpecId
   def lastState: Option[InstanceState]
+  def trigger: Option[mesos.Protos.TaskStatus]
 }
 
 /** The given instance has been created or updated. */
-case class InstanceUpdated(instance: Instance, lastState: Option[InstanceState]) extends InstanceChange
+case class InstanceUpdated(
+  instance: Instance,
+  lastState: Option[InstanceState],
+  trigger: Option[mesos.Protos.TaskStatus]) extends InstanceChange
+
 /** The given instance has been deleted. */
-case class InstanceDeleted(instance: Instance, lastState: Option[InstanceState]) extends InstanceChange
+case class InstanceDeleted(
+  instance: Instance,
+  lastState: Option[InstanceState],
+  trigger: Option[mesos.Protos.TaskStatus]) extends InstanceChange

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateEffect.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateEffect.scala
@@ -1,16 +1,22 @@
 package mesosphere.marathon.core.instance.update
 
 import mesosphere.marathon.core.instance.Instance
+import org.apache.mesos
 
 /** The state change effect after applying a state change operation to the instance */
 sealed trait InstanceUpdateEffect extends Product with Serializable
 
 object InstanceUpdateEffect {
   /** The instance must be updated with the given state */
-  case class Update(instance: Instance, oldState: Option[Instance]) extends InstanceUpdateEffect
+  case class Update(
+    instance: Instance,
+    oldState: Option[Instance],
+    trigger: Option[mesos.Protos.TaskStatus]) extends InstanceUpdateEffect
 
   /** The instance with the given Id must be expunged */
-  case class Expunge(instance: Instance) extends InstanceUpdateEffect
+  case class Expunge(
+    instance: Instance,
+    trigger: Option[mesos.Protos.TaskStatus]) extends InstanceUpdateEffect
 
   /** The state if the instance didn't change */
   // TODO(PODS): do we need the id?

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -38,6 +38,7 @@ object InstanceUpdateOperation {
   case class LaunchOnReservation(
     instanceId: Instance.Id,
     runSpecVersion: Timestamp,
+    timestamp: Timestamp,
     status: Task.Status, // TODO(PODS): the taskStatus must be created for each task and not passed in here
     hostPorts: Seq[Int]) extends InstanceUpdateOperation
 

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -193,6 +193,7 @@ class InstanceOpFactoryImpl(
         val stateOp = InstanceUpdateOperation.LaunchOnReservation(
           task.taskId.instanceId,
           runSpecVersion = spec.version,
+          timestamp = clock.now(),
           status = Task.Status(
             stagedAt = clock.now(),
             taskStatus = InstanceStatus.Created

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -430,8 +430,13 @@ object Task {
 
     override def launched: Option[Launched] = None
 
-    override def update(op: TaskUpdateOperation): TaskUpdateEffect = {
-      TaskUpdateEffect.Failure("Mesos task status updates cannot be applied to reserved tasks")
+    override def update(op: TaskUpdateOperation): TaskUpdateEffect = op match {
+      case TaskUpdateOperation.LaunchOnReservation(runSpecVersion, taskStatus, hostPorts) =>
+        val updatedTask = LaunchedOnReservation(taskId, agentInfo, runSpecVersion, taskStatus, hostPorts, reservation)
+        TaskUpdateEffect.Update(updatedTask)
+
+      case update: TaskUpdateOperation.MesosUpdate =>
+        TaskUpdateEffect.Failure("Mesos task status updates cannot be applied to reserved tasks")
     }
 
     override def version: Option[Timestamp] = None // TODO also Reserved tasks have a version

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImpl.scala
@@ -46,7 +46,7 @@ private[tracker] object InstanceOpProcessorImpl {
       implicit
       ec: ExecutionContext): Future[InstanceUpdateEffect] = {
       directInstanceTracker.instance(instanceId).map {
-        case Some(existingTask) =>
+        case Some(existingInstance) =>
           InstanceUpdateEffect.Failure( //
             new IllegalStateException(s"$instanceId of app [${instanceId.runSpecId}] already exists"))
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImpl.scala
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
 
+import org.apache.mesos
+
 private[tracker] object InstanceOpProcessorImpl {
 
   /**
@@ -38,7 +40,7 @@ private[tracker] object InstanceOpProcessorImpl {
         case op: InstanceUpdateOperation.Reserve => updateIfNotExists(op.instanceId, Instance(op.task))
         case op: InstanceUpdateOperation.ForceExpunge => expungeInstance(op.instanceId)
         case op: InstanceUpdateOperation.Revert =>
-          Future.successful(InstanceUpdateEffect.Update(op.instance, oldState = None))
+          Future.successful(InstanceUpdateEffect.Update(op.instance, oldState = None, trigger = None))
       }
     }
 
@@ -50,7 +52,7 @@ private[tracker] object InstanceOpProcessorImpl {
           InstanceUpdateEffect.Failure( //
             new IllegalStateException(s"$instanceId of app [${instanceId.runSpecId}] already exists"))
 
-        case None => InstanceUpdateEffect.Update(updatedInstance, oldState = None)
+        case None => InstanceUpdateEffect.Update(updatedInstance, oldState = None, trigger = None)
       }
     }
 
@@ -69,7 +71,7 @@ private[tracker] object InstanceOpProcessorImpl {
     private[this] def expungeInstance(id: Instance.Id)(implicit ec: ExecutionContext): Future[InstanceUpdateEffect] = {
       directInstanceTracker.instance(id).map {
         case Some(existingInstance: Instance) =>
-          InstanceUpdateEffect.Expunge(existingInstance)
+          InstanceUpdateEffect.Expunge(existingInstance, trigger = None)
 
         case None =>
           log.info("Ignoring ForceExpunge for [{}], task does not exist", id)
@@ -98,7 +100,8 @@ private[tracker] class InstanceOpProcessorImpl(
         // Used for task termination or as a result from a UpdateStatus action.
         // The expunge is propagated to the instanceTracker which informs the sender about the success (see Ack).
         repository.delete(change.instance.instanceId).map { _ => InstanceTrackerActor.Ack(op.sender, change) }
-          .recoverWith(tryToRecover(op)(expectedState = None, oldState = Some(change.instance)))
+          .recoverWith(tryToRecover(op)(
+            expectedState = None, oldState = Some(change.instance), trigger = change.trigger))
           .flatMap { ack: InstanceTrackerActor.Ack => notifyTaskTrackerActor(ack) }
 
       case change: InstanceUpdateEffect.Failure =>
@@ -118,7 +121,8 @@ private[tracker] class InstanceOpProcessorImpl(
         // Used for a create or as a result from a UpdateStatus action.
         // The update is propagated to the taskTracker which in turn informs the sender about the success (see Ack).
         repository.store(change.instance).map { _ => InstanceTrackerActor.Ack(op.sender, change) }
-          .recoverWith(tryToRecover(op)(expectedState = Some(change.instance), oldState = change.oldState))
+          .recoverWith(tryToRecover(op)(
+            expectedState = Some(change.instance), oldState = change.oldState, trigger = change.trigger))
           .flatMap { ack => notifyTaskTrackerActor(ack) }
     }
   }
@@ -145,7 +149,8 @@ private[tracker] class InstanceOpProcessorImpl(
     * This tries to isolate failures that only effect certain tasks, e.g. errors in the serialization logic
     * which are only triggered for a certain combination of fields.
     */
-  private[this] def tryToRecover(op: Operation)(expectedState: Option[Instance], oldState: Option[Instance])(
+  private[this] def tryToRecover(op: Operation)(
+    expectedState: Option[Instance], oldState: Option[Instance], trigger: Option[mesos.Protos.TaskStatus])(
     implicit
     ec: ExecutionContext): PartialFunction[Throwable, Future[InstanceTrackerActor.Ack]] = {
 
@@ -161,11 +166,11 @@ private[tracker] class InstanceOpProcessorImpl(
 
       repository.get(op.instanceId).map {
         case Some(instance) =>
-          val effect = InstanceUpdateEffect.Update(instance, oldState)
+          val effect = InstanceUpdateEffect.Update(instance, oldState, trigger)
           ack(Some(instance), effect)
         case None =>
           val effect = oldState match {
-            case Some(oldInstanceState) => InstanceUpdateEffect.Expunge(oldInstanceState)
+            case Some(oldInstanceState) => InstanceUpdateEffect.Expunge(oldInstanceState, trigger)
             case None => InstanceUpdateEffect.Noop(op.instanceId)
           }
           ack(None, effect)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -149,13 +149,13 @@ private[impl] class InstanceTrackerActor(
 
       case msg @ InstanceTrackerActor.StateChanged(ack) =>
         val maybeChange: Option[InstanceChange] = ack.effect match {
-          case InstanceUpdateEffect.Update(instance, oldState) =>
+          case InstanceUpdateEffect.Update(instance, oldState, trigger) =>
             becomeWithUpdatedApp(instance.runSpecId)(instance.instanceId, newInstance = Some(instance))
-            Some(InstanceUpdated(instance, lastState = oldState.map(_.state)))
+            Some(InstanceUpdated(instance, lastState = oldState.map(_.state), trigger))
 
-          case InstanceUpdateEffect.Expunge(instance) =>
+          case InstanceUpdateEffect.Expunge(instance, trigger) =>
             becomeWithUpdatedApp(instance.runSpecId)(instance.instanceId, newInstance = None)
-            Some(InstanceDeleted(instance, lastState = None))
+            Some(InstanceDeleted(instance, lastState = None, trigger))
 
           case InstanceUpdateEffect.Noop(_) |
             InstanceUpdateEffect.Failure(_) =>

--- a/src/main/scala/mesosphere/marathon/core/task/update/TaskUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/TaskUpdateOperation.scala
@@ -1,11 +1,20 @@
 package mesosphere.marathon.core.task.update
 
 import mesosphere.marathon.core.instance.InstanceStatus
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.state.Timestamp
 import org.apache.mesos
+
+import scala.collection.immutable.Seq
 
 /** Trait for operations attempting to change the state of a task */
 trait TaskUpdateOperation extends Product with Serializable
 
 object TaskUpdateOperation {
   case class MesosUpdate(status: InstanceStatus, taskStatus: mesos.Protos.TaskStatus) extends TaskUpdateOperation
+
+  case class LaunchOnReservation(
+    runSpecVersion: Timestamp,
+    status: Task.Status,
+    hostPorts: Seq[Int]) extends TaskUpdateOperation
 }

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -254,7 +254,7 @@ class LaunchQueueModuleTest
     val launch = new InstanceOpFactoryHelper(Some("principal"), Some("role")).launchEphemeral(mesosTask, marathonTask)
     val instanceChange = TaskStatusUpdateTestHelper(
       operation = InstanceUpdateOperation.LaunchEphemeral(marathonTask),
-      effect = InstanceUpdateEffect.Update(instance = marathonTask, oldState = None)
+      effect = InstanceUpdateEffect.Update(instance = marathonTask, oldState = None, trigger = None)
     ).wrapped
 
     lazy val clock: Clock = Clock()

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -547,7 +547,7 @@ object MarathonTestHelper extends InstanceConversions {
   def residentReservedTask(appId: PathId, localVolumeIds: Task.LocalVolumeId*) =
     minimalReservedTask(appId, Task.Reservation(localVolumeIds, taskReservationStateNew))
 
-  def residentLaunchedTask(appId: PathId, localVolumeIds: Task.LocalVolumeId*) = {
+  def residentStagedTask(appId: PathId, localVolumeIds: Task.LocalVolumeId*) = {
     val now = Timestamp.now()
     Task.LaunchedOnReservation(
       taskId = Task.Id.forRunSpec(appId),
@@ -557,7 +557,7 @@ object MarathonTestHelper extends InstanceConversions {
         stagedAt = now,
         startedAt = None,
         mesosStatus = None,
-        taskStatus = InstanceStatus.Running
+        taskStatus = InstanceStatus.Staging
       ),
       hostPorts = Seq.empty,
       reservation = Task.Reservation(localVolumeIds, Task.Reservation.State.Launched))

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -393,7 +393,7 @@ object MarathonTestHelper extends InstanceConversions {
 
   def taskLaunchedOp(taskId: Task.Id): InstanceUpdateOperation.LaunchOnReservation = {
     val now = Timestamp.now()
-    InstanceUpdateOperation.LaunchOnReservation(instanceId = taskId, runSpecVersion = now, status = Task.Status(stagedAt = now, taskStatus = InstanceStatus.Running), hostPorts = Seq.empty)
+    InstanceUpdateOperation.LaunchOnReservation(instanceId = taskId, runSpecVersion = now, timestamp = now, status = Task.Status(stagedAt = now, taskStatus = InstanceStatus.Running), hostPorts = Seq.empty)
   }
 
   def startingTaskForApp(appId: PathId, appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task.LaunchedEphemeral =

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -165,8 +165,8 @@ class TaskKillerTest extends MarathonSpec
 
     when(f.groupManager.app(appId)).thenReturn(Future.successful(Some(AppDefinition(appId))))
     when(f.tracker.specInstances(appId)).thenReturn(Future.successful(instancesToKill))
-    when(f.stateOpProcessor.process(expungeRunning)).thenReturn(Future.successful(InstanceUpdateEffect.Expunge(runningInstance)))
-    when(f.stateOpProcessor.process(expungeReserved)).thenReturn(Future.successful(InstanceUpdateEffect.Expunge(reservedInstance)))
+    when(f.stateOpProcessor.process(expungeRunning)).thenReturn(Future.successful(InstanceUpdateEffect.Expunge(runningInstance, trigger = None)))
+    when(f.stateOpProcessor.process(expungeReserved)).thenReturn(Future.successful(InstanceUpdateEffect.Expunge(reservedInstance, trigger = None)))
     when(f.service.killTasks(appId, launchedInstances))
       .thenReturn(Future.successful(MarathonSchedulerActor.TasksKilled(appId, launchedInstances.map(_.instanceId))))
 

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -114,6 +114,7 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
       val taskStateOp = InstanceUpdateOperation.LaunchOnReservation(
         instanceId = dummyTask.taskId,
         runSpecVersion = clock.now(),
+        timestamp = clock.now(),
         status = Task.Status(clock.now(), taskStatus = InstanceStatus.Running),
         hostPorts = Seq.empty)
       val launch = f.launchWithOldTask(

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -27,7 +27,7 @@ class TaskStatusUpdateTestHelper(val operation: InstanceUpdateOperation, val eff
   def wrapped: InstanceChange = effect match {
     case InstanceUpdateEffect.Update(instance, old) => InstanceUpdated(instance, old.map(_.state))
     case InstanceUpdateEffect.Expunge(instance) => InstanceDeleted(instance, None)
-    case _ => throw new scala.RuntimeException("The wrapped effect does not result in an InstanceChange")
+    case _ => throw new scala.RuntimeException(s"The wrapped effect does not result in an update or expunge: $effect")
   }
 }
 

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -25,8 +25,8 @@ class TaskStatusUpdateTestHelper(val operation: InstanceUpdateOperation, val eff
   }
   def reason: String = if (status.hasReason) status.getReason.toString else "no reason"
   def wrapped: InstanceChange = effect match {
-    case InstanceUpdateEffect.Update(instance, old) => InstanceUpdated(instance, old.map(_.state))
-    case InstanceUpdateEffect.Expunge(instance) => InstanceDeleted(instance, None)
+    case InstanceUpdateEffect.Update(instance, old, trigger) => InstanceUpdated(instance, old.map(_.state), trigger)
+    case InstanceUpdateEffect.Expunge(instance, trigger) => InstanceDeleted(instance, None, trigger)
     case _ => throw new scala.RuntimeException(s"The wrapped effect does not result in an update or expunge: $effect")
   }
 }
@@ -46,7 +46,7 @@ object TaskStatusUpdateTestHelper extends InstanceConversions {
 
   def taskLaunchFor(task: Task, timestamp: Timestamp = defaultTimestamp) = { // linter:ignore:UnusedParameter
     val operation = InstanceUpdateOperation.LaunchEphemeral(task)
-    val effect = InstanceUpdateEffect.Update(operation.instance, oldState = None)
+    val effect = InstanceUpdateEffect.Update(operation.instance, oldState = None, trigger = None)
     TaskStatusUpdateTestHelper(operation, effect)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceCreationHandlerAndUpdaterDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceCreationHandlerAndUpdaterDelegateTest.scala
@@ -21,7 +21,7 @@ class InstanceCreationHandlerAndUpdaterDelegateTest
     val appId: PathId = PathId("/test")
     val task = MarathonTestHelper.minimalTask(appId)
     val stateOp = InstanceUpdateOperation.LaunchEphemeral(task)
-    val expectedStateChange = InstanceUpdateEffect.Update(task, None)
+    val expectedStateChange = InstanceUpdateEffect.Update(task, None, trigger = None)
 
     When("created is called")
     val create = f.delegate.created(stateOp)
@@ -67,7 +67,7 @@ class InstanceCreationHandlerAndUpdaterDelegateTest
     val appId: PathId = PathId("/test")
     val task = MarathonTestHelper.minimalTask(appId)
     val stateOp = InstanceUpdateOperation.ForceExpunge(task.taskId)
-    val expectedStateChange = InstanceUpdateEffect.Expunge(task)
+    val expectedStateChange = InstanceUpdateEffect.Expunge(task, trigger = None)
 
     When("terminated is called")
     val terminated = f.delegate.process(stateOp)
@@ -128,7 +128,7 @@ class InstanceCreationHandlerAndUpdaterDelegateTest
     )
 
     When("the request is acknowledged")
-    val expectedStateChange = InstanceUpdateEffect.Update(task, Some(task))
+    val expectedStateChange = InstanceUpdateEffect.Update(task, Some(task), trigger = Some(update))
     f.taskTrackerProbe.reply(expectedStateChange)
     Then("The reply is the value of the future")
     statusUpdate.futureValue should be(expectedStateChange)

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImplTest.scala
@@ -391,7 +391,7 @@ class InstanceOpProcessorImplTest
     def stateOpLaunch(task: Task) = InstanceUpdateOperation.LaunchEphemeral(task)
     def stateOpUpdate(task: Task, mesosStatus: mesos.Protos.TaskStatus, now: Timestamp = now) = InstanceUpdateOperation.MesosUpdate(task, mesosStatus, now)
     def stateOpExpunge(task: Task) = InstanceUpdateOperation.ForceExpunge(task.taskId)
-    def stateOpLaunchOnReservation(task: Task, status: Task.Status) = InstanceUpdateOperation.LaunchOnReservation(task.taskId, now, status, Seq.empty)
+    def stateOpLaunchOnReservation(task: Task, status: Task.Status) = InstanceUpdateOperation.LaunchOnReservation(task.taskId, now, now, status, Seq.empty)
     def stateOpReservationTimeout(task: Task) = InstanceUpdateOperation.ReservationTimeout(task.taskId)
     def stateOpReserve(task: Task) = InstanceUpdateOperation.Reserve(task.asInstanceOf[Task.Reserved])
 

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImplTest.scala
@@ -48,7 +48,7 @@ class InstanceOpProcessorImplTest
     val task = MarathonTestHelper.minimalTask(appId)
     val stateOp = f.stateOpUpdate(task, MesosTaskStatusTestHelper.runningHealthy)
     val mesosStatus = stateOp.mesosStatus
-    val expectedEffect = InstanceUpdateEffect.Update(task, Some(task))
+    val expectedEffect = InstanceUpdateEffect.Update(task, Some(task), trigger = Some(mesosStatus))
     val ack = InstanceTrackerActor.Ack(f.opSender.ref, expectedEffect)
     f.stateOpResolver.resolve(stateOp) returns Future.successful(expectedEffect)
     f.instanceRepository.get(task.taskId) returns Future.successful(Some(task))
@@ -84,7 +84,7 @@ class InstanceOpProcessorImplTest
     Given("a taskRepository and existing task")
     val task = MarathonTestHelper.stagedTaskForApp(appId)
     val stateOp = f.stateOpUpdate(task, MesosTaskStatusTestHelper.running)
-    val expectedEffect = InstanceUpdateEffect.Update(task, Some(task))
+    val expectedEffect = InstanceUpdateEffect.Update(task, Some(task), trigger = Some(stateOp.mesosStatus))
     val ack = InstanceTrackerActor.Ack(f.opSender.ref, expectedEffect)
     f.stateOpResolver.resolve(stateOp) returns Future.successful(expectedEffect)
     f.instanceRepository.store(task) returns Future.failed(new RuntimeException("fail"))
@@ -128,7 +128,7 @@ class InstanceOpProcessorImplTest
     val task = MarathonTestHelper.minimalTask(appId)
     val taskProto = TaskSerializer.toProto(task)
     val stateOp = f.stateOpUpdate(task, MesosTaskStatusTestHelper.running)
-    val expectedEffect = InstanceUpdateEffect.Update(task, Some(task))
+    val expectedEffect = InstanceUpdateEffect.Update(task, Some(task), trigger = Some(stateOp.mesosStatus))
     val storeException: RuntimeException = new scala.RuntimeException("fail")
     val ack = InstanceTrackerActor.Ack(f.opSender.ref, InstanceUpdateEffect.Failure(storeException))
     f.stateOpResolver.resolve(stateOp) returns Future.successful(expectedEffect)
@@ -173,10 +173,9 @@ class InstanceOpProcessorImplTest
     Given("a taskRepository and existing task")
     val task = MarathonTestHelper.minimalTask(appId)
     val instance: Instance = task
-    val taskProto = TaskSerializer.toProto(task)
     val storeFailed: RuntimeException = new scala.RuntimeException("store failed")
     val stateOp = f.stateOpUpdate(task, MesosTaskStatusTestHelper.running)
-    val expectedEffect = InstanceUpdateEffect.Update(instance, Some(instance))
+    val expectedEffect = InstanceUpdateEffect.Update(instance, Some(instance), trigger = Some(stateOp.mesosStatus))
     f.stateOpResolver.resolve(stateOp) returns Future.successful(expectedEffect)
     f.instanceRepository.store(instance) returns Future.failed(storeFailed)
     f.instanceRepository.get(instance.instanceId) returns Future.failed(new RuntimeException("task failed"))
@@ -217,7 +216,7 @@ class InstanceOpProcessorImplTest
     val task = MarathonTestHelper.minimalTask(appId)
     val taskId = task.taskId
     val stateOp = f.stateOpExpunge(task)
-    val expectedEffect = InstanceUpdateEffect.Expunge(task)
+    val expectedEffect = InstanceUpdateEffect.Expunge(task, trigger = None)
     val ack = InstanceTrackerActor.Ack(f.opSender.ref, expectedEffect)
 
     f.stateOpResolver.resolve(stateOp) returns Future.successful(expectedEffect)
@@ -251,7 +250,7 @@ class InstanceOpProcessorImplTest
     val task = MarathonTestHelper.minimalTask(appId)
     val taskId = task.taskId
     val stateOp = f.stateOpExpunge(task)
-    val expectedEffect = InstanceUpdateEffect.Expunge(task)
+    val expectedEffect = InstanceUpdateEffect.Expunge(task, trigger = None)
     val ack = InstanceTrackerActor.Ack(f.opSender.ref, expectedEffect)
     f.stateOpResolver.resolve(stateOp) returns Future.successful(expectedEffect)
     f.instanceRepository.delete(taskId) returns Future.failed(new RuntimeException("expunge fails"))
@@ -290,7 +289,7 @@ class InstanceOpProcessorImplTest
     val task = MarathonTestHelper.minimalTask(appId)
     val expungeException: RuntimeException = new scala.RuntimeException("expunge fails")
     val stateOp = f.stateOpExpunge(task)
-    val resolvedEffect = InstanceUpdateEffect.Expunge(task)
+    val resolvedEffect = InstanceUpdateEffect.Expunge(task, trigger = None)
     val ack = InstanceTrackerActor.Ack(f.opSender.ref, InstanceUpdateEffect.Failure(expungeException))
     f.stateOpResolver.resolve(stateOp) returns Future.successful(resolvedEffect)
     f.instanceRepository.delete(task.taskId) returns Future.failed(expungeException)
@@ -446,7 +445,7 @@ class InstanceOpProcessorImplTest
 
     def toLaunched(instance: Instance, op: InstanceUpdateOperation.LaunchOnReservation): Instance = {
       instance.update(op) match {
-        case InstanceUpdateEffect.Update(updatedInstance, _) => updatedInstance
+        case InstanceUpdateEffect.Update(updatedInstance, _, _) => updatedInstance
         case _ => throw new scala.RuntimeException("op did not result in a launched instance")
       }
     }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
@@ -109,7 +109,7 @@ class InstanceTrackerActorTest
     val stagedUpdate = helper.effect
     val stagedAck = InstanceTrackerActor.Ack(probe.ref, stagedUpdate)
     probe.send(f.taskTrackerActor, InstanceTrackerActor.StateChanged(stagedAck))
-    probe.expectMsg(InstanceUpdateEffect.Expunge(helper.wrapped.instance))
+    probe.expectMsg(InstanceUpdateEffect.Expunge(helper.wrapped.instance, trigger = Some(helper.status)))
 
     Then("it will have set the correct metric counts")
     f.actorMetrics.runningCount.getValue should be(2)

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceUpdateOpResolverTest.scala
@@ -53,6 +53,7 @@ class InstanceUpdateOpResolverTest
     val stateChange = f.stateOpResolver.resolve(InstanceUpdateOperation.LaunchOnReservation(
       instanceId = f.notExistingTaskId,
       runSpecVersion = Timestamp(0),
+      timestamp = Timestamp(0),
       status = Task.Status(Timestamp(0), taskStatus = InstanceStatus.Running),
       hostPorts = Seq.empty)).futureValue
 

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceUpdateOpResolverTest.scala
@@ -153,7 +153,7 @@ class InstanceUpdateOpResolverTest
         tasksMap = updatedTasksMap
       )
 
-      stateChange shouldEqual InstanceUpdateEffect.Expunge(expectedState)
+      stateChange shouldEqual InstanceUpdateEffect.Expunge(expectedState, trigger = Some(stateOp.mesosStatus))
 
       And("there are no more interactions")
       f.verifyNoMoreInteractions()
@@ -287,7 +287,7 @@ class InstanceUpdateOpResolverTest
     val stateChange = f.stateOpResolver.resolve(InstanceUpdateOperation.Revert(f.existingReservedTask)).futureValue
 
     And("the result is an Update")
-    stateChange shouldEqual InstanceUpdateEffect.Update(f.existingReservedTask, None)
+    stateChange shouldEqual InstanceUpdateEffect.Update(f.existingReservedTask, None, trigger = None)
 
     And("The taskTracker is not queried at all")
     f.verifyNoMoreInteractions()

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -126,7 +126,7 @@ class TaskStatusUpdateProcessorImplTest
 
     Given("a task")
     f.taskTracker.instance(taskId) returns Future.successful(Some(task))
-    f.stateOpProcessor.process(expectedTaskStateOp) returns Future.successful(InstanceUpdateEffect.Update(task, Some(task)))
+    f.stateOpProcessor.process(expectedTaskStateOp) returns Future.successful(InstanceUpdateEffect.Update(task, Some(task), trigger = Some(status)))
 
     When("receive a TASK_KILLING update")
     f.updateProcessor.publish(status).futureValue

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonCallbackTestSupport.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonCallbackTestSupport.scala
@@ -93,7 +93,7 @@ trait MarathonCallbackTestSupport extends ExternalMarathonIntegrationTest {
 
 object UpdateEventsHelper {
   implicit class CallbackEventToStatusUpdateEvent(val event: CallbackEvent) extends AnyVal {
-    def taskStatus: String = event.info("taskStatus").toString
+    def taskStatus: String = event.info.get("taskStatus").map(_.toString).getOrElse("")
     def message: String = event.info("message").toString
     def id: String = event.info("id").toString
     def running: Boolean = taskStatus == "TASK_RUNNING"

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
@@ -191,7 +191,7 @@ class InstanceOpFactoryImplTest extends MarathonSpec with GivenWhenThen with Moc
     def residentApp = MTH.appWithPersistentVolume()
     def normalLaunchedTask(appId: PathId) = MTH.minimalTask(appId)
     def residentReservedTask(appId: PathId, volumeIds: LocalVolumeId*) = MTH.residentReservedTask(appId, volumeIds: _*)
-    def residentLaunchedTask(appId: PathId, volumeIds: LocalVolumeId*) = MTH.residentLaunchedTask(appId, volumeIds: _*)
+    def residentLaunchedTask(appId: PathId, volumeIds: LocalVolumeId*) = MTH.residentStagedTask(appId, volumeIds: _*)
     def offer = MTH.makeBasicOffer().build()
     def offerWithSpaceForLocalVolume = MTH.makeBasicOffer(disk = 1025).build()
     def insufficientOffer = MTH.makeBasicOffer(cpus = 0.01, mem = 1, disk = 0.01, beginPort = 31000, endPort = 31001).build()


### PR DESCRIPTION
## Problem
- Tasks using persistent volumes return to state `Reserved` when they terminate
- Instances become `Reserved` as well
- InstanceChanged events that get published report `Reserved`, MesosStatusUpdateEvents report `Reserved` as well – that breaks existing logic that depends on events reporting a terminal status for these

## Ugly solution
- The InstanceChange carries an optional trigger of type `TaskStatus`, which is the trigger that led to the  state change. Events use that status, or, if None, the new status of the instance. This solution is particularly ugly as it pollutes a significant amount of code and makes it hard to read and reason about.

I will setup another PR with a hopefully much more cleaner solution; this one is just for comparison _so please do not merge_ 😬 