### PR TITLE
Version with Git

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import com.typesafe.sbt.packager.docker.ExecCmd
 import mesosphere.raml.RamlGeneratorPlugin
 import sbt.Tests.SubProcess
-import sbtrelease.ReleaseStateTransformations._
 
 import scalariform.formatter.preferences.{AlignArguments, AlignParameters, AlignSingleLineCaseStatements, CompactControlReadability, DanglingCloseParenthesis, DoubleIndentClassDeclaration, FormatXml, FormattingPreferences, IndentSpaces, IndentWithTabs, MultilineScaladocCommentsStartOnFirstLine, PlaceScaladocAsterisksBeneathSecondAsterisk, Preserve, PreserveSpaceBeforeArguments, SpaceBeforeColon, SpaceInsideBrackets, SpaceInsideParentheses, SpacesAroundMultiImports, SpacesWithinPatternBinders}
 
@@ -106,15 +105,6 @@ lazy val commonSettings = inConfig(SerialIntegrationTest)(Defaults.testTasks) ++
     "Mesosphere Public Repo" at "https://downloads.mesosphere.com/maven"
   ),
   cancelable in Global := true,
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runTest,
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    pushChanges
-  ),
 
   publishTo := Some(s3resolver.value(
     "Mesosphere Public Repo (S3)",
@@ -170,7 +160,9 @@ lazy val commonSettings = inConfig(SerialIntegrationTest)(Defaults.testTasks) ++
   scapegoatVersion := "1.2.1",
 
   coverageMinimum := 67,
-  coverageFailOnMinimum := true
+  coverageFailOnMinimum := true,
+  // non-tagged builds use this. Should _always_ end in snapshot.
+  git.baseVersion := "1.4.0-SNAPSHOT"
 )
 
 // TODO: Move away from sbt-assembly, favoring sbt-native-packager
@@ -229,7 +221,7 @@ lazy val marathon = (project in file("."))
   .configs(UnstableTest)
   .configs(UnstableIntegrationTest)
   .enablePlugins(BuildInfoPlugin, GitBranchPrompt,
-    JavaServerAppPackaging, DockerPlugin, CopyPasteDetector, RamlGeneratorPlugin)
+    JavaServerAppPackaging, DockerPlugin, CopyPasteDetector, RamlGeneratorPlugin, GitVersioning)
   .dependsOn(`plugin-interface`)
   .settings(commonSettings: _*)
   .settings(formatSettings: _*)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "1.4.1"


### PR DESCRIPTION
Summary:
Instead of having a lot of potential for human error, let
the git tag define the proper version:

Exact tag, e.g. v1.5.0 => 1.5.0
Not at tag, use git.baseVersion => 1.5.0-SNAPSHOT-<num commits>-<short sha>

Backport of df08a615

Test Plan: tagged a build, checked version, deleted tag, got a new version (1.5.0-SNAPSHOT-356-gdafc58f)

Reviewers: jeschkies, timcharper, aquamatthias, jenkins

Reviewed By: jeschkies, jenkins

Subscribers: marathon-team

JIRA Issues: MARATHON-7120