### PR TITLE
Workaround for Mesos in Debian Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,21 +6,19 @@
 # It will reresolve all dependencies on every change (as opposed to Dockerfile.development)
 # but it ultimately results in a smaller docker image.
 #
-FROM openjdk:8-jdk
+FROM buildpack-deps:jessie-curl
 
 COPY . /marathon
 WORKDIR /marathon
 
-# TODO: line below starting touch /usr/local/bin/systemctl is a necessary hack for the installation
-# of mesos.  We need to find a better solution. https://jira.mesosphere.com/browse/MARATHON-7694
-
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
-    touch /usr/local/bin/systemctl && chmod +x /usr/local/bin/systemctl && \
+    echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
     echo "deb http://repos.mesosphere.com/debian jessie-unstable main" | tee /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     MESOS_VERSION=$(sed -n 's/^.*MesosDebian = "\(.*\)"/\1/p' </marathon/project/Dependencies.scala) && \
     apt-get update && \
+    apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java=20161107~bpo8+1 && \
     apt-get install --no-install-recommends -y --force-yes mesos=$MESOS_VERSION && \
     apt-get clean && \
     eval $(sed s/sbt.version/SBT_VERSION/ </marathon/project/build.properties) && \
@@ -29,8 +27,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
     cp /marathon/project/sbt /usr/local/bin && chmod +x /usr/local/bin/sbt && \
     sbt -Dsbt.log.format=false assembly && \
     mv $(find target -name 'marathon-assembly-*.jar' | sort | tail -1) ./ && \
-    rm -rf target/* ~/.sbt ~/.ivy2 && \
+    rm -rf project/target project/project/target plugin-interface/target target/* ~/.sbt ~/.ivy2 && \
     mv marathon-assembly-*.jar target && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 
 ENTRYPOINT ["./bin/start"]


### PR DESCRIPTION
openjdk:8-jdk has switched to Debian Stretch. However, there is not a
repository for Debian Stretch. We work-around by installing
libssl1.0.0 from Jessie backports.

See https://github.com/mesosphere/mesos-deb-packaging/issues/109