### PR TITLE
Enabled constraints to work with attributes that have the same name/k…

### DIFF
--- a/src/main/scala/mesosphere/mesos/Constraints.scala
+++ b/src/main/scala/mesosphere/mesos/Constraints.scala
@@ -5,170 +5,46 @@ import mesosphere.marathon.Protos.Constraint.Operator
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.RunSpec
 import mesosphere.marathon.stream.Implicits._
-import org.apache.mesos.Protos.{ Attribute, Offer, Value }
+import org.apache.mesos.Protos.Offer
 import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.Seq
-import scala.util.Try
-
-object Int {
-  def unapply(s: String): Option[Int] = Try(s.toInt).toOption
-}
-
-trait Placed {
-  def attributes: Seq[Attribute]
-  def hostname: String
-}
 
 object Constraints {
 
+  import constraints._
+
   private[this] val log = LoggerFactory.getLogger(getClass.getName)
-  private val GroupByDefault = 0
 
-  private def getIntValue(s: String, default: Int): Int = s match {
-    case "inf" => Integer.MAX_VALUE
-    case Int(x) => x
-    case _ => default
+  /**
+    *
+    * Decide if the given Constraint matches the attributes provided in Offer.
+    *
+    * @param allPlaced projection of Instace object. Caring Attributed and Hostnames.
+    * @param offer the offer made for the given host, containing the attributes and the operator.
+    * @param constraint given Constraint.
+    * @return a decision either the constraint is satisfied or not.
+    *         https://mesosphere.github.io/marathon/docs/constraints.html
+    */
+
+  def meetsConstraint(allPlaced: Seq[Placed], offer: Offer, constraint: Constraint): Boolean = {
+    lazy val attributes = offer.getAttributesList.filter(_.getName == constraint.getField)
+    (constraint.getField, attributes) match {
+      case ("hostname", _) =>
+        HostnameCondition(offer, constraint, allPlaced).check
+      case (_, _ :: _) =>
+        AttributeCondition(offer, constraint, allPlaced).check
+      case _ => constraint.getOperator == Operator.UNLIKE
+    }
   }
-
-  private def getValueString(attribute: Attribute): String = attribute.getType match {
-    case Value.Type.SCALAR =>
-      java.text.NumberFormat.getInstance.format(attribute.getScalar.getValue)
-    case Value.Type.TEXT =>
-      attribute.getText.getValue
-    case Value.Type.RANGES =>
-      val s = attribute.getRanges.getRangeList.to[Seq]
-        .sortWith(_.getBegin < _.getBegin)
-        .map(r => s"${r.getBegin.toString}-${r.getEnd.toString}")
-        .mkString(",")
-      s"[$s]"
-    case Value.Type.SET =>
-      val s = attribute.getSet.getItemList.to[Seq].sorted.mkString(",")
-      s"{$s}"
-  }
-
-  private final class ConstraintsChecker(allPlaced: Seq[Placed], offer: Offer, constraint: Constraint) {
-    val field = constraint.getField
-    val value = constraint.getValue
-    lazy val attr = offer.getAttributesList.find(_.getName == field)
-
-    def isMatch: Boolean =
-      if (field == "hostname") {
-        checkHostName
-      } else if (attr.nonEmpty) {
-        checkAttribute
-      } else {
-        // This will be reached in case we want to schedule for an attribute
-        // that's not supplied.
-        checkMissingAttribute
-      }
-
-    private def checkGroupBy(constraintValue: String, groupFunc: (Placed) => Option[String]) = {
-      // Minimum group count
-      val minimum = List(GroupByDefault, getIntValue(value, GroupByDefault)).max
-      // Group tasks by the constraint value, and calculate the task count of each group
-      val groupedTasks = allPlaced.groupBy(groupFunc).map { case (k, v) => k -> v.size }
-      // Task count of the smallest group
-      val minCount = groupedTasks.values.reduceOption(_ min _).getOrElse(0)
-
-      // Return true if any of these are also true:
-      // a) this offer matches the smallest grouping when there
-      // are >= minimum groupings
-      // b) the constraint value from the offer is not yet in the grouping
-      groupedTasks.find(_._1.contains(constraintValue))
-        .forall(pair => groupedTasks.size >= minimum && pair._2 == minCount)
-    }
-
-    private def checkMaxPer(constraintValue: String, maxCount: Int, groupFunc: (Placed) => Option[String]): Boolean = {
-      // Group tasks by the constraint value, and calculate the task count of each group
-      val groupedTasks = allPlaced.groupBy(groupFunc).map { case (k, v) => k -> v.size }
-
-      groupedTasks.find(_._1.contains(constraintValue)).forall(_._2 < maxCount)
-    }
-
-    private def checkHostName =
-      constraint.getOperator match {
-        case Operator.LIKE => offer.getHostname.matches(value)
-        case Operator.UNLIKE => !offer.getHostname.matches(value)
-        // All running tasks must have a hostname that is different from the one in the offer
-        case Operator.UNIQUE => allPlaced.forall(_.hostname != offer.getHostname)
-        case Operator.GROUP_BY => checkGroupBy(offer.getHostname, (p: Placed) => Some(p.hostname))
-        case Operator.MAX_PER => checkMaxPer(offer.getHostname, value.toInt, (p: Placed) => Some(p.hostname))
-        case Operator.CLUSTER =>
-          // Hostname must match or be empty
-          (value.isEmpty || value == offer.getHostname) &&
-            // All running tasks must have the same hostname as the one in the offer
-            allPlaced.forall(_.hostname == offer.getHostname)
-        case _ => false
-      }
-
-    @SuppressWarnings(Array("OptionGet"))
-    private def checkAttribute: Boolean = {
-      def matches: Seq[Placed] = matchTaskAttributes(allPlaced, field, getValueString(attr.get))
-      def groupFunc = (p: Placed) => p.attributes
-        .find(_.getName == field)
-        .map(getValueString)
-      constraint.getOperator match {
-        case Operator.UNIQUE => matches.isEmpty
-        case Operator.CLUSTER =>
-          // If no value is set, accept the first one. Otherwise check for it.
-          (value.isEmpty || getValueString(attr.get) == value) &&
-            // All running tasks should have the matching attribute
-            matches.size == allPlaced.size
-        case Operator.GROUP_BY =>
-          checkGroupBy(getValueString(attr.get), groupFunc)
-        case Operator.MAX_PER =>
-          checkMaxPer(offer.getHostname, value.toInt, groupFunc)
-        case Operator.LIKE => checkLike
-        case Operator.UNLIKE => checkUnlike
-      }
-    }
-
-    @SuppressWarnings(Array("OptionGet"))
-    private def checkLike: Boolean = {
-      if (value.nonEmpty) {
-        getValueString(attr.get).matches(value)
-      } else {
-        log.warn("Error, value is required for LIKE operation")
-        false
-      }
-    }
-
-    @SuppressWarnings(Array("OptionGet"))
-    private def checkUnlike: Boolean = {
-      if (value.nonEmpty) {
-        !getValueString(attr.get).matches(value)
-      } else {
-        log.warn("Error, value is required for UNLIKE operation")
-        false
-      }
-    }
-
-    private def checkMissingAttribute = constraint.getOperator == Operator.UNLIKE
-
-    /**
-      * Filters running tasks by matching their attributes to this field & value.
-      */
-    private def matchTaskAttributes(allPlaced: Seq[Placed], field: String, value: String) =
-      allPlaced.filter {
-        _.attributes
-          .exists { y =>
-            y.getName == field &&
-              getValueString(y) == value
-          }
-      }
-  }
-
-  def meetsConstraint(allPlaced: Seq[Placed], offer: Offer, constraint: Constraint): Boolean =
-    new ConstraintsChecker(allPlaced, offer, constraint).isMatch
 
   /**
     * Select instances to kill while maintaining the constraints of the application definition.
     * Note: It is possible, that the result of this operation does not select as many instances as needed.
     *
-    * @param runSpec the RunSpec.
+    * @param runSpec          the RunSpec.
     * @param runningInstances the list of running instances to filter
-    * @param toKillCount the expected number of instances to select for kill
+    * @param toKillCount      the expected number of instances to select for kill
     * @return the selected instances to kill. The number of instances will not exceed toKill but can be less.
     */
   def selectInstancesToKill(
@@ -183,8 +59,9 @@ object Constraints {
     val distributions = runSpec.constraints.withFilter(_.getOperator == Operator.GROUP_BY).map { constraint =>
       def groupFn(instance: Instance): Option[String] = constraint.getField match {
         case "hostname" => Some(instance.agentInfo.host)
-        case field: String => instance.agentInfo.attributes.find(_.getName == field).map(getValueString)
+        case field: String => instance.agentInfo.attributes.find(_.getName == field).map(getAttributeStringValue)
       }
+
       val instanceGroups: Seq[Map[Instance.Id, Instance]] =
         runningInstances.groupBy(groupFn).values.map(Instance.instancesById)(collection.breakOut)
       GroupByDistribution(constraint, instanceGroups)
@@ -217,7 +94,7 @@ object Constraints {
     //log the selected instances and why they were selected
     if (log.isInfoEnabled) {
       val instanceDesc = toKillInstances.values.map { instance =>
-        val attrs = instance.agentInfo.attributes.map(a => s"${a.getName}=${getValueString(a)}").mkString(", ")
+        val attrs = instance.agentInfo.attributes.map(a => s"${a.getName}=${getAttributeStringValue(a)}").mkString(", ")
         s"${instance.instanceId} host:${instance.agentInfo.host} attrs:$attrs"
       }.mkString("Selected Tasks to kill:\n", "\n", "\n")
       val distDesc = distributions.map { d =>

--- a/src/main/scala/mesosphere/mesos/constraints/OfferAttributeChecker.scala
+++ b/src/main/scala/mesosphere/mesos/constraints/OfferAttributeChecker.scala
@@ -1,0 +1,149 @@
+package mesosphere.mesos.constraints
+
+import mesosphere.marathon.Protos.Constraint
+import mesosphere.marathon.Protos.Constraint.Operator
+import mesosphere.mesos.Placed
+import org.apache.mesos.Protos.{ Attribute, Offer }
+import org.slf4j.LoggerFactory
+
+import scala.collection.immutable.Seq
+
+/**
+  *  This trait define the contract for any attribute checker.
+  */
+trait OfferAttributeChecker {
+
+  protected[this] val log = LoggerFactory.getLogger(getClass.getName)
+  final protected[this] val GroupByDefault = 0
+  val offer: Offer
+  val constraint: Constraint
+  val allPlaced: Seq[Placed]
+  final val cFieldName: String = constraint.getField
+  final val cFieldValue: String = constraint.getValue
+
+  import mesosphere.marathon.stream.Implicits._
+
+  final lazy val attributes: Seq[Attribute] =
+    offer.getAttributesList.filter(_.getName == cFieldName).to[Seq]
+
+  // Since the validation of any attribute is directly related
+  // to the operator, conditions for all operators should be defined.
+
+  final type OperatorCondition = PartialFunction[Operator, Boolean]
+  /* Operator Conditions */
+  val likeCondition: OperatorCondition
+  val unlikeCondition: OperatorCondition
+  val uniqueCondition: OperatorCondition
+  val groupByCondition: OperatorCondition
+  val maxPerCondition: OperatorCondition
+  val clusterCondition: OperatorCondition
+
+  /**
+    *  Check iterates over the conditions
+    *  and decide if the attributes satisfy
+    *  the operator.
+    */
+  lazy val check: Boolean = {
+    Seq(constraint.getOperator).map {
+      uniqueCondition orElse
+        clusterCondition orElse
+        groupByCondition orElse
+        maxPerCondition orElse
+        likeCondition orElse
+        unlikeCondition
+    }.headOption.getOrElse {
+      log.warn(s"Constraint: {$constraint} could not be matched to defined conditions.")
+      false
+    }
+  }
+}
+
+final case class HostnameCondition(
+    offer: Offer,
+    constraint: Constraint,
+    allPlaced: Seq[Placed]) extends OfferAttributeChecker {
+
+  override lazy val likeCondition: OperatorCondition = {
+    case Operator.LIKE =>
+      offer.getHostname.matches(cFieldValue)
+  }
+
+  override lazy val unlikeCondition: OperatorCondition = {
+    case Operator.UNLIKE =>
+      !offer.getHostname.matches(cFieldValue)
+  }
+
+  override lazy val uniqueCondition: OperatorCondition = {
+    case Operator.UNIQUE =>
+      allPlaced.forall(_.hostname != offer.getHostname)
+  }
+
+  override lazy val groupByCondition: OperatorCondition = {
+    case Operator.GROUP_BY =>
+      checkGroupBy(
+        offer.getHostname,
+        (p: Placed) => Some(p.hostname),
+        GroupByDefault,
+        cFieldValue,
+        allPlaced
+      )
+  }
+
+  override lazy val maxPerCondition: OperatorCondition = {
+    case Operator.MAX_PER =>
+      checkMaxPer(offer.getHostname, getIntValue(cFieldValue, 0),
+        (p: Placed) => Some(p.hostname), allPlaced)
+  }
+
+  override lazy val clusterCondition: OperatorCondition = {
+    case Operator.CLUSTER =>
+      // Hostname must match or be empty
+      (cFieldValue.isEmpty || cFieldValue == offer.getHostname) &&
+        // All running tasks must have the same hostname as the one in the offer
+        allPlaced.forall(_.hostname == offer.getHostname)
+  }
+}
+
+final case class AttributeCondition(
+    offer: Offer,
+    constraint: Constraint,
+    allPlaced: Seq[Placed]) extends OfferAttributeChecker {
+
+  private lazy val groupFunc = (p: Placed) => p.attributes
+    .find(_.getName == cFieldName)
+    .map(getAttributeStringValue)
+
+  override val uniqueCondition: OperatorCondition = {
+    case Operator.UNIQUE =>
+      matches(allPlaced, cFieldName, attributes).isEmpty
+  }
+
+  override val clusterCondition: OperatorCondition = {
+    case Operator.CLUSTER =>
+      // If no value is set, accept the first one. Otherwise check for it.
+      (cFieldValue.isEmpty || attributes.forall(getAttributeStringValue(_) == cFieldValue)) &&
+        // All running tasks should have the matching attribute
+        matches(allPlaced, cFieldName, attributes).size == allPlaced.size
+  }
+
+  override val groupByCondition: OperatorCondition = {
+    case Operator.GROUP_BY =>
+      attributes.forall { attr =>
+        checkGroupBy(getAttributeStringValue(attr), groupFunc, GroupByDefault, cFieldValue, allPlaced)
+      }
+  }
+
+  override val maxPerCondition: OperatorCondition = {
+    case Operator.MAX_PER =>
+      checkMaxPer(offer.getHostname, getIntValue(cFieldValue, 0), groupFunc, allPlaced)
+  }
+
+  override val likeCondition: OperatorCondition = {
+    case Operator.LIKE => checkLike(cFieldValue, attributes)
+  }
+
+  override val unlikeCondition: OperatorCondition = {
+    case Operator.UNLIKE => checkUnlike(cFieldValue, attributes)
+  }
+}
+

--- a/src/main/scala/mesosphere/mesos/constraints/package.scala
+++ b/src/main/scala/mesosphere/mesos/constraints/package.scala
@@ -1,0 +1,140 @@
+package mesosphere.mesos
+
+import org.apache.mesos.Protos.{ Attribute, Value }
+import org.slf4j.LoggerFactory
+
+import scala.collection.immutable.Seq
+import scala.util.Try
+
+// Projection trait to extract attributes and hostname from
+// Instance.
+trait Placed {
+  def attributes: Seq[Attribute]
+  def hostname: String
+}
+
+package object constraints {
+
+  /*
+      This package object contain helper methods related to constraint
+      parsing.
+  */
+
+  protected[this] val log = LoggerFactory.getLogger(getClass.getName)
+
+  object Int {
+    def unapply(s: String): Option[Int] = Try(s.toInt).toOption
+  }
+
+  import mesosphere.marathon.stream.Implicits._
+
+  def getIntValue(s: String, default: Int): Int = s match {
+    case "inf" => Integer.MAX_VALUE
+    case Int(x) => x
+    case _ =>
+      log.warn(s"Could not parse number from {$s}, default value {$default} is set instead.")
+      default
+  }
+
+  def getAttributeStringValue(attribute: Attribute): String = attribute.getType match {
+    case Value.Type.SCALAR =>
+      java.text.NumberFormat.getInstance.format(attribute.getScalar.getValue)
+    case Value.Type.TEXT =>
+      attribute.getText.getValue
+    case Value.Type.RANGES =>
+      val s = attribute.getRanges.getRangeList.to[Seq]
+        .sortWith(_.getBegin < _.getBegin)
+        .map(r => s"${r.getBegin.toString}-${r.getEnd.toString}")
+        .mkString(",")
+      s"[$s]"
+    case Value.Type.SET =>
+      val s = attribute.getSet.getItemList.to[Seq].sorted.mkString(",")
+      s"{$s}"
+  }
+
+  /**
+    * Filters running tasks by matching their attributes to this field & value.
+    */
+  def matchTaskAttributes(
+    allPlaced: Seq[Placed],
+    fieldName: String, fieldValue: String): Seq[Placed] = {
+    allPlaced.filter {
+      _.attributes
+        .exists { y =>
+          y.getName == fieldName &&
+            getAttributeStringValue(y) == fieldValue
+        }
+    }
+  }
+
+  def matches(allPlaced: Seq[Placed], fieldName: String, attributes: Seq[Attribute]): Seq[Placed] = {
+    attributes.flatMap { attr =>
+      matchTaskAttributes(allPlaced, fieldName, getAttributeStringValue(attr))
+    }
+  }
+
+  def checkGroupBy(
+    constraintValue: String,
+    groupFunc: (Placed) => Option[String],
+    groupByDefaultValue: Int = 0,
+    fieldValue: String,
+    allPlaced: Seq[Placed]
+  ) = {
+    // Minimum group count
+    val minimum = Iterable(groupByDefaultValue, getIntValue(fieldValue, groupByDefaultValue)).max
+    // Group tasks by the constraint value, and calculate the task count of each group
+    val groupedTasks = allPlaced.groupBy(groupFunc).map { case (k, v) => k -> v.size }
+    // Task count of the smallest group
+    val minCount = groupedTasks.values.reduceOption(_ min _).getOrElse(0)
+    // Check if offers are >= minimum groupings
+    val taskSizeSatisfied = groupedTasks.size >= minimum
+    // Return true if any of these are also true:
+    // a) this offer matches the smallest grouping when there
+    // are >= minimum groupings
+    // b) the constraint value from the offer is not yet in the grouping
+    groupedTasks.find {
+      case (constraint: Option[String], _) =>
+        constraint.contains(constraintValue)
+    }.forall {
+      case (_, taskCount: Int) =>
+        taskSizeSatisfied && taskCount == minCount
+    }
+  }
+
+  def checkLike(fieldValue: String, attributes: Seq[Attribute]): Boolean = {
+    if (fieldValue.nonEmpty) {
+      attributes.forall { attr =>
+        getAttributeStringValue(attr).matches(fieldValue)
+      }
+    } else {
+      log.warn("Error, value is required for LIKE operation")
+      false
+    }
+  }
+
+  def checkUnlike(fieldValue: String, attributes: Seq[Attribute]): Boolean = {
+    if (fieldValue.nonEmpty) {
+      !attributes.forall { attr =>
+        getAttributeStringValue(attr).matches(fieldValue)
+      }
+    } else {
+      log.warn("Error, value is required for UNLIKE operation")
+      false
+    }
+  }
+
+  def checkMaxPer(constraintValue: String, maxCount: Int,
+    groupFunc: (Placed) => Option[String],
+    allPlaced: Seq[Placed]): Boolean = {
+    // Group tasks by the constraint value, and calculate the task count of each group
+    val groupedTasks = allPlaced.groupBy(groupFunc).map { case (k, v) => k -> v.size }
+
+    groupedTasks.find {
+      case (constraint: Option[String], _) =>
+        constraint.contains(constraintValue)
+    }.forall {
+      case (_, taskCount: Int) =>
+        taskCount < maxCount
+    }
+  }
+}


### PR DESCRIPTION
- Enabled the attribute checker in constraints be able to manage multiple attributes with several names.
- Refactored the constraint check logic to separate the decision logic from parsing/helper functions.

Beside of fixing this small bug, I did this refactoring to separate the condition checking logic from the helper/parsing functions. However, I do not consider it as done, more as a good start.
The next step in terms of refactoring would be to dig down into the parsing logic and remove the boilerplate to make it more extendable. 

