### PR TITLE
peg doc updates to release branch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,3 +78,4 @@ following the instructions.
         $ cd /path/to/marathon-gh-pages
         $ git commit . -m "Syncing docs with release branch"
         $ git push
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,14 +67,14 @@ following the instructions.
         $ cd /path/to/marathon-gh-pages
         $ git checkout gh-pages
 
-3. Copy the contents of the "docs" directory in master to the root of your
+3. Check out the appropriate release branch, then copy the contents of the "docs" directory in master to the root of your
    marathon-gh-pages directory.
-
         $ cd /path/to/marathon
+        $ git checkout releases/1.x
         $ cp -r docs/** ../marathon-gh-pages
 
 4. Change to the marathon-gh-pages directory, commit, and push the changes
 
         $ cd /path/to/marathon-gh-pages
-        $ git commit . -m "Syncing docs with master branch"
+        $ git commit . -m "Syncing docs with release branch"
         $ git push

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ following the instructions.
 
 3. Check out the appropriate release branch, then copy the contents of the "docs" directory in master to the root of your
    marathon-gh-pages directory.
+        
         $ cd /path/to/marathon
         $ git checkout releases/1.x
         $ cp -r docs/** ../marathon-gh-pages


### PR DESCRIPTION
I believe this is the only change we need to make to get the docs published from the release branch instead of master.