### PR TITLE
Fix KillService behavior

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/termination/KillConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/KillConfig.scala
@@ -19,22 +19,12 @@ trait KillConfig extends ScallopConf {
   private[this] lazy val _killRetryTimeout = opt[Long](
     "kill_retry_timeout",
     descr = "INTERNAL TUNING PARAMETER: " +
-      "The timeout after which an instance kill will be retried.",
+      "The timeout after which unconfirmed instance kills will be retried.",
     noshort = true,
     hidden = true,
     default = Some(10.seconds.toMillis)
   )
 
-  private[this] lazy val _killRetryMax = opt[Int](
-    "kill_retry_max",
-    descr = "INTERNAL TUNING PARAMETER: " +
-      "The maximum number of kill retries before which an instance will be forcibly expunged from state.",
-    noshort = true,
-    hidden = true,
-    default = Some(5)
-  )
-
   lazy val killChunkSize: Int = _killChunkSize()
   lazy val killRetryTimeout: FiniteDuration = _killRetryTimeout().millis
-  lazy val killRetryMax: Int = _killRetryMax()
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/KillService.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/KillService.scala
@@ -37,7 +37,6 @@ trait KillService {
     *
     * @param taskId the id of the task that shall be killed.
     * @param reason the reason why the task shall be killed.
-    * @return a future that is completed when all tasks are killed.
     */
-  def killUnknownTask(taskId: Task.Id, reason: KillReason): Future[Done]
+  def killUnknownTask(taskId: Task.Id, reason: KillReason): Unit
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
@@ -29,12 +29,9 @@ private[termination] class KillServiceDelegate(actorRef: ActorRef) extends KillS
     killInstances(Seq(instance), reason)
   }
 
-  override def killUnknownTask(taskId: Task.Id, reason: KillReason): Future[Done] = {
+  override def killUnknownTask(taskId: Task.Id, reason: KillReason): Unit = {
     log.info(s"Killing unknown task for reason: $reason (id: {})", taskId)
-
-    val promise = Promise[Done]
-    actorRef ! KillUnknownTaskById(taskId, promise)
-    promise.future
+    actorRef ! KillUnknownTaskById(taskId)
   }
 }
 

--- a/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
@@ -38,7 +38,7 @@ class KillServiceMock(system: ActorSystem) extends KillService with Mockito {
     Future.successful(Done)
   }
 
-  override def killUnknownTask(taskId: Id, reason: KillReason): Future[Done] = {
+  override def killUnknownTask(taskId: Id, reason: KillReason): Unit = {
     val instance = mock[Instance]
     instance.instanceId returns taskId.instanceId
     killInstance(instance, reason)

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
@@ -59,7 +59,6 @@ class KillServiceActorTest extends FunSuiteLike
   }
 
   test("Kill unknown instance") {
-    // TODO
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
@@ -67,18 +66,16 @@ class KillServiceActorTest extends FunSuiteLike
     val taskId = Task.Id.forRunSpec(PathId("/unknown"))
 
     When("the service is asked to kill that taskId")
-    val promise = Promise[Done]()
-    actor ! KillServiceActor.KillUnknownTaskById(taskId, promise)
+    actor ! KillServiceActor.KillUnknownTaskById(taskId)
 
     Then("a kill is issued to the driver")
     verify(f.driver, timeout(500)).killTask(taskId.mesosTaskId)
-    noMoreInteractions(f.driver)
 
     When("an event is published indicating the unknown instance terminal")
     f.publishUnknownInstanceTerminated(taskId.instanceId)
 
-    Then("the promise is eventually completed successfully")
-    promise.future.futureValue should be (Done)
+    Then("no more kills are issued")
+    noMoreInteractions(f.driver)
   }
 
   test("Kill single known LOST instance") {
@@ -105,7 +102,6 @@ class KillServiceActorTest extends FunSuiteLike
     promise.future.futureValue should be (Done)
   }
 
-  // TODO(PODS): verify this test is still flaky https://github.com/mesosphere/marathon/issues/4202
   test("kill multiple instances at once") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
@@ -152,7 +148,6 @@ class KillServiceActorTest extends FunSuiteLike
     noMoreInteractions(f.driver)
   }
 
-  // TODO(PODS): verify this test is still flaky https://github.com/mesosphere/marathon/issues/4202
   test("kill multiple instances subsequently") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
@@ -271,18 +266,6 @@ class KillServiceActorTest extends FunSuiteLike
 
     Then("the service will eventually retry")
     verify(f.driver, timeout(1000)).killTask(task.taskId.mesosTaskId)
-
-    When("no statusUpdate is received and we reach the future")
-    f.clock.+=(10.seconds)
-
-    Then("the service will eventually expunge the task if it reached the max attempts")
-    verify(f.stateOpProcessor, timeout(1000)).process(InstanceUpdateOperation.ForceExpunge(task.taskId))
-
-    When("a terminal status update is published via the event stream")
-    f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(task).wrapped)
-
-    Then("the promise is eventually completed successfully")
-    promise.future.futureValue should be (Done)
   }
 
   private[this] implicit var actorSystem: ActorSystem = _
@@ -316,12 +299,10 @@ class KillServiceActorTest extends FunSuiteLike
     val defaultConfig: KillConfig = new KillConfig {
       override lazy val killChunkSize: Int = 5
       override lazy val killRetryTimeout: FiniteDuration = 10.minutes
-      override lazy val killRetryMax: Int = 5
     }
     val retryConfig: KillConfig = new KillConfig {
       override lazy val killChunkSize: Int = 5
       override lazy val killRetryTimeout: FiniteDuration = 500.millis
-      override lazy val killRetryMax: Int = 1
     }
     val stateOpProcessor: TaskStateOpProcessor = mock[TaskStateOpProcessor]
     val clock = ConstantClock()


### PR DESCRIPTION
Retry forever and don't spawn progress actors for unknown tasks

* killUnknownTask now has a unit return type (no one is interested in the result)
* Do not create KillProgressActors for unknown tasks
* remove maxRetries; if no terminal task status is received, the killService will retry until the task is confirmed to be terminal

Background: there is actually no reason for setting up progress actors/returning a future when killing unknown tasks: no one is interested in the result. Yet the KillServiceActor should retry until it receives a terminal status update for that unknown task.