### PR TITLE
Update application-groups.md

### DIFF
--- a/docs/docs/application-groups.md
+++ b/docs/docs/application-groups.md
@@ -37,7 +37,7 @@ The definition could look like this:
 }
 ```
 
-NOTE: Assuming that you provide a complete application definition based on groups, to push it to Marathon you can do it through a `POST` to **/v2/groups** REST API endpoint.
+**Note:** Deploy an application group through a `POST` to the `/v2/groups` REST API endpoint.
 
 ## Dependencies 
 

--- a/docs/docs/application-groups.md
+++ b/docs/docs/application-groups.md
@@ -37,6 +37,8 @@ The definition could look like this:
 }
 ```
 
+NOTE: Assuming that you provide a complete application definition based on groups, to push it to Marathon you can do it through a `POST` to **/v2/groups** REST API endpoint.
+
 ## Dependencies 
 
 Applications can have dependencies. For example a Play application could require a database to run. 


### PR DESCRIPTION
Being following the documentation from top to bottom, it is easy to be confused and think that to deploy an application configuration based on groups is the same as deploying a simple application. So better to clarify that now we are using the /v2/groups endpoint instead of the /v2/apps.