### PR TITLE
Fixes #4637 Allow filtering SSE events by types

### DIFF
--- a/docs/docs/rest-api/mesosphere/marathon/api/v2/EventResource_get.md
+++ b/docs/docs/rest-api/mesosphere/marathon/api/v2/EventResource_get.md
@@ -8,11 +8,13 @@ To use this endpoint, the client has to accept the text/event-stream content typ
 Please note: a request to this endpoint will not be closed by the server.
 If an event happens on the server side, this event will be propagated to the client immediately.
 See [Server Sent Events](http://www.w3schools.com/html/html5_serversentevents.asp) for a more detailed explanation.
+To filter events add `event_type` query param with desired event type. You can specify multiple params to get more than
+one event type.
 
 **Request:**
 
 ```
-GET /v2/events HTTP/1.1
+GET /v2/events?event_type=event_stream_attached&event_type=event_stream_attached HTTP/1.1
 Accept: text/event-stream
 Accept-Encoding: gzip, deflate
 Host: localhost:8080

--- a/docs/docs/rest-api/public/api/v2/events.raml
+++ b/docs/docs/rest-api/public/api/v2/events.raml
@@ -10,6 +10,13 @@ get:
 
     Note for ApiConsole&#58; this function will not yield the expected result from inside ApiConsole.
 
+  queryParameters:
+    event_type:
+        required: false
+        description:
+            Specify subscribed event types.
+            You can specify this parameter multiple times with different values.
+
   responses:
     200:
       description: the list of all tasks waiting to be scheduled.

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServlet.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServlet.scala
@@ -24,13 +24,21 @@ class HttpEventSSEHandle(request: HttpServletRequest, emitter: Emitter) extends 
 
   lazy val id: String = UUID.randomUUID().toString
 
+  val subscribedEventTypes = request.getParameterMap.getOrDefault("event_type", Array.empty).toSet
+
+  def subscribed(eventType: String): Boolean = {
+    subscribedEventTypes.isEmpty || subscribedEventTypes.contains(eventType)
+  }
+
   override def remoteAddress: String = request.getRemoteAddr
 
   override def close(): Unit = emitter.close()
 
-  override def sendEvent(event: String, message: String): Unit = blocking(emitter.event(event, message))
+  override def sendEvent(event: String, message: String): Unit = {
+    if (subscribed(event)) blocking(emitter.event(event, message))
+  }
 
-  override def toString: String = s"HttpEventSSEHandle($id on $remoteAddress)"
+  override def toString: String = s"HttpEventSSEHandle($id on $remoteAddress on event types from $subscribedEventTypes)"
 }
 
 /**

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventSSEHandleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventSSEHandleTest.scala
@@ -1,0 +1,59 @@
+package mesosphere.marathon.core.event.impl.stream
+
+import javax.servlet.http.HttpServletRequest
+
+import mesosphere.marathon.test.{ MarathonSpec, Mockito }
+import org.eclipse.jetty.servlets.EventSource.Emitter
+import org.scalatest.{ GivenWhenThen, Matchers }
+import collection.JavaConversions._
+
+class HttpEventSSEHandleTest extends MarathonSpec with Matchers with Mockito with GivenWhenThen {
+
+  test("events should be filtered") {
+    Given("An emiter")
+    val emitter = mock[Emitter]
+    Given("An request with params")
+    val req = mock[HttpServletRequest]
+    req.getParameterMap returns mapAsJavaMap(Map("event_type" -> Array("xyz")))
+
+    Given("handler for request is created")
+    val handle = new HttpEventSSEHandle(req, emitter)
+
+    When("Want to sent unwanted event")
+    handle.sendEvent("any event", "")
+
+    Then("event should NOT be sent")
+    verify(emitter, never).event("any event", "")
+
+    When("Want to sent subscribed event")
+    handle.sendEvent("xyz", "")
+
+    Then("event should be sent")
+    verify(emitter).event("xyz", "")
+  }
+
+  test("events should NOT be filtered") {
+    Given("An emiter")
+    val emitter = mock[Emitter]
+
+    Given("An request without params")
+    val req = mock[HttpServletRequest]
+    req.getParameterMap returns mapAsJavaMap(Map.empty)
+
+    Given("handler for request is created")
+    val handle = new HttpEventSSEHandle(req, emitter)
+
+    When("Want to sent event")
+    handle.sendEvent("any event", "")
+    Then("event should NOT be sent")
+
+    verify(emitter).event("any event", "")
+    When("Want to sent event")
+
+    handle.sendEvent("xyz", "")
+
+    Then("event should be sent")
+    verify(emitter).event("xyz", "")
+  }
+}
+


### PR DESCRIPTION
Allow recievieng only specific events by providing their types
in `event_type` query params. Old behavaiour remains unchanged.