### PR TITLE
Fix /ping endpoint Content-type

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/SystemResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/SystemResource.scala
@@ -37,6 +37,7 @@ class SystemResource @Inject() (val config: MarathonConf, cfg: Config)(implicit
 
   @GET
   @Path("ping")
+  @Produces(Array(MediaType.TEXT_PLAIN))
   def ping(): Response = ok("pong")
 
   @GET


### PR DESCRIPTION
Broken since v1.4.0

Prefer this over converting to JSON by adding double quotes since it is more
backward compatible.

Fixes MARATHON-7322