### PR TITLE
Use large instances instead of xlarge for SI tests.

### DIFF
--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -37,6 +37,7 @@ deployment_name: $DEPLOYMENT_NAME
 provider: aws
 aws_region: us-west-2
 template_parameters:
+    DefaultInstanceType: m4.large
     KeyName: default
     AdminLocation: 0.0.0.0/0
     PublicSlaveInstanceCount: 1


### PR DESCRIPTION
Summary:
The CloudFormation template's default is xlarge. We are supposed to use
large.

JIRA issue: MARATHON-7796