### PR TITLE
Do not use hard coded version 1.4.0 in migration

### DIFF
--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
@@ -103,7 +103,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen {
     "migrate on a legacy database with the same version will do nothing" in {
       val legacyConfig = mock[LegacyStorageConfig]
       val mockedPersistentStore = mock[PersistentStore]
-      val currentVersionEntity = InMemoryEntity(Migration.StorageVersionName, 0, StorageVersions(1, 4, 0).toByteArray.toIndexedSeq)
+      val currentVersionEntity = InMemoryEntity(Migration.StorageVersionName, 0, StorageVersions.current.toByteArray.toIndexedSeq)
       mockedPersistentStore.load(Migration.StorageVersionName) returns Future.successful(Some(currentVersionEntity))
 
       legacyConfig.store returns mockedPersistentStore
@@ -177,7 +177,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen {
       val legacyConfig = mock[LegacyStorageConfig]
       trait Store extends PersistentStore with PersistentStoreManagement
       val mockedPersistentStore = mock[Store]
-      val currentVersionEntity = InMemoryEntity(Migration.StorageVersionName, 0, StorageVersions(1, 4, 0).toByteArray.toIndexedSeq)
+      val currentVersionEntity = InMemoryEntity(Migration.StorageVersionName, 0, StorageVersions.current.toByteArray.toIndexedSeq)
       mockedPersistentStore.initialize() returns Future.successful(())
       mockedPersistentStore.close() returns Future.successful(Done)
       mockedPersistentStore.load(Migration.StorageVersionName) returns Future.successful(Some(currentVersionEntity))


### PR DESCRIPTION
Currently migration fails because in legacy storage tests the expected/given version is hard coded to 1.4.0, which is not valid since we released 1.4.1