### PR TITLE
Include TASK_FINISHED as failure state when upgrading

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -69,13 +69,13 @@ class TaskReplaceActor(
 
   def replaceBehavior: Receive = {
     // New task failed to start, restart it
-    case MesosStatusUpdateEvent(slaveId, taskId, FailedToStart(_), _, `appId`, _, _, _, `versionString`, _, _) if !oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
+    case MesosStatusUpdateEvent(slaveId, taskId, IsTerminal(_), _, `appId`, _, _, _, `versionString`, _, _) if !oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
       log.error(s"New task $taskId failed on slave $slaveId during app $appId restart")
       taskTerminated(taskId)
       launchQueue.add(app)
 
     // Old task successfully killed
-    case MesosStatusUpdateEvent(slaveId, taskId, KillComplete(_), _, `appId`, _, _, _, _, _, _) if oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
+    case MesosStatusUpdateEvent(slaveId, taskId, IsTerminal(_), _, `appId`, _, _, _, _, _, _) if oldTaskIds(taskId) => // scalastyle:ignore line.size.limit
       oldTaskIds -= taskId
       outstandingKills -= taskId
       reconcileNewTasks()
@@ -137,8 +137,7 @@ class TaskReplaceActor(
 object TaskReplaceActor {
   private[this] val log = LoggerFactory.getLogger(getClass)
 
-  val KillComplete = "^TASK_(ERROR|FAILED|FINISHED|LOST|KILLED)$".r
-  val FailedToStart = "^TASK_(ERROR|FAILED|LOST|KILLED)$".r
+  val IsTerminal = "^TASK_(ERROR|FAILED|FINISHED|LOST|KILLED)$".r
 
   //scalastyle:off
   def props(


### PR DESCRIPTION
If we upgrade an app with health check, and newly launched task
finished before passing health check, the current task replace actor
ignore this TASK_FINISHED message and run into a strange state:
  1. it waits for task status update event, but it won't get any;
  2. it won't try to launch a new task.