### PR TITLE
Update pods validation for command health check support.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -320,6 +320,5 @@ trait PodsValidation {
 }
 
 object PodsValidation extends PodsValidation {
-  // TODO: Change this value when mesos supports command checks for pods.
-  val MinCommandCheckMesosVersion = SemanticVersion(Int.MaxValue, Int.MaxValue, Int.MaxValue)
+  val MinCommandCheckMesosVersion = SemanticVersion(1, 3, 0)
 }


### PR DESCRIPTION
This PR updates the minimum version of Mesos required for command health check support in pods to 1.3.0.