### PR TITLE
Tharper/merge 1.4.2 snapshot3 changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,28 @@
 
+## Changes from 1.4.1 to 1.4.2 (unreleased)
+Bugfix release
+
+### Fixed issues
+- [MARATHON-4570](https://jira.mesosphere.com/browse/MARATHON-4570) Don't destroy persistent volumes when killing unreachable tasks
+- [MARATHON-4390](https://jira.mesosphere.com/browse/MARATHON-4390) Lazy event parsing
+- Improve health checks to log less warnings.
+- [MARATHON-1712](https://jira.mesosphere.com/browse/MARATHON-1712) Loosen SSL requirements for HTTPS health checks.
+- [MARATHON-1408](https://jira.mesosphere.com/browse/MARATHON-1408) Fix serialization of maxSize for persistent volumes.
+- [MARATHON-2311](https://jira.mesosphere.com/browse/MARATHON-2311) Publish a TASK_GONE mesos update when an unreachable instance's resources are seen.
+- [MARATHON-1682](https://jira.mesosphere.com/browse/MARATHON-1682) Persist kill selection.
+- Disable unreachable strategy for resident tasks
+- Add a migration to fix the unreachable strategy for resident apps.
+- Read LaunchedOnReservation and ReservedTasks.
+- ForceExpunge for a missing task is a noop rather than a failure.
+- Use non-deployment-interacting kill service during kill and wipe.
+- Validation of application dependencies is too restrictive, loosed the requirements.
+- Retry failed integration tests once.
+- Fix stability in many integration tests.
+
+### Known issues
+
+
+
 ## Changes from 1.4.0 to 1.4.1
 Bugfix release
 


### PR DESCRIPTION
I would motion that we actually merge these rather than squash / rebase.

```
$ git log origin/releases/1.4..v1.4.2-snapshot3
commit 73d5b3d6a35e3f9ba020514b9ad3ce3824b4d98e
Author: Tim Harper <tharper@mesosphere.com>
Date:   Tue Mar 14 16:24:18 2017 -0700

    Setting version to 1.4.2-snapshot3

commit 414d0a6dbecd987919f52478e41c1e293bc415c3
Author: Jason Gilanfarr <jason@mesosphere.com>
Date:   Thu Mar 9 13:59:26 2017 -0800

    Fix version.sbt too, it should only be missing -SNAPSHOT for official releases

commit 6a6c582246c0fae59099a29d79b11bf8191f071f
Author: Jason Gilanfarr <jason@mesosphere.com>
Date:   Thu Mar 9 13:21:17 2017 -0800

    Update changelog with 1.4.2 unreleased issues

    Summary: Follow through the log, try to find the JIRAs.

    Test Plan: N/A

    Reviewers: timcharper, jdef

    Subscribers: marathon-team

    Differential Revision: https://phabricator.mesosphere.com/D594

commit 25715d498af8d7bd6a9926faa06c09e45e92da55
Author: Matthias Veit <matthias_veit@yahoo.de>
Date:   Tue Mar 14 10:57:06 2017 -0700

    Fixes MARATHON-7055 by removing the Unstable tag.

    The test was already fixed, but the Unstable tag was not removed.
```