### PR TITLE
Fixes #4948 | Lazy event parsing

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -1,6 +1,8 @@
 package mesosphere.marathon.core.event
 
 import akka.event.EventStream
+import com.fasterxml.jackson.annotation.JsonIgnore
+import mesosphere.marathon.api.v2.json.Formats.eventToJson
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.core.instance.update.InstanceChange
@@ -9,12 +11,15 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.upgrade.{ DeploymentPlan, DeploymentStep }
 import org.apache.mesos.{ Protos => Mesos }
+import play.api.libs.json.Json
 
 import scala.collection.immutable.Seq
 
 sealed trait MarathonEvent {
   val eventType: String
   val timestamp: String
+  @JsonIgnore
+  lazy val jsonString: String = Json.stringify(eventToJson(this))
 }
 
 // api

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActor.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon.core.event.impl.stream
 import akka.actor._
 import com.google.inject.Inject
 import mesosphere.marathon.core.election.{ ElectionService, LocalLeadershipEvent }
+import mesosphere.marathon.core.event.MarathonEvent
 import mesosphere.marathon.core.event.impl.stream.HttpEventStreamActor._
 import mesosphere.marathon.metrics.Metrics.AtomicIntGauge
 import mesosphere.marathon.metrics.{ MetricPrefixes, Metrics }
@@ -16,7 +17,7 @@ import scala.util.Try
 trait HttpEventStreamHandle {
   def id: String
   def remoteAddress: String
-  def sendEvent(event: String, message: String): Unit
+  def sendEvent(event: MarathonEvent): Unit
   def close(): Unit
 }
 

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActor.scala
@@ -5,11 +5,9 @@ import java.io.EOFException
 import akka.actor.{ Actor, ActorLogging, Status }
 import akka.event.EventStream
 import akka.pattern.pipe
-import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.core.event.impl.stream.HttpEventStreamHandleActor._
 import mesosphere.marathon.core.event.{ EventStreamAttached, EventStreamDetached, MarathonEvent }
 import mesosphere.util.ThreadPoolContext
-import play.api.libs.json.Json
 
 import scala.concurrent.Future
 import scala.util.Try
@@ -60,7 +58,7 @@ class HttpEventStreamHandleActor(
       outstanding = List.empty[MarathonEvent]
       context.become(stashEvents)
       val sendFuture = Future {
-        toSend.foreach(event => handle.sendEvent(event.eventType, Json.stringify(eventToJson(event))))
+        toSend.foreach(event => handle.sendEvent(event))
         WorkDone
       }(ThreadPoolContext.ioContext)
 

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventSSEHandleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventSSEHandleTest.scala
@@ -5,36 +5,37 @@ import java.util.Collections
 import javax.servlet.http.HttpServletRequest
 
 import mesosphere.UnitTest
+import mesosphere.marathon.core.event.{ Subscribe, Unsubscribe }
 import mesosphere.marathon.stream._
 import org.eclipse.jetty.servlets.EventSource.Emitter
 
 class HttpEventSSEHandleTest extends UnitTest {
   "HttpEventSSEHandle" should {
     "events should be filtered" in {
-      Given("An emiter")
+      Given("An emitter")
       val emitter = mock[Emitter]
       Given("An request with params")
       val req = mock[HttpServletRequest]
-      req.getParameterMap returns Map("event_type" -> Array("xyz"))
+      req.getParameterMap returns Map("event_type" -> Array(unsubscribe.eventType))
 
       Given("handler for request is created")
       val handle = new HttpEventSSEHandle(req, emitter)
 
       When("Want to sent unwanted event")
-      handle.sendEvent("any event", "")
+      handle.sendEvent(subscribed)
 
       Then("event should NOT be sent")
-      verify(emitter, never).event("any event", "")
+      verify(emitter, never).event(eq(subscribed.eventType), any[String])
 
       When("Want to sent subscribed event")
-      handle.sendEvent("xyz", "")
+      handle.sendEvent(unsubscribe)
 
       Then("event should be sent")
-      verify(emitter).event("xyz", "")
+      verify(emitter).event(eq(unsubscribe.eventType), any[String])
     }
 
     "events should NOT be filtered" in {
-      Given("An emiter")
+      Given("An emitter")
       val emitter = mock[Emitter]
 
       Given("An request without params")
@@ -45,16 +46,19 @@ class HttpEventSSEHandleTest extends UnitTest {
       val handle = new HttpEventSSEHandle(req, emitter)
 
       When("Want to sent event")
-      handle.sendEvent("any event", "")
-      Then("event should NOT be sent")
-
-      verify(emitter).event("any event", "")
-      When("Want to sent event")
-
-      handle.sendEvent("xyz", "")
+      handle.sendEvent(subscribed)
 
       Then("event should be sent")
-      verify(emitter).event("xyz", "")
+      verify(emitter).event(eq(subscribed.eventType), any[String])
+
+      When("Want to sent event")
+      handle.sendEvent(unsubscribe)
+
+      Then("event should be sent")
+      verify(emitter).event(eq(unsubscribe.eventType), any[String])
     }
   }
+
+  val subscribed = Subscribe("client IP", "callback URL")
+  val unsubscribe = Unsubscribe("client IP", "callback URL")
 }


### PR DESCRIPTION
Change SSE event stream handler to use events that are
lazy parsed to JSON. This will reduce CPU time when most events
are filtered and/or when more then one subscriper is connected.