### PR TITLE
Include USER networked docker containers in text/plain v2/tasks output

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -1,22 +1,37 @@
 package mesosphere.marathon.api
 
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.state.AppDefinition
+import java.lang.{ StringBuilder => JavaStringBuilder }
+import mesosphere.marathon.state.Container.Docker.PortMapping
 
 object EndpointsHelper {
+  /**
+    * Traditionally, we only listed bridge or host networked apps in the text/plain tasks output; however, some
+    * expressed a pressing need to see ip-per-container docker containers as well.
+    *
+    * We cannot lift this filter altogether as service ports are not assigned for Mesos containerizer with ip-per-tasks
+    */
+  private def shouldListApp(app: AppDefinition) =
+    app.ipAddress.isEmpty || app.container.fold(false) { _.docker.nonEmpty }
+
   /**
     * Produces a script-friendly string representation of the supplied
     * apps' tasks.  The data columns in the result are separated by
     * the supplied delimiter string.
     */
   def appsToEndpointString(
-    taskTracker: TaskTracker,
+    tasksMap: TaskTracker.TasksByApp,
     apps: Seq[AppDefinition],
     delimiter: String): String = {
-    val tasksMap = taskTracker.tasksByAppSync
-
-    val sb = new StringBuilder
-    for (app <- apps if app.ipAddress.isEmpty) {
+    val sb = new JavaStringBuilder
+    for (app <- apps if shouldListApp(app)) {
+      /* Note - this method is flawed and outputs the WRONG thing in the event of a portDefinition / portMapping
+       * insertion or deletion.
+       *
+       * https://jira.mesosphere.com/browse/MARATHON-7407
+       */
       val tasks = tasksMap.appTasks(app.id)
       val cleanId = app.id.safePath
 
@@ -32,9 +47,25 @@ object EndpointsHelper {
         for ((port, i) <- servicePorts.zipWithIndex) {
           sb.append(cleanId).append(delimiter).append(port).append(delimiter)
 
-          for (task <- tasks if task.isRunning) {
-            val taskPort = task.launched.flatMap(_.hostPorts.drop(i).headOption).getOrElse(0)
-            sb.append(task.agentInfo.host).append(':').append(taskPort).append(delimiter)
+          val ipPerTaskPortMapping = if (app.ipAddress.nonEmpty) containerPortMapping(app, i) else None
+          val runningTasks = tasks.withFilter(_.isRunning)
+          ipPerTaskPortMapping match {
+            case Some(portMapping) if portMapping.hostPort.isEmpty =>
+              runningTasks.foreach { task =>
+                tryAppendContainerPort(sb, app, portMapping, task, i, delimiter)
+              }
+            case Some(portMapping) if portMapping.hostPort.nonEmpty =>
+              // the task hostPorts only contains an entry for each portMapping that has a hostPort defined
+              // We need to compute and use the new index
+              hostPortIndexOffset(app, i).foreach { computedHostPortIndex =>
+                runningTasks.foreach { task =>
+                  appendHostPortOrZero(sb, task, computedHostPortIndex, delimiter)
+                }
+              }
+            case _ =>
+              runningTasks.foreach { task =>
+                appendHostPortOrZero(sb, task, i, delimiter)
+              }
           }
           sb.append('\n')
         }
@@ -43,4 +74,52 @@ object EndpointsHelper {
     sb.toString()
   }
 
+  /**
+    * Adjusts the index based on portMapping definitions. Expects that the specified index refers to a nonEmpty hostPort
+    * portmapping record.
+    */
+  private def hostPortIndexOffset(app: AppDefinition, idx: Integer): Option[Integer] = {
+    app.container.flatMap(_.portMappings).flatMap { pm =>
+      if (idx < 0 || idx >= pm.length) // index 2, length 2 invalid
+        None
+      else if (pm(idx).hostPort.isEmpty)
+        None
+      else
+        // count each preceeding nonEmpty hostPort to get new index
+        Some(pm.toIterator.take(idx).filter(_.hostPort.nonEmpty).size)
+    }
+  }
+
+  private def containerPortMapping(app: AppDefinition, portIdx: Integer): Option[PortMapping] =
+    for {
+      container <- app.container
+      portMappings <- container.portMappings
+      portMapping <- portMappings.lift(portIdx) // After MARATHON-7407 is addressed, this should probably throw.
+    } yield portMapping
+
+  /**
+    * Append an entry to the provided string builder for the specified containerPort. If we cannot tell the
+    * effectiveIpAddress, output nothing.
+    */
+  private def tryAppendContainerPort(
+    sb: JavaStringBuilder, app: AppDefinition, portMapping: PortMapping, task: Task, portIdx: Integer,
+    delimiter: String): Unit = {
+    task.effectiveIpAddress(app).foreach { address =>
+      sb.append(address).append(':').append(portMapping.containerPort).append(delimiter)
+    }
+  }
+  /**
+    * Append an entry to the provided string builder using the task's agent host IP and specified host port
+    *
+    * Note, at some-point, as a work-around to MARATHON-7407, it was decided that it would be a good idea to output port
+    * 0 if no host port for the corresponding service port was found (this would happen in the event that you added a
+    * new portMapping). This is rather nonsensical and should be removed when MARATHON-7407 is properly addressed.
+    */
+  private def appendHostPortOrZero(
+    sb: JavaStringBuilder, task: Task, portIdx: Integer, delimiter: String): Unit = {
+    task.launched.foreach { launched =>
+      val taskPort = launched.hostPorts.lift(portIdx).getOrElse(0)
+      sb.append(task.agentInfo.host).append(':').append(taskPort).append(delimiter)
+    }
+  }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -74,7 +74,7 @@ class AppTasksResource @Inject() (
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
     val id = appId.toRootPath
     withAuthorization(ViewRunSpec, result(groupManager.app(id)), unknownApp(id)) { app =>
-      ok(EndpointsHelper.appsToEndpointString(taskTracker, Seq(app), "\t"))
+      ok(EndpointsHelper.appsToEndpointString(taskTracker.tasksByAppSync, Seq(app), "\t"))
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -91,7 +91,7 @@ class TasksResource @Inject() (
   @Timed
   def indexTxt(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
     ok(EndpointsHelper.appsToEndpointString(
-      taskTracker,
+      taskTracker.tasksByAppSync,
       result(groupManager.rootGroup()).transitiveApps.toSeq.filter(app => isAuthorized(ViewRunSpec, app)),
       "\t"
     ))

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -457,10 +457,10 @@ object MarathonTestHelper {
       .withStatus((status: Task.Status) =>
         status.copy(
           startedAt = Some(Timestamp(startedAt)),
-          mesosStatus = Some(statusForState(taskId, Mesos.TaskState.TASK_RUNNING))
+          mesosStatus = Some(statusForState(taskId, Mesos.TaskState.TASK_RUNNING)),
+          taskStatus = MarathonTaskStatus.Running
         )
       )
-
   }
 
   def healthyTask(appId: PathId): Task.LaunchedEphemeral = healthyTask(Task.Id.forRunSpec(appId).idString)

--- a/src/test/scala/mesosphere/marathon/api/EndpointsHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/EndpointsHelperTest.scala
@@ -1,0 +1,119 @@
+package mesosphere.marathon
+package api
+
+import mesosphere.UnitTest
+import mesosphere.marathon.MarathonTestHelper
+import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.state.{ IpAddress, PortDefinition }
+import org.apache.mesos.Protos
+import mesosphere.marathon.state.Container.Docker
+
+import scala.collection.immutable.Seq
+
+class EndpointsHelperTest extends UnitTest {
+  import MarathonTestHelper.Implicits._
+
+  "rendering docker containers with ip-per-container" should {
+
+    "routput the container port and container IP when hostPort is empty" in {
+      val app = MarathonTestHelper.makeBasicApp()
+        .withNoPortDefinitions()
+        .withIpAddress(IpAddress.empty)
+        .withDockerNetwork(Protos.ContainerInfo.DockerInfo.Network.USER)
+        .withPortMappings(Seq(
+          Docker.PortMapping(containerPort = 80, hostPort = None, servicePort = 10000, protocol = "tcp", name = Some("http"))
+        ))
+
+      val tasks = List("192.168.0.1", "192.168.0.2").map { ip =>
+        MarathonTestHelper.runningTaskForApp(app.id, app.version, 0, 0)
+          .withNetworkInfos(
+            Seq(MarathonTestHelper.networkInfoWithIPAddress(MarathonTestHelper.mesosIpAddress(ip))))
+          .withHostPorts(Seq.empty)
+      }
+
+      val result = EndpointsHelper.appsToEndpointString(TaskTracker.TasksByApp.forTasks(tasks: _*), Seq(app), " ")
+      result.trim.shouldBe("""test-app 10000 192.168.0.1:80 192.168.0.2:80""")
+    }
+
+    "output the agent IP and host port when hostPort is nonEmpty" in {
+      val app = MarathonTestHelper.makeBasicApp()
+        .withNoPortDefinitions()
+        .withIpAddress(IpAddress.empty)
+        .withDockerNetwork(Protos.ContainerInfo.DockerInfo.Network.USER)
+        .withPortMappings(Seq(
+          Docker.PortMapping(containerPort = 80, hostPort = Some(0), servicePort = 10000, protocol = "tcp", name = Some("http"))
+        ))
+
+      val tasks = List(1010, 1020).map { port =>
+        MarathonTestHelper.runningTaskForApp(app.id, app.version, 0, 0)
+          .withNetworkInfos(
+            Seq(MarathonTestHelper.networkInfoWithIPAddress(MarathonTestHelper.mesosIpAddress("192.168.1.1"))))
+          .withHostPorts(List(port))
+      }
+
+      val result = EndpointsHelper.appsToEndpointString(TaskTracker.TasksByApp.forTasks(tasks: _*), Seq(app), " ")
+      result.trim.shouldBe("""test-app 10000 some.host:1010 some.host:1020""")
+    }
+
+    "handle the task hostPorts offset heterogenous hostPort definition properly (empty, nonEmpty)" in {
+      val app = MarathonTestHelper.makeBasicApp()
+        .withNoPortDefinitions()
+        .withIpAddress(IpAddress.empty)
+        .withDockerNetwork(Protos.ContainerInfo.DockerInfo.Network.USER)
+        .withPortMappings(Seq(
+          Docker.PortMapping(containerPort = 80, hostPort = None, servicePort = 10000, name = Some("http")),
+          Docker.PortMapping(containerPort = 9998, hostPort = Some(0), servicePort = 10001, name = Some("service1")),
+          Docker.PortMapping(containerPort = 9999, hostPort = Some(0), servicePort = 10002, name = Some("service2"))
+        ))
+
+      val tasks = List(List(1010, 1011), List(1020, 1021)).map { ports =>
+        MarathonTestHelper.runningTaskForApp(app.id, app.version, 0, 0)
+          .withNetworkInfos(
+            Seq(MarathonTestHelper.networkInfoWithIPAddress(MarathonTestHelper.mesosIpAddress("192.168.1.1"))))
+          .withHostPorts(ports)
+      }
+
+      val result = EndpointsHelper.appsToEndpointString(TaskTracker.TasksByApp.forTasks(tasks: _*), Seq(app), " ")
+      result.shouldBe(
+        "test-app 10000 192.168.1.1:80 192.168.1.1:80 \n" +
+          "test-app 10001 some.host:1010 some.host:1020 \n" +
+          "test-app 10002 some.host:1011 some.host:1021 \n")
+    }
+  }
+
+  "does not include mesos containers using ip-per-container (as they lack service ports)" in {
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withIpAddress(IpAddress.empty)
+
+    EndpointsHelper.appsToEndpointString(TaskTracker.TasksByApp.empty, List(app), " ").shouldBe("")
+  }
+
+  "renders docker containers using host networking with multiple servicePorts properly" in {
+    val app = MarathonTestHelper.makeBasicApp()
+      .withDockerNetwork(Protos.ContainerInfo.DockerInfo.Network.HOST)
+      .withPortDefinitions(List(PortDefinition(10000), PortDefinition(10001)))
+
+    val tasks = List(List(1010, 1011), List(1020, 1021)).map { ports =>
+      MarathonTestHelper.runningTaskForApp(app.id, app.version, 0, 0)
+        .withHostPorts(ports)
+    }
+
+    val result = EndpointsHelper.appsToEndpointString(TaskTracker.TasksByApp.forTasks(tasks: _*), Seq(app), " ")
+    result.trim.shouldBe("test-app 10000 some.host:1010 some.host:1020 \n" +
+      "test-app 10001 some.host:1011 some.host:1021")
+  }
+
+  "simply outputs the hosts without ports when no servicePorts are defined" in {
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+
+    val tasks = (1 to 2).map { _ =>
+      MarathonTestHelper.runningTaskForApp(app.id, app.version, 0, 0)
+        .withHostPorts(Nil)
+    }
+
+    val result = EndpointsHelper.appsToEndpointString(TaskTracker.TasksByApp.forTasks(tasks: _*), Seq(app), " ")
+    result.trim.shouldBe("test-app   some.host some.host")
+  }
+}


### PR DESCRIPTION
Use phab for code review; posted here because CI doesn't work with phab and Marathon 1.3

Summary:
Historically, we only listed HOST or BRIDGE networked containers in v2/tasks, due to the fact that assumption USER networked containers are not necessarily reachable by other tasks.

With this change, we modify this restriction and output the containerIp and containerPort for ip-per-task containers

Test Plan: manually launch against container networks

Subscribers: marathon-dev

JIRA Issues: MARATHON-7397

Differential Revision: https://phabricator.mesosphere.com/D809

