### PR TITLE
Increased timeout to make TestUnreachableIntegrationTest more stable.

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -146,7 +146,7 @@ class TaskUnreachableIntegrationTest extends AkkaIntegrationFunTest with Embedde
 
     Then("the replacement task is running")
     // wait not longer than 1 second, because it should be replaced even faster
-    waitForEventMatching("Replacement task is declared running", 1.seconds) {
+    waitForEventMatching("Replacement task is declared running", 6.seconds) {
       matchEvent("TASK_RUNNING", app)
     }
 


### PR DESCRIPTION
Summary:
The change from 1 to 6 seconds timeout waiting for the TASK_RUNNING event is
needed, because the current mesos offer cycle is by accident to fall into this
1 second time frame. Therefore it is needed to enhance the timeout to a little
bit bigger than one offer cycle.
This will remove "No events matched <Replacement task is killed>" and make
TestUnreachableIntegrationTest more stable.

Test Plan: sbt "integration:test-only *TestUnreachableIntegrationTest"

Reviewers: jeschkies, kensipe, timcharper, jenkins

Reviewed By: jeschkies, kensipe, jenkins

Subscribers: marathon-dev, marathon-team

Differential Revision: https://phabricator.mesosphere.com/D1006