### PR TITLE
Add support for PATCH updates to apps in 1.4

### DIFF
--- a/docs/docs/rest-api/public/api/v2/apps.raml
+++ b/docs/docs/rest-api/public/api/v2/apps.raml
@@ -370,8 +370,8 @@
     #
     patch:
       description:
-        Replaces parameters of a running application. This will fail if no application with the given id
-        exists. If there is an application with this id, all running instances get upgraded to the new definition.
+        Replaces parameters of a running application. All running instances get upgraded to the new definition.
+        Any given application ID will be ignored.
 
         Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds.
          You can query the deployments endoint to see the status of the deployment.

--- a/docs/docs/rest-api/public/api/v2/apps.raml
+++ b/docs/docs/rest-api/public/api/v2/apps.raml
@@ -158,7 +158,7 @@
     queryParameters:
     body:
       application/json:
-        example: !include examples/apps_create.json
+        example: !include examples/apps_patch.json
         type: app.App[]
     responses:
       409:
@@ -379,7 +379,7 @@
       queryParameters:
       body:
         application/json:
-          example: !include examples/app.json
+          example: !include examples/app_patch.json
           type: app.App
       responses:
         200:

--- a/docs/docs/rest-api/public/api/v2/apps.raml
+++ b/docs/docs/rest-api/public/api/v2/apps.raml
@@ -138,6 +138,62 @@
                 }
 
   ###
+  # apply a patch update to a list of applications
+  #
+  patch:
+    description:
+      Change multiple existing applications by applying a patch.
+      All instances of these applications get replaced by the new version.
+      The order of dependencies will be applied correctly.
+      Each upgradeStrategy defines the behaviour of the upgrade for the related app.
+
+      The whole operation fails if the IDs of one or more applications are unknown.
+      The order of dependencies will be applied correctly.
+
+      If you have more complex scenarios with upgrades, use the groups endpoint.
+
+      Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds.
+       You can query the deployments endoint to see the status of the deployment.
+    is: [ secured, deployable ]
+    queryParameters:
+    body:
+      application/json:
+        example: !include examples/apps_create.json
+        type: app.App[]
+    responses:
+      409:
+        description: One or more specified applications is currently locked by a deployment
+        body:
+          application/json:
+            type: error.Error
+            example: |
+              {"message":"App is locked by one or more deployments."}
+      400:
+        description: The application definition provided in the body is not valid.
+        body:
+          application/json:
+            type: error.Error
+            example: |
+               {"message":"Invalid JSON","details":[{"path":"/id","errors":["error.expected.jsstring"]}]}
+      422:
+        description: The entity send can not be processed, since there are validation errors
+        body:
+          application/json:
+            type: error.Error
+            example: |
+                {
+                  "message": "Object is not valid",
+                  "details": [
+                    {
+                      "path": "/upgradeStrategy/minimumHealthCapacity",
+                      "errors": [
+                        "is greater than 1"
+                      ]
+                    }
+                  ]
+                }
+
+  ###
   # Create application
   #
   post:
@@ -274,6 +330,60 @@
       responses:
         201:
           description: The application has been created and a deployment is started.
+          body:
+            application/json:
+              example: !include examples/deployments_result.json
+        404:
+          description: No task found with this `app_id`.
+          body:
+            application/json:
+              type: error.Error
+              example: |
+                  { "message": "App '/not_existent' does not exist" }
+        400:
+          description: The application definition provided in the body is not valid.
+          body:
+            application/json:
+              type: error.Error
+              example: |
+                {"message":"Invalid JSON","details":[{"path":"/id","errors":["error.expected.jsstring"]}]}
+        422:
+          description: The entity sent can not be preocessed, since there are validation errors
+          body:
+            application/json:
+              type: error.Error
+              example: |
+                {
+                  "message": "Object is not valid",
+                  "details": [
+                    {
+                      "path": "/upgradeStrategy/minimumHealthCapacity",
+                      "errors": [
+                        "is greater than 1"
+                      ]
+                   }
+                  ]
+                }
+
+    ###
+    # Apply a patch update to a specific app.
+    #
+    patch:
+      description:
+        Replaces parameters of a running application. This will fail if no application with the given id
+        exists. If there is an application with this id, all running instances get upgraded to the new definition.
+
+        Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds.
+         You can query the deployments endoint to see the status of the deployment.
+      is: [ secured, deployable ]
+      queryParameters:
+      body:
+        application/json:
+          example: !include examples/app.json
+          type: app.App
+      responses:
+        200:
+          description: The application has been updated and a deployment is started.
           body:
             application/json:
               example: !include examples/deployments_result.json

