### PR TITLE
It is invalid to supply both "cmd" and "args"  in the same app.

### DIFF
--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/AppsResource_create.md
@@ -8,7 +8,6 @@ Here is an example of an application JSON which includes all fields.
 {
     "id": "/product/service/myApp",
     "cmd": "env && sleep 300",
-    "args": ["/bin/sh", "-c", "env && sleep 300"]
     "cpus": 1.5,
     "mem": 256.0,
     "portDefinitions": [


### PR DESCRIPTION
According to the documentation on the same page.