### PR TITLE
(backport) Publish a TASK_GONE MesosUpdate when an unreachable reserved instance's resources are seen

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -16,6 +16,7 @@ import mesosphere.marathon.core.health.HealthModule
 import mesosphere.marathon.core.history.HistoryModule
 import mesosphere.marathon.core.instance.update.InstanceChangeHandler
 import mesosphere.marathon.core.launcher.LauncherModule
+import mesosphere.marathon.core.launcher.impl.UnreachableReservedOfferMonitor
 import mesosphere.marathon.core.launchqueue.LaunchQueueModule
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.base.util.StopOnFirstMatchingOfferMatcher
@@ -28,6 +29,7 @@ import mesosphere.marathon.core.task.bus.TaskBusModule
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
 import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
+import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.io.storage.StorageProvider
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.storage.StorageModule
@@ -54,7 +56,9 @@ class CoreModuleImpl @Inject() (
   clock: Clock,
   storage: StorageProvider,
   scheduler: Provider[DeploymentService],
-  instanceUpdateSteps: Seq[InstanceChangeHandler])
+  instanceUpdateSteps: Seq[InstanceChangeHandler],
+  taskStatusUpdateProcessor: TaskStatusUpdateProcessor
+)
     extends CoreModule {
 
   // INFRASTRUCTURE LAYER
@@ -126,8 +130,14 @@ class CoreModuleImpl @Inject() (
       offerMatcherReconcilerModule.offerMatcherReconciler,
       offerMatcherManagerModule.globalOfferMatcher
     ),
-    pluginModule.pluginManager
+    pluginModule.pluginManager,
+    offerStreamInput
   )(clock)
