### PR TITLE
[Perf Tests]: Introduce Performance (scale) tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ __pycache__
 native/
 sandboxes/
 sandboxes.tar.gz
+tests/performance/results

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,91 @@
+# Marathon Performance Tests
+
+These tests can either run against a provisioned DC/OS Cluster, or locally using mesos simulator.
+
+Historically scale testing is a measure of the number of concurrent requests a service can handle or how the performance characteristics change over that load. In the case of Marathon and DCOS, scale specifically refers to the performance characteristics of Marathon and it's ability to handle X number of tasks.   The number of tasks are controlled by
+
+1) Number of Apps or Pods
+2) Number of Instances of Apps or Pods
+3) The complexity of the definition
+
+## Requirements
+
+* [DC/OS Performance Test Driver](https://github.com/mesosphere/dcos-perf-test-driver)
+* One of:
+    * A provisioned DC/OS Cluster (Enterprise or Open)
+    * A valid development environemnt that can run a development version of marathon
+
+To run the tests you can simply use the `dcos-perf-test-driver` tool. Some configurations require additional variables to be defined, for example:
+
+```
+dcos-perf-test-driver \
+    ./config/perf-driver/test-n-apps-n-instances-local.yml \
+    ./config/perf-driver/environments/cluster-oss.yml \
+    --define base_url="http://my-dcos-cluster.io"
+```
+
+If there are errors you would like to investigate you can run the driver in verbose mode:
+
+```
+dcos-perf-test-driver \
+    ./config/perf-driver/test-n-apps-n-instances-local.yml \
+    ./config/perf-driver/environments/cluster-oss.yml \
+    --define base_url="http://my-dcos-cluster.io" \
+    --verbose
+```
+
+## Scale Tests
+
+The following scale tests are available:
+
+* `config/perf-driver/test-n-apps-1-instances.yml` : Starts 50, 100, 150, ... 500 apps with 1 instance and measures:
+    - _Per-App Deployment Time_ : How long a deployment takes from the time the request is completed up to the deployment success or failure event
+    - _Overall Deployment Time_ : How long the bunch of deployments took to complete, from the completion of the first request til the last deployment success or failure event.
+    - _Failed Deployments_ : How many deployments failed
+    - _Groups Endpoint Response_ : How long does an HTTP request to `/v2/groups` end point take to complete.
+    - _CPU Load_ : The CPU load marathon caused while running.
+    - _Memory Usage_ : The ammount of memory consumed by marathon while running.
+    - _Thread Count_ : The number of threads in the JVM while marathon was running.
+
+* `config/perf-driver/test-1-apps-n-instances.yml` : Starts an app with 50, 100, 150, ... 500  1 instances and measures:
+    - _Per-App Deployment Time_ : How long a deployment takes from the time the request is completed up to the deployment success or failure event
+    - _Overall Deployment Time_ : How long the bunch of deployments took to complete, from the completion of the first request til the last deployment success or failure event.
+    - _Failed Deployments_ : How many deployments failed
+    - _Groups Endpoint Response_ : How long does an HTTP request to `/v2/groups` end point take to complete.
+    - _CPU Load_ : The CPU load marathon caused while running.
+    - _Memory Usage_ : The ammount of memory consumed by marathon while running.
+    - _Thread Count_ : The number of threads in the JVM while marathon was running.
+
+## Test Results
+
+The test is producing a variety of results:
+
+* _dump.json_ - Contains the raw dump of the metrics collected for various parameters during the scale test.
+* _results.csv_ - Contains a CSV with the summarised results for every parameter configuration.
+* _plot-*.png_ - Image plots with the scale test results. Every metric will have it's own image plot generated.
+* _S3 RAW Upload_ - In addition to the local raw dump, the results are uploaded to S3 for long-term archiving.
+* _Postgres Database_ - When used in CI, the results are posted in a Postgres database for long-term archiving and plotting through a PostgREST endpoint.
+* _Datadog_ - When used in CI, a single "indicator" result will be submitted to Datadog for long-term archiving and alerting.
+
+## Running in CI
+
+All of the CI automation is implenented as a set of `ci_*.sh` scripts. These scripts require some configuration environment variables and are appropriately configuring and launching `dcos-scale-test-driver`.
+
+This section describes the usage and dequirements of each script.
+
+### `ci_run_dcluster.sh` - Run tests against a thin cluster
+
+Installs missing dependencies, creates a local cluster  using the [macarhon-dcluster](https://github.com/wavesoft/marathon-dcluster) script and then it runs the tests on that cluster.
+
+The "thin cluster" deployed consists of 6 mesos agents (with over-commited resources), 1 mesos master, 1 zookeeper and 1 mesos containers using docker-compose. 
+
+#### Requirements
+
+* python3
+* python3-pip
+* docker
+* docker-compose
+
+#### Environment variables
+
+* `PARTIAL_TESTS` _[Optional]_ : A comma-separated list with the names of the tests to run. If missing the full set of tests will run.

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -42,18 +42,18 @@ The following scale tests are available:
     - _Per-App Deployment Time_ : How long a deployment takes from the time the request is completed up to the deployment success or failure event
     - _Overall Deployment Time_ : How long the bunch of deployments took to complete, from the completion of the first request til the last deployment success or failure event.
     - _Failed Deployments_ : How many deployments failed
-    - _Groups Endpoint Response_ : How long does an HTTP request to `/v2/groups` end point take to complete.
+    - _Groups Endpoint Response_ : How long does an HTTP request to `/v2/groups` endpoint take to complete.
     - _CPU Load_ : The CPU load marathon caused while running.
-    - _Memory Usage_ : The ammount of memory consumed by marathon while running.
+    - _Memory Usage_ : The amount of memory consumed by marathon while running.
     - _Thread Count_ : The number of threads in the JVM while marathon was running.
 
 * `config/perf-driver/test-1-apps-n-instances.yml` : Starts an app with 50, 100, 150, ... 500  1 instances and measures:
     - _Per-App Deployment Time_ : How long a deployment takes from the time the request is completed up to the deployment success or failure event
     - _Overall Deployment Time_ : How long the bunch of deployments took to complete, from the completion of the first request til the last deployment success or failure event.
     - _Failed Deployments_ : How many deployments failed
-    - _Groups Endpoint Response_ : How long does an HTTP request to `/v2/groups` end point take to complete.
+    - _Groups Endpoint Response_ : How long does an HTTP request to `/v2/groups` endpoint take to complete.
     - _CPU Load_ : The CPU load marathon caused while running.
-    - _Memory Usage_ : The ammount of memory consumed by marathon while running.
+    - _Memory Usage_ : The amount of memory consumed by marathon while running.
     - _Thread Count_ : The number of threads in the JVM while marathon was running.
 
 ## Test Results
@@ -62,22 +62,22 @@ The test is producing a variety of results:
 
 * _dump.json_ - Contains the raw dump of the metrics collected for various parameters during the scale test.
 * _results.csv_ - Contains a CSV with the summarised results for every parameter configuration.
-* _plot-*.png_ - Image plots with the scale test results. Every metric will have it's own image plot generated.
+* _plot-*.png_ - Image plots with the scale test results. Every metric will have its own image plot generated.
 * _S3 RAW Upload_ - In addition to the local raw dump, the results are uploaded to S3 for long-term archiving.
 * _Postgres Database_ - When used in CI, the results are posted in a Postgres database for long-term archiving and plotting through a PostgREST endpoint.
 * _Datadog_ - When used in CI, a single "indicator" result will be submitted to Datadog for long-term archiving and alerting.
 
 ## Running in CI
 
-All of the CI automation is implenented as a set of `ci_*.sh` scripts. These scripts require some configuration environment variables and are appropriately configuring and launching `dcos-scale-test-driver`.
+All of the CI automation is implemented as a set of `ci_*.sh` scripts. These scripts require some configuration environment variables and are appropriately configuring and launching `dcos-scale-test-driver`.
 
-This section describes the usage and dequirements of each script.
+This section describes the usage and requirements of each script.
 
 ### `ci_run_dcluster.sh` - Run tests against a thin cluster
 
 Installs missing dependencies, creates a local cluster  using the [macarhon-dcluster](https://github.com/wavesoft/marathon-dcluster) script and then it runs the tests on that cluster.
 
-The "thin cluster" deployed consists of 6 mesos agents (with over-commited resources), 1 mesos master, 1 zookeeper and 1 mesos containers using docker-compose. 
+The "thin cluster" deployed consists of 6 Mesos agents (with over-commited resources), 1 Mesos master, 1 Zookeeper and 1 Mesos containers using docker-compose. 
 
 #### Requirements
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -13,7 +13,7 @@ Historically scale testing is a measure of the number of concurrent requests a s
 * [DC/OS Performance Test Driver](https://github.com/mesosphere/dcos-perf-test-driver)
 * One of:
     * A provisioned DC/OS Cluster (Enterprise or Open)
-    * A valid development environemnt that can run a development version of marathon
+    * A valid development environment that can run a development version of marathon
 
 To run the tests you can simply use the `dcos-perf-test-driver` tool. Some configurations require additional variables to be defined, for example:
 
@@ -61,7 +61,7 @@ The following scale tests are available:
 The test is producing a variety of results:
 
 * _dump.json_ - Contains the raw dump of the metrics collected for various parameters during the scale test.
-* _results.csv_ - Contains a CSV with the summarised results for every parameter configuration.
+* _results.csv_ - Contains a CSV with the summarized results for every parameter configuration.
 * _plot-*.png_ - Image plots with the scale test results. Every metric will have its own image plot generated.
 * _S3 RAW Upload_ - In addition to the local raw dump, the results are uploaded to S3 for long-term archiving.
 * _Postgres Database_ - When used in CI, the results are posted in a Postgres database for long-term archiving and plotting through a PostgREST endpoint.
@@ -75,9 +75,9 @@ This section describes the usage and requirements of each script.
 
 ### `ci_run_dcluster.sh` - Run tests against a thin cluster
 
-Installs missing dependencies, creates a local cluster  using the [macarhon-dcluster](https://github.com/wavesoft/marathon-dcluster) script and then it runs the tests on that cluster.
+Installs missing dependencies, creates a local cluster  using the [marathon-dcluster](https://github.com/wavesoft/marathon-dcluster) script and then it runs the tests on that cluster.
 
-The "thin cluster" deployed consists of 6 Mesos agents (with over-commited resources), 1 Mesos master, 1 Zookeeper and 1 Mesos containers using docker-compose. 
+The "thin cluster" deployed consists of 6 Mesos agents (with overcommitted resources), 1 Mesos master, 1 Zookeeper and 1 Mesos containers using docker-compose. 
 
 #### Requirements
 

--- a/tests/performance/ci_run_dcluster.sh
+++ b/tests/performance/ci_run_dcluster.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# This script runs the scale tests locally, by deploying a development cluster
+# using docker-compose.
+
+# Current directory
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Allow some parameters to be overwritten from the environment
+[ -z "$MARATHON_DIR" ] && MARATHON_DIR=$(dirname $(dirname $BASEDIR))
+[ -z "$WORKDIR" ] && WORKDIR=$(pwd)
+
+# Export some variables that are going to be used by the step scripts
+export CONFIG_DIR=$BASEDIR/config
+export MARATHON_DIR=$MARATHON_DIR
+export PATH=$PATH:$WORKDIR/bin
+export WORKDIR=$WORKDIR
+
+# Tuning parameters
+export CLUSTER_CONFIG=$CONFIG_DIR/dcluster/large-cluster.conf
+export TESTS_DIR=$CONFIG_DIR/perf-driver
+
+# Step 1) Install dependencies
+source $BASEDIR/scripts/dcluster_install.sh
+RET=$?; [ $RET -ne 0 ] && exit $RET
+
+# Step 2) Build marathon
+source $BASEDIR/scripts/dcluster_build.sh
+RET=$?; [ $RET -ne 0 ] && exit $RET
+
+# Step 3) Deploy cluster
+source $BASEDIR/scripts/dcluster_deploy.sh
+RET=$?; [ $RET -ne 0 ] && exit $RET
+
+# Step 4) Run scale tests and carry the exit code
+source $BASEDIR/scripts/dcluster_run.sh $*
+# ^ This script exposes the EXITCODE environment variable
+
+# Step 5) Teardown cluster
+source $BASEDIR/scripts/dcluster_teardown.sh
+RET=$?; [ $RET -ne 0 ] && exit $RET
+
+# Exit with the test's exit code
+exit $EXITCODE

--- a/tests/performance/config/dcluster/large-cluster.conf
+++ b/tests/performance/config/dcluster/large-cluster.conf
@@ -1,0 +1,17 @@
+# This configuration file is used by the `marathon-dcluster` script
+# to deploy a cluster with over-commited resources for performance checks
+
+# Docker image versions
+mesos = 1.4.0-rc2
+zookeeper = 3.4
+
+# Overcommit the resources, allocing deployment of at least 1000 apps
+# with the minimum requirements
+mesos_slaves = 6
+mesos_resources_cpus = 250
+mesos_resources_mem = 8192000
+
+# Exposed ports
+marathon_port = 8080
+marathon_jmx = 9010
+mesos_master_port = 5050

--- a/tests/performance/config/dcluster/large-cluster.conf
+++ b/tests/performance/config/dcluster/large-cluster.conf
@@ -1,5 +1,5 @@
 # This configuration file is used by the `marathon-dcluster` script
-# to deploy a cluster with over-commited resources for performance checks
+# to deploy a cluster with overcommitted resources for performance checks
 
 # Docker image versions
 mesos = 1.4.0-rc2

--- a/tests/performance/config/perf-driver/common/config-common.yml
+++ b/tests/performance/config/perf-driver/common/config-common.yml
@@ -1,0 +1,20 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Shared Configuration               #
+# ----------------------------------------------------------- #
+# This fragment contains tunable definition and configuration #
+# parameters for the other fragmetns.                         #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # We are repeating everything 3 times
+  repeat: 3
+
+# Global definitions
+# ==================
+define:
+
+  # The version specification we are using when writing the reponrts
+  versionspec: "{{meta:ref|date(%Y%m%d)}}-{{meta:version|safepath(meta:branch)|'unversioned'}}-{{meta:env}}-{{meta:test}}"

--- a/tests/performance/config/perf-driver/environments/cluster-ee.yml
+++ b/tests/performance/config/perf-driver/environments/cluster-ee.yml
@@ -1,0 +1,41 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Cluster Environment                #
+# ----------------------------------------------------------- #
+# This fragment instructs the driver to use the marathon      #
+# exposed from an enterprise cluster. As part of it's setup   #
+# sequence, the driver will authenticate to the cluster with  #
+# the default superuser account.                              #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # We require the following definitions to be present (might be defined by
+  # other fragments, or must be given by the user)
+  definitions:
+    - name: base_url
+      desc: The URL to the deployed DC/OS cluster
+      required: yes
+
+# Test Metadata
+# ===========================
+meta:
+  env: extern-cluster-ee
+
+# Definitions
+# ===========================
+define:
+
+  # Define `marathon_url` as part of the cluster URL
+  marathon_url: "{{base_url}}/marathon"
+
+# One-time tasks
+# ===========================
+tasks:
+
+  # Authenticate to the cluster during the setup phase of the tests
+  - class: tasks.auth.AuthEE
+    password: deleteme
+    user: bootstrapuser
+    at: setup

--- a/tests/performance/config/perf-driver/environments/cluster-oss.yml
+++ b/tests/performance/config/perf-driver/environments/cluster-oss.yml
@@ -1,0 +1,52 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Cluster Environment                #
+# ----------------------------------------------------------- #
+# This fragment instructs the driver to use the marathon      #
+# exposed from an enterprise cluster. As part of it's setup   #
+# sequence, the driver will authenticate to the cluster with  #
+# the default superuser account.                              #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # We require the following definitions to be present (might be defined by
+  # other fragments, or must be given by the user)
+  definitions:
+    - name: base_url
+      desc: The URL to the deployed DC/OS cluster
+      required: yes
+
+# Test Metadata
+# ===========================
+meta:
+  env: extern-cluster-oss
+
+# Definitions
+# ===========================
+define:
+
+  # Define `marathon_url` as part of the cluster URL
+  marathon_url: "{{base_url}}/marathon"
+
+# One-time tasks
+# ===========================
+tasks:
+
+  # Authenticate using the testing token. This token valid until 2036
+  # for user albert@bekstil.net
+  #
+  #    {
+  #        "email": "albert@bekstil.net",
+  #        "email_verified": true,
+  #        "iss": "https://dcos.auth0.com/",
+  #        "sub": "google-oauth2|109964499011108905050",
+  #        "aud": "3yF5TOSzdlI45Q1xspxzeoGBe9fNxm9m",
+  #        "exp": 2090884974,
+  #        "iat": 1460164974
+  #    }
+  #
+  - class: tasks.auth.AuthOpen
+    token: eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UQkVOakZFTWtWQ09VRTRPRVpGTlRNMFJrWXlRa015Tnprd1JrSkVRemRCTWpBM1FqYzVOZyJ9.eyJlbWFpbCI6ImFsYmVydEBiZWtzdGlsLm5ldCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2Rjb3MuYXV0aDAuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTA5OTY0NDk5MDExMTA4OTA1MDUwIiwiYXVkIjoiM3lGNVRPU3pkbEk0NVExeHNweHplb0dCZTlmTnhtOW0iLCJleHAiOjIwOTA4ODQ5NzQsImlhdCI6MTQ2MDE2NDk3NH0.OxcoJJp06L1z2_41_p65FriEGkPzwFB_0pA9ULCvwvzJ8pJXw9hLbmsx-23aY2f-ydwJ7LSibL9i5NbQSR2riJWTcW4N7tLLCCMeFXKEK4hErN2hyxz71Fl765EjQSO5KD1A-HsOPr3ZZPoGTBjE0-EFtmXkSlHb1T2zd0Z8T5Z2-q96WkFoT6PiEdbrDA-e47LKtRmqsddnPZnp0xmMQdTr2MjpVgvqG7TlRvxDcYc-62rkwQXDNSWsW61FcKfQ-TRIZSf2GS9F9esDF4b5tRtrXcBNaorYa9ql0XAWH5W_ct4ylRNl3vwkYKWa4cmPvOqT5Wlj9Tf0af4lNO40PQ
+    at: setup

--- a/tests/performance/config/perf-driver/environments/dcluster.yml
+++ b/tests/performance/config/perf-driver/environments/dcluster.yml
@@ -1,0 +1,21 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Local Marathon Environment         #
+# ----------------------------------------------------------- #
+# This fragment instructs the driver to launch marathon with  #
+# it's own mesos simulator (locally). This fragment assumes   #
+# that the driver runs in a development environment with      #
+# scala properly configured.                                  #
+# ----------------------------------------------------------- #
+
+# Test Metadata
+# ===========================
+meta:
+  env: local-dcluster
+
+# Definitions
+# ===========================
+define:
+
+  # We are going to launch marathon ourselves, therefore we are defining
+  # `marathon_url` to point to localhost
+  marathon_url: http://127.0.0.1:8080

--- a/tests/performance/config/perf-driver/measure/measure-deploymentTime.yml
+++ b/tests/performance/config/perf-driver/measure/measure-deploymentTime.yml
@@ -1,0 +1,42 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Measure Deployment Time            #
+# ----------------------------------------------------------- #
+# This fragment installs a duration tracker that tracks the   #
+# duration in seconds between the completion of the HTTP      #
+# request and the completion of the deployment.
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # Define the metrics we are measuring
+  metrics:
+    - name: deploymentTime
+      uuid: cfac77fceb244862aedd89066441c416
+      desc: The time from the HTTP request completion till the deployment success
+      summarize: [mean_err]
+      units: sec
+
+  # Define the indicators that can summarise our values
+  indicators:
+
+    # Calculate `meanDeploymentTime` by calculating the normalizing average
+    # of all the `deploymentTime` mean values, normalized against each test's
+    # normalization expression
+    - name: meanDeploymentTime
+      class: indicator.NormalizedMeanMetricIndicator
+      metric: deploymentTime.mean_err
+      normalizeto: "{{normalize_to}}"
+
+# Tracker configuration
+# ===========================
+trackers:
+
+  # Track deploymentTime as the duration between an `MarathonDeploymentStartedEvent`
+  # and an `MarathonDeploymentSuccessEvent`
+  - class: tracker.DurationTracker
+    metric: deploymentTime
+    events:
+      start: MarathonDeploymentStartedEvent
+      end: MarathonDeploymentSuccessEvent

--- a/tests/performance/config/perf-driver/measure/measure-failedDeployments.yml
+++ b/tests/performance/config/perf-driver/measure/measure-failedDeployments.yml
@@ -1,0 +1,40 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Measure Deployment Failures        #
+# ----------------------------------------------------------- #
+# This fragment installs a counter tracker that tracks the    #
+# number of failed deployments.                               #
+# ----------------------------------------------------------- #
+
+
+# Global test configuration
+# ===========================
+config:
+
+  # Define the metrics we are measuring
+  metrics:
+    - name: failedDeployments
+      uuid: f1c4a1d569564600b7afe69e5f6a6548
+      desc: How many deployment failures occurred
+      summarize: [mean_err]
+      units: deployments
+
+  # Define the indicators that can summarise our values
+  indicators:
+
+    # Calculate `meanFailedDeployments` by calculating the normalizing average
+    # of all the `failedDeployments` mean values, normalized against each test's
+    # normalization expression
+    - name: meanFailedDeployments
+      class: indicator.NormalizedMeanMetricIndicator
+      metric: failedDeployments.mean_err
+      normalizeto: "{{normalize_to}}"
+
+# Tracker configuration
+# ===========================
+trackers:
+
+  # Track failedDeployments as the number of failed deployment events in the
+  # tracking session
+  - class: tracker.CountTracker
+    metric: failedDeployments
+    events: MarathonDeploymentFailedEvent

--- a/tests/performance/config/perf-driver/measure/measure-fullDeploymentTime.yml
+++ b/tests/performance/config/perf-driver/measure/measure-fullDeploymentTime.yml
@@ -1,0 +1,42 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Measure Deployment Time            #
+# ----------------------------------------------------------- #
+# This fragment installs a duration tracker that tracks the   #
+# duration in seconds between the completion of the HTTP      #
+# request and the completion of the deployment.
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # Define the metrics we are measuring
+  metrics:
+    - name: fullDeploymentTime
+      uuid: cfac77fceb244862aedd89066441c416
+      desc: The time from the first HTTP request completion till the last deployment success
+      summarize: [mean_err]
+      units: sec
+
+  # Define the indicators that can summarise our values
+  indicators:
+
+    # Calculate `meanFullDeploymentTime` by calculating the normalizing average
+    # of all the `fullDeploymentTime` mean values, normalized against each test's
+    # normalization expression
+    - name: meanFullDeploymentTime
+      class: indicator.NormalizedMeanMetricIndicator
+      metric: fullDeploymentTime.mean_err
+      normalizeto: "{{normalize_to}}"
+
+# Tracker configuration
+# ===========================
+trackers:
+
+  # Track fullDeploymentTime as the duration between an `MarathonDeploymentStartedEvent`
+  # and an `MarathonDeploymentSuccessEvent`
+  - class: tracker.DurationTracker
+    metric: fullDeploymentTime
+    events:
+      start: MarathonDeploymentStartedEvent:first
+      end: MarathonDeploymentSuccessEvent:last

--- a/tests/performance/config/perf-driver/measure/measure-groupsResponseTime.yml
+++ b/tests/performance/config/perf-driver/measure/measure-groupsResponseTime.yml
@@ -1,0 +1,44 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Extract groupsResponseTime time    #
+# ----------------------------------------------------------- #
+# This fragment installs a EventAttributeTracker that is      #
+# going to write the timing response of the groups endpoint   #
+# to the groups response endpoint.                            #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # Define the metrics we are measuring
+  metrics:
+    - name: groupsResponseTime
+      uuid: 6be71b57b76a49a180c4e8760513cf85
+      desc: The time it takes for the /groups endpoint to respond
+      summarize: [mean_err]
+      units: sec
+
+  # Define the indicators that can summarise our values
+  indicators:
+
+    # Calculate `meangroupsResponseTime` by calculating the normalizing average
+    # of all the `groupsResponseTime` mean values, normalized against each test's
+    # normalization expression
+    - name: meangroupsResponseTime
+      class: indicator.NormalizedMeanMetricIndicator
+      metric: groupsResponseTime.mean_err
+      normalizeto: "{{normalize_to}}"
+
+# Tracker configuration
+# ===========================
+trackers:
+
+  # We are writing down the value measured by the HTTPTimingObserver as a metric
+  # The observer is emitting a `HTTPTimingResultEvent` when the sampling is
+  # completed, so we are getting event values and storing them as metrics
+  - class: tracker.EventAttributeTracker
+    event: HTTPTimingResultEvent
+    extract:
+      # (You can consult the `Event Reference` to know which attributes you can use)
+      - attrib: totalTime
+        metric: groupsResponseTime

--- a/tests/performance/config/perf-driver/measure/measure-httpRequestTime.yml
+++ b/tests/performance/config/perf-driver/measure/measure-httpRequestTime.yml
@@ -1,0 +1,41 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Measure Deployment Time            #
+# ----------------------------------------------------------- #
+# This fragment installs a duration tracker that tracks the   #
+# duration in seconds between the beginning and the           #
+# completion of every API HTTP request.                       #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # Define the metrics we are measuring
+  metrics:
+    - name: httpRequestTime
+      uuid: d7071b36bb804a3c8df69c2de28ac222
+      desc: The time from the HTTP request till the completion of the HTTP response
+      summarize: [mean_err]
+      units: sec
+
+  # Define the indicators that can summarise our values
+  indicators:
+
+    # Calculate `meanHttpRequestTime` by calculating the normalizing average
+    # of all the `deploymentTime` mean values, normalized against each test's
+    # normalization expression
+    - name: meanHttpRequestTime
+      class: indicator.NormalizedMeanMetricIndicator
+      metric: httpRequestTime.mean_err
+      normalizeto: "{{normalize_to}}"
+
+# Tracker configuration
+# ===========================
+trackers:
+
+  # Track httpRequestTime as the duration between a deployment request and start
+  - class: tracker.DurationTracker
+    metric: httpRequestTime
+    events:
+      start: MarathonDeploymentRequestedEvent
+      end: MarathonDeploymentStartedEvent

--- a/tests/performance/config/perf-driver/measure/measure-jmx-cpuUsage.yml
+++ b/tests/performance/config/perf-driver/measure/measure-jmx-cpuUsage.yml
@@ -1,0 +1,42 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Extract cpuUsage from JMX         #
+# ----------------------------------------------------------- #
+# This fragment install a tracker that extracts the used      #
+# memory value metric from the JMX observer                   #
+# ----------------------------------------------------------- #
+
+
+# Global test configuration
+# ===========================
+config:
+
+  # Define the metrics we are measuring
+  metrics:
+    - name: cpuUsage
+      uuid: 124e89bd6eb142afa3406b6d489a8b7d
+      desc: The CPU load by marathon
+      summarize: [mean_err]
+      units: load
+
+  # Define the indicators that can summarise our values
+  indicators:
+
+    # Calculate `meanCpuUsage` by calculating the normalizing average
+    # of all the `cpuUsage` mean values, normalized against each test's
+    # normalization expression
+    - name: meanCpuUsage
+      class: indicator.NormalizedMeanMetricIndicator
+      metric: cpuUsage.mean_err
+      normalizeto: "{{normalize_to}}"
+
+# Tracker configuration
+# ===========================
+trackers:
+
+  # Extract values from the JMX measurements
+  - class: tracker.EventAttributeTracker
+    event: JMXMeasurement
+    extract:
+
+      - metric: cpuUsage
+        attrib: "fields['cpuUsage']"

--- a/tests/performance/config/perf-driver/measure/measure-jmx-threadCount.yml
+++ b/tests/performance/config/perf-driver/measure/measure-jmx-threadCount.yml
@@ -1,0 +1,42 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Extract threadCount from JMX       #
+# ----------------------------------------------------------- #
+# This fragment install a tracker that extracts the thread    #
+# count metric from the JMX observer                          #
+# ----------------------------------------------------------- #
+
+
+# Global test configuration
+# ===========================
+config:
+
+  # Define the metrics we are measuring
+  metrics:
+    - name: threadCount
+      uuid: 59d7d878001f4a398b74066dbd492746
+      desc: The number of threads in marathon
+      summarize: [mean_err]
+      units: threads
+
+  # Define the indicators that can summarise our values
+  indicators:
+
+    # Calculate `meanThreadCount` by calculating the normalizing average
+    # of all the `threadCount` mean values, normalized against each test's
+    # normalization expression
+    - name: meanThreadCount
+      class: indicator.NormalizedMeanMetricIndicator
+      metric: threadCount.mean_err
+      normalizeto: "{{normalize_to}}"
+
+# Tracker configuration
+# ===========================
+trackers:
+
+  # Extract values from the JMX measurements
+  - class: tracker.EventAttributeTracker
+    event: JMXMeasurement
+    extract:
+
+      - metric: threadCount
+        attrib: "fields['threadCount']"

--- a/tests/performance/config/perf-driver/measure/measure-jmx-usedMemory.yml
+++ b/tests/performance/config/perf-driver/measure/measure-jmx-usedMemory.yml
@@ -1,0 +1,42 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Extract usedMemory from JMX        #
+# ----------------------------------------------------------- #
+# This fragment install a tracker that extracts the used      #
+# memory value metric from the JMX observer                   #
+# ----------------------------------------------------------- #
+
+
+# Global test configuration
+# ===========================
+config:
+
+  # Define the metrics we are measuring
+  metrics:
+    - name: usedMemory
+      uuid: 124e89bd6eb142afa3406b6d489a8b7d
+      desc: The ammount of used memory by marathon
+      summarize: [mean_err]
+      units: bytes
+
+  # Define the indicators that can summarise our values
+  indicators:
+
+    # Calculate `meanUsedMemory` by calculating the normalizing average
+    # of all the `usedMemory` mean values, normalized against each test's
+    # normalization expression
+    - name: meanUsedMemory
+      class: indicator.NormalizedMeanMetricIndicator
+      metric: usedMemory.mean_err
+      normalizeto: "{{normalize_to}}"
+
+# Tracker configuration
+# ===========================
+trackers:
+
+  # Extract values from the JMX measurements
+  - class: tracker.EventAttributeTracker
+    event: JMXMeasurement
+    extract:
+
+      - metric: usedMemory
+        attrib: "fields['usedMemory']"

--- a/tests/performance/config/perf-driver/observers/observer-jmx.yml
+++ b/tests/performance/config/perf-driver/observers/observer-jmx.yml
@@ -1,0 +1,47 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : JMX Observer                       #
+# ----------------------------------------------------------- #
+# This fragment installs a JMX observer that is going to      #
+# connect on the specified Java Runtime and extract real-time #
+# measurements from the engine. The JMX port is assumed to    #
+# be openned on the local host.                               #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # We require the user to specify the JMX port to connect to
+  definitions:
+    - name: jmx_port
+      desc: The exposed JMX port where to connect in order to extract run-time metrics
+      required: yes
+
+# Observer configuration
+# ===========================
+observers:
+
+  # The events observer is subscribing to the
+  - class: observer.JMXObserver
+    connect:
+      host: 127.0.0.1
+      port: "{{jmx_port}}"
+
+    # Extract the specified values from the specified MBeans
+    metrics:
+      - field: threadCount
+        mbean: "java.lang:type=Threading"
+        attrib: ThreadCount
+
+      - field: usedMemory
+        mbean: "java.lang:type=Memory"
+        attrib: HeapMemoryUsage
+        value: "value['used']"
+
+      - field: cpuUsage
+        mbean: "java.lang:type=OperatingSystem"
+        attrib: ProcessCpuLoad
+
+    # Activate observer when marathon is started
+    events:
+      activate: MarathonStartedEvent

--- a/tests/performance/config/perf-driver/observers/observer-marathon-http-timing.yml
+++ b/tests/performance/config/perf-driver/observers/observer-marathon-http-timing.yml
@@ -1,0 +1,18 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Response time of grous endpoint    #
+# ----------------------------------------------------------- #
+# This fragment installs an http timing observer to the       #
+# /groups endpoint.
+# ----------------------------------------------------------- #
+
+# Observer configuration
+# ===========================
+observers:
+
+  # We are observing the response of the `/v2/groups` marathon endpoint
+  # with all the embeds the DC/OS UI is requesting
+  - class: observer.HTTPTimingObserver
+    url: "{{marathon_url}}/v2/groups?embed=group.groups&embed=group.apps&embed=group.pods&embed=group.apps.deployments&embed=group.apps.counts&embed=group.apps.tasks&embed=group.apps.taskStats&embed=group.apps.lastTaskFailure"
+
+    # We are polling every second
+    interval: 1

--- a/tests/performance/config/perf-driver/observers/observer-marathon-sse.yml
+++ b/tests/performance/config/perf-driver/observers/observer-marathon-sse.yml
@@ -1,0 +1,15 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Server-Side-Events Observer        #
+# ----------------------------------------------------------- #
+# This fragment installs an observer that attaches to the     #
+# marathon's SSE event stream and forwards the events in the  #
+# internal event bus.
+# ----------------------------------------------------------- #
+
+# Observer configuration
+# ===========================
+observers:
+
+  # The events observer is subscribing to the
+  - class: observer.MarathonEventsObserver
+    url: "{{marathon_url}}/v2/events"

--- a/tests/performance/config/perf-driver/policies/test-1-apps-n-instances.yml
+++ b/tests/performance/config/perf-driver/policies/test-1-apps-n-instances.yml
@@ -1,0 +1,102 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : 1 apps / N instances scale test    #
+# ----------------------------------------------------------- #
+# This fragment defines two parameters that we are going to   #
+# explore: the number of `instances`, fixing `apps` to 1.     #
+#                                                             #
+# It also defines how these parameters are going to be a      #
+# applied to the marathon instance.                           #
+#                                                             #
+# Finally, it also includes an inter-test clean-up phase that #
+# helps reduce the number of resources consumed by the test.  #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # Input parameters of the test
+  parameters:
+
+    - name: instances
+      uuid: 4a003e85e8bb4a95a340eec1727cfd0d
+      units: count
+      desc: The number of instances per application deployment
+
+# Definitions
+# ===========================
+define:
+
+  # Instruct whoever is trying to normalize the indicators to do so
+  # against the number of instances
+  normalize_to: instances
+
+# Test Metadata
+# ===========================
+meta:
+  test: 1-apps-n-instances
+
+# Test policy configuration
+# ===========================
+policies:
+
+  # Use multi-step exploration policy even if we are using only 1 step
+  - class: policy.MultiStepPolicy
+    steps:
+
+      # Scale the instances
+      - name: Scale Instances
+        values:
+          - parameter: instances
+            min: 50
+            step: 50
+            max: 500
+
+        tasks:
+          pre_value: intertest
+
+        events:
+
+          # Wait until marathon is started before continuing with the tests
+          start: MarathonStartedEvent:single
+
+          # We advance to next values every time we receive a deployment completion
+          advance: MarathonDeploymentSuccessEvent MarathonDeploymentFailedEvent
+
+
+# Channel configuration
+# ===========================
+channels:
+
+  # Perform a marathon deployment for every {{instances}} change
+  - class: channel.MarathonDeployChannel
+    url: "{{marathon_url}}"
+    deploy:
+      - type: app
+        spec: |
+          {
+            "cmd": "sleep infinity",
+            "cpus": 0.005,
+            "mem": 32,
+            "disk": 0,
+            "instances": {{instances}},
+            "id": "/scale-instances/{{uuid()}}",
+            "backoffFactor": 1.0,
+            "backoffSeconds": 0
+          }
+
+# One-shot tasks
+# ===========================
+tasks:
+
+  # Right after ever test run we should remove all the instances
+  - class: tasks.marathon.RemoveGroup
+    url: "{{marathon_url}}"
+    group: /scale-instances
+    at: intertest
+
+  # Also remove the tests if they were abruptly terminated
+  - class: tasks.marathon.RemoveGroup
+    url: "{{marathon_url}}"
+    group: /scale-instances
+    at: teardown

--- a/tests/performance/config/perf-driver/policies/test-n-apps-1-instances.yml
+++ b/tests/performance/config/perf-driver/policies/test-n-apps-1-instances.yml
@@ -1,0 +1,107 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : N apps / 1 instances scale test    #
+# ----------------------------------------------------------- #
+# This fragment defines two parameters that we are going to   #
+# explore: the number of `aps`, fixing `instances` to 1.      #
+#                                                             #
+# It also defines how these parameters are going to be a      #
+# applied to the marathon instance.                           #
+#                                                             #
+# Finally, it also includes an inter-test clean-up phase that #
+# helps reduce the number of resources consumed by the test.  #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # Input parameters of the test
+  parameters:
+
+    - name: apps
+      uuid: 7836e302bb7f43ea8e3477264c9b523e
+      units: count
+      desc: The number of apps deployed to marathon
+
+# Definitions
+# ===========================
+define:
+
+  # Instruct whoever is trying to normalize the indicators to do so
+  # against the number of apps
+  normalize_to: apps
+
+# Test Metadata
+# ===========================
+meta:
+  test: n-apps-1-instances
+
+# Test policy configuration
+# ===========================
+policies:
+
+  # Use multi-step exploration policy even if we are using only 1 step
+  - class: policy.MultiStepPolicy
+    steps:
+
+      # Scale the apps
+      - name: Scale Apps
+        values:
+          - parameter: apps
+            min: 50
+            step: 50
+            max: 500
+
+        events:
+          # Wait until marathon is started before continuing with the tests
+          start: MarathonStartedEvent:single
+
+          # We advance to next values every time we receive a deployment completion
+          advance: MarathonDeploymentSuccessEvent MarathonDeploymentFailedEvent
+
+        # Wait for "apps" number of advance events before actually advancing
+        advance_condition:
+          events: "apps"
+
+        tasks:
+          pre_value: intertest
+
+# Channel configuration
+# ===========================
+channels:
+
+  # Perform a bulk of marathon deployments for every {{apps}} change
+  - class: channel.MarathonDeployChannel
+    url: "{{marathon_url}}"
+    trigger:
+      parameters: apps
+    deploy:
+      - type: app
+        repeat: "apps"
+        spec: |
+          {
+            "cmd": "sleep infinity",
+            "cpus": 0.005,
+            "mem": 32,
+            "disk": 0,
+            "instances": 1,
+            "id": "/scale-instances/{{uuid()}}",
+            "backoffFactor": 1.0,
+            "backoffSeconds": 0
+          }
+
+# One-shot tasks
+# ===========================
+tasks:
+
+  # Right after ever test run we should remove all the instances
+  - class: tasks.marathon.RemoveGroup
+    url: "{{marathon_url}}"
+    group: /scale-instances
+    at: intertest
+
+  # Also remove the tests if they were abruptly terminated
+  - class: tasks.marathon.RemoveGroup
+    url: "{{marathon_url}}"
+    group: /scale-instances
+    at: teardown

--- a/tests/performance/config/perf-driver/reporters/report-csv.yml
+++ b/tests/performance/config/perf-driver/reporters/report-csv.yml
@@ -1,0 +1,15 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : CSV Summary Reporter               #
+# ----------------------------------------------------------- #
+# This fragment enables the CSVReporter that is going to      #
+# collect the summarised results in the `results/dump.json`   #
+# file.                                                       #
+# ----------------------------------------------------------- #
+
+# Reporter configuration
+# ===========================
+reporters:
+
+  # Dump summarized CSV values to results/results.csv
+  - class: reporter.CSVReporter
+    filename: results/results-{{versionspec}}.csv

--- a/tests/performance/config/perf-driver/reporters/report-datadog.yml
+++ b/tests/performance/config/perf-driver/reporters/report-datadog.yml
@@ -1,0 +1,46 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Measure Deployment Time            #
+# ----------------------------------------------------------- #
+# This fragment installs a duration tracker that tracks the   #
+# duration in seconds between the beginning and the           #
+# completion of every API HTTP request.                       #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # We require datadog credentials to be given through the command-line
+  definitions:
+    - name: datadog_api_key
+      desc: The datadog API Key
+      required: yes
+    - name: datadog_app_key
+      desc: The datadog App Key
+      required: yes
+
+# Global test configuration
+# ===========================
+reporters:
+
+  - class: reporter.DataDogReporter
+    api_key: "{{datadog_api_key}}"
+    app_key: "{{datadog_app_key}}"
+    prefix: "marathon.perf.{{meta:test}}."
+    points:
+      - name: meanDeploymentTime
+        indicator: meanDeploymentTime
+      - name: meanHttpRequestTime
+        indicator: meanHttpRequestTime
+      - name: meanFailedDeployments
+        indicator: meanFailedDeployments
+      - name: meanFullDeploymentTime
+        indicator: meanFullDeploymentTime
+      - name: meangroupsResponseTime
+        indicator: meangroupsResponseTime
+      - name: meanCpuUsage
+        indicator: meanCpuUsage
+      - name: meanThreadCount
+        indicator: meanThreadCount
+      - name: meanUsedMemory
+        indicator: meanUsedMemory

--- a/tests/performance/config/perf-driver/reporters/report-plot.yml
+++ b/tests/performance/config/perf-driver/reporters/report-plot.yml
@@ -1,0 +1,15 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Image Plots Reporter               #
+# ----------------------------------------------------------- #
+# This fragment enables the PlotReporter that is visualising  #
+# the results as a 2D plot image and stores it in the results #
+# folder.                                                     #
+# ----------------------------------------------------------- #
+
+# Reporter configuration
+# ===========================
+reporters:
+
+  # Create plots as images to results/plot-*.png
+  - class: reporter.PlotReporter
+    prefix: "results/plot-{{versionspec}}-"

--- a/tests/performance/config/perf-driver/reporters/report-raw.yml
+++ b/tests/performance/config/perf-driver/reporters/report-raw.yml
@@ -1,0 +1,14 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : PAW Dump Reporter                  #
+# ----------------------------------------------------------- #
+# This fragment enables the RAWReporter that is going to dump #
+# the collected results in the `results/dump.json` file.      #
+# ----------------------------------------------------------- #
+
+# Reporter configuration
+# ===========================
+reporters:
+
+  # Dump raw time series results to results/dump.json
+  - class: reporter.RawReporter
+    filename: "results/dump-{{versionspec}}.json"

--- a/tests/performance/config/perf-driver/reporters/report-s3.yml
+++ b/tests/performance/config/perf-driver/reporters/report-s3.yml
@@ -1,0 +1,22 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : S3 Dump Reporter                   #
+# ----------------------------------------------------------- #
+# This fragment enables the S3Reporter that is uploading the  #
+# raw tests results to an S3 bucket.                          #
+# ----------------------------------------------------------- #
+
+# Reporter configuration
+# ===========================
+reporters:
+
+  # Report raw results to amazon S3
+  - class: reporter.S3Reporter
+    bucket: marathon-artifacts
+    path: "metrics/dump-{{versionspec}}-results.json"
+    acl: public-read
+
+    # Update index with the archived test data
+    index:
+      path: dashboards/config/index.json
+      entry: "{{meta:test}}"
+

--- a/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
+++ b/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
@@ -1,0 +1,41 @@
+# ----------------------------------------------------------- #
+# Configuration Root : Run 1 Apps / N Instances Scale test    #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # The title of the test
+  title: "Marathon 1 Apps / N Instances Scale Test"
+
+# Fragments to include
+# ===========================
+include:
+
+  # Shared configuration
+  - common/config-common.yml
+
+  # Run the 1-apps-n-instances test policy
+  - policies/test-1-apps-n-instances.yml
+
+  # Use marathon's SSE endpoint to measure our metrics
+  - observers/observer-marathon-http-timing.yml
+  - observers/observer-marathon-sse.yml
+  - observers/observer-jmx.yml
+
+  # Measure the given metrics
+  - measure/measure-deploymentTime.yml
+  - measure/measure-fullDeploymentTime.yml
+  - measure/measure-httpRequestTime.yml
+  - measure/measure-failedDeployments.yml
+  - measure/measure-groupsResponseTime.yml
+  - measure/measure-jmx-threadCount.yml
+  - measure/measure-jmx-usedMemory.yml
+  - measure/measure-jmx-cpuUsage.yml
+
+  # Create the following reports
+  - reporters/report-raw.yml
+  - reporters/report-csv.yml
+  - reporters/report-s3.yml
+  - reporters/report-datadog.yml

--- a/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
+++ b/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
@@ -1,0 +1,41 @@
+# ----------------------------------------------------------- #
+# Configuration Root : Run N Apps / 1 Instances Scale test    #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # The title of the test
+  title: "Marathon N Apps / 1 Instances Scale Test"
+
+# Fragments to include
+# ===========================
+include:
+
+  # Shared configuration
+  - common/config-common.yml
+
+  # Run the n-apps-1-instances test policy
+  - policies/test-n-apps-1-instances.yml
+
+  # Use marathon's SSE endpoint to measure our metrics
+  - observers/observer-marathon-http-timing.yml
+  - observers/observer-marathon-sse.yml
+  - observers/observer-jmx.yml
+
+  # Measure the given metrics
+  - measure/measure-deploymentTime.yml
+  - measure/measure-fullDeploymentTime.yml
+  - measure/measure-httpRequestTime.yml
+  - measure/measure-failedDeployments.yml
+  - measure/measure-groupsResponseTime.yml
+  - measure/measure-jmx-threadCount.yml
+  - measure/measure-jmx-usedMemory.yml
+  - measure/measure-jmx-cpuUsage.yml
+
+  # Create the following reports
+  - reporters/report-raw.yml
+  - reporters/report-csv.yml
+  - reporters/report-s3.yml
+  - reporters/report-datadog.yml

--- a/tests/performance/scripts/dcluster_build.sh
+++ b/tests/performance/scripts/dcluster_build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+################################################################################
+# [Fragment] Marathon in Development (Local) Cluster
+# ------------------------------------------------------------------------------
+# This script builds a docker image with the current marathon and makes it
+# available to the next steps.
+################################################################################
+
+# Validate environment
+if [ -z "$MARATHON_DIR" ]; then
+  echo "ERROR: Required `MARATHON_DIR` environment variable"
+  exit 253
+fi
+
+(
+  # Cleanup marathon
+  cd $MARATHON_DIR;
+  rm -rf target;
+  sbt clean;
+
+  # Build docker image and keep track of the build log
+  # in order to extract the marathon image at the end.
+  sbt docker:publishLocal | tee build.log
+)
+RET=$?; [ $RET -ne 0 ] && exit $RET
+
+# Get the docker image name from the logs
+MARATHON_VERSION_EXPR=$(tail $MARATHON_DIR/build.log  | grep 'Built image' | awk '{print $4}' | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g')
+
+# Export marathon image and version for other scripts
+export MARATHON_IMAGE=$(echo $MARATHON_VERSION_EXPR | awk -F':' '{print $1}')
+export MARATHON_VERSION=$(echo $MARATHON_VERSION_EXPR | awk -F':' '{print $2}')

--- a/tests/performance/scripts/dcluster_deploy.sh
+++ b/tests/performance/scripts/dcluster_deploy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+################################################################################
+# [Fragment] Marathon in Development (Local) Cluster
+# ------------------------------------------------------------------------------
+# This script launches a local marathon development cluster for use by the later
+# run script.
+################################################################################
+
+# Validate environment
+if [ -z "$MARATHON_VERSION" ]; then
+  echo "ERROR: Required 'MARATHON_VERSION' environment variable"
+  exit 253
+fi
+if [ -z "$MARATHON_IMAGE" ]; then
+  echo "ERROR: Required 'MARATHON_IMAGE' environment variable"
+  exit 253
+fi
+if [ -z "$CLUSTER_CONFIG" ]; then
+  echo "ERROR: Required 'CLUSTER_CONFIG' environment variable"
+  exit 253
+fi
+
+# Launch a cluster
+marathon-dcluster \
+  --detach $CLUSTER_CONFIG \
+  --marathon $MARATHON_VERSION \
+  --marathon_image $MARATHON_IMAGE

--- a/tests/performance/scripts/dcluster_install.sh
+++ b/tests/performance/scripts/dcluster_install.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+################################################################################
+# [Fragment] Marathon in Development (Local) Cluster
+# ------------------------------------------------------------------------------
+# This script installs missing dependencies or bails early if something is not
+# available in the user's computer.
+################################################################################
+
+# Check for missing dependencies that we cannot install
+which python3 pip3 >/dev/null
+if [ $? -ne 0 ]; then
+  echo "ERROR: pip3 and python3 must be available in your system"
+  exit 255
+fi
+which docker docker-compose >/dev/null
+if [ $? -ne 0 ]; then
+  echo "ERROR: docker and docker-compose must be available in your system"
+  exit 255
+fi
+
+# Check for dependencies that we can install
+which marathon-dcluster >/dev/null
+if [ $? -ne 0 ]; then
+  echo "INFO: marathon-dcluster was not found in your system, installing..."
+
+  mkdir -p $WORKDIR/bin
+
+  # Marathon-dcluster is just a single-file python script with no dependencies
+  # to other packages. So it's pretty portable.
+  curl -o $WORKDIR/bin/marathon-dcluster \
+    https://raw.githubusercontent.com/wavesoft/marathon-dcluster/master/marathon-dcluster
+  if [ $? -ne 0 ]; then
+    echo "ERROR: Unable to download marathon-dcluster binary"
+    exit 254
+  fi
+
+  chmod +x $WORKDIR/bin/marathon-dcluster
+fi
+
+which dcos-perf-test-driver >/dev/null
+if [ $? -ne 0 ]; then
+  echo "INFO: dcos-perf-test-driver was not found in your system, installing..."
+
+  # Make workdir a python virtual env
+  python3 -m venv $WORKDIR
+
+  # Install perf driver
+  (source $WORKDIR/bin/activate; pip3 install git+https://github.com/mesosphere/dcos-perf-test-driver)
+
+  which dcos-perf-test-driver >/dev/null
+  if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to install dcos-perf-test-driver"
+    exit 254
+  fi
+fi

--- a/tests/performance/scripts/dcluster_run.sh
+++ b/tests/performance/scripts/dcluster_run.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+################################################################################
+# [Fragment] Marathon in Development (Local) Cluster
+# ------------------------------------------------------------------------------
+# This script runs the scale tests on the cluster deployed in the previous steps
+################################################################################
+
+# Validate environment
+if [ -z "$TESTS_DIR" ]; then
+  echo "ERROR: Required 'TESTS_DIR' environment variable"
+  exit 253
+fi
+if [ -z "$CLUSTER_CONFIG" ]; then
+  echo "ERROR: Required 'CLUSTER_CONFIG' environment variable"
+  exit 253
+fi
+if [ -z "$MARATHON_VERSION" ]; then
+  echo "ERROR: Required 'MARATHON_VERSION' environment variable"
+  exit 253
+fi
+# if [ -z "$DATADOG_API_KEY" ]; then
+#   echo "ERROR: Required 'DATADOG_API_KEY' environment variable"
+#   exit 253
+# fi
+# if [ -z "$DATADOG_APP_KEY" ]; then
+#   echo "ERROR: Required 'DATADOG_APP_KEY' environment variable"
+#   exit 253
+# fi
+
+# Get mesos version from the cluster config
+MESOS_VERSION=$(cat $CLUSTER_CONFIG | grep 'mesos\s*=' | awk -F'=' '{print $2}' | tr -d ' ')
+
+# Execute all the tests in the configuration
+EXITCODE=0
+for TEST_CONFIG in $TESTS_DIR/test-*.yml; do
+
+  # Get test name by removing 'test-' prefix and '.yml' suffix
+  TEST_NAME=$(basename $TEST_CONFIG)
+  TRIM_END=${#TEST_NAME}
+  let TRIM_END-=9
+  TEST_NAME=${TEST_NAME:5:$TRIM_END}
+
+  # If we have partial tests configured, check if this test exists
+  # in the PARTIAL_TESTS, otherwise skip
+  if [[ ! -z "$PARTIAL_TESTS" && ! "$PARTIAL_TESTS" =~ "$TEST_NAME" ]]; then
+    echo "INFO: Skipping test '${TEST_NAME}' according to PARTIAL_TESTS env vaiable"
+    continue
+  fi
+  echo "INFO: Executing test '${TEST_NAME}'"
+
+  # Launch the performance test driver with the correct arguments
+  eval dcos-perf-test-driver \
+    $TESTS_DIR/environments/dcluster.yml \
+    $TEST_CONFIG \
+    -M "version=${MARATHON_VERSION}" \
+    -M "mesos=${MESOS_VERSION}" \
+    -D "jmx_port=9010" \
+    -D "datadog_api_key=${DATADOG_API_KEY}" \
+    -D "datadog_app_key=${DATADOG_APP_KEY}" \
+    $*
+  EXITCODE=$?; [ $EXITCODE -ne 0 ] && break
+
+done
+
+# Expose EXITCODE to make it available to other tasks
+export EXITCODE=$EXITCODE

--- a/tests/performance/scripts/dcluster_run.sh
+++ b/tests/performance/scripts/dcluster_run.sh
@@ -18,14 +18,14 @@ if [ -z "$MARATHON_VERSION" ]; then
   echo "ERROR: Required 'MARATHON_VERSION' environment variable"
   exit 253
 fi
-# if [ -z "$DATADOG_API_KEY" ]; then
-#   echo "ERROR: Required 'DATADOG_API_KEY' environment variable"
-#   exit 253
-# fi
-# if [ -z "$DATADOG_APP_KEY" ]; then
-#   echo "ERROR: Required 'DATADOG_APP_KEY' environment variable"
-#   exit 253
-# fi
+if [ -z "$DATADOG_API_KEY" ]; then
+  echo "ERROR: Required 'DATADOG_API_KEY' environment variable"
+  exit 253
+fi
+if [ -z "$DATADOG_APP_KEY" ]; then
+  echo "ERROR: Required 'DATADOG_APP_KEY' environment variable"
+  exit 253
+fi
 
 # Get mesos version from the cluster config
 MESOS_VERSION=$(cat $CLUSTER_CONFIG | grep 'mesos\s*=' | awk -F'=' '{print $2}' | tr -d ' ')

--- a/tests/performance/scripts/dcluster_teardown.sh
+++ b/tests/performance/scripts/dcluster_teardown.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+################################################################################
+# [Fragment] Marathon in Development (Local) Cluster
+# ------------------------------------------------------------------------------
+# This script tears down the local cluster created in the previous steps.
+################################################################################
+
+# Validate environment
+if [ -z "$MARATHON_VERSION" ]; then
+  echo "ERROR: Required 'MARATHON_VERSION' environment variable"
+  exit 253
+fi
+if [ -z "$MARATHON_IMAGE" ]; then
+  echo "ERROR: Required 'MARATHON_IMAGE' environment variable"
+  exit 253
+fi
+if [ -z "$CLUSTER_CONFIG" ]; then
+  echo "ERROR: Required 'CLUSTER_CONFIG' environment variable"
+  exit 253
+fi
+
+# Launch a cluster
+marathon-dcluster \
+  --rm $CLUSTER_CONFIG \
+  --marathon $MARATHON_VERSION \
+  --marathon_image $MARATHON_IMAGE


### PR DESCRIPTION
This commit introduces the [dcos-perf-test-driver](https://github.com/mesosphere/dcos-perf-test-driver) configuration that drive the scale tests on marathon, along with a few helper entry point scripts.

In brief, the following is introduced with this PR. For more details look on the [`README.md`](https://github.com/mesosphere/marathon/blob/6ef8a4f4046fb388308717b73d753203ce87eb1b/tests/performance/README.md) file.

### Environments

* _Thin Cluster_ : Run the tests against a locally-deployed "thin" (mesos+marathon+zk) cluster using docker-compose and [marathon-dcluster](https://github.com/wavesoft/marathon-dcluster)

### Tests

* _1-Apps / N-Instances_ : Create apps with 50, 100, 150 ... 500 instances and measure the system response.
* _N-Apps / 1-Instances_ : Create 50, 50, 150 ... 500 apps with 1 instance and measure the system response.