### PR TITLE
Update arcconfig to refer to the correct repository

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,4 +1,4 @@
 {
-  "phabricator.uri": "https://phabricator.mesosphere.com"
+  "phabricator.uri": "https://phabricator.mesosphere.com",
+  "repository.callsign": "marathon"
 }
-


### PR DESCRIPTION
Summary:
arc was unable to detect the default repository
since github uses multiple URIs.

Test Plan: arc which lists the correct repository

Reviewers: aquamatthias

Subscribers: marathon-team

Differential Revision: https://phabricator.mesosphere.com/D21