### PR TITLE
Fixes #4921 by giving current running instances to the AppStartActor…

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -134,7 +134,7 @@ private class DeploymentActor(
     val promise = Promise[Unit]()
     instanceTracker.specInstances(runnableSpec.id).map { instances =>
       context.actorOf(AppStartActor.props(deploymentManager, status, scheduler, launchQueue, instanceTracker,
-        eventBus, readinessCheckExecutor, runnableSpec, scaleTo, promise))
+        eventBus, readinessCheckExecutor, runnableSpec, scaleTo, instances, promise))
     }
     promise.future
   }

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -1,7 +1,6 @@
 
 package mesosphere.marathon.upgrade
 
-import akka.Done
 import akka.actor.{ Actor, ActorLogging, ActorRef, Props }
 import akka.event.EventStream
 import mesosphere.marathon.core.event.DeploymentStatus
@@ -11,7 +10,7 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.RunSpec
 import mesosphere.marathon.{ SchedulerActions, TaskUpgradeCanceledException }
 
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.Promise
 
 class TaskStartActor(
     val deploymentManager: ActorRef,
@@ -30,11 +29,7 @@ class TaskStartActor(
     scaleTo - launchQueue.get(runSpec.id).map(_.finalInstanceCount)
       .getOrElse(instanceTracker.countLaunchedSpecInstancesSync(runSpec.id)))
 
-  def initializeStart(): Future[Done] = Future.successful{
-    if (nrToStart > 0)
-      launchQueue.add(runSpec, nrToStart)
-    Done
-  }
+  def initializeStart(): Unit = if (nrToStart > 0) launchQueue.add(runSpec, nrToStart)
 
   override def postStop(): Unit = {
     eventBus.unsubscribe(self)

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -110,7 +110,7 @@ class AppStartActorTest extends AkkaUnitTest {
 
       def startActor(app: AppDefinition, scaleTo: Int, promise: Promise[Unit]): TestActorRef[AppStartActor] =
         TestActorRef(AppStartActor.props(deploymentManager.ref, deploymentStatus, scheduler,
-          launchQueue, instanceTracker, system.eventStream, readinessCheckExecutor, app, scaleTo, promise)
+          launchQueue, instanceTracker, system.eventStream, readinessCheckExecutor, app, scaleTo, Seq.empty, promise)
         )
     }
   }

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -1,6 +1,9 @@
 package mesosphere.marathon
 package upgrade
 
+import java.util.UUID
+
+import akka.actor.Terminated
 import akka.testkit.{ TestActorRef, TestProbe }
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.condition.Condition
@@ -33,7 +36,9 @@ class AppStartActorTest extends AkkaUnitTest {
       promise.future.futureValue(Timeout(5.seconds))
 
       verify(f.scheduler).startRunSpec(app.copy(instances = 2))
-      expectTerminated(ref)
+      fishForMessage(max = Duration.Undefined, hint = "Actor terminated") {
+        case t: Terminated => t.actor == ref
+      }
     }
 
     "With Health Checks" in {
@@ -52,7 +57,9 @@ class AppStartActorTest extends AkkaUnitTest {
       promise.future.futureValue(Timeout(5.seconds))
 
       verify(f.scheduler).startRunSpec(app.copy(instances = 2))
-      expectTerminated(ref)
+      fishForMessage(max = Duration.Undefined, hint = "Actor terminated") {
+        case t: Terminated => t.actor == ref
+      }
     }
 
     "No tasks to start without health checks" in {
@@ -65,7 +72,9 @@ class AppStartActorTest extends AkkaUnitTest {
       promise.future.futureValue(Timeout(5.seconds))
 
       verify(f.scheduler).startRunSpec(app.copy(instances = 0))
-      expectTerminated(ref)
+      fishForMessage(max = Duration.Undefined, hint = "Actor terminated") {
+        case t: Terminated => t.actor == ref
+      }
     }
 
     "No tasks to start with health checks" in {
@@ -81,7 +90,9 @@ class AppStartActorTest extends AkkaUnitTest {
       promise.future.futureValue(Timeout(5.seconds))
 
       verify(f.scheduler).startRunSpec(app.copy(instances = 0))
-      expectTerminated(ref)
+      fishForMessage(max = Duration.Undefined, hint = "Actor terminated") {
+        case t: Terminated => t.actor == ref
+      }
     }
 
     class Fixture {
@@ -93,7 +104,7 @@ class AppStartActorTest extends AkkaUnitTest {
       val deploymentManager: TestProbe = TestProbe()
       val deploymentStatus: DeploymentStatus = mock[DeploymentStatus]
       val readinessCheckExecutor: ReadinessCheckExecutor = mock[ReadinessCheckExecutor]
-      val appId = PathId("/app")
+      val appId = PathId(s"/app-${UUID.randomUUID()}")
 
       launchQueue.get(appId) returns None
 


### PR DESCRIPTION
… instead of requesting this list inside the actor.

Note:
* this patch is re-applied because a previous cherry-pick incidentally reverted the original backport.
* the second commit addresses failures see in https://jenkins.mesosphere.com/service/jenkins/job/marathon-pipelines/job/releases%252F1.4/85/
```
assertion failed: expected: Terminated TestActor[akka://AppStartActorTest/user/$$ld] but got unexpected message Terminated(TestActor[akka://AppStartActorTest/user/$$kd])
```

Summary: This list has to be known before the actor actually starts.

Note: this patch was re-applied because an earlier verry-pick incidentally reverted the related changes.

Fixes MARATHON-7057

Test Plan: sbt test

Reviewers: jeschkies, timcharper, janisz

Reviewed By: jeschkies, timcharper, janisz

Subscribers: janisz, jenkins, marathon-team

Differential Revision: https://phabricator.mesosphere.com/D403

Conflicts:
	src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
	src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
	src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala