### PR TITLE
Use localhost of configuration for MetricsReporter

### DIFF
--- a/src/main/scala/mesosphere/marathon/metrics/MetricsReporterConf.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/MetricsReporterConf.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.metrics
 
-import org.rogach.scallop.ScallopConf
+import org.rogach.scallop.{ ScallopConf, ScallopOption }
 
 trait MetricsReporterConf extends ScallopConf {
 
@@ -15,5 +15,7 @@ trait MetricsReporterConf extends ScallopConf {
     descr = "URL to dogstatsd agent. e.g. udp://localhost:8125?prefix=marathon-test&tags=marathon&interval=10",
     noshort = true
   )
+
+  def hostname: ScallopOption[String]
 }
 

--- a/src/main/scala/mesosphere/marathon/metrics/MetricsReporterService.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/MetricsReporterService.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package metrics
 
-import java.net.{ InetAddress, InetSocketAddress, URI }
+import java.net.{ InetSocketAddress, URI }
 import java.util
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -115,7 +115,7 @@ class MetricsReporterService @Inject() (config: MetricsReporterConf, registry: M
     val reporter = DatadogReporter
       .forRegistry(registry)
       .withTransport(transport)
-      .withHost(InetAddress.getLocalHost.getHostName)
+      .withHost(config.hostname())
       .withPrefix(prefix)
       .withExpansions(util.EnumSet.copyOf(expansions.flatMap(e => Expansion.values().find(_.toString == e))))
       .withTags(tags)


### PR DESCRIPTION
MoM on centos has problems getting hostname for localhost. In general the own hostname should not be calculated each time, instead a configuration should be used or it should be calculated only on startup.

Test Plan:
sbt "test"
sbt "integration:test"

JIRA Issues:
DCOS-14303 Marathon requires the hostname inside /etc/hosts

Code not on master anymore, therefore only PR against releases/1.4