### PR TITLE
Additional fix for #4624 deadlock fix

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/election/impl/CuratorElectionService.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/impl/CuratorElectionService.scala
@@ -9,13 +9,14 @@ import com.codahale.metrics.MetricRegistry
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.core.base.{ toRichRuntime, ShutdownHooks }
+import mesosphere.marathon.core.election.impl.ElectionServiceBase.Abdicator
 import mesosphere.marathon.metrics.Metrics
 import org.apache.curator.framework.api.ACLProvider
-import org.apache.curator.{ RetrySleeper, RetryPolicy }
-import org.apache.curator.framework.{ CuratorFramework, CuratorFrameworkFactory, AuthInfo }
+import org.apache.curator.{ RetryPolicy, RetrySleeper }
+import org.apache.curator.framework.{ AuthInfo, CuratorFramework, CuratorFrameworkFactory }
 import org.apache.curator.framework.recipes.leader.{ LeaderLatch, LeaderLatchListener }
 import org.apache.zookeeper.data.ACL
-import org.apache.zookeeper.{ ZooDefs, KeeperException, CreateMode }
+import org.apache.zookeeper.{ CreateMode, KeeperException, ZooDefs }
 import org.slf4j.LoggerFactory
 
 import scala.util.control.NonFatal
@@ -67,13 +68,54 @@ class CuratorElectionService(
     maybeLatch.get.start()
   }
 
+  override protected def startLeadership(abdicate: Abdicator): Unit = {
+    maybeLatch match {
+      case None => super.startLeadership(abdicate)
+      case Some(l) =>
+        l.synchronized {
+          super.startLeadership(abdicate)
+        }
+    }
+  }
+
+  override protected def stopLeadership(): Unit = {
+    maybeLatch match {
+      case None => super.stopLeadership
+      case Some(l) =>
+        l.synchronized {
+          super.stopLeadership
+        }
+    }
+  }
+
+  override def isLeader: Boolean = {
+    maybeLatch match {
+      case None => super.isLeader
+      case Some(l) =>
+        l.synchronized {
+          super.isLeader
+        }
+    }
+  }
+
+  override def abdicateLeadership(
+    error: Boolean = false,
+    reoffer: Boolean = false): Unit = {
+    maybeLatch match {
+      case None => super.abdicateLeadership(error, reoffer)
+      case Some(l) =>
+        l.synchronized {
+          super.abdicateLeadership(error, reoffer)
+        }
+    }
+  }
+
   private object Listener extends LeaderLatchListener {
     override def notLeader(): Unit = CuratorElectionService.this.synchronized {
       log.info(s"Defeated (LeaderLatchListener Interface). New leader: ${leaderHostPort.getOrElse("-")}")
 
       // remove tombstone for twitter commons
       twitterCommonsTombstone.delete(onlyMyself = true)
-
       stopLeadership()
     }
 


### PR DESCRIPTION
An additional fix for #4624  

@jasongilanfarr 
We have been working on a fix for this for the last week and ended up with this solution.  We ran 2 different clusters of 3 configured to randomly change the time every 30 seconds for 5 days.  Both clusters recovered from the time changes without deadlocking with this fix.  On 2 separate single boxes we also did not see any deadlocks but noticed inconsistent state on one of the machines where a back-off offer was spawned but an abdicate flipped the state, so re-offer was never called.  I think your fix will resolve that last issue for sure.  I merged our changes with your commit from Friday and are re-staging out tests.