### PR TITLE
Create a better set of scala/java conversions.

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marahon/benchmarks/streams/ScalaConversions.scala
+++ b/benchmark/src/main/scala/mesosphere/marahon/benchmarks/streams/ScalaConversions.scala
@@ -1,0 +1,73 @@
+package mesosphere.marahon.benchmarks.streams
+
+import java.util
+import java.util.concurrent.TimeUnit
+
+import mesosphere.marathon.stream._
+import org.openjdk.jmh.annotations.{ Benchmark, BenchmarkMode, Fork, Mode, OutputTimeUnit, Scope, State }
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.collection.immutable.Seq
+
+@State(Scope.Benchmark)
+object ScalaConversionsState {
+  val small: Seq[Int] = 0.to(100)
+  val medium: Seq[Int] = 0.to(1000)
+  val large: Seq[Int] = 0.to(10000)
+  val veryLarge: Seq[Int] = 0.to(1000 * 1000)
+}
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
+@Fork(1)
+class ScalaConversions {
+  import ScalaConversionsState._
+
+  @Benchmark
+  def smallAsJavaStream(hole: Blackhole): Unit = {
+    val asJava: util.List[Int] = small
+    hole.consume(asJava)
+  }
+
+  @Benchmark
+  def smallConverted(hole: Blackhole): Unit = {
+    val asJava = small.asJava
+    hole.consume(asJava)
+  }
+
+  @Benchmark
+  def mediumAsJavaStream(hole: Blackhole): Unit = {
+    val asJava: util.List[Int] = medium
+    hole.consume(asJava)
+  }
+
+  @Benchmark
+  def mediumConverted(hole: Blackhole): Unit = {
+    val asJava = medium.asJava
+    hole.consume(asJava)
+  }
+
+  @Benchmark
+  def largeAsJavaStream(hole: Blackhole): Unit = {
+    val asJava: util.List[Int] = large
+    hole.consume(asJava)
+  }
+
+  @Benchmark
+  def largeConverted(hole: Blackhole): Unit = {
+    val asJava = large.asJava
+    hole.consume(asJava)
+  }
+
+  @Benchmark
+  def veryLargeAsJavaStream(hole: Blackhole): Unit = {
+    val asJava: util.List[Int] = veryLarge
+    hole.consume(asJava)
+  }
+
+  @Benchmark
+  def veryLargeConverted(hole: Blackhole): Unit = {
+    val asJava = veryLarge.asJava
+    hole.consume(asJava)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -73,10 +73,21 @@ lazy val commonSettings = inConfig(IntegrationTest)(Defaults.testTasks) ++ Seq(
     "-Xfuture",
     "-Xlog-reflective-calls",
     "-Xlint",
-    "-Ywarn-unused-import",
     "-Xfatal-warnings",
+    "-Ywarn-unused-import",
     "-Yno-adapted-args",
-    "-Ywarn-numeric-widen"
+    "-Ywarn-numeric-widen",
+    //"-Ywarn-dead-code", We should turn this one on soon
+    "-Ywarn-inaccessible",
+    "-Ywarn-infer-any",
+    "-Ywarn-nullary-override",
+    "-Ywarn-nullary-unit",
+    //"-Ywarn-unused", We should turn this one on soon
+    "-Ywarn-unused-import",
+    //"-Ywarn-value-discard", We should turn this one on soon.
+    "-Ybackend:GenBCode",
+    "-Yclosure-elim",
+    "-Ydead-code"
   ),
   scalacOptions in Test ~= { _.filter(co => !(co.startsWith("-Xplugin") || co.startsWith("-P"))) },
   javacOptions in Compile ++= Seq(

--- a/src/main/scala/mesosphere/marathon/AllConf.scala
+++ b/src/main/scala/mesosphere/marathon/AllConf.scala
@@ -20,7 +20,7 @@ class AllConf(args: Seq[String] = Nil) extends ScallopConf(args)
 
 object AllConf {
   def apply(args: String*): AllConf = {
-    new AllConf(args)
+    new AllConf(args.to[Seq])
   }
 
   def withTestConfig(args: String*): AllConf = {

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -24,7 +24,7 @@ class MarathonApp extends App {
     )
   }
 
-  override val conf = new AllConf(args)
+  override val conf = new AllConf(args.to[Seq])
 
   def runDefault(): Unit = {
     setConcurrentContextDefaults()

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory
 
 import scala.async.Async.{ async, await }
 import scala.collection.JavaConverters._
-import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -25,7 +25,6 @@ import org.apache.mesos.Protos.FrameworkID
 import org.apache.mesos.SchedulerDriver
 import org.slf4j.LoggerFactory
 
-import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future, TimeoutException }
 import scala.util.Failure

--- a/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
+++ b/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
@@ -59,11 +59,11 @@ trait ZookeeperConf extends ScallopConf {
   def zooKeeperServerSetPath: String = "%s/apps".format(zkPath)
 
   def zooKeeperHostAddresses: Seq[InetSocketAddress] =
-    for (s <- zkHosts.split(",")) yield {
+    zkHosts.split(",").map { s =>
       val splits = s.split(":")
       require(splits.length == 2, "expected host:port for zk servers")
       new InetSocketAddress(splits(0), splits(1).toInt)
-    }
+    }(collection.breakOut)
 
   @SuppressWarnings(Array("OptionGet"))
   def zkURL: String = zooKeeperUrl.get.get

--- a/src/main/scala/mesosphere/marathon/functional/FunctionConversions.scala
+++ b/src/main/scala/mesosphere/marathon/functional/FunctionConversions.scala
@@ -1,0 +1,78 @@
+package mesosphere.marathon.functional
+
+import scala.language.implicitConversions
+import java.util.function._
+import scala.compat.java8.FunctionConverters._
+
+trait FunctionConversions {
+  @inline implicit def asBiConsumer[A, B, R](f: (A, B) => R): BiConsumer[A, B] = asJavaBiConsumer{ (a: A, b: B) =>
+    f(a, b)
+    ()
+  }
+  @inline implicit def asBiFunction[A, B, R](f: (A, B) => R): BiFunction[A, B, R] = asJavaBiFunction[A, B, R](f)
+  @inline implicit def asBinaryOperator[A](f: (A, A) => A): BinaryOperator[A] = asJavaBinaryOperator[A](f)
+  @inline implicit def asBiPredicate[A, B](f: (A, B) => Boolean): BiPredicate[A, B] = asJavaBiPredicate[A, B](f)
+  @inline implicit def asBooleanSupplier(f: () => Boolean): BooleanSupplier = asJavaBooleanSupplier(f)
+  @inline implicit def asConsumer[A, R](f: A => R): Consumer[A] = asJavaConsumer { (a: A) =>
+    f(a)
+    ()
+  }
+  @inline implicit def asDoubleBinaryOperator(f: (Double, Double) => Double): DoubleBinaryOperator = asJavaDoubleBinaryOperator(f)
+  @inline implicit def asDoubleConsumer[R](f: Double => R): DoubleConsumer = asJavaDoubleConsumer { (a: Double) =>
+    f(a)
+    ()
+  }
+  @inline implicit def asDoubleFunction[R](f: Double => R): DoubleFunction[R] = asJavaDoubleFunction[R](f)
+  @inline implicit def asDoubleSupplier(f: () => Double): DoubleSupplier = asJavaDoubleSupplier(f)
+  @inline implicit def asDoublePredicte(f: Double => Boolean): DoublePredicate = asJavaDoublePredicate(f)
+  @inline implicit def asDoubleToIntFunction(f: Double => Int): DoubleToIntFunction = asJavaDoubleToIntFunction(f)
+  @inline implicit def asDoubleToLongFunction(f: Double => Long): DoubleToLongFunction = asJavaDoubleToLongFunction(f)
+  @inline implicit def asDoubleUnaryOperator(f: Double => Double): DoubleUnaryOperator = asJavaDoubleUnaryOperator(f)
+  @inline implicit def asFunction[A, R](f: A => R): Function[A, R] = asJavaFunction(f)
+  @inline implicit def asIntBinaryOperator(f: (Int, Int) => Int): IntBinaryOperator = asJavaIntBinaryOperator(f)
+  @inline implicit def asIntConsumer[R](f: Int => R): IntConsumer = asJavaIntConsumer { (a: Int) =>
+    f(a)
+    ()
+  }
+  @inline implicit def asIntFunction[R](f: Int => R): IntFunction[R] = asJavaIntFunction[R](f)
+  @inline implicit def asIntPredicate(f: Int => Boolean): IntPredicate = asJavaIntPredicate(f)
+  @inline implicit def asIntSupplier(f: () => Int): IntSupplier = asJavaIntSupplier(f)
+  @inline implicit def asIntToDoubleFunction(f: Int => Double): IntToDoubleFunction = asJavaIntToDoubleFunction(f)
+  @inline implicit def asIntToLongFunction(f: Int => Long): IntToLongFunction = asJavaIntToLongFunction(f)
+  @inline implicit def asIntUnaryOperator(f: Int => Int): IntUnaryOperator = asJavaIntUnaryOperator(f)
+  @inline implicit def asLongBinaryOperator(f: (Long, Long) => Long): LongBinaryOperator = asJavaLongBinaryOperator(f)
+  @inline implicit def asLongConsumer[R](f: Long => R): LongConsumer = asJavaLongConsumer { (a: Long) =>
+    f(a)
+    ()
+  }
+  @inline implicit def asLongFunction[R](f: Long => R): LongFunction[R] = asJavaLongFunction[R](f)
+  @inline implicit def asLongPredicate(f: Long => Boolean): LongPredicate = asJavaLongPredicate(f)
+  @inline implicit def asLongSupplier(f: () => Long): LongSupplier = asJavaLongSupplier(f)
+  @inline implicit def asLongToDoubleFunction(f: Long => Double): LongToDoubleFunction = asJavaLongToDoubleFunction(f)
+  @inline implicit def asLongToIntFunction(f: Long => Int): LongToIntFunction = asJavaLongToIntFunction(f)
+  @inline implicit def asLongUnaryOperator(f: Long => Long): LongUnaryOperator = asJavaLongUnaryOperator(f)
+  @inline implicit def asObjDoubleConsumer[A, R](f: (A, Double) => R): ObjDoubleConsumer[A] = asObjDoubleConsumer { (a: A, b: Double) =>
+    f(a, b)
+    ()
+  }
+  @inline implicit def asObjIntConsumer[A, R](f: (A, Int) => R): ObjIntConsumer[A] = asObjIntConsumer { (a: A, b: Int) =>
+    f(a, b)
+    ()
+  }
+  @inline implicit def asObjLongConsumer[A, R](f: (A, Long) => R): ObjLongConsumer[A] = asObjLongConsumer { (a: A, b: Long) =>
+    f(a, b)
+    ()
+  }
+  @inline implicit def asPredicate[A](f: A => Boolean): Predicate[A] = asJavaPredicate[A](f)
+  @inline implicit def asSupplier[R](f: () => R): Supplier[R] = asJavaSupplier[R](f)
+  @inline implicit def asToDoubleBiFunction[A, B](f: (A, B) => Double): ToDoubleBiFunction[A, B] = asJavaToDoubleBiFunction[A, B](f)
+  @inline implicit def asToDoubleFunction[A](f: A => Double): ToDoubleFunction[A] = asJavaToDoubleFunction[A](f)
+  @inline implicit def asToIntBiFunction[A, B](f: (A, B) => Int): ToIntBiFunction[A, B] = asJavaToIntBiFunction[A, B](f)
+  @inline implicit def asToIntFunction[A](f: A => Int): ToIntFunction[A] = asJavaToIntFunction[A](f)
+  @inline implicit def asLongBiFunction[A, B](f: (A, B) => Long): ToLongBiFunction[A, B] = asJavaToLongBiFunction[A, B](f)
+  @inline implicit def asLongFunction[A](f: A => Long): ToLongFunction[A] = asJavaToLongFunction[A](f)
+  @inline implicit def asUnaryOperator[A](f: A => A): UnaryOperator[A] = asJavaUnaryOperator[A](f)
+
+}
+
+object FunctionConversions extends FunctionConversions

--- a/src/main/scala/mesosphere/marathon/functional/package.scala
+++ b/src/main/scala/mesosphere/marathon/functional/package.scala
@@ -1,0 +1,3 @@
+package mesosphere.marathon
+
+package object functional extends FunctionConversions

--- a/src/main/scala/mesosphere/marathon/package.scala
+++ b/src/main/scala/mesosphere/marathon/package.scala
@@ -1,0 +1,19 @@
+package mesosphere
+
+/**
+  * Scala stupidly defines Seq/Indexed as "a generic sequence" which can be _mutable_
+  *
+  * Instead, provided you use
+  * ```
+  * package mesosphere.marathon
+  * package subpackage
+  * ```
+  * the correct Seq type till be imported for you automatically.
+  */
+package object marathon {
+  type Seq[+A] = scala.collection.immutable.Seq[A]
+  val Seq = scala.collection.immutable.Seq
+
+  type IndexedSeq[+A] = scala.collection.immutable.IndexedSeq[A]
+  val IndexedSeq = scala.collection.immutable.IndexedSeq
+}

--- a/src/main/scala/mesosphere/marathon/stream/Collectors.scala
+++ b/src/main/scala/mesosphere/marathon/stream/Collectors.scala
@@ -1,0 +1,65 @@
+package mesosphere.marathon.stream
+
+import java.util
+import java.util.function.{ BiConsumer, BinaryOperator, Function, Supplier }
+import java.util.stream.Collector
+import java.util.stream.Collector.Characteristics
+
+import mesosphere.marathon.functional._
+
+import scala.collection.immutable.{ IndexedSeq, Seq }
+import scala.collection.mutable
+
+private class GenericCollector[T, C <: TraversableOnce[T]](builder: () => mutable.Builder[T, C])
+    extends Collector[T, mutable.Builder[T, C], C] {
+  override def supplier(): Supplier[mutable.Builder[T, C]] = builder
+
+  override def combiner(): BinaryOperator[mutable.Builder[T, C]] =
+    (buf1: mutable.Builder[T, C], buf2: mutable.Builder[T, C]) => buf1 ++= buf2.result
+
+  override def finisher(): Function[mutable.Builder[T, C], C] = {
+    (buf: mutable.Builder[T, C]) => buf.result()
+  }
+
+  override def accumulator(): BiConsumer[mutable.Builder[T, C], T] = { (buf: mutable.Builder[T, C], v: T) =>
+    buf += v
+  }
+
+  override def characteristics(): util.Set[Characteristics] = util.Collections.emptySet()
+}
+
+private class MapCollector[K, V]()
+    extends Collector[util.Map.Entry[K, V], mutable.Builder[(K, V), Map[K, V]], Map[K, V]] {
+
+  override def supplier(): Supplier[mutable.Builder[(K, V), Map[K, V]]] = () => Map.newBuilder[K, V]
+
+  override def combiner(): BinaryOperator[mutable.Builder[(K, V), Map[K, V]]] = {
+    (buf1: mutable.Builder[(K, V), Map[K, V]], buf2: mutable.Builder[(K, V), Map[K, V]]) =>
+      buf1 ++= buf2.result()
+  }
+
+  override def finisher(): Function[mutable.Builder[(K, V), Map[K, V]], Map[K, V]] = {
+    (buf: mutable.Builder[(K, V), Map[K, V]]) => buf.result()
+  }
+
+  override def accumulator(): BiConsumer[mutable.Builder[(K, V), Map[K, V]], util.Map.Entry[K, V]] = {
+    (buf: mutable.Builder[(K, V), Map[K, V]], v: util.Map.Entry[K, V]) =>
+      buf += v.getKey -> v.getValue
+  }
+
+  override def characteristics(): util.Set[Characteristics] = util.Collections.emptySet()
+}
+
+/**
+  * Collectors for java 8 streaming apis
+  */
+object Collectors {
+  def seq[T]: Collector[T, mutable.Builder[T, Seq[T]], Seq[T]] = new GenericCollector(() => Seq.newBuilder[T])
+  def indexedSeq[T]: Collector[T, mutable.Builder[T, IndexedSeq[T]], IndexedSeq[T]] =
+    new GenericCollector(() => IndexedSeq.newBuilder[T])
+
+  def map[K, V]: Collector[util.Map.Entry[K, V], mutable.Builder[(K, V), Map[K, V]], Map[K, V]] =
+    new MapCollector[K, V]
+
+  def set[T]: Collector[T, mutable.Builder[T, Set[T]], Set[T]] = new GenericCollector(() => Set.newBuilder[T])
+}

--- a/src/main/scala/mesosphere/marathon/stream/JavaConversions.scala
+++ b/src/main/scala/mesosphere/marathon/stream/JavaConversions.scala
@@ -1,0 +1,37 @@
+package mesosphere.marathon
+package stream
+
+import java.util
+import java.util.AbstractMap.SimpleImmutableEntry
+import java.util.Map.Entry
+
+import scala.collection.convert.DecorateAsJava
+import scala.collection.immutable.Seq
+
+/**
+  * Very small and tight/fast wrappers around scala collections that integrate natively with java.
+  */
+trait JavaConversions extends DecorateAsJava {
+  implicit class JavaIterable[T](sc: Iterable[T]) extends util.AbstractCollection[T] {
+    override def size(): Int = sc.size
+    override def iterator(): util.Iterator[T] = sc.toIterator.asJava
+  }
+
+  implicit class JavaImmutableList[T](sc: Seq[T]) extends util.AbstractList[T] {
+    override def get(i: Int): T = sc(i)
+    override def size(): Int = sc.size
+  }
+
+  implicit class JavaSet[T](sc: Set[T]) extends util.AbstractSet[T] {
+    override def size(): Int = sc.size
+    override def iterator(): util.Iterator[T] = sc.toIterator.asJava
+  }
+
+  implicit class JavaMap[K, V](m: Map[K, V]) extends util.AbstractMap[K, V] {
+    lazy val entries: Set[Entry[K, V]] =
+      m.map { case (k, v) => new SimpleImmutableEntry[K, V](k, v) }(collection.breakOut)
+    override def entrySet(): util.Set[Entry[K, V]] = entries
+  }
+}
+
+object JavaConversions extends JavaConversions

--- a/src/main/scala/mesosphere/marathon/stream/RichStream.scala
+++ b/src/main/scala/mesosphere/marathon/stream/RichStream.scala
@@ -1,0 +1,218 @@
+package mesosphere.marathon
+package stream
+
+import java.util
+import java.util.stream.{ DoubleStream, IntStream, LongStream, Stream, StreamSupport }
+import java.util.{ Spliterator, Spliterators }
+
+import mesosphere.marathon.functional._
+
+import scala.collection.immutable
+import scala.collection.immutable.Seq
+import scala.compat.java8.OptionConverters._
+import scala.compat.java8.StreamConverters
+
+/**
+  * Enriches a Java Stream to appear as if its a scala collection that can be traversed once.
+  */
+class RichStream[T](val stream: Stream[T]) extends AnyVal with TraversableOnce[T] {
+  override def foreach[U](f: (T) => U): Unit = stream.forEach(f)
+
+  override def isEmpty: Boolean = false
+
+  override def hasDefiniteSize: Boolean = false
+
+  override def seq: Seq[T] = toTraversable
+
+  override def forall(p: (T) => Boolean): Boolean = stream.allMatch(p)
+
+  override def exists(p: (T) => Boolean): Boolean = stream.anyMatch(p)
+
+  override def find(p: (T) => Boolean): Option[T] = toScala(stream.filter(p).findFirst())
+
+  override def copyToArray[B >: T](xs: Array[B], start: Int, len: Int): Unit =
+    toStream.copyToArray(xs, start, len)
+
+  override def toTraversable: Seq[T] = stream.collect(Collectors.seq[T])
+
+  override def isTraversableAgain: Boolean = false
+
+  override def toStream: immutable.Stream[T] = StreamConverters.RichStream(stream).toScala[immutable.Stream]
+
+  override def toIterator: Iterator[T] = StreamConverters.RichStream(stream).toScala[Iterator]
+
+  def distinct(): RichStream[T] = stream.distinct()
+  def drop(l: Long): RichStream[T] = stream.skip(l)
+  def take(l: Long): RichStream[T] = stream.limit(l)
+  def max()(implicit order: Ordering[T]): Option[T] = toScala(stream.max(order))
+  def min()(implicit order: Ordering[T]): Option[T] = toScala(stream.min(order))
+}
+
+/**
+  * Enriches a Java Stream to appear as if its a scala collection that can be traversed once.
+  */
+class RichDoubleStream(val stream: DoubleStream) extends AnyVal with TraversableOnce[Double] {
+  override def foreach[U](f: (Double) => U): Unit = stream.forEach(f)
+
+  override def isEmpty: Boolean = false
+
+  override def hasDefiniteSize: Boolean = false
+
+  override def seq: Seq[Double] = toTraversable
+
+  override def forall(p: (Double) => Boolean): Boolean = stream.allMatch(p)
+
+  override def exists(p: (Double) => Boolean): Boolean = stream.anyMatch(p)
+
+  override def find(p: (Double) => Boolean): Option[Double] = toScala(stream.filter(p).findFirst())
+
+  override def copyToArray[B >: Double](xs: Array[B], start: Int, len: Int): Unit =
+    toStream.copyToArray(xs, start, len)
+
+  override def toTraversable: Seq[Double] = {
+    val supplier = () => Vector.empty[Double]
+    val accumulator = (buf: Vector[Double], v: Double) => buf :+ v
+    val collector = (b1: Vector[Double], b2: Vector[Double]) =>
+      b1 ++ b2
+    stream.collect(supplier, accumulator, collector)
+  }
+
+  override def isTraversableAgain: Boolean = false
+
+  override def toStream: immutable.Stream[Double] = StreamConverters.RichDoubleStream(stream).toScala[immutable.Stream]
+
+  override def toIterator: Iterator[Double] = StreamConverters.RichDoubleStream(stream).toScala[Iterator]
+  def distinct(): RichDoubleStream = stream.distinct()
+  def drop(l: Long): RichDoubleStream = stream.skip(l)
+  def take(l: Long): RichDoubleStream = stream.limit(l)
+  def map[R](f: Double => R): RichStream[R] = stream.map(f)
+  def max()(implicit order: Ordering[Double]): Double = stream.max(order)
+  def min()(implicit order: Ordering[Double]): Double = stream.min(order)
+}
+
+/**
+  * Enriches a Java Stream to appear as if its a scala collection that can be traversed once.
+  */
+class RichIntStream(val stream: IntStream) extends AnyVal with TraversableOnce[Int] {
+  override def foreach[U](f: (Int) => U): Unit = stream.forEach(f)
+
+  override def isEmpty: Boolean = false
+
+  override def hasDefiniteSize: Boolean = false
+
+  override def seq: Seq[Int] = toTraversable
+
+  override def forall(p: (Int) => Boolean): Boolean = stream.allMatch(p)
+
+  override def exists(p: (Int) => Boolean): Boolean = stream.anyMatch(p)
+
+  override def find(p: (Int) => Boolean): Option[Int] = toScala(stream.filter(p).findFirst())
+
+  override def copyToArray[B >: Int](xs: Array[B], start: Int, len: Int): Unit =
+    toStream.copyToArray(xs, start, len)
+
+  override def toTraversable: Seq[Int] = {
+    val supplier = () => Vector.empty[Int]
+    val accumulator = (buf: Vector[Int], v: Int) => buf :+ v
+    val collector = (b1: Vector[Int], b2: Vector[Int]) =>
+      b1 ++ b2
+    stream.collect(supplier, accumulator, collector)
+  }
+
+  override def isTraversableAgain: Boolean = false
+
+  override def toStream: immutable.Stream[Int] = StreamConverters.RichIntStream(stream).toScala[immutable.Stream]
+
+  override def toIterator: Iterator[Int] = StreamConverters.RichIntStream(stream).toScala[Iterator]
+  def distinct(): RichIntStream = stream.distinct()
+  def drop(l: Long): RichIntStream = stream.skip(l)
+  def take(l: Long): RichIntStream = stream.limit(l)
+  def map[R](f: Int => R): RichIntStream = stream.map(f)
+  def max()(implicit order: Ordering[Int]): Int = stream.max(order)
+  def min()(implicit order: Ordering[Int]): Int = stream.min(order)
+}
+
+/**
+  * Enriches a Java Stream to appear as if its a scala collection that can be traversed once.
+  */
+class RichLongStream(val stream: LongStream) extends AnyVal with TraversableOnce[Long] {
+  override def foreach[U](f: (Long) => U): Unit = stream.forEach(f)
+
+  override def isEmpty: Boolean = false
+
+  override def hasDefiniteSize: Boolean = false
+
+  override def seq: Seq[Long] = toTraversable
+
+  override def forall(p: (Long) => Boolean): Boolean = stream.anyMatch(p)
+
+  override def exists(p: (Long) => Boolean): Boolean = stream.allMatch(p)
+
+  override def find(p: (Long) => Boolean): Option[Long] = toScala(stream.filter(p).findFirst())
+
+  override def copyToArray[B >: Long](xs: Array[B], start: Int, len: Int): Unit =
+    toStream.copyToArray(xs, start, len)
+
+  override def toTraversable: Seq[Long] = {
+    val supplier = () => Vector.empty[Long]
+    val accumulator = (buf: Vector[Long], v: Long) => buf :+ v
+    val collector = (b1: Vector[Long], b2: Vector[Long]) =>
+      b1 ++ b2
+    stream.collect(supplier, accumulator, collector)
+  }
+
+  override def isTraversableAgain: Boolean = false
+
+  override def toStream: immutable.Stream[Long] = StreamConverters.RichLongStream(stream).toScala[immutable.Stream]
+
+  override def toIterator: Iterator[Long] = StreamConverters.RichLongStream(stream).toScala[Iterator]
+  def distinct(): RichLongStream = stream.distinct()
+  def drop(l: Long): RichLongStream = stream.skip(l)
+  def take(l: Long): RichLongStream = stream.limit(l)
+  def map[R](f: Long => R): RichStream[R] = stream.map(f)
+  def max()(implicit order: Ordering[Long]): Long = stream.max(order)
+  def min()(implicit order: Ordering[Long]): Long = stream.min(order)
+}
+
+/**
+  * Enriches a Enumerator by using the stream API to appear as if its a scala collection that can be traversed once.
+  */
+class RichEnumeration[T](enum: util.Enumeration[T]) extends TraversableOnce[T] {
+  val stream = StreamSupport.stream(
+    Spliterators.spliteratorUnknownSize(new util.Iterator[T] {
+      override def hasNext: Boolean = enum.hasMoreElements
+
+      override def next(): T = enum.nextElement()
+    }, Spliterator.ORDERED), false)
+
+  override def foreach[U](f: (T) => U): Unit = stream.foreach(f)
+
+  override def isEmpty: Boolean = enum.hasMoreElements
+
+  override def hasDefiniteSize: Boolean = false
+
+  override def seq: Seq[T] = stream.seq
+
+  override def forall(p: (T) => Boolean): Boolean = stream.forall(p)
+
+  override def exists(p: (T) => Boolean): Boolean = stream.exists(p)
+
+  override def find(p: (T) => Boolean): Option[T] = stream.find(p)
+
+  override def copyToArray[B >: T](xs: Array[B], start: Int, len: Int): Unit =
+    stream.copyToArray(xs, start, len)
+
+  override def toTraversable: Seq[T] = stream.toTraversable
+
+  override def isTraversableAgain: Boolean = false
+
+  override def toStream: immutable.Stream[T] = stream.toStream
+
+  override def toIterator: Iterator[T] = stream.toIterator
+  def distinct(): RichStream[T] = stream.distinct()
+  def drop(l: Long): RichStream[T] = stream.skip(l)
+  def take(l: Long): RichStream[T] = stream.limit(l)
+  def max()(implicit order: Ordering[T]): Option[T] = toScala(stream.max(order))
+  def min()(implicit order: Ordering[T]): Option[T] = toScala(stream.min(order))
+}
+

--- a/src/main/scala/mesosphere/marathon/stream/RichTraversableLike.scala
+++ b/src/main/scala/mesosphere/marathon/stream/RichTraversableLike.scala
@@ -1,4 +1,5 @@
-package mesosphere.marathon.stream
+package mesosphere.marathon
+package stream
 
 import scala.collection.TraversableLike
 import scala.collection.generic.CanBuildFrom

--- a/src/main/scala/mesosphere/marathon/stream/RichTraversableLike.scala
+++ b/src/main/scala/mesosphere/marathon/stream/RichTraversableLike.scala
@@ -1,0 +1,23 @@
+package mesosphere.marathon.stream
+
+import scala.collection.TraversableLike
+import scala.collection.generic.CanBuildFrom
+
+/**
+  * Extends traversable with a filter that isn't stupid
+  */
+class RichTraversableLike[+A, +Repr](to: TraversableLike[A, Repr]) {
+  private def filterAsImpl[B >: A, That](p: A => Boolean, isFlipped: Boolean)(implicit cbf: CanBuildFrom[Repr, B, That]): That = {
+    val b = cbf(to.repr)
+    to.foreach { x =>
+      if (p(x) != isFlipped) b += x
+    }
+    b.result
+  }
+
+  def filterAs[B >: A, That](p: A => Boolean)(implicit cbf: CanBuildFrom[Repr, B, That]): That =
+    filterAsImpl(p, isFlipped = false)
+
+  def filterNotAs[B >: A, That](p: A => Boolean)(implicit cbf: CanBuildFrom[Repr, B, That]): That =
+    filterAsImpl(p, isFlipped = true)
+}

--- a/src/main/scala/mesosphere/marathon/stream/ScalaConversions.scala
+++ b/src/main/scala/mesosphere/marathon/stream/ScalaConversions.scala
@@ -6,6 +6,7 @@ import java.util
 import mesosphere.marathon.functional._
 
 import scala.collection.immutable.{ IndexedSeq, Seq, Set }
+import scala.collection.mutable
 import scala.language.implicitConversions
 
 /**
@@ -13,6 +14,11 @@ import scala.language.implicitConversions
   * api to do so (its generally faster than scala's built-ins)
   */
 trait ScalaConversions {
+  implicit class RichArray[T](array: Array[T]) extends mutable.IndexedSeq[T] {
+    override def update(idx: Int, elem: T): Unit = array(idx) = elem
+    override def length: Int = array.length
+    override def apply(idx: Int): T = array(idx)
+  }
 
   implicit class RichCollection[T](collection: util.Collection[T]) extends Traversable[T] {
     override def foreach[U](f: (T) => U): Unit = collection.stream().foreach(f)

--- a/src/main/scala/mesosphere/marathon/stream/ScalaConversions.scala
+++ b/src/main/scala/mesosphere/marathon/stream/ScalaConversions.scala
@@ -1,0 +1,49 @@
+package mesosphere.marathon
+package stream
+
+import java.util
+
+import mesosphere.marathon.functional._
+
+import scala.collection.immutable.{ IndexedSeq, Seq, Set }
+import scala.language.implicitConversions
+
+/**
+  * Conversions that make java collections appear like scala collections, generally using the stream
+  * api to do so (its generally faster than scala's built-ins)
+  */
+trait ScalaConversions {
+
+  implicit class RichCollection[T](collection: util.Collection[T]) extends Traversable[T] {
+    override def foreach[U](f: (T) => U): Unit = collection.stream().foreach(f)
+    override def toSeq: Seq[T] = ScalaConversions.toSeq(collection)
+    override def toIndexedSeq: IndexedSeq[T] = ScalaConversions.toIndexedSeq(collection)
+    override def toSet[B >: T]: Set[B] = ScalaConversions.toSet(collection)
+  }
+
+  implicit class RichMap[K, V](map: util.Map[K, V]) extends Traversable[(K, V)] {
+    override def foreach[U](f: ((K, V)) => U): Unit =
+      map.entrySet().stream().foreach(entry => f(entry.getKey -> entry.getValue))
+    def toMap: Map[K, V] = ScalaConversions.toMap(map)
+  }
+
+  def toSeq[T](collection: util.Collection[T]): Seq[T] =
+    collection.stream().collect(Collectors.seq[T])
+
+  def toIndexedSeq[T](collection: util.Collection[T]): IndexedSeq[T] =
+    collection.stream().collect(Collectors.indexedSeq[T])
+
+  def toSet[T, B >: T](collection: util.Collection[T]): Set[B] =
+    collection.stream().collect(Collectors.set[B])
+
+  def toMap[K, V](map: util.Map[K, V]): Map[K, V] =
+    map.entrySet().stream().collect(Collectors.map[K, V])
+
+  implicit def toTraversableOnce[T](enum: util.Enumeration[T]): RichEnumeration[T] = new RichEnumeration[T](enum)
+
+  implicit class RichIterator[T](iterator: util.Iterator[T]) extends Traversable[T] {
+    override def foreach[U](f: (T) => U): Unit = iterator.forEachRemaining(f)
+  }
+}
+
+object ScalaConversions extends ScalaConversions

--- a/src/main/scala/mesosphere/marathon/stream/StreamConversions.scala
+++ b/src/main/scala/mesosphere/marathon/stream/StreamConversions.scala
@@ -1,0 +1,13 @@
+package mesosphere.marathon
+package stream
+
+import scala.language.implicitConversions
+
+import java.util.stream._
+
+trait StreamConversions {
+  implicit def toScalaTraversableOnce[T](stream: Stream[T]): RichStream[T] = new RichStream(stream)
+  implicit def toScalaTraversableOnce(stream: DoubleStream): RichDoubleStream = new RichDoubleStream(stream)
+  implicit def toScalaTraversableOnce(stream: IntStream): RichIntStream = new RichIntStream(stream)
+  implicit def toScalaTraversableOnce(stream: LongStream): RichLongStream = new RichLongStream(stream)
+}

--- a/src/main/scala/mesosphere/marathon/stream/package.scala
+++ b/src/main/scala/mesosphere/marathon/stream/package.scala
@@ -1,0 +1,9 @@
+package mesosphere.marathon
+
+import scala.language.implicitConversions
+import scala.collection.TraversableLike
+
+package object stream extends StreamConversions with ScalaConversions with JavaConversions {
+  implicit def toRichTraversableLike[A, Repr](t: TraversableLike[A, Repr]): RichTraversableLike[A, Repr] =
+    new RichTraversableLike[A, Repr](t)
+}

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -22,7 +22,6 @@ import org.scalatest.time.{ Millis, Span }
 import org.scalatest.{ GivenWhenThen, Matchers }
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration._
 


### PR DESCRIPTION
- Turn on some additional compiler linter/errors and
  generate b-code which is more native to Java8 and reduces
  the number of class files dramatically
- Create implicit conversions for all java.util.functional interfaces.
- Create package object "mesosphere.marathon" that _correctly_
  defines Seq and ImmutableSeq to be immutable.
  - Going forward, scala files should use "double" package declaration
    (which imports this package object automatically)
    See also: http://www.scala-lang.org/docu/files/ScalaReference.pdf
    Chapter 9, approximately page 135 in the pdf.
- Create Java8 stream collectors that can collect directly into a Scala
  Collection.
- Create JavaConversions that are a very simple view into the immutable
  scala collection.
- Create implicit for java8 streams that make them appear as if they are
  TraversableOnce collections and it will use the underlying stream
  operation in Java8 for most operations.
- Add a new RichTraversableLike which adds "filterAs" and "filterNotAs"
  that take in a CanBuildFrom allowing a filter to use the correct
  collection type desired, instead of always using the source collection
  type (which internally is what it does).
- Create richer conversions from JavaCollections that implement the
  appropriate scala interface and use the streaming API to implement it.
  This appears to be about 40% faster than scala's own conversions and
  allows you to duplicate a lot less.
- In a nutshell, one should always use "import mesosphere.marathon.stream._"
  and not scala.collection.JavaCon*.

Future TODOS:
- Add linter to enforce double package.
- Add linter to enforce no JavaConversions or JavaConverters and prefer
  stream package.