### PR TITLE
Fix MAX_PER constraint to work with attributes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -108,6 +108,8 @@ All validation specified in the RAML is now programatically enforced, leading to
 
 Marathon is in better compliance with various security best-practices. An example of this is that Marathon no longer responds to the directory listing request.
 
+### Fixed issues
+- [MARATHON-7320](https://jira.mesosphere.com/browse/MARATHON-7320) Fix MAX_PER constraint for attributes.
 
 ------------------------------------------------------------
 

--- a/src/main/scala/mesosphere/mesos/Constraints.scala
+++ b/src/main/scala/mesosphere/mesos/Constraints.scala
@@ -118,7 +118,7 @@ object Constraints {
         case Operator.GROUP_BY =>
           checkGroupBy(getValueString(attr.get), groupFunc)
         case Operator.MAX_PER =>
-          checkMaxPer(offer.getHostname, value.toInt, groupFunc)
+          checkMaxPer(getValueString(attr.get), value.toInt, groupFunc)
         case Operator.LIKE => checkLike
         case Operator.UNLIKE => checkUnlike
       }


### PR DESCRIPTION
The `MAX_PER` constraint currently works with `hostname`, but does not work with any other attribute.

The problem is that the attribute is not passed into `checkMaxPer` inside `checkAttribute`. Instead, the hostname is always passed to `checkMaxPer`.

This PR calls `checkMaxPer` with the correct argument, and adds a test that uses `MAX_PER` with a `rackid` attribute to show the fix.

JIRA Issue: [MARATHON-7320](https://jira.mesosphere.com/browse/MARATHON-7320)