### PR TITLE
remove ipAddress from RunSpec, introduce LegacyIpAddressSupport

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -4,7 +4,7 @@ import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.core.readiness.ReadinessCheck
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.raml.{ Pod, Raml, Resources }
-import mesosphere.marathon.state.{ AppDefinition, BackoffStrategy, EnvVarValue, IpAddress, MarathonState, PathId, PortAssignment, Residency, RunSpec, Secret, Timestamp, UpgradeStrategy, VersionInfo }
+import mesosphere.marathon.state.{ AppDefinition, BackoffStrategy, EnvVarValue, MarathonState, PathId, PortAssignment, Residency, RunSpec, Secret, Timestamp, UpgradeStrategy, VersionInfo }
 import mesosphere.marathon.{ Protos, plugin }
 import play.api.libs.json.Json
 
@@ -81,9 +81,6 @@ case class PodDefinition(
 
   // TODO(PODS) PortAssignments
   override def portAssignments(task: Task): Seq[PortAssignment] = Seq.empty[PortAssignment]
-
-  // TODO(PODS) ipaddress? is this even supported?
-  override val ipAddress = Option.empty[IpAddress]
 
   override def mergeFromProto(message: Protos.Json): PodDefinition = {
     Raml.fromRaml(Json.parse(message.getJson).as[Pod])

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -82,7 +82,8 @@ case class AppDefinition(
   residency: Option[Residency] = AppDefinition.DefaultResidency,
 
   secrets: Map[String, Secret] = AppDefinition.DefaultSecrets) extends RunSpec
-    with plugin.ApplicationSpec with MarathonState[Protos.ServiceDefinition, AppDefinition] {
+    with plugin.ApplicationSpec with MarathonState[Protos.ServiceDefinition, AppDefinition]
+    with LegacyIpAddressSupport {
 
   import mesosphere.mesos.protos.Implicits._
 

--- a/src/main/scala/mesosphere/marathon/state/IpAddress.scala
+++ b/src/main/scala/mesosphere/marathon/state/IpAddress.scala
@@ -40,3 +40,7 @@ object IpAddress {
     )
   }
 }
+
+trait LegacyIpAddressSupport {
+  val ipAddress: Option[IpAddress]
+}

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -59,7 +59,6 @@ trait RunSpec extends plugin.RunSpec {
   def needsRestart(to: RunSpec): Boolean
   def isOnlyScaleChange(to: RunSpec): Boolean
   val versionInfo: VersionInfo
-  val ipAddress: Option[IpAddress]
   // TODO: These ones probably should only exist in app and we should be pattern matching
   val requirePorts: Boolean = false
   val portNumbers = Seq.empty[Int]


### PR DESCRIPTION
Addresses an outstanding TODO: removes `ipAddress` from `PodDefinition` and therefore `RunSpec`