### PR TITLE
Fixes #5211 by defining the jersey annotated methods explicitly.

### DIFF
--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
@@ -1,8 +1,7 @@
-
 package mesosphere.mesos.scale
 
 import mesosphere.AkkaIntegrationFunTest
-import mesosphere.marathon.{ IntegrationTest, UnstableTest }
+import mesosphere.marathon.IntegrationTest
 import mesosphere.marathon.api.v2.json.AppUpdate
 import mesosphere.marathon.integration.facades.MarathonFacade._
 import mesosphere.marathon.integration.facades.{ ITDeploymentResult, MarathonFacade }
@@ -21,7 +20,6 @@ object SingleAppScalingTest {
 }
 
 @IntegrationTest
-@UnstableTest
 class SingleAppScalingTest extends AkkaIntegrationFunTest with ZookeeperServerTest with SimulatedMesosTest with MarathonTest with Eventually {
   val maxTasksPerOffer = Option(System.getenv("MARATHON_MAX_TASKS_PER_OFFER")).getOrElse("1")
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -293,7 +293,7 @@ class AppsResource @Inject() (
     * @return http servlet response
     */
   private[this] def update(id: String, body: Array[Byte], force: Boolean, partialUpdate: Boolean,
-      req: HttpServletRequest, allowCreation: Boolean)(implicit identity: Identity): Response = {
+    req: HttpServletRequest, allowCreation: Boolean)(implicit identity: Identity): Response = {
     val appId = id.toRootPath
 
     assumeValid {
@@ -301,8 +301,8 @@ class AppsResource @Inject() (
       val version = clock.now()
       val plan = result(groupManager.updateApp(appId, updateOrCreate(appId, _, appUpdate, partialUpdate, allowCreation), version, force))
       val response = plan.original.app(appId)
-          .map(_ => Response.ok())
-          .getOrElse(Response.created(new URI(appId.toString)))
+        .map(_ => Response.ok())
+        .getOrElse(Response.created(new URI(appId.toString)))
       plan.target.app(appId).foreach { appDef =>
         maybePostEvent(req, appDef)
       }
@@ -321,7 +321,7 @@ class AppsResource @Inject() (
     * @return http servlet response
     */
   private[this] def updateMultiple(force: Boolean, partialUpdate: Boolean,
-      body: Array[Byte], allowCreation: Boolean)(implicit identity: Identity): Response = {
+    body: Array[Byte], allowCreation: Boolean)(implicit identity: Identity): Response = {
 
     assumeValid {
       val version = clock.now()

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -17,7 +17,6 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 @IntegrationTest
-@UnstableTest
 class AppDeployIntegrationTest
     extends AkkaIntegrationFunTest
     with EmbeddedMarathonTest {

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployWithLeaderAbdicationIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployWithLeaderAbdicationIntegrationTest.scala
@@ -18,7 +18,6 @@ import scala.concurrent.duration._
 import scala.util.Try
 
 @IntegrationTest
-@UnstableTest
 class AppDeployWithLeaderAbdicationIntegrationTest extends AkkaIntegrationFunTest with MarathonClusterTest {
   private[this] val log = LoggerFactory.getLogger(getClass)
 

--- a/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
@@ -11,7 +11,6 @@ import spray.http.DateTime
 import scala.concurrent.duration._
 
 @IntegrationTest
-@UnstableTest
 class GroupDeployIntegrationTest extends AkkaIntegrationFunTest with EmbeddedMarathonTest {
 
   //clean up state before running the test case

--- a/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
@@ -19,7 +19,6 @@ import scala.concurrent.duration._
 import scala.util.Try
 
 @IntegrationTest
-@UnstableTest
 class ReadinessCheckIntegrationTest extends AkkaIntegrationFunTest with EmbeddedMarathonTest with Eventually {
 
   //clean up state before running the test case

--- a/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -11,7 +11,6 @@ import mesosphere.marathon.state.UnreachableStrategy
 import scala.concurrent.duration._
 
 @IntegrationTest
-@UnstableTest
 class TaskUnreachableIntegrationTest extends AkkaIntegrationFunTest with EmbeddedMarathonMesosClusterTest {
 
   override lazy val mesosNumMasters = 1


### PR DESCRIPTION
With the newly introduced `PATCH` semantic, we introduced a misleading method declaration which is not resolvable for jersey. Therefore this logic was restructured and methods are defined explicitly.
Reverted #5202 by the way.

Test Plan:
```
sbt "integration:test"
```

Change summary:

Status before:
```
replace(... , allowCreation: Boolean = true) {
  // all the logic
}

patch(...) {
  replace(... , allowCreation = false)
}
```

Status after:
```
replace(...) {
  update(... , allowCreation = true)
}

patch(...) {
  update(... , allowCreation = false)
}

private update(...) {
  // all the logic
}
```