### PR TITLE
Enhance Pod API to reflect resources for the executor

### DIFF
--- a/docs/docs/rest-api/public/api/v2/examples/pod.json
+++ b/docs/docs/rest-api/public/api/v2/examples/pod.json
@@ -97,5 +97,9 @@
         "killGracePeriodSeconds": 60
       }
     }
-  ]
+  ],
+  "executorResources": {
+    "cpus": 0.2,
+    "mem": 64
+  }
 }

--- a/docs/docs/rest-api/public/api/v2/examples/pod.json
+++ b/docs/docs/rest-api/public/api/v2/examples/pod.json
@@ -100,6 +100,7 @@
   ],
   "executorResources": {
     "cpus": 0.2,
-    "mem": 64
+    "mem": 64,
+    "disk": 50
   }
 }

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -146,3 +146,6 @@ types:
           At this time, only one stack is supported.
       scaling?: PodScalingPolicy
       scheduling?: PodSchedulingPolicy
+      executorResources?:
+          type: resources.Resources
+          description: The resources to allocate to the container.

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -147,5 +147,5 @@ types:
       scaling?: PodScalingPolicy
       scheduling?: PodSchedulingPolicy
       executorResources?:
-          type: resources.Resources
+          type: resources.ExecutorResources
           description: The resources to allocate to the executor.

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -148,4 +148,4 @@ types:
       scheduling?: PodSchedulingPolicy
       executorResources?:
           type: resources.Resources
-          description: The resources to allocate to the container.
+          description: The resources to allocate to the executor.

--- a/docs/docs/rest-api/public/api/v2/types/resources.raml
+++ b/docs/docs/rest-api/public/api/v2/types/resources.raml
@@ -13,7 +13,7 @@ types:
         example: 0.1
         default: 1.0
       mem:
-        displayName: memory shares
+        displayName: memory
         type: number
         minimum: 0.001
         format: double
@@ -45,23 +45,23 @@ types:
         displayName: cpu shares
         description: The number of CPU shares this pod needs per instance for its executor. This number does not have to be integer, but can be a fraction.
         type: number
-        minimum: 0.001
+        minimum: 0.1
         format: double
-        example: 0.1
+        example: 0.2
         default: 0.1
       mem?:
-        displayName: memory shares
+        displayName: memory
         type: number
-        minimum: 0.001
+        minimum: 32
         format: double
-        description: The amount of memory in MB that is needed for the pod instance for its executor
+        description: The amount of memory in MB that is needed for the pod instance for the pod instance's executor
         example: 512
         default: 32
       disk?:
         displayName: disk space
         type: number
-        minimum: 0.0
+        minimum: 10.0
         format: double
         description: How much disk space is needed for for the executor. This number does not have to be an integer, but can be a fraction.
-        example: 0.2
+        example: 50
         default: 10.0

--- a/docs/docs/rest-api/public/api/v2/types/resources.raml
+++ b/docs/docs/rest-api/public/api/v2/types/resources.raml
@@ -36,3 +36,32 @@ types:
         description: The amount of GPU cores that are needed for the pod
         example: 1
         default: 0
