### PR TITLE
Set a fixed ephemeral port range to avoid bing errors.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ node('JenkinsMarathonCI-Debian8') {
         }
         stage("Provision Jenkins Node") {
             sh "sudo -E ci/provision.sh"
+            sh "sudo -E ci/set_port_range.sh"
         }
         stageWithCommitStatus("1. Compile") {
           try {

--- a/ci/set_port_range.sh
+++ b/ci/set_port_range.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# See http://mesos.apache.org/documentation/latest/port-mapping-isolator/
+# and mesosphere.util.PortAllocator docs.
+echo "Ephemeral port range before: $(cat /proc/sys/net/ipv4/ip_local_port_range)"
+sysctl -w net.ipv4.ip_local_port_range="60001 61000"
+echo "Ephemeral port range after: $(cat /proc/sys/net/ipv4/ip_local_port_range)"

--- a/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package integration.setup
 
+import java.net.BindException
 import java.util.UUID
 import javax.inject.{ Inject, Named }
 import javax.ws.rs.core.Response
@@ -64,6 +65,7 @@ class ForwarderService {
   }
 
   private def start(trustStore: Seq[String] = Nil, args: Seq[String] = Nil): Unit = {
+    logger.info(s"Starting forwarder '${args.mkString(" ")}'")
     val java = sys.props.get("java.home").fold("java")(_ + "/bin/java")
     val cp = sys.props.getOrElse("java.class.path", "target/classes")
     val uuid = UUID.randomUUID().toString
@@ -73,8 +75,12 @@ class ForwarderService {
     val log = new ProcessLogger {
       def checkUp(s: String) = {
         logger.info(s)
-        if (!up.isCompleted && s.contains("ServerConnector@")) {
-          up.trySuccess(Done)
+        if (!up.isCompleted) {
+          if (s.contains("Started ServerConnector@")) {
+            up.trySuccess(Done)
+          } else if (s.contains("java.net.BindException: Address already in use")) {
+            up.tryFailure(new BindException("Address already in use"))
+          }
         }
       }
       override def out(s: => String): Unit = checkUp(s)
@@ -150,11 +156,13 @@ object ForwarderService {
   class ForwarderConf(args: Seq[String]) extends ScallopConf(args) with HttpConf with LeaderProxyConf
 
   def main(args: Array[String]): Unit = {
-    val service = args(0) match {
-      case "helloApp" =>
-        createHelloApp(args.tail: _*)
-      case "forwarder" =>
-        createForwarder(forwardToPort = args(1).toInt, args.drop(2): _*)
+    val service = args.toList match {
+      case "helloApp" :: tail =>
+        createHelloApp(tail: _*)
+      case "forwarder" :: port :: tail =>
+        createForwarder(forwardToPort = port.toInt, tail: _*)
+      case _ =>
+        throw new RuntimeException(s"Invlaid argumsents: ${args.mkString(" ")}")
     }
     service.startAsync().awaitRunning()
     service.awaitTerminated()
@@ -168,7 +176,7 @@ object ForwarderService {
 
   private def createForwarder(forwardToPort: Int, args: String*): Service = {
     val conf = createConf(args: _*)
-    log.info(s"Start forwarder on port  ${conf.httpPort()}, forwarding to $forwardToPort")
+    log.info(s"Start forwarder on port ${conf.httpPort()}, forwarding to $forwardToPort")
     startImpl(conf, new LeaderInfoModule(elected = false, leaderHostPort = Some(s"localhost:$forwardToPort")))
   }
 

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -261,7 +261,9 @@ trait MarathonTest extends Suite with StrictLogging with ScalaFutures with Befor
       }
     }
     val port = PortAllocator.ephemeralPort()
+    logger.info(s"Starting health check endpoint on port $port.")
     val server = Http().bindAndHandle(route, "localhost", port).futureValue
+    logger.info(s"Listening for health events on $port")
     logger.info(s"Listening for health events on $port")
     server
   }

--- a/src/test/scala/mesosphere/util/PortAllocator.scala
+++ b/src/test/scala/mesosphere/util/PortAllocator.scala
@@ -1,12 +1,76 @@
 package mesosphere.util
 
-import java.net.ServerSocket
+import java.net.{ InetSocketAddress, ServerSocket }
+import java.util.concurrent.atomic.AtomicInteger
 
-object PortAllocator {
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.annotation.tailrec
+import scala.util.{ Failure, Success, Try }
+
+object PortAllocator extends StrictLogging {
+
+  // https://en.wikipedia.org/wiki/Ephemeral_port
+  // The Internet Assigned Numbers Authority (IANA) suggests the range 49152 to 65535  for dynamic or private ports.
+  // Many Linux kernels use the port range 32768 to 61000.
+
+  // From http://mesos.apache.org/documentation/latest/port-mapping-isolator/
+  // Mesos provides two ranges of ports to containers:
+  //
+  // • OS allocated “ephemeral” ports are assigned by the OS in a range specified for each container by Mesos.
+  // • Mesos allocated “non-ephemeral” ports are acquired by a framework using the same Mesos resource offer mechanism
+  //   used for cpu, memory etc. for allocation to executors/tasks as required.
+  //
+  // Additionally, the host itself will require ephemeral ports for network communication. You need to configure these
+  // three non-overlapping port ranges on the host.
+
+  // We reserve 1000 ephemeral ports for Marathon/Zk/Mesos Master/Mesos Agent processes to listen on:
+  val EPHEMERAL_PORT_START = 32768
+  val EPHEMERAL_PORT_MAX = EPHEMERAL_PORT_START + 1000
+  // and use the rest of the range as ports resources for mesos agents to offer e.g. --resources="ports:[10000-110000]"
+  // IMPORTANT: These two ranges should NOT overlap with each other and with the operating system's ephemeral port range
+  // define in ci/set_port_range.sh!
+  val PORT_RANGE_START = EPHEMERAL_PORT_MAX + 1
+  val PORT_RANGE_MAX = 60000 // 60001 - 61000 is reserved for port 0 random allocation. See ci/set_port_range.sh.
+
+  // We use 2 different atomic counters: one for ephemeral ports and one for port ranges.
+  private val ephemeralPorts: AtomicInteger = new AtomicInteger(EPHEMERAL_PORT_START)
+  private val rangePorts: AtomicInteger = new AtomicInteger(PORT_RANGE_START)
+
+  // Make sure the same ephemeral port is not given out twice making port collisions less likely. We're iterating
+  // over ephemeral port range trying to open a socket and if successful return the port number. Should we ever run
+  // out of free ephemeral ports a RuntimeException is thrown.
+  @tailrec
+  private def freeSocket(): ServerSocket = {
+    def tryOpenSocket(port: Int): ServerSocket = {
+      val socket = new ServerSocket()
+      socket.setReuseAddress(false)
+      socket.bind(new InetSocketAddress("localhost", port))
+      socket
+    }
+
+    val port = ephemeralPorts.incrementAndGet()
+    if (port > EPHEMERAL_PORT_MAX) throw new RuntimeException("Out of ephemeral ports.")
+
+    Try(tryOpenSocket(port)) match {
+      case Success(socket) =>
+        // We can't return a port if we couldn't close it successfully: theoretically it would then
+        // stay bound until (after a timeout) the underlying OS decides that it's free. Hence we should
+        // return only successfully closed ports and retry if closing fails.
+        Try(socket.close()) match {
+          case Success(_) => socket
+          case Failure(ex) =>
+            logger.warn(s"Failed to close allocator's socket on port $port because: ${ex.getMessage}")
+            freeSocket()
+        }
+      case Failure(ex) =>
+        logger.warn(s"Failed to provide an ephemeral port $port because: ${ex.getMessage}. Will retry again...")
+        freeSocket()
+    }
+  }
+
   def ephemeralPort(): Int = {
-    val socket = new ServerSocket(0)
-    val port = socket.getLocalPort
-    socket.close()
-    port
+    val socket = freeSocket()
+    socket.getLocalPort
   }
 }


### PR DESCRIPTION
Summary:
We would sometimes see binding errors for the forwarder test services or the
health check endpoint. Mesos launches executor with port 0 thus an executor
could block the port for the mentioned services.

This change will set the port range for port 0 outside of the ports assigned to
our test services.

Note that `set_port_range.sh` as to be added to any loop.

Test Plan: loop

Reviewers: unterstein, zen-dog, ichernetsky, timcharper, kensipe, meln1k, jenkins

Reviewed By: zen-dog, timcharper, meln1k, jenkins

Subscribers: marathon-team, marathon-dev, jenkins

Differential Revision: https://phabricator.mesosphere.com/D1058