### PR TITLE
Added a MigrationTo1_1 class to handle broken app groups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 Added a migration that will fix improperly structured app groups. If an app entry is in the wrong group e.g.
 `Group( id = /, apps = [“/foo/bar”] )` it will be moved: `Group ( id = / , Group( id = /foo, apps = [”/foo/bar”] )` 
 thus taking care of structuring the groups properly. 
-Note: if an app has multiple entries with different versions then the oldest is kept.
+Note: if an app has multiple entries with different versions then the newest is kept.
 
 ## Changes from 0.15.3 to 1.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## Changes from 1.1.4 to 1.1.5
+Added a migration that will fix improperly structured app groups. If an app entry is in the wrong group e.g.
+`Group( id = /, apps = [“/foo/bar”] )` it will be moved: `Group ( id = / , Group( id = /foo, apps = [”/foo/bar”] )` 
+thus taking care of structuring the groups properly. 
+Note: if an app has multiple entries with different versions then the oldest is kept.
+
 ## Changes from 0.15.3 to 1.0.0
 
 ### Recommended Mesos version is 0.28.0

--- a/src/main/scala/mesosphere/marathon/state/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/state/Migration.scala
@@ -406,7 +406,7 @@ class MigrationTo1_1(groupRepository: GroupRepository, appRepository: AppReposit
     //            Group ( id = / ,
     //              Group( id = /foo, apps = [“/foo/bla, version = 2"] )
 
-    val id = groupRepository.zkRootName
+    val id = GroupRepository.zkRootName
 
     for {
       updatedGroups <- updateGroups(id) // Update root and it's versions
@@ -449,6 +449,7 @@ class MigrationTo1_1(groupRepository: GroupRepository, appRepository: AppReposit
   }
 
   def updateGroup(group: Group): Group = {
+    log.info(s"Migrating group: $group")
     // get all apps including duplicates with different versions
     val apps = allApps(group)
     // remove all apps, keeping the empty groups
@@ -460,7 +461,7 @@ class MigrationTo1_1(groupRepository: GroupRepository, appRepository: AppReposit
         if (that.version > app.version) that else app
       }, group.version)
     }
-    log.debug(s"Resulting root group: $updated")
+    log.info(s"Resulting root group: $updated")
     updated
   }
 

--- a/src/main/scala/mesosphere/marathon/state/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/state/Migration.scala
@@ -57,8 +57,8 @@ class Migration @Inject() (
       }
     },
     StorageVersions(1, 1, 5) -> { () =>
-      new MigrationTo1_1(groupRepo, appRepo, config).migrate().recover {
-        case NonFatal(e) => throw new MigrationFailedException("while migrating storage to 1.1", e)
+      new MigrationTo1_1_5(groupRepo, appRepo, config).migrate().recover {
+        case NonFatal(e) => throw new MigrationFailedException("while migrating storage to 1.1.5", e)
       }
     }
   )
@@ -374,11 +374,11 @@ class MigrationTo0_16(groupRepository: GroupRepository, appRepository: AppReposi
   }
 }
 
-class MigrationTo1_1(groupRepository: GroupRepository, appRepository: AppRepository, conf: MarathonConf) {
+class MigrationTo1_1_5(groupRepository: GroupRepository, appRepository: AppRepository, conf: MarathonConf) {
   private[this] val log = LoggerFactory.getLogger(getClass)
 
   def migrate(): Future[Unit] = {
-    log.info("Start 1.1 migration")
+    log.info("Start 1.1.5 migration")
 
     //        We can have 3 cases here:
     //          1. App has one entry at the wrong place and must be moved:
@@ -413,7 +413,7 @@ class MigrationTo1_1(groupRepository: GroupRepository, appRepository: AppReposit
       _ = log.info(s"Updated groups: $updatedGroups")
       _ <- storeGroups(id, updatedGroups) // Store updated groups
       _ <- updateApps() // Update apps from the root group
-    } yield log.info("Finished 1.1 migration")
+    } yield log.info("Finished 1.1.5 migration")
   }
 
   def updateGroups(id: String): Future[Iterable[Group]] = {

--- a/src/main/scala/mesosphere/marathon/state/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/state/Migration.scala
@@ -461,7 +461,7 @@ class MigrationTo1_1(groupRepository: GroupRepository, appRepository: AppReposit
         if (that.version > app.version) that else app
       }, group.version)
     }
