### PR TITLE
Only filter requests to /v2/*

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
@@ -17,8 +17,11 @@ import mesosphere.marathon.io.SSLContextUtil
 class LeaderProxyFilterModule extends ServletModule {
   protected override def configureServlets() {
     bind(classOf[RequestForwarder]).to(classOf[JavaUrlConnectionRequestForwarder]).in(Scopes.SINGLETON)
+
     bind(classOf[LeaderProxyFilter]).asEagerSingleton()
-    filter("/*").through(classOf[LeaderProxyFilter])
+    // only filter requests to versioned endpoints
+    // do not filter requests to system endpoints: /ping, /logging, /help, /metrics
+    filter("/v2/*").through(classOf[LeaderProxyFilter])
   }
 
   /**

--- a/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -62,7 +62,7 @@ case class ITDeployment(id: String, affectedApps: Seq[String])
   *
   * @param url the url of the remote marathon instance
   */
-class MarathonFacade(url: String, baseGroup: PathId, waitTime: Duration = 30.seconds)(implicit val system: ActorSystem) extends PlayJsonSupport {
+class MarathonFacade(val url: String, baseGroup: PathId, waitTime: Duration = 30.seconds)(implicit val system: ActorSystem) extends PlayJsonSupport {
   import SprayHttpResponse._
 
   import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/mesosphere/marathon/integration/setup/AppMockFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/AppMockFacade.scala
@@ -23,6 +23,7 @@ class AppMockFacade(https: Boolean = false, waitTime: Duration = 30.seconds)(imp
 
   val pipeline = sendReceive
   def ping(host: String, port: Int): RestResult[String] = custom("/ping")(host, port)
+  def info(host: String, port: Int): RestResult[String] = custom("/v2/info")(host, port)
 
   def scheme: String = if (https) "https" else "http"
 

--- a/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
@@ -35,6 +35,14 @@ object ForwarderService {
     }
   }
 
+  @Path("v2/info")
+  class InfoResource @Inject() () {
+    @GET
+    def index(): Response = {
+      Response.ok().entity("info\n").build()
+    }
+  }
+
   class LeaderInfoModule(elected: Boolean, leaderHostPort: Option[String]) extends AbstractModule {
     log.info(s"Leader configuration: elected=$elected leaderHostPort=$leaderHostPort")
 
@@ -64,6 +72,7 @@ object ForwarderService {
       bind(classOf[HttpConf]).toInstance(httpConf)
       bind(classOf[LeaderProxyConf]).toInstance(leaderProxyConf)
       bind(classOf[PingResource]).in(Scopes.SINGLETON)
+      bind(classOf[InfoResource]).in(Scopes.SINGLETON)
 
       install(new LeaderProxyFilterModule)
     }

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -261,13 +261,15 @@ trait SingleMarathonIntegrationTest
     ExternalMarathonIntegrationTest.healthChecks.clear()
 
     val deleteResult: RestResult[ITDeploymentResult] = marathon.deleteGroup(testBasePath, force = true)
-    if (deleteResult.code != 404) {
+    val ignoreCodes = Set(404, 503)
+    if (!ignoreCodes.contains(deleteResult.code)) {
       waitForChange(deleteResult)
     }
 
     waitForCleanSlateInMesos()
 
     val apps = marathon.listAppsInBaseGroup
+
     require(apps.value.isEmpty, s"apps weren't empty: ${apps.entityPrettyJsonString}")
     val groups = marathon.listGroupsInBaseGroup
     require(groups.value.isEmpty, s"groups weren't empty: ${groups.entityPrettyJsonString}")


### PR DESCRIPTION
Do not filter requests to system endpoints like /ping

Related to #5005 (**targets `releases/1.1`**)