### PR TITLE
Do not augument provided executor command.

### DIFF
--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -61,9 +61,8 @@ class TaskBuilder(
 
       case PathExecutor(path) =>
         val executorId = Task.Id.calculateLegacyExecutorId(taskId.idString)
-        val executorPath = s"'$path'" // TODO: Really escape this.
         val cmd = runSpec.cmd.getOrElse(runSpec.args.mkString(" "))
-        val shell = s"chmod ug+rx $executorPath && exec $executorPath $cmd"
+        val shell = path
 
         val info = ExecutorInfo.newBuilder()
           .setExecutorId(ExecutorID.newBuilder().setValue(executorId))

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -965,7 +965,7 @@ class TaskBuilderTest extends UnitTest {
       assert(cmd.getShell)
       assert(cmd.hasValue)
       assert(cmd.getArgumentsList.isEmpty)
-      assert(cmd.getValue == "chmod ug+rx '/custom/executor' && exec '/custom/executor' foo")
+      assert(cmd.getValue == "/custom/executor")
     }
 
     "BuildIfMatchesWithArgsAndExecutor" in {
@@ -988,7 +988,7 @@ class TaskBuilderTest extends UnitTest {
       val cmd = taskInfo.getExecutor.getCommand
 
       assert(!taskInfo.hasCommand)
-      assert(cmd.getValue == "chmod ug+rx '/custom/executor' && exec '/custom/executor' a b c")
+      assert(cmd.getValue == "/custom/executor")
     }
 
     "BuildIfMatchesWithRole" in {


### PR DESCRIPTION
This patch changes behavior with custom executor.
The executor command used to be wrapped with `chmod` to change permission
to launch it. This is not necessary, what's more this
could fail with Docker or system configuration where
executor permissions couldn't be changed by Mesos Agent.
This patch also removes command that used to be passed as
a argument to executor. There is no need for this since
all information about command to run will be delivered
to executor in LaunchTask event by Mesos Agent.

Fixes: [MARATHON-4210](https://jira.mesosphere.com/browse/MARATHON-4210)
Refs: http://mesos.apache.org/documentation/latest/executor-http-api/