### PR TITLE
Legacy Storage should log errors if there were invalid protos

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/MarathonStore.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/MarathonStore.scala
@@ -1,8 +1,9 @@
 package mesosphere.marathon.storage.repository.legacy.store
 
+import com.google.protobuf.InvalidProtocolBufferException
 import mesosphere.marathon.StoreCommandFailedException
 import mesosphere.marathon.metrics.Metrics.Histogram
-import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
+import mesosphere.marathon.metrics.{MetricPrefixes, Metrics}
 import mesosphere.marathon.state.MarathonState
 import mesosphere.util.LockManager
 import org.slf4j.LoggerFactory
@@ -37,7 +38,13 @@ class MarathonStore[S <: MarathonState[_, S]](
           stateFromBytes(entity.bytes.toArray)
         }
       }
-      .recover(exceptionTransform(s"Could not fetch ${ct.runtimeClass.getSimpleName} with key: $key"))
+      .recover {
+        case ipe: InvalidProtocolBufferException =>
+          log.warn(s"Unable to read $key due to a protocol buffer exception")
+          None
+        case NonFatal(ex) =>
+          throw new StoreCommandFailedException(s"Could not fetch ${ct.runtimeClass.getSimpleName} with key: $key")
+      }
   }
 
   def modify(key: String, onSuccess: (S) => Unit = _ => ())(f: Update): Future[S] = {

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/MarathonStore.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/MarathonStore.scala
@@ -43,7 +43,7 @@ class MarathonStore[S <: MarathonState[_, S]](
           log.warn(s"Unable to read $key due to a protocol buffer exception")
           None
         case NonFatal(ex) =>
-          throw new StoreCommandFailedException(s"Could not fetch ${ct.runtimeClass.getSimpleName} with key: $key")
+          throw new StoreCommandFailedException(s"Could not fetch ${ct.runtimeClass.getSimpleName} with key: $key", ex)
       }
   }
 

--- a/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
@@ -52,6 +52,18 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
     }
   }
 
+  test("FetchInvalidProto") {
+    val state = mock[PersistentStore]
+    val variable = mock[PersistentEntity]
+    when(variable.bytes).thenReturn(IndexedSeq[Byte](1, 1, 1))
+
+    when(state.load("app:testApp")).thenReturn(Future.successful(Some(variable)))
+    val store = new MarathonStore[AppDefinition](state, metrics, () => AppDefinition(), "app:")
+    val res = store.fetch("testApp")
+    verify(state).load("app:testApp")
+    res.futureValue should be ('empty)
+  }
+
   test("Modify") {
     val state = mock[PersistentStore]
     val variable = mock[PersistentEntity]


### PR DESCRIPTION
Summary:
#4470 shows that there are errors preventing migration from completing if the
protos changed in an incompatible way. In order to allow migration, we should instead
act as if the object didn't exist and log an error.

Should be cherry-picked into releases/1.3

Test Plan: sbt test

Reviewers: aquamatthias, jdef

Subscribers: marathon-team

Differential Revision: https://phabricator.mesosphere.com/D24