### PR TITLE
Create info controller for Akka HTTP layer.

### DIFF
--- a/docs/docs/rest-api/public/api/api.raml
+++ b/docs/docs/rest-api/public/api/api.raml
@@ -8,6 +8,7 @@ baseUri: ../
 uses:
   app: v2/types/app.raml
   error: v2/types/error.raml
+  info: v2/types/info.raml
   queue: v2/types/queue.raml
   group: v2/types/group.raml
   strings: v2/types/stringTypes.raml

--- a/docs/docs/rest-api/public/api/v2/examples/info.json
+++ b/docs/docs/rest-api/public/api/v2/examples/info.json
@@ -1,6 +1,7 @@
 {
   "name": "marathon",
   "version": "0.13.0-SNAPSHOT",
+  "buildref" : "unknown",
   "elected": true,
   "leader": "wrk.fritz.box:8080",
   "frameworkId": "80ba2050-bf0f-4472-a2f7-2636c4f7b8c8-0000",
@@ -14,15 +15,17 @@
     "local_port_max": 20000,
     "executor": "//cmd",
     "hostname": "wrk.fritz.box",
-    "webui_url": null,
-    "mesos_role": null,
+    "webui_url": "marathon.mesosphere.com/ui",
+    "mesos_role": "foo",
     "task_launch_timeout": 300000,
+    "task_reservation_timeout" : 20000,
     "reconciliation_initial_delay": 15000,
     "reconciliation_interval": 300000,
     "mesos_user": "matthias",
     "leader_proxy_connection_timeout_ms": 5000,
     "leader_proxy_read_timeout_ms": 10000,
-    "mesos_leader_ui_url": null
+    "features" : [ ],
+    "mesos_leader_ui_url": "mesos.mesosphere.com"
   },
   "zookeeper_config": {
     "zk": "zk://localhost:2181/marathon",
@@ -31,9 +34,7 @@
     "zk_session_timeout": 1800000,
     "zk_max_versions": 25
   },
-  "event_subscriber": null,
   "http_config": {
-    "assets_path": null,
     "http_port": 8080,
     "https_port": 8443
   }

--- a/docs/docs/rest-api/public/api/v2/info.raml
+++ b/docs/docs/rest-api/public/api/v2/info.raml
@@ -6,4 +6,5 @@ get:
       description: General configuration and runtime information about this Marathon instance.
       body:
         application/json:
+          type: info.MarathonInfo
           example: !include examples/info.json

--- a/docs/docs/rest-api/public/api/v2/types/info.raml
+++ b/docs/docs/rest-api/public/api/v2/types/info.raml
@@ -68,18 +68,18 @@ types:
         format: int64
       zk_max_versions:
         type: number
-        format: int64
+        format: int32
 
   HttpConfig:
     type: object
     properties:
       http_port:
         type: number
-        format: int64
+        format: int32
         minimum: 0
       https_port:
         type: number
-        format: int64
+        format: int32
         minimum: 0
 
   MarathonInfo:

