### PR TITLE
Fix an occasional NullPointer in the DeploymentActor

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -59,9 +59,7 @@ private class DeploymentActor(
 
       performStep(step) onComplete {
         case Success(_) => self ! NextStep
-        case Failure(t) =>
-          log.debug("Performing {} failed: {}", step, t)
-          self ! Fail(t)
+        case Failure(t) => self ! Fail(t)
       }
 
     case NextStep =>


### PR DESCRIPTION
Using log.xxx() from a future in an actor with ActorLogging trait is bad because it tries to access this.context from another thread.

Fixes: #DCOS-9936