### PR TITLE
Do a better job at maintaining task failure rate limiting values per RunSpec

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -90,6 +90,9 @@ trait LaunchQueue {
   /** Reset the backoff delay for the given RunnableSpec. */
   def resetDelay(spec: RunSpec): Unit
 
+  /** Advance the reference time point of the delay for the given RunSpec */
+  def advanceDelay(spec: RunSpec): Unit
+
   /** Notify queue about InstanceUpdate */
   def notifyOfInstanceUpdate(update: InstanceChange): Future[Done]
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -96,6 +96,8 @@ private[launchqueue] class LaunchQueueDelegate(
   override def addDelay(spec: RunSpec): Unit = rateLimiterRef ! RateLimiterActor.AddDelay(spec)
 
   override def resetDelay(spec: RunSpec): Unit = rateLimiterRef ! RateLimiterActor.ResetDelay(spec)
+
+  override def advanceDelay(spec: RunSpec): Unit = rateLimiterRef ! RateLimiterActor.AdvanceDelay(spec)
 }
 
 private[impl] object LaunchQueueDelegate {

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
@@ -9,9 +9,9 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.state.PathId
-import scala.async.Async._
+import mesosphere.marathon.state.{ PathId, RunSpec }
 
+import scala.async.Async._
 import scala.concurrent.Future
 
 class NotifyRateLimiterStepImpl @Inject() (
@@ -27,27 +27,36 @@ class NotifyRateLimiterStepImpl @Inject() (
   override def name: String = "notifyRateLimiter"
 
   override def process(update: InstanceChange): Future[Done] = {
-    if (limitWorthy(update.condition)) {
-      notifyRateLimiter(update.runSpecId, update.instance.runSpecVersion.toOffsetDateTime)
-    } else {
-      Future.successful(Done)
+    update.condition match {
+      case condition if limitWorthy(condition) =>
+        notifyRateLimiter(update.runSpecId, update.instance.runSpecVersion.toOffsetDateTime, launchQueue.addDelay)
+      case condition if advanceWorthy(condition) =>
+        notifyRateLimiter(update.runSpecId, update.instance.runSpecVersion.toOffsetDateTime, launchQueue.advanceDelay)
+      case _ =>
+        Future.successful(Done)
     }
   }
 
   @SuppressWarnings(Array("all")) // async/await
-  private[this] def notifyRateLimiter(runSpecId: PathId, version: OffsetDateTime): Future[Done] = async {
-    val appFuture = groupManager.appVersion(runSpecId, version)
-    val podFuture = groupManager.podVersion(runSpecId, version)
-    val (app, pod) = (await(appFuture), await(podFuture))
-    app.foreach(launchQueue.addDelay)
-    pod.foreach(launchQueue.addDelay)
-    Done
-  }
+  private[this] def notifyRateLimiter(runSpecId: PathId, version: OffsetDateTime, fn: RunSpec => Unit): Future[Done] =
+    async {
+      val appFuture = groupManager.appVersion(runSpecId, version)
+      val podFuture = groupManager.podVersion(runSpecId, version)
+      val (app, pod) = (await(appFuture), await(podFuture))
+      app.foreach(fn)
+      pod.foreach(fn)
+      Done
+    }
 }
 
 private[steps] object NotifyRateLimiterStep {
   // A set of conditions that are worth rate limiting the associated runSpec
   val limitWorthy: Set[Condition] = Set(
     Condition.Dropped, Condition.Error, Condition.Failed, Condition.Gone, Condition.Finished
+  )
+
+  // A set of conditions that are worth advancing an existing delay of the corresponding runSpec
+  val advanceWorthy: Set[Condition] = Set(
+    Condition.Staging, Condition.Starting, Condition.Running, Condition.Created
   )
 }


### PR DESCRIPTION
Use maxLaunchDelay to determine what delays to GC.

In addition to that, on conditions like Running, Created, existing delays are
advanced to make sure that delays are applied to failures, and time taken by
provisioning containers doesn't get subtracted from them.

In the future we might implement removal of rate-limiting delays when
a corresponding RunSpec becomes healthy.

JIRA Issues: MARATHON-7696