### PR TITLE
Wait for health status updates during deployments of pod instances

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -23,6 +23,7 @@ class PostToEventStreamStepImpl @Inject() (eventBus: EventStream, clock: Clock) 
     log.info("Publishing events for {} of runSpec [{}]: {}", update.id, update.runSpecId, update.status)
     update.events.foreach(eventBus.publish)
 
+    // TODO(PODS): this can be generated in InstanceChangedEventsGenerator as well
     if (update.lastState.flatMap(_.healthy) != update.instance.state.healthy) {
       eventBus.publish(InstanceHealthChanged(update.id, update.runSpecVersion,
         update.runSpecId, update.instance.state.healthy))

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -27,7 +27,7 @@ trait StartingBehavior extends ReadinessBehavior { this: Actor with ActorLogging
   def initializeStart(): Unit
 
   final override def preStart(): Unit = {
-    if (runSpec.healthChecks.nonEmpty) eventBus.subscribe(self, classOf[InstanceHealthChanged])
+    if (hasHealthChecks) eventBus.subscribe(self, classOf[InstanceHealthChanged])
     eventBus.subscribe(self, classOf[InstanceChanged])
 
     initializeStart()


### PR DESCRIPTION
Wait for health status updates during deployments of pod instances with configured health checks

Resolves #4505