### PR TITLE
[WIP] Update AgentInfo when launching on reservation

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -3,7 +3,8 @@ package core.instance.update
 
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.{ TaskCondition, Task }
+import mesosphere.marathon.core.instance.Instance.AgentInfo
+import mesosphere.marathon.core.task.{ Task, TaskCondition }
 import mesosphere.marathon.state.Timestamp
 import org.apache.mesos
 
@@ -42,7 +43,8 @@ object InstanceUpdateOperation {
     runSpecVersion: Timestamp,
     timestamp: Timestamp,
     status: Task.Status, // TODO(PODS): the taskStatus must be created for each task and not passed in here
-    hostPorts: Seq[Int]) extends InstanceUpdateOperation
+    hostPorts: Seq[Int],
+    agentInfo: AgentInfo) extends InstanceUpdateOperation
 
   /**
     * Describes an instance update.

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -97,7 +97,8 @@ object InstanceUpdater extends StrictLogging {
               since = op.timestamp
             ),
             tasksMap = Map(updatedTask.taskId -> updatedTask),
-            runSpecVersion = op.runSpecVersion
+            runSpecVersion = op.runSpecVersion,
+            agentInfo = op.agentInfo
           )
           val events = eventsGenerator.events(updated, task = None, op.timestamp, previousCondition = Some(instance.state.condition))
           InstanceUpdateEffect.Update(updated, oldState = Some(instance), events)

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -220,6 +220,7 @@ class InstanceOpFactoryImpl(
     val newTaskId = Task.Id.forResidentTask(currentTaskId)
     val (taskInfo, networkInfo) = new TaskBuilder(spec, newTaskId, config, runSpecTaskProc)
       .build(offer, resourceMatch, Some(volumeMatch))
+    val agentInfo = Instance.AgentInfo(offer)
     val stateOp = InstanceUpdateOperation.LaunchOnReservation(
       reservedInstance.instanceId,
       newTaskId,
@@ -230,7 +231,8 @@ class InstanceOpFactoryImpl(
         condition = Condition.Created,
         networkInfo = networkInfo
       ),
-      networkInfo.hostPorts)
+      networkInfo.hostPorts,
+      agentInfo)
 
     taskOperationFactory.launchOnReservation(taskInfo, stateOp, reservedInstance)
   }

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.core.instance.Instance.{ AgentInfo, InstanceState, Le
 import mesosphere.marathon.core.instance.update.{ InstanceUpdateOperation, InstanceUpdater }
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.state.NetworkInfoPlaceholder
+import mesosphere.marathon.core.task.state.{ AgentInfoPlaceholder, NetworkInfoPlaceholder }
 import mesosphere.marathon.state.{ PathId, Timestamp, UnreachableStrategy }
 import org.apache.mesos
 
@@ -111,7 +111,8 @@ case class TestInstanceBuilder(
       timestamp = now,
       runSpecVersion = instance.runSpecVersion,
       status = Task.Status(stagedAt = now, condition = Condition.Running, networkInfo = NetworkInfoPlaceholder()),
-      hostPorts = Seq.empty)
+      hostPorts = Seq.empty,
+      agentInfo = AgentInfoPlaceholder())
   }
 
   def stateOpExpunge() = InstanceUpdateOperation.ForceExpunge(instance.instanceId)

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
 import mesosphere.marathon.core.task.bus.{ MesosTaskStatusTestHelper, TaskStatusUpdateTestHelper }
-import mesosphere.marathon.core.task.state.{ NetworkInfoPlaceholder, TaskConditionMapping }
+import mesosphere.marathon.core.task.state.{ AgentInfoPlaceholder, NetworkInfoPlaceholder, TaskConditionMapping }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.{ Task, TaskCondition }
 import mesosphere.marathon.state.{ PathId, Timestamp }
@@ -47,7 +47,8 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
         runSpecVersion = Timestamp(0),
         timestamp = Timestamp(0),
         status = Task.Status(Timestamp(0), condition = Condition.Running, networkInfo = NetworkInfoPlaceholder()),
-        hostPorts = Seq.empty)).futureValue
+        hostPorts = Seq.empty,
+        agentInfo = AgentInfoPlaceholder())).futureValue
 
       When("call taskTracker.task")
       verify(instanceTracker).instance(notExistingInstanceId)

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.core.launcher.{ InstanceOp, OfferProcessorConfig, Tas
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.{ InstanceOpSource, InstanceOpWithSource, MatchedInstanceOps }
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.state.NetworkInfoPlaceholder
+import mesosphere.marathon.core.task.state.{ AgentInfoPlaceholder, NetworkInfoPlaceholder }
 import mesosphere.marathon.core.task.tracker.InstanceCreationHandler
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.MarathonTestHelper
@@ -147,7 +147,8 @@ class OfferProcessorImplTest extends UnitTest {
             runSpecVersion = clock.now(),
             timestamp = clock.now(),
             status = Task.Status(clock.now(), condition = Condition.Running, networkInfo = NetworkInfoPlaceholder()),
-            hostPorts = Seq.empty)
+            hostPorts = Seq.empty,
+            agentInfo = AgentInfoPlaceholder())
           val launch = f.launchWithNewTask(
             taskInfo,
             updateOperation,

--- a/src/test/scala/mesosphere/marathon/core/task/state/NetworkInfoPlaceholder.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/state/NetworkInfoPlaceholder.scala
@@ -2,7 +2,9 @@ package mesosphere.marathon
 package core.task.state
 
 import org.apache.mesos.Protos.NetworkInfo.IPAddress
-import NetworkInfoTestDefaults._
+import AgentTestDefaults._
+import mesosphere.marathon.core.instance.Instance.AgentInfo
+import org.apache.mesos
 
 /** NetworkInfo to use in tests if no specific values are required */
 object NetworkInfoPlaceholder {
@@ -13,8 +15,17 @@ object NetworkInfoPlaceholder {
 }
 
 /** Defaults for NetworkInfo to use in tests */
-object NetworkInfoTestDefaults {
+object AgentTestDefaults {
   val defaultHostName: String = "host.some"
+  val defaultAgentId: String = "agent-1"
   val defaultHostPorts: Seq[Int] = Nil
   val defaultIpAddresses: Seq[IPAddress] = Nil
+}
+
+object AgentInfoPlaceholder {
+  def apply(
+    host: String = defaultHostName,
+    agentId: Option[String] = Some(defaultAgentId),
+    attributes: Seq[mesos.Protos.Attribute] = Seq.empty
+  ): AgentInfo = AgentInfo(host, agentId, attributes)
 }


### PR DESCRIPTION
Background: When an agent (e.g. "agent-1") reboots, the `agentId` might change under certain circumstances (to, e.g. "agent-2"). If that agent's state contained dynamic reservations and persistent volumes, Marathon would not update the AgentInfo when launching a new instance based on these. As a result, the instance as reported via the Marathon API would still say "agent-1", when the actual task and the persistent volume would run on "agent-2"; the volume and task appear to be on different nodes.

This commit will update the AgentInfo for each LaunchOnReservation.

Fixes MARATHON-7707

(I'll provide a test and remove the WIP)