### PR TITLE
Add Marathon sbt plugin to clients listing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Across all installations Marathon is managing applications on more than 100,000 
 * [Strava](https://www.strava.com)
 * [Sveriges Television](http://www.svt.se)
 * [T2 Systems](http://t2systems.com)
+* [Tapad](https://tapad.com)
 * [Teradata](http://www.teradata.com)
 * [trivago](http://www.trivago.com/)
 * [VANAD Enovation](http://www.vanadenovation.nl/)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ To develop on the web UI look into the instructions of the [Marathon UI](https:/
 * [Go client](https://github.com/jbdalido/gomarathon) by Jean-Baptiste Dalido
 * [Node client](https://github.com/silas/node-mesos) by Silas Sewell
 * [Clojure client](https://github.com/codemomentum/marathonclj) by Halit Olali
+* [sbt plugin](https://github.com/Tapad/sbt-marathon), developed at [Tapad](https://tapad.com)
 
 ## Companies using Marathon
 


### PR DESCRIPTION
This PR adds a link to the [sbt-marathon](https://github.com/Tapad/sbt-marathon) [sbt](http://scala-sbt.org) plugin developed at [Tapad](https://tapad.com). It also adds Tapad to the list of companies using Marathon.