### PR TITLE
Run `sbt assembly` in pipeline. Fixes #5029.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,8 @@ node('JenkinsMarathonCI-Debian8') {
             junit allowEmptyResults: true, testResults: 'target/test-reports/integration/**/*.xml'
           }
         }
-        stage("4. Archive Binaries") {
+        stage("4. Assemble and Archive Binaries") {
+            sh "sudo -E sbt assembly"
             archiveArtifacts artifacts: 'target/**/classes/**', allowEmptyArchive: true
         }
     } catch (Exception err) {


### PR DESCRIPTION
Summary:
Due to a dependency version upgrade the release was broken. We can catch such
issues earlier by running the assembly for each commit.

Note this will break master until we fixed the dependency issue.

Test Plan:
n/a

Reviewers:
kensipe, zen-dog

Subscribers: jenkins, marathon-team