+
+  ExecutorResources:
+    type: object
+    description: Executor Resource Allocations. Same as Resources but reserved for the pod executor.
+    properties:
+      cpus?:
+        displayName: cpu shares
+        description: The number of CPU shares this pod needs per instance for its executor. This number does not have to be integer, but can be a fraction.
+        type: number
+        minimum: 0.001
+        format: double
+        example: 0.1
+        default: 0.1
+      mem?:
+        displayName: memory shares
+        type: number
+        minimum: 0.001
+        format: double
+        description: The amount of memory in MB that is needed for the pod instance for its executor
+        example: 512
+        default: 32
+      disk?:
+        displayName: disk space
+        type: number
+        minimum: 0.0
+        format: double
+        description: How much disk space is needed for for the executor. This number does not have to be an integer, but can be a fraction.
+        example: 0.2
+        default: 10.0

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -97,13 +97,11 @@ case class PodDefinition(
 }
 
 object PodDefinition {
-  import mesosphere.marathon.raml.PodConversion._
-
   def fromProto(proto: Protos.Json): PodDefinition = {
     Raml.fromRaml(Json.parse(proto.getJson).as[Pod])
   }
 
-  val DefaultExecutorResources: Resources = ExecutorResources().toRaml
+  val DefaultExecutorResources: Resources = ExecutorResources().fromRaml
   val DefaultId = PathId.empty
   val DefaultUser = Option.empty[String]
   val DefaultEnv = Map.empty[String, EnvVarValue]

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -28,16 +28,17 @@ case class PodDefinition(
     podVolumes: Seq[Volume] = PodDefinition.DefaultVolumes,
     networks: Seq[Network] = PodDefinition.DefaultNetworks,
     backoffStrategy: BackoffStrategy = PodDefinition.DefaultBackoffStrategy,
-    upgradeStrategy: UpgradeStrategy = PodDefinition.DefaultUpgradeStrategy
+    upgradeStrategy: UpgradeStrategy = PodDefinition.DefaultUpgradeStrategy,
+    executorResources: Resources
 ) extends RunSpec with plugin.PodSpec with MarathonState[Protos.Json, PodDefinition] {
 
   val endpoints: Seq[Endpoint] = containers.flatMap(_.endpoints)
   val resources = aggregateResources()
 
   def aggregateResources(filter: MesosContainer => Boolean = _ => true) = Resources(
-    cpus = PodDefinition.DefaultExecutorResources.cpus + containers.withFilter(filter).map(_.resources.cpus).sum,
-    mem = PodDefinition.DefaultExecutorResources.mem + containers.withFilter(filter).map(_.resources.mem).sum,
-    disk = PodDefinition.DefaultExecutorResources.disk + containers.withFilter(filter).map(_.resources.disk).sum,
+    cpus = executorResources.cpus + containers.withFilter(filter).map(_.resources.cpus).sum,
+    mem = executorResources.mem + containers.withFilter(filter).map(_.resources.mem).sum,
+    disk = executorResources.disk + containers.withFilter(filter).map(_.resources.disk).sum,
     gpus = containers.withFilter(filter).map(_.resources.gpus).sum
   )
 

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -97,11 +97,13 @@ case class PodDefinition(
 }
 
 object PodDefinition {
+  import mesosphere.marathon.raml.PodConversion._
+
   def fromProto(proto: Protos.Json): PodDefinition = {
     Raml.fromRaml(Json.parse(proto.getJson).as[Pod])
   }
 
-  val DefaultExecutorResources = ExecutorResources().toResources
+  val DefaultExecutorResources: Resources = ExecutorResources().toRaml
   val DefaultId = PathId.empty
   val DefaultUser = Option.empty[String]
   val DefaultEnv = Map.empty[String, EnvVarValue]
@@ -118,19 +120,4 @@ object PodDefinition {
   val DefaultBackoffStrategy = BackoffStrategy()
   val DefaultUpgradeStrategy = AppDefinition.DefaultUpgradeStrategy
 
-  implicit class ResourcesToExecutorResources(private val resources: Resources) extends AnyVal {
-    def toExecutorResources: ExecutorResources = ExecutorResources(
-      cpus = resources.cpus,
-      mem = resources.mem,
-      disk = resources.disk
-    )
-  }
-
-  implicit class ExecutorResourcesToResources(private val executorResources: ExecutorResources) extends AnyVal {
-    def toResources: Resources = Resources(
-      cpus = executorResources.cpus,
-      mem = executorResources.mem,
-      disk = executorResources.disk
-    )
-  }
 }

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -3,7 +3,7 @@ package core.pod
 
 // scalastyle:off
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.raml.{ Endpoint, Pod, Raml, Resources }
+import mesosphere.marathon.raml.{ Endpoint, ExecutorResources, Pod, Raml, Resources }
 import mesosphere.marathon.state.{ AppDefinition, BackoffStrategy, EnvVarValue, MarathonState, PathId, RunSpec, Secret, Timestamp, UpgradeStrategy, VersionInfo }
 import play.api.libs.json.Json
 
@@ -101,7 +101,7 @@ object PodDefinition {
     Raml.fromRaml(Json.parse(proto.getJson).as[Pod])
   }
 
-  val DefaultExecutorResources = Resources(cpus = 0.1, mem = 32.0, disk = 10.0, gpus = 0)
+  val DefaultExecutorResources = ExecutorResources().toResources
   val DefaultId = PathId.empty
   val DefaultUser = Option.empty[String]
   val DefaultEnv = Map.empty[String, EnvVarValue]
@@ -117,4 +117,20 @@ object PodDefinition {
   val DefaultNetworks = Seq.empty[Network]
   val DefaultBackoffStrategy = BackoffStrategy()
   val DefaultUpgradeStrategy = AppDefinition.DefaultUpgradeStrategy
+
+  implicit class ResourcesToExecutorResources(private val resources: Resources) extends AnyVal {
+    def toExecutorResources: ExecutorResources = ExecutorResources(
+      cpus = resources.cpus,
+      mem = resources.mem,
+      disk = resources.disk
+    )
+  }
+
+  implicit class ExecutorResourcesToResources(private val executorResources: ExecutorResources) extends AnyVal {
+    def toResources: Resources = Resources(
+      cpus = executorResources.cpus,
+      mem = executorResources.mem,
+      disk = executorResources.disk
+    )
+  }
 }

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -29,7 +29,7 @@ case class PodDefinition(
     networks: Seq[Network] = PodDefinition.DefaultNetworks,
     backoffStrategy: BackoffStrategy = PodDefinition.DefaultBackoffStrategy,
     upgradeStrategy: UpgradeStrategy = PodDefinition.DefaultUpgradeStrategy,
-    executorResources: Resources
+    executorResources: Resources = PodDefinition.DefaultExecutorResources
 ) extends RunSpec with plugin.PodSpec with MarathonState[Protos.Json, PodDefinition] {
 
   val endpoints: Seq[Endpoint] = containers.flatMap(_.endpoints)

--- a/src/main/scala/mesosphere/marathon/raml/PodConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodConversion.scala
@@ -50,8 +50,7 @@ trait PodConversion extends NetworkConversion with ConstraintConversion
       networks = networks,
       backoffStrategy = backoffStrategy,
       upgradeStrategy = upgradeStrategy,
-      executorResources = podDef.executorResources.getOrElse(PodDefinition.DefaultExecutorResources)
-    )
+      executorResources = podDef.executorResources.getOrElse(ExecutorResources()).toResources)
   }
 
   implicit val podRamlWriter: Writes[PodDefinition, Pod] = Writes { pod =>
@@ -83,7 +82,7 @@ trait PodConversion extends NetworkConversion with ConstraintConversion
       scheduling = Some(schedulingPolicy),
       volumes = pod.podVolumes.map(Raml.toRaml(_)),
       networks = pod.networks.map(Raml.toRaml(_)),
-      executorResources = Some(pod.executorResources)
+      executorResources = Some(pod.executorResources.toExecutorResources)
     )
   }
 }

