### PR TITLE
lazy cache for versions

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
@@ -11,12 +11,14 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
 import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
+import mesosphere.marathon.storage.VersionCacheConfig
 import mesosphere.util.LockManager
 
 import scala.async.Async.{ async, await }
 import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.Seq
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Random
 
 /**
   * A Write Ahead Cache of another persistence store that lazily loads values into the cache.
@@ -27,8 +29,8 @@ import scala.concurrent.{ ExecutionContext, Future }
   * @tparam K The persistence store's primary key type
   * @tparam Serialized The serialized format for the persistence store.
   */
-class LazyCachingPersistenceStore[K, Category, Serialized](
-    val store: BasePersistenceStore[K, Category, Serialized])(implicit
+case class LazyCachingPersistenceStore[K, Category, Serialized](
+    store: BasePersistenceStore[K, Category, Serialized])(implicit
   mat: Materializer,
     ctx: ExecutionContext) extends PersistenceStore[K, Category, Serialized] with StrictLogging {
 
@@ -64,7 +66,7 @@ class LazyCachingPersistenceStore[K, Category, Serialized](
     delete: () => Future[Done])(implicit ir: IdResolver[Id, V, Category, K]): Future[Done] = {
     val category = ir.category
     val storageId = ir.toStorageId(k, None)
-    lockManager.executeSequentially(ir.category.toString) {
+    lockManager.executeSequentially(category.toString) {
       lockManager.executeSequentially(storageId.toString) {
         async { // linter:ignore UnnecessaryElseBranch
           await(delete())
@@ -85,6 +87,7 @@ class LazyCachingPersistenceStore[K, Category, Serialized](
   override def deleteCurrent[Id, V](k: Id)(implicit ir: IdResolver[Id, V, Category, K]): Future[Done] = {
     deleteCurrentOrAll(k, () => store.deleteCurrent(k))
   }
+
   override def deleteAll[Id, V](k: Id)(implicit ir: IdResolver[Id, V, Category, K]): Future[Done] = {
     deleteCurrentOrAll(k, () => store.deleteAll(k))
   }
@@ -158,4 +161,195 @@ class LazyCachingPersistenceStore[K, Category, Serialized](
     store.deleteVersion(k, version)
 
   override def toString: String = s"LazyCachingPersistenceStore($store)"
+}
+
+case class LazyVersionCachingPersistentStore[K, Category, Serialized](
+    store: PersistenceStore[K, Category, Serialized],
+    config: VersionCacheConfig = VersionCacheConfig.Default)(implicit
+  mat: Materializer,
+    ctx: ExecutionContext) extends PersistenceStore[K, Category, Serialized] with StrictLogging {
+
+  private val lockManager = LockManager.create()
+  private[store] val versionCache = TrieMap.empty[(Category, K), Seq[OffsetDateTime]]
+  private[store] val versionedValueCache = TrieMap.empty[(K, OffsetDateTime), Option[Any]]
+
+  def withVersionedValueCache[Id, V, T](
+    future: => Future[T])(implicit ir: IdResolver[Id, V, Category, K]): Future[T] =
+    lockManager.executeSequentially(s"versionedValueCache::${ir.category}")(future)
+
+  def withVersionCache[Id, V, T](
+    id: Id)(future: (Category, K) => Future[T])(implicit ir: IdResolver[Id, V, Category, K]): Future[T] = {
+    val category = ir.category
+    val storageId = ir.toStorageId(id, None)
+    lockManager.executeSequentially((category, storageId).toString())(future(category, storageId))
+  }
+
+  private[cache] def maybePurgeCachedVersions(
+    maxEntries: Int = config.maxEntries,
+    purgeCount: Int = config.purgeCount,
+    pRemove: Double = config.pRemove): Unit =
+
+    while (versionedValueCache.size > maxEntries) {
+      // randomly GC the versions
+      var counter = 0
+      versionedValueCache.retain { (k, v) =>
+        val x = Random.nextDouble()
+        x > pRemove || { counter += 1; counter > purgeCount }
+      }
+    }
+
+  /**
+    * Assumes that callers have already implemented appropriate locking via [[withVersionCache]] and
+    * [[withVersionedValueCache]].
+    */
+  private[this] def updateCachedVersions[V](
+    storageId: K,
+    version: OffsetDateTime,
+    category: Category,
+    v: Option[V]): Unit = {
+
+    maybePurgeCachedVersions()
+    versionedValueCache.put((storageId, version), v)
+    val cached = versionCache.getOrElse((category, storageId), Nil) // linter:ignore UndesirableTypeInference
+    versionCache.put((category, storageId), (version +: cached).distinct)
+  }
+
+  @SuppressWarnings(Array("all")) // async/await
+  private def deleteCurrentOrAll[Id, V](
+    id: Id, delete: () => Future[Done])(implicit ir: IdResolver[Id, V, Category, K]): Future[Done] = {
+
+    if (!ir.hasVersions) {
+      delete()
+    } else {
+      withVersionCache(id) { (category, storageId) =>
+        withVersionedValueCache {
+          async {
+            // linter:ignore UnnecessaryElseBranch
+            await(delete())
+            versionedValueCache.retain { case ((sid, version), v) => sid != storageId }
+            versionCache.remove((category, storageId))
+            Done
+          }
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def get[Id, V](id: Id)(implicit
+    ir: IdResolver[Id, V, Category, K],
+    um: Unmarshaller[Serialized, V]): Future[Option[V]] = {
+
+    if (!ir.hasVersions) {
+      store.get(id)
+    } else {
+      withVersionCache(id) { (category, storageId) =>
+        withVersionedValueCache {
+          async { // linter:ignore UnnecessaryElseBranch
+            val value = await(store.get(id))
+            value.foreach { v =>
+              val version = ir.version(v)
+              updateCachedVersions(storageId, version, category, value)
+            }
+            value
+          }
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def get[Id, V](id: Id, version: OffsetDateTime)(implicit
+    ir: IdResolver[Id, V, Category, K],
+    um: Unmarshaller[Serialized, V]): Future[Option[V]] = {
+
+    withVersionCache(id) { (category, storageId) =>
+      withVersionedValueCache {
+        val cached = versionedValueCache.get((storageId, version)) // linter:ignore OptionOfOption
+        cached match {
+          case Some(v: Option[V] @unchecked) =>
+            Future.successful(v)
+          case _ =>
+            async { // linter:ignore UnnecessaryElseBranch
+              val value = await(store.get(id, version))
+              updateCachedVersions(storageId, version, category, value)
+              value
+            }
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def store[Id, V](id: Id, v: V)(implicit
+    ir: IdResolver[Id, V, Category, K],
+    m: Marshaller[V, Serialized]): Future[Done] = {
+
+    if (!ir.hasVersions) {
+      store.store(id, v)
+    } else {
+      withVersionCache(id) { (category, storageId) =>
+        withVersionedValueCache {
+          async { // linter:ignore UnnecessaryElseBranch
+            await(store.store(id, v))
+            val version = ir.version(v)
+            updateCachedVersions(storageId, version, category, Some(v))
+            Done
+          }
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def store[Id, V](id: Id, v: V, version: OffsetDateTime)(implicit
+    ir: IdResolver[Id, V, Category, K],
+    m: Marshaller[V, Serialized]): Future[Done] = {
+
+    withVersionCache(id) { (category, storageId) =>
+      withVersionedValueCache {
+        async { // linter:ignore UnnecessaryElseBranch
+          await(store.store(id, v, version))
+          updateCachedVersions(storageId, version, category, Some(v))
+          Done
+        }
+      }
+    }
+  }
+
+  override def deleteCurrent[Id, V](k: Id)(implicit ir: IdResolver[Id, V, Category, K]): Future[Done] =
+    deleteCurrentOrAll(k, () => store.deleteCurrent(k))
+
+  override def deleteAll[Id, V](k: Id)(implicit ir: IdResolver[Id, V, Category, K]): Future[Done] =
+    deleteCurrentOrAll(k, () => store.deleteAll(k))
+
+  override def deleteVersion[Id, V](
+    k: Id,
+    version: OffsetDateTime)(implicit ir: IdResolver[Id, V, Category, K]): Future[Done] =
+    deleteCurrentOrAll(k, () => store.deleteVersion(k, version))
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def versions[Id, V](id: Id)(implicit ir: IdResolver[Id, V, Category, K]): Source[OffsetDateTime, NotUsed] = {
+    val versionsFuture = withVersionCache(id) { (category, storageId) =>
+      if (versionCache.contains((category, storageId))) {
+        Future.successful(versionCache((category, storageId)))
+      } else {
+        async { // linter:ignore UnnecessaryElseBranch
+          val children = await(store.versions(id).toMat(Sink.seq)(Keep.right).run())
+          versionCache((category, storageId)) = children
+          children
+        }
+      }
+    }
+    Source.fromFuture(versionsFuture).mapConcat(identity)
+  }
+
+  override def ids[Id, V]()(implicit ir: IdResolver[Id, V, Category, K]): Source[Id, NotUsed] = store.ids()
+
+  override def storageVersion(): Future[Option[StorageVersion]] = store.storageVersion()
+
+  override def setStorageVersion(storageVersion: StorageVersion): Future[Done] =
+    store.setStorageVersion(storageVersion)
+
+  override def toString: String = s"LazyVersionCachingPersistenceStore($store)"
 }

--- a/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
@@ -7,7 +7,6 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.{ MesosContainer, PodDefinition }
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.RunSpec
 import mesosphere.marathon.stream._
 
 trait PodStatusConversion {
@@ -56,15 +55,9 @@ trait PodStatusConversion {
   /**
     * generate a pod instance status RAML for some instance.
     */
-  @throws[IllegalArgumentException]("if you provide a non-pod `spec`")
-  implicit val podInstanceStatusRamlWriter: Writes[(RunSpec, Instance), PodInstanceStatus] = Writes { src =>
+  implicit val podInstanceStatusRamlWriter: Writes[(PodDefinition, Instance), PodInstanceStatus] = Writes { src =>
 
-    val (spec, instance) = src
-
-    val pod: PodDefinition = spec match {
-      case x: PodDefinition => x
-      case _ => throw new IllegalArgumentException(s"expected a pod spec instead of $spec")
-    }
+    val (pod, instance) = src
 
     assume(
       pod.id == instance.instanceId.runSpecId,

--- a/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
@@ -32,4 +32,13 @@ trait StorageConf extends ZookeeperConf {
     hidden = true,
     descr = "Max outstanding requests to Zookeeper persistence"
   )
+
+  lazy val versionCacheEnabled = toggle(
+    "internal_version_caching",
+    default = Some(true),
+    noshort = true,
+    hidden = true,
+    descrYes = "(Default) Enable an additional layer of caching for object versions when store_cache is enabled.",
+    prefix = "disable_"
+  )
 }

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -346,8 +346,7 @@ object InMem {
 }
 
 object StorageConfig {
-  // TODO(jdef) disabled globally until proven; eventually the default value here will be non-empty
-  val DefaultVersionCacheConfig = Option.empty[VersionCacheConfig]
+  val DefaultVersionCacheConfig = Option(VersionCacheConfig.Default)
 
   val DefaultLegacyMaxVersions = 25
   val DefaultMaxVersions = 5000

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -10,7 +10,7 @@ import akka.stream.Materializer
 import com.typesafe.config.{ Config, ConfigMemorySize }
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
-import mesosphere.marathon.core.storage.store.impl.cache.{ LazyCachingPersistenceStore, LoadTimeCachingPersistenceStore }
+import mesosphere.marathon.core.storage.store.impl.cache.{ LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore }
 import mesosphere.marathon.core.storage.store.impl.memory.{ Identity, InMemoryPersistenceStore, RamId }
 import mesosphere.marathon.core.storage.store.impl.zk.{ NoRetryPolicy, RichCuratorFramework, ZkId, ZkPersistenceStore, ZkSerialized }
 import mesosphere.marathon.metrics.Metrics
@@ -186,17 +186,47 @@ object CacheType {
 sealed trait PersistenceStorageConfig[K, C, S] extends StorageConfig {
   val maxVersions: Int
   val cacheType: CacheType
+  val versionCacheConfig: Option[VersionCacheConfig]
+
   protected def leafStore(implicit metrics: Metrics, mat: Materializer, ctx: ExecutionContext,
     scheduler: Scheduler, actorRefFactory: ActorRefFactory): BasePersistenceStore[K, C, S]
+
+  protected def lazyStore(implicit metrics: Metrics, mat: Materializer, ctx: ExecutionContext,
+    scheduler: Scheduler, actorRefFactory: ActorRefFactory): PersistenceStore[K, C, S] = {
+    val lazyCachingStore: PersistenceStore[K, C, S] = LazyCachingPersistenceStore(leafStore)
+    versionCacheConfig.fold(lazyCachingStore){ config => LazyVersionCachingPersistentStore(lazyCachingStore, config) }
+  }
 
   def store(implicit metrics: Metrics, mat: Materializer,
     ctx: ExecutionContext, scheduler: Scheduler, actorRefFactory: ActorRefFactory): PersistenceStore[K, C, S] = {
     cacheType match {
       case NoCaching => leafStore
-      case LazyCaching => new LazyCachingPersistenceStore[K, C, S](leafStore)
+      case LazyCaching => lazyStore
       case EagerCaching => new LoadTimeCachingPersistenceStore[K, C, S](leafStore)
     }
   }
+}
+
+case class VersionCacheConfig(
+  maxEntries: Int,
+  purgeCount: Int,
+  pRemove: Double
+)
+
+object VersionCacheConfig {
+  /**
+    * max number of entries allowed in the versioned value cache before entries are purged
+    */
+  protected val MaxVersionedCacheSize = 10000
+  /**
+    * probability that, during a purge of the versioned value cache, a given entry will be removed
+    */
+  protected val ProbabilityToRemoveFromCache = 0.05
+
+  val Default = apply(MaxVersionedCacheSize, ProbabilityToRemoveFromCache)
+
+  def apply(maxEntries: Int, pRemove: Double): VersionCacheConfig =
+    new VersionCacheConfig(maxEntries, (maxEntries * pRemove).toInt, pRemove)
 }
 
 case class CuratorZk(
@@ -213,7 +243,9 @@ case class CuratorZk(
     retryConfig: RetryConfig,
     maxConcurrent: Int,
     maxOutstanding: Int,
-    maxVersions: Int) extends PersistenceStorageConfig[ZkId, String, ZkSerialized] {
+    maxVersions: Int,
+    versionCacheConfig: Option[VersionCacheConfig]
+) extends PersistenceStorageConfig[ZkId, String, ZkSerialized] {
 
   lazy val client: RichCuratorFramework = {
     val builder = CuratorFrameworkFactory.builder()
@@ -262,7 +294,8 @@ object CuratorZk {
       retryConfig = RetryConfig(),
       maxConcurrent = conf.zkMaxConcurrency(),
       maxOutstanding = 1024,
-      maxVersions = conf.maxVersions()
+      maxVersions = conf.maxVersions(),
+      versionCacheConfig = if (conf.versionCacheEnabled()) StorageConfig.DefaultVersionCacheConfig else None
     )
 
   def apply(config: Config): CuratorZk = {
@@ -286,13 +319,16 @@ object CuratorZk {
       retryConfig = RetryConfig(config),
       maxConcurrent = config.int("max-concurrent-requests", 32),
       maxOutstanding = config.int("max-concurrent-outstanding", 1024),
-      maxVersions = config.int("max-versions", StorageConfig.DefaultMaxVersions)
+      maxVersions = config.int("max-versions", StorageConfig.DefaultMaxVersions),
+      versionCacheConfig =
+        if (config.bool("version-cache-enabled", true)) StorageConfig.DefaultVersionCacheConfig else None
     )
   }
 }
 
 case class InMem(maxVersions: Int) extends PersistenceStorageConfig[RamId, String, Identity] {
   override val cacheType: CacheType = NoCaching
+  override val versionCacheConfig: Option[VersionCacheConfig] = None
 
   protected def leafStore(implicit metrics: Metrics, mat: Materializer, ctx: ExecutionContext,
     scheduler: Scheduler, actorRefFactory: ActorRefFactory): BasePersistenceStore[RamId, String, Identity] =
@@ -310,6 +346,9 @@ object InMem {
 }
 
 object StorageConfig {
+  // TODO(jdef) disabled globally until proven; eventually the default value here will be non-empty
+  val DefaultVersionCacheConfig = Option.empty[VersionCacheConfig]
+
   val DefaultLegacyMaxVersions = 25
   val DefaultMaxVersions = 5000
   def apply(conf: StorageConf)(implicit metrics: Metrics, actorRefFactory: ActorRefFactory): StorageConfig = {

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -98,9 +98,7 @@ object StorageModule {
       case zk: CuratorZk =>
         val store = zk.store
         val appRepository = AppRepository.zkRepository(store)
-        val podRepository = PodRepository.zkRepository(zk.copy(
-          // TODO(PODS) be conservative: for now, only enable versioned value caching for pods
-          versionCacheConfig = Some(VersionCacheConfig.Default)).store)
+        val podRepository = PodRepository.zkRepository(store)
         val groupRepository = GroupRepository.zkRepository(store, appRepository, podRepository)
 
         val taskRepository = TaskRepository.zkRepository(store)

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -98,7 +98,9 @@ object StorageModule {
       case zk: CuratorZk =>
         val store = zk.store
         val appRepository = AppRepository.zkRepository(store)
-        val podRepository = PodRepository.zkRepository(store)
+        val podRepository = PodRepository.zkRepository(zk.copy(
+          // TODO(PODS) be conservative: for now, only enable versioned value caching for pods
+          versionCacheConfig = Some(VersionCacheConfig.Default)).store)
         val groupRepository = GroupRepository.zkRepository(store, appRepository, podRepository)
 
         val taskRepository = TaskRepository.zkRepository(store)

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -13,12 +13,13 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.storage.repository.impl.PersistenceStoreVersionedRepository
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
-import mesosphere.marathon.core.storage.store.impl.cache.{ LazyCachingPersistenceStore, LoadTimeCachingPersistenceStore }
+import mesosphere.marathon.core.storage.store.impl.cache.{ LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore }
 import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
 import mesosphere.marathon.state.{ AppDefinition, Group, PathId, Timestamp }
 import mesosphere.marathon.stream._
 import mesosphere.marathon.util.{ RichLock, toRichFuture }
 
+import scala.annotation.tailrec
 import scala.async.Async.{ async, await }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.control.NonFatal
@@ -179,10 +180,12 @@ class StoredGroupRepositoryImpl[K, C, S](
   private[storage] var beforeStore = Option.empty[(StoredGroup) => Future[Done]]
 
   private val storedRepo = {
+    @tailrec
     def leafStore(store: PersistenceStore[K, C, S]): PersistenceStore[K, C, S] = store match {
       case s: BasePersistenceStore[K, C, S] => s
       case s: LoadTimeCachingPersistenceStore[K, C, S] => leafStore(s.store)
       case s: LazyCachingPersistenceStore[K, C, S] => leafStore(s.store)
+      case s: LazyVersionCachingPersistentStore[K, C, S] => leafStore(s.store)
     }
     new PersistenceStoreVersionedRepository[PathId, StoredGroup, K, C, S](leafStore(persistenceStore), _.id, _.version)
   }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
@@ -2,17 +2,22 @@ package mesosphere.marathon.core.storage.store.impl.cache
 
 import java.util.UUID
 
+import akka.Done
+import akka.http.scaladsl.marshalling.Marshaller
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.stream.scaladsl.Sink
 import com.codahale.metrics.MetricRegistry
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.storage.store.PersistenceStoreTest
+import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStoreTest, TestClass1 }
 import mesosphere.marathon.core.storage.store.impl.InMemoryTestClass1Serialization
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.storage.store.impl.zk.{ ZkPersistenceStore, ZkTestClass1Serialization }
 import mesosphere.marathon.integration.setup.ZookeeperServerTest
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.storage.store.InMemoryStoreSerialization
+import mesosphere.marathon.test.SettableClock
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 
 class LazyCachingPersistenceStoreTest extends AkkaUnitTest
     with PersistenceStoreTest with ZkTestClass1Serialization with ZookeeperServerTest
@@ -20,8 +25,10 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
 
   private def cachedInMemory = {
     implicit val metrics = new Metrics(new MetricRegistry)
-    new LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    LazyCachingPersistenceStore(new InMemoryPersistenceStore())
   }
+
+  private def withLazyVersionCaching = LazyVersionCachingPersistentStore(cachedInMemory)
 
   def zkStore: ZkPersistenceStore = {
     implicit val metrics = new Metrics(new MetricRegistry)
@@ -31,9 +38,139 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
     new ZkPersistenceStore(client, Duration.Inf, 8)
   }
 
-  private def cachedZk = new LazyCachingPersistenceStore(zkStore)
+  private def cachedZk = LazyCachingPersistenceStore(zkStore)
 
   behave like basicPersistenceStore("LazyCache(InMemory)", cachedInMemory)
   behave like basicPersistenceStore("LazyCache(Zk)", cachedZk)
+  behave like basicPersistenceStore("LazyVersionedCache(Zk)", withLazyVersionCaching)
+
   // TODO: Mock out the backing store.
+
+  behave like cachingPersistenceStore("cache internals(InMemory)", withLazyVersionCaching)
+
+  def cachingPersistenceStore[K, C, Serialized](
+    name: String,
+    newStore: => LazyVersionCachingPersistentStore[K, C, Serialized])(
+    implicit
+    ir: IdResolver[String, TestClass1, C, K],
+    m: Marshaller[TestClass1, Serialized],
+    um: Unmarshaller[Serialized, TestClass1]): Unit = {
+
+    name should {
+      "purge the cache appropriately" in {
+        implicit val clock = new SettableClock()
+        val store = newStore
+        1.to(100).foreach { i =>
+          val obj = TestClass1("abc", i)
+          clock.plus(1.second)
+          store.store("task-1", obj).futureValue should be(Done)
+        }
+        store.versionedValueCache.size should be(100) // sanity
+        store.maybePurgeCachedVersions(maxEntries = 50, purgeCount = 10)
+        store.versionedValueCache.size > 40 should be(true)
+        store.versionedValueCache.size <= 50 should be(true)
+      }
+      "caches versions independently" in {
+        implicit val clock = new SettableClock()
+        val store = newStore
+        val original = TestClass1("abc", 1)
+        clock.plus(1.minute)
+        val updated = TestClass1("def", 2)
+        store.store("task-1", original).futureValue should be(Done)
+        store.store("task-1", updated).futureValue should be(Done)
+        store.store("task-1", updated).futureValue should be(Done) // redundant store should not lead to dup data
+
+        val storageId = ir.toStorageId("task-1", None)
+        val cacheKey = (ir.category, storageId)
+
+        store.versionCache.size should be(1)
+        store.versionCache.contains(cacheKey) should be(true)
+        store.versionCache(cacheKey) should contain theSameElementsAs (Seq(original.version, updated.version))
+
+        store.versionedValueCache.size should be(2)
+        store.versionedValueCache((storageId, original.version)) should be(Some(original))
+        store.versionedValueCache((storageId, updated.version)) should be(Some(updated))
+      }
+
+      "invalidates all cached versions upon deletion" in {
+        implicit val clock = new SettableClock()
+        val store = newStore
+        val original = TestClass1("abc", 1)
+        clock.plus(1.minute)
+        val updated = TestClass1("def", 2)
+        store.store("task-1", original).futureValue should be(Done)
+        store.store("task-1", updated).futureValue should be(Done)
+        store.deleteVersion("task-1", original.version).futureValue should be(Done)
+
+        val storageId = ir.toStorageId("task-1", None)
+        val cacheKey = (ir.category, storageId)
+
+        store.versionCache.size should be(0)
+        store.versionedValueCache.size should be(0)
+      }
+
+      "reload versionCache upon versions request" in {
+        implicit val clock = new SettableClock()
+        val store = newStore
+        val original = TestClass1("abc", 1)
+        clock.plus(1.minute)
+        val updated = TestClass1("def", 2)
+        store.store("task-1", original).futureValue should be(Done)
+        store.store("task-1", updated).futureValue should be(Done)
+
+        store.versionCache.clear()
+        store.versionedValueCache.clear()
+
+        store.versions("task-1").runWith(Sink.seq).futureValue should contain
+        theSameElementsAs(Seq(original.version, updated.version))
+
+        store.versionedValueCache.size should be(0)
+      }
+
+      "reload versionedValueCache upon versioned get requests" in {
+        implicit val clock = new SettableClock()
+        val store = newStore
+        val original = TestClass1("abc", 1)
+        clock.plus(1.minute)
+        val updated = TestClass1("def", 2)
+        store.store("task-1", original).futureValue should be(Done)
+        store.store("task-1", updated).futureValue should be(Done)
+
+        store.versionCache.clear()
+        store.versionedValueCache.clear()
+
+        store.get("task-1", original.version).futureValue should be(Some(original)) // sanity check
+
+        val storageId = ir.toStorageId("task-1", None)
+
+        store.versionedValueCache.size should be(1)
+        store.versionedValueCache.contains((storageId, original.version)) should be(true)
+
+        store.versionCache.size should be(1)
+      }
+
+      "reload versionedValueCache upon unversioned get requests" in {
+        implicit val clock = new SettableClock()
+        val store = newStore
+        val original = TestClass1("abc", 1)
+        clock.plus(1.minute)
+        val updated = TestClass1("def", 2)
+        store.store("task-1", original).futureValue should be(Done)
+        store.store("task-1", updated).futureValue should be(Done)
+
+        store.versionCache.clear()
+        store.versionedValueCache.clear()
+
+        store.get("task-1").futureValue should be(Some(updated)) // sanity check
+
+        val storageId = ir.toStorageId("task-1", None)
+
+        store.versionedValueCache.size should be(1)
+        store.versionedValueCache.contains((storageId, updated.version)) should be(true)
+
+        store.versionCache.size should be(1)
+      }
+    }
+  }
+
 }

--- a/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
@@ -172,7 +172,7 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
 
   def createLazyCachingRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
-    val store = new LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }
 

--- a/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
@@ -187,7 +187,7 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
 
   def createLazyCachingRepo(maxVersions: Int): AppRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
-    AppRepository.inMemRepository(new LazyCachingPersistenceStore(new InMemoryPersistenceStore()))
+    AppRepository.inMemRepository(LazyCachingPersistenceStore(new InMemoryPersistenceStore()))
   }
 
   behave like basic("InMemEntity", createLegacyRepo(_, new InMemoryStore()))

--- a/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
@@ -81,7 +81,7 @@ class SingletonRepositoryTest extends AkkaUnitTest with ZookeeperServerTest {
 
   def createLazyCachingRepo(): FrameworkIdRepository = {
     implicit val metrics = new Metrics(new MetricRegistry)
-    FrameworkIdRepository.inMemRepository(new LazyCachingPersistenceStore(new InMemoryPersistenceStore()))
+    FrameworkIdRepository.inMemRepository(LazyCachingPersistenceStore(new InMemoryPersistenceStore()))
   }
 
   behave like basic("InMemEntity", createLegacyRepo(new InMemoryStore()))


### PR DESCRIPTION
Lazy cache for versions and versioned objects. Once the versioned object cache reaches a size threshold some number of entries are purged.