### PR TITLE
Call an optional start-hook script from /bin/start

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -40,6 +40,19 @@ require_arg() {
   fi
 }
 
+# Run the start-hook script [optional]
+if [ -f "$MARATHON_APP_START_HOOK" ]; then
+  "$MARATHON_APP_START_HOOK"
+  # if a $MARATHON_APP_START_HOOK.env file was produced it is evaluated
+  starthook_env=${MARATHON_APP_START_HOOK%.*}.env
+  starthook_env=${starthook_env##*/}
+
+  # In case the hook script needs to add/change environment variables or otherwise access the parent shell
+  [ -f "$starthook_env" ] && source "$starthook_env"
+else
+  echo "No start hook file found (\$MARATHON_APP_START_HOOK). Proceeding with the start script."
+fi
+
 # Filter out MARATHON_APP* env variables. All MARATHON_XXX=yyy variables are interpreted as -xxx yyy application parameter
 for env_op in `env | grep -v ^MARATHON_APP | grep ^MARATHON_ | awk '{gsub(/MARATHON_/,""); gsub(/=/," "); printf("%s%s ", "--", tolower($1)); for(i=2;i<=NF;i++){printf("%s ", $i)}}'`; do
   addApplication "$env_op"

--- a/bin/start
+++ b/bin/start
@@ -41,16 +41,16 @@ require_arg() {
 }
 
 # Run the start-hook script [optional]
-if [ -f "$MARATHON_APP_START_HOOK" ]; then
-  "$MARATHON_APP_START_HOOK"
-  # if a $MARATHON_APP_START_HOOK.env file was produced it is evaluated
-  starthook_env=${MARATHON_APP_START_HOOK%.*}.env
+if [ -x "$HOOK_MARATHON_START" ]; then
+  "$HOOK_MARATHON_START"
+  # if a $HOOK_MARATHON_START.env file was produced it is evaluated
+  starthook_env=${HOOK_MARATHON_START%.*}.env
   starthook_env=${starthook_env##*/}
 
   # In case the hook script needs to add/change environment variables or otherwise access the parent shell
   [ -f "$starthook_env" ] && source "$starthook_env"
 else
-  echo "No start hook file found (\$MARATHON_APP_START_HOOK). Proceeding with the start script."
+  echo "No start hook file found (\$HOOK_MARATHON_START). Proceeding with the start script."
 fi
 
 # Filter out MARATHON_APP* env variables. All MARATHON_XXX=yyy variables are interpreted as -xxx yyy application parameter


### PR DESCRIPTION
An optional start hook script defined via $MARATHON_APP_START_HOOK environment variable is called from /bin/start. This provides a possibility for additional initialization steps when starting marathon.