+
+  lazy val offerStreamInput = UnreachableReservedOfferMonitor.run(
+    lookupInstance = taskTrackerModule.instanceTracker.instance(_),
+    taskStatusPublisher = taskStatusUpdateProcessor.publish(_)
+  )(actorsModule.materializer)
 
   override lazy val appOfferMatcherModule = new LaunchQueueModule(
     marathonConf,

--- a/src/main/scala/mesosphere/marathon/core/launcher/LauncherModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/LauncherModule.scala
@@ -1,12 +1,14 @@
 package mesosphere.marathon.core.launcher
 
 import mesosphere.marathon.{ MarathonConf, MarathonSchedulerDriverHolder }
+import akka.stream.scaladsl.SourceQueue
 import mesosphere.marathon.core.base.Clock
 import mesosphere.marathon.core.launcher.impl.{ OfferProcessorImpl, TaskLauncherImpl, InstanceOpFactoryImpl }
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.task.tracker.InstanceCreationHandler
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.metrics.Metrics
+import org.apache.mesos.Protos.Offer
 
 /**
   * This module contains the glue code between matching tasks to resource offers
@@ -18,13 +20,16 @@ class LauncherModule(
     taskCreationHandler: InstanceCreationHandler,
     marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder,
     offerMatcher: OfferMatcher,
-    pluginManager: PluginManager)(implicit clock: Clock) {
+    pluginManager: PluginManager,
+    offerStreamInput: SourceQueue[Offer]
+)(implicit clock: Clock) {
 
   lazy val offerProcessor: OfferProcessor =
     new OfferProcessorImpl(
       conf, clock,
       metrics,
-      offerMatcher, taskLauncher, taskCreationHandler)
+      offerMatcher, taskLauncher, taskCreationHandler,
+      offerStreamInput)
 
   lazy val taskLauncher: TaskLauncher = new TaskLauncherImpl(
     metrics,

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitor.scala
@@ -1,0 +1,136 @@
+package mesosphere.marathon
+package core.launcher.impl
+
+import akka.event.Logging
+import akka.NotUsed
+import akka.stream.{ Attributes, Materializer }
+import mesosphere.marathon.stream._
+import scala.collection.breakOut
+import scala.concurrent.Future
+
+import akka.stream.{ ActorAttributes, OverflowStrategy, Supervision }
+import akka.stream.scaladsl.{ Flow, Sink, Source, SourceQueueWithComplete }
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.task.Task
+import mesosphere.util.state.FrameworkId
+import org.apache.mesos.Protos.{ Offer, SlaveID, TaskState, TaskStatus }
+
+/**
+  * Until Mesos 1.3.0, resident tasks have no path to become reachable / terminal (see GitHub issue #5284). This module
+  * is our workaround.
+  *
+  * We provide a graph which receives offers and watches for reservations for unreachable tasks, upon the sight of which
+  * we emit a TASK_GONE status for said unreachable task.
+  *
+  * We expect the stream (and therefore, the input buffer) to be idle / empty most of the time, and the lookup / publish
+  * operations to be cheap / near instantaneous. However, we restrict the concurrency because if, by chance, the system
+  * is under heavy load, we would prefer to drop offers and not overload the lookup / task status publish system so that
+  * other work-loads can finish. Mesos will eventually re-offer the reservation; dropping is harmless.
+  *
+  * [Offer] ~> [Reserved TaskIDs (for our framework id)] ~> [Looked up instances] ~> [unreachable instances] ~>
+  *   [TASK_GONE status] ~> publish (to a TaskStatusUpdateProcessor implementation's publish method)
+  *
+  * Errors are logged, dropping the error-inducing element and the stream resumes processing.
+  */
+object UnreachableReservedOfferMonitor extends StrictLogging {
+  /**
+    * Too low a value reduces scheduling efficiency
+    * Too high a value places more demand on the instance lookup and task status publisher systems.
+    */
+  private val Parallelism = 16
+
+  /**
+    * We buffer up to 32 offers in the event of back pressure. We should rarely hit this. If we do, then dropping offers
+    * is the right thing to do
+    */
+  private val BufferSize = 32
+
+  /** Given an offer, emit all Instance Ids pertaining to this Marathon instance that have reservations in the offer */
+  private[impl] val reservedInstanceIdsForReservations: Flow[Offer, Instance.Id, NotUsed] =
+    Flow[Offer]
+      .mapConcat { offer =>
+        // This doesn't change during the lifetime of Marathon but it's simpler to get it from here.
+        val frameworkId = FrameworkId(offer.getFrameworkId.getValue)
+        offer.getResourcesList.iterator
+          .flatMap(TaskLabels.taskIdForResource(frameworkId, _))
+          .map(_.instanceId)
+          .to[Seq]
+      }
+      .named("reservedInstanceIdsForReservations")
+
+  /** Looks up instances using the provided lookup function. Drops on None */
+  private[impl] def lookupInstanceFlow(
+    lookupInstance: Instance.Id => Future[Option[Instance]]) =
+    Flow[Instance.Id]
+      .mapAsync(parallelism = Parallelism)(lookupInstance)
+      .collect { case Some(instance) => instance }
+      .named("lookupInstance")
+
+  private def makeGoneStatus(taskId: Task.Id, slaveId: String): TaskStatus = {
+    TaskStatus.newBuilder
+      .setState(TaskState.TASK_GONE)
+      .setTaskId(taskId.mesosTaskId)
+      .setSlaveId(SlaveID.newBuilder.setValue(slaveId))
+      .setMessage("Reserved resources were offered")
+      .build()
+  }
+
+  /** Given a source of Instance, yield TASK_GONE mesos updates for every unreachable instance */
+  private[impl] val unreachableToMesosGoneUpdates =
+    Flow[Instance]
+      .filter(_.isUnreachable)
+      .mapConcat { instance =>
+        logger.info(s"Offer received for unreachable reserved instance ${instance.instanceId}")
+        instance.agentInfo.agentId match {
+          case Some(agentIdString) =>
+            instance.tasksMap.values.map { task =>
+              makeGoneStatus(task.taskId, agentIdString)
+            }(breakOut)
+          case None =>
+            Nil
+        }
+      }
+      .named("unreachableToMesosGoneUpdates")
+
+  private[impl] val attributes =
+    ActorAttributes.supervisionStrategy { exception =>
+      logger.error("Exception in offer monitor stream", exception)
+      Supervision.Resume
+    }.and(
+      Attributes.logLevels(
+        onElement = Logging.InfoLevel,
+        onFinish = Logging.InfoLevel,
+        onFailure = Logging.ErrorLevel))
+
+  /** ~> [Offer] ~> [Lookup instance] ~> [TaskStatus] */
+  private[impl] def monitorFlow(
+    lookupInstance: Instance.Id => Future[Option[Instance]]
+  ): Flow[Offer, TaskStatus, NotUsed] =
+    Flow[Offer]
+      .via(reservedInstanceIdsForReservations)
+      .via(lookupInstanceFlow(lookupInstance))
+      .via(unreachableToMesosGoneUpdates)
+      .log("Reservation seen for unreachable instance; Generating TASK_GONE update", identity)
+      .named("monitorFlow")
+
+  /**
+    * See [[UnreachableReservedOfferMonitor$]]
+    *
+    * @param lookupInstance - function used to lookup an instance
+    * @param taskStatusPublisher - function called with each resulting TASK_GONE update
+    */
+  def run(
+    lookupInstance: Instance.Id => Future[Option[Instance]],
+    taskStatusPublisher: TaskStatus => Future[Unit]
+  )(implicit m: Materializer): SourceQueueWithComplete[Offer] = {
+    Source.queue[Offer](
+      bufferSize = BufferSize, overflowStrategy = OverflowStrategy.dropNew)
+      .via(monitorFlow(lookupInstance))
+      // resolving the future will cause any errors to be logged
+      .mapAsyncUnordered(parallelism = Parallelism)(taskStatusPublisher)
+      .to(Sink.ignore) // just a bunch of Units at this point
+      .withAttributes(attributes)
+      .run
+  }
+}

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -28,6 +28,9 @@ case class TestInstanceBuilder(
   def addTaskResidentLaunched(localVolumeIds: Task.LocalVolumeId*): TestInstanceBuilder =
     addTaskWithBuilder().taskResidentLaunched(localVolumeIds: _*).build()
 
+  def addTaskResidentUnreachable(localVolumeIds: Task.LocalVolumeId*): TestInstanceBuilder =
+    addTaskWithBuilder().taskResidentUnreachable(localVolumeIds: _*).build()
+
   def addTaskRunning(containerName: Option[String] = None, stagedAt: Timestamp = now, startedAt: Timestamp = now): TestInstanceBuilder =
     addTaskWithBuilder().taskRunning(containerName, stagedAt, startedAt).build()
 

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -59,6 +59,11 @@ case class TestTaskBuilder(
     this.copy(task = Some(TestTaskBuilder.Helper.residentLaunchedTask(instance.instanceId.runSpecId, localVolumeIds: _*).copy(taskId = Task.Id.forInstanceId(instance.instanceId, None))))
   }
 
+  def taskResidentUnreachable(localVolumeIds: Task.LocalVolumeId*) = {
+    val instance = instanceBuilder.getInstance()
+    this.copy(task = Some(TestTaskBuilder.Helper.residentUnreachableTask(instance.instanceId.runSpecId, localVolumeIds: _*).copy(taskId = Task.Id.forInstanceId(instance.instanceId, None))))
+  }
+
   def taskRunning(containerName: Option[String] = None, stagedAt: Timestamp = now, startedAt: Timestamp = now) = {
     val instance = instanceBuilder.getInstance()
     this.copy(task = Some(TestTaskBuilder.Helper.runningTask(
@@ -289,6 +294,21 @@ object TestTaskBuilder {
           startedAt = Some(now),
           mesosStatus = None,
           condition = Condition.Running,
+          networkInfo = NetworkInfoPlaceholder()
+        ),
+        reservation = Task.Reservation(localVolumeIds.to[Seq], Task.Reservation.State.Launched))
+    }
+
+    def residentUnreachableTask(appId: PathId, localVolumeIds: Task.LocalVolumeId*) = {
+      val now = Timestamp.now()
+      Task.LaunchedOnReservation(
+        taskId = Task.Id.forRunSpec(appId),
+        runSpecVersion = now,
+        status = Task.Status(
+          stagedAt = now,
+          startedAt = Some(now),
+          mesosStatus = None,
+          condition = Condition.Unreachable,
           networkInfo = NetworkInfoPlaceholder()
         ),
         reservation = Task.Reservation(localVolumeIds.to[Seq], Task.Reservation.State.Launched))

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -16,6 +16,8 @@ import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.test.{ MarathonSpec, MarathonTestHelper, Mockito }
 import org.scalatest.GivenWhenThen
+import mesosphere.marathon.util.NoopSourceQueue
+import mesosphere.marathon.test.MarathonTestHelper
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
@@ -294,7 +296,7 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
     taskCreationHandler = mock[InstanceCreationHandler]
 
     new OfferProcessorImpl(
-      conf, clock, new Metrics(new MetricRegistry), offerMatcher, taskLauncher, taskCreationHandler
+      conf, clock, new Metrics(new MetricRegistry), offerMatcher, taskLauncher, taskCreationHandler, NoopSourceQueue()
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitorTest.scala
@@ -1,0 +1,123 @@
+package mesosphere.marathon
+package core.launcher.impl
+
+import org.apache.mesos.Protos.TaskStatus
+import scala.concurrent.{ Future, Promise }
+
+import akka.stream.scaladsl.{ Sink, Source }
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.Instance.AgentInfo
+import mesosphere.marathon.core.instance.TestInstanceBuilder
+import mesosphere.marathon.test.MarathonTestHelper
+import mesosphere.util.state.FrameworkId
+import org.scalatest.Inside
+
+class UnreachableReservedOfferMonitorTest extends AkkaUnitTest with Inside {
+  import mesosphere.marathon.state.PathId._
+  val myFrameworkId = FrameworkId("my-framework")
+
+  val lookupNone =
+    Map.empty[Instance.Id, Future[Option[Instance]]].withDefaultValue(Future.successful(None))
+
+  val appId = "/test".toRootPath
+  val agentInfo = AgentInfo("host", Some("deadbeef-S01"), Nil)
+
+  def reservationFor(instance: Instance, frameworkId: FrameworkId = myFrameworkId) = {
+    val labels = TaskLabels.labelsForTask(myFrameworkId, instance.tasksMap.values.head.taskId).labels
+    MarathonTestHelper.reservation(principal = "marathon", labels)
+  }
+
+  def reservedResource(instance: Instance, frameworkId: FrameworkId = myFrameworkId) = {
+    MarathonTestHelper.scalarResource(
+      "disk", 2, role = "marathon", reservation = Some(reservationFor(instance, frameworkId)))
+  }
+
+  def lookupForInstances(instances: Seq[Instance]) =
+    instances.map { instance =>
+      instance.instanceId -> Future.successful(Option(instance))
+    }.toMap.withDefaultValue(Future.successful(None))
+
+  def taskFor(instance: Instance) = instance.tasksMap.values.head
+
+  def newBuilder =
+    TestInstanceBuilder.newBuilder(appId).withAgentInfo(agentInfo)
+
+  val runningInstance = newBuilder.addTaskResidentLaunched().getInstance
+  val unreachableInstance = newBuilder.addTaskResidentUnreachable().getInstance
+
+  def reservedOffer(instances: Seq[Instance]) = {
+    val b = MarathonTestHelper.makeBasicOffer(role = "marathon").clearResources()
+    instances.foreach { i => b.addResources(reservedResource(i)) }
+    b.setFrameworkId(myFrameworkId.toProto)
+    b
+  }
+
+  "yields a TASK_GONE for unreachable instances, and nothing for running" in {
+    val offerForBothTasks =
+      reservedOffer(Seq(unreachableInstance, runningInstance)).build
+
+    val result = Source(List(offerForBothTasks))
+      .via(
+        UnreachableReservedOfferMonitor.monitorFlow(
+          lookupInstance = lookupForInstances(Seq(runningInstance, unreachableInstance))))
+      .runWith(Sink.seq)
+      .futureValue
+
+    inside(result) {
+      case Seq(taskGoneUpdate) =>
+        taskGoneUpdate.getTaskId.getValue shouldBe taskFor(unreachableInstance).taskId.idString
+    }
+  }
+
+  "ignores other framework Ids" in {
+    val offerForBothTasks =
+      reservedOffer(Seq(unreachableInstance)).build
+
+    val otherOffer = offerForBothTasks.toBuilder
+      .setFrameworkId(
+        FrameworkId("not-the-tasks-framework-id").toProto)
+      .build
+
+    val result = Source(List(otherOffer))
+      .via(
+        UnreachableReservedOfferMonitor.monitorFlow(
+          lookupInstance = lookupForInstances(Seq(runningInstance, unreachableInstance))))
+      .runWith(Sink.seq)
+      .futureValue
+
+    result shouldBe Nil
+  }
+
+  "ignores unknown instances" in {
+    val offerForBothTasks =
+      reservedOffer(Seq(unreachableInstance)).setFrameworkId(FrameworkId("some-other-framework").toProto).build
+
+    val result = Source(List(offerForBothTasks))
+      .via(
+        UnreachableReservedOfferMonitor.monitorFlow(
+          lookupInstance = Map.empty))
+      .runWith(Sink.seq)
+      .futureValue
+
+    result shouldBe Nil
+  }
+
+  "handles lookup exceptions" in {
+    val leTaskStatus = Promise[TaskStatus]
+    val input = UnreachableReservedOfferMonitor.run(
+      lookupInstance = Map(
+        runningInstance.instanceId -> Future.failed(new RuntimeException("very failure")),
+        unreachableInstance.instanceId -> Future.successful(Some(unreachableInstance))),
+      taskStatusPublisher = { status =>
+        leTaskStatus.success(status)
+        Future.successful(())
+      }
+    )
+
+    input.offer(reservedOffer(Seq(unreachableInstance, runningInstance)).build)
+    input.complete()
+
+    leTaskStatus.future.futureValue.getTaskId.getValue shouldBe taskFor(unreachableInstance).taskId.idString
+  }
+}

--- a/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
@@ -14,12 +14,13 @@ import mesosphere.marathon.test.Mockito
 import org.apache.mesos.{ Protos => MesosProtos }
 import org.scalatest.OptionValues._
 import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
+import org.scalatest.Inside
 import play.api.libs.json._
 
 // TODO(cleanup): remove most of the test cases into a NetworkInTest
 import scala.concurrent.duration._
 
-class TaskTest extends FunSuite with Mockito with GivenWhenThen with Matchers {
+class TaskTest extends FunSuite with Mockito with GivenWhenThen with Matchers with Inside {
 
   class Fixture {
 
@@ -162,9 +163,10 @@ class TaskTest extends FunSuite with Mockito with GivenWhenThen with Matchers {
     val mesosStatus = MesosTaskStatusTestHelper.running(taskId)
     val op = TaskUpdateOperation.MesosUpdate(Condition.Running, mesosStatus, f.clock.now)
 
-    val effect = task.update(op)
-
-    effect shouldBe a[TaskUpdateEffect.Failure]
+    inside(task.update(op)) {
+      case effect: TaskUpdateEffect.Update =>
+        effect.newState shouldBe a[Task.LaunchedOnReservation]
+    }
   }
 
   test("a reserved task returns an update") {

--- a/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -116,11 +116,11 @@ class TaskUnreachableIntegrationTest extends AkkaIntegrationFunTest with Embedde
     Then("the update deployment will eventually finish")
     waitForDeployment(update)
 
-      And("The unreachable task is expunged")
-      eventually(inside(marathon.tasks(app.id).value) {
-        case task :: Nil =>
-          task.state shouldBe "TASK_RUNNING"
-      })
+    And("The unreachable task is expunged")
+    eventually(inside(marathon.tasks(app.id).value) {
+      case task :: Nil =>
+        task.state shouldBe "TASK_RUNNING"
+    })
 
     marathon.listDeploymentsForBaseGroup().value should have size 0
   }

--- a/src/test/scala/mesosphere/marathon/util/NoopSourceQueue.scala
+++ b/src/test/scala/mesosphere/marathon/util/NoopSourceQueue.scala
@@ -1,0 +1,24 @@
+package mesosphere.marathon
+package util
+
+import akka.Done
+import akka.stream.QueueOfferResult
+import akka.stream.scaladsl.SourceQueueWithComplete
+import scala.concurrent.Future
+
+class NoopSourceQueue[T] extends SourceQueueWithComplete[T] {
+  override def offer(elem: T): Future[QueueOfferResult] =
+    Future.successful(QueueOfferResult.Enqueued)
+
+  override def watchCompletion(): Future[Done] =
+    Future.successful(Done)
+
+  override def complete(): Unit = ()
+
+  override def fail(ex: Throwable): Unit = ()
+}
+
+object NoopSourceQueue {
+  def apply[T]() =
+    new NoopSourceQueue[T]
+}


### PR DESCRIPTION
Summary: fixes #5284

backport of 32a6d1d1

Test Plan: launch resident tasks, reboot host, see that it is reoffered

Reviewers: meichstedt, jdef, jasongilanfarr, jenkins

Reviewed By: meichstedt, jdef, jasongilanfarr, jenkins

Subscribers: jasongilanfarr, jdef, marathon-team

Differential Revision: https://phabricator.mesosphere.com/D566