### PR TITLE
Log an error if we can't deserialize a task instead of throwing (#4470)

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/state/Migration.scala
@@ -144,7 +144,6 @@ class MigrationTo0_11(groupRepository: GroupRepository, appRepository: AppReposi
       appsWithVersions <- processApps(appIds, rootGroup)
       _ <- storeUpdatedAppsInRootGroup(rootGroup, appsWithVersions)
     } yield log.info("Finished 0.11 migration")
-    } yield log.info("Finished 0.11 migration")
   }
 
   private[this] def storeUpdatedAppsInRootGroup(
@@ -409,7 +408,7 @@ class MigrationTo1_2(deploymentRepository: DeploymentRepository, taskRepository:
           }
         case None =>
           log.warn("Inconsistency in the task store detected, " +
-          s"task with id $id not found, but delivered in allIds().")
+            s"task with id $id not found, but delivered in allIds().")
           Future.successful(None)
       }
     }

--- a/src/test/scala/mesosphere/marathon/state/MigrationTo1_2Test.scala
+++ b/src/test/scala/mesosphere/marathon/state/MigrationTo1_2Test.scala
@@ -109,6 +109,13 @@ class MigrationTo1_2Test extends MarathonSpec with GivenWhenThen with Matchers {
     }
   }
 
+  test("Skip over bad tasks") {
+    val f = new Fixture
+
+    f.store.create("task:abc", IndexedSeq[Byte](1, 1, 1)).futureValue
+    f.migration.migrate().futureValue
+  }
+
   private def makeMarathonTaskState(taskId: String, taskState: mesos.Protos.TaskState, maybeReason: Option[TaskStatus.Reason] = None, marathonTaskStatus: Option[MarathonTaskStatus] = None): MarathonTaskState = {
     val mesosStatus = TaskStatusUpdateTestHelper.makeMesosTaskStatus(Task.Id.forRunSpec(taskId.toPath), taskState, maybeReason = maybeReason)
     val builder = MarathonTask.newBuilder()


### PR DESCRIPTION
Summary:
- While the underlying storage caught the proto error, the migration didn't actually
  handle the inconsistency.
- This only applies to 1.3

Test Plan: - sbt test

Reviewers: jdef

Subscribers: marathon-team

Differential Revision: https://phabricator.mesosphere.com/D114