### PR TITLE
Wait for tasks to be expunged.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -43,7 +43,7 @@ class TaskKiller @Inject() (
           val allTasks = await(taskTracker.appTasks(appId))
           val foundTasks = findToKill(allTasks)
 
-          if (wipe) expunge(foundTasks) // linter:ignore UseIfExpression
+          if (wipe) await(expunge(foundTasks)) // linter:ignore UseIfExpression
 
           val launchedTasks = foundTasks.filter(_.launched.isDefined)
           if (launchedTasks.nonEmpty) await(service.killTasks(appId, launchedTasks))


### PR DESCRIPTION
Should fix the following error:

```sbt
sbt.ForkMain$ForkError: org.mockito.exceptions.verification.WantedButNotInvoked:
Wanted but not invoked:
taskStateOpProcessor.process(
    ForceExpunge(task [my_app.b347a7ae-80cc-11e6-a549-0242ac1106b3])
);
-> at mesosphere.marathon.api.TaskKillerTest$$anonfun$15.apply(TaskKillerTest.scala:180)

However, there were other interactions with this mock:
taskStateOpProcessor.process(
    ForceExpunge(task [my_app.b347809d-80cc-11e6-a549-0242ac1106b3])
);
-> at mesosphere.marathon.api.TaskKiller$$anonfun$mesosphere$marathon$api$TaskKiller$$expunge$1$$anonfun$apply$3.apply(TaskKiller.scala:66)
```

Mr. Jeschkies did not look close enough to realize that we wait for tasks to be
expunged. See here a3901ab0bb21bfa1ad8af56999f86ca606ef68b8

Anyways. I reproduced the error with a sleep right after `log.info("Expunge...")`.