### PR TITLE
Fix a race condition in the TaskStartActor

### DIFF
--- a/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/StartingBehavior.scala
@@ -36,8 +36,9 @@ trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Acto
 
     async {
       await(initializeStart())
-      checkFinished()
-      context.system.scheduler.scheduleOnce(1.seconds, self, Sync)
+      // We send ourselves a message to check if we're already finished since checking it in this async block
+      // would lead to a race condition because it's touching actor's state.
+      PostStart
     }.pipeTo(self)
   }
 
@@ -59,7 +60,8 @@ trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Acto
         logger.info(s"Reconciling app ${runSpec.id} scaling: queuing $instancesToStartNow new instances")
         await(launchQueue.addAsync(runSpec, instancesToStartNow))
       }
-      context.system.scheduler.scheduleOnce(5.seconds, self, Sync)
+      context.system.scheduler.scheduleOnce(StartingBehavior.syncInterval, self, Sync)
+      Done // Otherwise we will pipe the result of scheduleOnce(...) call which is a Cancellable
     }.pipeTo(self)
 
     case Status.Failure(e) =>
@@ -67,6 +69,10 @@ trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Acto
       // restart this actor. Next reincarnation should try to start from the beginning.
       logger.warn(s"Failure in the ${getClass.getSimpleName} deployment actor: ", e)
       throw e
+
+    case PostStart =>
+      checkFinished()
+      context.system.scheduler.scheduleOnce(StartingBehavior.firstSyncDelay, self, Sync)
 
     case Done => // This is the result of successful initializeStart(...) call. Nothing to do here
 
@@ -93,5 +99,9 @@ trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Acto
 
 object StartingBehavior {
   case object Sync
+  case object PostStart
+
+  val firstSyncDelay = 1.seconds
+  val syncInterval = 5.seconds
 }
 


### PR DESCRIPTION
Summary:
- Fixed a race condition when `checkFinished` method when called from an `async` block check actor's state
which is not synchronized.
- Fixed piping `Cacellable`s in `StartingBehavior`

Test Plan: unit

Reviewers: timcharper, jeschkies, unterstein, ichernetsky, jenkins, jdef

Reviewed By: ichernetsky, jenkins, jdef

Subscribers: jdef, marathon-team, marathon-dev, jenkins

JIRA Issues: MARATHON_EE-1579, MARATHON-7629

Differential Revision: https://phabricator.mesosphere.com/D930

(cherry picked from commit 071e6e2969f8152024a8291669c5690d300c2a3c)