### PR TITLE
Me/pods/kill strategy

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -269,18 +269,14 @@ object Instance {
       // E.g. if container A has a healthCheck and B doesn't, b.mesosStatus.hasHealthy will always be `false`,
       // but we don't know whether this is because no healthStatus is available yet, or because no HC is configured.
       // This is therefore simplified to `if there is no healthStatus with getHealthy == false, healthy is true`
-      log.info("1: foundHealthy = {}", foundHealthy)
       foundHealthy
     } else if (isRunningUnhealthy(tasks.head)) {
       // there is a running task that is unhealthy => the instance is considered unhealthy
-      log.info("2: foundRunningUnhealthy")
       Some(false)
     } else if (isPending(tasks.head)) {
       // there is a task that is NOT Running or Finished => None
-      log.info(s"2: foundPending: ${tasks.head.status.taskStatus}, hasHealthy = {}", tasks.head.status.mesosStatus.fold("")(_.hasHealthy.toString))
       None
     } else if (isRunningHealthy(tasks.head)) {
-      log.info("2: foundRunningHealthy")
       computeHealth(tasks.tail, Some(true))
     } else {
       computeHealth(tasks.tail, foundHealthy)

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -101,7 +101,25 @@ object TaskStatusUpdateTestHelper {
 
   def staging(instance: Instance = defaultInstance) = taskUpdateFor(instance, InstanceStatus.Staging, makeTaskStatus(Task.Id.forInstanceId(instance.instanceId, None), TaskState.TASK_STAGING))
 
-  def finished(instance: Instance = defaultInstance) = taskExpungeFor(instance, InstanceStatus.Finished, makeTaskStatus(Task.Id.forInstanceId(instance.instanceId, None), TaskState.TASK_FINISHED))
+  def finished(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {
+    val taskId = Task.Id.forInstanceId(instance.instanceId, container)
+    taskUpdateFor(instance, InstanceStatus.Finished, makeTaskStatus(taskId, TaskState.TASK_FINISHED))
+  }
+
+  def unknown(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {
+    val taskId = Task.Id.forInstanceId(instance.instanceId, container)
+    taskUpdateFor(instance, InstanceStatus.Unknown, makeTaskStatus(taskId, TaskState.TASK_UNKNOWN))
+  }
+
+  def gone(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {
+    val taskId = Task.Id.forInstanceId(instance.instanceId, container)
+    taskUpdateFor(instance, InstanceStatus.Gone, makeTaskStatus(taskId, TaskState.TASK_GONE))
+  }
+
+  def dropped(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {
+    val taskId = Task.Id.forInstanceId(instance.instanceId, container)
+    taskUpdateFor(instance, InstanceStatus.Dropped, makeTaskStatus(taskId, TaskState.TASK_DROPPED))
+  }
 
   def lost(reason: Reason, instance: Instance = defaultInstance, maybeMessage: Option[String] = None) = {
     val mesosStatus = makeTaskStatus(Task.Id.forInstanceId(instance.instanceId, None), TaskState.TASK_LOST, maybeReason = Some(reason), maybeMessage = maybeMessage)
@@ -132,12 +150,15 @@ object TaskStatusUpdateTestHelper {
   def killed(instance: Instance = defaultInstance) = {
     // TODO(PODS): the method signature should allow passing a taskId
     val taskId = instance.tasks.head.taskId
-    taskExpungeFor(instance, InstanceStatus.Killed, makeTaskStatus(taskId, TaskState.TASK_KILLED))
+    taskUpdateFor(instance, InstanceStatus.Killed, makeTaskStatus(taskId, TaskState.TASK_KILLED))
   }
 
   def killing(instance: Instance = defaultInstance) = taskUpdateFor(instance, InstanceStatus.Killing, makeTaskStatus(Task.Id.forInstanceId(instance.instanceId, None), TaskState.TASK_KILLING))
 
   def error(instance: Instance = defaultInstance) = taskExpungeFor(instance, InstanceStatus.Error, makeTaskStatus(Task.Id.forInstanceId(instance.instanceId, None), TaskState.TASK_ERROR))
 
-  def failed(instance: Instance = defaultInstance) = taskExpungeFor(instance, InstanceStatus.Failed, makeTaskStatus(Task.Id.forInstanceId(instance.instanceId, None), TaskState.TASK_FAILED))
+  def failed(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {
+    val taskId = Task.Id.forInstanceId(instance.instanceId, container)
+    taskUpdateFor(instance, InstanceStatus.Failed, makeTaskStatus(taskId, TaskState.TASK_FAILED))
+  }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
@@ -7,13 +7,16 @@ import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.event.{ InstanceChanged, UnknownInstanceTerminated }
 import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceUpdateOperation }
 import mesosphere.marathon.core.instance.{ Instance, InstanceStatus, TestInstanceBuilder }
+import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.core.task.termination.KillConfig
 import mesosphere.marathon.core.task.tracker.TaskStateOpProcessor
+import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.test.Mockito
 import org.apache.mesos
+import org.apache.mesos.Protos.TaskID
 import org.apache.mesos.SchedulerDriver
 import org.mockito.ArgumentCaptor
 import org.scalatest._
@@ -41,7 +44,7 @@ class KillServiceActorTest extends FunSuiteLike
     val actor = f.createTaskKillActor()
 
     Given("a single, known running task")
-    val instance = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
+    val instance = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
 
     When("the service is asked to kill that task")
     val promise = Promise[Done]()
@@ -81,8 +84,8 @@ class KillServiceActorTest extends FunSuiteLike
     val f = new Fixture
     val actor = f.createTaskKillActor()
 
-    Given("a single, known running task")
-    val instance = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_LOST)
+    Given("a single, known unreachable task")
+    val instance = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_UNREACHABLE)
 
     When("the service is asked to kill that task")
     val promise = Promise[Done]()
@@ -106,23 +109,23 @@ class KillServiceActorTest extends FunSuiteLike
     val actor = f.createTaskKillActor()
 
     Given("a list of tasks")
-    val runningInstance = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
-    val lostInstance = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_LOST)
-    val stagingInstance = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_STAGING)
+    val runningInstance = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
+    val unreachableInstance = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_UNREACHABLE)
+    val stagingInstance = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_STAGING)
 
     When("the service is asked to kill those tasks")
     val promise = Promise[Done]()
-    actor ! KillServiceActor.KillInstances(Seq(runningInstance, lostInstance, stagingInstance), promise)
+    actor ! KillServiceActor.KillInstances(Seq(runningInstance, unreachableInstance, stagingInstance), promise)
 
     Then("three kill requests are issued to the driver")
     verify(f.driver, timeout(500)).killTask(runningInstance.tasks.head.taskId.mesosTaskId)
-    verify(f.stateOpProcessor, timeout(500)).process(InstanceUpdateOperation.ForceExpunge(lostInstance.instanceId))
+    verify(f.stateOpProcessor, timeout(500)).process(InstanceUpdateOperation.ForceExpunge(unreachableInstance.instanceId))
     verify(f.driver, timeout(500)).killTask(stagingInstance.tasks.head.taskId.mesosTaskId)
     noMoreInteractions(f.driver)
 
     And("Eventually terminal status updates are published via the event stream")
     f.publishInstanceChanged(TaskStatusUpdateTestHelper.killed(runningInstance).wrapped)
-    f.publishInstanceChanged(TaskStatusUpdateTestHelper.unreachable(lostInstance).wrapped)
+    f.publishInstanceChanged(TaskStatusUpdateTestHelper.gone(unreachableInstance).wrapped)
     f.publishInstanceChanged(TaskStatusUpdateTestHelper.unreachable(stagingInstance).wrapped)
 
     Then("the promise is eventually completed successfully")
@@ -152,9 +155,9 @@ class KillServiceActorTest extends FunSuiteLike
     val actor = f.createTaskKillActor()
 
     Given("multiple tasks")
-    val instance1 = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
-    val instance2 = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
-    val instance3 = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
+    val instance1 = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
+    val instance2 = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
+    val instance3 = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
 
     val promise1 = Promise[Done]()
     val promise2 = Promise[Done]()
@@ -188,7 +191,7 @@ class KillServiceActorTest extends FunSuiteLike
 
     Given("multiple instances")
     val instances: Map[Instance.Id, Instance] = (1 to 10).map { index =>
-      val instance: Instance = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
+      val instance: Instance = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
       instance.instanceId -> instance
     }(collection.breakOut)
 
@@ -221,7 +224,7 @@ class KillServiceActorTest extends FunSuiteLike
 
     Given("multiple tasks")
     val instances: Map[Instance.Id, Instance] = (1 to 10).map { index =>
-      val instance = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
+      val instance = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
       instance.instanceId -> instance
     }(collection.breakOut)
 
@@ -251,7 +254,7 @@ class KillServiceActorTest extends FunSuiteLike
     val actor = f.createTaskKillActor(f.retryConfig)
 
     Given("a single, known running task")
-    val instance = f.mockInstance(f.appId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
+    val instance = f.mockInstance(f.runSpecId, f.now(), mesos.Protos.TaskState.TASK_RUNNING)
     val promise = Promise[Done]()
 
     When("the service is asked to kill that task")
@@ -265,6 +268,68 @@ class KillServiceActorTest extends FunSuiteLike
 
     Then("the service will eventually retry")
     verify(f.driver, timeout(1000)).killTask(instance.tasks.head.taskId.mesosTaskId)
+  }
+
+  test("All non-terminal tasks of a pod instance are killed") {
+    val f = new Fixture
+    val actor = f.createTaskKillActor(f.defaultConfig)
+
+    Given("a pod instance with 3 tasks (1 staging, 1 running, 1 Finished)")
+    val stagingContainer = f.container("stagingContainer")
+    val runningContainer = f.container("runningContainer")
+    val finishedContainer = f.container("finishedContainer")
+    var instance = TestInstanceBuilder.newBuilder(f.runSpecId)
+      .addTaskStaged(container = Some(stagingContainer))
+      .addTaskStaged(container = Some(runningContainer))
+      .addTaskStaged(container = Some(finishedContainer))
+      .getInstance()
+    instance = TaskStatusUpdateTestHelper.running(instance, Some(runningContainer)).updatedInstance
+    instance = TaskStatusUpdateTestHelper.finished(instance, Some(finishedContainer)).updatedInstance
+
+    When("the service is asked to kill that task")
+    val promise = Promise[Done]()
+    actor ! KillServiceActor.KillInstances(Seq(instance), promise)
+
+    Then("2 kills are issued to the driver")
+    val captor = ArgumentCaptor.forClass(classOf[TaskID])
+    verify(f.driver, timeout(500).times(2)).killTask(captor.capture())
+
+    And("The staging and Running tasks are killed")
+    captor.getAllValues should have size 2
+    captor.getAllValues should contain (f.taskIdFor(instance, stagingContainer))
+    captor.getAllValues should contain (f.taskIdFor(instance, runningContainer))
+
+    When("no statusUpdate is received and we reach the future")
+    f.clock.+=(10.seconds)
+
+    Then("the service will eventually retry")
+    verify(f.driver, timeout(1000)).killTask(instance.tasks.head.taskId.mesosTaskId)
+
+  }
+
+  test("A pod instance with only terminal tasks will be expunged and no kills issued") {
+    val f = new Fixture
+    val actor = f.createTaskKillActor(f.defaultConfig)
+
+    Given("a pod instance with 2 finished tasks")
+    val finishedContainer1 = f.container("finishedContainer1")
+    val finishedContainer2 = f.container("finishedContainer2")
+    var instance = TestInstanceBuilder.newBuilder(f.runSpecId)
+      .addTaskRunning(container = Some(finishedContainer1))
+      .addTaskRunning(container = Some(finishedContainer2))
+      .getInstance()
+    instance = TaskStatusUpdateTestHelper.finished(instance, Some(finishedContainer1)).updatedInstance
+    instance = TaskStatusUpdateTestHelper.finished(instance, Some(finishedContainer2)).updatedInstance
+
+    When("the service is asked to kill that instance")
+    val promise = Promise[Done]()
+    actor ! KillServiceActor.KillInstances(Seq(instance), promise)
+
+    Then("no kills are issued to the driver")
+    noMoreInteractions(f.driver)
+
+    And("the instance is expunged")
+    verify(f.stateOpProcessor, timeout(500)).process(InstanceUpdateOperation.ForceExpunge(instance.instanceId))
   }
 
   private[this] implicit var actorSystem: ActorSystem = _
@@ -288,7 +353,7 @@ class KillServiceActorTest extends FunSuiteLike
   class Fixture {
     import scala.concurrent.duration._
 
-    val appId = PathId("/test")
+    val runSpecId = PathId("/test")
     val driver = mock[SchedulerDriver]
     val driverHolder: MarathonSchedulerDriverHolder = {
       val holder = new MarathonSchedulerDriverHolder
@@ -329,6 +394,14 @@ class KillServiceActorTest extends FunSuiteLike
       log.info("publish {} on the event stream", event)
       actorSystem.eventStream.publish(event)
     }
+
+    def container(name: String) = MesosContainer(name = name, resources = Resources())
+
+    def taskIdFor(instance: Instance, container: MesosContainer): mesos.Protos.TaskID = {
+      val taskId = Task.Id.forInstanceId(instance.instanceId, Some(container))
+      taskId.mesosTaskId
+    }
+
   }
 }
 


### PR DESCRIPTION
### Fix task state transition for terminal tasks
    
Any processed TaskUpdateOperation for a terminal task will now lead to a Noop. This is to prevent bugs when Marathon tries to kill a task that has already terminated. It will likely receive a TASK_LOST as a result, but the task is actually not lost but still e.g. Finished.

### Issue kill requests for all non-terminal tasks of an instance

When killing an instance, this patch issues a kill request for each non-terminal task of an instance. It is possible that one or more tasks have terminated already when the killService eventually retries because the instance is not terminal yet.