### PR TITLE
added LeadershipAbdicationIntegrationTest and change deployment handling during leader abdication

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
@@ -2,14 +2,16 @@ package mesosphere.marathon.upgrade
 
 import akka.actor._
 import akka.event.EventStream
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.DeploymentStatus
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.RunSpec
 import mesosphere.marathon.{ AppStartCanceledException, SchedulerActions }
-import org.slf4j.LoggerFactory
 
+import scala.async.Async.{ async, await }
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
@@ -23,14 +25,17 @@ class AppStartActor(
     val readinessCheckExecutor: ReadinessCheckExecutor,
     val runSpec: RunSpec,
     val scaleTo: Int,
-    promise: Promise[Unit]) extends Actor with StartingBehavior {
+    promise: Promise[Unit]) extends Actor with StartingBehavior with StrictLogging {
 
-  private[this] val log = LoggerFactory.getLogger(getClass)
-
-  val nrToStart: Int = scaleTo
+  override val nrToStart: Int = scaleTo
 
   def initializeStart(): Unit = {
-    scheduler.startRunSpec(runSpec.withInstances(scaleTo))
+    async {
+      // In case we already have running instances (can happen on master abdication during deployment)
+      // with the correct version those will not be killed.
+      val runningInstances = await(instanceTracker.specInstances(runSpec.id)).count(_.isActive)
+      scheduler.startRunSpec(runSpec.withInstances(Math.max(runningInstances, nrToStart)))
+    }
   }
 
   override def postStop(): Unit = {
@@ -39,7 +44,7 @@ class AppStartActor(
   }
 
   def success(): Unit = {
-    log.info(s"Successfully started $scaleTo instances of ${runSpec.id}")
+    logger.info(s"Successfully started $scaleTo instances of ${runSpec.id}")
     promise.success(())
     context.stop(self)
   }
@@ -47,7 +52,7 @@ class AppStartActor(
   override def shutdown(): Unit = {
     if (!promise.isCompleted && promise.tryFailure(new AppStartCanceledException("The app start has been cancelled"))) {
       scheduler.stopRunSpec(runSpec).onFailure {
-        case NonFatal(e) => log.error(s"while stopping app ${runSpec.id}", e)
+        case NonFatal(e) => logger.error(s"while stopping app ${runSpec.id}", e)
       }(context.dispatcher)
     }
     context.stop(self)

--- a/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/AppStartActor.scala
@@ -29,6 +29,7 @@ class AppStartActor(
 
   override val nrToStart: Int = scaleTo
 
+  @SuppressWarnings(Array("all")) // async/await
   def initializeStart(): Unit = {
     async {
       // In case we already have running instances (can happen on master abdication during deployment)

--- a/src/test/scala/mesosphere/marathon/integration/LeadershipAbdicationIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/LeadershipAbdicationIntegrationTest.scala
@@ -1,0 +1,90 @@
+package mesosphere.marathon
+package integration
+
+import mesosphere.marathon.Protos.Constraint.Operator
+import mesosphere.marathon.integration.setup.WaitTestSupport
+
+import scala.concurrent.duration._
+
+/**
+  * Regression Test for https://github.com/mesosphere/marathon/issues/3783
+  *
+  * Adapted from https://github.com/EvanKrall/reproduce_marathon_issue_3783
+  */
+@IntegrationTest
+class LeadershipAbdicationIntegrationTest extends LeaderIntegrationTest {
+
+  after(cleanUp())
+
+  override val numAdditionalMarathons = 5
+
+  def firstProcess = runningServerProcesses.headOption.getOrElse(
+    fail("there are marathon servers running")
+  )
+
+  test("Abdicating a leader does not kill a running task") {
+    Given("a new app with an impossible constraint")
+    // Running locally, the constraint of a unique hostname should prevent the second instance from deploying.
+    val constraint = Protos.Constraint.newBuilder()
+      .setField("hostname")
+      .setOperator(Operator.UNIQUE)
+      .build()
+    val app = appProxy(testBasePath / "app3783", "v2", instances = 2)
+      .copy(constraints = Set(constraint))
+    marathon.createAppV2(app)
+
+    When("one of the tasks is deployed")
+    val tasksBeforeAbdication = waitForTasks(app.id, 1)
+
+    And("and the leader abdicates")
+    val firstResult = marathon.abdicate()
+    firstResult.code should be (200)
+    (firstResult.entityJson \ "message").as[String] should be ("Leadership abdicated")
+    WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstProcess.client.leader().code == 200 }
+    val tasksAfterFirstAbdication = waitForTasks(app.id, 1)(firstProcess.client)
+
+    Then("the task should not be killed")
+    tasksBeforeAbdication should be (tasksAfterFirstAbdication)
+
+    When("the leader abdicates")
+    val secondResult = firstProcess.client.abdicate()
+    secondResult.code should be (200)
+    (secondResult.entityJson \ "message").as[String] should be ("Leadership abdicated")
+    WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstProcess.client.leader().code == 200 }
+    val tasksAfterSecondAbdication = waitForTasks(app.id, 1)(firstProcess.client)
+
+    Then("the task should not be killed")
+    tasksBeforeAbdication should be (tasksAfterSecondAbdication)
+
+    When("the leader abdicates")
+    val thirdResult = firstProcess.client.abdicate()
+    thirdResult.code should be (200)
+    (thirdResult.entityJson \ "message").as[String] should be ("Leadership abdicated")
+    WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstProcess.client.leader().code == 200 }
+    val tasksAfterThirdAbdication = waitForTasks(app.id, 1)(firstProcess.client)
+
+    Then("the task should not be killed")
+    tasksBeforeAbdication should be (tasksAfterThirdAbdication)
+
+    When("the leader abdicates")
+    val fourthResult = firstProcess.client.abdicate()
+    fourthResult.code should be (200)
+    (fourthResult.entityJson \ "message").as[String] should be ("Leadership abdicated")
+    WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstProcess.client.leader().code == 200 }
+    val tasksAfterFourthAbdication = waitForTasks(app.id, 1)(firstProcess.client)
+
+    Then("the task should not be killed")
+    tasksBeforeAbdication should be (tasksAfterFourthAbdication)
+
+    When("the leader abdicates")
+    val fifthResult = firstProcess.client.abdicate()
+    fifthResult.code should be (200)
+    (fifthResult.entityJson \ "message").as[String] should be ("Leadership abdicated")
+    WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstProcess.client.leader().code == 200 }
+    val tasksAfterFifthAbdication = waitForTasks(app.id, 1)(firstProcess.client)
+
+    Then("the task should not be killed")
+    tasksBeforeAbdication should be (tasksAfterFifthAbdication)
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/integration/LeadershipAbdicationIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/LeadershipAbdicationIntegrationTest.scala
@@ -9,6 +9,11 @@ import scala.concurrent.duration._
 /**
   * Regression Test for https://github.com/mesosphere/marathon/issues/3783
   *
+  * Intention:
+  * During an abdication, there should be a deployment in progress, containing at
+  * least one running task. This running task should not be killed/replaced during
+  * the next leader takes over the deployment.
+  *
   * Adapted from https://github.com/EvanKrall/reproduce_marathon_issue_3783
   */
 @IntegrationTest
@@ -16,13 +21,14 @@ class LeadershipAbdicationIntegrationTest extends LeaderIntegrationTest {
 
   after(cleanUp())
 
-  override val numAdditionalMarathons = 5
+  // to simulate multiple leader abdicates, we do two loops
+  val abdicationLoops = 2
 
-  def firstProcess = runningServerProcesses.headOption.getOrElse(
-    fail("there are marathon servers running")
-  )
+  // we need the same amount of additional marathon instances, like we abdicate afterwards.
+  override val numAdditionalMarathons = abdicationLoops
 
-  test("Abdicating a leader does not kill a running task") {
+
+  test("Abdicating a leader does not kill a running task which is currently involved in a deployment") {
     Given("a new app with an impossible constraint")
     // Running locally, the constraint of a unique hostname should prevent the second instance from deploying.
     val constraint = Protos.Constraint.newBuilder()
@@ -36,55 +42,18 @@ class LeadershipAbdicationIntegrationTest extends LeaderIntegrationTest {
     When("one of the tasks is deployed")
     val tasksBeforeAbdication = waitForTasks(app.id, 1)
 
-    And("and the leader abdicates")
-    val firstResult = marathon.abdicate()
-    firstResult.code should be (200)
-    (firstResult.entityJson \ "message").as[String] should be ("Leadership abdicated")
-    WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstProcess.client.leader().code == 200 }
-    val tasksAfterFirstAbdication = waitForTasks(app.id, 1)(firstProcess.client)
+    (1 to abdicationLoops).foreach {
+      _ =>
+        And("the leader abdicates")
+        val result = firstRunningProcess.client.abdicate()
+        result.code should be (200)
+        (result.entityJson \ "message").as[String] should be ("Leadership abdicated")
+        WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstRunningProcess.client.leader().code == 200 }
+        val tasksAfterFirstAbdication = waitForTasks(app.id, 1)(firstRunningProcess.client)
 
-    Then("the task should not be killed")
-    tasksBeforeAbdication should be (tasksAfterFirstAbdication)
-
-    When("the leader abdicates")
-    val secondResult = firstProcess.client.abdicate()
-    secondResult.code should be (200)
-    (secondResult.entityJson \ "message").as[String] should be ("Leadership abdicated")
-    WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstProcess.client.leader().code == 200 }
-    val tasksAfterSecondAbdication = waitForTasks(app.id, 1)(firstProcess.client)
-
-    Then("the task should not be killed")
-    tasksBeforeAbdication should be (tasksAfterSecondAbdication)
-
-    When("the leader abdicates")
-    val thirdResult = firstProcess.client.abdicate()
-    thirdResult.code should be (200)
-    (thirdResult.entityJson \ "message").as[String] should be ("Leadership abdicated")
-    WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstProcess.client.leader().code == 200 }
-    val tasksAfterThirdAbdication = waitForTasks(app.id, 1)(firstProcess.client)
-
-    Then("the task should not be killed")
-    tasksBeforeAbdication should be (tasksAfterThirdAbdication)
-
-    When("the leader abdicates")
-    val fourthResult = firstProcess.client.abdicate()
-    fourthResult.code should be (200)
-    (fourthResult.entityJson \ "message").as[String] should be ("Leadership abdicated")
-    WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstProcess.client.leader().code == 200 }
-    val tasksAfterFourthAbdication = waitForTasks(app.id, 1)(firstProcess.client)
-
-    Then("the task should not be killed")
-    tasksBeforeAbdication should be (tasksAfterFourthAbdication)
-
-    When("the leader abdicates")
-    val fifthResult = firstProcess.client.abdicate()
-    fifthResult.code should be (200)
-    (fifthResult.entityJson \ "message").as[String] should be ("Leadership abdicated")
-    WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstProcess.client.leader().code == 200 }
-    val tasksAfterFifthAbdication = waitForTasks(app.id, 1)(firstProcess.client)
-
-    Then("the task should not be killed")
-    tasksBeforeAbdication should be (tasksAfterFifthAbdication)
+        Then("the already running task should not be killed")
+        tasksBeforeAbdication should be (tasksAfterFirstAbdication)
+    }
   }
 
 }

--- a/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/DeploymentActorTest.scala
@@ -111,7 +111,6 @@ class DeploymentActorTest
 
       managerProbe.expectMsg(5.seconds, DeploymentFinished(plan))
 
-      verify(f.scheduler).startRunSpec(app3.copy(instances = 0))
       println(f.killService.killed.mkString(","))
       f.killService.killed should contain (instance1_2.instanceId) // killed due to scale down
       f.killService.killed should contain (instance2_1.instanceId) // killed due to config change


### PR DESCRIPTION
`LeadershipAbdicationIntegrationTest` was taken from https://github.com/mesosphere/marathon/pull/4623 and adapted to current test classes.

Furthermore the claimed behavior was corrected to `keep running tasks after abdication` through the change in `AppStartActor`.

Fixes #3783