### PR TITLE
Consider Reserved instances for validating constraints.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package core.launcher.impl
 
 import mesosphere.marathon.core.base.Clock
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance.{ AgentInfo, InstanceState }
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
@@ -20,18 +21,16 @@ import mesosphere.mesos.{ NoOfferMatchReason, PersistentVolumeMatcher, ResourceM
 import mesosphere.util.state.FrameworkId
 import org.apache.mesos.Protos.{ ExecutorInfo, TaskGroupInfo, TaskInfo }
 import org.apache.mesos.{ Protos => Mesos }
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 
 class InstanceOpFactoryImpl(
   config: MarathonConf,
   pluginManager: PluginManager = PluginManager.None)(implicit clock: Clock)
-    extends InstanceOpFactory {
+    extends InstanceOpFactory with StrictLogging {
 
   import InstanceOpFactoryImpl._
 
-  private[this] val log = LoggerFactory.getLogger(getClass)
   private[this] val taskOperationFactory = {
     val principalOpt = config.mesosAuthenticationPrincipal.get
     val roleOpt = config.mesosRole.get
@@ -43,7 +42,7 @@ class InstanceOpFactoryImpl(
     pluginManager.plugins[RunSpecTaskProcessor].toIndexedSeq)
 
   override def matchOfferRequest(request: InstanceOpFactory.Request): OfferMatchResult = {
-    log.debug("matchOfferRequest")
+    logger.debug("matchOfferRequest")
 
     request.runSpec match {
       case app: AppDefinition =>
@@ -139,10 +138,12 @@ class InstanceOpFactoryImpl(
 
       maybeVolumeMatch.map { volumeMatch =>
 
-        // we must not consider the volumeMatch's Reserved instance because that would lead to a violation of constraints
-        // by the Reserved instance that we actually want to launch
+        // The volumeMatch identified a specific instance that matches the volume's reservation labels.
+        // This is the instance we want to launch. However, when validating constraints, we need to exclude that one
+        // instance: it would be considered as an instance on that agent, and would violate e.g. a hostname:unique
+        // constraint although it is just a placeholder for the instance that will be launched.
         val instancesToConsiderForConstraints: Stream[Instance] =
-          instances.valuesIterator.toStream.filterNotAs(_.instanceId != volumeMatch.instance.instanceId)
+          instances.valuesIterator.toStream.filterAs(_.instanceId != volumeMatch.instance.instanceId)
 
         // resources are reserved for this role, so we only consider those resources
         val rolesToConsider = config.mesosRole.get.toSet
@@ -173,7 +174,7 @@ class InstanceOpFactoryImpl(
       // We can only reserve unreserved resources
       val rolesToConsider = Set(ResourceRole.Unreserved).intersect(configuredRoles)
       if (rolesToConsider.isEmpty) {
-        log.warn(s"Will never match for ${runSpec.id}. The runSpec is not configured to accept unreserved resources.")
+        logger.warn(s"Will never match for ${runSpec.id}. The runSpec is not configured to accept unreserved resources.")
       }
 
       val resourceMatchResponse =
@@ -190,7 +191,7 @@ class InstanceOpFactoryImpl(
     maybeLaunchOnReservation
       .orElse(maybeReserveAndCreateVolumes)
       .getOrElse {
-        log.warn("No need to reserve or launch and offer request isForResidentRunSpec")
+        logger.warn("No need to reserve or launch and offer request isForResidentRunSpec")
         OfferMatchResult.NoMatch(app, request.offer,
           Seq(NoOfferMatchReason.NoCorrespondingReservationFound), clock.now())
       }

--- a/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package integration
 
-import mesosphere.{ AkkaIntegrationFunTest, IntegrationTag }
+import mesosphere.AkkaIntegrationFunTest
 import mesosphere.marathon.api.v2.json.AppUpdate
 import mesosphere.marathon.integration.facades.ITEnrichedTask
 import mesosphere.marathon.integration.facades.MarathonFacade._
@@ -218,37 +218,6 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationFunTest with EmbeddedMa
 
     And("all 5 tasks are of the new version")
     all.map(_.version).forall(_.contains(newVersion)) shouldBe true
-  }
-
-  /**
-    * FIXME (3043): implement the following tests. TASK_LOST can be induced when launching a task with permission:
-    *
-    * When a framework launches a task, “run_tasks” ACLs are checked to see if the framework
-    * (FrameworkInfo.principal) is authorized to run the task/executor as the given user. If not authorized,
-    * the launch is rejected and the framework gets a TASK_LOST.
-    *
-    * (From http://mesos.apache.org/documentation/latest/authorization/)
-    */
-
-  test("taskLostBehavior = RELAUNCH_AFTER_TIMEOUT, timeout = 10s", IntegrationTag) { f =>
-    Given("A resident app with 1 instance")
-    When("The task is lost")
-    Then("The task is not relaunched within the timeout")
-    And("The task is relaunched with a new Id after the timeout")
-  }
-
-  test("taskLostBehavior = WAIT_FOREVER", IntegrationTag) { f =>
-    Given("A resident app with 1 instance")
-    When("The task is lost")
-    Then("No timeout is scheduled") // can we easily verify this?
-    And("The task is not relaunched") // can we verify this without waiting?
-  }
-
-  test("relaunchEscalationTimeoutSeconds = 5s", IntegrationTag) { f =>
-    Given("A resident app with 1 instance")
-    When("The task terminates")
-    And("We don't get an offer within the timeout")
-    Then("We launch a new task on any matching offer")
   }
 
   private[this] def test(testName: String, testTags: Tag*)(testFun: (Fixture) => Unit): Unit = {

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -5,6 +5,7 @@ import mesosphere.marathon.Protos.Constraint.Operator
 import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfoTestDefaults
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo._
@@ -36,7 +37,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       portDefinitions = PortDefinitions(0, 0)
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
     val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
@@ -56,7 +57,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       portDefinitions = PortDefinitions(0, 0)
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
     val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
@@ -84,7 +85,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       ))
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
     val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
@@ -113,7 +114,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       ))
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
     val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
@@ -152,7 +153,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
 
     val resourceMatchResponse = ResourceMatcher.matchResources(
       offer, app,
-      runningInstances = Seq(), ResourceSelector.reservedWithLabels(Set(ResourceRole.Unreserved, "marathon"), labels))
+      knownInstances = Seq(), ResourceSelector.reservedWithLabels(Set(ResourceRole.Unreserved, "marathon"), labels))
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
     val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
@@ -183,7 +184,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
     // reserved resources with labels should not be matched by selector if don't match for reservation with labels
     ResourceMatcher.matchResources(
       offer, app,
-      runningInstances = Seq(), ResourceSelector.any(Set(ResourceRole.Unreserved, "marathon"))) shouldBe a[ResourceMatchResponse.NoMatch]
+      knownInstances = Seq(), ResourceSelector.any(Set(ResourceRole.Unreserved, "marathon"))) shouldBe a[ResourceMatchResponse.NoMatch]
   }
 
   test("dynamically reserved resources are matched if they have no labels") {
@@ -211,7 +212,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
 
     val resourceMatchResponse = ResourceMatcher.matchResources(
       offer, app,
-      runningInstances = Seq(), ResourceSelector.any(Set(ResourceRole.Unreserved, "marathon")))
+      knownInstances = Seq(), ResourceSelector.any(Set(ResourceRole.Unreserved, "marathon")))
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
     val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
@@ -266,7 +267,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
 
     val resourceMatchResponse = ResourceMatcher.matchResources(
       offer, app,
-      runningInstances = Seq(), ResourceSelector.any(Set(ResourceRole.Unreserved, "marathon")))
+      knownInstances = Seq(), ResourceSelector.any(Set(ResourceRole.Unreserved, "marathon")))
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
   }
@@ -291,7 +292,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
 
     val resourceMatchResponse = ResourceMatcher.matchResources(
       offer, app,
-      runningInstances = Seq(), ResourceSelector.reservedWithLabels(Set(ResourceRole.Unreserved, "marathon"), Map("some" -> "label"))
+      knownInstances = Seq(), ResourceSelector.reservedWithLabels(Set(ResourceRole.Unreserved, "marathon"), Map("some" -> "label"))
     )
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
@@ -307,7 +308,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
 
     val resourceMatchResponse = ResourceMatcher.matchResources(
       offer, app,
-      runningInstances = Seq(), ResourceSelector.any(Set("marathon")))
+      knownInstances = Seq(), ResourceSelector.any(Set("marathon")))
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
     val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
