### PR TITLE
Tharper/1.4 backport actor async and metrics

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -365,7 +365,7 @@ class SchedulerActions(
 
   // TODO move stuff below out of the scheduler
 
-  def startRunSpec(runSpec: RunSpec): Unit = {
+  def startRunSpec(runSpec: RunSpec): Future[Done] = {
     logger.info(s"Starting runSpec ${runSpec.id}")
     scale(runSpec)
   }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -45,27 +45,41 @@ object LaunchQueue {
 }
 
 /**
-  * The LaunchQueue contains requests to launch new instances for a run spec.
+  * The LaunchQueue contains requests to launch new instances for a run spec. For every method returning T
+  * there is a corresponding async method which returns a Future[T]. Async methods should be preferred
+  * where synchronous methods will be deprecated and gradually removed.
   */
 trait LaunchQueue {
 
   /** Returns all entries of the queue. */
   def list: Seq[QueuedInstanceInfo]
 
+  def listAsync: Future[Seq[QueuedInstanceInfo]]
+
   /** Returns all entries of the queue with embedded statistics */
   def listWithStatistics: Seq[QueuedInstanceInfoWithStatistics]
+
+  def listWithStatisticsAsync: Future[Seq[QueuedInstanceInfoWithStatistics]]
 
   /** Returns all runnable specs for which queue entries exist. */
   def listRunSpecs: Seq[RunSpec]
 
+  def listRunSpecsAsync: Future[Seq[RunSpec]]
+
   /** Request to launch `count` additional instances conforming to the given run spec. */
-  def add(spec: RunSpec, count: Int = 1): Unit
+  def add(spec: RunSpec, count: Int = 1): Done
+
+  def addAsync(spec: RunSpec, count: Int = 1): Future[Done]
 
   /** Get information for the given run spec id. */
   def get(specId: PathId): Option[QueuedInstanceInfo]
 
+  def getAsync(specId: PathId): Future[Option[QueuedInstanceInfo]]
+
   /** Return how many instances are still to be launched for this PathId. */
   def count(specId: PathId): Int
+
+  def countAsync(specId: PathId): Future[Int]
 
   /** Remove all instance launch requests for the given PathId from this queue. */
   def asyncPurge(specId: PathId): Future[Done]

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
@@ -187,13 +187,13 @@ private[impl] class LaunchQueueActor(
           val actorRef = createAppTaskLauncher(app, count)
           val eventualCount: Future[QueuedInstanceInfo] =
             (actorRef ? TaskLauncherActor.GetCount).mapTo[QueuedInstanceInfo]
-          eventualCount.map(_ => ()).pipeTo(sender())
+          eventualCount.map(_ => Done).pipeTo(sender())
 
         case Some(actorRef) =>
           import context.dispatcher
           val eventualCount: Future[QueuedInstanceInfo] =
             (actorRef ? TaskLauncherActor.AddInstances(app, count)).mapTo[QueuedInstanceInfo]
-          eventualCount.map(_ => ()).pipeTo(sender())
+          eventualCount.map(_ => Done).pipeTo(sender())
       }
 
     case msg @ RateLimiterActor.DelayUpdate(app, _) =>

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.state.{ PathId, RunSpec }
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{ Await, Future, ExecutionContext }
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
@@ -31,25 +31,46 @@ private[launchqueue] class LaunchQueueDelegate(
     askQueueActor[LaunchQueueDelegate.Request, Seq[QueuedInstanceInfo]]("list")(LaunchQueueDelegate.List)
   }
 
+  override def listAsync: Future[Seq[QueuedInstanceInfo]] =
+    askQueueActorFuture[LaunchQueueDelegate.Request, Seq[QueuedInstanceInfo]]("list")(LaunchQueueDelegate.List)
+
   override def listWithStatistics: Seq[QueuedInstanceInfoWithStatistics] = {
     askQueueActor[LaunchQueueDelegate.Request, Seq[QueuedInstanceInfoWithStatistics]]("listWithStatistics")(LaunchQueueDelegate.ListWithStatistics)
   }
 
+  override def listWithStatisticsAsync: Future[Seq[QueuedInstanceInfoWithStatistics]] =
+    askQueueActorFuture[LaunchQueueDelegate.Request, Seq[QueuedInstanceInfoWithStatistics]]("listWithStatistics")(LaunchQueueDelegate.ListWithStatistics)
+
   override def get(runSpecId: PathId): Option[QueuedInstanceInfo] =
     askQueueActor[LaunchQueueDelegate.Request, Option[QueuedInstanceInfo]]("get")(LaunchQueueDelegate.Count(runSpecId))
+
+  override def getAsync(runSpecId: PathId): Future[Option[QueuedInstanceInfo]] =
+    askQueueActorFuture[LaunchQueueDelegate.Request, Option[QueuedInstanceInfo]]("get")(LaunchQueueDelegate.Count(runSpecId))
 
   override def notifyOfInstanceUpdate(update: InstanceChange): Future[Done] =
     askQueueActorFuture[InstanceChange, Done]("notifyOfInstanceUpdate")(update)
 
   override def count(runSpecId: PathId): Int = get(runSpecId).map(_.instancesLeftToLaunch).getOrElse(0)
 
+  override def countAsync(runSpecId: PathId): Future[Int] =
+    getAsync(runSpecId).map {
+      case Some(i) => i.instancesLeftToLaunch
+      case None => 0
+    }(ExecutionContext.global)
+
   override def listRunSpecs: Seq[RunSpec] = list.map(_.runSpec)
 
-  override def asyncPurge(runSpecId: PathId): Future[Done] = {
-    askQueueActorFuture[LaunchQueueDelegate.Request, Done]("asyncPurge", timeout = purgeTimeout)(LaunchQueueDelegate.Purge(runSpecId))
-  }
+  override def listRunSpecsAsync: Future[Seq[RunSpec]] =
+    listAsync.map(_.map(_.runSpec))(ExecutionContext.global)
 
-  override def add(runSpec: RunSpec, count: Int): Unit = askQueueActor[LaunchQueueDelegate.Request, Unit]("add")(LaunchQueueDelegate.Add(runSpec, count))
+  override def asyncPurge(runSpecId: PathId): Future[Done] =
+    askQueueActorFuture[LaunchQueueDelegate.Request, Done]("asyncPurge", timeout = purgeTimeout)(LaunchQueueDelegate.Purge(runSpecId))
+
+  override def add(runSpec: RunSpec, count: Int): Done =
+    askQueueActor[LaunchQueueDelegate.Request, Done]("add")(LaunchQueueDelegate.Add(runSpec, count))
+
+  override def addAsync(runSpec: RunSpec, count: Int): Future[Done] =
+    askQueueActorFuture[LaunchQueueDelegate.Request, Done]("add")(LaunchQueueDelegate.Add(runSpec, count))
 
   private[this] def askQueueActor[T, R: ClassTag](
     method: String,

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -33,6 +33,8 @@ trait InstanceTracker {
   def countLaunchedSpecInstancesSync(appId: PathId, filter: Instance => Boolean): Int
   def countSpecInstancesSync(appId: PathId): Int
   def countSpecInstancesSync(appId: PathId, filter: Instance => Boolean): Int
+
+  def countLaunchedSpecInstances(appId: PathId): Future[Int]
   def countSpecInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Int]
 
   def hasSpecInstancesSync(appId: PathId): Boolean

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -52,6 +52,11 @@ private[tracker] class InstanceTrackerDelegate(
   override def countLaunchedSpecInstancesSync(appId: PathId, filter: Instance => Boolean): Int =
     instancesBySpecSync.specInstances(appId).count { t => t.isLaunched && filter(t) }
 
+  override def countLaunchedSpecInstances(appId: PathId): Future[Int] = {
+    import ExecutionContext.Implicits.global
+    instancesBySpec().map(_.specInstances(appId).count(_.isLaunched))
+  }
+
   override def countSpecInstancesSync(appId: PathId, filter: Instance => Boolean): Int =
     instancesBySpecSync.specInstances(appId).count(filter)
 

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentActor.scala
@@ -23,6 +23,7 @@ import com.typesafe.scalalogging.StrictLogging
 import scala.async.Async._
 import scala.concurrent.duration._
 import scala.concurrent.{ Future, Promise }
+import scala.util.control.NonFatal
 import scala.util.{ Failure, Success }
 
 private class DeploymentActor(
@@ -43,6 +44,32 @@ private class DeploymentActor(
 
   val steps = plan.steps.iterator
   var currentStepNr: Int = 0
+
+  // Default supervision strategy is overridden here to restart deployment child actors (responsible for individual
+  // deployment steps e.g. AppStartActor, TaskStartActor etc.) even if any exception occurs (even during initialisation).
+  // This is due to the fact that child actors tend to gather information during preStart about the tasks that are
+  // already running from the TaskTracker and LaunchQueue and those calls can timeout. In general deployment child
+  // actors are built idempotent which should make restarting them possible.
+  // Additionally a BackOffSupervisor is used to make sure child actor failures are not overloading other parts of the system
+  // (like LaunchQueue and InstanceTracker) and are not filling the log with exceptions.
+  import scala.concurrent.duration._
+  import akka.pattern.{ Backoff, BackoffSupervisor }
+
+  def childSupervisor(props: Props, name: String): Props = {
+    BackoffSupervisor.props(
+      Backoff.onFailure(
+        childProps = props,
+        childName = name,
+        minBackoff = 5.seconds,
+        maxBackoff = 1.minute,
+        randomFactor = 0.2 // adds 20% "noise" to vary the intervals slightly
+      ).withSupervisorStrategy(
+        OneForOneStrategy() {
+          case NonFatal(_) => SupervisorStrategy.Restart
+          case _ => SupervisorStrategy.Escalate
+        }
+      ))
+  }
 
   override def preStart(): Unit = {
     self ! NextStep
@@ -134,8 +161,8 @@ private class DeploymentActor(
   def startRunnable(runnableSpec: RunSpec, scaleTo: Int, status: DeploymentStatus): Future[Unit] = {
     val promise = Promise[Unit]()
     instanceTracker.specInstances(runnableSpec.id).map { instances =>
-      context.actorOf(AppStartActor.props(deploymentManager, status, scheduler, launchQueue, instanceTracker,
-        eventBus, readinessCheckExecutor, runnableSpec, scaleTo, instances, promise))
+      context.actorOf(childSupervisor(AppStartActor.props(deploymentManager, status, scheduler, launchQueue, instanceTracker,
+        eventBus, readinessCheckExecutor, runnableSpec, scaleTo, instances, promise), s"AppStart-${plan.id}"))
     }
     promise.future
   }
@@ -169,8 +196,8 @@ private class DeploymentActor(
         tasksToStart.fold(Future.successful(Done)) { tasksToStart =>
           logger.debug(s"Start next $tasksToStart tasks")
           val promise = Promise[Unit]()
-          context.actorOf(TaskStartActor.props(deploymentManager, status, scheduler, launchQueue, instanceTracker, eventBus,
-            readinessCheckExecutor, runnableSpec, scaleTo, promise))
+          context.actorOf(childSupervisor(TaskStartActor.props(deploymentManager, status, scheduler, launchQueue, instanceTracker, eventBus,
+            readinessCheckExecutor, runnableSpec, scaleTo, promise), s"TaskStart-${plan.id}"))
           promise.future.map(_ => Done)
         }
       }
@@ -197,8 +224,8 @@ private class DeploymentActor(
       Future.successful(Done)
     } else {
       val promise = Promise[Unit]()
-      context.actorOf(TaskReplaceActor.props(deploymentManager, status, killService,
-        launchQueue, instanceTracker, eventBus, readinessCheckExecutor, run, promise))
+      context.actorOf(childSupervisor(TaskReplaceActor.props(deploymentManager, status, killService,
+        launchQueue, instanceTracker, eventBus, readinessCheckExecutor, run, promise), s"TaskReplace-${plan.id}"))
       promise.future.map(_ => Done)
     }
   }

--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -1,72 +1,89 @@
 package mesosphere.marathon.upgrade
 
-import akka.actor.Actor
+import akka.Done
+import akka.pattern._
+import akka.actor.{ Actor, Status }
 import akka.event.EventStream
 import mesosphere.marathon.SchedulerActions
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition.Terminal
 import mesosphere.marathon.core.event.{ InstanceChanged, InstanceHealthChanged }
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import org.slf4j.LoggerFactory
 
+import scala.async.Async.{ async, await }
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
-trait StartingBehavior extends ReadinessBehavior { this: Actor =>
+trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Actor =>
   import context.dispatcher
   import mesosphere.marathon.upgrade.StartingBehavior._
 
   def eventBus: EventStream
   def scaleTo: Int
-  def nrToStart: Int
+  def nrToStart: Future[Int]
   def launchQueue: LaunchQueue
   def scheduler: SchedulerActions
   def instanceTracker: InstanceTracker
 
-  def initializeStart(): Unit
+  def initializeStart(): Future[Done]
 
-  private[this] val log = LoggerFactory.getLogger(getClass)
-
+  @SuppressWarnings(Array("all")) // async/await
   final override def preStart(): Unit = {
     if (hasHealthChecks) eventBus.subscribe(self, classOf[InstanceHealthChanged])
     eventBus.subscribe(self, classOf[InstanceChanged])
 
-    initializeStart()
-    checkFinished()
-    context.system.scheduler.scheduleOnce(1.seconds, self, Sync)
+    async {
+      await(initializeStart())
+      checkFinished()
+      context.system.scheduler.scheduleOnce(1.seconds, self, Sync)
+    }.pipeTo(self)
   }
 
   final override def receive: Receive = readinessBehavior orElse commonBehavior
 
+  @SuppressWarnings(Array("all")) // async/await
   def commonBehavior: Receive = {
     case InstanceChanged(id, `version`, `pathId`, _: Terminal, _) =>
-      log.warn(s"New instance [$id] failed during app ${runSpec.id.toString} scaling, queueing another instance")
+      logger.warn(s"New instance [$id] failed during app ${runSpec.id.toString} scaling, queueing another instance")
       instanceTerminated(id)
-      launchQueue.add(runSpec)
+      launchQueue.addAsync(runSpec, 1).pipeTo(self)
 
-    case Sync =>
-      val actualSize = launchQueue.get(runSpec.id)
-        .fold(instanceTracker.countLaunchedSpecInstancesSync(runSpec.id))(_.finalInstanceCount)
+    case Sync => async {
+      val launchedInstances = await(instanceTracker.countLaunchedSpecInstances(runSpec.id))
+      val actualSize = await(launchQueue.getAsync(runSpec.id)).fold(launchedInstances)(_.finalInstanceCount)
       val instancesToStartNow = Math.max(scaleTo - actualSize, 0)
-      log.debug(s"Sync start instancesToStartNow=$instancesToStartNow appId=${runSpec.id}")
+      logger.debug(s"Sync start instancesToStartNow=$instancesToStartNow appId=${runSpec.id}")
       if (instancesToStartNow > 0) {
-        log.info(s"Reconciling app ${runSpec.id} scaling: queuing $instancesToStartNow new instances")
-        launchQueue.add(runSpec, instancesToStartNow)
+        logger.info(s"Reconciling app ${runSpec.id} scaling: queuing $instancesToStartNow new instances")
+        await(launchQueue.addAsync(runSpec, instancesToStartNow))
       }
       context.system.scheduler.scheduleOnce(5.seconds, self, Sync)
+    }.pipeTo(self)
+
+    case Status.Failure(e) =>
+      // This is the result of failed initializeStart(...) call. Log the message and
+      // restart this actor. Next reincarnation should try to start from the beginning.
+      logger.warn(s"Failure in the ${getClass.getSimpleName} deployment actor: ", e)
+      throw e
+
+    case Done => // This is the result of successful initializeStart(...) call. Nothing to do here
 
     case DeploymentActor.Shutdown =>
       shutdown()
   }
 
   override def instanceConditionChanged(instanceId: Instance.Id): Unit = {
-    log.debug(s"New instance $instanceId changed during app ${runSpec.id} scaling, " +
-      s"${readyInstances.size} ready ${healthyInstances.size} healthy need $nrToStart")
+    logger.debug(s"New instance $instanceId changed during app ${runSpec.id} scaling, " +
+      s"${readyInstances.size} ready ${healthyInstances.size} healthy need ${nrToStart.value}")
     checkFinished()
   }
 
   def checkFinished(): Unit = {
-    if (targetCountReached(nrToStart)) success()
+    nrToStart.foreach{ n =>
+      if (targetCountReached(n)) success()
+    }
   }
 
   def success(): Unit

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskReplaceActor.scala
@@ -1,8 +1,10 @@
 package mesosphere.marathon.upgrade
 
+import akka.Done
 import akka.actor._
 import akka.event.EventStream
 import mesosphere.marathon._
+import akka.pattern.pipe
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.Id
@@ -16,7 +18,7 @@ import mesosphere.marathon.upgrade.TaskReplaceActor._
 import org.slf4j.LoggerFactory
 
 import scala.collection.{ SortedSet, mutable }
-import scala.concurrent.Promise
+import scala.concurrent.{ Future, Promise, ExecutionContext }
 
 class TaskReplaceActor(
     val deploymentManager: ActorRef,
@@ -100,8 +102,7 @@ class TaskReplaceActor(
     // Old instance successfully killed
     case InstanceChanged(id, _, `pathId`, condition, _) if oldInstanceIds(id) && considerTerminal(condition) =>
       oldInstanceIds -= id
-      launchInstances()
-      checkFinished()
+      launchInstances().foreach(_ => checkFinished())(context.dispatcher)
 
     // Ignore change events, that are not handled in parent receives
     case _: InstanceChanged =>
@@ -112,6 +113,15 @@ class TaskReplaceActor(
           new TaskUpgradeCanceledException(
             "The task upgrade has been cancelled"))
       context.stop(self)
+
+    case Status.Failure(e) =>
+      // This is the result of failed launchQueue.addAsync(...) call. Log the message and
+      // restart this actor. Next reincarnation should try to start from the beginning.
+      log.warning("Failed to launch instances: ", e)
+      throw e
+
+    case Done => // This is the result of successful launchQueue.addAsync(...) call. Nothing to do here
+
   }
 
   override def instanceConditionChanged(instanceId: Instance.Id): Unit = {
@@ -125,14 +135,19 @@ class TaskReplaceActor(
     instancesAlreadyStarted.foreach(reconcileHealthAndReadinessCheck)
   }
 
-  def launchInstances(): Unit = {
+  // Careful not to make this method completely asynchronous - it changes local actor's state `instancesStarted`.
+  // Only launching new instances needs to be asynchronous.
+  def launchInstances(): Future[Done] = {
     val leftCapacity = math.max(0, ignitionStrategy.maxCapacity - oldInstanceIds.size - instancesStarted)
     val instancesNotStartedYet = math.max(0, runSpec.instances - instancesStarted)
     val instancesToStartNow = math.min(instancesNotStartedYet, leftCapacity)
     if (instancesToStartNow > 0) {
       log.info(s"Reconciling instances during app $pathId restart: queuing $instancesToStartNow new instances")
-      launchQueue.add(runSpec, instancesToStartNow)
       instancesStarted += instancesToStartNow
+      import ExecutionContext.Implicits.global
+      launchQueue.addAsync(runSpec, instancesToStartNow).pipeTo(self)
+    } else {
+      Future.successful(Done)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/TaskStartActor.scala
@@ -1,7 +1,9 @@
-
-package mesosphere.marathon.upgrade
+package mesosphere.marathon
+package upgrade
 
 import akka.actor.{ Actor, ActorLogging, ActorRef, Props }
+import akka.Done
+import akka.pattern._
 import akka.event.EventStream
 import mesosphere.marathon.core.event.DeploymentStatus
 import mesosphere.marathon.core.launchqueue.LaunchQueue
@@ -10,8 +12,11 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.RunSpec
 import mesosphere.marathon.{ SchedulerActions, TaskUpgradeCanceledException }
 
-import scala.concurrent.Promise
+import scala.async.Async.{ async, await }
+import scala.concurrent.{ Future, Promise }
+import scala.concurrent.ExecutionContext.Implicits.global
 
+@SuppressWarnings(Array("all")) // async/await
 class TaskStartActor(
     val deploymentManager: ActorRef,
     val status: DeploymentStatus,
@@ -24,12 +29,20 @@ class TaskStartActor(
     val scaleTo: Int,
     promise: Promise[Unit]) extends Actor with ActorLogging with StartingBehavior {
 
-  val nrToStart: Int = Math.max(
-    0,
-    scaleTo - launchQueue.get(runSpec.id).map(_.finalInstanceCount)
-      .getOrElse(instanceTracker.countLaunchedSpecInstancesSync(runSpec.id)))
+  override val nrToStart: Future[Int] = async {
+    val alreadyLaunched = await(launchQueue.getAsync(runSpec.id)) match {
+      case Some(info) => info.finalInstanceCount
+      case None => await(instanceTracker.countLaunchedSpecInstances(runSpec.id))
+    }
+    Math.max(0, scaleTo - alreadyLaunched)
+  }.pipeTo(self)
 
-  def initializeStart(): Unit = if (nrToStart > 0) launchQueue.add(runSpec, nrToStart)
+  @SuppressWarnings(Array("all")) // async/await
+  override def initializeStart(): Future[Done] = async {
+    val toStart = await(nrToStart)
+    if (toStart > 0) await(launchQueue.addAsync(runSpec, toStart))
+    else Done
+  }.pipeTo(self)
 
   override def postStop(): Unit = {
     eventBus.unsubscribe(self)
@@ -38,7 +51,9 @@ class TaskStartActor(
 
   override def success(): Unit = {
     log.info(s"Successfully started $nrToStart instances of ${runSpec.id}")
-    promise.success(())
+    // Since a lot of StartingBehavior and this actor's code happens asynchronously now
+    // it can happen that this promise might succeed twice.
+    promise.trySuccess(())
     context.stop(self)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
@@ -41,7 +41,10 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
     new ZkPersistenceStore(client, Duration.Inf, 8)
   }
 
-  private def cachedZk = LazyCachingPersistenceStore(zkStore)
+  private def cachedZk = {
+    implicit val metrics = new Metrics(new MetricRegistry)
+    LazyCachingPersistenceStore(zkStore)
+  }
 
   behave like basicPersistenceStore("LazyCache(InMemory)", cachedInMemory)
   behave like basicPersistenceStore("LazyCache(Zk)", cachedZk)

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
@@ -28,7 +28,10 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
     LazyCachingPersistenceStore(new InMemoryPersistenceStore())
   }
 
-  private def withLazyVersionCaching = LazyVersionCachingPersistentStore(cachedInMemory)
+  private def withLazyVersionCaching = {
+    implicit val metrics = new Metrics(new MetricRegistry)
+    LazyVersionCachingPersistentStore(cachedInMemory)
+  }
 
   def zkStore: ZkPersistenceStore = {
     implicit val metrics = new Metrics(new MetricRegistry)

--- a/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/AppStartActorTest.scala
@@ -4,6 +4,7 @@ package upgrade
 import java.util.UUID
 
 import akka.actor.Terminated
+import akka.Done
 import akka.testkit.{ TestActorRef, TestProbe }
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.condition.Condition
@@ -19,7 +20,7 @@ import mesosphere.marathon.test.MarathonTestHelper
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 import scala.concurrent.duration._
-import scala.concurrent.Promise
+import scala.concurrent.{ Future, Promise }
 
 class AppStartActorTest extends AkkaUnitTest {
   "AppStartActor" should {
@@ -107,6 +108,7 @@ class AppStartActorTest extends AkkaUnitTest {
       val appId = PathId(s"/app-${UUID.randomUUID()}")
 
       launchQueue.get(appId) returns None
+      scheduler.startRunSpec(any) returns Future.successful(Done)
 
       def instanceChanged(app: AppDefinition, condition: Condition): InstanceChanged = {
         val instanceId = Instance.Id.forRunSpec(app.id)


### PR DESCRIPTION
This backports a few things from the master branch. In the stress test I ran in order to understand MARATHON-7400, we see about a 30% improvement in response times.