### PR TITLE
Fixes for TaskKillService

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -569,6 +569,15 @@ trait EventFormats {
     Json.writes[SchedulerRegisteredEvent]
   implicit lazy val SchedulerReregisteredEventWritesWrites: Writes[SchedulerReregisteredEvent] =
     Json.writes[SchedulerReregisteredEvent]
+  implicit lazy val UnknownTaskTerminatedEventWrites: Writes[UnknownTaskTerminated] = Writes { change =>
+    Json.obj(
+      "taskId" -> change.id,
+      "runSpecId" -> change.runSpecId,
+      "status" -> change.status.toString,
+      "timestamp" -> change.timestamp,
+      "eventType" -> change.eventType
+    )
+  }
 
   //scalastyle:off cyclomatic.complexity
   def eventToJson(event: MarathonEvent): JsValue = event match {
@@ -595,6 +604,7 @@ trait EventFormats {
     case event: SchedulerDisconnectedEvent => Json.toJson(event)
     case event: SchedulerRegisteredEvent => Json.toJson(event)
     case event: SchedulerReregisteredEvent => Json.toJson(event)
+    case event: UnknownTaskTerminated => Json.toJson(event)
   }
   //scalastyle:on
 }

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon.core.event
 
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.task.state.MarathonTaskStatus
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep }
 
@@ -192,3 +193,12 @@ case class MesosFrameworkMessageEvent(
   message: Array[Byte],
   eventType: String = "framework_message_event",
   timestamp: String = Timestamp.now().toString) extends MarathonEvent
+
+/** Event indicating an unknown task is terminal */
+case class UnknownTaskTerminated(
+    id: Task.Id,
+    runSpecId: PathId,
+    status: MarathonTaskStatus) extends MarathonEvent {
+  override val eventType: String = "unknown_task_terminated_event"
+  override val timestamp: String = Timestamp.now().toString
+}

--- a/src/main/scala/mesosphere/marathon/core/task/state/MarathonTaskStatus.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/state/MarathonTaskStatus.scala
@@ -9,7 +9,7 @@ import org.apache.mesos
   * - representations of the mesos.Protos.TaskStatus
   * - mapping of existing (soon-to-be deprecated) mesos.Protos.TaskStatus.TASK_LOST to the new representations
   */
