### PR TITLE
Parse JSON event only once before broadcast

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/event/impl/callback/HttpEventActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/callback/HttpEventActor.scala
@@ -10,6 +10,7 @@ import mesosphere.marathon.core.event.impl.callback.SubscribersKeeperActor.GetSu
 import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
 import mesosphere.marathon.util.Retry
 import org.slf4j.LoggerFactory
+import play.api.libs.json.JsValue
 import spray.client.pipelining.{ sendReceive, _ }
 import spray.http.{ HttpRequest, HttpResponse }
 import spray.httpx.PlayJsonSupport
@@ -103,7 +104,8 @@ class HttpEventActor(
     //remove all unsubscribed callback listener
     limiter = limiter.filterKeys(subscribers.urls).iterator.toMap.withDefaultValue(NoLimit)
     metrics.skippedCallbacks.mark(limited.size)
-    active.foreach(url => Try(post(url, event, self)) match {
+    val jsonEvent = eventToJson(event)
+    active.foreach(url => Try(post(url, jsonEvent, self)) match {
       case Success(res) =>
       case Failure(ex) =>
         log.warn(s"Failed to post $event to $url because ${ex.getClass.getSimpleName}: ${ex.getMessage}")
@@ -112,12 +114,12 @@ class HttpEventActor(
     })
   }
 
-  def post(url: String, event: MarathonEvent, eventActor: ActorRef): Unit = {
+  def post(url: String, event: JsValue, eventActor: ActorRef): Unit = {
     log.info("Sending POST to:" + url)
 
     metrics.outstandingCallbacks.inc()
     val start = clock.now()
-    val request = Post(url, eventToJson(event))
+    val request = Post(url, event)
 
     val response = pipeline(context.dispatcher)(request)
 


### PR DESCRIPTION
Current implementation parses events for every callback.
This patch make parsing happen only once for event.