@@ -327,7 +328,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
 
     val resourceMatchResponse = ResourceMatcher.matchResources(
       offer, app,
-      runningInstances = Seq(), unreservedResourceSelector)
+      knownInstances = Seq(), unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
   }
@@ -346,7 +347,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       )
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse should not be a[ResourceMatchResponse.NoMatch]
   }
@@ -365,7 +366,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       )
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
   }
@@ -378,7 +379,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       portDefinitions = PortDefinitions(0, 0)
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
   }
@@ -391,7 +392,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       portDefinitions = PortDefinitions(0, 0)
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
   }
@@ -409,7 +410,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       )
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
     val noMatch = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch]
@@ -426,7 +427,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       portDefinitions = PortDefinitions(0, 0)
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
   }
@@ -439,7 +440,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       portDefinitions = PortDefinitions(1, 2)
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
   }
@@ -452,7 +453,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       acceptedResourceRoles = Set("A", "B")
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, ResourceSelector.any(Set("A", "B")))
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, ResourceSelector.any(Set("A", "B")))
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
     val noMatch = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch]
@@ -468,7 +469,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       acceptedResourceRoles = Set(ResourceRole.Unreserved)
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
     val noMatch = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch]
@@ -483,7 +484,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0) // make sure it mismatches
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
     val noMatch = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch]
