### PR TITLE
Limit unit test and integration test logs to 256MB each.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ node('JenkinsMarathonCI-Debian8') {
           try {
               timeout(time: 20, unit: 'MINUTES') {
                 withEnv(['RUN_DOCKER_INTEGRATION_TESTS=true', 'RUN_MESOS_INTEGRATION_TESTS=true']) {
-                   sh "sudo -E sbt -Dsbt.log.format=false coverage test coverageReport"
+                   sh "sudo -E sbt -Dsbt.log.format=false coverage test coverageReport 2>&1 | head -c 268435456"
                 }
               }
           } finally {
@@ -80,7 +80,7 @@ node('JenkinsMarathonCI-Debian8') {
           try {
               timeout(time: 20, unit: 'MINUTES') {
                 withEnv(['RUN_DOCKER_INTEGRATION_TESTS=true', 'RUN_MESOS_INTEGRATION_TESTS=true']) {
-                   sh "sudo -E sbt -Dsbt.log.format=false coverage integration:test mesos-simulation/integration:test coverageReport"
+                   sh "sudo -E sbt -Dsbt.log.format=false coverage integration:test mesos-simulation/integration:test coverageReport 2>&1 | head -c 268435456"
                 }
             }
           } finally {


### PR DESCRIPTION
Summary:
In some cases the Jenkins jobs won't finish and fill up the master with logs. We
limit the size to 256MB. Note: This does not fix the hanging job but avoids
trashing the Jenkins master.

Test Plan:
see pipeline

Reviewers:
timcharper, zen-dog

Subscribers: jenkins, marathon-team