### PR TITLE
parse container name from task ID, some unit tests to go with it

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -143,8 +143,8 @@ object Task {
 
     def containerName(taskId: String): Option[String] = {
       taskId match {
-        case TaskIdWithInstanceIdRegex(runSpecId, prefix, instanceUuid, uuid) =>
-          if (uuid == anonymousContainerName) None else Some(uuid)
+        case TaskIdWithInstanceIdRegex(runSpecId, prefix, instanceUuid, maybeContainer) =>
+          if (maybeContainer == anonymousContainerName) None else Some(maybeContainer)
         case LegacyTaskIdRegex(runSpecId, uuid) => None
         case _ => throw new MatchError(s"taskId $taskId is no valid identifier")
       }

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -117,11 +117,14 @@ object Task {
     lazy val mesosTaskId: MesosProtos.TaskID = MesosProtos.TaskID.newBuilder().setValue(idString).build()
     lazy val runSpecId: PathId = Id.runSpecId(idString)
     lazy val instanceId: Instance.Id = Id.instanceId(idString)
+    lazy val containerName: Option[String] = Id.containerName(idString)
     override def toString: String = s"task [$idString]"
     override def compare(that: Id): Int = idString.compare(that.idString)
   }
 
   object Id {
+    val anonymousContainerName = "$anon" // presence of `$` is important since it's illegal for a real container name!
+
     // Regular expression for matching taskIds before instance-era
     private val LegacyTaskIdRegex = """^(.+)[\._]([^_\.]+)$""".r
 
@@ -132,8 +135,17 @@ object Task {
 
     def runSpecId(taskId: String): PathId = {
       taskId match {
-        case TaskIdWithInstanceIdRegex(runSpecId, prefix, instanceId, uuid) => PathId.fromSafePath(runSpecId)
+        case TaskIdWithInstanceIdRegex(runSpecId, prefix, instanceId, maybeContainer) => PathId.fromSafePath(runSpecId)
         case LegacyTaskIdRegex(runSpecId, uuid) => PathId.fromSafePath(runSpecId)
+        case _ => throw new MatchError(s"taskId $taskId is no valid identifier")
+      }
+    }
+
+    def containerName(taskId: String): Option[String] = {
+      taskId match {
+        case TaskIdWithInstanceIdRegex(runSpecId, prefix, instanceUuid, uuid) =>
+          if (uuid == anonymousContainerName) None else Some(uuid)
+        case LegacyTaskIdRegex(runSpecId, uuid) => None
         case _ => throw new MatchError(s"taskId $taskId is no valid identifier")
       }
     }
@@ -156,7 +168,7 @@ object Task {
     }
 
     def forInstanceId(instanceId: Instance.Id, container: Option[MesosContainer]): Id =
-      Id(instanceId.idString + "." + container.map(c => c.name).getOrElse("container"))
+      Id(instanceId.idString + "." + container.map(c => c.name).getOrElse(anonymousContainerName))
 
     implicit val taskIdFormat = Format(
       Reads.of[String](Reads.minLength[String](3)).map(Task.Id(_)),

--- a/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
@@ -19,7 +19,7 @@ class InstanceIdTest extends FunSuite with Matchers {
     val appId = "/test/foo/bla/rest".toPath
     val instanceId = Instance.Id.forRunSpec(appId)
     val taskId = Task.Id.forInstanceId(instanceId, container = None)
-    taskId.idString should be(instanceId.idString + ".container")
+    taskId.idString should be(instanceId.idString + ".$anon")
   }
 
   test("InstanceIds can be converted to TaskIds with container name") {
@@ -28,6 +28,23 @@ class InstanceIdTest extends FunSuite with Matchers {
     val container = MesosContainer("firstOne", resources = Resources())
     val taskId = Task.Id.forInstanceId(instanceId, Some(container))
     taskId.idString should be(instanceId.idString + ".firstOne")
+  }
+
+  test("InstanceIds can be converted from TaskIds with container name") {
+    val appId = "/test/foo/bla/rest".toPath
+    val parsedTaskId = Task.Id("test_foo_bla_rest.instance-myinstance.someContainerName")//Task.Id(taskIdString)
+    parsedTaskId.runSpecId should be(appId)
+    parsedTaskId.instanceId should be(Instance.Id("test_foo_bla_rest.instance-myinstance"))
+    parsedTaskId.containerName should be('nonEmpty)
+    parsedTaskId.containerName should be(Some("someContainerName"))
+  }
+
+  test("InstanceIds can be converted from TaskIds without a container name") {
+    val appId = "/test/foo/bla/rest".toPath
+    val parsedTaskId = Task.Id("test_foo_bla_rest.instance-myinstance.$anon")
+    parsedTaskId.runSpecId should be(appId)
+    parsedTaskId.instanceId should be(Instance.Id("test_foo_bla_rest.instance-myinstance"))
+    parsedTaskId.containerName should be('empty)
   }
 
   test("InstanceIds should be created by static string") {

--- a/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
@@ -32,7 +32,7 @@ class InstanceIdTest extends FunSuite with Matchers {
 
   test("InstanceIds can be converted from TaskIds with container name") {
     val appId = "/test/foo/bla/rest".toPath
-    val parsedTaskId = Task.Id("test_foo_bla_rest.instance-myinstance.someContainerName")//Task.Id(taskIdString)
+    val parsedTaskId = Task.Id("test_foo_bla_rest.instance-myinstance.someContainerName")
     parsedTaskId.runSpecId should be(appId)
     parsedTaskId.instanceId should be(Instance.Id("test_foo_bla_rest.instance-myinstance"))
     parsedTaskId.containerName should be('nonEmpty)


### PR DESCRIPTION
Also changed anonymous container name from `container` to `$anon` to avoid overlap with user-specified container names.