### PR TITLE
Extract the version of Mesos to use in Dockerfiles.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,12 @@ COPY . /marathon
 WORKDIR /marathon
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
+    echo "deb http://repos.mesosphere.com/debian jessie-unstable main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+    MESOS_VERSION=$(sed -n 's/^.*MesosDebian = "\(.*\)"/\1/p' </marathon/project/Dependencies.scala) && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=1.0.0-2.0.89.debian81 && \
+    apt-get install --no-install-recommends -y --force-yes mesos=$MESOS_VERSION && \
     apt-get clean && \
     eval $(sed s/sbt.version/SBT_VERSION/ </marathon/project/build.properties) && \
     mkdir -p /usr/local/bin && \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -14,18 +14,20 @@
 
 FROM java:8-jdk
 
+COPY . /marathon
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
-    echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie-unstable main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+    MESOS_VERSION=$(sed -n 's/^.*MesosDebian = "\(.*\)"/\1/p' </marathon/project/Dependencies.scala) && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=1.0.0-2.0.89.debian81 && \
+    apt-get install --no-install-recommends -y --force-yes mesos=$MESOS_VERSION && \
     curl -o /tmp/docker.tgz https://get.docker.com/builds/Linux/x86_64/docker-1.11.0.tgz && \
     cd /tmp && \
     tar zxf docker.tgz && \
     mv docker/docker /usr/bin/docker && \
     chmod +x /usr/bin/docker
 
-COPY . /marathon
 RUN rm -rf /marathon/project/project/target && \
     rm -rf /marathon/project/target && \
     eval $(sed s/sbt.version/SBT_VERSION/ < /marathon/project/build.properties) && \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -6,11 +6,14 @@
 #
 FROM java:8-jdk
 
+COPY ./project/Dependencies.scala /marathon/project/Dependencies.scala
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
-    echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie-unstable main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+    MESOS_VERSION=$(sed -n 's/^.*MesosDebian = "\(.*\)"/\1/p' </marathon/project/Dependencies.scala) && \
     apt-get update && \
-    apt-get install --no-install-recommends -y --force-yes mesos=1.0.0-2.0.89.debian81
+    apt-get install --no-install-recommends -y --force-yes mesos=$MESOS_VERSION
 
 # Install sbt manually
 COPY ./project/build.properties /marathon/project/build.properties

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,6 +75,8 @@ object Dependency {
     val Guava = "19.0"
     // FIXME (gkleiman): reenable deprecation checks after Mesos 1.0.0-rc2 deprecations are handled
     val Mesos = "1.1.0-SNAPSHOT"
+    // Version of Mesos to use in Dockerfile.
+    val MesosDebian = "1.1.0-0.0.316.pre.20161005gitb70a22b.debian81"
     val Akka = "2.4.10"
     val AsyncAwait = "0.9.6-RC5"
     val Spray = "1.3.3"


### PR DESCRIPTION
By making the Mesos version a build property, we don't need to repeat it in
every Dockerfile and make it accessible to external build systems that don't
necessarily rely on Docker.