### PR TITLE
Fix TaskKillService behavior: retry forever and don't spawn progress …

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -570,6 +570,16 @@ trait EventFormats {
   implicit lazy val SchedulerReregisteredEventWritesWrites: Writes[SchedulerReregisteredEvent] =
     Json.writes[SchedulerReregisteredEvent]
 
+  implicit lazy val UnknownTaskTerminatedEventWrites: Writes[UnknownTaskTerminated] = Writes { change =>
+    Json.obj(
+      "taskId" -> change.id,
+      "runSpecId" -> change.runSpecId,
+      "taskStatus" -> change.status.toString,
+      "timestamp" -> change.timestamp,
+      "eventType" -> change.eventType
+    )
+  }
+
   //scalastyle:off cyclomatic.complexity
   def eventToJson(event: MarathonEvent): JsValue = event match {
     case event: AppTerminatedEvent => Json.toJson(event)
@@ -595,6 +605,7 @@ trait EventFormats {
     case event: SchedulerDisconnectedEvent => Json.toJson(event)
     case event: SchedulerRegisteredEvent => Json.toJson(event)
     case event: SchedulerReregisteredEvent => Json.toJson(event)
+    case event: UnknownTaskTerminated => Json.toJson(event)
   }
   //scalastyle:on
 }

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.core.event
 
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.task.state.MarathonTaskStatus
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep }
 
