### PR TITLE
Terminal tasks should not be send in reconciliation

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -476,7 +476,7 @@ class SchedulerActions(
     appRepository.ids().concat(podRepository.ids()).runWith(Sink.set).flatMap { runSpecIds =>
       instanceTracker.instancesBySpec().map { instances =>
         val knownTaskStatuses = runSpecIds.flatMap { runSpecId =>
-          instances.specInstances(runSpecId).flatMap(_.tasks.flatMap(_.mesosStatus))
+          instances.specInstances(runSpecId).flatMap(_.tasks.filter(!_.isTerminal)).flatMap(_.mesosStatus)
         }
 
         (instances.allSpecIdsWithInstances -- runSpecIds).foreach { unknownId =>

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -3,18 +3,18 @@ package mesosphere.marathon
 import java.util.concurrent.TimeoutException
 
 import akka.Done
-import akka.actor.{ ActorRef, Props }
+import akka.actor.{ActorRef, Props}
 import akka.event.EventStream
 import akka.stream.scaladsl.Source
 import akka.testkit._
 import akka.util.Timeout
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.core.instance.TestInstanceBuilder
-import mesosphere.marathon.core.election.{ ElectionService, LocalLeadershipEvent }
+import mesosphere.marathon.core.election.{ElectionService, LocalLeadershipEvent}
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.history.impl.HistoryActor
-import mesosphere.marathon.core.instance.{ Instance, InstanceStatus }
+import mesosphere.marathon.core.instance.{Instance, InstanceStatus}
 import mesosphere.marathon.core.launcher.impl.LaunchQueueTestHelper
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
@@ -23,16 +23,18 @@ import mesosphere.marathon.core.task.KillServiceMock
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
-import mesosphere.marathon.storage.repository.{ AppRepository, DeploymentRepository, FrameworkIdRepository, GroupRepository, TaskFailureRepository, _ }
-import mesosphere.marathon.test.{ MarathonActorSupport, MarathonSpec, Mockito }
+import mesosphere.marathon.storage.repository.{AppRepository, DeploymentRepository, FrameworkIdRepository, GroupRepository, TaskFailureRepository, _}
+import mesosphere.marathon.test.{MarathonActorSupport, MarathonSpec, Mockito}
 import mesosphere.marathon.upgrade._
 import org.apache.mesos.Protos.Status
+import org.apache.mesos.Protos.TaskStatus
 import org.apache.mesos.SchedulerDriver
-import org.scalatest.{ BeforeAndAfterAll, FunSuiteLike, GivenWhenThen, Matchers }
+import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, GivenWhenThen, Matchers}
 
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Set
 import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
 class MarathonSchedulerActorTest extends MarathonActorSupport
     with FunSuiteLike
@@ -78,6 +80,33 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
       awaitAssert({
         killService.killed should contain (instance.instanceId)
+      }, 5.seconds, 10.millis)
+    } finally {
+      stopActor(schedulerActor)
+    }
+  }
+
+  test("Terminal tasks should not be submitted in reconciliation") {
+    val f = new Fixture
+    import f._
+    val app = AppDefinition(id = "/test-app".toPath, instances = 1)
+    val instance = TestInstanceBuilder.newBuilder(app.id).addTaskUnreachable(containerName = Some("unreachable")).addTaskRunning().addTaskGone(containerName = Some("gone")).getInstance()
+
+    appRepo.ids() returns Source.single(app.id)
+    instanceTracker.instancesBySpec()(any[ExecutionContext]) returns Future.successful(InstanceTracker.InstancesBySpec.of(InstanceTracker.SpecInstances.forInstances("nope".toPath, Iterable(instance))))
+    appRepo.get(app.id) returns Future.successful(Some(app))
+
+    val schedulerActor = createActor()
+    try {
+      schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
+      schedulerActor ! ReconcileTasks
+
+      expectMsg(5.seconds, TasksReconciled)
+
+      val expectedStatus: java.util.Collection[TaskStatus] = instance.tasks.filter(!_.task.isTerminal).flatMap(_.mesosStatus).toSet.asJava
+      assert(expectedStatus.size() == 2, "Only non-terminal tasks should be expected to be reconciled")
+      awaitAssert({
+        driver.reconcileTasks(expectedStatus)
       }, 5.seconds, 10.millis)
     } finally {
       stopActor(schedulerActor)

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -3,18 +3,18 @@ package mesosphere.marathon
 import java.util.concurrent.TimeoutException
 
 import akka.Done
-import akka.actor.{ActorRef, Props}
+import akka.actor.{ ActorRef, Props }
 import akka.event.EventStream
 import akka.stream.scaladsl.Source
 import akka.testkit._
 import akka.util.Timeout
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.core.instance.TestInstanceBuilder
-import mesosphere.marathon.core.election.{ElectionService, LocalLeadershipEvent}
+import mesosphere.marathon.core.election.{ ElectionService, LocalLeadershipEvent }
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.history.impl.HistoryActor
-import mesosphere.marathon.core.instance.{Instance, InstanceStatus}
+import mesosphere.marathon.core.instance.{ Instance, InstanceStatus }
 import mesosphere.marathon.core.launcher.impl.LaunchQueueTestHelper
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
@@ -23,18 +23,18 @@ import mesosphere.marathon.core.task.KillServiceMock
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
-import mesosphere.marathon.storage.repository.{AppRepository, DeploymentRepository, FrameworkIdRepository, GroupRepository, TaskFailureRepository, _}
-import mesosphere.marathon.test.{MarathonActorSupport, MarathonSpec, Mockito}
+import mesosphere.marathon.storage.repository.{ AppRepository, DeploymentRepository, FrameworkIdRepository, GroupRepository, TaskFailureRepository, _ }
+import mesosphere.marathon.test.{ MarathonActorSupport, MarathonSpec, Mockito }
 import mesosphere.marathon.upgrade._
 import org.apache.mesos.Protos.Status
 import org.apache.mesos.Protos.TaskStatus
 import org.apache.mesos.SchedulerDriver
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, GivenWhenThen, Matchers}
+import org.scalatest.{ BeforeAndAfterAll, FunSuiteLike, GivenWhenThen, Matchers }
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Set
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 
 class MarathonSchedulerActorTest extends MarathonActorSupport
     with FunSuiteLike

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -29,8 +29,11 @@ case class TestInstanceBuilder(
   def addTaskRunning(container: Option[MesosContainer] = None, stagedAt: Timestamp = now, startedAt: Timestamp = now): TestInstanceBuilder =
     addTaskWithBuilder().taskRunning(container, stagedAt, startedAt).build()
 
-  def addTaskUnreachable(since: Timestamp = now): TestInstanceBuilder =
-    addTaskWithBuilder().taskUnreachable(since).build()
+  def addTaskUnreachable(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
+    addTaskWithBuilder().taskUnreachable(since, containerName).build()
+
+  def addTaskGone(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
+    addTaskWithBuilder().taskGone(since, containerName).build()
 
   def addTaskStaged(stagedAt: Timestamp = now, version: Option[Timestamp] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskStaged(stagedAt, version).build()

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -6,9 +6,9 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.core.task.update.TaskUpdateOperation
-import mesosphere.marathon.core.task.{MarathonTaskStatus, Task}
+import mesosphere.marathon.core.task.{ MarathonTaskStatus, Task }
 import mesosphere.marathon.raml
-import mesosphere.marathon.state.{PathId, Timestamp}
+import mesosphere.marathon.state.{ PathId, Timestamp }
 import org.apache.mesos
 import org.apache.mesos.Protos._
 

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -6,8 +6,9 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.core.task.update.TaskUpdateOperation
-import mesosphere.marathon.core.task.{ MarathonTaskStatus, Task }
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.core.task.{MarathonTaskStatus, Task}
+import mesosphere.marathon.raml
+import mesosphere.marathon.state.{PathId, Timestamp}
 import org.apache.mesos
 import org.apache.mesos.Protos._
 
@@ -32,6 +33,8 @@ case class TestTaskBuilder(
     val mesosStatus = TestTaskBuilder.Helper.statusForState(taskId.idString, mesosState)
     this.copy(task = Some(TestTaskBuilder.Helper.minimalTask(taskId, stagedAt, Some(mesosStatus))))
   }
+
+  def maybeMesosContainerByName(name: Option[String]): Option[MesosContainer] = name.map(n => MesosContainer(name = n, resources = raml.Resources(cpus = 1.0f, mem = 128.0f)))
 
   def taskLaunched(container: Option[MesosContainer] = None) =
     this.copy(task = Some(TestTaskBuilder.Helper.minimalTask(instanceBuilder.getInstance().instanceId, container, now).copy(taskId = Task.Id.forInstanceId(instanceBuilder.getInstance().instanceId, None))))
@@ -63,9 +66,14 @@ case class TestTaskBuilder(
       instance.runSpecVersion, stagedAt = stagedAt.toDateTime.getMillis, startedAt = startedAt.toDateTime.getMillis).withAgentInfo(_ => instance.agentInfo)))
   }
 
-  def taskUnreachable(since: Timestamp = now) = {
+  def taskUnreachable(since: Timestamp = now, containerName: Option[String] = None) = {
     val instance = instanceBuilder.getInstance()
-    this.copy(task = Some(TestTaskBuilder.Helper.minimalUnreachableTask(instance.instanceId.runSpecId, since = since).copy(taskId = Task.Id.forInstanceId(instance.instanceId, None))))
+    this.copy(task = Some(TestTaskBuilder.Helper.minimalUnreachableTask(instance.instanceId.runSpecId, since = since).copy(taskId = Task.Id.forInstanceId(instance.instanceId, maybeMesosContainerByName(containerName)))))
+  }
+
+  def taskGone(since: Timestamp = now, containerName: Option[String] = None) = {
+    val instance = instanceBuilder.getInstance()
+    this.copy(task = Some(TestTaskBuilder.Helper.minimalLostTask(instance.instanceId.runSpecId, since = since, marathonTaskStatus = InstanceStatus.Gone).copy(taskId = Task.Id.forInstanceId(instance.instanceId, maybeMesosContainerByName(containerName)))))
   }
 
   def taskStaged(stagedAt: Timestamp = now, version: Option[Timestamp] = None) = {


### PR DESCRIPTION
A task group in Mesos will terminate when either all tasks are terminal or at least one task terminated abnormally (exit code != 0).
E.g., a valid state of a pod in Marathon is
> task1: Running
> task2: Finished

In this a case, the overall status of the instance is `Running`. If Marathon performs an explicit reconciliation for task2 in this case, Mesos will eventually send a status update that indicates that task2 is `Gone`, as it no longer exists.

On receiving this update, Marathon will interpret the overall instance status to be `Gone`, assuming the whole pod is not existing. A workaround is to **not** explicitly reconcile terminal tasks.

An improvement in the future would be to disallow changing a terminal task status to some other status (a task that is `Finished` should never become `Gone`).