### PR TITLE
Change Marathon UI version to 1.2.0-SNAPSHOT

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -96,7 +96,7 @@ object Dependency {
     val PlayJson = "2.5.10"
     val JsonSchemaValidator = "2.2.6"
     val RxScala = "0.26.4"
-    val MarathonUI = "1.2.0"
+    val MarathonUI = "1.2.0-SNAPSHOT"
     val MarathonApiConsole = "3.0.8"
     val Graphite = "3.1.2"
     val DataDog = "1.1.6"


### PR DESCRIPTION
Update the dependencies config to point to Marathon UI `1.2.0-SNAPSHOT` as  the there is no official `1.2.0` release yet and Marathon `master` should always use the latest Marathon UI build.

/cc @unterstein @wavesoft @Poltergeist 