### PR TITLE
Fix an exception when reporting metrics on non-leader marathon instance

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/group/GroupManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/GroupManagerModule.scala
@@ -5,12 +5,12 @@ import javax.inject.Provider
 import akka.actor.ActorRef
 import akka.event.EventStream
 import com.codahale.metrics.Gauge
-import mesosphere.marathon.core.group.impl.{GroupManagerActor, GroupManagerDelegate}
+import mesosphere.marathon.core.group.impl.{ GroupManagerActor, GroupManagerDelegate }
 import mesosphere.marathon.core.leadership.LeadershipModule
-import mesosphere.marathon.{DeploymentService, MarathonConf}
+import mesosphere.marathon.{ DeploymentService, MarathonConf }
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.metrics.Metrics
-import mesosphere.marathon.state.{AppRepository, Group, GroupRepository}
+import mesosphere.marathon.state.{ AppRepository, Group, GroupRepository }
 import mesosphere.util.CapConcurrentExecutions
 
 import scala.concurrent.Await
@@ -43,6 +43,8 @@ class GroupManagerModule(
 
   val groupManager: GroupManager = {
     val groupManager = new GroupManagerDelegate(config, groupManagerActorRef)
+
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     metrics.gauge("service.mesosphere.marathon.app.count", new Gauge[Int] {
       override def getValue: Int = {


### PR DESCRIPTION
"service.mesosphere.marathon.app.count" and "service.mesosphere.marathon.group.count" metrics will now user groupRepo instead of groupManager to get the corresponding values.

Fixes: DCOS-10418