--- a/src/main/scala/mesosphere/marathon/raml/PodConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodConversion.scala
@@ -10,7 +10,6 @@ import scala.concurrent.duration._
 
 trait PodConversion extends NetworkConversion with ConstraintConversion
     with ContainerConversion with EnvVarConversion with SecretConversion {
-  import mesosphere.marathon.raml.PodConversion._
 
   implicit val podRamlReader: Reads[Pod, PodDefinition] = Reads { podDef =>
     val (instances, maxInstances) = podDef.scaling.fold(DefaultInstances -> DefaultMaxInstances) {
@@ -54,7 +53,7 @@ trait PodConversion extends NetworkConversion with ConstraintConversion
       networks = networks,
       backoffStrategy = backoffStrategy,
       upgradeStrategy = upgradeStrategy,
-      executorResources = executorResources.toRaml
+      executorResources = executorResources.fromRaml
     )
   }
 
@@ -90,11 +89,8 @@ trait PodConversion extends NetworkConversion with ConstraintConversion
       executorResources = Some(pod.executorResources.toRaml)
     )
   }
-}
 
-object PodConversion extends PodConversion {
-
-  implicit val executorResourcesWrites: Writes[ExecutorResources, Resources] = Writes { executorResources =>
+  implicit val resourcesReads: Reads[ExecutorResources, Resources] = Reads { executorResources =>
     Resources(
       cpus = executorResources.cpus,
       mem = executorResources.mem,
@@ -102,7 +98,7 @@ object PodConversion extends PodConversion {
     )
   }
 
-  implicit val resourcesWrites: Writes[Resources, ExecutorResources] = Writes { resources =>
+  implicit val executorResourcesWrites: Writes[Resources, ExecutorResources] = Writes { resources =>
     ExecutorResources(
       cpus = resources.cpus,
       mem = resources.mem,
@@ -110,3 +106,5 @@ object PodConversion extends PodConversion {
     )
   }
 }
+
+object PodConversion extends PodConversion

--- a/src/main/scala/mesosphere/marathon/raml/PodConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodConversion.scala
@@ -49,7 +49,8 @@ trait PodConversion extends NetworkConversion with ConstraintConversion
       podVolumes = podDef.volumes.map(Raml.fromRaml(_)),
       networks = networks,
       backoffStrategy = backoffStrategy,
-      upgradeStrategy = upgradeStrategy
+      upgradeStrategy = upgradeStrategy,
+      executorResources = podDef.executorResources.getOrElse(PodDefinition.DefaultExecutorResources)
     )
   }
 
@@ -81,7 +82,8 @@ trait PodConversion extends NetworkConversion with ConstraintConversion
       secrets = Raml.toRaml(pod.secrets),
       scheduling = Some(schedulingPolicy),
       volumes = pod.podVolumes.map(Raml.toRaml(_)),
-      networks = pod.networks.map(Raml.toRaml(_))
+      networks = pod.networks.map(Raml.toRaml(_)),
+      executorResources = Some(pod.executorResources)
     )
   }
 }

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -165,10 +165,10 @@ object TaskGroupBuilder {
       .setExecutorId(executorID)
       .setFrameworkId(frameworkId)
 
-    executorInfo.addResources(scalarResource("cpus", PodDefinition.DefaultExecutorResources.cpus))
-    executorInfo.addResources(scalarResource("mem", PodDefinition.DefaultExecutorResources.mem))
-    executorInfo.addResources(scalarResource("disk", PodDefinition.DefaultExecutorResources.disk))
-    executorInfo.addResources(scalarResource("gpus", PodDefinition.DefaultExecutorResources.gpus.toDouble))
+    executorInfo.addResources(scalarResource("cpus", podDefinition.executorResources.cpus))
+    executorInfo.addResources(scalarResource("mem", podDefinition.executorResources.mem))
+    executorInfo.addResources(scalarResource("disk", podDefinition.executorResources.disk))
+    executorInfo.addResources(scalarResource("gpus", podDefinition.executorResources.gpus.toDouble))
     executorInfo.addAllResources(portsMatch.resources)
 
     def toMesosLabels(labels: Map[String, String]): mesos.Labels.Builder = {

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon._
 import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
 import mesosphere.marathon.api.{ RestResource, TaskKiller, TestAuthFixture }
 import mesosphere.marathon.core.appinfo.PodStatusService
+import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.instance.Instance.InstanceState
@@ -394,6 +395,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
       val config = AllConf.withTestConfig(configArgs: _*)
       implicit val authz: Authorizer = auth.auth
       implicit val authn: Authenticator = auth.auth
+      implicit val clock = ConstantClock()
       new Fixture(
         new PodsResource(config),
         auth,

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -108,6 +108,8 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
         pod.executorResources should be (defined) // validate that executor resources are defined
         pod.executorResources.get.cpus should be (100)
         pod.executorResources.get.mem should be (100)
+        // disk is not assigned in the posted pod definition, therefore this should be the default value 10
+        pod.executorResources.get.disk should be (10)
         pod.executorResources.get.gpus should be (0)
 
         response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -82,7 +82,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
         val maybePod = parsedResponse.map(_.as[Pod])
         maybePod should be (defined) // validate that we DID get back a pod definition
         val pod = maybePod.get
-        pod.executorResources should be (defined) // validate that we DID get back a executor resources
+        pod.executorResources should be (defined) // validate that executor resources are defined
         pod.executorResources.get should be (PodDefinition.DefaultExecutorResources)
 
         response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
@@ -105,7 +105,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
         val maybePod = parsedResponse.map(_.as[Pod])
         maybePod should be (defined) // validate that we DID get back a pod definition
         val pod = maybePod.get
-        pod.executorResources should be (defined) // validate that we DID get back a executor resources
+        pod.executorResources should be (defined) // validate that executor resources are defined
         pod.executorResources.get.cpus should be (100)
         pod.executorResources.get.mem should be (100)
         pod.executorResources.get.gpus should be (0)

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -20,13 +20,12 @@ import mesosphere.marathon.core.pod.{ PodDefinition, PodManager }
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer }
-import mesosphere.marathon.raml.{ FixedPodScalingPolicy, Pod, Raml }
+import mesosphere.marathon.raml.{ ExecutorResources, FixedPodScalingPolicy, Pod, Raml }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.storage.repository.PodRepository
 import mesosphere.marathon.test.Mockito
 import mesosphere.marathon.upgrade.DeploymentPlan
-
 import play.api.libs.json._
 
 import scala.collection.immutable.Seq
@@ -83,7 +82,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
         maybePod should be (defined) // validate that we DID get back a pod definition
         val pod = maybePod.get
         pod.executorResources should be (defined) // validate that executor resources are defined
-        pod.executorResources.get should be (PodDefinition.DefaultExecutorResources)
+        pod.executorResources.get should be (ExecutorResources()) // validate that the executor resources has default values
 
         response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
       }
@@ -110,7 +109,6 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
         pod.executorResources.get.mem should be (100)
         // disk is not assigned in the posted pod definition, therefore this should be the default value 10
         pod.executorResources.get.disk should be (10)
-        pod.executorResources.get.gpus should be (0)
 
         response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
       }

