### PR TITLE
Don't cache `Group.toProto`

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -24,7 +24,7 @@ case class Group(
   override def mergeFromProto(msg: GroupDefinition): Group = Group.fromProto(msg)
   override def mergeFromProto(bytes: Array[Byte]): Group = Group.fromProto(GroupDefinition.parseFrom(bytes))
 
-  override lazy val toProto: GroupDefinition = {
+  override def toProto: GroupDefinition = {
     val b = GroupDefinition.newBuilder
       .setId(id.toString)
       .setVersion(version.toString)


### PR DESCRIPTION
It may not have been helping much (no data to support it), but it is
significantly burdening our heap as each DeploymentPlan has a unique
instance of a Group (even if the version is identical, protobuf
deserialization ensures a deep copy, eventaully), which leads to about
double the number of instances in memory.