### PR TITLE
Stabilize ReadinessCheckIntegrationTest

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
@@ -4,19 +4,20 @@ package integration
 import java.io.File
 import java.util.UUID
 
-import mesosphere.{ AkkaIntegrationFunTest, Unstable }
+import mesosphere.AkkaIntegrationFunTest
 import mesosphere.marathon.api.v2.json.AppUpdate
 import mesosphere.marathon.core.health.{ HealthCheck, MarathonHttpHealthCheck, PortReference }
 import mesosphere.marathon.core.readiness.ReadinessCheck
+import mesosphere.marathon.integration.facades.ITEnrichedTask
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state._
 import org.apache.commons.io.FileUtils
+import org.apache.mesos.{ Protos => MesosProtos }
 import org.scalatest.concurrent.Eventually
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
-import scala.util.Try
 
 @IntegrationTest
 class ReadinessCheckIntegrationTest extends AkkaIntegrationFunTest with EmbeddedMarathonTest with Eventually {
@@ -40,35 +41,38 @@ class ReadinessCheckIntegrationTest extends AkkaIntegrationFunTest with Embedded
     deploy(serviceProxy("/noreadynohealth".toTestPath, "phase()", withHealth = false), continue = false)
   }
 
-  test("An upgrade of an application will wait for the readiness checks", Unstable) {
+  test("An upgrade of an application will wait for the readiness checks") {
     val serviceDef = serviceProxy("/upgrade".toTestPath, "phase(block1!,block2!,block3!)", withHealth = false)
     deploy(serviceDef, continue = true)
 
-    When("The service is upgraded")
-    val oldTask = marathon.tasks(serviceDef.id).value.head
-    val update = marathon.updateApp(serviceDef.id, AppUpdate(env = Some(EnvVarValue(sys.env))))
-    val newTask = eventually {
-      marathon.tasks(serviceDef.id).value.find(_.id != oldTask.id).get
-    }
+      When("The service is upgraded")
+      val oldTask = marathon.tasks(serviceDef.id).value.head
+      val update = marathon.updateApp(serviceDef.id, AppUpdate(env = Some(EnvVarValue(sys.env))))
 
-    Then("The deployment does not succeed until the readiness checks succeed")
-    val serviceFacade = new ServiceMockFacade(newTask)
-    WaitTestSupport.waitUntil("ServiceMock is up", patienceConfig.timeout.totalNanos.nanos){ Try(serviceFacade.plan()).isSuccess }
-    while (serviceFacade.plan().code != 200) {
-      When("We continue on block until the plan is ready")
-      serviceFacade.continue()
-      marathon.listDeploymentsForBaseGroup().value should have size 1
-    }
-    waitForDeployment(update)
+        And("The ServiceMock is up")
+      val serviceFacade = createServiceFacade(serviceDef.id){ task =>
+        task.id != oldTask.id&& task.state == MesosProtos.TaskState.TASK_RUNNING.name()
+      }
+
+      Then("The deployment does not succeed until the readiness checks succeed")
+
+      while (serviceFacade.plan().code != 200) {
+        When("We continue on block until the plan is ready")
+        serviceFacade.continue()
+        marathon.listDeploymentsForBaseGroup().value should have size 1
+      }
+      waitForDeployment(update)
+
   }
 
   def deploy(service: AppDefinition, continue: Boolean): Unit = {
     Given("An application service")
     val result = marathon.createAppV2(service)
     result.code should be (201)
-    val task = waitForTasks(service.id, 1).head //make sure, the app has really started
-    val serviceFacade = new ServiceMockFacade(task)
-    WaitTestSupport.waitUntil("ServiceMock is up", patienceConfig.timeout.totalNanos.nanos){ Try(serviceFacade.plan()).isSuccess }
+    When("The ServiceMock is up")
+    val serviceFacade = createServiceFacade(service.id) { task =>
+      task.state == MesosProtos.TaskState.TASK_RUNNING.name()
+    }
 
     while (continue && serviceFacade.plan().code != 200) {
       When("We continue on block until the plan is ready")
@@ -78,6 +82,13 @@ class ReadinessCheckIntegrationTest extends AkkaIntegrationFunTest with Embedded
 
     Then("The deployment should finish")
     waitForDeployment(result)
+  }
+
+  def createServiceFacade(id: PathId)(predicate: (ITEnrichedTask) => Boolean): ServiceMockFacade = eventually {
+    val newTask = marathon.tasks(id).value.find(predicate(_)).get
+    val serviceFacade = new ServiceMockFacade(newTask)
+    serviceFacade.plan()
+    serviceFacade
   }
 
   def serviceProxy(appId: PathId, plan: String, withHealth: Boolean): AppDefinition = {


### PR DESCRIPTION
Summary: Fixes #5277 by making sure that the service facade used in ReadinessCheckIntegrationTest uses a task that's actually running.

cherry-picked from master
Test Plan: sbt test

Reviewers: jdef, timcharper, unterstein, jenkins

Reviewed By: jdef, unterstein, jenkins

Subscribers: marathon-team

Differential Revision: https://phabricator.mesosphere.com/D578