### PR TITLE
Make pytest verbose and print full stack traces on errors

### DIFF
--- a/ci/system_integration.sh
+++ b/ci/system_integration.sh
@@ -16,6 +16,8 @@ TERM=velocity shakedown \
   --ssl-no-verify \
   --timeout 360000 \
   --pytest-option "--junitxml=shakedown.xml" \
+  --pytest-option --verbose \
+  --pytest-option --full-trace \
   --ssh-key-file "$CLI_TEST_SSH_KEY" \
   --dcos-url "$DCOS_URL" tests/system/test_marathon_root.py tests/system/test_marathon_universe.py
 


### PR DESCRIPTION
It is convenient to have more information when trying to understand
why SI tests fail by reading console output in Jenkins.