--- a/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
@@ -23,6 +23,12 @@ class PodRepositoryTest extends AkkaUnitTest with ZookeeperServerTest {
       f.repo.store(pod).futureValue
       f.repo.get(pod.id).futureValue.value should equal(pod)
     }
+    "store and retrieve pods with executor resources" in {
+      val pod = PodDefinition("a".toRootPath, executorResources = PodDefinition.DefaultExecutorResources.copy(cpus = 10))
+      val f = new Fixture()
+      f.repo.store(pod).futureValue
+      f.repo.get(pod.id).futureValue.value should equal(pod)
+    }
   }
 
   class Fixture {

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -8,6 +8,7 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.plugin.task.RunSpecTaskProcessor
 import mesosphere.marathon.plugin.{ ApplicationSpec, PodSpec }
 import mesosphere.marathon.raml
+import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ Command, EnvVarString, ResourceRole }
 import mesosphere.marathon.stream._
@@ -658,6 +659,41 @@ class TaskGroupBuilderTest extends UnitTest {
       assert(task1Artifacts.size == 1)
 
       assert(task1Artifacts.head.getValue == "foo")
+    }
+
+    "executor info has correct values" in {
+      val offer = MarathonTestHelper.makeBasicOffer(cpus = 21.1, mem = 256.0, disk = 10.0).build
+
+      val podSpec = PodDefinition(
+        id = "/product/frontend".toPath,
+        containers = List(
+          MesosContainer(
+            name = "Foo1",
+            resources = raml.Resources(cpus = 1.0f, mem = 128.0f),
+            artifacts = List(
+              raml.Artifact(
+                uri = "foo"
+              )
+            )
+          )
+        ),
+        executorResources = Resources(cpus = 20.0)
+      )
+
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+
+      val (executorInfo, _, _, _) = TaskGroupBuilder.build(
+        podSpec,
+        offer,
+        s => Instance.Id.forRunSpec(s),
+        defaultBuilderConfig,
+        RunSpecTaskProcessor.empty,
+        resourceMatch.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
+      )
+
+      val cpuExecutorInfo = executorInfo.getResourcesList.find(info => info.getName == "cpus")
+      assert(cpuExecutorInfo.isDefined)
+      assert(cpuExecutorInfo.get.getScalar.getValue == 20.0)
     }
 
     "support networks and port mappings for pods and containers" in {

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -694,6 +694,7 @@ class TaskGroupBuilderTest extends UnitTest {
       val cpuExecutorInfo = executorInfo.getResourcesList.find(info => info.getName == "cpus")
       assert(cpuExecutorInfo.isDefined)
       assert(cpuExecutorInfo.get.getScalar.getValue == 20.0)
+      assert(podSpec.resources.cpus == 21.0)
     }
 
     "support networks and port mappings for pods and containers" in {


### PR DESCRIPTION
Fixes #4707 

When running pods, marathon will consume more resources than reserved through the containers. These more resources are allocated to the executor. To make this transparent and configurable for the user this must be added to the PodDefinition and the Pod API.