### PR TITLE
Removed an unused function: `updateGroup`.

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -79,11 +79,6 @@ case class Group(
       version = timestamp))
   }
 
-  def updateGroup(fn: Group => Option[Group]): Option[Group] = {
-    fn(this).map(_.copy(groupsById = groups.flatMap(_.updateGroup(fn))
-      .map(group => group.id -> group)(collection.breakOut)))
-  }
-
   /** Removes the group with the given gid if it exists */
   def remove(gid: PathId, timestamp: Timestamp = Timestamp.now()): Group = {
     copy(groupsById = groups.filter(_.id != gid).map{ currentGroup =>

--- a/src/test/scala/mesosphere/marathon/state/GroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/GroupTest.scala
@@ -51,40 +51,6 @@ class GroupTest extends FunSpec with GivenWhenThen with Matchers {
       current.group(path) should be('empty)
     }
 
-    it("can filter a group by a filter function") {
-      Given("an group with subgroups")
-      val group1App1 = AppDefinition("/test/group1/app1".toPath)
-      val group2App2 = AppDefinition("/test/group2/app2".toPath)
-      val group2AApp1 = AppDefinition("/test/group2/a/app1".toPath)
-      val group2BApp1 = AppDefinition("/test/group2/b/app1".toPath)
-      val current = Group(
-        id = Group.empty.id,
-        groups = Set(
-          Group("/test".toPath, groups = Set(
-            Group("/test/group1".toPath, Map(group1App1.id -> group1App1)),
-            Group("/test/group2".toPath, Map(group2App2.id -> group2App2), Set(
-              Group("/test/group2/a".toPath, Map(group2AApp1.id -> group2AApp1)),
-              Group("/test/group2/b".toPath, Map(group2BApp1.id -> group2BApp1))
-            ))
-          ))))
-
-      When("a group with a specific path is requested")
-      val allowed = "/test/group2/a".toPath
-      val updated = current.updateGroup { group =>
-        if (group.id.includes(allowed)) Some(group) //child
-        else if (allowed.includes(group.id)) Some(group.copy(apps = Map.empty, dependencies = Set.empty)) //taskTrackerRef
-        else None
-      }
-
-      Then("the group is not found")
-      updated should be('defined)
-      updated.get.group("/test/group1".toPath) should be('empty)
-      updated.get.group("/test".toPath) should be('defined)
-      updated.get.group("/test/group2".toPath) should be('defined)
-      updated.get.group("/test/group2/a".toPath) should be('defined)
-      updated.get.group("/test/group2/b".toPath) should be('empty)
-    }
-
     it("can do an update by applying a change function") {
       Given("an existing group with two subgroups")
       val app1 = AppDefinition("/test/group1/app1".toPath)


### PR DESCRIPTION
The `updateGroup` function was not used aside from in a unit test.
This is preliminary work in ultimately replacing the `update` function
which is too flexible.

Test Plan: sbt test

Differential Revision: https://phabricator.mesosphere.com/D5