### PR TITLE
Stabilize OverdueTasksActorTest

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
@@ -1,6 +1,8 @@
 package mesosphere.marathon
 package core.task.jobs.impl
 
+import java.util.UUID
+
 import akka.actor._
 import akka.testkit.TestProbe
 import mesosphere.marathon
@@ -43,7 +45,7 @@ class OverdueTasksActorTest extends MarathonSpec with GivenWhenThen with maratho
     val config = MarathonTestHelper.defaultConfig()
     checkActor = actorSystem.actorOf(
       OverdueTasksActor.props(config, taskTracker, taskReservationTimeoutHandler, killService, clock),
-      "check")
+      "check-" + UUID.randomUUID.toString)
   }
 
   after {


### PR DESCRIPTION
Summary:
There was one failure during the last 100 loop test runs `actor name [check] is not unique!`. The fixture now generates a unique name for each actor.

cherry-picked from master
Fixes #5281

Test Plan: sbt test

Reviewers: timcharper, jasongilanfarr, jeschkies, jenkins

Reviewed By: timcharper, jasongilanfarr, jeschkies, jenkins

Subscribers: marathon-team

Differential Revision: https://phabricator.mesosphere.com/D580