### PR TITLE
Refactor integration tests and add Pod tests

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/setup/AppMock.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/AppMock.scala
@@ -52,10 +52,10 @@ class AppMock(appId: String, version: String, url: String) extends AbstractHandl
 
 object AppMock {
   def main(args: Array[String]): Unit = {
-    val port = sys.env("PORT0").toInt
-    val appId = args(0)
-    val version = args(1)
-    val url = args(2) + "/" + port
+    val port = args(0).toInt
+    val appId = args(1)
+    val version = args(2)
+    val url = args(3) + "/" + port
     new AppMock(appId, version, url).start(port)
   }
 }

--- a/src/test/scala/mesosphere/marathon/integration/setup/DockerAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/DockerAppIntegrationTest.scala
@@ -4,6 +4,7 @@ import mesosphere.marathon.integration.facades.MarathonFacade
 import MarathonFacade._
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state.{ AppDefinition, Container }
+import mesosphere.marathon.integration.setup.ProcessKeeper.MesosConfig
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
 
 import scala.concurrent.duration._
@@ -13,67 +14,54 @@ class DockerAppIntegrationTest
     with SingleMarathonIntegrationTest
     with Matchers
     with BeforeAndAfter
-    with GivenWhenThen {
+    with GivenWhenThen
+    with RunInEnvironment {
+
+  // FIXME (gkleiman): Docker tests don't work under Docker Machine yet. So they can be disabled through an env variable.
+  override val envVar = "RUN_DOCKER_INTEGRATION_TESTS"
+
+  // Configure Mesos to provide the Docker containerizer.
+  override def startMesos(): Unit = {
+    ProcessKeeper.startMesosLocal(MesosConfig(
+      port = config.mesosPort,
+      containerizers = "docker,mesos"))
+  }
+
   //clean up state before running the test case
   before(cleanUp())
 
-  // FIXME (gkleiman): Docker tests don't work under Docker Machine yet. So they can be disabled through an env variable.
-  if (sys.env.getOrElse("RUN_DOCKER_INTEGRATION_TESTS", "true") == "true") {
-    test("deploy a simple Docker app") {
-      Given("a new Docker app")
-      val app = AppDefinition(
-        id = testBasePath / "dockerapp",
-        cmd = Some("sleep 600"),
-        container = Some(Container.Docker(image = "busybox")),
-        resources = Resources(cpus = 0.2, mem = 16.0),
-        instances = 1
-      )
+  test("deploy a simple Docker app") {
+    Given("a new Docker app")
+    val app = AppDefinition(
+      id = testBasePath / "dockerapp",
+      cmd = Some("sleep 600"),
+      container = Some(Container.Docker(image = "busybox")),
+      resources = Resources(cpus = 0.2, mem = 16.0),
+      instances = 1
+    )
 
-      When("The app is deployed")
-      val result = marathon.createAppV2(app)
+    When("The app is deployed")
+    val result = marathon.createAppV2(app)
 
-      Then("The app is created")
-      result.code should be(201) // Created
-      extractDeploymentIds(result) should have size 1
-      waitForEvent("deployment_success")
-      waitForTasks(app.id, 1) // The app has really started
-    }
+    Then("The app is created")
+    result.code should be(201) // Created
+    extractDeploymentIds(result) should have size 1
+    waitForEvent("deployment_success")
+    waitForTasks(app.id, 1) // The app has really started
+  }
 
-    // TODO(nfnt): Enable this test when integration tests aren't run in a Docker container.
-    // The Mesos containerizer needs access to cgroups, which is hard to provide in a container.
-    ignore("deploy a simple Docker app using the Mesos containerizer") {
-      Given("a new Docker app")
-      val app = AppDefinition(
-        id = testBasePath / "mesosdockerapp",
-        cmd = Some("sleep 600"),
-        container = Some(Container.MesosDocker(image = "busybox")),
-        resources = Resources(cpus = 0.2, mem = 16.0),
-        instances = 1
-      )
+  test("create a simple docker app using http health checks with HOST networking") {
+    Given("a new app")
+    val app = dockerAppProxy(testBasePath / "docker-http-app", "v1", instances = 1, withHealth = true)
+    val check = appProxyCheck(app.id, "v1", true)
 
-      When("The app is deployed")
-      val result = marathon.createAppV2(app)
+    When("The app is deployed")
+    val result = marathon.createAppV2(app)
 
-      Then("The app is created")
-      result.code should be(201) // Created
-      extractDeploymentIds(result) should have size 1
-      waitForEvent("deployment_success")
-      waitForTasks(app.id, 1) // The app has really started
-    }
-
-    test("create a simple docker app using http health checks with HOST networking") {
-      Given("a new app")
-      val app = dockerAppProxy(testBasePath / "docker-http-app", "v1", instances = 1, withHealth = true)
-      val check = appProxyCheck(app.id, "v1", true)
-
-      When("The app is deployed")
-      val result = marathon.createAppV2(app)
-
-      Then("The app is created")
-      result.code should be(201) //Created
-      extractDeploymentIds(result) should have size 1
-      waitForEvent("deployment_success")
-      check.pingSince(5.seconds) should be(true) //make sure, the app has really started
-    }
+    Then("The app is created")
+    result.code should be(201) //Created
+    extractDeploymentIds(result) should have size 1
+    waitForEvent("deployment_success")
+    check.pingSince(5.seconds) should be(true) //make sure, the app has really started
   }
 }

--- a/src/test/scala/mesosphere/marathon/integration/setup/IntegrationFunSuite.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/IntegrationFunSuite.scala
@@ -29,6 +29,21 @@ trait IntegrationFunSuite extends FunSuite {
 }
 
 /**
+  * Trait for enabling or disabling test cases based on environment variables.
+  */
+trait RunInEnvironment extends FunSuite {
+  def envVar: String
+
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
+    if (sys.env.getOrElse(envVar, "true") == "true") {
+      super.test(testName, testTags: _*)(testFun)
+    } else {
+      super.ignore(testName, testTags: _*)(testFun)
+    }
+  }
+}
+
+/**
   * Trait for running external marathon instances.
   */
 trait ExternalMarathonIntegrationTest {

--- a/src/test/scala/mesosphere/marathon/integration/setup/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MesosAppIntegrationTest.scala
@@ -1,10 +1,14 @@
 package mesosphere.marathon.integration.setup
 
+import mesosphere.marathon.core.pod.{ HostNetwork, HostVolume, MesosContainer, PodDefinition }
 import mesosphere.marathon.integration.facades.MarathonFacade._
 import mesosphere.marathon.integration.setup.ProcessKeeper.MesosConfig
-import mesosphere.marathon.raml.Resources
+import mesosphere.marathon.raml
 import mesosphere.marathon.state.{ AppDefinition, Container }
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
+
+import scala.collection.immutable.Seq
+import scala.concurrent.duration._
 
 class MesosAppIntegrationTest
     extends IntegrationFunSuite
@@ -49,5 +53,128 @@ class MesosAppIntegrationTest
     extractDeploymentIds(result) should have size 1
     waitForEvent("deployment_success")
     waitForTasks(app.id, 1) // The app has really started
+  }
+
+  test("deploy a simple pod") {
+    Given("a pod with a single task")
+    val podId = testBasePath / "simplepod"
+
+    val pod = PodDefinition(
+      id = podId,
+      containers = Seq(
+        MesosContainer(
+          name = "task1",
+          exec = Some(raml.MesosExec(raml.ShellCommand("sleep 1000"))),
+          resources = raml.Resources(cpus = 0.1, mem = 32.0)
+        )
+      ),
+      networks = Seq(HostNetwork),
+      instances = 1
+    )
+
+    When("The pod is deployed")
+    val createResult = marathon.createPodV2(pod)
+
+    Then("The pod is created")
+    createResult.code should be(201) // Created
+    waitForEvent("deployment_success")
+    waitForPod(pod.id)
+
+    When("The pod should be scaled")
+    val scaledPod = pod.copy(instances = 2)
+    val updateResult = marathon.updatePod(pod.id, scaledPod)
+
+    Then("The pod is scaled")
+    updateResult.code should be(200)
+    waitForEvent("deployment_success")
+
+    When("The pod should be deleted")
+    val deleteResult = marathon.deletePod(pod.id)
+
+    Then("The pod is deleted")
+    deleteResult.code should be (202) // Deleted
+    waitForEvent("deployment_success")
+  }
+
+  test("deploy a simple pod with health checks") {
+    val projectDir = sys.props.getOrElse("user.dir", ".")
+    val homeDir = sys.props.getOrElse("user.home", "~")
+
+    Given("a pod with two tasks that are health checked")
+    val podId = testBasePath / "healthypod"
+    val containerDir = "/opt/marathon"
+    def appMockCommand(port: String) = appProxyCommand(podId, "v1", containerDir, port)
+
+    val pod = PodDefinition(
+      id = podId,
+      containers = Seq(
+        MesosContainer(
+          name = "task1",
+          exec = Some(raml.MesosExec(raml.ShellCommand(appMockCommand("$ENDPOINT_TASK1")))),
+          resources = raml.Resources(cpus = 0.1, mem = 32.0),
+          endpoints = Seq(raml.Endpoint(name = "task1", hostPort = Some(0))),
+          image = Some(raml.Image(raml.ImageType.Docker, "openjdk:8-jre-alpine")),
+          healthCheck = Some(raml.HealthCheck(http = Some(raml.HttpHealthCheck("task1", Some("/"))))),
+          volumeMounts = Seq(
+            raml.VolumeMount("target", s"$containerDir/target", Some(true)),
+            raml.VolumeMount("ivy2", s"$containerDir/.ivy2", Some(true)),
+            raml.VolumeMount("sbt", s"$containerDir/.sbt", Some(true))
+          )
+        ),
+        MesosContainer(
+          name = "task2",
+          exec = Some(raml.MesosExec(raml.ShellCommand(appMockCommand("$ENDPOINT_TASK2")))),
+          resources = raml.Resources(cpus = 0.1, mem = 32.0),
+          endpoints = Seq(raml.Endpoint(name = "task2", hostPort = Some(0))),
+          image = Some(raml.Image(raml.ImageType.Docker, "openjdk:8-jre-alpine")),
+          healthCheck = Some(raml.HealthCheck(http = Some(raml.HttpHealthCheck("task2", Some("/"))))),
+          volumeMounts = Seq(
+            raml.VolumeMount("target", s"$containerDir/target", Some(true)),
+            raml.VolumeMount("ivy2", s"$containerDir/.ivy2", Some(true)),
+            raml.VolumeMount("sbt", s"$containerDir/.sbt", Some(true))
+          )
+        )
+      ),
+      podVolumes = Seq(
+        HostVolume("target", s"$projectDir/target"),
+        HostVolume("ivy2", s"$homeDir/.ivy2"),
+        HostVolume("sbt", s"$homeDir/.sbt")
+      ),
+      networks = Seq(HostNetwork),
+      instances = 1
+    )
+
+    val check = appProxyCheck(pod.id, "v1", true)
+
+    When("The pod is deployed")
+    val createResult = marathon.createPodV2(pod)
+
+    Then("The pod is created")
+    createResult.code should be(201) //Created
+    // The timeout is 5 minutes because downloading and provisioning the Python image can take some time.
+    waitForEvent("deployment_success", 300.seconds)
+    waitForPod(podId)
+    check.pingSince(5.seconds) should be(true) //make sure, the app has really started
+
+    When("The pod definition is changed")
+    val updatedPod = pod.copy(
+      containers = pod.containers :+ MesosContainer(
+      name = "task3",
+      exec = Some(raml.MesosExec(raml.ShellCommand("sleep 1000"))),
+      resources = raml.Resources(cpus = 0.1, mem = 32.0)
+    )
+    )
+    val updateResult = marathon.updatePod(pod.id, updatedPod)
+
+    Then("The pod is updated")
+    updateResult.code should be(200)
+    waitForEvent("deployment_success")
+
+    When("The pod should be deleted")
+    val deleteResult = marathon.deletePod(pod.id)
+
+    Then("The pod is deleted")
+    deleteResult.code should be (202) // Deleted
+    waitForEvent("deployment_success")
   }
 }

