### PR TITLE
Add issue template pointing people towards JIRA

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## Head over to JIRA!
 
-Please note that we use JIRA for issue tracking and only keep GitHub issues around to not break existing links. Please prefer filing issues [directly in JIRA](https://jira.mesosphere.com/secure/CreateIssue!default.jspa?pid=10401).
+Please note that we use JIRA for issue tracking and only keep GitHub issues around to not break existing links. Please prefer filing issues [directly in JIRA](https://jira.mesosphere.com/secure/CreateIssue!default.jspa?pid=10401). Use `Improvement` or `Bug` depending on the context of your report. Also make sure to create the issue in project `MARATHON`, which is the preset as per the provided link.
 
 You can sign in to JIRA using Github or Google as identity providers.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Head over to JIRA!
+
+Please note that we use JIRA for issue tracking and only keep GitHub issues around to not break existing links. Please prefer filing issues [directly in JIRA](https://jira.mesosphere.com/secure/CreateIssue!default.jspa?pid=10401).
+
+You can sign in to JIRA using github or google as identity providers.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,4 +2,4 @@
 
 Please note that we use JIRA for issue tracking and only keep GitHub issues around to not break existing links. Please prefer filing issues [directly in JIRA](https://jira.mesosphere.com/secure/CreateIssue!default.jspa?pid=10401).
 
-You can sign in to JIRA using github or google as identity providers.
+You can sign in to JIRA using Github or Google as identity providers.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,5 +1,7 @@
 ## Head over to JIRA!
 
-Please note that we use JIRA for issue tracking and only keep GitHub issues around to not break existing links. Please prefer filing issues [directly in JIRA](https://jira.mesosphere.com/secure/CreateIssue!default.jspa?pid=10401). Use `Improvement` or `Bug` depending on the context of your report. Also make sure to create the issue in project `MARATHON`, which is the preset as per the provided link.
+Please note that we use JIRA for issue tracking and only keep GitHub issues around to not break existing links. Please prefer filing issues [directly in JIRA](https://jira.mesosphere.com/secure/CreateIssue!default.jspa?pid=10401).
+
+Use `Improvement` or `Bug` depending on the context of your report. Also make sure to create the issue in project `MARATHON`, which is the preset as per the provided link. You don't need to set any labels, components, or designate an assignee. Yet what helps us triaging your request is used version and environment, steps to reproduce, or any specific use case you have in mind.
 
 You can sign in to JIRA using Github or Google as identity providers.


### PR DESCRIPTION
Github issues are still enabled for reference and to keep links alive. Instead of having people write a nicely formatted issue in markdown syntax and then letting them see it being closed, locked and migrated to JIRA, we should directly hint that they might consider creating an issue directly in JIRA.

We should consider adding a pull request template as well, and move github related files to a `.github` folder later. See https://github.com/blog/2111-issue-and-pull-request-templates for reference.