-sealed trait MarathonTaskStatus {
+sealed trait MarathonTaskStatus extends Product with Serializable {
   def toMesosStateName: String = {
     import MarathonTaskStatus._
     this match {

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskKillConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskKillConfig.scala
@@ -19,22 +19,12 @@ trait TaskKillConfig extends ScallopConf {
   private[this] lazy val _killRetryTimeout = opt[Long](
     "kill_retry_timeout",
     descr = "INTERNAL TUNING PARAMETER: " +
-      "The timeout after which a task kill will be retried.",
+      "The timeout after which unconfirmed task kills will be retried.",
     noshort = true,
     hidden = true,
     default = Some(10.seconds.toMillis)
   )
 
-  private[this] lazy val _killRetryMax = opt[Int](
-    "kill_retry_max",
-    descr = "INTERNAL TUNING PARAMETER: " +
-      "The maximum number of kill retries before which a task will be forcibly expunged from state.",
-    noshort = true,
-    hidden = true,
-    default = Some(5) //scalastyle:off magic.number
-  )
-
   lazy val killChunkSize: Int = _killChunkSize()
   lazy val killRetryTimeout: FiniteDuration = _killRetryTimeout().millis
-  lazy val killRetryMax: Int = _killRetryMax()
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskKillService.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskKillService.scala
@@ -36,7 +36,6 @@ trait TaskKillService {
     *
     * @param taskId the id of the task that shall be killed.
     * @param reason the reason why the task shall be killed.
-    * @return a future that is completed when all tasks are killed.
     */
-  def killUnknownTask(taskId: Task.Id, reason: TaskKillReason): Future[Done]
+  def killUnknownTask(taskId: Task.Id, reason: TaskKillReason): Unit
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
@@ -14,11 +14,10 @@ class TaskTerminationModule(
     config: TaskKillConfig,
     clock: Clock) {
 
-  private[this] lazy val taskTracker = taskTrackerModule.taskTracker
   private[this] lazy val stateOpProcessor = taskTrackerModule.stateOpProcessor
 
   private[this] lazy val taskKillServiceActorProps: Props =
-    TaskKillServiceActor.props(taskTracker, driverHolder, stateOpProcessor, config, clock)
+    TaskKillServiceActor.props(driverHolder, stateOpProcessor, config, clock)
 
   private[this] lazy val taskKillServiceActor: ActorRef =
     leadershipModule.startWhenLeader(taskKillServiceActorProps, "taskKillServiceActor")

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActor.scala
@@ -5,9 +5,10 @@ import akka.actor.{ Actor, ActorLogging, Cancellable, Props }
 import mesosphere.marathon.MarathonSchedulerDriverHolder
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.task.termination.TaskKillConfig
-import mesosphere.marathon.state.Timestamp
+import mesosphere.marathon.core.task.tracker.TaskStateOpProcessor
 import mesosphere.marathon.core.task.{ Task, TaskStateOp }
-import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskTracker }
+import mesosphere.marathon.core.event.UnknownTaskTerminated
+import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.core.event.MesosStatusUpdateEvent
 
 import scala.collection.mutable
@@ -31,7 +32,6 @@ import scala.concurrent.Promise
   * See [[TaskKillConfig]] for configuration options.
   */
 private[impl] class TaskKillServiceActor(
-    taskTracker: TaskTracker,
     driverHolder: MarathonSchedulerDriverHolder,
     stateOpProcessor: TaskStateOpProcessor,
     config: TaskKillConfig,
@@ -39,8 +39,8 @@ private[impl] class TaskKillServiceActor(
   import TaskKillServiceActor._
   import context.dispatcher
 
-  val tasksToKill: mutable.HashMap[Task.Id, Option[Task]] = mutable.HashMap.empty
-  val inFlight: mutable.HashMap[Task.Id, TaskToKill] = mutable.HashMap.empty
+  val tasksToKill: mutable.HashMap[Task.Id, ToKill] = mutable.HashMap.empty
+  val inFlight: mutable.HashMap[Task.Id, ToKill] = mutable.HashMap.empty
 
   val retryTimer: RetryTimer = new RetryTimer {
     override def createTimer(): Cancellable = {
@@ -50,6 +50,7 @@ private[impl] class TaskKillServiceActor(
 
   override def preStart(): Unit = {
     context.system.eventStream.subscribe(self, classOf[MesosStatusUpdateEvent])
+    context.system.eventStream.subscribe(self, classOf[UnknownTaskTerminated])
   }
 
   override def postStop(): Unit = {
@@ -72,17 +73,17 @@ private[impl] class TaskKillServiceActor(
     case Terminal(event) if inFlight.contains(event.taskId) || tasksToKill.contains(event.taskId) =>
       handleTerminal(event.taskId)
 
+    case UnknownTaskTerminated(id, _, _) if inFlight.contains(id) || tasksToKill.contains(id) =>
+      handleTerminal(id)
+
     case Retry =>
       retry()
-
-    case unhandled: InternalRequest =>
-      log.warning("Received unhandled {}", unhandled)
   }
 
   def killUnknownTaskById(taskId: Task.Id, promise: Promise[Done]): Unit = {
     log.debug("Received KillUnknownTaskById({})", taskId)
     setupProgressActor(Seq(taskId), promise)
-    tasksToKill.update(taskId, None)
+    tasksToKill.update(taskId, ToKill(taskId, maybeTask = None, attempts = 0))
     processKills()
   }
 
@@ -90,7 +91,10 @@ private[impl] class TaskKillServiceActor(
     log.debug("Adding {} tasks to queue; setting up child actor to track progress", tasks.size)
     setupProgressActor(tasks.map(_.taskId), promise)
     tasks.foreach { task =>
-      tasksToKill.update(task.taskId, Some(task))
+      tasksToKill.update(
+        task.taskId,
+        ToKill(task.taskId, maybeTask = Some(task), attempts = 0)
+      )
     }
     processKills()
   }
@@ -104,9 +108,7 @@ private[impl] class TaskKillServiceActor(
     val toKillNow = tasksToKill.take(killCount)
 
     log.info("processing {} kills", toKillNow.size)
-    toKillNow.foreach {
-      case (taskId, maybeTask) => processKill(taskId, maybeTask)
-    }
+    toKillNow.values.foreach(processKill)
 
     if (inFlight.isEmpty) {
       retryTimer.cancel()
@@ -115,21 +117,25 @@ private[impl] class TaskKillServiceActor(
     }
   }
 
-  def processKill(taskId: Task.Id, maybeTask: Option[Task]): Unit = {
-    val taskIsLost: Boolean = maybeTask.fold(false)(isLost)
+  def processKill(toKill: ToKill): Unit = {
+    val taskId = toKill.taskId
+
+    val taskIsLost: Boolean = toKill.maybeTask.fold(false) { task =>
+      task.isGone || task.isUnknown || task.isDropped || task.isUnreachable
+    }
 
     if (taskIsLost) {
       log.warning("Expunging lost {} from state because it should be killed", taskId)
       // we will eventually be notified of a taskStatusUpdate after the task has been expunged
       stateOpProcessor.process(TaskStateOp.ForceExpunge(taskId))
     } else {
-      val knownOrNot = if (maybeTask.isDefined) "known" else "unknown"
+      val knownOrNot = if (toKill.maybeTask.isDefined) "known" else "unknown"
       log.warning("Killing {} {}", knownOrNot, taskId)
       driverHolder.driver.foreach(_.killTask(taskId.mesosTaskId))
     }
 
     val attempts = inFlight.get(taskId).fold(1)(_.attempts + 1)
-    inFlight.update(taskId, TaskToKill(taskId, maybeTask, issued = clock.now(), attempts))
+    inFlight.update(taskId, ToKill(taskId, toKill.maybeTask, attempts, issued = clock.now()))
     tasksToKill.remove(taskId)
   }
 
@@ -144,13 +150,13 @@ private[impl] class TaskKillServiceActor(
     val now = clock.now()
 
     inFlight.foreach {
-      case (taskId, taskToKill) if taskToKill.attempts >= config.killRetryMax =>
+      case (taskId, toKill) if toKill.attempts >= config.killRetryMax =>
         log.warning("Expunging {} from state: max retries reached", taskId)
         stateOpProcessor.process(TaskStateOp.ForceExpunge(taskId))
 
-      case (taskId, taskToKill) if (taskToKill.issued + config.killRetryTimeout) < now =>
+      case (taskId, toKill) if (toKill.issued + config.killRetryTimeout) < now =>
         log.warning("No kill ack received for {}, retrying", taskId)
-        processKill(taskId, taskToKill.maybeTask)
+        processKill(toKill)
 
       case _ => // ignore
     }
@@ -171,15 +177,25 @@ private[termination] object TaskKillServiceActor {
   sealed trait InternalRequest
   case object Retry extends InternalRequest
 
-  case class TaskToKill(taskId: Task.Id, maybeTask: Option[Task], issued: Timestamp, attempts: Int)
+  /**
+    * Metadata used to track which tasks to kill and how many attempts have been made
+    * @param taskId id of the task to kill
+    * @param maybeTask the task, if available
+    * @param attempts the number of kill attempts
+    * @param issued the time of the last issued kill request
+    */
+  case class ToKill(
+    taskId: Task.Id,
+    maybeTask: Option[Task],
+    attempts: Int,
+    issued: Timestamp = Timestamp.zero)
 
   def props(
-    taskTracker: TaskTracker,
     driverHolder: MarathonSchedulerDriverHolder,
     stateOpProcessor: TaskStateOpProcessor,
     config: TaskKillConfig,
     clock: Clock): Props = Props(
-    new TaskKillServiceActor(taskTracker, driverHolder, stateOpProcessor, config, clock))
+    new TaskKillServiceActor(driverHolder, stateOpProcessor, config, clock))
 }
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceDelegate.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.core.task.termination.{ TaskKillReason, TaskKillServi
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ Future, Promise }
+import scala.collection.immutable.Seq
 
 private[termination] class TaskKillServiceDelegate(actorRef: ActorRef) extends TaskKillService {
   import TaskKillServiceDelegate.log
@@ -27,7 +28,7 @@ private[termination] class TaskKillServiceDelegate(actorRef: ActorRef) extends T
   }
 
   override def killUnknownTask(taskId: Task.Id, reason: TaskKillReason): Future[Done] = {
-    log.info(s"Killing 1 unknown task for reason: $reason (id: {})", taskId)
+    log.info(s"Killing unknown task for reason: $reason (id: $taskId)")
 
     val promise = Promise[Done]
     actorRef ! KillUnknownTaskById(taskId, promise)

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceDelegate.scala
@@ -27,12 +27,9 @@ private[termination] class TaskKillServiceDelegate(actorRef: ActorRef) extends T
     killTasks(Seq(task), reason)
   }
 
-  override def killUnknownTask(taskId: Task.Id, reason: TaskKillReason): Future[Done] = {
+  override def killUnknownTask(taskId: Task.Id, reason: TaskKillReason): Unit = {
     log.info(s"Killing unknown task for reason: $reason (id: $taskId)")
-
-    val promise = Promise[Done]
-    actorRef ! KillUnknownTaskById(taskId, promise)
-    promise.future
+    actorRef ! KillUnknownTaskById(taskId)
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
+++ b/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
@@ -116,11 +116,10 @@ object TaskFailure {
   protected[this] def taskState(s: String): mesos.TaskState =
     mesos.TaskState.valueOf(s)
 
-  // Note that this will also store taskFailures for TASK_LOST no matter the reason
   private[this] def isFailureState(state: mesos.TaskState): Boolean = {
     import mesos.TaskState._
     state match {
-      case TASK_FAILED | TASK_LOST | TASK_ERROR => true
+      case TASK_FAILED | TASK_ERROR | TASK_LOST => true
       case _ => false
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/task/TaskKillServiceMock.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskKillServiceMock.scala
@@ -35,6 +35,6 @@ class TaskKillServiceMock(system: ActorSystem) extends TaskKillService {
 
   override def killTask(task: Task, reason: TaskKillReason): Future[Done] = killTaskById(task.taskId, reason)
 
-  override def killUnknownTask(taskId: Id, reason: TaskKillReason): Future[Done] = killTaskById(taskId, reason)
+  override def killUnknownTask(taskId: Id, reason: TaskKillReason): Unit = killTaskById(taskId, reason)
 }
 

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/TaskKillServiceActorTest.scala
@@ -2,12 +2,12 @@ package mesosphere.marathon.core.task.termination.impl
 
 import akka.Done
 import akka.actor.{ ActorRef, ActorSystem }
-import akka.testkit.{ ImplicitSender, TestActorRef, TestKit, TestProbe }
-import mesosphere.marathon.MarathonSchedulerDriverHolder
+import mesosphere.marathon.{ MarathonSchedulerDriverHolder, MarathonTestHelper }
 import mesosphere.marathon.core.base.ConstantClock
-import mesosphere.marathon.core.event.MesosStatusUpdateEvent
+import mesosphere.marathon.core.event.{ MesosStatusUpdateEvent, UnknownTaskTerminated }
+import mesosphere.marathon.core.task.state.MarathonTaskStatus
 import mesosphere.marathon.core.task.termination.TaskKillConfig
-import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, TaskTracker }
+import mesosphere.marathon.core.task.tracker.TaskStateOpProcessor
 import mesosphere.marathon.core.task.{ Task, TaskStateOp }
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.test.Mockito
@@ -15,7 +15,7 @@ import org.apache.mesos
 import org.apache.mesos.SchedulerDriver
 import org.mockito.ArgumentCaptor
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{ Seconds, Span }
+import org.scalatest.time.{ Millis, Span }
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, GivenWhenThen, Matchers }
 import org.slf4j.LoggerFactory
 
@@ -23,19 +23,17 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
-    with FunSuiteLike
+class TaskKillServiceActorTest extends FunSuiteLike
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with GivenWhenThen
     with ScalaFutures
     with Matchers
-    with ImplicitSender
     with Mockito {
 
   import TaskKillServiceActorTest.log
 
-  ignore("Kill single known task - https://github.com/mesosphere/marathon/issues/4202") {
+  test("Kill single known instance") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
@@ -57,7 +55,6 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
   }
 
   test("Kill unknown task") {
-    // TODO
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
@@ -68,15 +65,12 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     val promise = Promise[Done]()
     actor ! TaskKillServiceActor.KillUnknownTaskById(taskId, promise)
 
-    Then("it will not fetch the task from the taskTracker")
-    noMoreInteractions(f.taskTracker)
-
-    And("a kill is issued to the driver")
+    Then("a kill is issued to the driver")
     verify(f.driver, timeout(500)).killTask(taskId.mesosTaskId)
     noMoreInteractions(f.driver)
 
     When("a terminal status update is published via the event stream")
-    f.publishStatusUpdate(taskId, mesos.Protos.TaskState.TASK_KILLED)
+    f.publishUnknownTaskTerminated(taskId)
 
     Then("the promise is eventually completed successfully")
     promise.future.futureValue should be (Done)
@@ -106,7 +100,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     promise.future.futureValue should be (Done)
   }
 
-  ignore("kill multiple tasks at once - https://github.com/mesosphere/marathon/issues/4202") {
+  test("kill multiple instances at once") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
@@ -119,10 +113,7 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     val promise = Promise[Done]()
     actor ! TaskKillServiceActor.KillTasks(Seq(runningTask, lostTask, stagingTask), promise)
 
-    Then("the task tracker is not queried")
-    noMoreInteractions(f.taskTracker)
-
-    And("three kill requests are issued to the driver")
+    Then("three kill requests are issued to the driver")
     verify(f.driver, timeout(500)).killTask(runningTask.taskId.mesosTaskId)
     verify(f.stateOpProcessor, timeout(500)).process(TaskStateOp.ForceExpunge(lostTask.taskId))
     verify(f.driver, timeout(500)).killTask(stagingTask.taskId.mesosTaskId)
@@ -151,14 +142,11 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     Then("the promise is eventually completed successfully")
     promise.future.futureValue should be (Done)
 
-    And("the task tracker is not queried")
-    noMoreInteractions(f.taskTracker)
-
-    And("no kill is issued")
+    Then("no kill is issued")
     noMoreInteractions(f.driver)
   }
 
-  ignore("kill multiple tasks subsequently - https://github.com/mesosphere/marathon/issues/4202") {
+  test("kill multiple instances subsequently") {
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
@@ -289,28 +277,28 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
     promise.future.futureValue should be (Done)
   }
 
+  private[this] implicit var actorSystem: ActorSystem = _
+  private[this] var actor: ActorRef = _
+  private[this] var actorCounter: Int = 0
+
+  override protected def beforeAll(): Unit = {
+    actorSystem = ActorSystem()
+  }
+
   override protected def afterAll(): Unit = {
-    shutdown()
+    actorSystem.terminate()
   }
 
   override protected def afterEach(): Unit = {
-    import TaskKillServiceActorTest._
-    actor match {
-      case Some(actorRef) => system.stop(actorRef)
-      case _ =>
-        val msg = "The test didn't set a reference to the tested actor. Either make sure to set the ref" +
-          "so it can be stopped automatically, or move the test to a suite that doesn't test this actor."
-        fail(msg)
-    }
+    actorSystem.stop(actor)
   }
 
-  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)))
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(4000, Millis)))
 
   class Fixture {
     import scala.concurrent.duration._
 
     val appId = PathId("/test")
-    val taskTracker: TaskTracker = mock[TaskTracker]
     val driver = mock[SchedulerDriver]
     val driverHolder: MarathonSchedulerDriverHolder = {
       val holder = new MarathonSchedulerDriverHolder
@@ -328,28 +316,19 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
       override lazy val killRetryMax: Int = 1
     }
     val stateOpProcessor: TaskStateOpProcessor = mock[TaskStateOpProcessor]
-    val parent = TestProbe()
     val clock = ConstantClock()
 
     def createTaskKillActor(config: TaskKillConfig = defaultConfig): ActorRef = {
-      import TaskKillServiceActorTest._
-      val actorRef: ActorRef = TestActorRef(TaskKillServiceActor.props(taskTracker, driverHolder, stateOpProcessor, config, clock), parent.ref, "TaskKillService")
-      actor = Some(actorRef)
-      actorRef
+      actorCounter += 1
+      actor = actorSystem.actorOf(TaskKillServiceActor.props(driverHolder, stateOpProcessor, config, clock), s"TaskKillService-$actorCounter")
+      actor
     }
 
     def mockTask(taskId: Task.Id, stagedAt: Timestamp, mesosState: mesos.Protos.TaskState): Task.LaunchedEphemeral = {
-      val status: Task.Status = mock[Task.Status]
-      status.stagedAt returns stagedAt
-      val mesosStatus: mesos.Protos.TaskStatus = mesos.Protos.TaskStatus.newBuilder()
-        .setState(mesosState)
-        .buildPartial()
-      val task = mock[Task.LaunchedEphemeral]
-      task.taskId returns taskId
-      task.status returns status
-      task.mesosStatus returns Some(mesosStatus)
-      task
+      val mesosStatus: mesos.Protos.TaskStatus = MarathonTestHelper.statusForState(taskId.idString, mesosState)
+      MarathonTestHelper.mininimalTask(taskId.idString, stagedAt, Some(mesosStatus))
     }
+
     def now(): Timestamp = Timestamp(0)
     def publishStatusUpdate(taskId: Task.Id, state: mesos.Protos.TaskState): Unit = {
       val appId = taskId.runSpecId
@@ -359,12 +338,18 @@ class TaskKillServiceActorTest extends TestKit(ActorSystem("test"))
           ipAddresses = None, ports = Nil, version = "version"
         )
       log.info("publish {} on the event stream", statusUpdateEvent)
-      system.eventStream.publish(statusUpdateEvent)
+      actorSystem.eventStream.publish(statusUpdateEvent)
     }
+
+    def publishUnknownTaskTerminated(taskId: Task.Id): Unit = {
+      val event = UnknownTaskTerminated(taskId, taskId.runSpecId, MarathonTaskStatus.Killed)
+      log.info("publish {} on the event stream", event)
+      actorSystem.eventStream.publish(event)
+    }
+
   }
 }
 
 object TaskKillServiceActorTest {
   val log = LoggerFactory.getLogger(getClass)
-  var actor: Option[ActorRef] = None
 }

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -173,7 +173,8 @@ class TaskStatusUpdateProcessorImplTest
       taskTracker,
       stateOpProcessor,
       marathonSchedulerDriverHolder,
-      killService
+      killService,
+      eventStream = actorSystem.eventStream
     )
 
     def verifyNoMoreInteractions(): Unit = {


### PR DESCRIPTION
**Please don't squash merge**

Cherry picking 2 commits from `master` to `releases/1.3`:

### Introducing UnknownTaskTerminated event
Until now, no event was dispatched on the event stream when the related task was terminal and unknown, thus making the TaskKillService unable to track the progress of these kill requests. Promises created by TaskKillProgressActors were never completed, leading to a memory leak. With this change, an UnknownTaskTerminated event will be dispatched on the event bus when a terminal status update for an unknown task is received. This event is also visible for subscribers to the event stream. The TaskKillService handles this event and correctly recognizes it as a kill success.

Cherry-picked from feature/pods (was: Adjust the KillService to handle instances instead of tasks (#4414))

### Fix KillService behavior: retry forever and don't spawn progress actors for unknown tasks

* killUnknownTask now has a unit return type (no one is interested in the result)
* Do not create KillProgressActors for unknown tasks
* remove maxRetries; if no terminal task status is received, the killService will retry until the task is confirmed to be terminal