### PR TITLE
Overall SI pod tests stabilisation

### DIFF
--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -1,4 +1,5 @@
 import os.path
+import uuid
 
 from utils import make_id, get_resource
 
@@ -30,8 +31,12 @@ def ucr_docker_http_server():
     return load_app('ucr-docker-http-server')
 
 
-def sleep_app():
-    return load_app('sleep-app')
+def sleep_app(app_id=None):
+    if app_id is None:
+        app_id = '/sleep-{}'.format(uuid.uuid4().hex)
+    app = load_app('sleep-app')
+    app['id'] = app_id
+    return app
 
 
 def docker_nginx_ssl():

--- a/tests/system/apps/sleep-app.json
+++ b/tests/system/apps/sleep-app.json
@@ -3,6 +3,6 @@
   "instances": 1,
   "cmd": "sleep 100000000",
   "cpus": 0.01,
-  "mem": 8,
+  "mem": 32,
   "disk": 0
 }

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -654,3 +654,23 @@ def agent_hostname_by_id(agent_id):
             return agent['hostname']
 
     return None
+
+
+def deployment_predicate(service_id=None):
+    deployments = marathon.create_client().get_deployments()
+    if (service_id is None):
+        return len(deployments) == 0
+    else:
+        filtered = [
+            deployment for deployment in deployments
+            if (service_id in deployment['affectedApps'] or service_id in deployment['affectedPods'])
+        ]
+        return len(filtered) == 0
+
+
+def deployment_wait(timeout=120, service_id=None):
+    """ Overriding default shakedown method to make it possible to wait
+        for specific pods in addition to apps. However we should probably fix
+        the dcos-cli and remove this method later.
+    """
+    shakedown.time_wait(lambda: deployment_predicate(service_id), timeout)

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -641,6 +641,7 @@ def test_pinned_task_does_not_scale_to_unpinned_host():
     """
 
     app_def = apps.sleep_app()
+    app_id = app['id']
     app_def['cpus'] = 3.5
     host = common.ip_other_than_mom()
     common.pin_to_host(app_def, host)
@@ -648,12 +649,12 @@ def test_pinned_task_does_not_scale_to_unpinned_host():
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait()
-    client.scale_app(app_def["id"], 2)
+    shakedown.deployment_wait(app_id=app_id)
+    client.scale_app(app_id, 2)
 
     time.sleep(5)
-    deployments = client.get_deployments()
-    tasks = client.get_tasks(app_def["id"])
+    deployments = client.get_deployments(app_id=app_id)
+    tasks = client.get_tasks(app_id)
 
     # still deploying
     assert len(deployments) == 1, "The number of deployments is {}, but 1 was expected".format(len(deployments))

--- a/tests/system/pods/__init__.py
+++ b/tests/system/pods/__init__.py
@@ -1,4 +1,5 @@
 import os.path
+import uuid
 
 from utils import make_id, get_resource
 
@@ -14,8 +15,12 @@ def load_pod(pod_name):
     return pod
 
 
-def simple_pod():
-    return load_pod('simple-pod')
+def simple_pod(pod_id=None):
+    if pod_id is None:
+        pod_id = '/simple-pod-{}'.format(uuid.uuid4().hex)
+    pod = load_pod('simple-pod')
+    pod['id'] = pod_id
+    return pod
 
 
 def private_docker_pod():

--- a/tests/system/pods/ports-pod.json
+++ b/tests/system/pods/ports-pod.json
@@ -15,7 +15,7 @@
         }
       },
       "resources": {
-        "cpus": 0.1,
+        "cpus": 0.5,
         "mem": 128,
         "disk": 0,
         "gpus": 0
@@ -51,7 +51,7 @@
         }
       },
       "resources": {
-        "cpus": 0.1,
+        "cpus": 0.5,
         "mem": 128,
         "disk": 0,
         "gpus": 0

--- a/tests/system/pods/test-pod.json
+++ b/tests/system/pods/test-pod.json
@@ -9,7 +9,7 @@
         }
       },
       "resources": {
-        "cpus": 0.1,
+        "cpus": 0.5,
         "mem": 32,
         "disk": 0,
         "gpus": 0
@@ -50,7 +50,7 @@
         }
       },
       "resources": {
-        "cpus": 0.1,
+        "cpus": 0.5,
         "mem": 32,
         "disk": 0,
         "gpus": 0

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -487,7 +487,7 @@ def test_app_file_based_secret(secret_fixture):
     app_def = {
         "id": app_id,
         "instances": 1,
-        "cpus": 0.1,
+        "cpus": 0.5,
         "mem": 64,
         "cmd": "cat {} >> {}_file && /opt/mesosphere/bin/python -m http.server $PORT_API".format(
             secret_container_path, secret_container_path),
@@ -542,7 +542,7 @@ def test_app_secret_env_var(secret_fixture):
     app_def = {
         "id": app_id,
         "instances": 1,
-        "cpus": 0.1,
+        "cpus": 0.5,
         "mem": 64,
         "cmd": "echo $SECRET_ENV >> $MESOS_SANDBOX/secret-env && /opt/mesosphere/bin/python -m http.server $PORT_API",
         "env": {
@@ -682,7 +682,7 @@ def test_pod_secret_env_var(secret_fixture):
         "containers": [{
             "name": "container-1",
             "resources": {
-                "cpus": 0.1,
+                "cpus": 0.5,
                 "mem": 64
             },
             "endpoints": [{
@@ -717,7 +717,7 @@ def test_pod_secret_env_var(secret_fixture):
 
     client = marathon.create_client()
     client.add_pod(pod_def)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=pod_id)
 
     instances = client.show_pod(pod_id)['instances']
     assert len(instances) == 1, 'Failed to start the secret environment variable pod'
@@ -744,7 +744,7 @@ def test_pod_file_based_secret(secret_fixture):
         "containers": [{
             "name": "container-1",
             "resources": {
-                "cpus": 0.1,
+                "cpus": 0.5,
                 "mem": 64
             },
             "endpoints": [{
@@ -781,7 +781,7 @@ def test_pod_file_based_secret(secret_fixture):
 
     client = marathon.create_client()
     client.add_pod(pod_def)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=pod_id)
 
     instances = client.show_pod(pod_id)['instances']
     assert len(instances) == 1, 'Failed to start the file based secret pod'


### PR DESCRIPTION
Summary:
- introduced `deployment_wait` method that can wait for specific `pod_id` and `marathon_pod_tests` are changed to use it
- `common.sleep_app()` and `sleep_pod()` are used multiple times across the tests - they are now setting a random `pod_id` and `app_id`
  since we're not always successful cleaning after tests
- tuned cpu usage for pod tests that use python http server - they now have `0.5` cpus (related to recent mesos cfs changes)

JIRA issues: MARATHON_EE-1654
