### PR TITLE
Cherry-picked  MigrationTo1_1_5 class to handle broken app groups (#4711)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -206,6 +206,11 @@ __Caution: Will not be promoting a Marathon v1.2 RC to a final release.__
 We have been focusing our efforts on two big new features for the upcoming DC/OS v1.8 release and had to work around the feature freeze in the Marathon v1.2 release candidates. Therefore, we discontinued work on the v1.2 release in favor of a new Marathon v1.3 release candidate.
 See: https://groups.google.com/forum/#!topic/marathon-framework/j6fNc4xk5tQ
 
+## Changes from 1.1.4 to 1.1.5
+Added a migration that will fix improperly structured app groups. If an app entry is in the wrong group e.g.
+`Group( id = /, apps = [“/foo/bar”] )` it will be moved: `Group ( id = / , Group( id = /foo, apps = [”/foo/bar”] )` 
+thus taking care of structuring the groups properly. 
+Note: if an app has multiple entries with different versions then the newest is kept.
 
 ## Changes from 1.0.0 to 1.1.0
 

--- a/src/main/scala/mesosphere/marathon/state/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/state/Migration.scala
@@ -6,6 +6,7 @@ import javax.inject.Inject
 
 import akka.Done
 import mesosphere.marathon.Protos.{ Constraint, MarathonTask, StorageVersion }
+import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.task.state.MarathonTaskStatus
 import mesosphere.marathon.core.task.tracker.impl.MarathonTaskStatusSerializer
 import mesosphere.marathon.metrics.Metrics
@@ -21,8 +22,8 @@ import scala.collection.SortedSet
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
-import scala.util.control.NonFatal
 import scala.util.Try
+import scala.util.control.NonFatal
 
 class Migration @Inject() (
     store: PersistentStore,
@@ -60,6 +61,11 @@ class Migration @Inject() (
     StorageVersions(0, 16, 0) -> { () =>
       new MigrationTo0_16(groupRepo, appRepo).migrate().recover {
         case NonFatal(e) => throw new MigrationFailedException("while migrating storage to 0.16", e)
+      }
+    },
+    StorageVersions(1, 1, 5) -> { () =>
+      new MigrationTo1_1_5(groupRepo, appRepo, config).migrate().recover {
+        case NonFatal(e) => throw new MigrationFailedException("while migrating storage to 1.1.5", e)
       }
     },
     StorageVersions(1, 2, 0) -> { () =>
@@ -379,6 +385,123 @@ class MigrationTo0_16(groupRepository: GroupRepository, appRepository: AppReposi
         }
       }
     }
+  }
+}
+
+class MigrationTo1_1_5(groupRepository: GroupRepository, appRepository: AppRepository, conf: MarathonConf) {
+  private[this] val log = LoggerFactory.getLogger(getClass)
+
+  def migrate(): Future[Unit] = {
+    log.info("Start 1.1.5 migration")
+
+    //        We can have 3 cases here:
+    //          1. App has one entry at the wrong place and must be moved:
+    //
+    //              Group( id = /, apps = [“/foo/bla”] )
+    //              —>
+    //              Group ( id = / ,
+    //                Group( id = /foo, apps = [”/foo/bla”] )
+    //
+    //          2. App has 2 entries but both entries have the same version so the wrong one can be deleted:
+    //
+    //            Group( id = /, apps = [“/foo/bla, version = 1"],
+    //              Group( id = /foo, apps = [“/foo/bla, version = 1"])
+    //            —>
+    //            Group ( id = / ,
+    //              Group( id = /foo, apps = [“/foo/bla, version = 1"] )
+    //
+    //          3. App has 2 entries with different versions. At this point we can either fail the migration or
+    //             keep one of the versions. After some discussion we decided to keep the latest version.
+    //             CAUTION: this migration can potentially result in data loss:
+    //
+    //            Group( id = /, apps = [“/foo/bla, version = 1"],
+    //              Group( id = /foo, apps = [“/foo/bla, version = 2"])
+    //            —>
+    //            Group ( id = / ,
+    //              Group( id = /foo, apps = [“/foo/bla, version = 2"] )
+
+    val id = GroupRepository.zkRootName
+
+    for {
+      updatedGroups <- updateGroups(id) // Update root and it's versions
+      _ = log.info(s"Updated groups: $updatedGroups")
+      _ <- storeGroups(id, updatedGroups) // Store updated groups
+      _ <- updateApps() // Update apps from the root group
+    } yield log.info("Finished 1.1.5 migration")
+  }
+
+  def updateGroups(id: String): Future[Iterable[Group]] = {
+    groupRepository.listVersions(id).map(d => d.toSeq.sorted).flatMap { versions =>
+      val fs = versions.map(version =>
+        groupRepository.group(id, version).map {
+          case Some(group) =>
+            log.info(s"Loaded group: $group")
+            val updated = validateGroup(updateGroup(group))
+            log.info(s"Updated group: $updated")
+            updated
+          case None => throw new MigrationFailedException(s"Group $id:$version not found")
+        }
+      )
+      Future.sequence(fs)
+    }
+  }
+
+  def storeGroups(id: String, updatedGroups: Iterable[Group]): Future[Iterable[Group]] = {
+    val storedGroups = updatedGroups.map { group =>
+      groupRepository.store(id, group)
+    }
+    Future.sequence(storedGroups)
+  }
+
+  def updateApps(): Future[Set[AppDefinition]] = {
+    val rootGroupFuture = groupRepository.rootGroup().map(_.getOrElse(Group.empty))
+
+    rootGroupFuture.flatMap{ rootGroup =>
+      val apps = rootGroup.transitiveApps
+      Future.sequence(apps.map(appRepository.store(_)))
+    }
+  }
+
+  def updateGroup(group: Group): Group = {
+    log.info(s"Migrating group: $group")
+    // get all apps including duplicates with different versions
+    val apps = allApps(group)
+    // remove all apps, keeping the empty groups
+    val empty = removeAllApps(group)
+    // update the groups with the apps while keeping the oldest app version
+    val updated = apps.foldLeft(empty) { (group, app) =>
+      log.debug(s"Migrating $app")
+      group.updateApp(app.id, _.fold(app) { that =>
+        if (that.version > app.version) that else app
+      }, group.version)
+    }
+    log.info(s"Resulting group: $updated")
+    updated
+  }
+
+  import mesosphere.marathon.ValidationFailedException
+
+  implicit private val validator = Group.validRootGroup(conf.maxApps.get)
+
+  def validateGroup(group: Group): Group = {
+    // Try-catch to log the reason for failed validation
+    try {
+      Validation.validateOrThrow(group)
+    } catch {
+      case e @ ValidationFailedException(f, t) =>
+        log.error(s"Validation failed for $f, because: $t")
+        throw e
+      case e: Exception => throw e
+    }
+    group
+  }
+
+  def allApps(group: Group): Iterable[AppDefinition] = {
+    group.apps.values ++ group.groups.flatMap(allApps)
+  }
+
+  def removeAllApps(group: Group): Group = {
+    group.update(group.version)(_.copy(apps = Group.defaultApps))
   }
 }
 

