### PR TITLE
Dockerize our local Jekyll doc rendering engine

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,19 @@
+FROM buildpack-deps:stretch-curl
+
+COPY Gemfile Gemfile.lock /jekyll/
+
+RUN apt-get update && \
+  curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+  apt-get install -y gcc git libxml2 zlib1g-dev libxml2-dev ruby ruby-dev make autoconf nodejs python python-dev && \
+  gem install bundler && \
+  cd /jekyll && bundle install && \
+  apt-get purge -y gcc ruby-dev python-dev && \
+  apt-get -y autoremove && \
+  rm -rf /var/lib/apt/lists
+
+COPY entrypoint.sh /
+
+EXPOSE 4000
+VOLUME ["/marathon-docs"]
+
+ENTRYPOINT /entrypoint.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,21 @@ following the instructions.
 
 ### Instructions
 
+#### Using Docker
+
+1. Build the docker image:
+
+        docker build . -t marathon-jekyll
+
+2. Run it (from this folder)
+
+        docker run --rm -it -v $(pwd):/marathon-docs -p 4000:4000 marathon-jekyll
+
+3. Visit the site at
+   [http://localhost:4000/marathon/](http://localhost:4000/marathon/)
+
+#### Native OS
+
 1. Install packages needed to generate the site
 
     * On Linux:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -24,3 +24,4 @@ kramdown:
 safe: true
 source: .
 exclude: [vendor/bundle]
+repository: mesosphere/marathon

--- a/docs/entrypoint.sh
+++ b/docs/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd /marathon-docs
+
+# BUNDLE_IGNORE_CONFIG=1 in case the user has a .bundle/config file from invoking bundler locally; we want to use the docker container's bundler files
+BUNDLE_IGNORE_CONFIG=1 bundle exec jekyll serve --watch -H 0.0.0.0


### PR DESCRIPTION
Summary: Installing the rubygems with native extensions is riddled with errors. So let's use docker instead!

Backport of https://phabricator.mesosphere.com/D955

Reviewers: kensipe, sascala, jenkins

Reviewed By: kensipe, sascala, jenkins

Subscribers: marathon-dev