### PR TITLE
Remove FraemworkId from Scheduler Service

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -16,12 +16,11 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.leadership.LeadershipCoordinator
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.storage.migration.Migration
-import mesosphere.marathon.storage.repository.{ FrameworkIdRepository, ReadOnlyAppRepository }
+import mesosphere.marathon.storage.repository.ReadOnlyAppRepository
 import mesosphere.marathon.stream.Sink
 import mesosphere.marathon.upgrade.DeploymentManager.{ CancelDeployment, DeploymentStepInfo }
 import mesosphere.marathon.upgrade.DeploymentPlan
 import mesosphere.util.PromiseActor
-import org.apache.mesos.Protos.FrameworkID
 import org.apache.mesos.SchedulerDriver
 import org.slf4j.LoggerFactory
 
@@ -67,7 +66,6 @@ trait DeploymentService {
 class MarathonSchedulerService @Inject() (
   leadershipCoordinator: LeadershipCoordinator,
   config: MarathonConf,
-  frameworkIdRepository: FrameworkIdRepository,
   electionService: ElectionService,
   prePostDriverCallbacks: Seq[PrePostDriverCallback],
   appRepository: ReadOnlyAppRepository,
@@ -103,9 +101,6 @@ class MarathonSchedulerService @Inject() (
   private[mesosphere] var timer = newTimer()
 
   val log = LoggerFactory.getLogger(getClass.getName)
-
-  // FIXME: Remove from this class
-  def frameworkId: Option[FrameworkID] = Await.result(frameworkIdRepository.get(), timeout.duration).map(_.toProto)
 
   // This is a little ugly as we are using a mutable variable. But drivers can't
   // be reused (i.e. once stopped they can't be started again. Thus,

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon.BuildInfo
 import mesosphere.marathon.api.{ AuthResource, MarathonMediaType }
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.plugin.auth._
+import mesosphere.marathon.storage.repository.FrameworkIdRepository
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService }
 import mesosphere.util.state.MesosLeaderInfo
 import play.api.libs.json.{ JsObject, Json }
@@ -19,6 +20,7 @@ import play.api.libs.json.{ JsObject, Json }
 class InfoResource @Inject() (
     schedulerService: MarathonSchedulerService,
     mesosLeaderInfo: MesosLeaderInfo,
+    frameworkIdRepository: FrameworkIdRepository,
     electionService: ElectionService,
     val authenticator: Authenticator,
     val authorizer: Authorizer,
@@ -88,7 +90,7 @@ class InfoResource @Inject() (
           "buildref" -> BuildInfo.buildref,
           "elected" -> electionService.isLeader,
           "leader" -> electionService.leaderHostPort,
-          "frameworkId" -> schedulerService.frameworkId.map(_.getValue),
+          "frameworkId" -> result(frameworkIdRepository.get()).map(_.id),
           "marathon_config" -> (marathonConfigValues ++ mesosLeaderUiUrl),
           "zookeeper_config" -> zookeeperConfigValues,
           "event_subscriber" -> config.eventSubscriber.get.map(_ => eventHandlerConfigValues),

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -4,7 +4,6 @@ import java.util.{ Timer, TimerTask }
 
 import akka.actor.ActorRef
 import akka.testkit.TestProbe
-import com.codahale.metrics.MetricRegistry
 import mesosphere.AkkaFunTest
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.Protos.StorageVersion
@@ -12,12 +11,9 @@ import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.heartbeat._
 import mesosphere.marathon.core.leadership.LeadershipCoordinator
-import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.storage.repository.{ AppRepository, FrameworkIdRepository }
-import mesosphere.util.state.FrameworkId
 import org.apache.mesos.{ SchedulerDriver, Protos => mesos }
 import org.mockito.Matchers.{ eq => mockEq }
 import org.mockito.Mockito
@@ -107,12 +103,9 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
   }
 
   test("Start timer when elected") {
-    when(frameworkIdRepository.get()).thenReturn(Future.successful(None))
-
     val schedulerService = new MarathonSchedulerService(
       leadershipCoordinator,
       config,
-      frameworkIdRepository,
       electionService,
       prePostDriverCallbacks,
       appRepository,
@@ -131,13 +124,10 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
   }
 
   test("Cancel timer when defeated") {
-    when(frameworkIdRepository.get()).thenReturn(Future.successful(None))
-
     val driver = mock[SchedulerDriver]
     val schedulerService = new MarathonSchedulerService(
       leadershipCoordinator,
       config,
-      frameworkIdRepository,
       electionService,
       prePostDriverCallbacks,
       appRepository,
@@ -161,12 +151,9 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
   }
 
   test("Re-enable timer when re-elected") {
-    when(frameworkIdRepository.get()).thenReturn(Future.successful(None))
-
     val schedulerService = new MarathonSchedulerService(
       leadershipCoordinator,
       config,
-      frameworkIdRepository,
       electionService,
       prePostDriverCallbacks,
       appRepository,
@@ -193,45 +180,10 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
     verify(mockTimer).cancel()
   }
 
-  test("Always fetch current framework ID") {
-    val frameworkId = mesos.FrameworkID.newBuilder.setValue("myId").build()
-    implicit val metrics = new Metrics(new MetricRegistry)
-    frameworkIdRepository = FrameworkIdRepository.inMemRepository(new InMemoryPersistenceStore())
-
-    val schedulerService = new MarathonSchedulerService(
-      leadershipCoordinator,
-      config,
-      frameworkIdRepository,
-      electionService,
-      prePostDriverCallbacks,
-      appRepository,
-      driverFactory(mock[SchedulerDriver]),
-      system,
-      migration,
-      schedulerActor,
-      heartbeatActor
-    ) {
-      override def startLeadership(): Unit = ()
-      override def newTimer() = mockTimer
-    }
-
-    schedulerService.timer = mockTimer
-
-    schedulerService.frameworkId should be(None)
-
-    implicit lazy val timeout = 1.second
-    frameworkIdRepository.store(FrameworkId(frameworkId.getValue)).futureValue
-
-    awaitAssert(schedulerService.frameworkId should be(Some(frameworkId)))
-  }
-
   test("Abdicate leadership when migration fails and reoffer leadership") {
-    when(frameworkIdRepository.get()).thenReturn(Future.successful(None))
-
     val schedulerService = new MarathonSchedulerService(
       leadershipCoordinator,
       config,
-      frameworkIdRepository,
       electionService,
       prePostDriverCallbacks,
       appRepository,
@@ -264,13 +216,11 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
   }
 
   test("Abdicate leadership when the driver creation fails by some exception") {
-    when(frameworkIdRepository.get()).thenReturn(Future.successful(None))
     val driverFactory = mock[SchedulerDriverFactory]
 
     val schedulerService = new MarathonSchedulerService(
       leadershipCoordinator,
       config,
-      frameworkIdRepository,
       electionService,
       prePostDriverCallbacks,
       appRepository,
@@ -296,14 +246,12 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
   }
 
   test("Abdicate leadership when driver ends with error") {
-    when(frameworkIdRepository.get()).thenReturn(Future.successful(None))
     val driver = mock[SchedulerDriver]
     val driverFactory = mock[SchedulerDriverFactory]
 
     val schedulerService = new MarathonSchedulerService(
       leadershipCoordinator,
       config,
-      frameworkIdRepository,
       electionService,
       prePostDriverCallbacks,
       appRepository,
@@ -329,14 +277,12 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
     Mockito.when(cb.postDriverTerminates).thenReturn(Future(()))
     Mockito.when(cb.preDriverStarts).thenReturn(Future(()))
 
-    when(frameworkIdRepository.get()).thenReturn(Future.successful(None))
     val driver = mock[SchedulerDriver]
     val driverFactory = mock[SchedulerDriverFactory]
 
     val schedulerService = new MarathonSchedulerService(
       leadershipCoordinator,
       config,
-      frameworkIdRepository,
       electionService,
       scala.collection.immutable.Seq(cb),
       appRepository,

--- a/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.api.v2
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.election.ElectionService
+import mesosphere.marathon.storage.repository.FrameworkIdRepository
 import mesosphere.marathon.test.{ MarathonSpec, Mockito }
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService }
 import mesosphere.util.state.MesosLeaderInfo
@@ -43,6 +44,8 @@ class InfoResourceTest extends MarathonSpec with Matchers with Mockito with Give
     val electionService = mock[ElectionService]
     val auth = new TestAuthFixture
     val config = mock[MarathonConf with HttpConf]
-    def infoResource() = new InfoResource(schedulerService, leaderInfo, electionService, auth.auth, auth.auth, config)
+    val frameworkIdRepository = mock[FrameworkIdRepository]
+
+    def infoResource() = new InfoResource(schedulerService, leaderInfo, frameworkIdRepository, electionService, auth.auth, auth.auth, config)
   }
 }


### PR DESCRIPTION
Use FrameworkIdRepository directly instead of wrapping it
with MarathonSchedulerService.