### PR TITLE
[WIP] Fixes #3154 Filter events

### DIFF
--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/EventSubscriptionsResource_listSubscribers.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/EventSubscriptionsResource_listSubscribers.md
@@ -29,5 +29,9 @@ Transfer-Encoding: chunked
         "http://localhost:9090/callback",
         "http://localhost:9191/callback"
     ]
+    "callbacks": {
+        "http://localhost:9090/callback": {},
+        "http://localhost:9191/callback": {}
+    }
 }
 ```

--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/EventSubscriptionsResource_subscribe.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/EventSubscriptionsResource_subscribe.md
@@ -30,6 +30,58 @@ Transfer-Encoding: chunked
 {
     "callbackUrl": "http://localhost:9292/callback",
     "clientIp": "127.0.0.1",
+    "filters": [],
     "eventType": "subscribe_event"
+}
+```
+
+Messages could be filtered by event type. To register filters provide JSON body
+with event filters definitions.
+
+### Example
+
+example below will subscribe callback that recieve only events with type
+`deployment_info`,`deployment_step_success` or `api_post_event`
+
+
+**Request:**
+
+```
+POST /v2/eventSubscriptions?callbackUrl=http://127.0.0.1:8001 HTTP/1.1
+Content-Type: application/json
+Cache-Control: no-cache
+
+
+[
+    {
+      "query": "event_type",
+      "values": ["deployment_info","deployment_step_success","api_post_event"]
+    }
+]
+```
+
+**Response**
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Server: Jetty(8.y.z-SNAPSHOT)
+Transfer-Encoding: chunked
+
+{
+  "clientIp": "127.0.0.1",
+  "callbackUrl": "http://127.0.0.1:8001",
+  "filters": [
+    {
+      "query": "event_type",
+      "values": [
+        "deployment_info",
+        "deployment_step_success",
+        "api_post_event"
+      ]
+    }
+  ],
+  "eventType": "subscribe_event",
+  "timestamp": "2016-11-19T22:31:07.573Z"
 }
 ```

--- a/docs/docs/rest-api/public/api/v2/eventSubscriptions.raml
+++ b/docs/docs/rest-api/public/api/v2/eventSubscriptions.raml
@@ -18,12 +18,15 @@ get:
 
 post:
   description:
-    Subscribe to the event callback mechanism with the specified callback URL.
+    Subscribe to the event callback mechanism with the specified callback URL and filters.
   queryParameters:
     callbackUrl:
       description: The URL to an endpoint that is able to handle post requests for every event that is send.
       type: string
       pattern: ^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$
+  body:
+    application/json:
+      example: !include examples/subscribe.json
   responses:
     200:
       description:

--- a/docs/docs/rest-api/public/api/v2/examples/subscribe.json
+++ b/docs/docs/rest-api/public/api/v2/examples/subscribe.json
@@ -1,0 +1,10 @@
+[
+  {
+    "query": "event_type",
+    "values": [
+      "deployment_info",
+      "deployment_step_success",
+      "api_post_event"
+    ]
+  }
+]

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -8,10 +8,10 @@ public final class Protos {
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
   }
-  public interface ConstraintOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface ConstraintOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Constraint)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required string field = 1;
     /**
      * <code>required string field = 1;</code>
      */
@@ -26,7 +26,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getFieldBytes();
 
-    // required .mesosphere.marathon.Constraint.Operator operator = 2;
     /**
      * <code>required .mesosphere.marathon.Constraint.Operator operator = 2;</code>
      */
@@ -36,7 +35,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.Constraint.Operator getOperator();
 
-    // optional string value = 3;
     /**
      * <code>optional string value = 3;</code>
      */
@@ -55,8 +53,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.Constraint}
    */
   public static final class Constraint extends
-      com.google.protobuf.GeneratedMessage
-      implements ConstraintOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.Constraint)
+      ConstraintOrBuilder {
     // Use Constraint.newBuilder() to construct.
     private Constraint(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -103,8 +102,9 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              field_ = input.readBytes();
+              field_ = bs;
               break;
             }
             case 16: {
@@ -119,8 +119,9 @@ public final class Protos {
               break;
             }
             case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000004;
-              value_ = input.readBytes();
+              value_ = bs;
               break;
             }
           }
@@ -331,7 +332,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required string field = 1;
     public static final int FIELD_FIELD_NUMBER = 1;
     private java.lang.Object field_;
     /**
@@ -374,7 +374,6 @@ public final class Protos {
       }
     }
 
-    // required .mesosphere.marathon.Constraint.Operator operator = 2;
     public static final int OPERATOR_FIELD_NUMBER = 2;
     private mesosphere.marathon.Protos.Constraint.Operator operator_;
     /**
@@ -390,7 +389,6 @@ public final class Protos {
       return operator_;
     }
 
-    // optional string value = 3;
     public static final int VALUE_FIELD_NUMBER = 3;
     private java.lang.Object value_;
     /**
@@ -441,7 +439,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasField()) {
         memoizedIsInitialized = 0;
@@ -570,8 +569,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.Constraint}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.ConstraintOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Constraint)
+        mesosphere.marathon.Protos.ConstraintOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Constraint_descriptor;
@@ -714,7 +714,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required string field = 1;
       private java.lang.Object field_ = "";
       /**
        * <code>required string field = 1;</code>
@@ -728,9 +727,12 @@ public final class Protos {
       public java.lang.String getField() {
         java.lang.Object ref = field_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          field_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            field_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -788,7 +790,6 @@ public final class Protos {
         return this;
       }
 
-      // required .mesosphere.marathon.Constraint.Operator operator = 2;
       private mesosphere.marathon.Protos.Constraint.Operator operator_ = mesosphere.marathon.Protos.Constraint.Operator.UNIQUE;
       /**
        * <code>required .mesosphere.marathon.Constraint.Operator operator = 2;</code>
@@ -824,7 +825,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string value = 3;
       private java.lang.Object value_ = "";
       /**
        * <code>optional string value = 3;</code>
@@ -838,9 +838,12 @@ public final class Protos {
       public java.lang.String getValue() {
         java.lang.Object ref = value_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          value_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            value_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -909,10 +912,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.Constraint)
   }
 
-  public interface HealthCheckDefinitionOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface HealthCheckDefinitionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.HealthCheckDefinition)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;
     /**
      * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
      */
@@ -922,7 +925,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.HealthCheckDefinition.Protocol getProtocol();
 
-    // optional uint32 portIndex = 2;
     /**
      * <code>optional uint32 portIndex = 2;</code>
      */
@@ -932,7 +934,6 @@ public final class Protos {
      */
     int getPortIndex();
 
-    // optional uint32 gracePeriodSeconds = 3 [default = 15];
     /**
      * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
      */
@@ -942,7 +943,6 @@ public final class Protos {
      */
     int getGracePeriodSeconds();
 
-    // optional uint32 intervalSeconds = 4 [default = 10];
     /**
      * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
      */
@@ -952,7 +952,6 @@ public final class Protos {
      */
     int getIntervalSeconds();
 
-    // optional uint32 timeoutSeconds = 5 [default = 20];
     /**
      * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
      */
@@ -962,7 +961,6 @@ public final class Protos {
      */
     int getTimeoutSeconds();
 
-    // optional string path = 6 [default = "/"];
     /**
      * <code>optional string path = 6 [default = "/"];</code>
      *
@@ -989,7 +987,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getPathBytes();
 
-    // optional uint32 maxConsecutiveFailures = 7 [default = 3];
     /**
      * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
      */
@@ -999,7 +996,6 @@ public final class Protos {
      */
     int getMaxConsecutiveFailures();
 
-    // optional .mesos.CommandInfo command = 8;
     /**
      * <code>optional .mesos.CommandInfo command = 8;</code>
      */
@@ -1013,7 +1009,6 @@ public final class Protos {
      */
     org.apache.mesos.Protos.CommandInfoOrBuilder getCommandOrBuilder();
 
-    // optional bool ignoreHttp1xx = 9 [default = false];
     /**
      * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
      */
@@ -1023,7 +1018,6 @@ public final class Protos {
      */
     boolean getIgnoreHttp1Xx();
 
-    // optional uint32 port = 10;
     /**
      * <code>optional uint32 port = 10;</code>
      */
@@ -1033,7 +1027,6 @@ public final class Protos {
      */
     int getPort();
 
-    // optional uint32 delaySeconds = 11 [default = 15];
     /**
      * <code>optional uint32 delaySeconds = 11 [default = 15];</code>
      */
@@ -1043,7 +1036,6 @@ public final class Protos {
      */
     int getDelaySeconds();
 
-    // optional string portName = 12;
     /**
      * <code>optional string portName = 12;</code>
      *
@@ -1074,8 +1066,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
    */
   public static final class HealthCheckDefinition extends
-      com.google.protobuf.GeneratedMessage
-      implements HealthCheckDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.HealthCheckDefinition)
+      HealthCheckDefinitionOrBuilder {
     // Use HealthCheckDefinition.newBuilder() to construct.
     private HealthCheckDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -1153,8 +1146,9 @@ public final class Protos {
               break;
             }
             case 50: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000020;
-              path_ = input.readBytes();
+              path_ = bs;
               break;
             }
             case 56: {
@@ -1191,8 +1185,9 @@ public final class Protos {
               break;
             }
             case 98: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000800;
-              portName_ = input.readBytes();
+              portName_ = bs;
               break;
             }
           }
@@ -1362,7 +1357,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;
     public static final int PROTOCOL_FIELD_NUMBER = 1;
     private mesosphere.marathon.Protos.HealthCheckDefinition.Protocol protocol_;
     /**
@@ -1378,7 +1372,6 @@ public final class Protos {
       return protocol_;
     }
 
-    // optional uint32 portIndex = 2;
     public static final int PORTINDEX_FIELD_NUMBER = 2;
     private int portIndex_;
     /**
@@ -1394,7 +1387,6 @@ public final class Protos {
       return portIndex_;
     }
 
-    // optional uint32 gracePeriodSeconds = 3 [default = 15];
     public static final int GRACEPERIODSECONDS_FIELD_NUMBER = 3;
     private int gracePeriodSeconds_;
     /**
@@ -1410,7 +1402,6 @@ public final class Protos {
       return gracePeriodSeconds_;
     }
 
-    // optional uint32 intervalSeconds = 4 [default = 10];
     public static final int INTERVALSECONDS_FIELD_NUMBER = 4;
     private int intervalSeconds_;
     /**
@@ -1426,7 +1417,6 @@ public final class Protos {
       return intervalSeconds_;
     }
 
-    // optional uint32 timeoutSeconds = 5 [default = 20];
     public static final int TIMEOUTSECONDS_FIELD_NUMBER = 5;
     private int timeoutSeconds_;
     /**
@@ -1442,7 +1432,6 @@ public final class Protos {
       return timeoutSeconds_;
     }
 
-    // optional string path = 6 [default = "/"];
     public static final int PATH_FIELD_NUMBER = 6;
     private java.lang.Object path_;
     /**
@@ -1497,7 +1486,6 @@ public final class Protos {
       }
     }
 
-    // optional uint32 maxConsecutiveFailures = 7 [default = 3];
     public static final int MAXCONSECUTIVEFAILURES_FIELD_NUMBER = 7;
     private int maxConsecutiveFailures_;
     /**
@@ -1513,7 +1501,6 @@ public final class Protos {
       return maxConsecutiveFailures_;
     }
 
-    // optional .mesos.CommandInfo command = 8;
     public static final int COMMAND_FIELD_NUMBER = 8;
     private org.apache.mesos.Protos.CommandInfo command_;
     /**
@@ -1535,7 +1522,6 @@ public final class Protos {
       return command_;
     }
 
-    // optional bool ignoreHttp1xx = 9 [default = false];
     public static final int IGNOREHTTP1XX_FIELD_NUMBER = 9;
     private boolean ignoreHttp1Xx_;
     /**
@@ -1551,7 +1537,6 @@ public final class Protos {
       return ignoreHttp1Xx_;
     }
 
-    // optional uint32 port = 10;
     public static final int PORT_FIELD_NUMBER = 10;
     private int port_;
     /**
@@ -1567,7 +1552,6 @@ public final class Protos {
       return port_;
     }
 
-    // optional uint32 delaySeconds = 11 [default = 15];
     public static final int DELAYSECONDS_FIELD_NUMBER = 11;
     private int delaySeconds_;
     /**
@@ -1583,7 +1567,6 @@ public final class Protos {
       return delaySeconds_;
     }
 
-    // optional string portName = 12;
     public static final int PORTNAME_FIELD_NUMBER = 12;
     private java.lang.Object portName_;
     /**
@@ -1655,7 +1638,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasProtocol()) {
         memoizedIsInitialized = 0;
@@ -1849,8 +1833,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.HealthCheckDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.HealthCheckDefinition)
+        mesosphere.marathon.Protos.HealthCheckDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor;
@@ -2085,7 +2070,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;
       private mesosphere.marathon.Protos.HealthCheckDefinition.Protocol protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
       /**
        * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
@@ -2121,7 +2105,6 @@ public final class Protos {
         return this;
       }
 
-      // optional uint32 portIndex = 2;
       private int portIndex_ ;
       /**
        * <code>optional uint32 portIndex = 2;</code>
@@ -2154,7 +2137,6 @@ public final class Protos {
         return this;
       }
 
-      // optional uint32 gracePeriodSeconds = 3 [default = 15];
       private int gracePeriodSeconds_ = 15;
       /**
        * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
@@ -2187,7 +2169,6 @@ public final class Protos {
         return this;
       }
 
-      // optional uint32 intervalSeconds = 4 [default = 10];
       private int intervalSeconds_ = 10;
       /**
        * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
@@ -2220,7 +2201,6 @@ public final class Protos {
         return this;
       }
 
-      // optional uint32 timeoutSeconds = 5 [default = 20];
       private int timeoutSeconds_ = 20;
       /**
        * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
@@ -2253,7 +2233,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string path = 6 [default = "/"];
       private java.lang.Object path_ = "/";
       /**
        * <code>optional string path = 6 [default = "/"];</code>
@@ -2275,9 +2254,12 @@ public final class Protos {
       public java.lang.String getPath() {
         java.lang.Object ref = path_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          path_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            path_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -2351,7 +2333,6 @@ public final class Protos {
         return this;
       }
 
-      // optional uint32 maxConsecutiveFailures = 7 [default = 3];
       private int maxConsecutiveFailures_ = 3;
       /**
        * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
@@ -2384,7 +2365,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesos.CommandInfo command = 8;
       private org.apache.mesos.Protos.CommandInfo command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder> commandBuilder_;
@@ -2493,7 +2473,7 @@ public final class Protos {
         if (commandBuilder_ == null) {
           commandBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder>(
-                  command_,
+                  getCommand(),
                   getParentForChildren(),
                   isClean());
           command_ = null;
@@ -2501,7 +2481,6 @@ public final class Protos {
         return commandBuilder_;
       }
 
-      // optional bool ignoreHttp1xx = 9 [default = false];
       private boolean ignoreHttp1Xx_ ;
       /**
        * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
@@ -2534,7 +2513,6 @@ public final class Protos {
         return this;
       }
 
-      // optional uint32 port = 10;
       private int port_ ;
       /**
        * <code>optional uint32 port = 10;</code>
@@ -2567,7 +2545,6 @@ public final class Protos {
         return this;
       }
 
-      // optional uint32 delaySeconds = 11 [default = 15];
       private int delaySeconds_ = 15;
       /**
        * <code>optional uint32 delaySeconds = 11 [default = 15];</code>
@@ -2600,7 +2577,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string portName = 12;
       private java.lang.Object portName_ = "";
       /**
        * <code>optional string portName = 12;</code>
@@ -2622,9 +2598,12 @@ public final class Protos {
       public java.lang.String getPortName() {
         java.lang.Object ref = portName_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          portName_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            portName_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -2709,10 +2688,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.HealthCheckDefinition)
   }
 
-  public interface ReadinessCheckDefinitionOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface ReadinessCheckDefinitionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ReadinessCheckDefinition)
+      com.google.protobuf.MessageOrBuilder {
 
-    // optional string name = 1;
     /**
      * <code>optional string name = 1;</code>
      */
@@ -2727,7 +2706,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getNameBytes();
 
-    // optional .mesosphere.marathon.ReadinessCheckDefinition.Protocol protocol = 2;
     /**
      * <code>optional .mesosphere.marathon.ReadinessCheckDefinition.Protocol protocol = 2;</code>
      */
@@ -2737,7 +2715,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ReadinessCheckDefinition.Protocol getProtocol();
 
-    // optional string path = 3;
     /**
      * <code>optional string path = 3;</code>
      */
@@ -2752,7 +2729,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getPathBytes();
 
-    // optional string portName = 4;
     /**
      * <code>optional string portName = 4;</code>
      */
@@ -2767,7 +2743,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getPortNameBytes();
 
-    // optional uint64 intervalMillis = 5;
     /**
      * <code>optional uint64 intervalMillis = 5;</code>
      */
@@ -2777,7 +2752,6 @@ public final class Protos {
      */
     long getIntervalMillis();
 
-    // optional uint64 timeoutMillis = 6;
     /**
      * <code>optional uint64 timeoutMillis = 6;</code>
      */
@@ -2787,7 +2761,6 @@ public final class Protos {
      */
     long getTimeoutMillis();
 
-    // repeated uint32 httpStatusCodeForReady = 7;
     /**
      * <code>repeated uint32 httpStatusCodeForReady = 7;</code>
      */
@@ -2801,7 +2774,6 @@ public final class Protos {
      */
     int getHttpStatusCodeForReady(int index);
 
-    // optional bool preserveLastResponse = 8;
     /**
      * <code>optional bool preserveLastResponse = 8;</code>
      */
@@ -2815,8 +2787,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ReadinessCheckDefinition}
    */
   public static final class ReadinessCheckDefinition extends
-      com.google.protobuf.GeneratedMessage
-      implements ReadinessCheckDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ReadinessCheckDefinition)
+      ReadinessCheckDefinitionOrBuilder {
     // Use ReadinessCheckDefinition.newBuilder() to construct.
     private ReadinessCheckDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -2863,8 +2836,9 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              name_ = input.readBytes();
+              name_ = bs;
               break;
             }
             case 16: {
@@ -2879,13 +2853,15 @@ public final class Protos {
               break;
             }
             case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000004;
-              path_ = input.readBytes();
+              path_ = bs;
               break;
             }
             case 34: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
-              portName_ = input.readBytes();
+              portName_ = bs;
               break;
             }
             case 40: {
@@ -3049,7 +3025,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // optional string name = 1;
     public static final int NAME_FIELD_NUMBER = 1;
     private java.lang.Object name_;
     /**
@@ -3092,7 +3067,6 @@ public final class Protos {
       }
     }
 
-    // optional .mesosphere.marathon.ReadinessCheckDefinition.Protocol protocol = 2;
     public static final int PROTOCOL_FIELD_NUMBER = 2;
     private mesosphere.marathon.Protos.ReadinessCheckDefinition.Protocol protocol_;
     /**
@@ -3108,7 +3082,6 @@ public final class Protos {
       return protocol_;
     }
 
-    // optional string path = 3;
     public static final int PATH_FIELD_NUMBER = 3;
     private java.lang.Object path_;
     /**
@@ -3151,7 +3124,6 @@ public final class Protos {
       }
     }
 
-    // optional string portName = 4;
     public static final int PORTNAME_FIELD_NUMBER = 4;
     private java.lang.Object portName_;
     /**
@@ -3194,7 +3166,6 @@ public final class Protos {
       }
     }
 
-    // optional uint64 intervalMillis = 5;
     public static final int INTERVALMILLIS_FIELD_NUMBER = 5;
     private long intervalMillis_;
     /**
@@ -3210,7 +3181,6 @@ public final class Protos {
       return intervalMillis_;
     }
 
-    // optional uint64 timeoutMillis = 6;
     public static final int TIMEOUTMILLIS_FIELD_NUMBER = 6;
     private long timeoutMillis_;
     /**
@@ -3226,7 +3196,6 @@ public final class Protos {
       return timeoutMillis_;
     }
 
-    // repeated uint32 httpStatusCodeForReady = 7;
     public static final int HTTPSTATUSCODEFORREADY_FIELD_NUMBER = 7;
     private java.util.List<java.lang.Integer> httpStatusCodeForReady_;
     /**
@@ -3249,7 +3218,6 @@ public final class Protos {
       return httpStatusCodeForReady_.get(index);
     }
 
-    // optional bool preserveLastResponse = 8;
     public static final int PRESERVELASTRESPONSE_FIELD_NUMBER = 8;
     private boolean preserveLastResponse_;
     /**
@@ -3278,7 +3246,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       memoizedIsInitialized = 1;
       return true;
@@ -3439,8 +3408,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ReadinessCheckDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.ReadinessCheckDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ReadinessCheckDefinition)
+        mesosphere.marathon.Protos.ReadinessCheckDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor;
@@ -3630,7 +3600,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // optional string name = 1;
       private java.lang.Object name_ = "";
       /**
        * <code>optional string name = 1;</code>
@@ -3644,9 +3613,12 @@ public final class Protos {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          name_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            name_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -3704,7 +3676,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesosphere.marathon.ReadinessCheckDefinition.Protocol protocol = 2;
       private mesosphere.marathon.Protos.ReadinessCheckDefinition.Protocol protocol_ = mesosphere.marathon.Protos.ReadinessCheckDefinition.Protocol.HTTP;
       /**
        * <code>optional .mesosphere.marathon.ReadinessCheckDefinition.Protocol protocol = 2;</code>
@@ -3740,7 +3711,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string path = 3;
       private java.lang.Object path_ = "";
       /**
        * <code>optional string path = 3;</code>
@@ -3754,9 +3724,12 @@ public final class Protos {
       public java.lang.String getPath() {
         java.lang.Object ref = path_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          path_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            path_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -3814,7 +3787,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string portName = 4;
       private java.lang.Object portName_ = "";
       /**
        * <code>optional string portName = 4;</code>
@@ -3828,9 +3800,12 @@ public final class Protos {
       public java.lang.String getPortName() {
         java.lang.Object ref = portName_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          portName_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            portName_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -3888,7 +3863,6 @@ public final class Protos {
         return this;
       }
 
-      // optional uint64 intervalMillis = 5;
       private long intervalMillis_ ;
       /**
        * <code>optional uint64 intervalMillis = 5;</code>
@@ -3921,7 +3895,6 @@ public final class Protos {
         return this;
       }
 
-      // optional uint64 timeoutMillis = 6;
       private long timeoutMillis_ ;
       /**
        * <code>optional uint64 timeoutMillis = 6;</code>
@@ -3954,7 +3927,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated uint32 httpStatusCodeForReady = 7;
       private java.util.List<java.lang.Integer> httpStatusCodeForReady_ = java.util.Collections.emptyList();
       private void ensureHttpStatusCodeForReadyIsMutable() {
         if (!((bitField0_ & 0x00000040) == 0x00000040)) {
@@ -4006,7 +3978,8 @@ public final class Protos {
       public Builder addAllHttpStatusCodeForReady(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureHttpStatusCodeForReadyIsMutable();
-        super.addAll(values, httpStatusCodeForReady_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, httpStatusCodeForReady_);
         onChanged();
         return this;
       }
@@ -4020,7 +3993,6 @@ public final class Protos {
         return this;
       }
 
-      // optional bool preserveLastResponse = 8;
       private boolean preserveLastResponse_ ;
       /**
        * <code>optional bool preserveLastResponse = 8;</code>
@@ -4064,15 +4036,15 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ReadinessCheckDefinition)
   }
 
-  public interface IpAddressOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface IpAddressOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.IpAddress)
+      com.google.protobuf.MessageOrBuilder {
 
-    // repeated string groups = 1;
     /**
      * <code>repeated string groups = 1;</code>
      */
-    java.util.List<java.lang.String>
-    getGroupsList();
+    com.google.protobuf.ProtocolStringList
+        getGroupsList();
     /**
      * <code>repeated string groups = 1;</code>
      */
@@ -4087,7 +4059,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getGroupsBytes(int index);
 
-    // repeated .mesos.Label labels = 2;
     /**
      * <code>repeated .mesos.Label labels = 2;</code>
      */
@@ -4112,7 +4083,6 @@ public final class Protos {
     org.apache.mesos.Protos.LabelOrBuilder getLabelsOrBuilder(
         int index);
 
-    // optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;
     /**
      * <code>optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;</code>
      */
@@ -4126,7 +4096,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.DiscoveryInfoOrBuilder getDiscoveryInfoOrBuilder();
 
-    // optional string networkName = 4;
     /**
      * <code>optional string networkName = 4;</code>
      */
@@ -4145,8 +4114,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.IpAddress}
    */
   public static final class IpAddress extends
-      com.google.protobuf.GeneratedMessage
-      implements IpAddressOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.IpAddress)
+      IpAddressOrBuilder {
     // Use IpAddress.newBuilder() to construct.
     private IpAddress(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -4193,11 +4163,12 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 groups_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000001;
               }
-              groups_.add(input.readBytes());
+              groups_.add(bs);
               break;
             }
             case 18: {
@@ -4222,8 +4193,9 @@ public final class Protos {
               break;
             }
             case 34: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              networkName_ = input.readBytes();
+              networkName_ = bs;
               break;
             }
           }
@@ -4235,7 +4207,7 @@ public final class Protos {
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          groups_ = new com.google.protobuf.UnmodifiableLazyStringList(groups_);
+          groups_ = groups_.getUnmodifiableView();
         }
         if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
           labels_ = java.util.Collections.unmodifiableList(labels_);
@@ -4272,13 +4244,12 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // repeated string groups = 1;
     public static final int GROUPS_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList groups_;
     /**
      * <code>repeated string groups = 1;</code>
      */
-    public java.util.List<java.lang.String>
+    public com.google.protobuf.ProtocolStringList
         getGroupsList() {
       return groups_;
     }
@@ -4302,7 +4273,6 @@ public final class Protos {
       return groups_.getByteString(index);
     }
 
-    // repeated .mesos.Label labels = 2;
     public static final int LABELS_FIELD_NUMBER = 2;
     private java.util.List<org.apache.mesos.Protos.Label> labels_;
     /**
@@ -4338,7 +4308,6 @@ public final class Protos {
       return labels_.get(index);
     }
 
-    // optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;
     public static final int DISCOVERYINFO_FIELD_NUMBER = 3;
     private mesosphere.marathon.Protos.DiscoveryInfo discoveryInfo_;
     /**
@@ -4360,7 +4329,6 @@ public final class Protos {
       return discoveryInfo_;
     }
 
-    // optional string networkName = 4;
     public static final int NETWORKNAME_FIELD_NUMBER = 4;
     private java.lang.Object networkName_;
     /**
@@ -4412,7 +4380,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       for (int i = 0; i < getLabelsCount(); i++) {
         if (!getLabels(i).isInitialized()) {
@@ -4557,8 +4526,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.IpAddress}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.IpAddressOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.IpAddress)
+        mesosphere.marathon.Protos.IpAddressOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_IpAddress_descriptor;
@@ -4638,8 +4608,7 @@ public final class Protos {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          groups_ = new com.google.protobuf.UnmodifiableLazyStringList(
-              groups_);
+          groups_ = groups_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.groups_ = groups_;
@@ -4763,7 +4732,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // repeated string groups = 1;
       private com.google.protobuf.LazyStringList groups_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureGroupsIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4774,9 +4742,9 @@ public final class Protos {
       /**
        * <code>repeated string groups = 1;</code>
        */
-      public java.util.List<java.lang.String>
+      public com.google.protobuf.ProtocolStringList
           getGroupsList() {
-        return java.util.Collections.unmodifiableList(groups_);
+        return groups_.getUnmodifiableView();
       }
       /**
        * <code>repeated string groups = 1;</code>
@@ -4829,7 +4797,8 @@ public final class Protos {
       public Builder addAllGroups(
           java.lang.Iterable<java.lang.String> values) {
         ensureGroupsIsMutable();
-        super.addAll(values, groups_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, groups_);
         onChanged();
         return this;
       }
@@ -4856,7 +4825,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated .mesos.Label labels = 2;
       private java.util.List<org.apache.mesos.Protos.Label> labels_ =
         java.util.Collections.emptyList();
       private void ensureLabelsIsMutable() {
@@ -4998,7 +4966,8 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Label> values) {
         if (labelsBuilder_ == null) {
           ensureLabelsIsMutable();
-          super.addAll(values, labels_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, labels_);
           onChanged();
         } else {
           labelsBuilder_.addAllMessages(values);
@@ -5096,7 +5065,6 @@ public final class Protos {
         return labelsBuilder_;
       }
 
-      // optional .mesosphere.marathon.DiscoveryInfo discoveryInfo = 3;
       private mesosphere.marathon.Protos.DiscoveryInfo discoveryInfo_ = mesosphere.marathon.Protos.DiscoveryInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.DiscoveryInfo, mesosphere.marathon.Protos.DiscoveryInfo.Builder, mesosphere.marathon.Protos.DiscoveryInfoOrBuilder> discoveryInfoBuilder_;
@@ -5205,7 +5173,7 @@ public final class Protos {
         if (discoveryInfoBuilder_ == null) {
           discoveryInfoBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.DiscoveryInfo, mesosphere.marathon.Protos.DiscoveryInfo.Builder, mesosphere.marathon.Protos.DiscoveryInfoOrBuilder>(
-                  discoveryInfo_,
+                  getDiscoveryInfo(),
                   getParentForChildren(),
                   isClean());
           discoveryInfo_ = null;
@@ -5213,7 +5181,6 @@ public final class Protos {
         return discoveryInfoBuilder_;
       }
 
-      // optional string networkName = 4;
       private java.lang.Object networkName_ = "";
       /**
        * <code>optional string networkName = 4;</code>
@@ -5227,9 +5194,12 @@ public final class Protos {
       public java.lang.String getNetworkName() {
         java.lang.Object ref = networkName_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          networkName_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            networkName_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -5298,10 +5268,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.IpAddress)
   }
 
-  public interface DiscoveryInfoOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface DiscoveryInfoOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.DiscoveryInfo)
+      com.google.protobuf.MessageOrBuilder {
 
-    // repeated .mesos.Port ports = 1;
     /**
      * <code>repeated .mesos.Port ports = 1;</code>
      */
@@ -5330,8 +5300,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.DiscoveryInfo}
    */
   public static final class DiscoveryInfo extends
-      com.google.protobuf.GeneratedMessage
-      implements DiscoveryInfoOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.DiscoveryInfo)
+      DiscoveryInfoOrBuilder {
     // Use DiscoveryInfo.newBuilder() to construct.
     private DiscoveryInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -5427,7 +5398,6 @@ public final class Protos {
       return PARSER;
     }
 
-    // repeated .mesos.Port ports = 1;
     public static final int PORTS_FIELD_NUMBER = 1;
     private java.util.List<org.apache.mesos.Protos.Port> ports_;
     /**
@@ -5469,7 +5439,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       for (int i = 0; i < getPortsCount(); i++) {
         if (!getPorts(i).isInitialized()) {
@@ -5582,8 +5553,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.DiscoveryInfo}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.DiscoveryInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.DiscoveryInfo)
+        mesosphere.marathon.Protos.DiscoveryInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_DiscoveryInfo_descriptor;
@@ -5733,7 +5705,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // repeated .mesos.Port ports = 1;
       private java.util.List<org.apache.mesos.Protos.Port> ports_ =
         java.util.Collections.emptyList();
       private void ensurePortsIsMutable() {
@@ -5875,7 +5846,8 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Port> values) {
         if (portsBuilder_ == null) {
           ensurePortsIsMutable();
-          super.addAll(values, ports_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, ports_);
           onChanged();
         } else {
           portsBuilder_.addAllMessages(values);
@@ -5984,10 +5956,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.DiscoveryInfo)
   }
 
-  public interface ServiceDefinitionOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface ServiceDefinitionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ServiceDefinition)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required string id = 1;
     /**
      * <code>required string id = 1;</code>
      */
@@ -6002,7 +5974,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getIdBytes();
 
-    // required .mesos.CommandInfo cmd = 2;
     /**
      * <code>required .mesos.CommandInfo cmd = 2;</code>
      */
@@ -6016,7 +5987,6 @@ public final class Protos {
      */
     org.apache.mesos.Protos.CommandInfoOrBuilder getCmdOrBuilder();
 
-    // required uint32 instances = 3;
     /**
      * <code>required uint32 instances = 3;</code>
      */
@@ -6026,7 +5996,6 @@ public final class Protos {
      */
     int getInstances();
 
-    // repeated .mesos.Resource resources = 4;
     /**
      * <code>repeated .mesos.Resource resources = 4;</code>
      */
@@ -6051,7 +6020,6 @@ public final class Protos {
     org.apache.mesos.Protos.ResourceOrBuilder getResourcesOrBuilder(
         int index);
 
-    // optional string description = 5;
     /**
      * <code>optional string description = 5;</code>
      */
@@ -6066,7 +6034,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getDescriptionBytes();
 
-    // repeated uint32 ports = 6;
     /**
      * <code>repeated uint32 ports = 6;</code>
      */
@@ -6080,7 +6047,6 @@ public final class Protos {
      */
     int getPorts(int index);
 
-    // repeated .mesosphere.marathon.Constraint constraints = 7;
     /**
      * <code>repeated .mesosphere.marathon.Constraint constraints = 7;</code>
      */
@@ -6105,7 +6071,6 @@ public final class Protos {
     mesosphere.marathon.Protos.ConstraintOrBuilder getConstraintsOrBuilder(
         int index);
 
-    // required string executor = 8 [default = ""];
     /**
      * <code>required string executor = 8 [default = ""];</code>
      */
@@ -6120,7 +6085,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getExecutorBytes();
 
-    // optional .mesosphere.marathon.ContainerInfo OBSOLETE_container = 10;
     /**
      * <code>optional .mesosphere.marathon.ContainerInfo OBSOLETE_container = 10;</code>
      *
@@ -6146,7 +6110,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ContainerInfoOrBuilder getOBSOLETEContainerOrBuilder();
 
-    // optional string version = 11 [default = "1970-01-01T00:00:00.000Z"];
     /**
      * <code>optional string version = 11 [default = "1970-01-01T00:00:00.000Z"];</code>
      *
@@ -6173,7 +6136,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getVersionBytes();
 
-    // repeated .mesosphere.marathon.HealthCheckDefinition healthChecks = 12;
     /**
      * <code>repeated .mesosphere.marathon.HealthCheckDefinition healthChecks = 12;</code>
      */
@@ -6198,7 +6160,6 @@ public final class Protos {
     mesosphere.marathon.Protos.HealthCheckDefinitionOrBuilder getHealthChecksOrBuilder(
         int index);
 
-    // optional int64 backoff = 13 [default = 1000];
     /**
      * <code>optional int64 backoff = 13 [default = 1000];</code>
      *
@@ -6216,7 +6177,6 @@ public final class Protos {
      */
     long getBackoff();
 
-    // optional double backoffFactor = 14 [default = 1.15];
     /**
      * <code>optional double backoffFactor = 14 [default = 1.15];</code>
      */
@@ -6226,7 +6186,6 @@ public final class Protos {
      */
     double getBackoffFactor();
 
-    // optional .mesosphere.marathon.UpgradeStrategyDefinition upgradeStrategy = 15;
     /**
      * <code>optional .mesosphere.marathon.UpgradeStrategyDefinition upgradeStrategy = 15;</code>
      */
@@ -6240,12 +6199,11 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.UpgradeStrategyDefinitionOrBuilder getUpgradeStrategyOrBuilder();
 
-    // repeated string dependencies = 16;
     /**
      * <code>repeated string dependencies = 16;</code>
      */
-    java.util.List<java.lang.String>
-    getDependenciesList();
+    com.google.protobuf.ProtocolStringList
+        getDependenciesList();
     /**
      * <code>repeated string dependencies = 16;</code>
      */
@@ -6260,12 +6218,11 @@ public final class Protos {
     com.google.protobuf.ByteString
         getDependenciesBytes(int index);
 
-    // repeated string storeUrls = 17;
     /**
      * <code>repeated string storeUrls = 17;</code>
      */
-    java.util.List<java.lang.String>
-    getStoreUrlsList();
+    com.google.protobuf.ProtocolStringList
+        getStoreUrlsList();
     /**
      * <code>repeated string storeUrls = 17;</code>
      */
@@ -6280,7 +6237,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getStoreUrlsBytes(int index);
 
-    // optional bool require_ports = 18 [default = false];
     /**
      * <code>optional bool require_ports = 18 [default = false];</code>
      */
@@ -6290,7 +6246,6 @@ public final class Protos {
      */
     boolean getRequirePorts();
 
-    // optional .mesosphere.marathon.ExtendedContainerInfo container = 19;
     /**
      * <code>optional .mesosphere.marathon.ExtendedContainerInfo container = 19;</code>
      */
@@ -6304,7 +6259,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ExtendedContainerInfoOrBuilder getContainerOrBuilder();
 
-    // repeated .mesos.Parameter labels = 20;
     /**
      * <code>repeated .mesos.Parameter labels = 20;</code>
      */
@@ -6329,7 +6283,6 @@ public final class Protos {
     org.apache.mesos.Protos.ParameterOrBuilder getLabelsOrBuilder(
         int index);
 
-    // optional int64 maxLaunchDelay = 21 [default = 3600000];
     /**
      * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
      *
@@ -6347,7 +6300,6 @@ public final class Protos {
      */
     long getMaxLaunchDelay();
 
-    // optional .mesosphere.marathon.ResourceRoles acceptedResourceRoles = 22;
     /**
      * <code>optional .mesosphere.marathon.ResourceRoles acceptedResourceRoles = 22;</code>
      */
@@ -6361,7 +6313,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ResourceRolesOrBuilder getAcceptedResourceRolesOrBuilder();
 
-    // optional int64 last_scaling_at = 23;
     /**
      * <code>optional int64 last_scaling_at = 23;</code>
      */
@@ -6371,7 +6322,6 @@ public final class Protos {
      */
     long getLastScalingAt();
 
-    // optional int64 last_config_change_at = 24;
     /**
      * <code>optional int64 last_config_change_at = 24;</code>
      */
@@ -6381,7 +6331,6 @@ public final class Protos {
      */
     long getLastConfigChangeAt();
 
-    // optional .mesosphere.marathon.IpAddress ipAddress = 25;
     /**
      * <code>optional .mesosphere.marathon.IpAddress ipAddress = 25;</code>
      */
@@ -6395,7 +6344,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.IpAddressOrBuilder getIpAddressOrBuilder();
 
-    // optional .mesosphere.marathon.ResidencyDefinition residency = 26;
     /**
      * <code>optional .mesosphere.marathon.ResidencyDefinition residency = 26;</code>
      */
@@ -6409,7 +6357,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ResidencyDefinitionOrBuilder getResidencyOrBuilder();
 
-    // repeated .mesos.Port portDefinitions = 27;
     /**
      * <code>repeated .mesos.Port portDefinitions = 27;</code>
      */
@@ -6434,7 +6381,6 @@ public final class Protos {
     org.apache.mesos.Protos.PortOrBuilder getPortDefinitionsOrBuilder(
         int index);
 
-    // repeated .mesosphere.marathon.ReadinessCheckDefinition readinessCheckDefinition = 28;
     /**
      * <code>repeated .mesosphere.marathon.ReadinessCheckDefinition readinessCheckDefinition = 28;</code>
      */
@@ -6459,7 +6405,6 @@ public final class Protos {
     mesosphere.marathon.Protos.ReadinessCheckDefinitionOrBuilder getReadinessCheckDefinitionOrBuilder(
         int index);
 
-    // repeated .mesosphere.marathon.Secret secrets = 29;
     /**
      * <code>repeated .mesosphere.marathon.Secret secrets = 29;</code>
      */
@@ -6484,7 +6429,6 @@ public final class Protos {
     mesosphere.marathon.Protos.SecretOrBuilder getSecretsOrBuilder(
         int index);
 
-    // repeated .mesosphere.marathon.EnvVarReference envVarReferences = 30;
     /**
      * <code>repeated .mesosphere.marathon.EnvVarReference envVarReferences = 30;</code>
      */
@@ -6509,7 +6453,6 @@ public final class Protos {
     mesosphere.marathon.Protos.EnvVarReferenceOrBuilder getEnvVarReferencesOrBuilder(
         int index);
 
-    // optional int64 taskKillGracePeriod = 31;
     /**
      * <code>optional int64 taskKillGracePeriod = 31;</code>
      *
@@ -6531,8 +6474,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ServiceDefinition}
    */
   public static final class ServiceDefinition extends
-      com.google.protobuf.GeneratedMessage
-      implements ServiceDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ServiceDefinition)
+      ServiceDefinitionOrBuilder {
     // Use ServiceDefinition.newBuilder() to construct.
     private ServiceDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -6579,8 +6523,9 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
+              id_ = bs;
               break;
             }
             case 18: {
@@ -6610,8 +6555,9 @@ public final class Protos {
               break;
             }
             case 42: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
-              description_ = input.readBytes();
+              description_ = bs;
               break;
             }
             case 48: {
@@ -6644,8 +6590,9 @@ public final class Protos {
               break;
             }
             case 66: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000010;
-              executor_ = input.readBytes();
+              executor_ = bs;
               break;
             }
             case 82: {
@@ -6662,8 +6609,9 @@ public final class Protos {
               break;
             }
             case 90: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000040;
-              version_ = input.readBytes();
+              version_ = bs;
               break;
             }
             case 98: {
@@ -6698,19 +6646,21 @@ public final class Protos {
               break;
             }
             case 130: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
                 dependencies_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00004000;
               }
-              dependencies_.add(input.readBytes());
+              dependencies_.add(bs);
               break;
             }
             case 138: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00008000) == 0x00008000)) {
                 storeUrls_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00008000;
               }
-              storeUrls_.add(input.readBytes());
+              storeUrls_.add(bs);
               break;
             }
             case 144: {
@@ -6851,10 +6801,10 @@ public final class Protos {
           healthChecks_ = java.util.Collections.unmodifiableList(healthChecks_);
         }
         if (((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
-          dependencies_ = new com.google.protobuf.UnmodifiableLazyStringList(dependencies_);
+          dependencies_ = dependencies_.getUnmodifiableView();
         }
         if (((mutable_bitField0_ & 0x00008000) == 0x00008000)) {
-          storeUrls_ = new com.google.protobuf.UnmodifiableLazyStringList(storeUrls_);
+          storeUrls_ = storeUrls_.getUnmodifiableView();
         }
         if (((mutable_bitField0_ & 0x00040000) == 0x00040000)) {
           labels_ = java.util.Collections.unmodifiableList(labels_);
@@ -6903,7 +6853,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -6946,7 +6895,6 @@ public final class Protos {
       }
     }
 
-    // required .mesos.CommandInfo cmd = 2;
     public static final int CMD_FIELD_NUMBER = 2;
     private org.apache.mesos.Protos.CommandInfo cmd_;
     /**
@@ -6968,7 +6916,6 @@ public final class Protos {
       return cmd_;
     }
 
-    // required uint32 instances = 3;
     public static final int INSTANCES_FIELD_NUMBER = 3;
     private int instances_;
     /**
@@ -6984,7 +6931,6 @@ public final class Protos {
       return instances_;
     }
 
-    // repeated .mesos.Resource resources = 4;
     public static final int RESOURCES_FIELD_NUMBER = 4;
     private java.util.List<org.apache.mesos.Protos.Resource> resources_;
     /**
@@ -7020,7 +6966,6 @@ public final class Protos {
       return resources_.get(index);
     }
 
-    // optional string description = 5;
     public static final int DESCRIPTION_FIELD_NUMBER = 5;
     private java.lang.Object description_;
     /**
@@ -7063,7 +7008,6 @@ public final class Protos {
       }
     }
 
-    // repeated uint32 ports = 6;
     public static final int PORTS_FIELD_NUMBER = 6;
     private java.util.List<java.lang.Integer> ports_;
     /**
@@ -7086,7 +7030,6 @@ public final class Protos {
       return ports_.get(index);
     }
 
-    // repeated .mesosphere.marathon.Constraint constraints = 7;
     public static final int CONSTRAINTS_FIELD_NUMBER = 7;
     private java.util.List<mesosphere.marathon.Protos.Constraint> constraints_;
     /**
@@ -7122,7 +7065,6 @@ public final class Protos {
       return constraints_.get(index);
     }
 
-    // required string executor = 8 [default = ""];
     public static final int EXECUTOR_FIELD_NUMBER = 8;
     private java.lang.Object executor_;
     /**
@@ -7165,7 +7107,6 @@ public final class Protos {
       }
     }
 
-    // optional .mesosphere.marathon.ContainerInfo OBSOLETE_container = 10;
     public static final int OBSOLETE_CONTAINER_FIELD_NUMBER = 10;
     private mesosphere.marathon.Protos.ContainerInfo oBSOLETEContainer_;
     /**
@@ -7199,7 +7140,6 @@ public final class Protos {
       return oBSOLETEContainer_;
     }
 
-    // optional string version = 11 [default = "1970-01-01T00:00:00.000Z"];
     public static final int VERSION_FIELD_NUMBER = 11;
     private java.lang.Object version_;
     /**
@@ -7254,7 +7194,6 @@ public final class Protos {
       }
     }
 
-    // repeated .mesosphere.marathon.HealthCheckDefinition healthChecks = 12;
     public static final int HEALTHCHECKS_FIELD_NUMBER = 12;
     private java.util.List<mesosphere.marathon.Protos.HealthCheckDefinition> healthChecks_;
     /**
@@ -7290,7 +7229,6 @@ public final class Protos {
       return healthChecks_.get(index);
     }
 
-    // optional int64 backoff = 13 [default = 1000];
     public static final int BACKOFF_FIELD_NUMBER = 13;
     private long backoff_;
     /**
@@ -7314,7 +7252,6 @@ public final class Protos {
       return backoff_;
     }
 
-    // optional double backoffFactor = 14 [default = 1.15];
     public static final int BACKOFFFACTOR_FIELD_NUMBER = 14;
     private double backoffFactor_;
     /**
@@ -7330,7 +7267,6 @@ public final class Protos {
       return backoffFactor_;
     }
 
-    // optional .mesosphere.marathon.UpgradeStrategyDefinition upgradeStrategy = 15;
     public static final int UPGRADESTRATEGY_FIELD_NUMBER = 15;
     private mesosphere.marathon.Protos.UpgradeStrategyDefinition upgradeStrategy_;
     /**
@@ -7352,13 +7288,12 @@ public final class Protos {
       return upgradeStrategy_;
     }
 
-    // repeated string dependencies = 16;
     public static final int DEPENDENCIES_FIELD_NUMBER = 16;
     private com.google.protobuf.LazyStringList dependencies_;
     /**
      * <code>repeated string dependencies = 16;</code>
      */
-    public java.util.List<java.lang.String>
+    public com.google.protobuf.ProtocolStringList
         getDependenciesList() {
       return dependencies_;
     }
@@ -7382,13 +7317,12 @@ public final class Protos {
       return dependencies_.getByteString(index);
     }
 
-    // repeated string storeUrls = 17;
     public static final int STOREURLS_FIELD_NUMBER = 17;
     private com.google.protobuf.LazyStringList storeUrls_;
     /**
      * <code>repeated string storeUrls = 17;</code>
      */
-    public java.util.List<java.lang.String>
+    public com.google.protobuf.ProtocolStringList
         getStoreUrlsList() {
       return storeUrls_;
     }
@@ -7412,7 +7346,6 @@ public final class Protos {
       return storeUrls_.getByteString(index);
     }
 
-    // optional bool require_ports = 18 [default = false];
     public static final int REQUIRE_PORTS_FIELD_NUMBER = 18;
     private boolean requirePorts_;
     /**
@@ -7428,7 +7361,6 @@ public final class Protos {
       return requirePorts_;
     }
 
-    // optional .mesosphere.marathon.ExtendedContainerInfo container = 19;
     public static final int CONTAINER_FIELD_NUMBER = 19;
     private mesosphere.marathon.Protos.ExtendedContainerInfo container_;
     /**
@@ -7450,7 +7382,6 @@ public final class Protos {
       return container_;
     }
 
-    // repeated .mesos.Parameter labels = 20;
     public static final int LABELS_FIELD_NUMBER = 20;
     private java.util.List<org.apache.mesos.Protos.Parameter> labels_;
     /**
@@ -7486,7 +7417,6 @@ public final class Protos {
       return labels_.get(index);
     }
 
-    // optional int64 maxLaunchDelay = 21 [default = 3600000];
     public static final int MAXLAUNCHDELAY_FIELD_NUMBER = 21;
     private long maxLaunchDelay_;
     /**
@@ -7510,7 +7440,6 @@ public final class Protos {
       return maxLaunchDelay_;
     }
 
-    // optional .mesosphere.marathon.ResourceRoles acceptedResourceRoles = 22;
     public static final int ACCEPTEDRESOURCEROLES_FIELD_NUMBER = 22;
     private mesosphere.marathon.Protos.ResourceRoles acceptedResourceRoles_;
     /**
@@ -7532,7 +7461,6 @@ public final class Protos {
       return acceptedResourceRoles_;
     }
 
-    // optional int64 last_scaling_at = 23;
     public static final int LAST_SCALING_AT_FIELD_NUMBER = 23;
     private long lastScalingAt_;
     /**
@@ -7548,7 +7476,6 @@ public final class Protos {
       return lastScalingAt_;
     }
 
-    // optional int64 last_config_change_at = 24;
     public static final int LAST_CONFIG_CHANGE_AT_FIELD_NUMBER = 24;
     private long lastConfigChangeAt_;
     /**
@@ -7564,7 +7491,6 @@ public final class Protos {
       return lastConfigChangeAt_;
     }
 
-    // optional .mesosphere.marathon.IpAddress ipAddress = 25;
     public static final int IPADDRESS_FIELD_NUMBER = 25;
     private mesosphere.marathon.Protos.IpAddress ipAddress_;
     /**
@@ -7586,7 +7512,6 @@ public final class Protos {
       return ipAddress_;
     }
 
-    // optional .mesosphere.marathon.ResidencyDefinition residency = 26;
     public static final int RESIDENCY_FIELD_NUMBER = 26;
     private mesosphere.marathon.Protos.ResidencyDefinition residency_;
     /**
@@ -7608,7 +7533,6 @@ public final class Protos {
       return residency_;
     }
 
-    // repeated .mesos.Port portDefinitions = 27;
     public static final int PORTDEFINITIONS_FIELD_NUMBER = 27;
     private java.util.List<org.apache.mesos.Protos.Port> portDefinitions_;
     /**
@@ -7644,7 +7568,6 @@ public final class Protos {
       return portDefinitions_.get(index);
     }
 
-    // repeated .mesosphere.marathon.ReadinessCheckDefinition readinessCheckDefinition = 28;
     public static final int READINESSCHECKDEFINITION_FIELD_NUMBER = 28;
     private java.util.List<mesosphere.marathon.Protos.ReadinessCheckDefinition> readinessCheckDefinition_;
     /**
@@ -7680,7 +7603,6 @@ public final class Protos {
       return readinessCheckDefinition_.get(index);
     }
 
-    // repeated .mesosphere.marathon.Secret secrets = 29;
     public static final int SECRETS_FIELD_NUMBER = 29;
     private java.util.List<mesosphere.marathon.Protos.Secret> secrets_;
     /**
@@ -7716,7 +7638,6 @@ public final class Protos {
       return secrets_.get(index);
     }
 
-    // repeated .mesosphere.marathon.EnvVarReference envVarReferences = 30;
     public static final int ENVVARREFERENCES_FIELD_NUMBER = 30;
     private java.util.List<mesosphere.marathon.Protos.EnvVarReference> envVarReferences_;
     /**
@@ -7752,7 +7673,6 @@ public final class Protos {
       return envVarReferences_.get(index);
     }
 
-    // optional int64 taskKillGracePeriod = 31;
     public static final int TASKKILLGRACEPERIOD_FIELD_NUMBER = 31;
     private long taskKillGracePeriod_;
     /**
@@ -7811,7 +7731,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasId()) {
         memoizedIsInitialized = 0;
@@ -8222,8 +8143,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ServiceDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.ServiceDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ServiceDefinition)
+        mesosphere.marathon.Protos.ServiceDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ServiceDefinition_descriptor;
@@ -8504,14 +8426,12 @@ public final class Protos {
           result.upgradeStrategy_ = upgradeStrategyBuilder_.build();
         }
         if (((bitField0_ & 0x00004000) == 0x00004000)) {
-          dependencies_ = new com.google.protobuf.UnmodifiableLazyStringList(
-              dependencies_);
+          dependencies_ = dependencies_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00004000);
         }
         result.dependencies_ = dependencies_;
         if (((bitField0_ & 0x00008000) == 0x00008000)) {
-          storeUrls_ = new com.google.protobuf.UnmodifiableLazyStringList(
-              storeUrls_);
+          storeUrls_ = storeUrls_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00008000);
         }
         result.storeUrls_ = storeUrls_;
@@ -9044,7 +8964,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>required string id = 1;</code>
@@ -9058,9 +8977,12 @@ public final class Protos {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          id_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            id_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -9118,7 +9040,6 @@ public final class Protos {
         return this;
       }
 
-      // required .mesos.CommandInfo cmd = 2;
       private org.apache.mesos.Protos.CommandInfo cmd_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder> cmdBuilder_;
@@ -9227,7 +9148,7 @@ public final class Protos {
         if (cmdBuilder_ == null) {
           cmdBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder>(
-                  cmd_,
+                  getCmd(),
                   getParentForChildren(),
                   isClean());
           cmd_ = null;
@@ -9235,7 +9156,6 @@ public final class Protos {
         return cmdBuilder_;
       }
 
-      // required uint32 instances = 3;
       private int instances_ ;
       /**
        * <code>required uint32 instances = 3;</code>
@@ -9268,7 +9188,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated .mesos.Resource resources = 4;
       private java.util.List<org.apache.mesos.Protos.Resource> resources_ =
         java.util.Collections.emptyList();
       private void ensureResourcesIsMutable() {
@@ -9410,7 +9329,8 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Resource> values) {
         if (resourcesBuilder_ == null) {
           ensureResourcesIsMutable();
-          super.addAll(values, resources_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, resources_);
           onChanged();
         } else {
           resourcesBuilder_.addAllMessages(values);
@@ -9508,7 +9428,6 @@ public final class Protos {
         return resourcesBuilder_;
       }
 
-      // optional string description = 5;
       private java.lang.Object description_ = "";
       /**
        * <code>optional string description = 5;</code>
@@ -9522,9 +9441,12 @@ public final class Protos {
       public java.lang.String getDescription() {
         java.lang.Object ref = description_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          description_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            description_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -9582,7 +9504,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated uint32 ports = 6;
       private java.util.List<java.lang.Integer> ports_ = java.util.Collections.emptyList();
       private void ensurePortsIsMutable() {
         if (!((bitField0_ & 0x00000020) == 0x00000020)) {
@@ -9634,7 +9555,8 @@ public final class Protos {
       public Builder addAllPorts(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensurePortsIsMutable();
-        super.addAll(values, ports_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, ports_);
         onChanged();
         return this;
       }
@@ -9648,7 +9570,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated .mesosphere.marathon.Constraint constraints = 7;
       private java.util.List<mesosphere.marathon.Protos.Constraint> constraints_ =
         java.util.Collections.emptyList();
       private void ensureConstraintsIsMutable() {
@@ -9790,7 +9711,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.Constraint> values) {
         if (constraintsBuilder_ == null) {
           ensureConstraintsIsMutable();
-          super.addAll(values, constraints_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, constraints_);
           onChanged();
         } else {
           constraintsBuilder_.addAllMessages(values);
@@ -9888,7 +9810,6 @@ public final class Protos {
         return constraintsBuilder_;
       }
 
-      // required string executor = 8 [default = ""];
       private java.lang.Object executor_ = "";
       /**
        * <code>required string executor = 8 [default = ""];</code>
@@ -9902,9 +9823,12 @@ public final class Protos {
       public java.lang.String getExecutor() {
         java.lang.Object ref = executor_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          executor_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            executor_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -9962,7 +9886,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesosphere.marathon.ContainerInfo OBSOLETE_container = 10;
       private mesosphere.marathon.Protos.ContainerInfo oBSOLETEContainer_ = mesosphere.marathon.Protos.ContainerInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ContainerInfo, mesosphere.marathon.Protos.ContainerInfo.Builder, mesosphere.marathon.Protos.ContainerInfoOrBuilder> oBSOLETEContainerBuilder_;
@@ -10107,7 +10030,7 @@ public final class Protos {
         if (oBSOLETEContainerBuilder_ == null) {
           oBSOLETEContainerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ContainerInfo, mesosphere.marathon.Protos.ContainerInfo.Builder, mesosphere.marathon.Protos.ContainerInfoOrBuilder>(
-                  oBSOLETEContainer_,
+                  getOBSOLETEContainer(),
                   getParentForChildren(),
                   isClean());
           oBSOLETEContainer_ = null;
@@ -10115,7 +10038,6 @@ public final class Protos {
         return oBSOLETEContainerBuilder_;
       }
 
-      // optional string version = 11 [default = "1970-01-01T00:00:00.000Z"];
       private java.lang.Object version_ = "1970-01-01T00:00:00.000Z";
       /**
        * <code>optional string version = 11 [default = "1970-01-01T00:00:00.000Z"];</code>
@@ -10137,9 +10059,12 @@ public final class Protos {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          version_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            version_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -10213,7 +10138,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated .mesosphere.marathon.HealthCheckDefinition healthChecks = 12;
       private java.util.List<mesosphere.marathon.Protos.HealthCheckDefinition> healthChecks_ =
         java.util.Collections.emptyList();
       private void ensureHealthChecksIsMutable() {
@@ -10355,7 +10279,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.HealthCheckDefinition> values) {
         if (healthChecksBuilder_ == null) {
           ensureHealthChecksIsMutable();
-          super.addAll(values, healthChecks_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, healthChecks_);
           onChanged();
         } else {
           healthChecksBuilder_.addAllMessages(values);
@@ -10453,7 +10378,6 @@ public final class Protos {
         return healthChecksBuilder_;
       }
 
-      // optional int64 backoff = 13 [default = 1000];
       private long backoff_ = 1000L;
       /**
        * <code>optional int64 backoff = 13 [default = 1000];</code>
@@ -10502,7 +10426,6 @@ public final class Protos {
         return this;
       }
 
-      // optional double backoffFactor = 14 [default = 1.15];
       private double backoffFactor_ = 1.15D;
       /**
        * <code>optional double backoffFactor = 14 [default = 1.15];</code>
@@ -10535,7 +10458,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesosphere.marathon.UpgradeStrategyDefinition upgradeStrategy = 15;
       private mesosphere.marathon.Protos.UpgradeStrategyDefinition upgradeStrategy_ = mesosphere.marathon.Protos.UpgradeStrategyDefinition.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.UpgradeStrategyDefinition, mesosphere.marathon.Protos.UpgradeStrategyDefinition.Builder, mesosphere.marathon.Protos.UpgradeStrategyDefinitionOrBuilder> upgradeStrategyBuilder_;
@@ -10644,7 +10566,7 @@ public final class Protos {
         if (upgradeStrategyBuilder_ == null) {
           upgradeStrategyBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.UpgradeStrategyDefinition, mesosphere.marathon.Protos.UpgradeStrategyDefinition.Builder, mesosphere.marathon.Protos.UpgradeStrategyDefinitionOrBuilder>(
-                  upgradeStrategy_,
+                  getUpgradeStrategy(),
                   getParentForChildren(),
                   isClean());
           upgradeStrategy_ = null;
@@ -10652,7 +10574,6 @@ public final class Protos {
         return upgradeStrategyBuilder_;
       }
 
-      // repeated string dependencies = 16;
       private com.google.protobuf.LazyStringList dependencies_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureDependenciesIsMutable() {
         if (!((bitField0_ & 0x00004000) == 0x00004000)) {
@@ -10663,9 +10584,9 @@ public final class Protos {
       /**
        * <code>repeated string dependencies = 16;</code>
        */
-      public java.util.List<java.lang.String>
+      public com.google.protobuf.ProtocolStringList
           getDependenciesList() {
-        return java.util.Collections.unmodifiableList(dependencies_);
+        return dependencies_.getUnmodifiableView();
       }
       /**
        * <code>repeated string dependencies = 16;</code>
@@ -10718,7 +10639,8 @@ public final class Protos {
       public Builder addAllDependencies(
           java.lang.Iterable<java.lang.String> values) {
         ensureDependenciesIsMutable();
-        super.addAll(values, dependencies_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, dependencies_);
         onChanged();
         return this;
       }
@@ -10745,7 +10667,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated string storeUrls = 17;
       private com.google.protobuf.LazyStringList storeUrls_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureStoreUrlsIsMutable() {
         if (!((bitField0_ & 0x00008000) == 0x00008000)) {
@@ -10756,9 +10677,9 @@ public final class Protos {
       /**
        * <code>repeated string storeUrls = 17;</code>
        */
-      public java.util.List<java.lang.String>
+      public com.google.protobuf.ProtocolStringList
           getStoreUrlsList() {
-        return java.util.Collections.unmodifiableList(storeUrls_);
+        return storeUrls_.getUnmodifiableView();
       }
       /**
        * <code>repeated string storeUrls = 17;</code>
@@ -10811,7 +10732,8 @@ public final class Protos {
       public Builder addAllStoreUrls(
           java.lang.Iterable<java.lang.String> values) {
         ensureStoreUrlsIsMutable();
-        super.addAll(values, storeUrls_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, storeUrls_);
         onChanged();
         return this;
       }
@@ -10838,7 +10760,6 @@ public final class Protos {
         return this;
       }
 
-      // optional bool require_ports = 18 [default = false];
       private boolean requirePorts_ ;
       /**
        * <code>optional bool require_ports = 18 [default = false];</code>
@@ -10871,7 +10792,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesosphere.marathon.ExtendedContainerInfo container = 19;
       private mesosphere.marathon.Protos.ExtendedContainerInfo container_ = mesosphere.marathon.Protos.ExtendedContainerInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ExtendedContainerInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfoOrBuilder> containerBuilder_;
@@ -10980,7 +10900,7 @@ public final class Protos {
         if (containerBuilder_ == null) {
           containerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ExtendedContainerInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfoOrBuilder>(
-                  container_,
+                  getContainer(),
                   getParentForChildren(),
                   isClean());
           container_ = null;
@@ -10988,7 +10908,6 @@ public final class Protos {
         return containerBuilder_;
       }
 
-      // repeated .mesos.Parameter labels = 20;
       private java.util.List<org.apache.mesos.Protos.Parameter> labels_ =
         java.util.Collections.emptyList();
       private void ensureLabelsIsMutable() {
@@ -11130,7 +11049,8 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Parameter> values) {
         if (labelsBuilder_ == null) {
           ensureLabelsIsMutable();
-          super.addAll(values, labels_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, labels_);
           onChanged();
         } else {
           labelsBuilder_.addAllMessages(values);
@@ -11228,7 +11148,6 @@ public final class Protos {
         return labelsBuilder_;
       }
 
-      // optional int64 maxLaunchDelay = 21 [default = 3600000];
       private long maxLaunchDelay_ = 3600000L;
       /**
        * <code>optional int64 maxLaunchDelay = 21 [default = 3600000];</code>
@@ -11277,7 +11196,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesosphere.marathon.ResourceRoles acceptedResourceRoles = 22;
       private mesosphere.marathon.Protos.ResourceRoles acceptedResourceRoles_ = mesosphere.marathon.Protos.ResourceRoles.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ResourceRoles, mesosphere.marathon.Protos.ResourceRoles.Builder, mesosphere.marathon.Protos.ResourceRolesOrBuilder> acceptedResourceRolesBuilder_;
@@ -11386,7 +11304,7 @@ public final class Protos {
         if (acceptedResourceRolesBuilder_ == null) {
           acceptedResourceRolesBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ResourceRoles, mesosphere.marathon.Protos.ResourceRoles.Builder, mesosphere.marathon.Protos.ResourceRolesOrBuilder>(
-                  acceptedResourceRoles_,
+                  getAcceptedResourceRoles(),
                   getParentForChildren(),
                   isClean());
           acceptedResourceRoles_ = null;
@@ -11394,7 +11312,6 @@ public final class Protos {
         return acceptedResourceRolesBuilder_;
       }
 
-      // optional int64 last_scaling_at = 23;
       private long lastScalingAt_ ;
       /**
        * <code>optional int64 last_scaling_at = 23;</code>
@@ -11427,7 +11344,6 @@ public final class Protos {
         return this;
       }
 
-      // optional int64 last_config_change_at = 24;
       private long lastConfigChangeAt_ ;
       /**
        * <code>optional int64 last_config_change_at = 24;</code>
@@ -11460,7 +11376,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesosphere.marathon.IpAddress ipAddress = 25;
       private mesosphere.marathon.Protos.IpAddress ipAddress_ = mesosphere.marathon.Protos.IpAddress.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.IpAddress, mesosphere.marathon.Protos.IpAddress.Builder, mesosphere.marathon.Protos.IpAddressOrBuilder> ipAddressBuilder_;
@@ -11569,7 +11484,7 @@ public final class Protos {
         if (ipAddressBuilder_ == null) {
           ipAddressBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.IpAddress, mesosphere.marathon.Protos.IpAddress.Builder, mesosphere.marathon.Protos.IpAddressOrBuilder>(
-                  ipAddress_,
+                  getIpAddress(),
                   getParentForChildren(),
                   isClean());
           ipAddress_ = null;
@@ -11577,7 +11492,6 @@ public final class Protos {
         return ipAddressBuilder_;
       }
 
-      // optional .mesosphere.marathon.ResidencyDefinition residency = 26;
       private mesosphere.marathon.Protos.ResidencyDefinition residency_ = mesosphere.marathon.Protos.ResidencyDefinition.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ResidencyDefinition, mesosphere.marathon.Protos.ResidencyDefinition.Builder, mesosphere.marathon.Protos.ResidencyDefinitionOrBuilder> residencyBuilder_;
@@ -11686,7 +11600,7 @@ public final class Protos {
         if (residencyBuilder_ == null) {
           residencyBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ResidencyDefinition, mesosphere.marathon.Protos.ResidencyDefinition.Builder, mesosphere.marathon.Protos.ResidencyDefinitionOrBuilder>(
-                  residency_,
+                  getResidency(),
                   getParentForChildren(),
                   isClean());
           residency_ = null;
@@ -11694,7 +11608,6 @@ public final class Protos {
         return residencyBuilder_;
       }
 
-      // repeated .mesos.Port portDefinitions = 27;
       private java.util.List<org.apache.mesos.Protos.Port> portDefinitions_ =
         java.util.Collections.emptyList();
       private void ensurePortDefinitionsIsMutable() {
@@ -11836,7 +11749,8 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Port> values) {
         if (portDefinitionsBuilder_ == null) {
           ensurePortDefinitionsIsMutable();
-          super.addAll(values, portDefinitions_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, portDefinitions_);
           onChanged();
         } else {
           portDefinitionsBuilder_.addAllMessages(values);
@@ -11934,7 +11848,6 @@ public final class Protos {
         return portDefinitionsBuilder_;
       }
 
-      // repeated .mesosphere.marathon.ReadinessCheckDefinition readinessCheckDefinition = 28;
       private java.util.List<mesosphere.marathon.Protos.ReadinessCheckDefinition> readinessCheckDefinition_ =
         java.util.Collections.emptyList();
       private void ensureReadinessCheckDefinitionIsMutable() {
@@ -12076,7 +11989,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.ReadinessCheckDefinition> values) {
         if (readinessCheckDefinitionBuilder_ == null) {
           ensureReadinessCheckDefinitionIsMutable();
-          super.addAll(values, readinessCheckDefinition_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, readinessCheckDefinition_);
           onChanged();
         } else {
           readinessCheckDefinitionBuilder_.addAllMessages(values);
@@ -12174,7 +12088,6 @@ public final class Protos {
         return readinessCheckDefinitionBuilder_;
       }
 
-      // repeated .mesosphere.marathon.Secret secrets = 29;
       private java.util.List<mesosphere.marathon.Protos.Secret> secrets_ =
         java.util.Collections.emptyList();
       private void ensureSecretsIsMutable() {
@@ -12316,7 +12229,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.Secret> values) {
         if (secretsBuilder_ == null) {
           ensureSecretsIsMutable();
-          super.addAll(values, secrets_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, secrets_);
           onChanged();
         } else {
           secretsBuilder_.addAllMessages(values);
@@ -12414,7 +12328,6 @@ public final class Protos {
         return secretsBuilder_;
       }
 
-      // repeated .mesosphere.marathon.EnvVarReference envVarReferences = 30;
       private java.util.List<mesosphere.marathon.Protos.EnvVarReference> envVarReferences_ =
         java.util.Collections.emptyList();
       private void ensureEnvVarReferencesIsMutable() {
@@ -12556,7 +12469,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.EnvVarReference> values) {
         if (envVarReferencesBuilder_ == null) {
           ensureEnvVarReferencesIsMutable();
-          super.addAll(values, envVarReferences_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, envVarReferences_);
           onChanged();
         } else {
           envVarReferencesBuilder_.addAllMessages(values);
@@ -12654,7 +12568,6 @@ public final class Protos {
         return envVarReferencesBuilder_;
       }
 
-      // optional int64 taskKillGracePeriod = 31;
       private long taskKillGracePeriod_ ;
       /**
        * <code>optional int64 taskKillGracePeriod = 31;</code>
@@ -12714,10 +12627,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ServiceDefinition)
   }
 
-  public interface JsonOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface JsonOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Json)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required string json = 1;
     /**
      * <code>required string json = 1;</code>
      */
@@ -12740,8 +12653,9 @@ public final class Protos {
    * </pre>
    */
   public static final class Json extends
-      com.google.protobuf.GeneratedMessage
-      implements JsonOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.Json)
+      JsonOrBuilder {
     // Use Json.newBuilder() to construct.
     private Json(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -12788,8 +12702,9 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              json_ = input.readBytes();
+              json_ = bs;
               break;
             }
           }
@@ -12832,7 +12747,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required string json = 1;
     public static final int JSON_FIELD_NUMBER = 1;
     private java.lang.Object json_;
     /**
@@ -12881,7 +12795,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasJson()) {
         memoizedIsInitialized = 0;
@@ -12996,8 +12911,9 @@ public final class Protos {
      * </pre>
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.JsonOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Json)
+        mesosphere.marathon.Protos.JsonOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Json_descriptor;
@@ -13116,7 +13032,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required string json = 1;
       private java.lang.Object json_ = "";
       /**
        * <code>required string json = 1;</code>
@@ -13130,9 +13045,12 @@ public final class Protos {
       public java.lang.String getJson() {
         java.lang.Object ref = json_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          json_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            json_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -13201,15 +13119,15 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.Json)
   }
 
-  public interface ResourceRolesOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface ResourceRolesOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ResourceRoles)
+      com.google.protobuf.MessageOrBuilder {
 
-    // repeated string role = 1;
     /**
      * <code>repeated string role = 1;</code>
      */
-    java.util.List<java.lang.String>
-    getRoleList();
+    com.google.protobuf.ProtocolStringList
+        getRoleList();
     /**
      * <code>repeated string role = 1;</code>
      */
@@ -13228,8 +13146,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ResourceRoles}
    */
   public static final class ResourceRoles extends
-      com.google.protobuf.GeneratedMessage
-      implements ResourceRolesOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ResourceRoles)
+      ResourceRolesOrBuilder {
     // Use ResourceRoles.newBuilder() to construct.
     private ResourceRoles(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -13276,11 +13195,12 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 role_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000001;
               }
-              role_.add(input.readBytes());
+              role_.add(bs);
               break;
             }
           }
@@ -13292,7 +13212,7 @@ public final class Protos {
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          role_ = new com.google.protobuf.UnmodifiableLazyStringList(role_);
+          role_ = role_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -13325,13 +13245,12 @@ public final class Protos {
       return PARSER;
     }
 
-    // repeated string role = 1;
     public static final int ROLE_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList role_;
     /**
      * <code>repeated string role = 1;</code>
      */
-    public java.util.List<java.lang.String>
+    public com.google.protobuf.ProtocolStringList
         getRoleList() {
       return role_;
     }
@@ -13361,7 +13280,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       memoizedIsInitialized = 1;
       return true;
@@ -13473,8 +13393,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ResourceRoles}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.ResourceRolesOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ResourceRoles)
+        mesosphere.marathon.Protos.ResourceRolesOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ResourceRoles_descriptor;
@@ -13537,8 +13458,7 @@ public final class Protos {
         mesosphere.marathon.Protos.ResourceRoles result = new mesosphere.marathon.Protos.ResourceRoles(this);
         int from_bitField0_ = bitField0_;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          role_ = new com.google.protobuf.UnmodifiableLazyStringList(
-              role_);
+          role_ = role_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.role_ = role_;
@@ -13594,7 +13514,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // repeated string role = 1;
       private com.google.protobuf.LazyStringList role_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureRoleIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -13605,9 +13524,9 @@ public final class Protos {
       /**
        * <code>repeated string role = 1;</code>
        */
-      public java.util.List<java.lang.String>
+      public com.google.protobuf.ProtocolStringList
           getRoleList() {
-        return java.util.Collections.unmodifiableList(role_);
+        return role_.getUnmodifiableView();
       }
       /**
        * <code>repeated string role = 1;</code>
@@ -13660,7 +13579,8 @@ public final class Protos {
       public Builder addAllRole(
           java.lang.Iterable<java.lang.String> values) {
         ensureRoleIsMutable();
-        super.addAll(values, role_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, role_);
         onChanged();
         return this;
       }
@@ -13698,10 +13618,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ResourceRoles)
   }
 
-  public interface MarathonTaskOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface MarathonTaskOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.MarathonTask)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required string id = 1;
     /**
      * <code>required string id = 1;</code>
      */
@@ -13716,7 +13636,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getIdBytes();
 
-    // optional string host = 2;
     /**
      * <code>optional string host = 2;</code>
      */
@@ -13731,7 +13650,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getHostBytes();
 
-    // repeated uint32 ports = 3;
     /**
      * <code>repeated uint32 ports = 3;</code>
      */
@@ -13745,7 +13663,6 @@ public final class Protos {
      */
     int getPorts(int index);
 
-    // repeated .mesos.Attribute attributes = 4;
     /**
      * <code>repeated .mesos.Attribute attributes = 4;</code>
      */
@@ -13770,7 +13687,6 @@ public final class Protos {
     org.apache.mesos.Protos.AttributeOrBuilder getAttributesOrBuilder(
         int index);
 
-    // optional int64 staged_at = 5;
     /**
      * <code>optional int64 staged_at = 5;</code>
      */
@@ -13780,7 +13696,6 @@ public final class Protos {
      */
     long getStagedAt();
 
-    // optional int64 started_at = 6;
     /**
      * <code>optional int64 started_at = 6;</code>
      */
@@ -13790,7 +13705,6 @@ public final class Protos {
      */
     long getStartedAt();
 
-    // repeated .mesos.TaskStatus OBSOLETE_statuses = 7;
     /**
      * <code>repeated .mesos.TaskStatus OBSOLETE_statuses = 7;</code>
      */
@@ -13815,7 +13729,6 @@ public final class Protos {
     org.apache.mesos.Protos.TaskStatusOrBuilder getOBSOLETEStatusesOrBuilder(
         int index);
 
-    // optional string version = 8 [default = "1970-01-01T00:00:00.000Z"];
     /**
      * <code>optional string version = 8 [default = "1970-01-01T00:00:00.000Z"];</code>
      *
@@ -13842,7 +13755,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getVersionBytes();
 
-    // optional .mesos.TaskStatus status = 9;
     /**
      * <code>optional .mesos.TaskStatus status = 9;</code>
      */
@@ -13856,7 +13768,6 @@ public final class Protos {
      */
     org.apache.mesos.Protos.TaskStatusOrBuilder getStatusOrBuilder();
 
-    // optional .mesos.SlaveID slaveId = 10;
     /**
      * <code>optional .mesos.SlaveID slaveId = 10;</code>
      */
@@ -13870,7 +13781,6 @@ public final class Protos {
      */
     org.apache.mesos.Protos.SlaveIDOrBuilder getSlaveIdOrBuilder();
 
-    // repeated .mesos.NetworkInfo OBSOLETE_networks = 11;
     /**
      * <code>repeated .mesos.NetworkInfo OBSOLETE_networks = 11;</code>
      *
@@ -13915,7 +13825,6 @@ public final class Protos {
     org.apache.mesos.Protos.NetworkInfoOrBuilder getOBSOLETENetworksOrBuilder(
         int index);
 
-    // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
     /**
      * <code>optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;</code>
      *
@@ -13941,7 +13850,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder getReservationOrBuilder();
 
-    // optional .mesosphere.marathon.MarathonTask.Condition condition = 13;
     /**
      * <code>optional .mesosphere.marathon.MarathonTask.Condition condition = 13;</code>
      */
@@ -13955,8 +13863,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.MarathonTask}
    */
   public static final class MarathonTask extends
-      com.google.protobuf.GeneratedMessage
-      implements MarathonTaskOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.MarathonTask)
+      MarathonTaskOrBuilder {
     // Use MarathonTask.newBuilder() to construct.
     private MarathonTask(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -14003,13 +13912,15 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
+              id_ = bs;
               break;
             }
             case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              host_ = input.readBytes();
+              host_ = bs;
               break;
             }
             case 24: {
@@ -14060,8 +13971,9 @@ public final class Protos {
               break;
             }
             case 66: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000010;
-              version_ = input.readBytes();
+              version_ = bs;
               break;
             }
             case 74: {
@@ -14381,15 +14293,15 @@ public final class Protos {
       // @@protoc_insertion_point(enum_scope:mesosphere.marathon.MarathonTask.Condition)
     }
 
-    public interface ReservationOrBuilder
-        extends com.google.protobuf.MessageOrBuilder {
+    public interface ReservationOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.MarathonTask.Reservation)
+        com.google.protobuf.MessageOrBuilder {
 
-      // repeated string local_volume_ids = 1;
       /**
        * <code>repeated string local_volume_ids = 1;</code>
        */
-      java.util.List<java.lang.String>
-      getLocalVolumeIdsList();
+      com.google.protobuf.ProtocolStringList
+          getLocalVolumeIdsList();
       /**
        * <code>repeated string local_volume_ids = 1;</code>
        */
@@ -14404,7 +14316,6 @@ public final class Protos {
       com.google.protobuf.ByteString
           getLocalVolumeIdsBytes(int index);
 
-      // required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;
       /**
        * <code>required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;</code>
        */
@@ -14422,8 +14333,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation}
      */
     public static final class Reservation extends
-        com.google.protobuf.GeneratedMessage
-        implements ReservationOrBuilder {
+        com.google.protobuf.GeneratedMessage implements
+        // @@protoc_insertion_point(message_implements:mesosphere.marathon.MarathonTask.Reservation)
+        ReservationOrBuilder {
       // Use Reservation.newBuilder() to construct.
       private Reservation(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -14470,11 +14382,12 @@ public final class Protos {
                 break;
               }
               case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                   localVolumeIds_ = new com.google.protobuf.LazyStringArrayList();
                   mutable_bitField0_ |= 0x00000001;
                 }
-                localVolumeIds_.add(input.readBytes());
+                localVolumeIds_.add(bs);
                 break;
               }
               case 18: {
@@ -14499,7 +14412,7 @@ public final class Protos {
               e.getMessage()).setUnfinishedMessage(this);
         } finally {
           if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-            localVolumeIds_ = new com.google.protobuf.UnmodifiableLazyStringList(localVolumeIds_);
+            localVolumeIds_ = localVolumeIds_.getUnmodifiableView();
           }
           this.unknownFields = unknownFields.build();
           makeExtensionsImmutable();
@@ -14532,10 +14445,10 @@ public final class Protos {
         return PARSER;
       }
 
-      public interface StateOrBuilder
-          extends com.google.protobuf.MessageOrBuilder {
+      public interface StateOrBuilder extends
+          // @@protoc_insertion_point(interface_extends:mesosphere.marathon.MarathonTask.Reservation.State)
+          com.google.protobuf.MessageOrBuilder {
 
-        // required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;
         /**
          * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
          */
@@ -14545,7 +14458,6 @@ public final class Protos {
          */
         mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type getType();
 
-        // optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;
         /**
          * <code>optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;</code>
          */
@@ -14563,8 +14475,9 @@ public final class Protos {
        * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State}
        */
       public static final class State extends
-          com.google.protobuf.GeneratedMessage
-          implements StateOrBuilder {
+          com.google.protobuf.GeneratedMessage implements
+          // @@protoc_insertion_point(message_implements:mesosphere.marathon.MarathonTask.Reservation.State)
+          StateOrBuilder {
         // Use State.newBuilder() to construct.
         private State(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
           super(builder);
@@ -14782,10 +14695,10 @@ public final class Protos {
           // @@protoc_insertion_point(enum_scope:mesosphere.marathon.MarathonTask.Reservation.State.Type)
         }
 
-        public interface TimeoutOrBuilder
-            extends com.google.protobuf.MessageOrBuilder {
+        public interface TimeoutOrBuilder extends
+            // @@protoc_insertion_point(interface_extends:mesosphere.marathon.MarathonTask.Reservation.State.Timeout)
+            com.google.protobuf.MessageOrBuilder {
 
-          // required int64 initiated = 1;
           /**
            * <code>required int64 initiated = 1;</code>
            */
@@ -14795,7 +14708,6 @@ public final class Protos {
            */
           long getInitiated();
 
-          // required int64 deadline = 2;
           /**
            * <code>required int64 deadline = 2;</code>
            */
@@ -14805,7 +14717,6 @@ public final class Protos {
            */
           long getDeadline();
 
-          // required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;
           /**
            * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
            */
@@ -14819,8 +14730,9 @@ public final class Protos {
          * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State.Timeout}
          */
         public static final class Timeout extends
-            com.google.protobuf.GeneratedMessage
-            implements TimeoutOrBuilder {
+            com.google.protobuf.GeneratedMessage implements
+            // @@protoc_insertion_point(message_implements:mesosphere.marathon.MarathonTask.Reservation.State.Timeout)
+            TimeoutOrBuilder {
           // Use Timeout.newBuilder() to construct.
           private Timeout(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
             super(builder);
@@ -15009,7 +14921,6 @@ public final class Protos {
           }
 
           private int bitField0_;
-          // required int64 initiated = 1;
           public static final int INITIATED_FIELD_NUMBER = 1;
           private long initiated_;
           /**
@@ -15025,7 +14936,6 @@ public final class Protos {
             return initiated_;
           }
 
-          // required int64 deadline = 2;
           public static final int DEADLINE_FIELD_NUMBER = 2;
           private long deadline_;
           /**
@@ -15041,7 +14951,6 @@ public final class Protos {
             return deadline_;
           }
 
-          // required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;
           public static final int REASON_FIELD_NUMBER = 3;
           private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason reason_;
           /**
@@ -15065,7 +14974,8 @@ public final class Protos {
           private byte memoizedIsInitialized = -1;
           public final boolean isInitialized() {
             byte isInitialized = memoizedIsInitialized;
-            if (isInitialized != -1) return isInitialized == 1;
+            if (isInitialized == 1) return true;
+            if (isInitialized == 0) return false;
 
             if (!hasInitiated()) {
               memoizedIsInitialized = 0;
@@ -15198,8 +15108,9 @@ public final class Protos {
            * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State.Timeout}
            */
           public static final class Builder extends
-              com.google.protobuf.GeneratedMessage.Builder<Builder>
-             implements mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder {
+              com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+              // @@protoc_insertion_point(builder_implements:mesosphere.marathon.MarathonTask.Reservation.State.Timeout)
+              mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder {
             public static final com.google.protobuf.Descriptors.Descriptor
                 getDescriptor() {
               return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor;
@@ -15342,7 +15253,6 @@ public final class Protos {
             }
             private int bitField0_;
 
-            // required int64 initiated = 1;
             private long initiated_ ;
             /**
              * <code>required int64 initiated = 1;</code>
@@ -15375,7 +15285,6 @@ public final class Protos {
               return this;
             }
 
-            // required int64 deadline = 2;
             private long deadline_ ;
             /**
              * <code>required int64 deadline = 2;</code>
@@ -15408,7 +15317,6 @@ public final class Protos {
               return this;
             }
 
-            // required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;
             private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason reason_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Reason.RelaunchEscalationTimeout;
             /**
              * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Timeout.Reason reason = 3;</code>
@@ -15456,7 +15364,6 @@ public final class Protos {
         }
 
         private int bitField0_;
-        // required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;
         public static final int TYPE_FIELD_NUMBER = 1;
         private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type type_;
         /**
@@ -15472,7 +15379,6 @@ public final class Protos {
           return type_;
         }
 
-        // optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;
         public static final int TIMEOUT_FIELD_NUMBER = 2;
         private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout timeout_;
         /**
@@ -15501,7 +15407,8 @@ public final class Protos {
         private byte memoizedIsInitialized = -1;
         public final boolean isInitialized() {
           byte isInitialized = memoizedIsInitialized;
-          if (isInitialized != -1) return isInitialized == 1;
+          if (isInitialized == 1) return true;
+          if (isInitialized == 0) return false;
 
           if (!hasType()) {
             memoizedIsInitialized = 0;
@@ -15625,8 +15532,9 @@ public final class Protos {
          * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation.State}
          */
         public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder>
-           implements mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder {
+            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+            // @@protoc_insertion_point(builder_implements:mesosphere.marathon.MarathonTask.Reservation.State)
+            mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder {
           public static final com.google.protobuf.Descriptors.Descriptor
               getDescriptor() {
             return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor;
@@ -15767,7 +15675,6 @@ public final class Protos {
           }
           private int bitField0_;
 
-          // required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;
           private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type type_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Type.New;
           /**
            * <code>required .mesosphere.marathon.MarathonTask.Reservation.State.Type type = 1;</code>
@@ -15803,7 +15710,6 @@ public final class Protos {
             return this;
           }
 
-          // optional .mesosphere.marathon.MarathonTask.Reservation.State.Timeout timeout = 2;
           private mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout timeout_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.getDefaultInstance();
           private com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder> timeoutBuilder_;
@@ -15912,7 +15818,7 @@ public final class Protos {
             if (timeoutBuilder_ == null) {
               timeoutBuilder_ = new com.google.protobuf.SingleFieldBuilder<
                   mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Timeout.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.State.TimeoutOrBuilder>(
-                      timeout_,
+                      getTimeout(),
                       getParentForChildren(),
                       isClean());
               timeout_ = null;
@@ -15932,13 +15838,12 @@ public final class Protos {
       }
 
       private int bitField0_;
-      // repeated string local_volume_ids = 1;
       public static final int LOCAL_VOLUME_IDS_FIELD_NUMBER = 1;
       private com.google.protobuf.LazyStringList localVolumeIds_;
       /**
        * <code>repeated string local_volume_ids = 1;</code>
        */
-      public java.util.List<java.lang.String>
+      public com.google.protobuf.ProtocolStringList
           getLocalVolumeIdsList() {
         return localVolumeIds_;
       }
@@ -15962,7 +15867,6 @@ public final class Protos {
         return localVolumeIds_.getByteString(index);
       }
 
-      // required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;
       public static final int STATE_FIELD_NUMBER = 2;
       private mesosphere.marathon.Protos.MarathonTask.Reservation.State state_;
       /**
@@ -15991,7 +15895,8 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
 
         if (!hasState()) {
           memoizedIsInitialized = 0;
@@ -16118,8 +16023,9 @@ public final class Protos {
        * Protobuf type {@code mesosphere.marathon.MarathonTask.Reservation}
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.MarathonTask.Reservation)
+          mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor;
@@ -16190,8 +16096,7 @@ public final class Protos {
           int from_bitField0_ = bitField0_;
           int to_bitField0_ = 0;
           if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            localVolumeIds_ = new com.google.protobuf.UnmodifiableLazyStringList(
-                localVolumeIds_);
+            localVolumeIds_ = localVolumeIds_.getUnmodifiableView();
             bitField0_ = (bitField0_ & ~0x00000001);
           }
           result.localVolumeIds_ = localVolumeIds_;
@@ -16267,7 +16172,6 @@ public final class Protos {
         }
         private int bitField0_;
 
-        // repeated string local_volume_ids = 1;
         private com.google.protobuf.LazyStringList localVolumeIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         private void ensureLocalVolumeIdsIsMutable() {
           if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -16278,9 +16182,9 @@ public final class Protos {
         /**
          * <code>repeated string local_volume_ids = 1;</code>
          */
-        public java.util.List<java.lang.String>
+        public com.google.protobuf.ProtocolStringList
             getLocalVolumeIdsList() {
-          return java.util.Collections.unmodifiableList(localVolumeIds_);
+          return localVolumeIds_.getUnmodifiableView();
         }
         /**
          * <code>repeated string local_volume_ids = 1;</code>
@@ -16333,7 +16237,8 @@ public final class Protos {
         public Builder addAllLocalVolumeIds(
             java.lang.Iterable<java.lang.String> values) {
           ensureLocalVolumeIdsIsMutable();
-          super.addAll(values, localVolumeIds_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, localVolumeIds_);
           onChanged();
           return this;
         }
@@ -16360,7 +16265,6 @@ public final class Protos {
           return this;
         }
 
-        // required .mesosphere.marathon.MarathonTask.Reservation.State state = 2;
         private mesosphere.marathon.Protos.MarathonTask.Reservation.State state_ = mesosphere.marathon.Protos.MarathonTask.Reservation.State.getDefaultInstance();
         private com.google.protobuf.SingleFieldBuilder<
             mesosphere.marathon.Protos.MarathonTask.Reservation.State, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder> stateBuilder_;
@@ -16469,7 +16373,7 @@ public final class Protos {
           if (stateBuilder_ == null) {
             stateBuilder_ = new com.google.protobuf.SingleFieldBuilder<
                 mesosphere.marathon.Protos.MarathonTask.Reservation.State, mesosphere.marathon.Protos.MarathonTask.Reservation.State.Builder, mesosphere.marathon.Protos.MarathonTask.Reservation.StateOrBuilder>(
-                    state_,
+                    getState(),
                     getParentForChildren(),
                     isClean());
             state_ = null;
@@ -16489,7 +16393,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -16532,7 +16435,6 @@ public final class Protos {
       }
     }
 
-    // optional string host = 2;
     public static final int HOST_FIELD_NUMBER = 2;
     private java.lang.Object host_;
     /**
@@ -16575,7 +16477,6 @@ public final class Protos {
       }
     }
 
-    // repeated uint32 ports = 3;
     public static final int PORTS_FIELD_NUMBER = 3;
     private java.util.List<java.lang.Integer> ports_;
     /**
@@ -16598,7 +16499,6 @@ public final class Protos {
       return ports_.get(index);
     }
 
-    // repeated .mesos.Attribute attributes = 4;
     public static final int ATTRIBUTES_FIELD_NUMBER = 4;
     private java.util.List<org.apache.mesos.Protos.Attribute> attributes_;
     /**
@@ -16634,7 +16534,6 @@ public final class Protos {
       return attributes_.get(index);
     }
 
-    // optional int64 staged_at = 5;
     public static final int STAGED_AT_FIELD_NUMBER = 5;
     private long stagedAt_;
     /**
@@ -16650,7 +16549,6 @@ public final class Protos {
       return stagedAt_;
     }
 
-    // optional int64 started_at = 6;
     public static final int STARTED_AT_FIELD_NUMBER = 6;
     private long startedAt_;
     /**
@@ -16666,7 +16564,6 @@ public final class Protos {
       return startedAt_;
     }
 
-    // repeated .mesos.TaskStatus OBSOLETE_statuses = 7;
     public static final int OBSOLETE_STATUSES_FIELD_NUMBER = 7;
     private java.util.List<org.apache.mesos.Protos.TaskStatus> oBSOLETEStatuses_;
     /**
@@ -16702,7 +16599,6 @@ public final class Protos {
       return oBSOLETEStatuses_.get(index);
     }
 
-    // optional string version = 8 [default = "1970-01-01T00:00:00.000Z"];
     public static final int VERSION_FIELD_NUMBER = 8;
     private java.lang.Object version_;
     /**
@@ -16757,7 +16653,6 @@ public final class Protos {
       }
     }
 
-    // optional .mesos.TaskStatus status = 9;
     public static final int STATUS_FIELD_NUMBER = 9;
     private org.apache.mesos.Protos.TaskStatus status_;
     /**
@@ -16779,7 +16674,6 @@ public final class Protos {
       return status_;
     }
 
-    // optional .mesos.SlaveID slaveId = 10;
     public static final int SLAVEID_FIELD_NUMBER = 10;
     private org.apache.mesos.Protos.SlaveID slaveId_;
     /**
@@ -16801,7 +16695,6 @@ public final class Protos {
       return slaveId_;
     }
 
-    // repeated .mesos.NetworkInfo OBSOLETE_networks = 11;
     public static final int OBSOLETE_NETWORKS_FIELD_NUMBER = 11;
     private java.util.List<org.apache.mesos.Protos.NetworkInfo> oBSOLETENetworks_;
     /**
@@ -16857,7 +16750,6 @@ public final class Protos {
       return oBSOLETENetworks_.get(index);
     }
 
-    // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
     public static final int RESERVATION_FIELD_NUMBER = 12;
     private mesosphere.marathon.Protos.MarathonTask.Reservation reservation_;
     /**
@@ -16891,7 +16783,6 @@ public final class Protos {
       return reservation_;
     }
 
-    // optional .mesosphere.marathon.MarathonTask.Condition condition = 13;
     public static final int CONDITION_FIELD_NUMBER = 13;
     private mesosphere.marathon.Protos.MarathonTask.Condition condition_;
     /**
@@ -16925,7 +16816,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasId()) {
         memoizedIsInitialized = 0;
@@ -17161,8 +17053,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.MarathonTask}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.MarathonTaskOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.MarathonTask)
+        mesosphere.marathon.Protos.MarathonTaskOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonTask_descriptor;
@@ -17563,7 +17456,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>required string id = 1;</code>
@@ -17577,9 +17469,12 @@ public final class Protos {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          id_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            id_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -17637,7 +17532,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string host = 2;
       private java.lang.Object host_ = "";
       /**
        * <code>optional string host = 2;</code>
@@ -17651,9 +17545,12 @@ public final class Protos {
       public java.lang.String getHost() {
         java.lang.Object ref = host_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          host_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            host_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -17711,7 +17608,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated uint32 ports = 3;
       private java.util.List<java.lang.Integer> ports_ = java.util.Collections.emptyList();
       private void ensurePortsIsMutable() {
         if (!((bitField0_ & 0x00000004) == 0x00000004)) {
@@ -17763,7 +17659,8 @@ public final class Protos {
       public Builder addAllPorts(
           java.lang.Iterable<? extends java.lang.Integer> values) {
         ensurePortsIsMutable();
-        super.addAll(values, ports_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, ports_);
         onChanged();
         return this;
       }
@@ -17777,7 +17674,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated .mesos.Attribute attributes = 4;
       private java.util.List<org.apache.mesos.Protos.Attribute> attributes_ =
         java.util.Collections.emptyList();
       private void ensureAttributesIsMutable() {
@@ -17919,7 +17815,8 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.Attribute> values) {
         if (attributesBuilder_ == null) {
           ensureAttributesIsMutable();
-          super.addAll(values, attributes_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, attributes_);
           onChanged();
         } else {
           attributesBuilder_.addAllMessages(values);
@@ -18017,7 +17914,6 @@ public final class Protos {
         return attributesBuilder_;
       }
 
-      // optional int64 staged_at = 5;
       private long stagedAt_ ;
       /**
        * <code>optional int64 staged_at = 5;</code>
@@ -18050,7 +17946,6 @@ public final class Protos {
         return this;
       }
 
-      // optional int64 started_at = 6;
       private long startedAt_ ;
       /**
        * <code>optional int64 started_at = 6;</code>
@@ -18083,7 +17978,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated .mesos.TaskStatus OBSOLETE_statuses = 7;
       private java.util.List<org.apache.mesos.Protos.TaskStatus> oBSOLETEStatuses_ =
         java.util.Collections.emptyList();
       private void ensureOBSOLETEStatusesIsMutable() {
@@ -18225,7 +18119,8 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.TaskStatus> values) {
         if (oBSOLETEStatusesBuilder_ == null) {
           ensureOBSOLETEStatusesIsMutable();
-          super.addAll(values, oBSOLETEStatuses_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, oBSOLETEStatuses_);
           onChanged();
         } else {
           oBSOLETEStatusesBuilder_.addAllMessages(values);
@@ -18323,7 +18218,6 @@ public final class Protos {
         return oBSOLETEStatusesBuilder_;
       }
 
-      // optional string version = 8 [default = "1970-01-01T00:00:00.000Z"];
       private java.lang.Object version_ = "1970-01-01T00:00:00.000Z";
       /**
        * <code>optional string version = 8 [default = "1970-01-01T00:00:00.000Z"];</code>
@@ -18345,9 +18239,12 @@ public final class Protos {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          version_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            version_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -18421,7 +18318,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesos.TaskStatus status = 9;
       private org.apache.mesos.Protos.TaskStatus status_ = org.apache.mesos.Protos.TaskStatus.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.TaskStatus, org.apache.mesos.Protos.TaskStatus.Builder, org.apache.mesos.Protos.TaskStatusOrBuilder> statusBuilder_;
@@ -18530,7 +18426,7 @@ public final class Protos {
         if (statusBuilder_ == null) {
           statusBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.TaskStatus, org.apache.mesos.Protos.TaskStatus.Builder, org.apache.mesos.Protos.TaskStatusOrBuilder>(
-                  status_,
+                  getStatus(),
                   getParentForChildren(),
                   isClean());
           status_ = null;
@@ -18538,7 +18434,6 @@ public final class Protos {
         return statusBuilder_;
       }
 
-      // optional .mesos.SlaveID slaveId = 10;
       private org.apache.mesos.Protos.SlaveID slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder> slaveIdBuilder_;
@@ -18647,7 +18542,7 @@ public final class Protos {
         if (slaveIdBuilder_ == null) {
           slaveIdBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder>(
-                  slaveId_,
+                  getSlaveId(),
                   getParentForChildren(),
                   isClean());
           slaveId_ = null;
@@ -18655,7 +18550,6 @@ public final class Protos {
         return slaveIdBuilder_;
       }
 
-      // repeated .mesos.NetworkInfo OBSOLETE_networks = 11;
       private java.util.List<org.apache.mesos.Protos.NetworkInfo> oBSOLETENetworks_ =
         java.util.Collections.emptyList();
       private void ensureOBSOLETENetworksIsMutable() {
@@ -18837,7 +18731,8 @@ public final class Protos {
           java.lang.Iterable<? extends org.apache.mesos.Protos.NetworkInfo> values) {
         if (oBSOLETENetworksBuilder_ == null) {
           ensureOBSOLETENetworksIsMutable();
-          super.addAll(values, oBSOLETENetworks_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, oBSOLETENetworks_);
           onChanged();
         } else {
           oBSOLETENetworksBuilder_.addAllMessages(values);
@@ -18967,7 +18862,6 @@ public final class Protos {
         return oBSOLETENetworksBuilder_;
       }
 
-      // optional .mesosphere.marathon.MarathonTask.Reservation reservation = 12;
       private mesosphere.marathon.Protos.MarathonTask.Reservation reservation_ = mesosphere.marathon.Protos.MarathonTask.Reservation.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.MarathonTask.Reservation, mesosphere.marathon.Protos.MarathonTask.Reservation.Builder, mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder> reservationBuilder_;
@@ -19112,7 +19006,7 @@ public final class Protos {
         if (reservationBuilder_ == null) {
           reservationBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.MarathonTask.Reservation, mesosphere.marathon.Protos.MarathonTask.Reservation.Builder, mesosphere.marathon.Protos.MarathonTask.ReservationOrBuilder>(
-                  reservation_,
+                  getReservation(),
                   getParentForChildren(),
                   isClean());
           reservation_ = null;
@@ -19120,7 +19014,6 @@ public final class Protos {
         return reservationBuilder_;
       }
 
-      // optional .mesosphere.marathon.MarathonTask.Condition condition = 13;
       private mesosphere.marathon.Protos.MarathonTask.Condition condition_ = mesosphere.marathon.Protos.MarathonTask.Condition.Invalid;
       /**
        * <code>optional .mesosphere.marathon.MarathonTask.Condition condition = 13;</code>
@@ -19167,10 +19060,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonTask)
   }
 
-  public interface MarathonAppOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface MarathonAppOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.MarathonApp)
+      com.google.protobuf.MessageOrBuilder {
 
-    // optional string name = 1;
     /**
      * <code>optional string name = 1;</code>
      */
@@ -19185,7 +19078,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getNameBytes();
 
-    // repeated .mesosphere.marathon.MarathonTask tasks = 2;
     /**
      * <code>repeated .mesosphere.marathon.MarathonTask tasks = 2;</code>
      */
@@ -19214,8 +19106,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.MarathonApp}
    */
   public static final class MarathonApp extends
-      com.google.protobuf.GeneratedMessage
-      implements MarathonAppOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.MarathonApp)
+      MarathonAppOrBuilder {
     // Use MarathonApp.newBuilder() to construct.
     private MarathonApp(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -19262,8 +19155,9 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              name_ = input.readBytes();
+              name_ = bs;
               break;
             }
             case 18: {
@@ -19317,7 +19211,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // optional string name = 1;
     public static final int NAME_FIELD_NUMBER = 1;
     private java.lang.Object name_;
     /**
@@ -19360,7 +19253,6 @@ public final class Protos {
       }
     }
 
-    // repeated .mesosphere.marathon.MarathonTask tasks = 2;
     public static final int TASKS_FIELD_NUMBER = 2;
     private java.util.List<mesosphere.marathon.Protos.MarathonTask> tasks_;
     /**
@@ -19403,7 +19295,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       for (int i = 0; i < getTasksCount(); i++) {
         if (!getTasks(i).isInitialized()) {
@@ -19523,8 +19416,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.MarathonApp}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.MarathonAppOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.MarathonApp)
+        mesosphere.marathon.Protos.MarathonAppOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_MarathonApp_descriptor;
@@ -19687,7 +19581,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // optional string name = 1;
       private java.lang.Object name_ = "";
       /**
        * <code>optional string name = 1;</code>
@@ -19701,9 +19594,12 @@ public final class Protos {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          name_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            name_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -19761,7 +19657,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated .mesosphere.marathon.MarathonTask tasks = 2;
       private java.util.List<mesosphere.marathon.Protos.MarathonTask> tasks_ =
         java.util.Collections.emptyList();
       private void ensureTasksIsMutable() {
@@ -19903,7 +19798,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.MarathonTask> values) {
         if (tasksBuilder_ == null) {
           ensureTasksIsMutable();
-          super.addAll(values, tasks_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, tasks_);
           onChanged();
         } else {
           tasksBuilder_.addAllMessages(values);
@@ -20012,10 +19908,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.MarathonApp)
   }
 
-  public interface ContainerInfoOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface ContainerInfoOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ContainerInfo)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required bytes image = 1 [default = ""];
     /**
      * <code>required bytes image = 1 [default = ""];</code>
      */
@@ -20025,7 +19921,6 @@ public final class Protos {
      */
     com.google.protobuf.ByteString getImage();
 
-    // repeated bytes options = 2;
     /**
      * <code>repeated bytes options = 2;</code>
      */
@@ -20043,8 +19938,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ContainerInfo}
    */
   public static final class ContainerInfo extends
-      com.google.protobuf.GeneratedMessage
-      implements ContainerInfoOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ContainerInfo)
+      ContainerInfoOrBuilder {
     // Use ContainerInfo.newBuilder() to construct.
     private ContainerInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -20146,7 +20042,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required bytes image = 1 [default = ""];
     public static final int IMAGE_FIELD_NUMBER = 1;
     private com.google.protobuf.ByteString image_;
     /**
@@ -20162,7 +20057,6 @@ public final class Protos {
       return image_;
     }
 
-    // repeated bytes options = 2;
     public static final int OPTIONS_FIELD_NUMBER = 2;
     private java.util.List<com.google.protobuf.ByteString> options_;
     /**
@@ -20192,7 +20086,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasImage()) {
         memoizedIsInitialized = 0;
@@ -20315,8 +20210,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ContainerInfo}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.ContainerInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ContainerInfo)
+        mesosphere.marathon.Protos.ContainerInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ContainerInfo_descriptor;
@@ -20450,7 +20346,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required bytes image = 1 [default = ""];
       private com.google.protobuf.ByteString image_ = com.google.protobuf.Internal.bytesDefaultValue("");
       /**
        * <code>required bytes image = 1 [default = ""];</code>
@@ -20486,7 +20381,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated bytes options = 2;
       private java.util.List<com.google.protobuf.ByteString> options_ = java.util.Collections.emptyList();
       private void ensureOptionsIsMutable() {
         if (!((bitField0_ & 0x00000002) == 0x00000002)) {
@@ -20544,7 +20438,8 @@ public final class Protos {
       public Builder addAllOptions(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
         ensureOptionsIsMutable();
-        super.addAll(values, options_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, options_);
         onChanged();
         return this;
       }
@@ -20569,10 +20464,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ContainerInfo)
   }
 
-  public interface ExtendedContainerInfoOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface ExtendedContainerInfoOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ExtendedContainerInfo)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required .mesos.ContainerInfo.Type type = 1;
     /**
      * <code>required .mesos.ContainerInfo.Type type = 1;</code>
      */
@@ -20582,7 +20477,6 @@ public final class Protos {
      */
     org.apache.mesos.Protos.ContainerInfo.Type getType();
 
-    // repeated .mesosphere.marathon.Volume volumes = 2;
     /**
      * <code>repeated .mesosphere.marathon.Volume volumes = 2;</code>
      */
@@ -20607,7 +20501,6 @@ public final class Protos {
     mesosphere.marathon.Protos.VolumeOrBuilder getVolumesOrBuilder(
         int index);
 
-    // optional .mesosphere.marathon.ExtendedContainerInfo.DockerInfo docker = 3;
     /**
      * <code>optional .mesosphere.marathon.ExtendedContainerInfo.DockerInfo docker = 3;</code>
      */
@@ -20621,7 +20514,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfoOrBuilder getDockerOrBuilder();
 
-    // optional .mesosphere.marathon.ExtendedContainerInfo.MesosDockerInfo mesosDocker = 4;
     /**
      * <code>optional .mesosphere.marathon.ExtendedContainerInfo.MesosDockerInfo mesosDocker = 4;</code>
      */
@@ -20635,7 +20527,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfoOrBuilder getMesosDockerOrBuilder();
 
-    // optional .mesosphere.marathon.ExtendedContainerInfo.MesosAppCInfo mesosAppC = 5;
     /**
      * <code>optional .mesosphere.marathon.ExtendedContainerInfo.MesosAppCInfo mesosAppC = 5;</code>
      */
@@ -20658,8 +20549,9 @@ public final class Protos {
    * </pre>
    */
   public static final class ExtendedContainerInfo extends
-      com.google.protobuf.GeneratedMessage
-      implements ExtendedContainerInfoOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ExtendedContainerInfo)
+      ExtendedContainerInfoOrBuilder {
     // Use ExtendedContainerInfo.newBuilder() to construct.
     private ExtendedContainerInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -20805,10 +20697,10 @@ public final class Protos {
       return PARSER;
     }
 
-    public interface DockerInfoOrBuilder
-        extends com.google.protobuf.MessageOrBuilder {
+    public interface DockerInfoOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ExtendedContainerInfo.DockerInfo)
+        com.google.protobuf.MessageOrBuilder {
 
-      // required string image = 1;
       /**
        * <code>required string image = 1;</code>
        */
@@ -20823,7 +20715,6 @@ public final class Protos {
       com.google.protobuf.ByteString
           getImageBytes();
 
-      // optional .mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];
       /**
        * <code>optional .mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];</code>
        */
@@ -20833,7 +20724,6 @@ public final class Protos {
        */
       org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network getNetwork();
 
-      // repeated .mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping port_mappings = 3;
       /**
        * <code>repeated .mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping port_mappings = 3;</code>
        */
@@ -20858,7 +20748,6 @@ public final class Protos {
       mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMappingOrBuilder getPortMappingsOrBuilder(
           int index);
 
-      // optional bool privileged = 4 [default = false];
       /**
        * <code>optional bool privileged = 4 [default = false];</code>
        */
@@ -20868,7 +20757,6 @@ public final class Protos {
        */
       boolean getPrivileged();
 
-      // repeated .mesos.Parameter parameters = 5;
       /**
        * <code>repeated .mesos.Parameter parameters = 5;</code>
        *
@@ -20928,7 +20816,6 @@ public final class Protos {
       org.apache.mesos.Protos.ParameterOrBuilder getParametersOrBuilder(
           int index);
 
-      // optional bool force_pull_image = 6;
       /**
        * <code>optional bool force_pull_image = 6;</code>
        *
@@ -20958,8 +20845,9 @@ public final class Protos {
      * </pre>
      */
     public static final class DockerInfo extends
-        com.google.protobuf.GeneratedMessage
-        implements DockerInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage implements
+        // @@protoc_insertion_point(message_implements:mesosphere.marathon.ExtendedContainerInfo.DockerInfo)
+        DockerInfoOrBuilder {
       // Use DockerInfo.newBuilder() to construct.
       private DockerInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -21006,8 +20894,9 @@ public final class Protos {
                 break;
               }
               case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
-                image_ = input.readBytes();
+                image_ = bs;
                 break;
               }
               case 16: {
@@ -21092,10 +20981,10 @@ public final class Protos {
         return PARSER;
       }
 
-      public interface PortMappingOrBuilder
-          extends com.google.protobuf.MessageOrBuilder {
+      public interface PortMappingOrBuilder extends
+          // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping)
+          com.google.protobuf.MessageOrBuilder {
 
-        // optional uint32 host_port = 1;
         /**
          * <code>optional uint32 host_port = 1;</code>
          */
@@ -21105,7 +20994,6 @@ public final class Protos {
          */
         int getHostPort();
 
-        // required uint32 container_port = 2;
         /**
          * <code>required uint32 container_port = 2;</code>
          */
@@ -21115,7 +21003,6 @@ public final class Protos {
          */
         int getContainerPort();
 
-        // optional string protocol = 3;
         /**
          * <code>optional string protocol = 3;</code>
          */
@@ -21130,7 +21017,6 @@ public final class Protos {
         com.google.protobuf.ByteString
             getProtocolBytes();
 
-        // optional string name = 4;
         /**
          * <code>optional string name = 4;</code>
          */
@@ -21145,7 +21031,6 @@ public final class Protos {
         com.google.protobuf.ByteString
             getNameBytes();
 
-        // repeated .mesos.Label labels = 5;
         /**
          * <code>repeated .mesos.Label labels = 5;</code>
          */
@@ -21170,7 +21055,6 @@ public final class Protos {
         org.apache.mesos.Protos.LabelOrBuilder getLabelsOrBuilder(
             int index);
 
-        // optional uint32 service_port = 100 [default = 0];
         /**
          * <code>optional uint32 service_port = 100 [default = 0];</code>
          */
@@ -21184,8 +21068,9 @@ public final class Protos {
        * Protobuf type {@code mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping}
        */
       public static final class PortMapping extends
-          com.google.protobuf.GeneratedMessage
-          implements PortMappingOrBuilder {
+          com.google.protobuf.GeneratedMessage implements
+          // @@protoc_insertion_point(message_implements:mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping)
+          PortMappingOrBuilder {
         // Use PortMapping.newBuilder() to construct.
         private PortMapping(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
           super(builder);
@@ -21242,13 +21127,15 @@ public final class Protos {
                   break;
                 }
                 case 26: {
+                  com.google.protobuf.ByteString bs = input.readBytes();
                   bitField0_ |= 0x00000004;
-                  protocol_ = input.readBytes();
+                  protocol_ = bs;
                   break;
                 }
                 case 34: {
+                  com.google.protobuf.ByteString bs = input.readBytes();
                   bitField0_ |= 0x00000008;
-                  name_ = input.readBytes();
+                  name_ = bs;
                   break;
                 }
                 case 42: {
@@ -21307,7 +21194,6 @@ public final class Protos {
         }
 
         private int bitField0_;
-        // optional uint32 host_port = 1;
         public static final int HOST_PORT_FIELD_NUMBER = 1;
         private int hostPort_;
         /**
@@ -21323,7 +21209,6 @@ public final class Protos {
           return hostPort_;
         }
 
-        // required uint32 container_port = 2;
         public static final int CONTAINER_PORT_FIELD_NUMBER = 2;
         private int containerPort_;
         /**
@@ -21339,7 +21224,6 @@ public final class Protos {
           return containerPort_;
         }
 
-        // optional string protocol = 3;
         public static final int PROTOCOL_FIELD_NUMBER = 3;
         private java.lang.Object protocol_;
         /**
@@ -21382,7 +21266,6 @@ public final class Protos {
           }
         }
 
-        // optional string name = 4;
         public static final int NAME_FIELD_NUMBER = 4;
         private java.lang.Object name_;
         /**
@@ -21425,7 +21308,6 @@ public final class Protos {
           }
         }
 
-        // repeated .mesos.Label labels = 5;
         public static final int LABELS_FIELD_NUMBER = 5;
         private java.util.List<org.apache.mesos.Protos.Label> labels_;
         /**
@@ -21461,7 +21343,6 @@ public final class Protos {
           return labels_.get(index);
         }
 
-        // optional uint32 service_port = 100 [default = 0];
         public static final int SERVICE_PORT_FIELD_NUMBER = 100;
         private int servicePort_;
         /**
@@ -21488,7 +21369,8 @@ public final class Protos {
         private byte memoizedIsInitialized = -1;
         public final boolean isInitialized() {
           byte isInitialized = memoizedIsInitialized;
-          if (isInitialized != -1) return isInitialized == 1;
+          if (isInitialized == 1) return true;
+          if (isInitialized == 0) return false;
 
           if (!hasContainerPort()) {
             memoizedIsInitialized = 0;
@@ -21640,8 +21522,9 @@ public final class Protos {
          * Protobuf type {@code mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping}
          */
         public static final class Builder extends
-            com.google.protobuf.GeneratedMessage.Builder<Builder>
-           implements mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMappingOrBuilder {
+            com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+            // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping)
+            mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMappingOrBuilder {
           public static final com.google.protobuf.Descriptors.Descriptor
               getDescriptor() {
             return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor;
@@ -21846,7 +21729,6 @@ public final class Protos {
           }
           private int bitField0_;
 
-          // optional uint32 host_port = 1;
           private int hostPort_ ;
           /**
            * <code>optional uint32 host_port = 1;</code>
@@ -21879,7 +21761,6 @@ public final class Protos {
             return this;
           }
 
-          // required uint32 container_port = 2;
           private int containerPort_ ;
           /**
            * <code>required uint32 container_port = 2;</code>
@@ -21912,7 +21793,6 @@ public final class Protos {
             return this;
           }
 
-          // optional string protocol = 3;
           private java.lang.Object protocol_ = "";
           /**
            * <code>optional string protocol = 3;</code>
@@ -21926,9 +21806,12 @@ public final class Protos {
           public java.lang.String getProtocol() {
             java.lang.Object ref = protocol_;
             if (!(ref instanceof java.lang.String)) {
-              java.lang.String s = ((com.google.protobuf.ByteString) ref)
-                  .toStringUtf8();
-              protocol_ = s;
+              com.google.protobuf.ByteString bs =
+                  (com.google.protobuf.ByteString) ref;
+              java.lang.String s = bs.toStringUtf8();
+              if (bs.isValidUtf8()) {
+                protocol_ = s;
+              }
               return s;
             } else {
               return (java.lang.String) ref;
@@ -21986,7 +21869,6 @@ public final class Protos {
             return this;
           }
 
-          // optional string name = 4;
           private java.lang.Object name_ = "";
           /**
            * <code>optional string name = 4;</code>
@@ -22000,9 +21882,12 @@ public final class Protos {
           public java.lang.String getName() {
             java.lang.Object ref = name_;
             if (!(ref instanceof java.lang.String)) {
-              java.lang.String s = ((com.google.protobuf.ByteString) ref)
-                  .toStringUtf8();
-              name_ = s;
+              com.google.protobuf.ByteString bs =
+                  (com.google.protobuf.ByteString) ref;
+              java.lang.String s = bs.toStringUtf8();
+              if (bs.isValidUtf8()) {
+                name_ = s;
+              }
               return s;
             } else {
               return (java.lang.String) ref;
@@ -22060,7 +21945,6 @@ public final class Protos {
             return this;
           }
 
-          // repeated .mesos.Label labels = 5;
           private java.util.List<org.apache.mesos.Protos.Label> labels_ =
             java.util.Collections.emptyList();
           private void ensureLabelsIsMutable() {
@@ -22202,7 +22086,8 @@ public final class Protos {
               java.lang.Iterable<? extends org.apache.mesos.Protos.Label> values) {
             if (labelsBuilder_ == null) {
               ensureLabelsIsMutable();
-              super.addAll(values, labels_);
+              com.google.protobuf.AbstractMessageLite.Builder.addAll(
+                  values, labels_);
               onChanged();
             } else {
               labelsBuilder_.addAllMessages(values);
@@ -22300,7 +22185,6 @@ public final class Protos {
             return labelsBuilder_;
           }
 
-          // optional uint32 service_port = 100 [default = 0];
           private int servicePort_ ;
           /**
            * <code>optional uint32 service_port = 100 [default = 0];</code>
@@ -22345,7 +22229,6 @@ public final class Protos {
       }
 
       private int bitField0_;
-      // required string image = 1;
       public static final int IMAGE_FIELD_NUMBER = 1;
       private java.lang.Object image_;
       /**
@@ -22388,7 +22271,6 @@ public final class Protos {
         }
       }
 
-      // optional .mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];
       public static final int NETWORK_FIELD_NUMBER = 2;
       private org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network network_;
       /**
@@ -22404,7 +22286,6 @@ public final class Protos {
         return network_;
       }
 
-      // repeated .mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping port_mappings = 3;
       public static final int PORT_MAPPINGS_FIELD_NUMBER = 3;
       private java.util.List<mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMapping> portMappings_;
       /**
@@ -22440,7 +22321,6 @@ public final class Protos {
         return portMappings_.get(index);
       }
 
-      // optional bool privileged = 4 [default = false];
       public static final int PRIVILEGED_FIELD_NUMBER = 4;
       private boolean privileged_;
       /**
@@ -22456,7 +22336,6 @@ public final class Protos {
         return privileged_;
       }
 
-      // repeated .mesos.Parameter parameters = 5;
       public static final int PARAMETERS_FIELD_NUMBER = 5;
       private java.util.List<org.apache.mesos.Protos.Parameter> parameters_;
       /**
@@ -22527,7 +22406,6 @@ public final class Protos {
         return parameters_.get(index);
       }
 
-      // optional bool force_pull_image = 6;
       public static final int FORCE_PULL_IMAGE_FIELD_NUMBER = 6;
       private boolean forcePullImage_;
       /**
@@ -22566,7 +22444,8 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
 
         if (!hasImage()) {
           memoizedIsInitialized = 0;
@@ -22728,8 +22607,9 @@ public final class Protos {
        * </pre>
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfoOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ExtendedContainerInfo.DockerInfo)
+          mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfoOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor;
@@ -22971,7 +22851,6 @@ public final class Protos {
         }
         private int bitField0_;
 
-        // required string image = 1;
         private java.lang.Object image_ = "";
         /**
          * <code>required string image = 1;</code>
@@ -22985,9 +22864,12 @@ public final class Protos {
         public java.lang.String getImage() {
           java.lang.Object ref = image_;
           if (!(ref instanceof java.lang.String)) {
-            java.lang.String s = ((com.google.protobuf.ByteString) ref)
-                .toStringUtf8();
-            image_ = s;
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              image_ = s;
+            }
             return s;
           } else {
             return (java.lang.String) ref;
@@ -23045,7 +22927,6 @@ public final class Protos {
           return this;
         }
 
-        // optional .mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];
         private org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network network_ = org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network.HOST;
         /**
          * <code>optional .mesos.ContainerInfo.DockerInfo.Network network = 2 [default = HOST];</code>
@@ -23081,7 +22962,6 @@ public final class Protos {
           return this;
         }
 
-        // repeated .mesosphere.marathon.ExtendedContainerInfo.DockerInfo.PortMapping port_mappings = 3;
         private java.util.List<mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMapping> portMappings_ =
           java.util.Collections.emptyList();
         private void ensurePortMappingsIsMutable() {
@@ -23223,7 +23103,8 @@ public final class Protos {
             java.lang.Iterable<? extends mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.PortMapping> values) {
           if (portMappingsBuilder_ == null) {
             ensurePortMappingsIsMutable();
-            super.addAll(values, portMappings_);
+            com.google.protobuf.AbstractMessageLite.Builder.addAll(
+                values, portMappings_);
             onChanged();
           } else {
             portMappingsBuilder_.addAllMessages(values);
@@ -23321,7 +23202,6 @@ public final class Protos {
           return portMappingsBuilder_;
         }
 
-        // optional bool privileged = 4 [default = false];
         private boolean privileged_ ;
         /**
          * <code>optional bool privileged = 4 [default = false];</code>
@@ -23354,7 +23234,6 @@ public final class Protos {
           return this;
         }
 
-        // repeated .mesos.Parameter parameters = 5;
         private java.util.List<org.apache.mesos.Protos.Parameter> parameters_ =
           java.util.Collections.emptyList();
         private void ensureParametersIsMutable() {
@@ -23566,7 +23445,8 @@ public final class Protos {
             java.lang.Iterable<? extends org.apache.mesos.Protos.Parameter> values) {
           if (parametersBuilder_ == null) {
             ensureParametersIsMutable();
-            super.addAll(values, parameters_);
+            com.google.protobuf.AbstractMessageLite.Builder.addAll(
+                values, parameters_);
             onChanged();
           } else {
             parametersBuilder_.addAllMessages(values);
@@ -23720,7 +23600,6 @@ public final class Protos {
           return parametersBuilder_;
         }
 
-        // optional bool force_pull_image = 6;
         private boolean forcePullImage_ ;
         /**
          * <code>optional bool force_pull_image = 6;</code>
@@ -23788,17 +23667,16 @@ public final class Protos {
       // @@protoc_insertion_point(class_scope:mesosphere.marathon.ExtendedContainerInfo.DockerInfo)
     }
 
-    public interface MesosDockerInfoOrBuilder
-        extends com.google.protobuf.MessageOrBuilder {
+    public interface MesosDockerInfoOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ExtendedContainerInfo.MesosDockerInfo)
+        com.google.protobuf.MessageOrBuilder {
 
-      // required string image = 1;
       /**
        * <code>required string image = 1;</code>
        *
        * <pre>
        * The name of the image. Expected format:
-       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-       *
+       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
        * See: https://docs.docker.com/reference/commandline/pull/
        * </pre>
        */
@@ -23808,8 +23686,7 @@ public final class Protos {
        *
        * <pre>
        * The name of the image. Expected format:
-       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-       *
+       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
        * See: https://docs.docker.com/reference/commandline/pull/
        * </pre>
        */
@@ -23819,15 +23696,13 @@ public final class Protos {
        *
        * <pre>
        * The name of the image. Expected format:
-       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-       *
+       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
        * See: https://docs.docker.com/reference/commandline/pull/
        * </pre>
        */
       com.google.protobuf.ByteString
           getImageBytes();
 
-      // optional .mesos.Credential credential = 2;
       /**
        * <code>optional .mesos.Credential credential = 2;</code>
        *
@@ -23859,7 +23734,6 @@ public final class Protos {
        */
       org.apache.mesos.Protos.CredentialOrBuilder getCredentialOrBuilder();
 
-      // optional bool force_pull_image = 3;
       /**
        * <code>optional bool force_pull_image = 3;</code>
        *
@@ -23889,8 +23763,9 @@ public final class Protos {
      * </pre>
      */
     public static final class MesosDockerInfo extends
-        com.google.protobuf.GeneratedMessage
-        implements MesosDockerInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage implements
+        // @@protoc_insertion_point(message_implements:mesosphere.marathon.ExtendedContainerInfo.MesosDockerInfo)
+        MesosDockerInfoOrBuilder {
       // Use MesosDockerInfo.newBuilder() to construct.
       private MesosDockerInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -23937,8 +23812,9 @@ public final class Protos {
                 break;
               }
               case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
-                image_ = input.readBytes();
+                image_ = bs;
                 break;
               }
               case 18: {
@@ -23999,7 +23875,6 @@ public final class Protos {
       }
 
       private int bitField0_;
-      // required string image = 1;
       public static final int IMAGE_FIELD_NUMBER = 1;
       private java.lang.Object image_;
       /**
@@ -24007,8 +23882,7 @@ public final class Protos {
        *
        * <pre>
        * The name of the image. Expected format:
-       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-       *
+       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
        * See: https://docs.docker.com/reference/commandline/pull/
        * </pre>
        */
@@ -24020,8 +23894,7 @@ public final class Protos {
        *
        * <pre>
        * The name of the image. Expected format:
-       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-       *
+       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
        * See: https://docs.docker.com/reference/commandline/pull/
        * </pre>
        */
@@ -24044,8 +23917,7 @@ public final class Protos {
        *
        * <pre>
        * The name of the image. Expected format:
-       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-       *
+       *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
        * See: https://docs.docker.com/reference/commandline/pull/
        * </pre>
        */
@@ -24063,7 +23935,6 @@ public final class Protos {
         }
       }
 
-      // optional .mesos.Credential credential = 2;
       public static final int CREDENTIAL_FIELD_NUMBER = 2;
       private org.apache.mesos.Protos.Credential credential_;
       /**
@@ -24103,7 +23974,6 @@ public final class Protos {
         return credential_;
       }
 
-      // optional bool force_pull_image = 3;
       public static final int FORCE_PULL_IMAGE_FIELD_NUMBER = 3;
       private boolean forcePullImage_;
       /**
@@ -24139,7 +24009,8 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
 
         if (!hasImage()) {
           memoizedIsInitialized = 0;
@@ -24274,8 +24145,9 @@ public final class Protos {
        * </pre>
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfoOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ExtendedContainerInfo.MesosDockerInfo)
+          mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfoOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_descriptor;
@@ -24427,15 +24299,13 @@ public final class Protos {
         }
         private int bitField0_;
 
-        // required string image = 1;
         private java.lang.Object image_ = "";
         /**
          * <code>required string image = 1;</code>
          *
          * <pre>
          * The name of the image. Expected format:
-         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-         *
+         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
          * See: https://docs.docker.com/reference/commandline/pull/
          * </pre>
          */
@@ -24447,17 +24317,19 @@ public final class Protos {
          *
          * <pre>
          * The name of the image. Expected format:
-         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-         *
+         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
          * See: https://docs.docker.com/reference/commandline/pull/
          * </pre>
          */
         public java.lang.String getImage() {
           java.lang.Object ref = image_;
           if (!(ref instanceof java.lang.String)) {
-            java.lang.String s = ((com.google.protobuf.ByteString) ref)
-                .toStringUtf8();
-            image_ = s;
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              image_ = s;
+            }
             return s;
           } else {
             return (java.lang.String) ref;
@@ -24468,8 +24340,7 @@ public final class Protos {
          *
          * <pre>
          * The name of the image. Expected format:
-         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-         *
+         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
          * See: https://docs.docker.com/reference/commandline/pull/
          * </pre>
          */
@@ -24491,8 +24362,7 @@ public final class Protos {
          *
          * <pre>
          * The name of the image. Expected format:
-         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-         *
+         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
          * See: https://docs.docker.com/reference/commandline/pull/
          * </pre>
          */
@@ -24511,8 +24381,7 @@ public final class Protos {
          *
          * <pre>
          * The name of the image. Expected format:
-         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-         *
+         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
          * See: https://docs.docker.com/reference/commandline/pull/
          * </pre>
          */
@@ -24527,8 +24396,7 @@ public final class Protos {
          *
          * <pre>
          * The name of the image. Expected format:
-         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@TYPE:DIGEST]
-         *
+         *   [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|&#64;TYPE:DIGEST]
          * See: https://docs.docker.com/reference/commandline/pull/
          * </pre>
          */
@@ -24543,7 +24411,6 @@ public final class Protos {
           return this;
         }
 
-        // optional .mesos.Credential credential = 2;
         private org.apache.mesos.Protos.Credential credential_ = org.apache.mesos.Protos.Credential.getDefaultInstance();
         private com.google.protobuf.SingleFieldBuilder<
             org.apache.mesos.Protos.Credential, org.apache.mesos.Protos.Credential.Builder, org.apache.mesos.Protos.CredentialOrBuilder> credentialBuilder_;
@@ -24706,7 +24573,7 @@ public final class Protos {
           if (credentialBuilder_ == null) {
             credentialBuilder_ = new com.google.protobuf.SingleFieldBuilder<
                 org.apache.mesos.Protos.Credential, org.apache.mesos.Protos.Credential.Builder, org.apache.mesos.Protos.CredentialOrBuilder>(
-                    credential_,
+                    getCredential(),
                     getParentForChildren(),
                     isClean());
             credential_ = null;
@@ -24714,7 +24581,6 @@ public final class Protos {
           return credentialBuilder_;
         }
 
-        // optional bool force_pull_image = 3;
         private boolean forcePullImage_ ;
         /**
          * <code>optional bool force_pull_image = 3;</code>
@@ -24782,10 +24648,10 @@ public final class Protos {
       // @@protoc_insertion_point(class_scope:mesosphere.marathon.ExtendedContainerInfo.MesosDockerInfo)
     }
 
-    public interface MesosAppCInfoOrBuilder
-        extends com.google.protobuf.MessageOrBuilder {
+    public interface MesosAppCInfoOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ExtendedContainerInfo.MesosAppCInfo)
+        com.google.protobuf.MessageOrBuilder {
 
-      // required string image = 1;
       /**
        * <code>required string image = 1;</code>
        *
@@ -24812,7 +24678,6 @@ public final class Protos {
       com.google.protobuf.ByteString
           getImageBytes();
 
-      // optional string id = 2;
       /**
        * <code>optional string id = 2;</code>
        *
@@ -24848,7 +24713,6 @@ public final class Protos {
       com.google.protobuf.ByteString
           getIdBytes();
 
-      // repeated .mesos.Label labels = 3;
       /**
        * <code>repeated .mesos.Label labels = 3;</code>
        *
@@ -24893,7 +24757,6 @@ public final class Protos {
       org.apache.mesos.Protos.LabelOrBuilder getLabelsOrBuilder(
           int index);
 
-      // optional bool force_pull_image = 4;
       /**
        * <code>optional bool force_pull_image = 4;</code>
        *
@@ -24923,8 +24786,9 @@ public final class Protos {
      * </pre>
      */
     public static final class MesosAppCInfo extends
-        com.google.protobuf.GeneratedMessage
-        implements MesosAppCInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage implements
+        // @@protoc_insertion_point(message_implements:mesosphere.marathon.ExtendedContainerInfo.MesosAppCInfo)
+        MesosAppCInfoOrBuilder {
       // Use MesosAppCInfo.newBuilder() to construct.
       private MesosAppCInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -24971,13 +24835,15 @@ public final class Protos {
                 break;
               }
               case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
-                image_ = input.readBytes();
+                image_ = bs;
                 break;
               }
               case 18: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000002;
-                id_ = input.readBytes();
+                id_ = bs;
                 break;
               }
               case 26: {
@@ -25036,7 +24902,6 @@ public final class Protos {
       }
 
       private int bitField0_;
-      // required string image = 1;
       public static final int IMAGE_FIELD_NUMBER = 1;
       private java.lang.Object image_;
       /**
@@ -25091,7 +24956,6 @@ public final class Protos {
         }
       }
 
-      // optional string id = 2;
       public static final int ID_FIELD_NUMBER = 2;
       private java.lang.Object id_;
       /**
@@ -25155,7 +25019,6 @@ public final class Protos {
         }
       }
 
-      // repeated .mesos.Label labels = 3;
       public static final int LABELS_FIELD_NUMBER = 3;
       private java.util.List<org.apache.mesos.Protos.Label> labels_;
       /**
@@ -25211,7 +25074,6 @@ public final class Protos {
         return labels_.get(index);
       }
 
-      // optional bool force_pull_image = 4;
       public static final int FORCE_PULL_IMAGE_FIELD_NUMBER = 4;
       private boolean forcePullImage_;
       /**
@@ -25248,7 +25110,8 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
 
         if (!hasImage()) {
           memoizedIsInitialized = 0;
@@ -25390,8 +25253,9 @@ public final class Protos {
        * </pre>
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfoOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ExtendedContainerInfo.MesosAppCInfo)
+          mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfoOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_descriptor;
@@ -25578,7 +25442,6 @@ public final class Protos {
         }
         private int bitField0_;
 
-        // required string image = 1;
         private java.lang.Object image_ = "";
         /**
          * <code>required string image = 1;</code>
@@ -25600,9 +25463,12 @@ public final class Protos {
         public java.lang.String getImage() {
           java.lang.Object ref = image_;
           if (!(ref instanceof java.lang.String)) {
-            java.lang.String s = ((com.google.protobuf.ByteString) ref)
-                .toStringUtf8();
-            image_ = s;
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              image_ = s;
+            }
             return s;
           } else {
             return (java.lang.String) ref;
@@ -25676,7 +25542,6 @@ public final class Protos {
           return this;
         }
 
-        // optional string id = 2;
         private java.lang.Object id_ = "";
         /**
          * <code>optional string id = 2;</code>
@@ -25704,9 +25569,12 @@ public final class Protos {
         public java.lang.String getId() {
           java.lang.Object ref = id_;
           if (!(ref instanceof java.lang.String)) {
-            java.lang.String s = ((com.google.protobuf.ByteString) ref)
-                .toStringUtf8();
-            id_ = s;
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              id_ = s;
+            }
             return s;
           } else {
             return (java.lang.String) ref;
@@ -25792,7 +25660,6 @@ public final class Protos {
           return this;
         }
 
-        // repeated .mesos.Label labels = 3;
         private java.util.List<org.apache.mesos.Protos.Label> labels_ =
           java.util.Collections.emptyList();
         private void ensureLabelsIsMutable() {
@@ -25974,7 +25841,8 @@ public final class Protos {
             java.lang.Iterable<? extends org.apache.mesos.Protos.Label> values) {
           if (labelsBuilder_ == null) {
             ensureLabelsIsMutable();
-            super.addAll(values, labels_);
+            com.google.protobuf.AbstractMessageLite.Builder.addAll(
+                values, labels_);
             onChanged();
           } else {
             labelsBuilder_.addAllMessages(values);
@@ -26104,7 +25972,6 @@ public final class Protos {
           return labelsBuilder_;
         }
 
-        // optional bool force_pull_image = 4;
         private boolean forcePullImage_ ;
         /**
          * <code>optional bool force_pull_image = 4;</code>
@@ -26173,7 +26040,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required .mesos.ContainerInfo.Type type = 1;
     public static final int TYPE_FIELD_NUMBER = 1;
     private org.apache.mesos.Protos.ContainerInfo.Type type_;
     /**
@@ -26189,7 +26055,6 @@ public final class Protos {
       return type_;
     }
 
-    // repeated .mesosphere.marathon.Volume volumes = 2;
     public static final int VOLUMES_FIELD_NUMBER = 2;
     private java.util.List<mesosphere.marathon.Protos.Volume> volumes_;
     /**
@@ -26225,7 +26090,6 @@ public final class Protos {
       return volumes_.get(index);
     }
 
-    // optional .mesosphere.marathon.ExtendedContainerInfo.DockerInfo docker = 3;
     public static final int DOCKER_FIELD_NUMBER = 3;
     private mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo docker_;
     /**
@@ -26247,7 +26111,6 @@ public final class Protos {
       return docker_;
     }
 
-    // optional .mesosphere.marathon.ExtendedContainerInfo.MesosDockerInfo mesosDocker = 4;
     public static final int MESOSDOCKER_FIELD_NUMBER = 4;
     private mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfo mesosDocker_;
     /**
@@ -26269,7 +26132,6 @@ public final class Protos {
       return mesosDocker_;
     }
 
-    // optional .mesosphere.marathon.ExtendedContainerInfo.MesosAppCInfo mesosAppC = 5;
     public static final int MESOSAPPC_FIELD_NUMBER = 5;
     private mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfo mesosAppC_;
     /**
@@ -26301,7 +26163,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasType()) {
         memoizedIsInitialized = 0;
@@ -26469,8 +26332,9 @@ public final class Protos {
      * </pre>
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.ExtendedContainerInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ExtendedContainerInfo)
+        mesosphere.marathon.Protos.ExtendedContainerInfoOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor;
@@ -26707,7 +26571,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required .mesos.ContainerInfo.Type type = 1;
       private org.apache.mesos.Protos.ContainerInfo.Type type_ = org.apache.mesos.Protos.ContainerInfo.Type.DOCKER;
       /**
        * <code>required .mesos.ContainerInfo.Type type = 1;</code>
@@ -26743,7 +26606,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated .mesosphere.marathon.Volume volumes = 2;
       private java.util.List<mesosphere.marathon.Protos.Volume> volumes_ =
         java.util.Collections.emptyList();
       private void ensureVolumesIsMutable() {
@@ -26885,7 +26747,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.Volume> values) {
         if (volumesBuilder_ == null) {
           ensureVolumesIsMutable();
-          super.addAll(values, volumes_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, volumes_);
           onChanged();
         } else {
           volumesBuilder_.addAllMessages(values);
@@ -26983,7 +26846,6 @@ public final class Protos {
         return volumesBuilder_;
       }
 
-      // optional .mesosphere.marathon.ExtendedContainerInfo.DockerInfo docker = 3;
       private mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo docker_ = mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfoOrBuilder> dockerBuilder_;
@@ -27092,7 +26954,7 @@ public final class Protos {
         if (dockerBuilder_ == null) {
           dockerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfo.DockerInfoOrBuilder>(
-                  docker_,
+                  getDocker(),
                   getParentForChildren(),
                   isClean());
           docker_ = null;
@@ -27100,7 +26962,6 @@ public final class Protos {
         return dockerBuilder_;
       }
 
-      // optional .mesosphere.marathon.ExtendedContainerInfo.MesosDockerInfo mesosDocker = 4;
       private mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfo mesosDocker_ = mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfoOrBuilder> mesosDockerBuilder_;
@@ -27209,7 +27070,7 @@ public final class Protos {
         if (mesosDockerBuilder_ == null) {
           mesosDockerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfo.MesosDockerInfoOrBuilder>(
-                  mesosDocker_,
+                  getMesosDocker(),
                   getParentForChildren(),
                   isClean());
           mesosDocker_ = null;
@@ -27217,7 +27078,6 @@ public final class Protos {
         return mesosDockerBuilder_;
       }
 
-      // optional .mesosphere.marathon.ExtendedContainerInfo.MesosAppCInfo mesosAppC = 5;
       private mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfo mesosAppC_ = mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfoOrBuilder> mesosAppCBuilder_;
@@ -27326,7 +27186,7 @@ public final class Protos {
         if (mesosAppCBuilder_ == null) {
           mesosAppCBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfo, mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfo.Builder, mesosphere.marathon.Protos.ExtendedContainerInfo.MesosAppCInfoOrBuilder>(
-                  mesosAppC_,
+                  getMesosAppC(),
                   getParentForChildren(),
                   isClean());
           mesosAppC_ = null;
@@ -27345,10 +27205,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ExtendedContainerInfo)
   }
 
-  public interface VolumeOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface VolumeOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Volume)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required .mesos.Volume.Mode mode = 3;
     /**
      * <code>required .mesos.Volume.Mode mode = 3;</code>
      */
@@ -27358,7 +27218,6 @@ public final class Protos {
      */
     org.apache.mesos.Protos.Volume.Mode getMode();
 
-    // required string container_path = 1;
     /**
      * <code>required string container_path = 1;</code>
      *
@@ -27394,7 +27253,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getContainerPathBytes();
 
-    // optional string host_path = 2;
     /**
      * <code>optional string host_path = 2;</code>
      *
@@ -27424,7 +27282,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getHostPathBytes();
 
-    // optional .mesos.Image image = 4;
     /**
      * <code>optional .mesos.Image image = 4;</code>
      *
@@ -27453,7 +27310,6 @@ public final class Protos {
      */
     org.apache.mesos.Protos.ImageOrBuilder getImageOrBuilder();
 
-    // optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;
     /**
      * <code>optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;</code>
      *
@@ -27479,7 +27335,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder getPersistentOrBuilder();
 
-    // optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;
     /**
      * <code>optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;</code>
      *
@@ -27515,8 +27370,9 @@ public final class Protos {
    * </pre>
    */
   public static final class Volume extends
-      com.google.protobuf.GeneratedMessage
-      implements VolumeOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.Volume)
+      VolumeOrBuilder {
     // Use Volume.newBuilder() to construct.
     private Volume(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -27563,13 +27419,15 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              containerPath_ = input.readBytes();
+              containerPath_ = bs;
               break;
             }
             case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000004;
-              hostPath_ = input.readBytes();
+              hostPath_ = bs;
               break;
             }
             case 24: {
@@ -27661,10 +27519,10 @@ public final class Protos {
       return PARSER;
     }
 
-    public interface PersistentVolumeInfoOrBuilder
-        extends com.google.protobuf.MessageOrBuilder {
+    public interface PersistentVolumeInfoOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Volume.PersistentVolumeInfo)
+        com.google.protobuf.MessageOrBuilder {
 
-      // required uint64 size = 1;
       /**
        * <code>required uint64 size = 1;</code>
        */
@@ -27674,7 +27532,6 @@ public final class Protos {
        */
       long getSize();
 
-      // optional .mesos.Resource.DiskInfo.Source.Type type = 2;
       /**
        * <code>optional .mesos.Resource.DiskInfo.Source.Type type = 2;</code>
        */
@@ -27684,7 +27541,6 @@ public final class Protos {
        */
       org.apache.mesos.Protos.Resource.DiskInfo.Source.Type getType();
 
-      // repeated .mesosphere.marathon.Constraint constraints = 3;
       /**
        * <code>repeated .mesosphere.marathon.Constraint constraints = 3;</code>
        */
@@ -27709,7 +27565,6 @@ public final class Protos {
       mesosphere.marathon.Protos.ConstraintOrBuilder getConstraintsOrBuilder(
           int index);
 
-      // optional uint64 maxSize = 4;
       /**
        * <code>optional uint64 maxSize = 4;</code>
        */
@@ -27727,8 +27582,9 @@ public final class Protos {
      * </pre>
      */
     public static final class PersistentVolumeInfo extends
-        com.google.protobuf.GeneratedMessage
-        implements PersistentVolumeInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage implements
+        // @@protoc_insertion_point(message_implements:mesosphere.marathon.Volume.PersistentVolumeInfo)
+        PersistentVolumeInfoOrBuilder {
       // Use PersistentVolumeInfo.newBuilder() to construct.
       private PersistentVolumeInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -27846,7 +27702,6 @@ public final class Protos {
       }
 
       private int bitField0_;
-      // required uint64 size = 1;
       public static final int SIZE_FIELD_NUMBER = 1;
       private long size_;
       /**
@@ -27862,7 +27717,6 @@ public final class Protos {
         return size_;
       }
 
-      // optional .mesos.Resource.DiskInfo.Source.Type type = 2;
       public static final int TYPE_FIELD_NUMBER = 2;
       private org.apache.mesos.Protos.Resource.DiskInfo.Source.Type type_;
       /**
@@ -27878,7 +27732,6 @@ public final class Protos {
         return type_;
       }
 
-      // repeated .mesosphere.marathon.Constraint constraints = 3;
       public static final int CONSTRAINTS_FIELD_NUMBER = 3;
       private java.util.List<mesosphere.marathon.Protos.Constraint> constraints_;
       /**
@@ -27914,7 +27767,6 @@ public final class Protos {
         return constraints_.get(index);
       }
 
-      // optional uint64 maxSize = 4;
       public static final int MAXSIZE_FIELD_NUMBER = 4;
       private long maxSize_;
       /**
@@ -27939,7 +27791,8 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
 
         if (!hasSize()) {
           memoizedIsInitialized = 0;
@@ -28081,8 +27934,9 @@ public final class Protos {
        * </pre>
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Volume.PersistentVolumeInfo)
+          mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor;
@@ -28265,7 +28119,6 @@ public final class Protos {
         }
         private int bitField0_;
 
-        // required uint64 size = 1;
         private long size_ ;
         /**
          * <code>required uint64 size = 1;</code>
@@ -28298,7 +28151,6 @@ public final class Protos {
           return this;
         }
 
-        // optional .mesos.Resource.DiskInfo.Source.Type type = 2;
         private org.apache.mesos.Protos.Resource.DiskInfo.Source.Type type_ = org.apache.mesos.Protos.Resource.DiskInfo.Source.Type.PATH;
         /**
          * <code>optional .mesos.Resource.DiskInfo.Source.Type type = 2;</code>
@@ -28334,7 +28186,6 @@ public final class Protos {
           return this;
         }
 
-        // repeated .mesosphere.marathon.Constraint constraints = 3;
         private java.util.List<mesosphere.marathon.Protos.Constraint> constraints_ =
           java.util.Collections.emptyList();
         private void ensureConstraintsIsMutable() {
@@ -28476,7 +28327,8 @@ public final class Protos {
             java.lang.Iterable<? extends mesosphere.marathon.Protos.Constraint> values) {
           if (constraintsBuilder_ == null) {
             ensureConstraintsIsMutable();
-            super.addAll(values, constraints_);
+            com.google.protobuf.AbstractMessageLite.Builder.addAll(
+                values, constraints_);
             onChanged();
           } else {
             constraintsBuilder_.addAllMessages(values);
@@ -28574,7 +28426,6 @@ public final class Protos {
           return constraintsBuilder_;
         }
 
-        // optional uint64 maxSize = 4;
         private long maxSize_ ;
         /**
          * <code>optional uint64 maxSize = 4;</code>
@@ -28618,10 +28469,10 @@ public final class Protos {
       // @@protoc_insertion_point(class_scope:mesosphere.marathon.Volume.PersistentVolumeInfo)
     }
 
-    public interface ExternalVolumeInfoOrBuilder
-        extends com.google.protobuf.MessageOrBuilder {
+    public interface ExternalVolumeInfoOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Volume.ExternalVolumeInfo)
+        com.google.protobuf.MessageOrBuilder {
 
-      // optional uint64 size = 1;
       /**
        * <code>optional uint64 size = 1;</code>
        */
@@ -28631,7 +28482,6 @@ public final class Protos {
        */
       long getSize();
 
-      // required string name = 2;
       /**
        * <code>required string name = 2;</code>
        */
@@ -28646,7 +28496,6 @@ public final class Protos {
       com.google.protobuf.ByteString
           getNameBytes();
 
-      // required string provider = 3;
       /**
        * <code>required string provider = 3;</code>
        */
@@ -28661,7 +28510,6 @@ public final class Protos {
       com.google.protobuf.ByteString
           getProviderBytes();
 
-      // repeated .mesos.Label options = 4;
       /**
        * <code>repeated .mesos.Label options = 4;</code>
        */
@@ -28694,8 +28542,9 @@ public final class Protos {
      * </pre>
      */
     public static final class ExternalVolumeInfo extends
-        com.google.protobuf.GeneratedMessage
-        implements ExternalVolumeInfoOrBuilder {
+        com.google.protobuf.GeneratedMessage implements
+        // @@protoc_insertion_point(message_implements:mesosphere.marathon.Volume.ExternalVolumeInfo)
+        ExternalVolumeInfoOrBuilder {
       // Use ExternalVolumeInfo.newBuilder() to construct.
       private ExternalVolumeInfo(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -28747,13 +28596,15 @@ public final class Protos {
                 break;
               }
               case 18: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000002;
-                name_ = input.readBytes();
+                name_ = bs;
                 break;
               }
               case 26: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000004;
-                provider_ = input.readBytes();
+                provider_ = bs;
                 break;
               }
               case 34: {
@@ -28807,7 +28658,6 @@ public final class Protos {
       }
 
       private int bitField0_;
-      // optional uint64 size = 1;
       public static final int SIZE_FIELD_NUMBER = 1;
       private long size_;
       /**
@@ -28823,7 +28673,6 @@ public final class Protos {
         return size_;
       }
 
-      // required string name = 2;
       public static final int NAME_FIELD_NUMBER = 2;
       private java.lang.Object name_;
       /**
@@ -28866,7 +28715,6 @@ public final class Protos {
         }
       }
 
-      // required string provider = 3;
       public static final int PROVIDER_FIELD_NUMBER = 3;
       private java.lang.Object provider_;
       /**
@@ -28909,7 +28757,6 @@ public final class Protos {
         }
       }
 
-      // repeated .mesos.Label options = 4;
       public static final int OPTIONS_FIELD_NUMBER = 4;
       private java.util.List<org.apache.mesos.Protos.Label> options_;
       /**
@@ -28954,7 +28801,8 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
 
         if (!hasName()) {
           memoizedIsInitialized = 0;
@@ -29100,8 +28948,9 @@ public final class Protos {
        * </pre>
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Volume.ExternalVolumeInfo)
+          mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor;
@@ -29292,7 +29141,6 @@ public final class Protos {
         }
         private int bitField0_;
 
-        // optional uint64 size = 1;
         private long size_ ;
         /**
          * <code>optional uint64 size = 1;</code>
@@ -29325,7 +29173,6 @@ public final class Protos {
           return this;
         }
 
-        // required string name = 2;
         private java.lang.Object name_ = "";
         /**
          * <code>required string name = 2;</code>
@@ -29339,9 +29186,12 @@ public final class Protos {
         public java.lang.String getName() {
           java.lang.Object ref = name_;
           if (!(ref instanceof java.lang.String)) {
-            java.lang.String s = ((com.google.protobuf.ByteString) ref)
-                .toStringUtf8();
-            name_ = s;
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              name_ = s;
+            }
             return s;
           } else {
             return (java.lang.String) ref;
@@ -29399,7 +29249,6 @@ public final class Protos {
           return this;
         }
 
-        // required string provider = 3;
         private java.lang.Object provider_ = "";
         /**
          * <code>required string provider = 3;</code>
@@ -29413,9 +29262,12 @@ public final class Protos {
         public java.lang.String getProvider() {
           java.lang.Object ref = provider_;
           if (!(ref instanceof java.lang.String)) {
-            java.lang.String s = ((com.google.protobuf.ByteString) ref)
-                .toStringUtf8();
-            provider_ = s;
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              provider_ = s;
+            }
             return s;
           } else {
             return (java.lang.String) ref;
@@ -29473,7 +29325,6 @@ public final class Protos {
           return this;
         }
 
-        // repeated .mesos.Label options = 4;
         private java.util.List<org.apache.mesos.Protos.Label> options_ =
           java.util.Collections.emptyList();
         private void ensureOptionsIsMutable() {
@@ -29615,7 +29466,8 @@ public final class Protos {
             java.lang.Iterable<? extends org.apache.mesos.Protos.Label> values) {
           if (optionsBuilder_ == null) {
             ensureOptionsIsMutable();
-            super.addAll(values, options_);
+            com.google.protobuf.AbstractMessageLite.Builder.addAll(
+                values, options_);
             onChanged();
           } else {
             optionsBuilder_.addAllMessages(values);
@@ -29725,7 +29577,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required .mesos.Volume.Mode mode = 3;
     public static final int MODE_FIELD_NUMBER = 3;
     private org.apache.mesos.Protos.Volume.Mode mode_;
     /**
@@ -29741,7 +29592,6 @@ public final class Protos {
       return mode_;
     }
 
-    // required string container_path = 1;
     public static final int CONTAINER_PATH_FIELD_NUMBER = 1;
     private java.lang.Object containerPath_;
     /**
@@ -29805,7 +29655,6 @@ public final class Protos {
       }
     }
 
-    // optional string host_path = 2;
     public static final int HOST_PATH_FIELD_NUMBER = 2;
     private java.lang.Object hostPath_;
     /**
@@ -29863,7 +29712,6 @@ public final class Protos {
       }
     }
 
-    // optional .mesos.Image image = 4;
     public static final int IMAGE_FIELD_NUMBER = 4;
     private org.apache.mesos.Protos.Image image_;
     /**
@@ -29900,7 +29748,6 @@ public final class Protos {
       return image_;
     }
 
-    // optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;
     public static final int PERSISTENT_FIELD_NUMBER = 5;
     private mesosphere.marathon.Protos.Volume.PersistentVolumeInfo persistent_;
     /**
@@ -29934,7 +29781,6 @@ public final class Protos {
       return persistent_;
     }
 
-    // optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;
     public static final int EXTERNAL_FIELD_NUMBER = 6;
     private mesosphere.marathon.Protos.Volume.ExternalVolumeInfo external_;
     /**
@@ -29979,7 +29825,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasMode()) {
         memoizedIsInitialized = 0;
@@ -30153,8 +30000,9 @@ public final class Protos {
      * </pre>
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.VolumeOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Volume)
+        mesosphere.marathon.Protos.VolumeOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Volume_descriptor;
@@ -30369,7 +30217,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required .mesos.Volume.Mode mode = 3;
       private org.apache.mesos.Protos.Volume.Mode mode_ = org.apache.mesos.Protos.Volume.Mode.RW;
       /**
        * <code>required .mesos.Volume.Mode mode = 3;</code>
@@ -30405,7 +30252,6 @@ public final class Protos {
         return this;
       }
 
-      // required string container_path = 1;
       private java.lang.Object containerPath_ = "";
       /**
        * <code>required string container_path = 1;</code>
@@ -30433,9 +30279,12 @@ public final class Protos {
       public java.lang.String getContainerPath() {
         java.lang.Object ref = containerPath_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          containerPath_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            containerPath_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -30521,7 +30370,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string host_path = 2;
       private java.lang.Object hostPath_ = "";
       /**
        * <code>optional string host_path = 2;</code>
@@ -30545,9 +30393,12 @@ public final class Protos {
       public java.lang.String getHostPath() {
         java.lang.Object ref = hostPath_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          hostPath_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            hostPath_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -30625,7 +30476,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesos.Image image = 4;
       private org.apache.mesos.Protos.Image image_ = org.apache.mesos.Protos.Image.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.Image, org.apache.mesos.Protos.Image.Builder, org.apache.mesos.Protos.ImageOrBuilder> imageBuilder_;
@@ -30779,7 +30629,7 @@ public final class Protos {
         if (imageBuilder_ == null) {
           imageBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.Image, org.apache.mesos.Protos.Image.Builder, org.apache.mesos.Protos.ImageOrBuilder>(
-                  image_,
+                  getImage(),
                   getParentForChildren(),
                   isClean());
           image_ = null;
@@ -30787,7 +30637,6 @@ public final class Protos {
         return imageBuilder_;
       }
 
-      // optional .mesosphere.marathon.Volume.PersistentVolumeInfo persistent = 5;
       private mesosphere.marathon.Protos.Volume.PersistentVolumeInfo persistent_ = mesosphere.marathon.Protos.Volume.PersistentVolumeInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.Volume.PersistentVolumeInfo, mesosphere.marathon.Protos.Volume.PersistentVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder> persistentBuilder_;
@@ -30932,7 +30781,7 @@ public final class Protos {
         if (persistentBuilder_ == null) {
           persistentBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.Volume.PersistentVolumeInfo, mesosphere.marathon.Protos.Volume.PersistentVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.PersistentVolumeInfoOrBuilder>(
-                  persistent_,
+                  getPersistent(),
                   getParentForChildren(),
                   isClean());
           persistent_ = null;
@@ -30940,7 +30789,6 @@ public final class Protos {
         return persistentBuilder_;
       }
 
-      // optional .mesosphere.marathon.Volume.ExternalVolumeInfo external = 6;
       private mesosphere.marathon.Protos.Volume.ExternalVolumeInfo external_ = mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.Volume.ExternalVolumeInfo, mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder> externalBuilder_;
@@ -31085,7 +30933,7 @@ public final class Protos {
         if (externalBuilder_ == null) {
           externalBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.Volume.ExternalVolumeInfo, mesosphere.marathon.Protos.Volume.ExternalVolumeInfo.Builder, mesosphere.marathon.Protos.Volume.ExternalVolumeInfoOrBuilder>(
-                  external_,
+                  getExternal(),
                   getParentForChildren(),
                   isClean());
           external_ = null;
@@ -31104,15 +30952,15 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.Volume)
   }
 
-  public interface EventSubscribersOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface EventSubscribersOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.EventSubscribers)
+      com.google.protobuf.MessageOrBuilder {
 
-    // repeated string callback_urls = 1;
     /**
      * <code>repeated string callback_urls = 1;</code>
      */
-    java.util.List<java.lang.String>
-    getCallbackUrlsList();
+    com.google.protobuf.ProtocolStringList
+        getCallbackUrlsList();
     /**
      * <code>repeated string callback_urls = 1;</code>
      */
@@ -31126,13 +30974,38 @@ public final class Protos {
      */
     com.google.protobuf.ByteString
         getCallbackUrlsBytes(int index);
+
+    /**
+     * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+     */
+    java.util.List<mesosphere.marathon.Protos.Callback> 
+        getCallbackUrlsWithFiltersList();
+    /**
+     * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+     */
+    mesosphere.marathon.Protos.Callback getCallbackUrlsWithFilters(int index);
+    /**
+     * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+     */
+    int getCallbackUrlsWithFiltersCount();
+    /**
+     * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+     */
+    java.util.List<? extends mesosphere.marathon.Protos.CallbackOrBuilder> 
+        getCallbackUrlsWithFiltersOrBuilderList();
+    /**
+     * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+     */
+    mesosphere.marathon.Protos.CallbackOrBuilder getCallbackUrlsWithFiltersOrBuilder(
+        int index);
   }
   /**
    * Protobuf type {@code mesosphere.marathon.EventSubscribers}
    */
   public static final class EventSubscribers extends
-      com.google.protobuf.GeneratedMessage
-      implements EventSubscribersOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.EventSubscribers)
+      EventSubscribersOrBuilder {
     // Use EventSubscribers.newBuilder() to construct.
     private EventSubscribers(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -31179,11 +31052,20 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 callbackUrls_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000001;
               }
-              callbackUrls_.add(input.readBytes());
+              callbackUrls_.add(bs);
+              break;
+            }
+            case 18: {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                callbackUrlsWithFilters_ = new java.util.ArrayList<mesosphere.marathon.Protos.Callback>();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              callbackUrlsWithFilters_.add(input.readMessage(mesosphere.marathon.Protos.Callback.PARSER, extensionRegistry));
               break;
             }
           }
@@ -31195,7 +31077,10 @@ public final class Protos {
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          callbackUrls_ = new com.google.protobuf.UnmodifiableLazyStringList(callbackUrls_);
+          callbackUrls_ = callbackUrls_.getUnmodifiableView();
+        }
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          callbackUrlsWithFilters_ = java.util.Collections.unmodifiableList(callbackUrlsWithFilters_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -31228,13 +31113,12 @@ public final class Protos {
       return PARSER;
     }
 
-    // repeated string callback_urls = 1;
     public static final int CALLBACK_URLS_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList callbackUrls_;
     /**
      * <code>repeated string callback_urls = 1;</code>
      */
-    public java.util.List<java.lang.String>
+    public com.google.protobuf.ProtocolStringList
         getCallbackUrlsList() {
       return callbackUrls_;
     }
@@ -31258,13 +31142,50 @@ public final class Protos {
       return callbackUrls_.getByteString(index);
     }
 
+    public static final int CALLBACK_URLS_WITH_FILTERS_FIELD_NUMBER = 2;
+    private java.util.List<mesosphere.marathon.Protos.Callback> callbackUrlsWithFilters_;
+    /**
+     * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+     */
+    public java.util.List<mesosphere.marathon.Protos.Callback> getCallbackUrlsWithFiltersList() {
+      return callbackUrlsWithFilters_;
+    }
+    /**
+     * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+     */
+    public java.util.List<? extends mesosphere.marathon.Protos.CallbackOrBuilder> 
+        getCallbackUrlsWithFiltersOrBuilderList() {
+      return callbackUrlsWithFilters_;
+    }
+    /**
+     * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+     */
+    public int getCallbackUrlsWithFiltersCount() {
+      return callbackUrlsWithFilters_.size();
+    }
+    /**
+     * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+     */
+    public mesosphere.marathon.Protos.Callback getCallbackUrlsWithFilters(int index) {
+      return callbackUrlsWithFilters_.get(index);
+    }
+    /**
+     * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+     */
+    public mesosphere.marathon.Protos.CallbackOrBuilder getCallbackUrlsWithFiltersOrBuilder(
+        int index) {
+      return callbackUrlsWithFilters_.get(index);
+    }
+
     private void initFields() {
       callbackUrls_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      callbackUrlsWithFilters_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       memoizedIsInitialized = 1;
       return true;
@@ -31275,6 +31196,9 @@ public final class Protos {
       getSerializedSize();
       for (int i = 0; i < callbackUrls_.size(); i++) {
         output.writeBytes(1, callbackUrls_.getByteString(i));
+      }
+      for (int i = 0; i < callbackUrlsWithFilters_.size(); i++) {
+        output.writeMessage(2, callbackUrlsWithFilters_.get(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -31293,6 +31217,10 @@ public final class Protos {
         }
         size += dataSize;
         size += 1 * getCallbackUrlsList().size();
+      }
+      for (int i = 0; i < callbackUrlsWithFilters_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, callbackUrlsWithFilters_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -31376,8 +31304,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.EventSubscribers}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.EventSubscribersOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.EventSubscribers)
+        mesosphere.marathon.Protos.EventSubscribersOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_EventSubscribers_descriptor;
@@ -31402,6 +31331,7 @@ public final class Protos {
       }
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getCallbackUrlsWithFiltersFieldBuilder();
         }
       }
       private static Builder create() {
@@ -31412,6 +31342,12 @@ public final class Protos {
         super.clear();
         callbackUrls_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000001);
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          callbackUrlsWithFilters_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+        } else {
+          callbackUrlsWithFiltersBuilder_.clear();
+        }
         return this;
       }
 
@@ -31440,11 +31376,19 @@ public final class Protos {
         mesosphere.marathon.Protos.EventSubscribers result = new mesosphere.marathon.Protos.EventSubscribers(this);
         int from_bitField0_ = bitField0_;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          callbackUrls_ = new com.google.protobuf.UnmodifiableLazyStringList(
-              callbackUrls_);
+          callbackUrls_ = callbackUrls_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.callbackUrls_ = callbackUrls_;
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            callbackUrlsWithFilters_ = java.util.Collections.unmodifiableList(callbackUrlsWithFilters_);
+            bitField0_ = (bitField0_ & ~0x00000002);
+          }
+          result.callbackUrlsWithFilters_ = callbackUrlsWithFilters_;
+        } else {
+          result.callbackUrlsWithFilters_ = callbackUrlsWithFiltersBuilder_.build();
+        }
         onBuilt();
         return result;
       }
@@ -31469,6 +31413,32 @@ public final class Protos {
             callbackUrls_.addAll(other.callbackUrls_);
           }
           onChanged();
+        }
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          if (!other.callbackUrlsWithFilters_.isEmpty()) {
+            if (callbackUrlsWithFilters_.isEmpty()) {
+              callbackUrlsWithFilters_ = other.callbackUrlsWithFilters_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+            } else {
+              ensureCallbackUrlsWithFiltersIsMutable();
+              callbackUrlsWithFilters_.addAll(other.callbackUrlsWithFilters_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.callbackUrlsWithFilters_.isEmpty()) {
+            if (callbackUrlsWithFiltersBuilder_.isEmpty()) {
+              callbackUrlsWithFiltersBuilder_.dispose();
+              callbackUrlsWithFiltersBuilder_ = null;
+              callbackUrlsWithFilters_ = other.callbackUrlsWithFilters_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+              callbackUrlsWithFiltersBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getCallbackUrlsWithFiltersFieldBuilder() : null;
+            } else {
+              callbackUrlsWithFiltersBuilder_.addAllMessages(other.callbackUrlsWithFilters_);
+            }
+          }
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -31497,7 +31467,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // repeated string callback_urls = 1;
       private com.google.protobuf.LazyStringList callbackUrls_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureCallbackUrlsIsMutable() {
         if (!((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -31508,9 +31477,9 @@ public final class Protos {
       /**
        * <code>repeated string callback_urls = 1;</code>
        */
-      public java.util.List<java.lang.String>
+      public com.google.protobuf.ProtocolStringList
           getCallbackUrlsList() {
-        return java.util.Collections.unmodifiableList(callbackUrls_);
+        return callbackUrls_.getUnmodifiableView();
       }
       /**
        * <code>repeated string callback_urls = 1;</code>
@@ -31563,7 +31532,8 @@ public final class Protos {
       public Builder addAllCallbackUrls(
           java.lang.Iterable<java.lang.String> values) {
         ensureCallbackUrlsIsMutable();
-        super.addAll(values, callbackUrls_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, callbackUrls_);
         onChanged();
         return this;
       }
@@ -31590,6 +31560,246 @@ public final class Protos {
         return this;
       }
 
+      private java.util.List<mesosphere.marathon.Protos.Callback> callbackUrlsWithFilters_ =
+        java.util.Collections.emptyList();
+      private void ensureCallbackUrlsWithFiltersIsMutable() {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          callbackUrlsWithFilters_ = new java.util.ArrayList<mesosphere.marathon.Protos.Callback>(callbackUrlsWithFilters_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          mesosphere.marathon.Protos.Callback, mesosphere.marathon.Protos.Callback.Builder, mesosphere.marathon.Protos.CallbackOrBuilder> callbackUrlsWithFiltersBuilder_;
+
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public java.util.List<mesosphere.marathon.Protos.Callback> getCallbackUrlsWithFiltersList() {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(callbackUrlsWithFilters_);
+        } else {
+          return callbackUrlsWithFiltersBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public int getCallbackUrlsWithFiltersCount() {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          return callbackUrlsWithFilters_.size();
+        } else {
+          return callbackUrlsWithFiltersBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public mesosphere.marathon.Protos.Callback getCallbackUrlsWithFilters(int index) {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          return callbackUrlsWithFilters_.get(index);
+        } else {
+          return callbackUrlsWithFiltersBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public Builder setCallbackUrlsWithFilters(
+          int index, mesosphere.marathon.Protos.Callback value) {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureCallbackUrlsWithFiltersIsMutable();
+          callbackUrlsWithFilters_.set(index, value);
+          onChanged();
+        } else {
+          callbackUrlsWithFiltersBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public Builder setCallbackUrlsWithFilters(
+          int index, mesosphere.marathon.Protos.Callback.Builder builderForValue) {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          ensureCallbackUrlsWithFiltersIsMutable();
+          callbackUrlsWithFilters_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          callbackUrlsWithFiltersBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public Builder addCallbackUrlsWithFilters(mesosphere.marathon.Protos.Callback value) {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureCallbackUrlsWithFiltersIsMutable();
+          callbackUrlsWithFilters_.add(value);
+          onChanged();
+        } else {
+          callbackUrlsWithFiltersBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public Builder addCallbackUrlsWithFilters(
+          int index, mesosphere.marathon.Protos.Callback value) {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureCallbackUrlsWithFiltersIsMutable();
+          callbackUrlsWithFilters_.add(index, value);
+          onChanged();
+        } else {
+          callbackUrlsWithFiltersBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public Builder addCallbackUrlsWithFilters(
+          mesosphere.marathon.Protos.Callback.Builder builderForValue) {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          ensureCallbackUrlsWithFiltersIsMutable();
+          callbackUrlsWithFilters_.add(builderForValue.build());
+          onChanged();
+        } else {
+          callbackUrlsWithFiltersBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public Builder addCallbackUrlsWithFilters(
+          int index, mesosphere.marathon.Protos.Callback.Builder builderForValue) {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          ensureCallbackUrlsWithFiltersIsMutable();
+          callbackUrlsWithFilters_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          callbackUrlsWithFiltersBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public Builder addAllCallbackUrlsWithFilters(
+          java.lang.Iterable<? extends mesosphere.marathon.Protos.Callback> values) {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          ensureCallbackUrlsWithFiltersIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, callbackUrlsWithFilters_);
+          onChanged();
+        } else {
+          callbackUrlsWithFiltersBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public Builder clearCallbackUrlsWithFilters() {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          callbackUrlsWithFilters_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+          onChanged();
+        } else {
+          callbackUrlsWithFiltersBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public Builder removeCallbackUrlsWithFilters(int index) {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          ensureCallbackUrlsWithFiltersIsMutable();
+          callbackUrlsWithFilters_.remove(index);
+          onChanged();
+        } else {
+          callbackUrlsWithFiltersBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public mesosphere.marathon.Protos.Callback.Builder getCallbackUrlsWithFiltersBuilder(
+          int index) {
+        return getCallbackUrlsWithFiltersFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public mesosphere.marathon.Protos.CallbackOrBuilder getCallbackUrlsWithFiltersOrBuilder(
+          int index) {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          return callbackUrlsWithFilters_.get(index);  } else {
+          return callbackUrlsWithFiltersBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public java.util.List<? extends mesosphere.marathon.Protos.CallbackOrBuilder> 
+           getCallbackUrlsWithFiltersOrBuilderList() {
+        if (callbackUrlsWithFiltersBuilder_ != null) {
+          return callbackUrlsWithFiltersBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(callbackUrlsWithFilters_);
+        }
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public mesosphere.marathon.Protos.Callback.Builder addCallbackUrlsWithFiltersBuilder() {
+        return getCallbackUrlsWithFiltersFieldBuilder().addBuilder(
+            mesosphere.marathon.Protos.Callback.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public mesosphere.marathon.Protos.Callback.Builder addCallbackUrlsWithFiltersBuilder(
+          int index) {
+        return getCallbackUrlsWithFiltersFieldBuilder().addBuilder(
+            index, mesosphere.marathon.Protos.Callback.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.Callback callback_urls_with_filters = 2;</code>
+       */
+      public java.util.List<mesosphere.marathon.Protos.Callback.Builder> 
+           getCallbackUrlsWithFiltersBuilderList() {
+        return getCallbackUrlsWithFiltersFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          mesosphere.marathon.Protos.Callback, mesosphere.marathon.Protos.Callback.Builder, mesosphere.marathon.Protos.CallbackOrBuilder> 
+          getCallbackUrlsWithFiltersFieldBuilder() {
+        if (callbackUrlsWithFiltersBuilder_ == null) {
+          callbackUrlsWithFiltersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              mesosphere.marathon.Protos.Callback, mesosphere.marathon.Protos.Callback.Builder, mesosphere.marathon.Protos.CallbackOrBuilder>(
+                  callbackUrlsWithFilters_,
+                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  getParentForChildren(),
+                  isClean());
+          callbackUrlsWithFilters_ = null;
+        }
+        return callbackUrlsWithFiltersBuilder_;
+      }
+
       // @@protoc_insertion_point(builder_scope:mesosphere.marathon.EventSubscribers)
     }
 
@@ -31601,10 +31811,1553 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.EventSubscribers)
   }
 
-  public interface StorageVersionOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface CallbackOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Callback)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required uint32 major = 1;
+    /**
+     * <code>optional string url = 1;</code>
+     */
+    boolean hasUrl();
+    /**
+     * <code>optional string url = 1;</code>
+     */
+    java.lang.String getUrl();
+    /**
+     * <code>optional string url = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getUrlBytes();
+
+    /**
+     * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+     */
+    java.util.List<mesosphere.marathon.Protos.CallbackFilter> 
+        getCallbackFiltersList();
+    /**
+     * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+     */
+    mesosphere.marathon.Protos.CallbackFilter getCallbackFilters(int index);
+    /**
+     * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+     */
+    int getCallbackFiltersCount();
+    /**
+     * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+     */
+    java.util.List<? extends mesosphere.marathon.Protos.CallbackFilterOrBuilder> 
+        getCallbackFiltersOrBuilderList();
+    /**
+     * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+     */
+    mesosphere.marathon.Protos.CallbackFilterOrBuilder getCallbackFiltersOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code mesosphere.marathon.Callback}
+   */
+  public static final class Callback extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.Callback)
+      CallbackOrBuilder {
+    // Use Callback.newBuilder() to construct.
+    private Callback(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private Callback(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final Callback defaultInstance;
+    public static Callback getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public Callback getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Callback(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              url_ = bs;
+              break;
+            }
+            case 18: {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                callbackFilters_ = new java.util.ArrayList<mesosphere.marathon.Protos.CallbackFilter>();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              callbackFilters_.add(input.readMessage(mesosphere.marathon.Protos.CallbackFilter.PARSER, extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          callbackFilters_ = java.util.Collections.unmodifiableList(callbackFilters_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Callback_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Callback_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              mesosphere.marathon.Protos.Callback.class, mesosphere.marathon.Protos.Callback.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<Callback> PARSER =
+        new com.google.protobuf.AbstractParser<Callback>() {
+      public Callback parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Callback(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Callback> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int URL_FIELD_NUMBER = 1;
+    private java.lang.Object url_;
+    /**
+     * <code>optional string url = 1;</code>
+     */
+    public boolean hasUrl() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional string url = 1;</code>
+     */
+    public java.lang.String getUrl() {
+      java.lang.Object ref = url_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          url_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string url = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getUrlBytes() {
+      java.lang.Object ref = url_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        url_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CALLBACK_FILTERS_FIELD_NUMBER = 2;
+    private java.util.List<mesosphere.marathon.Protos.CallbackFilter> callbackFilters_;
+    /**
+     * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+     */
+    public java.util.List<mesosphere.marathon.Protos.CallbackFilter> getCallbackFiltersList() {
+      return callbackFilters_;
+    }
+    /**
+     * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+     */
+    public java.util.List<? extends mesosphere.marathon.Protos.CallbackFilterOrBuilder> 
+        getCallbackFiltersOrBuilderList() {
+      return callbackFilters_;
+    }
+    /**
+     * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+     */
+    public int getCallbackFiltersCount() {
+      return callbackFilters_.size();
+    }
+    /**
+     * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+     */
+    public mesosphere.marathon.Protos.CallbackFilter getCallbackFilters(int index) {
+      return callbackFilters_.get(index);
+    }
+    /**
+     * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+     */
+    public mesosphere.marathon.Protos.CallbackFilterOrBuilder getCallbackFiltersOrBuilder(
+        int index) {
+      return callbackFilters_.get(index);
+    }
+
+    private void initFields() {
+      url_ = "";
+      callbackFilters_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeBytes(1, getUrlBytes());
+      }
+      for (int i = 0; i < callbackFilters_.size(); i++) {
+        output.writeMessage(2, callbackFilters_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getUrlBytes());
+      }
+      for (int i = 0; i < callbackFilters_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, callbackFilters_.get(i));
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static mesosphere.marathon.Protos.Callback parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static mesosphere.marathon.Protos.Callback parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.Callback parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static mesosphere.marathon.Protos.Callback parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.Callback parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static mesosphere.marathon.Protos.Callback parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.Callback parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static mesosphere.marathon.Protos.Callback parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.Callback parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static mesosphere.marathon.Protos.Callback parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(mesosphere.marathon.Protos.Callback prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mesosphere.marathon.Callback}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Callback)
+        mesosphere.marathon.Protos.CallbackOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Callback_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Callback_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                mesosphere.marathon.Protos.Callback.class, mesosphere.marathon.Protos.Callback.Builder.class);
+      }
+
+      // Construct using mesosphere.marathon.Protos.Callback.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getCallbackFiltersFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        url_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        if (callbackFiltersBuilder_ == null) {
+          callbackFilters_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+        } else {
+          callbackFiltersBuilder_.clear();
+        }
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Callback_descriptor;
+      }
+
+      public mesosphere.marathon.Protos.Callback getDefaultInstanceForType() {
+        return mesosphere.marathon.Protos.Callback.getDefaultInstance();
+      }
+
+      public mesosphere.marathon.Protos.Callback build() {
+        mesosphere.marathon.Protos.Callback result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public mesosphere.marathon.Protos.Callback buildPartial() {
+        mesosphere.marathon.Protos.Callback result = new mesosphere.marathon.Protos.Callback(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.url_ = url_;
+        if (callbackFiltersBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            callbackFilters_ = java.util.Collections.unmodifiableList(callbackFilters_);
+            bitField0_ = (bitField0_ & ~0x00000002);
+          }
+          result.callbackFilters_ = callbackFilters_;
+        } else {
+          result.callbackFilters_ = callbackFiltersBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof mesosphere.marathon.Protos.Callback) {
+          return mergeFrom((mesosphere.marathon.Protos.Callback)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(mesosphere.marathon.Protos.Callback other) {
+        if (other == mesosphere.marathon.Protos.Callback.getDefaultInstance()) return this;
+        if (other.hasUrl()) {
+          bitField0_ |= 0x00000001;
+          url_ = other.url_;
+          onChanged();
+        }
+        if (callbackFiltersBuilder_ == null) {
+          if (!other.callbackFilters_.isEmpty()) {
+            if (callbackFilters_.isEmpty()) {
+              callbackFilters_ = other.callbackFilters_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+            } else {
+              ensureCallbackFiltersIsMutable();
+              callbackFilters_.addAll(other.callbackFilters_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.callbackFilters_.isEmpty()) {
+            if (callbackFiltersBuilder_.isEmpty()) {
+              callbackFiltersBuilder_.dispose();
+              callbackFiltersBuilder_ = null;
+              callbackFilters_ = other.callbackFilters_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+              callbackFiltersBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getCallbackFiltersFieldBuilder() : null;
+            } else {
+              callbackFiltersBuilder_.addAllMessages(other.callbackFilters_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        mesosphere.marathon.Protos.Callback parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (mesosphere.marathon.Protos.Callback) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object url_ = "";
+      /**
+       * <code>optional string url = 1;</code>
+       */
+      public boolean hasUrl() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional string url = 1;</code>
+       */
+      public java.lang.String getUrl() {
+        java.lang.Object ref = url_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            url_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string url = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getUrlBytes() {
+        java.lang.Object ref = url_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          url_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string url = 1;</code>
+       */
+      public Builder setUrl(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        url_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string url = 1;</code>
+       */
+      public Builder clearUrl() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        url_ = getDefaultInstance().getUrl();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string url = 1;</code>
+       */
+      public Builder setUrlBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        url_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<mesosphere.marathon.Protos.CallbackFilter> callbackFilters_ =
+        java.util.Collections.emptyList();
+      private void ensureCallbackFiltersIsMutable() {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          callbackFilters_ = new java.util.ArrayList<mesosphere.marathon.Protos.CallbackFilter>(callbackFilters_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          mesosphere.marathon.Protos.CallbackFilter, mesosphere.marathon.Protos.CallbackFilter.Builder, mesosphere.marathon.Protos.CallbackFilterOrBuilder> callbackFiltersBuilder_;
+
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public java.util.List<mesosphere.marathon.Protos.CallbackFilter> getCallbackFiltersList() {
+        if (callbackFiltersBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(callbackFilters_);
+        } else {
+          return callbackFiltersBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public int getCallbackFiltersCount() {
+        if (callbackFiltersBuilder_ == null) {
+          return callbackFilters_.size();
+        } else {
+          return callbackFiltersBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public mesosphere.marathon.Protos.CallbackFilter getCallbackFilters(int index) {
+        if (callbackFiltersBuilder_ == null) {
+          return callbackFilters_.get(index);
+        } else {
+          return callbackFiltersBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public Builder setCallbackFilters(
+          int index, mesosphere.marathon.Protos.CallbackFilter value) {
+        if (callbackFiltersBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureCallbackFiltersIsMutable();
+          callbackFilters_.set(index, value);
+          onChanged();
+        } else {
+          callbackFiltersBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public Builder setCallbackFilters(
+          int index, mesosphere.marathon.Protos.CallbackFilter.Builder builderForValue) {
+        if (callbackFiltersBuilder_ == null) {
+          ensureCallbackFiltersIsMutable();
+          callbackFilters_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          callbackFiltersBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public Builder addCallbackFilters(mesosphere.marathon.Protos.CallbackFilter value) {
+        if (callbackFiltersBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureCallbackFiltersIsMutable();
+          callbackFilters_.add(value);
+          onChanged();
+        } else {
+          callbackFiltersBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public Builder addCallbackFilters(
+          int index, mesosphere.marathon.Protos.CallbackFilter value) {
+        if (callbackFiltersBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureCallbackFiltersIsMutable();
+          callbackFilters_.add(index, value);
+          onChanged();
+        } else {
+          callbackFiltersBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public Builder addCallbackFilters(
+          mesosphere.marathon.Protos.CallbackFilter.Builder builderForValue) {
+        if (callbackFiltersBuilder_ == null) {
+          ensureCallbackFiltersIsMutable();
+          callbackFilters_.add(builderForValue.build());
+          onChanged();
+        } else {
+          callbackFiltersBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public Builder addCallbackFilters(
+          int index, mesosphere.marathon.Protos.CallbackFilter.Builder builderForValue) {
+        if (callbackFiltersBuilder_ == null) {
+          ensureCallbackFiltersIsMutable();
+          callbackFilters_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          callbackFiltersBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public Builder addAllCallbackFilters(
+          java.lang.Iterable<? extends mesosphere.marathon.Protos.CallbackFilter> values) {
+        if (callbackFiltersBuilder_ == null) {
+          ensureCallbackFiltersIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, callbackFilters_);
+          onChanged();
+        } else {
+          callbackFiltersBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public Builder clearCallbackFilters() {
+        if (callbackFiltersBuilder_ == null) {
+          callbackFilters_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+          onChanged();
+        } else {
+          callbackFiltersBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public Builder removeCallbackFilters(int index) {
+        if (callbackFiltersBuilder_ == null) {
+          ensureCallbackFiltersIsMutable();
+          callbackFilters_.remove(index);
+          onChanged();
+        } else {
+          callbackFiltersBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public mesosphere.marathon.Protos.CallbackFilter.Builder getCallbackFiltersBuilder(
+          int index) {
+        return getCallbackFiltersFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public mesosphere.marathon.Protos.CallbackFilterOrBuilder getCallbackFiltersOrBuilder(
+          int index) {
+        if (callbackFiltersBuilder_ == null) {
+          return callbackFilters_.get(index);  } else {
+          return callbackFiltersBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public java.util.List<? extends mesosphere.marathon.Protos.CallbackFilterOrBuilder> 
+           getCallbackFiltersOrBuilderList() {
+        if (callbackFiltersBuilder_ != null) {
+          return callbackFiltersBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(callbackFilters_);
+        }
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public mesosphere.marathon.Protos.CallbackFilter.Builder addCallbackFiltersBuilder() {
+        return getCallbackFiltersFieldBuilder().addBuilder(
+            mesosphere.marathon.Protos.CallbackFilter.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public mesosphere.marathon.Protos.CallbackFilter.Builder addCallbackFiltersBuilder(
+          int index) {
+        return getCallbackFiltersFieldBuilder().addBuilder(
+            index, mesosphere.marathon.Protos.CallbackFilter.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .mesosphere.marathon.CallbackFilter callback_filters = 2;</code>
+       */
+      public java.util.List<mesosphere.marathon.Protos.CallbackFilter.Builder> 
+           getCallbackFiltersBuilderList() {
+        return getCallbackFiltersFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          mesosphere.marathon.Protos.CallbackFilter, mesosphere.marathon.Protos.CallbackFilter.Builder, mesosphere.marathon.Protos.CallbackFilterOrBuilder> 
+          getCallbackFiltersFieldBuilder() {
+        if (callbackFiltersBuilder_ == null) {
+          callbackFiltersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              mesosphere.marathon.Protos.CallbackFilter, mesosphere.marathon.Protos.CallbackFilter.Builder, mesosphere.marathon.Protos.CallbackFilterOrBuilder>(
+                  callbackFilters_,
+                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  getParentForChildren(),
+                  isClean());
+          callbackFilters_ = null;
+        }
+        return callbackFiltersBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:mesosphere.marathon.Callback)
+    }
+
+    static {
+      defaultInstance = new Callback(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:mesosphere.marathon.Callback)
+  }
+
+  public interface CallbackFilterOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.CallbackFilter)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string filter_query = 1;</code>
+     *
+     * <pre>
+     * query to find interested field in event
+     * </pre>
+     */
+    boolean hasFilterQuery();
+    /**
+     * <code>optional string filter_query = 1;</code>
+     *
+     * <pre>
+     * query to find interested field in event
+     * </pre>
+     */
+    java.lang.String getFilterQuery();
+    /**
+     * <code>optional string filter_query = 1;</code>
+     *
+     * <pre>
+     * query to find interested field in event
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getFilterQueryBytes();
+
+    /**
+     * <code>repeated string accepted_values = 2;</code>
+     */
+    com.google.protobuf.ProtocolStringList
+        getAcceptedValuesList();
+    /**
+     * <code>repeated string accepted_values = 2;</code>
+     */
+    int getAcceptedValuesCount();
+    /**
+     * <code>repeated string accepted_values = 2;</code>
+     */
+    java.lang.String getAcceptedValues(int index);
+    /**
+     * <code>repeated string accepted_values = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getAcceptedValuesBytes(int index);
+  }
+  /**
+   * Protobuf type {@code mesosphere.marathon.CallbackFilter}
+   */
+  public static final class CallbackFilter extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.CallbackFilter)
+      CallbackFilterOrBuilder {
+    // Use CallbackFilter.newBuilder() to construct.
+    private CallbackFilter(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private CallbackFilter(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final CallbackFilter defaultInstance;
+    public static CallbackFilter getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public CallbackFilter getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private CallbackFilter(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              filterQuery_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                acceptedValues_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              acceptedValues_.add(bs);
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          acceptedValues_ = acceptedValues_.getUnmodifiableView();
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_CallbackFilter_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_CallbackFilter_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              mesosphere.marathon.Protos.CallbackFilter.class, mesosphere.marathon.Protos.CallbackFilter.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<CallbackFilter> PARSER =
+        new com.google.protobuf.AbstractParser<CallbackFilter>() {
+      public CallbackFilter parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new CallbackFilter(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<CallbackFilter> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int FILTER_QUERY_FIELD_NUMBER = 1;
+    private java.lang.Object filterQuery_;
+    /**
+     * <code>optional string filter_query = 1;</code>
+     *
+     * <pre>
+     * query to find interested field in event
+     * </pre>
+     */
+    public boolean hasFilterQuery() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional string filter_query = 1;</code>
+     *
+     * <pre>
+     * query to find interested field in event
+     * </pre>
+     */
+    public java.lang.String getFilterQuery() {
+      java.lang.Object ref = filterQuery_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          filterQuery_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string filter_query = 1;</code>
+     *
+     * <pre>
+     * query to find interested field in event
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getFilterQueryBytes() {
+      java.lang.Object ref = filterQuery_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        filterQuery_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ACCEPTED_VALUES_FIELD_NUMBER = 2;
+    private com.google.protobuf.LazyStringList acceptedValues_;
+    /**
+     * <code>repeated string accepted_values = 2;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getAcceptedValuesList() {
+      return acceptedValues_;
+    }
+    /**
+     * <code>repeated string accepted_values = 2;</code>
+     */
+    public int getAcceptedValuesCount() {
+      return acceptedValues_.size();
+    }
+    /**
+     * <code>repeated string accepted_values = 2;</code>
+     */
+    public java.lang.String getAcceptedValues(int index) {
+      return acceptedValues_.get(index);
+    }
+    /**
+     * <code>repeated string accepted_values = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getAcceptedValuesBytes(int index) {
+      return acceptedValues_.getByteString(index);
+    }
+
+    private void initFields() {
+      filterQuery_ = "";
+      acceptedValues_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeBytes(1, getFilterQueryBytes());
+      }
+      for (int i = 0; i < acceptedValues_.size(); i++) {
+        output.writeBytes(2, acceptedValues_.getByteString(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getFilterQueryBytes());
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < acceptedValues_.size(); i++) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeBytesSizeNoTag(acceptedValues_.getByteString(i));
+        }
+        size += dataSize;
+        size += 1 * getAcceptedValuesList().size();
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static mesosphere.marathon.Protos.CallbackFilter parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static mesosphere.marathon.Protos.CallbackFilter parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.CallbackFilter parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static mesosphere.marathon.Protos.CallbackFilter parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.CallbackFilter parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static mesosphere.marathon.Protos.CallbackFilter parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.CallbackFilter parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static mesosphere.marathon.Protos.CallbackFilter parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.CallbackFilter parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static mesosphere.marathon.Protos.CallbackFilter parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(mesosphere.marathon.Protos.CallbackFilter prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mesosphere.marathon.CallbackFilter}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.CallbackFilter)
+        mesosphere.marathon.Protos.CallbackFilterOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_CallbackFilter_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_CallbackFilter_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                mesosphere.marathon.Protos.CallbackFilter.class, mesosphere.marathon.Protos.CallbackFilter.Builder.class);
+      }
+
+      // Construct using mesosphere.marathon.Protos.CallbackFilter.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        filterQuery_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        acceptedValues_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_CallbackFilter_descriptor;
+      }
+
+      public mesosphere.marathon.Protos.CallbackFilter getDefaultInstanceForType() {
+        return mesosphere.marathon.Protos.CallbackFilter.getDefaultInstance();
+      }
+
+      public mesosphere.marathon.Protos.CallbackFilter build() {
+        mesosphere.marathon.Protos.CallbackFilter result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public mesosphere.marathon.Protos.CallbackFilter buildPartial() {
+        mesosphere.marathon.Protos.CallbackFilter result = new mesosphere.marathon.Protos.CallbackFilter(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.filterQuery_ = filterQuery_;
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          acceptedValues_ = acceptedValues_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000002);
+        }
+        result.acceptedValues_ = acceptedValues_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof mesosphere.marathon.Protos.CallbackFilter) {
+          return mergeFrom((mesosphere.marathon.Protos.CallbackFilter)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(mesosphere.marathon.Protos.CallbackFilter other) {
+        if (other == mesosphere.marathon.Protos.CallbackFilter.getDefaultInstance()) return this;
+        if (other.hasFilterQuery()) {
+          bitField0_ |= 0x00000001;
+          filterQuery_ = other.filterQuery_;
+          onChanged();
+        }
+        if (!other.acceptedValues_.isEmpty()) {
+          if (acceptedValues_.isEmpty()) {
+            acceptedValues_ = other.acceptedValues_;
+            bitField0_ = (bitField0_ & ~0x00000002);
+          } else {
+            ensureAcceptedValuesIsMutable();
+            acceptedValues_.addAll(other.acceptedValues_);
+          }
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        mesosphere.marathon.Protos.CallbackFilter parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (mesosphere.marathon.Protos.CallbackFilter) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object filterQuery_ = "";
+      /**
+       * <code>optional string filter_query = 1;</code>
+       *
+       * <pre>
+       * query to find interested field in event
+       * </pre>
+       */
+      public boolean hasFilterQuery() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional string filter_query = 1;</code>
+       *
+       * <pre>
+       * query to find interested field in event
+       * </pre>
+       */
+      public java.lang.String getFilterQuery() {
+        java.lang.Object ref = filterQuery_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            filterQuery_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string filter_query = 1;</code>
+       *
+       * <pre>
+       * query to find interested field in event
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getFilterQueryBytes() {
+        java.lang.Object ref = filterQuery_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          filterQuery_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string filter_query = 1;</code>
+       *
+       * <pre>
+       * query to find interested field in event
+       * </pre>
+       */
+      public Builder setFilterQuery(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        filterQuery_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string filter_query = 1;</code>
+       *
+       * <pre>
+       * query to find interested field in event
+       * </pre>
+       */
+      public Builder clearFilterQuery() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        filterQuery_ = getDefaultInstance().getFilterQuery();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string filter_query = 1;</code>
+       *
+       * <pre>
+       * query to find interested field in event
+       * </pre>
+       */
+      public Builder setFilterQueryBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        filterQuery_ = value;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList acceptedValues_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureAcceptedValuesIsMutable() {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          acceptedValues_ = new com.google.protobuf.LazyStringArrayList(acceptedValues_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+      /**
+       * <code>repeated string accepted_values = 2;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getAcceptedValuesList() {
+        return acceptedValues_.getUnmodifiableView();
+      }
+      /**
+       * <code>repeated string accepted_values = 2;</code>
+       */
+      public int getAcceptedValuesCount() {
+        return acceptedValues_.size();
+      }
+      /**
+       * <code>repeated string accepted_values = 2;</code>
+       */
+      public java.lang.String getAcceptedValues(int index) {
+        return acceptedValues_.get(index);
+      }
+      /**
+       * <code>repeated string accepted_values = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getAcceptedValuesBytes(int index) {
+        return acceptedValues_.getByteString(index);
+      }
+      /**
+       * <code>repeated string accepted_values = 2;</code>
+       */
+      public Builder setAcceptedValues(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAcceptedValuesIsMutable();
+        acceptedValues_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string accepted_values = 2;</code>
+       */
+      public Builder addAcceptedValues(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAcceptedValuesIsMutable();
+        acceptedValues_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string accepted_values = 2;</code>
+       */
+      public Builder addAllAcceptedValues(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureAcceptedValuesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, acceptedValues_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string accepted_values = 2;</code>
+       */
+      public Builder clearAcceptedValues() {
+        acceptedValues_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string accepted_values = 2;</code>
+       */
+      public Builder addAcceptedValuesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAcceptedValuesIsMutable();
+        acceptedValues_.add(value);
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:mesosphere.marathon.CallbackFilter)
+    }
+
+    static {
+      defaultInstance = new CallbackFilter(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:mesosphere.marathon.CallbackFilter)
+  }
+
+  public interface StorageVersionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.StorageVersion)
+      com.google.protobuf.MessageOrBuilder {
+
     /**
      * <code>required uint32 major = 1;</code>
      */
@@ -31614,7 +33367,6 @@ public final class Protos {
      */
     int getMajor();
 
-    // required uint32 minor = 2;
     /**
      * <code>required uint32 minor = 2;</code>
      */
@@ -31624,7 +33376,6 @@ public final class Protos {
      */
     int getMinor();
 
-    // required uint32 patch = 3;
     /**
      * <code>required uint32 patch = 3;</code>
      */
@@ -31634,7 +33385,6 @@ public final class Protos {
      */
     int getPatch();
 
-    // optional .mesosphere.marathon.StorageVersion.StorageFormat format = 4 [default = LEGACY];
     /**
      * <code>optional .mesosphere.marathon.StorageVersion.StorageFormat format = 4 [default = LEGACY];</code>
      *
@@ -31656,8 +33406,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.StorageVersion}
    */
   public static final class StorageVersion extends
-      com.google.protobuf.GeneratedMessage
-      implements StorageVersionOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.StorageVersion)
+      StorageVersionOrBuilder {
     // Use StorageVersion.newBuilder() to construct.
     private StorageVersion(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -31851,7 +33602,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required uint32 major = 1;
     public static final int MAJOR_FIELD_NUMBER = 1;
     private int major_;
     /**
@@ -31867,7 +33617,6 @@ public final class Protos {
       return major_;
     }
 
-    // required uint32 minor = 2;
     public static final int MINOR_FIELD_NUMBER = 2;
     private int minor_;
     /**
@@ -31883,7 +33632,6 @@ public final class Protos {
       return minor_;
     }
 
-    // required uint32 patch = 3;
     public static final int PATCH_FIELD_NUMBER = 3;
     private int patch_;
     /**
@@ -31899,7 +33647,6 @@ public final class Protos {
       return patch_;
     }
 
-    // optional .mesosphere.marathon.StorageVersion.StorageFormat format = 4 [default = LEGACY];
     public static final int FORMAT_FIELD_NUMBER = 4;
     private mesosphere.marathon.Protos.StorageVersion.StorageFormat format_;
     /**
@@ -31932,7 +33679,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasMajor()) {
         memoizedIsInitialized = 0;
@@ -32072,8 +33820,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.StorageVersion}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.StorageVersionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.StorageVersion)
+        mesosphere.marathon.Protos.StorageVersionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_StorageVersion_descriptor;
@@ -32225,7 +33974,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required uint32 major = 1;
       private int major_ ;
       /**
        * <code>required uint32 major = 1;</code>
@@ -32258,7 +34006,6 @@ public final class Protos {
         return this;
       }
 
-      // required uint32 minor = 2;
       private int minor_ ;
       /**
        * <code>required uint32 minor = 2;</code>
@@ -32291,7 +34038,6 @@ public final class Protos {
         return this;
       }
 
-      // required uint32 patch = 3;
       private int patch_ ;
       /**
        * <code>required uint32 patch = 3;</code>
@@ -32324,7 +34070,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesosphere.marathon.StorageVersion.StorageFormat format = 4 [default = LEGACY];
       private mesosphere.marathon.Protos.StorageVersion.StorageFormat format_ = mesosphere.marathon.Protos.StorageVersion.StorageFormat.LEGACY;
       /**
        * <code>optional .mesosphere.marathon.StorageVersion.StorageFormat format = 4 [default = LEGACY];</code>
@@ -32387,10 +34132,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.StorageVersion)
   }
 
-  public interface UpgradeStrategyDefinitionOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface UpgradeStrategyDefinitionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.UpgradeStrategyDefinition)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required double minimumHealthCapacity = 1;
     /**
      * <code>required double minimumHealthCapacity = 1;</code>
      */
@@ -32400,7 +34145,6 @@ public final class Protos {
      */
     double getMinimumHealthCapacity();
 
-    // optional double maximumOverCapacity = 2 [default = 1];
     /**
      * <code>optional double maximumOverCapacity = 2 [default = 1];</code>
      */
@@ -32414,8 +34158,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.UpgradeStrategyDefinition}
    */
   public static final class UpgradeStrategyDefinition extends
-      com.google.protobuf.GeneratedMessage
-      implements UpgradeStrategyDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.UpgradeStrategyDefinition)
+      UpgradeStrategyDefinitionOrBuilder {
     // Use UpgradeStrategyDefinition.newBuilder() to construct.
     private UpgradeStrategyDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -32511,7 +34256,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required double minimumHealthCapacity = 1;
     public static final int MINIMUMHEALTHCAPACITY_FIELD_NUMBER = 1;
     private double minimumHealthCapacity_;
     /**
@@ -32527,7 +34271,6 @@ public final class Protos {
       return minimumHealthCapacity_;
     }
 
-    // optional double maximumOverCapacity = 2 [default = 1];
     public static final int MAXIMUMOVERCAPACITY_FIELD_NUMBER = 2;
     private double maximumOverCapacity_;
     /**
@@ -32550,7 +34293,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasMinimumHealthCapacity()) {
         memoizedIsInitialized = 0;
@@ -32668,8 +34412,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.UpgradeStrategyDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.UpgradeStrategyDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.UpgradeStrategyDefinition)
+        mesosphere.marathon.Protos.UpgradeStrategyDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor;
@@ -32795,7 +34540,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required double minimumHealthCapacity = 1;
       private double minimumHealthCapacity_ ;
       /**
        * <code>required double minimumHealthCapacity = 1;</code>
@@ -32828,7 +34572,6 @@ public final class Protos {
         return this;
       }
 
-      // optional double maximumOverCapacity = 2 [default = 1];
       private double maximumOverCapacity_ = 1D;
       /**
        * <code>optional double maximumOverCapacity = 2 [default = 1];</code>
@@ -32872,10 +34615,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.UpgradeStrategyDefinition)
   }
 
-  public interface GroupDefinitionOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface GroupDefinitionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.GroupDefinition)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required string id = 1;
     /**
      * <code>required string id = 1;</code>
      */
@@ -32890,7 +34633,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getIdBytes();
 
-    // required string version = 2;
     /**
      * <code>required string version = 2;</code>
      */
@@ -32905,7 +34647,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getVersionBytes();
 
-    // repeated .mesosphere.marathon.ServiceDefinition deprecated_apps = 3;
     /**
      * <code>repeated .mesosphere.marathon.ServiceDefinition deprecated_apps = 3;</code>
      *
@@ -32950,7 +34691,6 @@ public final class Protos {
     mesosphere.marathon.Protos.ServiceDefinitionOrBuilder getDeprecatedAppsOrBuilder(
         int index);
 
-    // repeated .mesosphere.marathon.Json deprecated_pods = 8;
     /**
      * <code>repeated .mesosphere.marathon.Json deprecated_pods = 8;</code>
      */
@@ -32975,7 +34715,6 @@ public final class Protos {
     mesosphere.marathon.Protos.JsonOrBuilder getDeprecatedPodsOrBuilder(
         int index);
 
-    // repeated .mesosphere.marathon.GroupDefinition groups = 4;
     /**
      * <code>repeated .mesosphere.marathon.GroupDefinition groups = 4;</code>
      */
@@ -33000,12 +34739,11 @@ public final class Protos {
     mesosphere.marathon.Protos.GroupDefinitionOrBuilder getGroupsOrBuilder(
         int index);
 
-    // repeated string dependencies = 5;
     /**
      * <code>repeated string dependencies = 5;</code>
      */
-    java.util.List<java.lang.String>
-    getDependenciesList();
+    com.google.protobuf.ProtocolStringList
+        getDependenciesList();
     /**
      * <code>repeated string dependencies = 5;</code>
      */
@@ -33020,7 +34758,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getDependenciesBytes(int index);
 
-    // repeated .mesosphere.marathon.GroupDefinition.AppReference apps = 6;
     /**
      * <code>repeated .mesosphere.marathon.GroupDefinition.AppReference apps = 6;</code>
      */
@@ -33045,7 +34782,6 @@ public final class Protos {
     mesosphere.marathon.Protos.GroupDefinition.AppReferenceOrBuilder getAppsOrBuilder(
         int index);
 
-    // repeated .mesosphere.marathon.GroupDefinition.AppReference pods = 7;
     /**
      * <code>repeated .mesosphere.marathon.GroupDefinition.AppReference pods = 7;</code>
      */
@@ -33074,8 +34810,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.GroupDefinition}
    */
   public static final class GroupDefinition extends
-      com.google.protobuf.GeneratedMessage
-      implements GroupDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.GroupDefinition)
+      GroupDefinitionOrBuilder {
     // Use GroupDefinition.newBuilder() to construct.
     private GroupDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -33122,13 +34859,15 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
+              id_ = bs;
               break;
             }
             case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              version_ = input.readBytes();
+              version_ = bs;
               break;
             }
             case 26: {
@@ -33148,11 +34887,12 @@ public final class Protos {
               break;
             }
             case 42: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
                 dependencies_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000020;
               }
-              dependencies_.add(input.readBytes());
+              dependencies_.add(bs);
               break;
             }
             case 50: {
@@ -33194,7 +34934,7 @@ public final class Protos {
           groups_ = java.util.Collections.unmodifiableList(groups_);
         }
         if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-          dependencies_ = new com.google.protobuf.UnmodifiableLazyStringList(dependencies_);
+          dependencies_ = dependencies_.getUnmodifiableView();
         }
         if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
           apps_ = java.util.Collections.unmodifiableList(apps_);
@@ -33236,10 +34976,10 @@ public final class Protos {
       return PARSER;
     }
 
-    public interface AppReferenceOrBuilder
-        extends com.google.protobuf.MessageOrBuilder {
+    public interface AppReferenceOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mesosphere.marathon.GroupDefinition.AppReference)
+        com.google.protobuf.MessageOrBuilder {
 
-      // required string id = 1;
       /**
        * <code>required string id = 1;</code>
        */
@@ -33254,7 +34994,6 @@ public final class Protos {
       com.google.protobuf.ByteString
           getIdBytes();
 
-      // required string version = 2;
       /**
        * <code>required string version = 2;</code>
        */
@@ -33273,8 +35012,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.GroupDefinition.AppReference}
      */
     public static final class AppReference extends
-        com.google.protobuf.GeneratedMessage
-        implements AppReferenceOrBuilder {
+        com.google.protobuf.GeneratedMessage implements
+        // @@protoc_insertion_point(message_implements:mesosphere.marathon.GroupDefinition.AppReference)
+        AppReferenceOrBuilder {
       // Use AppReference.newBuilder() to construct.
       private AppReference(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
         super(builder);
@@ -33321,13 +35061,15 @@ public final class Protos {
                 break;
               }
               case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
-                id_ = input.readBytes();
+                id_ = bs;
                 break;
               }
               case 18: {
+                com.google.protobuf.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000002;
-                version_ = input.readBytes();
+                version_ = bs;
                 break;
               }
             }
@@ -33370,7 +35112,6 @@ public final class Protos {
       }
 
       private int bitField0_;
-      // required string id = 1;
       public static final int ID_FIELD_NUMBER = 1;
       private java.lang.Object id_;
       /**
@@ -33413,7 +35154,6 @@ public final class Protos {
         }
       }
 
-      // required string version = 2;
       public static final int VERSION_FIELD_NUMBER = 2;
       private java.lang.Object version_;
       /**
@@ -33463,7 +35203,8 @@ public final class Protos {
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
-        if (isInitialized != -1) return isInitialized == 1;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
 
         if (!hasId()) {
           memoizedIsInitialized = 0;
@@ -33585,8 +35326,9 @@ public final class Protos {
        * Protobuf type {@code mesosphere.marathon.GroupDefinition.AppReference}
        */
       public static final class Builder extends
-          com.google.protobuf.GeneratedMessage.Builder<Builder>
-         implements mesosphere.marathon.Protos.GroupDefinition.AppReferenceOrBuilder {
+          com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mesosphere.marathon.GroupDefinition.AppReference)
+          mesosphere.marathon.Protos.GroupDefinition.AppReferenceOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
           return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_GroupDefinition_AppReference_descriptor;
@@ -33720,7 +35462,6 @@ public final class Protos {
         }
         private int bitField0_;
 
-        // required string id = 1;
         private java.lang.Object id_ = "";
         /**
          * <code>required string id = 1;</code>
@@ -33734,9 +35475,12 @@ public final class Protos {
         public java.lang.String getId() {
           java.lang.Object ref = id_;
           if (!(ref instanceof java.lang.String)) {
-            java.lang.String s = ((com.google.protobuf.ByteString) ref)
-                .toStringUtf8();
-            id_ = s;
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              id_ = s;
+            }
             return s;
           } else {
             return (java.lang.String) ref;
@@ -33794,7 +35538,6 @@ public final class Protos {
           return this;
         }
 
-        // required string version = 2;
         private java.lang.Object version_ = "";
         /**
          * <code>required string version = 2;</code>
@@ -33808,9 +35551,12 @@ public final class Protos {
         public java.lang.String getVersion() {
           java.lang.Object ref = version_;
           if (!(ref instanceof java.lang.String)) {
-            java.lang.String s = ((com.google.protobuf.ByteString) ref)
-                .toStringUtf8();
-            version_ = s;
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              version_ = s;
+            }
             return s;
           } else {
             return (java.lang.String) ref;
@@ -33880,7 +35626,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -33923,7 +35668,6 @@ public final class Protos {
       }
     }
 
-    // required string version = 2;
     public static final int VERSION_FIELD_NUMBER = 2;
     private java.lang.Object version_;
     /**
@@ -33966,7 +35710,6 @@ public final class Protos {
       }
     }
 
-    // repeated .mesosphere.marathon.ServiceDefinition deprecated_apps = 3;
     public static final int DEPRECATED_APPS_FIELD_NUMBER = 3;
     private java.util.List<mesosphere.marathon.Protos.ServiceDefinition> deprecatedApps_;
     /**
@@ -34022,7 +35765,6 @@ public final class Protos {
       return deprecatedApps_.get(index);
     }
 
-    // repeated .mesosphere.marathon.Json deprecated_pods = 8;
     public static final int DEPRECATED_PODS_FIELD_NUMBER = 8;
     private java.util.List<mesosphere.marathon.Protos.Json> deprecatedPods_;
     /**
@@ -34058,7 +35800,6 @@ public final class Protos {
       return deprecatedPods_.get(index);
     }
 
-    // repeated .mesosphere.marathon.GroupDefinition groups = 4;
     public static final int GROUPS_FIELD_NUMBER = 4;
     private java.util.List<mesosphere.marathon.Protos.GroupDefinition> groups_;
     /**
@@ -34094,13 +35835,12 @@ public final class Protos {
       return groups_.get(index);
     }
 
-    // repeated string dependencies = 5;
     public static final int DEPENDENCIES_FIELD_NUMBER = 5;
     private com.google.protobuf.LazyStringList dependencies_;
     /**
      * <code>repeated string dependencies = 5;</code>
      */
-    public java.util.List<java.lang.String>
+    public com.google.protobuf.ProtocolStringList
         getDependenciesList() {
       return dependencies_;
     }
@@ -34124,7 +35864,6 @@ public final class Protos {
       return dependencies_.getByteString(index);
     }
 
-    // repeated .mesosphere.marathon.GroupDefinition.AppReference apps = 6;
     public static final int APPS_FIELD_NUMBER = 6;
     private java.util.List<mesosphere.marathon.Protos.GroupDefinition.AppReference> apps_;
     /**
@@ -34160,7 +35899,6 @@ public final class Protos {
       return apps_.get(index);
     }
 
-    // repeated .mesosphere.marathon.GroupDefinition.AppReference pods = 7;
     public static final int PODS_FIELD_NUMBER = 7;
     private java.util.List<mesosphere.marathon.Protos.GroupDefinition.AppReference> pods_;
     /**
@@ -34209,7 +35947,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasId()) {
         memoizedIsInitialized = 0;
@@ -34408,8 +36147,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.GroupDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.GroupDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.GroupDefinition)
+        mesosphere.marathon.Protos.GroupDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_GroupDefinition_descriptor;
@@ -34547,8 +36287,7 @@ public final class Protos {
           result.groups_ = groupsBuilder_.build();
         }
         if (((bitField0_ & 0x00000020) == 0x00000020)) {
-          dependencies_ = new com.google.protobuf.UnmodifiableLazyStringList(
-              dependencies_);
+          dependencies_ = dependencies_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000020);
         }
         result.dependencies_ = dependencies_;
@@ -34801,7 +36540,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>required string id = 1;</code>
@@ -34815,9 +36553,12 @@ public final class Protos {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          id_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            id_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -34875,7 +36616,6 @@ public final class Protos {
         return this;
       }
 
-      // required string version = 2;
       private java.lang.Object version_ = "";
       /**
        * <code>required string version = 2;</code>
@@ -34889,9 +36629,12 @@ public final class Protos {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          version_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            version_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -34949,7 +36692,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated .mesosphere.marathon.ServiceDefinition deprecated_apps = 3;
       private java.util.List<mesosphere.marathon.Protos.ServiceDefinition> deprecatedApps_ =
         java.util.Collections.emptyList();
       private void ensureDeprecatedAppsIsMutable() {
@@ -35131,7 +36873,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.ServiceDefinition> values) {
         if (deprecatedAppsBuilder_ == null) {
           ensureDeprecatedAppsIsMutable();
-          super.addAll(values, deprecatedApps_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, deprecatedApps_);
           onChanged();
         } else {
           deprecatedAppsBuilder_.addAllMessages(values);
@@ -35261,7 +37004,6 @@ public final class Protos {
         return deprecatedAppsBuilder_;
       }
 
-      // repeated .mesosphere.marathon.Json deprecated_pods = 8;
       private java.util.List<mesosphere.marathon.Protos.Json> deprecatedPods_ =
         java.util.Collections.emptyList();
       private void ensureDeprecatedPodsIsMutable() {
@@ -35403,7 +37145,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.Json> values) {
         if (deprecatedPodsBuilder_ == null) {
           ensureDeprecatedPodsIsMutable();
-          super.addAll(values, deprecatedPods_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, deprecatedPods_);
           onChanged();
         } else {
           deprecatedPodsBuilder_.addAllMessages(values);
@@ -35501,7 +37244,6 @@ public final class Protos {
         return deprecatedPodsBuilder_;
       }
 
-      // repeated .mesosphere.marathon.GroupDefinition groups = 4;
       private java.util.List<mesosphere.marathon.Protos.GroupDefinition> groups_ =
         java.util.Collections.emptyList();
       private void ensureGroupsIsMutable() {
@@ -35643,7 +37385,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.GroupDefinition> values) {
         if (groupsBuilder_ == null) {
           ensureGroupsIsMutable();
-          super.addAll(values, groups_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, groups_);
           onChanged();
         } else {
           groupsBuilder_.addAllMessages(values);
@@ -35741,7 +37484,6 @@ public final class Protos {
         return groupsBuilder_;
       }
 
-      // repeated string dependencies = 5;
       private com.google.protobuf.LazyStringList dependencies_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureDependenciesIsMutable() {
         if (!((bitField0_ & 0x00000020) == 0x00000020)) {
@@ -35752,9 +37494,9 @@ public final class Protos {
       /**
        * <code>repeated string dependencies = 5;</code>
        */
-      public java.util.List<java.lang.String>
+      public com.google.protobuf.ProtocolStringList
           getDependenciesList() {
-        return java.util.Collections.unmodifiableList(dependencies_);
+        return dependencies_.getUnmodifiableView();
       }
       /**
        * <code>repeated string dependencies = 5;</code>
@@ -35807,7 +37549,8 @@ public final class Protos {
       public Builder addAllDependencies(
           java.lang.Iterable<java.lang.String> values) {
         ensureDependenciesIsMutable();
-        super.addAll(values, dependencies_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, dependencies_);
         onChanged();
         return this;
       }
@@ -35834,7 +37577,6 @@ public final class Protos {
         return this;
       }
 
-      // repeated .mesosphere.marathon.GroupDefinition.AppReference apps = 6;
       private java.util.List<mesosphere.marathon.Protos.GroupDefinition.AppReference> apps_ =
         java.util.Collections.emptyList();
       private void ensureAppsIsMutable() {
@@ -35976,7 +37718,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.GroupDefinition.AppReference> values) {
         if (appsBuilder_ == null) {
           ensureAppsIsMutable();
-          super.addAll(values, apps_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, apps_);
           onChanged();
         } else {
           appsBuilder_.addAllMessages(values);
@@ -36074,7 +37817,6 @@ public final class Protos {
         return appsBuilder_;
       }
 
-      // repeated .mesosphere.marathon.GroupDefinition.AppReference pods = 7;
       private java.util.List<mesosphere.marathon.Protos.GroupDefinition.AppReference> pods_ =
         java.util.Collections.emptyList();
       private void ensurePodsIsMutable() {
@@ -36216,7 +37958,8 @@ public final class Protos {
           java.lang.Iterable<? extends mesosphere.marathon.Protos.GroupDefinition.AppReference> values) {
         if (podsBuilder_ == null) {
           ensurePodsIsMutable();
-          super.addAll(values, pods_);
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, pods_);
           onChanged();
         } else {
           podsBuilder_.addAllMessages(values);
@@ -36325,10 +38068,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.GroupDefinition)
   }
 
-  public interface DeploymentPlanDefinitionOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface DeploymentPlanDefinitionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.DeploymentPlanDefinition)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required string id = 1;
     /**
      * <code>required string id = 1;</code>
      */
@@ -36343,7 +38086,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getIdBytes();
 
-    // optional string timestamp = 2;
     /**
      * <code>optional string timestamp = 2;</code>
      */
@@ -36358,7 +38100,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getTimestampBytes();
 
-    // optional .mesosphere.marathon.GroupDefinition deprecated_original = 4;
     /**
      * <code>optional .mesosphere.marathon.GroupDefinition deprecated_original = 4;</code>
      *
@@ -36387,7 +38128,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.GroupDefinitionOrBuilder getDeprecatedOriginalOrBuilder();
 
-    // optional .mesosphere.marathon.GroupDefinition deprecated_target = 5;
     /**
      * <code>optional .mesosphere.marathon.GroupDefinition deprecated_target = 5;</code>
      */
@@ -36401,7 +38141,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.GroupDefinitionOrBuilder getDeprecatedTargetOrBuilder();
 
-    // optional string original_root_version = 6;
     /**
      * <code>optional string original_root_version = 6;</code>
      *
@@ -36428,7 +38167,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getOriginalRootVersionBytes();
 
-    // optional string target_root_version = 7;
     /**
      * <code>optional string target_root_version = 7;</code>
      */
@@ -36447,8 +38185,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.DeploymentPlanDefinition}
    */
   public static final class DeploymentPlanDefinition extends
-      com.google.protobuf.GeneratedMessage
-      implements DeploymentPlanDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.DeploymentPlanDefinition)
+      DeploymentPlanDefinitionOrBuilder {
     // Use DeploymentPlanDefinition.newBuilder() to construct.
     private DeploymentPlanDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -36495,13 +38234,15 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
+              id_ = bs;
               break;
             }
             case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              timestamp_ = input.readBytes();
+              timestamp_ = bs;
               break;
             }
             case 34: {
@@ -36531,13 +38272,15 @@ public final class Protos {
               break;
             }
             case 50: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000010;
-              originalRootVersion_ = input.readBytes();
+              originalRootVersion_ = bs;
               break;
             }
             case 58: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000020;
-              targetRootVersion_ = input.readBytes();
+              targetRootVersion_ = bs;
               break;
             }
           }
@@ -36580,7 +38323,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -36623,7 +38365,6 @@ public final class Protos {
       }
     }
 
-    // optional string timestamp = 2;
     public static final int TIMESTAMP_FIELD_NUMBER = 2;
     private java.lang.Object timestamp_;
     /**
@@ -36666,7 +38407,6 @@ public final class Protos {
       }
     }
 
-    // optional .mesosphere.marathon.GroupDefinition deprecated_original = 4;
     public static final int DEPRECATED_ORIGINAL_FIELD_NUMBER = 4;
     private mesosphere.marathon.Protos.GroupDefinition deprecatedOriginal_;
     /**
@@ -36703,7 +38443,6 @@ public final class Protos {
       return deprecatedOriginal_;
     }
 
-    // optional .mesosphere.marathon.GroupDefinition deprecated_target = 5;
     public static final int DEPRECATED_TARGET_FIELD_NUMBER = 5;
     private mesosphere.marathon.Protos.GroupDefinition deprecatedTarget_;
     /**
@@ -36725,7 +38464,6 @@ public final class Protos {
       return deprecatedTarget_;
     }
 
-    // optional string original_root_version = 6;
     public static final int ORIGINAL_ROOT_VERSION_FIELD_NUMBER = 6;
     private java.lang.Object originalRootVersion_;
     /**
@@ -36780,7 +38518,6 @@ public final class Protos {
       }
     }
 
-    // optional string target_root_version = 7;
     public static final int TARGET_ROOT_VERSION_FIELD_NUMBER = 7;
     private java.lang.Object targetRootVersion_;
     /**
@@ -36834,7 +38571,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasId()) {
         memoizedIsInitialized = 0;
@@ -36992,8 +38730,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.DeploymentPlanDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.DeploymentPlanDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.DeploymentPlanDefinition)
+        mesosphere.marathon.Protos.DeploymentPlanDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor;
@@ -37193,7 +38932,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>required string id = 1;</code>
@@ -37207,9 +38945,12 @@ public final class Protos {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          id_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            id_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -37267,7 +39008,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string timestamp = 2;
       private java.lang.Object timestamp_ = "";
       /**
        * <code>optional string timestamp = 2;</code>
@@ -37281,9 +39021,12 @@ public final class Protos {
       public java.lang.String getTimestamp() {
         java.lang.Object ref = timestamp_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          timestamp_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            timestamp_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -37341,7 +39084,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesosphere.marathon.GroupDefinition deprecated_original = 4;
       private mesosphere.marathon.Protos.GroupDefinition deprecatedOriginal_ = mesosphere.marathon.Protos.GroupDefinition.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.GroupDefinition, mesosphere.marathon.Protos.GroupDefinition.Builder, mesosphere.marathon.Protos.GroupDefinitionOrBuilder> deprecatedOriginalBuilder_;
@@ -37495,7 +39237,7 @@ public final class Protos {
         if (deprecatedOriginalBuilder_ == null) {
           deprecatedOriginalBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.GroupDefinition, mesosphere.marathon.Protos.GroupDefinition.Builder, mesosphere.marathon.Protos.GroupDefinitionOrBuilder>(
-                  deprecatedOriginal_,
+                  getDeprecatedOriginal(),
                   getParentForChildren(),
                   isClean());
           deprecatedOriginal_ = null;
@@ -37503,7 +39245,6 @@ public final class Protos {
         return deprecatedOriginalBuilder_;
       }
 
-      // optional .mesosphere.marathon.GroupDefinition deprecated_target = 5;
       private mesosphere.marathon.Protos.GroupDefinition deprecatedTarget_ = mesosphere.marathon.Protos.GroupDefinition.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.GroupDefinition, mesosphere.marathon.Protos.GroupDefinition.Builder, mesosphere.marathon.Protos.GroupDefinitionOrBuilder> deprecatedTargetBuilder_;
@@ -37612,7 +39353,7 @@ public final class Protos {
         if (deprecatedTargetBuilder_ == null) {
           deprecatedTargetBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.GroupDefinition, mesosphere.marathon.Protos.GroupDefinition.Builder, mesosphere.marathon.Protos.GroupDefinitionOrBuilder>(
-                  deprecatedTarget_,
+                  getDeprecatedTarget(),
                   getParentForChildren(),
                   isClean());
           deprecatedTarget_ = null;
@@ -37620,7 +39361,6 @@ public final class Protos {
         return deprecatedTargetBuilder_;
       }
 
-      // optional string original_root_version = 6;
       private java.lang.Object originalRootVersion_ = "";
       /**
        * <code>optional string original_root_version = 6;</code>
@@ -37642,9 +39382,12 @@ public final class Protos {
       public java.lang.String getOriginalRootVersion() {
         java.lang.Object ref = originalRootVersion_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          originalRootVersion_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            originalRootVersion_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -37718,7 +39461,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string target_root_version = 7;
       private java.lang.Object targetRootVersion_ = "";
       /**
        * <code>optional string target_root_version = 7;</code>
@@ -37732,9 +39474,12 @@ public final class Protos {
       public java.lang.String getTargetRootVersion() {
         java.lang.Object ref = targetRootVersion_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          targetRootVersion_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            targetRootVersion_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -37803,10 +39548,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.DeploymentPlanDefinition)
   }
 
-  public interface TaskFailureOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface TaskFailureOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.TaskFailure)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required string app_id = 1;
     /**
      * <code>required string app_id = 1;</code>
      */
@@ -37821,7 +39566,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getAppIdBytes();
 
-    // required .mesos.TaskID task_id = 2;
     /**
      * <code>required .mesos.TaskID task_id = 2;</code>
      */
@@ -37835,7 +39579,6 @@ public final class Protos {
      */
     org.apache.mesos.Protos.TaskIDOrBuilder getTaskIdOrBuilder();
 
-    // required .mesos.TaskState state = 3;
     /**
      * <code>required .mesos.TaskState state = 3;</code>
      */
@@ -37845,7 +39588,6 @@ public final class Protos {
      */
     org.apache.mesos.Protos.TaskState getState();
 
-    // optional string message = 4 [default = ""];
     /**
      * <code>optional string message = 4 [default = ""];</code>
      */
@@ -37860,7 +39602,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getMessageBytes();
 
-    // optional string host = 5 [default = ""];
     /**
      * <code>optional string host = 5 [default = ""];</code>
      */
@@ -37875,7 +39616,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getHostBytes();
 
-    // required string version = 6;
     /**
      * <code>required string version = 6;</code>
      */
@@ -37890,7 +39630,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getVersionBytes();
 
-    // required string timestamp = 7;
     /**
      * <code>required string timestamp = 7;</code>
      */
@@ -37905,7 +39644,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getTimestampBytes();
 
-    // optional .mesos.SlaveID slaveId = 8;
     /**
      * <code>optional .mesos.SlaveID slaveId = 8;</code>
      */
@@ -37923,8 +39661,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.TaskFailure}
    */
   public static final class TaskFailure extends
-      com.google.protobuf.GeneratedMessage
-      implements TaskFailureOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.TaskFailure)
+      TaskFailureOrBuilder {
     // Use TaskFailure.newBuilder() to construct.
     private TaskFailure(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -37971,8 +39710,9 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              appId_ = input.readBytes();
+              appId_ = bs;
               break;
             }
             case 18: {
@@ -38000,23 +39740,27 @@ public final class Protos {
               break;
             }
             case 34: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
-              message_ = input.readBytes();
+              message_ = bs;
               break;
             }
             case 42: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000010;
-              host_ = input.readBytes();
+              host_ = bs;
               break;
             }
             case 50: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000020;
-              version_ = input.readBytes();
+              version_ = bs;
               break;
             }
             case 58: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000040;
-              timestamp_ = input.readBytes();
+              timestamp_ = bs;
               break;
             }
             case 66: {
@@ -38072,7 +39816,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required string app_id = 1;
     public static final int APP_ID_FIELD_NUMBER = 1;
     private java.lang.Object appId_;
     /**
@@ -38115,7 +39858,6 @@ public final class Protos {
       }
     }
 
-    // required .mesos.TaskID task_id = 2;
     public static final int TASK_ID_FIELD_NUMBER = 2;
     private org.apache.mesos.Protos.TaskID taskId_;
     /**
@@ -38137,7 +39879,6 @@ public final class Protos {
       return taskId_;
     }
 
-    // required .mesos.TaskState state = 3;
     public static final int STATE_FIELD_NUMBER = 3;
     private org.apache.mesos.Protos.TaskState state_;
     /**
@@ -38153,7 +39894,6 @@ public final class Protos {
       return state_;
     }
 
-    // optional string message = 4 [default = ""];
     public static final int MESSAGE_FIELD_NUMBER = 4;
     private java.lang.Object message_;
     /**
@@ -38196,7 +39936,6 @@ public final class Protos {
       }
     }
 
-    // optional string host = 5 [default = ""];
     public static final int HOST_FIELD_NUMBER = 5;
     private java.lang.Object host_;
     /**
@@ -38239,7 +39978,6 @@ public final class Protos {
       }
     }
 
-    // required string version = 6;
     public static final int VERSION_FIELD_NUMBER = 6;
     private java.lang.Object version_;
     /**
@@ -38282,7 +40020,6 @@ public final class Protos {
       }
     }
 
-    // required string timestamp = 7;
     public static final int TIMESTAMP_FIELD_NUMBER = 7;
     private java.lang.Object timestamp_;
     /**
@@ -38325,7 +40062,6 @@ public final class Protos {
       }
     }
 
-    // optional .mesos.SlaveID slaveId = 8;
     public static final int SLAVEID_FIELD_NUMBER = 8;
     private org.apache.mesos.Protos.SlaveID slaveId_;
     /**
@@ -38360,7 +40096,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasAppId()) {
         memoizedIsInitialized = 0;
@@ -38546,8 +40283,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.TaskFailure}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.TaskFailureOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.TaskFailure)
+        mesosphere.marathon.Protos.TaskFailureOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_TaskFailure_descriptor;
@@ -38781,7 +40519,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required string app_id = 1;
       private java.lang.Object appId_ = "";
       /**
        * <code>required string app_id = 1;</code>
@@ -38795,9 +40532,12 @@ public final class Protos {
       public java.lang.String getAppId() {
         java.lang.Object ref = appId_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          appId_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            appId_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -38855,7 +40595,6 @@ public final class Protos {
         return this;
       }
 
-      // required .mesos.TaskID task_id = 2;
       private org.apache.mesos.Protos.TaskID taskId_ = org.apache.mesos.Protos.TaskID.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.TaskID, org.apache.mesos.Protos.TaskID.Builder, org.apache.mesos.Protos.TaskIDOrBuilder> taskIdBuilder_;
@@ -38964,7 +40703,7 @@ public final class Protos {
         if (taskIdBuilder_ == null) {
           taskIdBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.TaskID, org.apache.mesos.Protos.TaskID.Builder, org.apache.mesos.Protos.TaskIDOrBuilder>(
-                  taskId_,
+                  getTaskId(),
                   getParentForChildren(),
                   isClean());
           taskId_ = null;
@@ -38972,7 +40711,6 @@ public final class Protos {
         return taskIdBuilder_;
       }
 
-      // required .mesos.TaskState state = 3;
       private org.apache.mesos.Protos.TaskState state_ = org.apache.mesos.Protos.TaskState.TASK_STAGING;
       /**
        * <code>required .mesos.TaskState state = 3;</code>
@@ -39008,7 +40746,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string message = 4 [default = ""];
       private java.lang.Object message_ = "";
       /**
        * <code>optional string message = 4 [default = ""];</code>
@@ -39022,9 +40759,12 @@ public final class Protos {
       public java.lang.String getMessage() {
         java.lang.Object ref = message_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          message_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            message_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -39082,7 +40822,6 @@ public final class Protos {
         return this;
       }
 
-      // optional string host = 5 [default = ""];
       private java.lang.Object host_ = "";
       /**
        * <code>optional string host = 5 [default = ""];</code>
@@ -39096,9 +40835,12 @@ public final class Protos {
       public java.lang.String getHost() {
         java.lang.Object ref = host_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          host_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            host_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -39156,7 +40898,6 @@ public final class Protos {
         return this;
       }
 
-      // required string version = 6;
       private java.lang.Object version_ = "";
       /**
        * <code>required string version = 6;</code>
@@ -39170,9 +40911,12 @@ public final class Protos {
       public java.lang.String getVersion() {
         java.lang.Object ref = version_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          version_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            version_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -39230,7 +40974,6 @@ public final class Protos {
         return this;
       }
 
-      // required string timestamp = 7;
       private java.lang.Object timestamp_ = "";
       /**
        * <code>required string timestamp = 7;</code>
@@ -39244,9 +40987,12 @@ public final class Protos {
       public java.lang.String getTimestamp() {
         java.lang.Object ref = timestamp_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          timestamp_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            timestamp_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -39304,7 +41050,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesos.SlaveID slaveId = 8;
       private org.apache.mesos.Protos.SlaveID slaveId_ = org.apache.mesos.Protos.SlaveID.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder> slaveIdBuilder_;
@@ -39413,7 +41158,7 @@ public final class Protos {
         if (slaveIdBuilder_ == null) {
           slaveIdBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.apache.mesos.Protos.SlaveID, org.apache.mesos.Protos.SlaveID.Builder, org.apache.mesos.Protos.SlaveIDOrBuilder>(
-                  slaveId_,
+                  getSlaveId(),
                   getParentForChildren(),
                   isClean());
           slaveId_ = null;
@@ -39432,10 +41177,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.TaskFailure)
   }
 
-  public interface ZKStoreEntryOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface ZKStoreEntryOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ZKStoreEntry)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required string name = 1;
     /**
      * <code>required string name = 1;</code>
      */
@@ -39450,7 +41195,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getNameBytes();
 
-    // required bytes uuid = 2;
     /**
      * <code>required bytes uuid = 2;</code>
      */
@@ -39460,7 +41204,6 @@ public final class Protos {
      */
     com.google.protobuf.ByteString getUuid();
 
-    // required bytes value = 3;
     /**
      * <code>required bytes value = 3;</code>
      */
@@ -39470,7 +41213,6 @@ public final class Protos {
      */
     com.google.protobuf.ByteString getValue();
 
-    // optional bool compressed = 4 [default = false];
     /**
      * <code>optional bool compressed = 4 [default = false];</code>
      *
@@ -39503,8 +41245,9 @@ public final class Protos {
    * </pre>
    */
   public static final class ZKStoreEntry extends
-      com.google.protobuf.GeneratedMessage
-      implements ZKStoreEntryOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ZKStoreEntry)
+      ZKStoreEntryOrBuilder {
     // Use ZKStoreEntry.newBuilder() to construct.
     private ZKStoreEntry(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -39551,8 +41294,9 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              name_ = input.readBytes();
+              name_ = bs;
               break;
             }
             case 18: {
@@ -39610,7 +41354,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required string name = 1;
     public static final int NAME_FIELD_NUMBER = 1;
     private java.lang.Object name_;
     /**
@@ -39653,7 +41396,6 @@ public final class Protos {
       }
     }
 
-    // required bytes uuid = 2;
     public static final int UUID_FIELD_NUMBER = 2;
     private com.google.protobuf.ByteString uuid_;
     /**
@@ -39669,7 +41411,6 @@ public final class Protos {
       return uuid_;
     }
 
-    // required bytes value = 3;
     public static final int VALUE_FIELD_NUMBER = 3;
     private com.google.protobuf.ByteString value_;
     /**
@@ -39685,7 +41426,6 @@ public final class Protos {
       return value_;
     }
 
-    // optional bool compressed = 4 [default = false];
     public static final int COMPRESSED_FIELD_NUMBER = 4;
     private boolean compressed_;
     /**
@@ -39722,7 +41462,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasName()) {
         memoizedIsInitialized = 0;
@@ -39869,8 +41610,9 @@ public final class Protos {
      * </pre>
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.ZKStoreEntryOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ZKStoreEntry)
+        mesosphere.marathon.Protos.ZKStoreEntryOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ZKStoreEntry_descriptor;
@@ -40024,7 +41766,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required string name = 1;
       private java.lang.Object name_ = "";
       /**
        * <code>required string name = 1;</code>
@@ -40038,9 +41779,12 @@ public final class Protos {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          name_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            name_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -40098,7 +41842,6 @@ public final class Protos {
         return this;
       }
 
-      // required bytes uuid = 2;
       private com.google.protobuf.ByteString uuid_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes uuid = 2;</code>
@@ -40134,7 +41877,6 @@ public final class Protos {
         return this;
       }
 
-      // required bytes value = 3;
       private com.google.protobuf.ByteString value_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <code>required bytes value = 3;</code>
@@ -40170,7 +41912,6 @@ public final class Protos {
         return this;
       }
 
-      // optional bool compressed = 4 [default = false];
       private boolean compressed_ ;
       /**
        * <code>optional bool compressed = 4 [default = false];</code>
@@ -40238,10 +41979,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ZKStoreEntry)
   }
 
-  public interface ResidencyDefinitionOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface ResidencyDefinitionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.ResidencyDefinition)
+      com.google.protobuf.MessageOrBuilder {
 
-    // optional int64 relaunchEscalationTimeoutSeconds = 1;
     /**
      * <code>optional int64 relaunchEscalationTimeoutSeconds = 1;</code>
      */
@@ -40251,7 +41992,6 @@ public final class Protos {
      */
     long getRelaunchEscalationTimeoutSeconds();
 
-    // optional .mesosphere.marathon.ResidencyDefinition.TaskLostBehavior taskLostBehavior = 2;
     /**
      * <code>optional .mesosphere.marathon.ResidencyDefinition.TaskLostBehavior taskLostBehavior = 2;</code>
      */
@@ -40265,8 +42005,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.ResidencyDefinition}
    */
   public static final class ResidencyDefinition extends
-      com.google.protobuf.GeneratedMessage
-      implements ResidencyDefinitionOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.ResidencyDefinition)
+      ResidencyDefinitionOrBuilder {
     // Use ResidencyDefinition.newBuilder() to construct.
     private ResidencyDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -40450,7 +42191,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // optional int64 relaunchEscalationTimeoutSeconds = 1;
     public static final int RELAUNCHESCALATIONTIMEOUTSECONDS_FIELD_NUMBER = 1;
     private long relaunchEscalationTimeoutSeconds_;
     /**
@@ -40466,7 +42206,6 @@ public final class Protos {
       return relaunchEscalationTimeoutSeconds_;
     }
 
-    // optional .mesosphere.marathon.ResidencyDefinition.TaskLostBehavior taskLostBehavior = 2;
     public static final int TASKLOSTBEHAVIOR_FIELD_NUMBER = 2;
     private mesosphere.marathon.Protos.ResidencyDefinition.TaskLostBehavior taskLostBehavior_;
     /**
@@ -40489,7 +42228,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       memoizedIsInitialized = 1;
       return true;
@@ -40603,8 +42343,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.ResidencyDefinition}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.ResidencyDefinitionOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.ResidencyDefinition)
+        mesosphere.marathon.Protos.ResidencyDefinitionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_ResidencyDefinition_descriptor;
@@ -40726,7 +42467,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // optional int64 relaunchEscalationTimeoutSeconds = 1;
       private long relaunchEscalationTimeoutSeconds_ ;
       /**
        * <code>optional int64 relaunchEscalationTimeoutSeconds = 1;</code>
@@ -40759,7 +42499,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesosphere.marathon.ResidencyDefinition.TaskLostBehavior taskLostBehavior = 2;
       private mesosphere.marathon.Protos.ResidencyDefinition.TaskLostBehavior taskLostBehavior_ = mesosphere.marathon.Protos.ResidencyDefinition.TaskLostBehavior.RELAUNCH_AFTER_TIMEOUT;
       /**
        * <code>optional .mesosphere.marathon.ResidencyDefinition.TaskLostBehavior taskLostBehavior = 2;</code>
@@ -40806,10 +42545,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.ResidencyDefinition)
   }
 
-  public interface SecretOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface SecretOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.Secret)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required string id = 1;
     /**
      * <code>required string id = 1;</code>
      */
@@ -40824,7 +42563,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getIdBytes();
 
-    // required string source = 2;
     /**
      * <code>required string source = 2;</code>
      */
@@ -40843,8 +42581,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.Secret}
    */
   public static final class Secret extends
-      com.google.protobuf.GeneratedMessage
-      implements SecretOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.Secret)
+      SecretOrBuilder {
     // Use Secret.newBuilder() to construct.
     private Secret(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -40891,13 +42630,15 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
+              id_ = bs;
               break;
             }
             case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              source_ = input.readBytes();
+              source_ = bs;
               break;
             }
           }
@@ -40940,7 +42681,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required string id = 1;
     public static final int ID_FIELD_NUMBER = 1;
     private java.lang.Object id_;
     /**
@@ -40983,7 +42723,6 @@ public final class Protos {
       }
     }
 
-    // required string source = 2;
     public static final int SOURCE_FIELD_NUMBER = 2;
     private java.lang.Object source_;
     /**
@@ -41033,7 +42772,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasId()) {
         memoizedIsInitialized = 0;
@@ -41155,8 +42895,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.Secret}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.SecretOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.Secret)
+        mesosphere.marathon.Protos.SecretOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_Secret_descriptor;
@@ -41290,7 +43031,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required string id = 1;
       private java.lang.Object id_ = "";
       /**
        * <code>required string id = 1;</code>
@@ -41304,9 +43044,12 @@ public final class Protos {
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          id_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            id_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -41364,7 +43107,6 @@ public final class Protos {
         return this;
       }
 
-      // required string source = 2;
       private java.lang.Object source_ = "";
       /**
        * <code>required string source = 2;</code>
@@ -41378,9 +43120,12 @@ public final class Protos {
       public java.lang.String getSource() {
         java.lang.Object ref = source_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          source_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            source_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -41449,10 +43194,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.Secret)
   }
 
-  public interface EnvVarReferenceOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface EnvVarReferenceOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.EnvVarReference)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required .mesosphere.marathon.EnvVarReference.Type type = 1;
     /**
      * <code>required .mesosphere.marathon.EnvVarReference.Type type = 1;</code>
      */
@@ -41462,7 +43207,6 @@ public final class Protos {
      */
     mesosphere.marathon.Protos.EnvVarReference.Type getType();
 
-    // required string name = 2;
     /**
      * <code>required string name = 2;</code>
      */
@@ -41477,7 +43221,6 @@ public final class Protos {
     com.google.protobuf.ByteString
         getNameBytes();
 
-    // optional .mesosphere.marathon.EnvVarSecretRef secretRef = 3;
     /**
      * <code>optional .mesosphere.marathon.EnvVarSecretRef secretRef = 3;</code>
      */
@@ -41495,8 +43238,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.EnvVarReference}
    */
   public static final class EnvVarReference extends
-      com.google.protobuf.GeneratedMessage
-      implements EnvVarReferenceOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.EnvVarReference)
+      EnvVarReferenceOrBuilder {
     // Use EnvVarReference.newBuilder() to construct.
     private EnvVarReference(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -41554,8 +43298,9 @@ public final class Protos {
               break;
             }
             case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
-              name_ = input.readBytes();
+              name_ = bs;
               break;
             }
             case 26: {
@@ -41693,7 +43438,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required .mesosphere.marathon.EnvVarReference.Type type = 1;
     public static final int TYPE_FIELD_NUMBER = 1;
     private mesosphere.marathon.Protos.EnvVarReference.Type type_;
     /**
@@ -41709,7 +43453,6 @@ public final class Protos {
       return type_;
     }
 
-    // required string name = 2;
     public static final int NAME_FIELD_NUMBER = 2;
     private java.lang.Object name_;
     /**
@@ -41752,7 +43495,6 @@ public final class Protos {
       }
     }
 
-    // optional .mesosphere.marathon.EnvVarSecretRef secretRef = 3;
     public static final int SECRETREF_FIELD_NUMBER = 3;
     private mesosphere.marathon.Protos.EnvVarSecretRef secretRef_;
     /**
@@ -41782,7 +43524,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasType()) {
         memoizedIsInitialized = 0;
@@ -41917,8 +43660,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.EnvVarReference}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.EnvVarReferenceOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.EnvVarReference)
+        mesosphere.marathon.Protos.EnvVarReferenceOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_EnvVarReference_descriptor;
@@ -42074,7 +43818,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required .mesosphere.marathon.EnvVarReference.Type type = 1;
       private mesosphere.marathon.Protos.EnvVarReference.Type type_ = mesosphere.marathon.Protos.EnvVarReference.Type.UNKNOWN;
       /**
        * <code>required .mesosphere.marathon.EnvVarReference.Type type = 1;</code>
@@ -42110,7 +43853,6 @@ public final class Protos {
         return this;
       }
 
-      // required string name = 2;
       private java.lang.Object name_ = "";
       /**
        * <code>required string name = 2;</code>
@@ -42124,9 +43866,12 @@ public final class Protos {
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          name_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            name_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -42184,7 +43929,6 @@ public final class Protos {
         return this;
       }
 
-      // optional .mesosphere.marathon.EnvVarSecretRef secretRef = 3;
       private mesosphere.marathon.Protos.EnvVarSecretRef secretRef_ = mesosphere.marathon.Protos.EnvVarSecretRef.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           mesosphere.marathon.Protos.EnvVarSecretRef, mesosphere.marathon.Protos.EnvVarSecretRef.Builder, mesosphere.marathon.Protos.EnvVarSecretRefOrBuilder> secretRefBuilder_;
@@ -42293,7 +44037,7 @@ public final class Protos {
         if (secretRefBuilder_ == null) {
           secretRefBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               mesosphere.marathon.Protos.EnvVarSecretRef, mesosphere.marathon.Protos.EnvVarSecretRef.Builder, mesosphere.marathon.Protos.EnvVarSecretRefOrBuilder>(
-                  secretRef_,
+                  getSecretRef(),
                   getParentForChildren(),
                   isClean());
           secretRef_ = null;
@@ -42312,10 +44056,10 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.EnvVarReference)
   }
 
-  public interface EnvVarSecretRefOrBuilder
-      extends com.google.protobuf.MessageOrBuilder {
+  public interface EnvVarSecretRefOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mesosphere.marathon.EnvVarSecretRef)
+      com.google.protobuf.MessageOrBuilder {
 
-    // required string secretId = 1;
     /**
      * <code>required string secretId = 1;</code>
      */
@@ -42334,8 +44078,9 @@ public final class Protos {
    * Protobuf type {@code mesosphere.marathon.EnvVarSecretRef}
    */
   public static final class EnvVarSecretRef extends
-      com.google.protobuf.GeneratedMessage
-      implements EnvVarSecretRefOrBuilder {
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:mesosphere.marathon.EnvVarSecretRef)
+      EnvVarSecretRefOrBuilder {
     // Use EnvVarSecretRef.newBuilder() to construct.
     private EnvVarSecretRef(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
@@ -42382,8 +44127,9 @@ public final class Protos {
               break;
             }
             case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
-              secretId_ = input.readBytes();
+              secretId_ = bs;
               break;
             }
           }
@@ -42426,7 +44172,6 @@ public final class Protos {
     }
 
     private int bitField0_;
-    // required string secretId = 1;
     public static final int SECRETID_FIELD_NUMBER = 1;
     private java.lang.Object secretId_;
     /**
@@ -42475,7 +44220,8 @@ public final class Protos {
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
 
       if (!hasSecretId()) {
         memoizedIsInitialized = 0;
@@ -42586,8 +44332,9 @@ public final class Protos {
      * Protobuf type {@code mesosphere.marathon.EnvVarSecretRef}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.EnvVarSecretRefOrBuilder {
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mesosphere.marathon.EnvVarSecretRef)
+        mesosphere.marathon.Protos.EnvVarSecretRefOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
         return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor;
@@ -42706,7 +44453,6 @@ public final class Protos {
       }
       private int bitField0_;
 
-      // required string secretId = 1;
       private java.lang.Object secretId_ = "";
       /**
        * <code>required string secretId = 1;</code>
@@ -42720,9 +44466,12 @@ public final class Protos {
       public java.lang.String getSecretId() {
         java.lang.Object ref = secretId_;
         if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          secretId_ = s;
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            secretId_ = s;
+          }
           return s;
         } else {
           return (java.lang.String) ref;
@@ -42791,172 +44540,182 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:mesosphere.marathon.EnvVarSecretRef)
   }
 
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Constraint_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Constraint_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ReadinessCheckDefinition_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_IpAddress_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_DiscoveryInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ServiceDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Json_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Json_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ResourceRoles_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ResourceRoles_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonTask_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_MarathonApp_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ContainerInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ContainerInfo_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ExtendedContainerInfo_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Volume_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Volume_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_EventSubscribers_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mesosphere_marathon_Callback_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_mesosphere_marathon_Callback_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mesosphere_marathon_CallbackFilter_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_mesosphere_marathon_CallbackFilter_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_StorageVersion_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_StorageVersion_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_GroupDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_GroupDefinition_AppReference_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_GroupDefinition_AppReference_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_DeploymentPlanDefinition_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_TaskFailure_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_TaskFailure_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ZKStoreEntry_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_ResidencyDefinition_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_ResidencyDefinition_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_Secret_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_Secret_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_EnvVarReference_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_mesosphere_marathon_EnvVarReference_fieldAccessorTable;
-  private static com.google.protobuf.Descriptors.Descriptor
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -43103,269 +44862,288 @@ public final class Protos {
       "raint\022\017\n\007maxSize\030\004 \001(\004\032a\n\022ExternalVolume" +
       "Info\022\014\n\004size\030\001 \001(\004\022\014\n\004name\030\002 \002(\t\022\020\n\010prov" +
       "ider\030\003 \002(\t\022\035\n\007options\030\004 \003(\0132\014.mesos.Labe" +
-      "l\")\n\020EventSubscribers\022\025\n\rcallback_urls\030\001" +
-      " \003(\t\"\274\001\n\016StorageVersion\022\r\n\005major\030\001 \002(\r\022\r" +
-      "\n\005minor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\022I\n\006format\030\004" +
-      " \001(\01621.mesosphere.marathon.StorageVersio" +
-      "n.StorageFormat:\006LEGACY\"2\n\rStorageFormat" +
-      "\022\n\n\006LEGACY\020\000\022\025\n\021PERSISTENCE_STORE\020\001\"Z\n\031U" +
-      "pgradeStrategyDefinition\022\035\n\025minimumHealt",
-      "hCapacity\030\001 \002(\001\022\036\n\023maximumOverCapacity\030\002" +
-      " \001(\001:\0011\"\236\003\n\017GroupDefinition\022\n\n\002id\030\001 \002(\t\022" +
-      "\017\n\007version\030\002 \002(\t\022?\n\017deprecated_apps\030\003 \003(" +
-      "\0132&.mesosphere.marathon.ServiceDefinitio" +
-      "n\0222\n\017deprecated_pods\030\010 \003(\0132\031.mesosphere." +
-      "marathon.Json\0224\n\006groups\030\004 \003(\0132$.mesosphe" +
-      "re.marathon.GroupDefinition\022\024\n\014dependenc" +
-      "ies\030\005 \003(\t\022?\n\004apps\030\006 \003(\01321.mesosphere.mar" +
-      "athon.GroupDefinition.AppReference\022?\n\004po" +
-      "ds\030\007 \003(\01321.mesosphere.marathon.GroupDefi",
-      "nition.AppReference\032+\n\014AppReference\022\n\n\002i" +
-      "d\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\"\371\001\n\030DeploymentP" +
-      "lanDefinition\022\n\n\002id\030\001 \002(\t\022\021\n\ttimestamp\030\002" +
-      " \001(\t\022A\n\023deprecated_original\030\004 \001(\0132$.meso" +
-      "sphere.marathon.GroupDefinition\022?\n\021depre" +
-      "cated_target\030\005 \001(\0132$.mesosphere.marathon" +
-      ".GroupDefinition\022\035\n\025original_root_versio" +
-      "n\030\006 \001(\t\022\033\n\023target_root_version\030\007 \001(\t\"\306\001\n" +
-      "\013TaskFailure\022\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id\030" +
-      "\002 \002(\0132\r.mesos.TaskID\022\037\n\005state\030\003 \002(\0162\020.me",
-      "sos.TaskState\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004host" +
-      "\030\005 \001(\t:\000\022\017\n\007version\030\006 \002(\t\022\021\n\ttimestamp\030\007" +
-      " \002(\t\022\037\n\007slaveId\030\010 \001(\0132\016.mesos.SlaveID\"T\n" +
-      "\014ZKStoreEntry\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002(" +
-      "\014\022\r\n\005value\030\003 \002(\014\022\031\n\ncompressed\030\004 \001(\010:\005fa" +
-      "lse\"\326\001\n\023ResidencyDefinition\022(\n relaunchE" +
-      "scalationTimeoutSeconds\030\001 \001(\003\022S\n\020taskLos" +
-      "tBehavior\030\002 \001(\01629.mesosphere.marathon.Re" +
-      "sidencyDefinition.TaskLostBehavior\"@\n\020Ta" +
-      "skLostBehavior\022\032\n\026RELAUNCH_AFTER_TIMEOUT",
-      "\020\000\022\020\n\014WAIT_FOREVER\020\001\"$\n\006Secret\022\n\n\002id\030\001 \002" +
-      "(\t\022\016\n\006source\030\002 \002(\t\"\262\001\n\017EnvVarReference\0227" +
-      "\n\004type\030\001 \002(\0162).mesosphere.marathon.EnvVa" +
-      "rReference.Type\022\014\n\004name\030\002 \002(\t\0227\n\tsecretR" +
-      "ef\030\003 \001(\0132$.mesosphere.marathon.EnvVarSec" +
-      "retRef\"\037\n\004Type\022\013\n\007UNKNOWN\020\000\022\n\n\006SECRET\020\001\"" +
-      "#\n\017EnvVarSecretRef\022\020\n\010secretId\030\001 \002(\tB\035\n\023" +
-      "mesosphere.marathonB\006Protos"
+      "l\"l\n\020EventSubscribers\022\025\n\rcallback_urls\030\001" +
+      " \003(\t\022A\n\032callback_urls_with_filters\030\002 \003(\013" +
+      "2\035.mesosphere.marathon.Callback\"V\n\010Callb" +
+      "ack\022\013\n\003url\030\001 \001(\t\022=\n\020callback_filters\030\002 \003" +
+      "(\0132#.mesosphere.marathon.CallbackFilter\"" +
+      "?\n\016CallbackFilter\022\024\n\014filter_query\030\001 \001(\t\022" +
+      "\027\n\017accepted_values\030\002 \003(\t\"\274\001\n\016StorageVers",
+      "ion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005pat" +
+      "ch\030\003 \002(\r\022I\n\006format\030\004 \001(\01621.mesosphere.ma" +
+      "rathon.StorageVersion.StorageFormat:\006LEG" +
+      "ACY\"2\n\rStorageFormat\022\n\n\006LEGACY\020\000\022\025\n\021PERS" +
+      "ISTENCE_STORE\020\001\"Z\n\031UpgradeStrategyDefini" +
+      "tion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023m" +
+      "aximumOverCapacity\030\002 \001(\001:\0011\"\236\003\n\017GroupDef" +
+      "inition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\022?\n\017" +
+      "deprecated_apps\030\003 \003(\0132&.mesosphere.marat" +
+      "hon.ServiceDefinition\0222\n\017deprecated_pods",
+      "\030\010 \003(\0132\031.mesosphere.marathon.Json\0224\n\006gro" +
+      "ups\030\004 \003(\0132$.mesosphere.marathon.GroupDef" +
+      "inition\022\024\n\014dependencies\030\005 \003(\t\022?\n\004apps\030\006 " +
+      "\003(\01321.mesosphere.marathon.GroupDefinitio" +
+      "n.AppReference\022?\n\004pods\030\007 \003(\01321.mesospher" +
+      "e.marathon.GroupDefinition.AppReference\032" +
+      "+\n\014AppReference\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002" +
+      " \002(\t\"\371\001\n\030DeploymentPlanDefinition\022\n\n\002id\030" +
+      "\001 \002(\t\022\021\n\ttimestamp\030\002 \001(\t\022A\n\023deprecated_o" +
+      "riginal\030\004 \001(\0132$.mesosphere.marathon.Grou",
+      "pDefinition\022?\n\021deprecated_target\030\005 \001(\0132$" +
+      ".mesosphere.marathon.GroupDefinition\022\035\n\025" +
+      "original_root_version\030\006 \001(\t\022\033\n\023target_ro" +
+      "ot_version\030\007 \001(\t\"\306\001\n\013TaskFailure\022\016\n\006app_" +
+      "id\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID" +
+      "\022\037\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007mes" +
+      "sage\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030" +
+      "\006 \002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(" +
+      "\0132\016.mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004nam" +
+      "e\030\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\n",
+      "compressed\030\004 \001(\010:\005false\"\326\001\n\023ResidencyDef" +
+      "inition\022(\n relaunchEscalationTimeoutSeco" +
+      "nds\030\001 \001(\003\022S\n\020taskLostBehavior\030\002 \001(\01629.me" +
+      "sosphere.marathon.ResidencyDefinition.Ta" +
+      "skLostBehavior\"@\n\020TaskLostBehavior\022\032\n\026RE" +
+      "LAUNCH_AFTER_TIMEOUT\020\000\022\020\n\014WAIT_FOREVER\020\001" +
+      "\"$\n\006Secret\022\n\n\002id\030\001 \002(\t\022\016\n\006source\030\002 \002(\t\"\262" +
+      "\001\n\017EnvVarReference\0227\n\004type\030\001 \002(\0162).mesos" +
+      "phere.marathon.EnvVarReference.Type\022\014\n\004n" +
+      "ame\030\002 \002(\t\0227\n\tsecretRef\030\003 \001(\0132$.mesospher",
+      "e.marathon.EnvVarSecretRef\"\037\n\004Type\022\013\n\007UN" +
+      "KNOWN\020\000\022\n\n\006SECRET\020\001\"#\n\017EnvVarSecretRef\022\020" +
+      "\n\010secretId\030\001 \002(\tB\035\n\023mesosphere.marathonB" +
+      "\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-      new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-        public com.google.protobuf.ExtensionRegistry assignDescriptors(
-            com.google.protobuf.Descriptors.FileDescriptor root) {
-          descriptor = root;
-          internal_static_mesosphere_marathon_Constraint_descriptor =
-            getDescriptor().getMessageTypes().get(0);
-          internal_static_mesosphere_marathon_Constraint_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Constraint_descriptor,
-              new java.lang.String[] { "Field", "Operator", "Value", });
-          internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(1);
-          internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
-              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "Port", "DelaySeconds", "PortName", });
-          internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(2);
-          internal_static_mesosphere_marathon_ReadinessCheckDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor,
-              new java.lang.String[] { "Name", "Protocol", "Path", "PortName", "IntervalMillis", "TimeoutMillis", "HttpStatusCodeForReady", "PreserveLastResponse", });
-          internal_static_mesosphere_marathon_IpAddress_descriptor =
-            getDescriptor().getMessageTypes().get(3);
-          internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_IpAddress_descriptor,
-              new java.lang.String[] { "Groups", "Labels", "DiscoveryInfo", "NetworkName", });
-          internal_static_mesosphere_marathon_DiscoveryInfo_descriptor =
-            getDescriptor().getMessageTypes().get(4);
-          internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_DiscoveryInfo_descriptor,
-              new java.lang.String[] { "Ports", });
-          internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(5);
-          internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ServiceDefinition_descriptor,
-              new java.lang.String[] { "Id", "Cmd", "Instances", "Resources", "Description", "Ports", "Constraints", "Executor", "OBSOLETEContainer", "Version", "HealthChecks", "Backoff", "BackoffFactor", "UpgradeStrategy", "Dependencies", "StoreUrls", "RequirePorts", "Container", "Labels", "MaxLaunchDelay", "AcceptedResourceRoles", "LastScalingAt", "LastConfigChangeAt", "IpAddress", "Residency", "PortDefinitions", "ReadinessCheckDefinition", "Secrets", "EnvVarReferences", "TaskKillGracePeriod", });
-          internal_static_mesosphere_marathon_Json_descriptor =
-            getDescriptor().getMessageTypes().get(6);
-          internal_static_mesosphere_marathon_Json_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Json_descriptor,
-              new java.lang.String[] { "Json", });
-          internal_static_mesosphere_marathon_ResourceRoles_descriptor =
-            getDescriptor().getMessageTypes().get(7);
-          internal_static_mesosphere_marathon_ResourceRoles_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ResourceRoles_descriptor,
-              new java.lang.String[] { "Role", });
-          internal_static_mesosphere_marathon_MarathonTask_descriptor =
-            getDescriptor().getMessageTypes().get(8);
-          internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_descriptor,
-              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "OBSOLETENetworks", "Reservation", "Condition", });
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor =
-            internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor,
-              new java.lang.String[] { "LocalVolumeIds", "State", });
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor =
-            internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor,
-              new java.lang.String[] { "Type", "Timeout", });
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor =
-            internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor,
-              new java.lang.String[] { "Initiated", "Deadline", "Reason", });
-          internal_static_mesosphere_marathon_MarathonApp_descriptor =
-            getDescriptor().getMessageTypes().get(9);
-          internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonApp_descriptor,
-              new java.lang.String[] { "Name", "Tasks", });
-          internal_static_mesosphere_marathon_ContainerInfo_descriptor =
-            getDescriptor().getMessageTypes().get(10);
-          internal_static_mesosphere_marathon_ContainerInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ContainerInfo_descriptor,
-              new java.lang.String[] { "Image", "Options", });
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor =
-            getDescriptor().getMessageTypes().get(11);
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor,
-              new java.lang.String[] { "Type", "Volumes", "Docker", "MesosDocker", "MesosAppC", });
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor =
-            internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor,
-              new java.lang.String[] { "Image", "Network", "PortMappings", "Privileged", "Parameters", "ForcePullImage", });
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor =
-            internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor,
-              new java.lang.String[] { "HostPort", "ContainerPort", "Protocol", "Name", "Labels", "ServicePort", });
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_descriptor =
-            internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(1);
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_descriptor,
-              new java.lang.String[] { "Image", "Credential", "ForcePullImage", });
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_descriptor =
-            internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(2);
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_descriptor,
-              new java.lang.String[] { "Image", "Id", "Labels", "ForcePullImage", });
-          internal_static_mesosphere_marathon_Volume_descriptor =
-            getDescriptor().getMessageTypes().get(12);
-          internal_static_mesosphere_marathon_Volume_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Volume_descriptor,
-              new java.lang.String[] { "Mode", "ContainerPath", "HostPath", "Image", "Persistent", "External", });
-          internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor =
-            internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor,
-              new java.lang.String[] { "Size", "Type", "Constraints", "MaxSize", });
-          internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor =
-            internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(1);
-          internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor,
-              new java.lang.String[] { "Size", "Name", "Provider", "Options", });
-          internal_static_mesosphere_marathon_EventSubscribers_descriptor =
-            getDescriptor().getMessageTypes().get(13);
-          internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_EventSubscribers_descriptor,
-              new java.lang.String[] { "CallbackUrls", });
-          internal_static_mesosphere_marathon_StorageVersion_descriptor =
-            getDescriptor().getMessageTypes().get(14);
-          internal_static_mesosphere_marathon_StorageVersion_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_StorageVersion_descriptor,
-              new java.lang.String[] { "Major", "Minor", "Patch", "Format", });
-          internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(15);
-          internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor,
-              new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", });
-          internal_static_mesosphere_marathon_GroupDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(16);
-          internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_GroupDefinition_descriptor,
-              new java.lang.String[] { "Id", "Version", "DeprecatedApps", "DeprecatedPods", "Groups", "Dependencies", "Apps", "Pods", });
-          internal_static_mesosphere_marathon_GroupDefinition_AppReference_descriptor =
-            internal_static_mesosphere_marathon_GroupDefinition_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_GroupDefinition_AppReference_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_GroupDefinition_AppReference_descriptor,
-              new java.lang.String[] { "Id", "Version", });
-          internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(17);
-          internal_static_mesosphere_marathon_DeploymentPlanDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor,
-              new java.lang.String[] { "Id", "Timestamp", "DeprecatedOriginal", "DeprecatedTarget", "OriginalRootVersion", "TargetRootVersion", });
-          internal_static_mesosphere_marathon_TaskFailure_descriptor =
-            getDescriptor().getMessageTypes().get(18);
-          internal_static_mesosphere_marathon_TaskFailure_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_TaskFailure_descriptor,
-              new java.lang.String[] { "AppId", "TaskId", "State", "Message", "Host", "Version", "Timestamp", "SlaveId", });
-          internal_static_mesosphere_marathon_ZKStoreEntry_descriptor =
-            getDescriptor().getMessageTypes().get(19);
-          internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ZKStoreEntry_descriptor,
-              new java.lang.String[] { "Name", "Uuid", "Value", "Compressed", });
-          internal_static_mesosphere_marathon_ResidencyDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(20);
-          internal_static_mesosphere_marathon_ResidencyDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ResidencyDefinition_descriptor,
-              new java.lang.String[] { "RelaunchEscalationTimeoutSeconds", "TaskLostBehavior", });
-          internal_static_mesosphere_marathon_Secret_descriptor =
-            getDescriptor().getMessageTypes().get(21);
-          internal_static_mesosphere_marathon_Secret_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Secret_descriptor,
-              new java.lang.String[] { "Id", "Source", });
-          internal_static_mesosphere_marathon_EnvVarReference_descriptor =
-            getDescriptor().getMessageTypes().get(22);
-          internal_static_mesosphere_marathon_EnvVarReference_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_EnvVarReference_descriptor,
-              new java.lang.String[] { "Type", "Name", "SecretRef", });
-          internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor =
-            getDescriptor().getMessageTypes().get(23);
-          internal_static_mesosphere_marathon_EnvVarSecretRef_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor,
-              new java.lang.String[] { "SecretId", });
-          return null;
-        }
-      };
+        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
+          public com.google.protobuf.ExtensionRegistry assignDescriptors(
+              com.google.protobuf.Descriptors.FileDescriptor root) {
+            descriptor = root;
+            return null;
+          }
+        };
     com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           org.apache.mesos.Protos.getDescriptor(),
         }, assigner);
+    internal_static_mesosphere_marathon_Constraint_descriptor =
+      getDescriptor().getMessageTypes().get(0);
+    internal_static_mesosphere_marathon_Constraint_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_Constraint_descriptor,
+        new java.lang.String[] { "Field", "Operator", "Value", });
+    internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor =
+      getDescriptor().getMessageTypes().get(1);
+    internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
+        new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "Port", "DelaySeconds", "PortName", });
+    internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor =
+      getDescriptor().getMessageTypes().get(2);
+    internal_static_mesosphere_marathon_ReadinessCheckDefinition_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor,
+        new java.lang.String[] { "Name", "Protocol", "Path", "PortName", "IntervalMillis", "TimeoutMillis", "HttpStatusCodeForReady", "PreserveLastResponse", });
+    internal_static_mesosphere_marathon_IpAddress_descriptor =
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_IpAddress_descriptor,
+        new java.lang.String[] { "Groups", "Labels", "DiscoveryInfo", "NetworkName", });
+    internal_static_mesosphere_marathon_DiscoveryInfo_descriptor =
+      getDescriptor().getMessageTypes().get(4);
+    internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_DiscoveryInfo_descriptor,
+        new java.lang.String[] { "Ports", });
+    internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
+      getDescriptor().getMessageTypes().get(5);
+    internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ServiceDefinition_descriptor,
+        new java.lang.String[] { "Id", "Cmd", "Instances", "Resources", "Description", "Ports", "Constraints", "Executor", "OBSOLETEContainer", "Version", "HealthChecks", "Backoff", "BackoffFactor", "UpgradeStrategy", "Dependencies", "StoreUrls", "RequirePorts", "Container", "Labels", "MaxLaunchDelay", "AcceptedResourceRoles", "LastScalingAt", "LastConfigChangeAt", "IpAddress", "Residency", "PortDefinitions", "ReadinessCheckDefinition", "Secrets", "EnvVarReferences", "TaskKillGracePeriod", });
+    internal_static_mesosphere_marathon_Json_descriptor =
+      getDescriptor().getMessageTypes().get(6);
+    internal_static_mesosphere_marathon_Json_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_Json_descriptor,
+        new java.lang.String[] { "Json", });
+    internal_static_mesosphere_marathon_ResourceRoles_descriptor =
+      getDescriptor().getMessageTypes().get(7);
+    internal_static_mesosphere_marathon_ResourceRoles_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ResourceRoles_descriptor,
+        new java.lang.String[] { "Role", });
+    internal_static_mesosphere_marathon_MarathonTask_descriptor =
+      getDescriptor().getMessageTypes().get(8);
+    internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_MarathonTask_descriptor,
+        new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "OBSOLETENetworks", "Reservation", "Condition", });
+    internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor =
+      internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(0);
+    internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor,
+        new java.lang.String[] { "LocalVolumeIds", "State", });
+    internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor =
+      internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor.getNestedTypes().get(0);
+    internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor,
+        new java.lang.String[] { "Type", "Timeout", });
+    internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor =
+      internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor.getNestedTypes().get(0);
+    internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor,
+        new java.lang.String[] { "Initiated", "Deadline", "Reason", });
+    internal_static_mesosphere_marathon_MarathonApp_descriptor =
+      getDescriptor().getMessageTypes().get(9);
+    internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_MarathonApp_descriptor,
+        new java.lang.String[] { "Name", "Tasks", });
+    internal_static_mesosphere_marathon_ContainerInfo_descriptor =
+      getDescriptor().getMessageTypes().get(10);
+    internal_static_mesosphere_marathon_ContainerInfo_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ContainerInfo_descriptor,
+        new java.lang.String[] { "Image", "Options", });
+    internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor =
+      getDescriptor().getMessageTypes().get(11);
+    internal_static_mesosphere_marathon_ExtendedContainerInfo_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor,
+        new java.lang.String[] { "Type", "Volumes", "Docker", "MesosDocker", "MesosAppC", });
+    internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor =
+      internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(0);
+    internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor,
+        new java.lang.String[] { "Image", "Network", "PortMappings", "Privileged", "Parameters", "ForcePullImage", });
+    internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor =
+      internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor.getNestedTypes().get(0);
+    internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor,
+        new java.lang.String[] { "HostPort", "ContainerPort", "Protocol", "Name", "Labels", "ServicePort", });
+    internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_descriptor =
+      internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(1);
+    internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_descriptor,
+        new java.lang.String[] { "Image", "Credential", "ForcePullImage", });
+    internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_descriptor =
+      internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(2);
+    internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_descriptor,
+        new java.lang.String[] { "Image", "Id", "Labels", "ForcePullImage", });
+    internal_static_mesosphere_marathon_Volume_descriptor =
+      getDescriptor().getMessageTypes().get(12);
+    internal_static_mesosphere_marathon_Volume_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_Volume_descriptor,
+        new java.lang.String[] { "Mode", "ContainerPath", "HostPath", "Image", "Persistent", "External", });
+    internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor =
+      internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(0);
+    internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor,
+        new java.lang.String[] { "Size", "Type", "Constraints", "MaxSize", });
+    internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor =
+      internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(1);
+    internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor,
+        new java.lang.String[] { "Size", "Name", "Provider", "Options", });
+    internal_static_mesosphere_marathon_EventSubscribers_descriptor =
+      getDescriptor().getMessageTypes().get(13);
+    internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_EventSubscribers_descriptor,
+        new java.lang.String[] { "CallbackUrls", "CallbackUrlsWithFilters", });
+    internal_static_mesosphere_marathon_Callback_descriptor =
+      getDescriptor().getMessageTypes().get(14);
+    internal_static_mesosphere_marathon_Callback_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_Callback_descriptor,
+        new java.lang.String[] { "Url", "CallbackFilters", });
+    internal_static_mesosphere_marathon_CallbackFilter_descriptor =
+      getDescriptor().getMessageTypes().get(15);
+    internal_static_mesosphere_marathon_CallbackFilter_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_CallbackFilter_descriptor,
+        new java.lang.String[] { "FilterQuery", "AcceptedValues", });
+    internal_static_mesosphere_marathon_StorageVersion_descriptor =
+      getDescriptor().getMessageTypes().get(16);
+    internal_static_mesosphere_marathon_StorageVersion_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_StorageVersion_descriptor,
+        new java.lang.String[] { "Major", "Minor", "Patch", "Format", });
+    internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor =
+      getDescriptor().getMessageTypes().get(17);
+    internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor,
+        new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", });
+    internal_static_mesosphere_marathon_GroupDefinition_descriptor =
+      getDescriptor().getMessageTypes().get(18);
+    internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_GroupDefinition_descriptor,
+        new java.lang.String[] { "Id", "Version", "DeprecatedApps", "DeprecatedPods", "Groups", "Dependencies", "Apps", "Pods", });
+    internal_static_mesosphere_marathon_GroupDefinition_AppReference_descriptor =
+      internal_static_mesosphere_marathon_GroupDefinition_descriptor.getNestedTypes().get(0);
+    internal_static_mesosphere_marathon_GroupDefinition_AppReference_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_GroupDefinition_AppReference_descriptor,
+        new java.lang.String[] { "Id", "Version", });
+    internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor =
+      getDescriptor().getMessageTypes().get(19);
+    internal_static_mesosphere_marathon_DeploymentPlanDefinition_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor,
+        new java.lang.String[] { "Id", "Timestamp", "DeprecatedOriginal", "DeprecatedTarget", "OriginalRootVersion", "TargetRootVersion", });
+    internal_static_mesosphere_marathon_TaskFailure_descriptor =
+      getDescriptor().getMessageTypes().get(20);
+    internal_static_mesosphere_marathon_TaskFailure_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_TaskFailure_descriptor,
+        new java.lang.String[] { "AppId", "TaskId", "State", "Message", "Host", "Version", "Timestamp", "SlaveId", });
+    internal_static_mesosphere_marathon_ZKStoreEntry_descriptor =
+      getDescriptor().getMessageTypes().get(21);
+    internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ZKStoreEntry_descriptor,
+        new java.lang.String[] { "Name", "Uuid", "Value", "Compressed", });
+    internal_static_mesosphere_marathon_ResidencyDefinition_descriptor =
+      getDescriptor().getMessageTypes().get(22);
+    internal_static_mesosphere_marathon_ResidencyDefinition_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_ResidencyDefinition_descriptor,
+        new java.lang.String[] { "RelaunchEscalationTimeoutSeconds", "TaskLostBehavior", });
+    internal_static_mesosphere_marathon_Secret_descriptor =
+      getDescriptor().getMessageTypes().get(23);
+    internal_static_mesosphere_marathon_Secret_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_Secret_descriptor,
+        new java.lang.String[] { "Id", "Source", });
+    internal_static_mesosphere_marathon_EnvVarReference_descriptor =
+      getDescriptor().getMessageTypes().get(24);
+    internal_static_mesosphere_marathon_EnvVarReference_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_EnvVarReference_descriptor,
+        new java.lang.String[] { "Type", "Name", "SecretRef", });
+    internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor =
+      getDescriptor().getMessageTypes().get(25);
+    internal_static_mesosphere_marathon_EnvVarSecretRef_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor,
+        new java.lang.String[] { "SecretId", });
+    org.apache.mesos.Protos.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -328,6 +328,18 @@ message Volume {
 
 message EventSubscribers {
   repeated string callback_urls = 1;
+  repeated Callback callback_urls_with_filters = 2;
+}
+
+message Callback {
+  optional string url = 1;
+  repeated CallbackFilter callback_filters = 2;
+}
+
+message CallbackFilter {
+  // query to find interested field in event
+  optional string filter_query = 1;
+  repeated string accepted_values = 2;
 }
 
 message StorageVersion {

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -677,8 +677,22 @@ trait EventSubscribersFormats {
 
   implicit lazy val EventSubscribersWrites: Writes[EventSubscribers] = Writes { eventSubscribers =>
     Json.obj(
-      "callbackUrls" -> eventSubscribers.urls
+      "callbackUrls" -> eventSubscribers.urls,
+      "callbacks" -> eventSubscribers.callbacks
     )
+  }
+
+  implicit lazy val EventFilterWriters: Writes[EventFilter] = Writes { filter =>
+    Json.obj(
+      "query" -> filter.query,
+      "values" -> filter.values
+    )
+  }
+
+  implicit lazy val EventFilterReads: Reads[EventFilter] = Reads { eventFilterJson =>
+    val query = (eventFilterJson \ "query").asOpt[String].getOrElse("")
+    val values = (eventFilterJson \ "values").asOpt[Set[String]].getOrElse(Set.empty)
+    JsSuccess(EventFilter(query, values))
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.core.event
 import akka.actor.{ ActorRef, ActorSystem, Props }
 import akka.event.EventStream
 import akka.pattern.ask
+import mesosphere.marathon
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.event.impl.callback._
@@ -44,7 +45,7 @@ class EventModule(
     conf.httpEventEndpoints.get foreach { urls =>
       log.info(s"http_endpoints($urls) are specified at startup. Those will be added to subscribers list.")
       urls foreach { url =>
-        val f = (actor ? Subscribe(local_ip, url)).mapTo[MarathonSubscriptionEvent]
+        val f = (actor ? Subscribe(local_ip, url, marathon.Seq.empty[EventFilter])).mapTo[MarathonSubscriptionEvent]
         f.onFailure {
           case NonFatal(th) =>
             log.warn(s"Failed to add $url to event subscribers. exception message => ${th.getMessage}")

--- a/src/main/scala/mesosphere/marathon/core/event/EventSubscribers.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/EventSubscribers.scala
@@ -4,11 +4,23 @@ package core.event
 import mesosphere.marathon.state.{ MarathonState, Timestamp }
 import mesosphere.marathon.stream._
 
-case class EventSubscribers(urls: Set[String] = Set.empty[String])
+case class EventSubscribers(callbacks: Map[String, Seq[EventFilter]] = Map.empty[String, Seq[EventFilter]])
     extends MarathonState[Protos.EventSubscribers, EventSubscribers] {
 
-  override def mergeFromProto(message: Protos.EventSubscribers): EventSubscribers =
-    EventSubscribers(message.getCallbackUrlsList.toSet)
+  override def mergeFromProto(message: Protos.EventSubscribers): EventSubscribers = {
+
+    val callbacksWithoutFilter = message.getCallbackUrlsList.map(callback => callback -> EventFilters.empty)
+    val callbacksWithFilters = message.getCallbackUrlsWithFiltersList.map(callback => {
+      callback.getUrl -> callback.getCallbackFiltersList.map(EventFilter.fromProto)
+    })
+
+    val callbacks = callbacksWithoutFilter.toSeq ++ callbacksWithFilters.toSeq
+    val grouped = callbacks.groupBy(_._1)
+    val cleaned = grouped.mapValues(_.flatMap(_._2))
+    val transformed = cleaned.map(x => x._1 -> Seq(x._2: _*))
+
+    EventSubscribers(transformed)
+  }
 
   override def mergeFromProto(bytes: Array[Byte]): EventSubscribers = {
     val proto = Protos.EventSubscribers.parseFrom(bytes)
@@ -17,10 +29,65 @@ case class EventSubscribers(urls: Set[String] = Set.empty[String])
 
   override def toProto: Protos.EventSubscribers = {
     val builder = Protos.EventSubscribers.newBuilder()
-    urls.foreach(builder.addCallbackUrls)
+    callbacks.foreach(callback => {
+      val b = Protos.Callback.newBuilder()
+      b.setUrl(callback._1)
+      b.addAllCallbackFilters(callback._2.map(_.toProto))
+      builder.addCallbackUrlsWithFilters(b)
+    })
     builder.build()
   }
 
   override def version: Timestamp = Timestamp.zero
+
+  def urls: Set[String] = callbacks.keySet
+
+  def subscribedUrls(e: MarathonEvent): Iterable[String] = {
+    callbacks.filter(_._2.forall(_.accept(e))).keys
+  }
+
 }
 
+object EventSubscribers {
+  def apply(urls: Set[String]): EventSubscribers = new EventSubscribers(urls.map(url => url -> EventFilters.empty).toMap)
+}
+
+case class EventFilter(query: String = "", values: Set[String] = Set.empty[String])
+    extends MarathonState[Protos.CallbackFilter, EventFilter] {
+
+  override def mergeFromProto(message: Protos.CallbackFilter): EventFilter =
+    EventFilter(message.getFilterQuery, message.getAcceptedValuesList.toSet)
+
+  override def mergeFromProto(bytes: Array[Byte]): EventFilter = {
+    val proto = Protos.CallbackFilter.parseFrom(bytes)
+    mergeFromProto(proto)
+  }
+
+  override def toProto: Protos.CallbackFilter = {
+    val builder = Protos.CallbackFilter.newBuilder()
+    builder.setFilterQuery(query)
+    builder.addAllAcceptedValues(values)
+    builder.build()
+  }
+
+  override def version: Timestamp = Timestamp.zero
+
+  def accept(e: MarathonEvent): Boolean = {
+    //TODO(janisz) handle other events fields (e.g. with jsonpath)
+    query == "event_type" && values.contains(e.eventType)
+  }
+}
+
+object EventFilter {
+  def fromProto(message: Protos.CallbackFilter): EventFilter =
+    EventFilter(message.getFilterQuery, message.getAcceptedValuesList.toSet)
+
+  def fromProto(bytes: Array[Byte]): EventFilter = {
+    val proto = Protos.CallbackFilter.parseFrom(bytes)
+    fromProto(proto)
+  }
+}
+
+object EventFilters {
+  def empty: Seq[EventFilter] = Seq.empty
+}

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -76,6 +76,7 @@ sealed trait MarathonSubscriptionEvent extends MarathonEvent
 case class Subscribe(
   clientIp: String,
   callbackUrl: String,
+  filters: Seq[EventFilter],
   eventType: String = "subscribe_event",
   timestamp: String = Timestamp.now().toString)
     extends MarathonSubscriptionEvent

--- a/src/main/scala/mesosphere/marathon/core/event/impl/callback/HttpEventActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/callback/HttpEventActor.scala
@@ -90,7 +90,7 @@ class HttpEventActor(
   }
 
   def broadcast(event: MarathonEvent, subscribers: EventSubscribers): Unit = {
-    val (active, limited) = subscribers.urls.partition(limiter(_).notLimited)
+    val (active, limited) = subscribers.subscribedUrls(event).partition(limiter(_).notLimited)
     if (limited.nonEmpty) {
       log.info(s"""Will not send event ${event.eventType} to unresponsive hosts: ${limited.mkString(" ")}""")
     }

--- a/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
@@ -275,7 +275,7 @@ trait EventSubscribersRepository extends SingletonRepository[EventSubscribers]
 
 object EventSubscribersRepository {
   def legacyRepository(store: (String, () => EventSubscribers) => EntityStore[EventSubscribers]): EventSubscribersEntityRepository = {
-    val entityStore = store("events:", () => EventSubscribers(Set.empty[String]))
+    val entityStore = store("events:", () => EventSubscribers())
     new EventSubscribersEntityRepository(entityStore)
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/EventSubscriptionsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/EventSubscriptionsResourceTest.scala
@@ -15,7 +15,7 @@ class EventSubscriptionsResourceTest extends MarathonSpec with Matchers with Moc
     f.auth.authenticated = false
 
     When("we try to subscribe")
-    val subscribe = resource.subscribe(f.auth.request, "http://callback")
+    val subscribe = resource.subscribe(f.auth.request, "http://callback", Array.empty)
     Then("we receive a NotAuthenticated response")
     subscribe.getStatus should be(f.auth.NotAuthenticatedStatus)
 
@@ -38,7 +38,7 @@ class EventSubscriptionsResourceTest extends MarathonSpec with Matchers with Moc
     f.auth.authorized = false
 
     When("we try to subscribe")
-    val subscribe = resource.subscribe(f.auth.request, "http://callback")
+    val subscribe = resource.subscribe(f.auth.request, "http://callback", Array.empty)
     Then("we receive a NotAuthenticated response")
     subscribe.getStatus should be(f.auth.UnauthorizedStatus)
 

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActorTest.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.CountDownLatch
 import akka.actor.Props
 import akka.event.EventStream
 import akka.testkit.{ EventFilter, ImplicitSender, TestActorRef }
-import mesosphere.marathon.core.event.{ EventStreamAttached, EventStreamDetached, Subscribe }
+import mesosphere.marathon.core.event.{ EventFilters, EventStreamAttached, EventStreamDetached, Subscribe }
 import mesosphere.marathon.test.{ MarathonActorSupport, MarathonSpec, Mockito }
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
 
@@ -66,7 +66,7 @@ class HttpEventStreamHandleActorTest extends MarathonActorSupport
     ))
     val attached = EventStreamAttached("remote")
     val detached = EventStreamDetached("remote")
-    val subscribe = Subscribe("ip", "url")
+    val subscribe = Subscribe("ip", "url", EventFilters.empty)
 
     When("One message is send directly and 2 are queued for later delivery")
     handleActor ! attached


### PR DESCRIPTION
First draft of enabling filtering of event callbacks to fix #3154
My goal it to provide configurable way of filtering events before they were sent. On big clusters events becomes a problem (especially deployments events with size 10MB). This leads to errors and increase events delay. 

My idea is to allow user use jsonpath or some other way to get field and compare it with accepted values. Accepted values contains specific field event will be delivered if no then it will be skipped.

Pleas give me some clues if this is good idea. Maybe we should stick to `event_type` and do not allow more filtering but it was request in #4637 by @tobilg 

> [here might be use cases where it would make sense to filter on field values as well, so as if an application wants to only listen to a specific applications events, such as status updates of a certain appId.](https://github.com/mesosphere/marathon/issues/4637#issuecomment-261202413)

Related to: [allegro/marathon-consul#139](https://github.com/allegro/marathon-consul/issues/139)