### PR TITLE
Fix DC/OS docs link for private Docker registry setup

### DIFF
--- a/docs/docs/native-docker-private-registry.md
+++ b/docs/docs/native-docker-private-registry.md
@@ -96,4 +96,4 @@ the `uris` field of your app. The `docker.tar.gz` file should include the `.dock
 
 ## More information
 
-Find out how to [set up a private Docker registry](https://dcos.io/docs/1.8/usage/registry/) with DC/OS. 
+Find out how to [set up a private Docker registry](https://dcos.io/docs/1.8/usage/tutorials/registry/) with DC/OS. 


### PR DESCRIPTION
There is a 404 on the https://mesosphere.github.io/marathon/docs/native-docker-private-registry.html page's link to the DC/OS tutorial regarding setting up a private Docker registry. This PR fixes the issue.