--- a/src/test/scala/mesosphere/marathon/integration/setup/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MesosAppIntegrationTest.scala
@@ -1,0 +1,53 @@
+package mesosphere.marathon.integration.setup
+
+import mesosphere.marathon.integration.facades.MarathonFacade._
+import mesosphere.marathon.integration.setup.ProcessKeeper.MesosConfig
+import mesosphere.marathon.raml.Resources
+import mesosphere.marathon.state.{ AppDefinition, Container }
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
+
+class MesosAppIntegrationTest
+    extends IntegrationFunSuite
+    with SingleMarathonIntegrationTest
+    with Matchers
+    with BeforeAndAfter
+    with GivenWhenThen
+    with RunInEnvironment {
+
+  // Integration tests using docker image provisioning with the Mesos containerizer need to be
+  // run as root in a Linux environment. They have to be explicitly enabled through an env variable.
+  override val envVar = "RUN_MESOS_INTEGRATION_TESTS"
+
+  // Configure Mesos to provide the Mesos containerizer with Docker image support.
+  override def startMesos(): Unit = {
+    ProcessKeeper.startMesosLocal(MesosConfig(
+      port = config.mesosPort,
+      launcher = "linux",
+      containerizers = "mesos",
+      isolation = Some("filesystem/linux,docker/runtime"),
+      imageProviders = Some("docker")))
+  }
+
+  //clean up state before running the test case
+  before(cleanUp())
+
+  test("deploy a simple Docker app using the Mesos containerizer") {
+    Given("a new Docker app")
+    val app = AppDefinition(
+      id = testBasePath / "mesosdockerapp",
+      cmd = Some("sleep 600"),
+      container = Some(Container.MesosDocker(image = "busybox")),
+      resources = raml.Resources(cpus = 0.2, mem = 16.0),
+      instances = 1
+    )
+
+    When("The app is deployed")
+    val result = marathon.createAppV2(app)
+
+    Then("The app is created")
+    result.code should be(201) // Created
+    extractDeploymentIds(result) should have size 1
+    waitForEvent("deployment_success")
+    waitForTasks(app.id, 1) // The app has really started
+  }
+}

