### PR TITLE
Fix `TaskUnreachableIntegrationTest` cherry-pick by matching appId string

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -158,7 +158,7 @@ class TaskUnreachableIntegrationTest extends AkkaIntegrationFunTest with Embedde
 
   def matchEvent(status: String, app: AppDefinition): CallbackEvent => Boolean = { event =>
     event.info.get("taskStatus").contains(status) &&
-      event.info.get("appId").contains(app.id)
+      event.info.get("appId").contains(app.id.toString)
   }
 
   def matchEvent(status: String, task: ITEnrichedTask): CallbackEvent => Boolean = { event =>


### PR DESCRIPTION
...instead of the `PathId`