### PR TITLE
Upgrade wix-accord to 0.7.1

### DIFF
--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/validation/RunSpecValidator.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/validation/RunSpecValidator.scala
@@ -19,11 +19,11 @@ object RunSpecValidator {
       override def apply(seq: Iterable[T]): Result = {
 
         val violations = seq.view.map(item => (item, validator(item))).zipWithIndex.collect {
-          case ((item, f: Failure), pos: Int) => GroupViolation(item, "not valid", Some(s"($pos)"), f.violations)
+          case ((item, f: Failure), pos: Int) => GroupViolation(item, "not valid", f.violations, Descriptions.Indexed(pos.toLong))
         }
 
         if (violations.isEmpty) Success
-        else Failure(Set(GroupViolation(seq, "Seq contains elements, which are not valid.", None, violations.toSet)))
+        else Failure(Set(GroupViolation(seq, "Seq contains elements, which are not valid.", violations.toSet)))
       }
     }
   }
@@ -33,7 +33,7 @@ object RunSpecValidator {
     // into a shared validations subproject.
     import ViolationBuilder._
     override def apply(value: T): Result = {
-      if (test(value)) Success else RuleViolation(value, constraint(value), None)
+      if (test(value)) Success else RuleViolation(value, constraint(value))
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,6 @@ object Dependencies {
     Test.akkaHttpTestKit % "test",
     Test.junit % "test",
     Test.scalacheck % "test",
-    Test.wixAccordScalatest % "test",
     Test.curatorTest % "test"
   ) ++ Kamon.all).map(
     _.excludeAll(excludeSlf4jLog4j12)
@@ -191,7 +190,6 @@ object Dependency {
     val diffson = "org.gnieh" %% "diffson" % V.Diffson
     val junit = "junit" % "junit" % V.JUnit
     val scalacheck = "org.scalacheck" %% "scalacheck" % V.ScalaCheck
-    val wixAccordScalatest = "com.wix" %% "accord-scalatest" % V.WixAccord
     val curatorTest = "org.apache.curator" % "curator-test" % V.Curator
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -108,7 +108,7 @@ object Dependency {
     val MarathonApiConsole = "3.0.8-accept"
     val Logback = "1.1.3"
     val Logstash = "4.9"
-    val WixAccord = "0.5"
+    val WixAccord = "0.7.1"
     val Curator = "2.11.1"
     val Java8Compat = "0.8.0"
     val ScalaLogging = "3.5.0"

--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -64,16 +64,15 @@ trait RestResource {
     * See [[assumeValid]], which is preferred to this.
     *
     * @param t object to validate
-    * @param description optional description which might be injected into the failure message
     * @param fn function to execute after successful validation
     * @param validator validator to use
     * @tparam T type of object
     * @return returns a 422 response if there is a failure due to validation. Executes fn function if successful.
     */
-  protected def withValid[T](t: T, description: Option[String] = None)(fn: T => Response)(implicit validator: Validator[T]): Response = {
+  protected def withValid[T](t: T)(fn: T => Response)(implicit validator: Validator[T]): Response = {
     validator(t) match {
       case f: Failure =>
-        val entity = Json.toJson(description.map(f.withDescription).getOrElse(f)).toString
+        val entity = Json.toJson(f).toString
         Response.status(StatusCodes.UnprocessableEntity.intValue).entity(entity).build()
       case Success => fn(t)
     }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{ Rejection, RejectionError, Route }
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
-import com.wix.accord.Descriptions.Explicit
+import com.wix.accord.Descriptions.{ Generic, Path }
 import com.wix.accord.{ Failure, RuleViolation, Success, Validator }
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import mesosphere.marathon.api.v2.Validation
@@ -16,6 +16,8 @@ import mesosphere.marathon.raml.{ LoggerChange, MarathonInfo, Metrics }
 import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.state.AppDefinition
 import play.api.libs.json._
+
+import scala.collection.breakOut
 
 object EntityMarshallers {
   import Directives.complete
@@ -33,6 +35,18 @@ object EntityMarshallers {
   private val jsonStringMarshaller =
     Marshaller.stringMarshaller(`application/json`)
 
+  def jsErrorToFailure(error: JsError): Failure = Failure(
+    error.errors.flatMap {
+      case (path, validationErrors) =>
+        validationErrors.map { validationError =>
+          RuleViolation(
+            validationError.args.mkString(", "),
+            validationError.message,
+            path = Path(path.toString.split("/").filter(_ != "").map(Generic(_)): _*))
+        }
+    }(breakOut)
+  )
+
   /**
     * HTTP entity => `A`
     *
@@ -48,17 +62,9 @@ object EntityMarshallers {
       reads
         .reads(json)
         .recoverTotal {
-          case JsError(errors) =>
-            val violations = errors.flatMap {
-              case (path, validationErrors) =>
-                validationErrors.map { validationError =>
-                  RuleViolation(
-                    validationError.args.mkString(", "),
-                    validationError.message,
-                    path = Explicit(path.toString()))
-                }
-            }
-            throw RejectionError(ValidationFailed(Failure(violations.toSet)))
+          case error: JsError =>
+            throw RejectionError(
+              ValidationFailed(jsErrorToFailure(error)))
         }
     jsonStringUnmarshaller.map(data => read(Json.parse(data)))
   }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{ Rejection, RejectionError, Route }
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
+import com.wix.accord.Descriptions.Explicit
 import com.wix.accord.{ Failure, RuleViolation, Success, Validator }
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import mesosphere.marathon.api.v2.Validation
@@ -54,7 +55,7 @@ object EntityMarshallers {
                   RuleViolation(
                     validationError.args.mkString(", "),
                     validationError.message,
-                    Some(path.toString()))
+                    path = Explicit(path.toString()))
                 }
             }
             throw RejectionError(ValidationFailed(Failure(violations.toSet)))

--- a/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
@@ -80,7 +80,8 @@ trait Validation {
               case Success => accum
               case Failure(violations) =>
                 val scopedViolations = violations.map { violation =>
-                  violation.withPath(Generic(key) +: violation.path) }
+                  violation.withPath(Generic(key) +: violation.path)
+                }
                 accum.and(Failure(scopedViolations))
             }
         }
@@ -116,7 +117,8 @@ trait Validation {
               case Success => accum
               case Failure(violations) =>
                 val scopedViolations = violations.map { violation =>
-                  violation.withPath(Indexed(index.toLong) +: violation.path) }
+                  violation.withPath(Indexed(index.toLong) +: violation.path)
+                }
                 accum.and(Failure(scopedViolations))
             }
         }

--- a/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
@@ -3,9 +3,11 @@ package api.v2
 
 import java.net._
 
+import com.wix.accord.Descriptions._
 import com.wix.accord._
 import com.wix.accord.dsl._
 import com.wix.accord.ViolationBuilder._
+import mesosphere.marathon.api.v2.Validation.ConstraintViolation
 import mesosphere.marathon.state.FetchUri
 import mesosphere.marathon.stream.Implicits._
 import org.slf4j.LoggerFactory
@@ -13,7 +15,6 @@ import play.api.libs.json._
 
 import scala.collection.GenTraversableOnce
 import scala.util.matching.Regex
-
 import scala.language.implicitConversions
 
 // TODO(jdef) move this into package "validation"
@@ -35,7 +36,7 @@ trait Validation {
   def definedAnd[T](implicit validator: Validator[T]): Validator[Option[T]] = {
     new Validator[Option[T]] {
       override def apply(option: Option[T]): Result = option.map(validator).getOrElse(
-        Failure(Set(RuleViolation(None, "not defined", None)))
+        Failure(Set(RuleViolation(None, "not defined")))
       )
     }
   }
@@ -52,35 +53,45 @@ trait Validation {
     override def apply(t: T): Result = if (!b(t)) Success else validator(t)
   }
 
-  implicit def every[T](implicit validator: Validator[T]): Validator[Iterable[T]] = {
-    new Validator[Iterable[T]] {
-      override def apply(seq: Iterable[T]): Result = {
-
-        val violations: Set[Violation] = seq match {
-          case m: Map[_, _] =>
-            m.map(item => (item, validator(item))).collect {
-              case ((k, v), f: Failure) => GroupViolation(k, "not valid", Some(s"($k)"), f.violations)
-            }(collection.breakOut)
-          case _ =>
-            seq.map(item => (item, validator(item))).zipWithIndex.collect {
-              case ((item, f: Failure), pos: Int) => GroupViolation(item, "not valid", Some(s"($pos)"), f.violations)
-            }(collection.breakOut)
+  implicit def everyKeyValue[T](implicit validator: Validator[T]): Validator[Iterable[(String, T)]] = {
+    def mapViolation(violation: Violation, desc: Description): Violation = {
+      violation match {
+        case RuleViolation(value, constraint, path) =>
+          RuleViolation(value, constraint, desc +: path)
+        case GroupViolation(value, constraint, children, path) =>
+          GroupViolation(value, constraint, children, desc +: path)
+      }
+    }
+    new Validator[Iterable[(String, T)]] {
+      override def apply(seq: Iterable[(String, T)]): Result = {
+        seq.foldLeft[Result](Success) {
+          case (result, (key, value)) =>
+            validator(value) match {
+              case Success => result
+              case Failure(violations) => result.and(Failure(violations.map(mapViolation(_, Generic(key)))))
+            }
         }
-
-        if (violations.isEmpty) Success
-        else Failure(Set(GroupViolation(seq, "contains elements, which are not valid.", None, violations)))
       }
     }
   }
-
-  def mapDescription[T](change: String => String)(wrapped: Validator[T]): Validator[T] = new Validator[T] {
-    override def apply(value: T): Result = {
-      wrapped(value) match {
-        case Success => Success
-        case f: Failure =>
-          Failure(
-            f.violations.map(v => v.description.fold(v)(oldDescription => v.withDescription(change(oldDescription))))
-          )
+  implicit def every[T](implicit validator: Validator[T]): Validator[Iterable[T]] = {
+    def mapViolation(violation: Violation, desc: Description): Violation = {
+      violation match {
+        case RuleViolation(value, constraint, path) =>
+          RuleViolation(value, constraint, desc +: path)
+        case GroupViolation(value, constraint, children, path) =>
+          GroupViolation(value, constraint, children, desc +: path)
+      }
+    }
+    new Validator[Iterable[T]] {
+      override def apply(seq: Iterable[T]): Result = {
+        seq.zipWithIndex.foldLeft[Result](Success) {
+          case (result, (item, index)) =>
+            validator(item) match {
+              case Success => result
+              case Failure(violations) => result.and(Failure(violations.map(mapViolation(_, Indexed(index.toLong)))))
+            }
+        }
       }
     }
   }
@@ -102,63 +113,16 @@ trait Validation {
     Json.obj(
       "message" -> "Object is not valid",
       "details" -> {
-        f.violations
-          .flatMap(allRuleViolationsWithFullDescription(_))
-          .groupBy(_.description)
+        allViolations(f)
+          .groupBy(_.path)
           .map {
-            case (description, ruleViolation) =>
+            case (path, ruleViolations) =>
               Json.obj(
-                "path" -> description,
-                "errors" -> ruleViolation.map(r => JsString(r.constraint))
+                "path" -> path,
+                "errors" -> ruleViolations.map(_.constraint)
               )
           }
       })
-  }
-
-  // TODO: fix non-tail recursion
-  def allRuleViolationsWithFullDescription(
-    violation: Violation,
-    parentDesc: Option[String] = None,
-    prependSlash: Boolean = false): Set[RuleViolation] = {
-    def concatPath(parent: String, child: Option[String], slash: Boolean): String = {
-      child.map(c => parent + { if (slash) "/" else "" } + c).getOrElse(parent)
-    }
-
-    violation match {
-      case r: RuleViolation => Set(
-        parentDesc.map {
-          p =>
-            r.description.map {
-              // Error is on object level, having a parent description. Omit 'value', prepend '/' as root.
-              case "value" => r.withDescription("/" + p)
-              // Error is on property level, having a parent description. Prepend '/' as root.
-              case s: String =>
-                // This was necessary if you validate a sub field, e.g. volume.external.size is valid(...)
-                // generates a description containing "external.size".
-                val slashPath: Some[String] = Some(s.replace('.', '/'))
-                r.withDescription(concatPath("/" + p, slashPath, prependSlash))
-              // Error is on unknown level, having a parent description. Prepend '/' as root.
-            } getOrElse r.withDescription("/" + p)
-        } getOrElse {
-          r.withDescription(r.description.map {
-            // Error is on object level, having no parent description, being a root error.
-            case "value" => "/"
-            // Error is on property level, having no parent description, being a property of root error.
-            case s: String => "/" + s
-          } getOrElse "/")
-        })
-      case g: GroupViolation => g.children.flatMap { c =>
-        val dot = g.value match {
-          case _: Iterable[_] => false
-          case _ => true
-        }
-
-        val desc: Option[String] = parentDesc.map { p =>
-          concatPath(p, g.description, prependSlash)
-        }.orElse(g.description.map(d => concatPath("", Some(d), prependSlash)))
-        allRuleViolationsWithFullDescription(c, desc, dot)
-      }
-    }
   }
 
   def urlIsValid: Validator[String] = {
@@ -168,7 +132,7 @@ trait Validation {
           new URL(url)
           Success
         } catch {
-          case e: MalformedURLException => Failure(Set(RuleViolation(url, e.getMessage, None)))
+          case e: MalformedURLException => Failure(Set(RuleViolation(url, e.getMessage)))
         }
       }
     }
@@ -181,14 +145,14 @@ trait Validation {
           new URI(uri)
           Success
         } catch {
-          case _: URISyntaxException => Failure(Set(RuleViolation(uri, "URI has invalid syntax.", None)))
+          case _: URISyntaxException => Failure(Set(RuleViolation(uri, "URI has invalid syntax.")))
         }
       }
     }
   }
 
   def fetchUriIsValid: Validator[FetchUri] = validator[FetchUri] { fetch =>
-    fetch.uri is valid(uriIsValid)
+    fetch.uri is uriIsValid
   }
 
   def elementsAreUnique[A](errorMessage: String = "Elements must be unique."): Validator[Seq[A]] = {
@@ -225,7 +189,7 @@ trait Validation {
 
   private[this] def areUnique[A](seq: Seq[A], errorMessage: String): Result = {
     if (seq.size == seq.distinct.size) Success
-    else Failure(Set(RuleViolation(seq, errorMessage, None)))
+    else Failure(Set(RuleViolation(seq, errorMessage)))
   }
 
   def theOnlyDefinedOptionIn[A <: Product, B](product: A): Validator[Option[B]] =
@@ -241,7 +205,7 @@ trait Validation {
             if (n == 1)
               Success
             else
-              Failure(Set(RuleViolation(product, "not allowed in conjunction with other properties.", None)))
+              Failure(Set(RuleViolation(product, "not allowed in conjunction with other properties.")))
           case None => Success
         }
       }
@@ -274,7 +238,7 @@ trait Validation {
   def isTrue[T](constraint: T => String)(test: T => Boolean): Validator[T] = new Validator[T] {
     import ViolationBuilder._
     override def apply(value: T): Result = {
-      if (test(value)) Success else RuleViolation(value, constraint(value), None)
+      if (test(value)) Success else RuleViolation(value, constraint(value))
     }
   }
 
@@ -299,9 +263,41 @@ trait Validation {
     )
 
   def validateAll[T](x: T, all: Validator[T]*): Result = all.map(v => validate(x)(v)).fold(Success)(_ and _)
+
+  def allViolations(result: Result): Seq[ConstraintViolation] = {
+    def renderPath(desc: Description): String = desc match {
+      case Explicit(s) => s"/${s}"
+      case Generic(s) => s"/${s}"
+      case Indexed(index) => s"($index)"
+      case _ => ""
+    }
+    def mkPath(path: Path): String =
+      if (path.isEmpty)
+        "/"
+      else
+        path.map(renderPath).mkString("")
+
+    def collectViolation(violation: Violation, parents: Path): Seq[ConstraintViolation] = {
+      violation match {
+        case RuleViolation(_, constraint, path) => Seq(ConstraintViolation(mkPath(parents ++ path), constraint))
+        case GroupViolation(_, _, children, path) => children.to[Seq].flatMap(collectViolation(_, parents ++ path))
+      }
+    }
+    result match {
+      case Success => Seq.empty
+      case Failure(violations) =>
+        violations.to[Seq].flatMap(collectViolation(_, Nil))
+    }
+  }
 }
 
 object Validation extends Validation {
+
+  case class ConstraintViolation(path: String, constraint: String)
+
+  implicit class AsDescription(val optional: Option[String]) extends AnyVal {
+    def asDescription: Description = ??? //optional.fold[Description](Empty)(Explicit)
+  }
 
   def forAll[T](all: Validator[T]*): Validator[T] = new Validator[T] {
     override def apply(x: T): Result = validateAll(x, all: _*)

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -3,6 +3,7 @@ package api.v2.validation
 
 import java.util.regex.Pattern
 
+import com.wix.accord.Descriptions.{ Generic, Path }
 import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation.{ featureEnabled, _ }
@@ -54,7 +55,7 @@ trait AppValidation {
     val validDockerEngineSpec: Validator[DockerContainer] = validator[DockerContainer] { docker =>
       docker.image is notEmpty
       docker.pullConfig is isTrue("pullConfig is not supported with Docker containerizer")(_.isEmpty)
-      docker.portMappings is valid(optional(portMappingsValidator(networks)))
+      docker.portMappings is optional(portMappingsValidator(networks))
     }
     validator { (container: Container) =>
       container.docker is definedAnd(validDockerEngineSpec)
@@ -69,10 +70,10 @@ trait AppValidation {
     val validMesosEngineSpec: Validator[DockerContainer] = validator[DockerContainer] { docker =>
       docker.image is notEmpty
       docker.pullConfig is empty or featureEnabled(enabledFeatures, Features.SECRETS)
-      docker.pullConfig is optional(valid(validPullConfigSpec))
+      docker.pullConfig is optional(validPullConfigSpec)
     }
     validator { (container: Container) =>
-      container.docker is valid(definedAnd(validMesosEngineSpec))
+      container.docker is definedAnd(validMesosEngineSpec)
     }
   }
 
@@ -91,7 +92,7 @@ trait AppValidation {
       appc.id is optional(validId)
     }
     validator{ (container: Container) =>
-      container.appc is valid(definedAnd(validMesosEngineSpec))
+      container.appc is definedAnd(validMesosEngineSpec)
     }
   }
 
@@ -106,7 +107,7 @@ trait AppValidation {
         docker.credential is empty // credentials aren't supported this way anymore
       }
       validator[Container] { container =>
-        container.docker is optional(valid(oldDockerDockerContainerAPI))
+        container.docker is optional(oldDockerDockerContainerAPI)
       }
     }
     val forMesosContainerizer: Validator[Container] = {
@@ -117,7 +118,7 @@ trait AppValidation {
         docker.portMappings is empty
       }
       validator[Container] { container =>
-        container.docker is optional(valid(oldMesosDockerContainerAPI))
+        container.docker is optional(oldMesosDockerContainerAPI)
       }
     }
     override def apply(container: Container): Result = {
@@ -130,16 +131,20 @@ trait AppValidation {
   }
 
   def validContainer(enabledFeatures: Set[String], networks: Seq[Network], secrets: Map[String, SecretDef]): Validator[Container] = {
+    // When https://github.com/wix/accord/issues/120 is resolved, we can inline this expression again
+    def secretVolumes(container: Container) =
+      container.volumes.filterPF { case _: AppSecretVolume => true }
+
     def volumesValidator(container: Container): Validator[Seq[AppVolume]] =
       isTrue("Volume names must be unique") { (vols: Seq[AppVolume]) =>
         val names: Seq[String] = vols.collect{ case v: AppExternalVolume => v.external.name }.flatten
         names.distinct.size == names.size
-      } and every(valid(validVolume(container, enabledFeatures, secrets)))
+      } and every(validVolume(container, enabledFeatures, secrets))
 
     val validGeneralContainer: Validator[Container] = validator[Container] { container =>
       container.portMappings is optional(portMappingsValidator(networks))
       container.volumes is volumesValidator(container)
-      container.volumes.filterPF { case _: AppSecretVolume => true } is empty or featureEnabled(enabledFeatures, Features.SECRETS)
+      secretVolumes(container) is empty or featureEnabled(enabledFeatures, Features.SECRETS)
     }
 
     val mesosContainerImageValidator = new Validator[Container] {
@@ -148,7 +153,7 @@ trait AppValidation {
           case (Some(_), None, EngineType.Mesos) => validate(container)(mesosDockerContainerValidator(enabledFeatures, secrets))
           case (None, Some(_), EngineType.Mesos) => validate(container)(mesosAppcContainerValidator)
           case (None, None, EngineType.Mesos) => validate(container)(mesosImagelessContainerValidator)
-          case _ => Failure(Set(RuleViolation(container, "mesos containers should specify, at most, a single image type", None)))
+          case _ => Failure(Set(RuleViolation(container, "mesos containers should specify, at most, a single image type")))
         }
       }
     }
@@ -163,8 +168,8 @@ trait AppValidation {
   def validVolume(container: Container, enabledFeatures: Set[String], secrets: Map[String, SecretDef]): Validator[AppVolume] = new Validator[AppVolume] {
     import state.PathPatterns._
     val validHostVolume = validator[AppDockerVolume] { v =>
-      v.containerPath is valid(notEmpty)
-      v.hostPath is valid(notEmpty)
+      v.containerPath is notEmpty
+      v.hostPath is notEmpty
     }
     val validPersistentVolume = {
       val notHaveConstraintsOnRoot = isTrue[PersistentVolume](
@@ -188,22 +193,22 @@ trait AppValidation {
           import Protos.Constraint.Operator._
           (c.headOption, c.lift(1), c.lift(2)) match {
             case (None, None, _) =>
-              Failure(Set(RuleViolation(c, "Missing field and operator", None)))
+              Failure(Set(RuleViolation(c, "Missing field and operator")))
             case (Some("path"), Some(op), Some(value)) =>
               Try(Protos.Constraint.Operator.valueOf(op)).toOption.map {
                 case LIKE | UNLIKE =>
                   Try(Pattern.compile(value)).toOption.map(_ => Success).getOrElse(
-                    Failure(Set(RuleViolation(c, "Invalid regular expression", Some(value))))
+                    Failure(Set(RuleViolation(c, "Invalid regular expression", Path(Generic(value)))))
                   )
                 case _ =>
                   Failure(Set(
-                    RuleViolation(c, "Operator must be one of LIKE, UNLIKE", None)))
+                    RuleViolation(c, "Operator must be one of LIKE, UNLIKE")))
               }.getOrElse(
                 Failure(Set(
-                  RuleViolation(c, s"unknown constraint operator $op", None)))
+                  RuleViolation(c, s"unknown constraint operator $op")))
               )
             case _ =>
-              Failure(Set(RuleViolation(c, s"Unsupported constraint ${c.mkString(",")}", None)))
+              Failure(Set(RuleViolation(c, s"Unsupported constraint ${c.mkString(",")}")))
           }
         }
       }
@@ -214,10 +219,10 @@ trait AppValidation {
       } and meetMaxSizeConstraint and notHaveConstraintsOnRoot and haveProperlyOrderedMaxSize
 
       validator[AppPersistentVolume] { v =>
-        v.containerPath is valid(notEqualTo("") and notOneOf(DotPaths: _*))
-        v.containerPath is valid(matchRegexWithFailureMessage(NoSlashesPattern, "value must not contain \"/\""))
+        v.containerPath is notEqualTo("") and notOneOf(DotPaths: _*)
+        v.containerPath is matchRegexWithFailureMessage(NoSlashesPattern, "value must not contain \"/\"")
         v.mode is equalTo(ReadMode.Rw) // see AppConversion, default is RW
-        v.persistent is valid(validPersistentInfo)
+        v.persistent is validPersistentInfo
       }
     }
     val validExternalVolume: Validator[AppExternalVolume] = {
@@ -226,15 +231,15 @@ trait AppValidation {
         option.keys.each should matchRegex(OptionKeyRegex)
       }
       val validExternalInfo: Validator[ExternalVolume] = validator[ExternalVolume] { info =>
-        info.name is valid(definedAnd(matchRegex(LabelRegex)))
-        info.provider is valid(definedAnd(matchRegex(LabelRegex)))
+        info.name is definedAnd(matchRegex(LabelRegex))
+        info.provider is definedAnd(matchRegex(LabelRegex))
         info.options is validOptions
       }
 
       forAll(
         validator[AppExternalVolume] { v =>
-          v.containerPath is valid(notEmpty)
-          v.external is valid(validExternalInfo)
+          v.containerPath is notEmpty
+          v.external is validExternalInfo
         },
         { v: AppExternalVolume => v.external.provider.nonEmpty } -> ExternalVolumes.validRamlVolume(container),
         featureEnabled[AppVolume](enabledFeatures, Features.EXTERNAL_VOLUMES)
@@ -250,7 +255,7 @@ trait AppValidation {
         case v: AppPersistentVolume => validate(v)(validPersistentVolume)
         case v: AppExternalVolume => validate(v)(validExternalVolume)
         case v: AppSecretVolume => validate(v)(validSecretVolume) // Validate that the secret reference is valid
-        case _ => Failure(Set(RuleViolation(v, "Unknown app volume type", None)))
+        case _ => Failure(Set(RuleViolation(v, "Unknown app volume type")))
       }
     }
   }
@@ -263,7 +268,7 @@ trait AppValidation {
       portNames.contains(name)
     }
     validator[ReadinessCheck] { rc =>
-      rc.portName is valid(portNameExists)
+      rc.portName is portNameExists
       rc.timeoutSeconds should be < rc.intervalSeconds
     }
   }
@@ -273,7 +278,7 @@ trait AppValidation {
     */
   def validateOldAppUpdateAPI: Validator[AppUpdate] = forAll(
     validator[AppUpdate] { update =>
-      update.container is optional(valid(validOldContainerAPI))
+      update.container is optional(validOldContainerAPI)
       update.container.flatMap(_.docker.flatMap(_.portMappings)) is optional(portMappingsIndependentOfNetworks)
       update.ipAddress is optional(isTrue(
         "ipAddress/discovery is not allowed for Docker containers") { (ipAddress: IpAddress) =>
@@ -310,11 +315,11 @@ trait AppValidation {
       update.dependencies.map(_.map(PathId(_))) as "dependencies" is optional(every(valid))
       update.env is optional(envValidator(strictNameValidation = false, update.secrets.getOrElse(Map.empty), enabledFeatures))
       update.secrets is empty or featureEnabled(enabledFeatures, Features.SECRETS)
-      update.secrets is optional(featureEnabledImplies(enabledFeatures, Features.SECRETS)(every(secretEntryValidator)))
+      update.secrets is optional(featureEnabledImplies(enabledFeatures, Features.SECRETS)(secretValidator))
       update.fetch is optional(every(valid))
       update.portDefinitions is optional(portDefinitionsValidator)
-      update.container is optional(valid(validContainer(enabledFeatures, update.networks.getOrElse(Nil), update.secrets.getOrElse(Map.empty))))
-      update.acceptedResourceRoles is valid(optional(ResourceRole.validAcceptedResourceRoles(update.residency.isDefined) and notEmpty))
+      update.container is optional(validContainer(enabledFeatures, update.networks.getOrElse(Nil), update.secrets.getOrElse(Map.empty)))
+      update.acceptedResourceRoles is optional(ResourceRole.validAcceptedResourceRoles(update.residency.isDefined) and notEmpty)
       update.networks is optional(NetworkValidation.defaultNetworkNameValidator(defaultNetworkName))
     },
     isTrue("must not be root")(!_.id.fold(false)(PathId(_).isRoot)),
@@ -339,7 +344,7 @@ trait AppValidation {
     */
   val validateOldAppAPI: Validator[App] = forAll(
     validator[App] { app =>
-      app.container is optional(valid(validOldContainerAPI))
+      app.container is optional(validOldContainerAPI)
       app.container.flatMap(_.docker.flatMap(_.portMappings)) is optional(portMappingsIndependentOfNetworks)
       app.ipAddress is optional(isTrue(
         "ipAddress/discovery is not allowed for Docker containers") { (ipAddress: IpAddress) =>
@@ -398,18 +403,18 @@ trait AppValidation {
 
   /** validate most canonical API fields */
   private def validBasicAppDefinition(enabledFeatures: Set[String]): Validator[App] = validator[App] { app =>
-    app.container is optional(valid(validContainer(enabledFeatures, app.networks, app.secrets)))
+    app.container is optional(validContainer(enabledFeatures, app.networks, app.secrets))
     app.portDefinitions is optional(portDefinitionsValidator)
     app is containsCmdArgsOrContainer
     app.healthChecks is every(portIndexIsValid(portIndices(app)))
     app must haveAtMostOneMesosHealthCheck
     app.fetch is every(valid)
-    app.secrets is valid({ secrets: Map[String, SecretDef] =>
+    app.secrets is { secrets: Map[String, SecretDef] =>
       secrets.nonEmpty
-    } -> (featureEnabled(enabledFeatures, Features.SECRETS)))
-    app.secrets is valid(featureEnabledImplies(enabledFeatures, Features.SECRETS)(every(secretEntryValidator)))
+    } -> (featureEnabled(enabledFeatures, Features.SECRETS))
+    app.secrets is featureEnabledImplies(enabledFeatures, Features.SECRETS)(secretValidator)
     app.env is envValidator(strictNameValidation = false, app.secrets, enabledFeatures)
-    app.acceptedResourceRoles is valid(optional(ResourceRole.validAcceptedResourceRoles(app.residency.isDefined) and notEmpty))
+    app.acceptedResourceRoles is optional(ResourceRole.validAcceptedResourceRoles(app.residency.isDefined) and notEmpty)
     app must complyWithGpuRules(enabledFeatures)
     app must complyWithMigrationAPI
     app must complyWithReadinessCheckRules

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/ArtifactValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/ArtifactValidation.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.raml.Artifact
 
 trait ArtifactValidation {
   implicit val artifactUriIsValid: Validator[Artifact] = validator[Artifact] { artifact =>
-    artifact.uri is valid(api.v2.Validation.uriIsValid)
+    artifact.uri is api.v2.Validation.uriIsValid
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/NetworkValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/NetworkValidation.scala
@@ -14,7 +14,7 @@ trait NetworkValidation {
 
   implicit val modelNetworkValidator: Validator[pod.Network] = new Validator[pod.Network] {
     val containerNetworkValidator: Validator[pod.ContainerNetwork] = validator[pod.ContainerNetwork] { net =>
-      net.name is valid(validName)
+      net.name is validName
     }
     override def apply(net: pod.Network): Result = net match {
       case ct: pod.ContainerNetwork => validate(ct)(containerNetworkValidator)

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/SchedulingValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/SchedulingValidation.scala
@@ -42,19 +42,19 @@ trait SchedulingValidation {
 
   lazy val validForResidentTasks: Validator[UpgradeStrategy] = validator[UpgradeStrategy] { strategy =>
     strategy.minimumHealthCapacity is between(0.0, 1.0)
-    strategy.maximumOverCapacity should valid(be == 0.0)
+    strategy.maximumOverCapacity should be == 0.0
   }
 
   lazy val validForSingleInstanceApps: Validator[UpgradeStrategy] = validator[UpgradeStrategy] { strategy =>
-    strategy.minimumHealthCapacity should valid(be == 0.0)
-    strategy.maximumOverCapacity should valid(be == 0.0)
+    strategy.minimumHealthCapacity should be == 0.0
+    strategy.maximumOverCapacity should be == 0.0
   }
 
   val complyWithConstraintRules: Validator[Constraint] = new Validator[Constraint] {
     import mesosphere.marathon.raml.ConstraintOperator._
     override def apply(c: Constraint): Result = {
-      def failure(constraintViolation: String, description: Option[String] = None) =
-        Failure(Set(RuleViolation(c, constraintViolation, description)))
+      def failure(constraintViolation: String) =
+        Failure(Set(RuleViolation(c, constraintViolation)))
       if (c.fieldName.isEmpty) {
         failure(ConstraintRequiresField)
       } else {
@@ -82,7 +82,7 @@ trait SchedulingValidation {
             } { p =>
               Try(Pattern.compile(p)) match {
                 case util.Success(_) => Success
-                case util.Failure(e) => failure(InvalidRegularExpression, Option(e.getMessage))
+                case util.Failure(e) => failure(InvalidRegularExpression)
               }
             }
         }
@@ -102,11 +102,11 @@ trait SchedulingValidation {
   }
 
   val complyWithAppConstraintRules: Validator[Seq[String]] = new Validator[Seq[String]] {
-    def failureIllegalOperator(c: Any) = Failure(Set(RuleViolation(c, ConstraintOperatorInvalid, None)))
+    def failureIllegalOperator(c: Any) = Failure(Set(RuleViolation(c, ConstraintOperatorInvalid)))
 
     override def apply(c: Seq[String]): Result = {
-      def badConstraint(reason: String, desc: Option[String] = None): Result =
-        Failure(Set(RuleViolation(c, reason, desc)))
+      def badConstraint(reason: String): Result =
+        Failure(Set(RuleViolation(c, reason)))
       if (c.length < 2 || c.length > 3) badConstraint("Each constraint must have either 2 or 3 fields")
       else (c.headOption, c.lift(1), c.lift(2)) match {
         case (None, None, _) =>

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/SecretValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/SecretValidation.scala
@@ -15,21 +15,20 @@ trait SecretValidation {
       case EnvVarValue(value: String) => value // this should never be called; if it is, validation output will not be friendly
     }
 
-  def secretValidator(secrets: Map[String, EnvVarSecret]) = validator[(String, EnvVarValueOrSecret)] { entry =>
-    entry._2 as stringify(entry._2) is isTrue("references an undefined secret"){
+  def secretValidator(secrets: Map[String, EnvVarSecret]) = validator[EnvVarValueOrSecret] { entry =>
+    entry as "secret" is isTrue("references an undefined secret"){
       case EnvVarSecret(ref: String) => secrets.contains(ref)
       case _ => true
     }
   }
 
-  val secretEntryValidator: Validator[(String, SecretDef)] = validator[(String, SecretDef)] { t =>
-    t._1 as "" is notEmpty
-    t._2.source as "source" is notEmpty
+  private val secretEntryValidator: Validator[SecretDef] = validator[SecretDef] { t =>
+    t.source is notEmpty
   }
 
   val secretValidator = validator[Map[String, SecretDef]] { s =>
     s.keys is every(notEmpty)
-    s.values.map(_.source) as "source" is every(notEmpty)
+    s is everyKeyValue(secretEntryValidator)
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
@@ -339,7 +339,7 @@ object DeploymentPlan {
 
   def deploymentPlanValidator(): Validator[DeploymentPlan] = {
     validator[DeploymentPlan] { plan =>
-      plan.createdOrUpdatedApps as "app" is every(valid(AppDefinition.updateIsValid(plan.original)))
+      plan.createdOrUpdatedApps as "app" is every(AppDefinition.updateIsValid(plan.original))
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/ExternalVolumes.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/ExternalVolumes.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package core.externalvolume
 
+import com.wix.accord.Descriptions.{ Path, Explicit }
 import com.wix.accord._
 import mesosphere.marathon.core.externalvolume.impl._
 import mesosphere.marathon.raml.AppExternalVolume
@@ -20,7 +21,7 @@ object ExternalVolumes {
   def validExternalVolume: Validator[ExternalVolume] = new Validator[ExternalVolume] {
     def apply(ev: ExternalVolume) = providers.get(ev.external.provider) match {
       case Some(p) => p.validations.volume(ev)
-      case None => Failure(Set(RuleViolation(None, "is unknown provider", Some("external/provider"))))
+      case None => Failure(Set(RuleViolation(None, "is unknown provider", Path(Explicit("external"), Explicit("provider")))))
     }
   }
 
@@ -29,7 +30,7 @@ object ExternalVolumes {
       case Some(p) =>
         validate(ev)(p.validations.ramlVolume(container))
       case None =>
-        Failure(Set(RuleViolation(None, "is unknown provider", Some("external/provider"))))
+        Failure(Set(RuleViolation(None, "is unknown provider", Path(Explicit("external"), Explicit("provider")))))
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
@@ -141,7 +141,7 @@ private[impl] object DVDIProviderValidations extends ExternalVolumeValidations {
         val conflicts = volumeNameCounts(app).filter { case (volumeName, number) => number > 1 }.keys
         group(
           conflicts.toSet[String].map { e =>
-            RuleViolation(app.id, s"Requested DVDI volume '$e' is declared more than once within app ${app.id}", None)
+            RuleViolation(app.id, s"Requested DVDI volume '$e' is declared more than once within app ${app.id}")
           }
         )
       }
@@ -166,7 +166,7 @@ private[impl] object DVDIProviderValidations extends ExternalVolumeValidations {
       }
 
       val validDockerVolume = validator[AppExternalVolume] { volume =>
-        volume.external is valid(validDockerExternalVolume)
+        volume.external is validDockerExternalVolume
         volume.containerPath is notOneOf(DotPaths: _*)
       }
 
@@ -186,7 +186,7 @@ private[impl] object DVDIProviderValidations extends ExternalVolumeValidations {
     validator[App] { app =>
       app should haveUniqueExternalVolumeNames
       app should haveOnlyOneInstance
-      app.container is valid(optional(validContainer))
+      app.container is optional(validContainer)
       app.upgradeStrategy is optional(SchedulingValidation.validForResidentTasks)
     }
   }
@@ -204,7 +204,7 @@ private[impl] object DVDIProviderValidations extends ExternalVolumeValidations {
         val conflicts = volumeNameCounts(app).filter { case (volumeName, number) => number > 1 }.keys
         group(
           conflicts.toSet[String].map { e =>
-            RuleViolation(app.id, s"Requested DVDI volume '$e' is declared more than once within app ${app.id}", None)
+            RuleViolation(app.id, s"Requested DVDI volume '$e' is declared more than once within app ${app.id}")
           }
         )
       }
@@ -247,24 +247,18 @@ private[impl] object DVDIProviderValidations extends ExternalVolumeValidations {
     validator[AppDefinition] { app =>
       app should haveUniqueExternalVolumeNames
       app should haveOnlyOneInstance
-      app.container is valid(optional(validContainer))
-      app.upgradeStrategy is valid(UpgradeStrategy.validForResidentTasks)
+      app.container is optional(validContainer)
+      app.upgradeStrategy is UpgradeStrategy.validForResidentTasks
     }
   }
 
   object VolumeOptions {
-    def optionalOption(options: Map[String, String], optionValidator: Validator[String]): Validator[String] =
-      validator[String] { optionName => options.get(optionName) is optional(optionValidator) }
 
-    val validRexRayOptions: Validator[Map[String, String]] = {
-      mapDescription(description => s"($description)") {
-        validator[Map[String, String]] { opts =>
-          "dvdi/volumetype" is optionalOption(opts, validLabel)
-          "dvdi/newfstype" is optionalOption(opts, validLabel)
-          "dvdi/iops" is optionalOption(opts, validNaturalNumber)
-          "dvdi/overwritefs" is optionalOption(opts, validBoolean)
-        }
-      }
+    val validRexRayOptions: Validator[Map[String, String]] = validator[Map[String, String]] { opts =>
+      opts.get("dvdi/volumetype") as "\"dvdi/volumetype\"" is optional(validLabel)
+      opts.get("dvdi/newfstype") as "\"dvdi/newfstype\"" is optional(validLabel)
+      opts.get("dvdi/iops") as "\"dvdi/iops\"" is optional(validNaturalNumber)
+      opts.get("dvdi/overwritefs") as "\"dvdi/overwritefs\"" is optional(validBoolean)
     }
   }
 
@@ -274,9 +268,9 @@ private[impl] object DVDIProviderValidations extends ExternalVolumeValidations {
       v.external.name is notEmpty
       v.external.provider is equalTo(name)
 
-      v.external.options.get(driverOption) as s"external/options($quotedDriverOption)" is valid(definedAnd(validLabel))
+      v.external.options.get(driverOption) as s""""external/options($quotedDriverOption)"""" is definedAnd(validLabel)
       v.external.options as "external/options" is
-        valid(conditional[Map[String, String]](_.get(driverOption).contains("rexray"))(validRexRayOptions))
+        conditional[Map[String, String]](_.get(driverOption).contains("rexray"))(validRexRayOptions)
     }
   }
 
@@ -286,22 +280,22 @@ private[impl] object DVDIProviderValidations extends ExternalVolumeValidations {
 
     val validMesosVolume = validator[AppExternalVolume] {
       volume =>
-        volume.mode is valid(equalTo(ReadMode.Rw))
-        volume.containerPath is valid(notOneOf(DotPaths: _*))
+        volume.mode is equalTo(ReadMode.Rw)
+        volume.containerPath is notOneOf(DotPaths: _*)
     }
     val dockerVolumeInfo = validator[raml.ExternalVolume] { v =>
       v.options is isTrue(s"must only contain $driverOption")(_.filterKeys(_ != driverOption).isEmpty)
       v.size is isTrue("must be undefined for Docker containers")(_.isEmpty)
     }
     val validDockerVolume = validator[AppExternalVolume] { volume =>
-      volume.containerPath is valid(notOneOf(DotPaths: _*))
-      volume.external is valid(valid(dockerVolumeInfo))
+      volume.containerPath is notOneOf(DotPaths: _*)
+      volume.external is dockerVolumeInfo
     }
     val volumeInfo = validator[raml.ExternalVolume] { v =>
-      v.name is valid(definedAnd(notEmpty))
-      v.provider is valid(definedAnd(equalTo(name)))
-      v.options.get(driverOption) as s"options($quotedDriverOption)" is valid(definedAnd(validLabel))
-      v.options is valid(conditional[Map[String, String]](_.get(driverOption).contains("rexray"))(validRexRayOptions))
+      v.name is definedAnd(notEmpty)
+      v.provider is definedAnd(equalTo(name))
+      v.options.get(driverOption) as s"options($quotedDriverOption)" is definedAnd(validLabel)
+      v.options is conditional[Map[String, String]](_.get(driverOption).contains("rexray"))(validRexRayOptions)
     }
     forAll(
       validator[AppExternalVolume] { v =>

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/OptionSupport.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/OptionSupport.scala
@@ -22,7 +22,7 @@ protected[providers] object OptionSupport {
       val parsed = Try(v.toLong)
       parsed match {
         case util.Success(x) if x > 0 => Success
-        case _ => Failure(Set(RuleViolation(v, s"Expected a valid, positive integer instead of $v", None)))
+        case _ => Failure(Set(RuleViolation(v, s"Expected a valid, positive integer instead of $v")))
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -446,7 +446,7 @@ object AppDefinition extends GeneralPurposeCombinators {
     enabledFeatures: Set[String])(implicit pluginManager: PluginManager): Validator[AppDefinition] =
     validator[AppDefinition] { app =>
       app.id is valid and PathId.absolutePathValidator and PathId.nonEmptyPath
-      app.dependencies is valid
+      app.dependencies is every(PathId.pathIdValidator)
     } and validBasicAppDefinition(enabledFeatures) and pluginValidators
 
   /**
@@ -546,7 +546,7 @@ object AppDefinition extends GeneralPurposeCombinators {
 
   private def validBasicAppDefinition(enabledFeatures: Set[String]) = validator[AppDefinition] { appDef =>
     appDef.upgradeStrategy is valid
-    appDef.container.each is valid(Container.validContainer(appDef.networks, enabledFeatures))
+    appDef.container is optional(Container.validContainer(appDef.networks, enabledFeatures))
     appDef.portDefinitions is PortDefinitions.portDefinitionsValidator
     appDef.executor should matchRegexFully("^(//cmd)|(/?[^/]+(/[^/]+)*)|$")
     appDef must containsCmdArgsOrContainer

--- a/src/main/scala/mesosphere/marathon/state/EnvVarValue.scala
+++ b/src/main/scala/mesosphere/marathon/state/EnvVarValue.scala
@@ -35,7 +35,7 @@ object EnvVarValue {
 
   // forward implicit validation to the internal API we've defined
   implicit def valueValidator: Validator[EnvVarValue] = validator[EnvVarValue] { v =>
-    v is valid(v.valueValidator)
+    v is v.valueValidator
   }
 
   /** @return a validator that checks the validity of a container given the related secrets */
@@ -84,7 +84,7 @@ object EnvVarSecretRef {
     ) { (t: (AppDefinition, String, EnvVarSecretRef)) => t._1.secrets.keySet.contains(t._3.secret) }
 
     validator[(AppDefinition, String, EnvVarSecretRef)] { t =>
-      t as s"env(${t._2})" is valid(ifSecretIsDefined)
+      t as s"env(${t._2})" is ifSecretIsDefined
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -128,10 +128,8 @@ object PathId {
   private[this] val ID_PATH_SEGMENT_PATTERN =
     "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$".r
 
-  private val validPathChars = new Validator[PathId] {
-    override def apply(pathId: PathId): Result = {
-      validate(pathId.path)(validator = pathId.path.each should matchRegexFully(ID_PATH_SEGMENT_PATTERN.pattern))
-    }
+  private val validPathChars = isTrue[PathId](s"must fully match regular expression '${ID_PATH_SEGMENT_PATTERN.pattern.pattern()}'") { id =>
+    id.path.forall(part => ID_PATH_SEGMENT_PATTERN.pattern.matcher(part).matches())
   }
 
   /**

--- a/src/main/scala/mesosphere/marathon/state/ResourceRole.scala
+++ b/src/main/scala/mesosphere/marathon/state/ResourceRole.scala
@@ -16,7 +16,7 @@ object ResourceRole {
   def validAcceptedResourceRoles(isResident: Boolean): Validator[Set[String]] =
     validator[Set[String]] { acceptedResourceRoles =>
       acceptedResourceRoles is notEmpty
-      acceptedResourceRoles.each is valid(ResourceRole.validResourceRole)
+      acceptedResourceRoles.each is ResourceRole.validResourceRole
     } and isTrue("""A resident app must have `acceptedResourceRoles = ["*"]`.""") { acceptedResourceRoles =>
       !isResident || acceptedResourceRoles == Set(ResourceRole.Unreserved)
     }
@@ -42,7 +42,7 @@ object ResourceRole {
       isTrue[String](message.format("\"..\"")) { role => role != ".."; } and
       isTrue[String]("A role name must not start with a '-'.") { role => !role.startsWith("-") } and
       validator[String] { role =>
-        role.each is valid(validResourceRoleChar)
+        role.each is validResourceRoleChar
       }
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/Secret.scala
+++ b/src/main/scala/mesosphere/marathon/state/Secret.scala
@@ -20,6 +20,6 @@ object Secret {
 
   def secretValidator: Validator[(String, Secret)] = validator[(String, Secret)] { t =>
     t._1 as s"(${t._1})" is notEmpty
-    t._2 as s"(${t._1})" is valid(validSecret)
+    t._2 as s"(${t._1})" is validSecret
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon
 package state
 
+import com.wix.accord.Descriptions.{ Generic, Path => WixPath }
 import java.util.regex.Pattern
 
-import com.wix.accord.Descriptions.Generic
 import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.Protos.Constraint
@@ -169,7 +169,7 @@ object PersistentVolumeInfo {
       if (!c.hasField || !c.hasOperator) {
         Failure(Set(RuleViolation(c, "Missing field and operator")))
       } else if (c.getField != "path") {
-        Failure(Set(RuleViolation(c, "Unsupported field", Generic(c.getField))))
+        Failure(Set(RuleViolation(c, "Unsupported field", WixPath(Generic(c.getField)))))
       } else {
         c.getOperator match {
           case LIKE | UNLIKE =>
@@ -181,13 +181,13 @@ object PersistentVolumeInfo {
                   Failure(Set(RuleViolation(
                     c,
                     "Invalid regular expression",
-                    Generic("value"))))
+                    WixPath(Generic("value")))))
               }
             } else {
-              Failure(Set(RuleViolation(c, "A regular expression value must be provided", Generic("value"))))
+              Failure(Set(RuleViolation(c, "A regular expression value must be provided", WixPath(Generic("value")))))
             }
           case _ =>
-            Failure(Set(RuleViolation(c, "Operator must be one of LIKE, UNLIKE", Generic("operator"))))
+            Failure(Set(RuleViolation(c, "Operator must be one of LIKE, UNLIKE", WixPath(Generic("operator")))))
         }
       }
     }

--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -3,6 +3,7 @@ package state
 
 import java.util.regex.Pattern
 
+import com.wix.accord.Descriptions.Generic
 import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.Protos.Constraint
@@ -166,9 +167,9 @@ object PersistentVolumeInfo {
     import Constraint.Operator._
     override def apply(c: Constraint): Result = {
       if (!c.hasField || !c.hasOperator) {
-        Failure(Set(RuleViolation(c, "Missing field and operator", None)))
+        Failure(Set(RuleViolation(c, "Missing field and operator")))
       } else if (c.getField != "path") {
-        Failure(Set(RuleViolation(c, "Unsupported field", Some(c.getField))))
+        Failure(Set(RuleViolation(c, "Unsupported field", Generic(c.getField))))
       } else {
         c.getOperator match {
           case LIKE | UNLIKE =>
@@ -180,14 +181,13 @@ object PersistentVolumeInfo {
                   Failure(Set(RuleViolation(
                     c,
                     "Invalid regular expression",
-                    Some(s"${c.getValue}\n${e.getMessage}"))))
+                    Generic("value"))))
               }
             } else {
-              Failure(Set(RuleViolation(c, "A regular expression value must be provided", None)))
+              Failure(Set(RuleViolation(c, "A regular expression value must be provided", Generic("value"))))
             }
           case _ =>
-            Failure(Set(
-              RuleViolation(c, "Operator must be one of LIKE, UNLIKE", None)))
+            Failure(Set(RuleViolation(c, "Operator must be one of LIKE, UNLIKE", Generic("operator"))))
         }
       }
     }
@@ -210,7 +210,7 @@ object PersistentVolumeInfo {
     }
 
     val haveProperlyOrderedMaxSize = isTrue[PersistentVolumeInfo]("Max size must be larger than size") { info =>
-      info.maxSize.map(_ > info.size).getOrElse(true)
+      info.maxSize.forall(_ > info.size)
     }
 
     validator[PersistentVolumeInfo] { info =>
@@ -302,7 +302,7 @@ object ExternalVolumeInfo {
     info.size.each should be > 0L
     info.name should matchRegex(LabelRegex)
     info.provider should matchRegex(LabelRegex)
-    info.options is valid(validOptions)
+    info.options is validOptions
   }
 
   def fromProto(evi: Protos.Volume.ExternalVolumeInfo): ExternalVolumeInfo =
@@ -323,7 +323,7 @@ object ExternalVolume {
   def validExternalVolume(enabledFeatures: Set[String]): Validator[ExternalVolume] = validator[ExternalVolume] { ev =>
     ev is featureEnabled(enabledFeatures, Features.EXTERNAL_VOLUMES)
     ev.containerPath is notEmpty
-    ev.external is valid(ExternalVolumeInfo.validExternalVolumeInfo)
+    ev.external is ExternalVolumeInfo.validExternalVolumeInfo
   } and ExternalVolumes.validExternalVolume
 }
 

--- a/src/test/scala/mesosphere/ValidationTestLike.scala
+++ b/src/test/scala/mesosphere/ValidationTestLike.scala
@@ -1,0 +1,81 @@
+package mesosphere
+
+import com.wix.accord.{ Failure, Result, Success }
+import mesosphere.marathon.Normalization
+import mesosphere.marathon.ValidationFailedException
+import mesosphere.marathon.api.v2.Validation
+import mesosphere.marathon.api.v2.Validation.ConstraintViolation
+import org.scalatest._
+import org.scalatest.matchers.{ BePropertyMatchResult, BePropertyMatcher, MatchResult, Matcher }
+
+/**
+  * Provides a set of scalatest matchers for use when testing validation.
+  *
+  * Wix Accord does provide matchers in import com.wix.accord.scalatest.ResultMatchers; however, the interface and the
+  * output of these matchers is not as friendly as we would prefer.
+  */
+trait ValidationTestLike extends Validation {
+  this: Assertions =>
+
+  protected implicit val normalizeResult: Normalization[Result] = Normalization {
+    // normalize failures => human readable error messages
+    case f: Failure => f
+    case x => x
+  }
+
+  def withValidationClue[T](f: => T): T = scala.util.Try { f }.recover {
+    // handle RAML validation errors
+    case vfe: ValidationFailedException => fail(vfe.failure.violations.toString())
+    case th => throw th
+  }.get
+
+  private def describeViolation(c: ConstraintViolation) =
+    s"""- "${c.path}" -> "${c.constraint}""""
+
+  case class haveViolations(expectedViolations: (String, String)*) extends Matcher[Result] {
+    val expectedConstraintViolations = expectedViolations.map(ConstraintViolation.tupled)
+    override def apply(result: Result): MatchResult = {
+      result match {
+        case Success =>
+          MatchResult(
+            matches = false,
+            "Validation succeeded, had no violations",
+            "" /* This MatchResult is explicitly false; negated failure does not apply */ )
+        case f: Failure =>
+          val violations = Validation.allViolations(f)
+          val matches = expectedConstraintViolations.forall { e => violations contains e }
+          MatchResult(
+            matches,
+            s"""Validation failed, but expected violation not in actual violation set
+               |  Expected:
+               |  ${expectedConstraintViolations.map(describeViolation).mkString("\n  ")}
+               |  All violations:
+               |  ${violations.map(describeViolation).mkString("\n  ")}
+               |""".stripMargin.trim,
+            s"""Validation failed, but expected violations were in actual violation set
+               |  Expected:
+               |  ${expectedConstraintViolations.map(describeViolation).mkString("\n  ")}
+               |  All violations:
+               |  ${violations.map(describeViolation).mkString("\n  ")}
+               |""".stripMargin.trim)
+      }
+    }
+  }
+
+  object aSuccess extends BePropertyMatcher[Result] {
+    override def apply(result: Result): BePropertyMatchResult = {
+      result match {
+        case Success =>
+          BePropertyMatchResult(true, "Expected a failure, got success")
+        case f: Failure =>
+          val violations = Validation.allViolations(f)
+          BePropertyMatchResult(
+            false,
+            s"""Validation failed, but expected success
+               |  All violations:
+               |  ${violations.map(describeViolation).mkString("\n  ")}
+               |""".stripMargin.trim)
+      }
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -115,7 +115,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
 
       When("The request is processed")
 
-      appsResource.create(body.getBytes("UTF-8"), false, auth.request)
+      appsResource.create(body.getBytes("UTF-8"), force = false, auth.request)
     }
   }
 
@@ -694,7 +694,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
 
       Then("It fails")
       response.getStatus should be(422)
-      response.getEntity.toString should include("/env(NAMED_FOO)")
+      response.getEntity.toString should include("/env/NAMED_FOO/secret")
       response.getEntity.toString should include("references an undefined secret")
     }
 
@@ -778,7 +778,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
         val (body, plan) = prepareApp(app, groupManager)
 
         Then("A constraint violation exception is thrown")
-        val response = appsResource.create(body, false, auth.request)
+        val response = appsResource.create(body, force = false, auth.request)
         response.getStatus should be(422)
       }
 
@@ -787,7 +787,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
           cpus = -1)
         val (body, _) = prepareApp(app, groupManager)
 
-        val response = appsResource.create(body, false, auth.request)
+        val response = appsResource.create(body, force = false, auth.request)
         response.getStatus should be(422)
       }
 
@@ -796,7 +796,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
           instances = -1)
         val (body, _) = prepareApp(app, groupManager)
 
-        val response = appsResource.create(body, false, auth.request)
+        val response = appsResource.create(body, force = false, auth.request)
         response.getStatus should be(422)
       }
 
@@ -838,7 +838,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       val (body, _) = prepareApp(app, groupManager)
 
       Then("A constraint violation exception is thrown")
-      val response = appsResource.create(body, false, auth.request)
+      val response = appsResource.create(body, force = false, auth.request)
       response.getStatus should be(422)
     }
 
@@ -852,7 +852,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
 
       Then("A constraint violation exception is thrown")
       val body = invalidAppJson.getBytes("UTF-8")
-      val response = appsResource.create(body, false, auth.request)
+      val response = appsResource.create(body, force = false, auth.request)
       response.getStatus should be(422)
     }
 
@@ -1091,7 +1091,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
 
       Then("The return code indicates validation error")
       response.getStatus should be(422)
-      response.getEntity.toString should include("/container/volumes(0)/external/options(\\\"dvdi/iops\\\")")
+      response.getEntity.toString should include("/container/volumes(0)/external/options/\\\"dvdi/iops\\\"")
     }
 
     "Creating an app with an external volume w/ relative containerPath DOCKER containerizer should succeed (available with Mesos 1.0)" in new Fixture {
@@ -1405,7 +1405,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       index.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("we try to add an app")
-      val create = appsResource.create(app.getBytes("UTF-8"), false, req)
+      val create = appsResource.create(app.getBytes("UTF-8"), force = false, req)
       Then("we receive a NotAuthenticated response")
       create.getStatus should be(auth.NotAuthenticatedStatus)
 
@@ -1425,12 +1425,12 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       replaceMultiple.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("we try to delete an app")
-      val delete = appsResource.delete(false, "", req)
+      val delete = appsResource.delete(force = false, "", req)
       Then("we receive a NotAuthenticated response")
       delete.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("we try to restart an app")
-      val restart = appsResource.restart("", false, req)
+      val restart = appsResource.restart("", force = false, req)
       Then("we receive a NotAuthenticated response")
       restart.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -1448,7 +1448,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       val app = """{"id":"/a","cmd":"foo","ports":[]}"""
 
       When("we try to create an app")
-      val create = appsResource.create(app.getBytes("UTF-8"), false, req)
+      val create = appsResource.create(app.getBytes("UTF-8"), force = false, req)
       Then("we receive a NotAuthorized response")
       create.getStatus should be(auth.UnauthorizedStatus)
 
@@ -1468,12 +1468,12 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       replaceMultiple.getStatus should be(auth.UnauthorizedStatus)
 
       When("we try to remove an app")
-      val delete = appsResource.delete(false, "/a", req)
+      val delete = appsResource.delete(force = false, "/a", req)
       Then("we receive a NotAuthorized response")
       delete.getStatus should be(auth.UnauthorizedStatus)
 
       When("we try to restart an app")
-      val restart = appsResource.restart("/a", false, req)
+      val restart = appsResource.restart("/a", force = false, req)
       Then("we receive a NotAuthorized response")
       restart.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -1516,7 +1516,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
 
       Then("A 404 is returned")
       val exception = intercept[AppNotFoundException] {
-        appsResource.delete(false, "/foo", req)
+        appsResource.delete(force = false, "/foo", req)
       }
       exception.getMessage should be("App '/foo' does not exist")
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/ValidationHelper.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ValidationHelper.scala
@@ -2,30 +2,21 @@ package mesosphere.marathon
 package api.v2
 
 import com.wix.accord._
+import mesosphere.marathon.api.v2.Validation.ConstraintViolation
 import play.api.libs.json.{ JsError, JsResult }
 
 object ValidationHelper {
-  case class ViolationMessageAndPath(message: String, path: Option[String]) {
-    override def toString: String = path.map(p => s"Path: $p. Error message: $message")
-      .getOrElse(s"Error message: $message")
-  }
 
-  def getAllRuleConstrains(r: Result): Set[ViolationMessageAndPath] = {
-    r match {
-      case f: Failure => f.violations.flatMap(Validation.allRuleViolationsWithFullDescription(_))
-        .map(r => ViolationMessageAndPath(r.constraint, r.description))
-      case _ => Set.empty
-    }
-  }
+  def getAllRuleConstrains(r: Result): Set[ConstraintViolation] = Validation.allViolations(r).toSet
 
-  def getAllRuleConstrains(r: JsResult[_]): Set[ViolationMessageAndPath] = {
+  def getAllRuleConstrains(r: JsResult[_]): Set[ConstraintViolation] = {
     r match {
       case f: JsError => f.errors.flatMap {
         case (path, errors) =>
           errors.flatMap { err =>
             val messages = err.messages
             messages.map { msg =>
-              ViolationMessageAndPath(msg, Option(path.toString))
+              ConstraintViolation(path.toString, msg)
             }
           }
       }(collection.breakOut)

--- a/src/test/scala/mesosphere/marathon/api/v2/ValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ValidationTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package api.v2
 
+import com.wix.accord.Descriptions.Explicit
 import mesosphere.UnitTest
 import com.wix.accord.{ Failure, RuleViolation }
 import play.api.libs.json._
@@ -10,7 +11,7 @@ class ValidationTest extends UnitTest {
 
   "The failure format" should {
     "write validations errors" in {
-      val violation = RuleViolation(value = Some("foo"), constraint = "is a number", description = Some("id"))
+      val violation = RuleViolation(value = Some("foo"), constraint = "is a number", path = Explicit("id"))
       val failure = Failure(Set(violation))
       val json = Json.toJson(failure)
       json.toString should be("""{"message":"Object is not valid","details":[{"path":"/id","errors":["is a number"]}]}""")

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -408,7 +408,7 @@ class AppDefinitionFormatsTest extends UnitTest
           |    }
           |  }
           |}""".stripMargin).as[raml.App]
-      shouldViolate(app, "/container/docker/credential" -> "must be empty")(AppValidation.validateOldAppAPI)
+      AppValidation.validateOldAppAPI(app) should haveViolations("/container/docker/credential" -> "must be empty")
     }
 
     "FromJSON should parse Mesos Docker container" in {
@@ -447,7 +447,7 @@ class AppDefinitionFormatsTest extends UnitTest
           |  }
           |}""".stripMargin).as[raml.App]
 
-      shouldViolate(app, "/container/docker/portMappings" -> "must be empty")(AppValidation.validateOldAppAPI)
+      AppValidation.validateOldAppAPI(app) should haveViolations("/container/docker/portMappings" -> "must be empty")
 
       // network is currently not supported
       val app2 = Json.parse(
@@ -461,7 +461,7 @@ class AppDefinitionFormatsTest extends UnitTest
           |    }
           |  }
           |}""".stripMargin).as[raml.App]
-      shouldViolate(app2, "/container/docker/network" -> "must be empty")(AppValidation.validateOldAppAPI)
+      AppValidation.validateOldAppAPI(app2) should haveViolations("/container/docker/network" -> "must be empty")
 
       // parameters are currently not supported
       val app3 = Json.parse(
@@ -475,7 +475,7 @@ class AppDefinitionFormatsTest extends UnitTest
         |    }
         |  }
         |}""".stripMargin).as[raml.App]
-      shouldViolate(app3, "/container/docker/parameters" -> "must be empty")(AppValidation.validateOldAppAPI)
+      AppValidation.validateOldAppAPI(app3) should haveViolations("/container/docker/parameters" -> "must be empty")
     }
 
     "FromJSON should parse Mesos AppC container" in {
@@ -664,8 +664,8 @@ class AppDefinitionFormatsTest extends UnitTest
           |  "container": {}
           |}""".stripMargin)
       val ramlApp = json.as[raml.App]
-      shouldViolate(ramlApp, "/container/docker" -> "not defined")(
-        AppValidation.validateCanonicalAppAPI(Set.empty, () => config.defaultNetworkName))
+      val validator = AppValidation.validateCanonicalAppAPI(Set.empty, () => config.defaultNetworkName)
+      validator(ramlApp) should haveViolations("/container/docker" -> "not defined")
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 
 class AppDefinitionTest extends UnitTest with ValidationTestLike {
   val enabledFeatures = Set("secrets")
-  implicit val validAppDefinition = AppDefinition.validAppDefinition(enabledFeatures)(PluginManager.None)
+  implicit val validator = AppDefinition.validAppDefinition(enabledFeatures)(PluginManager.None)
 
   private[this] def appNormalization(app: raml.App): raml.App =
     AppHelpers.appNormalization(
@@ -36,23 +36,23 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
       var app = AppDefinition(id = "a b".toRootPath)
       val idError = "must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$'"
       MarathonTestHelper.validateJsonSchema(app, false)
-      shouldViolate(app, "/id" -> idError)
+      validator(app) should haveViolations("/id" -> idError)
 
       app = app.copy(id = "a#$%^&*b".toRootPath)
       MarathonTestHelper.validateJsonSchema(app, false)
-      shouldViolate(app, "/id" -> idError)
+      validator(app) should haveViolations("/id" -> idError)
 
       app = app.copy(id = "-dash-disallowed-at-start".toRootPath)
       MarathonTestHelper.validateJsonSchema(app, false)
-      shouldViolate(app, "/id" -> idError)
+      validator(app) should haveViolations("/id" -> idError)
 
       app = app.copy(id = "dash-disallowed-at-end-".toRootPath)
       MarathonTestHelper.validateJsonSchema(app, false)
-      shouldViolate(app, "/id" -> idError)
+      validator(app) should haveViolations("/id" -> idError)
 
       app = app.copy(id = "uppercaseLettersNoGood".toRootPath)
       MarathonTestHelper.validateJsonSchema(app, false)
-      shouldViolate(app, "/id" -> idError)
+      validator(app) should haveViolations("/id" -> idError)
 
       val correct = AppDefinition(id = "test".toRootPath)
 
@@ -65,10 +65,8 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
           )
         )),
         portDefinitions = Nil)
-      shouldNotViolate(
-        app,
-        "/container/portMappings(0)" ->
-          "hostPort is required for BRIDGE mode.")
+      validator(app) shouldNot haveViolations(
+        "/container/portMappings(0)" -> "hostPort is required for BRIDGE mode.")
 
       val caught = intercept[IllegalArgumentException] {
         correct.copy(
@@ -84,87 +82,64 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
       caught.getMessage should include("bridge networking requires that every host-port in a port-mapping is non-empty (but may be zero)")
 
       app = correct.copy(executor = "//cmd")
-      shouldNotViolate(
-        app,
-        "/executor" ->
-          "{javax.validation.constraints.Pattern.message}")
+      validator(app) shouldNot haveViolations(
+        "/executor" -> "{javax.validation.constraints.Pattern.message}")
       MarathonTestHelper.validateJsonSchema(app)
 
       app = correct.copy(executor = "some/relative/path.mte")
-      shouldNotViolate(
-        app,
-        "/executor" ->
-          "{javax.validation.constraints.Pattern.message}")
+      validator(app) shouldNot haveViolations(
+        "/executor" -> "{javax.validation.constraints.Pattern.message}")
       MarathonTestHelper.validateJsonSchema(app)
 
       app = correct.copy(executor = "/some/absolute/path")
-      shouldNotViolate(
-        app,
-        "/executor" ->
-          "{javax.validation.constraints.Pattern.message}")
+      validator(app) shouldNot haveViolations(
+        "/executor" -> "{javax.validation.constraints.Pattern.message}")
+
       MarathonTestHelper.validateJsonSchema(app)
 
       app = correct.copy(executor = "")
-      shouldNotViolate(
-        app,
-        "/executor" ->
-          "{javax.validation.constraints.Pattern.message}")
+      validator(app) shouldNot haveViolations(
+        "/executor" -> "{javax.validation.constraints.Pattern.message}")
       MarathonTestHelper.validateJsonSchema(app)
 
       app = correct.copy(executor = "/test/")
-      shouldViolate(
-        app,
-        "/executor" ->
-          "must fully match regular expression '^(//cmd)|(/?[^/]+(/[^/]+)*)|$'")
+      validator(app) should haveViolations(
+        "/executor" -> "must fully match regular expression '^(//cmd)|(/?[^/]+(/[^/]+)*)|$'")
       MarathonTestHelper.validateJsonSchema(app, false)
 
       app = correct.copy(executor = "/test//path")
-      shouldViolate(
-        app,
-        "/executor" ->
-          "must fully match regular expression '^(//cmd)|(/?[^/]+(/[^/]+)*)|$'")
+      validator(app) should haveViolations(
+        "/executor" -> "must fully match regular expression '^(//cmd)|(/?[^/]+(/[^/]+)*)|$'")
       MarathonTestHelper.validateJsonSchema(app, false)
 
       app = correct.copy(cmd = Some("command"), args = Seq("a", "b", "c"))
-      shouldViolate(
-        app,
-        "/" ->
-          "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.")
+      validator(app) should haveViolations(
+        "/" -> "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.")
       MarathonTestHelper.validateJsonSchema(app, false)
 
       app = correct.copy(cmd = None, args = Seq("a", "b", "c"))
-      shouldNotViolate(
-        app,
-        "/" ->
-          "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.")
+      validator(app) shouldNot haveViolations(
+        "/" -> "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'.")
       MarathonTestHelper.validateJsonSchema(app)
 
       app = correct.copy(upgradeStrategy = UpgradeStrategy(1.2))
-      shouldViolate(
-        app,
-        "/upgradeStrategy/minimumHealthCapacity" ->
-          "got 1.2, expected between 0.0 and 1.0")
+      validator(app) should haveViolations(
+        "/upgradeStrategy/minimumHealthCapacity" -> "got 1.2, expected between 0.0 and 1.0")
       MarathonTestHelper.validateJsonSchema(app, false)
 
       app = correct.copy(upgradeStrategy = UpgradeStrategy(0.5, 1.2))
-      shouldViolate(
-        app,
-        "/upgradeStrategy/maximumOverCapacity" ->
-          "got 1.2, expected between 0.0 and 1.0")
+      validator(app) should haveViolations(
+        "/upgradeStrategy/maximumOverCapacity" -> "got 1.2, expected between 0.0 and 1.0")
       MarathonTestHelper.validateJsonSchema(app, false)
 
       app = correct.copy(upgradeStrategy = UpgradeStrategy(-1.2))
-      shouldViolate(
-        app,
-        "/upgradeStrategy/minimumHealthCapacity" ->
-          "got -1.2, expected between 0.0 and 1.0")
+      validator(app) should haveViolations(
+        "/upgradeStrategy/minimumHealthCapacity" -> "got -1.2, expected between 0.0 and 1.0")
       MarathonTestHelper.validateJsonSchema(app, false)
 
       app = correct.copy(upgradeStrategy = UpgradeStrategy(0.5, -1.2))
-      shouldViolate(
-        app,
-        "/upgradeStrategy/maximumOverCapacity" ->
-          "got -1.2, expected between 0.0 and 1.0")
+      validator(app) should haveViolations(
+        "/upgradeStrategy/maximumOverCapacity" -> "got -1.2, expected between 0.0 and 1.0")
       MarathonTestHelper.validateJsonSchema(app, false)
 
       app = correct.copy(
@@ -178,10 +153,8 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
         portDefinitions = Nil,
         healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(PortReference(1))))
       )
-      shouldNotViolate(
-        app,
-        "/healthChecks(0)" ->
-          "Health check port indices must address an element of the ports array or container port mappings.")
+      validator(app) shouldNot haveViolations(
+        "/healthChecks(0)" -> "Health check port indices must address an element of the ports array or container port mappings.")
       MarathonTestHelper.validateJsonSchema(app, false) // missing image
 
       app = correct.copy(
@@ -189,29 +162,23 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
         portDefinitions = Nil,
         healthChecks = Set(MarathonHttpHealthCheck(port = Some(80)))
       )
-      shouldNotViolate(
-        app,
-        "/healthChecks(0)" ->
-          "Health check port indices must address an element of the ports array or container port mappings.")
+      validator(app) shouldNot haveViolations(
+        "/healthChecks(0)" -> "Health check port indices must address an element of the ports array or container port mappings.")
       MarathonTestHelper.validateJsonSchema(app, false) // missing image
 
       app = correct.copy(
         healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(PortReference(1))))
       )
-      shouldViolate(
-        app,
-        "/healthChecks(0)" ->
-          "Health check port indices must address an element of the ports array or container port mappings.")
+      validator(app) should haveViolations(
+        "/healthChecks(0)" -> "Health check port indices must address an element of the ports array or container port mappings.")
       MarathonTestHelper.validateJsonSchema(app)
 
       app = correct.copy(
         fetch = Seq(FetchUri(uri = "http://example.com/valid"), FetchUri(uri = "d://\not-a-uri"))
       )
 
-      shouldViolate(
-        app,
-        "/fetch(1)/uri" ->
-          "URI has invalid syntax.")
+      validator(app) should haveViolations(
+        "/fetch(1)/uri" -> "URI has invalid syntax.")
       MarathonTestHelper.validateJsonSchema(app)
 
       app = correct.copy(
@@ -222,54 +189,55 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
       app = correct.copy(
         fetch = Seq(FetchUri(uri = "http://example.com/valid"), FetchUri(uri = "/root/file")))
 
-      shouldNotViolate(app, "/fetch(1)" -> "URI has invalid syntax.")
+      validator(app) shouldNot haveViolations("/fetch(1)" -> "URI has invalid syntax.")
 
-      shouldViolate(app.copy(resources = Resources(mem = -3.0)), "/mem" -> "got -3.0, expected 0.0 or more")
-      shouldViolate(app.copy(resources = Resources(cpus = -3.0)), "/cpus" -> "got -3.0, expected 0.0 or more")
-      shouldViolate(app.copy(resources = Resources(disk = -3.0)), "/disk" -> "got -3.0, expected 0.0 or more")
-      shouldViolate(app.copy(resources = Resources(gpus = -3)), "/gpus" -> "got -3, expected 0 or more")
-      shouldViolate(app.copy(instances = -3), "/instances" -> "got -3, expected 0 or more")
+      validator(app.copy(resources = Resources(mem = -3.0))) should haveViolations("/mem" -> "got -3.0, expected 0.0 or more")
+      validator(app.copy(resources = Resources(cpus = -3.0))) should haveViolations("/cpus" -> "got -3.0, expected 0.0 or more")
+      validator(app.copy(resources = Resources(disk = -3.0))) should haveViolations("/disk" -> "got -3.0, expected 0.0 or more")
+      validator(app.copy(resources = Resources(gpus = -3))) should haveViolations("/gpus" -> "got -3, expected 0 or more")
+      validator(app.copy(instances = -3)) should haveViolations("/instances" -> "got -3, expected 0 or more")
 
-      shouldViolate(app.copy(resources = Resources(gpus = 1)), "/" -> "Feature gpu_resources is not enabled. Enable with --enable_features gpu_resources)")
+      validator(app.copy(resources = Resources(gpus = 1))) should haveViolations("/" -> "Feature gpu_resources is not enabled. Enable with --enable_features gpu_resources)")
 
       {
-        implicit val appValidator = AppDefinition.validAppDefinition(Set("gpu_resources"))(PluginManager.None)
-        shouldNotViolate(app.copy(resources = Resources(gpus = 1)), "/" -> "Feature gpu_resources is not enabled. Enable with --enable_features gpu_resources)")(appValidator)
+        val appValidator = AppDefinition.validAppDefinition(Set("gpu_resources"))(PluginManager.None)
+        appValidator(app.copy(resources = Resources(gpus = 1))) shouldNot haveViolations(
+          "/" -> "Feature gpu_resources is not enabled. Enable with --enable_features gpu_resources)")
       }
 
       app = correct.copy(
         resources = Resources(gpus = 1),
         container = Some(Container.Docker()))
 
-      shouldViolate(app, "/" -> "GPU resources only work with the Mesos containerizer")
+      validator(app) should haveViolations("/" -> "GPU resources only work with the Mesos containerizer")
 
       app = correct.copy(
         resources = Resources(gpus = 1),
         container = Some(Container.Mesos())
       )
 
-      shouldNotViolate(app, "/" -> "GPU resources only work with the Mesos containerizer")
+      validator(app) shouldNot haveViolations("/" -> "GPU resources only work with the Mesos containerizer")
 
       app = correct.copy(
         resources = Resources(gpus = 1),
         container = Some(Container.MesosDocker())
       )
 
-      shouldNotViolate(app, "/" -> "GPU resources only work with the Mesos containerizer")
+      validator(app) shouldNot haveViolations("/" -> "GPU resources only work with the Mesos containerizer")
 
       app = correct.copy(
         resources = Resources(gpus = 1),
         container = Some(Container.MesosAppC())
       )
 
-      shouldNotViolate(app, "/" -> "GPU resources only work with the Mesos containerizer")
+      validator(app) shouldNot haveViolations("/" -> "GPU resources only work with the Mesos containerizer")
 
       app = correct.copy(
         resources = Resources(gpus = 1),
         container = None
       )
 
-      shouldNotViolate(app, "/" -> "GPU resources only work with the Mesos containerizer")
+      validator(app) shouldNot haveViolations("/" -> "GPU resources only work with the Mesos containerizer")
     }
 
     "SerializationRoundtrip empty" in {

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -1,10 +1,11 @@
 package mesosphere.marathon
 package api.v2.json
 
+import com.wix.accord.Descriptions.Generic
 import com.wix.accord._
-import mesosphere.UnitTest
+import mesosphere.marathon.api.v2.ValidationHelper
+import mesosphere.{ UnitTest, ValidationTestLike }
 import mesosphere.marathon.api.JsonTestHelper
-import mesosphere.marathon.api.v2.Validation.validateOrThrow
 import mesosphere.marathon.api.v2.validation.{ AppValidation, NetworkValidationMessages }
 import mesosphere.marathon.api.v2.{ AppNormalization, AppHelpers, ValidationHelper }
 import mesosphere.marathon.core.readiness.ReadinessCheckTestHelper
@@ -12,13 +13,25 @@ import mesosphere.marathon.raml.{ AppCContainer, AppUpdate, Artifact, Container,
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import org.apache.mesos.{ Protos => Mesos }
-import play.api.libs.json.{ JsError, Json }
+import play.api.libs.json.{ Json, JsError }
 
 import scala.collection.immutable.Seq
 
-class AppUpdateTest extends UnitTest {
+class AppUpdateTest extends UnitTest with ValidationTestLike {
 
   implicit val appUpdateValidator: Validator[AppUpdate] = AppValidation.validateCanonicalAppUpdateAPI(Set("secrets"), () => AppNormalization.Configuration(None, "mesos-bridge-name").defaultNetworkName)
+
+  val roundTripValidator = new Validator[AppUpdate] {
+    override def apply(update: AppUpdate) = {
+      Json.fromJson[AppUpdate](Json.toJson(update)) match {
+        case err: JsError =>
+          Failure(ValidationHelper.getAllRuleConstrains(err).map { cv =>
+            RuleViolation(None, cv.constraint, cv.path.split("/").filter(_ != "").map(Generic(_)).toSeq)
+          })
+        case obj => appUpdateValidator(obj.get)
+      }
+    }
+  }
 
   val runSpecId = PathId("/test")
 
@@ -31,71 +44,50 @@ class AppUpdateTest extends UnitTest {
       .normalized(validateOrThrow(update)(AppValidation.validateOldAppUpdateAPI))
   }
 
-  def shouldViolate(update: AppUpdate, path: String, template: String): Unit = {
-    val violations = Json.fromJson[AppUpdate](Json.toJson(update)) match {
-      case err: JsError => ValidationHelper.getAllRuleConstrains(err)
-      case obj => ValidationHelper.getAllRuleConstrains(validate(obj.get))
-    }
-    assert(violations.nonEmpty)
-    assert(violations.exists(v =>
-      v.path.getOrElse(false) == path && v.message == template
-    ), s"expected path $path and message $template, but instead found" + violations)
-  }
-
-  def shouldNotViolate(update: AppUpdate, path: String, template: String): Unit = {
-    val violations = Json.fromJson[AppUpdate](Json.toJson(update)) match {
-      case err: JsError => ValidationHelper.getAllRuleConstrains(err)
-      case obj => ValidationHelper.getAllRuleConstrains(validate(obj.get))
-    }
-    assert(!violations.exists(v =>
-      v.path.getOrElse(false) == path && v.message == template))
-  }
-
   "AppUpdate" should {
     "Validation" in {
       val update = AppUpdate()
 
       shouldViolate(
         update.copy(portDefinitions = Some(PortDefinitions(9000, 8080, 9000))),
-        "/portDefinitions",
-        "Ports must be unique."
-      )
+        "/portDefinitions" ->
+          "Ports must be unique.")
 
       shouldViolate(
         update.copy(portDefinitions = Some(Seq(
           PortDefinition(9000, name = Some("foo")),
           PortDefinition(9001, name = Some("foo"))))
         ),
-        "/portDefinitions",
-        "Port names must be unique."
-      )
+        "/portDefinitions" ->
+          "Port names must be unique.")
 
       shouldNotViolate(
         update.copy(portDefinitions = Some(Seq(
           PortDefinition(9000, name = Some("foo")),
           PortDefinition(9001, name = Some("bar"))))
         ),
-        "/portDefinitions",
-        "Port names must be unique."
-      )
+        "/portDefinitions" ->
+          "Port names must be unique.")
 
-      shouldViolate(update.copy(mem = Some(-3.0)), "/mem", "error.min")
-      shouldViolate(update.copy(cpus = Some(-3.0)), "/cpus", "error.min")
-      shouldViolate(update.copy(disk = Some(-3.0)), "/disk", "error.min")
-      shouldViolate(update.copy(instances = Some(-3)), "/instances", "error.min")
-      shouldViolate(update.copy(networks = Some(Seq(Network(mode = NetworkMode.Container)))), "/networks", NetworkValidationMessages.NetworkNameMustBeSpecified)
+      shouldViolate(update.copy(mem = Some(-3.0)), "/mem" -> "error.min")(roundTripValidator)
+      shouldViolate(update.copy(cpus = Some(-3.0)), "/cpus" -> "error.min")(roundTripValidator)
+      shouldViolate(update.copy(disk = Some(-3.0)), "/disk" -> "error.min")(roundTripValidator)
+      shouldViolate(update.copy(instances = Some(-3)), "/instances" -> "error.min")(roundTripValidator)
+      shouldViolate(
+        update.copy(networks = Some(Seq(Network(mode = NetworkMode.Container)))),
+        "/networks" -> NetworkValidationMessages.NetworkNameMustBeSpecified)
     }
 
     "Validate secrets" in {
       val update = AppUpdate()
 
-      shouldViolate(update.copy(secrets = Some(Map(
-        "a" -> SecretDef("")
-      ))), "/secrets/a/source", "error.minLength")
+      shouldViolate(
+        update.copy(secrets = Some(Map("a" -> SecretDef("")))),
+        "/secrets/a/source" -> "error.minLength")(roundTripValidator)
 
-      shouldViolate(update.copy(secrets = Some(Map(
-        "" -> SecretDef("a/b/c")
-      ))), "/secrets()/", "must not be empty")
+      shouldViolate(
+        update.copy(secrets = Some(Map("" -> SecretDef("a/b/c")))),
+        "/secrets/keys(0)" -> "must not be empty")(roundTripValidator)
     }
 
     "SerializationRoundtrip for empty definition" in {

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/EnvVarValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/EnvVarValidationTest.scala
@@ -1,23 +1,21 @@
 package mesosphere.marathon
 package api.v2.validation
 
-import com.wix.accord.scalatest.ResultMatchers
-import com.wix.accord.{ Validator, validate }
+import com.wix.accord.Validator
 import com.wix.accord.dsl._
+import mesosphere.marathon.raml.{ EnvVarSecret, EnvVarValue, EnvVarValueOrSecret, Environment, SecretDef }
 import mesosphere.{ UnitTest, ValidationTestLike }
-import mesosphere.marathon.raml.{ EnvVarValueOrSecret, Environment }
 
-class EnvVarValidationTest extends UnitTest with ResultMatchers with ValidationTestLike {
+class EnvVarValidationTest extends UnitTest with ValidationTestLike {
 
-  import Normalization._
   import EnvVarValidationMessages._
 
   "EnvVarValidation" when {
     "an environment is validated" should {
 
       def compliantEnv(title: String, m: Map[String, EnvVarValueOrSecret], strictNameValidation: Boolean = true): Unit = {
-        s"$title is compliant with validation rules" in new WithoutSecrets(strictNameValidation) {
-          validate(m) should be(aSuccess)
+        s"$title is compliant with validation rules" in new Fixtures(strictNameValidation) {
+          shouldSucceed(m)
         }
       }
 
@@ -30,39 +28,58 @@ class EnvVarValidationTest extends UnitTest with ResultMatchers with ValidationT
       behave like compliantEnv("hyphen env", Environment("-" -> "x"), strictNameValidation = false)
       behave like compliantEnv("numerical env", Environment("9" -> "x"), strictNameValidation = false)
 
-      "fail with a numerical env variable name" in new WithoutSecrets {
-        validate(Wrapper(Environment("9" -> "x"))).normalize should failWith("/env(9)" -> MustContainOnlyAlphanumeric)
+      "fail with a numerical env variable name" in new Fixtures {
+        shouldViolate(Wrapper(Environment("9" -> "x")), "/env/keys(0)" -> MustContainOnlyAlphanumeric)
       }
 
-      def failsWhenExpected(subtitle: String, strictNameValidation: Boolean): Unit = {
-        s"fail with empty variable name $subtitle" in new WithoutSecrets(strictNameValidation) {
-          val alwaysExpected: Seq[ViolationMatcher] = Seq("/env()" -> "must not be empty")
-          val expectedNow =
-            if (strictNameValidation) alwaysExpected ++ (Seq[ViolationMatcher]("/env()" -> MustContainOnlyAlphanumeric))
-            else alwaysExpected
-
-          validate(Wrapper(Environment("" -> "x"))).normalize should failWith(expectedNow: _*)
+      def failsWhenExpected(subtitle: String, strict: Boolean): Unit = {
+        s"fail with empty variable name $subtitle" in new Fixtures(strict) {
+          shouldViolate(Wrapper(Environment("" -> "x")), "/env/keys(0)" -> "must not be empty")
+          if (strict) shouldViolate(Wrapper(Environment("" -> "x")), "/env/keys(0)" -> MustContainOnlyAlphanumeric)
         }
 
-        s"fail with too long variable name $subtitle" in new WithoutSecrets(strictNameValidation) {
-          val name = ("x" * 255)
-          val result = validate(Wrapper(Environment(name -> "x"))).normalize
-          if (strictNameValidation) {
-            result should failWith(s"/env($name)" -> MustContainOnlyAlphanumeric)
+        s"fail with too long variable name $subtitle" in new Fixtures(strict) {
+          val name = "x" * 255
+          if (strict) {
+            shouldViolate(Wrapper(Environment(name -> "x")), "/env/keys(0)" -> MustContainOnlyAlphanumeric)
           } else {
-            result should be(aSuccess)
+            shouldSucceed(Wrapper(Environment(name -> "x")))
           }
         }
       }
 
-      behave like failsWhenExpected("(strict)", true)
-      behave like failsWhenExpected("(non-strict)", false)
+      behave like failsWhenExpected("(strict)", strict = true)
+      behave like failsWhenExpected("(non-strict)", strict = false)
+    }
+
+    "validating secrets" should {
+      "fail when an undefined secret is referenced" in new Fixtures(secrets = true) {
+        val env = Map[String, EnvVarValueOrSecret](
+          "VALIDVAR" -> EnvVarValue("validvalue"),
+          "INVALIDVAR" -> EnvVarSecret("undefined-secret")
+        )
+
+        shouldViolate(env, "/INVALIDVAR/secret" -> "references an undefined secret")
+      }
     }
   }
 
-  class WithoutSecrets(strictNameValidation: Boolean = true) {
+  class Fixtures(strictNameValidation: Boolean = true, secrets: Boolean = false) {
+    val definedSecrets: Map[String, SecretDef] = if (secrets)
+      Map("secret" -> SecretDef("var"))
+    else
+      Map.empty
+
+    val enabledFeatures: Set[String] = if (secrets)
+      Set(Features.SECRETS)
+    else
+      Set.empty
+
     implicit lazy val envVarValidation: Validator[Map[String, EnvVarValueOrSecret]] =
-      EnvVarValidation.envValidator(strictNameValidation, Map.empty, Set.empty)
+      EnvVarValidation.envValidator(
+        strictNameValidation,
+        secrets = definedSecrets,
+        enabledFeatures = enabledFeatures)
 
     case class Wrapper(env: Map[String, EnvVarValueOrSecret])
 

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/PodsValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/PodsValidationTest.scala
@@ -1,81 +1,77 @@
 package mesosphere.marathon
 package api.v2.validation
 
-import com.wix.accord.scalatest.ResultMatchers
-import com.wix.accord.{ Result, Validator }
+import com.wix.accord.{ Result, Validator, Failure }
 import mesosphere.marathon.raml.{ Constraint, ConstraintOperator, DockerPullConfig, Endpoint, EnvVarSecret, EphemeralVolume, Image, ImageType, Network, NetworkMode, Pod, PodContainer, PodSecretVolume, Resources, SecretDef, VolumeMount }
 import mesosphere.marathon.util.SemanticVersion
 import mesosphere.{ UnitTest, ValidationTestLike }
 
-class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidation with SchedulingValidation with ValidationTestLike {
+class PodsValidationTest extends UnitTest with ValidationTestLike with PodsValidation with SchedulingValidation {
 
   "A pod definition" should {
 
-    "be rejected if the id is empty" in new Fixture {
-      private val invalid = validPod.copy(id = "/")
-      validator(invalid) should failWith("id" -> "Path must contain at least one path element")
+    "be rejected if the id is empty" in new Fixture() {
+      shouldViolate(validPod.copy(id = "/"), "/id" -> "Path must contain at least one path element")
     }
 
-    "be rejected if the id is not absolute" in new Fixture {
-      private val invalid = validPod.copy(id = "some/foo")
-      validator(invalid) should failWith("id" -> "Path needs to be absolute")
+    "be rejected if the id is not absolute" in new Fixture() {
+      shouldViolate(validPod.copy(id = "some/foo"), "/id" -> "Path needs to be absolute")
     }
 
-    "be rejected if a defined user is empty" in new Fixture {
-      private val invalid = validPod.copy(user = Some(""))
-      validator(invalid) should failWith("user" -> "must not be empty")
+    "be rejected if a defined user is empty" in new Fixture() {
+      shouldViolate(validPod.copy(user = Some("")), "/user" -> "must not be empty")
     }
 
-    "be accepted if secrets defined" in new Fixture {
+    "be accepted if secrets defined" in new Fixture(validateSecrets = true) {
       private val valid = validPod.copy(secrets = Map("secret1" -> SecretDef(source = "/foo")), environment = Map("TEST" -> EnvVarSecret("secret1")))
-      secretValidator(valid) shouldBe aSuccess
+      shouldSucceed(valid)
     }
 
-    "be rejected if no container is defined" in new Fixture {
-      private val invalid = validPod.copy(containers = Seq.empty)
-      validator(invalid) should failWith("containers" -> "must not be empty")
+    "be rejected if no container is defined" in new Fixture() {
+      shouldViolate(validPod.copy(containers = Seq.empty), "/containers" -> "must not be empty")
     }
 
-    "be rejected if container names are not unique" in new Fixture {
-      private val invalid = validPod.copy(containers = Seq(validContainer, validContainer))
-      validator(invalid) should failWith("containers" -> PodsValidationMessages.ContainerNamesMustBeUnique)
+    "be rejected if container names are not unique" in new Fixture() {
+      shouldViolate(
+        validPod.copy(containers = Seq(validContainer, validContainer)),
+        "/containers" -> PodsValidationMessages.ContainerNamesMustBeUnique)
     }
 
-    "be rejected if endpoint names are not unique" in new Fixture {
+    "be rejected if endpoint names are not unique" in new Fixture() {
       val endpoint1 = Endpoint("endpoint", hostPort = Some(123))
       val endpoint2 = Endpoint("endpoint", hostPort = Some(124))
       private val invalid = validPod.copy(containers = Seq(validContainer.copy(endpoints = Seq(endpoint1, endpoint2))))
-      validator(invalid) should failWith("value" -> PodsValidationMessages.EndpointNamesMustBeUnique)
+      shouldViolate(invalid, "/" -> PodsValidationMessages.EndpointNamesMustBeUnique)
     }
 
-    "be rejected if endpoint host ports are not unique" in new Fixture {
+    "be rejected if endpoint host ports are not unique" in new Fixture() {
       val endpoint1 = Endpoint("endpoint1", hostPort = Some(123))
       val endpoint2 = Endpoint("endpoint2", hostPort = Some(123))
       private val invalid = validPod.copy(containers = Seq(validContainer.copy(endpoints = Seq(endpoint1, endpoint2))))
-      validator(invalid) should failWith("value" -> PodsValidationMessages.HostPortsMustBeUnique)
+      shouldViolate(invalid, "/" -> PodsValidationMessages.HostPortsMustBeUnique)
     }
 
-    "be rejected if endpoint container ports are not unique" in new Fixture {
+    "be rejected if endpoint container ports are not unique" in new Fixture() {
       val endpoint1 = Endpoint("endpoint1", containerPort = Some(123))
       val endpoint2 = Endpoint("endpoint2", containerPort = Some(123))
       private val invalid = validPod.copy(
         networks = Seq(Network(mode = NetworkMode.Container, name = Some("default-network-name"))),
         containers = Seq(validContainer.copy(endpoints = Seq(endpoint1, endpoint2)))
       )
-      validator(invalid) should failWith("value" -> PodsValidationMessages.ContainerPortsMustBeUnique)
+      shouldViolate(invalid, "/" -> PodsValidationMessages.ContainerPortsMustBeUnique)
     }
 
-    "be rejected if volume names are not unique" in new Fixture {
+    "be rejected if volume names are not unique" in new Fixture() {
       val volume = EphemeralVolume("volume")
       val volumeMount = VolumeMount(volume.name, "/bla")
       private val invalid = validPod.copy(
         volumes = Seq(volume, volume),
         containers = Seq(validContainer.copy(volumeMounts = Seq(volumeMount)))
       )
-      validator(invalid) should failWith("volumes" -> PodsValidationMessages.VolumeNamesMustBeUnique)
+      shouldViolate(invalid, "/volumes" -> PodsValidationMessages.VolumeNamesMustBeUnique)
     }
 
-    "be rejected if a secret volume is defined without a corresponding secret" in new Fixture {
+    "be rejected if a secret volume is defined without a corresponding secret" in new Fixture(validateSecrets = true) {
       val volume = PodSecretVolume("volume", "foo")
       val volumeMount = VolumeMount(volume.name, "/bla")
       private val invalid = validPod.copy(
@@ -86,39 +82,31 @@ class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidatio
       validator(invalid).toString should include(PodsValidationMessages.SecretVolumeMustReferenceSecret)
     }
 
-    "be accepted if it is a valid pod with a Docker pull config" in new Fixture {
-      secretValidator(pullConfigPod) shouldBe aSuccess
+    "be accepted if it is a valid pod with a Docker pull config" in new Fixture(validateSecrets = true) {
+      shouldSucceed(pullConfigPod)
     }
 
-    "be rejected if a pull config pod is provided when secrets features is disabled" in new Fixture {
+    "be rejected if a pull config pod is provided when secrets features is disabled" in new Fixture(validateSecrets = false) {
       val validationResult: Result = validator(pullConfigPod)
-      validationResult shouldBe aFailure
+      validationResult shouldBe a[Failure]
       val validationResultString: String = validationResult.toString
       validationResultString should include("must be empty")
       validationResultString should include("Feature secrets is not enabled. Enable with --enable_features secrets)")
     }
 
-    "be rejected if a pull config pod doesn't have secrets" in new Fixture {
+    "be rejected if a pull config pod doesn't have secrets" in new Fixture(validateSecrets = true) {
       private val invalid = pullConfigPod.copy(secrets = Map.empty)
-      secretValidator(invalid) should failWith(
-        GroupViolationMatcher(
-          description = "containers",
-          constraint = "contains elements, which are not valid.",
-          violations = Set(group("(0)", "not valid",
-            "image" -> "pullConfig.secret must refer to an existing secret"))))
+      shouldViolate(invalid, "/containers(0)/image/pullConfig" ->
+        "pullConfig.secret must refer to an existing secret")
     }
 
-    "be rejected if a pull config image is not Docker" in new Fixture {
+    "be rejected if a pull config image is not Docker" in new Fixture() {
       private val invalid = pullConfigPod.copy(
         containers = Seq(pullConfigContainer.copy(
           image = Some(pullConfigContainer.image.get.copy(kind = ImageType.Appc))
         )))
-      secretValidator(invalid) should failWith(
-        GroupViolationMatcher(
-          description = "containers",
-          constraint = "contains elements, which are not valid.",
-          violations = Set(group("(0)", "not valid",
-            "image" -> "pullConfig is supported only with Docker images"))))
+      shouldViolate(invalid, "/containers(0)/image/pullConfig" ->
+        "pullConfig is supported only with Docker images")
     }
   }
 
@@ -133,7 +121,7 @@ class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidatio
     }
   }
 
-  class Fixture {
+  class Fixture(validateSecrets: Boolean = false) {
     val validContainer = PodContainer(
       name = "ct1",
       resources = Resources()
@@ -155,12 +143,12 @@ class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidatio
       secrets = Map("aSecret" -> SecretDef("/pull/config"))
     )
 
-    val validator: Validator[Pod] = podValidator(Set.empty, SemanticVersion.zero, None)
-    val secretValidator: Validator[Pod] = podValidator(Set(Features.SECRETS), SemanticVersion.zero, None)
+    val features: Set[String] = if (validateSecrets) Set(Features.SECRETS) else Set.empty
+    implicit val validator: Validator[Pod] = podValidator(features, SemanticVersion.zero, None)
   }
 
   "network validation" when {
-    val validator: Validator[Pod] = podValidator(Set.empty, SemanticVersion.zero, Some("default-network-name"))
+    implicit val validator: Validator[Pod] = podValidator(Set.empty, SemanticVersion.zero, Some("default-network-name"))
 
     def podContainer(name: String = "ct1", resources: Resources = Resources(), endpoints: Seq[Endpoint] = Nil) =
       PodContainer(
@@ -195,7 +183,7 @@ class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidatio
         val app = networkedPod(
           Seq(podContainer(endpoints = Seq(Endpoint("endpoint", containerPort = Some(80))))),
           networks(2))
-        validator(app) shouldBe (aSuccess)
+        shouldSucceed(app)
       }
 
       "allow endpoints for pods with bridge networking" in {
@@ -205,7 +193,7 @@ class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidatio
           containers = Seq(podContainer(endpoints = Seq(Endpoint("endpoint", hostPort = Some(0), containerPort = Some(80)))))
         )
 
-        validator(pod) shouldBe (aSuccess)
+        shouldSucceed(pod)
       }
 
       "allow endpoints that both declare a hostPort and a networkNames" in {
@@ -217,7 +205,7 @@ class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidatio
               containerPort = Some(80),
               networkNames = List("1"))))),
           networks(2))
-        validator(app) shouldBe (aSuccess)
+        shouldSucceed(app)
       }
     }
 
@@ -225,61 +213,56 @@ class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidatio
 
       def containerAndBridgeMode(subtitle: String, networks: => Seq[Network]): Unit = {
         s"${subtitle} allow endpoint with no networkNames" in {
-          validator(
+          shouldSucceed(
             networkedPod(Seq(
               podContainer(endpoints = Seq(
                 Endpoint(
                   "endpoint",
                   hostPort = Some(80),
                   containerPort = Some(80),
-                  networkNames = Nil)))), networks)) shouldBe (aSuccess)
+                  networkNames = Nil)))), networks))
         }
 
         s"${subtitle} allow endpoint without hostport" in {
-          validator(
+          shouldSucceed(
             networkedPod(Seq(
               podContainer(endpoints = Seq(
                 Endpoint(
                   "endpoint",
                   hostPort = None,
                   containerPort = Some(80),
-                  networkNames = Nil)))), networks)) shouldBe (aSuccess)
+                  networkNames = Nil)))), networks))
         }
 
         s"${subtitle} allow endpoint with zero hostport" in {
-          validator(
+          shouldSucceed(
             networkedPod(Seq(
               podContainer(endpoints = Seq(
                 Endpoint(
                   "endpoint",
                   containerPort = Some(80),
-                  hostPort = Some(0))))), networks)) shouldBe (aSuccess)
+                  hostPort = Some(0))))), networks))
         }
 
         s"${subtitle} allows containerPort of zero" in {
-          val result = validator(
+          shouldSucceed(
             networkedPod(Seq(
               podContainer(endpoints = Seq(
                 Endpoint("name1", containerPort = Some(0)),
                 Endpoint("name2", containerPort = Some(0))
               ))), networks))
-
-          result shouldBe aSuccess
         }
 
         s"${subtitle} require that hostPort is unique" in {
-          val result = validator(
-            networkedPod(Seq(
-              podContainer(endpoints = Seq(
-                Endpoint(
-                  "name1",
-                  hostPort = Some(123)),
-                Endpoint(
-                  "name2",
-                  hostPort = Some(123))))), networks))
-
-          result should containViolation(
-            "/" -> PodsValidationMessages.HostPortsMustBeUnique)
+          val pod = networkedPod(Seq(
+            podContainer(endpoints = Seq(
+              Endpoint(
+                "name1",
+                hostPort = Some(123)),
+              Endpoint(
+                "name2",
+                hostPort = Some(123))))), networks)
+          shouldViolate(pod, "/" -> PodsValidationMessages.HostPortsMustBeUnique)
         }
       }
 
@@ -288,26 +271,24 @@ class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidatio
     }
 
     "container-mode: requires containerPort" in {
-      val result = validator(
-        networkedPod(Seq(
-          podContainer(endpoints = Seq(
-            Endpoint(
-              "name1",
-              hostPort = Some(123)))))))
-
-      result should containViolation(
-        "/containers(0)/endpoints(0)/containerPort" -> "is required when using container-mode networking")
+      val pod = networkedPod(Seq(
+        podContainer(endpoints = Seq(
+          Endpoint(
+            "name1",
+            hostPort = Some(123))))))
+      shouldViolate(pod, "/containers(0)/endpoints(0)/containerPort" ->
+        "is required when using container-mode networking")
     }
 
     "allow endpoint with a networkNames" in {
-      validator(
+      shouldSucceed(
         networkedPod(Seq(
           podContainer(endpoints = Seq(
             Endpoint(
               "endpoint",
               hostPort = Some(80),
               containerPort = Some(80),
-              networkNames = List("1"))))))) shouldBe (aSuccess)
+              networkNames = List("1")))))))
     }
 
     "disallow endpoint with a host port and two valid networkNames" in {
@@ -318,7 +299,7 @@ class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidatio
               "endpoint",
               hostPort = Some(80),
               containerPort = Some(80),
-              networkNames = List("1", "2"))))))) shouldBe (aFailure)
+              networkNames = List("1", "2"))))))) shouldBe a[Failure]
     }
 
     "disallow endpoint with a non-matching network name" in {
@@ -334,10 +315,9 @@ class PodsValidationTest extends UnitTest with ResultMatchers with PodsValidatio
     }
 
     "allow endpoint without hostPort for host networking" in {
-      val result = validator(networkedPod(Seq(
+      shouldSucceed(networkedPod(Seq(
         podContainer(endpoints = Seq(Endpoint("ep")))
       ), hostNetwork))
-      result shouldBe aSuccess
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/SchedulingValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/SchedulingValidationTest.scala
@@ -11,14 +11,18 @@ class SchedulingValidationTest extends UnitTest with ValidationTestLike {
   "SchedulingValidation" when {
     "validating bogus operator" should {
       "fail with human readable error message" in {
-        shouldViolate(Seq("a", "b", "c"), "/" -> ConstraintOperatorInvalid)(complyWithAppConstraintRules)
+        complyWithAppConstraintRules(Seq("a", "b", "c")) should haveViolations("/" -> ConstraintOperatorInvalid)
       }
     }
     def validAppConstraint(subtitle: String, c: Seq[String]): Unit = {
-      subtitle in shouldSucceed(c)(complyWithAppConstraintRules)
+      subtitle in {
+        complyWithAppConstraintRules(c) should be(aSuccess)
+      }
     }
     def failsAsExpected(subtitle: String, c: Seq[String], violatedConstraint: String): Unit = {
-      subtitle in shouldViolate(c, "/" -> violatedConstraint)(complyWithAppConstraintRules)
+      subtitle in {
+        complyWithAppConstraintRules(c) should haveViolations("/" -> violatedConstraint)
+      }
     }
     "validating CLUSTER constraint" should {
 

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/SchedulingValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/SchedulingValidationTest.scala
@@ -1,11 +1,9 @@
 package mesosphere.marathon
 package api.v2.validation
 
-import com.wix.accord.scalatest.ResultMatchers
-import com.wix.accord.validate
 import mesosphere.{ UnitTest, ValidationTestLike }
 
-class SchedulingValidationTest extends UnitTest with ValidationTestLike with ResultMatchers {
+class SchedulingValidationTest extends UnitTest with ValidationTestLike {
 
   import SchedulingValidation._
   import SchedulingValidationMessages._
@@ -13,22 +11,14 @@ class SchedulingValidationTest extends UnitTest with ValidationTestLike with Res
   "SchedulingValidation" when {
     "validating bogus operator" should {
       "fail with human readable error message" in {
-        validate(Seq("a", "b", "c"))(complyWithAppConstraintRules) should failWith(RuleViolationMatcher(
-          constraint = ConstraintOperatorInvalid
-        ))
+        shouldViolate(Seq("a", "b", "c"), "/" -> ConstraintOperatorInvalid)(complyWithAppConstraintRules)
       }
     }
     def validAppConstraint(subtitle: String, c: Seq[String]): Unit = {
-      subtitle in {
-        validate(c)(complyWithAppConstraintRules) should be(aSuccess)
-      }
+      subtitle in shouldSucceed(c)(complyWithAppConstraintRules)
     }
     def failsAsExpected(subtitle: String, c: Seq[String], violatedConstraint: String): Unit = {
-      subtitle in {
-        validate(c)(complyWithAppConstraintRules) should failWith(RuleViolationMatcher(
-          constraint = violatedConstraint
-        ))
-      }
+      subtitle in shouldViolate(c, "/" -> violatedConstraint)(complyWithAppConstraintRules)
     }
     "validating CLUSTER constraint" should {
 

--- a/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidationTest.scala
@@ -13,7 +13,7 @@ class AppDefinitionValidationTest extends UnitTest with ValidationTestLike {
     "created with the default unreachable strategy" should {
       "be valid" in new Fixture {
         val app = AppDefinition(id = PathId("/test"), cmd = Some("sleep 1000"))
-        shouldSucceed(app)
+        validator(app) shouldBe aSuccess
       }
     }
 
@@ -25,7 +25,7 @@ class AppDefinitionValidationTest extends UnitTest with ValidationTestLike {
           cmd = Some("sleep 1000"),
           dependencies = Set(PathId("/a/b/c/e"))
         )
-        shouldSucceed(app)
+        validator(app) shouldBe aSuccess
       }
 
       "be valid with dependencies pointing to a different subtree (Regression for #5024)" in new Fixture {
@@ -34,7 +34,7 @@ class AppDefinitionValidationTest extends UnitTest with ValidationTestLike {
           cmd = Some("sleep 1000"),
           dependencies = Set(PathId("/x/y/z"))
         )
-        shouldSucceed(app)
+        validator(app) shouldBe aSuccess
       }
 
       "be invalid with dependencies with invalid path chars" in new Fixture {
@@ -44,7 +44,8 @@ class AppDefinitionValidationTest extends UnitTest with ValidationTestLike {
           dependencies = Set(PathId("/a/.../"))
         )
 
-        shouldViolate(app, "/dependencies(0)" -> """must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])|(\.|\.\.)$'""")
+        validator(app) should haveViolations(
+          "/dependencies(0)" -> """must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])|(\.|\.\.)$'""")
       }
     }
 
@@ -53,45 +54,53 @@ class AppDefinitionValidationTest extends UnitTest with ValidationTestLike {
       "be invalid if persistent volumes change" in new Fixture {
         val app = validResidentApp
         val to = app.copy(container = Some(Container.Mesos(Seq(persistentVolume("foo", 2)))))
-        shouldViolate(to, "/" -> "Persistent volumes can not be changed!")(AppDefinition.residentUpdateIsValid(app))
+        AppDefinition.residentUpdateIsValid(app)(to) should haveViolations(
+          "/" -> "Persistent volumes can not be changed!")
       }
 
       "be invalid if ports change" in new Fixture {
         val app = validResidentApp
         val to1 = app.copy(portDefinitions = Seq.empty) // no port
         val to2 = app.copy(portDefinitions = Seq(PortDefinition(1))) // different port
-        shouldViolate(to1, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
-        shouldViolate(to2, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
+        AppDefinition.residentUpdateIsValid(app)(to1) should haveViolations(
+          "/" -> "Resident Tasks may not change resource requirements!")
+        AppDefinition.residentUpdateIsValid(app)(to2) should haveViolations(
+          "/" -> "Resident Tasks may not change resource requirements!")
       }
 
       "be invalid if cpu changes" in new Fixture {
         val app = validResidentApp
         val to = app.copy(resources = app.resources.copy(cpus = 3))
-        shouldViolate(to, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
+        AppDefinition.residentUpdateIsValid(app)(to) should haveViolations(
+          "/" -> "Resident Tasks may not change resource requirements!")
       }
 
       "be invalid if mem changes" in new Fixture {
         val app = validResidentApp
         val to = app.copy(resources = app.resources.copy(mem = 3))
-        shouldViolate(to, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
+        AppDefinition.residentUpdateIsValid(app)(to) should haveViolations(
+          "/" -> "Resident Tasks may not change resource requirements!")
       }
 
       "be invalid if disk changes" in new Fixture {
         val app = validResidentApp
         val to = app.copy(resources = app.resources.copy(disk = 3))
-        shouldViolate(to, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
+        AppDefinition.residentUpdateIsValid(app)(to) should haveViolations(
+          "/" -> "Resident Tasks may not change resource requirements!")
       }
 
       "be invalid if gpus change" in new Fixture {
         val app = validResidentApp
         val to = app.copy(resources = app.resources.copy(gpus = 3))
-        shouldViolate(to, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
+        AppDefinition.residentUpdateIsValid(app)(to) should haveViolations(
+          "/" -> "Resident Tasks may not change resource requirements!")
       }
 
       "be invalid with default upgrade strategy" in new Fixture {
         val app = validResidentApp
         val to = app.copy(upgradeStrategy = UpgradeStrategy.empty)
-        shouldViolate(to, "/upgradeStrategy/maximumOverCapacity" -> "got 1.0, expected 0.0")(AppDefinition.residentUpdateIsValid(app))
+        AppDefinition.residentUpdateIsValid(app)(to) should haveViolations(
+          "/upgradeStrategy/maximumOverCapacity" -> "got 1.0, expected 0.0")
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidationTest.scala
@@ -1,22 +1,19 @@
 package mesosphere.marathon
 package api.validation
 
-import com.wix.accord.scalatest.ResultMatchers
-import mesosphere.UnitTest
+import com.wix.accord.Validator
+import mesosphere.{ UnitTest, ValidationTestLike }
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.state._
 import org.apache.mesos.{ Protos => Mesos }
 
-class AppDefinitionValidationTest extends UnitTest with ResultMatchers {
+class AppDefinitionValidationTest extends UnitTest with ValidationTestLike {
 
   "AppDefinition" when {
     "created with the default unreachable strategy" should {
       "be valid" in new Fixture {
         val app = AppDefinition(id = PathId("/test"), cmd = Some("sleep 1000"))
-
-        val validation = validator(app)
-        validation shouldBe aSuccess
-
+        shouldSucceed(app)
       }
     }
 
@@ -28,7 +25,7 @@ class AppDefinitionValidationTest extends UnitTest with ResultMatchers {
           cmd = Some("sleep 1000"),
           dependencies = Set(PathId("/a/b/c/e"))
         )
-        validator(app) shouldBe aSuccess
+        shouldSucceed(app)
       }
 
       "be valid with dependencies pointing to a different subtree (Regression for #5024)" in new Fixture {
@@ -37,7 +34,7 @@ class AppDefinitionValidationTest extends UnitTest with ResultMatchers {
           cmd = Some("sleep 1000"),
           dependencies = Set(PathId("/x/y/z"))
         )
-        validator(app) shouldBe aSuccess
+        shouldSucceed(app)
       }
 
       "be invalid with dependencies with invalid path chars" in new Fixture {
@@ -46,8 +43,8 @@ class AppDefinitionValidationTest extends UnitTest with ResultMatchers {
           cmd = Some("sleep 1000"),
           dependencies = Set(PathId("/a/.../"))
         )
-        val expectedViolation = GroupViolationMatcher(description = "dependencies", constraint = "is invalid")
-        validator(app) should failWith(expectedViolation)
+
+        shouldViolate(app, "/dependencies(0)" -> """must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])|(\.|\.\.)$'""")
       }
     }
 
@@ -56,52 +53,51 @@ class AppDefinitionValidationTest extends UnitTest with ResultMatchers {
       "be invalid if persistent volumes change" in new Fixture {
         val app = validResidentApp
         val to = app.copy(container = Some(Container.Mesos(Seq(persistentVolume("foo", 2)))))
-        AppDefinition.residentUpdateIsValid(app)(to) should failWith("value" -> "Persistent volumes can not be changed!")
+        shouldViolate(to, "/" -> "Persistent volumes can not be changed!")(AppDefinition.residentUpdateIsValid(app))
       }
 
       "be invalid if ports change" in new Fixture {
         val app = validResidentApp
         val to1 = app.copy(portDefinitions = Seq.empty) // no port
         val to2 = app.copy(portDefinitions = Seq(PortDefinition(1))) // different port
-        AppDefinition.residentUpdateIsValid(app)(to1) should failWith("value" -> "Resident Tasks may not change resource requirements!")
-        AppDefinition.residentUpdateIsValid(app)(to2) should failWith("value" -> "Resident Tasks may not change resource requirements!")
+        shouldViolate(to1, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
+        shouldViolate(to2, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
       }
 
       "be invalid if cpu changes" in new Fixture {
         val app = validResidentApp
         val to = app.copy(resources = app.resources.copy(cpus = 3))
-        AppDefinition.residentUpdateIsValid(app)(to) should failWith("value" -> "Resident Tasks may not change resource requirements!")
+        shouldViolate(to, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
       }
 
       "be invalid if mem changes" in new Fixture {
         val app = validResidentApp
         val to = app.copy(resources = app.resources.copy(mem = 3))
-        AppDefinition.residentUpdateIsValid(app)(to) should failWith("value" -> "Resident Tasks may not change resource requirements!")
+        shouldViolate(to, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
       }
 
       "be invalid if disk changes" in new Fixture {
         val app = validResidentApp
         val to = app.copy(resources = app.resources.copy(disk = 3))
-        AppDefinition.residentUpdateIsValid(app)(to) should failWith("value" -> "Resident Tasks may not change resource requirements!")
+        shouldViolate(to, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
       }
 
       "be invalid if gpus change" in new Fixture {
         val app = validResidentApp
         val to = app.copy(resources = app.resources.copy(gpus = 3))
-        AppDefinition.residentUpdateIsValid(app)(to) should failWith("value" -> "Resident Tasks may not change resource requirements!")
+        shouldViolate(to, "/" -> "Resident Tasks may not change resource requirements!")(AppDefinition.residentUpdateIsValid(app))
       }
 
       "be invalid with default upgrade strategy" in new Fixture {
         val app = validResidentApp
         val to = app.copy(upgradeStrategy = UpgradeStrategy.empty)
-        AppDefinition.residentUpdateIsValid(app)(to) should failWith("upgradeStrategy" -> "got 1.0, expected 0.0")
+        shouldViolate(to, "/upgradeStrategy/maximumOverCapacity" -> "got 1.0, expected 0.0")(AppDefinition.residentUpdateIsValid(app))
       }
-
     }
   }
 
   class Fixture {
-    val validator = AppDefinition.validAppDefinition(Set.empty)(PluginManager.None)
+    implicit val validator: Validator[AppDefinition] = AppDefinition.validAppDefinition(Set.empty)(PluginManager.None)
     def validApp = AppDefinition(
       id = PathId("/a/b/c/d"),
       cmd = Some("sleep 1000"),

--- a/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
@@ -2,9 +2,8 @@ package mesosphere.marathon
 package api.validation
 
 import com.wix.accord.validate
-import mesosphere.UnitTest
+import mesosphere.{ UnitTest, ValidationTestLike }
 import mesosphere.marathon.api.v2.AppNormalization
-import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.core.health.{ MarathonHttpHealthCheck, MesosCommandHealthCheck }
 import mesosphere.marathon.core.plugin.{ PluginDefinitions, PluginManager }
@@ -19,7 +18,7 @@ import play.api.libs.json.Json
 import scala.collection.immutable.Seq
 import scala.reflect.ClassTag
 
-class RunSpecValidatorTest extends UnitTest {
+class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
 
   val config = AppNormalization.Configuration(None, "mesos-bridge-name")
   private implicit lazy val validApp = AppValidation.validateCanonicalAppAPI(Set(), () => config.defaultNetworkName)
@@ -108,7 +107,7 @@ class RunSpecValidatorTest extends UnitTest {
         id = PathId("relative/asd"),
         cmd = Some("true"))
 
-      the[ValidationFailedException] thrownBy validateOrThrow(app) should have message "Validation failed: Failure(Set(RuleViolation(relative/asd,Path needs to be absolute,Some(id))))"
+      shouldViolate(app, "/id" -> "Path needs to be absolute")
 
       MarathonTestHelper.validateJsonSchema(app)
     }
@@ -119,8 +118,7 @@ class RunSpecValidatorTest extends UnitTest {
         id = PathId("../relative"),
         cmd = Some("true"))
 
-      the[ValidationFailedException] thrownBy validateOrThrow(app) should have message ("Validation failed: Failure(Set(RuleViolation(../relative,Path needs to be absolute,Some(id))))")
-
+      shouldViolate(app, "/id" -> "Path needs to be absolute")
       MarathonTestHelper.validateJsonSchema(app)
     }
 

--- a/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
@@ -107,7 +107,7 @@ class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
         id = PathId("relative/asd"),
         cmd = Some("true"))
 
-      shouldViolate(app, "/id" -> "Path needs to be absolute")
+      validAppDefinition(app) should haveViolations("/id" -> "Path needs to be absolute")
 
       MarathonTestHelper.validateJsonSchema(app)
     }
@@ -118,7 +118,7 @@ class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
         id = PathId("../relative"),
         cmd = Some("true"))
 
-      shouldViolate(app, "/id" -> "Path needs to be absolute")
+      validAppDefinition(app) should haveViolations("/id" -> "Path needs to be absolute")
       MarathonTestHelper.validateJsonSchema(app)
     }
 

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
@@ -1,9 +1,10 @@
 package mesosphere.marathon
 package core.externalvolume.impl.providers
 
-import com.wix.accord.{ Failure, Result, RuleViolation, Success }
+import com.wix.accord.{ Failure, Result, Success }
 import mesosphere.UnitTest
 import mesosphere.marathon.api.v2.Validation
+import mesosphere.marathon.api.v2.Validation.ConstraintViolation
 import mesosphere.marathon.core.externalvolume.ExternalVolumes
 import mesosphere.marathon.state._
 import mesosphere.marathon.test.GroupCreation
@@ -58,15 +59,13 @@ class DVDIProviderRootGroupValidationTest extends UnitTest with GroupCreation {
       f.checkResult(
         rootGroup,
         expectedViolations = Set(
-          RuleViolation(
-            value = app1.externalVolumes.head,
+          ConstraintViolation(
             constraint = "Volume name 'vol' in /nested/app1 conflicts with volume(s) of same name in app(s): /nested/app2",
-            description = Some("/groups(0)/apps(0)/externalVolumes(0)")
+            path = "/groups(0)/apps(0)/externalVolumes(0)"
           ),
-          RuleViolation(
-            value = app2.externalVolumes.head,
+          ConstraintViolation(
             constraint = "Volume name 'vol' in /nested/app2 conflicts with volume(s) of same name in app(s): /nested/app1",
-            description = Some("/groups(0)/apps(1)/externalVolumes(0)")
+            path = "/groups(0)/apps(1)/externalVolumes(0)"
           )
         )
       )
@@ -107,7 +106,7 @@ class DVDIProviderRootGroupValidationTest extends UnitTest with GroupCreation {
         )
       }
 
-      def checkResult(rootGroup: RootGroup, expectedViolations: Set[RuleViolation]): Unit = {
+      def checkResult(rootGroup: RootGroup, expectedViolations: Set[ConstraintViolation]): Unit = {
         val expectFailure = expectedViolations.nonEmpty
 
         When("validating the root group")
@@ -125,13 +124,13 @@ class DVDIProviderRootGroupValidationTest extends UnitTest with GroupCreation {
         withClue(jsonResult(globalResult)) { globalResult.isFailure should be(expectFailure) }
 
         val ruleViolations = globalResult match {
-          case Success => Set.empty[RuleViolation]
-          case f: Failure => f.violations.flatMap(Validation.allRuleViolationsWithFullDescription(_))
+          case Success => Seq.empty[ConstraintViolation]
+          case f: Failure => Validation.allViolations(f)
         }
 
         And("the rule violations are the expected ones")
         withClue(jsonResult(globalResult)) {
-          ruleViolations should equal(expectedViolations)
+          ruleViolations.toSet should equal(expectedViolations)
         }
       }
     }

--- a/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
@@ -170,14 +170,15 @@ class PathIdTest extends UnitTest with ValidationTestLike {
     "passed legal characters" should {
       "be valid" in {
         val path = PathId("/foobar-0")
-        shouldSucceed(path)
+        pathIdValidator(path) shouldBe aSuccess
       }
     }
 
     "passed illegal characters" should {
       "be invalid" in {
         val path = PathId("/@§\'foobar-0")
-        shouldViolate(path, "/" -> "must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$'")
+        pathIdValidator(path) should haveViolations(
+          "/" -> "must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$'")
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
@@ -1,13 +1,12 @@
 package mesosphere.marathon
 package state
 
-import mesosphere.UnitTest
+import mesosphere.{ UnitTest, ValidationTestLike }
 import mesosphere.marathon.state.PathId._
-import com.wix.accord.scalatest.ResultMatchers
 
 import scala.collection.SortedSet
 
-class PathIdTest extends UnitTest with ResultMatchers {
+class PathIdTest extends UnitTest with ValidationTestLike {
   "A PathId" can {
     "be parsed from string" in {
       Given("A base id")
@@ -171,17 +170,14 @@ class PathIdTest extends UnitTest with ResultMatchers {
     "passed legal characters" should {
       "be valid" in {
         val path = PathId("/foobar-0")
-        val validation = PathId.pathIdValidator(path)
-        validation shouldBe aSuccess
+        shouldSucceed(path)
       }
     }
 
     "passed illegal characters" should {
       "be invalid" in {
         val path = PathId("/@§\'foobar-0")
-        val validation = PathId.pathIdValidator(path)
-        val expectedViolation = RuleViolationMatcher(value = "@§'foobar-0", constraint = "must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$'")
-        validation should failWith(expectedViolation)
+        shouldViolate(path, "/" -> "must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$'")
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
@@ -150,7 +150,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val result = validate(changed)(RootGroup.rootGroupValidator(Set()))
       result.isFailure should be(true)
       ValidationHelper.getAllRuleConstrains(result).head
-        .message should be("Groups and Applications may not have the same identifier.")
+        .constraint should be("Groups and Applications may not have the same identifier.")
     }
 
     "cannot replace a group with pods by an app definition" in {
@@ -183,7 +183,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val result = validate(changed)(RootGroup.rootGroupValidator(Set()))
       result.isFailure should be(true)
       ValidationHelper.getAllRuleConstrains(result).head
-        .message should be("Groups and Applications may not have the same identifier.")
+        .constraint should be("Groups and Applications may not have the same identifier.")
     }
 
     "cannot replace a group with pods by an pod definition" in {
@@ -218,7 +218,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val result = validate(changed)(RootGroup.rootGroupValidator(Set()))
       result.isFailure should be(true)
       ValidationHelper.getAllRuleConstrains(result).head
-        .message should be("Groups and Pods may not have the same identifier.")
+        .constraint should be("Groups and Pods may not have the same identifier.")
     }
 
     "can turn a group with group dependencies into a dependency graph" in {

--- a/src/test/scala/mesosphere/marathon/state/UnreachableStrategyTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/UnreachableStrategyTest.scala
@@ -7,32 +7,32 @@ import scala.concurrent.duration._
 
 class UnreachableStrategyTest extends UnitTest with ValidationTestLike {
 
-  implicit def validate = UnreachableStrategy.unreachableStrategyValidator
+  implicit def validator = UnreachableStrategy.unreachableStrategyValidator
 
   "UnreachableStrategy.unreachableStrategyValidator" should {
     "validate default strategy" in {
       val strategy = UnreachableEnabled()
-      shouldSucceed(strategy)
+      validator(strategy) shouldBe aSuccess
     }
 
     "validate with other parameters successfully" in {
       val strategy = UnreachableEnabled(13.minutes, 37.minutes)
-      shouldSucceed(strategy)
+      validator(strategy) shouldBe aSuccess
     }
 
     "sees disabled as valid" in {
       val strategy = UnreachableDisabled
-      shouldSucceed(strategy)
+      validator(strategy) shouldBe aSuccess
     }
 
     "fail when time until expunge is smaller" in {
       val strategy = UnreachableEnabled(inactiveAfter = 2.seconds, expungeAfter = 1.second)
-      shouldViolate(strategy, "/inactiveAfter" -> "got 2 seconds, expected 1 second or less")
+      validator(strategy) should haveViolations("/inactiveAfter" -> "got 2 seconds, expected 1 second or less")
     }
 
     "succeed when time until expunge is equal to time until inactive" in {
       val strategy = UnreachableEnabled(inactiveAfter = 2.seconds, expungeAfter = 2.seconds)
-      shouldSucceed(strategy)
+      validator(strategy) shouldBe aSuccess
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/state/UnreachableStrategyTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/UnreachableStrategyTest.scala
@@ -1,40 +1,38 @@
 package mesosphere.marathon
 package state
 
-import com.wix.accord.scalatest.ResultMatchers
-import mesosphere.UnitTest
+import mesosphere.{ UnitTest, ValidationTestLike }
 
 import scala.concurrent.duration._
 
-class UnreachableStrategyTest extends UnitTest with ResultMatchers {
+class UnreachableStrategyTest extends UnitTest with ValidationTestLike {
 
-  def validate = UnreachableStrategy.unreachableStrategyValidator
+  implicit def validate = UnreachableStrategy.unreachableStrategyValidator
 
   "UnreachableStrategy.unreachableStrategyValidator" should {
     "validate default strategy" in {
       val strategy = UnreachableEnabled()
-      validate(strategy) shouldBe aSuccess
+      shouldSucceed(strategy)
     }
 
     "validate with other parameters successfully" in {
       val strategy = UnreachableEnabled(13.minutes, 37.minutes)
-      validate(strategy) shouldBe aSuccess
+      shouldSucceed(strategy)
     }
 
     "sees disabled as valid" in {
       val strategy = UnreachableDisabled
-      validate(strategy) shouldBe aSuccess
+      shouldSucceed(strategy)
     }
 
     "fail when time until expunge is smaller" in {
       val strategy = UnreachableEnabled(inactiveAfter = 2.seconds, expungeAfter = 1.second)
-      validate(strategy) should failWith(
-        "inactiveAfter" -> "got 2 seconds, expected 1 second or less")
+      shouldViolate(strategy, "/inactiveAfter" -> "got 2 seconds, expected 1 second or less")
     }
 
-    "fail when time until expunge is equal to time until inactive" in {
+    "succeed when time until expunge is equal to time until inactive" in {
       val strategy = UnreachableEnabled(inactiveAfter = 2.seconds, expungeAfter = 2.seconds)
-      validate(strategy) shouldBe aSuccess
+      shouldSucceed(strategy)
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
@@ -85,7 +85,7 @@ class VolumeTest extends UnitTest {
 
       val result = validate(pvi)
       result.isSuccess shouldBe false
-      ValidationHelper.getAllRuleConstrains(result).map(_.message) shouldBe Set("Unsupported field")
+      ValidationHelper.getAllRuleConstrains(result).map(_.constraint) shouldBe Set("Unsupported field")
     }
 
     "validating PersistentVolumeInfo constraints rejected for root resources" in {
@@ -95,7 +95,7 @@ class VolumeTest extends UnitTest {
           `type` = DiskType.Root,
           constraints = Set(constraint("path", "LIKE", Some("regex")))))
       result.isSuccess shouldBe false
-      ValidationHelper.getAllRuleConstrains(result).map(_.message) shouldBe Set("Constraints on root volumes are not supported")
+      ValidationHelper.getAllRuleConstrains(result).map(_.constraint) shouldBe Set("Constraints on root volumes are not supported")
     }
 
     "validating PersistentVolumeInfo constraints rejects bad regex" in {
@@ -105,7 +105,7 @@ class VolumeTest extends UnitTest {
         constraints = Set(constraint("path", "LIKE", Some("(bad regex"))))
       val result = validate(pvi)
       result.isSuccess shouldBe false
-      ValidationHelper.getAllRuleConstrains(result).map(_.message) shouldBe Set("Invalid regular expression")
+      ValidationHelper.getAllRuleConstrains(result).map(_.constraint) shouldBe Set("Invalid regular expression")
     }
 
     "validating PersistentVolumeInfo accepts a valid constraint" in new Fixture {
@@ -117,12 +117,12 @@ class VolumeTest extends UnitTest {
       val resultRoot = validate(
         PersistentVolumeInfo(1024, `type` = DiskType.Root, maxSize = Some(2048)))
       resultRoot.isSuccess shouldBe false
-      ValidationHelper.getAllRuleConstrains(resultRoot).map(_.message) shouldBe Set("Only mount volumes can have maxSize")
+      ValidationHelper.getAllRuleConstrains(resultRoot).map(_.constraint) shouldBe Set("Only mount volumes can have maxSize")
 
       val resultPath = validate(
         PersistentVolumeInfo(1024, `type` = DiskType.Path, maxSize = Some(2048)))
       resultPath.isSuccess shouldBe false
-      ValidationHelper.getAllRuleConstrains(resultPath).map(_.message) shouldBe Set("Only mount volumes can have maxSize")
+      ValidationHelper.getAllRuleConstrains(resultPath).map(_.constraint) shouldBe Set("Only mount volumes can have maxSize")
 
       validate(mountVolWithMaxSize).isSuccess shouldBe true
     }

--- a/src/test/scala/mesosphere/mesos/PersistentVolumeValidationTest.scala
+++ b/src/test/scala/mesosphere/mesos/PersistentVolumeValidationTest.scala
@@ -1,11 +1,10 @@
 package mesosphere.mesos
 
-import com.wix.accord._
-import mesosphere.UnitTest
+import mesosphere.{ UnitTest, ValidationTestLike }
 import mesosphere.marathon.state.{ PersistentVolume, PersistentVolumeInfo, Volume }
 import org.apache.mesos
 
-class PersistentVolumeValidationTest extends UnitTest {
+class PersistentVolumeValidationTest extends UnitTest with ValidationTestLike {
   "PersistentVolumeValidation" should {
     "create a PersistentVolume with no validation violations" in {
       Given("a PersistentVolume with no validation violations")
@@ -28,16 +27,9 @@ class PersistentVolumeValidationTest extends UnitTest {
       When("The volume is created and validation failed")
       volume should not be null
       volume.containerPath should be (path)
-      val validation = Volume.validVolume(Set())(volume)
-      validation.isSuccess should be (false)
 
       Then("A validation exists with a readable error message")
-      validation match {
-        case Failure(violations) =>
-          violations should contain (RuleViolation("/path", "value must not contain \"/\"", Some("containerPath")))
-        case Success =>
-          fail("validation should fail!")
-      }
+      shouldViolate(volume, "/containerPath" -> "value must not contain \"/\"")(Volume.validVolume(Set()))
     }
   }
 }

--- a/src/test/scala/mesosphere/mesos/PersistentVolumeValidationTest.scala
+++ b/src/test/scala/mesosphere/mesos/PersistentVolumeValidationTest.scala
@@ -29,7 +29,8 @@ class PersistentVolumeValidationTest extends UnitTest with ValidationTestLike {
       volume.containerPath should be (path)
 
       Then("A validation exists with a readable error message")
-      shouldViolate(volume, "/containerPath" -> "value must not contain \"/\"")(Volume.validVolume(Set()))
+      Volume.validVolume(Set())(volume) should haveViolations(
+        "/containerPath" -> "value must not contain \"/\"")
     }
   }
 }


### PR DESCRIPTION
This is a pre-requisite to moving to Scala 2.12

A common source of frustration when testing validations has been to
figure out the right matcher format. To help with that aim, we
introduce the shouldViolate and shouldSucceed test helpers which have
much easier-to-grok output.

Started with @aquamatthias's branch https://github.com/mesosphere/marathon/tree/mv/wix_06

JIRA Issues: MARATHON-1779