@@ -499,7 +500,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       acceptedResourceRoles = Set("A", "B")
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
     val noMatch = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch]
@@ -514,7 +515,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       resources = Resources(cpus = 2, mem = 2, disk = 2, gpus = 2) // make sure it mismatches
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
     val noMatch = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch]
@@ -531,7 +532,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       portDefinitions = PortDefinitions(1, 2) // this match fails
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
     val noMatch = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch]
@@ -548,7 +549,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
       portDefinitions = PortDefinitions(1, 2) // this would fail as well, but is not evaluated of the resource matcher
     )
 
-    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, runningInstances = Seq.empty, unreservedResourceSelector)
+    val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
     val noMatch = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch]
@@ -679,12 +680,12 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
 
     ResourceMatcher.matchResources(
       offerDisksTooSmall, app,
-      runningInstances = Seq(),
+      knownInstances = Seq(),
       ResourceSelector.reservable) shouldBe a[ResourceMatchResponse.NoMatch]
 
     val resourceMatchResponse = ResourceMatcher.matchResources(
       offerSufficeWithMultOffers, app,
-      runningInstances = Seq(),
+      knownInstances = Seq(),
       ResourceSelector.reservable)
 
     resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
@@ -722,12 +723,12 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
 
     ResourceMatcher.matchResources(
       offers("/mnt/disk-a"), app,
-      runningInstances = Seq(),
+      knownInstances = Seq(),
       ResourceSelector.reservable) shouldBe a[ResourceMatchResponse.NoMatch]
 
     ResourceMatcher.matchResources(
       offers("/mnt/disk-b"), app,
-      runningInstances = Seq(),
+      knownInstances = Seq(),
       ResourceSelector.reservable) shouldBe a[ResourceMatchResponse.Match]
   }
 
