### PR TITLE
Avoid race condition in WorkQueue.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -211,7 +211,8 @@ class ZkPersistenceStore(
         await(client.setData(id.path, v.bytes).asTry) match {
           case Success(_) =>
             Done
-          case Failure(_: NoNodeException) =>
+          case Failure(e: NoNodeException) =>
+            logger.debug(s"Node for $id not found. Creating node now", e)
             await(limitRequests(client.create(
               id.path,
               creatingParentContainersIfNeeded = true, data = Some(v.bytes))).asTry) match {
@@ -229,8 +230,10 @@ class ZkPersistenceStore(
             }
 
           case Failure(e: KeeperException) =>
+            logger.warn(s"Could not store under $id", e)
             throw new StoreCommandFailedException(s"Unable to store $id", e)
           case Failure(e) =>
+            logger.warn(s"Could not store under $id", e)
             throw e
         }
       }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImpl.scala
@@ -2,12 +2,12 @@ package mesosphere.marathon.core.task.tracker.impl
 
 import akka.actor.{ ActorRef, Status }
 import akka.util.Timeout
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.MarathonEvent
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.{ InstanceUpdateEffect, InstanceUpdateOpResolver }
 import mesosphere.marathon.core.task.tracker.InstanceTrackerConfig
 import mesosphere.marathon.storage.repository.InstanceRepository
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.collection.immutable.Seq
@@ -20,10 +20,8 @@ private[tracker] class InstanceOpProcessorImpl(
     instanceTrackerRef: ActorRef,
     repository: InstanceRepository,
     stateOpResolver: InstanceUpdateOpResolver,
-    config: InstanceTrackerConfig) extends InstanceOpProcessor {
+    config: InstanceTrackerConfig) extends InstanceOpProcessor with StrictLogging {
   import InstanceOpProcessor._
-
-  private[this] val log = LoggerFactory.getLogger(getClass)
 
   override def process(op: Operation)(implicit ec: ExecutionContext): Future[Unit] = {
     val stateChange = stateOpResolver.resolve(op.op)
@@ -32,7 +30,10 @@ private[tracker] class InstanceOpProcessorImpl(
       case change: InstanceUpdateEffect.Expunge =>
         // Used for task termination or as a result from a UpdateStatus action.
         // The expunge is propagated to the instanceTracker which informs the sender about the success (see Ack).
-        repository.delete(change.instance.instanceId).map { _ => InstanceTrackerActor.Ack(op.sender, change) }
+        repository.delete(change.instance.instanceId).map { _ =>
+          logger.debug(s"Expunged $change")
+          InstanceTrackerActor.Ack(op.sender, change)
+        }
           .recoverWith(tryToRecover(op)(
             expectedState = None, oldState = Some(change.instance), change.events))
           .flatMap { ack: InstanceTrackerActor.Ack => notifyTaskTrackerActor(ack) }
@@ -53,7 +54,10 @@ private[tracker] class InstanceOpProcessorImpl(
       case change: InstanceUpdateEffect.Update =>
         // Used for a create or as a result from a UpdateStatus action.
         // The update is propagated to the taskTracker which in turn informs the sender about the success (see Ack).
-        repository.store(change.instance).map { _ => InstanceTrackerActor.Ack(op.sender, change) }
+        repository.store(change.instance).map { _ =>
+          logger.debug(s"Stored $change")
+          InstanceTrackerActor.Ack(op.sender, change)
+        }
           .recoverWith(tryToRecover(op)(
             expectedState = Some(change.instance), oldState = change.oldState, change.events))
           .flatMap { ack => notifyTaskTrackerActor(ack) }
@@ -70,6 +74,7 @@ private[tracker] class InstanceOpProcessorImpl(
     implicit val taskTrackerQueryTimeout: Timeout = config.internalTaskTrackerRequestTimeout().milliseconds
 
     val msg = InstanceTrackerActor.StateChanged(ack)
+    logger.debug(s"Notify instance tracker actor: msg=$msg")
     (instanceTrackerRef ? msg).map(_ => ())
   }
 
@@ -95,7 +100,7 @@ private[tracker] class InstanceOpProcessorImpl(
         InstanceTrackerActor.Ack(op.sender, msg)
       }
 
-      log.warn(s"${op.instanceId} of app [${op.instanceId.runSpecId}]: try to recover from failed ${op.op}", cause)
+      logger.warn(s"${op.instanceId} of app [${op.instanceId.runSpecId}]: try to recover from failed ${op.op}", cause)
 
       repository.get(op.instanceId).map {
         case Some(instance) =>
@@ -109,7 +114,7 @@ private[tracker] class InstanceOpProcessorImpl(
           ack(None, effect)
       }.recover {
         case NonFatal(loadingFailure) =>
-          log.warn(
+          logger.warn(
             s"${op.instanceId} of app [${op.instanceId.runSpecId}]: instance reloading failed as well",
             loadingFailure)
           throw cause

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -6,6 +6,7 @@ import akka.Done
 import akka.actor.SupervisorStrategy.Escalate
 import akka.actor._
 import akka.event.LoggingReceive
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.appinfo.TaskCounts
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceDeleted, InstanceUpdateEffect, InstanceUpdateOperation, InstanceUpdated }
@@ -37,12 +38,13 @@ object InstanceTrackerActor {
   private[impl] case class ForwardTaskOp(deadline: Timestamp, instanceId: Instance.Id, op: InstanceUpdateOperation)
 
   /** Describes where and what to send after an update event has been processed by the [[InstanceTrackerActor]]. */
-  private[impl] case class Ack(initiator: ActorRef, effect: InstanceUpdateEffect) {
+  private[impl] case class Ack(initiator: ActorRef, effect: InstanceUpdateEffect) extends StrictLogging {
     def sendAck(): Unit = {
       val msg = effect match {
         case InstanceUpdateEffect.Failure(cause) => Status.Failure(cause)
         case _ => effect
       }
+      logger.debug(s"Send acknowledgement: initiator=$initiator msg=$msg")
       initiator ! msg
     }
   }
@@ -170,7 +172,7 @@ private[impl] class InstanceTrackerActor(
           updateStepProcessor.process(change).recover {
             case NonFatal(cause) =>
               // since we currently only use ContinueOnErrorSteps, we can simply ignore failures here
-              log.warn("updateStepProcessor.process failed: {}", cause)
+              log.warn("updateStepProcessor.process failed", cause)
               Done
           }
         }.getOrElse(Future.successful(Done)).foreach { _ =>

--- a/src/main/scala/mesosphere/marathon/util/WorkQueue.scala
+++ b/src/main/scala/mesosphere/marathon/util/WorkQueue.scala
@@ -1,11 +1,9 @@
 package mesosphere.marathon
 package util
 
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.atomic.AtomicInteger
+import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.{ ExecutionContext, Future, Promise }
-import mesosphere.marathon.functional._
 
 import scala.collection.mutable
 
@@ -26,53 +24,86 @@ import scala.collection.mutable
   * @param maxConcurrent The maximum number of work items allowed in parallel.
   * @param maxQueueLength The maximum number of items allowed to queue up, if the length is exceeded,
   *                       the future will fail with an IllegalStateException
-  * @param parent An optional parent queue (this allows stacking). This can come in handy with [[KeyedLock]]
-  *               so that you can say "lock on this key" and "limit the total number of outstanding to 32".
-  *               There can be other use cases as well, where you may want to limit the number of
-  *               total operations for a class to X while limiting a particular operation to Y where Y < X.
   */
-case class WorkQueue(name: String, maxConcurrent: Int, maxQueueLength: Int, parent: Option[WorkQueue] = None) {
+case class WorkQueue(name: String, maxConcurrent: Int, maxQueueLength: Int) extends StrictLogging {
   require(maxConcurrent > 0 && maxQueueLength >= 0)
-  private case class WorkItem[T](f: () => Future[T], ctx: ExecutionContext, promise: Promise[T])
-  private val queue = new ConcurrentLinkedQueue[WorkItem[_]]()
-  private val totalOutstanding = new AtomicInteger(0)
 
-  private def run[T](workItem: WorkItem[T]): Future[T] = {
-    parent.fold {
-      workItem.ctx.execute(new Runnable {
-        override def run(): Unit = {
-          val future = workItem.f()
-          future.onComplete(_ => executeNextIfPossible())(workItem.ctx)
-          workItem.promise.completeWith(future)
-        }
-      })
-      workItem.promise.future
-    } { p =>
-      p(workItem.f())(workItem.ctx)
+  private case class WorkItem[T](f: () => Future[T], ctx: ExecutionContext, promise: Promise[T])
+
+  // Our queue of work. We synchronize on the whole class so this queue does not have to be threadsafe.
+  private val queue = mutable.Queue[WorkItem[_]]()
+
+  // Number of open work slots. This work queue is not using worker threads but triggers the next future once one
+  // finishes. If now slot is left we queue. If no work is left we open up a slot.
+  private var openSlotsCount: Int = maxConcurrent
+
+  /**
+    * Runs future that is wrapped in the work item.
+    *
+    * When the work item finished processing we execute the next if one is in the queue. Otherwise we just stop. A new
+    * run might be triggered by [[WorkQueue.apply]].
+    *
+    * @param workItem
+    * @tparam T
+    * @return Future that completes when work item fished.
+    */
+  private def run[T](workItem: WorkItem[T]): Unit = synchronized {
+    workItem.ctx.execute(new Runnable {
+      override def run(): Unit = {
+        val future = workItem.f()
+        future.onComplete { _ =>
+          // This might block for a short time if something is put into the queue. This is fine for two reasons
+          // * The time it takes to complete apply() is very short.
+          // * The blocking does not take place in this thread. So we won't deadlock.
+          executeNextIfPossible()
+        }(workItem.ctx)
+        workItem.promise.completeWith(future)
+      }
+    })
+  }
+
+  /**
+    * Executes the next work item or opens up a work slot for [[WorkQueue.apply]].
+    *
+    * If the queue is empty we free up a slot by decrementing the count.
+    * If the queue is not empty we use our current slot to process the next item. The slot stays blocked and thus the
+    * open slots count does not change.
+    */
+  private def executeNextIfPossible(): Unit = synchronized {
+    if (queue.isEmpty) {
+      openSlotsCount += 1
+    } else {
+      run(queue.dequeue())
     }
   }
 
-  private def executeNextIfPossible(): Unit = {
-    Option(queue.poll()).fold[Unit] {
-      totalOutstanding.decrementAndGet()
-    } { run(_) }
-  }
-
-  def blocking[T](f: => T)(implicit ctx: ExecutionContext): Future[T] = {
+  def blocking[T](f: => T)(implicit ctx: ExecutionContext): Future[T] = synchronized {
     apply(Future(concurrent.blocking(f)))
   }
 
-  def apply[T](f: => Future[T])(implicit ctx: ExecutionContext): Future[T] = {
-    val previouslyOutstanding = totalOutstanding.getAndUpdate((total: Int) => if (total < maxConcurrent) total + 1 else total)
-    if (previouslyOutstanding < maxConcurrent) {
+  /**
+    * Put work into the queue.
+    *
+    * @param f Future that is executed. Note that it's passed by name.
+    * @param ctx
+    * @tparam T
+    * @return Future that completes when f completed.
+    */
+  def apply[T](f: => Future[T])(implicit ctx: ExecutionContext): Future[T] = synchronized {
+    if (openSlotsCount > 0) {
+      // We have an open slot so start processing the work immediately.
+      openSlotsCount -= 1
       val promise = Promise[T]()
       run(WorkItem(() => f, ctx, promise))
+      promise.future
     } else {
+      // No work slot is left. Let's queue the work if possible.
       if (queue.size + 1 > maxQueueLength) {
+        logger.warn(s"$name queue exceeded $maxQueueLength")
         Future.failed(new IllegalStateException(s"$name queue may not exceed $maxQueueLength entries"))
       } else {
         val promise = Promise[T]()
-        queue.add(WorkItem(() => f, ctx, promise))
+        queue += WorkItem(() => f, ctx, promise)
         promise.future
       }
     }
@@ -81,9 +112,9 @@ case class WorkQueue(name: String, maxConcurrent: Int, maxQueueLength: Int, pare
 
 /**
   * Allows serialized execution of futures based on a Key (specifically the Hash of that key).
-  * Does not block any threads and will schedule any items on a parent queue, if supplied.
+  * Does not block any threads.
   */
-case class KeyedLock[K](name: String, maxQueueLength: Int, parent: Option[WorkQueue] = None) {
+case class KeyedLock[K](name: String, maxQueueLength: Int) {
   private val queues = Lock(mutable.HashMap.empty[K, WorkQueue])
 
   def blocking[T](key: K)(f: => T)(implicit ctx: ExecutionContext): Future[T] = {
@@ -91,6 +122,6 @@ case class KeyedLock[K](name: String, maxQueueLength: Int, parent: Option[WorkQu
   }
 
   def apply[T](key: K)(f: => Future[T])(implicit ctx: ExecutionContext): Future[T] = {
-    queues(_.getOrElseUpdate(key, WorkQueue(s"$name-$key", maxConcurrent = 1, maxQueueLength, parent))(f))
+    queues(_.getOrElseUpdate(key, WorkQueue(s"$name-$key", maxConcurrent = 1, maxQueueLength))(f))
   }
 }


### PR DESCRIPTION
Summary:
The mesosphere.marathon.util.WorkQueue has a race condition. The queue might
false see no queued item while at the same time one is queued. This can happen
because `totalOutstanding` and `ConcurrentLinkedQueue` are not syncrhonized.
Further, `ConcurrentLinkedQueue.size` might give an inaccurate view on the
state. To avoid this situation we just syncrhonized on the whole queue.

This change also removes the parent queue since it's not used and complicates
things.

Test Plan: unstable loop

Reviewers: zen-dog, timcharper, ichernetsky, kensipe, jenkins

Reviewed By: ichernetsky, kensipe, jenkins

Subscribers: kensipe, jenkins, marathon-dev, marathon-team

JIRA Issues: MARATHON-7462

Differential Revision: https://phabricator.mesosphere.com/D860