--- a/src/test/scala/mesosphere/marathon/state/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MigrationTest.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.StorageVersions._
 import mesosphere.marathon.test.Mockito
 import mesosphere.marathon.upgrade.DeploymentPlan
-import mesosphere.marathon.{ MarathonConf, MarathonSpec }
+import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
 import mesosphere.util.state.memory.InMemoryEntity
 import mesosphere.util.state.{ PersistentEntity, PersistentStore, PersistentStoreManagement }
 import org.scalatest.concurrent.ScalaFutures
@@ -33,6 +33,7 @@ class MigrationTest extends MarathonSpec with Mockito with Matchers with GivenWh
   test("migration calls initialization") {
     val f = new Fixture
 
+    f.groupRepo.listVersions(any) returns Future.successful(Iterable.empty)
     f.groupRepo.rootGroup() returns Future.successful(None)
     f.groupRepo.store(any, any) returns Future.successful(Group.empty)
     f.store.load("internal:storage:version") returns Future.successful(None)
@@ -117,7 +118,7 @@ class MigrationTest extends MarathonSpec with Mockito with Matchers with GivenWh
     val store = mock[StoreWithManagement]
     val appRepo = mock[AppRepository]
     val groupRepo = mock[GroupRepository]
-    val config = mock[MarathonConf]
+    val config = MarathonTestHelper.defaultConfig()
     val deploymentRepo = new DeploymentRepository(
       new MarathonStore[DeploymentPlan](
         store = store,

--- a/src/test/scala/mesosphere/marathon/state/MigrationTo1_1_5Test.scala
+++ b/src/test/scala/mesosphere/marathon/state/MigrationTo1_1_5Test.scala
@@ -1,0 +1,293 @@
+package mesosphere.marathon.state
+
+import com.codahale.metrics.MetricRegistry
+import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
+import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.state.AppDefinition.VersionInfo
+import mesosphere.util.state.memory.InMemoryStore
+import org.scalatest.{ GivenWhenThen, Matchers }
+import org.slf4j.LoggerFactory
+import mesosphere.marathon.state.PathId._
+
+class MigrationTo1_1_5Test extends MarathonSpec with GivenWhenThen with Matchers {
+  import mesosphere.FutureTestSupport._
+
+  private[this] val log = LoggerFactory.getLogger(getClass)
+
+  private val id = GroupRepository.zkRootName
+
+  test("Migrating broken app groups should not change an empty root group") {
+    val f = new Fixture
+
+    val root: Group = Group.empty.copy(version = Timestamp(0))
+    f.groupRepo.store(id, root).futureValue
+
+    f.migration.migrate().futureValue
+
+    f.groupRepo.rootGroup().futureValue.get shouldBe root
+  }
+
+  test("Migrating broken app groups should not change a correct flat root group e.g. /foo") {
+    val f = new Fixture
+
+    val app = AppDefinition("/foo/bar".toPath, cmd = Some("cmd"))
+    val root = Group(
+      id = Group.empty.id,
+      groups = Set(Group("/foo".toPath, Map(app.id -> app)).copy(version = Timestamp(0)))
+    ).copy(version = Timestamp(1))
+
+    f.groupRepo.store(id, root).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.apps should be ('empty)
+    storedRoot.group("/foo".toPath).get.apps should equal (Map(app.id -> app))
+  }
+
+  test("Migrating broken app groups should not change a correct nested root group e.g. /foo/bar ") {
+    val f = new Fixture
+
+    val app = AppDefinition("/foo/bar/bazz".toPath, cmd = Some("cmd"))
+    val root = Group(
+      id = Group.empty.id,
+      groups = Set(Group(
+        "/foo".toPath,
+        groups = Set(Group("/foo/bar".toPath, Map(app.id -> app)))
+      ))
+    )
+
+    f.groupRepo.store(id, root).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.apps should be ('empty)
+    storedRoot.group("/foo".toPath).get.apps should be ('empty)
+    storedRoot.group("/foo/bar".toPath).get.apps should equal (Map(app.id -> app))
+  }
+
+  test("Migrating broken app groups should correct an app in the wrong group") {
+    val f = new Fixture
+
+    val app = AppDefinition("/foo/bar".toPath, cmd = Some("cmd"))
+    val correctRoot = Group(
+      id = Group.empty.id,
+      groups = Set(
+        Group("/foo".toPath, Map(app.id -> app))
+      )
+    )
+
+    val brokenRoot = Group(
+      id = Group.empty.id,
+      apps = Map(app.id -> app)
+    )
+
+    f.groupRepo.store(id, brokenRoot).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.apps should be ('empty)
+    storedRoot.group("/foo".toPath).get.apps should equal (Map(app.id -> app))
+  }
+
+  test("Migrating broken app groups should remove an app in the wrong group when having two apps with the same version") {
+    val f = new Fixture
+
+    val app = AppDefinition("/foo/bar".toPath, cmd = Some("cmd"))
+    val correctRoot = Group(
+      id = Group.empty.id,
+      groups = Set(
+        Group("/foo".toPath, Map(app.id -> app)
+        )
+      )
+    )
+
+    val brokenRoot = Group(
+      id = Group.empty.id,
+      apps = Map(app.id -> app),
+      groups = Set(
+        Group("/foo".toPath, Map(app.id -> app))
+      )
+    )
+
+    f.groupRepo.store(id, brokenRoot).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.apps should be ('empty)
+    storedRoot.group("/foo".toPath).get.apps should equal (Map(app.id -> app))
+  }
+
+  test("Migrating broken app groups should remove an app with the oldest version when having two apps with the same path but different versions") {
+    val f = new Fixture
+
+    val app1 = AppDefinition("/foo/bar".toPath, cmd = Some("cmd"), versionInfo = VersionInfo.OnlyVersion(Timestamp(1)))
+    val app2 = app1.copy(versionInfo = VersionInfo.OnlyVersion(Timestamp(2)))
+    val correctRoot = Group(
+      id = Group.empty.id,
+      groups = Set(
+        Group("/foo".toPath, Map(app2.id -> app2)
+        )
+      )
+    )
+
+    val brokenRoot = Group(
+      id = Group.empty.id,
+      apps = Map(app2.id -> app2),
+      groups = Set(
+        Group("/foo".toPath, Map(app1.id -> app1))
+      )
+    )
+
+    f.groupRepo.store(id, brokenRoot).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.apps should be ('empty)
+    storedRoot.group("/foo".toPath).get.apps should equal (Map(app2.id -> app2))
+  }
+
+  test("Migrating broken app groups should remove an app with the oldest version when having two apps with the same path but different versions in a nested group") {
+    val f = new Fixture
+
+    val app1 = AppDefinition("/foo/bar/bazz".toPath, cmd = Some("cmd"), versionInfo = VersionInfo.OnlyVersion(Timestamp(1)))
+    val app2 = app1.copy(versionInfo = VersionInfo.OnlyVersion(Timestamp(2)))
+    val correctRoot = Group(
+      id = Group.empty.id,
+      groups = Set(Group(
+        "/foo".toPath,
+        groups = Set(Group("/foo/bar".toPath, Map(app2.id -> app2)))
+      ))
+    )
+
+    val brokenRoot = Group(
+      id = Group.empty.id,
+      groups = Set(Group("/foo".toPath, Map(app2.id -> app2),
+        groups = Set(Group("/foo/bar".toPath, Map(app1.id -> app1)))
+      ))
+    )
+
+    f.groupRepo.store(id, brokenRoot).futureValue
+
+    f.migration.migrate().futureValue
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.apps should be ('empty)
+    storedRoot.group("/foo".toPath).get.apps should be ('empty)
+    storedRoot.group("/foo/bar".toPath).get.apps should equal (Map(app2.id -> app2))
+    storedRoot.transitiveApps should equal (correctRoot.transitiveApps)
+    storedRoot.transitiveApps should not equal brokenRoot.transitiveApps
+  }
+
+  test("Migrating broken app groups should remove an app with the oldest version when having two apps with different versions and mutliple root groups") {
+    val f = new Fixture
+
+    val app1 = AppDefinition("/foo/bar/bazz".toPath, cmd = Some("cmd"), versionInfo = VersionInfo.OnlyVersion(Timestamp(1)))
+    val app2 = app1.copy(versionInfo = VersionInfo.OnlyVersion(Timestamp(2)))
+    val correctRootV1 = Group(
+      id = Group.empty.id,
+      groups = Set(Group(
+        "/foo".toPath,
+        groups = Set(Group("/foo/bar".toPath, Map(app1.id -> app1), version = Timestamp(1))),
+        version = Timestamp(1)
+      )),
+      version = Timestamp(1)
+    )
+
+    val correctRootV2 = Group(
+      id = Group.empty.id,
+      groups = Set(Group(
+        "/foo".toPath,
+        groups = Set(Group("/foo/bar".toPath, Map(app2.id -> app2), version = Timestamp(2))),
+        version = Timestamp(2)
+      )),
+      version = Timestamp(2)
+    )
+
+    val brokenRootV1 = Group(
+      id = Group.empty.id,
+      apps = Map(app1.id -> app1),
+      groups = Set(Group(
+        "/foo".toPath,
+        groups = Set(Group("/foo/bar".toPath))
+      )),
+      version = Timestamp(1)
+    )
+
+    val brokenRootV2 = Group(
+      id = Group.empty.id,
+      groups = Set(Group("/foo".toPath, Map(app2.id -> app2),
+        groups = Set(Group("/foo/bar".toPath, Map(app1.id -> app1)))
+      )),
+      version = Timestamp(2)
+    )
+
+    f.groupRepo.store(id, brokenRootV1).futureValue
+    f.groupRepo.store(id, brokenRootV2).futureValue
+
+    f.migration.migrate().futureValue
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val storedRoot = f.groupRepo.rootGroup().futureValue.get
+    storedRoot.apps should be ('empty)
+    storedRoot.group("/foo".toPath).get.apps should be ('empty)
+    storedRoot.group("/foo/bar".toPath).get.apps should equal (Map(app2.id -> app2))
+
+    val storedVersions = f.groupRepo.listVersions(id).map(d => d.toSeq.sorted).futureValue
+    storedVersions.size shouldEqual 2
+    log.debug(s"Stored versions: $storedVersions")
+    val v1 = f.groupRepo.group(id, storedVersions(0)).futureValue.get
+    val v2 = f.groupRepo.group(id, storedVersions(1)).futureValue.get
+
+    v1.withNormalizedVersion should equal (correctRootV1.withNormalizedVersion)
+    v1.transitiveApps should equal (correctRootV1.transitiveApps)
+    v1.transitiveApps should not equal correctRootV2.transitiveApps
+    v1.transitiveAppGroups should equal (correctRootV1.transitiveAppGroups)
+    v1.transitiveAppGroups should not equal correctRootV2.transitiveAppGroups
+
+    assert(v2.withNormalizedVersion == correctRootV2.withNormalizedVersion)
+    assert(v2.transitiveApps == correctRootV2.transitiveApps)
+    assert(v2.transitiveAppGroups == correctRootV2.transitiveAppGroups)
+  }
+
+  test("Migrating broken app groups should store all apps of the normalized group") {
+    val f = new Fixture
+
+    val app1 = AppDefinition("/foo/bizz".toPath, cmd = Some("cmd"), versionInfo = VersionInfo.OnlyVersion(Timestamp(1)))
+    val app2 = AppDefinition("/foo/bar/bazz".toPath, cmd = Some("cmd"), versionInfo = VersionInfo.OnlyVersion(Timestamp(1)))
+
+    val brokenRoot = Group(
+      id = Group.empty.id,
+      groups = Set(Group(
+        "/foo".toPath,
+        groups = Set(Group("/foo/bar".toPath, Map(app1.id -> app1, app2.id -> app2)))
+      ))
+    )
+
+    f.groupRepo.store(id, brokenRoot).futureValue
+
+    f.migration.migrate().futureValue
+
+    val apps = f.appRepo.apps().futureValue
+    apps.size shouldEqual (2)
+    apps should contain (app1)
+    apps should contain (app2)
+  }
+
+  class Fixture {
+    lazy val metrics = new Metrics(new MetricRegistry)
+    lazy val store = new InMemoryStore()
+
+    lazy val groupStore = new MarathonStore[Group](store, metrics, () => Group.empty, prefix = "group:")
+    lazy val groupRepo = new GroupRepository(groupStore, maxVersions = None, metrics)
+    lazy val appStore = new MarathonStore[AppDefinition](store, metrics, () => AppDefinition(), prefix = "app:")
+    lazy val appRepo = new AppRepository(appStore, maxVersions = None, metrics)
+
+    lazy val migration = new MigrationTo1_1_5(groupRepository = groupRepo, appRepository = appRepo, conf = MarathonTestHelper.defaultConfig())
+  }
+}


### PR DESCRIPTION
Migration to 1.1.5:
- loads root group from the group repository
- filters out multiple app entries with the same version
- filters out multiple app entries with different version by keeping the oldest
- rebuilds the root group and stores it in the group repository

Fixes: DCOS-11627