### PR TITLE
Changed default of UnreachableEnabled to (0,0)

### DIFF
--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -825,12 +825,12 @@
             "inactiveAfterSeconds": {
               "type": "integer",
               "description": "If an instance is unreachable for longer than inactiveAfter seconds it is marked as inactive. This will trigger a new instance launch. The original task is not expunged yet. Must be less than expungeAfterSeconds.",
-              "minimum": 1
+              "minimum": 0
             },
             "expungeAfterSeconds": {
               "type": "number",
               "description": "If an instance is unreachable for longer than unreachableExpungeAfter seconds it will be expunged.  That means it will be killed if it ever comes back. Instances are usually marked as unreachable before they are expunged but they don't have to. This value is required to be greater than inactiveAfterSeconds.\n\nIf the instance has any persistent volumes associated with it, then they will be destroyed and associated data will be deleted.\n\nDefault is 7 days (604800 seconds).",
-              "minimum": 2
+              "minimum": 0
             }
           }
         }

--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -824,12 +824,12 @@
           "properties": {
             "inactiveAfterSeconds": {
               "type": "integer",
-              "description": "If an instance is unreachable for longer than inactiveAfter seconds it is marked as inactive. This will trigger a new instance launch. The original task is not expunged yet. Must be less than expungeAfterSeconds.",
+              "description": "If an instance is unreachable for longer than inactiveAfter seconds it is marked as inactive. This will trigger a new instance launch. The original task is not expunged yet. Must be less than or equal to expungeAfterSeconds.",
               "minimum": 0
             },
             "expungeAfterSeconds": {
               "type": "number",
-              "description": "If an instance is unreachable for longer than unreachableExpungeAfter seconds it will be expunged.  That means it will be killed if it ever comes back. Instances are usually marked as unreachable before they are expunged but they don't have to. This value is required to be greater than inactiveAfterSeconds.\n\nIf the instance has any persistent volumes associated with it, then they will be destroyed and associated data will be deleted.\n\nDefault is 7 days (604800 seconds).",
+              "description": "If an instance is unreachable for longer than expungeAfterSeconds it will be expunged.  That means it will be killed if it ever comes back. Instances are usually marked as unreachable before they are expunged but they don't have to. This value is required to be greater than inactiveAfterSeconds unless both are zero.\n\nIf the instance has any persistent volumes associated with it, then they will be destroyed and associated data will be deleted.\n\nDefault is 0 seconds.",
               "minimum": 0
             }
           }

--- a/docs/docs/rest-api/public/api/v2/types/unreachableStrategy.raml
+++ b/docs/docs/rest-api/public/api/v2/types/unreachableStrategy.raml
@@ -16,7 +16,7 @@ types:
         description: |
           If an instance is unreachable for longer than inactiveAfter seconds it is marked
           as inactive. This will trigger a new instance launch. The original task is not
-          expunged yet. Must be less than expungeAfterSeconds.
+          expunged yet. Must be less than or equal to expungeAfterSeconds.
 
           The default value is set to 0 seconds.
 
@@ -26,8 +26,8 @@ types:
         default: 0
         minimum: 0
         description: |
-          If an instance is unreachable for longer than unreachableExpungeAfter seconds it will be expunged.  That means
+          If an instance is unreachable for longer than expungeAfterSeconds it will be expunged.  That means
           it will be killed if it ever comes back. Instances are usually marked as unreachable before they are expunged
-          but they don't have to. This value is required to be greater than inactiveAfterSeconds.
+          but they don't have to. This value is required to be greater than or equal to inactiveAfterSeconds.
 
           The default value is set to 0 seconds.

--- a/docs/docs/rest-api/public/api/v2/types/unreachableStrategy.raml
+++ b/docs/docs/rest-api/public/api/v2/types/unreachableStrategy.raml
@@ -11,23 +11,23 @@ types:
       inactiveAfterSeconds?:
         type: integer
         format: int64
-        default: 300
+        default: 0
         minimum: 0
         description: |
           If an instance is unreachable for longer than inactiveAfter seconds it is marked
           as inactive. This will trigger a new instance launch. The original task is not
           expunged yet. Must be less than expungeAfterSeconds.
 
-          The default value is set to 5 minutes (300 seconds).
+          The default value is set to 0 seconds.
 
       expungeAfterSeconds?:
         type: integer
         format: int64
-        default: 600
+        default: 0
         minimum: 0
         description: |
           If an instance is unreachable for longer than unreachableExpungeAfter seconds it will be expunged.  That means
           it will be killed if it ever comes back. Instances are usually marked as unreachable before they are expunged
           but they don't have to. This value is required to be greater than inactiveAfterSeconds.
 
-          The default value is set to 10 minutes (600 seconds).
+          The default value is set to 0 seconds.

