### PR TITLE
Improve performance of zookeeper layer and groups

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -24,14 +24,14 @@ case class Group(
   override def mergeFromProto(msg: GroupDefinition): Group = Group.fromProto(msg)
   override def mergeFromProto(bytes: Array[Byte]): Group = Group.fromProto(GroupDefinition.parseFrom(bytes))
 
-  override def toProto: GroupDefinition = {
-    GroupDefinition.newBuilder
+  override lazy val toProto: GroupDefinition = {
+    val b = GroupDefinition.newBuilder
       .setId(id.toString)
       .setVersion(version.toString)
-      .addAllApps(apps.map(_.toProto))
-      .addAllGroups(groups.map(_.toProto))
-      .addAllDependencies(dependencies.map(_.toString))
-      .build()
+    apps.foreach { app => b.addApps(app.toProto) }
+    groups.foreach { group => b.addGroups(group.toProto) }
+    dependencies.foreach { dependency => b.addDependencies(dependency.toString) }
+    b.build()
   }
 
   def findGroup(fn: Group => Boolean): Option[Group] = {

--- a/src/main/scala/mesosphere/util/state/zk/ZKStore.scala
+++ b/src/main/scala/mesosphere/util/state/zk/ZKStore.scala
@@ -80,7 +80,7 @@ class ZKStore(val client: ZkClient, root: ZNode, compressionConf: CompressionCon
       .recover(exceptionTransform("Can not list all identifiers"))
   }
 
-  private[this] def exceptionTransform[T](errorMessage: String): PartialFunction[Throwable, T] = {
+  private[this] def exceptionTransform[T](errorMessage: => String): PartialFunction[Throwable, T] = {
     case ex: KeeperException => throw new StoreCommandFailedException(errorMessage, ex)
   }
 


### PR DESCRIPTION
We unnecessarily stringify every protobuf that we serialize to
Zookeeper. This is quite expensive. We modify the code to only serialize
the protobuf if an exception is actually thrown.

Group.toProto unnecessarily creates a few new interim sets, which causes
each proto to hashed unnecessarily. This is wasteful and quite
expensive. Also, since groups are immutable, we cache this result with a
lazy val.