### PR TITLE
Added NetworkInfo as a wrapper for a task's network stuff

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -36,7 +36,7 @@ object EndpointsHelper {
             instance <- instances if instance.isRunning
             (_, task) <- instance.tasksMap
           } {
-            val taskPort = task.launched.flatMap(_.hostPorts.drop(i).headOption).getOrElse(0)
+            val taskPort = task.status.networkInfo.hostPorts.drop(i).headOption.getOrElse(0)
             sb.append(instance.agentInfo.host).append(':').append(taskPort).append(delimiter)
           }
           sb.append('\n')

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -5,6 +5,7 @@ import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.Protos.Constraint.Operator
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.Protos.ResidencyDefinition.TaskLostBehavior
+import mesosphere.marathon._
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health._
@@ -13,6 +14,7 @@ import mesosphere.marathon.core.plugin.{ PluginDefinition, PluginDefinitions }
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.readiness.ReadinessCheck
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.raml.{ Pod, Raml, Resources }
 import mesosphere.marathon.state._
 import mesosphere.marathon.upgrade.DeploymentManager.DeploymentStepInfo
@@ -117,6 +119,13 @@ trait Formats
     Json.arr(instance.tasksMap.values.map(TaskWrites.writes(_).as[JsObject]))
   }
 
+  implicit val TaskStatusNetworkInfoWrites: Format[NetworkInfo] = (
+    (__ \ "hasConfiguredIpAddress").format[Boolean] ~
+    (__ \ "hostPorts").format[Seq[Int]] ~
+    (__ \ "effectiveIpAddress").formatNullable[String] ~
+    (__ \ "ipAddresses").formatNullable[Seq[mesos.NetworkInfo.IPAddress]]
+  )(NetworkInfo(_, _, _, _), unlift(NetworkInfo.unapply))
+
   implicit val TaskWrites: Writes[Task] = Writes { task =>
     val base = Json.obj(
       "id" -> task.taskId,
@@ -126,11 +135,11 @@ trait Formats
     )
 
     val launched = task.launched.map { launched =>
-      task.status.ipAddresses.foldLeft(
+      task.status.networkInfo.ipAddresses.foldLeft(
         base ++ Json.obj (
           "startedAt" -> task.status.startedAt,
           "stagedAt" -> task.status.stagedAt,
-          "ports" -> launched.hostPorts,
+          "ports" -> task.status.networkInfo.hostPorts,
           "version" -> task.runSpecVersion
         )
       ){

--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
@@ -79,7 +79,7 @@ sealed trait MarathonHealthCheck extends HealthCheckWithPort { this: HealthCheck
 
   @SuppressWarnings(Array("OptionGet"))
   def effectivePort(app: AppDefinition, task: Task): Int = {
-    def portViaIndex: Option[Int] = portIndex.map(_(app.portAssignments(task)).effectivePort)
+    def portViaIndex: Option[Int] = portIndex.map(_(task.status.networkInfo.portAssignments(app)).effectivePort)
     port.orElse(portViaIndex).get
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
@@ -45,9 +45,9 @@ class HealthCheckWorkerActor extends Actor {
         .onComplete { _ => self ! PoisonPill }
   }
 
-  def doCheck(
-    app: AppDefinition, task: Task, check: MarathonHealthCheck): Future[Option[HealthResult]] =
-    task.effectiveIpAddress(app) match {
+  def doCheck(app: AppDefinition, task: Task, check: MarathonHealthCheck): Future[Option[HealthResult]] = {
+    val effectiveIpAddress = task.status.networkInfo.effectiveIpAddress
+    effectiveIpAddress match {
       case Some(host) =>
         val port = check.effectivePort(app, task)
         check match {
@@ -71,6 +71,7 @@ class HealthCheckWorkerActor extends Actor {
           new UnsupportedOperationException(message)
         }
     }
+  }
 
   def http(
     task: Task,

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangedEventsGenerator.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangedEventsGenerator.scala
@@ -25,9 +25,9 @@ object InstanceChangedEventsGenerator {
 
     task.fold(instanceEvent) { task =>
       val maybeTaskStatus = task.status.mesosStatus
-      val ports = task.launched.fold(Seq.empty[Int])(_.hostPorts)
+      val ports = task.status.networkInfo.hostPorts
       val host = instance.agentInfo.host
-      val ipAddresses = maybeTaskStatus.flatMap(status => Task.MesosStatus.ipAddresses(status))
+      val ipAddresses = task.status.networkInfo.ipAddresses
       val slaveId = maybeTaskStatus.fold("")(_.getSlaveId.getValue)
       val message = maybeTaskStatus.fold("")(status => if (status.hasMessage) status.getMessage else "")
       val status = condition.toReadableName

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon.core.launcher.{ InstanceOp, InstanceOpFactory, OfferM
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.plugin.task.RunSpecTaskProcessor
 import mesosphere.marathon.plugin.{ ApplicationSpec, PodSpec }
 import mesosphere.marathon.state.{ AppDefinition, DiskSource, ResourceRole, RunSpec }
@@ -90,16 +91,16 @@ class InstanceOpFactoryImpl(
     matchResponse match {
       case matches: ResourceMatchResponse.Match =>
         val taskBuilder = new TaskBuilder(app, Task.Id.forRunSpec, config, runSpecTaskProc)
-        val (taskInfo, ports) = taskBuilder.build(request.offer, matches.resourceMatch, None)
+        val (taskInfo, networkInfo) = taskBuilder.build(request.offer, matches.resourceMatch, None)
         val task = Task.LaunchedEphemeral(
           taskId = Task.Id(taskInfo.getTaskId),
           agentInfo = Instance.AgentInfo(offer),
           runSpecVersion = runSpec.version,
           status = Task.Status(
             stagedAt = clock.now(),
-            condition = Condition.Created
-          ),
-          hostPorts = ports.flatten
+            condition = Condition.Created,
+            networkInfo = networkInfo
+          )
         )
 
         val instanceOp = taskOperationFactory.launchEphemeral(taskInfo, task, LegacyAppInstance(task))
@@ -201,16 +202,17 @@ class InstanceOpFactoryImpl(
     volumeMatch: PersistentVolumeMatcher.VolumeMatch): InstanceOp = {
 
     // create a TaskBuilder that used the id of the existing task as id for the created TaskInfo
-    val (taskInfo, ports) = new TaskBuilder(spec, (_) => task.taskId, config, runSpecTaskProc).build(offer, resourceMatch, Some(volumeMatch))
+    val (taskInfo, networkInfo) = new TaskBuilder(spec, (_) => task.taskId, config, runSpecTaskProc).build(offer, resourceMatch, Some(volumeMatch))
     val stateOp = InstanceUpdateOperation.LaunchOnReservation(
       task.taskId.instanceId,
       runSpecVersion = spec.version,
       timestamp = clock.now(),
       status = Task.Status(
         stagedAt = clock.now(),
-        condition = Condition.Created
+        condition = Condition.Created,
+        networkInfo = networkInfo
       ),
-      hostPorts = ports.flatten)
+      networkInfo.hostPorts)
 
     taskOperationFactory.launchOnReservation(taskInfo, stateOp, task)
   }
@@ -234,13 +236,16 @@ class InstanceOpFactoryImpl(
       reason = Task.Reservation.Timeout.Reason.ReservationTimeout
     )
     val agentInfo = Instance.AgentInfo(offer)
+    val hostPorts = resourceMatch.hostPorts.flatten
+    val networkInfo = NetworkInfo(runSpec, offer.getHostname, hostPorts, ipAddresses = None)
     val task = Task.Reserved(
       taskId = Task.Id.forRunSpec(runSpec.id),
       agentInfo = agentInfo,
       reservation = Task.Reservation(persistentVolumeIds, Task.Reservation.State.New(timeout = Some(timeout))),
       status = Task.Status(
         stagedAt = now,
-        condition = Condition.Reserved
+        condition = Condition.Reserved,
+        networkInfo = networkInfo
       ),
       runSpecVersion = runSpec.version
     )
@@ -307,12 +312,12 @@ object InstanceOpFactoryImpl {
           allocPortsByCTName.withFilter{ case (name, port) => name == ctName }.map(_._2)
         }.getOrElse(Seq.empty[Int])
 
+        val networkInfo = NetworkInfo(pod, agentInfo.host, taskHostPorts, ipAddresses = None)
         val task = Task.LaunchedEphemeral(
           taskId = taskId,
           agentInfo = agentInfo,
           runSpecVersion = pod.version,
-          status = Task.Status(stagedAt = since, condition = Condition.Created),
-          hostPorts = taskHostPorts
+          status = Task.Status(stagedAt = since, condition = Condition.Created, networkInfo = networkInfo)
         )
         task.taskId -> task
       }(collection.breakOut),

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
@@ -46,7 +46,7 @@ object ReadinessCheckExecutor {
       require(task.runSpecId == runSpec.id, s"Task id and RunSpec id must match: ${task.runSpecId} != ${runSpec.id}")
       require(task.launched.contains(launched), "Launched info is not the one contained in the task")
       require(
-        task.effectiveIpAddress(runSpec).isDefined,
+        task.status.networkInfo.effectiveIpAddress.isDefined,
         "Task is unreachable: an IP address was requested but not yet assigned")
 
       runSpec match {
@@ -60,8 +60,9 @@ object ReadinessCheckExecutor {
                 case ReadinessCheck.Protocol.HTTPS => "https"
               }
 
-              val portAssignmentsByName: Map[Option[String], PortAssignment] = app.portAssignments(task)
-                .map(portAssignment => portAssignment.portName -> portAssignment)(collection.breakOut)
+              val portAssignmentsByName: Map[Option[String], PortAssignment] =
+                task.status.networkInfo.portAssignments(app)
+                  .map(portAssignment => portAssignment.portName -> portAssignment)(collection.breakOut)
 
               val effectivePortAssignment = portAssignmentsByName.getOrElse(
                 Some(checkDef.portName),

--- a/src/main/scala/mesosphere/marathon/core/task/state/NetworkInfo.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/state/NetworkInfo.scala
@@ -1,0 +1,143 @@
+package mesosphere.marathon
+package core.task.state
+
+import mesosphere.marathon.stream._
+import mesosphere.marathon.state._
+import org.apache.mesos
+
+/**
+  * Metadata about a task's networking information
+  *
+  * @param hasConfiguredIpAddress If the associated app definition has a configured IP address, set this to true.
+  * @param hostPorts The hostPorts as taken originally from the accepted offer
+  * @param effectiveIpAddress the task's effective IP address, computed from runSpec, hostName and ipAddresses
+  * @param ipAddresses all associated IP addresses, computed from mesosStatus
+  */
+case class NetworkInfo(
+    hasConfiguredIpAddress: Boolean,
+    hostPorts: Seq[Int],
+    effectiveIpAddress: Option[String],
+    ipAddresses: Option[Seq[mesos.Protos.NetworkInfo.IPAddress]]) {
+
+  import NetworkInfo._
+
+  // TODO(cleanup): this should be a val, but we currently don't have the app when updating a task with a TaskStatus
+  def portAssignments(app: AppDefinition): Seq[PortAssignment] =
+    computePortAssignments(app, hostPorts, effectiveIpAddress)
+
+  /**
+    * Update the network info with the given mesos TaskStatus. This will eventually update ipAddresses and the
+    * effectiveIpAddress.
+    */
+  def update(mesosStatus: mesos.Protos.TaskStatus) = {
+    val newIpAddresses = resolveIpAddresses(mesosStatus)
+
+    if (ipAddresses != newIpAddresses) {
+      val newEffectiveIpAddress = if (hasConfiguredIpAddress) {
+        firstIpAddressFrom(newIpAddresses)
+      } else {
+        effectiveIpAddress
+      }
+      copy(ipAddresses = newIpAddresses, effectiveIpAddress = newEffectiveIpAddress)
+    } else {
+      // nothing has changed
+      this
+    }
+  }
+}
+
+object NetworkInfo {
+  val empty = new NetworkInfo(hasConfiguredIpAddress = false, hostPorts = Nil, effectiveIpAddress = None, ipAddresses = None)
+
+  private[state] def firstIpAddressFrom(ipAddresses: Option[Seq[mesos.Protos.NetworkInfo.IPAddress]]): Option[String] =
+    ipAddresses.flatMap(_.headOption).map(_.getIpAddress)
+
+  def apply(
+    runSpec: RunSpec,
+    hostName: String,
+    hostPorts: Seq[Int],
+    ipAddresses: Option[Seq[mesos.Protos.NetworkInfo.IPAddress]]): NetworkInfo = {
+
+    val hasConfiguredIpAddress: Boolean = runSpec match {
+      case app: AppDefinition if app.ipAddress.isDefined => true
+      case _ => false
+    }
+
+    val effectiveIpAddress = if (hasConfiguredIpAddress) {
+      firstIpAddressFrom(ipAddresses)
+    } else {
+      // TODO(PODS) extract ip address from launched task
+      Some(hostName)
+    }
+
+    new NetworkInfo(hasConfiguredIpAddress, hostPorts, effectiveIpAddress, ipAddresses)
+  }
+
+  private[state] def resolveIpAddresses(mesosStatus: mesos.Protos.TaskStatus): Option[Seq[mesos.Protos.NetworkInfo.IPAddress]] = {
+    if (mesosStatus.hasContainerStatus && mesosStatus.getContainerStatus.getNetworkInfosCount > 0) {
+      Some(mesosStatus.getContainerStatus.getNetworkInfosList.flatMap(_.getIpAddressesList)(collection.breakOut))
+    } else {
+      None
+    }
+  }
+
+  private[state] def computePortAssignments(
+    app: AppDefinition,
+    hostPorts: Seq[Int],
+    effectiveIpAddress: Option[String]): Seq[PortAssignment] = {
+
+    def fromDiscoveryInfo: Seq[PortAssignment] = app.ipAddress.map {
+      case IpAddress(_, _, DiscoveryInfo(appPorts), _) =>
+        appPorts.zip(hostPorts).map {
+          case (appPort, hostPort) =>
+            PortAssignment(
+              portName = Some(appPort.name),
+              effectiveIpAddress = effectiveIpAddress,
+              effectivePort = hostPort,
+              hostPort = Some(hostPort))
+        }
+    }.getOrElse(Nil)
+
+    @SuppressWarnings(Array("OptionGet", "TraversableHead"))
+    def fromPortMappings(container: Container): Seq[PortAssignment] =
+      container.portMappings.map { portMapping =>
+        val hostPort: Option[Int] =
+          if (portMapping.hostPort.isEmpty) {
+            None
+          } else {
+            val hostPort = hostPorts.head
+            Some(hostPort)
+          }
+
+        val effectivePort =
+          if (app.ipAddress.isDefined || portMapping.hostPort.isEmpty) {
+            portMapping.containerPort
+          } else {
+            hostPort.get
+          }
+
+        PortAssignment(
+          portName = portMapping.name,
+          effectiveIpAddress = effectiveIpAddress,
+          effectivePort = effectivePort,
+          hostPort = hostPort,
+          containerPort = Some(portMapping.containerPort))
+      }
+
+    def fromPortDefinitions: Seq[PortAssignment] =
+      app.portDefinitions.zip(hostPorts).map {
+        case (portDefinition, hostPort) =>
+          PortAssignment(
+            portName = portDefinition.name,
+            effectiveIpAddress = effectiveIpAddress,
+            effectivePort = hostPort,
+            hostPort = Some(hostPort))
+      }
+
+    app.container.collect {
+      // TODO(portMappings) support other container types (bridge and user modes are docker-specific)
+      case c: Container if app.networkModeBridge || app.networkModeUser => fromPortMappings(c)
+    }.getOrElse(if (app.ipAddress.isDefined) fromDiscoveryInfo else fromPortDefinitions)
+  }
+
+}

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializer.scala
@@ -5,6 +5,7 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.{ Task, TaskCondition }
 import mesosphere.marathon.core.task.Task.{ LocalVolumeId, Reservation }
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.stream._
 import org.apache.mesos.{ Protos => MesosProtos }
@@ -44,6 +45,8 @@ object TaskSerializer {
 
     def maybeAppVersion: Option[Timestamp] = opt(_.hasVersion, _.getVersion).map(Timestamp.apply)
 
+    lazy val hostPorts = proto.getPortsList.map(_.intValue())(collection.breakOut)
+
     val taskStatus = Task.Status(
       stagedAt = Timestamp(proto.getStagedAt),
       startedAt = opt(_.hasStartedAt, _.getStartedAt).map(Timestamp.apply),
@@ -56,10 +59,9 @@ object TaskSerializer {
         // although this is an optional field, migration should have really taken care of this.
         // because of a bug in migration, some empties slipped through. so we make up for it here.
         .orElse(opt(_.hasStatus, _.getStatus).map(TaskCondition.apply))
-        .getOrElse(Condition.Unknown)
+        .getOrElse(Condition.Unknown),
+      networkInfo = NetworkInfo.empty.copy(hostPorts = hostPorts) // TODO(cleanup): serialization will only be supported after migration to Instance
     )
-
-    def hostPorts = proto.getPortsList.map(_.intValue())(collection.breakOut)
 
     def launchedTask: Option[Task.Launched] = {
       // TODO: this has super low cohesion (DCOS-10332)
@@ -99,14 +101,14 @@ object TaskSerializer {
 
       case (Some(reservation), Some(launched)) =>
         Task.LaunchedOnReservation(
-          taskId, agentInfo, runSpecVersion, taskStatus, launched.hostPorts, reservation)
+          taskId, agentInfo, runSpecVersion, taskStatus, reservation)
 
       case (Some(reservation), None) =>
         Task.Reserved(taskId, agentInfo, reservation, taskStatus, runSpecVersion)
 
       case (None, Some(launched)) =>
         Task.LaunchedEphemeral(
-          taskId, agentInfo, runSpecVersion, taskStatus, launched.hostPorts)
+          taskId, agentInfo, runSpecVersion, taskStatus)
 
       case (None, None) =>
         val msg = s"Unable to deserialize task $taskId, agentInfo=$agentInfo. It is neither reserved nor launched"
@@ -148,13 +150,13 @@ object TaskSerializer {
 
     task match {
       case launched: Task.LaunchedEphemeral =>
-        setLaunched(launched.status, launched.hostPorts)
+        setLaunched(launched.status, task.status.networkInfo.hostPorts)
 
       case reserved: Task.Reserved =>
         setReservation(reserved.reservation)
 
       case launchedOnR: Task.LaunchedOnReservation =>
-        setLaunched(launchedOnR.status, launchedOnR.hostPorts)
+        setLaunched(launchedOnR.status, task.status.networkInfo.hostPorts)
         setReservation(launchedOnR.reservation)
     }
 

--- a/src/main/scala/mesosphere/marathon/core/task/update/TaskUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/TaskUpdateOperation.scala
@@ -19,5 +19,5 @@ object TaskUpdateOperation {
   case class LaunchOnReservation(
     runSpecVersion: Timestamp,
     status: Task.Status,
-    hostPorts: Seq[Int]) extends TaskUpdateOperation
+    hostPorts: Seq[Int]) extends TaskUpdateOperation // TODO(cleanup): remove hostPorts, they're included in status
 }

--- a/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
@@ -181,7 +181,7 @@ trait PodStatusConversion {
           pod.container(containerName).flatMap { containerSpec =>
             val endpointRequestedHostPort: Seq[String] =
               containerSpec.endpoints.withFilter(_.hostPort.isDefined).map(_.name)
-            val reservedHostPorts: Seq[Int] = launched.hostPorts
+            val reservedHostPorts: Seq[Int] = task.status.networkInfo.hostPorts
 
             // TODO(jdef): This assumption doesn't work...
             /*assume(

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -13,7 +13,6 @@ import mesosphere.marathon.core.externalvolume.ExternalVolumes
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.readiness.ReadinessCheck
-import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.plugin.validation.RunSpecValidator
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state.AppDefinition.Labels
@@ -336,69 +335,6 @@ case class AppDefinition(
   def withCanonizedIds(base: PathId = PathId.empty): AppDefinition = {
     val baseId = id.canonicalPath(base)
     copy(id = baseId, dependencies = dependencies.map(_.canonicalPath(baseId)))
-  }
-
-  def portAssignments(task: Task): Seq[PortAssignment] = {
-    def fromDiscoveryInfo: Seq[PortAssignment] = ipAddress.flatMap {
-      case IpAddress(_, _, DiscoveryInfo(appPorts), _) =>
-        for {
-          launched <- task.launched
-          effectiveIpAddress <- task.effectiveIpAddress(this)
-        } yield appPorts.zip(launched.hostPorts).map {
-          case (appPort, hostPort) =>
-            PortAssignment(
-              portName = Some(appPort.name),
-              effectiveIpAddress = Some(effectiveIpAddress),
-              effectivePort = hostPort,
-              hostPort = Some(hostPort))
-        }.toList
-    }.getOrElse(Nil)
-
-    @SuppressWarnings(Array("OptionGet", "TraversableHead"))
-    def fromPortMappings(container: Container): Seq[PortAssignment] =
-      task.launched.map { launched =>
-        var hostPorts = launched.hostPorts
-        container.portMappings.map { portMapping =>
-          val hostPort: Option[Int] =
-            if (portMapping.hostPort.isEmpty) {
-              None
-            } else {
-              val hostPort = hostPorts.head
-              hostPorts = hostPorts.drop(1)
-              Some(hostPort)
-            }
-
-          val effectivePort =
-            if (ipAddress.isDefined || portMapping.hostPort.isEmpty) {
-              portMapping.containerPort
-            } else {
-              hostPort.get
-            }
-
-          PortAssignment(
-            portName = portMapping.name,
-            effectiveIpAddress = task.effectiveIpAddress(this),
-            effectivePort = effectivePort,
-            hostPort = hostPort,
-            containerPort = Some(portMapping.containerPort))
-        }
-      }.getOrElse(Nil)
-
-    def fromPortDefinitions: Seq[PortAssignment] = task.launched.map { launched =>
-      portDefinitions.zip(launched.hostPorts).map {
-        case (portDefinition, hostPort) =>
-          PortAssignment(
-            portName = portDefinition.name,
-            effectiveIpAddress = Some(task.agentInfo.host),
-            effectivePort = hostPort,
-            hostPort = Some(hostPort))
-      }
-    }.getOrElse(Nil)
-
-    container.collect {
-      // TODO(portMappings) support other container types (bridge and user modes are docker-specific)
-      case c: Container if networkModeBridge || networkModeUser => fromPortMappings(c)
-    }.getOrElse(if (ipAddress.isDefined) fromDiscoveryInfo else fromPortDefinitions)
   }
 
   val portNames: Seq[String] = {

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -13,8 +13,6 @@ import mesosphere.marathon.plugin.auth.Identity
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ Group, PathId, _ }
 import mesosphere.marathon.test.{ MarathonSpec, Mockito }
-import mesosphere.marathon.{ BadRequestException, MarathonConf, MarathonSchedulerService }
-import org.mockito.Matchers.{ eq => equalTo }
 import org.mockito.Mockito._
 import org.scalatest.{ GivenWhenThen, Matchers }
 import play.api.libs.json.Json

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -38,7 +38,7 @@ class TasksResourceTest extends MarathonSpec with GivenWhenThen with Matchers wi
     val rootGroup = Group("/".toRootPath, apps = Map(app.id -> app))
     groupManager.rootGroup() returns Future.successful(rootGroup)
 
-    assert(app.servicePorts.size > instance.tasksMap.values.head.launched.get.hostPorts.size)
+    assert(app.servicePorts.size > instance.tasksMap.values.head.status.networkInfo.hostPorts.size)
 
     When("Getting the txt tasks index")
     val response = taskResource.indexTxt(auth.request)

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
@@ -4,6 +4,7 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.{ Instance, TestTaskBuilder }
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.test.{ MarathonSpec, Mockito }
 import org.scalatest.{ GivenWhenThen, Matchers }
@@ -196,9 +197,9 @@ class Fixture {
       stagedAt = Timestamp(1),
       startedAt = None,
       mesosStatus = None,
-      condition = Condition.Running
-    ),
-    hostPorts = Seq.empty
+      condition = Condition.Running,
+      networkInfo = NetworkInfo.empty
+    )
   )
 
 }

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
 import mesosphere.marathon.core.pod.{ HostNetwork, MesosContainer, PodDefinition }
 import mesosphere.marathon.core.readiness.ReadinessCheckResult
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state._
@@ -404,8 +405,8 @@ class AppInfoBaseDataTest extends MarathonSpec with GivenWhenThen with Mockito w
           stagedAt = f.clock.now(),
           startedAt = Some(f.clock.now()),
           mesosStatus = None,
-          condition = Condition.Running),
-        hostPorts = Nil)
+          condition = Condition.Running,
+          networkInfo = NetworkInfo.empty))
     }(collection.breakOut)
 
     Instance(

--- a/src/test/scala/mesosphere/marathon/core/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/HealthCheckTest.scala
@@ -5,6 +5,8 @@ import mesosphere.marathon.Protos
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.api.v2.ValidationHelper
 import mesosphere.marathon.core.instance.TestTaskBuilder
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state._
 import mesosphere.marathon.test.{ MarathonSpec, MarathonTestHelper }
 import play.api.libs.json.Json
@@ -287,7 +289,12 @@ class HealthCheckTest extends MarathonSpec {
     import MarathonTestHelper.Implicits._
     val check = new MarathonTcpHealthCheck(portIndex = Some(PortReference(0)))
     val app = MarathonTestHelper.makeBasicApp().withPortDefinitions(Seq(PortDefinition(0)))
-    val task = TestTaskBuilder.Helper.runningTaskForApp(app.id).withHostPorts(Seq(4321))
+    val task = {
+      val t: Task.LaunchedEphemeral = TestTaskBuilder.Helper.runningTaskForApp(app.id)
+      val hostName = "hostName"
+      val hostPorts = Seq(4321)
+      t.copy(status = t.status.copy(networkInfo = NetworkInfo(app, hostName, hostPorts, ipAddresses = None)))
+    }
 
     assert(check.effectivePort(app, task) == 4321)
   }

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
@@ -6,6 +6,8 @@ import akka.actor.Props
 import akka.testkit.{ ImplicitSender, TestActorRef }
 import mesosphere.marathon.core.health.{ HealthResult, Healthy, MarathonTcpHealthCheck, PortReference }
 import mesosphere.marathon.core.instance.TestTaskBuilder
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{ AppDefinition, PathId }
 import mesosphere.marathon.test.{ MarathonActorSupport, MarathonSpec }
 import org.scalatest.Matchers
@@ -21,12 +23,9 @@ class HealthCheckWorkerActorTest
     with Matchers {
 
   import HealthCheckWorker._
-  import mesosphere.marathon.test.MarathonTestHelper.Implicits._
-
   import scala.concurrent.ExecutionContext.Implicits.global
 
   test("A TCP health check should correctly resolve the hostname") {
-    val appId = PathId("/test_id")
     val socket = new ServerSocket(0)
     val socketPort: Int = socket.getLocalPort
 
@@ -34,13 +33,16 @@ class HealthCheckWorkerActorTest
       socket.accept().close()
     }
 
-    val task =
-      TestTaskBuilder.Helper.runningTaskForApp(appId)
-        .withAgentInfo(_.copy(host = InetAddress.getLocalHost.getCanonicalHostName))
-        .withHostPorts(Seq(socketPort))
+    val appId = PathId("/test_id")
+    val app = AppDefinition(id = appId)
+    val task = {
+      val t: Task.LaunchedEphemeral = TestTaskBuilder.Helper.runningTaskForApp(appId)
+      val hostName = InetAddress.getLocalHost.getCanonicalHostName
+      val hostPorts = Seq(socketPort)
+      t.copy(status = t.status.copy(networkInfo = NetworkInfo(app, hostName, hostPorts, ipAddresses = None)))
+    }
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
-    val app = AppDefinition(id = appId)
     ref ! HealthCheckJob(app, task, MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))
 
     try { Await.result(res, 1.seconds) }
@@ -60,13 +62,15 @@ class HealthCheckWorkerActorTest
     }
 
     val appId = PathId("/test_id")
-    val task =
-      TestTaskBuilder.Helper.runningTaskForApp(appId)
-        .withAgentInfo(_.copy(host = InetAddress.getLocalHost.getCanonicalHostName))
-        .withHostPorts(Seq(socketPort))
+    val app = AppDefinition(id = appId)
+    val task = {
+      val t: Task.LaunchedEphemeral = TestTaskBuilder.Helper.runningTaskForApp(appId)
+      val hostName = InetAddress.getLocalHost.getCanonicalHostName
+      val hostPorts = Seq(socketPort)
+      t.copy(status = t.status.copy(networkInfo = NetworkInfo(app, hostName, hostPorts, ipAddresses = None)))
+    }
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
-    val app = AppDefinition(id = appId)
     ref ! HealthCheckJob(app, task, MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))
 
     try { Await.result(res, 1.seconds) }

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceUpdateTest.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon.core.instance.update.{ InstanceUpdateEffect, Instance
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.{ MesosTaskStatusTestHelper, TaskStatusUpdateTestHelper }
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state.PathId
 
@@ -227,9 +228,10 @@ class InstanceUpdateTest extends UnitTest {
       stagedAt = clock.now(),
       startedAt = Some(clock.now()),
       mesosStatus = Some(mesosTaskStatus),
-      condition = Condition.Running
+      condition = Condition.Running,
+      networkInfo = NetworkInfo.empty
     )
-    val task = Task.LaunchedEphemeral(taskId, agentInfo, runSpecVersion = clock.now(), status = taskStatus, hostPorts = Seq.empty)
+    val task = Task.LaunchedEphemeral(taskId, agentInfo, runSpecVersion = clock.now(), status = taskStatus)
     val instance = Instance(Instance.Id("foobar.instance-baz"), agentInfo, instanceState, Map(taskId -> task), clock.now())
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -5,6 +5,7 @@ import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import org.apache.mesos
 
@@ -95,7 +96,12 @@ case class TestInstanceBuilder(
   def stateOpUpdate(mesosStatus: mesos.Protos.TaskStatus) = InstanceUpdateOperation.MesosUpdate(instance, mesosStatus, now)
 
   def taskLaunchedOp(): InstanceUpdateOperation.LaunchOnReservation = {
-    InstanceUpdateOperation.LaunchOnReservation(instanceId = instance.instanceId, timestamp = now, runSpecVersion = instance.runSpecVersion, status = Task.Status(stagedAt = now, condition = Condition.Running), hostPorts = Seq.empty)
+    InstanceUpdateOperation.LaunchOnReservation(
+      instanceId = instance.instanceId,
+      timestamp = now,
+      runSpecVersion = instance.runSpecVersion,
+      status = Task.Status(stagedAt = now, condition = Condition.Running, networkInfo = NetworkInfo.empty),
+      hostPorts = Seq.empty)
   }
 
   def stateOpExpunge() = InstanceUpdateOperation.ForceExpunge(instance.instanceId)

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -5,22 +5,22 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.core.task.update.TaskUpdateOperation
-import mesosphere.marathon.core.task.{ TaskCondition, Task }
+import mesosphere.marathon.core.task.{ Task, TaskCondition }
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.stream._
 import mesosphere.marathon.test.MarathonTestHelper
 import mesosphere.marathon.test.MarathonTestHelper.Implicits._
 import org.apache.mesos
-import org.apache.mesos.Protos._
 
 case class TestTaskBuilder(
     task: Option[Task], instanceBuilder: TestInstanceBuilder, now: Timestamp = Timestamp.now()
 ) {
 
   def taskFromTaskInfo(
-    taskInfo: TaskInfo,
-    offer: Offer = MarathonTestHelper.makeBasicOffer().build(),
+    taskInfo: mesos.Protos.TaskInfo,
+    offer: mesos.Protos.Offer = MarathonTestHelper.makeBasicOffer().build(),
     version: Timestamp = Timestamp(10),
     taskCondition: Condition = Condition.Staging) = {
     val instance = instanceBuilder.getInstance()
@@ -143,7 +143,7 @@ case class TestTaskBuilder(
 
   def withHostPorts(update: Seq[Int]): TestTaskBuilder = this.copy(task = task.map(_.withHostPorts(update)))
 
-  def withNetworkInfos(update: scala.collection.Seq[NetworkInfo]): TestTaskBuilder = this.copy(task = task.map(_.withNetworkInfos(update)))
+  def withNetworkInfos(update: scala.collection.Seq[mesos.Protos.NetworkInfo]): TestTaskBuilder = this.copy(task = task.map(_.withNetworkInfos(update)))
 
   def asHealthyTask(): TestTaskBuilder = {
     import mesosphere.marathon.test.MarathonTestHelper.Implicits._
@@ -171,8 +171,8 @@ object TestTaskBuilder {
 
   object Helper {
     def makeTaskFromTaskInfo(
-      taskInfo: TaskInfo,
-      offer: Offer = MarathonTestHelper.makeBasicOffer().build(),
+      taskInfo: mesos.Protos.TaskInfo,
+      offer: mesos.Protos.Offer = MarathonTestHelper.makeBasicOffer().build(),
       version: Timestamp = Timestamp(10), now: Timestamp = Timestamp(10),
       taskCondition: Condition = Condition.Staging): Task.LaunchedEphemeral = {
 
@@ -186,9 +186,9 @@ object TestTaskBuilder {
         runSpecVersion = version,
         status = Task.Status(
           stagedAt = now,
-          condition = taskCondition
-        ),
-        hostPorts = Seq(1, 2, 3)
+          condition = taskCondition,
+          networkInfo = NetworkInfo.empty.copy(hostPorts = Seq(1, 2, 3))
+        )
       )
     }
 
@@ -197,11 +197,11 @@ object TestTaskBuilder {
     def minimalTask(instanceId: Instance.Id, container: Option[MesosContainer], now: Timestamp): Task.LaunchedEphemeral =
       minimalTask(Task.Id.forInstanceId(instanceId, container), now)
 
-    def minimalTask(taskId: Task.Id, now: Timestamp = Timestamp.now(), mesosStatus: Option[TaskStatus] = None): Task.LaunchedEphemeral = {
+    def minimalTask(taskId: Task.Id, now: Timestamp = Timestamp.now(), mesosStatus: Option[mesos.Protos.TaskStatus] = None): Task.LaunchedEphemeral = {
       minimalTask(taskId, now, mesosStatus, if (mesosStatus.isDefined) TaskCondition(mesosStatus.get) else Condition.Created)
     }
 
-    def minimalTask(taskId: Task.Id, now: Timestamp, mesosStatus: Option[TaskStatus], taskCondition: Condition): Task.LaunchedEphemeral = {
+    def minimalTask(taskId: Task.Id, now: Timestamp, mesosStatus: Option[mesos.Protos.TaskStatus], taskCondition: Condition): Task.LaunchedEphemeral = {
       Task.LaunchedEphemeral(
         taskId,
         Instance.AgentInfo(host = "host.some", agentId = None, attributes = Seq.empty),
@@ -210,15 +210,15 @@ object TestTaskBuilder {
           stagedAt = now,
           startedAt = None,
           mesosStatus = mesosStatus,
-          condition = taskCondition
-        ),
-        hostPorts = Seq.empty
+          condition = taskCondition,
+          networkInfo = NetworkInfo.empty
+        )
       )
     }
 
     def minimalLostTask(appId: PathId, taskCondition: Condition = Condition.Gone, since: Timestamp = Timestamp.now()): Task.LaunchedEphemeral = {
       val taskId = Task.Id.forRunSpec(appId)
-      val status = MesosTaskStatusTestHelper.lost(TaskStatus.Reason.REASON_RECONCILIATION, taskId, since)
+      val status = MesosTaskStatusTestHelper.lost(mesos.Protos.TaskStatus.Reason.REASON_RECONCILIATION, taskId, since)
       minimalTask(
         taskId = taskId,
         now = since,
@@ -236,7 +236,7 @@ object TestTaskBuilder {
 
     def minimalRunning(appId: PathId, taskCondition: Condition = Condition.Running, since: Timestamp = Timestamp.now()): Task.LaunchedEphemeral = {
       val taskId = Task.Id.forRunSpec(appId)
-      val status = MesosTaskStatusTestHelper.mesosStatus(state = TaskState.TASK_RUNNING, maybeHealthy = Option(true), taskId = taskId)
+      val status = MesosTaskStatusTestHelper.mesosStatus(state = mesos.Protos.TaskState.TASK_RUNNING, maybeHealthy = Option(true), taskId = taskId)
       minimalTask(
         taskId = taskId,
         now = since,
@@ -250,7 +250,7 @@ object TestTaskBuilder {
         taskId = instance.map(i => Task.Id.forInstanceId(i.instanceId, None)).getOrElse(Task.Id.forRunSpec(appId)),
         Instance.AgentInfo(host = "host.some", agentId = None, attributes = Seq.empty),
         reservation = reservation,
-        status = Task.Status(Timestamp.now(), condition = Condition.Reserved),
+        status = Task.Status(Timestamp.now(), condition = Condition.Reserved, networkInfo = NetworkInfo.empty),
         runSpecVersion = Timestamp.now())
 
     def newReservation: Task.Reservation = Task.Reservation(Seq.empty, taskReservationStateNew)
@@ -274,9 +274,9 @@ object TestTaskBuilder {
           stagedAt = now,
           startedAt = None,
           mesosStatus = None,
-          condition = Condition.Running
+          condition = Condition.Running,
+          networkInfo = NetworkInfo.empty
         ),
-        hostPorts = Seq.empty,
         reservation = Task.Reservation(localVolumeIds.to[Seq], Task.Reservation.State.Launched))
     }
 
@@ -295,10 +295,10 @@ object TestTaskBuilder {
         status = Task.Status(
           stagedAt = Timestamp(stagedAt),
           startedAt = None,
-          mesosStatus = Some(statusForState(taskId.idString, TaskState.TASK_STARTING)),
-          condition = Condition.Starting
-        ),
-        hostPorts = Seq.empty
+          mesosStatus = Some(statusForState(taskId.idString, mesos.Protos.TaskState.TASK_STARTING)),
+          condition = Condition.Starting,
+          networkInfo = NetworkInfo.empty
+        )
       )
 
     def stagedTaskForApp(
@@ -316,16 +316,16 @@ object TestTaskBuilder {
         status = Task.Status(
           stagedAt = Timestamp(stagedAt),
           startedAt = None,
-          mesosStatus = Some(statusForState(taskId.idString, TaskState.TASK_STAGING)),
-          condition = Condition.Staging
-        ),
-        hostPorts = Seq.empty
+          mesosStatus = Some(statusForState(taskId.idString, mesos.Protos.TaskState.TASK_STAGING)),
+          condition = Condition.Staging,
+          networkInfo = NetworkInfo.empty
+        )
       )
 
-    def statusForState(taskId: String, state: TaskState, maybeReason: Option[TaskStatus.Reason] = None): TaskStatus = {
-      val builder = TaskStatus
+    def statusForState(taskId: String, state: mesos.Protos.TaskState, maybeReason: Option[mesos.Protos.TaskStatus.Reason] = None): mesos.Protos.TaskStatus = {
+      val builder = mesos.Protos.TaskStatus
         .newBuilder()
-        .setTaskId(TaskID.newBuilder().setValue(taskId))
+        .setTaskId(mesos.Protos.TaskID.newBuilder().setValue(taskId))
         .setState(state)
 
       maybeReason.foreach(builder.setReason)
@@ -356,7 +356,7 @@ object TestTaskBuilder {
         .withStatus((status: Task.Status) =>
           status.copy(
             startedAt = Some(Timestamp(startedAt)),
-            mesosStatus = Some(statusForState(taskId.idString, TaskState.TASK_RUNNING))
+            mesosStatus = Some(statusForState(taskId.idString, mesos.Protos.TaskState.TASK_RUNNING))
           )
         )
 
@@ -372,7 +372,7 @@ object TestTaskBuilder {
         .withStatus((status: Task.Status) =>
           status.copy(
             startedAt = Some(Timestamp(startedAt)),
-            mesosStatus = Some(statusForState(taskId.idString, TaskState.TASK_KILLED))
+            mesosStatus = Some(statusForState(taskId.idString, mesos.Protos.TaskState.TASK_KILLED))
           )
         )
     }
@@ -401,7 +401,7 @@ object TestTaskBuilder {
       MarathonTask
         .newBuilder()
         .setId(id)
-        .setStatus(statusForState(id, TaskState.TASK_LOST))
+        .setStatus(statusForState(id, mesos.Protos.TaskState.TASK_LOST))
         .buildPartial()
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImplTest.scala
@@ -99,7 +99,7 @@ class InstanceOpFactoryImplTest extends MarathonSpec with Matchers {
     instance.tasksMap.size should be(pod.containers.size)
     instance.tasksMap.keys.toSeq should be(taskIDs)
 
-    val mappedPorts: Seq[Int] = instance.tasksMap.values.view.flatMap(_.launched.map(_.hostPorts)).flatten.toIndexedSeq
+    val mappedPorts: Seq[Int] = instance.tasksMap.values.view.flatMap(_.status.networkInfo.hostPorts).toIndexedSeq
     mappedPorts should be(hostPortsAllocatedFromOffer.flatten)
 
     val expectedHostPortsPerCT: Map[String, Seq[Int]] = pod.containers.map { ct =>
@@ -117,7 +117,7 @@ class InstanceOpFactoryImplTest extends MarathonSpec with Matchers {
     val allocatedPortsPerTask: Map[String, Seq[Int]] = instance.tasksMap.map {
       case (taskId, task) =>
         val ctName = taskId.containerName.get
-        val ports: Seq[Int] = task.launched.map(_.hostPorts).getOrElse(Seq.empty[Int])
+        val ports: Seq[Int] = task.status.networkInfo.hostPorts
         ctName -> ports
     }(collection.breakOut)
 

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon.core.launcher.{ InstanceOp, OfferProcessor, OfferProc
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.{ InstanceOpSource, InstanceOpWithSource, MatchedInstanceOps }
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.core.task.tracker.InstanceCreationHandler
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{ PathId, Timestamp }
@@ -122,7 +123,7 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
         instanceId = dummyTask.instanceId,
         runSpecVersion = clock.now(),
         timestamp = clock.now(),
-        status = Task.Status(clock.now(), condition = Condition.Running),
+        status = Task.Status(clock.now(), condition = Condition.Running, networkInfo = NetworkInfo.empty),
         hostPorts = Seq.empty)
       val launch = f.launchWithOldTask(
         task._1,

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceUpdateOpResolverTest.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.update.{ InstanceChangedEventsGenerator, InstanceUpdateEffect, InstanceUpdateOperation }
 import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
 import mesosphere.marathon.core.task.bus.{ MesosTaskStatusTestHelper, TaskStatusUpdateTestHelper }
-import mesosphere.marathon.core.task.state.TaskConditionMapping
+import mesosphere.marathon.core.task.state.{ NetworkInfo, TaskConditionMapping }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.impl.InstanceOpProcessorImpl.InstanceUpdateOpResolver
 import mesosphere.marathon.core.task.{ Task, TaskCondition }
@@ -55,7 +55,7 @@ class InstanceUpdateOpResolverTest
       instanceId = f.notExistingInstanceId,
       runSpecVersion = Timestamp(0),
       timestamp = Timestamp(0),
-      status = Task.Status(Timestamp(0), condition = Condition.Running),
+      status = Task.Status(Timestamp(0), condition = Condition.Running, networkInfo = NetworkInfo.empty),
       hostPorts = Seq.empty)).futureValue
 
     Then("taskTracker.task is called")

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/TaskSerializerTest.scala
@@ -6,10 +6,10 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.{ Instance, TestTaskBuilder }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.LocalVolumeId
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.stream._
 import mesosphere.marathon.test.{ MarathonTestHelper, Mockito }
-import org.apache.mesos.Protos._
 import org.apache.mesos.{ Protos => MesosProtos }
 import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 
@@ -76,7 +76,11 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
     val task = TaskSerializer.fromProto(taskProto)
 
     Then("we get the expected task state")
-    val expectedState = f.fullSampleTaskStateWithoutNetworking.copy(hostPorts = samplePorts)
+    val expectedState = f.fullSampleTaskStateWithoutNetworking.copy(
+      status = f.fullSampleTaskStateWithoutNetworking.status.copy(
+        networkInfo = f.fullSampleTaskStateWithoutNetworking.status.networkInfo.copy(hostPorts = samplePorts)
+      )
+    )
 
     task should be(expectedState)
 
@@ -94,10 +98,10 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
     val taskProto =
       f.completeTask.toBuilder
         .setStatus(
-          TaskStatus.newBuilder()
+          MesosProtos.TaskStatus.newBuilder()
             .setTaskId(f.taskId.mesosTaskId)
-            .setState(TaskState.TASK_RUNNING)
-            .setContainerStatus(ContainerStatus.newBuilder().addAllNetworkInfos(f.sampleNetworks))
+            .setState(MesosProtos.TaskState.TASK_RUNNING)
+            .setContainerStatus(MesosProtos.ContainerStatus.newBuilder().addAllNetworkInfos(f.sampleNetworks))
         )
         .build()
 
@@ -174,11 +178,11 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
     private[this] val appId = PathId.fromSafePath("/test")
     val taskId = Task.Id("task")
     val sampleHost: String = "host.some"
-    private[this] val sampleAttributes: Seq[Attribute] = Seq(attribute("label1", "value1"))
+    private[this] val sampleAttributes: Seq[MesosProtos.Attribute] = Seq(attribute("label1", "value1"))
     private[this] val stagedAtLong: Long = 1
     private[this] val startedAtLong: Long = 2
     private[this] val appVersion: Timestamp = Timestamp(3)
-    private[this] val sampleTaskStatus: TaskStatus =
+    private[this] val sampleTaskStatus: MesosProtos.TaskStatus =
       MesosProtos.TaskStatus.newBuilder()
         .setTaskId(MesosProtos.TaskID.newBuilder().setValue(taskId.idString))
         .setState(MesosProtos.TaskState.TASK_RUNNING)
@@ -199,9 +203,9 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
           stagedAt = Timestamp(stagedAtLong),
           startedAt = Some(Timestamp(startedAtLong)),
           mesosStatus = Some(sampleTaskStatus),
-          condition = Condition.Running
+          condition = Condition.Running,
+          networkInfo = NetworkInfo.empty
         ),
-        hostPorts = Seq.empty,
         reservation = Task.Reservation(
           Seq(LocalVolumeId(appId, "my-volume", "uuid-123")),
           Task.Reservation.State.Launched)
@@ -245,8 +249,8 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
       private[this] val stagedAt = now - 1.minute
       private[this] val startedAt = now - 55.seconds
       private[this] val mesosStatus = TestTaskBuilder.Helper.statusForState(taskId.idString, MesosProtos.TaskState.TASK_RUNNING)
-      private[this] val status = Task.Status(stagedAt, Some(startedAt), Some(mesosStatus), condition = Condition.Running)
       private[this] val hostPorts = Seq(1, 2, 3)
+      private[this] val status = Task.Status(stagedAt, Some(startedAt), Some(mesosStatus), condition = Condition.Running, networkInfo = NetworkInfo.empty.copy(hostPorts = hostPorts))
 
       def reservedProto = MarathonTask.newBuilder()
         .setId(taskId.idString)
@@ -270,7 +274,7 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
         Instance.AgentInfo(host = host, agentId = Some(agentId), attributes),
         reservation = Task.Reservation(localVolumeIds, Task.Reservation.State.New(Some(Task.Reservation.Timeout(
           initiated = now, deadline = now + 1.minute, reason = Task.Reservation.Timeout.Reason.ReservationTimeout)))),
-        status = Task.Status(stagedAt = Timestamp(0), condition = Condition.Reserved),
+        status = Task.Status(stagedAt = Timestamp(0), condition = Condition.Reserved, networkInfo = NetworkInfo.empty),
         runSpecVersion = appVersion
       )
 
@@ -299,7 +303,6 @@ class TaskSerializerTest extends FunSuite with Mockito with Matchers with GivenW
         Instance.AgentInfo(host = host, agentId = Some(agentId), attributes),
         appVersion,
         status,
-        hostPorts,
         Task.Reservation(localVolumeIds, Task.Reservation.State.Launched)
       )
 

--- a/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.core.health.{ MesosCommandHealthCheck, MesosHttpHealt
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.{ ContainerNetwork, MesosContainer, PodDefinition }
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.stream._
 import mesosphere.marathon.test.MarathonSpec
@@ -477,9 +478,9 @@ object PodStatusConversionTest {
             stagedAt = since,
             startedAt = if (taskStatus == Condition.Created) None else Some(since),
             mesosStatus = mesosStatus,
-            condition = taskStatus
-          ),
-          hostPorts = Seq(1001)
+            condition = taskStatus,
+            networkInfo = NetworkInfo.empty.copy(hostPorts = Seq(1001))
+          )
         )
       ).map(t => t.taskId -> t)(collection.breakOut),
       runSpecVersion = pod.version
@@ -501,10 +502,10 @@ object PodStatusConversionTest {
           .setContainerStatus(Protos.ContainerStatus.newBuilder()
             .addAllNetworkInfos(networks).build())
           .build()),
-        condition = Condition.Finished
+        condition = Condition.Finished,
+        networkInfo = NetworkInfo.empty
       ),
-      runSpecVersion = Timestamp.zero,
-      hostPorts = Seq.empty)
+      runSpecVersion = Timestamp.zero)
   }
 
   def withCommandLineHealthChecks(pod: PodDefinition): PodDefinition = pod.copy(

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo1_4_PersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo1_4_PersistenceStoreTest.scala
@@ -7,11 +7,12 @@ import com.codahale.metrics.MetricRegistry
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.event.EventSubscribers
-import mesosphere.marathon.core.instance.{ LegacyAppInstance, Instance }
+import mesosphere.marathon.core.instance.{ Instance, LegacyAppInstance }
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.Status
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.{ LegacyInMemConfig, LegacyStorageConfig }
@@ -116,10 +117,10 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito {
         val tasks = Seq(
           Task.LaunchedEphemeral(
             Task.Id.forRunSpec("123".toRootPath),
-            Instance.AgentInfo("abc", None, Nil), Timestamp(0), Status(Timestamp(0), condition = Condition.Created), Nil),
+            Instance.AgentInfo("abc", None, Nil), Timestamp(0), Status(Timestamp(0), condition = Condition.Created, networkInfo = NetworkInfo.empty)),
           Task.LaunchedEphemeral(
             Task.Id.forRunSpec("123".toRootPath),
-            Instance.AgentInfo("abc", None, Nil), Timestamp(0), Status(Timestamp(0), condition = Condition.Created), Nil)
+            Instance.AgentInfo("abc", None, Nil), Timestamp(0), Status(Timestamp(0), condition = Condition.Created, networkInfo = NetworkInfo.empty))
         )
         tasks.foreach(oldRepo.store(_).futureValue)
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -465,7 +465,7 @@ class InstanceTrackerImplTest extends MarathonSpec with MarathonActorSupport
   def containsTask(tasks: Seq[Instance], task: Instance) =
     tasks.exists(t => t.instanceId == task.instanceId
       && t.agentInfo.host == task.agentInfo.host
-      && t.tasksMap.values.flatMap(_.launched.map(_.hostPorts)) == task.tasksMap.values.flatMap(_.launched.map(_.hostPorts)))
+      && t.tasksMap.values.flatMap(_.status.networkInfo.hostPorts) == task.tasksMap.values.flatMap(_.status.networkInfo.hostPorts))
   def shouldContainTask(tasks: Seq[Instance], task: Instance) =
     assert(containsTask(tasks, task), s"Should contain ${task.instanceId}")
   def shouldNotContainTask(tasks: Seq[Instance], task: Instance) =

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -455,9 +455,11 @@ object MarathonTestHelper {
       }
 
       def withHostPorts(update: Seq[Int]): Task = task match {
-        case launchedEphemeral: Task.LaunchedEphemeral => launchedEphemeral.copy(hostPorts = update)
-        case launchedOnReservation: Task.LaunchedOnReservation => launchedOnReservation.copy(hostPorts = update)
-        case reserved: Task.Reserved => throw new scala.RuntimeException("Reserved task cannot have hostPorts")
+        case launchedEphemeral: Task.LaunchedEphemeral => launchedEphemeral.copy() // TODO(cleanup): this is broken
+        case launchedOnReservation: Task.LaunchedOnReservation => launchedOnReservation.copy() // TODO(cleanup): this is broken
+        case reserved: Task.Reserved =>
+          println(update)
+          throw new scala.RuntimeException("Reserved task cannot have hostPorts")
       }
 
       def withNetworkInfos(update: scala.collection.Seq[NetworkInfo]): Task = {

--- a/src/test/scala/mesosphere/marathon/test/Mockito.scala
+++ b/src/test/scala/mesosphere/marathon/test/Mockito.scala
@@ -11,6 +11,7 @@ import org.scalatest.mockito.MockitoSugar
   */
 trait Mockito extends MockitoSugar {
 
+  def equalTo[T](t: T) = org.mockito.Matchers.eq(t)
   def eq[T](t: T) = org.mockito.Matchers.eq(t)
   def any[T] = org.mockito.Matchers.any[T]
   def anyBoolean = org.mockito.Matchers.anyBoolean

--- a/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
@@ -3,6 +3,7 @@ package upgrade
 
 import akka.actor.{ Actor, ActorRef }
 import akka.testkit.{ TestActorRef, TestProbe }
+import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.health.{ MesosCommandHealthCheck, MesosTcpHealthCheck }
 import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.core.condition.Condition.Running
@@ -13,6 +14,8 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.{ MesosContainer, PodDefinition }
+import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state._
 import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }
@@ -37,7 +40,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
     val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
 
     When("The task becomes running")
-    system.eventStream.publish(f.instanceRunning)
+    system.eventStream.publish(f.instanceRunning(appWithReadyCheck))
 
     Then("Task should become ready")
     eventually(taskIsReady should be (true))
@@ -57,7 +60,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
     val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
 
     When("The task becomes healthy")
-    system.eventStream.publish(f.instanceRunning)
+    system.eventStream.publish(f.instanceRunning(appWithReadyCheck))
     system.eventStream.publish(f.instanceIsHealthy)
 
     Then("Task should become ready")
@@ -120,7 +123,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
     val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
 
     When("The task becomes running")
-    system.eventStream.publish(f.instanceRunning)
+    system.eventStream.publish(f.instanceRunning(appWithReadyCheck))
 
     Then("Task should become ready")
     eventually(taskIsReady should be (true))
@@ -140,7 +143,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
     val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
 
     When("The task becomes running")
-    system.eventStream.publish(f.instanceRunning)
+    system.eventStream.publish(f.instanceRunning(appWithReadyCheck))
 
     Then("Task readiness checks are performed")
     eventually(taskIsReady should be (false))
@@ -168,7 +171,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
       versionInfo = VersionInfo.OnlyVersion(f.version),
       readinessChecks = Seq(ReadinessCheck("test")))
     val actor = f.readinessActor(appWithReadyCheck, f.checkIsNotReady, _ => taskIsReady = true)
-    system.eventStream.publish(f.instanceRunning)
+    system.eventStream.publish(f.instanceRunning(appWithReadyCheck))
     eventually(actor.underlyingActor.healthyInstances should have size 1)
 
     When("The task is killed")
@@ -183,6 +186,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
 
   class Fixture {
 
+    // no port definition for port name 'http-api' was found
     val deploymentManagerProbe = TestProbe()
     val step = DeploymentStep(Seq.empty)
     val plan = DeploymentPlan("deploy", Group.empty, Group.empty, Seq(step), Timestamp.now())
@@ -193,28 +197,41 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
     val taskId = Task.Id.forInstanceId(instanceId, container = None)
     val launched = mock[Task.Launched]
     val agentInfo = mock[Instance.AgentInfo]
-    val task = {
+    val mesosStatus = MesosTaskStatusTestHelper.running(taskId)
+    val hostName = "some.host"
+    def mockTask(app: AppDefinition) = {
+      val status = Task.Status(
+        stagedAt = Timestamp.now(),
+        startedAt = Some(Timestamp.now()),
+        mesosStatus = Some(mesosStatus),
+        condition = Condition.Running,
+        networkInfo = NetworkInfo(app, hostName, hostPorts = Seq(1, 2, 3), ipAddresses = None))
+
       val t = mock[Task]
       t.taskId returns taskId
       t.launched returns Some(launched)
       t.runSpecId returns appId
-      t.effectiveIpAddress(any) returns Some("some.host")
       t.agentInfo returns agentInfo
+      t.agentInfo.host returns hostName
+      t.status returns status
       t
     }
 
     val version = Timestamp.now()
 
-    val instance = Instance(instanceId, agentInfo, InstanceState(Running, version, Some(version), healthy = Some(true)), Map(task.taskId -> task), runSpecVersion = version)
+    def instance(app: AppDefinition) = {
+      val task = mockTask(app)
+      val instance = Instance(instanceId, agentInfo, InstanceState(Running, version, Some(version), healthy = Some(true)), Map(task.taskId -> task), runSpecVersion = version)
+      tracker.instance(any) returns Future.successful(Some(instance))
+      instance
+    }
 
     val checkIsReady = Seq(ReadinessCheckResult("test", taskId, ready = true, None))
     val checkIsNotReady = Seq(ReadinessCheckResult("test", taskId, ready = false, None))
-    val instanceRunning = InstanceChanged(instanceId, version, appId, Running, instance)
+    def instanceRunning(app: AppDefinition) = InstanceChanged(instanceId, version, appId, Running, instance(app))
     val instanceIsHealthy = InstanceHealthChanged(instanceId, version, appId, healthy = Some(true))
 
-    agentInfo.host returns "some.host"
-    launched.hostPorts returns Seq(1, 2, 3)
-    tracker.instance(any) returns Future.successful(Some(instance))
+    agentInfo.host returns hostName
 
     def readinessActor(spec: RunSpec, readinessCheckResults: Seq[ReadinessCheckResult], readyFn: Instance.Id => Unit) = {
       val executor = new ReadinessCheckExecutor {


### PR DESCRIPTION
NetworkInfo no contains network related information (hostPorts, effectiveIpAddress, ipAddresses and portAssignments).

Extracted computation from and usages of AppDefinition.portAssignments, task.effectiveIpAddress MesosStatus.IpAddresses and task.launched.hostPorts into this wrapper and adjusted call sites to use task.status.networkInfo instead.

**_hint: please follow the ninja below to get to evaluate review ninja, or click [here](https://app.review.ninja/mesosphere/marathon/pull/4673)_**