### PR TITLE
Add a custom constructor to ServiceMockFacade and make default private

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
@@ -4,65 +4,62 @@ package integration
 import java.io.File
 import java.util.UUID
 
-import mesosphere.AkkaIntegrationFunTest
+import mesosphere.AkkaIntegrationTest
 import mesosphere.marathon.api.v2.json.AppUpdate
 import mesosphere.marathon.core.health.{ HealthCheck, MarathonHttpHealthCheck, PortReference }
 import mesosphere.marathon.core.readiness.ReadinessCheck
-import mesosphere.marathon.integration.facades.ITEnrichedTask
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state._
 import org.apache.commons.io.FileUtils
-import org.apache.mesos.{ Protos => MesosProtos }
 import org.scalatest.concurrent.Eventually
 
-import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 @IntegrationTest
-class ReadinessCheckIntegrationTest extends AkkaIntegrationFunTest with EmbeddedMarathonTest with Eventually {
+class ReadinessCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Eventually {
 
   //clean up state before running the test case
   after(cleanUp())
 
-  test("A deployment of an application with readiness checks (no health) does finish when the plan is ready") {
-    deploy(serviceProxy("/readynohealth".toTestPath, "phase(block1!,block2!,block3!)", withHealth = false), continue = true)
-  }
+  "ReadinessChecks" should {
+    "A deployment of an application with readiness checks (no health) does finish when the plan is ready" in {
+      deploy(serviceProxy("/readynohealth".toTestPath, "phase(block1!,block2!,block3!)", withHealth = false), continue = true)
+    }
 
-  test("A deployment of an application with readiness checks and health does finish when health checks succeed and plan is ready") {
-    deploy(serviceProxy("/readyhealth".toTestPath, "phase(block1!,block2!,block3!)", withHealth = true), continue = true)
-  }
+    "A deployment of an application with readiness checks and health does finish when health checks succeed and plan is ready" in {
+      deploy(serviceProxy("/readyhealth".toTestPath, "phase(block1!,block2!,block3!)", withHealth = true), continue = true)
+    }
 
-  test("A deployment of an application without readiness checks and health does finish when health checks succeed") {
-    deploy(serviceProxy("/noreadyhealth".toTestPath, "phase()", withHealth = true), continue = false)
-  }
+    "A deployment of an application without readiness checks and health does finish when health checks succeed" in {
+      deploy(serviceProxy("/noreadyhealth".toTestPath, "phase()", withHealth = true), continue = false)
+    }
 
-  test("A deployment of an application without readiness checks and without health does finish") {
-    deploy(serviceProxy("/noreadynohealth".toTestPath, "phase()", withHealth = false), continue = false)
-  }
+    "A deployment of an application without readiness checks and without health does finish" in {
+      deploy(serviceProxy("/noreadynohealth".toTestPath, "phase()", withHealth = false), continue = false)
+    }
 
-  test("An upgrade of an application will wait for the readiness checks") {
-    val serviceDef = serviceProxy("/upgrade".toTestPath, "phase(block1!,block2!,block3!)", withHealth = false)
-    deploy(serviceDef, continue = true)
+    "An upgrade of an application will wait for the readiness checks" in {
+      val serviceDef = serviceProxy("/upgrade".toTestPath, "phase(block1!,block2!,block3!)", withHealth = false)
+      deploy(serviceDef, continue = true)
 
       When("The service is upgraded")
       val oldTask = marathon.tasks(serviceDef.id).value.head
       val update = marathon.updateApp(serviceDef.id, AppUpdate(env = Some(EnvVarValue(sys.env))))
 
-        And("The ServiceMock is up")
-      val serviceFacade = createServiceFacade(serviceDef.id){ task =>
-        task.id != oldTask.id&& task.state == MesosProtos.TaskState.TASK_RUNNING.name()
+      And("The ServiceMock is up")
+      val serviceFacade = ServiceMockFacade(marathon.tasks(serviceDef.id).value){ task =>
+        task.id != oldTask.id && task.launched
       }
 
       Then("The deployment does not succeed until the readiness checks succeed")
-
       while (serviceFacade.plan().code != 200) {
         When("We continue on block until the plan is ready")
         serviceFacade.continue()
         marathon.listDeploymentsForBaseGroup().value should have size 1
       }
       waitForDeployment(update)
-
+    }
   }
 
   def deploy(service: AppDefinition, continue: Boolean): Unit = {
@@ -70,9 +67,7 @@ class ReadinessCheckIntegrationTest extends AkkaIntegrationFunTest with Embedded
     val result = marathon.createAppV2(service)
     result.code should be (201)
     When("The ServiceMock is up")
-    val serviceFacade = createServiceFacade(service.id) { task =>
-      task.state == MesosProtos.TaskState.TASK_RUNNING.name()
-    }
+    val serviceFacade = ServiceMockFacade(marathon.tasks(service.id).value)(_.launched)
 
     while (continue && serviceFacade.plan().code != 200) {
       When("We continue on block until the plan is ready")
@@ -84,19 +79,12 @@ class ReadinessCheckIntegrationTest extends AkkaIntegrationFunTest with Embedded
     waitForDeployment(result)
   }
 
-  def createServiceFacade(id: PathId)(predicate: (ITEnrichedTask) => Boolean): ServiceMockFacade = eventually {
-    val newTask = marathon.tasks(id).value.find(predicate(_)).get
-    val serviceFacade = new ServiceMockFacade(newTask)
-    serviceFacade.plan()
-    serviceFacade
-  }
-
   def serviceProxy(appId: PathId, plan: String, withHealth: Boolean): AppDefinition = {
     AppDefinition(
       id = appId,
       cmd = Some(s"""$serviceMockScript '$plan'"""),
       executor = "//cmd",
-      resources = Resources(cpus = 0.5, mem = 128.0),
+      resources = Resources(cpus = 0.01, mem = 128.0),
       upgradeStrategy = UpgradeStrategy(0, 0),
       portDefinitions = Seq(PortDefinition(0, name = Some("http"))),
       healthChecks =

--- a/src/test/scala/mesosphere/marathon/integration/setup/ServiceMockFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ServiceMockFacade.scala
@@ -1,29 +1,48 @@
 package mesosphere.marathon.integration.setup
 
 import akka.actor.ActorSystem
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.integration.facades.ITEnrichedTask
-import org.slf4j.LoggerFactory
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{ Seconds, Span }
 import play.api.libs.json.{ JsValue, Json }
 import spray.client.pipelining._
 import spray.http.HttpResponse
 
 import scala.concurrent.duration.{ Duration, _ }
 
-class ServiceMockFacade(task: ITEnrichedTask, waitTime: Duration = 30.seconds)(implicit system: ActorSystem) {
+class ServiceMockFacade private (val task: ITEnrichedTask, waitTime: Duration = 30.seconds)(implicit system: ActorSystem) extends StrictLogging {
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  val log = LoggerFactory.getLogger(classOf[ServiceMockFacade])
+  private val baseUrl = s"http://${task.host}:${task.ports.map(_.head).get}"
 
-  val baseUrl = s"http://${task.host}:${task.ports.map(_.head).get}"
-
-  val pipeline = sendReceive
+  private val pipeline = sendReceive
 
   def continue(): RestResult[HttpResponse] = {
-    log.info(s"Continue with the service migration: $baseUrl/v1/plan/continue")
+    logger.info(s"Continue with the service migration: $baseUrl/v1/plan/continue")
     RestResult.await(pipeline(Post(s"$baseUrl/v1/plan/continue")), waitTime)
   }
 
   def plan(): RestResult[JsValue] = {
     RestResult.await(pipeline(Get(s"$baseUrl/v1/plan")), waitTime).map(_.entity.asString).map(Json.parse)
+  }
+}
+
+object ServiceMockFacade extends Eventually {
+  override implicit lazy val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(30, Seconds))
+
+  /**
+    * Eventually creates a ServiceMockFacade if a task can be found that responds to http requests.
+    * @param loadTasks A function that is able to load tasks. This is by name on purpose because it will be polled
+    *                  until a task can be loaded that matches the given predicate.
+    *                  This will usually be something like marathonFacade.tasks(runSpecId)
+    * @param predicate The predicate that a task must fulfil in order to build wrap a ServiceMockFacade around it
+    *                  Use the predicate to look for a task in a certain state, or check it's ID for (un-)equality.
+    */
+  def apply(loadTasks: => Seq[ITEnrichedTask])(predicate: (ITEnrichedTask) => Boolean)(implicit system: ActorSystem): ServiceMockFacade = eventually {
+    val newTask = loadTasks.find(predicate(_)).get
+    val serviceFacade = new ServiceMockFacade(newTask)
+    serviceFacade.plan()
+    serviceFacade
   }
 }


### PR DESCRIPTION
Summary:
The tests previously used the facade as soon as a task was running and did not realize when the task failed (e.g. when failing to bind to the configured port). The custom constructor ensures that the facade is only used when the task actually responds to a request.

Note: RestartIntegrationTest is not applicable to releases/1.4 since dependent test classes are not present.

cherry-picked from master 8814cda7439e117adcd7caa34894c321fb0bfe74

Addresses MARATHON-1840, MARATHON-6993, MARATHON-7000

Test Plan: integration:test

Reviewers: timcharper, zen-dog, jenkins, unterstein, jeschkies

Reviewed By: zen-dog, jenkins, unterstein

Subscribers: marathon-team

Differential Revision: https://phabricator.mesosphere.com/D589

Conflicts:
	src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
	src/test/scala/mesosphere/marathon/integration/RestartIntegrationTest.scala