-    log.info(s"Resulting root group: $updated")
+    log.info(s"Resulting group: $updated")
     updated
   }
 

--- a/src/main/scala/mesosphere/marathon/state/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/state/Migration.scala
@@ -4,10 +4,12 @@ import java.io.{ ByteArrayInputStream, ObjectInputStream }
 import javax.inject.Inject
 
 import mesosphere.marathon.Protos.{ MarathonTask, StorageVersion }
+import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.StorageVersions._
 import mesosphere.marathon.{ BuildInfo, MarathonConf, MigrationFailedException }
 import mesosphere.util.Logging
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.util.state.{ PersistentStore, PersistentStoreManagement }
 import org.slf4j.LoggerFactory
@@ -52,6 +54,11 @@ class Migration @Inject() (
     StorageVersions(0, 16, 0) -> { () =>
       new MigrationTo0_16(groupRepo, appRepo).migrate().recover {
         case NonFatal(e) => throw new MigrationFailedException("while migrating storage to 0.16", e)
+      }
+    },
+    StorageVersions(1, 1, 0) -> { () =>
+      new MigrationTo1_1(groupRepo, appRepo, config).migrate().recover {
+        case NonFatal(e) => throw new MigrationFailedException("while migrating storage to 1.1", e)
       }
     }
   )
@@ -364,6 +371,131 @@ class MigrationTo0_16(groupRepository: GroupRepository, appRepository: AppReposi
         }
       }
     }
+  }
+}
+
+class MigrationTo1_1(groupRepository: GroupRepository, appRepository: AppRepository, conf: MarathonConf) {
+  private[this] val log = LoggerFactory.getLogger(getClass)
+
+  def migrate(): Future[Unit] = {
+    log.info("Start 1.1 migration")
+
+    //        We can have 3 cases here:
+    //          1. App has one entry at the wrong place and must be moved:
+    //
+    //              Group( id = /, apps = [“/foo/bla”] )
+    //              —>
+    //              Group ( id = / ,
+    //                Group( id = /foo, apps = [”/foo/bla”] )
+    //
+    //          2. App has 2 entries but both entries has the same version so the wrong one can be deleted:
+    //
+    //            Group( id = /, apps = [“/foo/bla, version = 1"],
+    //              Group( id = /foo, apps = [“/foo/bla, version = 1"])
+    //            —>
+    //            Group ( id = / ,
+    //              Group( id = /foo, apps = [“/foo/bla, version = 1"] )
+    //
+    //          3. App has 2 entries with different versions. At this point we can either fail the migration or
+    //             keep one of the versions. After some discussion we decided to keep the latest version.
+    //             CAUTION: this migration can potentially result in data loss:
+    //
+    //            Group( id = /, apps = [“/foo/bla, version = 1"],
+    //              Group( id = /foo, apps = [“/foo/bla, version = 2"])
+    //            —>
+    //            Group ( id = / ,
+    //              Group( id = /foo, apps = [“/foo/bla, version = 2"] )
+
+    val id = groupRepository.zkRootName
+
+    for {
+      updatedGroups <- updateGroups(id) // Update root and it's versions
+      _ = log.info(s"Updated groups: $updatedGroups")
+      _ <- storeGroups(id, updatedGroups) // Store updated groups
+      _ <- updateApps() // Update apps from the root group
+    } yield log.info("Finished 1.1 migration")
+  }
+
+  def updateGroups(id: String): Future[Iterable[Group]] = {
+    groupRepository.listVersions(id).flatMap { versions =>
+      val fs = versions.map(version =>
+        groupRepository.group(id, version).map {
+          case Some(group) =>
+            log.debug(s"Loaded group: $group")
+            val updated = validateGroup(updateGroup(group))
+            log.debug(s"Updated group: $updated")
+            updated
+          case None => throw new MigrationFailedException(s"Group $id:$version not found")
+        }
+      )
+      Future.sequence(fs)
+    }
+  }
+
+  def storeGroups(id: String, updatedGroups: Iterable[Group]): Future[Iterable[Group]] = {
+    val storedGroups = updatedGroups.map { group =>
+      groupRepository.store(id, group)
+    }
+    Future.sequence(storedGroups)
+  }
+
+  def updateApps(): Future[Set[AppDefinition]] = {
+    val rootGroupFuture = groupRepository.rootGroup().map(_.getOrElse(Group.empty))
+
+    rootGroupFuture.flatMap{ rootGroup =>
+      val apps = rootGroup.transitiveApps
+      Future.sequence(apps.map(appRepository.store(_)))
+    }
+  }
+
+  def updateGroup(group: Group): Group = {
+    // get all apps including duplicates with different versions
+    val apps = allApps(group)
+    // remove all apps, keeping the empty groups
+    val empty = removeAllApps(group)
+    // update the groups with the apps while keeping the oldest app version
+    val updated = apps.foldLeft(empty) { (group, app) =>
+      log.debug(s"Migrating $app")
+      group.updateApp(app.id, _.fold(app) { that =>
+        if (that.version.compare(app.version) > 0) that else app
+      }, app.version)
+    }
+    log.debug(s"Resulting root group: $updated")
+    updated
+  }
+
+  import mesosphere.marathon.ValidationFailedException
+
+  implicit private val validator = Group.validRootGroup(conf.maxApps.get)
+
+  def validateGroup(group: Group): Group = {
+    // Try-catch to log the reason for failed validation
+    try {
+      Validation.validateOrThrow(group)
+    }
+    catch {
+      case e @ ValidationFailedException(f, t) =>
+        log.error(s"Validation failed for $f, because: $t")
+        throw e
+      case e: Exception => throw e
+    }
+    group
+  }
+
+  def allApps(group: Group): Iterable[AppDefinition] = {
+    group.apps ++ group.groups.flatMap(allApps)
+  }
+
+  def removeAllApps(group: Group): Group = {
+    update(group)(_.copy(apps = Group.defaultApps))
+  }
+
+  def update(group: Group)(fn: Group => Group): Group = {
+    def in(groups: List[Group]): List[Group] = groups match {
+      case head :: rest => head.update(head.version)(fn) :: in(rest)
+      case Nil          => Nil
+    }
+    fn(group.copy(groups = in(group.groups.toList).toSet))
   }
 }
 