--- a/src/main/scala/mesosphere/marathon/state/UnreachableStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/state/UnreachableStrategy.scala
@@ -30,8 +30,8 @@ case class UnreachableEnabled(
       build
 }
 object UnreachableEnabled {
-  val DefaultInactiveAfter: FiniteDuration = 5.minutes
-  val DefaultExpungeAfter: FiniteDuration = 10.minutes
+  val DefaultInactiveAfter: FiniteDuration = 0.seconds
+  val DefaultExpungeAfter: FiniteDuration = 0.seconds
   val default = UnreachableEnabled()
 
   implicit val unreachableEnabledValidator = validator[UnreachableEnabled] { strategy =>

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.core.instance.update.{ InstanceUpdateOperation, Insta
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.{ AgentInfoPlaceholder, AgentTestDefaults, NetworkInfoPlaceholder }
-import mesosphere.marathon.state.{ PathId, Timestamp, UnreachableStrategy }
+import mesosphere.marathon.state.{ PathId, Timestamp, UnreachableEnabled, UnreachableStrategy }
 import org.apache.mesos
 
 import scala.collection.immutable.Seq
@@ -41,8 +41,9 @@ case class TestInstanceBuilder(
   def addTaskLost(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskLost(since, containerName).build()
 
-  def addTaskUnreachable(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
-    addTaskWithBuilder().taskUnreachable(since, containerName).build()
+  def addTaskUnreachable(since: Timestamp = now, containerName: Option[String] = None, unreachableStrategy: UnreachableStrategy = UnreachableEnabled()): TestInstanceBuilder =
+    this.copy(instance = instance.copy(unreachableStrategy = unreachableStrategy)) // we need to update the unreachable strategy first before adding an unreachable task
+      .addTaskWithBuilder().taskUnreachable(since, containerName).build()
 
   def addTaskUnreachableInactive(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskUnreachableInactive(since, containerName).build()

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -22,7 +22,7 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.core.task.state.TaskConditionMapping
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
+import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp, UnreachableEnabled }
 import mesosphere.marathon.test.MarathonTestHelper
 import org.mockito
 import org.mockito.{ ArgumentCaptor, Mockito }
@@ -206,10 +206,11 @@ class TaskLauncherActorTest extends AkkaUnitTest {
         .setOperator(Operator.UNIQUE)
         .setValue("")
         .build
-      val constraintApp: AppDefinition = f.app.copy(constraints = Set(uniqueConstraint))
+      val unreachableStrategy = UnreachableEnabled(5.minutes, 10.minutes)
+      val constraintApp: AppDefinition = f.app.copy(constraints = Set(uniqueConstraint), unreachableStrategy = unreachableStrategy)
       val offer = MarathonTestHelper.makeBasicOffer().build()
 
-      val lostInstance = TestInstanceBuilder.newBuilder(f.app.id).addTaskUnreachable().getInstance()
+      val lostInstance = TestInstanceBuilder.newBuilder(f.app.id).addTaskUnreachable(unreachableStrategy = unreachableStrategy).getInstance()
 
       Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(lostInstance))
       val captor = ArgumentCaptor.forClass(classOf[InstanceOpFactory.Request])

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -214,7 +214,7 @@ class TaskLauncherActorTest extends AkkaUnitTest {
 
       Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(lostInstance))
       val captor = ArgumentCaptor.forClass(classOf[InstanceOpFactory.Request])
-      // we're only interested in capturing the argument, so return value doesn't matte
+      // we're only interested in capturing the argument, so return value doesn't matter
       Mockito.when(instanceOpFactory.matchOfferRequest(captor.capture())).thenReturn(f.noMatchResult)
 
       val launcherRef = createLauncherRef(instances = 1, constraintApp)
@@ -227,6 +227,37 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       Mockito.verify(instanceTracker).instancesBySpecSync
       Mockito.verify(instanceOpFactory).matchOfferRequest(m.any())
       assert(captor.getValue.instanceMap.isEmpty)
+      verifyClean()
+    }
+
+    "Restart a replacement task for an unreachable task with default unreachableStrategy instantly" in new Fixture {
+      import mesosphere.marathon.Protos.Constraint.Operator
+
+      val uniqueConstraint = Protos.Constraint.newBuilder
+        .setField("hostname")
+        .setOperator(Operator.UNIQUE)
+        .setValue("")
+        .build
+      val constraintApp: AppDefinition = f.app.copy(constraints = Set(uniqueConstraint))
+      val offer = MarathonTestHelper.makeBasicOffer().build()
+
+      val lostInstance = TestInstanceBuilder.newBuilder(f.app.id).addTaskUnreachable().getInstance()
+
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(lostInstance))
+      val captor = ArgumentCaptor.forClass(classOf[InstanceOpFactory.Request])
+      // we're only interested in capturing the argument, so return value doesn't matter
+      Mockito.when(instanceOpFactory.matchOfferRequest(captor.capture())).thenReturn(f.noMatchResult)
+
+      val launcherRef = createLauncherRef(instances = 1, constraintApp)
+      launcherRef ! RateLimiterActor.DelayUpdate(constraintApp, clock.now())
+
+      val promise = Promise[MatchedInstanceOps]
+      launcherRef ! ActorOfferMatcher.MatchOffer(offer, promise)
+      promise.future.futureValue
+
+      Mockito.verify(instanceTracker).instancesBySpecSync
+      Mockito.verify(instanceOpFactory).matchOfferRequest(m.any())
+      assert(captor.getValue.instanceMap.size == 1) // we should have one replacement task scheduled already
       verifyClean()
     }
 


### PR DESCRIPTION
Summary:
Most users would expect the same behavior in terms of unreachable task as marathon had before introducing the unreachableStrategy.
Therefore this patch re-introduces the old behavior as default configuration.

Test Plan:
sbt test
sbt integration:test

JIRA Issues: MARATHON-7576

Differential Revision (abandoned): https://phabricator.mesosphere.com/D1072