--- a/src/test/scala/mesosphere/marathon/integration/setup/ProcessKeeper.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ProcessKeeper.scala
@@ -8,6 +8,7 @@ import com.google.common.util.concurrent.{ AbstractIdleService, Service }
 import com.google.inject.Guice
 import mesosphere.chaos.http.{ HttpConf, HttpModule, HttpService }
 import mesosphere.chaos.metrics.MetricsModule
+import mesosphere.util.PortAllocator
 import org.apache.commons.io.FileUtils
 import org.rogach.scallop.ScallopConf
 import org.slf4j.LoggerFactory
@@ -32,6 +33,14 @@ object ProcessKeeper {
   private[this] var services = List.empty[Service]
 
   private[this] val ENV_MESOS_WORK_DIR: String = "MESOS_WORK_DIR"
+
+  case class MesosConfig(
+    port: Int = PortAllocator.ephemeralPort(),
+    launcher: String = "posix",
+    containerizers: String = "mesos",
+    isolation: Option[String] = None,
+    imageProviders: Option[String] = None
+  )
 
   def startHttpService(port: Int, assetPath: String) = {
     startService {
@@ -64,28 +73,20 @@ object ProcessKeeper {
       sys.env, _.contains("binding to port"))
   }
 
-  def startMesosLocal(port: Int): Process = {
+  def startMesosLocal(config: MesosConfig): Process = {
     val mesosWorkDirForMesos: String = "/tmp/marathon-itest-mesos"
     val mesosWorkDirFile: File = new File(mesosWorkDirForMesos)
     FileUtils.deleteDirectory(mesosWorkDirFile)
     FileUtils.forceMkdir(mesosWorkDirFile)
 
-    val mesosEnv = setupMesosEnv(mesosWorkDirFile, mesosWorkDirForMesos)
+    val mesosEnv = setupMesosEnv(mesosWorkDirFile, mesosWorkDirForMesos, config)
     startProcess(
       "mesos",
-      Process(Seq("mesos-local", "--ip=127.0.0.1", s"--port=$port"), cwd = None, mesosEnv: _*),
+      Process(Seq("mesos-local", "--ip=127.0.0.1", s"--port=${config.port}"), cwd = None, mesosEnv: _*),
       upWhen = _.toLowerCase.contains("registered with master"))
   }
 
-  private[this] def defaultContainerizers: String = {
-    if (sys.env.getOrElse("RUN_DOCKER_INTEGRATION_TESTS", "true") == "true") {
-      "docker,mesos"
-    } else {
-      "mesos"
-    }
-  }
-  def setupMesosEnv(workDirFile: File, workDir: String, containerizers: Option[String] = None) = {
-    val effectiveContainerizers = containerizers.getOrElse(defaultContainerizers)
+  def setupMesosEnv(workDirFile: File, workDir: String, config: MesosConfig) = {
     val credentialsPath = write(workDirFile, fileName = "credentials", content = "principal1 secret1")
     val aclsPath = write(workDirFile, fileName = "acls.json", content =
       """
@@ -114,11 +115,13 @@ object ProcessKeeper {
     Seq(
       ENV_MESOS_WORK_DIR -> workDir,
       "MESOS_RUNTIME_DIR" -> workDir,
-      "MESOS_LAUNCHER" -> "posix",
-      "MESOS_CONTAINERIZERS" -> effectiveContainerizers,
+      "MESOS_LAUNCHER" -> config.launcher,
+      "MESOS_CONTAINERIZERS" -> config.containerizers,
       "MESOS_ROLES" -> "public,foo",
       "MESOS_ACLS" -> s"file://$aclsPath",
-      "MESOS_CREDENTIALS" -> s"file://$credentialsPath")
+      "MESOS_CREDENTIALS" -> s"file://$credentialsPath") ++
+      (if (config.isolation.isDefined) Seq("MESOS_ISOLATION" -> config.isolation.get) else Nil) ++
+      (if (config.imageProviders.isDefined) Seq("MESOS_IMAGE_PROVIDERS" -> config.imageProviders.get) else Nil)
   }
 
   def startMesos(processName: String, workDir: String, args: Seq[String], startMessage: String, wipe: Boolean): Process = {
@@ -126,7 +129,7 @@ object ProcessKeeper {
     if (wipe) FileUtils.deleteDirectory(workDirFile)
     FileUtils.forceMkdir(workDirFile)
 
-    val mesosEnv = setupMesosEnv(workDirFile, workDir, containerizers = Some("mesos"))
+    val mesosEnv = setupMesosEnv(workDirFile, workDir, MesosConfig(containerizers = "mesos"))
     startProcess(
       processName,
       Process(args, cwd = None, mesosEnv: _*),

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -109,7 +109,7 @@ trait SingleMarathonIntegrationTest
     }
   }
 
-  protected def startMesos(): Unit = ProcessKeeper.startMesosLocal(config.mesosPort)
+  protected def startMesos(): Unit = ProcessKeeper.startMesosLocal(ProcessKeeper.MesosConfig(config.mesosPort))
 
   protected def createConfig(configMap: ConfigMap): IntegrationTestConfig = IntegrationTestConfig(configMap)
 

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -6,7 +6,7 @@ import java.util
 
 import mesosphere.marathon.core.health.{ HealthCheck, MarathonHttpHealthCheck }
 import mesosphere.marathon.integration.facades.{ ITDeploymentResult, ITEnrichedTask, MarathonFacade, MesosFacade }
-import mesosphere.marathon.raml.Resources
+import mesosphere.marathon.raml.{ PodState, PodStatus, Resources }
 import mesosphere.marathon.state.{ AppDefinition, Container, DockerVolume, PathId }
 import mesosphere.marathon.stream._
 import org.apache.commons.io.FileUtils
@@ -199,6 +199,13 @@ trait SingleMarathonIntegrationTest
 
   def waitForHealthCheck(check: IntegrationHealthCheck, maxWait: FiniteDuration = 30.seconds) = {
     WaitTestSupport.waitUntil("Health check to get queried", maxWait) { check.pinged }
+  }
+
+  def waitForPod(podId: PathId, maxWait: FiniteDuration = 30.seconds): PodStatus = {
+    def checkPods = {
+      Try(marathon.status(podId)).map(_.value).toOption.filter(_.status == PodState.Stable)
+    }
+    WaitTestSupport.waitFor(s"Pod to launch", maxWait)(checkPods)
   }
 
   private def appProxyMainInvocationImpl: String = {

--- a/tests/integration/unit-integration-tests.sh
+++ b/tests/integration/unit-integration-tests.sh
@@ -26,10 +26,13 @@ if [[ -z ${RUN_DOCKER_INTEGRATION_TESTS+x} ]]; then
   fi
 fi
 
+# these test cannot run inside a container
+RUN_MESOS_INTEGRATION_TESTS="false"
+
 export MARATHON_MAX_TASKS_PER_OFFER="${MARATHON_MAX_TASKS_PER_OFFER-1}"
 
 
-DOCKER_OPTIONS="run --entrypoint=/bin/bash --rm --name marathon-itests-$BUILD_ID --net host --privileged -e TARGETS_DIR=$TARGETS_DIR -e RUN_DOCKER_INTEGRATION_TESTS=$RUN_DOCKER_INTEGRATION_TESTS -e MARATHON_MAX_TASKS_PER_OFFER=$MARATHON_MAX_TASKS_PER_OFFER -v $WORKSPACE:/marathon -v $TARGET:/marathon/target -v /var/run/docker.sock:/var/run/docker.sock -v /etc/hosts:/etc/hosts -i"
+DOCKER_OPTIONS="run --entrypoint=/bin/bash --rm --name marathon-itests-$BUILD_ID --net host --privileged -e TARGETS_DIR=$TARGETS_DIR -e RUN_DOCKER_INTEGRATION_TESTS=$RUN_DOCKER_INTEGRATION_TESTS -e RUN_MESOS_INTEGRATION_TESTS=$RUN_MESOS_INTEGRATION_TESTS -e MARATHON_MAX_TASKS_PER_OFFER=$MARATHON_MAX_TASKS_PER_OFFER -v $WORKSPACE:/marathon -v $TARGET:/marathon/target -v /var/run/docker.sock:/var/run/docker.sock -v /etc/hosts:/etc/hosts -i"
 
 DOCKER_CMD="/usr/local/bin/sbt -Dsbt.log.format=false coverage doc test integration:test scapegoat coverageReport mesos-simulation/integration:test"
 


### PR DESCRIPTION
This refactors the current integration tests to support tests using the Mesos containerizer and adds a (simple) test for pods. Currently this can be tested only locally because it doesn't work inside of a Docker container -- the Mesos agent needs certain things not available there. Next step would be to update the Velocity infrastructure to support running these tests.