@@ -763,7 +764,7 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
 
     inside(ResourceMatcher.matchResources(
       offer, mountRequest(500, None),
-      runningInstances = Seq(),
+      knownInstances = Seq(),
       ResourceSelector.reservable)) {
       case matches: ResourceMatchResponse.Match =>
         matches.resourceMatch.scalarMatches.collectFirst {
@@ -774,13 +775,75 @@ class ResourceMatcherTest extends MarathonSpec with Matchers with Inside {
 
     ResourceMatcher.matchResources(
       offer, mountRequest(500, Some(750)),
-      runningInstances = Seq(),
+      knownInstances = Seq(),
       ResourceSelector.reservable) shouldBe a[ResourceMatchResponse.NoMatch]
 
     ResourceMatcher.matchResources(
       offer, mountRequest(500, Some(1024)),
-      runningInstances = Seq(),
+      knownInstances = Seq(),
       ResourceSelector.reservable) shouldBe a[ResourceMatchResponse.Match]
+  }
+
+  test("a Reserved instance prevents creation of another reservation when hostname constraint is set") {
+    val offer = MarathonTestHelper.makeBasicOffer().
+      addResources(MarathonTestHelper.scalarResource("disk", 1024.0)).
+      setHostname(NetworkInfoTestDefaults.defaultHostName).
+      build()
+
+    val volume = PersistentVolume(
+      containerPath = "/var/data",
+      mode = Mesos.Volume.Mode.RW,
+      persistent = PersistentVolumeInfo(
+        size = 500, `type` = DiskType.Root))
+
+    val app = AppDefinition(
+      id = "/test-persistent-volumes-with-unique-constraint".toRootPath,
+      instances = 3,
+      resources = Resources(cpus = 0.1, mem = 32.0, disk = 0.0),
+      constraints = Set(Constraint.newBuilder.setField("hostname").
+        setOperator(Constraint.Operator.UNIQUE).build),
+      container = Some(Container.Mesos(
+        volumes = List(volume))))
+
+    // Since offer matcher checks the instance version it's should be >= app.version
+    val instance = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskReserved(
+      Task.LocalVolumeId(app.id, volume))
+      .getInstance()
+
+    val response = ResourceMatcher.matchResources(
+      offer, app, knownInstances = Seq(instance), ResourceSelector.reservable)
+
+    response shouldBe a[ResourceMatchResponse.NoMatch]
+  }
+
+  test("a Reserved instance DOES NOT prevent creation of another reservation when NO hostname constraint is set") {
+    val offer = MarathonTestHelper.makeBasicOffer().
+      addResources(MarathonTestHelper.scalarResource("disk", 1024.0)).
+      setHostname(NetworkInfoTestDefaults.defaultHostName).
+      build()
+
+    val volume = PersistentVolume(
+      containerPath = "/var/data",
+      mode = Mesos.Volume.Mode.RW,
+      persistent = PersistentVolumeInfo(
+        size = 500, `type` = DiskType.Root))
+
+    val app = AppDefinition(
+      id = "/test-persistent-volumes-without-unique-constraint".toRootPath,
+      instances = 3,
+      resources = Resources(cpus = 0.1, mem = 32.0, disk = 0.0),
+      container = Some(Container.Mesos(
+        volumes = List(volume))))
+
+    // Since offer matcher checks the instance version it's should be >= app.version
+    val instance = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskReserved(
+      Task.LocalVolumeId(app.id, volume))
+      .getInstance()
+
+    val response = ResourceMatcher.matchResources(
+      offer, app, knownInstances = Seq(instance), ResourceSelector.reservable)
+
+    response shouldBe a[ResourceMatchResponse.Match]
   }
 
   val appId = PathId("/test")


### PR DESCRIPTION
Summary:
When matching offers for resident tasks, Marathon would not consider instances in state Reserved when validating constraints. This potentially resulted in multiple reservations on the same agent, even if a hostname: unique constraint was applied to the run spec. The problem boils down to the fact that the ResourceMatcher filtered for `instance.isLaunched` and only considered those instances. This was accidentally introduced via the fact that previously, instances which weren't launched had no runSpecVersion and therefore could not be compared to the last config change.

Compare 3bf03f86, which needed to access `_.launched` to compare the version. Deriving the need to check for `isLaunched` later was a wrong assumption.

While at it, StrictLogging has been introduced and unnecessary `if(xyzEnabled)` statements have been removed.

Added two unit tests for offer matching with unique constraints

Backporting df5e2e7c8424 onto 1.4

Test Plan: sbt test

JIRA Issues: MARATHON-7706, COPS-598

Original Differential Revision: https://phabricator.mesosphere.com/D1003

Conflicts:
	src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
	src/main/scala/mesosphere/mesos/ResourceMatcher.scala
	src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
	src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala