### PR TITLE
Fixes #4624 System Time Change - Leadership Deadlock & Socket Leaks

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -235,7 +235,6 @@ class MarathonSchedulerService @Inject() (
         driver.foreach(_.run())
       }
     } onComplete { result =>
-      synchronized {
 
         log.info(s"Driver future completed with result=$result.")
         result match {
@@ -257,7 +256,6 @@ class MarathonSchedulerService @Inject() (
         log.info(s"Call postDriverRuns callbacks on ${prePostDriverCallbacks.mkString(", ")}")
         Await.result(Future.sequence(prePostDriverCallbacks.map(_.postDriverTerminates)), config.zkTimeoutDuration)
         log.info("Finished postDriverRuns callbacks")
-      }
     }
   }
 


### PR DESCRIPTION
Fixes  #4624 

To resolve the issue, we noted that there was a nested (and seemingly unnecessary) synchronized block causing the deadlock as described in #4624. To prove our theory, a machine was set up with marathon, mesos and zookeeper stack.

The marathon runnable JAR was rebuilt with the included fix and a systemd service was added to increment the system time by 10-20 seconds every 30 seconds. The system was then left for 24 hours. Marathon
correctly handled the Zookeeper timeout by abdicating leadership without hitting the described deadlock. After disabling the tool used to increment time, Marathon then stabilized.

We also noted that inside the synchronized block calls are made to the _ElectionServiceBase.abdicateLeadership_ operation which itself is already protected with the synchronized keyword. The _MarathonSchedulerService.startLeadership_ operation which contained the synchronized block is also protected itself with the synchronized keyword. 

It seems that this block is not required although a review from a maintainer better versed in this asynchronous leader election system would provide valuable guidance.
