### PR TITLE
Update AgentInfo when launching on an existing reservation

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -90,8 +90,8 @@ object Instance {
     )
   }
 
-  def instancesById(tasks: Seq[Instance]): Map[Instance.Id, Instance] =
-    tasks.map(task => task.instanceId -> task)(collection.breakOut)
+  def instancesById(instances: Seq[Instance]): Map[Instance.Id, Instance] =
+    instances.map(instance => instance.instanceId -> instance)(collection.breakOut)
 
   /**
     * Describes the state of an instance which is an accumulation of task states.

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -2,7 +2,8 @@ package mesosphere.marathon.core.instance.update
 
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.{ TaskCondition, Task }
+import mesosphere.marathon.core.instance.Instance.AgentInfo
+import mesosphere.marathon.core.task.{ Task, TaskCondition }
 import mesosphere.marathon.state.Timestamp
 import org.apache.mesos
 
@@ -36,13 +37,28 @@ object InstanceUpdateOperation {
     override def possibleNewState: Option[Instance] = Some(instance)
   }
 
+  /**
+    * @param instanceId Designating the instance that shall be launched.
+    * @param newTaskId The id of the task that will be launched via Mesos
+    * @param runSpecVersion The runSpec version
+    * @param timestamp time
+    * @param status
+    * @param hostPorts the assigned hostPorts
+    * @param agentInfo The (possibly updated) AgentInfo based on the offer that was used to launch this task. There are
+    *                  times when an agent gets a new agentId after a reboot. There might have been a task using
+    *                  reservations and a persistent volume on agent-1 in the past. When agent-1 is rebooted and looses
+    *                  the task, Marathon might see the resources offered from agent-2 in the future - if the agent has
+    *                  been re-registered with that new ID. In order to report correct AgentInfo, it is now required in
+    *                  this message.
+    */
   case class LaunchOnReservation(
     instanceId: Instance.Id,
     newTaskId: Task.Id,
     runSpecVersion: Timestamp,
     timestamp: Timestamp,
     status: Task.Status, // TODO(PODS): the taskStatus must be created for each task and not passed in here
-    hostPorts: Seq[Int]) extends InstanceUpdateOperation
+    hostPorts: Seq[Int],
+    agentInfo: AgentInfo) extends InstanceUpdateOperation
 
   /**
     * Describes an instance update.

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -44,12 +44,11 @@ object InstanceUpdateOperation {
     * @param timestamp time
     * @param status
     * @param hostPorts the assigned hostPorts
-    * @param agentInfo The (possibly updated) AgentInfo based on the offer that was used to launch this task. There are
-    *                  times when an agent gets a new agentId after a reboot. There might have been a task using
-    *                  reservations and a persistent volume on agent-1 in the past. When agent-1 is rebooted and looses
-    *                  the task, Marathon might see the resources offered from agent-2 in the future - if the agent has
-    *                  been re-registered with that new ID. In order to report correct AgentInfo, it is now required in
-    *                  this message.
+    * @param agentInfo The (possibly updated) AgentInfo based on the offer that was used to launch this task, needed to
+    *                  keep an Instance's agentInfo updated when re-launching resident tasks. Until Mesos 1.4.0, an
+    *                  agent will get a new agentId after a host reboot. Further, in dynamic IP environments, the
+    *                  hostname could potentially change after a reboot (especially important to keep up-to-date in the
+    *                  context of unique hostname constraints).
     */
   case class LaunchOnReservation(
     instanceId: Instance.Id,

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -96,7 +96,9 @@ object InstanceUpdater extends StrictLogging {
               since = op.timestamp
             ),
             tasksMap = Map(updatedTask.taskId -> updatedTask),
-            runSpecVersion = op.runSpecVersion
+            runSpecVersion = op.runSpecVersion,
+            // The AgentInfo might have changed if the agent re-registered with a new ID after a reboot
+            agentInfo = op.agentInfo
           )
           val events = eventsGenerator.events(updated, task = None, op.timestamp, previousCondition = Some(instance.state.condition))
           InstanceUpdateEffect.Update(updated, oldState = Some(instance), events)

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -220,6 +220,10 @@ class InstanceOpFactoryImpl(
     val newTaskId = Task.Id.forResidentTask(currentTaskId)
     val (taskInfo, networkInfo) = new TaskBuilder(spec, newTaskId, config, runSpecTaskProc)
       .build(offer, resourceMatch, Some(volumeMatch))
+
+    // The agentId might have changed if the agent re-registered with a new ID after a reboot. In order to reflect
+    // this change, we recreate the AgentInfo each time we launch on an existing reservation.
+    val agentInfo = Instance.AgentInfo(offer)
     val stateOp = InstanceUpdateOperation.LaunchOnReservation(
       reservedInstance.instanceId,
       newTaskId,
@@ -230,7 +234,8 @@ class InstanceOpFactoryImpl(
         condition = Condition.Created,
         networkInfo = networkInfo
       ),
-      networkInfo.hostPorts)
+      networkInfo.hostPorts,
+      agentInfo)
 
     taskOperationFactory.launchOnReservation(taskInfo, stateOp, reservedInstance)
   }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -221,8 +221,8 @@ class InstanceOpFactoryImpl(
     val (taskInfo, networkInfo) = new TaskBuilder(spec, newTaskId, config, runSpecTaskProc)
       .build(offer, resourceMatch, Some(volumeMatch))
 
-    // The agentId might have changed if the agent re-registered with a new ID after a reboot. In order to reflect
-    // this change, we recreate the AgentInfo each time we launch on an existing reservation.
+    // The agentInfo could have possibly changed after a reboot. See the docs for
+    // InstanceUpdateOperation.LaunchOnReservation for more details
     val agentInfo = Instance.AgentInfo(offer)
     val stateOp = InstanceUpdateOperation.LaunchOnReservation(
       reservedInstance.instanceId,

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.core.instance.Instance.{ AgentInfo, InstanceState }
 import mesosphere.marathon.core.instance.update.{ InstanceUpdateOperation, InstanceUpdater }
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.state.NetworkInfoPlaceholder
+import mesosphere.marathon.core.task.state.{ AgentInfoPlaceholder, AgentTestDefaults, NetworkInfoPlaceholder }
 import mesosphere.marathon.state.{ PathId, Timestamp, UnreachableStrategy }
 import org.apache.mesos
 
@@ -117,7 +117,8 @@ case class TestInstanceBuilder(
       timestamp = now,
       runSpecVersion = instance.runSpecVersion,
       status = Task.Status(stagedAt = now, condition = Condition.Running, networkInfo = NetworkInfoPlaceholder()),
-      hostPorts = Seq.empty)
+      hostPorts = Seq.empty,
+      agentInfo = AgentInfoPlaceholder())
   }
 
   def stateOpExpunge() = InstanceUpdateOperation.ForceExpunge(instance.instanceId)
