### PR TITLE
Properly mark health check props as optional

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -82,7 +82,7 @@ types:
     type: object
     properties:
       command?: CommandCheck
-      gracePeriodSeconds:
+      gracePeriodSeconds?:
         type: integer
         format: int32
         description: |
@@ -94,13 +94,13 @@ types:
       ignoreHttp1xx?:
         type: boolean
         description: Ignore HTTP 1xx responses
-      intervalSeconds:
+      intervalSeconds?:
         type: integer
         format: int32
         description: Number of seconds to wait between health checks
         minimum: 0
         default: 60
-      maxConsecutiveFailures:
+      maxConsecutiveFailures?:
         type: integer
         format: int32
         description: |
@@ -129,7 +129,7 @@ types:
       protocol?:
         type: AppHealthCheckProtocol
         default: HTTP
-      timeoutSeconds:
+      timeoutSeconds?:
         type: integer
         format: int32
         default: 20


### PR DESCRIPTION
Mark implicit optional props as optional to avoid confusion and fix related validation errors.

Closes #4811

/cc @unterstein  