### PR TITLE
Switch tests to use SSE event stream instead of webhooks

### DIFF
--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
@@ -13,6 +13,7 @@ import play.api.libs.json._
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
+import scala.concurrent.Future
 
 object SingleAppScalingTest {
   val metricsFile = "scaleUp20s-metrics"
@@ -29,6 +30,8 @@ class SingleAppScalingTest extends AkkaIntegrationFunTest with ZookeeperServerTe
     "task_launch_confirm_timeout" -> "1000"),
     mainClass = "mesosphere.mesos.simulation.SimulateMesosMain")
 
+  override lazy val leadingMarathon = Future.successful(marathonServer)
+
   override lazy val marathonUrl: String = s"http://localhost:${marathonServer.httpPort}"
   override lazy val testBasePath: PathId = PathId.empty
   override lazy val marathon: MarathonFacade = new MarathonFacade(marathonUrl, testBasePath)
@@ -39,6 +42,9 @@ class SingleAppScalingTest extends AkkaIntegrationFunTest with ZookeeperServerTe
   override def beforeAll(): Unit = {
     super.beforeAll()
     marathonServer.start().futureValue
+    val sseStream = startEventSubscriber()
+    system.registerOnTermination(sseStream.cancel())
+    waitForSSEConnect()
   }
 
   override def afterAll(): Unit = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,7 +54,6 @@ object Dependencies {
     scalaLogging % "compile",
     logstash % "compile",
     raven % "compile",
-    akkaHttpPlayJson % "compile",
 
     // test
     Test.diffson % "test",
@@ -63,7 +62,8 @@ object Dependencies {
     Test.akkaTestKit % "test",
     Test.junit % "test",
     Test.scalacheck % "test",
-    Test.wixAccordScalatest % "test"
+    Test.wixAccordScalatest % "test",
+    Test.akkaSse % "test"
   ).map(_.excludeAll(excludeSlf4jLog4j12).excludeAll(excludeLog4j).excludeAll(excludeJCL))
 
   val benchmark = Seq(
@@ -80,7 +80,7 @@ object Dependency {
     val Mesos = "1.1.0"
     // Version of Mesos to use in Dockerfile.
     val MesosDebian = "1.1.0-2.0.107.debian81"
-    val Akka = "2.4.13"
+    val Akka = "2.4.17"
     val AsyncAwait = "0.9.6"
     val Spray = "1.3.4"
     val TwitterCommons = "0.0.76"
@@ -123,8 +123,7 @@ object Dependency {
   val akkaActor = "com.typesafe.akka" %% "akka-actor" % V.Akka
   val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % V.Akka
   val akkaStream = "com.typesafe.akka" %% "akka-stream" % V.Akka
-  val akkaHttp = "com.typesafe.akka" %% "akka-http-experimental" % "2.4.11"
-  val akkaHttpPlayJson = "de.heikoseeberger" %% "akka-http-play-json" % "1.10.1"
+  val akkaHttp = "com.typesafe.akka" %% "akka-http" % "10.0.5"
   val asyncAwait = "org.scala-lang.modules" %% "scala-async" % V.AsyncAwait
   val sprayClient = "io.spray" %% "spray-client" % V.Spray
   val sprayHttpx = "io.spray" %% "spray-httpx" % V.Spray
@@ -170,5 +169,6 @@ object Dependency {
     val junit = "junit" % "junit" % V.JUnit
     val scalacheck = "org.scalacheck" %% "scalacheck" % V.ScalaCheck
     val wixAccordScalatest = "com.wix" %% "accord-scalatest" % V.WixAccord
+    val akkaSse = "de.heikoseeberger" %% "akka-sse" % "2.0.0"
   }
 }

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployWithLeaderAbdicationIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployWithLeaderAbdicationIntegrationTest.scala
@@ -71,6 +71,7 @@ class AppDeployWithLeaderAbdicationIntegrationTest extends AkkaIntegrationFunTes
 
     And("a new leader is elected")
     WaitTestSupport.waitUntil("the leader changes", 30.seconds) { secondary.leader().value != leader }
+    waitForSSEConnect()
 
     And("the updated task becomes healthy")
     // This would move the service mock from "InProgress" [HTTP 503] to "Complete" [HTTP 200]

--- a/src/test/scala/mesosphere/marathon/integration/DeploymentLeaderAbdicationIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/DeploymentLeaderAbdicationIntegrationTest.scala
@@ -53,6 +53,8 @@ abstract class DeploymentLeaderAbdicationIntegrationTest extends LeaderIntegrati
 
     And("a new leader is elected")
     WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstRunningProcess.client.leader().code == 200 }
+    waitForSSEConnect()
+
     marathonFacade = firstRunningProcess.client
 
     And("second updated task becomes healthy")

--- a/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
@@ -156,7 +156,7 @@ class ReelectionLeaderIntegrationTest extends LeaderIntegrationTest {
 
   test("it survives a small reelection test") {
 
-    for (_ <- 1 to 15) {
+    for (_ <- 1 to 8) {
       Given("a leader")
       WaitTestSupport.waitUntil("a leader has been elected", 30.seconds) { firstRunningProcess.client.leader().code == 200 }
 

--- a/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -123,7 +123,7 @@ class MesosAppIntegrationTest
     val podId = testBasePath / "healthypod"
     val containerDir = "/opt/marathon"
     def appMockCommand(port: String) = s"""echo APP PROXY $$MESOS_TASK_ID RUNNING; /opt/marathon/python/app_mock.py """ +
-      s"""$port $podId v1 http://127.0.0.1:${callbackEndpoint.localAddress.getPort}/health$podId/v1"""
+      s"""$port $podId v1 http://127.0.0.1:${healthEndpoint.localAddress.getPort}/health$podId/v1"""
 
     val pod = PodDefinition(
       id = podId,

--- a/src/test/scala/mesosphere/marathon/integration/NetworkPartitionIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/NetworkPartitionIntegrationTest.scala
@@ -82,6 +82,7 @@ class NetworkPartitionIntegrationTest extends AkkaIntegrationFunTest
     // Simulate Systemd rebooting Marathon
     marathonServer.start()
     eventually { marathonServer.isRunning should be(true) }
+    waitForSSEConnect()
 
     Then("The task reappears as running")
     waitForEventMatching("Task is declared running again") {

--- a/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -1,9 +1,11 @@
 package mesosphere.marathon
 package integration.facades
 
+import com.typesafe.scalalogging.StrictLogging
 import java.io.File
 import java.util.Date
 
+import akka.NotUsed
 import akka.actor.ActorSystem
 import mesosphere.marathon.api.v2.json.{ AppUpdate, GroupUpdate }
 import mesosphere.marathon.core.event.{ EventSubscribers, Subscribe, Unsubscribe }
@@ -18,12 +20,38 @@ import play.api.libs.json.JsArray
 import spray.client.pipelining._
 import spray.http._
 import spray.httpx.PlayJsonSupport
+import akka.http.scaladsl.{ Http => AkkaHttp }
+import akka.http.scaladsl.client.RequestBuilding.{ Get => AkkaGet }
+import akka.http.scaladsl.model.{ MediaType => AkkaMediaType }
+import akka.http.scaladsl.model.headers.{ Accept => AkkaAccept }
+import akka.http.scaladsl.unmarshalling.{ Unmarshal => AkkaUnmarshal }
+import de.heikoseeberger.akkasse.ServerSentEvent
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Await.result
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import mesosphere.marathon.stream._
+
+import com.typesafe.scalalogging.StrictLogging
+
+import akka.NotUsed
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import de.heikoseeberger.akkasse.EventStreamUnmarshalling
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import akka.http.scaladsl.{ Http => AkkaHttp }
+import akka.http.scaladsl.client.RequestBuilding.{ Get => AkkaGet }
+import akka.http.scaladsl.model.{ MediaType => AkkaMediaType }
+import akka.http.scaladsl.model.headers.{ Accept => AkkaAccept }
+import akka.http.scaladsl.unmarshalling.{ Unmarshal => AkkaUnmarshal }
+import de.heikoseeberger.akkasse.ServerSentEvent
+import scala.concurrent.Future
 
 /**
   * GET /apps will deliver something like Apps instead of List[App]
@@ -51,7 +79,7 @@ case class ITEnrichedTask(
   def suspended: Boolean = startedAt.isEmpty
 }
 case class ITLeaderResult(leader: String) {
-  val port = leader.split(":")(1)
+  val port: Integer = leader.split(":")(1).toInt
 }
 
 case class ITListDeployments(deployments: Seq[ITDeployment])
@@ -62,15 +90,25 @@ case class ITLaunchQueue(queue: List[ITQueueItem])
 
 case class ITDeployment(id: String, affectedApps: Seq[String], affectedPods: Seq[String])
 
+sealed trait ITSSEEvent
+/** Used to signal that the SSE stream is connected */
+case object ITConnected extends ITSSEEvent
+
+/** models each SSE published event */
+case class ITEvent(eventType: String, info: Map[String, Any]) extends ITSSEEvent
+
 /**
   * The MarathonFacade offers the REST API of a remote marathon instance
   * with all local domain objects.
   *
   * @param url the url of the remote marathon instance
   */
-class MarathonFacade(val url: String, baseGroup: PathId, waitTime: Duration = 30.seconds)(implicit val system: ActorSystem)
+class MarathonFacade(
+  val url: String, baseGroup: PathId, waitTime: Duration = 30.seconds)(
+  implicit
+  val system: ActorSystem, mat: Materializer)
     extends PlayJsonSupport
-    with PodConversion {
+    with PodConversion with StrictLogging {
   implicit val scheduler = system.scheduler
   import SprayHttpResponse._
 
@@ -119,6 +157,38 @@ class MarathonFacade(val url: String, baseGroup: PathId, waitTime: Duration = 30
 
   def marathonSendReceive: SendReceive = {
     addHeader("Accept", "*/*") ~> sendReceive
+  }
+
+  // we don't want to lose any events and the default maxEventSize is too small (8K)
+  object EventUnmarshalling extends EventStreamUnmarshalling {
+    override protected def maxEventSize: Int = Int.MaxValue
+    override protected def maxLineSize: Int = Int.MaxValue
+  }
+
+  /**
+    * Connects to the Marathon SSE endpoint. Future completes when the http connection is established. Events are
+    * streamed via the materializable-once Source.
+    */
+  def events(): Future[Source[ITEvent, NotUsed]] = {
+
+    import EventUnmarshalling.fromEventStream
+    val mapper = new ObjectMapper() with ScalaObjectMapper
+    mapper.registerModule(DefaultScalaModule)
+
+    AkkaHttp().singleRequest(AkkaGet(s"$url/v2/events").withHeaders(AkkaAccept(AkkaMediaType.text("event-stream"))))
+      .flatMap { response =>
+        AkkaUnmarshal(response).to[Source[ServerSentEvent, NotUsed]]
+      }
+      .map { stream =>
+        stream
+          .map { event =>
+            event.data.map { d =>
+              val json = mapper.readValue[Map[String, Any]](d) // linter:ignore
+              ITEvent(event.`type`.getOrElse("unknown"), json)
+            }
+          }
+          .collect { case Some(event) => event }
+      }
   }
 
   //app resource ----------------------------------------------
@@ -387,8 +457,12 @@ class MarathonFacade(val url: String, baseGroup: PathId, waitTime: Duration = 30
 
   //leader ----------------------------------------------
   def leader(): RestResult[ITLeaderResult] = {
+    result(leaderAsync(), waitTime)
+  }
+
+  def leaderAsync(): Future[RestResult[ITLeaderResult]] = {
     val pipeline = marathonSendReceive ~> read[ITLeaderResult]
-    result(Retry("leader") { pipeline(Get(s"$url/v2/leader")) }, waitTime)
+    Retry("leader") { pipeline(Get(s"$url/v2/leader")) }
   }
 
   def abdicate(): RestResult[HttpResponse] = {


### PR DESCRIPTION
Summary:
This preserves ordering of events in the receiver as emitted by
Marathon. Builds on a subset of the changes from D364

Backport of 1c48c8e2

Test Plan: target with loop build; observe stability

Reviewers: jeschkies, jasongilanfarr, jenkins

Reviewed By: jeschkies, jasongilanfarr, jenkins

Subscribers: marathon-team

JIRA Issues: MARATHON-7123, MARATHON-7181, MARATHON-7177