@@ -136,7 +137,7 @@ object TestInstanceBuilder {
     UnreachableStrategy.default()
   )
 
-  private val defaultAgentInfo = Instance.AgentInfo(host = "host.some", agentId = None, attributes = Seq.empty)
+  private val defaultAgentInfo = Instance.AgentInfo(host = AgentTestDefaults.defaultHostName, agentId = Some(AgentTestDefaults.defaultAgentId), attributes = Seq.empty)
 
   def newBuilder(runSpecId: PathId, now: Timestamp = Timestamp.now(), version: Timestamp = Timestamp.zero): TestInstanceBuilder = newBuilderWithInstanceId(Instance.Id.forRunSpec(runSpecId), now, version)
 

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.core.base.ConstantClock
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
 import mesosphere.marathon.core.task.bus.{ MesosTaskStatusTestHelper, TaskStatusUpdateTestHelper }
-import mesosphere.marathon.core.task.state.{ NetworkInfoPlaceholder, TaskConditionMapping }
+import mesosphere.marathon.core.task.state.{ AgentInfoPlaceholder, NetworkInfoPlaceholder, TaskConditionMapping }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.{ Task, TaskCondition }
 import mesosphere.marathon.state.{ PathId, Timestamp }
@@ -41,7 +41,8 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       newTaskId = Task.Id.forResidentTask(Task.Id.forRunSpec(f.notExistingInstanceId.runSpecId)), runSpecVersion = Timestamp(0),
       timestamp = Timestamp(0),
       status = Task.Status(Timestamp(0), condition = Condition.Running, networkInfo = NetworkInfoPlaceholder()),