@@ -185,6 +186,15 @@ case class MesosStatusUpdateEvent(
   version: String,
   eventType: String = "status_update_event",
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
+
+/** Event indicating an unknown task is terminal */
+case class UnknownTaskTerminated(
+    id: Task.Id,
+    runSpecId: PathId,
+    status: MarathonTaskStatus) extends MarathonEvent {
+  override val eventType: String = "unknown_task_terminated_event"
+  override val timestamp: String = Timestamp.now().toString
+}
 
 case class MesosFrameworkMessageEvent(
   executorId: String,

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
@@ -14,11 +14,10 @@ class TaskTerminationModule(
     config: TaskKillConfig,
     clock: Clock) {
 
-  private[this] lazy val taskTracker = taskTrackerModule.taskTracker
   private[this] lazy val stateOpProcessor = taskTrackerModule.stateOpProcessor
 
   private[this] lazy val taskKillServiceActorProps: Props =
-    TaskKillServiceActor.props(taskTracker, driverHolder, stateOpProcessor, config, clock)
+    TaskKillServiceActor.props(driverHolder, stateOpProcessor, config, clock)
 
   private[this] lazy val taskKillServiceActor: ActorRef =
     leadershipModule.startWhenLeader(taskKillServiceActorProps, "taskKillServiceActor")

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillProgressActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillProgressActor.scala
@@ -4,7 +4,7 @@ import akka.Done
 import akka.actor.{ Actor, ActorLogging, Props }
 import mesosphere.marathon.KillingTasksFailedException
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.event.MesosStatusUpdateEvent
+import mesosphere.marathon.core.event.{ MesosStatusUpdateEvent, UnknownTaskTerminated }
 
 import scala.concurrent.Promise
 import scala.collection.mutable
@@ -35,6 +35,7 @@ private[this] class TaskKillProgressActor(
   override def preStart(): Unit = {
     if (taskIds.nonEmpty) {
       context.system.eventStream.subscribe(self, classOf[MesosStatusUpdateEvent])
+      context.system.eventStream.subscribe(self, classOf[UnknownTaskTerminated])
       log.info("Starting {} to track kill progress of {} tasks", name, taskIds.size)
     } else {
       promise.tryComplete(Try(Done))
@@ -50,23 +51,31 @@ private[this] class TaskKillProgressActor(
       // we don't expect to be stopped without all tasks being killed, so the promise should fail:
       val msg = s"$name was stopped before all tasks are killed. Outstanding: ${taskIds.mkString(",")}"
       log.error(msg)
-      promise.failure(new KillingTasksFailedException(msg))
+      promise.tryFailure(new KillingTasksFailedException(msg))
     }
   }
 
   override def receive: Receive = {
     case Terminal(event) if taskIds.contains(event.taskId) =>
-      log.debug("Received terminal update for {}", event.taskId)
-      taskIds.remove(event.taskId)
-      if (taskIds.isEmpty) {
-        log.info("All tasks watched by {} are killed, completing promise", name)
-        val success = promise.tryComplete(Try(Done))
-        if (!success) log.error("Promise has already been completed in {}", name)
-        context.stop(self)
-      } else {
-        log.info("{} still waiting for {} tasks to be killed", name, taskIds.size)
-      }
+      handleTerminal(event.taskId)
+
+    case UnknownTaskTerminated(id, _, _) if taskIds.contains(id) =>
+      handleTerminal(id)
   }
+
+  private[this] def handleTerminal(id: Task.Id): Unit = {
+    log.debug("Received terminal update for {}", id)
+    taskIds.remove(id)
+    if (taskIds.isEmpty) {
+      log.info("All tasks watched by {} are killed, completing promise", name)
+      val success = promise.tryComplete(Try(Done))
+      if (!success) log.error("Promise has already been completed in {}", name)
+      context.stop(self)
+    } else {
+      log.info("{} still waiting for {} tasks to be killed", name, taskIds.size)
+    }
+  }
+
 }
 
 private[impl] object TaskKillProgressActor {

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActor.scala
@@ -7,8 +7,8 @@ import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.task.termination.TaskKillConfig
 import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.core.task.{ Task, TaskStateOp }
-import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskTracker }
-import mesosphere.marathon.core.event.MesosStatusUpdateEvent
+import mesosphere.marathon.core.task.tracker.TaskStateOpProcessor
+import mesosphere.marathon.core.event.{ MesosStatusUpdateEvent, UnknownTaskTerminated }
 
 import scala.collection.mutable
 import scala.concurrent.Promise
@@ -31,7 +31,6 @@ import scala.concurrent.Promise
   * See [[TaskKillConfig]] for configuration options.
   */
 private[impl] class TaskKillServiceActor(
-    taskTracker: TaskTracker,
     driverHolder: MarathonSchedulerDriverHolder,
     stateOpProcessor: TaskStateOpProcessor,
     config: TaskKillConfig,
@@ -39,8 +38,8 @@ private[impl] class TaskKillServiceActor(
   import TaskKillServiceActor._
   import context.dispatcher
 
-  val tasksToKill: mutable.HashMap[Task.Id, Option[Task]] = mutable.HashMap.empty
-  val inFlight: mutable.HashMap[Task.Id, TaskToKill] = mutable.HashMap.empty
+  val tasksToKill: mutable.HashMap[Task.Id, ToKill] = mutable.HashMap.empty
+  val inFlight: mutable.HashMap[Task.Id, ToKill] = mutable.HashMap.empty
 
   val retryTimer: RetryTimer = new RetryTimer {
     override def createTimer(): Cancellable = {
@@ -50,6 +49,7 @@ private[impl] class TaskKillServiceActor(
 
   override def preStart(): Unit = {
     context.system.eventStream.subscribe(self, classOf[MesosStatusUpdateEvent])
+    context.system.eventStream.subscribe(self, classOf[UnknownTaskTerminated])
   }
 
   override def postStop(): Unit = {
@@ -72,17 +72,17 @@ private[impl] class TaskKillServiceActor(
     case Terminal(event) if inFlight.contains(event.taskId) || tasksToKill.contains(event.taskId) =>
       handleTerminal(event.taskId)
 
+    case UnknownTaskTerminated(id, _, _) if inFlight.contains(id) || tasksToKill.contains(id) =>
+      handleTerminal(id)
+
     case Retry =>
       retry()
-
-    case unhandled: InternalRequest =>
-      log.warning("Received unhandled {}", unhandled)
   }
 
   def killUnknownTaskById(taskId: Task.Id, promise: Promise[Done]): Unit = {
     log.debug("Received KillUnknownTaskById({})", taskId)
     setupProgressActor(Seq(taskId), promise)
-    tasksToKill.update(taskId, None)
+    tasksToKill.update(taskId, ToKill(taskId, maybeTask = None, attempts = 0))
     processKills()
   }
 
@@ -90,7 +90,10 @@ private[impl] class TaskKillServiceActor(
     log.debug("Adding {} tasks to queue; setting up child actor to track progress", tasks.size)
     setupProgressActor(tasks.map(_.taskId), promise)
     tasks.foreach { task =>
-      tasksToKill.update(task.taskId, Some(task))
+      tasksToKill.update(
+        task.taskId,
+        ToKill(task.taskId, maybeTask = Some(task), attempts = 0)
+      )
     }
     processKills()
   }
@@ -105,7 +108,7 @@ private[impl] class TaskKillServiceActor(
 
     log.info("processing {} kills", toKillNow.size)
     toKillNow.foreach {
-      case (taskId, maybeTask) => processKill(taskId, maybeTask)
+      case (taskId, data) => processKill(data)
     }
 
     if (inFlight.isEmpty) {
@@ -115,21 +118,25 @@ private[impl] class TaskKillServiceActor(
     }
   }
 
-  def processKill(taskId: Task.Id, maybeTask: Option[Task]): Unit = {
-    val taskIsLost: Boolean = maybeTask.fold(false)(isLost)
+  def processKill(toKill: ToKill): Unit = {
+    val taskId = toKill.taskId
+
+    val taskIsLost: Boolean = toKill.maybeTask.fold(false) { task =>
+      task.isGone || task.isUnknown || task.isDropped || task.isUnreachable
+    }
 
     if (taskIsLost) {
       log.warning("Expunging lost {} from state because it should be killed", taskId)
       // we will eventually be notified of a taskStatusUpdate after the task has been expunged
       stateOpProcessor.process(TaskStateOp.ForceExpunge(taskId))
     } else {
-      val knownOrNot = if (maybeTask.isDefined) "known" else "unknown"
+      val knownOrNot = if (toKill.maybeTask.isDefined) "known" else "unknown"
       log.warning("Killing {} {}", knownOrNot, taskId)
       driverHolder.driver.foreach(_.killTask(taskId.mesosTaskId))
     }
 
     val attempts = inFlight.get(taskId).fold(1)(_.attempts + 1)
-    inFlight.update(taskId, TaskToKill(taskId, maybeTask, issued = clock.now(), attempts))
+    inFlight.update(taskId, ToKill(taskId, toKill.maybeTask, attempts, issued = clock.now()))
     tasksToKill.remove(taskId)
   }
 
@@ -144,13 +151,13 @@ private[impl] class TaskKillServiceActor(
     val now = clock.now()
 
     inFlight.foreach {
-      case (taskId, taskToKill) if taskToKill.attempts >= config.killRetryMax =>
+      case (taskId, toKill) if toKill.attempts >= config.killRetryMax =>
         log.warning("Expunging {} from state: max retries reached", taskId)
         stateOpProcessor.process(TaskStateOp.ForceExpunge(taskId))
 
-      case (taskId, taskToKill) if (taskToKill.issued + config.killRetryTimeout) < now =>
+      case (taskId, toKill) if (toKill.issued + config.killRetryTimeout) < now =>
         log.warning("No kill ack received for {}, retrying", taskId)
-        processKill(taskId, taskToKill.maybeTask)
+        processKill(toKill)
 
       case _ => // ignore
     }
@@ -171,15 +178,25 @@ private[termination] object TaskKillServiceActor {
   sealed trait InternalRequest
   case object Retry extends InternalRequest
 
-  case class TaskToKill(taskId: Task.Id, maybeTask: Option[Task], issued: Timestamp, attempts: Int)
+  /**
+    * Metadata used to track which tasks to kill and how many attempts have been made
+    * @param taskId id of the task to kill
+    * @param maybeTask the task, if available
+    * @param attempts the number of kill attempts
+    * @param issued the time of the last issued kill request
+    */
+  case class ToKill(
+    taskId: Task.Id,
+    maybeTask: Option[Task],
+    attempts: Int,
+    issued: Timestamp = Timestamp.zero)
 
   def props(
-    taskTracker: TaskTracker,
     driverHolder: MarathonSchedulerDriverHolder,
     stateOpProcessor: TaskStateOpProcessor,
     config: TaskKillConfig,
     clock: Clock): Props = Props(
-    new TaskKillServiceActor(taskTracker, driverHolder, stateOpProcessor, config, clock))
+    new TaskKillServiceActor(driverHolder, stateOpProcessor, config, clock))
 }
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceDelegate.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillServi
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ Future, Promise }
+import scala.collection.immutable.Seq
 
 private[termination] class TaskKillServiceDelegate(actorRef: ActorRef) extends TaskKillService {
   import TaskKillServiceDelegate.log
@@ -27,7 +28,7 @@ private[termination] class TaskKillServiceDelegate(actorRef: ActorRef) extends T
   }
 
   override def killUnknownTask(taskId: Task.Id, reason: TaskKillReason): Future[Done] = {
-    log.info(s"Killing 1 unknown task for reason: $reason (id: {})", taskId)
+    log.info(s"Killing unknown task for reason: $reason (id: {})", taskId)
 
     val promise = Promise[Done]
     actorRef ! KillUnknownTaskById(taskId, promise)

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -2,9 +2,12 @@ package mesosphere.marathon.core.task.update.impl
 
 import javax.inject.Inject
 
+import akka.event.EventStream
 import com.google.inject.name.Names
 import mesosphere.marathon.MarathonSchedulerDriverHolder
 import mesosphere.marathon.core.base.Clock
+import mesosphere.marathon.core.event.UnknownTaskTerminated
+import mesosphere.marathon.core.task.state.MarathonTaskStatus
 import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillService }
 import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskTracker }
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
@@ -25,7 +28,8 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     taskTracker: TaskTracker,
     stateOpProcessor: TaskStateOpProcessor,
     driverHolder: MarathonSchedulerDriverHolder,
-    killService: TaskKillService) extends TaskStatusUpdateProcessor {
+    killService: TaskKillService,
+    eventStream: EventStream) extends TaskStatusUpdateProcessor {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   private[this] val log = LoggerFactory.getLogger(getClass)
@@ -43,13 +47,19 @@ class TaskStatusUpdateProcessorImpl @Inject() (
 
     val now = clock.now()
     val taskId = Task.Id(status.getTaskId)
+    val marathonTaskStatus = MarathonTaskStatus(status)
 
     taskTracker.task(taskId).flatMap {
       case Some(task) =>
         val taskStateOp = TaskStateOp.MesosUpdate(task, status, now)
         stateOpProcessor.process(taskStateOp).flatMap(_ => acknowledge(status))
 
-      case None if killWhenUnknown(status) =>
+      case None if terminal(marathonTaskStatus) =>
+        log.warn("Received terminal status update for unknown {}", taskId)
+        eventStream.publish(UnknownTaskTerminated(taskId, taskId.runSpecId, marathonTaskStatus))
+        acknowledge(status)
+
+      case None if killWhenUnknown(marathonTaskStatus) =>
         killUnknownTaskTimer {
           log.warn("Kill unknown {}", taskId)
           killService.killUnknownTask(taskId, TaskKillReason.Unknown)
@@ -72,18 +82,26 @@ class TaskStatusUpdateProcessorImpl @Inject() (
 object TaskStatusUpdateProcessorImpl {
   lazy val name = Names.named(getClass.getSimpleName)
 
-  private[this] val ignoreWhenUnknown = Set(
-    MesosProtos.TaskState.TASK_KILLED,
-    MesosProtos.TaskState.TASK_KILLING,
-    MesosProtos.TaskState.TASK_ERROR,
-    MesosProtos.TaskState.TASK_FAILED,
-    MesosProtos.TaskState.TASK_FINISHED,
-    MesosProtos.TaskState.TASK_LOST
+  def terminal(status: MarathonTaskStatus): Boolean = status match {
+    case t: MarathonTaskStatus.Terminal => true
+    case _ => false
+  }
+
+  private[this] val ignoreWhenUnknown = Set[MarathonTaskStatus](
+    MarathonTaskStatus.Killed,
+    MarathonTaskStatus.Killing,
+    MarathonTaskStatus.Error,
+    MarathonTaskStatus.Failed,
+    MarathonTaskStatus.Finished,
+    MarathonTaskStatus.Unreachable,
+    MarathonTaskStatus.Gone,
+    MarathonTaskStatus.Dropped,
+    MarathonTaskStatus.Unknown
   )
   // It doesn't make sense to kill an unknown task if it is in a terminal or killing state
   // We'd only get another update for the same task
-  private def killWhenUnknown(status: MesosProtos.TaskStatus): Boolean = {
-    !ignoreWhenUnknown.contains(status.getState)
+  private def killWhenUnknown(status: MarathonTaskStatus): Boolean = {
+    !ignoreWhenUnknown.contains(status)
   }
 
   private def taskKnownOrNotStr(maybeTask: Option[Task]): String = if (maybeTask.isDefined) "known" else "unknown"

--- a/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
+++ b/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
@@ -116,11 +116,10 @@ object TaskFailure {
   protected[this] def taskState(s: String): mesos.TaskState =
     mesos.TaskState.valueOf(s)
 
-  // Note that this will also store taskFailures for TASK_LOST no matter the reason
   private[this] def isFailureState(state: mesos.TaskState): Boolean = {
     import mesos.TaskState._
     state match {
-      case TASK_FAILED | TASK_LOST | TASK_ERROR => true
+      case TASK_FAILED | TASK_ERROR | TASK_LOST => true
       case _ => false
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -173,7 +173,8 @@ class TaskStatusUpdateProcessorImplTest
       taskTracker,
       stateOpProcessor,
       marathonSchedulerDriverHolder,
-      killService
+      killService,
+      eventStream = actorSystem.eventStream
     )
 
     def verifyNoMoreInteractions(): Unit = {


### PR DESCRIPTION
Conflicts:
	src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
	src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
	src/main/scala/mesosphere/marathon/core/event/Events.scala
	src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
	src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
	src/main/scala/mesosphere/marathon/core/task/termination/TaskKillService.scala
	src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
	src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillProgressActor.scala
	src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActor.scala
	src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskTaskKillServiceDelegate.scala
	src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
	src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
	src/main/scala/mesosphere/marathon/state/TaskFailure.scala
	src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
	src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
	src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
	src/test/scala/mesosphere/marathon/core/task/TaskKillServiceMock.scala
	src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
	src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
	src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskTaskKillServiceActorTest.scala
	src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskTrackerActorTest.scala