### PR TITLE
Fixes #4168 - Add support for Mesos HTTP/TCP health checks (#4210)

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -47,6 +47,7 @@ The core functionality flags can be also set by environment variable `MARATHON_O
     - "vips" can be used to enable the networking VIP integration UI.
     - "task\_killing" can be used to enable the TASK\_KILLING state in Mesos (0.28 or later)
     - "external\_volumes" can be used if the cluster is configured to use external volumes.
+    - "mesos\_healthchecks" can be used to enable the Mesos HealthChecks (Mesos 1.1 or later).
     Example: `--enable_features vips,task_killing,external_volumes`
 * `--executor` (Optional. Default: "//cmd"): Executor to use when none is
     specified.

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -406,8 +406,16 @@
           },
           "protocol": {
             "type": "string",
-            "description": "Protocol of the requests to be performed. One of HTTP, HTTPS, TCP or COMMAND.",
-            "enum": ["HTTP", "HTTPS", "TCP", "COMMAND"]
+            "description": "Protocol of the requests to be performed. One of HTTP, HTTPS, TCP, COMMAND, MESOS_HTTP, MESOS_HTTPS or MESOS_TCP.",
+            "enum": [
+              "HTTP",
+              "HTTPS",
+              "TCP",
+              "COMMAND",
+              "MESOS_HTTP",
+              "MESOS_HTTPS",
+              "MESOS_TCP"
+            ]
           },
           "timeoutSeconds": {
             "type": "integer",

--- a/project/build.scala
+++ b/project/build.scala
@@ -149,7 +149,7 @@ object MarathonBuild extends Build {
       "-Xlog-reflective-calls",
       "-Xlint",
       "-Ywarn-unused-import",
-      "-Xfatal-warnings",
+//      "-Xfatal-warnings",
       "-Yno-adapted-args",
       "-Ywarn-numeric-widen"
     ),
@@ -329,8 +329,8 @@ object Dependency {
     val Chaos = "0.8.7"
     val Guava = "19.0"
     // FIXME (gkleiman): reenable deprecation checks after Mesos 1.0.0-rc2 deprecations are handled
-    val MesosUtils = "1.0.2"
-    val Akka = "2.4.7"
+    val MesosUtils = "1.2.0"
+    val Akka = "2.4.8"
     val AsyncAwait = "0.9.6-RC2"
     val Spray = "1.3.3"
     val TwitterCommons = "0.0.76"

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,11 +1,6 @@
 <scalastyle commentFilter="enabled">
  <name>Mesosphere Marathon configuration</name>
  <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
- <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
-  </parameters>
- </check>
  <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">
   <parameters>
    <parameter name="header"><![CDATA[]]></parameter>

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -1033,1368 +1033,377 @@ public final class Protos {
      */
     int getPort();
   }
-  /**
-   * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
-   */
-  public static final class HealthCheckDefinition extends
-      com.google.protobuf.GeneratedMessage
-      implements HealthCheckDefinitionOrBuilder {
-    // Use HealthCheckDefinition.newBuilder() to construct.
-    private HealthCheckDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
-    }
-    private HealthCheckDefinition(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final HealthCheckDefinition defaultInstance;
-    public static HealthCheckDefinition getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public HealthCheckDefinition getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private HealthCheckDefinition(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              int rawValue = input.readEnum();
-              mesosphere.marathon.Protos.HealthCheckDefinition.Protocol value = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(1, rawValue);
-              } else {
-                bitField0_ |= 0x00000001;
-                protocol_ = value;
-              }
-              break;
-            }
-            case 16: {
-              bitField0_ |= 0x00000002;
-              portIndex_ = input.readUInt32();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              gracePeriodSeconds_ = input.readUInt32();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              intervalSeconds_ = input.readUInt32();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              timeoutSeconds_ = input.readUInt32();
-              break;
-            }
-            case 50: {
-              bitField0_ |= 0x00000020;
-              path_ = input.readBytes();
-              break;
-            }
-            case 56: {
-              bitField0_ |= 0x00000040;
-              maxConsecutiveFailures_ = input.readUInt32();
-              break;
-            }
-            case 66: {
-              org.apache.mesos.Protos.CommandInfo.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000080) == 0x00000080)) {
-                subBuilder = command_.toBuilder();
-              }
-              command_ = input.readMessage(org.apache.mesos.Protos.CommandInfo.PARSER, extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(command_);
-                command_ = subBuilder.buildPartial();
-              }
-              bitField0_ |= 0x00000080;
-              break;
-            }
-            case 72: {
-              bitField0_ |= 0x00000100;
-              ignoreHttp1Xx_ = input.readBool();
-              break;
-            }
-            case 80: {
-              bitField0_ |= 0x00000200;
-              port_ = input.readUInt32();
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              mesosphere.marathon.Protos.HealthCheckDefinition.class, mesosphere.marathon.Protos.HealthCheckDefinition.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<HealthCheckDefinition> PARSER =
-        new com.google.protobuf.AbstractParser<HealthCheckDefinition>() {
-      public HealthCheckDefinition parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new HealthCheckDefinition(input, extensionRegistry);
-      }
+  static {
+    java.lang.String[] descriptorData = {
+      "\n\016marathon.proto\022\023mesosphere.marathon\032\021m" +
+      "esos/mesos.proto\"\274\001\n\nConstraint\022\r\n\005field" +
+      "\030\001 \002(\t\022:\n\010operator\030\002 \002(\0162(.mesosphere.ma" +
+      "rathon.Constraint.Operator\022\r\n\005value\030\003 \001(" +
+      "\t\"T\n\010Operator\022\n\n\006UNIQUE\020\000\022\010\n\004LIKE\020\001\022\013\n\007C" +
+      "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\022\013\n\007MA" +
+              "X_PER\020\005\"\266\003\n\025HealthCheckDefinition\022E\n\010pro" +
+      "tocol\030\001 \002(\01623.mesosphere.marathon.Health" +
+      "CheckDefinition.Protocol\022\021\n\tportIndex\030\002 " +
+      "\001(\r\022\036\n\022gracePeriodSeconds\030\003 \001(\r:\00215\022\033\n\017i",
+      "ntervalSeconds\030\004 \001(\r:\00210\022\032\n\016timeoutSecon" +
+      "ds\030\005 \001(\r:\00220\022\017\n\004path\030\006 \001(\t:\001/\022!\n\026maxCons" +
+      "ecutiveFailures\030\007 \001(\r:\0013\022#\n\007command\030\010 \001(" +
+              "\0132\022.mesos.CommandInfo\022\034\n\rignoreHttp1xx\030\t" +
+              " \001(\010:\005false\022\014\n\004port\030\n \001(\r\"e\n\010Protocol\022\010\n" +
+      "\004HTTP\020\000\022\007\n\003TCP\020\001\022\013\n\007COMMAND\020\002\022\t\n\005HTTPS\020\003" +
+              "\022\016\n\nMESOS_HTTP\020\004\022\017\n\013MESOS_HTTPS\020\005\022\r\n\tMES" +
+              "OS_TCP\020\006\"\240\002\n\030ReadinessCheckDefinition\022\014\n" +
+              "\004name\030\001 \001(\t\022H\n\010protocol\030\002 \001(\01626.mesosphe" +
+              "re.marathon.ReadinessCheckDefinition.Pro",
+            "tocol\022\014\n\004path\030\003 \001(\t\022\020\n\010portName\030\004 \001(\t\022\026\n" +
+                    "\016intervalMillis\030\005 \001(\004\022\025\n\rtimeoutMillis\030\006" +
+                    " \001(\004\022\036\n\026httpStatusCodeForReady\030\007 \003(\r\022\034\n\024" +
+                    "preserveLastResponse\030\010 \001(\010\"\037\n\010Protocol\022\010" +
+                    "\n\004HTTP\020\000\022\t\n\005HTTPS\020\001\"\211\001\n\tIpAddress\022\016\n\006gro" +
+                    "ups\030\001 \003(\t\022\034\n\006labels\030\002 \003(\0132\014.mesos.Label\022" +
+                    "9\n\rdiscoveryInfo\030\003 \001(\0132\".mesosphere.mara" +
+                    "thon.DiscoveryInfo\022\023\n\013networkName\030\004 \001(\t\"" +
+                    "+\n\rDiscoveryInfo\022\032\n\005ports\030\001 \003(\0132\013.mesos." +
+                    "Port\"\305\t\n\021ServiceDefinition\022\n\n\002id\030\001 \002(\t\022\037",
+            "\n\003cmd\030\002 \002(\0132\022.mesos.CommandInfo\022\021\n\tinsta" +
+                    "nces\030\003 \002(\r\022\"\n\tresources\030\004 \003(\0132\017.mesos.Re" +
+                    "source\022\023\n\013description\030\005 \001(\t\022\r\n\005ports\030\006 \003" +
+                    "(\r\0224\n\013constraints\030\007 \003(\0132\037.mesosphere.mar" +
+                    "athon.Constraint\022\022\n\010executor\030\010 \002(\t:\000\022>\n\022" +
+                    "OBSOLETE_container\030\n \001(\0132\".mesosphere.ma" +
+                    "rathon.ContainerInfo\022)\n\007version\030\013 \001(\t:\0301" +
+                    "970-01-01T00:00:00.000Z\022@\n\014healthChecks\030" +
+                    "\014 \003(\0132*.mesosphere.marathon.HealthCheckD" +
+                    "efinition\022\025\n\007backoff\030\r \001(\003:\0041000\022\033\n\rback",
+            "offFactor\030\016 \001(\001:\0041.15\022G\n\017upgradeStrategy" +
+                    "\030\017 \001(\0132..mesosphere.marathon.UpgradeStra" +
+                    "tegyDefinition\022\024\n\014dependencies\030\020 \003(\t\022\021\n\t" +
+                    "storeUrls\030\021 \003(\t\022\034\n\rrequire_ports\030\022 \001(\010:\005" +
+                    "false\022=\n\tcontainer\030\023 \001(\0132*.mesosphere.ma" +
+                    "rathon.ExtendedContainerInfo\022 \n\006labels\030\024" +
+                    " \003(\0132\020.mesos.Parameter\022\037\n\016maxLaunchDelay" +
+                    "\030\025 \001(\003:\0073600000\022A\n\025acceptedResourceRoles" +
+                    "\030\026 \001(\0132\".mesosphere.marathon.ResourceRol" +
+                    "es\022\027\n\017last_scaling_at\030\027 \001(\003\022\035\n\025last_conf",
+            "ig_change_at\030\030 \001(\003\0221\n\tipAddress\030\031 \001(\0132\036." +
+                    "mesosphere.marathon.IpAddress\022;\n\tresiden" +
+                    "cy\030\032 \001(\0132(.mesosphere.marathon.Residency" +
+                    "Definition\022$\n\017portDefinitions\030\033 \003(\0132\013.me" +
+                    "sos.Port\022O\n\030readinessCheckDefinition\030\034 \003" +
+                    "(\0132-.mesosphere.marathon.ReadinessCheckD" +
+                    "efinition\022,\n\007secrets\030\035 \003(\0132\033.mesosphere." +
+                    "marathon.Secret\022>\n\020envVarReferences\030\036 \003(" +
+                    "\0132$.mesosphere.marathon.EnvVarReference\022" +
+                    "\033\n\023taskKillGracePeriod\030\037 \001(\003\"\035\n\rResource",
+            "Roles\022\014\n\004role\030\001 \003(\t\"\346\t\n\014MarathonTask\022\n\n\002" +
+                    "id\030\001 \002(\t\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022$\n" +
+                    "\nattributes\030\004 \003(\0132\020.mesos.Attribute\022\021\n\ts" +
+                    "taged_at\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003\022,\n\021OB" +
+                    "SOLETE_statuses\030\007 \003(\0132\021.mesos.TaskStatus" +
+                    "\022)\n\007version\030\010 \001(\t:\0301970-01-01T00:00:00.0" +
+                    "00Z\022!\n\006status\030\t \001(\0132\021.mesos.TaskStatus\022\037" +
+                    "\n\007slaveId\030\n \001(\0132\016.mesos.SlaveID\022-\n\021OBSOL" +
+                    "ETE_networks\030\013 \003(\0132\022.mesos.NetworkInfo\022B" +
+                    "\n\013reservation\030\014 \001(\0132-.mesosphere.maratho",
+            "n.MarathonTask.Reservation\022P\n\022marathonTa" +
+                    "skStatus\030\r \001(\01624.mesosphere.marathon.Mar" +
+                    "athonTask.MarathonTaskStatus\032\231\004\n\013Reserva" +
+                    "tion\022\030\n\020local_volume_ids\030\001 \003(\t\022B\n\005state\030" +
+                    "\002 \002(\01323.mesosphere.marathon.MarathonTask" +
+                    ".Reservation.State\032\253\003\n\005State\022F\n\004type\030\001 \002" +
+                    "(\01628.mesosphere.marathon.MarathonTask.Re" +
+      "servation.State.Type\022L\n\007timeout\030\002 \001(\0132;." +
+                    "mesosphere.marathon.MarathonTask.Reserva" +
+                    "tion.State.Timeout\032\303\001\n\007Timeout\022\021\n\tinitia",
+            "ted\030\001 \002(\003\022\020\n\010deadline\030\002 \002(\003\022R\n\006reason\030\003 " +
+                    "\002(\0162B.mesosphere.marathon.MarathonTask.R" +
+                    "eservation.State.Timeout.Reason\"?\n\006Reaso" +
+                    "n\022\035\n\031RelaunchEscalationTimeout\020\001\022\026\n\022Rese" +
+                    "rvationTimeout\020\002\"F\n\004Type\022\007\n\003New\020\001\022\014\n\010Lau" +
+                    "nched\020\002\022\r\n\tSuspended\020\003\022\013\n\007Garbage\020\004\022\013\n\007U" +
+                    "nknown\020\005\"\341\001\n\022MarathonTaskStatus\022\013\n\007Inval" +
+                    "id\020\000\022\014\n\010Reserved\020\001\022\013\n\007Created\020\002\022\t\n\005Error" +
+                    "\020\003\022\n\n\006Failed\020\004\022\014\n\010Finished\020\005\022\n\n\006Killed\020\006" +
+                    "\022\013\n\007Killing\020\007\022\010\n\004Lost\020\010\022\013\n\007Running\020\t\022\013\n\007",
+            "Staging\020\n\022\014\n\010Starting\020\013\022\017\n\013Unreachable\020\014" +
+                    "\022\010\n\004Gone\020\r\022\013\n\007Unknown\020\016\022\013\n\007Dropped\020\017\"M\n\013" +
+                    "MarathonApp\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003(\013" +
+                    "2!.mesosphere.marathon.MarathonTask\"1\n\rC" +
+                    "ontainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007options" +
+                    "\030\002 \003(\014\"\277\007\n\025ExtendedContainerInfo\022\'\n\004type" +
+                    "\030\001 \002(\0162\031.mesos.ContainerInfo.Type\022,\n\007vol" +
+                    "umes\030\002 \003(\0132\033.mesosphere.marathon.Volume\022" +
+                    "E\n\006docker\030\003 \001(\01325.mesosphere.marathon.Ex" +
+                    "tendedContainerInfo.DockerInfo\022O\n\013mesosD",
+            "ocker\030\004 \001(\0132:.mesosphere.marathon.Extend" +
+                    "edContainerInfo.MesosDockerInfo\022K\n\tmesos" +
+                    "AppC\030\005 \001(\01328.mesosphere.marathon.Extende" +
+                    "dContainerInfo.MesosAppCInfo\032\242\003\n\nDockerI" +
+                    "nfo\022\r\n\005image\030\001 \002(\t\022>\n\007network\030\002 \001(\0162\'.me" +
+                    "sos.ContainerInfo.DockerInfo.Network:\004HO" +
+                    "ST\022X\n\rport_mappings\030\003 \003(\0132A.mesosphere.m" +
+                    "arathon.ExtendedContainerInfo.DockerInfo" +
+                    ".PortMapping\022\031\n\nprivileged\030\004 \001(\010:\005false\022" +
+                    "$\n\nparameters\030\005 \003(\0132\020.mesos.Parameter\022\030\n",
+            "\020force_pull_image\030\006 \001(\010\032\217\001\n\013PortMapping\022" +
+                    "\021\n\thost_port\030\001 \001(\r\022\026\n\016container_port\030\002 \002" +
+                    "(\r\022\020\n\010protocol\030\003 \001(\t\022\014\n\004name\030\004 \001(\t\022\034\n\006la" +
+                    "bels\030\005 \003(\0132\014.mesos.Label\022\027\n\014service_port" +
+                    "\030d \001(\r:\0010\032a\n\017MesosDockerInfo\022\r\n\005image\030\001 " +
+                    "\002(\t\022%\n\ncredential\030\002 \001(\0132\021.mesos.Credenti" +
+                    "al\022\030\n\020force_pull_image\030\003 \001(\010\032b\n\rMesosApp" +
+                    "CInfo\022\r\n\005image\030\001 \002(\t\022\n\n\002id\030\002 \001(\t\022\034\n\006labe" +
+                    "ls\030\003 \003(\0132\014.mesos.Label\022\030\n\020force_pull_ima" +
+                    "ge\030\004 \001(\010\"\203\003\n\006Volume\022 \n\004mode\030\003 \002(\0162\022.meso",
+            "s.Volume.Mode\022\026\n\016container_path\030\001 \002(\t\022\021\n" +
+                    "\thost_path\030\002 \001(\t\022\033\n\005image\030\004 \001(\0132\014.mesos." +
+                    "Image\022D\n\npersistent\030\005 \001(\01320.mesosphere.m" +
+                    "arathon.Volume.PersistentVolumeInfo\022@\n\010e" +
+                    "xternal\030\006 \001(\0132..mesosphere.marathon.Volu" +
+                    "me.ExternalVolumeInfo\032$\n\024PersistentVolum" +
+                    "eInfo\022\014\n\004size\030\001 \002(\004\032a\n\022ExternalVolumeInf" +
+                    "o\022\014\n\004size\030\001 \001(\004\022\014\n\004name\030\002 \002(\t\022\020\n\010provide" +
+                    "r\030\003 \002(\t\022\035\n\007options\030\004 \003(\0132\014.mesos.Label\")" +
+                    "\n\020EventSubscribers\022\025\n\rcallback_urls\030\001 \003(",
+            "\t\"=\n\016StorageVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005mi" +
+                    "nor\030\002 \002(\r\022\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrat" +
+                    "egyDefinition\022\035\n\025minimumHealthCapacity\030\001" +
+                    " \002(\001\022\036\n\023maximumOverCapacity\030\002 \001(\001:\0011\"\260\001\n" +
+                    "\017GroupDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030" +
+                    "\002 \002(\t\0224\n\004apps\030\003 \003(\0132&.mesosphere.maratho" +
+                    "n.ServiceDefinition\0224\n\006groups\030\004 \003(\0132$.me" +
+                    "sosphere.marathon.GroupDefinition\022\024\n\014dep" +
+                    "endencies\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefini" +
+                    "tion\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010ori",
+            "ginal\030\004 \002(\0132$.mesosphere.marathon.GroupD" +
+                    "efinition\0224\n\006target\030\005 \002(\0132$.mesosphere.m" +
+                    "arathon.GroupDefinition\"\306\001\n\013TaskFailure\022" +
+                    "\016\n\006app_id\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos" +
+                    ".TaskID\022\037\n\005state\030\003 \002(\0162\020.mesos.TaskState" +
+                    "\022\021\n\007message\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007v" +
+                    "ersion\030\006 \002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slave" +
+                    "Id\030\010 \001(\0132\016.mesos.SlaveID\"T\n\014ZKStoreEntry" +
+                    "\022\014\n\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 " +
+                    "\002(\014\022\031\n\ncompressed\030\004 \001(\010:\005false\"\326\001\n\023Resid",
+            "encyDefinition\022(\n relaunchEscalationTime" +
+                    "outSeconds\030\001 \001(\003\022S\n\020taskLostBehavior\030\002 \001" +
+                    "(\01629.mesosphere.marathon.ResidencyDefini" +
+                    "tion.TaskLostBehavior\"@\n\020TaskLostBehavio" +
+                    "r\022\032\n\026RELAUNCH_AFTER_TIMEOUT\020\000\022\020\n\014WAIT_FO" +
+                    "REVER\020\001\"$\n\006Secret\022\n\n\002id\030\001 \002(\t\022\016\n\006source\030" +
+                    "\002 \002(\t\"\262\001\n\017EnvVarReference\0227\n\004type\030\001 \002(\0162" +
+                    ").mesosphere.marathon.EnvVarReference.Ty" +
+                    "pe\022\014\n\004name\030\002 \002(\t\0227\n\tsecretRef\030\003 \001(\0132$.me" +
+                    "sosphere.marathon.EnvVarSecretRef\"\037\n\004Typ",
+            "e\022\013\n\007UNKNOWN\020\000\022\n\n\006SECRET\020\001\"#\n\017EnvVarSecr" +
+                    "etRef\022\020\n\010secretId\030\001 \002(\tB\035\n\023mesosphere.ma" +
+      "rathonB\006Protos"
     };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<HealthCheckDefinition> getParserForType() {
-      return PARSER;
-    }
-
-    /**
-     * Protobuf enum {@code mesosphere.marathon.HealthCheckDefinition.Protocol}
-     */
-    public enum Protocol
-        implements com.google.protobuf.ProtocolMessageEnum {
-      /**
-       * <code>HTTP = 0;</code>
-       */
-      HTTP(0, 0),
-      /**
-       * <code>TCP = 1;</code>
-       */
-      TCP(1, 1),
-      /**
-       * <code>COMMAND = 2;</code>
-       */
-      COMMAND(2, 2),
-      /**
-       * <code>HTTPS = 3;</code>
-       */
-      HTTPS(3, 3),
-      ;
-
-      /**
-       * <code>HTTP = 0;</code>
-       */
-      public static final int HTTP_VALUE = 0;
-      /**
-       * <code>TCP = 1;</code>
-       */
-      public static final int TCP_VALUE = 1;
-      /**
-       * <code>COMMAND = 2;</code>
-       */
-      public static final int COMMAND_VALUE = 2;
-      /**
-       * <code>HTTPS = 3;</code>
-       */
-      public static final int HTTPS_VALUE = 3;
-
-
-      public final int getNumber() { return value; }
-
-      public static Protocol valueOf(int value) {
-        switch (value) {
-          case 0: return HTTP;
-          case 1: return TCP;
-          case 2: return COMMAND;
-          case 3: return HTTPS;
-          default: return null;
+    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
+      new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
+        public com.google.protobuf.ExtensionRegistry assignDescriptors(
+            com.google.protobuf.Descriptors.FileDescriptor root) {
+          descriptor = root;
+          internal_static_mesosphere_marathon_Constraint_descriptor =
+            getDescriptor().getMessageTypes().get(0);
+          internal_static_mesosphere_marathon_Constraint_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Constraint_descriptor,
+              new java.lang.String[] { "Field", "Operator", "Value", });
+          internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(1);
+          internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
+              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "Port", });
+          internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(2);
+          internal_static_mesosphere_marathon_ReadinessCheckDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor,
+              new java.lang.String[] { "Name", "Protocol", "Path", "PortName", "IntervalMillis", "TimeoutMillis", "HttpStatusCodeForReady", "PreserveLastResponse", });
+          internal_static_mesosphere_marathon_IpAddress_descriptor =
+            getDescriptor().getMessageTypes().get(3);
+          internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_IpAddress_descriptor,
+              new java.lang.String[] { "Groups", "Labels", "DiscoveryInfo", "NetworkName", });
+          internal_static_mesosphere_marathon_DiscoveryInfo_descriptor =
+            getDescriptor().getMessageTypes().get(4);
+          internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_DiscoveryInfo_descriptor,
+              new java.lang.String[] { "Ports", });
+          internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(5);
+          internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ServiceDefinition_descriptor,
+              new java.lang.String[] { "Id", "Cmd", "Instances", "Resources", "Description", "Ports", "Constraints", "Executor", "OBSOLETEContainer", "Version", "HealthChecks", "Backoff", "BackoffFactor", "UpgradeStrategy", "Dependencies", "StoreUrls", "RequirePorts", "Container", "Labels", "MaxLaunchDelay", "AcceptedResourceRoles", "LastScalingAt", "LastConfigChangeAt", "IpAddress", "Residency", "PortDefinitions", "ReadinessCheckDefinition", "Secrets", "EnvVarReferences", "TaskKillGracePeriod", });
+          internal_static_mesosphere_marathon_ResourceRoles_descriptor =
+            getDescriptor().getMessageTypes().get(6);
+          internal_static_mesosphere_marathon_ResourceRoles_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ResourceRoles_descriptor,
+              new java.lang.String[] { "Role", });
+          internal_static_mesosphere_marathon_MarathonTask_descriptor =
+            getDescriptor().getMessageTypes().get(7);
+          internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonTask_descriptor,
+              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "OBSOLETENetworks", "Reservation", "MarathonTaskStatus", });
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor =
+            internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor,
+              new java.lang.String[] { "LocalVolumeIds", "State", });
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor =
+            internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor,
+              new java.lang.String[] { "Type", "Timeout", });
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor =
+            internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor,
+              new java.lang.String[] { "Initiated", "Deadline", "Reason", });
+          internal_static_mesosphere_marathon_MarathonApp_descriptor =
+            getDescriptor().getMessageTypes().get(8);
+          internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_MarathonApp_descriptor,
+              new java.lang.String[] { "Name", "Tasks", });
+          internal_static_mesosphere_marathon_ContainerInfo_descriptor =
+            getDescriptor().getMessageTypes().get(9);
+          internal_static_mesosphere_marathon_ContainerInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ContainerInfo_descriptor,
+              new java.lang.String[] { "Image", "Options", });
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor =
+            getDescriptor().getMessageTypes().get(10);
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor,
+              new java.lang.String[] { "Type", "Volumes", "Docker", "MesosDocker", "MesosAppC", });
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor =
+            internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor,
+              new java.lang.String[] { "Image", "Network", "PortMappings", "Privileged", "Parameters", "ForcePullImage", });
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor =
+            internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor,
+              new java.lang.String[] { "HostPort", "ContainerPort", "Protocol", "Name", "Labels", "ServicePort", });
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_descriptor =
+            internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(1);
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_descriptor,
+              new java.lang.String[] { "Image", "Credential", "ForcePullImage", });
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_descriptor =
+            internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(2);
+          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_descriptor,
+              new java.lang.String[] { "Image", "Id", "Labels", "ForcePullImage", });
+          internal_static_mesosphere_marathon_Volume_descriptor =
+            getDescriptor().getMessageTypes().get(11);
+          internal_static_mesosphere_marathon_Volume_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Volume_descriptor,
+              new java.lang.String[] { "Mode", "ContainerPath", "HostPath", "Image", "Persistent", "External", });
+          internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor =
+            internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(0);
+          internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor,
+              new java.lang.String[] { "Size", });
+          internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor =
+            internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(1);
+          internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor,
+              new java.lang.String[] { "Size", "Name", "Provider", "Options", });
+          internal_static_mesosphere_marathon_EventSubscribers_descriptor =
+            getDescriptor().getMessageTypes().get(12);
+          internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_EventSubscribers_descriptor,
+              new java.lang.String[] { "CallbackUrls", });
+          internal_static_mesosphere_marathon_StorageVersion_descriptor =
+            getDescriptor().getMessageTypes().get(13);
+          internal_static_mesosphere_marathon_StorageVersion_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_StorageVersion_descriptor,
+              new java.lang.String[] { "Major", "Minor", "Patch", });
+          internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(14);
+          internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor,
+              new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", });
+          internal_static_mesosphere_marathon_GroupDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(15);
+          internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_GroupDefinition_descriptor,
+              new java.lang.String[] { "Id", "Version", "Apps", "Groups", "Dependencies", });
+          internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(16);
+          internal_static_mesosphere_marathon_DeploymentPlanDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor,
+              new java.lang.String[] { "Id", "Version", "Original", "Target", });
+          internal_static_mesosphere_marathon_TaskFailure_descriptor =
+            getDescriptor().getMessageTypes().get(17);
+          internal_static_mesosphere_marathon_TaskFailure_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_TaskFailure_descriptor,
+              new java.lang.String[] { "AppId", "TaskId", "State", "Message", "Host", "Version", "Timestamp", "SlaveId", });
+          internal_static_mesosphere_marathon_ZKStoreEntry_descriptor =
+            getDescriptor().getMessageTypes().get(18);
+          internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ZKStoreEntry_descriptor,
+              new java.lang.String[] { "Name", "Uuid", "Value", "Compressed", });
+          internal_static_mesosphere_marathon_ResidencyDefinition_descriptor =
+            getDescriptor().getMessageTypes().get(19);
+          internal_static_mesosphere_marathon_ResidencyDefinition_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_ResidencyDefinition_descriptor,
+              new java.lang.String[] { "RelaunchEscalationTimeoutSeconds", "TaskLostBehavior", });
+          internal_static_mesosphere_marathon_Secret_descriptor =
+            getDescriptor().getMessageTypes().get(20);
+          internal_static_mesosphere_marathon_Secret_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_Secret_descriptor,
+              new java.lang.String[] { "Id", "Source", });
+          internal_static_mesosphere_marathon_EnvVarReference_descriptor =
+            getDescriptor().getMessageTypes().get(21);
+          internal_static_mesosphere_marathon_EnvVarReference_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_EnvVarReference_descriptor,
+              new java.lang.String[] { "Type", "Name", "SecretRef", });
+          internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor =
+            getDescriptor().getMessageTypes().get(22);
+          internal_static_mesosphere_marathon_EnvVarSecretRef_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor,
+              new java.lang.String[] { "SecretId", });
+          return null;
         }
-      }
-
-      public static com.google.protobuf.Internal.EnumLiteMap<Protocol>
-          internalGetValueMap() {
-        return internalValueMap;
-      }
-      private static com.google.protobuf.Internal.EnumLiteMap<Protocol>
-          internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<Protocol>() {
-              public Protocol findValueByNumber(int number) {
-                return Protocol.valueOf(number);
-              }
-            };
-
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return mesosphere.marathon.Protos.HealthCheckDefinition.getDescriptor().getEnumTypes().get(0);
-      }
-
-      private static final Protocol[] VALUES = values();
-
-      public static Protocol valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-
-      private final int index;
-      private final int value;
-
-      private Protocol(int index, int value) {
-        this.index = index;
-        this.value = value;
-      }
-
-      // @@protoc_insertion_point(enum_scope:mesosphere.marathon.HealthCheckDefinition.Protocol)
-    }
-
-    private int bitField0_;
-    // required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;
-    public static final int PROTOCOL_FIELD_NUMBER = 1;
-    private mesosphere.marathon.Protos.HealthCheckDefinition.Protocol protocol_;
-    /**
-     * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
-     */
-    public boolean hasProtocol() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
-    }
-    /**
-     * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
-     */
-    public mesosphere.marathon.Protos.HealthCheckDefinition.Protocol getProtocol() {
-      return protocol_;
-    }
-
-    // optional uint32 portIndex = 2;
-    public static final int PORTINDEX_FIELD_NUMBER = 2;
-    private int portIndex_;
-    /**
-     * <code>optional uint32 portIndex = 2;</code>
-     */
-    public boolean hasPortIndex() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
-    }
-    /**
-     * <code>optional uint32 portIndex = 2;</code>
-     */
-    public int getPortIndex() {
-      return portIndex_;
-    }
-
-    // optional uint32 gracePeriodSeconds = 3 [default = 15];
-    public static final int GRACEPERIODSECONDS_FIELD_NUMBER = 3;
-    private int gracePeriodSeconds_;
-    /**
-     * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
-     */
-    public boolean hasGracePeriodSeconds() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
-    }
-    /**
-     * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
-     */
-    public int getGracePeriodSeconds() {
-      return gracePeriodSeconds_;
-    }
-
-    // optional uint32 intervalSeconds = 4 [default = 10];
-    public static final int INTERVALSECONDS_FIELD_NUMBER = 4;
-    private int intervalSeconds_;
-    /**
-     * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
-     */
-    public boolean hasIntervalSeconds() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
-    }
-    /**
-     * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
-     */
-    public int getIntervalSeconds() {
-      return intervalSeconds_;
-    }
-
-    // optional uint32 timeoutSeconds = 5 [default = 20];
-    public static final int TIMEOUTSECONDS_FIELD_NUMBER = 5;
-    private int timeoutSeconds_;
-    /**
-     * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
-     */
-    public boolean hasTimeoutSeconds() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
-    }
-    /**
-     * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
-     */
-    public int getTimeoutSeconds() {
-      return timeoutSeconds_;
-    }
-
-    // optional string path = 6 [default = "/"];
-    public static final int PATH_FIELD_NUMBER = 6;
-    private java.lang.Object path_;
-    /**
-     * <code>optional string path = 6 [default = "/"];</code>
-     *
-     * <pre>
-     * used for HTTP only
-     * </pre>
-     */
-    public boolean hasPath() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
-    }
-    /**
-     * <code>optional string path = 6 [default = "/"];</code>
-     *
-     * <pre>
-     * used for HTTP only
-     * </pre>
-     */
-    public java.lang.String getPath() {
-      java.lang.Object ref = path_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          path_ = s;
-        }
-        return s;
-      }
-    }
-    /**
-     * <code>optional string path = 6 [default = "/"];</code>
-     *
-     * <pre>
-     * used for HTTP only
-     * </pre>
-     */
-    public com.google.protobuf.ByteString
-        getPathBytes() {
-      java.lang.Object ref = path_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        path_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
-    }
-
-    // optional uint32 maxConsecutiveFailures = 7 [default = 3];
-    public static final int MAXCONSECUTIVEFAILURES_FIELD_NUMBER = 7;
-    private int maxConsecutiveFailures_;
-    /**
-     * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
-     */
-    public boolean hasMaxConsecutiveFailures() {
-      return ((bitField0_ & 0x00000040) == 0x00000040);
-    }
-    /**
-     * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
-     */
-    public int getMaxConsecutiveFailures() {
-      return maxConsecutiveFailures_;
-    }
-
-    // optional .mesos.CommandInfo command = 8;
-    public static final int COMMAND_FIELD_NUMBER = 8;
-    private org.apache.mesos.Protos.CommandInfo command_;
-    /**
-     * <code>optional .mesos.CommandInfo command = 8;</code>
-     */
-    public boolean hasCommand() {
-      return ((bitField0_ & 0x00000080) == 0x00000080);
-    }
-    /**
-     * <code>optional .mesos.CommandInfo command = 8;</code>
-     */
-    public org.apache.mesos.Protos.CommandInfo getCommand() {
-      return command_;
-    }
-    /**
-     * <code>optional .mesos.CommandInfo command = 8;</code>
-     */
-    public org.apache.mesos.Protos.CommandInfoOrBuilder getCommandOrBuilder() {
-      return command_;
-    }
-
-    // optional bool ignoreHttp1xx = 9 [default = false];
-    public static final int IGNOREHTTP1XX_FIELD_NUMBER = 9;
-    private boolean ignoreHttp1Xx_;
-    /**
-     * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
-     */
-    public boolean hasIgnoreHttp1Xx() {
-      return ((bitField0_ & 0x00000100) == 0x00000100);
-    }
-    /**
-     * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
-     */
-    public boolean getIgnoreHttp1Xx() {
-      return ignoreHttp1Xx_;
-    }
-
-    // optional uint32 port = 10;
-    public static final int PORT_FIELD_NUMBER = 10;
-    private int port_;
-    /**
-     * <code>optional uint32 port = 10;</code>
-     */
-    public boolean hasPort() {
-      return ((bitField0_ & 0x00000200) == 0x00000200);
-    }
-    /**
-     * <code>optional uint32 port = 10;</code>
-     */
-    public int getPort() {
-      return port_;
-    }
-
-    private void initFields() {
-      protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
-      portIndex_ = 0;
-      gracePeriodSeconds_ = 15;
-      intervalSeconds_ = 10;
-      timeoutSeconds_ = 20;
-      path_ = "/";
-      maxConsecutiveFailures_ = 3;
-      command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
-      ignoreHttp1Xx_ = false;
-      port_ = 0;
-    }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized != -1) return isInitialized == 1;
-
-      if (!hasProtocol()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (hasCommand()) {
-        if (!getCommand().isInitialized()) {
-          memoizedIsInitialized = 0;
-          return false;
-        }
-      }
-      memoizedIsInitialized = 1;
-      return true;
-    }
-
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeEnum(1, protocol_.getNumber());
-      }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeUInt32(2, portIndex_);
-      }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeUInt32(3, gracePeriodSeconds_);
-      }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeUInt32(4, intervalSeconds_);
-      }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        output.writeUInt32(5, timeoutSeconds_);
-      }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
-        output.writeBytes(6, getPathBytes());
-      }
-      if (((bitField0_ & 0x00000040) == 0x00000040)) {
-        output.writeUInt32(7, maxConsecutiveFailures_);
-      }
-      if (((bitField0_ & 0x00000080) == 0x00000080)) {
-        output.writeMessage(8, command_);
-      }
-      if (((bitField0_ & 0x00000100) == 0x00000100)) {
-        output.writeBool(9, ignoreHttp1Xx_);
-      }
-      if (((bitField0_ & 0x00000200) == 0x00000200)) {
-        output.writeUInt32(10, port_);
-      }
-      getUnknownFields().writeTo(output);
-    }
-
-    private int memoizedSerializedSize = -1;
-    public int getSerializedSize() {
-      int size = memoizedSerializedSize;
-      if (size != -1) return size;
-
-      size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(1, protocol_.getNumber());
-      }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(2, portIndex_);
-      }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(3, gracePeriodSeconds_);
-      }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(4, intervalSeconds_);
-      }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(5, timeoutSeconds_);
-      }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(6, getPathBytes());
-      }
-      if (((bitField0_ & 0x00000040) == 0x00000040)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(7, maxConsecutiveFailures_);
-      }
-      if (((bitField0_ & 0x00000080) == 0x00000080)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(8, command_);
-      }
-      if (((bitField0_ & 0x00000100) == 0x00000100)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBoolSize(9, ignoreHttp1Xx_);
-      }
-      if (((bitField0_ & 0x00000200) == 0x00000200)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(10, port_);
-      }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
-      return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
-    }
-
-    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-    public static mesosphere.marathon.Protos.HealthCheckDefinition parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-    public static mesosphere.marathon.Protos.HealthCheckDefinition parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(mesosphere.marathon.Protos.HealthCheckDefinition prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-    public Builder toBuilder() { return newBuilder(this); }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    /**
-     * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
-     */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder>
-       implements mesosphere.marathon.Protos.HealthCheckDefinitionOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                mesosphere.marathon.Protos.HealthCheckDefinition.class, mesosphere.marathon.Protos.HealthCheckDefinition.Builder.class);
-      }
-
-      // Construct using mesosphere.marathon.Protos.HealthCheckDefinition.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getCommandFieldBuilder();
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
-
-      public Builder clear() {
-        super.clear();
-        protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        portIndex_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        gracePeriodSeconds_ = 15;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        intervalSeconds_ = 10;
-        bitField0_ = (bitField0_ & ~0x00000008);
-        timeoutSeconds_ = 20;
-        bitField0_ = (bitField0_ & ~0x00000010);
-        path_ = "/";
-        bitField0_ = (bitField0_ & ~0x00000020);
-        maxConsecutiveFailures_ = 3;
-        bitField0_ = (bitField0_ & ~0x00000040);
-        if (commandBuilder_ == null) {
-          command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
-        } else {
-          commandBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000080);
-        ignoreHttp1Xx_ = false;
-        bitField0_ = (bitField0_ & ~0x00000100);
-        port_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000200);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor;
-      }
-
-      public mesosphere.marathon.Protos.HealthCheckDefinition getDefaultInstanceForType() {
-        return mesosphere.marathon.Protos.HealthCheckDefinition.getDefaultInstance();
-      }
-
-      public mesosphere.marathon.Protos.HealthCheckDefinition build() {
-        mesosphere.marathon.Protos.HealthCheckDefinition result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public mesosphere.marathon.Protos.HealthCheckDefinition buildPartial() {
-        mesosphere.marathon.Protos.HealthCheckDefinition result = new mesosphere.marathon.Protos.HealthCheckDefinition(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.protocol_ = protocol_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.portIndex_ = portIndex_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.gracePeriodSeconds_ = gracePeriodSeconds_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.intervalSeconds_ = intervalSeconds_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.timeoutSeconds_ = timeoutSeconds_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-          to_bitField0_ |= 0x00000020;
-        }
-        result.path_ = path_;
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-          to_bitField0_ |= 0x00000040;
-        }
-        result.maxConsecutiveFailures_ = maxConsecutiveFailures_;
-        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
-          to_bitField0_ |= 0x00000080;
-        }
-        if (commandBuilder_ == null) {
-          result.command_ = command_;
-        } else {
-          result.command_ = commandBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
-          to_bitField0_ |= 0x00000100;
-        }
-        result.ignoreHttp1Xx_ = ignoreHttp1Xx_;
-        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
-          to_bitField0_ |= 0x00000200;
-        }
-        result.port_ = port_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof mesosphere.marathon.Protos.HealthCheckDefinition) {
-          return mergeFrom((mesosphere.marathon.Protos.HealthCheckDefinition)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(mesosphere.marathon.Protos.HealthCheckDefinition other) {
-        if (other == mesosphere.marathon.Protos.HealthCheckDefinition.getDefaultInstance()) return this;
-        if (other.hasProtocol()) {
-          setProtocol(other.getProtocol());
-        }
-        if (other.hasPortIndex()) {
-          setPortIndex(other.getPortIndex());
-        }
-        if (other.hasGracePeriodSeconds()) {
-          setGracePeriodSeconds(other.getGracePeriodSeconds());
-        }
-        if (other.hasIntervalSeconds()) {
-          setIntervalSeconds(other.getIntervalSeconds());
-        }
-        if (other.hasTimeoutSeconds()) {
-          setTimeoutSeconds(other.getTimeoutSeconds());
-        }
-        if (other.hasPath()) {
-          bitField0_ |= 0x00000020;
-          path_ = other.path_;
-          onChanged();
-        }
-        if (other.hasMaxConsecutiveFailures()) {
-          setMaxConsecutiveFailures(other.getMaxConsecutiveFailures());
-        }
-        if (other.hasCommand()) {
-          mergeCommand(other.getCommand());
-        }
-        if (other.hasIgnoreHttp1Xx()) {
-          setIgnoreHttp1Xx(other.getIgnoreHttp1Xx());
-        }
-        if (other.hasPort()) {
-          setPort(other.getPort());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        if (!hasProtocol()) {
-          
-          return false;
-        }
-        if (hasCommand()) {
-          if (!getCommand().isInitialized()) {
-            
-            return false;
-          }
-        }
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        mesosphere.marathon.Protos.HealthCheckDefinition parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (mesosphere.marathon.Protos.HealthCheckDefinition) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      // required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;
-      private mesosphere.marathon.Protos.HealthCheckDefinition.Protocol protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
-      /**
-       * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
-       */
-      public boolean hasProtocol() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
-      }
-      /**
-       * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
-       */
-      public mesosphere.marathon.Protos.HealthCheckDefinition.Protocol getProtocol() {
-        return protocol_;
-      }
-      /**
-       * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
-       */
-      public Builder setProtocol(mesosphere.marathon.Protos.HealthCheckDefinition.Protocol value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
-        protocol_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
-       */
-      public Builder clearProtocol() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
-        onChanged();
-        return this;
-      }
-
-      // optional uint32 portIndex = 2;
-      private int portIndex_ ;
-      /**
-       * <code>optional uint32 portIndex = 2;</code>
-       */
-      public boolean hasPortIndex() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
-      }
-      /**
-       * <code>optional uint32 portIndex = 2;</code>
-       */
-      public int getPortIndex() {
-        return portIndex_;
-      }
-      /**
-       * <code>optional uint32 portIndex = 2;</code>
-       */
-      public Builder setPortIndex(int value) {
-        bitField0_ |= 0x00000002;
-        portIndex_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional uint32 portIndex = 2;</code>
-       */
-      public Builder clearPortIndex() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        portIndex_ = 0;
-        onChanged();
-        return this;
-      }
-
-      // optional uint32 gracePeriodSeconds = 3 [default = 15];
-      private int gracePeriodSeconds_ = 15;
-      /**
-       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
-       */
-      public boolean hasGracePeriodSeconds() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
-      }
-      /**
-       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
-       */
-      public int getGracePeriodSeconds() {
-        return gracePeriodSeconds_;
-      }
-      /**
-       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
-       */
-      public Builder setGracePeriodSeconds(int value) {
-        bitField0_ |= 0x00000004;
-        gracePeriodSeconds_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
-       */
-      public Builder clearGracePeriodSeconds() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        gracePeriodSeconds_ = 15;
-        onChanged();
-        return this;
-      }
-
-      // optional uint32 intervalSeconds = 4 [default = 10];
-      private int intervalSeconds_ = 10;
-      /**
-       * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
-       */
-      public boolean hasIntervalSeconds() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
-      }
-      /**
-       * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
-       */
-      public int getIntervalSeconds() {
-        return intervalSeconds_;
-      }
-      /**
-       * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
-       */
-      public Builder setIntervalSeconds(int value) {
-        bitField0_ |= 0x00000008;
-        intervalSeconds_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
-       */
-      public Builder clearIntervalSeconds() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        intervalSeconds_ = 10;
-        onChanged();
-        return this;
-      }
-
-      // optional uint32 timeoutSeconds = 5 [default = 20];
-      private int timeoutSeconds_ = 20;
-      /**
-       * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
-       */
-      public boolean hasTimeoutSeconds() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
-      }
-      /**
-       * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
-       */
-      public int getTimeoutSeconds() {
-        return timeoutSeconds_;
-      }
-      /**
-       * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
-       */
-      public Builder setTimeoutSeconds(int value) {
-        bitField0_ |= 0x00000010;
-        timeoutSeconds_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
-       */
-      public Builder clearTimeoutSeconds() {
-        bitField0_ = (bitField0_ & ~0x00000010);
-        timeoutSeconds_ = 20;
-        onChanged();
-        return this;
-      }
-
-      // optional string path = 6 [default = "/"];
-      private java.lang.Object path_ = "/";
-      /**
-       * <code>optional string path = 6 [default = "/"];</code>
-       *
-       * <pre>
-       * used for HTTP only
-       * </pre>
-       */
-      public boolean hasPath() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
-      }
-      /**
-       * <code>optional string path = 6 [default = "/"];</code>
-       *
-       * <pre>
-       * used for HTTP only
-       * </pre>
-       */
-      public java.lang.String getPath() {
-        java.lang.Object ref = path_;
-        if (!(ref instanceof java.lang.String)) {
-          java.lang.String s = ((com.google.protobuf.ByteString) ref)
-              .toStringUtf8();
-          path_ = s;
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
-      }
-      /**
-       * <code>optional string path = 6 [default = "/"];</code>
-       *
-       * <pre>
-       * used for HTTP only
-       * </pre>
-       */
-      public com.google.protobuf.ByteString
-          getPathBytes() {
-        java.lang.Object ref = path_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          path_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
-      }
-      /**
-       * <code>optional string path = 6 [default = "/"];</code>
-       *
-       * <pre>
-       * used for HTTP only
-       * </pre>
-       */
-      public Builder setPath(
-          java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000020;
-        path_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional string path = 6 [default = "/"];</code>
-       *
-       * <pre>
-       * used for HTTP only
-       * </pre>
-       */
-      public Builder clearPath() {
-        bitField0_ = (bitField0_ & ~0x00000020);
-        path_ = getDefaultInstance().getPath();
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional string path = 6 [default = "/"];</code>
-       *
-       * <pre>
-       * used for HTTP only
-       * </pre>
-       */
-      public Builder setPathBytes(
-          com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000020;
-        path_ = value;
-        onChanged();
-        return this;
-      }
-
-      // optional uint32 maxConsecutiveFailures = 7 [default = 3];
-      private int maxConsecutiveFailures_ = 3;
-      /**
-       * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
-       */
-      public boolean hasMaxConsecutiveFailures() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
-      }
-      /**
-       * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
-       */
-      public int getMaxConsecutiveFailures() {
-        return maxConsecutiveFailures_;
-      }
-      /**
-       * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
-       */
-      public Builder setMaxConsecutiveFailures(int value) {
-        bitField0_ |= 0x00000040;
-        maxConsecutiveFailures_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
-       */
-      public Builder clearMaxConsecutiveFailures() {
-        bitField0_ = (bitField0_ & ~0x00000040);
-        maxConsecutiveFailures_ = 3;
-        onChanged();
-        return this;
-      }
-
-      // optional .mesos.CommandInfo command = 8;
-      private org.apache.mesos.Protos.CommandInfo command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
-          org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder> commandBuilder_;
-      /**
-       * <code>optional .mesos.CommandInfo command = 8;</code>
-       */
-      public boolean hasCommand() {
-        return ((bitField0_ & 0x00000080) == 0x00000080);
-      }
-      /**
-       * <code>optional .mesos.CommandInfo command = 8;</code>
-       */
-      public org.apache.mesos.Protos.CommandInfo getCommand() {
-        if (commandBuilder_ == null) {
-          return command_;
-        } else {
-          return commandBuilder_.getMessage();
-        }
-      }
-      /**
-       * <code>optional .mesos.CommandInfo command = 8;</code>
-       */
-      public Builder setCommand(org.apache.mesos.Protos.CommandInfo value) {
-        if (commandBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          command_ = value;
-          onChanged();
-        } else {
-          commandBuilder_.setMessage(value);
-        }
-        bitField0_ |= 0x00000080;
-        return this;
-      }
-      /**
-       * <code>optional .mesos.CommandInfo command = 8;</code>
-       */
-      public Builder setCommand(
-          org.apache.mesos.Protos.CommandInfo.Builder builderForValue) {
-        if (commandBuilder_ == null) {
-          command_ = builderForValue.build();
-          onChanged();
-        } else {
-          commandBuilder_.setMessage(builderForValue.build());
-        }
-        bitField0_ |= 0x00000080;
-        return this;
-      }
-      /**
-       * <code>optional .mesos.CommandInfo command = 8;</code>
-       */
-      public Builder mergeCommand(org.apache.mesos.Protos.CommandInfo value) {
-        if (commandBuilder_ == null) {
-          if (((bitField0_ & 0x00000080) == 0x00000080) &&
-              command_ != org.apache.mesos.Protos.CommandInfo.getDefaultInstance()) {
-            command_ =
-              org.apache.mesos.Protos.CommandInfo.newBuilder(command_).mergeFrom(value).buildPartial();
-          } else {
-            command_ = value;
-          }
-          onChanged();
-        } else {
-          commandBuilder_.mergeFrom(value);
-        }
-        bitField0_ |= 0x00000080;
-        return this;
-      }
-      /**
-       * <code>optional .mesos.CommandInfo command = 8;</code>
-       */
-      public Builder clearCommand() {
-        if (commandBuilder_ == null) {
-          command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
-          onChanged();
-        } else {
-          commandBuilder_.clear();
-        }
-        bitField0_ = (bitField0_ & ~0x00000080);
-        return this;
-      }
-      /**
-       * <code>optional .mesos.CommandInfo command = 8;</code>
-       */
-      public org.apache.mesos.Protos.CommandInfo.Builder getCommandBuilder() {
-        bitField0_ |= 0x00000080;
-        onChanged();
-        return getCommandFieldBuilder().getBuilder();
-      }
-      /**
-       * <code>optional .mesos.CommandInfo command = 8;</code>
-       */
-      public org.apache.mesos.Protos.CommandInfoOrBuilder getCommandOrBuilder() {
-        if (commandBuilder_ != null) {
-          return commandBuilder_.getMessageOrBuilder();
-        } else {
-          return command_;
-        }
-      }
-      /**
-       * <code>optional .mesos.CommandInfo command = 8;</code>
-       */
-      private com.google.protobuf.SingleFieldBuilder<
-          org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder> 
-          getCommandFieldBuilder() {
-        if (commandBuilder_ == null) {
-          commandBuilder_ = new com.google.protobuf.SingleFieldBuilder<
-              org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder>(
-                  command_,
-                  getParentForChildren(),
-                  isClean());
-          command_ = null;
-        }
-        return commandBuilder_;
-      }
-
-      // optional bool ignoreHttp1xx = 9 [default = false];
-      private boolean ignoreHttp1Xx_ ;
-      /**
-       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
-       */
-      public boolean hasIgnoreHttp1Xx() {
-        return ((bitField0_ & 0x00000100) == 0x00000100);
-      }
-      /**
-       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
-       */
-      public boolean getIgnoreHttp1Xx() {
-        return ignoreHttp1Xx_;
-      }
-      /**
-       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
-       */
-      public Builder setIgnoreHttp1Xx(boolean value) {
-        bitField0_ |= 0x00000100;
-        ignoreHttp1Xx_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
-       */
-      public Builder clearIgnoreHttp1Xx() {
-        bitField0_ = (bitField0_ & ~0x00000100);
-        ignoreHttp1Xx_ = false;
-        onChanged();
-        return this;
-      }
-
-      // optional uint32 port = 10;
-      private int port_ ;
-      /**
-       * <code>optional uint32 port = 10;</code>
-       */
-      public boolean hasPort() {
-        return ((bitField0_ & 0x00000200) == 0x00000200);
-      }
-      /**
-       * <code>optional uint32 port = 10;</code>
-       */
-      public int getPort() {
-        return port_;
-      }
-      /**
-       * <code>optional uint32 port = 10;</code>
-       */
-      public Builder setPort(int value) {
-        bitField0_ |= 0x00000200;
-        port_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional uint32 port = 10;</code>
-       */
-      public Builder clearPort() {
-        bitField0_ = (bitField0_ & ~0x00000200);
-        port_ = 0;
-        onChanged();
-        return this;
-      }
-
-      // @@protoc_insertion_point(builder_scope:mesosphere.marathon.HealthCheckDefinition)
-    }
-
-    static {
-      defaultInstance = new HealthCheckDefinition(true);
-      defaultInstance.initFields();
-    }
-
-    // @@protoc_insertion_point(class_scope:mesosphere.marathon.HealthCheckDefinition)
+      };
+    com.google.protobuf.Descriptors.FileDescriptor
+      .internalBuildGeneratedFileFrom(descriptorData,
+        new com.google.protobuf.Descriptors.FileDescriptor[] {
+          org.apache.mesos.Protos.getDescriptor(),
+        }, assigner);
   }
 
   public interface ReadinessCheckDefinitionOrBuilder
@@ -39114,376 +38123,1399 @@ public final class Protos {
   }
   private static com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
-  static {
-    java.lang.String[] descriptorData = {
-      "\n\016marathon.proto\022\023mesosphere.marathon\032\021m" +
-      "esos/mesos.proto\"\274\001\n\nConstraint\022\r\n\005field" +
-      "\030\001 \002(\t\022:\n\010operator\030\002 \002(\0162(.mesosphere.ma" +
-      "rathon.Constraint.Operator\022\r\n\005value\030\003 \001(" +
-      "\t\"T\n\010Operator\022\n\n\006UNIQUE\020\000\022\010\n\004LIKE\020\001\022\013\n\007C" +
-      "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\022\013\n\007MA" +
-      "X_PER\020\005\"\206\003\n\025HealthCheckDefinition\022E\n\010pro" +
-      "tocol\030\001 \002(\01623.mesosphere.marathon.Health" +
-      "CheckDefinition.Protocol\022\021\n\tportIndex\030\002 " +
-      "\001(\r\022\036\n\022gracePeriodSeconds\030\003 \001(\r:\00215\022\033\n\017i",
-      "ntervalSeconds\030\004 \001(\r:\00210\022\032\n\016timeoutSecon" +
-      "ds\030\005 \001(\r:\00220\022\017\n\004path\030\006 \001(\t:\001/\022!\n\026maxCons" +
-      "ecutiveFailures\030\007 \001(\r:\0013\022#\n\007command\030\010 \001(" +
-      "\0132\022.mesos.CommandInfo\022\034\n\rignoreHttp1xx\030\t" +
-      " \001(\010:\005false\022\014\n\004port\030\n \001(\r\"5\n\010Protocol\022\010\n" +
-      "\004HTTP\020\000\022\007\n\003TCP\020\001\022\013\n\007COMMAND\020\002\022\t\n\005HTTPS\020\003" +
-      "\"\240\002\n\030ReadinessCheckDefinition\022\014\n\004name\030\001 " +
-      "\001(\t\022H\n\010protocol\030\002 \001(\01626.mesosphere.marat" +
-      "hon.ReadinessCheckDefinition.Protocol\022\014\n" +
-      "\004path\030\003 \001(\t\022\020\n\010portName\030\004 \001(\t\022\026\n\016interva",
-      "lMillis\030\005 \001(\004\022\025\n\rtimeoutMillis\030\006 \001(\004\022\036\n\026" +
-      "httpStatusCodeForReady\030\007 \003(\r\022\034\n\024preserve" +
-      "LastResponse\030\010 \001(\010\"\037\n\010Protocol\022\010\n\004HTTP\020\000" +
-      "\022\t\n\005HTTPS\020\001\"\211\001\n\tIpAddress\022\016\n\006groups\030\001 \003(" +
-      "\t\022\034\n\006labels\030\002 \003(\0132\014.mesos.Label\0229\n\rdisco" +
-      "veryInfo\030\003 \001(\0132\".mesosphere.marathon.Dis" +
-      "coveryInfo\022\023\n\013networkName\030\004 \001(\t\"+\n\rDisco" +
-      "veryInfo\022\032\n\005ports\030\001 \003(\0132\013.mesos.Port\"\305\t\n" +
-      "\021ServiceDefinition\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030\002 " +
-      "\002(\0132\022.mesos.CommandInfo\022\021\n\tinstances\030\003 \002",
-      "(\r\022\"\n\tresources\030\004 \003(\0132\017.mesos.Resource\022\023" +
-      "\n\013description\030\005 \001(\t\022\r\n\005ports\030\006 \003(\r\0224\n\013co" +
-      "nstraints\030\007 \003(\0132\037.mesosphere.marathon.Co" +
-      "nstraint\022\022\n\010executor\030\010 \002(\t:\000\022>\n\022OBSOLETE" +
-      "_container\030\n \001(\0132\".mesosphere.marathon.C" +
-      "ontainerInfo\022)\n\007version\030\013 \001(\t:\0301970-01-0" +
-      "1T00:00:00.000Z\022@\n\014healthChecks\030\014 \003(\0132*." +
-      "mesosphere.marathon.HealthCheckDefinitio" +
-      "n\022\025\n\007backoff\030\r \001(\003:\0041000\022\033\n\rbackoffFacto" +
-      "r\030\016 \001(\001:\0041.15\022G\n\017upgradeStrategy\030\017 \001(\0132.",
-      ".mesosphere.marathon.UpgradeStrategyDefi" +
-      "nition\022\024\n\014dependencies\030\020 \003(\t\022\021\n\tstoreUrl" +
-      "s\030\021 \003(\t\022\034\n\rrequire_ports\030\022 \001(\010:\005false\022=\n" +
-      "\tcontainer\030\023 \001(\0132*.mesosphere.marathon.E" +
-      "xtendedContainerInfo\022 \n\006labels\030\024 \003(\0132\020.m" +
-      "esos.Parameter\022\037\n\016maxLaunchDelay\030\025 \001(\003:\007" +
-      "3600000\022A\n\025acceptedResourceRoles\030\026 \001(\0132\"" +
-      ".mesosphere.marathon.ResourceRoles\022\027\n\017la" +
-      "st_scaling_at\030\027 \001(\003\022\035\n\025last_config_chang" +
-      "e_at\030\030 \001(\003\0221\n\tipAddress\030\031 \001(\0132\036.mesosphe",
-      "re.marathon.IpAddress\022;\n\tresidency\030\032 \001(\013" +
-      "2(.mesosphere.marathon.ResidencyDefiniti" +
-      "on\022$\n\017portDefinitions\030\033 \003(\0132\013.mesos.Port" +
-      "\022O\n\030readinessCheckDefinition\030\034 \003(\0132-.mes" +
-      "osphere.marathon.ReadinessCheckDefinitio" +
-      "n\022,\n\007secrets\030\035 \003(\0132\033.mesosphere.marathon" +
-      ".Secret\022>\n\020envVarReferences\030\036 \003(\0132$.meso" +
-      "sphere.marathon.EnvVarReference\022\033\n\023taskK" +
-      "illGracePeriod\030\037 \001(\003\"\035\n\rResourceRoles\022\014\n" +
-      "\004role\030\001 \003(\t\"\346\t\n\014MarathonTask\022\n\n\002id\030\001 \002(\t",
-      "\022\014\n\004host\030\002 \001(\t\022\r\n\005ports\030\003 \003(\r\022$\n\nattribu" +
-      "tes\030\004 \003(\0132\020.mesos.Attribute\022\021\n\tstaged_at" +
-      "\030\005 \001(\003\022\022\n\nstarted_at\030\006 \001(\003\022,\n\021OBSOLETE_s" +
-      "tatuses\030\007 \003(\0132\021.mesos.TaskStatus\022)\n\007vers" +
-      "ion\030\010 \001(\t:\0301970-01-01T00:00:00.000Z\022!\n\006s" +
-      "tatus\030\t \001(\0132\021.mesos.TaskStatus\022\037\n\007slaveI" +
-      "d\030\n \001(\0132\016.mesos.SlaveID\022-\n\021OBSOLETE_netw" +
-      "orks\030\013 \003(\0132\022.mesos.NetworkInfo\022B\n\013reserv" +
-      "ation\030\014 \001(\0132-.mesosphere.marathon.Marath" +
-      "onTask.Reservation\022P\n\022marathonTaskStatus",
-      "\030\r \001(\01624.mesosphere.marathon.MarathonTas" +
-      "k.MarathonTaskStatus\032\231\004\n\013Reservation\022\030\n\020" +
-      "local_volume_ids\030\001 \003(\t\022B\n\005state\030\002 \002(\01323." +
-      "mesosphere.marathon.MarathonTask.Reserva" +
-      "tion.State\032\253\003\n\005State\022F\n\004type\030\001 \002(\01628.mes" +
-      "osphere.marathon.MarathonTask.Reservatio" +
-      "n.State.Type\022L\n\007timeout\030\002 \001(\0132;.mesosphe" +
-      "re.marathon.MarathonTask.Reservation.Sta" +
-      "te.Timeout\032\303\001\n\007Timeout\022\021\n\tinitiated\030\001 \002(" +
-      "\003\022\020\n\010deadline\030\002 \002(\003\022R\n\006reason\030\003 \002(\0162B.me",
-      "sosphere.marathon.MarathonTask.Reservati" +
-      "on.State.Timeout.Reason\"?\n\006Reason\022\035\n\031Rel" +
-      "aunchEscalationTimeout\020\001\022\026\n\022ReservationT" +
-      "imeout\020\002\"F\n\004Type\022\007\n\003New\020\001\022\014\n\010Launched\020\002\022" +
-      "\r\n\tSuspended\020\003\022\013\n\007Garbage\020\004\022\013\n\007Unknown\020\005" +
-      "\"\341\001\n\022MarathonTaskStatus\022\013\n\007Invalid\020\000\022\014\n\010" +
-      "Reserved\020\001\022\013\n\007Created\020\002\022\t\n\005Error\020\003\022\n\n\006Fa" +
-      "iled\020\004\022\014\n\010Finished\020\005\022\n\n\006Killed\020\006\022\013\n\007Kill" +
-      "ing\020\007\022\010\n\004Lost\020\010\022\013\n\007Running\020\t\022\013\n\007Staging\020" +
-      "\n\022\014\n\010Starting\020\013\022\017\n\013Unreachable\020\014\022\010\n\004Gone",
-      "\020\r\022\013\n\007Unknown\020\016\022\013\n\007Dropped\020\017\"M\n\013Marathon" +
-      "App\022\014\n\004name\030\001 \001(\t\0220\n\005tasks\030\002 \003(\0132!.mesos" +
-      "phere.marathon.MarathonTask\"1\n\rContainer" +
-      "Info\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007options\030\002 \003(\014\"\277" +
-      "\007\n\025ExtendedContainerInfo\022\'\n\004type\030\001 \002(\0162\031" +
-      ".mesos.ContainerInfo.Type\022,\n\007volumes\030\002 \003" +
-      "(\0132\033.mesosphere.marathon.Volume\022E\n\006docke" +
-      "r\030\003 \001(\01325.mesosphere.marathon.ExtendedCo" +
-      "ntainerInfo.DockerInfo\022O\n\013mesosDocker\030\004 " +
-      "\001(\0132:.mesosphere.marathon.ExtendedContai",
-      "nerInfo.MesosDockerInfo\022K\n\tmesosAppC\030\005 \001" +
-      "(\01328.mesosphere.marathon.ExtendedContain" +
-      "erInfo.MesosAppCInfo\032\242\003\n\nDockerInfo\022\r\n\005i" +
-      "mage\030\001 \002(\t\022>\n\007network\030\002 \001(\0162\'.mesos.Cont" +
-      "ainerInfo.DockerInfo.Network:\004HOST\022X\n\rpo" +
-      "rt_mappings\030\003 \003(\0132A.mesosphere.marathon." +
-      "ExtendedContainerInfo.DockerInfo.PortMap" +
-      "ping\022\031\n\nprivileged\030\004 \001(\010:\005false\022$\n\nparam" +
-      "eters\030\005 \003(\0132\020.mesos.Parameter\022\030\n\020force_p" +
-      "ull_image\030\006 \001(\010\032\217\001\n\013PortMapping\022\021\n\thost_",
-      "port\030\001 \001(\r\022\026\n\016container_port\030\002 \002(\r\022\020\n\010pr" +
-      "otocol\030\003 \001(\t\022\014\n\004name\030\004 \001(\t\022\034\n\006labels\030\005 \003" +
-      "(\0132\014.mesos.Label\022\027\n\014service_port\030d \001(\r:\001" +
-      "0\032a\n\017MesosDockerInfo\022\r\n\005image\030\001 \002(\t\022%\n\nc" +
-      "redential\030\002 \001(\0132\021.mesos.Credential\022\030\n\020fo" +
-      "rce_pull_image\030\003 \001(\010\032b\n\rMesosAppCInfo\022\r\n" +
-      "\005image\030\001 \002(\t\022\n\n\002id\030\002 \001(\t\022\034\n\006labels\030\003 \003(\013" +
-      "2\014.mesos.Label\022\030\n\020force_pull_image\030\004 \001(\010" +
-      "\"\203\003\n\006Volume\022 \n\004mode\030\003 \002(\0162\022.mesos.Volume" +
-      ".Mode\022\026\n\016container_path\030\001 \002(\t\022\021\n\thost_pa",
-      "th\030\002 \001(\t\022\033\n\005image\030\004 \001(\0132\014.mesos.Image\022D\n" +
-      "\npersistent\030\005 \001(\01320.mesosphere.marathon." +
-      "Volume.PersistentVolumeInfo\022@\n\010external\030" +
-      "\006 \001(\0132..mesosphere.marathon.Volume.Exter" +
-      "nalVolumeInfo\032$\n\024PersistentVolumeInfo\022\014\n" +
-      "\004size\030\001 \002(\004\032a\n\022ExternalVolumeInfo\022\014\n\004siz" +
-      "e\030\001 \001(\004\022\014\n\004name\030\002 \002(\t\022\020\n\010provider\030\003 \002(\t\022" +
-      "\035\n\007options\030\004 \003(\0132\014.mesos.Label\")\n\020EventS" +
-      "ubscribers\022\025\n\rcallback_urls\030\001 \003(\t\"=\n\016Sto" +
-      "rageVersion\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(",
-      "\r\022\r\n\005patch\030\003 \002(\r\"Z\n\031UpgradeStrategyDefin" +
-      "ition\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023" +
-      "maximumOverCapacity\030\002 \001(\001:\0011\"\260\001\n\017GroupDe" +
-      "finition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0224\n" +
-      "\004apps\030\003 \003(\0132&.mesosphere.marathon.Servic" +
-      "eDefinition\0224\n\006groups\030\004 \003(\0132$.mesosphere" +
-      ".marathon.GroupDefinition\022\024\n\014dependencie" +
-      "s\030\005 \003(\t\"\245\001\n\030DeploymentPlanDefinition\022\n\n\002" +
-      "id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\0226\n\010original\030\004 " +
-      "\002(\0132$.mesosphere.marathon.GroupDefinitio",
-      "n\0224\n\006target\030\005 \002(\0132$.mesosphere.marathon." +
-      "GroupDefinition\"\306\001\n\013TaskFailure\022\016\n\006app_i" +
-      "d\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022" +
-      "\037\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007mess" +
-      "age\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006" +
-      " \002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\013" +
-      "2\016.mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004name" +
-      "\030\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\nc" +
-      "ompressed\030\004 \001(\010:\005false\"\326\001\n\023ResidencyDefi" +
-      "nition\022(\n relaunchEscalationTimeoutSecon",
-      "ds\030\001 \001(\003\022S\n\020taskLostBehavior\030\002 \001(\01629.mes" +
-      "osphere.marathon.ResidencyDefinition.Tas" +
-      "kLostBehavior\"@\n\020TaskLostBehavior\022\032\n\026REL" +
-      "AUNCH_AFTER_TIMEOUT\020\000\022\020\n\014WAIT_FOREVER\020\001\"" +
-      "$\n\006Secret\022\n\n\002id\030\001 \002(\t\022\016\n\006source\030\002 \002(\t\"\262\001" +
-      "\n\017EnvVarReference\0227\n\004type\030\001 \002(\0162).mesosp" +
-      "here.marathon.EnvVarReference.Type\022\014\n\004na" +
-      "me\030\002 \002(\t\0227\n\tsecretRef\030\003 \001(\0132$.mesosphere" +
-      ".marathon.EnvVarSecretRef\"\037\n\004Type\022\013\n\007UNK" +
-      "NOWN\020\000\022\n\n\006SECRET\020\001\"#\n\017EnvVarSecretRef\022\020\n",
-      "\010secretId\030\001 \002(\tB\035\n\023mesosphere.marathonB\006" +
-      "Protos"
-    };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-      new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-        public com.google.protobuf.ExtensionRegistry assignDescriptors(
-            com.google.protobuf.Descriptors.FileDescriptor root) {
-          descriptor = root;
-          internal_static_mesosphere_marathon_Constraint_descriptor =
-            getDescriptor().getMessageTypes().get(0);
-          internal_static_mesosphere_marathon_Constraint_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Constraint_descriptor,
-              new java.lang.String[] { "Field", "Operator", "Value", });
-          internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(1);
-          internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
-              new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "Port", });
-          internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(2);
-          internal_static_mesosphere_marathon_ReadinessCheckDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor,
-              new java.lang.String[] { "Name", "Protocol", "Path", "PortName", "IntervalMillis", "TimeoutMillis", "HttpStatusCodeForReady", "PreserveLastResponse", });
-          internal_static_mesosphere_marathon_IpAddress_descriptor =
-            getDescriptor().getMessageTypes().get(3);
-          internal_static_mesosphere_marathon_IpAddress_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_IpAddress_descriptor,
-              new java.lang.String[] { "Groups", "Labels", "DiscoveryInfo", "NetworkName", });
-          internal_static_mesosphere_marathon_DiscoveryInfo_descriptor =
-            getDescriptor().getMessageTypes().get(4);
-          internal_static_mesosphere_marathon_DiscoveryInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_DiscoveryInfo_descriptor,
-              new java.lang.String[] { "Ports", });
-          internal_static_mesosphere_marathon_ServiceDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(5);
-          internal_static_mesosphere_marathon_ServiceDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ServiceDefinition_descriptor,
-              new java.lang.String[] { "Id", "Cmd", "Instances", "Resources", "Description", "Ports", "Constraints", "Executor", "OBSOLETEContainer", "Version", "HealthChecks", "Backoff", "BackoffFactor", "UpgradeStrategy", "Dependencies", "StoreUrls", "RequirePorts", "Container", "Labels", "MaxLaunchDelay", "AcceptedResourceRoles", "LastScalingAt", "LastConfigChangeAt", "IpAddress", "Residency", "PortDefinitions", "ReadinessCheckDefinition", "Secrets", "EnvVarReferences", "TaskKillGracePeriod", });
-          internal_static_mesosphere_marathon_ResourceRoles_descriptor =
-            getDescriptor().getMessageTypes().get(6);
-          internal_static_mesosphere_marathon_ResourceRoles_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ResourceRoles_descriptor,
-              new java.lang.String[] { "Role", });
-          internal_static_mesosphere_marathon_MarathonTask_descriptor =
-            getDescriptor().getMessageTypes().get(7);
-          internal_static_mesosphere_marathon_MarathonTask_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_descriptor,
-              new java.lang.String[] { "Id", "Host", "Ports", "Attributes", "StagedAt", "StartedAt", "OBSOLETEStatuses", "Version", "Status", "SlaveId", "OBSOLETENetworks", "Reservation", "MarathonTaskStatus", });
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor =
-            internal_static_mesosphere_marathon_MarathonTask_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor,
-              new java.lang.String[] { "LocalVolumeIds", "State", });
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor =
-            internal_static_mesosphere_marathon_MarathonTask_Reservation_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor,
-              new java.lang.String[] { "Type", "Timeout", });
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor =
-            internal_static_mesosphere_marathon_MarathonTask_Reservation_State_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonTask_Reservation_State_Timeout_descriptor,
-              new java.lang.String[] { "Initiated", "Deadline", "Reason", });
-          internal_static_mesosphere_marathon_MarathonApp_descriptor =
-            getDescriptor().getMessageTypes().get(8);
-          internal_static_mesosphere_marathon_MarathonApp_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_MarathonApp_descriptor,
-              new java.lang.String[] { "Name", "Tasks", });
-          internal_static_mesosphere_marathon_ContainerInfo_descriptor =
-            getDescriptor().getMessageTypes().get(9);
-          internal_static_mesosphere_marathon_ContainerInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ContainerInfo_descriptor,
-              new java.lang.String[] { "Image", "Options", });
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor =
-            getDescriptor().getMessageTypes().get(10);
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor,
-              new java.lang.String[] { "Type", "Volumes", "Docker", "MesosDocker", "MesosAppC", });
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor =
-            internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor,
-              new java.lang.String[] { "Image", "Network", "PortMappings", "Privileged", "Parameters", "ForcePullImage", });
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor =
-            internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ExtendedContainerInfo_DockerInfo_PortMapping_descriptor,
-              new java.lang.String[] { "HostPort", "ContainerPort", "Protocol", "Name", "Labels", "ServicePort", });
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_descriptor =
-            internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(1);
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosDockerInfo_descriptor,
-              new java.lang.String[] { "Image", "Credential", "ForcePullImage", });
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_descriptor =
-            internal_static_mesosphere_marathon_ExtendedContainerInfo_descriptor.getNestedTypes().get(2);
-          internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ExtendedContainerInfo_MesosAppCInfo_descriptor,
-              new java.lang.String[] { "Image", "Id", "Labels", "ForcePullImage", });
-          internal_static_mesosphere_marathon_Volume_descriptor =
-            getDescriptor().getMessageTypes().get(11);
-          internal_static_mesosphere_marathon_Volume_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Volume_descriptor,
-              new java.lang.String[] { "Mode", "ContainerPath", "HostPath", "Image", "Persistent", "External", });
-          internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor =
-            internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(0);
-          internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Volume_PersistentVolumeInfo_descriptor,
-              new java.lang.String[] { "Size", });
-          internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor =
-            internal_static_mesosphere_marathon_Volume_descriptor.getNestedTypes().get(1);
-          internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Volume_ExternalVolumeInfo_descriptor,
-              new java.lang.String[] { "Size", "Name", "Provider", "Options", });
-          internal_static_mesosphere_marathon_EventSubscribers_descriptor =
-            getDescriptor().getMessageTypes().get(12);
-          internal_static_mesosphere_marathon_EventSubscribers_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_EventSubscribers_descriptor,
-              new java.lang.String[] { "CallbackUrls", });
-          internal_static_mesosphere_marathon_StorageVersion_descriptor =
-            getDescriptor().getMessageTypes().get(13);
-          internal_static_mesosphere_marathon_StorageVersion_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_StorageVersion_descriptor,
-              new java.lang.String[] { "Major", "Minor", "Patch", });
-          internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(14);
-          internal_static_mesosphere_marathon_UpgradeStrategyDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_UpgradeStrategyDefinition_descriptor,
-              new java.lang.String[] { "MinimumHealthCapacity", "MaximumOverCapacity", });
-          internal_static_mesosphere_marathon_GroupDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(15);
-          internal_static_mesosphere_marathon_GroupDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_GroupDefinition_descriptor,
-              new java.lang.String[] { "Id", "Version", "Apps", "Groups", "Dependencies", });
-          internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(16);
-          internal_static_mesosphere_marathon_DeploymentPlanDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_DeploymentPlanDefinition_descriptor,
-              new java.lang.String[] { "Id", "Version", "Original", "Target", });
-          internal_static_mesosphere_marathon_TaskFailure_descriptor =
-            getDescriptor().getMessageTypes().get(17);
-          internal_static_mesosphere_marathon_TaskFailure_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_TaskFailure_descriptor,
-              new java.lang.String[] { "AppId", "TaskId", "State", "Message", "Host", "Version", "Timestamp", "SlaveId", });
-          internal_static_mesosphere_marathon_ZKStoreEntry_descriptor =
-            getDescriptor().getMessageTypes().get(18);
-          internal_static_mesosphere_marathon_ZKStoreEntry_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ZKStoreEntry_descriptor,
-              new java.lang.String[] { "Name", "Uuid", "Value", "Compressed", });
-          internal_static_mesosphere_marathon_ResidencyDefinition_descriptor =
-            getDescriptor().getMessageTypes().get(19);
-          internal_static_mesosphere_marathon_ResidencyDefinition_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_ResidencyDefinition_descriptor,
-              new java.lang.String[] { "RelaunchEscalationTimeoutSeconds", "TaskLostBehavior", });
-          internal_static_mesosphere_marathon_Secret_descriptor =
-            getDescriptor().getMessageTypes().get(20);
-          internal_static_mesosphere_marathon_Secret_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_Secret_descriptor,
-              new java.lang.String[] { "Id", "Source", });
-          internal_static_mesosphere_marathon_EnvVarReference_descriptor =
-            getDescriptor().getMessageTypes().get(21);
-          internal_static_mesosphere_marathon_EnvVarReference_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_EnvVarReference_descriptor,
-              new java.lang.String[] { "Type", "Name", "SecretRef", });
-          internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor =
-            getDescriptor().getMessageTypes().get(22);
-          internal_static_mesosphere_marathon_EnvVarSecretRef_fieldAccessorTable = new
-            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-              internal_static_mesosphere_marathon_EnvVarSecretRef_descriptor,
-              new java.lang.String[] { "SecretId", });
-          return null;
+
+  /**
+   * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
+   */
+  public static final class HealthCheckDefinition extends
+      com.google.protobuf.GeneratedMessage
+      implements HealthCheckDefinitionOrBuilder {
+    // Use HealthCheckDefinition.newBuilder() to construct.
+    private HealthCheckDefinition(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private HealthCheckDefinition(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final HealthCheckDefinition defaultInstance;
+    public static HealthCheckDefinition getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public HealthCheckDefinition getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private HealthCheckDefinition(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              int rawValue = input.readEnum();
+              mesosphere.marathon.Protos.HealthCheckDefinition.Protocol value = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(1, rawValue);
+              } else {
+                bitField0_ |= 0x00000001;
+                protocol_ = value;
+              }
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              portIndex_ = input.readUInt32();
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              gracePeriodSeconds_ = input.readUInt32();
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000008;
+              intervalSeconds_ = input.readUInt32();
+              break;
+            }
+            case 40: {
+              bitField0_ |= 0x00000010;
+              timeoutSeconds_ = input.readUInt32();
+              break;
+            }
+            case 50: {
+              bitField0_ |= 0x00000020;
+              path_ = input.readBytes();
+              break;
+            }
+            case 56: {
+              bitField0_ |= 0x00000040;
+              maxConsecutiveFailures_ = input.readUInt32();
+              break;
+            }
+            case 66: {
+              org.apache.mesos.Protos.CommandInfo.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000080) == 0x00000080)) {
+                subBuilder = command_.toBuilder();
+              }
+              command_ = input.readMessage(org.apache.mesos.Protos.CommandInfo.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(command_);
+                command_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000080;
+              break;
+            }
+            case 72: {
+              bitField0_ |= 0x00000100;
+              ignoreHttp1Xx_ = input.readBool();
+              break;
+            }
+            case 80: {
+              bitField0_ |= 0x00000200;
+              port_ = input.readUInt32();
+              break;
+            }
+          }
         }
-      };
-    com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-          org.apache.mesos.Protos.getDescriptor(),
-        }, assigner);
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              mesosphere.marathon.Protos.HealthCheckDefinition.class, mesosphere.marathon.Protos.HealthCheckDefinition.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<HealthCheckDefinition> PARSER =
+        new com.google.protobuf.AbstractParser<HealthCheckDefinition>() {
+      public HealthCheckDefinition parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new HealthCheckDefinition(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<HealthCheckDefinition> getParserForType() {
+      return PARSER;
+    }
+
+    /**
+     * Protobuf enum {@code mesosphere.marathon.HealthCheckDefinition.Protocol}
+     */
+    public enum Protocol
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>HTTP = 0;</code>
+       */
+      HTTP(0, 0),
+      /**
+       * <code>TCP = 1;</code>
+       */
+      TCP(1, 1),
+      /**
+       * <code>COMMAND = 2;</code>
+       */
+      COMMAND(2, 2),
+      /**
+       * <code>HTTPS = 3;</code>
+       */
+      HTTPS(3, 3),
+        /**
+         * <code>MESOS_HTTP = 4;</code>
+         */
+        MESOS_HTTP(4, 4),
+        /**
+         * <code>MESOS_HTTPS = 5;</code>
+         */
+        MESOS_HTTPS(5, 5),
+        /**
+         * <code>MESOS_TCP = 6;</code>
+         */
+        MESOS_TCP(6, 6),
+      ;
+
+      /**
+       * <code>HTTP = 0;</code>
+       */
+      public static final int HTTP_VALUE = 0;
+      /**
+       * <code>TCP = 1;</code>
+       */
+      public static final int TCP_VALUE = 1;
+      /**
+       * <code>COMMAND = 2;</code>
+       */
+      public static final int COMMAND_VALUE = 2;
+      /**
+       * <code>HTTPS = 3;</code>
+       */
+      public static final int HTTPS_VALUE = 3;
+        /**
+         * <code>MESOS_HTTP = 4;</code>
+         */
+        public static final int MESOS_HTTP_VALUE = 4;
+        /**
+         * <code>MESOS_HTTPS = 5;</code>
+         */
+        public static final int MESOS_HTTPS_VALUE = 5;
+        /**
+         * <code>MESOS_TCP = 6;</code>
+         */
+        public static final int MESOS_TCP_VALUE = 6;
+
+
+      public final int getNumber() { return value; }
+
+      public static Protocol valueOf(int value) {
+        switch (value) {
+          case 0: return HTTP;
+          case 1: return TCP;
+            case 2:
+                return COMMAND;
+            case 3:
+                return HTTPS;
+            case 4:
+                return MESOS_HTTP;
+            case 5: return MESOS_HTTPS;
+          case 6: return MESOS_TCP;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<Protocol>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static com.google.protobuf.Internal.EnumLiteMap<Protocol>
+          internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<Protocol>() {
+              public Protocol findValueByNumber(int number) {
+                return Protocol.valueOf(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        return getDescriptor().getValues().get(index);
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return mesosphere.marathon.Protos.HealthCheckDefinition.getDescriptor().getEnumTypes().get(0);
+      }
+
+      private static final Protocol[] VALUES = values();
+
+      public static Protocol valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int index;
+      private final int value;
+
+      private Protocol(int index, int value) {
+        this.index = index;
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:mesosphere.marathon.HealthCheckDefinition.Protocol)
+    }
+
+    private int bitField0_;
+    // required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;
+    public static final int PROTOCOL_FIELD_NUMBER = 1;
+    private mesosphere.marathon.Protos.HealthCheckDefinition.Protocol protocol_;
+    /**
+     * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
+     */
+    public boolean hasProtocol() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
+     */
+    public mesosphere.marathon.Protos.HealthCheckDefinition.Protocol getProtocol() {
+      return protocol_;
+    }
+
+    // optional uint32 portIndex = 2;
+    public static final int PORTINDEX_FIELD_NUMBER = 2;
+    private int portIndex_;
+    /**
+     * <code>optional uint32 portIndex = 2;</code>
+     */
+    public boolean hasPortIndex() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional uint32 portIndex = 2;</code>
+     */
+    public int getPortIndex() {
+      return portIndex_;
+    }
+
+    // optional uint32 gracePeriodSeconds = 3 [default = 15];
+    public static final int GRACEPERIODSECONDS_FIELD_NUMBER = 3;
+    private int gracePeriodSeconds_;
+    /**
+     * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
+     */
+    public boolean hasGracePeriodSeconds() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
+     */
+    public int getGracePeriodSeconds() {
+      return gracePeriodSeconds_;
+    }
+
+    // optional uint32 intervalSeconds = 4 [default = 10];
+    public static final int INTERVALSECONDS_FIELD_NUMBER = 4;
+    private int intervalSeconds_;
+    /**
+     * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
+     */
+    public boolean hasIntervalSeconds() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
+     */
+    public int getIntervalSeconds() {
+      return intervalSeconds_;
+    }
+
+    // optional uint32 timeoutSeconds = 5 [default = 20];
+    public static final int TIMEOUTSECONDS_FIELD_NUMBER = 5;
+    private int timeoutSeconds_;
+    /**
+     * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
+     */
+    public boolean hasTimeoutSeconds() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
+     */
+    public int getTimeoutSeconds() {
+      return timeoutSeconds_;
+    }
+
+    // optional string path = 6 [default = "/"];
+    public static final int PATH_FIELD_NUMBER = 6;
+    private java.lang.Object path_;
+    /**
+     * <code>optional string path = 6 [default = "/"];</code>
+     *
+     * <pre>
+     * used for HTTP only
+     * </pre>
+     */
+    public boolean hasPath() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional string path = 6 [default = "/"];</code>
+     *
+     * <pre>
+     * used for HTTP only
+     * </pre>
+     */
+    public java.lang.String getPath() {
+      java.lang.Object ref = path_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          path_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string path = 6 [default = "/"];</code>
+     *
+     * <pre>
+     * used for HTTP only
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getPathBytes() {
+      java.lang.Object ref = path_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        path_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    // optional uint32 maxConsecutiveFailures = 7 [default = 3];
+    public static final int MAXCONSECUTIVEFAILURES_FIELD_NUMBER = 7;
+    private int maxConsecutiveFailures_;
+    /**
+     * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
+     */
+    public boolean hasMaxConsecutiveFailures() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
+     */
+    public int getMaxConsecutiveFailures() {
+      return maxConsecutiveFailures_;
+    }
+
+    // optional .mesos.CommandInfo command = 8;
+    public static final int COMMAND_FIELD_NUMBER = 8;
+    private org.apache.mesos.Protos.CommandInfo command_;
+    /**
+     * <code>optional .mesos.CommandInfo command = 8;</code>
+     */
+    public boolean hasCommand() {
+      return ((bitField0_ & 0x00000080) == 0x00000080);
+    }
+    /**
+     * <code>optional .mesos.CommandInfo command = 8;</code>
+     */
+    public org.apache.mesos.Protos.CommandInfo getCommand() {
+      return command_;
+    }
+    /**
+     * <code>optional .mesos.CommandInfo command = 8;</code>
+     */
+    public org.apache.mesos.Protos.CommandInfoOrBuilder getCommandOrBuilder() {
+      return command_;
+    }
+
+    // optional bool ignoreHttp1xx = 9 [default = false];
+    public static final int IGNOREHTTP1XX_FIELD_NUMBER = 9;
+    private boolean ignoreHttp1Xx_;
+    /**
+     * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+     */
+    public boolean hasIgnoreHttp1Xx() {
+      return ((bitField0_ & 0x00000100) == 0x00000100);
+    }
+    /**
+     * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+     */
+    public boolean getIgnoreHttp1Xx() {
+      return ignoreHttp1Xx_;
+    }
+
+    // optional uint32 port = 10;
+    public static final int PORT_FIELD_NUMBER = 10;
+    private int port_;
+    /**
+     * <code>optional uint32 port = 10;</code>
+     */
+    public boolean hasPort() {
+      return ((bitField0_ & 0x00000200) == 0x00000200);
+    }
+    /**
+     * <code>optional uint32 port = 10;</code>
+     */
+    public int getPort() {
+      return port_;
+    }
+
+    private void initFields() {
+      protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
+      portIndex_ = 0;
+      gracePeriodSeconds_ = 15;
+      intervalSeconds_ = 10;
+      timeoutSeconds_ = 20;
+      path_ = "/";
+      maxConsecutiveFailures_ = 3;
+      command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
+      ignoreHttp1Xx_ = false;
+      port_ = 0;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      if (!hasProtocol()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (hasCommand()) {
+        if (!getCommand().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeEnum(1, protocol_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeUInt32(2, portIndex_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeUInt32(3, gracePeriodSeconds_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeUInt32(4, intervalSeconds_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeUInt32(5, timeoutSeconds_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeBytes(6, getPathBytes());
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeUInt32(7, maxConsecutiveFailures_);
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        output.writeMessage(8, command_);
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        output.writeBool(9, ignoreHttp1Xx_);
+      }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        output.writeUInt32(10, port_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(1, protocol_.getNumber());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(2, portIndex_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(3, gracePeriodSeconds_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(4, intervalSeconds_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(5, timeoutSeconds_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(6, getPathBytes());
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(7, maxConsecutiveFailures_);
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(8, command_);
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(9, ignoreHttp1Xx_);
+      }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(10, port_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.HealthCheckDefinition parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static mesosphere.marathon.Protos.HealthCheckDefinition parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static mesosphere.marathon.Protos.HealthCheckDefinition parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(mesosphere.marathon.Protos.HealthCheckDefinition prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements mesosphere.marathon.Protos.HealthCheckDefinitionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                mesosphere.marathon.Protos.HealthCheckDefinition.class, mesosphere.marathon.Protos.HealthCheckDefinition.Builder.class);
+      }
+
+      // Construct using mesosphere.marathon.Protos.HealthCheckDefinition.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getCommandFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        portIndex_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        gracePeriodSeconds_ = 15;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        intervalSeconds_ = 10;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        timeoutSeconds_ = 20;
+        bitField0_ = (bitField0_ & ~0x00000010);
+        path_ = "/";
+        bitField0_ = (bitField0_ & ~0x00000020);
+        maxConsecutiveFailures_ = 3;
+        bitField0_ = (bitField0_ & ~0x00000040);
+        if (commandBuilder_ == null) {
+          command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
+        } else {
+          commandBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000080);
+        ignoreHttp1Xx_ = false;
+        bitField0_ = (bitField0_ & ~0x00000100);
+        port_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000200);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return mesosphere.marathon.Protos.internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor;
+      }
+
+      public mesosphere.marathon.Protos.HealthCheckDefinition getDefaultInstanceForType() {
+        return mesosphere.marathon.Protos.HealthCheckDefinition.getDefaultInstance();
+      }
+
+      public mesosphere.marathon.Protos.HealthCheckDefinition build() {
+        mesosphere.marathon.Protos.HealthCheckDefinition result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public mesosphere.marathon.Protos.HealthCheckDefinition buildPartial() {
+        mesosphere.marathon.Protos.HealthCheckDefinition result = new mesosphere.marathon.Protos.HealthCheckDefinition(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.protocol_ = protocol_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.portIndex_ = portIndex_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.gracePeriodSeconds_ = gracePeriodSeconds_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.intervalSeconds_ = intervalSeconds_;
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.timeoutSeconds_ = timeoutSeconds_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        result.path_ = path_;
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        result.maxConsecutiveFailures_ = maxConsecutiveFailures_;
+        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+          to_bitField0_ |= 0x00000080;
+        }
+        if (commandBuilder_ == null) {
+          result.command_ = command_;
+        } else {
+          result.command_ = commandBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
+          to_bitField0_ |= 0x00000100;
+        }
+        result.ignoreHttp1Xx_ = ignoreHttp1Xx_;
+        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+          to_bitField0_ |= 0x00000200;
+        }
+        result.port_ = port_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof mesosphere.marathon.Protos.HealthCheckDefinition) {
+          return mergeFrom((mesosphere.marathon.Protos.HealthCheckDefinition)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(mesosphere.marathon.Protos.HealthCheckDefinition other) {
+        if (other == mesosphere.marathon.Protos.HealthCheckDefinition.getDefaultInstance()) return this;
+        if (other.hasProtocol()) {
+          setProtocol(other.getProtocol());
+        }
+        if (other.hasPortIndex()) {
+          setPortIndex(other.getPortIndex());
+        }
+        if (other.hasGracePeriodSeconds()) {
+          setGracePeriodSeconds(other.getGracePeriodSeconds());
+        }
+        if (other.hasIntervalSeconds()) {
+          setIntervalSeconds(other.getIntervalSeconds());
+        }
+        if (other.hasTimeoutSeconds()) {
+          setTimeoutSeconds(other.getTimeoutSeconds());
+        }
+        if (other.hasPath()) {
+          bitField0_ |= 0x00000020;
+          path_ = other.path_;
+          onChanged();
+        }
+        if (other.hasMaxConsecutiveFailures()) {
+          setMaxConsecutiveFailures(other.getMaxConsecutiveFailures());
+        }
+        if (other.hasCommand()) {
+          mergeCommand(other.getCommand());
+        }
+        if (other.hasIgnoreHttp1Xx()) {
+          setIgnoreHttp1Xx(other.getIgnoreHttp1Xx());
+        }
+        if (other.hasPort()) {
+          setPort(other.getPort());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!hasProtocol()) {
+
+          return false;
+        }
+        if (hasCommand()) {
+          if (!getCommand().isInitialized()) {
+
+            return false;
+          }
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        mesosphere.marathon.Protos.HealthCheckDefinition parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (mesosphere.marathon.Protos.HealthCheckDefinition) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;
+      private mesosphere.marathon.Protos.HealthCheckDefinition.Protocol protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
+      /**
+       * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
+       */
+      public boolean hasProtocol() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
+       */
+      public mesosphere.marathon.Protos.HealthCheckDefinition.Protocol getProtocol() {
+        return protocol_;
+      }
+      /**
+       * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
+       */
+      public Builder setProtocol(mesosphere.marathon.Protos.HealthCheckDefinition.Protocol value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000001;
+        protocol_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required .mesosphere.marathon.HealthCheckDefinition.Protocol protocol = 1;</code>
+       */
+      public Builder clearProtocol() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        protocol_ = mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.HTTP;
+        onChanged();
+        return this;
+      }
+
+      // optional uint32 portIndex = 2;
+      private int portIndex_ ;
+      /**
+       * <code>optional uint32 portIndex = 2;</code>
+       */
+      public boolean hasPortIndex() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional uint32 portIndex = 2;</code>
+       */
+      public int getPortIndex() {
+        return portIndex_;
+      }
+      /**
+       * <code>optional uint32 portIndex = 2;</code>
+       */
+      public Builder setPortIndex(int value) {
+        bitField0_ |= 0x00000002;
+        portIndex_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 portIndex = 2;</code>
+       */
+      public Builder clearPortIndex() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        portIndex_ = 0;
+        onChanged();
+        return this;
+      }
+
+      // optional uint32 gracePeriodSeconds = 3 [default = 15];
+      private int gracePeriodSeconds_ = 15;
+      /**
+       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
+       */
+      public boolean hasGracePeriodSeconds() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
+       */
+      public int getGracePeriodSeconds() {
+        return gracePeriodSeconds_;
+      }
+      /**
+       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
+       */
+      public Builder setGracePeriodSeconds(int value) {
+        bitField0_ |= 0x00000004;
+        gracePeriodSeconds_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 gracePeriodSeconds = 3 [default = 15];</code>
+       */
+      public Builder clearGracePeriodSeconds() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        gracePeriodSeconds_ = 15;
+        onChanged();
+        return this;
+      }
+
+      // optional uint32 intervalSeconds = 4 [default = 10];
+      private int intervalSeconds_ = 10;
+      /**
+       * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
+       */
+      public boolean hasIntervalSeconds() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
+       */
+      public int getIntervalSeconds() {
+        return intervalSeconds_;
+      }
+      /**
+       * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
+       */
+      public Builder setIntervalSeconds(int value) {
+        bitField0_ |= 0x00000008;
+        intervalSeconds_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 intervalSeconds = 4 [default = 10];</code>
+       */
+      public Builder clearIntervalSeconds() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        intervalSeconds_ = 10;
+        onChanged();
+        return this;
+      }
+
+      // optional uint32 timeoutSeconds = 5 [default = 20];
+      private int timeoutSeconds_ = 20;
+      /**
+       * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
+       */
+      public boolean hasTimeoutSeconds() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
+       */
+      public int getTimeoutSeconds() {
+        return timeoutSeconds_;
+      }
+      /**
+       * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
+       */
+      public Builder setTimeoutSeconds(int value) {
+        bitField0_ |= 0x00000010;
+        timeoutSeconds_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 timeoutSeconds = 5 [default = 20];</code>
+       */
+      public Builder clearTimeoutSeconds() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        timeoutSeconds_ = 20;
+        onChanged();
+        return this;
+      }
+
+      // optional string path = 6 [default = "/"];
+      private java.lang.Object path_ = "/";
+      /**
+       * <code>optional string path = 6 [default = "/"];</code>
+       *
+       * <pre>
+       * used for HTTP only
+       * </pre>
+       */
+      public boolean hasPath() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional string path = 6 [default = "/"];</code>
+       *
+       * <pre>
+       * used for HTTP only
+       * </pre>
+       */
+      public java.lang.String getPath() {
+        java.lang.Object ref = path_;
+        if (!(ref instanceof java.lang.String)) {
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          path_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string path = 6 [default = "/"];</code>
+       *
+       * <pre>
+       * used for HTTP only
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getPathBytes() {
+        java.lang.Object ref = path_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          path_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string path = 6 [default = "/"];</code>
+       *
+       * <pre>
+       * used for HTTP only
+       * </pre>
+       */
+      public Builder setPath(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+        path_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string path = 6 [default = "/"];</code>
+       *
+       * <pre>
+       * used for HTTP only
+       * </pre>
+       */
+      public Builder clearPath() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        path_ = getDefaultInstance().getPath();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string path = 6 [default = "/"];</code>
+       *
+       * <pre>
+       * used for HTTP only
+       * </pre>
+       */
+      public Builder setPathBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+        path_ = value;
+        onChanged();
+        return this;
+      }
+
+      // optional uint32 maxConsecutiveFailures = 7 [default = 3];
+      private int maxConsecutiveFailures_ = 3;
+      /**
+       * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
+       */
+      public boolean hasMaxConsecutiveFailures() {
+        return ((bitField0_ & 0x00000040) == 0x00000040);
+      }
+      /**
+       * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
+       */
+      public int getMaxConsecutiveFailures() {
+        return maxConsecutiveFailures_;
+      }
+      /**
+       * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
+       */
+      public Builder setMaxConsecutiveFailures(int value) {
+        bitField0_ |= 0x00000040;
+        maxConsecutiveFailures_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 maxConsecutiveFailures = 7 [default = 3];</code>
+       */
+      public Builder clearMaxConsecutiveFailures() {
+        bitField0_ = (bitField0_ & ~0x00000040);
+        maxConsecutiveFailures_ = 3;
+        onChanged();
+        return this;
+      }
+
+      // optional .mesos.CommandInfo command = 8;
+      private org.apache.mesos.Protos.CommandInfo command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder> commandBuilder_;
+      /**
+       * <code>optional .mesos.CommandInfo command = 8;</code>
+       */
+      public boolean hasCommand() {
+        return ((bitField0_ & 0x00000080) == 0x00000080);
+      }
+      /**
+       * <code>optional .mesos.CommandInfo command = 8;</code>
+       */
+      public org.apache.mesos.Protos.CommandInfo getCommand() {
+        if (commandBuilder_ == null) {
+          return command_;
+        } else {
+          return commandBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .mesos.CommandInfo command = 8;</code>
+       */
+      public Builder setCommand(org.apache.mesos.Protos.CommandInfo value) {
+        if (commandBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          command_ = value;
+          onChanged();
+        } else {
+          commandBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .mesos.CommandInfo command = 8;</code>
+       */
+      public Builder setCommand(
+          org.apache.mesos.Protos.CommandInfo.Builder builderForValue) {
+        if (commandBuilder_ == null) {
+          command_ = builderForValue.build();
+          onChanged();
+        } else {
+          commandBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .mesos.CommandInfo command = 8;</code>
+       */
+      public Builder mergeCommand(org.apache.mesos.Protos.CommandInfo value) {
+        if (commandBuilder_ == null) {
+          if (((bitField0_ & 0x00000080) == 0x00000080) &&
+              command_ != org.apache.mesos.Protos.CommandInfo.getDefaultInstance()) {
+            command_ =
+              org.apache.mesos.Protos.CommandInfo.newBuilder(command_).mergeFrom(value).buildPartial();
+          } else {
+            command_ = value;
+          }
+          onChanged();
+        } else {
+          commandBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .mesos.CommandInfo command = 8;</code>
+       */
+      public Builder clearCommand() {
+        if (commandBuilder_ == null) {
+          command_ = org.apache.mesos.Protos.CommandInfo.getDefaultInstance();
+          onChanged();
+        } else {
+          commandBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000080);
+        return this;
+      }
+      /**
+       * <code>optional .mesos.CommandInfo command = 8;</code>
+       */
+      public org.apache.mesos.Protos.CommandInfo.Builder getCommandBuilder() {
+        bitField0_ |= 0x00000080;
+        onChanged();
+        return getCommandFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .mesos.CommandInfo command = 8;</code>
+       */
+      public org.apache.mesos.Protos.CommandInfoOrBuilder getCommandOrBuilder() {
+        if (commandBuilder_ != null) {
+          return commandBuilder_.getMessageOrBuilder();
+        } else {
+          return command_;
+        }
+      }
+      /**
+       * <code>optional .mesos.CommandInfo command = 8;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder>
+          getCommandFieldBuilder() {
+        if (commandBuilder_ == null) {
+          commandBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.apache.mesos.Protos.CommandInfo, org.apache.mesos.Protos.CommandInfo.Builder, org.apache.mesos.Protos.CommandInfoOrBuilder>(
+                  command_,
+                  getParentForChildren(),
+                  isClean());
+          command_ = null;
+        }
+        return commandBuilder_;
+      }
+
+      // optional bool ignoreHttp1xx = 9 [default = false];
+      private boolean ignoreHttp1Xx_ ;
+      /**
+       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+       */
+      public boolean hasIgnoreHttp1Xx() {
+        return ((bitField0_ & 0x00000100) == 0x00000100);
+      }
+      /**
+       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+       */
+      public boolean getIgnoreHttp1Xx() {
+        return ignoreHttp1Xx_;
+      }
+      /**
+       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+       */
+      public Builder setIgnoreHttp1Xx(boolean value) {
+        bitField0_ |= 0x00000100;
+        ignoreHttp1Xx_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool ignoreHttp1xx = 9 [default = false];</code>
+       */
+      public Builder clearIgnoreHttp1Xx() {
+        bitField0_ = (bitField0_ & ~0x00000100);
+        ignoreHttp1Xx_ = false;
+        onChanged();
+        return this;
+      }
+
+      // optional uint32 port = 10;
+      private int port_ ;
+      /**
+       * <code>optional uint32 port = 10;</code>
+       */
+      public boolean hasPort() {
+        return ((bitField0_ & 0x00000200) == 0x00000200);
+      }
+      /**
+       * <code>optional uint32 port = 10;</code>
+       */
+      public int getPort() {
+        return port_;
+      }
+      /**
+       * <code>optional uint32 port = 10;</code>
+       */
+      public Builder setPort(int value) {
+        bitField0_ |= 0x00000200;
+        port_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 port = 10;</code>
+       */
+      public Builder clearPort() {
+        bitField0_ = (bitField0_ & ~0x00000200);
+        port_ = 0;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:mesosphere.marathon.HealthCheckDefinition)
+    }
+
+    static {
+      defaultInstance = new HealthCheckDefinition(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:mesosphere.marathon.HealthCheckDefinition)
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -35,6 +35,9 @@ message HealthCheckDefinition {
     TCP = 1;
     COMMAND = 2;
     HTTPS = 3;
+    MESOS_HTTP = 4;
+    MESOS_HTTPS = 5;
+    MESOS_TCP = 6;
   }
   required Protocol protocol = 1;
   optional uint32 portIndex = 2;

--- a/src/main/scala/mesosphere/marathon/Features.scala
+++ b/src/main/scala/mesosphere/marathon/Features.scala
@@ -17,12 +17,16 @@ object Features {
   //enable GPUs
   lazy val GPU_RESOURCES = "gpu_resources"
 
+  //enable Mesos HealthChecks
+  lazy val MESOS_HEALTHCHECKS = "mesos_healthchecks"
+
   lazy val availableFeatures = Map(
     VIPS -> "Enable networking VIPs UI",
     TASK_KILLING -> "Enable the optional TASK_KILLING state, available in Mesos 0.28 and later",
     EXTERNAL_VOLUMES -> "Enable external volumes support in Marathon",
     SECRETS -> "Enable support for secrets in Marathon (experimental)",
-    GPU_RESOURCES -> "Enable support for GPU in Marathon (experimental)"
+    GPU_RESOURCES -> "Enable support for GPU in Marathon (experimental)",
+    MESOS_HEALTHCHECKS -> "Enable support for Mesos Native Healthchecks in Marathon (require Mesos version >= 1.1.0)"
   )
 
   def description: String = {

--- a/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/AppUpdate.scala
@@ -4,8 +4,8 @@ import com.wix.accord.dsl._
 import mesosphere.marathon.Features
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.api.v2.Validation._
-import mesosphere.marathon.core.readiness.ReadinessCheck
 import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.readiness.ReadinessCheck
 import mesosphere.marathon.state._
 
 import scala.collection.immutable.Seq
@@ -53,7 +53,7 @@ case class AppUpdate(
 
     container: Option[Container] = None,
 
-    healthChecks: Option[Set[HealthCheck]] = None,
+    healthChecks: Option[Set[_ <: HealthCheck]] = None,
 
     readinessChecks: Option[Seq[ReadinessCheck]] = None,
 

--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon.core.health
 
 import com.wix.accord._
-import com.wix.accord.dsl._
 import mesosphere.marathon.Protos
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.core.task.Task
@@ -10,101 +9,49 @@ import org.apache.mesos.{ Protos => MesosProtos }
 
 import scala.concurrent.duration._
 
-case class HealthCheck(
+sealed trait HealthCheck {
+  def gracePeriod: FiniteDuration
 
-  path: Option[String] = HealthCheck.DefaultPath,
+  def interval: FiniteDuration
 
-  protocol: Protocol = HealthCheck.DefaultProtocol,
+  def timeout: FiniteDuration
 
-  portIndex: Option[Int] = HealthCheck.DefaultPortIndex,
+  def maxConsecutiveFailures: Int
 
-  command: Option[Command] = HealthCheck.DefaultCommand,
+  def toProto: Protos.HealthCheckDefinition
 
-  gracePeriod: FiniteDuration = HealthCheck.DefaultGracePeriod,
-
-  interval: FiniteDuration = HealthCheck.DefaultInterval,
-
-  timeout: FiniteDuration = HealthCheck.DefaultTimeout,
-
-  maxConsecutiveFailures: Int = HealthCheck.DefaultMaxConsecutiveFailures,
-
-  ignoreHttp1xx: Boolean = HealthCheck.DefaultIgnoreHttp1xx,
-
-  port: Option[Int] = HealthCheck.DefaultPort)
-    extends MarathonState[Protos.HealthCheckDefinition, HealthCheck] {
-
-  def toProto: Protos.HealthCheckDefinition = {
-    val builder = Protos.HealthCheckDefinition.newBuilder
-      .setProtocol(this.protocol)
+  protected def protoBuilder: Protos.HealthCheckDefinition.Builder =
+    Protos.HealthCheckDefinition.newBuilder
       .setGracePeriodSeconds(this.gracePeriod.toSeconds.toInt)
       .setIntervalSeconds(this.interval.toSeconds.toInt)
       .setTimeoutSeconds(this.timeout.toSeconds.toInt)
       .setMaxConsecutiveFailures(this.maxConsecutiveFailures)
-      .setIgnoreHttp1Xx(this.ignoreHttp1xx)
+}
 
-    command foreach { c => builder.setCommand(c.toProto) }
+sealed trait HealthCheckWithPort {
+  this: HealthCheck =>
+  def portIndex: Option[Int]
 
-    path foreach builder.setPath
+  def port: Option[Int]
+}
 
-    portIndex foreach { p => builder.setPortIndex(p.toInt) }
-    port foreach { p => builder.setPort(p.toInt) }
+object HealthCheckWithPort {
+  val DefaultPortIndex = None
+  val DefaultPort = None
 
-    builder.build
-  }
+  import mesosphere.marathon.api.v2.Validation.isTrue
 
-  def mergeFromProto(proto: Protos.HealthCheckDefinition): HealthCheck =
-    HealthCheck(
-      path =
-      if (proto.hasPath) Some(proto.getPath) else None,
-      protocol = proto.getProtocol,
-      portIndex =
-      if (proto.hasPortIndex)
-        Some(proto.getPortIndex)
-      else if (!proto.hasPort && proto.getProtocol != Protocol.COMMAND)
-        Some(0) // backward compatibility, this used to be the default value in marathon.proto
-      else
-        None,
-      command =
-      if (proto.hasCommand) Some(Command("").mergeFromProto(proto.getCommand))
-      else None,
-      gracePeriod = proto.getGracePeriodSeconds.seconds,
-      timeout = proto.getTimeoutSeconds.seconds,
-      interval = proto.getIntervalSeconds.seconds,
-      maxConsecutiveFailures = proto.getMaxConsecutiveFailures,
-      ignoreHttp1xx = proto.getIgnoreHttp1Xx,
-      port = if (proto.hasPort) Some(proto.getPort) else None
-    )
-
-  def mergeFromProto(bytes: Array[Byte]): HealthCheck =
-    mergeFromProto(Protos.HealthCheckDefinition.parseFrom(bytes))
-
-  // Mesos supports COMMAND health checks, others to be added in the future
-  def toMesos: MesosProtos.HealthCheck = {
-    val builder = this.protocol match {
-      case Protocol.COMMAND =>
-        assert(
-          command.isDefined,
-          "A command is required when using the COMMAND health check protocol."
-        )
-        MesosProtos.HealthCheck.newBuilder
-          .setCommand(this.command.get.toProto)
-
-      case Protocol.HTTP =>
-        throw new UnsupportedOperationException(
-          s"Mesos does not support health checks of type [$protocol]")
-
-      case _ =>
-        throw new UnsupportedOperationException(
-          s"Mesos does not support health checks of type [$protocol]")
+  implicit val Validator: Validator[HealthCheckWithPort] =
+    isTrue("HealthCheck must specify either a port or a portIndex") { hc =>
+      hc.portIndex.isDefined ^ hc.port.isDefined
     }
+}
 
-    builder.setDelaySeconds(0)
-      .setIntervalSeconds(this.interval.toSeconds.toDouble)
-      .setTimeoutSeconds(this.timeout.toSeconds.toDouble)
-      .setConsecutiveFailures(this.maxConsecutiveFailures)
-      .setGracePeriodSeconds(this.gracePeriod.toUnit(SECONDS))
-      .build
-  }
+sealed trait MarathonHealthCheck extends HealthCheckWithPort {
+  this: HealthCheck =>
+  def portIndex: Option[Int]
+
+  def port: Option[Int]
 
   def effectivePort(app: AppDefinition, task: Task): Option[Int] = {
     def portViaIndex: Option[Int] = portIndex.flatMap { portIndex =>
@@ -113,16 +60,272 @@ case class HealthCheck(
 
     port.orElse(portViaIndex)
   }
+}
 
-  override def version: Timestamp = Timestamp.zero
+sealed trait MesosHealthCheck {
+  this: HealthCheck =>
+  def gracePeriod: FiniteDuration
+
+  def interval: FiniteDuration
+
+  def timeout: FiniteDuration
+
+  def maxConsecutiveFailures: Int
+
+  def toMesos(portAssignments: Seq[PortAssignment] = Seq.empty): MesosProtos.HealthCheck
+}
+
+sealed trait MesosHealthCheckWithPorts extends HealthCheckWithPort {
+  this: HealthCheck =>
+  def effectivePort(portAssignments: Seq[PortAssignment]): Int = {
+    port match {
+      case Some(port) => port
+      case None =>
+        val portAssignment = portIndex.map(portAssignments(_))
+        portAssignment.flatMap(_.containerPort).getOrElse(portAssignment.flatMap(_.hostPort).get)
+    }
+  }
+}
+
+case class MarathonHttpHealthCheck(
+  gracePeriod: FiniteDuration = HealthCheck.DefaultGracePeriod,
+  interval: FiniteDuration = HealthCheck.DefaultInterval,
+  timeout: FiniteDuration = HealthCheck.DefaultTimeout,
+  maxConsecutiveFailures: Int = HealthCheck.DefaultMaxConsecutiveFailures,
+  portIndex: Option[Int] = HealthCheckWithPort.DefaultPortIndex,
+  port: Option[Int] = HealthCheckWithPort.DefaultPort,
+  path: Option[String] = MarathonHttpHealthCheck.DefaultPath,
+  protocol: Protocol = MarathonHttpHealthCheck.DefaultProtocol,
+  ignoreHttp1xx: Boolean = MarathonHttpHealthCheck.DefaultIgnoreHttp1xx)
+    extends HealthCheck with MarathonHealthCheck {
+  override def toProto: Protos.HealthCheckDefinition = {
+    val builder = protoBuilder
+      .setProtocol(protocol)
+      .setIgnoreHttp1Xx(this.ignoreHttp1xx)
+
+    path.foreach(builder.setPath)
+
+    portIndex.foreach(builder.setPortIndex)
+    port.foreach(builder.setPort)
+
+    builder.build
+  }
+}
+
+object MarathonHttpHealthCheck {
+  val DefaultPath = None
+  val DefaultIgnoreHttp1xx = false
+  val DefaultProtocol = Protocol.HTTP
+
+  def mergeFromProto(proto: Protos.HealthCheckDefinition): MarathonHttpHealthCheck =
+    MarathonHttpHealthCheck(
+      gracePeriod = proto.getGracePeriodSeconds.seconds,
+      timeout = proto.getTimeoutSeconds.seconds,
+      interval = proto.getIntervalSeconds.seconds,
+      maxConsecutiveFailures = proto.getMaxConsecutiveFailures,
+      ignoreHttp1xx = proto.getIgnoreHttp1Xx,
+      path = if (proto.hasPath) Some(proto.getPath) else None,
+      portIndex =
+      if (proto.hasPortIndex)
+        Some(proto.getPortIndex)
+      else if (!proto.hasPort)
+        Some(0) // backward compatibility, this used to be the default value in marathon.proto
+      else
+        None,
+      port = if (proto.hasPort) Some(proto.getPort) else None,
+      protocol = proto.getProtocol
+    )
+}
+
+case class MarathonTcpHealthCheck(
+  gracePeriod: FiniteDuration = HealthCheck.DefaultGracePeriod,
+  interval: FiniteDuration = HealthCheck.DefaultInterval,
+  timeout: FiniteDuration = HealthCheck.DefaultTimeout,
+  maxConsecutiveFailures: Int = HealthCheck.DefaultMaxConsecutiveFailures,
+  portIndex: Option[Int] = HealthCheckWithPort.DefaultPortIndex,
+  port: Option[Int] = HealthCheckWithPort.DefaultPort)
+    extends HealthCheck with MarathonHealthCheck {
+  override def toProto: Protos.HealthCheckDefinition = {
+    val builder = protoBuilder.setProtocol(Protos.HealthCheckDefinition.Protocol.TCP)
+
+    portIndex.foreach(builder.setPortIndex)
+    port.foreach(builder.setPort)
+
+    builder.build
+  }
+}
+
+object MarathonTcpHealthCheck {
+  def mergeFromProto(proto: Protos.HealthCheckDefinition): MarathonTcpHealthCheck =
+    MarathonTcpHealthCheck(
+      gracePeriod = proto.getGracePeriodSeconds.seconds,
+      timeout = proto.getTimeoutSeconds.seconds,
+      interval = proto.getIntervalSeconds.seconds,
+      maxConsecutiveFailures = proto.getMaxConsecutiveFailures,
+      portIndex =
+      if (proto.hasPortIndex)
+        Some(proto.getPortIndex)
+      else if (!proto.hasPort)
+        Some(0) // backward compatibility, this used to be the default value in marathon.proto
+      else
+        None,
+      port = if (proto.hasPort) Some(proto.getPort) else None
+    )
+}
+
+case class MesosCommandHealthCheck(
+  gracePeriod: FiniteDuration = HealthCheck.DefaultGracePeriod,
+  interval: FiniteDuration = HealthCheck.DefaultInterval,
+  timeout: FiniteDuration = HealthCheck.DefaultTimeout,
+  maxConsecutiveFailures: Int = HealthCheck.DefaultMaxConsecutiveFailures,
+  command: Command)
+    extends HealthCheck with MesosHealthCheck {
+  override def toProto: Protos.HealthCheckDefinition = {
+    protoBuilder
+      .setProtocol(Protos.HealthCheckDefinition.Protocol.COMMAND)
+      .setCommand(command.toProto)
+      .build
+  }
+
+  def toMesos(portAssignments: Seq[PortAssignment] = Seq.empty): MesosProtos.HealthCheck = {
+    MesosProtos.HealthCheck.newBuilder
+      .setType(MesosProtos.HealthCheck.Type.COMMAND)
+      .setIntervalSeconds(this.interval.toSeconds.toDouble)
+      .setTimeoutSeconds(this.timeout.toSeconds.toDouble)
+      .setConsecutiveFailures(this.maxConsecutiveFailures)
+      .setGracePeriodSeconds(this.gracePeriod.toUnit(SECONDS))
+      .setCommand(this.command.toProto)
+      .build()
+  }
+}
+
+object MesosCommandHealthCheck {
+  def mergeFromProto(proto: Protos.HealthCheckDefinition): MesosCommandHealthCheck =
+    MesosCommandHealthCheck(
+      gracePeriod = proto.getGracePeriodSeconds.seconds,
+      timeout = proto.getTimeoutSeconds.seconds,
+      interval = proto.getIntervalSeconds.seconds,
+      maxConsecutiveFailures = proto.getMaxConsecutiveFailures,
+      command = Command("").mergeFromProto(proto.getCommand)
+    )
+}
+
+case class MesosHttpHealthCheck(
+  gracePeriod: FiniteDuration = HealthCheck.DefaultGracePeriod,
+  interval: FiniteDuration = HealthCheck.DefaultInterval,
+  timeout: FiniteDuration = HealthCheck.DefaultTimeout,
+  maxConsecutiveFailures: Int = HealthCheck.DefaultMaxConsecutiveFailures,
+  portIndex: Option[Int] = HealthCheckWithPort.DefaultPortIndex,
+  port: Option[Int] = HealthCheckWithPort.DefaultPort,
+  path: Option[String] = MarathonHttpHealthCheck.DefaultPath,
+  protocol: Protocol = MesosHttpHealthCheck.DefaultProtocol)
+    extends HealthCheck with MesosHealthCheck with MesosHealthCheckWithPorts {
+  require(protocol == Protocol.MESOS_HTTP || protocol == Protocol.MESOS_HTTPS)
+
+  override def toProto: Protos.HealthCheckDefinition = {
+    val builder = protoBuilder
+      .setProtocol(protocol)
+
+    path.foreach(builder.setPath)
+
+    portIndex.foreach(builder.setPortIndex)
+    port.foreach(builder.setPort)
+
+    builder.build
+  }
+
+  override def toMesos(portAssignments: Seq[PortAssignment] = Seq.empty): MesosProtos.HealthCheck = {
+    val httpInfoBuilder = MesosProtos.HealthCheck.HTTPCheckInfo.newBuilder()
+      .setScheme(if (protocol == Protocol.MESOS_HTTP) "http" else "https")
+      .setPort(effectivePort(portAssignments))
+    path.foreach(httpInfoBuilder.setPath)
+
+    MesosProtos.HealthCheck.newBuilder
+      .setType(MesosProtos.HealthCheck.Type.HTTP)
+      .setIntervalSeconds(this.interval.toSeconds.toDouble)
+      .setTimeoutSeconds(this.timeout.toSeconds.toDouble)
+      .setConsecutiveFailures(this.maxConsecutiveFailures)
+      .setGracePeriodSeconds(this.gracePeriod.toUnit(SECONDS))
+      .setHttp(httpInfoBuilder)
+      .build()
+  }
+}
+
+object MesosHttpHealthCheck {
+  val DefaultPath = None
+  val DefaultProtocol = Protocol.MESOS_HTTP
+
+  def mergeFromProto(proto: Protos.HealthCheckDefinition): MesosHttpHealthCheck =
+    MesosHttpHealthCheck(
+      gracePeriod = proto.getGracePeriodSeconds.seconds,
+      timeout = proto.getTimeoutSeconds.seconds,
+      interval = proto.getIntervalSeconds.seconds,
+      maxConsecutiveFailures = proto.getMaxConsecutiveFailures,
+      path = if (proto.hasPath) Some(proto.getPath) else None,
+      portIndex =
+      if (proto.hasPortIndex)
+        Some(proto.getPortIndex)
+      else if (!proto.hasPort)
+        Some(0) // backward compatibility, this used to be the default value in marathon.proto
+      else
+        None,
+      port = if (proto.hasPort) Some(proto.getPort) else None,
+      protocol = proto.getProtocol
+    )
+}
+
+case class MesosTcpHealthCheck(
+  gracePeriod: FiniteDuration = HealthCheck.DefaultGracePeriod,
+  interval: FiniteDuration = HealthCheck.DefaultInterval,
+  timeout: FiniteDuration = HealthCheck.DefaultTimeout,
+  maxConsecutiveFailures: Int = HealthCheck.DefaultMaxConsecutiveFailures,
+  portIndex: Option[Int] = HealthCheckWithPort.DefaultPortIndex,
+  port: Option[Int] = HealthCheckWithPort.DefaultPort)
+    extends HealthCheck with MesosHealthCheck with MesosHealthCheckWithPorts {
+  override def toProto: Protos.HealthCheckDefinition = {
+    val builder = protoBuilder.setProtocol(Protos.HealthCheckDefinition.Protocol.MESOS_TCP)
+
+    portIndex.foreach(builder.setPortIndex)
+    port.foreach(builder.setPort)
+
+    builder.build
+  }
+
+  override def toMesos(portAssignments: Seq[PortAssignment] = Seq.empty): MesosProtos.HealthCheck = {
+    val tcpInfoBuilder = MesosProtos.HealthCheck.TCPCheckInfo.newBuilder().setPort(effectivePort(portAssignments))
+
+    MesosProtos.HealthCheck.newBuilder
+      .setType(MesosProtos.HealthCheck.Type.TCP)
+      .setIntervalSeconds(this.interval.toSeconds.toDouble)
+      .setTimeoutSeconds(this.timeout.toSeconds.toDouble)
+      .setConsecutiveFailures(this.maxConsecutiveFailures)
+      .setGracePeriodSeconds(this.gracePeriod.toUnit(SECONDS))
+      .setTcp(tcpInfoBuilder)
+      .build()
+  }
+}
+
+object MesosTcpHealthCheck {
+  def mergeFromProto(proto: Protos.HealthCheckDefinition): MesosTcpHealthCheck =
+    MesosTcpHealthCheck(
+      gracePeriod = proto.getGracePeriodSeconds.seconds,
+      timeout = proto.getTimeoutSeconds.seconds,
+      interval = proto.getIntervalSeconds.seconds,
+      maxConsecutiveFailures = proto.getMaxConsecutiveFailures,
+      portIndex =
+      if (proto.hasPortIndex)
+        Some(proto.getPortIndex)
+      else if (!proto.hasPort)
+        Some(0) // backward compatibility, this used to be the default value in marathon.proto
+      else
+        None,
+      port = if (proto.hasPort) Some(proto.getPort) else None
+    )
 }
 
 object HealthCheck {
-  val DefaultPath = None
   val DefaultProtocol = Protocol.HTTP
-  val DefaultPortIndex = None
-  val DefaultCommand = None
-  // Dockers can take a long time to download, so default to a fairly long wait.
+  // Docker images can take a long time to download, so default to a fairly long wait.
   val DefaultGracePeriod = 5.minutes
   val DefaultInterval = 1.minute
   val DefaultTimeout = 20.seconds
@@ -133,26 +336,22 @@ object HealthCheck {
   // We optimistically set a low value here, for tasks that start really fast
   val DefaultFirstHealthCheckAfter = 5.seconds
 
-  implicit val healthCheck = validator[HealthCheck] { hc =>
-    (hc.portIndex.nonEmpty is true) or (hc.port.nonEmpty is true)
-    hc is validProtocol
-  }
-
-  //scalastyle:off
-  private def validProtocol: Validator[HealthCheck] = {
-    new Validator[HealthCheck] {
-      override def apply(hc: HealthCheck): Result = {
-        def eitherPortIndexOrPort: Boolean = hc.portIndex.isDefined ^ hc.port.isDefined
-        val hasCommand = hc.command.isDefined
-        val hasPath = hc.path.isDefined
-        if (hc.protocol match {
-          case Protocol.COMMAND => hasCommand && !hasPath && hc.port.isEmpty
-          case Protocol.HTTP => !hasCommand && eitherPortIndexOrPort
-          case Protocol.TCP => !hasCommand && !hasPath && eitherPortIndexOrPort
-          case _ => true
-        }) Success else Failure(Set(RuleViolation(hc, s"HealthCheck is having parameters violation ${hc.protocol} protocol.", None)))
+  implicit val Validator: Validator[HealthCheck] = new Validator[HealthCheck] {
+    override def apply(hc: HealthCheck): Result = {
+      hc match {
+        case h: HealthCheckWithPort => HealthCheckWithPort.Validator(h)
+        case _ => Success
       }
     }
   }
-  //scalastyle:on
+
+  def fromProto(proto: Protos.HealthCheckDefinition): HealthCheck = {
+    proto.getProtocol match {
+      case Protocol.COMMAND => MesosCommandHealthCheck.mergeFromProto(proto)
+      case Protocol.TCP => MarathonTcpHealthCheck.mergeFromProto(proto)
+      case Protocol.HTTP | Protocol.HTTPS => MarathonHttpHealthCheck.mergeFromProto(proto)
+      case Protocol.MESOS_TCP => MesosTcpHealthCheck.mergeFromProto(proto)
+      case Protocol.MESOS_HTTP | Protocol.MESOS_HTTPS => MesosHttpHealthCheck.mergeFromProto(proto)
+    }
+  }
 }

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -2,7 +2,6 @@ package mesosphere.marathon.core.health.impl
 
 import akka.actor.{ Actor, ActorLogging, ActorRef, Cancellable, Props }
 import akka.event.EventStream
-import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.health.impl.HealthCheckActor._
@@ -82,32 +81,35 @@ private[health] class HealthCheckActor(
     }
   }
 
-  def scheduleNextHealthCheck(interval: Option[FiniteDuration] = None): Unit =
-    if (healthCheck.protocol != Protocol.COMMAND) {
+  def scheduleNextHealthCheck(interval: Option[FiniteDuration] = None): Unit = healthCheck match {
+    case hc: MarathonHealthCheck =>
       log.debug(
         "Scheduling next health check for app [{}] version [{}] and healthCheck [{}]",
         app.id,
         app.version,
-        healthCheck
+        hc
       )
       nextScheduledCheck = Some(
-        context.system.scheduler.scheduleOnce(interval.getOrElse(healthCheck.interval)) {
+        context.system.scheduler.scheduleOnce(interval.getOrElse(hc.interval)) {
           self ! Tick
         }
       )
-    }
+    case _ => // Don't do anything for Mesos health checks
+  }
 
-  def dispatchJobs(tasks: Iterable[Task]): Unit = {
-    log.debug("Dispatching health check jobs to workers")
-    tasks.foreach { task =>
-      task.launched.foreach { launched =>
-        if (launched.runSpecVersion == app.version && task.isRunning) {
-          log.debug("Dispatching health check job for {}", task.taskId)
-          val worker: ActorRef = context.actorOf(workerProps)
-          worker ! HealthCheckJob(app, task, launched, healthCheck)
+  def dispatchJobs(tasks: Iterable[Task]): Unit = healthCheck match {
+    case hc: MarathonHealthCheck =>
+      log.debug("Dispatching health check jobs to workers")
+      tasks.foreach { task =>
+        task.launched.foreach { launched =>
+          if (launched.runSpecVersion == app.version && task.isRunning) {
+            log.debug("Dispatching health check job for {}", task.taskId)
+            val worker: ActorRef = context.actorOf(workerProps)
+            worker ! HealthCheckJob(app, task, launched, hc)
+          }
         }
       }
-    }
+    case _ => // Don't do anything for Mesos health checks
   }
 
   def checkConsecutiveFailures(task: Task, health: Health): Unit = {

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
@@ -6,9 +6,9 @@ import javax.net.ssl.{ KeyManager, SSLContext, X509TrustManager }
 
 import akka.actor.{ Actor, ActorLogging, PoisonPill }
 import akka.util.Timeout
-import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol.{ COMMAND, HTTP, HTTPS, TCP }
+import mesosphere.marathon.Protos
+import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.health.{ HealthCheck, HealthResult, Healthy, Unhealthy }
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
 import mesosphere.util.ThreadPoolContext
 import spray.client.pipelining._
@@ -43,33 +43,30 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
   }
 
   def doCheck(
-    app: AppDefinition, task: Task, launched: Task.Launched, check: HealthCheck): Future[Option[HealthResult]] =
+    app: AppDefinition, task: Task, launched: Task.Launched, check: MarathonHealthCheck): Future[Option[HealthResult]] =
     task.effectiveIpAddress(app) match {
       case Some(host) =>
         check.effectivePort(app, task) match {
+          case Some(port) => check match {
+            case hc: MarathonHttpHealthCheck =>
+              hc.protocol match {
+                case Protos.HealthCheckDefinition.Protocol.HTTPS => https(task, launched, hc, host, port)
+                case Protos.HealthCheckDefinition.Protocol.HTTP => http(task, launched, hc, host, port)
+                case invalidProtocol: Protos.HealthCheckDefinition.Protocol =>
+                  Future.failed {
+                    val message = s"Health check failed: HTTP health check contains invalid protocol: $invalidProtocol"
+                    log.warning(message)
+                    new UnsupportedOperationException(message)
+                  }
+              }
+            case hc: MarathonTcpHealthCheck => tcp(task, launched, hc, host, port)
+          }
           case None => Future.successful {
             Some(
               Unhealthy(
                 task.taskId,
                 launched.runSpecVersion,
                 "Missing/invalid port index and no explicit port specified"))
-          }
-          case Some(port) => check.protocol match {
-            case HTTP => http(task, launched, check, host, port)
-            case TCP => tcp(task, launched, check, host, port)
-            case HTTPS => https(task, launched, check, host, port)
-            case COMMAND =>
-              Future.failed {
-                val message = "COMMAND health checks can only be performed by the Mesos executor."
-                log.warning(message)
-                new UnsupportedOperationException(message)
-              }
-            case _ =>
-              Future.failed {
-                val message = s"Unknown health check protocol: [${check.protocol}]"
-                log.warning(message)
-                new UnsupportedOperationException(message)
-              }
           }
         }
       case None =>
@@ -81,7 +78,11 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
     }
 
   def http(
-    task: Task, launched: Task.Launched, check: HealthCheck, host: String, port: Int): Future[Option[HealthResult]] = {
+    task: Task,
+    launched: Task.Launched,
+    check: MarathonHttpHealthCheck,
+    host: String,
+    port: Int): Future[Option[HealthResult]] = {
     val rawPath = check.path.getOrElse("")
     val absolutePath = if (rawPath.startsWith("/")) rawPath else s"/$rawPath"
     val url = s"http://$host:$port$absolutePath"
@@ -106,7 +107,11 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
   }
 
   def tcp(
-    task: Task, launched: Task.Launched, check: HealthCheck, host: String, port: Int): Future[Option[HealthResult]] = {
+    task: Task,
+    launched: Task.Launched,
+    check: MarathonTcpHealthCheck,
+    host: String,
+    port: Int): Future[Option[HealthResult]] = {
     val address = s"$host:$port"
     val timeoutMillis = check.timeout.toMillis.toInt
     log.debug("Checking the health of [{}] via TCP", address)
@@ -123,7 +128,11 @@ class HealthCheckWorkerActor extends Actor with ActorLogging {
   }
 
   def https(
-    task: Task, launched: Task.Launched, check: HealthCheck, host: String, port: Int): Future[Option[HealthResult]] = {
+    task: Task,
+    launched: Task.Launched,
+    check: MarathonHttpHealthCheck,
+    host: String,
+    port: Int): Future[Option[HealthResult]] = {
     val rawPath = check.path.getOrElse("")
     val absolutePath = if (rawPath.startsWith("/")) rawPath else s"/$rawPath"
     val url = s"https://$host:$port$absolutePath"
@@ -165,5 +174,5 @@ object HealthCheckWorker {
   protected[health] val acceptableResponses = Range(200, 400)
   protected[health] val toIgnoreResponses = Range(100, 200)
 
-  case class HealthCheckJob(app: AppDefinition, task: Task, launched: Task.Launched, check: HealthCheck)
+  case class HealthCheckJob(app: AppDefinition, task: Task, launched: Task.Launched, check: MarathonHealthCheck)
 }

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
@@ -63,7 +63,8 @@ object ReadinessCheckExecutor {
             throw new IllegalArgumentException(s"no port definition for port name '${checkDef.portName}' was found")
           )
 
-          val host = effectivePortAssignment.effectiveIpAddress
+          val host = effectivePortAssignment.effectiveIpAddress.getOrElse(
+            throw new IllegalArgumentException(s"no effective IP address for '${checkDef.portName}' was found"))
           val port = effectivePortAssignment.effectivePort
 
           s"$schema://$host:$port${checkDef.path}"

--- a/src/main/scala/mesosphere/marathon/core/task/state/MarathonTaskStatus.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/state/MarathonTaskStatus.scala
@@ -38,6 +38,8 @@ object MarathonTaskStatus {
       case TASK_RUNNING => Running
       case TASK_STAGING => Staging
       case TASK_STARTING => Starting
+      // FIXME (gkleiman): REMOVE ONCE MARATHON IS PARTITION_AWARE
+      case _ => Error
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -606,6 +606,7 @@ object AppDefinition extends GeneralPurposeCombinators {
     appDef must complyWithUpgradeStrategyRules
     appDef must complyWithGpuRules
     appDef.constraints.each must complyWithConstraintRules
+    appDef must complyWithMesosHealthChecks
     appDef.ipAddress must optional(complyWithIpAddressRules(appDef))
   } and ExternalVolumes.validApp and EnvVarValue.validApp
 
@@ -768,6 +769,13 @@ object AppDefinition extends GeneralPurposeCombinators {
       }
     }
   }
+
+  private val complyWithMesosHealthChecks: Validator[AppDefinition] =
+    conditional[AppDefinition](appDef =>
+      (appDef.healthChecks.count(_.isInstanceOf[MesosHealthCheck]) -
+        appDef.healthChecks.count(_.isInstanceOf[MesosCommandHealthCheck])) > 0) {
+      featureEnabled(Features.MESOS_HEALTHCHECKS)
+    }
 
   private val haveAtMostOneMesosHealthCheck: Validator[AppDefinition] =
     isTrue[AppDefinition]("AppDefinition can contain at most one Mesos health check") { appDef =>

--- a/src/main/scala/mesosphere/marathon/state/PortAssignment.scala
+++ b/src/main/scala/mesosphere/marathon/state/PortAssignment.scala
@@ -1,11 +1,19 @@
 package mesosphere.marathon.state
 
 /**
-  * @param portName name of the port
-  * @param effectiveIpAddress ip address on which the port can be reached (can be an agent's IP or an IP-per-Task)
-  * @param effectivePort resolved non-dynamic port. The task is reachable under effectiveIpAddress:effectivePort.
+  * @param portName           name of the port
+  * @param effectiveIpAddress ip address on which the port can be reached (can be an agent's IP, an IP-per-Task
+  *                           or None if its not known yet)
+  * @param effectivePort      resolved non-dynamic port. The task is reachable under effectiveIpAddress:effectivePort.
+  * @param hostPort           port requested on the Mesos Agent.
+  * @param containerPort      port on which the container is listening.
   */
-case class PortAssignment(portName: Option[String], effectiveIpAddress: String, effectivePort: Int)
+case class PortAssignment(
+  portName: Option[String],
+  effectiveIpAddress: Option[String],
+  effectivePort: Int,
+  hostPort: Option[Int] = None,
+  containerPort: Option[Int] = None)
 
 object PortAssignment {
   /**

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -1,14 +1,14 @@
 package mesosphere.marathon.state
 
 import mesosphere.marathon.Protos.Constraint
+import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.core.readiness.ReadinessCheck
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.plugin
 import mesosphere.marathon.state.AppDefinition.VersionInfo
 
-import scala.concurrent.duration.FiniteDuration
 import scala.collection.immutable.Seq
+import scala.concurrent.duration.FiniteDuration
 
 //scalastyle:off
 trait RunSpec extends plugin.RunSpec {
@@ -53,7 +53,7 @@ trait RunSpec extends plugin.RunSpec {
 
   def container: Option[Container]
 
-  def healthChecks: Set[HealthCheck]
+  def healthChecks: Set[_ <: HealthCheck]
 
   def readinessChecks: Seq[ReadinessCheck]
 

--- a/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonTestHelper.scala
@@ -608,6 +608,9 @@ object MarathonTestHelper {
 
         app.copy(container = Some(docker))
       }
+
+      def withHealthCheck(healthCheck: mesosphere.marathon.core.health.HealthCheck): AppDefinition =
+        app.copy(healthChecks = Set(healthCheck))
     }
 
     implicit class TaskImprovements(task: Task) {

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -1,19 +1,18 @@
 package mesosphere.marathon.api.v2.json
 
 import com.wix.accord._
-import mesosphere.marathon.core.plugin.PluginManager
-import mesosphere.marathon.core.readiness.ReadinessCheckTestHelper
-import mesosphere.marathon.{ AllConf, Protos, MarathonTestHelper, MarathonSpec }
 import mesosphere.marathon.Protos.Constraint
-import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.api.JsonTestHelper
 import mesosphere.marathon.api.v2.ValidationHelper
-import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.health.{ MarathonHttpHealthCheck, MesosCommandHealthCheck, MesosHttpHealthCheck }
+import mesosphere.marathon.core.plugin.PluginManager
+import mesosphere.marathon.core.readiness.ReadinessCheckTestHelper
 import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state.DiscoveryInfo.Port
-import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.EnvVarValue._
+import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
+import mesosphere.marathon.{ AllConf, MarathonSpec, MarathonTestHelper, Protos }
 import org.apache.mesos.{ Protos => mesos }
 import org.scalatest.Matchers
 import play.api.data.validation.ValidationError
@@ -334,21 +333,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
         ))
       )),
       portDefinitions = Nil,
-      healthChecks = Set(HealthCheck(portIndex = Some(1)))
-    )
-    shouldNotViolate(
-      app,
-      "/healthCecks(0)",
-      "Health check port indices must address an element of the ports array or container port mappings."
-    )
-    MarathonTestHelper.validateJsonSchema(app, false) // missing image
-
-    app = correct.copy(
-      container = Some(Docker(
-        network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE)
-      )),
-      portDefinitions = Nil,
-      healthChecks = Set(HealthCheck(protocol = Protocol.COMMAND))
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(1)))
     )
     shouldNotViolate(
       app,
@@ -358,9 +343,22 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
     MarathonTestHelper.validateJsonSchema(app, false) // missing image
 
     app = correct.copy(
-      healthChecks = Set(HealthCheck(portIndex = Some(1)))
+      container = Some(Docker(
+        network = Some(mesos.ContainerInfo.DockerInfo.Network.BRIDGE)
+      )),
+      portDefinitions = Nil,
+      healthChecks = Set(MarathonHttpHealthCheck(port = Some(80)))
     )
+    shouldNotViolate(
+      app,
+      "/healthChecks(0)",
+      "Health check port indices must address an element of the ports array or container port mappings."
+    )
+    MarathonTestHelper.validateJsonSchema(app, false) // missing image
 
+    app = correct.copy(
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(1)))
+    )
     shouldViolate(
       app,
       "/healthChecks(0)",
@@ -473,7 +471,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       }
       """
     val readResult2 = fromJson(json2)
-    assert(readResult2.healthChecks.head.command.isDefined)
+    assert(readResult2.healthChecks.head == MesosCommandHealthCheck(command = Command("env && http http://$HOST:$PORT0/")))
   }
 
   test("SerializationRoundtrip with complex example") {
@@ -503,7 +501,7 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       backoffFactor = 1.5,
       maxLaunchDelay = 3.minutes,
       container = Some(Docker(image = "group/image")),
-      healthChecks = Set(HealthCheck(portIndex = Some(0))),
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(0))),
       dependencies = Set(PathId("/prod/product/backend")),
       upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.75)
     )
@@ -517,46 +515,44 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       id = PathId("/prod/product/frontend/my-app"),
       cmd = Some("sleep 30"),
       portDefinitions = PortDefinitions(9001, 9002),
-      healthChecks = Set(HealthCheck(portIndex = Some(1)))
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(1)))
     )
     JsonTestHelper.assertSerializationRoundtripWorks(app3)
   }
 
-  test("Reading AppDefinition adds portIndex if you have ports") {
+  test("Reading AppDefinition adds portIndex to a Marathon HTTP health check if the app has ports") {
     import Formats._
 
     val app = AppDefinition(
       id = PathId("/prod/product/frontend/my-app"),
       cmd = Some("sleep 30"),
       portDefinitions = PortDefinitions(9001, 9002),
-      healthChecks = Set(HealthCheck())
+      healthChecks = Set(MarathonHttpHealthCheck())
     )
 
     val json = Json.toJson(app)
     val reread = Json.fromJson[AppDefinition](json).get
 
-    reread.healthChecks.headOption should be(defined)
-    reread.healthChecks.head.portIndex should be(Some(0))
+    reread.healthChecks.headOption should be(Some(MarathonHttpHealthCheck(portIndex = Some(0))))
   }
 
-  test("Reading AppDefinition does not add portIndex if there are no ports") {
+  test("Reading AppDefinition does not add portIndex to a Marathon HTTP health check if the app doesn't have ports") {
     import Formats._
 
     val app = AppDefinition(
       id = PathId("/prod/product/frontend/my-app"),
       cmd = Some("sleep 30"),
       portDefinitions = Seq.empty,
-      healthChecks = Set(HealthCheck())
+      healthChecks = Set(MarathonHttpHealthCheck())
     )
 
     val json = Json.toJson(app)
     val reread = Json.fromJson[AppDefinition](json).get
 
-    reread.healthChecks.headOption should be(defined)
-    reread.healthChecks.head.portIndex should be(None)
+    reread.healthChecks.headOption should be(Some(MarathonHttpHealthCheck(portIndex = None)))
   }
 
-  test("Reading AppDefinition adds portIndex if you have at least one portMapping") {
+  test("Reading AppDefinition adds portIndex to a Marathon HTTP health check if it has at least one portMapping") {
     import Formats._
 
     val app = AppDefinition(
@@ -569,17 +565,16 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
           portMappings = Some(Seq.empty)
         )
       ),
-      healthChecks = Set(HealthCheck())
+      healthChecks = Set(MarathonHttpHealthCheck())
     )
 
     val json = Json.toJson(app)
     val reread = Json.fromJson[AppDefinition](json).get
 
-    reread.healthChecks.headOption should be(defined)
-    reread.healthChecks.head.portIndex should be(Some(0))
+    reread.healthChecks.headOption should be(Some(MarathonHttpHealthCheck(portIndex = Some(0))))
   }
 
-  test("Reading AppDefinition does not add portIndex if there are no ports nor portMappings") {
+  test("Reading AppDefinition adds not add portIndex to a Marathon HTTP health check if it has no ports nor portMappings") {
     import Formats._
 
     val app = AppDefinition(
@@ -587,14 +582,68 @@ class AppDefinitionTest extends MarathonSpec with Matchers {
       cmd = Some("sleep 30"),
       portDefinitions = Seq.empty,
       container = Some(Docker()),
-      healthChecks = Set(HealthCheck())
+      healthChecks = Set(MarathonHttpHealthCheck())
     )
 
     val json = Json.toJson(app)
     val reread = Json.fromJson[AppDefinition](json).get
 
-    reread.healthChecks.headOption should be(defined)
-    reread.healthChecks.head.portIndex should be(None)
+    reread.healthChecks.headOption should be(Some(MarathonHttpHealthCheck(portIndex = None)))
+  }
+
+  test("Reading AppDefinition does not add portIndex to a Mesos HTTP health check if the app doesn't have ports") {
+    import Formats._
+
+    val app = AppDefinition(
+      id = PathId("/prod/product/frontend/my-app"),
+      cmd = Some("sleep 30"),
+      portDefinitions = Seq.empty,
+      healthChecks = Set(MesosHttpHealthCheck())
+    )
+
+    val json = Json.toJson(app)
+    val reread = Json.fromJson[AppDefinition](json).get
+
+    reread.healthChecks.headOption should be(Some(MesosHttpHealthCheck(portIndex = None)))
+  }
+
+  test("Reading AppDefinition adds portIndex to a Mesos HTTP health check if it has at least one portMapping") {
+    import Formats._
+
+    val app = AppDefinition(
+      id = PathId("/prod/product/frontend/my-app"),
+      cmd = Some("sleep 30"),
+      portDefinitions = Seq.empty,
+      container = Some(
+        Docker(
+          network = Some(mesos.ContainerInfo.DockerInfo.Network.USER),
+          portMappings = Some(Seq.empty)
+        )
+      ),
+      healthChecks = Set(MesosHttpHealthCheck())
+    )
+
+    val json = Json.toJson(app)
+    val reread = Json.fromJson[AppDefinition](json).get
+
+    reread.healthChecks.headOption should be(Some(MesosHttpHealthCheck(portIndex = Some(0))))
+  }
+
+  test("Reading AppDefinition does not add portIndex to a Mesos HTTP health check if it has no ports nor portMappings") {
+    import Formats._
+
+    val app = AppDefinition(
+      id = PathId("/prod/product/frontend/my-app"),
+      cmd = Some("sleep 30"),
+      portDefinitions = Seq.empty,
+      container = Some(Docker()),
+      healthChecks = Set(MesosHttpHealthCheck())
+    )
+
+    val json = Json.toJson(app)
+    val reread = Json.fromJson[AppDefinition](json).get
+
+    reread.healthChecks.headOption should be(Some(MesosHttpHealthCheck(portIndex = None)))
   }
 
   test("Read app with container definition and port mappings") {

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon.api.v2.json
 
 import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.core.health.MarathonHttpHealthCheck
 import mesosphere.marathon.state.ResourceRole
 import org.scalatest.Matchers
 import play.api.libs.json.{ JsResultException, Json }
@@ -47,7 +48,7 @@ class AppUpdateFormatTest extends MarathonSpec with Matchers {
   test("FromJSON should set healthCheck portIndex to 0 when neither port nor portIndex are set") {
     val json = Json.parse(""" { "id": "test", "healthChecks": [{ "path": "/", "protocol": "HTTP" }] } """)
     val appUpdate = json.as[AppUpdate]
-    appUpdate.healthChecks.get.head.portIndex should equal(Some(0))
+    appUpdate.healthChecks.get.head.asInstanceOf[MarathonHttpHealthCheck].portIndex should equal(Some(0))
   }
 
 }

--- a/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionMesosHealthCheckValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionMesosHealthCheckValidationTest.scala
@@ -1,0 +1,60 @@
+package mesosphere.marathon.api.validation
+
+import mesosphere.marathon.MarathonSpec
+import mesosphere.marathon.core.health.{ HealthCheck, MarathonHttpHealthCheck, MesosCommandHealthCheck, MesosHttpHealthCheck }
+import mesosphere.marathon.core.plugin.PluginManager
+import mesosphere.marathon.state._
+import org.scalatest.{ GivenWhenThen, Matchers }
+
+class AppDefinitionMesosHealthCheckValidationTest extends MarathonSpec with Matchers with GivenWhenThen {
+
+  lazy val validAppDefinition = AppDefinition.validAppDefinition(PluginManager.None)
+
+  test("app with 0 Mesos health checks is valid") {
+    val f = new Fixture
+    Given("an app with only Marathon Health Checks")
+    val app = f.app()
+
+    Then("the app is considered valid")
+    validAppDefinition(app).isSuccess shouldBe true
+  }
+
+  test("app with 1 Mesos health check is valid") {
+    val f = new Fixture
+    Given("an app with one health check")
+    val app = f.app(healthChecks = Set(MesosCommandHealthCheck(command = Command("true"))))
+
+    Then("the app is considered valid")
+    validAppDefinition(app).isSuccess shouldBe true
+  }
+
+  test("app with more than 1 non-command Mesos health check is invalid") {
+    val f = new Fixture
+    Given("an app with one health check")
+    val app = f.app(healthChecks = Set(MesosHttpHealthCheck(port = Some(80)), MesosHttpHealthCheck()))
+
+    Then("the app is considered invalid")
+    validAppDefinition(app).isFailure shouldBe true
+  }
+
+  test("app with more than 1 command Mesos health check is valid") {
+    val f = new Fixture
+    Given("an app with one health check")
+    val app = f.app(healthChecks = Set(
+      MesosCommandHealthCheck(command = Command("true")),
+      MesosCommandHealthCheck(command = Command("true"))))
+
+    Then("the app is considered valid")
+    validAppDefinition(app).isSuccess shouldBe true
+  }
+
+  class Fixture {
+    def app(healthChecks: Set[_ <: HealthCheck] = Set(MarathonHttpHealthCheck())): AppDefinition =
+      AppDefinition(
+        cmd = Some("sleep 1000"),
+        instances = 1,
+        healthChecks = healthChecks
+      )
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidationTest.scala
@@ -2,12 +2,35 @@ package mesosphere.marathon
 package api.validation
 
 import mesosphere.UnitTest
+import mesosphere.marathon.core.health.MesosTcpHealthCheck
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.state.{ AppDefinition, PathId }
 
 class AppDefinitionValidationTest extends UnitTest {
 
   "AppDefinition" when {
+
+    "created with mesos healthchecks" should {
+      "be valid when configuration allows to" in new Fixture {
+        AllConf.withTestConfig(Seq("--enable_features", Features.MESOS_HEALTHCHECKS))
+        val app = AppDefinition(
+          id = PathId("/a/b/c/d"),
+          cmd = Some("sleep 1000"),
+          healthChecks = Set(new MesosTcpHealthCheck())
+        )
+        validator(app).isSuccess shouldBe true
+      }
+
+      "be invalid when configuration do NOT allows to" in new Fixture {
+        AllConf.withTestConfig(Seq())
+        val app = AppDefinition(
+          id = PathId("/a/b/c/d"),
+          cmd = Some("sleep 1000"),
+          healthChecks = Set(new MesosTcpHealthCheck())
+        )
+        validator(app).isFailure shouldBe true
+      }
+    }
 
     "created with dependencies" should {
 

--- a/src/test/scala/mesosphere/marathon/api/validation/ReadinessCheckValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/ReadinessCheckValidatorTest.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.api.validation
 
-import com.wix.accord.validate
+import com.wix.accord.{ Validator, validate }
 import mesosphere.marathon.core.readiness.ReadinessCheck
 import mesosphere.marathon.state.PortDefinition
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper }
@@ -121,5 +121,5 @@ class ReadinessCheckValidatorTest extends MarathonSpec with Matchers with GivenW
       PortDefinition(
         port = 123,
         name = Some(ReadinessCheck.DefaultPortName))))
-  implicit val readinessCheckValidator = ReadinessCheck.readinessCheckValidator(app)
+  implicit val readinessCheckValidator: Validator[ReadinessCheck] = ReadinessCheck.readinessCheckValidator(app)
 }

--- a/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
@@ -1,13 +1,13 @@
 package mesosphere.marathon.api.validation
 
 import com.wix.accord.validate
-import mesosphere.marathon.Protos.{ Constraint, HealthCheckDefinition }
+import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon._
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.json.Formats
+import mesosphere.marathon.core.health.{ MarathonHttpHealthCheck, MesosCommandHealthCheck }
 import mesosphere.marathon.core.plugin.{ PluginDefinitions, PluginManager }
 import mesosphere.marathon.core.readiness.ReadinessCheck
-import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.state._
 import org.apache.mesos.{ Protos => mesos }
 import org.scalatest.{ GivenWhenThen, Matchers }
@@ -151,9 +151,8 @@ class RunSpecValidatorTest extends MarathonSpec with Matchers with GivenWhenThen
       id = PathId("/test"),
       cmd = Some("true"),
       healthChecks = Set(
-        HealthCheck(
-          protocol = HealthCheckDefinition.Protocol.COMMAND,
-          command = Some(Command("curl http://localhost:$PORT"))
+        MesosCommandHealthCheck(
+          command = Command("curl http://localhost:$PORT")
         )
       )
     )
@@ -653,7 +652,7 @@ class RunSpecValidatorTest extends MarathonSpec with Matchers with GivenWhenThen
       )),
       portDefinitions = List.empty,
       healthChecks = Set(
-        HealthCheck(
+        MarathonHttpHealthCheck(
           path = Some("/"),
           protocol = Protos.HealthCheckDefinition.Protocol.HTTP,
           port = Some(8000),

--- a/src/test/scala/mesosphere/marathon/core/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/HealthCheckTest.scala
@@ -1,19 +1,19 @@
 package mesosphere.marathon.core.health
 
+import com.wix.accord.validate
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.api.v2.ValidationHelper
-import mesosphere.marathon.state.{ Command, PortDefinition }
+import mesosphere.marathon.state._
 import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper, Protos }
 import play.api.libs.json.Json
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
-import com.wix.accord.validate
 
 class HealthCheckTest extends MarathonSpec {
 
-  test("ToProto") {
-    val healthCheck = HealthCheck(
+  test("ToProto Marathon HTTP HealthCheck with portIndex") {
+    val healthCheck = MarathonHttpHealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTP,
       portIndex = Some(0),
@@ -33,8 +33,8 @@ class HealthCheckTest extends MarathonSpec {
     assert(!proto.hasPort)
   }
 
-  test("ToProto with port") {
-    val healthCheck = HealthCheck(
+  test("ToProto Marathon HTTP HealthCheck with port") {
+    val healthCheck = MarathonHttpHealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTP,
       gracePeriod = 10.seconds,
@@ -54,9 +54,8 @@ class HealthCheckTest extends MarathonSpec {
     assert(12345 == proto.getPort)
   }
 
-  test("ToProtoTcp") {
-    val healthCheck = HealthCheck(
-      protocol = Protocol.TCP,
+  test("ToProto Marathon TCP HealthCheck with portIndex") {
+    val healthCheck = MarathonTcpHealthCheck(
       portIndex = Some(1),
       gracePeriod = 7.seconds,
       interval = 35.seconds,
@@ -72,7 +71,24 @@ class HealthCheckTest extends MarathonSpec {
     assert(10 == proto.getMaxConsecutiveFailures)
   }
 
-  test("MergeFromProto with portIndex") {
+  test("ToProto Marathon TCP HealthCheck with port") {
+    val healthCheck = MarathonTcpHealthCheck(
+      port = Some(80),
+      gracePeriod = 7.seconds,
+      interval = 35.seconds,
+      maxConsecutiveFailures = 10
+    )
+
+    val proto = healthCheck.toProto
+
+    assert(Protocol.TCP == proto.getProtocol)
+    assert(80 == proto.getPort)
+    assert(7 == proto.getGracePeriodSeconds)
+    assert(35 == proto.getIntervalSeconds)
+    assert(10 == proto.getMaxConsecutiveFailures)
+  }
+
+  test("FromProto Marathon HTTP HealthCheck with portIndex") {
     val proto = Protos.HealthCheckDefinition.newBuilder
       .setPath("/health")
       .setProtocol(Protocol.HTTP)
@@ -83,9 +99,9 @@ class HealthCheckTest extends MarathonSpec {
       .setMaxConsecutiveFailures(10)
       .build
 
-    val mergeResult = HealthCheck().mergeFromProto(proto)
+    val mergeResult = HealthCheck.fromProto(proto)
 
-    val expectedResult = HealthCheck(
+    val expectedResult = MarathonHttpHealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTP,
       portIndex = Some(0),
@@ -99,7 +115,7 @@ class HealthCheckTest extends MarathonSpec {
     assert(mergeResult == expectedResult)
   }
 
-  test("MergeFromProto with port") {
+  test("FromProto Marathon HTTP HealthCheck with port") {
     val proto = Protos.HealthCheckDefinition.newBuilder
       .setPath("/health")
       .setProtocol(Protocol.HTTP)
@@ -110,9 +126,9 @@ class HealthCheckTest extends MarathonSpec {
       .setPort(12345)
       .build
 
-    val mergeResult = HealthCheck().mergeFromProto(proto)
+    val mergeResult = HealthCheck.fromProto(proto)
 
-    val expectedResult = HealthCheck(
+    val expectedResult = MarathonHttpHealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTP,
       portIndex = None,
@@ -126,7 +142,7 @@ class HealthCheckTest extends MarathonSpec {
     assert(mergeResult == expectedResult)
   }
 
-  test("MergeFromProto with neither port nor portIndex") {
+  test("FromProto Marathon HTTP HealthCheck with neither port nor portIndex") {
     val proto = Protos.HealthCheckDefinition.newBuilder
       .setPath("/health")
       .setProtocol(Protocol.HTTP)
@@ -136,9 +152,9 @@ class HealthCheckTest extends MarathonSpec {
       .setMaxConsecutiveFailures(10)
       .build
 
-    val mergeResult = HealthCheck().mergeFromProto(proto)
+    val mergeResult = HealthCheck.fromProto(proto)
 
-    val expectedResult = HealthCheck(
+    val expectedResult = MarathonHttpHealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTP,
       portIndex = Some(0),
@@ -152,7 +168,7 @@ class HealthCheckTest extends MarathonSpec {
     assert(mergeResult == expectedResult)
   }
 
-  test("MergeFromProtoTcp") {
+  test("FromProto Marathon TCP HealthCheck with portIndex") {
     val proto = Protos.HealthCheckDefinition.newBuilder
       .setProtocol(Protocol.TCP)
       .setPortIndex(1)
@@ -162,11 +178,9 @@ class HealthCheckTest extends MarathonSpec {
       .setMaxConsecutiveFailures(10)
       .build
 
-    val mergeResult = HealthCheck().mergeFromProto(proto)
+    val mergeResult = HealthCheck.fromProto(proto)
 
-    val expectedResult = HealthCheck(
-      path = None,
-      protocol = Protocol.TCP,
+    val expectedResult = MarathonTcpHealthCheck(
       portIndex = Some(1),
       gracePeriod = 7.seconds,
       interval = 35.seconds,
@@ -177,7 +191,7 @@ class HealthCheckTest extends MarathonSpec {
     assert(mergeResult == expectedResult)
   }
 
-  test("MergeFromProtoHttps") {
+  test("FromProto Marathon HTTPS HealthCheck") {
     val proto = Protos.HealthCheckDefinition.newBuilder
       .setPath("/health")
       .setProtocol(Protocol.HTTPS)
@@ -188,9 +202,9 @@ class HealthCheckTest extends MarathonSpec {
       .setMaxConsecutiveFailures(10)
       .build
 
-    val mergeResult = HealthCheck().mergeFromProto(proto)
+    val mergeResult = HealthCheck.fromProto(proto)
 
-    val expectedResult = HealthCheck(
+    val expectedResult = MarathonHttpHealthCheck(
       path = Some("/health"),
       protocol = Protocol.HTTPS,
       portIndex = Some(0),
@@ -209,119 +223,23 @@ class HealthCheckTest extends MarathonSpec {
   }
   private[this] def fromJson(json: String): HealthCheck = {
     import mesosphere.marathon.api.v2.json.Formats._
-    Json.fromJson[HealthCheck](Json.parse(json)).get
+    Json.fromJson[HealthCheck](Json.parse(json))(HealthCheckFormat).get
   }
 
   test("SerializationRoundtrip empty") {
-    val original = HealthCheck()
+    val original = MesosCommandHealthCheck(command = Command("true"))
     val json = toJson(original)
     val readResult = fromJson(json)
     assert(readResult == original)
   }
 
-  test("Read COMMAND health check") {
-    val json =
-      """
-        {
-          "protocol": "COMMAND",
-          "command": { "value": "echo healthy" },
-          "gracePeriodSeconds": 300,
-          "intervalSeconds": 60,
-          "timeoutSeconds": 20,
-          "maxConsecutiveFailures": 3
-        }
-      """
-    val expected =
-      HealthCheck(
-        protocol = Protocol.COMMAND,
-        command = Some(Command("echo healthy"))
-      )
-    val readResult = fromJson(json)
-    assert(readResult == expected)
-  }
-
-  test("Read COMMAND health check (portIndex may be provided for backwards-compatibility)") {
-    val json =
-      """
-        {
-          "protocol": "COMMAND",
-          "command": { "value": "echo healthy" },
-          "portIndex": 0,
-          "gracePeriodSeconds": 300,
-          "intervalSeconds": 60,
-          "timeoutSeconds": 20,
-          "maxConsecutiveFailures": 3
-        }
-      """
-    val expected =
-      HealthCheck(
-        protocol = Protocol.COMMAND,
-        command = Some(Command("echo healthy")),
-        portIndex = Some(0)
-      )
-    val readResult = fromJson(json)
-    assert(readResult == expected)
-  }
-
-  def shouldBeInvalid(hc: HealthCheck): Unit = {
-    assert(validate(hc).isFailure)
-  }
-
-  def shouldBeValid(hc: HealthCheck): Unit = {
-    val result = validate(hc)
-    assert(result.isSuccess, s"violations: ${ValidationHelper.getAllRuleConstrains(result)}")
-  }
-
   test("A default HealthCheck should be valid") {
     // portIndex is added in the Format conversion of the app
-    shouldBeValid(HealthCheck(portIndex = Some(0)))
-  }
-
-  test("path is not accepted for a COMMAND HealthCheck") {
-    shouldBeInvalid(HealthCheck(protocol = Protocol.COMMAND, path = Some("/health")))
-  }
-
-  test("command is required for a COMMAND HealthCheck") {
-    shouldBeInvalid(HealthCheck(protocol = Protocol.COMMAND, command = None))
-  }
-
-  test("command is not accepted for a HTTP HealthCheck") {
-    shouldBeInvalid(HealthCheck(
-      protocol = Protocol.HTTP,
-      command = Some(Command("echo healthy"))
-    ))
-  }
-
-  test("path is not accepted for a TCP HealthCheck") {
-    shouldBeInvalid(HealthCheck(
-      protocol = Protocol.TCP,
-      path = Some("/")
-    ))
-  }
-
-  test("command is not accepted for a TCP HealthCheck") {
-    shouldBeInvalid(HealthCheck(
-      protocol = Protocol.TCP,
-      command = Some(Command("echo healthy"))
-    ))
-  }
-
-  test("port is not accepted for a COMMAND HealthCheck") {
-    shouldBeInvalid(HealthCheck(
-      protocol = Protocol.COMMAND,
-      port = Some(1)
-    ))
-  }
-
-  test("portIndex is not accepted for a COMMAND HealthCheck") {
-    shouldBeInvalid(HealthCheck(
-      protocol = Protocol.COMMAND,
-      portIndex = Some(0)
-    ))
+    shouldBeValid(MarathonHttpHealthCheck(portIndex = Some(0)))
   }
 
   test("both port and portIndex are not accepted at the same time for a HTTP HealthCheck") {
-    shouldBeInvalid(HealthCheck(
+    shouldBeInvalid(MarathonHttpHealthCheck(
       protocol = Protocol.HTTP,
       port = Some(1),
       portIndex = Some(0)
@@ -329,56 +247,55 @@ class HealthCheckTest extends MarathonSpec {
   }
 
   test("both port and portIndex are not accepted at the same time for a TCP HealthCheck") {
-    shouldBeInvalid(HealthCheck(
-      protocol = Protocol.TCP,
+    shouldBeInvalid(MarathonTcpHealthCheck(
       port = Some(1),
       portIndex = Some(0)
     ))
   }
 
   test("port is accepted for a HTTP HealthCheck") {
-    shouldBeValid(HealthCheck(
+    shouldBeValid(MarathonHttpHealthCheck(
       protocol = Protocol.HTTP,
       port = Some(1)
     ))
   }
 
   test("port is accepted for a TCP HealthCheck") {
-    shouldBeValid(HealthCheck(
-      protocol = Protocol.TCP,
-      port = Some(1)
-    ))
+    shouldBeValid(MarathonTcpHealthCheck(port = Some(1)))
   }
 
   test("portIndex is accepted for a HTTP HealthCheck") {
-    shouldBeValid(HealthCheck(
-      protocol = Protocol.HTTP,
-      portIndex = Some(0)
-    ))
+    shouldBeValid(MarathonHttpHealthCheck(portIndex = Some(0)))
   }
 
   test("portIndex is accepted for a TCP HealthCheck") {
-    shouldBeValid(HealthCheck(
-      protocol = Protocol.TCP,
-      portIndex = Some(0)
-    ))
+    shouldBeValid(MarathonTcpHealthCheck(portIndex = Some(0)))
   }
 
   test("effectivePort with a hard-coded port") {
     import MarathonTestHelper.Implicits._
-    val check = new HealthCheck(port = Some(1234))
+    val check = new MarathonTcpHealthCheck(port = Some(1234))
     val app = MarathonTestHelper.makeBasicApp().withPortDefinitions(Seq(PortDefinition(0)))
     val task = MarathonTestHelper.runningTask("test_id").withHostPorts(Seq(4321))
 
-    assert(check.effectivePort(app, task).contains(1234))
+    assert(check.effectivePort(app, task).get == 1234)
   }
 
   test("effectivePort with a port index") {
     import MarathonTestHelper.Implicits._
-    val check = new HealthCheck(portIndex = Some(0))
+    val check = new MarathonTcpHealthCheck(portIndex = Some(0))
     val app = MarathonTestHelper.makeBasicApp().withPortDefinitions(Seq(PortDefinition(0)))
     val task = MarathonTestHelper.runningTask("test_id").withHostPorts(Seq(4321))
 
-    assert(check.effectivePort(app, task).contains(4321))
+    assert(check.effectivePort(app, task).get == 4321)
+  }
+
+  private[this] def shouldBeInvalid(hc: HealthCheck): Unit = {
+    assert(validate(hc).isFailure)
+  }
+
+  private[this] def shouldBeValid(hc: HealthCheck): Unit = {
+    val result = validate(hc)
+    assert(result.isSuccess, s"violations: ${ValidationHelper.getAllRuleConstrains(result)}")
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -1,0 +1,841 @@
+package mesosphere.marathon.core.health
+
+import com.wix.accord.validate
+import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
+import mesosphere.marathon.api.JsonTestHelper
+import mesosphere.marathon.api.v2.ValidationHelper
+import mesosphere.marathon.api.v2.json.Formats.HealthCheckFormat
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.state.Container.Docker
+import mesosphere.marathon.state._
+import mesosphere.marathon.{ MarathonSpec, MarathonTestHelper, Protos }
+import mesosphere.mesos.TaskBuilder
+import org.apache.mesos.{ Protos => MesosProtos }
+import play.api.libs.json.Json
+
+import scala.collection.immutable.Seq
+import scala.concurrent.duration._
+
+class MesosHealthCheckTest extends MarathonSpec {
+  // COMMAND health check
+  test("Read COMMAND health check") {
+    val json =
+      """
+        {
+          "protocol": "COMMAND",
+          "command": { "value": "echo healthy" },
+          "gracePeriodSeconds": 300,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 3
+        }
+      """
+    val expected = MesosCommandHealthCheck(command = Command("echo healthy"))
+    val readResult = fromJson(json)
+    assert(readResult == expected)
+  }
+
+  test("Write COMMAND health check") {
+    val json =
+      """
+        {
+          "protocol": "COMMAND",
+          "command": { "value": "echo healthy" },
+          "gracePeriodSeconds": 300,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 3
+        }
+      """
+    JsonTestHelper.assertThatJsonOf(MesosCommandHealthCheck(command = Command("echo healthy")))(HealthCheckFormat)
+      .correspondsToJsonString(json)
+  }
+
+  test("Read COMMAND health check (portIndex may be provided for backwards-compatibility)") {
+    val json =
+      """
+        {
+          "protocol": "COMMAND",
+          "command": { "value": "echo healthy" },
+          "portIndex": 0,
+          "gracePeriodSeconds": 300,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 3
+        }
+      """
+    val expected = MesosCommandHealthCheck(command = Command("echo healthy"))
+    val readResult = fromJson(json)
+    assert(readResult == expected)
+  }
+
+  // Mesos HTTP[S] health check
+  test("Read Mesos HTTP health check") {
+    val portIndexJson =
+      """
+        {
+          "path": "/health",
+          "protocol": "MESOS_HTTP",
+          "portIndex": 0,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0
+        }
+      """
+    assert(fromJson(portIndexJson) == mesosHttpHealthCheckWithPortIndex)
+
+    val portJson =
+      """
+        {
+          "path": "/health",
+          "protocol": "MESOS_HTTP",
+          "port": 80,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0
+        }
+      """
+    assert(fromJson(portJson) == mesosHttpHealthCheckWithPort)
+  }
+
+  test("Write Mesos HTTP health check") {
+    val portIndexJson =
+      """
+        {
+          "protocol": "MESOS_HTTP",
+          "path": "/health",
+          "portIndex": 0,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0
+        }
+      """
+    JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPortIndex)(HealthCheckFormat)
+      .correspondsToJsonString(portIndexJson)
+
+    val portJson =
+      """
+        {
+          "protocol": "MESOS_HTTP",
+          "path": "/health",
+          "port": 80,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0
+        }
+      """
+    JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPort)(HealthCheckFormat)
+      .correspondsToJsonString(portJson)
+  }
+
+  test("Read Mesos HTTPS health check") {
+    val portIndexJson =
+      """
+        {
+          "protocol": "MESOS_HTTPS",
+          "path": "/health",
+          "portIndex": 0,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0
+        }
+      """
+    assert(fromJson(portIndexJson) == mesosHttpHealthCheckWithPortIndex.copy(protocol = Protocol.MESOS_HTTPS))
+
+    val portJson =
+      """
+        {
+          "protocol": "MESOS_HTTPS",
+          "path": "/health",
+          "port": 80,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0
+        }
+      """
+    assert(fromJson(portJson) == mesosHttpHealthCheckWithPort.copy(protocol = Protocol.MESOS_HTTPS))
+  }
+
+  test("Write Mesos HTTPS health check") {
+    val portIndexJson =
+      """
+        {
+          "protocol": "MESOS_HTTPS",
+          "path": "/health",
+          "portIndex": 0,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0
+        }
+      """
+    JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPortIndex.copy(protocol = Protocol.MESOS_HTTPS))(HealthCheckFormat)
+      .correspondsToJsonString(portIndexJson)
+
+    val portJson =
+      """
+        {
+          "protocol": "MESOS_HTTPS",
+          "path": "/health",
+          "port": 80,
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0
+        }
+      """
+    JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPort.copy(protocol = Protocol.MESOS_HTTPS))(HealthCheckFormat)
+      .correspondsToJsonString(portJson)
+  }
+
+  test("both port and portIndex are not accepted at the same time for a Mesos HTTP HealthCheck") {
+    shouldBeInvalid(MesosHttpHealthCheck(
+      port = Some(1),
+      portIndex = Some(0)
+    ))
+  }
+
+  test("port is accepted for a Mesos HTTP HealthCheck") {
+    shouldBeValid(MesosHttpHealthCheck(port = Some(1)))
+  }
+
+  test("portIndex is accepted for a Mesos HTTP HealthCheck") {
+    shouldBeValid(MesosHttpHealthCheck(portIndex = Some(0)))
+  }
+
+  test("ToProto Mesos HTTP HealthCheck with portIndex") {
+    val healthCheck = MesosHttpHealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.MESOS_HTTP,
+      portIndex = Some(0),
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      maxConsecutiveFailures = 0
+    )
+
+    val proto = healthCheck.toProto
+
+    assert("/health" == proto.getPath)
+    assert(Protocol.MESOS_HTTP == proto.getProtocol)
+    assert(0 == proto.getPortIndex)
+    assert(10 == proto.getGracePeriodSeconds)
+    assert(60 == proto.getIntervalSeconds)
+    assert(0 == proto.getMaxConsecutiveFailures)
+    assert(!proto.hasPort)
+  }
+
+  test("ToProto Mesos HTTPS HealthCheck with port") {
+    val healthCheck = MesosHttpHealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.MESOS_HTTPS,
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      maxConsecutiveFailures = 0,
+      port = Some(12345)
+    )
+
+    val proto = healthCheck.toProto
+
+    assert("/health" == proto.getPath)
+    assert(Protocol.MESOS_HTTPS == proto.getProtocol)
+    assert(!proto.hasPortIndex)
+    assert(10 == proto.getGracePeriodSeconds)
+    assert(60 == proto.getIntervalSeconds)
+    assert(0 == proto.getMaxConsecutiveFailures)
+    assert(12345 == proto.getPort)
+  }
+
+  test("ToProto Mesos TCP HealthCheck with port") {
+    val healthCheck = MesosTcpHealthCheck(
+      port = Some(80),
+      gracePeriod = 7.seconds,
+      interval = 35.seconds,
+      maxConsecutiveFailures = 10
+    )
+
+    val proto = healthCheck.toProto
+
+    assert(Protocol.MESOS_TCP == proto.getProtocol)
+    assert(80 == proto.getPort)
+    assert(7 == proto.getGracePeriodSeconds)
+    assert(35 == proto.getIntervalSeconds)
+    assert(10 == proto.getMaxConsecutiveFailures)
+  }
+
+  test("FromProto Mesos HTTP HealthCheck with portIndex") {
+    val proto = Protos.HealthCheckDefinition.newBuilder
+      .setPath("/health")
+      .setProtocol(Protocol.MESOS_HTTP)
+      .setPortIndex(0)
+      .setGracePeriodSeconds(10)
+      .setIntervalSeconds(60)
+      .setTimeoutSeconds(10)
+      .setMaxConsecutiveFailures(10)
+      .build
+
+    val mergeResult = HealthCheck.fromProto(proto)
+
+    val expectedResult = MesosHttpHealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.MESOS_HTTP,
+      portIndex = Some(0),
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      timeout = 10.seconds,
+      maxConsecutiveFailures = 10,
+      port = None
+    )
+
+    assert(mergeResult == expectedResult)
+  }
+
+  test("FromProto Mesos HTTPS HealthCheck with port") {
+    val proto = Protos.HealthCheckDefinition.newBuilder
+      .setPath("/health")
+      .setProtocol(Protocol.MESOS_HTTPS)
+      .setGracePeriodSeconds(10)
+      .setIntervalSeconds(60)
+      .setTimeoutSeconds(10)
+      .setMaxConsecutiveFailures(10)
+      .setPort(12345)
+      .build
+
+    val mergeResult = HealthCheck.fromProto(proto)
+
+    val expectedResult = MesosHttpHealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.MESOS_HTTPS,
+      portIndex = None,
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      timeout = 10.seconds,
+      maxConsecutiveFailures = 10,
+      port = Some(12345)
+    )
+
+    assert(mergeResult == expectedResult)
+  }
+
+  test("FromProto Mesos HTTP HealthCheck with neither port nor portIndex") {
+    val proto = Protos.HealthCheckDefinition.newBuilder
+      .setPath("/health")
+      .setProtocol(Protocol.MESOS_HTTP)
+      .setGracePeriodSeconds(10)
+      .setIntervalSeconds(60)
+      .setTimeoutSeconds(10)
+      .setMaxConsecutiveFailures(10)
+      .build
+
+    val mergeResult = HealthCheck.fromProto(proto)
+
+    val expectedResult = MesosHttpHealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.MESOS_HTTP,
+      portIndex = Some(0),
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      timeout = 10.seconds,
+      maxConsecutiveFailures = 10,
+      port = None
+    )
+
+    assert(mergeResult == expectedResult)
+  }
+
+  test("FromProto Mesos HTTPS HealthCheck") {
+    val proto = Protos.HealthCheckDefinition.newBuilder
+      .setPath("/health")
+      .setProtocol(Protocol.MESOS_HTTPS)
+      .setPortIndex(0)
+      .setGracePeriodSeconds(10)
+      .setIntervalSeconds(60)
+      .setTimeoutSeconds(10)
+      .setMaxConsecutiveFailures(10)
+      .build
+
+    val mergeResult = HealthCheck.fromProto(proto)
+
+    val expectedResult = MesosHttpHealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.MESOS_HTTPS,
+      portIndex = Some(0),
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      timeout = 10.seconds,
+      maxConsecutiveFailures = 10
+    )
+
+    assert(mergeResult == expectedResult)
+  }
+
+  test("Mesos HTTP HealthCheck toMesos with host networking and portIndex") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp().withHealthCheck(mesosHttpHealthCheckWithPortIndex)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, taskPorts) = task.get
+    assertHttpHealthCheckProto(taskInfo, taskPorts.head.get, "http")
+  }
+
+  test("Mesos HTTPS HealthCheck toMesos with host networking and portIndex") {
+    import MarathonTestHelper.Implicits._
+
+    val healthCheck = MesosHttpHealthCheck(
+      path = Some("/health"),
+      protocol = Protocol.MESOS_HTTPS,
+      portIndex = Some(0),
+      gracePeriod = 10.seconds,
+      interval = 60.seconds,
+      maxConsecutiveFailures = 0)
+
+    val app = MarathonTestHelper.makeBasicApp().withHealthCheck(healthCheck)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, taskPorts) = task.get
+    assertHttpHealthCheckProto(taskInfo, taskPorts.head.get, "https")
+  }
+
+  test("Mesos HTTP HealthCheck toMesos with Docker HOST networking and portIndex") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.HOST)
+      .withHealthCheck(mesosHttpHealthCheckWithPortIndex)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, taskPorts) = task.get
+    assertHttpHealthCheckProto(taskInfo, taskPorts.head.get, "http")
+  }
+
+  test("Mesos HTTP HealthCheck toMesos with Docker HOST networking and port") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.HOST)
+      .withHealthCheck(mesosHttpHealthCheckWithPort)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertHttpHealthCheckProto(taskInfo, 80, "http")
+  }
+
+  test("Mesos HTTP HealthCheck toMesos with Docker BRIDGE networking and portIndex") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.BRIDGE)
+      .withPortMappings(Seq(
+        Docker.PortMapping(containerPort = 80, hostPort = Some(0), servicePort = 0, protocol = "tcp",
+          name = Some("http"))
+      ))
+      .withHealthCheck(mesosHttpHealthCheckWithPortIndex)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertHttpHealthCheckProto(taskInfo, 80, "http")
+  }
+
+  test("Mesos HTTP HealthCheck toMesos with Docker BRIDGE networking and port") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.BRIDGE)
+      .withPortMappings(Seq(
+        Docker.PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 0, protocol = "tcp",
+          name = Some("http"))
+      ))
+      .withHealthCheck(mesosHttpHealthCheckWithPort)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertHttpHealthCheckProto(taskInfo, 80, "http")
+  }
+
+  test("Mesos HTTP HealthCheck toMesos with Docker USER networking and a port mapping NOT requesting a host port, with portIndex") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withIpAddress(IpAddress.empty)
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.USER)
+      .withPortMappings(Seq(Docker.PortMapping(containerPort = 80, hostPort = None)))
+      .withHealthCheck(mesosHttpHealthCheckWithPortIndex)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertHttpHealthCheckProto(taskInfo, 80, "http")
+  }
+
+  test("Mesos HTTP HealthCheck toMesos with Docker USER networking and a port mapping requesting a host port, with portIndex") {
+    import MarathonTestHelper.Implicits._
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withIpAddress(IpAddress.empty)
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.USER)
+      .withPortMappings(Seq(Docker.PortMapping(containerPort = 80, hostPort = Some(0))))
+      .withHealthCheck(mesosHttpHealthCheckWithPortIndex)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertHttpHealthCheckProto(taskInfo, 80, "http")
+  }
+
+  test("Mesos HTTP HealthCheck toMesos with Docker USER networking with port") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withIpAddress(IpAddress.empty)
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.USER)
+      .withPortMappings(Seq(Docker.PortMapping(containerPort = 31337, hostPort = Some(0))))
+      .withHealthCheck(mesosHttpHealthCheckWithPort)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertHttpHealthCheckProto(taskInfo, 80, "http")
+  }
+
+  // Mesos TCP health check
+  test("both port and portIndex are not accepted at the same time for a Mesos TCP HealthCheck") {
+    shouldBeInvalid(MesosTcpHealthCheck(
+      port = Some(1),
+      portIndex = Some(0)
+    ))
+  }
+
+  test("port is accepted for a Mesos TCP HealthCheck") {
+    shouldBeValid(MesosTcpHealthCheck(port = Some(1)))
+  }
+
+  test("portIndex is accepted for a Mesos TCP HealthCheck") {
+    shouldBeValid(MesosTcpHealthCheck(portIndex = Some(0)))
+  }
+
+  test("ToProto Mesos TCP HealthCheck with portIndex") {
+    val healthCheck = MesosTcpHealthCheck(
+      portIndex = Some(1),
+      gracePeriod = 7.seconds,
+      interval = 35.seconds,
+      maxConsecutiveFailures = 10
+    )
+
+    val proto = healthCheck.toProto
+
+    assert(Protocol.MESOS_TCP == proto.getProtocol)
+    assert(1 == proto.getPortIndex)
+    assert(7 == proto.getGracePeriodSeconds)
+    assert(35 == proto.getIntervalSeconds)
+    assert(10 == proto.getMaxConsecutiveFailures)
+  }
+
+  test("FromProto Mesos TCP HealthCheck with portIndex") {
+    val proto = Protos.HealthCheckDefinition.newBuilder
+      .setProtocol(Protocol.MESOS_TCP)
+      .setPortIndex(1)
+      .setGracePeriodSeconds(7)
+      .setIntervalSeconds(35)
+      .setTimeoutSeconds(10)
+      .setMaxConsecutiveFailures(10)
+      .build
+
+    val mergeResult = HealthCheck.fromProto(proto)
+
+    val expectedResult = MesosTcpHealthCheck(
+      portIndex = Some(1),
+      gracePeriod = 7.seconds,
+      interval = 35.seconds,
+      timeout = 10.seconds,
+      maxConsecutiveFailures = 10
+    )
+
+    assert(mergeResult == expectedResult)
+  }
+
+  test("Mesos TCP HealthCheck toMesos with host networking and portIndex") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp().withHealthCheck(mesosTcpHealthCheckWithPortIndex)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, taskPorts) = task.get
+    assertTcpHealthCheckProto(taskInfo, taskPorts.head.get)
+  }
+
+  test("Mesos TCP HealthCheck toMesos with Docker HOST networking and portIndex") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.HOST)
+      .withHealthCheck(mesosTcpHealthCheckWithPortIndex)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, taskPorts) = task.get
+    assertTcpHealthCheckProto(taskInfo, taskPorts.head.get)
+  }
+
+  test("Mesos TCP HealthCheck toMesos with Docker HOST networking and port") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.HOST)
+      .withHealthCheck(mesosTcpHealthCheckWithPort)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertTcpHealthCheckProto(taskInfo, 80)
+  }
+
+  test("Mesos TCP HealthCheck toMesos with Docker BRIDGE networking and portIndex") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.BRIDGE)
+      .withPortMappings(Seq(
+        Docker.PortMapping(containerPort = 80, hostPort = Some(0), servicePort = 0, protocol = "tcp",
+          name = Some("http"))
+      ))
+      .withHealthCheck(mesosTcpHealthCheckWithPortIndex)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertTcpHealthCheckProto(taskInfo, 80)
+  }
+
+  test("Mesos TCP HealthCheck toMesos with Docker BRIDGE networking and port") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.BRIDGE)
+      .withPortMappings(Seq(
+        Docker.PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 0, protocol = "tcp",
+          name = Some("http"))
+      ))
+      .withHealthCheck(mesosTcpHealthCheckWithPort)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertTcpHealthCheckProto(taskInfo, 80)
+  }
+
+  test("Mesos TCP HealthCheck toMesos with Docker USER networking and a port mapping NOT requesting a host port, with portIndex") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withIpAddress(IpAddress.empty)
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.USER)
+      .withPortMappings(Seq(Docker.PortMapping(containerPort = 80, hostPort = None)))
+      .withHealthCheck(mesosTcpHealthCheckWithPortIndex)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertTcpHealthCheckProto(taskInfo, 80)
+  }
+
+  test("Mesos TCP HealthCheck toMesos with Docker USER networking and a port mapping requesting a host port, with portIndex") {
+    import MarathonTestHelper.Implicits._
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withIpAddress(IpAddress.empty)
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.USER)
+      .withPortMappings(Seq(Docker.PortMapping(containerPort = 80, hostPort = Some(0))))
+      .withHealthCheck(mesosTcpHealthCheckWithPortIndex)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertTcpHealthCheckProto(taskInfo, 80)
+  }
+
+  test("Mesos TCP HealthCheck toMesos with Docker USER networking with port") {
+    import MarathonTestHelper.Implicits._
+
+    val app = MarathonTestHelper.makeBasicApp()
+      .withNoPortDefinitions()
+      .withIpAddress(IpAddress.empty)
+      .withDockerNetwork(MesosProtos.ContainerInfo.DockerInfo.Network.USER)
+      .withPortMappings(Seq(Docker.PortMapping(containerPort = 31337, hostPort = Some(0))))
+      .withHealthCheck(mesosTcpHealthCheckWithPort)
+
+    val task: Option[(MesosProtos.TaskInfo, Seq[Option[Int]])] = buildIfMatches(app)
+    assert(task.isDefined)
+
+    val (taskInfo, _) = task.get
+    assertTcpHealthCheckProto(taskInfo, 80)
+  }
+
+  test("Read Mesos TCP health check") {
+    val portIndexJson =
+      """
+        {
+          "protocol": "MESOS_TCP",
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0,
+          "portIndex": 0
+        }
+      """
+    assert(fromJson(portIndexJson) == mesosTcpHealthCheckWithPortIndex)
+
+    val portJson =
+      """
+        {
+          "protocol": "MESOS_TCP",
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0,
+          "port": 80
+        }
+      """
+    assert(fromJson(portJson) == mesosTcpHealthCheckWithPort)
+  }
+
+  test("Write Mesos TCP health check") {
+    val portIndexJson =
+      """
+        {
+          "protocol": "MESOS_TCP",
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0,
+          "portIndex": 0
+        }
+      """
+    JsonTestHelper.assertThatJsonOf(mesosTcpHealthCheckWithPortIndex)(HealthCheckFormat)
+      .correspondsToJsonString(portIndexJson)
+
+    val portJson =
+      """
+        {
+          "protocol": "MESOS_TCP",
+          "gracePeriodSeconds": 10,
+          "intervalSeconds": 60,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 0,
+          "port": 80
+        }
+      """
+    JsonTestHelper.assertThatJsonOf(mesosTcpHealthCheckWithPort)(HealthCheckFormat)
+      .correspondsToJsonString(portJson)
+  }
+
+  val mesosHttpHealthCheckWithPortIndex = MesosHttpHealthCheck(
+    path = Some("/health"),
+    protocol = Protocol.MESOS_HTTP,
+    portIndex = Some(0),
+    gracePeriod = 10.seconds,
+    interval = 60.seconds,
+    maxConsecutiveFailures = 0)
+  val mesosHttpHealthCheckWithPort = mesosHttpHealthCheckWithPortIndex.copy(portIndex = None, port = Some(80))
+  val mesosTcpHealthCheckWithPortIndex = MesosTcpHealthCheck(
+    portIndex = Some(0),
+    gracePeriod = 10.seconds,
+    interval = 60.seconds,
+    maxConsecutiveFailures = 0)
+  val mesosTcpHealthCheckWithPort = mesosTcpHealthCheckWithPortIndex.copy(portIndex = None, port = Some(80))
+
+  def assertHttpHealthCheckProto(taskInfo: MesosProtos.TaskInfo, port: Int, scheme: String): Unit = {
+    assert(taskInfo.hasHealthCheck)
+    val healthCheckProto = taskInfo.getHealthCheck
+    assertHealthCheckProto(healthCheckProto, MesosProtos.HealthCheck.Type.HTTP)
+
+    assert(!healthCheckProto.hasTcp)
+    assert(!healthCheckProto.hasCommand)
+    assert(healthCheckProto.hasHttp)
+    val httpProto = healthCheckProto.getHttp
+    assert(httpProto.getPath == "/health")
+    assert(httpProto.getScheme == scheme)
+    assert(httpProto.getPort == port)
+  }
+
+  def assertHealthCheckProto(healthCheckProto: MesosProtos.HealthCheck, protocol: MesosProtos.HealthCheck.Type): Unit = {
+    assert(healthCheckProto.getType == protocol)
+    assert(healthCheckProto.getGracePeriodSeconds == 10)
+    assert(healthCheckProto.getIntervalSeconds == 60)
+    assert(healthCheckProto.getConsecutiveFailures == 0)
+  }
+
+  def assertTcpHealthCheckProto(taskInfo: MesosProtos.TaskInfo, port: Int): Unit = {
+    assert(taskInfo.hasHealthCheck)
+    val healthCheckProto = taskInfo.getHealthCheck
+    assertHealthCheckProto(healthCheckProto, MesosProtos.HealthCheck.Type.TCP)
+
+    assert(!healthCheckProto.hasCommand)
+    assert(!healthCheckProto.hasHttp)
+    assert(healthCheckProto.hasTcp)
+    val tcpProto = healthCheckProto.getTcp
+    assert(tcpProto.getPort == port)
+  }
+
+  def buildIfMatches(app: AppDefinition) = {
+    val offer = MarathonTestHelper.makeBasicOfferWithRole(
+      cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved).build
+
+    val builder = new TaskBuilder(app, s => Task.Id(s.toString), MarathonTestHelper.defaultConfig())
+    builder.buildIfMatches(offer, Iterable.empty)
+  }
+
+  private[this] def toJson(healthCheck: HealthCheck): String = {
+    import mesosphere.marathon.api.v2.json.Formats._
+    Json.prettyPrint(Json.toJson(healthCheck))
+  }
+
+  private[this] def fromJson(json: String): HealthCheck = {
+    import mesosphere.marathon.api.v2.json.Formats._
+    Json.fromJson[HealthCheck](Json.parse(json))(HealthCheckFormat).get
+  }
+
+  private[this] def shouldBeInvalid(hc: HealthCheck): Unit = {
+    assert(validate(hc).isFailure)
+  }
+
+  private[this] def shouldBeValid(hc: HealthCheck): Unit = {
+    val result = validate(hc)
+    assert(result.isSuccess, s"violations: ${ValidationHelper.getAllRuleConstrains(result)}")
+  }
+}

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
@@ -4,8 +4,7 @@ import java.net.{ InetAddress, ServerSocket }
 
 import akka.actor.Props
 import akka.testkit.{ ImplicitSender, TestActorRef }
-import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
-import mesosphere.marathon.core.health.{ HealthCheck, HealthResult, Healthy }
+import mesosphere.marathon.core.health.{ HealthResult, Healthy, MarathonTcpHealthCheck }
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.test.MarathonActorSupport
@@ -42,7 +41,7 @@ class HealthCheckWorkerActorTest
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
     val app = AppDefinition(id = "test_id".toPath)
-    ref ! HealthCheckJob(app, task, task.launched.get, HealthCheck(protocol = Protocol.TCP, portIndex = Some(0)))
+    ref ! HealthCheckJob(app, task, task.launched.get, MarathonTcpHealthCheck(portIndex = Some(0)))
 
     try { Await.result(res, 1.seconds) }
     finally { socket.close() }
@@ -67,7 +66,7 @@ class HealthCheckWorkerActorTest
 
     val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor]))
     val app = AppDefinition(id = "test_id".toPath)
-    ref ! HealthCheckJob(app, task, task.launched.get, HealthCheck(protocol = Protocol.TCP, portIndex = Some(0)))
+    ref ! HealthCheckJob(app, task, task.launched.get, MarathonTcpHealthCheck(portIndex = Some(0)))
 
     try { Await.result(res, 1.seconds) }
     finally { socket.close() }

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -6,9 +6,9 @@ import mesosphere.marathon.Protos
 import mesosphere.marathon.Protos.Constraint.Operator
 import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.api.v2.json.AppUpdate
-import mesosphere.marathon.core.health.HealthCheck
-import mesosphere.marathon.integration.facades.{ ITEnrichedTask, ITDeployment, ITQueueItem, MarathonFacade }
-import MarathonFacade._
+import mesosphere.marathon.core.health.{ MarathonHttpHealthCheck, MesosCommandHealthCheck }
+import mesosphere.marathon.integration.facades.MarathonFacade._
+import mesosphere.marathon.integration.facades.{ ITDeployment, ITEnrichedTask, ITQueueItem }
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.state._
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
@@ -233,7 +233,7 @@ class AppDeployIntegrationTest
   ignore("create a simple app with command health checks") {
     Given("a new app")
     val app = appProxy(testBasePath / "command-app", "v1", instances = 1, withHealth = false).
-      copy(healthChecks = Set(healthCheck.copy(protocol = Protocol.COMMAND, command = Some(Command("true")))))
+      copy(healthChecks = Set(MesosCommandHealthCheck(command = Command("true"))))
 
     When("The app is deployed")
     val result = marathon.createAppV2(app)
@@ -640,5 +640,54 @@ class AppDeployIntegrationTest
     maybeContainer1.get.docker shouldBe (empty)
   }
 
-  def healthCheck = HealthCheck(gracePeriod = 20.second, interval = 1.second, maxConsecutiveFailures = 10)
+  test("create a simple app with a docker container and update it") {
+    import scala.collection.immutable.Seq
+
+    Given("a new app")
+    val appId = testBasePath / "app"
+
+    val container = Container.Docker(
+      network = Some(org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network.BRIDGE),
+      image = "jdef/helpme",
+      portMappings = Some(Seq(
+        Container.Docker.PortMapping(containerPort = 3000, protocol = "tcp")
+      ))
+    )
+
+    val app = AppDefinition(
+      id = appId,
+      cmd = Some("cmd"),
+      container = Some(container),
+      instances = 0
+    )
+
+    When("The app is deployed")
+    val result = marathon.createAppV2(app)
+
+    Then("The app is created")
+    result.code should be(201) //Created
+    extractDeploymentIds(result) should have size 1
+    waitForEvent("deployment_success")
+
+    val appUpdate = AppUpdate(container = Some(container.copy(portMappings = Some(Seq(
+      Container.Docker.PortMapping(containerPort = 4000, protocol = "tcp")
+    )))))
+    val updateResult = marathon.updateApp(app.id, appUpdate, true)
+
+    And("The app is updated")
+    updateResult.code should be(200)
+
+    Then("The container is updated correctly")
+    val updatedApp = marathon.app(appId)
+    updatedApp.value.app.container should not be None
+    updatedApp.value.app.container.get.portMappings should not be None
+    updatedApp.value.app.container.get.portMappings.get should have size 1
+    updatedApp.value.app.container.get.portMappings.get.head.containerPort should be(4000)
+  }
+
+  val healthCheck = MarathonHttpHealthCheck(
+    gracePeriod = 20.second,
+    interval = 1.second,
+    maxConsecutiveFailures = 10,
+    portIndex = Some(0))
 }

--- a/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon.integration
 
-import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.health.MarathonHttpHealthCheck
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.state._
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
@@ -89,5 +89,9 @@ class GracefulTaskKillIntegrationTest
     waitedForTaskKilledEvent.toMillis should be < taskKillGracePeriod.toMillis
   }
 
-  def healthCheck = HealthCheck(gracePeriod = 20.second, interval = 1.second, maxConsecutiveFailures = 10)
+  def healthCheck = MarathonHttpHealthCheck(
+    gracePeriod = 20.second,
+    interval = 1.second,
+    maxConsecutiveFailures = 10,
+    portIndex = Some(0))
 }

--- a/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
@@ -3,16 +3,16 @@ package mesosphere.marathon.integration
 import java.io.File
 
 import mesosphere.marathon.api.v2.json.AppUpdate
+import mesosphere.marathon.core.health.{ HealthCheck, MarathonHttpHealthCheck }
 import mesosphere.marathon.core.readiness.ReadinessCheck
-import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.state._
 import org.apache.commons.io.FileUtils
-import org.scalatest.{ Matchers, BeforeAndAfter, GivenWhenThen }
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen, Matchers }
 
-import scala.util.Try
-import scala.concurrent.duration._
 import scala.collection.immutable.Seq
+import scala.concurrent.duration._
+import scala.util.Try
 
 class ReadinessCheckIntegrationTest extends IntegrationFunSuite with SingleMarathonIntegrationTest with Matchers with BeforeAndAfter with GivenWhenThen {
 
@@ -84,7 +84,10 @@ class ReadinessCheckIntegrationTest extends IntegrationFunSuite with SingleMarat
       mem = 128.0,
       upgradeStrategy = UpgradeStrategy(0, 0),
       portDefinitions = Seq(PortDefinition(0, name = Some("http"))),
-      healthChecks = if (withHealth) Set(HealthCheck(path = Some("/ping"), portIndex = Some(0), interval = 2.seconds, timeout = 1.second)) else Set.empty[HealthCheck],
+      healthChecks =
+        if (withHealth)
+          Set(MarathonHttpHealthCheck(path = Some("/ping"), portIndex = Some(0), interval = 2.seconds, timeout = 1.second))
+        else Set.empty[HealthCheck],
       readinessChecks = Seq(ReadinessCheck("ready", portName = "http", path = "/v1/plan", interval = 2.seconds, timeout = 1.second, preserveLastResponse = true))
     )
   }

--- a/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/SingleMarathonIntegrationTest.scala
@@ -3,14 +3,14 @@ package mesosphere.marathon.integration.setup
 import java.io.File
 import java.util
 
-import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.health.{ HealthCheck, MarathonHttpHealthCheck }
 import mesosphere.marathon.integration.facades.{ ITDeploymentResult, ITEnrichedTask, MarathonFacade, MesosFacade }
 import mesosphere.marathon.state.{ AppDefinition, Container, DockerVolume, PathId }
 import org.apache.commons.io.FileUtils
 import org.apache.mesos.Protos
 import org.apache.zookeeper.ZooDefs.Perms
-import org.apache.zookeeper.data.{ ACL, Id }
 import org.apache.zookeeper._
+import org.apache.zookeeper.data.{ ACL, Id }
 import org.scalatest.{ BeforeAndAfterAllConfigMap, ConfigMap, Suite }
 import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
@@ -219,7 +219,7 @@ trait SingleMarathonIntegrationTest
   }
 
   private lazy val appProxyHealthChecks = Set(
-    HealthCheck(gracePeriod = 20.second, interval = 1.second, maxConsecutiveFailures = 10))
+    MarathonHttpHealthCheck(gracePeriod = 20.second, interval = 1.second, maxConsecutiveFailures = 10, portIndex = Some(0)))
 
   def dockerAppProxy(appId: PathId, versionId: String, instances: Int, withHealth: Boolean = true, dependencies: Set[PathId] = Set.empty): AppDefinition = {
     val targetDirs = sys.env.getOrElse("TARGET_DIRS", "/marathon")

--- a/src/test/scala/mesosphere/marathon/integration/setup/V2TestFormats.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/V2TestFormats.scala
@@ -69,7 +69,7 @@ object V2TestFormats {
       "backoffFactor" -> update.backoffFactor,
       "maxLaunchDelaySeconds" -> update.maxLaunchDelay.map(_.toSeconds),
       "container" -> update.container,
-      "healthChecks" -> update.healthChecks,
+      "healthChecks" -> update.healthChecks.map(_.map(Json.toJson(_)(HealthCheckFormat))),
       "readinessChecks" -> update.readinessChecks,
       "taskKillGracePeriodSeconds" -> update.taskKillGracePeriod.map(_.toSeconds),
       "dependencies" -> update.dependencies,

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon.state
 import mesosphere.marathon.MarathonTestHelper
 import mesosphere.marathon.state.Container.Docker
 import org.apache.mesos.Protos
-import org.scalatest.{ OptionValues, GivenWhenThen, Matchers, FunSuiteLike }
+import org.scalatest.{ FunSuiteLike, GivenWhenThen, Matchers, OptionValues }
 
 import scala.collection.immutable.Seq
 
@@ -25,12 +25,17 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
       .withHostPorts(Seq(1))
 
     When("Getting the ports assignments")
-    val portAssignments = app.portAssignments(task)
+    val portAssignments = app.portAssignments(task).get
 
     Then("The right port assignment is returned")
-    portAssignments should equal(Some(Seq(
-      PortAssignment(portName = Some("http"), effectiveIpAddress = "192.168.0.1", effectivePort = 1)
-    )))
+    portAssignments should equal(Seq(
+      PortAssignment(
+        portName = Some("http"),
+        effectiveIpAddress = Some("192.168.0.1"),
+        effectivePort = 1,
+        hostPort = Some(1),
+        containerPort = None)
+    ))
   }
 
   test("portAssignments with IP-per-task defining ports, but a task which doesn't have an IP address yet") {
@@ -46,8 +51,8 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
       .withNetworkInfos(Seq.empty)
       .withHostPorts(Seq.empty)
 
-    Then("The port assignments are None")
-    app.portAssignments(task) should be(None)
+    Then("The port assignments are empty")
+    app.portAssignments(task).get should be(empty)
   }
 
   test("portAssignments with IP-per-task without ports") {
@@ -65,7 +70,7 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
       .withHostPorts(Seq.empty)
 
     Then("The port assignments are empty")
-    app.portAssignments(task).value should be(empty)
+    app.portAssignments(task).get should be(empty)
   }
 
   test("portAssignments with a reserved task") {
@@ -75,8 +80,8 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
     Given("A reserved task")
     val task = MarathonTestHelper.minimalReservedTask(app.id, MarathonTestHelper.newReservation)
 
-    Then("The port assignments are None")
-    app.portAssignments(task) should be(None)
+    Then("The port assignments are empty")
+    app.portAssignments(task) should be(empty)
   }
 
   test("portAssignments without IP-per-task and Docker BRIDGE mode with a port mapping") {
@@ -93,10 +98,15 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
     val task = MarathonTestHelper.mininimalTask(app.id).withHostPorts(Seq(1))
 
     Then("The right port assignment is returned")
-    val portAssignments = app.portAssignments(task)
-    portAssignments should be(Some(Seq(
-      PortAssignment(portName = Some("http"), effectiveIpAddress = task.agentInfo.host, effectivePort = 1)
-    )))
+    val portAssignments = app.portAssignments(task).get
+    portAssignments should be(Seq(
+      PortAssignment(
+        portName = Some("http"),
+        effectiveIpAddress = Some(task.agentInfo.host),
+        effectivePort = 1,
+        hostPort = Some(1),
+        containerPort = Some(80))
+    ))
   }
 
   test("portAssignments without IP-per-task using Docker BRIDGE network and no port mappings") {
@@ -113,7 +123,7 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
     val task = MarathonTestHelper.mininimalTask(app.id)
 
     Then("The port assignments are empty")
-    app.portAssignments(task) should be(None)
+    app.portAssignments(task) should be(empty)
   }
 
   test("portAssignments with IP-per-task using Docker USER networking and a port mapping NOT requesting a host port") {
@@ -134,10 +144,15 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
       )
 
     Then("The right port assignment is returned")
-    val portAssignments = app.portAssignments(task)
-    portAssignments should be(Some(Seq(
-      PortAssignment(portName = Some("http"), effectiveIpAddress = "192.168.0.1", effectivePort = 80)
-    )))
+    val portAssignments = app.portAssignments(task).get
+    portAssignments should be(Seq(
+      PortAssignment(
+        portName = Some("http"),
+        effectiveIpAddress = Some("192.168.0.1"),
+        effectivePort = 80,
+        containerPort = Some(80),
+        hostPort = None)
+    ))
   }
 
   test("portAssignments with IP-per-task Docker USER networking and a port mapping requesting a host port") {
@@ -159,10 +174,15 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
       )
 
     Then("The right port assignment is returned")
-    val portAssignments = app.portAssignments(task)
-    portAssignments should be(Some(Seq(
-      PortAssignment(portName = Some("http"), effectiveIpAddress = "192.168.0.1", effectivePort = 80)
-    )))
+    val portAssignments = app.portAssignments(task).get
+    portAssignments should be(Seq(
+      PortAssignment(
+        portName = Some("http"),
+        effectiveIpAddress = Some("192.168.0.1"),
+        effectivePort = 80,
+        containerPort = Some(80),
+        hostPort = Some(30000))
+    ))
   }
 
   test("portAssignments with IP-per-task Docker, USER networking, and a mix of port mappings") {
@@ -185,11 +205,21 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
       )
 
     Then("The right port assignment is returned")
-    val portAssignments = app.portAssignments(task)
-    portAssignments should be(Some(Seq(
-      PortAssignment(portName = Some("http"), effectiveIpAddress = "192.168.0.1", effectivePort = 80),
-      PortAssignment(portName = Some("https"), effectiveIpAddress = "192.168.0.1", effectivePort = 443)
-    )))
+    val portAssignments = app.portAssignments(task).get
+    portAssignments should be(Seq(
+      PortAssignment(
+        portName = Some("http"),
+        effectiveIpAddress = Some("192.168.0.1"),
+        effectivePort = 80,
+        containerPort = Some(80),
+        hostPort = None),
+      PortAssignment(
+        portName = Some("https"),
+        effectiveIpAddress = Some("192.168.0.1"),
+        effectivePort = 443,
+        containerPort = Some(443),
+        hostPort = Some(30000))
+    ))
   }
 
   test("portAssignments without IP-per-task, with Docker USER networking and a mix of port mappings") {
@@ -208,13 +238,23 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
     val task = MarathonTestHelper.mininimalTask(app.id).withHostPorts(Seq(30000))
 
     Then("The right port assignment is returned")
-    val portAssignments = app.portAssignments(task)
-    portAssignments should be(Some(Seq(
+    val portAssignments = app.portAssignments(task).get
+    portAssignments should be(Seq(
       // If there's no IP-per-task and no host port is required, fall back to the container port
-      PortAssignment(portName = Some("http"), effectiveIpAddress = task.agentInfo.host, effectivePort = 80),
+      PortAssignment(
+        portName = Some("http"),
+        effectiveIpAddress = Some(task.agentInfo.host),
+        effectivePort = 80,
+        containerPort = Some(80),
+        hostPort = None),
       // If there's no IP-per-task and a host port is required, use that host port
-      PortAssignment(portName = Some("https"), effectiveIpAddress = task.agentInfo.host, effectivePort = 30000)
-    )))
+      PortAssignment(
+        portName = Some("https"),
+        effectiveIpAddress = Some(task.agentInfo.host),
+        effectivePort = 30000,
+        containerPort = Some(443),
+        hostPort = Some(30000))
+    ))
   }
 
   test("portAssignments with port definitions") {
@@ -226,10 +266,15 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
     val task = MarathonTestHelper.mininimalTask(app.id).withHostPorts(Seq(1))
 
     Then("The right port assignment is returned")
-    val portAssignments = app.portAssignments(task)
-    portAssignments should be(Some(Seq(
-      PortAssignment(portName = Some("http"), effectiveIpAddress = task.agentInfo.host, effectivePort = 1)
-    )))
+    val portAssignments = app.portAssignments(task).get
+    portAssignments should be(Seq(
+      PortAssignment(
+        portName = Some("http"),
+        effectiveIpAddress = Some(task.agentInfo.host),
+        effectivePort = 1,
+        containerPort = None,
+        hostPort = Some(1))
+    ))
   }
 
   test("portAssignments with absolutely no ports") {
@@ -242,6 +287,6 @@ class AppDefinitionPortAssignmentsTest extends FunSuiteLike with GivenWhenThen w
     val task = MarathonTestHelper.mininimalTask(app.id).withHostPorts(Seq.empty)
 
     Then("The port assignments are empty")
-    app.portAssignments(task).value should be(empty)
+    app.portAssignments(task).get should be(empty)
   }
 }

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -1,21 +1,21 @@
 package mesosphere.marathon.upgrade
 
-import akka.testkit.{ TestProbe, TestActorRef }
+import akka.testkit.{ TestActorRef, TestProbe }
+import mesosphere.marathon.core.event.{ DeploymentStatus, HealthStatusChanged, MesosStatusUpdateEvent }
+import mesosphere.marathon.core.health.MarathonHttpHealthCheck
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.core.event.{ DeploymentStatus, HealthStatusChanged, MesosStatusUpdateEvent }
-import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.state.{ AppDefinition, PathId }
-import mesosphere.marathon.test.{ Mockito, MarathonActorSupport }
-import mesosphere.marathon.{ MarathonTestHelper, AppStartCanceledException, MarathonSpec, SchedulerActions }
+import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }
+import mesosphere.marathon.{ AppStartCanceledException, MarathonSpec, MarathonTestHelper, SchedulerActions }
 import org.apache.mesos.SchedulerDriver
 import org.scalatest.{ BeforeAndAfterAll, Matchers }
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Future, Await, Promise }
+import scala.concurrent.{ Await, Future, Promise }
 
 class AppStartActorTest
     extends MarathonActorSupport
@@ -53,7 +53,10 @@ class AppStartActorTest
 
   test("With Health Checks") {
     val f = new Fixture
-    val app = AppDefinition(id = PathId("app"), instances = 10, healthChecks = Set(HealthCheck()))
+    val app = AppDefinition(
+      id = PathId("app"),
+      instances = 10,
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(0))))
     val promise = Promise[Unit]()
     val ref = f.startActor(app, scaleTo = 2, promise)
     watch(ref)
@@ -102,7 +105,10 @@ class AppStartActorTest
 
   test("No tasks to start with health checks") {
     val f = new Fixture
-    val app = AppDefinition(id = PathId("app"), instances = 10, healthChecks = Set(HealthCheck()))
+    val app = AppDefinition(
+      id = PathId("app"),
+      instances = 10,
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(0))))
     val promise = Promise[Unit]()
     val ref = f.startActor(app, scaleTo = 0, promise)
     watch(ref)

--- a/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/ReadinessBehaviorTest.scala
@@ -1,19 +1,20 @@
 package mesosphere.marathon.upgrade
 
-import akka.actor.{ ActorLogging, ActorRef, Actor }
+import akka.actor.{ Actor, ActorLogging, ActorRef }
 import akka.testkit.{ TestActorRef, TestProbe }
+import mesosphere.marathon.core.event.{ DeploymentStatus, HealthStatusChanged, MesosStatusUpdateEvent }
+import mesosphere.marathon.core.health.MesosCommandHealthCheck
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
-import mesosphere.marathon.core.readiness.{ ReadinessCheckResult, ReadinessCheck, ReadinessCheckExecutor }
+import mesosphere.marathon.core.readiness.{ ReadinessCheck, ReadinessCheckExecutor, ReadinessCheckResult }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.core.event.{ HealthStatusChanged, MesosStatusUpdateEvent, DeploymentStatus }
-import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.state.AppDefinition.VersionInfo
 import mesosphere.marathon.state._
 import mesosphere.marathon.test.{ MarathonActorSupport, Mockito }
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{ Matchers, GivenWhenThen, FunSuite }
+import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 import rx.lang.scala.Observable
+
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
@@ -46,7 +47,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
       f.appId,
       portDefinitions = Seq(PortDefinition(123, "tcp", name = Some("http-api"))),
       versionInfo = VersionInfo.OnlyVersion(f.version),
-      healthChecks = Set(HealthCheck()),
+      healthChecks = Set(MesosCommandHealthCheck(command = Command("true"))),
       readinessChecks = Seq(ReadinessCheck("test")))
     val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
 
@@ -67,7 +68,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
       f.appId,
       portDefinitions = Seq(PortDefinition(123, "tcp", name = Some("http-api"))),
       versionInfo = VersionInfo.OnlyVersion(f.version),
-      healthChecks = Set(HealthCheck()))
+      healthChecks = Set(MesosCommandHealthCheck(command = Command("true"))))
     val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
 
     When("The task becomes healthy")
@@ -103,7 +104,7 @@ class ReadinessBehaviorTest extends FunSuite with Mockito with GivenWhenThen wit
       f.appId,
       portDefinitions = Seq(PortDefinition(123, "tcp", name = Some("http-api"))),
       versionInfo = VersionInfo.OnlyVersion(f.version),
-      healthChecks = Set(HealthCheck()),
+      healthChecks = Set(MesosCommandHealthCheck(command = Command("true"))),
       readinessChecks = Seq(ReadinessCheck("test")))
     val actor = f.readinessActor(appWithReadyCheck, f.checkIsReady, _ => taskIsReady = true)
 

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskReplaceActorTest.scala
@@ -2,12 +2,12 @@ package mesosphere.marathon.upgrade
 
 import akka.actor.Props
 import akka.testkit.TestActorRef
-import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.core.readiness.{ ReadinessCheckResult, ReadinessCheck, ReadinessCheckExecutor }
-import mesosphere.marathon.core.task.{ Task, TaskKillServiceMock }
-import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.event.{ DeploymentStatus, HealthStatusChanged, MesosStatusUpdateEvent }
-import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.health.MarathonHttpHealthCheck
+import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.readiness.{ ReadinessCheck, ReadinessCheckExecutor, ReadinessCheckResult }
+import mesosphere.marathon.core.task.tracker.TaskTracker
+import mesosphere.marathon.core.task.{ Task, TaskKillServiceMock }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, UpgradeStrategy }
 import mesosphere.marathon.test.MarathonActorSupport
@@ -19,9 +19,9 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ BeforeAndAfterAll, FunSuiteLike, Matchers }
 
+import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Promise }
-import scala.collection.immutable.Seq
 
 class TaskReplaceActorTest
     extends MarathonActorSupport
@@ -59,7 +59,7 @@ class TaskReplaceActorTest
     val app = AppDefinition(
       id = "/myApp".toPath,
       instances = 5,
-      healthChecks = Set(HealthCheck()),
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(0))),
       upgradeStrategy = UpgradeStrategy(0.0))
 
     val taskA = MarathonTestHelper.runningTask(Task.Id.forRunSpec(app.id).idString)
@@ -116,7 +116,7 @@ class TaskReplaceActorTest
     val app = AppDefinition(
       id = "/myApp".toPath,
       instances = 3,
-      healthChecks = Set(HealthCheck()),
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(0))),
       upgradeStrategy = UpgradeStrategy(0.5)
     )
 
@@ -164,7 +164,7 @@ class TaskReplaceActorTest
     val app = AppDefinition(
       id = "/myApp".toPath,
       instances = 3,
-      healthChecks = Set(HealthCheck()),
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(0))),
       upgradeStrategy = UpgradeStrategy(0.5, 0.0)
     )
 
@@ -216,7 +216,7 @@ class TaskReplaceActorTest
     val app = AppDefinition(
       id = "/myApp".toPath,
       instances = 3,
-      healthChecks = Set(HealthCheck()),
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(0))),
       upgradeStrategy = UpgradeStrategy(1.0, 0.0) // 1 task over-capacity is ok
     )
 
@@ -266,7 +266,7 @@ class TaskReplaceActorTest
     val app = AppDefinition(
       id = "/myApp".toPath,
       instances = 3,
-      healthChecks = Set(HealthCheck()),
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(0))),
       upgradeStrategy = UpgradeStrategy(1.0, 0.7)
     )
 
@@ -316,7 +316,7 @@ class TaskReplaceActorTest
     val app = AppDefinition(
       id = "/myApp".toPath,
       instances = 3,
-      healthChecks = Set(HealthCheck()),
+      healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(0))),
       upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 1.0, maximumOverCapacity = 0.3)
     )
 
@@ -416,7 +416,7 @@ class TaskReplaceActorTest
     val app = AppDefinition(
       id = "/myApp".toPath,
       instances = 1,
-      healthChecks = Set(HealthCheck()),
+      healthChecks = Set(MarathonHttpHealthCheck()),
       readinessChecks = Seq(ReadinessCheck()),
       upgradeStrategy = UpgradeStrategy(1.0, 1.0)
     )

--- a/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/TaskStartActorTest.scala
@@ -1,18 +1,18 @@
 package mesosphere.marathon.upgrade
 
-import akka.testkit.{ TestProbe, TestActorRef }
+import akka.testkit.{ TestActorRef, TestProbe }
 import com.codahale.metrics.MetricRegistry
+import mesosphere.marathon.core.event.{ DeploymentStatus, HealthStatusChanged, MesosStatusUpdateEvent }
+import mesosphere.marathon.core.health.MesosCommandHealthCheck
 import mesosphere.marathon.core.launcher.impl.LaunchQueueTestHelper
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
-import mesosphere.marathon.core.task.{ TaskStateOp, Task }
 import mesosphere.marathon.core.task.tracker.{ TaskCreationHandler, TaskTracker }
-import mesosphere.marathon.core.event.{ DeploymentStatus, HealthStatusChanged, MesosStatusUpdateEvent }
-import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.task.{ Task, TaskStateOp }
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{ AppDefinition, Timestamp }
+import mesosphere.marathon.state.{ AppDefinition, Command, Timestamp }
 import mesosphere.marathon.test.MarathonActorSupport
 import mesosphere.marathon.{ MarathonTestHelper, SchedulerActions, TaskUpgradeCanceledException }
 import mesosphere.util.state.memory.InMemoryStore
@@ -126,7 +126,7 @@ class TaskStartActorTest
     val app = AppDefinition(
       "/myApp".toPath,
       instances = 5,
-      healthChecks = Set(HealthCheck())
+      healthChecks = Set(MesosCommandHealthCheck(command = Command("true")))
     )
     when(f.launchQueue.get(app.id)).thenReturn(None)
 
@@ -149,7 +149,7 @@ class TaskStartActorTest
     val app = AppDefinition(
       "/myApp".toPath,
       instances = 0,
-      healthChecks = Set(HealthCheck())
+      healthChecks = Set(MesosCommandHealthCheck(command = Command("true")))
     )
     when(f.launchQueue.get(app.id)).thenReturn(None)
 


### PR DESCRIPTION
This is a cherrypick of a @gkleiman's PR #4210. 
Marathon 1.4 introduced Mesos HTTP/TCP healthchecks. This could result in better performance of a Marathon. Unfortunately Marathon 1.4 introduced a performance degradation making it unusable in bigger installations ([MARATHON-7358](https://jira.mesosphere.com/browse/MARATHON-7358)). This PR add Mesos Healthcecks support to Marathon 1.3. This change is future proof and upgrading to 1.4 is safe.

Moving all Marathon applications from Marathon healthcecks to Mesos Healthcecks can't be done at once. Every application need to be redeployed with new configuration. This PR allow users to slowly move to Mesos Healthchecks and then upgrade to Marathon 1.4

<details>
Manually fixed Conflicts:

-	[`project/build.scala`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/project/build.scala)
-	[`src/main/java/mesosphere/marathon/Protos.java`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/src/main/java/mesosphere/marathon/Protos.java)
-	[`src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala)
-	[`src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala)
-	[`src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala)
-	[`src/main/scala/mesosphere/marathon/state/AppDefinition.scala`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/src/main/scala/mesosphere/marathon/state/AppDefinition.scala)
-	[`src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala)
-	[`src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala)
-	[`src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala)
-	[`src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala)
-	[`src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala`](https://github.com/janisz/marathon/blob/431de4e8932b048433405131a8875904895f4d73/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala)
</details>