### PR TITLE
Wait for Marathon to exit in integration tests.

### DIFF
--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/scheduler/SchedulerPlugin.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/scheduler/SchedulerPlugin.scala
@@ -9,7 +9,7 @@ import org.apache.mesos.Protos.Offer
   * Allows to use external logic to decline offers.
   */
 trait SchedulerPlugin extends Plugin {
- 
+
   /**
     * @return true if offer matches
     */

--- a/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
@@ -134,7 +134,7 @@ class ReelectionLeaderIntegrationTest extends LeaderIntegrationTest {
 
         And("the leader must have died")
         WaitTestSupport.waitUntil("the former leading marathon process dies", 30.seconds) { !leadingProcess.isRunning() }
-        leadingProcess.stop() // already stopped, but still need to clear old state
+        leadingProcess.stop().futureValue // already stopped, but still need to clear old state
 
         And("the leader must have changed")
         WaitTestSupport.waitUntil("the leader changes") {
@@ -198,7 +198,7 @@ class KeepAppsRunningDuringAbdicationIntegrationTest extends LeaderIntegrationTe
 
       And("the leader must have died")
       WaitTestSupport.waitUntil("the former leading marathon process dies", 30.seconds) { !leadingProcess.isRunning() }
-      leadingProcess.stop() // already stopped, but still need to clear old state
+      leadingProcess.stop().futureValue // already stopped, but still need to clear old state
 
       And("the leader must have changed")
       WaitTestSupport.waitUntil("the leader changes") {
@@ -274,7 +274,7 @@ class BackupRestoreIntegrationTest extends LeaderIntegrationTest {
 
       And("the leader must have died")
       WaitTestSupport.waitUntil("the former leading marathon process dies", 30.seconds) { !leadingProcess1.isRunning() }
-      leadingProcess1.stop() // already stopped, but still need to clear old state
+      leadingProcess1.stop().futureValue // already stopped, but still need to clear old state
 
       And("the leader must have changed")
       WaitTestSupport.waitUntil("the leader changes", 30.seconds) {
@@ -391,7 +391,7 @@ class DeleteAppAndBackupIntegrationTest extends LeaderIntegrationTest {
 
       And("the leader must have died")
       WaitTestSupport.waitUntil("the former leading marathon process dies", 30.seconds) { !leadingProcess.isRunning() }
-      leadingProcess.stop() // already stopped, but still need to clear old state
+      leadingProcess.stop().futureValue // already stopped, but still need to clear old state
 
       And("the leader must have changed")
       WaitTestSupport.waitUntil("the leader changes", 30.seconds) {
@@ -421,7 +421,7 @@ class DeleteAppAndBackupIntegrationTest extends LeaderIntegrationTest {
       WaitTestSupport.waitUntil("the former leading marathon process dies", 30.seconds) {
         !leadingProcess2.isRunning()
       }
-      leadingProcess2.stop() // already stopped, but still need to clear old state
+      leadingProcess2.stop().futureValue // already stopped, but still need to clear old state
 
       And("the leader must have changed")
       WaitTestSupport.waitUntil("the leader changes", 30.seconds) {

--- a/src/test/scala/mesosphere/marathon/integration/MarathonStartupIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MarathonStartupIntegrationTest.scala
@@ -32,7 +32,7 @@ class MarathonStartupIntegrationTest extends AkkaIntegrationTest
         conflictingMarathon.exitValue().get should be > 0 withClue (s"Conflicting Marathon exited with ${conflictingMarathon.exitValue()} instead of an error code > 0.")
       } finally {
         // Destroy process if it did not exit in time.
-        conflictingMarathon.stop()
+        conflictingMarathon.stop().futureValue
       }
     }
   }


### PR DESCRIPTION
Summary:
We destroy the Marathon process but did not wait for it to exit. This
created a race between Marathon shutting down and the test setup sending
a SIGKILL.

Test Plan: sbt integration:test

Reviewers: unterstein, zen-dog, ichernetsky, timcharper, kensipe, meln1k

Subscribers: marathon-team, marathon-dev, jenkins

Differential Revision: https://phabricator.mesosphere.com/D1046