### PR TITLE
Prevent multiple ScaleRunSpec during instance gets terminal

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
@@ -32,7 +32,10 @@ class ScaleAppUpdateStepImpl @Inject() (
         val state = update.status
         log.info(s"initiating a scale check for runSpec [$runSpecId] due to [$instanceId] $state")
         // TODO(PODS): we should rename the Message and make the SchedulerActor generic
-        schedulerActor ! ScaleRunSpec(runSpecId)
+        // only dispatch ScaleRunSpec if last state was not terminal and current new state is terminal
+        if (update.lastState.exists(!_.status.isTerminal) && update.status.isTerminal) {
+          schedulerActor ! ScaleRunSpec(runSpecId)
+        }
 
       case _ =>
       // nothing

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
@@ -33,7 +33,7 @@ class ScaleAppUpdateStepImpl @Inject() (
         log.info(s"initiating a scale check for runSpec [$runSpecId] due to [$instanceId] $state")
         // TODO(PODS): we should rename the Message and make the SchedulerActor generic
         // only dispatch ScaleRunSpec if last state was not terminal and current new state is terminal
-        if (update.lastState.exists(!_.status.isTerminal) && update.status.isTerminal) {
+        if (update.lastState.forall(!_.status.isTerminal) && update.status.isTerminal) {
           schedulerActor ! ScaleRunSpec(runSpecId)
         }
 

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImplTest.scala
@@ -25,7 +25,7 @@ class ScaleAppUpdateStepImplTest extends FunSuite with Matchers with GivenWhenTh
       .getInstance()
 
     When("process a task_failed update")
-    val failedUpdate1 = f.makeFailedUpdateOp(instance, InstanceStatus.Running, InstanceStatus.Failed)
+    val failedUpdate1 = f.makeFailedUpdateOp(instance, Some(InstanceStatus.Running), InstanceStatus.Failed)
     f.step.process(failedUpdate1)
 
     Then("a scale request is sent to the scheduler actor")
@@ -33,8 +33,28 @@ class ScaleAppUpdateStepImplTest extends FunSuite with Matchers with GivenWhenTh
     answer.runSpecId should be (instance.instanceId.runSpecId)
 
     Then("process a task_failed again")
-    val failedUpdate2 = f.makeFailedUpdateOp(instance, InstanceStatus.Failed, InstanceStatus.Failed)
+    val failedUpdate2 = f.makeFailedUpdateOp(instance, Some(InstanceStatus.Failed), InstanceStatus.Failed)
     f.step.process(failedUpdate2)
+    f.schedulerActor.expectNoMsg()
+  }
+
+  test("ScaleAppUpdateStep should send one ScaleRunSpec if task is directly failed without lastState") {
+    val f = new Fixture
+
+    Given("an instance with terminal containers")
+    val instance = TestInstanceBuilder.newBuilder(PathId("/app"))
+      .addTaskUnreachable(containerName = Some("unreachable1"))
+      .getInstance()
+
+    When("process a task_failed update for a task with no last state")
+    val failedUpdate1 = f.makeFailedUpdateOp(instance, None, InstanceStatus.Failed)
+    f.step.process(failedUpdate1)
+
+    Then("a scale request is sent to the scheduler actor")
+    val answer = f.schedulerActor.expectMsgType[ScaleRunSpec]
+    answer.runSpecId should be (instance.instanceId.runSpecId)
+
+    Then("no more messages are processed")
     f.schedulerActor.expectNoMsg()
   }
 
@@ -44,8 +64,8 @@ class ScaleAppUpdateStepImplTest extends FunSuite with Matchers with GivenWhenTh
       override def get(): ActorRef = schedulerActor.ref
     }
 
-    def makeFailedUpdateOp(instance: Instance, lastState: InstanceStatus, newState: InstanceStatus) =
-      InstanceUpdated(instance.copy(state = instance.state.copy(status = newState)), Some(Instance.InstanceState(lastState, Timestamp.now(), instance.runSpecVersion, Some(true))), Seq.empty[MarathonEvent])
+    def makeFailedUpdateOp(instance: Instance, lastState: Option[InstanceStatus], newState: InstanceStatus) =
+      InstanceUpdated(instance.copy(state = instance.state.copy(status = newState)), lastState.map(state => Instance.InstanceState(state, Timestamp.now(), instance.runSpecVersion, Some(true))), Seq.empty[MarathonEvent])
 
     val step = new ScaleAppUpdateStepImpl(schedulerActorProvider)
   }

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImplTest.scala
@@ -1,0 +1,52 @@
+package mesosphere.marathon.core.task.update.impl.steps
+
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.testkit.TestProbe
+import com.google.inject.Provider
+import mesosphere.marathon.MarathonSchedulerActor.ScaleRunSpec
+import mesosphere.marathon.core.event.MarathonEvent
+import mesosphere.marathon.core.instance.update.InstanceUpdated
+import mesosphere.marathon.core.instance.{ Instance, InstanceStatus, TestInstanceBuilder }
+import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.test.Mockito
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
+
+class ScaleAppUpdateStepImplTest extends FunSuite with Matchers with GivenWhenThen with Mockito with ScalaFutures {
+
+  implicit lazy val system = ActorSystem()
+
+  test("ScaleAppUpdateStep should only send one ScaleRunSpec when receiving multiple failed tasks") {
+    val f = new Fixture
+
+    Given("an instance with terminal containers")
+    val instance = TestInstanceBuilder.newBuilder(PathId("/app"))
+      .addTaskUnreachable(containerName = Some("unreachable1"))
+      .getInstance()
+
+    When("process a task_failed update")
+    val failedUpdate1 = f.makeFailedUpdateOp(instance, InstanceStatus.Running, InstanceStatus.Failed)
+    f.step.process(failedUpdate1)
+
+    Then("a scale request is sent to the scheduler actor")
+    val answer = f.schedulerActor.expectMsgType[ScaleRunSpec]
+    answer.runSpecId should be (instance.instanceId.runSpecId)
+
+    Then("process a task_failed again")
+    val failedUpdate2 = f.makeFailedUpdateOp(instance, InstanceStatus.Failed, InstanceStatus.Failed)
+    f.step.process(failedUpdate2)
+    f.schedulerActor.expectNoMsg()
+  }
+
+  class Fixture {
+    val schedulerActor: TestProbe = TestProbe()
+    val schedulerActorProvider = new Provider[ActorRef] {
+      override def get(): ActorRef = schedulerActor.ref
+    }
+
+    def makeFailedUpdateOp(instance: Instance, lastState: InstanceStatus, newState: InstanceStatus) =
+      InstanceUpdated(instance.copy(state = instance.state.copy(status = newState)), Some(Instance.InstanceState(lastState, Timestamp.now(), instance.runSpecVersion, Some(true))), Seq.empty[MarathonEvent])
+
+    val step = new ScaleAppUpdateStepImpl(schedulerActorProvider)
+  }
+}


### PR DESCRIPTION
When receiving multiple terminal task updated inside a pod for each task update an instance update will be triggered which leads to an ScaleRunSpec for this application. Therefore this patch makes sure that only an ScaleRunSpec is triggered if the instance reaches a terminal state.