--- a/docs/docs/rest-api/public/api/v2/types/info.raml
+++ b/docs/docs/rest-api/public/api/v2/types/info.raml
@@ -1,0 +1,105 @@
+types:
+  MarathonConfig:
+    type: object
+    properties:
+      master?:
+        type: string
+      failover_timeout?:
+        type: number
+        format: int64
+      framework_name?:
+        type: string
+      ha?:
+        type: boolean
+      checkpoint?:
+        type: boolean
+      local_port_min?:
+          type: number
+          format: int32
+      local_port_max?:
+          type: number
+          format: int32
+      executor?:
+        type: string
+      hostname?:
+        type: string
+      webui_url?:
+        type: string
+      mesos_role?:
+        type: string
+      task_launch_timeout?:
+        type: number
+        format: int64
+      task_reservation_timeout?:
+        type: number
+        format: int64
+      reconciliation_initial_delay?:
+        type: number
+        format: int64
+      reconciliation_interval?:
+        type: number
+        format: int64
+      mesos_user?:
+        type: string
+      leader_proxy_connection_timeout_ms?:
+        type: number
+        format: int32
+      leader_proxy_read_timeout_ms?:
+        type: number
+        format: int32
+      mesos_leader_ui_url?:
+        type: string
+      features:
+        type: string[]
+
+  ZooKeeperConfig:
+    type: object
+    properties:
+      zk:
+        type: string
+      zk_timeout:
+        type: number
+        format: int64
+      zk_connection_timeout:
+        type: number
+        format: int64
+      zk_session_timeout:
+        type: number
+        format: int64
+      zk_max_versions:
+        type: number
+        format: int64
+
+  HttpConfig:
+    type: object
+    properties:
+      http_port:
+        type: number
+        format: int64
+        minimum: 0
+      https_port:
+        type: number
+        format: int64
+        minimum: 0
+
+  MarathonInfo:
+    type: object
+    properties:
+      name:
+        type: string
+      version:
+        type: string
+      buildref:
+        type: string
+      elected:
+        type: boolean
+      leader?:
+        type: string
+      frameworkId?:
+        type: string
+      marathon_config:
+        type: MarathonConfig
+      zookeeper_config:
+        type: ZooKeeperConfig
+      http_config:
+        type: HttpConfig

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
@@ -19,6 +19,8 @@ import mesosphere.marathon.api.akkahttp.v2.{AppsController, EventsController, In
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.http.HttpRequestHandler
+import mesosphere.marathon.storage.StorageModule
+import mesosphere.util.state.MesosLeaderInfo
 
 class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
   override def configure(): Unit = {
@@ -36,6 +38,8 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     groupManager: GroupManager,
     pluginManager: PluginManager,
     marathonSchedulerService: MarathonSchedulerService,
+    storageModule: StorageModule,
+    mesosLeaderInfo: MesosLeaderInfo,
     appTasksRes: mesosphere.marathon.api.v2.AppTasksResource)(implicit
     actorSystem: ActorSystem,
     authenticator: Authenticator,
@@ -56,7 +60,7 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     val resourceController = new ResourceController
     val systemController = new SystemController(config)
     val eventsController = new EventsController(conf, eventBus)
-    val infoController = new InfoController()
+    val infoController = InfoController(mesosLeaderInfo, storageModule.frameworkIdRepository, conf)
     val pluginsController = new PluginsController(pluginManager.plugins[HttpRequestHandler], pluginManager.definitions)
     val v2Controller = new V2Controller(appsController, eventsController, pluginsController, infoController)
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
@@ -6,16 +6,16 @@ import java.time.Clock
 import akka.actor.ActorSystem
 import akka.event.EventStream
 import com.google.inject.AbstractModule
-import com.google.inject.{Provides, Scopes, Singleton}
+import com.google.inject.{ Provides, Scopes, Singleton }
 import com.typesafe.config.Config
 import mesosphere.chaos.http.HttpConf
-import mesosphere.marathon.api.{MarathonHttpService, TaskKiller}
+import mesosphere.marathon.api.{ MarathonHttpService, TaskKiller }
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.api.akkahttp.v2.{AppsController, EventsController, InfoController, PluginsController}
+import mesosphere.marathon.api.akkahttp.v2.{ AppsController, EventsController, InfoController, PluginsController }
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.http.HttpRequestHandler

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
@@ -6,16 +6,18 @@ import java.time.Clock
 import akka.actor.ActorSystem
 import akka.event.EventStream
 import com.google.inject.AbstractModule
-import com.google.inject.{ Provides, Scopes, Singleton }
+import com.google.inject.{Provides, Scopes, Singleton}
 import com.typesafe.config.Config
 import mesosphere.chaos.http.HttpConf
-import mesosphere.marathon.api.MarathonHttpService
+import mesosphere.marathon.api.{MarathonHttpService, TaskKiller}
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.api.akkahttp.v2.{ AppsController, EventsController, PluginsController }
+import mesosphere.marathon.api.akkahttp.v2.{AppsController, EventsController, InfoController, PluginsController}
+import mesosphere.marathon.core.health.HealthCheckManager
+import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.http.HttpRequestHandler
 
 class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
@@ -54,8 +56,9 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     val resourceController = new ResourceController
     val systemController = new SystemController(config)
     val eventsController = new EventsController(conf, eventBus)
+    val infoController = new InfoController()
     val pluginsController = new PluginsController(pluginManager.plugins[HttpRequestHandler], pluginManager.definitions)
-    val v2Controller = new V2Controller(appsController, eventsController, pluginsController)
+    val v2Controller = new V2Controller(appsController, eventsController, pluginsController, infoController)
 
     new AkkaHttpMarathonService(
       conf,

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AuthDirectives.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AuthDirectives.scala
@@ -101,9 +101,9 @@ trait AuthDirectives extends AkkaDirectives {
 
 object AuthDirectives {
 
-  private[AuthDirectives] case object AuthServiceUnavailable extends Rejection
-  private[AuthDirectives] case class NotAuthorized(toResponse: HttpResponse) extends Rejection
-  private[AuthDirectives] case class NotAuthenticated(toResponse: HttpResponse) extends Rejection
+  private[akkahttp] case object AuthServiceUnavailable extends Rejection
+  private[akkahttp] case class NotAuthorized(toResponse: HttpResponse) extends Rejection
+  private[akkahttp] case class NotAuthenticated(toResponse: HttpResponse) extends Rejection
 
   def handleAuthRejections: PartialFunction[Rejection, Route] = {
     case AuthServiceUnavailable => Directives.complete(StatusCodes.ServiceUnavailable -> "Auth Service currently not available.")

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -11,7 +11,7 @@ import com.wix.accord.{ Failure, RuleViolation, Success, Validator }
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.appinfo.AppInfo
-import mesosphere.marathon.raml.{ LoggerChange, Metrics }
+import mesosphere.marathon.raml.{ LoggerChange, MarathonInfo, Metrics }
 import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.state.AppDefinition
 import play.api.libs.json._
@@ -105,6 +105,8 @@ object EntityMarshallers {
   implicit val wixResultMarshaller = playJsonMarshaller[com.wix.accord.Failure](Validation.failureWrites)
   implicit val messageMarshaller = playJsonMarshaller[Rejections.Message]
   implicit val appInfoMarshaller = playJsonMarshaller[AppInfo]
+  implicit val infoMarshaller = playJsonMarshaller[MarathonInfo]
+  implicit val infoUnmarshaller = playJsonUnmarshaller[MarathonInfo]
   implicit val metricsMarshaller = internalToRamlJsonMarshaller[TickMetricSnapshot, Metrics]
   implicit val loggerChangeMarshaller = playJsonMarshaller[LoggerChange]
   implicit val loggerChangeUnmarshaller = playJsonUnmarshaller[LoggerChange]

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/V2Controller.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/V2Controller.scala
@@ -18,14 +18,14 @@ class V2Controller(
     pathPrefix("apps") {
       appsController.route
     } ~
-    pathPrefix("events") {
-      eventsController.route
-    } ~
-    pathPrefix("plugins") {
-      pluginsController.route
-    } ~
-    pathPrefix("info") {
-      infoController.route
-    }
+      pathPrefix("events") {
+        eventsController.route
+      } ~
+      pathPrefix("plugins") {
+        pluginsController.route
+      } ~
+      pathPrefix("info") {
+        infoController.route
+      }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/V2Controller.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/V2Controller.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package api.akkahttp
 
 import akka.http.scaladsl.server.Route
-import v2.{ AppsController, EventsController, PluginsController }
+import v2.{ AppsController, EventsController, InfoController, PluginsController }
 
 /**
   * Dispatches to various v2 controller routes
@@ -10,18 +10,22 @@ import v2.{ AppsController, EventsController, PluginsController }
 class V2Controller(
     appsController: AppsController,
     eventsController: EventsController,
-    pluginsController: PluginsController
+    pluginsController: PluginsController,
+    infoController: InfoController
 ) extends Controller {
   import Directives._
   override val route: Route = {
     pathPrefix("apps") {
       appsController.route
     } ~
-      pathPrefix("events") {
-        eventsController.route
-      } ~
-      pathPrefix("plugins") {
-        pluginsController.route
-      }
+    pathPrefix("events") {
+      eventsController.route
+    } ~
+    pathPrefix("plugins") {
+      pluginsController.route
+    } ~
+    pathPrefix("info") {
+      infoController.route
+    }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
@@ -9,7 +9,6 @@ import mesosphere.marathon.plugin.auth.{ Authenticator, AuthorizedResource, Auth
 import mesosphere.marathon.raml.{ HttpConfig, MarathonConfig, MarathonInfo, ZooKeeperConfig }
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
 import mesosphere.util.state.MesosLeaderInfo
-import play.api.libs.json._
 
 import scala.async.Async._
 import scala.concurrent.ExecutionContext
@@ -33,7 +32,7 @@ case class InfoController(
     config.frameworkName.get,
     config.highlyAvailable.get,
     config.checkpoint.get,
-    config.localPortMax.get,
+    config.localPortMin.get,
     config.localPortMax.get,
     config.defaultExecutor.get,
     config.hostname.get,

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.api.akkahttp.Controller
 import mesosphere.marathon.core.election.ElectionService
-import mesosphere.marathon.plugin.auth.{Authenticator, AuthorizedResource, Authorizer, ViewResource}
+import mesosphere.marathon.plugin.auth.{ Authenticator, AuthorizedResource, Authorizer, ViewResource }
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
 import mesosphere.util.state.MesosLeaderInfo
 import play.api.libs.json._
@@ -13,14 +13,15 @@ import play.api.libs.json._
 import scala.async.Async._
 import scala.concurrent.ExecutionContext
 
-case class InfoController(mesosLeaderInfo: MesosLeaderInfo,
-  val frameworkIdRepository: FrameworkIdRepository,
-  val config: MarathonConf)(
-  implicit
-  val authenticator: Authenticator,
-  val authorizer: Authorizer,
-  val electionService: ElectionService,
-  val executionContext: ExecutionContext) extends Controller with StrictLogging {
+case class InfoController(
+    val mesosLeaderInfo: MesosLeaderInfo,
+    val frameworkIdRepository: FrameworkIdRepository,
+    val config: MarathonConf)(
+    implicit
+    val authenticator: Authenticator,
+    val authorizer: Authorizer,
+    val electionService: ElectionService,
+    val executionContext: ExecutionContext) extends Controller with StrictLogging {
 
   import mesosphere.marathon.api.akkahttp.Directives._
   import mesosphere.marathon.api.akkahttp.EntityMarshallers._
@@ -57,10 +58,10 @@ case class InfoController(mesosLeaderInfo: MesosLeaderInfo,
     "zk_max_versions" -> config.maxVersions()
   )
 
-//  lazy val httpConfigValues = Json.obj(
-//    "http_port" -> config.httpPort.get,
-//    "https_port" -> config.httpsPort.get
-//  )
+  //  lazy val httpConfigValues = Json.obj(
+  //    "http_port" -> config.httpPort.get,
+  //    "https_port" -> config.httpsPort.get
+  //  )
 
   def info(): Route =
     authenticated.apply { implicit identity =>
@@ -72,7 +73,8 @@ case class InfoController(mesosLeaderInfo: MesosLeaderInfo,
             // Current lead might change so we have to fetch it each time.
             val mesosLeaderUiUrl = Json.obj("mesos_leader_ui_url" -> mesosLeaderInfo.currentLeaderUrl)
 
-            Json.obj("name" -> BuildInfo.name,
+            Json.obj(
+              "name" -> BuildInfo.name,
               "name" -> BuildInfo.name,
               "version" -> BuildInfo.version,
               "buildref" -> BuildInfo.buildref,
@@ -81,7 +83,7 @@ case class InfoController(mesosLeaderInfo: MesosLeaderInfo,
               "frameworkId" -> frameworkId,
               "marathon_config" -> (marathonConfigValues ++ mesosLeaderUiUrl),
               "zookeeper_config" -> zookeeperConfigValues
-              //          "http_config" -> httpConfigValues)).build()
+            //          "http_config" -> httpConfigValues)).build()
             )
           }
         }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
@@ -5,23 +5,93 @@ import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.api.akkahttp.Controller
 import mesosphere.marathon.core.election.ElectionService
-import mesosphere.marathon.plugin.auth.{Authenticator, AuthorizedResource, Authorizer}
+import mesosphere.marathon.plugin.auth.{Authenticator, AuthorizedResource, Authorizer, ViewResource}
+import mesosphere.marathon.storage.repository.FrameworkIdRepository
+import mesosphere.util.state.MesosLeaderInfo
+import play.api.libs.json._
 
-class InfoController(implicit
+import scala.async.Async._
+import scala.concurrent.ExecutionContext
+
+case class InfoController(mesosLeaderInfo: MesosLeaderInfo,
+  val frameworkIdRepository: FrameworkIdRepository,
+  val config: MarathonConf)(
+  implicit
   val authenticator: Authenticator,
   val authorizer: Authorizer,
-  val electionService: ElectionService) extends Controller with StrictLogging {
+  val electionService: ElectionService,
+  val executionContext: ExecutionContext) extends Controller with StrictLogging {
 
   import mesosphere.marathon.api.akkahttp.Directives._
+  import mesosphere.marathon.api.akkahttp.EntityMarshallers._
 
-  def info(): Route = complete { ??? }
+  // Marathon configurations
+  val marathonConfigValues = Json.obj(
+    "master" -> config.mesosMaster.get,
+    "failover_timeout" -> config.mesosFailoverTimeout.get,
+    "framework_name" -> config.frameworkName.get,
+    "ha" -> config.highlyAvailable.get,
+    "checkpoint" -> config.checkpoint.get,
+    "local_port_min" -> config.localPortMin.get,
+    "local_port_max" -> config.localPortMax.get,
+    "executor" -> config.defaultExecutor.get,
+    "hostname" -> config.hostname.get,
+    "webui_url" -> config.webuiUrl.get,
+    "mesos_role" -> config.mesosRole.get,
+    "task_launch_timeout" -> config.taskLaunchTimeout.get,
+    "task_reservation_timeout" -> config.taskReservationTimeout.get,
+    "reconciliation_initial_delay" -> config.reconciliationInitialDelay.get,
+    "reconciliation_interval" -> config.reconciliationInterval.get,
+    "mesos_user" -> config.mesosUser.get,
+    "leader_proxy_connection_timeout_ms" -> config.leaderProxyConnectionTimeout.get,
+    "leader_proxy_read_timeout_ms" -> config.leaderProxyReadTimeout.get,
+    "features" -> config.availableFeatures
+  )
+
+  // ZooKeeper configurations
+  val zookeeperConfigValues = Json.obj(
+    "zk" -> s"zk://${config.zkHosts}${config.zkPath}",
+    "zk_timeout" -> config.zooKeeperTimeout(),
+    "zk_connection_timeout" -> config.zooKeeperConnectionTimeout(),
+    "zk_session_timeout" -> config.zooKeeperSessionTimeout(),
+    "zk_max_versions" -> config.maxVersions()
+  )
+
+//  lazy val httpConfigValues = Json.obj(
+//    "http_port" -> config.httpPort.get,
+//    "https_port" -> config.httpsPort.get
+//  )
+
+  def info(): Route =
+    authenticated.apply { implicit identity =>
+      authorized(ViewResource, AuthorizedResource.SystemConfig).apply {
+        complete {
+          async {
+            val frameworkId = await(frameworkIdRepository.get()).map(_.id)
+
+            // Current lead might change so we have to fetch it each time.
+            val mesosLeaderUiUrl = Json.obj("mesos_leader_ui_url" -> mesosLeaderInfo.currentLeaderUrl)
+
+            Json.obj("name" -> BuildInfo.name,
+              "name" -> BuildInfo.name,
+              "version" -> BuildInfo.version,
+              "buildref" -> BuildInfo.buildref,
+              "elected" -> electionService.isLeader,
+              "leader" -> electionService.leaderHostPort,
+              "frameworkId" -> frameworkId,
+              "marathon_config" -> (marathonConfigValues ++ mesosLeaderUiUrl),
+              "zookeeper_config" -> zookeeperConfigValues
+              //          "http_config" -> httpConfigValues)).build()
+            )
+          }
+        }
+      }
+    }
 
   override val route: Route = {
-    asLeader(electionService) {
-      get {
-        pathEnd {
-          info()
-        }
+    get {
+      pathEndOrSingleSlash {
+        info()
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
@@ -6,6 +6,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.api.akkahttp.Controller
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.plugin.auth.{ Authenticator, AuthorizedResource, Authorizer, ViewResource }
+import mesosphere.marathon.raml.{ HttpConfig, MarathonConfig, MarathonInfo, ZooKeeperConfig }
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
 import mesosphere.util.state.MesosLeaderInfo
 import play.api.libs.json._
@@ -26,42 +27,38 @@ case class InfoController(
   import mesosphere.marathon.api.akkahttp.Directives._
   import mesosphere.marathon.api.akkahttp.EntityMarshallers._
 
-  // Marathon configurations
-  val marathonConfigValues = Json.obj(
-    "master" -> config.mesosMaster.get,
-    "failover_timeout" -> config.mesosFailoverTimeout.get,
-    "framework_name" -> config.frameworkName.get,
-    "ha" -> config.highlyAvailable.get,
-    "checkpoint" -> config.checkpoint.get,
-    "local_port_min" -> config.localPortMin.get,
-    "local_port_max" -> config.localPortMax.get,
-    "executor" -> config.defaultExecutor.get,
-    "hostname" -> config.hostname.get,
-    "webui_url" -> config.webuiUrl.get,
-    "mesos_role" -> config.mesosRole.get,
-    "task_launch_timeout" -> config.taskLaunchTimeout.get,
-    "task_reservation_timeout" -> config.taskReservationTimeout.get,
-    "reconciliation_initial_delay" -> config.reconciliationInitialDelay.get,
-    "reconciliation_interval" -> config.reconciliationInterval.get,
-    "mesos_user" -> config.mesosUser.get,
-    "leader_proxy_connection_timeout_ms" -> config.leaderProxyConnectionTimeout.get,
-    "leader_proxy_read_timeout_ms" -> config.leaderProxyReadTimeout.get,
-    "features" -> config.availableFeatures
+  val marathonConfig = MarathonConfig(
+    config.mesosMaster.get,
+    config.mesosFailoverTimeout.get,
+    config.frameworkName.get,
+    config.highlyAvailable.get,
+    config.checkpoint.get,
+    config.localPortMax.get,
+    config.localPortMax.get,
+    config.defaultExecutor.get,
+    config.hostname.get,
+    config.webuiUrl.get,
+    config.mesosRole.get,
+    config.taskLaunchTimeout.get,
+    config.taskReservationTimeout.get,
+    config.reconciliationInitialDelay.get,
+    config.reconciliationInterval.get,
+    config.mesosUser.get,
+    config.leaderProxyConnectionTimeout.get,
+    config.leaderProxyReadTimeout.get,
+    mesosLeaderInfo.currentLeaderUrl,
+    config.availableFeatures.toIndexedSeq
   )
 
-  // ZooKeeper configurations
-  val zookeeperConfigValues = Json.obj(
-    "zk" -> s"zk://${config.zkHosts}${config.zkPath}",
-    "zk_timeout" -> config.zooKeeperTimeout(),
-    "zk_connection_timeout" -> config.zooKeeperConnectionTimeout(),
-    "zk_session_timeout" -> config.zooKeeperSessionTimeout(),
-    "zk_max_versions" -> config.maxVersions()
+  val zookeeperConfig = ZooKeeperConfig(
+    s"zk://${config.zkHosts}${config.zkPath}",
+    config.zooKeeperTimeout(),
+    config.zooKeeperConnectionTimeout(),
+    config.zooKeeperSessionTimeout(),
+    config.maxVersions()
   )
 
-  //  lazy val httpConfigValues = Json.obj(
-  //    "http_port" -> config.httpPort.get,
-  //    "https_port" -> config.httpsPort.get
-  //  )
+  val httpConfig = HttpConfig(8080, 8081)
 
   def info(): Route =
     authenticated.apply { implicit identity =>
@@ -70,20 +67,17 @@ case class InfoController(
           async {
             val frameworkId = await(frameworkIdRepository.get()).map(_.id)
 
-            // Current lead might change so we have to fetch it each time.
-            val mesosLeaderUiUrl = Json.obj("mesos_leader_ui_url" -> mesosLeaderInfo.currentLeaderUrl)
-
-            Json.obj(
-              "name" -> BuildInfo.name,
-              "name" -> BuildInfo.name,
-              "version" -> BuildInfo.version,
-              "buildref" -> BuildInfo.buildref,
-              "elected" -> electionService.isLeader,
-              "leader" -> electionService.leaderHostPort,
-              "frameworkId" -> frameworkId,
-              "marathon_config" -> (marathonConfigValues ++ mesosLeaderUiUrl),
-              "zookeeper_config" -> zookeeperConfigValues
-            //          "http_config" -> httpConfigValues)).build()
+            MarathonInfo(
+              BuildInfo.name,
+              BuildInfo.version,
+              BuildInfo.buildref,
+              electionService.isLeader,
+              electionService.leaderHostPort,
+              frameworkId,
+              // Current lead might change so we have to fetch it each time.
+              marathonConfig.copy(mesos_leader_ui_url = mesosLeaderInfo.currentLeaderUrl),
+              zookeeperConfig,
+              httpConfig
             )
           }
         }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
@@ -1,0 +1,28 @@
+package mesosphere.marathon
+package api.akkahttp.v2
+
+import akka.http.scaladsl.server.Route
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.api.akkahttp.Controller
+import mesosphere.marathon.core.election.ElectionService
+import mesosphere.marathon.plugin.auth.{Authenticator, AuthorizedResource, Authorizer}
+
+class InfoController(implicit
+  val authenticator: Authenticator,
+  val authorizer: Authorizer,
+  val electionService: ElectionService) extends Controller with StrictLogging {
+
+  import mesosphere.marathon.api.akkahttp.Directives._
+
+  def info(): Route = complete { ??? }
+
+  override val route: Route = {
+    asLeader(electionService) {
+      get {
+        pathEnd {
+          info()
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
@@ -3,6 +3,7 @@ package api.akkahttp.v2
 
 import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.api.akkahttp.Controller
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.plugin.auth.{ Authenticator, AuthorizedResource, Authorizer, ViewResource }
@@ -16,7 +17,7 @@ import scala.concurrent.ExecutionContext
 case class InfoController(
     val mesosLeaderInfo: MesosLeaderInfo,
     val frameworkIdRepository: FrameworkIdRepository,
-    val config: MarathonConf)(
+    val config: MarathonConf with HttpConf)(
     implicit
     val authenticator: Authenticator,
     val authorizer: Authorizer,
@@ -57,8 +58,9 @@ case class InfoController(
     config.maxVersions()
   )
 
-  val httpConfig = HttpConfig(8080, 8081)
+  val httpConfig = HttpConfig(config.httpPort(), config.httpsPort())
 
+  @SuppressWarnings(Array("all")) // async/await
   def info(): Route =
     authenticated.apply { implicit identity =>
       authorized(ViewResource, AuthorizedResource.SystemConfig).apply {

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
@@ -50,12 +50,12 @@ class InfoControllerTest extends UnitTest with ScalatestRouteTest with Inside {
             |    "local_port_min" : 10000,
             |    "local_port_max" : 20000,
             |    "executor" : "//cmd",
-            |    "hostname" : "Karstens-MacBook-Pro.local",
+            |    "hostname" : "heart.of.gold",
             |    "task_launch_timeout" : 300000,
             |    "task_reservation_timeout" : 20000,
             |    "reconciliation_initial_delay" : 15000,
             |    "reconciliation_interval" : 600000,
-            |    "mesos_user" : "kjeschkies",
+            |    "mesos_user" : "Adam Douglas",
             |    "leader_proxy_connection_timeout_ms" : 5000,
             |    "leader_proxy_read_timeout_ms" : 10000,
             |    "features" : [ ],
@@ -115,7 +115,7 @@ class InfoControllerTest extends UnitTest with ScalatestRouteTest with Inside {
   }
 
   class Fixture(authenticated: Boolean = true, authorized: Boolean = true) {
-    val config: MarathonConf = new ScallopConf(Seq("--master", "foo")) with MarathonConf {
+    val config: MarathonConf = new ScallopConf(Seq("--master", "foo", "--mesos_user", "Adam Douglas", "--hostname", "heart.of.gold")) with MarathonConf {
       verify()
     }
     val auth = new TestAuthFixture()

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
@@ -1,0 +1,124 @@
+package mesosphere.marathon
+package api.akkahttp.v2
+
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import mesosphere.UnitTest
+import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
+import mesosphere.marathon.api.akkahttp.AuthDirectives.{NotAuthenticated, NotAuthorized}
+import mesosphere.marathon.core.election.ElectionService
+import mesosphere.marathon.storage.repository.FrameworkIdRepository
+import mesosphere.util.state.{FrameworkId, MesosLeaderInfo}
+import org.rogach.scallop.ScallopConf
+import org.scalatest.Inside
+
+import scala.concurrent.Future
+
+class InfoControllerTest extends UnitTest with ScalatestRouteTest with Inside {
+
+  "InfoController" should {
+    "return all info" in {
+      Given("An authenticated request")
+      val f = new Fixture()
+      implicit val electionService = mock[ElectionService]
+      implicit val authenticator = f.auth.auth
+
+      electionService.leaderHostPort returns Some("80")
+      f.frameworkIdRepository.get() returns Future.successful(Some(FrameworkId("foobar")))
+      f.leaderInfo.currentLeaderUrl returns Some("leader")
+
+      val controller = new InfoController(f.leaderInfo, f.frameworkIdRepository, f.config)
+
+      When("we try to fetch the info")
+      Get(Uri./) ~> controller.route ~> check {
+        Then("we receive all info")
+        status should be(StatusCodes.OK)
+        val expected =
+          """{
+            |  "name" : "unknown",
+            |  "version" : "1.5.0-SNAPSHOT",
+            |  "buildref" : "unknown",
+            |  "elected" : false,
+            |  "leader" : "80",
+            |  "frameworkId" : "foobar",
+            |  "marathon_config" : {
+            |    "master" : "foo",
+            |    "failover_timeout" : 604800,
+            |    "framework_name" : "marathon",
+            |    "ha" : true,
+            |    "checkpoint" : true,
+            |    "local_port_min" : 10000,
+            |    "local_port_max" : 20000,
+            |    "executor" : "//cmd",
+            |    "hostname" : "Karstens-MacBook-Pro.local",
+            |    "webui_url" : null,
+            |    "mesos_role" : null,
+            |    "task_launch_timeout" : 300000,
+            |    "task_reservation_timeout" : 20000,
+            |    "reconciliation_initial_delay" : 15000,
+            |    "reconciliation_interval" : 600000,
+            |    "mesos_user" : "kjeschkies",
+            |    "leader_proxy_connection_timeout_ms" : 5000,
+            |    "leader_proxy_read_timeout_ms" : 10000,
+            |    "features" : [ ],
+            |    "mesos_leader_ui_url" : "leader"
+            |  },
+            |  "zookeeper_config" : {
+            |    "zk" : "zk://localhost:2181/marathon",
+            |    "zk_timeout" : 10000,
+            |    "zk_connection_timeout" : 10000,
+            |    "zk_session_timeout" : 10000,
+            |    "zk_max_versions" : 50
+            |  }
+            |}""".stripMargin
+        JsonTestHelper.assertThatJsonString(responseAs[String]).correspondsToJsonString(expected)
+      }
+    }
+
+    "deny access without authentication" in {
+      Given("An unauthenticated request")
+      val f = new Fixture(authenticated = false)
+      implicit val electionService = mock[ElectionService]
+      implicit val authenticator = f.auth.auth
+      val controller = new InfoController(f.leaderInfo, f.frameworkIdRepository, f.config)
+
+      When("we try to fetch the info")
+      Get(Uri./) ~> controller.route ~> check {
+        Then("we receive a NotAuthenticated response")
+        rejection shouldBe a[NotAuthenticated]
+        inside(rejection) { case NotAuthenticated(response) =>
+          response.status should be(StatusCodes.Forbidden)
+        }
+      }
+    }
+
+    "deny without authorization" in {
+      Given("An unauthorized request")
+      val f = new Fixture(authorized = false)
+      implicit val electionService = mock[ElectionService]
+      implicit val authenticator = f.auth.auth
+      val controller = new InfoController(f.leaderInfo, f.frameworkIdRepository, f.config)
+
+      When("we try to fetch the info")
+      Get(Uri./) ~> controller.route ~> check {
+        Then("we receive a NotAuthenticated response")
+        rejection shouldBe a[NotAuthorized]
+        inside(rejection) { case NotAuthorized(response) =>
+          response.status should be(StatusCodes.Unauthorized)
+        }
+      }
+    }
+  }
+
+  class Fixture(authenticated: Boolean = true, authorized: Boolean = true) {
+    val config: MarathonConf = new ScallopConf(Seq("--master", "foo")) with MarathonConf {
+      verify()
+    }
+    val auth = new TestAuthFixture()
+    auth.authenticated = authenticated
+    auth.authorized = authorized
+
+    val frameworkIdRepository = mock[FrameworkIdRepository]
+    val leaderInfo = mock[MesosLeaderInfo]
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
@@ -4,6 +4,7 @@ package api.akkahttp.v2
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import mesosphere.UnitTest
+import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.api.{ JsonTestHelper, TestAuthFixture }
 import mesosphere.marathon.api.akkahttp.AuthDirectives.{ NotAuthenticated, NotAuthorized }
 import mesosphere.marathon.core.election.ElectionService
@@ -115,7 +116,14 @@ class InfoControllerTest extends UnitTest with ScalatestRouteTest with Inside {
   }
 
   class Fixture(authenticated: Boolean = true, authorized: Boolean = true) {
-    val config: MarathonConf = new ScallopConf(Seq("--master", "foo", "--mesos_user", "Adam Douglas", "--hostname", "heart.of.gold")) with MarathonConf {
+    val options = Seq(
+      "--master", "foo",
+      "--mesos_user", "Adam Douglas",
+      "--hostname", "heart.of.gold",
+      "--http_port", "8080",
+      "--https_port", "8081"
+    )
+    val config = new ScallopConf(options) with MarathonConf with HttpConf {
       verify()
     }
     val auth = new TestAuthFixture()

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
@@ -51,8 +51,6 @@ class InfoControllerTest extends UnitTest with ScalatestRouteTest with Inside {
             |    "local_port_max" : 20000,
             |    "executor" : "//cmd",
             |    "hostname" : "Karstens-MacBook-Pro.local",
-            |    "webui_url" : null,
-            |    "mesos_role" : null,
             |    "task_launch_timeout" : 300000,
             |    "task_reservation_timeout" : 20000,
             |    "reconciliation_initial_delay" : 15000,
@@ -69,6 +67,10 @@ class InfoControllerTest extends UnitTest with ScalatestRouteTest with Inside {
             |    "zk_connection_timeout" : 10000,
             |    "zk_session_timeout" : 10000,
             |    "zk_max_versions" : 50
+            |  },
+            |  "http_config" : {
+            |    "http_port" : 8080,
+            |    "https_port" : 8081
             |  }
             |}""".stripMargin
         JsonTestHelper.assertThatJsonString(responseAs[String]).correspondsToJsonString(expected)

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
@@ -2,13 +2,13 @@ package mesosphere.marathon
 package api.akkahttp.v2
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import mesosphere.UnitTest
-import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
-import mesosphere.marathon.api.akkahttp.AuthDirectives.{NotAuthenticated, NotAuthorized}
+import mesosphere.marathon.api.{ JsonTestHelper, TestAuthFixture }
+import mesosphere.marathon.api.akkahttp.AuthDirectives.{ NotAuthenticated, NotAuthorized }
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
-import mesosphere.util.state.{FrameworkId, MesosLeaderInfo}
+import mesosphere.util.state.{ FrameworkId, MesosLeaderInfo }
 import org.rogach.scallop.ScallopConf
 import org.scalatest.Inside
 
@@ -86,8 +86,9 @@ class InfoControllerTest extends UnitTest with ScalatestRouteTest with Inside {
       Get(Uri./) ~> controller.route ~> check {
         Then("we receive a NotAuthenticated response")
         rejection shouldBe a[NotAuthenticated]
-        inside(rejection) { case NotAuthenticated(response) =>
-          response.status should be(StatusCodes.Forbidden)
+        inside(rejection) {
+          case NotAuthenticated(response) =>
+            response.status should be(StatusCodes.Forbidden)
         }
       }
     }
@@ -103,8 +104,9 @@ class InfoControllerTest extends UnitTest with ScalatestRouteTest with Inside {
       Get(Uri./) ~> controller.route ~> check {
         Then("we receive a NotAuthenticated response")
         rejection shouldBe a[NotAuthorized]
-        inside(rejection) { case NotAuthorized(response) =>
-          response.status should be(StatusCodes.Unauthorized)
+        inside(rejection) {
+          case NotAuthorized(response) =>
+            response.status should be(StatusCodes.Unauthorized)
         }
       }
     }

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.condition.Condition._
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{ Timestamp, UnreachableStrategy }
+import mesosphere.marathon.state.UnreachableStrategy
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 class InstanceTest extends UnitTest with TableDrivenPropertyChecks {

--- a/src/test/scala/mesosphere/marathon/integration/ForwardToLeaderIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ForwardToLeaderIntegrationTest.scala
@@ -6,7 +6,6 @@ import org.apache.commons.io.IOUtils
 import mesosphere.AkkaIntegrationTest
 import mesosphere.marathon.api.{ JavaUrlConnectionRequestForwarder, LeaderProxyFilter }
 import mesosphere.marathon.integration.setup._
-import mesosphere.marathon.io.IO
 import mesosphere.util.PortAllocator
 import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.time.{ Milliseconds, Seconds, Span }

--- a/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/PortWithRoleRandomPortsFromRangesTest.scala
@@ -2,14 +2,12 @@ package mesosphere.marathon
 package tasks
 
 import java.util
-import java.util.concurrent.TimeUnit
 
 import mesosphere.UnitTest
 import mesosphere.marathon.tasks.PortsMatcher.{ PortRange, PortWithRole }
 import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.Seq
-import scala.concurrent.duration.FiniteDuration
 import scala.util.Random
 
 class PortWithRoleRandomPortsFromRangesTest extends UnitTest {


### PR DESCRIPTION
Summary:
We add a simple info endpoint with authentication and authorization.

JIRA issues: MARATHON-7302
