### PR TITLE
Only modify the version cache if it was loaded from the underlying store

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
@@ -1,4 +1,5 @@
-package mesosphere.marathon.api.v2
+package mesosphere.marathon
+package api.v2
 
 import java.net._
 

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
@@ -197,8 +197,11 @@ case class LazyVersionCachingPersistentStore[K, Category, Serialized](
     val unversionedId = ir.toStorageId(id, None)
     maybePurgeCachedVersions()
     versionedValueCache.put((unversionedId, version), v)
-    val cached = versionCache.getOrElse((category, unversionedId), Set.empty) // linter:ignore UndesirableTypeInference
-    versionCache.put((category, unversionedId), cached + version)
+    if (versionCache.contains((category, unversionedId))) {
+      // possible race: there is no way to get/update the value in place
+      val cached = versionCache.getOrElse((category, unversionedId), Set.empty) // linter:ignore UndesirableTypeInference
+      versionCache.put((category, unversionedId), cached + version)
+    }
   }
 
   @SuppressWarnings(Array("all")) // async/await

--- a/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
@@ -2,10 +2,11 @@ package mesosphere.marathon.state
 
 import mesosphere.marathon.state.PathId._
 import org.scalatest.{ FunSpec, GivenWhenThen, Matchers }
+import com.wix.accord.scalatest.ResultMatchers
 
 import scala.collection.SortedSet
 
-class PathIdTest extends FunSpec with GivenWhenThen with Matchers {
+class PathIdTest extends FunSpec with GivenWhenThen with Matchers with ResultMatchers {
 
   describe("A PathId") {
 
@@ -162,6 +163,26 @@ class PathIdTest extends FunSpec with GivenWhenThen with Matchers {
     it("can be sorted if it was reversed") {
       SortedSet(c, b, a).toSeq should equal(Seq(a, b, c))
       SortedSet(ac, ab, aa).toSeq should equal(Seq(aa, ab, ac))
+    }
+  }
+
+  describe("The PathId validation") {
+
+    describe("passed legal characters") {
+      it("be valid") {
+        val path = PathId("/foobar-0")
+        val validation = PathId.pathIdValidator(path)
+        validation shouldBe aSuccess
+      }
+    }
+
+    describe("passed illegal characters") {
+      it("be invalid") {
+        val path = PathId("/@§\'foobar-0")
+        val validation = PathId.pathIdValidator(path)
+        val expectedViolation = RuleViolationMatcher(value = "@§'foobar-0", constraint = "must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$'")
+        validation should failWith(expectedViolation)
+      }
     }
   }
 }


### PR DESCRIPTION
Summary:
Fixes MARATHON-7133

See also D626 and D627

Backport of 3357f792

Test Plan: sbt test

Reviewers: jeschkies, jenkins, aquamatthias

Reviewed By: jeschkies, jenkins, aquamatthias

Subscribers: marathon-team

JIRA Issues: MARATHON-7133

Differential Revision: https://phabricator.mesosphere.com/D631