### PR TITLE
Revert "Mark unstable tests"

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
@@ -144,7 +144,7 @@ class TombstoneLeaderIntegrationTest extends LeaderIntegrationTest {
   }
 }
 
-@UnstableTest
+@IntegrationTest
 class ReelectionLeaderIntegrationTest extends LeaderIntegrationTest {
 
   override val marathonArgs: Map[String, String] = Map(

--- a/src/test/scala/mesosphere/marathon/integration/NetworkPartitionIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/NetworkPartitionIntegrationTest.scala
@@ -17,7 +17,7 @@ import org.scalatest.time.{ Second, Seconds, Span }
   * This collection of integration tests is intended to go beyond the experience at Verizon.  The network partition in these tests
   * are simulated with a disconnection from the processes.
   */
-@UnstableTest
+@SerialIntegrationTest
 class NetworkPartitionIntegrationTest extends AkkaIntegrationFunTest
     with EmbeddedMarathonMesosClusterTest with Eventually {
 


### PR DESCRIPTION
This reverts commit a509790c9306432fa2ee6159960525af073faf3f.

Let`s mark them stable again for `releases/1.4` <3