### PR TITLE
Cache hostname for MarathonConf.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -20,6 +20,10 @@ import org.rogach.scallop.ScallopConf
 
 import scala.sys.SystemProperties
 
+object FancyHostNameCache {
+  val hostname = java.net.InetAddress.getLocalHost.getHostName
+}
+
 trait MarathonConf
     extends ScallopConf
     with EventConf with GroupManagerConfig with LaunchQueueConfig with LaunchTokenConfig with LeaderProxyConf
@@ -111,7 +115,7 @@ trait MarathonConf
     "hostname",
     descr = "The advertised hostname that is used for the communication with the Mesos master. " +
       "The value is also stored in the persistent store so another standby host can redirect to the elected leader.",
-    default = Some(java.net.InetAddress.getLocalHost.getHostName))
+    default = Some(FancyHostNameCache.hostname))
 
   lazy val webuiUrl = opt[String](
     "webui_url",

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -20,8 +20,8 @@ import org.rogach.scallop.ScallopConf
 
 import scala.sys.SystemProperties
 
-object FancyHostNameCache {
-  val hostname = java.net.InetAddress.getLocalHost.getHostName
+private[marathon] object MarathonConfHostNameCache {
+  lazy val hostname = java.net.InetAddress.getLocalHost.getHostName
 }
 
 trait MarathonConf
@@ -115,7 +115,7 @@ trait MarathonConf
     "hostname",
     descr = "The advertised hostname that is used for the communication with the Mesos master. " +
       "The value is also stored in the persistent store so another standby host can redirect to the elected leader.",
-    default = Some(FancyHostNameCache.hostname))
+    default = Some(MarathonConfHostNameCache.hostname))
 
   lazy val webuiUrl = opt[String](
     "webui_url",


### PR DESCRIPTION
Somehow `java.net.InetAddress.getLocalHost.getHostName` is blocking and
takes a few seconds (at least with macOS Sierra). So my tests took more
than 40 minutes. Once the hostname is cached the tests take less than a
minute to complete.

I don't think this will ahve any impact in production since the conf
should be created only once.