### PR TITLE
update docs index to reference release v1.3.5

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,21 +5,21 @@ title: A container orchestration platform for Mesos and DCOS
 <div class="jumbotron text-center">
   <h1>Marathon</h1>
   <p class="lead">
-    A container orchestration platform for Mesos and DCOS
+    A container orchestration platform for Mesos and DC/OS
   </p>
   <p>
-    <a href="http://downloads.mesosphere.com/marathon/v1.3.4/marathon-1.3.4.tgz"
+    <a href="http://downloads.mesosphere.com/marathon/v1.3.5/marathon-1.3.5.tgz"
         class="btn btn-lg btn-primary">
-      Download Marathon v1.3.4
+      Download Marathon v1.3.5
     </a>
   </p>
   <a class="btn btn-link"
-      href="http://downloads.mesosphere.com/marathon/v1.1.1/marathon-1.3.4.tgz.sha256">
-    v1.3.4 SHA-256 Checksum
+      href="http://downloads.mesosphere.com/marathon/v1.3.5/marathon-1.3.5.tgz.sha256">
+    v1.3.5 SHA-256 Checksum
   </a> &middot;
   <a class="btn btn-link"
-      href="https://github.com/mesosphere/marathon/releases/tag/v1.3.4">
-    v1.3.4 Release Notes
+      href="https://github.com/mesosphere/marathon/releases/tag/v1.3.5">
+    v1.3.5 Release Notes
   </a>
 </div>
 


### PR DESCRIPTION
Summary: Docs page should reference latest stable release.

Test Plan: Click on the links, make sure they work.

Reviewers: meichstedt, jasongilanfarr

Reviewed By: jasongilanfarr

Subscribers: marathon-team

Differential Revision: https://phabricator.mesosphere.com/D122

Conflicts:
	docs/index.md