### PR TITLE
no tests in assembly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,8 @@ lazy val asmSettings = Seq(
       "jsp-api-2.1.jar"
     )
     (fullClasspath in assembly).value.filter { x => exclude(x.data.getName) }
-  }
+  },
+  test in assembly := {}
 )
 
 lazy val packagingSettings = Seq(


### PR DESCRIPTION
`sbt assembly` runs unit tests which are failing during docker image creation because of timeouts. To avoid this timeouts, unit tests during assembly step should be disabled.

Note:
This behavior is already on master, but not on this release track.

This change should be picked to `releases/1.3` and `releases/1.1` as well