--- a/src/test/scala/mesosphere/marathon/state/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MigrationTest.scala
@@ -7,11 +7,11 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.StorageVersions._
 import mesosphere.marathon.test.Mockito
-import mesosphere.marathon.{MarathonConf, MarathonSpec, MarathonTestHelper}
+import mesosphere.marathon.{ MarathonConf, MarathonSpec, MarathonTestHelper }
 import mesosphere.util.state.memory.InMemoryEntity
-import mesosphere.util.state.{PersistentEntity, PersistentStore, PersistentStoreManagement}
+import mesosphere.util.state.{ PersistentEntity, PersistentStore, PersistentStoreManagement }
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{GivenWhenThen, Matchers}
+import org.scalatest.{ GivenWhenThen, Matchers }
 
 import scala.concurrent.Future
 
@@ -32,6 +32,7 @@ class MigrationTest extends MarathonSpec with Mockito with Matchers with GivenWh
   test("migration calls initialization") {
     val f = new Fixture
 
+    f.groupRepo.listVersions(any) returns Future.successful(Iterable.empty)
     f.groupRepo.rootGroup() returns Future.successful(None)
     f.groupRepo.store(any, any) returns Future.successful(Group.empty)
     f.store.load("internal:storage:version") returns Future.successful(None)

--- a/src/test/scala/mesosphere/marathon/state/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MigrationTest.scala
@@ -7,11 +7,11 @@ import mesosphere.marathon.Protos.MarathonTask
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.StorageVersions._
 import mesosphere.marathon.test.Mockito
-import mesosphere.marathon.{ MarathonConf, MarathonSpec }
+import mesosphere.marathon.{MarathonConf, MarathonSpec, MarathonTestHelper}
 import mesosphere.util.state.memory.InMemoryEntity
-import mesosphere.util.state.{ PersistentEntity, PersistentStore, PersistentStoreManagement }
+import mesosphere.util.state.{PersistentEntity, PersistentStore, PersistentStoreManagement}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ GivenWhenThen, Matchers }
+import org.scalatest.{GivenWhenThen, Matchers}
 
 import scala.concurrent.Future
 
