### PR TITLE
Fixes #3957 - Load previously stored health status when becoming leader

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/Health.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/Health.scala
@@ -16,12 +16,12 @@ case class Health(
   }
 
   def update(result: HealthResult): Health = result match {
-    case Healthy(_, _, time) => copy(
+    case Healthy(_, _, time, _) => copy(
       firstSuccess = firstSuccess.orElse(Some(time)),
       lastSuccess = Some(time),
       consecutiveFailures = 0
     )
-    case Unhealthy(_, _, cause, time) => copy(
+    case Unhealthy(_, _, cause, time, _) => copy(
       lastFailure = Some(time),
       lastFailureCause = Some(cause),
       consecutiveFailures = consecutiveFailures + 1

--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheckManager.scala
@@ -21,12 +21,12 @@ trait HealthCheckManager {
   /**
     * Adds a health check of the supplied app.
     */
-  def add(appDefinition: AppDefinition, healthCheck: HealthCheck): Unit
+  def add(appDefinition: AppDefinition, healthCheck: HealthCheck, tasks: Iterable[Task]): Unit
 
   /**
     * Adds all health checks for the supplied app.
     */
-  def addAllFor(app: AppDefinition): Unit
+  def addAllFor(app: AppDefinition, tasks: Iterable[Task]): Unit
 
   /**
     * Removes a health check from the app with the supplied id.

--- a/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
@@ -7,15 +7,18 @@ sealed trait HealthResult {
   def taskId: Task.Id
   def version: Timestamp
   def time: Timestamp
+  def publishEvent: Boolean
 }
 
 case class Healthy(
   taskId: Task.Id,
   version: Timestamp,
-  time: Timestamp = Timestamp.now()) extends HealthResult
+  time: Timestamp = Timestamp.now(),
+  publishEvent: Boolean = true) extends HealthResult
 
 case class Unhealthy(
   taskId: Task.Id,
   version: Timestamp,
   cause: String,
-  time: Timestamp = Timestamp.now()) extends HealthResult
+  time: Timestamp = Timestamp.now(),
+  publishEvent: Boolean = true) extends HealthResult

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -162,16 +162,18 @@ private[health] class HealthCheckActor(
       val health = taskHealth.getOrElse(taskId, Health(taskId))
 
       val newHealth = result match {
-        case Healthy(_, _, _) =>
+        case Healthy(_, _, _, _) =>
           health.update(result)
-        case Unhealthy(_, _, _, _) =>
+        case Unhealthy(_, _, _, _, _) =>
           taskTracker.tasksByAppSync.task(taskId) match {
             case Some(task) =>
               if (ignoreFailures(task, health)) {
                 // Don't update health
                 health
               } else {
-                eventBus.publish(FailedHealthCheck(app.id, taskId, healthCheck))
+                if (result.publishEvent) {
+                  eventBus.publish(FailedHealthCheck(app.id, taskId, healthCheck))
+                }
                 checkConsecutiveFailures(task, health)
                 health.update(result)
               }
@@ -183,7 +185,7 @@ private[health] class HealthCheckActor(
 
       taskHealth += (taskId -> newHealth)
 
-      if (health.alive != newHealth.alive) {
+      if (health.alive != newHealth.alive && result.publishEvent) {
         eventBus.publish(
           HealthStatusChanged(
             appId = app.id,

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -50,20 +50,34 @@ class MarathonHealthCheckManager(
       ahcs(appId)(appVersion)
     }
 
-  override def add(app: AppDefinition, healthCheck: HealthCheck): Unit =
+  override def add(app: AppDefinition, healthCheck: HealthCheck, tasks: Iterable[Task]): Unit =
     appHealthChecks.writeLock { ahcs =>
       val healthChecksForApp = listActive(app.id, app.version)
 
-      if (healthChecksForApp.exists(_.healthCheck == healthCheck))
-        log.debug(s"Not adding duplicate health check for app [$app.id] and version [${app.version}]: [$healthCheck]")
-
-      else {
+      if (healthChecksForApp.exists(_.healthCheck == healthCheck)) {
+        log.debug(s"Not adding duplicated health check for app [$app.id] and version [${app.version}]: [$healthCheck]")
+      } else {
         log.info(s"Adding health check for app [${app.id}] and version [${app.version}]: [$healthCheck]")
 
         val ref = actorSystem.actorOf(
           HealthCheckActor.props(app, killService, healthCheck, taskTracker, eventBus))
         val newHealthChecksForApp =
           healthChecksForApp + ActiveHealthCheck(healthCheck, ref)
+
+        if (healthCheck.protocol == Protocol.COMMAND) {
+          tasks.foreach { task =>
+            task.launched.foreach { launched =>
+              launched.status.mesosStatus match {
+                case Some(mesosStatus) if mesosStatus.hasHealthy =>
+                  val health =
+                    if (mesosStatus.getHealthy) Healthy(task.taskId, launched.runSpecVersion, publishEvent = false)
+                    else Unhealthy(task.taskId, launched.runSpecVersion, "", publishEvent = false)
+                  ref ! health
+                case None =>
+              }
+            }
+          }
+        }
 
         val appMap = ahcs(app.id) + (app.version -> newHealthChecksForApp)
         ahcs += app.id -> appMap
@@ -72,9 +86,9 @@ class MarathonHealthCheckManager(
       }
     }
 
-  override def addAllFor(app: AppDefinition): Unit =
-    appHealthChecks.writeLock { _ => // atomically add all checks
-      app.healthChecks.foreach(add(app, _))
+  override def addAllFor(app: AppDefinition, tasks: Iterable[Task]): Unit =
+    appHealthChecks.writeLock { _ => // atomically add all checks for this app version
+      app.healthChecks.foreach(add(app, _, tasks))
     }
 
   override def remove(appId: PathId, appVersion: Timestamp, healthCheck: HealthCheck): Unit =
@@ -111,13 +125,26 @@ class MarathonHealthCheckManager(
       }
     }
 
-  override def reconcileWith(appId: PathId): Future[Unit] =
-    appRepository.currentVersion(appId) flatMap {
+  override def reconcileWith(appId: PathId): Future[Unit] = {
+    def groupTasksByVersion(tasks: Iterable[Task]): Map[Timestamp, List[Task]] =
+      tasks.foldLeft(Map[Timestamp, List[Task]]()) {
+        case (acc, task) =>
+          task.launched match {
+            case Some(launched) =>
+              val version = launched.runSpecVersion
+              acc + (version -> (task :: acc.getOrElse(version, Nil)))
+            case None => acc
+          }
+      }
+
+    appRepository.currentVersion(appId).flatMap {
       case None => Future(())
       case Some(app) =>
         log.info(s"reconcile [$appId] with latest version [${app.version}]")
 
         val tasks: Iterable[Task] = taskTracker.appTasksSync(app.id)
+        val tasksByVersion = groupTasksByVersion(tasks)
+
         val activeAppVersions: Set[Timestamp] =
           tasks.iterator.flatMap(_.launched.map(_.runSpecVersion)).toSet + app.version
 
@@ -148,11 +175,12 @@ class MarathonHealthCheckManager(
 
             case Some(appVersion) =>
               log.info(s"addAllFor [$appId] version [$version]")
-              addAllFor(appVersion)
+              addAllFor(appVersion, tasksByVersion.getOrElse(version, Seq.empty))
           }
         }
         Future.sequence(res) map { _ => () }
     }
+  }
 
   override def update(taskStatus: TaskStatus, version: Timestamp): Unit =
     appHealthChecks.readLock { ahcs =>

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -86,7 +86,8 @@ private class DeploymentActor(
       eventBus.publish(status)
 
       val futures = step.actions.map { action =>
-        healthCheckManager.addAllFor(action.app) // ensure health check actors are in place before tasks are launched
+        // ensure health check actors are in place before tasks are launched
+        healthCheckManager.addAllFor(action.app, Seq.empty)
         action match {
           case StartApplication(app, scaleTo) => startApp(app, scaleTo, status)
           case ScaleApplication(app, scaleTo, toKill) => scaleApp(app, scaleTo, toKill, status)

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
@@ -48,7 +48,7 @@ class HealthCheckWorkerActorTest
     finally { socket.close() }
 
     expectMsgPF(1.seconds) {
-      case Healthy(taskId, _, _) => ()
+      case Healthy(taskId, _, _, _) => ()
     }
   }
 


### PR DESCRIPTION
(cherry picked from commit 25c59df10fb4d6ee941c8289a2ad4904332dde79)