### PR TITLE
cherry-pick: mitigate 1.2 migration issues related to task status/condition

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/state/Migration.scala
@@ -398,9 +398,13 @@ class MigrationTo1_2(deploymentRepository: DeploymentRepository, taskRepository:
     def loadAndMigrateTasks(id: String): Future[MarathonTaskState] = {
       store.fetch(id).flatMap {
         case Some(entity) =>
-          if (!entity.toProto.hasMarathonTaskStatus) {
-            val updatedEntity = entity.toProto.toBuilder
-              .setMarathonTaskStatus(MarathonTaskStatusSerializer.toProto(MarathonTaskStatus(entity.toProto.getStatus)))
+          val proto = entity.toProto
+          if (!proto.hasMarathonTaskStatus) {
+            val updatedEntity = proto.toBuilder
+              .setMarathonTaskStatus(
+                if (proto.hasStatus) MarathonTaskStatusSerializer.toProto(MarathonTaskStatus(proto.getStatus))
+                else MarathonTask.MarathonTaskStatus.Unknown
+              )
               .build()
             store.store(id, MarathonTaskState(updatedEntity))
           } else {


### PR DESCRIPTION
Summary: https://mesosphere.atlassian.net/browse/DCOS-10875

Test Plan:
sbt test

perform an actual migration from

Reviewers: unterstein, aquamatthias, jasongilanfarr

Reviewed By: unterstein, aquamatthias, jasongilanfarr

Subscribers: jenkins, marathon-team

Differential Revision: https://phabricator.mesosphere.com/D101

Conflicts:
	src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializer.scala
	src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo1_2.scala
	src/test/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo1_2Test.scala

Thanks for providing your workaround to us @timcharper !