### PR TITLE
Fix health status in pod instances

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -14,6 +14,8 @@ import org.apache._
 import org.apache.mesos.Protos.Attribute
 import org.slf4j.{ Logger, LoggerFactory }
 import play.api.libs.json.{ Reads, Writes }
+
+import scala.annotation.tailrec
 // TODO: Remove timestamp format
 import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
 import play.api.libs.json.{ Format, JsResult, JsString, JsValue, Json }
@@ -139,46 +141,7 @@ case class Instance(
 
   private[instance] def updatedInstance(updatedTask: Task, now: Timestamp): Instance = {
     val updatedTasks = tasksMap.updated(updatedTask.taskId, updatedTask)
-    copy(tasksMap = updatedTasks, state = newInstanceState(updatedTasks, now))
-  }
-
-  @SuppressWarnings(Array("TraversableHead"))
-  private[instance] def newInstanceState(newTaskMap: Map[Task.Id, Task], timestamp: Timestamp): InstanceState = {
-    val tasks = newTaskMap.values
-
-    //compute the new instance status
-    val stateMap = tasks.groupBy(_.status.taskStatus)
-    val status = if (stateMap.size == 1) {
-      // all tasks have the same status -> this is the instance status
-      stateMap.keys.head
-    } else {
-      // since we don't have a distinct state, we remove states where all tasks have to agree on
-      // and search for a distinct state
-      val distinctStates = Instance.AllInstanceStatuses.foldLeft(stateMap) { (ds, status) => ds - status }
-      Instance.DistinctInstanceStatuses.find(distinctStates.contains).getOrElse {
-        // if no distinct state is found all tasks are in different AllInstanceStatuses
-        // we pick the first matching one
-        Instance.AllInstanceStatuses.find(stateMap.contains).getOrElse {
-          // if we come here, something is wrong, since we covered all existing states
-          Instance.log.error(s"Could not compute new instance state for state map: $stateMap")
-          InstanceStatus.Unknown
-        }
-
-      }
-    }
-
-    // an instance is healthy, if all tasks are healthy
-    // an instance is unhealthy, if at least one task is unhealthy
-    // otherwise the health is unknown
-    val healthy = {
-      val tasksHealth = tasks.map(_.status.mesosStatus.flatMap(p => if (p.hasHealthy) Some(p.getHealthy) else None))
-      if (tasksHealth.exists(_.exists(healthy => !healthy))) Some(false)
-      else if (tasksHealth.forall(_.exists(identity))) Some(true)
-      else None
-    }
-
-    if (this.state.status == status && this.state.healthy == healthy) this.state
-    else InstanceState(status, timestamp, this.state.version, healthy)
+    copy(tasksMap = updatedTasks, state = Instance.newInstanceState(Some(state), updatedTasks, now))
   }
 }
 