--- a/docs/docs/rest-api/public/api/v2/examples/app_patch.json
+++ b/docs/docs/rest-api/public/api/v2/examples/app_patch.json
@@ -1,0 +1,4 @@
+{
+  "id": "/foo",
+  "instances": 2
+}

--- a/docs/docs/rest-api/public/api/v2/examples/apps_patch.json
+++ b/docs/docs/rest-api/public/api/v2/examples/apps_patch.json
@@ -1,0 +1,7 @@
+[{
+  "id": "/test/sleep60",
+  "cpus": 0.3
+},{
+  "id": "/test/sleep120",
+  "instances": 2
+}]

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -252,7 +252,6 @@ class AppsResource @Inject() (
   @Timed
   def patchMultiple(
     @DefaultValue("false")@QueryParam("force") force: Boolean,
-    @DefaultValue("true")@QueryParam("partialUpdate") partialUpdate: Boolean,
     body: Array[Byte],
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -12,7 +12,7 @@ import com.codahale.metrics.annotation.Timed
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.json.AppUpdate
 import mesosphere.marathon.api.v2.json.Formats._
-import mesosphere.marathon.api.{ AuthResource, MarathonMediaType, RestResource }
+import mesosphere.marathon.api.{ AuthResource, MarathonMediaType, PATCH, RestResource }
 import mesosphere.marathon.core.appinfo.{ AppInfo, AppInfoService, AppSelector, Selector, TaskCounts }
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.event.ApiPostEvent
@@ -213,6 +213,18 @@ class AppsResource @Inject() (
     }
   }
 
+  @PATCH
+  @Path("""{id:.+}""")
+  @Timed
+  def patch(
+    @PathParam("id") id: String,
+    body: Array[Byte],
+    @DefaultValue("false")@QueryParam("force") force: Boolean,
+    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+
+    replace(id, body, force, partialUpdate = true, req)
+  }
+
   @PUT
   @Timed
   def replaceMultiple(
@@ -234,6 +246,17 @@ class AppsResource @Inject() (
 
       deploymentResult(result(groupManager.updateRoot(updateGroup, version, force)))
     }
+  }
+
+  @PATCH
+  @Timed
+  def patchMultiple(
+    @DefaultValue("false")@QueryParam("force") force: Boolean,
+    @DefaultValue("true")@QueryParam("partialUpdate") partialUpdate: Boolean,
+    body: Array[Byte],
+    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+
+    replaceMultiple(force, partialUpdate = true, body, req)
   }
 
   @DELETE

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -195,14 +195,15 @@ class AppsResource @Inject() (
     body: Array[Byte],
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @DefaultValue("true")@QueryParam("partialUpdate") partialUpdate: Boolean,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    allowCreation: Boolean = true): Response = authenticated(req) { implicit identity =>
 
     val appId = id.toRootPath
 
     assumeValid {
       val appUpdate = canonicalAppUpdateFromJson(appId, body, partialUpdate)
       val version = clock.now()
-      val plan = result(groupManager.updateApp(appId, updateOrCreate(appId, _, appUpdate, partialUpdate), version, force))
+      val plan = result(groupManager.updateApp(appId, updateOrCreate(appId, _, appUpdate, partialUpdate, allowCreation), version, force))
       val response = plan.original.app(appId)
         .map(_ => Response.ok())
         .getOrElse(Response.created(new URI(appId.toString)))
@@ -222,7 +223,7 @@ class AppsResource @Inject() (
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
 
-    replace(id, body, force, partialUpdate = true, req)
+    replace(id, body, force, partialUpdate = true, req, allowCreation = false)
   }
 
   @PUT
@@ -231,7 +232,8 @@ class AppsResource @Inject() (
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @DefaultValue("true")@QueryParam("partialUpdate") partialUpdate: Boolean,
     body: Array[Byte],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    allowCreation: Boolean = true): Response = authenticated(req) { implicit identity =>
 
     assumeValid {
       val version = clock.now()
@@ -239,7 +241,7 @@ class AppsResource @Inject() (
 
       def updateGroup(rootGroup: RootGroup): RootGroup = updates.foldLeft(rootGroup) { (group, update) =>
         update.id match {
-          case Some(id) => group.updateApp(id, updateOrCreate(id, _, update, partialUpdate), version)
+          case Some(id) => group.updateApp(id, updateOrCreate(id, _, update, partialUpdate, allowCreation = allowCreation), version)
           case None => group
         }
       }
@@ -255,7 +257,7 @@ class AppsResource @Inject() (
     body: Array[Byte],
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
 
-    replaceMultiple(force, partialUpdate = true, body, req)
+    replaceMultiple(force, partialUpdate = true, body, req, allowCreation = false)
   }
 
   @DELETE
@@ -309,7 +311,8 @@ class AppsResource @Inject() (
     appId: PathId,
     existing: Option[AppDefinition],
     appUpdate: AppUpdate,
-    partialUpdate: Boolean)(implicit identity: Identity): AppDefinition = {
+    partialUpdate: Boolean,
+    allowCreation: Boolean)(implicit identity: Identity): AppDefinition = {
     def createApp(): AppDefinition = {
       val app = validateOrThrow(appUpdate.empty(appId))
       checkAuthorization(CreateRunSpec, app)
@@ -336,8 +339,10 @@ class AppsResource @Inject() (
       case Some(app) =>
         // we can only rollback existing apps because we deleted all old versions when dropping an app
         updateOrRollback(app)
-      case None =>
+      case None if allowCreation =>
         createApp()
+      case None =>
+        throw AppNotFoundException(appId)
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -116,6 +116,27 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
     response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
   }
 
+  test("Do partial update with patch methods") {
+    Given("An app")
+    val id = PathId("/app")
+    val app = AppDefinition(
+      id = id,
+      cmd = Some("cmd"),
+      instances = 1
+    )
+    prepareApp(app) // app is stored
+
+    When("The application is updated")
+    val updateRequest = AppDefinition(id = id, instances = 2)
+    val updatedJson = Json.toJson(updateRequest).as[JsObject] - "uris" - "version"
+    val updatedBody = Json.stringify(updatedJson).getBytes("UTF-8")
+    val response = appsResource.patch(app.id.toString, updatedBody, force = false, auth.request)
+
+    Then("It is successful")
+    response.getStatus should be(200)
+    response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
+  }
+
   test("Create a new app with IP/CT on virtual network foo") {
     Given("An app and group")
     val app = AppDefinition(

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -1072,13 +1072,13 @@ class AppsResourceTest extends MarathonSpec with MarathonActorSupport with Match
 
     Then("the application is updated")
     appsResource.updateOrCreate(
-      app.id, Some(app), appUpdate, partialUpdate = false)(auth.identity)
+      app.id, Some(app), appUpdate, partialUpdate = false, allowCreation = true)(auth.identity)
 
     And("fails when the update operation uses partial-update semantics")
     val caught = intercept[IllegalArgumentException] {
       val partUpdate = appsResource.canonicalAppUpdateFromJson(app.id, body, partialUpdate = true)
       appsResource.updateOrCreate(
-        app.id, Some(app), partUpdate, partialUpdate = true)(auth.identity)
+        app.id, Some(app), partUpdate, partialUpdate = true, allowCreation = false)(auth.identity)
     }
     assert(caught.getMessage.indexOf(
       s"IP address (${Option(IpAddress())}) and ports (${PortDefinitions(0)}) are not allowed at the same time"

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -353,6 +353,11 @@ class AppDeployIntegrationTest
     waitForDeployment(update)
     waitForTasks(appId, before.value.size)
     check.pingSince(5.seconds) should be (true) //make sure, the new version is alive
+
+    Then("Check if healthcheck is not updated")
+    val appResult = marathon.app(appId)
+    appResult.code should be (200)
+    appResult.value.app.healthChecks
   }
 
   test("scale an app up and down") {

--- a/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -158,6 +158,15 @@ class MarathonFacade(val url: String, baseGroup: PathId, waitTime: Duration = 30
     result(pipeline(Put(putUrl, app)), waitTime)
   }
 
+  def patchApp(id: PathId, app: AppUpdate, force: Boolean = false): RestResult[ITDeploymentResult] = {
+    requireInBaseGroup(id)
+    val pipeline = marathonSendReceive ~> read[ITDeploymentResult]
+    val putUrl: String = s"$url/v2/apps$id?force=$force"
+    LoggerFactory.getLogger(getClass).info(s"put url = $putUrl")
+
+    result(pipeline(Patch(putUrl, app)), waitTime)
+  }
+
   def restartApp(id: PathId, force: Boolean = false): RestResult[ITDeploymentResult] = {
     requireInBaseGroup(id)
     val pipeline = marathonSendReceive ~> read[ITDeploymentResult]


### PR DESCRIPTION
Add support for PATCH updates to apps

This introduces support for http `PATCH` requests to one or multiple apps via `/v2/apps` as a replacement to using http `PUT` with the default setting of `partialUpdate: true`. The ability to patch with a `PUT` request will be deprecated in 1.4 and is to be removed in 1.5.

`PATCH` updates will not create an app if the specified id doesn't exist.

Fixes #5161 