-      hostPorts = Seq.empty)).futureValue
+      hostPorts = Seq.empty,
+      agentInfo = AgentInfoPlaceholder())).futureValue
 
     "call taskTracker.task" in { verify(f.instanceTracker).instance(f.notExistingInstanceId) }
     "result in a Failure" in { stateChange shouldBe a[InstanceUpdateEffect.Failure] }

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.core.launcher.{ InstanceOp, OfferProcessor, OfferProc
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.{ InstanceOpSource, InstanceOpWithSource, MatchedInstanceOps }
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.state.NetworkInfoPlaceholder
+import mesosphere.marathon.core.task.state.{ AgentInfoPlaceholder, NetworkInfoPlaceholder }
 import mesosphere.marathon.core.task.tracker.InstanceCreationHandler
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{ PathId, Timestamp }
@@ -124,10 +124,12 @@ class OfferProcessorImplTest extends MarathonSpec with GivenWhenThen with Mockit
         val dummyInstance = TestInstanceBuilder.newBuilder(appId).addTaskResidentReserved().getInstance()
         val updateOperation = InstanceUpdateOperation.LaunchOnReservation(
           instanceId = dummyInstance.instanceId,
-          newTaskId = Task.Id.forResidentTask(Task.Id(taskInfo.getTaskId)), runSpecVersion = clock.now(),
+          newTaskId = Task.Id.forResidentTask(Task.Id(taskInfo.getTaskId)),
+          runSpecVersion = clock.now(),
           timestamp = clock.now(),
           status = Task.Status(clock.now(), condition = Condition.Running, networkInfo = NetworkInfoPlaceholder()),
-          hostPorts = Seq.empty)
+          hostPorts = Seq.empty,
+          agentInfo = AgentInfoPlaceholder())
         val launch = f.launchWithNewTask(
           taskInfo,
           updateOperation,

--- a/src/test/scala/mesosphere/marathon/core/task/state/NetworkInfoPlaceholder.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/state/NetworkInfoPlaceholder.scala
@@ -2,7 +2,9 @@ package mesosphere.marathon
 package core.task.state
 
 import org.apache.mesos.Protos.NetworkInfo.IPAddress
-import NetworkInfoTestDefaults._
+import AgentTestDefaults._
+import mesosphere.marathon.core.instance.Instance.AgentInfo
+import org.apache.mesos
 
 /** NetworkInfo to use in tests if no specific values are required */
 object NetworkInfoPlaceholder {
@@ -13,8 +15,17 @@ object NetworkInfoPlaceholder {
 }
 
 /** Defaults for NetworkInfo to use in tests */
-object NetworkInfoTestDefaults {
+object AgentTestDefaults {
   val defaultHostName: String = "host.some"
+  val defaultAgentId: String = "agent-1"
   val defaultHostPorts: Seq[Int] = Nil
   val defaultIpAddresses: Seq[IPAddress] = Nil
+}
+
+object AgentInfoPlaceholder {
+  def apply(
+    host: String = defaultHostName,
+    agentId: Option[String] = Some(defaultAgentId),
+    attributes: Seq[mesos.Protos.Attribute] = Seq.empty
+  ): AgentInfo = AgentInfo(host, agentId, attributes)
 }

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -371,6 +371,15 @@ object MarathonTestHelper {
     ).addAllResources(persistentVolumeResources(taskId, localVolumeIds: _*)).build()
   }
 
+  def offerWithVolumes(taskId: Task.Id, hostname: String, agentId: String, localVolumeIds: Task.LocalVolumeId*) = {
+    MarathonTestHelper.makeBasicOffer(
+      reservation = Some(TaskLabels.labelsForTask(frameworkId, taskId)),
+      role = "test"
+    ).setHostname(hostname)
+      .setSlaveId(Mesos.SlaveID.newBuilder().setValue(agentId).build())
+      .addAllResources(persistentVolumeResources(taskId, localVolumeIds: _*)).build()
+  }
+
   def offerWithVolumesOnly(taskId: Task.Id, localVolumeIds: Task.LocalVolumeId*) = {
     MarathonTestHelper.makeBasicOffer()
       .clearResources()

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.Protos.Constraint.Operator
 import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.state.NetworkInfoTestDefaults
+import mesosphere.marathon.core.task.state.AgentTestDefaults
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo._
@@ -787,7 +787,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
   test("a Reserved instance prevents creation of another reservation when hostname constraint is set") {
     val offer = MarathonTestHelper.makeBasicOffer().
       addResources(MarathonTestHelper.scalarResource("disk", 1024.0)).
-      setHostname(NetworkInfoTestDefaults.defaultHostName).
+      setHostname(AgentTestDefaults.defaultHostName).
       build()
 
     val volume = PersistentVolume(
@@ -819,7 +819,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
   test("a Reserved instance DOES NOT prevent creation of another reservation when NO hostname constraint is set") {
     val offer = MarathonTestHelper.makeBasicOffer().
       addResources(MarathonTestHelper.scalarResource("disk", 1024.0)).
-      setHostname(NetworkInfoTestDefaults.defaultHostName).
+      setHostname(AgentTestDefaults.defaultHostName).
       build()
 
     val volume = PersistentVolume(


### PR DESCRIPTION
Summary:
When an agent (e.g. "agent-1") reboots, the agentId might change under certain circumstances (to, e.g. "agent-2"). If that agent's state contained dynamic reservations and persistent volumes, Marathon would not update the AgentInfo when launching a new instance based on these. As a result, the instance as reported via the Marathon API would still say "agent-1", when the actual task and the persistent volume would run on "agent-2"; the volume and task appear to be on different nodes.

This commit will update the AgentInfo for each LaunchOnReservation.

Test Plan: sbt test

Reviewers: jeschkies, zen-dog, kensipe

Subscribers: marathon-dev, marathon-team

JIRA Issues: MARATHON-7714

Backporting 1f73e96e to 1.4

Original Differential Revision: https://phabricator.mesosphere.com/D1002

Conflicts:
	src/main/scala/mesosphere/marathon/core/instance/Instance.scala
	src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
	src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
	src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala