### PR TITLE
Fixes #4901 by removing the short circuit for root group changes.

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -139,11 +139,11 @@ object PathId {
 
   /**
     * Make sure that the given path is a child of the defined parent path.
-    * Every root and every relative path can be ignored.
+    * Every relative path can be ignored.
     */
   private def childOf(parent: PathId): Validator[PathId] = {
     isTrue[PathId](s"Identifier is not child of $parent. Hint: use relative paths.") { child =>
-      parent == PathId.empty || !parent.absolute || (parent.absolute && child.canonicalPath(parent).parent == parent)
+      !parent.absolute || (child.canonicalPath(parent).parent == parent)
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
@@ -473,7 +473,19 @@ class RootGroupTest extends FunSpec with GivenWhenThen with Matchers with GroupC
       invalidResult.isSuccess should be(false)
     }
 
-    it("Group with app in correct group is valid") {
+    it("Root Group with app in wrong group is not valid (Regression for #4901)") {
+      Given("Group with nested app of wrong path")
+      val app = AppDefinition(PathId("/foo/bla"), cmd = Some("test"))
+      val invalid = createRootGroup(apps = Map(app.id -> app))
+
+      When("group is validated")
+      val invalidResult = validate(invalid)(RootGroup.valid(Set()))
+
+      Then("validation is not successful")
+      invalidResult.isSuccess should be(false)
+    }
+
+    "Group with app in correct group is valid" in {
       Given("Group with nested app of wrong path")
       val app = AppDefinition(PathId("/nested/foo"), cmd = Some("test"))
       val valid = createRootGroup(groups = Set(

--- a/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
@@ -485,7 +485,7 @@ class RootGroupTest extends FunSpec with GivenWhenThen with Matchers with GroupC
       invalidResult.isSuccess should be(false)
     }
 
-    "Group with app in correct group is valid" in {
+    it("Group with app in correct group is valid") {
       Given("Group with nested app of wrong path")
       val app = AppDefinition(PathId("/nested/foo"), cmd = Some("test"))
       val valid = createRootGroup(groups = Set(


### PR DESCRIPTION
Summary:
PathId.childOf validation yielded true for all paths relative to base root.
Wrong assumption is removed + test case added.

Test Plan:
sbt test

Start Marathon and call this curl:
curl -H "Content-Type: application/json" -X PUT -d '{"id": "/", "apps": [{"id":"/test/hello", "cmd":"while true; do echo hello; sleep 1; done"}]}' http://localhost:8080/v2/groups
Before this change, this json was accepted. After this change this is not valid and gives this result:
```
{
    "details": [
        {
            "errors": [
                "Identifier is not child of /. Hint: use relative paths."
            ],
            "path": "/apps(0)/id"
        }
    ],
    "message": "Object is not valid"
}
```

Migration:
Added a migration to 1.4, that repairs the group hierarchy.