### PR TITLE
Removed unnecessary `Group.emptyWithId`.

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -232,7 +232,6 @@ object Group {
     new Group(id = id, groupsById = groups.map(group => group.id -> group)(collection.breakOut))
 
   def empty: Group = Group(PathId(Nil))
-  def emptyWithId(id: PathId): Group = empty.copy(id = id)
 
   def fromProto(msg: GroupDefinition): Group = {
     Group(

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -66,7 +66,7 @@ class TaskKillerTest extends MarathonSpec
     val tasksToKill = Set(task1, task2)
 
     when(f.tracker.hasAppTasksSync(appId)).thenReturn(true)
-    when(f.groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
+    when(f.groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group(appId.parent))))
 
     val groupUpdateCaptor = ArgumentCaptor.forClass(classOf[(Group) => Group])
     val forceCaptor = ArgumentCaptor.forClass(classOf[Boolean])
@@ -135,7 +135,7 @@ class TaskKillerTest extends MarathonSpec
     val tasksToKill = Set(task1, task2)
 
     when(f.tracker.hasAppTasksSync(appId)).thenReturn(true)
-    when(f.groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group.emptyWithId(appId.parent))))
+    when(f.groupManager.group(appId.parent)).thenReturn(Future.successful(Some(Group(appId.parent))))
     val groupUpdateCaptor = ArgumentCaptor.forClass(classOf[(Group) => Group])
     val forceCaptor = ArgumentCaptor.forClass(classOf[Boolean])
     when(f.groupManager.update(


### PR DESCRIPTION
Moving towards removing the concept of an "empty" `Group`.

Test Plan: sbt test

Differential Revision: https://phabricator.mesosphere.com/D7