@@ -227,20 +190,101 @@ object Instance {
 
   // TODO(PODS-BLOCKER) ju remove apply
   def apply(task: Task): Instance = {
-    def defaultVersion: Timestamp = {
+    val since = task.status.startedAt.getOrElse(task.status.stagedAt)
+    val tasksMap = Map(task.taskId -> task)
+    val state = newInstanceState(None, tasksMap, since)
+
+    new Instance(task.taskId.instanceId, task.agentInfo, state, tasksMap)
+  }
+  case class InstanceState(status: InstanceStatus, since: Timestamp, version: Timestamp, healthy: Option[Boolean])
+
+  @SuppressWarnings(Array("TraversableHead"))
+  private[instance] def newInstanceState(
+    maybeOldState: Option[InstanceState],
+    newTaskMap: Map[Task.Id, Task],
+    timestamp: Timestamp): InstanceState = {
+
+    val tasks = newTaskMap.values
+    lazy val defaultVersion: Timestamp = {
       // TODO(PODS): fix this
       log.error("A default Timestamp.zero breaks things!")
       Timestamp.zero
     }
-    new Instance(task.taskId.instanceId, task.agentInfo,
-      InstanceState(
-        status = task.status.taskStatus,
-        since = task.status.startedAt.getOrElse(task.status.stagedAt),
-        version = task.version.getOrElse(defaultVersion),
-        healthy = None),
-      Map(task.taskId -> task))
+    val version = tasks.flatMap(_.version).headOption.getOrElse(defaultVersion)
+
+    //compute the new instance status
+    val stateMap = tasks.groupBy(_.status.taskStatus)
+    val status = if (stateMap.size == 1) {
+      // all tasks have the same status -> this is the instance status
+      stateMap.keys.head
+    } else {
+      // since we don't have a distinct state, we remove states where all tasks have to agree on
+      // and search for a distinct state
+      val distinctStates = Instance.AllInstanceStatuses.foldLeft(stateMap) { (ds, status) => ds - status }
+      Instance.DistinctInstanceStatuses.find(distinctStates.contains).getOrElse {
+        // if no distinct state is found all tasks are in different AllInstanceStatuses
+        // we pick the first matching one
+        Instance.AllInstanceStatuses.find(stateMap.contains).getOrElse {
+          // if we come here, something is wrong, since we covered all existing states
+          Instance.log.error(s"Could not compute new instance state for state map: $stateMap")
+          InstanceStatus.Unknown
+        }
+      }
+    }
+
+    val healthy = computeHealth(tasks.toVector)
+    maybeOldState match {
+      case Some(state) if state.status == status && state.healthy == healthy => state
+      case _ => InstanceState(status, timestamp, version, healthy)
+    }
   }
-  case class InstanceState(status: InstanceStatus, since: Timestamp, version: Timestamp, healthy: Option[Boolean])
+
+  private[this] def isRunningUnhealthy(task: Task): Boolean = {
+    task.isRunning && task.status.mesosStatus.fold(false)(m => m.hasHealthy && !m.getHealthy)
+  }
+  private[this] def isRunningHealthy(task: Task): Boolean = {
+    task.isRunning && task.status.mesosStatus.fold(false)(m => m.hasHealthy && m.getHealthy)
+  }
+  private[this] def isPending(task: Task): Boolean = {
+    task.status.taskStatus != InstanceStatus.Running && task.status.taskStatus != InstanceStatus.Finished
+  }
+
+  /**
+    * Infer the health status of an instance by looking at its tasks
+    * @param tasks all tasks of an instance
+    * @param foundHealthy used internally to track whether at least one running and
+    *                     healthy task was found.
+    * @return
+    *         Some(true), if at least one task is Running and healthy and all other
+    *         tasks are either Running or Finished and no task is unhealthy
+    *         Some(false), if at least one task is Running and unhealthy
+    *         None, if at least one task is not Running or Finished
+    */
+  @tailrec
+  private[instance] def computeHealth(tasks: Seq[Task], foundHealthy: Option[Boolean] = None): Option[Boolean] = {
+    if (tasks.isEmpty) {
+      // no unhealthy running tasks and all are running or finished
+      // TODO(PODS): we do not have sufficient information about the configured healthChecks here
+      // E.g. if container A has a healthCheck and B doesn't, b.mesosStatus.hasHealthy will always be `false`,
+      // but we don't know whether this is because no healthStatus is available yet, or because no HC is configured.
+      // This is therefore simplified to `if there is no healthStatus with getHealthy == false, healthy is true`
+      log.info("1: foundHealthy = {}", foundHealthy)
+      foundHealthy
+    } else if (isRunningUnhealthy(tasks.head)) {
+      // there is a running task that is unhealthy => the instance is considered unhealthy
+      log.info("2: foundRunningUnhealthy")
+      Some(false)
+    } else if (isPending(tasks.head)) {
+      // there is a task that is NOT Running or Finished => None
+      log.info(s"2: foundPending: ${tasks.head.status.taskStatus}, hasHealthy = {}", tasks.head.status.mesosStatus.fold("")(_.hasHealthy.toString))
+      None
+    } else if (isRunningHealthy(tasks.head)) {
+      log.info("2: foundRunningHealthy")
+      computeHealth(tasks.tail, Some(true))
+    } else {
+      computeHealth(tasks.tail, foundHealthy)
+    }
+  }
 
   case class Id(idString: String) extends Ordered[Id] {
     lazy val runSpecId: PathId = Id.runSpecId(idString)

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceHealthTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceHealthTest.scala
@@ -1,0 +1,67 @@
+package mesosphere.marathon.core.instance
+
+import mesosphere.marathon.core.pod.MesosContainer
+import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
+import mesosphere.marathon.raml.Resources
+import mesosphere.marathon.state.PathId
+import org.scalatest._
+
+class InstanceHealthTest extends WordSpecLike
+    with Matchers
+    with GivenWhenThen
+    with OptionValues
+    with BeforeAndAfterEach {
+
+  val f = new Fixture
+  var instance: Instance = _
+
+  override protected def beforeEach(): Unit = {
+    instance = {
+      TestInstanceBuilder.newBuilder(PathId("/pod"))
+        .addTaskStaged(container = Some(f.container1))
+        .addTaskStaged(container = Some(f.container2))
+        .getInstance()
+    }
+  }
+
+  "An instance with 2 containers" should {
+    "have no health info if container1 is healthy and container2 is not Running" in {
+      instance = TaskStatusUpdateTestHelper.runningHealthy(instance, Some(f.container1)).wrapped.instance
+      instance.state.healthy shouldBe None
+    }
+
+    "be considered healthy if container1 is healthy and container2 has no health information" in {
+      instance = TaskStatusUpdateTestHelper.running(instance, Some(f.container2)).updatedInstance
+      instance = TaskStatusUpdateTestHelper.runningHealthy(instance, Some(f.container1)).updatedInstance
+      instance.state.healthy.value shouldBe true
+    }
+
+    "be considered healthy if both containers A and B are healthy " in {
+      instance = TaskStatusUpdateTestHelper.runningHealthy(instance, Some(f.container1)).updatedInstance
+      instance = TaskStatusUpdateTestHelper.runningHealthy(instance, Some(f.container2)).updatedInstance
+      instance.state.healthy.value shouldBe true
+    }
+
+    "be considered unhealthy if container1 is unhealthy and container2 has no health information" in {
+      instance = TaskStatusUpdateTestHelper.runningUnhealthy(instance, Some(f.container1)).updatedInstance
+      instance.state.healthy.value shouldBe false
+    }
+
+    "be considered unhealthy if container1 is healthy and container2 is unhealthy" in {
+      instance = TaskStatusUpdateTestHelper.runningHealthy(instance, Some(f.container1)).updatedInstance
+      instance = TaskStatusUpdateTestHelper.runningUnhealthy(instance, Some(f.container2)).updatedInstance
+      instance.state.healthy.value shouldBe false
+    }
+  }
+}
+
+class Fixture {
+  val container1 = MesosContainer(
+    name = "container1",
+    resources = Resources()
+  )
+  val container2 = MesosContainer(
+    name = "container2",
+    resources = Resources()
+  )
+}

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
@@ -35,7 +35,7 @@ class InstanceTest extends FunSuite with Matchers with GivenWhenThen {
     val (instance, tasks) = instanceWith(from, withTasks)
 
     When(s"The tasks become ${withTasks.mkString(", ")}")
-    val status = instance.newInstanceState(tasks, clock.now())
+    val status = Instance.newInstanceState(Some(instance.state), tasks, clock.now())
 
     Then(s"The status should be $to")
     status.status should be(to)

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -35,8 +35,8 @@ case class TestInstanceBuilder(
   def addTaskGone(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskGone(since, containerName).build()
 
-  def addTaskStaged(stagedAt: Timestamp = now, version: Option[Timestamp] = None): TestInstanceBuilder =
-    addTaskWithBuilder().taskStaged(stagedAt, version).build()
+  def addTaskStaged(stagedAt: Timestamp = now, version: Option[Timestamp] = None, container: Option[MesosContainer] = None): TestInstanceBuilder =
+    addTaskWithBuilder().taskStaged(container, stagedAt, version).build()
 
   def addTaskStarting(stagedAt: Timestamp = now): TestInstanceBuilder =
     addTaskWithBuilder().taskStarting(stagedAt).build()

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -76,9 +76,9 @@ case class TestTaskBuilder(
     this.copy(task = Some(TestTaskBuilder.Helper.minimalLostTask(instance.instanceId.runSpecId, since = since, marathonTaskStatus = InstanceStatus.Gone).copy(taskId = Task.Id.forInstanceId(instance.instanceId, maybeMesosContainerByName(containerName)))))
   }
 
-  def taskStaged(stagedAt: Timestamp = now, version: Option[Timestamp] = None) = {
+  def taskStaged(container: Option[MesosContainer] = None, stagedAt: Timestamp = now, version: Option[Timestamp] = None) = {
     val instance = instanceBuilder.getInstance()
-    this.copy(task = Some(TestTaskBuilder.Helper.stagedTask(Task.Id.forInstanceId(instance.instanceId, None), version.getOrElse(instance.runSpecVersion), stagedAt = stagedAt.toDateTime.getMillis).withAgentInfo(_ => instance.agentInfo)))
+    this.copy(task = Some(TestTaskBuilder.Helper.stagedTask(Task.Id.forInstanceId(instance.instanceId, container), version.getOrElse(instance.runSpecVersion), stagedAt = stagedAt.toDateTime.getMillis).withAgentInfo(_ => instance.agentInfo)))
   }
 
   def taskStarting(stagedAt: Timestamp = now) = {

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import mesosphere.marathon.core.instance.update._
 import mesosphere.marathon.core.instance.{ Instance, InstanceStatus, TestInstanceBuilder }
+import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.{ MarathonTaskStatus, Task }
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import org.apache.mesos.Protos.TaskStatus.Reason
@@ -27,6 +28,17 @@ class TaskStatusUpdateTestHelper(val operation: InstanceUpdateOperation, val eff
     case InstanceUpdateEffect.Expunge(instance, events) => InstanceDeleted(instance, None, events)
     case _ => throw new scala.RuntimeException(s"The wrapped effect does not result in an update or expunge: $effect")
   }
+  private[this] def instanceFromOperation: Instance = operation match {
+    case launch: InstanceUpdateOperation.LaunchEphemeral => launch.instance
+    case update: InstanceUpdateOperation.MesosUpdate => update.instance
+    case _ => throw new RuntimeException(s"Unable to fetch instance from ${operation.getClass.getSimpleName}")
+  }
+  def updatedInstance: Instance = effect match {
+    case InstanceUpdateEffect.Update(instance, old, events) => instance
+    case InstanceUpdateEffect.Expunge(instance, events) => instance
+    case _ => instanceFromOperation
+  }
+
 }
 
 object TaskStatusUpdateTestHelper {
@@ -72,11 +84,20 @@ object TaskStatusUpdateTestHelper {
     makeMesosTaskStatus(taskId, state, maybeHealth, maybeReason, maybeMessage)
   }
 
-  def running(instance: Instance = defaultInstance) = taskUpdateFor(instance, InstanceStatus.Running, makeTaskStatus(Task.Id.forInstanceId(instance.instanceId, None), TaskState.TASK_RUNNING))
+  def running(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {
+    val taskId = Task.Id.forInstanceId(instance.instanceId, container)
+    taskUpdateFor(instance, InstanceStatus.Running, makeTaskStatus(taskId, TaskState.TASK_RUNNING))
+  }
 
-  def runningHealthy(instance: Instance = defaultInstance) = taskUpdateFor(instance, InstanceStatus.Running, makeTaskStatus(Task.Id.forInstanceId(instance.instanceId, None), TaskState.TASK_RUNNING, maybeHealth = Some(true)))
+  def runningHealthy(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {
+    val taskId = Task.Id.forInstanceId(instance.instanceId, container)
+    taskUpdateFor(instance, InstanceStatus.Running, makeTaskStatus(taskId, TaskState.TASK_RUNNING, maybeHealth = Some(true)))
+  }
 
-  def runningUnhealthy(instance: Instance = defaultInstance) = taskUpdateFor(instance, InstanceStatus.Running, makeTaskStatus(Task.Id.forInstanceId(instance.instanceId, None), TaskState.TASK_RUNNING, maybeHealth = Some(false)))
+  def runningUnhealthy(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {
+    val taskId = Task.Id.forInstanceId(instance.instanceId, container)
+    taskUpdateFor(instance, InstanceStatus.Running, makeTaskStatus(taskId, TaskState.TASK_RUNNING, maybeHealth = Some(false)))
+  }
 
   def staging(instance: Instance = defaultInstance) = taskUpdateFor(instance, InstanceStatus.Staging, makeTaskStatus(Task.Id.forInstanceId(instance.instanceId, None), TaskState.TASK_STAGING))
 


### PR DESCRIPTION
The logic to infer instance health changes was broken in that it only reported instances as healthy if **all** tasks were reported healthy. This is wrong when a task has no configured healthCheck and will never have a health status.

This patch changes this to
- an instance is healthy if
  - all tasks are running or finished AND
  - no task is reported unhealthy AND
  - at least one task is reported healthy
- an instance is unhealthy if
  - at least one task is running and reported unhealthy (this ignores unhealthy tasks which are **not** running)
- an instance has no health status if
  - not all tasks are running or finished OR
  - no task has health information

This should only act as a band aid until we provide information about the actual configured health checks. (An instance should not be reported healthy if a task that has a healthCheck configured has no health status information yet.)