### PR TITLE
ForceExpunge for missing task is a no-op, rather than a failure

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -28,7 +28,7 @@ class InstanceUpdateOpResolverTest extends UnitTest {
     f.instanceTracker.instance(f.notExistingInstanceId) returns Future.successful(None)
     val stateChange = f.updateOpResolver.resolve(InstanceUpdateOperation.ForceExpunge(f.notExistingInstanceId)).futureValue
     "call taskTracker.task" in { verify(f.instanceTracker).instance(f.notExistingInstanceId) }
-    "result in a Failure" in { stateChange shouldBe a[InstanceUpdateEffect.Failure] }
+    "result in a Failure" in { stateChange shouldBe a[InstanceUpdateEffect.Noop] }
     "invoke no more interactions" in { f.verifyNoMoreInteractions() }
   }
 


### PR DESCRIPTION
Summary:
If a resident app is deleted before Marathon has a chance to
release the associated resources, then later attempts to release them
fail because because we ForceExpunge the task-ID when processing our
UnreserveAndDestroyVolumes operation.

This change makes ForceExpunge for a non-existent task respond with
no-op, rather than failure.

Fixes #5142

Backport of f441c57

Test Plan: n/a

Reviewers: jasongilanfarr, meichstedt

Subscribers: marathon-team

Differential Revision: https://phabricator.mesosphere.com/D547