### PR TITLE
Resident tasks should update network info on MesosUpdate with assigned ipAddresses

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -486,11 +486,13 @@ object Task {
 
       // case 1: now running
       case TaskUpdateOperation.MesosUpdate(Condition.Running, mesosStatus, now) if !hasStartedRunning =>
+        val updatedNetworkInfo = status.networkInfo.update(mesosStatus)
         val updated = copy(
           status = status.copy(
             startedAt = Some(now),
             mesosStatus = Some(mesosStatus),
-            condition = Condition.Running))
+            condition = Condition.Running,
+            networkInfo = updatedNetworkInfo))
         TaskUpdateEffect.Update(updated)
 
       // case 2: terminal
@@ -508,11 +510,14 @@ object Task {
         TaskUpdateEffect.Update(updatedTask)
 
       // case 3: health or state updated
-      case TaskUpdateOperation.MesosUpdate(newStatus, mesosUpdate, _) =>
-        updatedHealthOrState(status.mesosStatus, mesosUpdate).map { newTaskStatus =>
+      case TaskUpdateOperation.MesosUpdate(newStatus, mesosStatus, _) =>
+        updatedHealthOrState(status.mesosStatus, mesosStatus).map { newTaskStatus =>
+          val updatedNetworkInfo = status.networkInfo.update(mesosStatus)
           val updatedTask = copy(status = status.copy(
             mesosStatus = Some(newTaskStatus),
-            condition = newStatus))
+            condition = newStatus,
+            networkInfo = updatedNetworkInfo
+          ))
           TaskUpdateEffect.Update(newState = updatedTask)
         } getOrElse {
           log.debug("Ignoring status update for {}. Status did not change.", taskId)


### PR DESCRIPTION
Summary:
Currently resident task do not store assigned ipAddresses during Task#update.

Fixes: https://jira.mesosphere.com/browse/MARATHON-7050
Fixes: https://jira.mesosphere.com/browse/MARATHON-7056

also-by: unterstein, meichstedt

Test Plan: sbt "test-only *TaskTest"

Reviewers: timcharper, jasongilanfarr, jenkins, unterstein, jdef

Reviewed By: timcharper, jenkins, unterstein, jdef

Subscribers: jdef, marathon-team

Differential Revision: https://phabricator.mesosphere.com/D606

Conflicts:
	src/test/scala/mesosphere/marathon/core/task/TaskTest.scala