### PR TITLE
Allow migration from previous UnreachableStrategy default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,16 @@ unreachableStrategy: {
 **Note**: Instantly means as soon as marathon becomes aware of the unreachable task. By default marathon is notified after 75 seconds by mesos
   that an agent is disconnected. You can change this duration in mesos by configuring `agent_ping_timeout` and `max_agent_ping_timeouts`.
 
+#### Migrating unreachableStrategy
+If you want all of your apps and pods to adopt a `UnreachableStrategy` that retains the previous behavior where instance were immediately replaced so that you does not have to update every single app definition.
+
+To change the `unreachableStrategy` of all apps and pods, you can define the environment parameter `MIGRATION_1_4_6_UNREACHABLE_STRATEGY` which leads to the following behavior during migration:
+
+When opting in to the unreachable migration step
+1) all app and pod definitions that had a config of `UnreachableStrategy(300 seconds, 600 seconds)` (previous default) are migrated to have `UnreachableStrategy(0 seconds, 0 seconds)`
+2) all app and pod definitions that had a config of `UnreachableStrategy(1 second, x seconds)` are migrated to have `UnreachableStrategy(0 seconds, x seconds)`
+3) all app and pod definitions that had a config of `UnreachableStrategy(1 second, 2 seconds)` are migrated to have `UnreachableStrategy(0 seconds, 0 seconds)`
+
 ### Fixed issues
 
 - [MARATHON-7681](https://jira.mesosphere.com/browse/MARATHON-7681) - Fixes an issue in WorkQueue that could cause Marathon to drop exceptions and become unresponsive.

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -76,7 +76,7 @@ object StorageModule {
         val eventSubscribersStore = l.entityStore[EventSubscribers] _
         val eventSubscribersRepository = EventSubscribersRepository.legacyRepository(eventSubscribersStore)
 
-        val migration = new Migration(l.availableFeatures, legacyConfig, None, appRepository, groupRepository,
+        val migration = new Migration(l.availableFeatures, legacyConfig, None, appRepository, podRepository, groupRepository,
           deploymentRepository, taskRepository, instanceRepository, taskFailureRepository,
           frameworkIdRepository, eventSubscribersRepository)
 
@@ -107,7 +107,7 @@ object StorageModule {
             Nil
         }
 
-        val migration = new Migration(zk.availableFeatures, legacyConfig, Some(store), appRepository, groupRepository,
+        val migration = new Migration(zk.availableFeatures, legacyConfig, Some(store), appRepository, podRepository, groupRepository,
           deploymentRepository, taskRepository, instanceRepository, taskFailureRepository,
           frameworkIdRepository, eventSubscribersRepository)
         StorageModuleImpl(
@@ -141,7 +141,7 @@ object StorageModule {
             Nil
         }
 
-        val migration = new Migration(mem.availableFeatures, legacyConfig, Some(store), appRepository, groupRepository,
+        val migration = new Migration(mem.availableFeatures, legacyConfig, Some(store), appRepository, podRepository, groupRepository,
           deploymentRepository, taskRepository, instanceRepository, taskFailureRepository,
           frameworkIdRepository, eventSubscribersRepository)
         StorageModuleImpl(

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -31,6 +31,7 @@ class Migration(
     private[migration] val legacyConfig: Option[LegacyStorageConfig],
     private[migration] val persistenceStore: Option[PersistenceStore[_, _, _]],
     private[migration] val appRepository: AppRepository,
+    private[migration] val podRepository: PodRepository,
     private[migration] val groupRepository: GroupRepository,
     private[migration] val deploymentRepository: DeploymentRepository,
     private[migration] val taskRepo: TaskRepository,
@@ -109,6 +110,11 @@ class Migration(
       StorageVersions(1, 4, 2, StorageVersion.StorageFormat.PERSISTENCE_STORE) -> { () =>
         new MigrationTo_1_4_2(appRepository).migrate().recover {
           case NonFatal(e) => throw new MigrationFailedException("while migrating storage to 1.4.2", e)
+        }
+      },
+      StorageVersions(1, 4, 6, StorageVersion.StorageFormat.PERSISTENCE_STORE) -> { () =>
+        new MigrationTo_1_4_6(appRepository, podRepository).migrate().recover {
+          case NonFatal(e) => throw new MigrationFailedException("while migrating storage to 1.4.6", e)
         }
       }
     )

--- a/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_6.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_6.scala
@@ -1,0 +1,112 @@
+package mesosphere.marathon.storage.migration.legacy
+
+import akka.Done
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Flow, Keep, Sink }
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.pod.PodDefinition
+import mesosphere.marathon.state._
+import mesosphere.marathon.storage.repository.{ AppRepository, PodRepository }
+
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Future }
+
+@SuppressWarnings(Array("ClassNames"))
+class MigrationTo_1_4_6(appRepository: AppRepository, podRepository: PodRepository)(implicit ctx: ExecutionContext, mat: Materializer) extends StrictLogging {
+
+  def migrate(): Future[Done] = {
+    logger.info("Starting migration to 1.4.6")
+
+    import MigrationTo_1_4_6.Environment
+
+    MigrationTo_1_4_6.migrateUnreachableApps(appRepository, podRepository)(Environment(sys.env), ctx, mat)
+  }
+}
+
+object MigrationTo_1_4_6 extends StrictLogging {
+  val MigrateUnreachableStrategyEnvVar = "MIGRATION_1_4_6_UNREACHABLE_STRATEGY"
+
+  case class Environment(vars: Map[String, String])
+
+  private def changeUnreachableStrategyForApps(app: AppDefinition): AppDefinition = {
+    app.copy(unreachableStrategy = changeUnreachableStrategy(app.unreachableStrategy))
+  }
+
+  private def changeUnreachableStrategyForPods(pod: PodDefinition): PodDefinition = {
+    pod.copy(unreachableStrategy = changeUnreachableStrategy(pod.unreachableStrategy))
+  }
+
+  /**
+    * When opting in to the unreachable migration step
+    * 1) all app and pod definitions that had a config of `UnreachableStrategy(300 seconds, 600 seconds)` (previous default) are migrated to have `UnreachableStrategy(0 seconds, 0 seconds)`
+    * 2) all app and pod definitions that had a config of `UnreachableStrategy(1 second, x seconds)` are migrated to have `UnreachableStrategy(0 seconds, x seconds)`
+    * 3) all app and pod definitions that had a config of `UnreachableStrategy(1 second, 2 seconds)` are migrated to have `UnreachableStrategy(0 seconds, 0 seconds)`
+    *
+    * @return migrated app
+    */
+  private def changeUnreachableStrategy(unreachableStrategy: UnreachableStrategy): UnreachableStrategy = {
+    unreachableStrategy match {
+      // migrate previous `hack` to achieve fastest replacement - case 3
+      case UnreachableEnabled(inactiveAfter, expungeAfter) if inactiveAfter == 1.seconds && expungeAfter == 2.seconds =>
+        UnreachableEnabled(0.seconds, 0.seconds)
+
+      // migrate previous `hack` to achieve fastest replacement, but keep unreachable task in state for a while - case 2
+      case UnreachableEnabled(inactiveAfter, expungeAfter) if inactiveAfter == 1.seconds =>
+        UnreachableEnabled(0.seconds, expungeAfter)
+
+      // migrate previous default - case 1
+      case UnreachableEnabled(inactiveAfter, expungeAfter) if inactiveAfter == UnreachableEnabled.DefaultInactiveAfter && expungeAfter == UnreachableEnabled.DefaultExpungeAfter =>
+        UnreachableEnabled(0.seconds, 0.seconds)
+    }
+  }
+
+  def migrateUnreachableApps(appRepository: AppRepository, podRepository: PodRepository)(implicit env: Environment, ctx: ExecutionContext, mat: Materializer): Future[Done] = {
+    val appSink =
+      Flow[AppDefinition]
+        .mapAsync(Int.MaxValue)(appRepository.store)
+        .toMat(Sink.ignore)(Keep.right)
+
+    val podSink =
+      Flow[PodDefinition]
+        .mapAsync(Int.MaxValue)(podRepository.store)
+        .toMat(Sink.ignore)(Keep.right)
+
+    val migrateUnreachableStrategyWanted = env.vars.getOrElse(MigrationTo_1_4_6.MigrateUnreachableStrategyEnvVar, "false")
+
+    if (migrateUnreachableStrategyWanted == "true") {
+      appRepository.all()
+        .via(appMigrationFlow)
+        .runWith(appSink)
+        .andThen {
+          case _ =>
+            logger.info("Finished 1.4.6 migration for unreachable strategy for apps")
+        }
+      podRepository.all()
+        .via(podMigrationFlow)
+        .runWith(podSink)
+        .andThen {
+          case _ =>
+            logger.info("Finished 1.4.6 migration for unreachable strategy for pod")
+        }
+    } else {
+      logger.info("No unreachable strategy migration to 1.4.6 wanted")
+      Future.successful(Done)
+    }
+  }
+
+  val appMigrationFlow =
+    Flow[AppDefinition]
+      .filter(_.unreachableStrategy != UnreachableDisabled)
+      .map { app =>
+        logger.info(s"Migrate unreachable strategy for app: ${app.id}")
+        changeUnreachableStrategyForApps(app)
+      }
+
+  val podMigrationFlow =
+    Flow[PodDefinition]
+      .filter(_.unreachableStrategy != UnreachableDisabled)
+      .map { pod =>
+        logger.info(s"Migrate unreachable strategy for pod: ${pod.id}")
+        changeUnreachableStrategyForPods(pod)
+      }
+}

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
@@ -25,6 +25,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen {
     legacyConfig: Option[LegacyStorageConfig] = None,
     persistenceStore: Option[PersistenceStore[_, _, _]] = None,
     appRepository: AppRepository = mock[AppRepository],
+    podRepository: PodRepository = mock[PodRepository],
     groupRepository: GroupRepository = mock[GroupRepository],
     deploymentRepository: DeploymentRepository = mock[DeploymentRepository],
     taskRepository: TaskRepository = mock[TaskRepository],
@@ -33,7 +34,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen {
     frameworkIdRepository: FrameworkIdRepository = mock[FrameworkIdRepository],
     eventSubscribersRepository: EventSubscribersRepository = mock[EventSubscribersRepository]): Migration = {
     groupRepository.invalidateGroupCache() returns Future.successful(Done)
-    new Migration(Set.empty, legacyConfig, persistenceStore, appRepository, groupRepository, deploymentRepository,
+    new Migration(Set.empty, legacyConfig, persistenceStore, appRepository, podRepository, groupRepository, deploymentRepository,
       taskRepository, instanceRepository, taskFailureRepository, frameworkIdRepository, eventSubscribersRepository)
   }
   // scalastyle:on

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo1_4_PersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo1_4_PersistenceStoreTest.scala
@@ -42,7 +42,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
     val frameworkIdRepository = FrameworkIdRepository.inMemRepository(persistenceStore)
     val eventSubscribersRepository = EventSubscribersRepository.inMemRepository(persistenceStore)
 
-    new Migration(Set.empty, legacyConfig, Some(persistenceStore), appRepository, groupRepository, deploymentRepository,
+    new Migration(Set.empty, legacyConfig, Some(persistenceStore), appRepository, podRepository, groupRepository, deploymentRepository,
       taskRepo, instanceRepo, taskFailureRepository, frameworkIdRepository, eventSubscribersRepository)
   }
 

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo_1_4_6_Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo_1_4_6_Test.scala
@@ -1,0 +1,61 @@
+package mesosphere.marathon
+package storage.migration
+
+import akka.Done
+import akka.stream.scaladsl.Source
+import akka.stream.{ ActorMaterializer, Materializer }
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.pod.PodDefinition
+import mesosphere.marathon.state._
+import mesosphere.marathon.storage.migration.legacy.MigrationTo_1_4_6
+import mesosphere.marathon.storage.migration.legacy.MigrationTo_1_4_6.Environment
+import mesosphere.marathon.storage.repository.{ AppRepository, PodRepository }
+import mesosphere.marathon.test.GroupCreation
+
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+
+class MigrationTo_1_4_6_Test extends AkkaUnitTest with GroupCreation with StrictLogging {
+
+  "Migration to 1.4.6" should {
+    "do nothing if env var is not configured" in new Fixture {
+      MigrationTo_1_4_6.migrateUnreachableApps(appRepository, podRepository)(env, ctx, mat)
+      verify(appRepository, never).all()
+      verify(appRepository, never).store(_: AppDefinition)
+      verify(podRepository, never).all()
+      verify(podRepository, never).store(_: PodDefinition)
+    }
+
+    "do migration if env var is configured" in new Fixture(Map(MigrationTo_1_4_6.MigrateUnreachableStrategyEnvVar -> "true")) {
+      MigrationTo_1_4_6.migrateUnreachableApps(appRepository, podRepository)(env, ctx, mat)
+      val targetApp = app.copy(unreachableStrategy = UnreachableEnabled(0.seconds, 5.seconds)) // case 2
+      val targetApp2 = app2.copy(unreachableStrategy = UnreachableEnabled(0.seconds, 0.seconds)) // case 1
+      val targetPod = pod.copy(unreachableStrategy = UnreachableEnabled(0.seconds, 0.seconds)) // case 3
+
+      logger.info(s"Migration app ($app, $app2) and pod ($pod)")
+      verify(appRepository, once).all()
+      verify(appRepository, once).store(targetApp)
+      verify(appRepository, once).store(targetApp2)
+
+      verify(podRepository, once).all()
+      verify(podRepository, once).store(targetPod)
+    }
+  }
+
+  private class Fixture(val environment: Map[String, String] = Map.empty) {
+    val appRepository: AppRepository = mock[AppRepository]
+    val podRepository: PodRepository = mock[PodRepository]
+    implicit lazy val env = Environment(environment)
+    implicit lazy val mat: Materializer = ActorMaterializer()
+    implicit lazy val ctx: ExecutionContextExecutor = system.dispatcher
+    val app = AppDefinition(PathId("/app"), unreachableStrategy = UnreachableEnabled(1.seconds, 5.seconds))
+    val app2 = AppDefinition(PathId("/app2"), unreachableStrategy = UnreachableEnabled())
+    val pod = PodDefinition(PathId("/pod"), unreachableStrategy = UnreachableEnabled(1.seconds, 2.seconds))
+    appRepository.all() returns Source(Seq(app, app2))
+    appRepository.store(any) returns Future.successful(Done)
+    podRepository.all() returns Source.single(pod)
+    podRepository.store(any) returns Future.successful(Done)
+  }
+
+}


### PR DESCRIPTION
Summary:
To change the `unreachableStrategy` of all apps and pods, you can define the environment parameter `MIGRATION_1_4_6_UNREACHABLE_STRATEGY` which leads to the following behavior during migration:

When opting in to the unreachable migration step
1) all app and pod definitions that had a config of `UnreachableStrategy(300 seconds, 600 seconds)` (previous default) are migrated to have `UnreachableStrategy(0 seconds, 0 seconds)`
2) all app and pod definitions that had a config of `UnreachableStrategy(1 second, x seconds)` are migrated to have `UnreachableStrategy(0 seconds, x seconds)`
3) all app and pod definitions that had a config of `UnreachableStrategy(1 second, 2 seconds)` are migrated to have `UnreachableStrategy(0 seconds, 0 seconds)`

Depends D963

Test Plan:
test migration manually
sbt test

Reviewers: zen-dog, jeschkies, jenkins, ichernetsky

Reviewed By: jeschkies, jenkins

Subscribers: meichstedt, marathon-dev, marathon-team

JIRA Issues: MARATHON_EE-1591

Differential Revision: https://phabricator.mesosphere.com/D970