### PR TITLE
Releases/1.3 async task tracker

### DIFF
--- a/bin/marathon-framework
+++ b/bin/marathon-framework
@@ -109,10 +109,10 @@ function load_options_and_log {
         clean_cmd+=( "${i}" )
       fi
     done
-    cmd_to_env $clean_cmd
+    cmd_to_env "${clean_cmd[@]}"
     run_jar
   else
-    cmd_to_env $cmd
+    cmd_to_env "${cmd[@]}"
     logged marathon run_jar "$@"
   fi
 }

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -158,6 +158,8 @@ private[health] class HealthCheckActor(
     val health = th.health
     val newHealth = th.newHealth
     val taskId = result.taskId
+
+    log.info("Received health result for app [{}] version [{}]: [{}]", app.id, app.version, result)
     taskHealth += (taskId -> newHealth)
 
     if (health.alive != newHealth.alive && result.publishEvent) {
@@ -172,7 +174,6 @@ private[health] class HealthCheckActor(
   }
 
   def handleHealthResult(result: HealthResult): Unit = {
-    log.info("Received health result for app [{}] version [{}]: [{}]", app.id, app.version, result)
     val taskId = result.taskId
     val health = taskHealth.getOrElse(taskId, Health(taskId))
 

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -129,6 +129,7 @@ private class DeploymentActor(
       def killTasksIfNeeded: Future[Unit] = tasksToKill.fold(Future.successful(())) { tasks =>
         killService.killTasks(tasks, TaskKillReason.ScalingApp).map(_ => ())
       }
+      await(killTasksIfNeeded)
 
       def startTasksIfNeeded: Future[Unit] = tasksToStart.fold(Future.successful(())) { _ =>
         val promise = Promise[Unit]()
@@ -138,8 +139,6 @@ private class DeploymentActor(
         )
         promise.future
       }
-
-      await(killTasksIfNeeded)
       await(startTasksIfNeeded)
     }
   }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -87,11 +87,11 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     queue.get(app.id) returns Some(LaunchQueueTestHelper.zeroCounts)
     repo.allPathIds() returns Future.successful(Seq(app.id))
-    taskTracker.appTasksSync(app.id) returns Iterable.empty[Task]
-    taskTracker.tasksByAppSync returns TaskTracker.TasksByApp.of(TaskTracker.AppTasks.forTasks("nope".toPath, tasks))
-    taskTracker.appTasksSync("nope".toPath) returns tasks
+    taskTracker.appTasks(org.mockito.Matchers.eq(app.id))(any[ExecutionContext]) returns Future.successful(Iterable.empty[Task])
+    taskTracker.tasksByApp()(any[ExecutionContext]) returns Future.successful(
+      TaskTracker.TasksByApp.of(TaskTracker.AppTasks.forTasks("nope".toPath, tasks)))
+    taskTracker.appTasks(org.mockito.Matchers.eq("nope".toPath))(any[ExecutionContext]) returns Future.successful(tasks)
     repo.currentVersion(app.id) returns Future.successful(Some(app))
-    taskTracker.countLaunchedAppTasksSync(app.id) returns 0
 
     val schedulerActor = createActor()
     try {
@@ -111,10 +111,9 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
 
     queue.get(app.id) returns Some(LaunchQueueTestHelper.zeroCounts)
     repo.allIds() returns Future.successful(Seq(app.id.toString))
-    taskTracker.appTasksSync(app.id) returns Iterable.empty[Task]
+    taskTracker.appTasks(org.mockito.Matchers.eq(app.id))(any[ExecutionContext]) returns Future.successful(Iterable.empty[Task])
 
     repo.currentVersion(app.id) returns Future.successful(Some(app))
-    taskTracker.countLaunchedAppTasksSync(app.id) returns 0
 
     val schedulerActor = createActor()
     try {
@@ -565,7 +564,7 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     repo.apps() returns Future.successful(Nil)
     groupRepo.rootGroup() returns Future.successful(None)
     queue.get(any[PathId]) returns None
-    taskTracker.countLaunchedAppTasksSync(any[PathId]) returns 0
+    taskTracker.appTasks(any[PathId])(any[ExecutionContext]) returns Future.successful(Seq.empty[Task])
     conf.killBatchCycle returns 1.seconds
     conf.killBatchSize returns 100
   }

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -118,10 +118,11 @@ class SchedulerActionsTest
       tasksLost = 5,
       backOffUntil = f.clock.now())
     f.queue.get(app.id) returns Some(queued)
-    f.taskTracker.countAppTasksSync(eq(app.id), any) returns (queued.finalTaskCount - queued.tasksLost) // 10
+    val tasks = (1 to queued.finalTaskCount - queued.tasksLost).map(i => MarathonTestHelper.runningTask(s"running-$i"))
+    f.taskTracker.appTasks(app.id) returns Future.successful(tasks)
 
     When("the app is scaled")
-    f.scheduler.scale(f.driver, app)
+    f.scheduler.scale(f.driver, app).futureValue
 
     Then("5 tasks should be placed onto the launchQueue")
     verify(f.queue, times(1)).add(app, 5)
@@ -133,10 +134,11 @@ class SchedulerActionsTest
     Given("An active queue and lost tasks")
     val app = MarathonTestHelper.makeBasicApp().copy(instances = 15)
     f.queue.get(app.id) returns None
-    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 10
+    val tasks = (1 to 10).map(i => MarathonTestHelper.runningTask(s"running-$i"))
+    f.taskTracker.appTasks(app.id) returns Future.successful(tasks)
 
     When("the app is scaled")
-    f.scheduler.scale(f.driver, app)
+    f.scheduler.scale(f.driver, app).futureValue
 
     Then("5 tasks should be placed onto the launchQueue")
     verify(f.queue, times(1)).add(app, 5)
@@ -175,10 +177,9 @@ class SchedulerActionsTest
     )
 
     f.queue.get(app.id) returns Some(queued)
-    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 7
-    f.taskTracker.appTasksSync(app.id) returns tasks
+    f.taskTracker.appTasks(app.id) returns Future.successful(tasks)
     When("the app is scaled")
-    f.scheduler.scale(f.driver, app)
+    f.scheduler.scale(f.driver, app).futureValue
 
     Then("the queue is purged")
     verify(f.queue, times(1)).purge(app.id)
@@ -210,10 +211,9 @@ class SchedulerActionsTest
     )
 
     f.queue.get(app.id) returns None
