### PR TITLE
Made `update` function private.

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -69,7 +69,7 @@ case class Group(
     update(timestamp) { group => group.copy(apps = group.apps.mapValues(fn)) }
   }
 
-  def update(timestamp: Timestamp = Timestamp.now())(fn: Group => Group): Group = {
+  private[state] def update(timestamp: Timestamp = Timestamp.now())(fn: Group => Group): Group = {
     def in(groups: List[Group]): List[Group] = groups match {
       case head :: rest => head.update(timestamp)(fn) :: in(rest)
       case Nil => Nil


### PR DESCRIPTION
The `update` function is only used within the `Group` class.
Made it `private` to keep it this way until we ultimately replace it.

Test Plan: sbt test

Differential Revision: https://phabricator.mesosphere.com/D6