### PR TITLE
Make network name optional

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/network.raml
+++ b/docs/docs/rest-api/public/api/v2/types/network.raml
@@ -10,10 +10,12 @@ types:
       Endpoints accept connections from outside of a pod.
       Endpoints may also be advertised outside of a cluster.
     properties:
-      name:
+      name?:
         type: strings.Name
         description: |
           Name of this port. Should be unique in the context of the pod.
+          Required if the network mode is container and  `default_network_name`
+          command line arg isn't specified.
       containerPort?:
         type: numbers.Port
         description: |


### PR DESCRIPTION
Make the network name optional as it is only required if the network mode is container and  `default_network_name` command line arg isn't specified. This aligns the network name with the rest of the network type dependent properties.

Closes #4821