### PR TITLE
Correct issue description for support page

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -9,8 +9,13 @@ title: Getting Support for Marathon
 Marathon is under constant development by the team at Mesosphere. The team keeps
 an eye on questions in a few places.
 
-### GitHub Issues
-Issues and feature requests can be filed through the [GitHub Issues page](https://github.com/mesosphere/marathon/issues).
+### Jira Issues
+We use JIRA for issue tracking and only keep GitHub issues around to not break existing links. Please file issues [directly in JIRA](https://jira.mesosphere.com/secure/CreateIssue!default.jspa?pid=10401).
+
+Use `Improvement` or `Bug` depending on the context of your report. Also make sure to create the issue in project `MARATHON`, which is the preset as per the provided link. You don't need to set any labels, components, or designate an assignee. Yet what helps us triaging your request is used version and environment, steps to reproduce, or any specific use case you have in mind.
+
+You can sign in to JIRA using Github or Google as identity providers.
+
 For all requests specific to the **Marathon UI**, we ask you to kindly supply
 the [`gui`](https://github.com/mesosphere/marathon/issues?q=is%3Aopen+is%3Aissue+label%3Agui) label.
 
@@ -26,7 +31,3 @@ questions.
 The
 ["**marathon**" Stack Overflow tag](https://stackoverflow.com/questions/tagged/marathon)
 is for specific questions that can be solved with a small amount of code.
-
-### Mesosphere UX Research
-
-If you'd like to take part in design research and test new features in Marathon before they're released, please add your name to our [UX Research](http://uxresearch.mesosphere.com) list.


### PR DESCRIPTION
Correct issue description for support page

Summary:
* Direct to JIRA instead of Github issues page
* Remove section about inactive UX research list
