### PR TITLE
Backport: Don't destroy persistent volumes when killing unreachable resident tasks

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -49,6 +49,11 @@ case class Instance(
   def isDropped: Boolean = state.condition == Condition.Dropped
   def isTerminated: Boolean = state.condition.isTerminal
   def isActive: Boolean = state.condition.isActive
+  def hasReservation =
+    tasksMap.values.exists {
+      case _: Task.ReservedTask => true
+      case _ => false
+    }
 
   override def mergeFromProto(message: Protos.Json): Instance = {
     Json.parse(message.getJson).as[Instance]

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillAction.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillAction.scala
@@ -1,0 +1,95 @@
+package mesosphere.marathon
+package core.task.termination.impl
+
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.condition.Condition
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.task.Task
+
+/**
+  * Possible actions that can be chosen in order to `kill` a given instance.
+  * Depending on the instance's state this can be one of
+  * - [[KillAction.ExpungeFromState]]
+  * - [[KillAction.Noop]]
+  * - [[KillAction.IssueKillRequest]]
+  */
+private[termination] sealed trait KillAction
+
+private[termination] object KillAction extends StrictLogging {
+  /**
+    * Any normal, reachable and stateless instance will simply be killed via the scheduler driver.
+    */
+  case object IssueKillRequest extends KillAction
+
+  /**
+    * Do nothing. This is currently what we do for unreachable tasks with reservations. See #5261
+    */
+  case object Noop extends KillAction
+
+  /**
+    * In case of an instance being Unreachable, killing the related Mesos task is impossible.
+    * In order to get rid of the instance, processing this action expunges the metadata from
+    * state. If the instance is reported to be non-terminal in the future, it will be killed.
+    */
+  case object ExpungeFromState extends KillAction
+
+  /* returns whether or not we can expect the task to report a terminal state after sending a kill signal */
+  private val wontRespondToKill: Condition => Boolean = {
+    import Condition._
+    Set(
+      Unknown, Unreachable, UnreachableInactive,
+      // TODO: it should be safe to remove these from this list, because
+      // 1) all taskId's should be removed at this point, because Gone & Dropped are terminal.
+      // 2) Killing a Gone / Dropped task will cause it to be in a terminal state.
+      // 3) Killing a Gone / Dropped task may result in no status change at all.
+      // 4) Either way, we end up in a terminal state.
+      // However, we didn't want to risk changing behavior in a point release. So they remain here.
+      Dropped, Gone
+    )
+  }
+
+  /**
+    * Computes the [[KillAction]] based on the instance's state.
+    *
+    * if the instance can't be reached, issuing a kill request won't cause the instance to progress towards a terminal
+    * state; Mesos will simply re-send the current state. Our current behavior, for ephemeral, is to simply delete any
+    * knowledge that the instance might be running, such that if it is reported by Mesos later we will kill it. (that
+    * could be improved).
+    *
+    * If the instance is lost _and_ has reservations, we do nothing.
+    *
+    * any other case -> issue a kill request
+    */
+  def apply(instanceId: Instance.Id, taskIds: Iterable[Task.Id], knownInstance: Option[Instance]): KillAction = {
+    val hasReservations = knownInstance.fold(false)(_.hasReservation)
+
+    // TODO(PODS): align this with other Terminal/Unreachable/whatever extractors
+    val maybeCondition = knownInstance.map(_.state.condition)
+    val isUnkillable = maybeCondition.fold(false)(wontRespondToKill)
+
+    // Ephemeral instances are expunged once all tasks are terminal, it's unlikely for this to be true for them.
+    // Resident tasks, however, could be in this state if scaled down, or, if kill is attempted between recovery.
+    val allTerminal: Boolean = taskIds.isEmpty
+
+    if (isUnkillable || allTerminal) {
+      val msg = if (isUnkillable)
+        s"it is ${maybeCondition.fold("unknown")(_.toString)}"
+      else
+        "none of its tasks are running"
+      if (hasReservations) {
+        logger.info(
+          s"Ignoring kill request for ${instanceId}; killing it while ${msg} is unsupported")
+        KillAction.Noop
+      } else {
+        logger.warn(s"Expunging ${instanceId} from state because ${msg}")
+        // we will eventually be notified of a taskStatusUpdate after the instance has been expunged
+        KillAction.ExpungeFromState
+      }
+    } else {
+      val knownOrNot = if (knownInstance.isDefined) "known" else "unknown"
+      logger.warn("Killing {} {} of instance {}", knownOrNot, taskIds.mkString(","), instanceId)
+      KillAction.IssueKillRequest
+    }
+  }
+
+}

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImpl.scala
@@ -27,6 +27,7 @@ private[tracker] class InstanceOpProcessorImpl(
 
   override def process(op: Operation)(implicit ec: ExecutionContext): Future[Unit] = {
     val stateChange = stateOpResolver.resolve(op.op)
+
     stateChange.flatMap {
       case change: InstanceUpdateEffect.Expunge =>
         // Used for task termination or as a result from a UpdateStatus action.

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -11,6 +11,7 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.{ Task, TaskCondition }
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import org.apache.mesos
+import org.scalatest.Inside
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
@@ -20,7 +21,7 @@ import scala.concurrent.Future
   *
   * More tests are in [[mesosphere.marathon.tasks.InstanceTrackerImplTest]]
   */
-class InstanceUpdateOpResolverTest extends UnitTest {
+class InstanceUpdateOpResolverTest extends UnitTest with Inside {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   "ForceExpunge for an unknown task" should {

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillActionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillActionTest.scala
@@ -1,0 +1,49 @@
+package mesosphere.marathon
+package core.task.termination.impl
+
+import mesosphere.UnitTest
+import mesosphere.marathon.core.base.ConstantClock
+import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
+import mesosphere.marathon.core.task.Task.LocalVolumeId
+import mesosphere.marathon.state.PathId
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class KillActionTest extends UnitTest with TableDrivenPropertyChecks {
+
+  val clock = ConstantClock()
+  val appId = PathId("/test")
+
+  lazy val localVolumeId = LocalVolumeId(appId, "unwanted-persistent-volume", "uuid1")
+  lazy val residentLaunchedInstance: Instance = TestInstanceBuilder.newBuilder(appId).
+    addTaskResidentLaunched(localVolumeId).
+    getInstance()
+
+  lazy val residentUnreachableInstance: Instance = TestInstanceBuilder.newBuilder(appId).
+    addTaskWithBuilder().
+    taskResidentUnreachable(localVolumeId).
+    build().
+    getInstance()
+
+  lazy val unreachableInstance: Instance = TestInstanceBuilder.newBuilder(appId).addTaskUnreachable().getInstance()
+  lazy val runningInstance: Instance = TestInstanceBuilder.newBuilder(appId).addTaskLaunched().getInstance()
+
+  "computeKillAction" when {
+    Table(
+      ("name", "instance", "expected"),
+      ("an unreachable reserved instance", residentUnreachableInstance, KillAction.Noop),
+      ("a running reserved instance", residentLaunchedInstance, KillAction.IssueKillRequest),
+      ("an unreachable ephemeral instance", unreachableInstance, KillAction.ExpungeFromState),
+      ("a running ephemeral instance", runningInstance, KillAction.IssueKillRequest)
+    ).
+      foreach {
+        case (name, instance, expected) =>
+          s"killing ${name}" should {
+            s"result in ${expected}" in {
+              KillAction(
+                instance.instanceId, instance.tasksMap.keys, Some(instance)).
+                shouldBe(expected)
+            }
+          }
+      }
+  }
+}


### PR DESCRIPTION
Summary:
Killing an unreachable resident task will do nothing, rather than
destroy the reservations.

Fixes #5207

Also-By: tharper@mesosphere.com

Test Plan: sbt test

Reviewers: unterstein, meichstedt, jasongilanfarr, jenkins

Reviewed By: meichstedt, jasongilanfarr, jenkins

Subscribers: jdef, marathon-team

Differential Revision: https://phabricator.mesosphere.com/D529