### PR TITLE
Disable shell globbing for start script.

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o errexit -o pipefail
+set -o errexit -o pipefail -o noglob
 
 declare -a java_args
 declare -a app_args


### PR DESCRIPTION
If globbing is enabled, and someone sets MARATHON_MESOS_ROLE='\*', it'll
result in '\*' being expanded.  IE, it'll literally include the files
in the cwd as arguments, rather than just passing *.

Nothing in the script relies on shell globbing, thus disable it, fixing
the problem in the process.