### PR TITLE
Set default scheme to MESOS_HTTP in health checks.

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -13,7 +13,9 @@ types:
           The endpoint name to use.
           In "host" mode health checks use the hostPort. In other modes use the containerPort.
       path?: strings.Path
-      scheme?: strings.HttpScheme
+      scheme?:
+        type: strings.HttpScheme
+        default: HTTP
   TcpHealthCheck:
     type: object
     properties:

--- a/src/main/scala/mesosphere/marathon/raml/HealthCheckConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/HealthCheckConversion.scala
@@ -36,7 +36,7 @@ trait HealthCheckConversion {
         maxConsecutiveFailures = maxConFailures,
         delay = delay.seconds,
         path = httpCheck.path,
-        protocol = httpCheck.scheme.map(Raml.fromRaml(_)).getOrElse(HealthCheckDefinition.Protocol.HTTP),
+        protocol = Raml.fromRaml[HttpScheme, HealthCheckDefinition.Protocol](httpCheck.scheme),
         portIndex = Some(PortReference(httpCheck.endpoint))
       )
     case HealthCheck(None, Some(tcpCheck), None, gracePeriod, interval, maxConFailures, timeout, delay) =>
@@ -83,7 +83,7 @@ trait HealthCheckConversion {
           http = Some(HttpHealthCheck(
             endpoint = requireEndpoint(httpCheck.portIndex),
             path = httpCheck.path,
-            scheme = Some(Raml.toRaml(httpCheck.protocol))))
+            scheme = Raml.toRaml(httpCheck.protocol)))
         )
       case tcpCheck: MesosTcpHealthCheck =>
         partialCheck.copy(

--- a/src/test/scala/mesosphere/marathon/raml/HealthCheckConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/HealthCheckConversionTest.scala
@@ -101,4 +101,15 @@ class HealthCheckConversionTest extends FunTest {
     raml.timeoutSeconds should be(check.timeout.toSeconds)
   }
 
+  test("A HealthCheck with HttpHealthCheck defined should convert to a MesosHealthCheck") {
+    val check = HealthCheck(http = Some(HttpHealthCheck(endpoint = "localhost")))
+    val core = Some(check.fromRaml).collect {
+      case c: MesosHttpHealthCheck => c
+    }.getOrElse(fail("expected MesosHttpHealthCheck"))
+    core.protocol should be(Protos.HealthCheckDefinition.Protocol.MESOS_HTTP)
+    core.maxConsecutiveFailures should be(check.maxConsecutiveFailures)
+    core.path should not be 'defined
+    core.port should not be 'defined
+    core.portIndex should be (Some(PortReference("localhost")))
+  }
 }


### PR DESCRIPTION
Summary:
The default scheme for Mesos health checks was HTTP and not MESOS_HTTP.
That caused a bug described in the ticket.

Test Plan: unit-test

Reviewers: unterstein, jdef, jenkins

Reviewed By: unterstein, jdef, jenkins

Subscribers: marathon-team, marathon-dev, jenkins

JIRA Issues: DCOS-14890

Differential Revision: https://phabricator.mesosphere.com/D663