### PR TITLE
Fix code tag in rest API docs

### DIFF
--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -534,7 +534,7 @@ Kill the task with ID `taskId` that belongs to the application `appId`.
       <td><code>boolean</code></td>
       <td>Scale the app down (i.e. decrement its <code>instances</code> setting
         by the number of tasks killed) after killing the specified task.
-        Only possible if <code>wipe=false</false> or not specified.
+        Only possible if <code>wipe=false</code> or not specified.
         Default: <code>false</code>.</td>
     </tr>
     <tr>


### PR DESCRIPTION
This addresses the problem in the source markdown file, but the generated html still needs to be... generated. The `gh-pages` branch would also need it's own PR most likely, but I haven't cut a release of the marathon docs before. Suggestions are welcome.