### PR TITLE
fix misleading missed-heartbeat logs: only log when there is actually a potential problem

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/heartbeat/HeartbeatActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/heartbeat/HeartbeatActor.scala
@@ -30,12 +30,13 @@ class HeartbeatActor(config: Heartbeat.Config) extends LoggingFSM[HeartbeatInter
       stay using data.copy(missed = 0)
 
     case Event(StateTimeout, data: DataActive) =>
-      if (data.missed + 1 >= config.missedHeartbeatsThreshold) {
-        data.reactor.onFailure
+      val missed = data.missed + 1
+      if (missed >= config.missedHeartbeatsThreshold) {
+        data.reactor.onFailure()
         goto(StateInactive) using DataNone
       } else {
-        data.reactor.onSkip
-        stay using data.copy(missed = data.missed + 1)
+        data.reactor.onSkip(missed)
+        stay using data.copy(missed = missed)
       }
 
     case Event(MessageDeactivate(token), data: DataActive) =>
@@ -69,7 +70,7 @@ object Heartbeat {
   case class Config(
       heartbeatTimeout: FiniteDuration,
       missedHeartbeatsThreshold: Int,
-      reactorDecorator: Option[Reactor.Decorator] = Some(Reactor.withLogging)) {
+      reactorDecorator: Option[Reactor.Decorator] = Some(Reactor.withLogging()())) {
 
     /** withReactor applies the optional reactorDecorator */
     def withReactor: Reactor.Decorator = Reactor.Decorator { r =>
@@ -83,7 +84,7 @@ object Heartbeat {
   case class MessageActivate(reactor: Reactor, sessionToken: AnyRef) extends Message
 
   trait Reactor {
-    def onSkip(): Unit
+    def onSkip(skipped: Int): Unit
     def onFailure(): Unit
   }
 
@@ -101,18 +102,20 @@ object Heartbeat {
     /**
       * withLogging decorates the given Reactor by logging messages prior to forwarding each callback
       */
-    final val withLogging: Decorator = Decorator { r =>
+    final def withLogging(
+      skipLogger: String => Unit = log.debug)(
+      failureLogger: String => Unit = log.debug): Decorator = Decorator { r =>
       new Reactor {
-        def onSkip(): Unit = {
-          log.info("detected skipped heartbeat")
-          r.onSkip
+        def onSkip(skipped: Int): Unit = {
+          skipLogger("detected skipped heartbeat")
+          r.onSkip(skipped)
         }
 
         def onFailure(): Unit = {
           // might be a little redundant (depending what is logged elsewhere) but this is a
           // pretty important event that we don't want to miss
-          log.warn("detected heartbeat failure")
-          r.onFailure
+          failureLogger("detected heartbeat failure")
+          r.onFailure()
         }
       }
     }

--- a/src/main/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitor.scala
+++ b/src/main/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitor.scala
@@ -43,7 +43,14 @@ class MesosHeartbeatMonitor @Inject() (
     // to use the new mesos v1 http API.
     private[this] val virtualHeartbeatTasks: java.util.Collection[TaskStatus] = Seq(fakeHeartbeatStatus).asJava
 
-    override def onSkip(): Unit = {
+    override def onSkip(skipped: Int): Unit = {
+      // the first skip (skipped == 1) may be because there simply haven't been any offers or task status updates
+      // sent by the master within the heartbeat interval. that's completely normal, so we only log if skipped > 1
+      // because that means that we've prompted mesos via task reconciliation and it still hasn't responded in a
+      // timely manner.
+      if (skipped > 1) {
+        log.info(s"missed ${skipped - 1} expected heartbeat(s) from mesos master; possibly disconnected")
+      }
       log.debug("Prompting mesos for a heartbeat via explicit task reconciliation")
       driver.reconcileTasks(virtualHeartbeatTasks)
     }

--- a/src/test/scala/mesosphere/marathon/core/heartbeat/HeartbeatActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/heartbeat/HeartbeatActorTest.scala
@@ -75,7 +75,7 @@ class HeartbeatActorTest extends AkkaUnitTest with TestKitBase with ImplicitSend
     // ActorReactor translates Reactor callbacks into messages delivered to testActor (from ImplicitSender),
     // allows us to use things like "expectMsg" for simpler test cases.
     class ActorReactor extends Reactor {
-      def onSkip(): Unit = testActor ! Skipped
+      def onSkip(skipped: Int): Unit = testActor ! Skipped
       def onFailure(): Unit = testActor ! Failure
     }
 
@@ -84,9 +84,9 @@ class HeartbeatActorTest extends AkkaUnitTest with TestKitBase with ImplicitSend
 
     lazy val fakeReactorDecorator = Reactor.Decorator { r =>
       new Reactor {
-        def onSkip(): Unit = {
+        def onSkip(skipped: Int): Unit = {
           testActor ! SkipDecorated
-          r.onSkip
+          r.onSkip(skipped)
         }
         def onFailure(): Unit = {
           testActor ! FailureDecorated
@@ -128,7 +128,7 @@ object HeartbeatActorTest {
   import Heartbeat._
 
   case object FakeReactor extends Reactor {
-    def onSkip(): Unit = ???
+    def onSkip(skipped: Int): Unit = ???
     def onFailure(): Unit = ???
   }
 

--- a/src/test/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitorTest.scala
@@ -112,7 +112,7 @@ class MesosHeartbeatMonitorTest extends MarathonActorSupport
     val fakeDriver = mock[SchedulerDriver]
     val reactor = monitor.heartbeatReactor(fakeDriver)
 
-    reactor.onSkip()
+    reactor.onSkip(1)
     verify(fakeDriver, times(1)).reconcileTasks(any)
 
     reactor.onFailure()


### PR DESCRIPTION
cherry-picked from master; backport of https://github.com/mesosphere/marathon/commit/c96ccbb49b437a90b83f6a0185a3827d58e41a2b