@@ -116,7 +116,7 @@ class MigrationTest extends MarathonSpec with Mockito with Matchers with GivenWh
     val store = mock[StoreWithManagement]
     val appRepo = mock[AppRepository]
     val groupRepo = mock[GroupRepository]
-    val config = mock[MarathonConf]
+    val config = MarathonTestHelper.defaultConfig()
     val taskRepo = new TaskRepository(
       new MarathonStore[MarathonTaskState](
         store = store,

--- a/src/test/scala/mesosphere/marathon/state/MigrationTo1_1Test.scala
+++ b/src/test/scala/mesosphere/marathon/state/MigrationTo1_1Test.scala
@@ -1,0 +1,189 @@
+package mesosphere.marathon.state
+
+import com.codahale.metrics.MetricRegistry
+import mesosphere.marathon.{MarathonSpec, MarathonTestHelper}
+import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.state.AppDefinition.VersionInfo
+import mesosphere.util.state.memory.InMemoryStore
+import org.scalatest.{GivenWhenThen, Matchers}
+import org.slf4j.LoggerFactory
+import mesosphere.marathon.state.PathId._
+
+class MigrationTo1_1Test extends MarathonSpec with GivenWhenThen with Matchers {
+  import mesosphere.FutureTestSupport._
+
+  private[this] val log = LoggerFactory.getLogger(getClass)
+
+  private val id = GroupRepository.zkRootName
+
+  test("Migrating broken app groups should not change an empty root group") {
+    val f = new Fixture
+
+    val root: Group = Group.empty
+    f.groupRepo.store(id, root).futureValue
+
+    f.migration.migrate().futureValue
+
+    f.groupRepo.rootGroup().futureValue.get.withNormalizedVersion should be equals root.withNormalizedVersion
+  }
+
+  test("Migrating broken app groups should not change a correct flat root group e.g. /foo") {
+    val f = new Fixture
+
+    val app = AppDefinition("/foo/bar".toPath, cmd = Some("cmd"))
+    val root = Group(
+      id = Group.empty.id,
+      groups = Set(Group("/foo".toPath, Set(app)).copy(version = Timestamp(0)) )
+    ).copy(version = Timestamp(1))
+
+    f.groupRepo.store(id, root).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.withNormalizedVersion should be equals root.withNormalizedVersion
+  }
+
+  test("Migrating broken app groups should not change a correct nested root group e.g. /foo/bar ") {
+    val f = new Fixture
+
+    val app = AppDefinition("/foo/bar/bazz".toPath, cmd = Some("cmd"))
+    val root = Group(
+      id = Group.empty.id,
+      groups = Set(Group("/foo".toPath,
+        groups = Set(Group("/foo/bar".toPath, Set(app) ))
+      ))
+    )
+
+    f.groupRepo.store(id, root).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.withNormalizedVersion should be equals root.withNormalizedVersion
+  }
+
+  test("Migrating broken app groups should correct an app in the wrong group") {
+    val f = new Fixture
+
+    val app = AppDefinition("/foo/bar".toPath, cmd = Some("cmd"))
+    val correctRoot = Group(
+      id = Group.empty.id,
+      groups = Set(
+        Group("/foo".toPath, Set(app)
+        )
+      )
+    )
+
+    val brokenRoot = Group(
+      id = Group.empty.id,
+      apps = Set(app),
+      groups = Set(
+        Group("/foo".toPath)
+      )
+    )
+
+    f.groupRepo.store(id, brokenRoot).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.withNormalizedVersion should be equals correctRoot.withNormalizedVersion
+  }
+
+  test("Migrating broken app groups should remove an app in the wrong group when having two apps with the same version") {
+    val f = new Fixture
+
+    val app = AppDefinition("/foo/bar".toPath, cmd = Some("cmd"))
+    val correctRoot = Group(
+      id = Group.empty.id,
+      groups = Set(
+        Group("/foo".toPath, Set(app)
+        )
+      )
+    )
+
+    val brokenRoot = Group(
+      id = Group.empty.id,
+      apps = Set(app),
+      groups = Set(
+        Group("/foo".toPath, Set(app))
+      )
+    )
+
+    f.groupRepo.store(id, brokenRoot).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.withNormalizedVersion should be equals correctRoot.withNormalizedVersion
+  }
+
+  test("Migrating broken app groups should remove an app with the oldest version when having two apps with the same path but different versions") {
+    val f = new Fixture
+
+    val app1 = AppDefinition("/foo/bar".toPath, cmd = Some("cmd"), versionInfo = VersionInfo.OnlyVersion(Timestamp(1)))
+    val app2 = app1.copy(versionInfo = VersionInfo.OnlyVersion(Timestamp(2)))
+    val correctRoot = Group(
+      id = Group.empty.id,
+      groups = Set(
+        Group("/foo".toPath, Set(app2)
+        )
+      )
+    )
+
+    val brokenRoot = Group(
+      id = Group.empty.id,
+      apps = Set(app2),
+      groups = Set(
+        Group("/foo".toPath, Set(app1))
+      )
+    )
+
+    f.groupRepo.store(id, brokenRoot).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.withNormalizedVersion should be equals correctRoot.withNormalizedVersion
+  }
+
+  test("Migrating broken app groups should remove an app with the oldest version when having two apps with the same path but different versions in a nested group") {
+    val f = new Fixture
+
+    val app1 = AppDefinition("/foo/bar/bazz".toPath, cmd = Some("cmd"), versionInfo = VersionInfo.OnlyVersion(Timestamp(1)))
+    val app2 = app1.copy(versionInfo = VersionInfo.OnlyVersion(Timestamp(2)))
+    val correctRoot = Group(
+      id = Group.empty.id,
+      groups = Set(Group("/foo".toPath,
+        groups = Set(Group("/foo/bar".toPath, Set(app2) ))
+      ))
+    )
+
+    val brokenRoot = Group(
+      id = Group.empty.id,
+      groups = Set(Group("/foo".toPath, Set(app2),
+        groups = Set(Group("/foo/bar".toPath, Set(app1) ))
+      ))
+    )
+
+    f.groupRepo.store(id, brokenRoot).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.withNormalizedVersion should be equals correctRoot.withNormalizedVersion
+  }
+
+  class Fixture {
+    lazy val metrics = new Metrics(new MetricRegistry)
+    lazy val store = new InMemoryStore()
+
+    lazy val groupStore = new MarathonStore[Group](store, metrics, () => Group.empty, prefix = "group:")
+    lazy val groupRepo = new GroupRepository(groupStore, maxVersions = None, metrics)
+    lazy val appStore = new MarathonStore[AppDefinition](store, metrics, () => AppDefinition(), prefix = "app:")
+    lazy val appRepo = new AppRepository(appStore, maxVersions = None, metrics)
+
+    lazy val migration = new MigrationTo1_1(groupRepository = groupRepo, appRepository = appRepo, conf = MarathonTestHelper.defaultConfig())
+  }
+}

--- a/src/test/scala/mesosphere/marathon/state/MigrationTo1_1_5Test.scala
+++ b/src/test/scala/mesosphere/marathon/state/MigrationTo1_1_5Test.scala
@@ -9,7 +9,7 @@ import org.scalatest.{ GivenWhenThen, Matchers }
 import org.slf4j.LoggerFactory
 import mesosphere.marathon.state.PathId._
 
-class MigrationTo1_1Test extends MarathonSpec with GivenWhenThen with Matchers {
+class MigrationTo1_1_5Test extends MarathonSpec with GivenWhenThen with Matchers {
   import mesosphere.FutureTestSupport._
 
   private[this] val log = LoggerFactory.getLogger(getClass)
@@ -282,6 +282,6 @@ class MigrationTo1_1Test extends MarathonSpec with GivenWhenThen with Matchers {
     lazy val appStore = new MarathonStore[AppDefinition](store, metrics, () => AppDefinition(), prefix = "app:")
     lazy val appRepo = new AppRepository(appStore, maxVersions = None, metrics)
 
-    lazy val migration = new MigrationTo1_1(groupRepository = groupRepo, appRepository = appRepo, conf = MarathonTestHelper.defaultConfig())
+    lazy val migration = new MigrationTo1_1_5(groupRepository = groupRepo, appRepository = appRepo, conf = MarathonTestHelper.defaultConfig())
   }
 }


### PR DESCRIPTION
Migration to 1.1:
- loads root group from the group repository
- filters out multiple app entries with the same version
- filters out multiple app entries with different version by keeping the oldest
- rebuilds the root group and stores it in the group repository

Fixes: DCOS-11627