### PR TITLE
Don't restart tasks on non runtime change.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -57,9 +57,7 @@ case class PodDefinition(
           containers != to.containers ||
           constraints != to.constraints ||
           podVolumes != to.podVolumes ||
-          networks != to.networks ||
-          backoffStrategy != to.backoffStrategy ||
-          upgradeStrategy != to.upgradeStrategy
+          networks != to.networks
       }
     case _ =>
       // A validation rule will ensure, this can not happen

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -313,20 +313,17 @@ case class AppDefinition(
           storeUrls != to.storeUrls ||
           portDefinitions != to.portDefinitions ||
           requirePorts != to.requirePorts ||
-          backoffStrategy != to.backoffStrategy ||
           container != to.container ||
           healthChecks != to.healthChecks ||
           taskKillGracePeriod != to.taskKillGracePeriod ||
           dependencies != to.dependencies ||
-          upgradeStrategy != to.upgradeStrategy ||
+          (isResident && upgradeStrategy != to.upgradeStrategy) ||
           labels != to.labels ||
           acceptedResourceRoles != to.acceptedResourceRoles ||
           ipAddress != to.ipAddress ||
           readinessChecks != to.readinessChecks ||
           residency != to.residency ||
-          secrets != to.secrets ||
-          unreachableStrategy != to.unreachableStrategy ||
-          killSelection != to.killSelection
+          secrets != to.secrets
       }
     case _ =>
       // A validation rule will ensure, this can not happen


### PR DESCRIPTION
Fixes #4987. After changing non runtime setting, application will not
be restarted. New version won't be created.