### PR TITLE
Added `agentId` to the pod status

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/podStatus.raml
+++ b/docs/docs/rest-api/public/api/v2/types/podStatus.raml
@@ -150,6 +150,10 @@ types:
         description: |
           Hostname that this instance was launched on.
           May be an IP address if the agent was configured to advertise its hostname that way.
+      agentId?:
+        type: string
+        description: |
+          The Mesos-generated ID of the agent upon which the instance was launched.
       resources?:
         type: resources.Resources
         description: |

--- a/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
@@ -79,6 +79,7 @@ trait PodStatusConversion {
       id = instance.instanceId.idString,
       status = derivedStatus,
       statusSince = instance.state.since.toOffsetDateTime,
+      agentId = instance.agentInfo.agentId,
       agentHostname = Some(instance.agentInfo.host),
       resources = Some(resources),
       networks = networkStatus,

--- a/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
@@ -75,6 +75,7 @@ class PodStatusConversionTest extends MarathonSpec with Matchers {
     status.id should be(fixture.instance.instanceId.idString)
     status.specReference should be(Option(s"/v2/pods/foo::versions/${pod.version.toOffsetDateTime}"))
     status.agentHostname should be(Some("agent1"))
+    status.agentId should be (Some("agentId1"))
     status.status should be(PodInstanceState.Pending)
     status.resources should be(Some(PodDefinition.DefaultExecutorResources))
     status.containers should be(Seq(
@@ -103,6 +104,7 @@ class PodStatusConversionTest extends MarathonSpec with Matchers {
     val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
     status.id should be(fixture.instance.instanceId.idString)
     status.agentHostname should be(Some("agent1"))
+    status.agentId should be (Some("agentId1"))
     status.status should be(PodInstanceState.Staging)
     status.resources should be(Some(pod.aggregateResources()))
     status.containers should be(Seq(
@@ -133,6 +135,7 @@ class PodStatusConversionTest extends MarathonSpec with Matchers {
     val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
     status.id should be(fixture.instance.instanceId.idString)
     status.agentHostname should be(Some("agent1"))
+    status.agentId should be (Some("agentId1"))
     status.status should be(PodInstanceState.Staging)
     status.resources should be(Some(pod.aggregateResources()))
     status.containers should be(Seq(
@@ -166,6 +169,7 @@ class PodStatusConversionTest extends MarathonSpec with Matchers {
     val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
     status.id should be(fixture.instance.instanceId.idString)
     status.agentHostname should be(Some("agent1"))
+    status.agentId should be (Some("agentId1"))
     status.status should be(PodInstanceState.Degraded)
     status.resources should be(Some(pod.aggregateResources()))
     status.containers should be(Seq(
@@ -203,6 +207,7 @@ class PodStatusConversionTest extends MarathonSpec with Matchers {
     val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
     status.id should be(fixture.instance.instanceId.idString)
     status.agentHostname should be(Some("agent1"))
+    status.agentId should be (Some("agentId1"))
     status.status should be(PodInstanceState.Degraded)
     status.resources should be(Some(pod.aggregateResources()))
     status.containers should be(Seq(
@@ -240,6 +245,7 @@ class PodStatusConversionTest extends MarathonSpec with Matchers {
     val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
     status.id should be(fixture.instance.instanceId.idString)
     status.agentHostname should be(Some("agent1"))
+    status.agentId should be (Some("agentId1"))
     status.status should be(PodInstanceState.Stable)
     status.resources should be(Some(pod.aggregateResources()))
     status.containers should be(Seq(
@@ -278,6 +284,7 @@ class PodStatusConversionTest extends MarathonSpec with Matchers {
     val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
     status.id should be(fixture.instance.instanceId.idString)
     status.agentHostname should be(Some("agent1"))
+    status.agentId should be (Some("agentId1"))
     status.status should be(PodInstanceState.Degraded)
     status.resources should be(Some(pod.aggregateResources()))
     status.containers should be(Seq(
@@ -316,6 +323,7 @@ class PodStatusConversionTest extends MarathonSpec with Matchers {
     val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
     status.id should be(fixture.instance.instanceId.idString)
     status.agentHostname should be(Some("agent1"))
+    status.agentId should be (Some("agentId1"))
     status.status should be(PodInstanceState.Degraded)
     status.resources should be(Some(pod.aggregateResources()))
     status.containers should be(Seq(
@@ -354,6 +362,7 @@ class PodStatusConversionTest extends MarathonSpec with Matchers {
     val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
     status.id should be(fixture.instance.instanceId.idString)
     status.agentHostname should be(Some("agent1"))
+    status.agentId should be (Some("agentId1"))
     status.status should be(PodInstanceState.Stable)
     status.resources should be(Some(pod.aggregateResources()))
     status.containers should be(Seq(
@@ -379,6 +388,7 @@ class PodStatusConversionTest extends MarathonSpec with Matchers {
       NetworkStatus(Some("dcos"), Seq("1.2.3.4")),
       NetworkStatus(Some("bigdog"), Seq("2.3.4.5"))
     ))
+
   }
 }
 
@@ -435,7 +445,7 @@ object PodStatusConversionTest {
     maybeHealthy: Option[Boolean] = None)(implicit clock: ConstantClock): InstanceFixture = {
 
     val since = clock.now()
-    val agentInfo = Instance.AgentInfo("agent1", None, Seq.empty)
+    val agentInfo = Instance.AgentInfo("agent1", Some("agentId1"), Seq.empty)
     val instanceId = Instance.Id.forRunSpec(pod.id)
     val taskIds = pod.containers.map { container =>
       Task.Id.forInstanceId(instanceId, Some(container))


### PR DESCRIPTION
Summary: To align the pod api with the app api, the `agentId` property for running instances is introduced. Furthermore the agentId need for different purposes (e.g. accessing the mesos sandbox for a given container), so it makes sense to expose the agentId here.

Test Plan: sbt test

Reviewers: jdef, jeschkies, zen-dog, jenkins, timcharper

Reviewed By: jdef, jenkins, timcharper

Subscribers: tillt, marathon-dev, marathon-team

JIRA Issues: MARATHON-7628

Differential Revision: https://phabricator.mesosphere.com/D926