-    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 7
-    f.taskTracker.appTasksSync(app.id) returns tasks
+    f.taskTracker.appTasks(app.id) returns Future.successful(tasks)
     When("the app is scaled")
-    f.scheduler.scale(f.driver, app)
+    f.scheduler.scale(f.driver, app).futureValue
 
     Then("the queue is purged")
     verify(f.queue, times(1)).purge(app.id)
@@ -252,10 +252,9 @@ class SchedulerActionsTest
     )
 
     f.queue.get(app.id) returns Some(queued)
-    f.taskTracker.countAppTasksSync(eq(app.id), any) returns 5
-    f.taskTracker.appTasksSync(app.id) returns tasks
+    f.taskTracker.appTasks(app.id) returns Future.successful(tasks)
     When("the app is scaled")
-    f.scheduler.scale(f.driver, app)
+    f.scheduler.scale(f.driver, app).futureValue
 
     Then("the queue is purged")
     verify(f.queue, times(1)).purge(app.id)


### PR DESCRIPTION
It looks like Marathon 1.4 needs more time to be production ready. I prepared a PR that reflects critical changes made for 1.4 `InstanceTracker` and port it to 1.3 `TaskTracker`. With this changes threads count is more stable and keeps below 500.

Below you can see comparison between 1.3.6 before and after applying this patch (11:30 to 13:15).

![async_vs_blocking_task_tracker](https://cloud.githubusercontent.com/assets/1616386/21519725/b9c8c7ac-ccef-11e6-8042-583d1da636fd.png)
