### PR TITLE
[WIP] Remove formats import from marshalling. 

### DIFF
--- a/docs/docs/rest-api/public/api/api.raml
+++ b/docs/docs/rest-api/public/api/api.raml
@@ -12,6 +12,7 @@ uses:
   queue: v2/types/queue.raml
   group: v2/types/group.raml
   strings: v2/types/stringTypes.raml
+  pluginDefinition: v2/types/pluginDefinition.raml
   pod: v2/types/pod.raml
   podStatus: v2/types/podStatus.raml
   metrics: v2/types/metrics.raml

--- a/docs/docs/rest-api/public/api/api.raml
+++ b/docs/docs/rest-api/public/api/api.raml
@@ -7,6 +7,7 @@ baseUri: ../
 
 uses:
   app: v2/types/app.raml
+  appInfo: v2/types/appInfo.raml
   error: v2/types/error.raml
   info: v2/types/info.raml
   queue: v2/types/queue.raml

--- a/docs/docs/rest-api/public/api/v2/plugins.raml
+++ b/docs/docs/rest-api/public/api/v2/plugins.raml
@@ -6,6 +6,7 @@ get:
       description: The list of all loaded plugins
       body:
         application/json:
+          type: pluginDefinition.PluginDefinitions
           example: |
             {
                 "plugins": [
@@ -26,6 +27,11 @@ get:
 /{plugin_id}/{path}:
   get:
     description: Get request is handled by the plugin.
+    responses:
+      200:
+        body:
+          application/json:
+            type: pluginDefinition.PluginDefinition
   put:
     description: Put request is handled by the plugin.
   post:

--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -20,30 +20,6 @@ uses:
   killSelection: killSelection.raml
 
 types:
-  AppInfo:
-    type: object
-    properties:
-      app:
-        type: App
-        properties:
-        # Task counts
-          tasksStaged?:
-            type: number
-            format: int32
-          tasksRunning?:
-            type: number
-            format: int32
-          tasksHealthy?:
-            type: number
-            format: int32
-          tasksUnhealthy?:
-            type: number
-            format: int32
-       #   deployments?: Deployment[]
-       #   readinessCheckResults?: ReadinessCheckResult[]
-       #   tasks?: EnrichedTask[]
-       #   lastTaskFailures?: TaskFailure
-       #   taskStats?: TaskStatsByVersion
   AppResidency:
     type: object
     description: |

--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -25,25 +25,25 @@ types:
     properties:
       app:
         type: App
-        # properties:
+        properties:
         # Task counts
-      #  tasksStaged?:
-      #    type: number
-      #    format: int32
-      #  tasksRunning?:
-      #    type: number
-      #    format: int32
-      #  tasksHealthy?:
-      #    type: number
-      #    format: int32
-      #  tasksUnhealthy?:
-      #    type: number
-      #    format: int32
-      #  deployments?: Deployment[]
-      #  readinessCheckResults?: ReadinessCheckResult[]
-      #  tasks?: EnrichedTask[]
-      #  lastTaskFailures?: TaskFailure
-      #  taskStats?: TaskStatsByVersion
+          tasksStaged?:
+            type: number
+            format: int32
+          tasksRunning?:
+            type: number
+            format: int32
+          tasksHealthy?:
+            type: number
+            format: int32
+          tasksUnhealthy?:
+            type: number
+            format: int32
+       #   deployments?: Deployment[]
+       #   readinessCheckResults?: ReadinessCheckResult[]
+       #   tasks?: EnrichedTask[]
+       #   lastTaskFailures?: TaskFailure
+       #   taskStats?: TaskStatsByVersion
   AppResidency:
     type: object
     description: |

--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -20,6 +20,26 @@ uses:
   killSelection: killSelection.raml
 
 types:
+  TaskCounts:
+    type: object
+    properties:
+      tasksStaged:
+        type: number
+        format: int32
+      tasksRunning:
+        type: number
+        format: int32
+      tasksHealthy:
+        type: number
+        format: int32
+      tasksUnhealthy:
+        type: number
+        format: int32
+  AppInfo:
+    type: object
+    properties:
+      # TODO: It is actually flattened
+      task_counts?: TaskCounts
   AppResidency:
     type: object
     description: |

--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -38,8 +38,10 @@ types:
   AppInfo:
     type: object
     properties:
+      app:
+        type: App
       # TODO: It is actually flattened
-      task_counts?: TaskCounts
+      #task_counts?: TaskCounts
   AppResidency:
     type: object
     description: |

--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -20,28 +20,30 @@ uses:
   killSelection: killSelection.raml
 
 types:
-  TaskCounts:
-    type: object
-    properties:
-      tasksStaged:
-        type: number
-        format: int32
-      tasksRunning:
-        type: number
-        format: int32
-      tasksHealthy:
-        type: number
-        format: int32
-      tasksUnhealthy:
-        type: number
-        format: int32
   AppInfo:
     type: object
     properties:
       app:
         type: App
-      # TODO: It is actually flattened
-      #task_counts?: TaskCounts
+        # properties:
+        # Task counts
+      #  tasksStaged?:
+      #    type: number
+      #    format: int32
+      #  tasksRunning?:
+      #    type: number
+      #    format: int32
+      #  tasksHealthy?:
+      #    type: number
+      #    format: int32
+      #  tasksUnhealthy?:
+      #    type: number
+      #    format: int32
+      #  deployments?: Deployment[]
+      #  readinessCheckResults?: ReadinessCheckResult[]
+      #  tasks?: EnrichedTask[]
+      #  lastTaskFailures?: TaskFailure
+      #  taskStats?: TaskStatsByVersion
   AppResidency:
     type: object
     description: |

--- a/docs/docs/rest-api/public/api/v2/types/appInfo.raml
+++ b/docs/docs/rest-api/public/api/v2/types/appInfo.raml
@@ -1,0 +1,34 @@
+#%RAML 1.0 Library
+uses:
+  readiness: readinessCheckResult.raml
+
+types:
+  Identifiable:
+    type: object
+    properties:
+      id: string
+  AppInfo:
+    type: object
+    properties:
+      app:
+        #type: App we should inherit from App
+        type: object
+        properties:
+          # Task counts
+          tasksStaged?:
+            type: number
+            format: int32
+          tasksRunning?:
+            type: number
+            format: int32
+          tasksHealthy?:
+            type: number
+            format: int32
+          tasksUnhealthy?:
+            type: number
+            format: int32
+          deployments?: Identifiable[]
+          readinessCheckResults?: readiness.ReadinessCheckResult[]
+       #   tasks?: EnrichedTask[]
+       #   lastTaskFailures?: TaskFailure
+       #   taskStats?: TaskStatsByVersion

--- a/docs/docs/rest-api/public/api/v2/types/appInfo.raml
+++ b/docs/docs/rest-api/public/api/v2/types/appInfo.raml
@@ -1,6 +1,7 @@
 #%RAML 1.0 Library
 uses:
   readiness: readinessCheckResult.raml
+  task: enrichedTask.raml
 
 types:
   Identifiable:
@@ -29,6 +30,6 @@ types:
             format: int32
           deployments?: Identifiable[]
           readinessCheckResults?: readiness.ReadinessCheckResult[]
-       #   tasks?: EnrichedTask[]
+          tasks?: task.EnrichedTask[]
        #   lastTaskFailures?: TaskFailure
        #   taskStats?: TaskStatsByVersion

--- a/docs/docs/rest-api/public/api/v2/types/enrichedTask.raml
+++ b/docs/docs/rest-api/public/api/v2/types/enrichedTask.raml
@@ -1,0 +1,31 @@
+#%RAML 1.0 Library
+uses:
+  health: healthCheck.raml
+  numbers: numberTypes.raml
+  strings: stringTypes.raml
+
+types:
+  # Not to be confused with network.IpAddress
+  IpAddr:
+    type: object
+    properties:
+      ipAddress: string
+      protocol: strings.IpProtocol
+
+  EnrichedTask:
+    type: object
+    properties:
+      appId: strings.PathId
+      healthCheckResults?: health.Health[]
+      host: string
+      id: string
+      ipAddresses?: IpAddr[]
+      ports?: numbers.Port[]
+      servicePorts?: numbers.Port[]
+      slaveId: string
+      state: strings.MesosTaskState
+      stagedAt?: string
+      startedAt?: string
+      version?: string
+      #localVolumes?:
+      #  type: LocalVolumeId[]

--- a/docs/docs/rest-api/public/api/v2/types/enrichedTask.raml
+++ b/docs/docs/rest-api/public/api/v2/types/enrichedTask.raml
@@ -12,6 +12,14 @@ types:
       ipAddress: string
       protocol: strings.IpProtocol
 
+  LocalVolumeId:
+    type: object
+    properties:
+      runSpecId: strings.PathId
+      containerPath: string
+      uuid: string
+      persistensId: strings.PersistenceId
+
   EnrichedTask:
     type: object
     properties:
@@ -27,5 +35,4 @@ types:
       stagedAt?: string
       startedAt?: string
       version?: string
-      #localVolumes?:
-      #  type: LocalVolumeId[]
+      localVolumes?: LocalVolumeId[]

--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -148,3 +148,15 @@ types:
         description: Amount of time to wait until starting the health checks.
         minimum: 0
         default: 15
+  Health:
+    type: object
+    properties:
+      alive: boolean
+      consecutiveFailures:
+        type: number
+        format: int32
+      firstSuccess?: string
+      instanceId: strings.InstanceId
+      lastSuccess?: string
+      lastFailure?: string
+      lastFailureCause?: string

--- a/docs/docs/rest-api/public/api/v2/types/info.raml
+++ b/docs/docs/rest-api/public/api/v2/types/info.raml
@@ -1,3 +1,4 @@
+#%RAML 1.0 Library
 types:
   MarathonConfig:
     type: object

--- a/docs/docs/rest-api/public/api/v2/types/info.raml
+++ b/docs/docs/rest-api/public/api/v2/types/info.raml
@@ -3,31 +3,24 @@ types:
   MarathonConfig:
     type: object
     properties:
-      master?:
-        type: string
+      master?: string
       failover_timeout?:
         type: number
         format: int64
       framework_name?:
         type: string
-      ha?:
-        type: boolean
-      checkpoint?:
-        type: boolean
+      ha?: boolean
+      checkpoint?: boolean
       local_port_min?:
           type: number
           format: int32
       local_port_max?:
           type: number
           format: int32
-      executor?:
-        type: string
-      hostname?:
-        type: string
-      webui_url?:
-        type: string
-      mesos_role?:
-        type: string
+      executor?: string
+      hostname?: string
+      webui_url?: string
+      mesos_role?: string
       task_launch_timeout?:
         type: number
         format: int64
@@ -40,24 +33,20 @@ types:
       reconciliation_interval?:
         type: number
         format: int64
-      mesos_user?:
-        type: string
+      mesos_user?: string
       leader_proxy_connection_timeout_ms?:
         type: number
         format: int32
       leader_proxy_read_timeout_ms?:
         type: number
         format: int32
-      mesos_leader_ui_url?:
-        type: string
-      features:
-        type: string[]
+      mesos_leader_ui_url?: string
+      features: string[]
 
   ZooKeeperConfig:
     type: object
     properties:
-      zk:
-        type: string
+      zk: string
       zk_timeout:
         type: number
         format: int64

--- a/docs/docs/rest-api/public/api/v2/types/pluginDefinition.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pluginDefinition.raml
@@ -1,0 +1,19 @@
+#%RAML 1.0 Library
+types:
+  PluginDefinition:
+    type: object
+    properties:
+      id:
+        type: string
+      plugin:
+        type: string
+      implementation:
+        type: string
+      tags?:
+        type: string[]
+      info?:
+        type: any
+  PluginDefinitions:
+    type: object
+    properties:
+      plugins: PluginDefinition[]

--- a/docs/docs/rest-api/public/api/v2/types/pluginDefinition.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pluginDefinition.raml
@@ -3,16 +3,11 @@ types:
   PluginDefinition:
     type: object
     properties:
-      id:
-        type: string
-      plugin:
-        type: string
-      implementation:
-        type: string
-      tags?:
-        type: string[]
-      info?:
-        type: any
+      id: string
+      plugin: string
+      implementation: string
+      tags?: string[]
+      info: object
   PluginDefinitions:
     type: object
     properties:

--- a/docs/docs/rest-api/public/api/v2/types/readinessCheckResult.raml
+++ b/docs/docs/rest-api/public/api/v2/types/readinessCheckResult.raml
@@ -1,0 +1,18 @@
+#%RAML 1.0 Library
+
+types:
+  HttpResponse:
+    type: object
+    properties:
+      status:
+        type: number
+        format: int32
+      contentType: string
+      body: string
+  ReadinessCheckResult:
+    type: object
+    properties:
+      name: string
+      taskId: string
+      ready: boolean
+      lastResponse?: HttpResponse

--- a/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
+++ b/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
@@ -1,5 +1,8 @@
 #%RAML 1.0 Library
 types:
+  InstanceId:
+    type: string
+    pattern: ^(.+)\.(instance-|marathon-)([^\.]+)$
   Name:
     type: string
     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -33,6 +36,9 @@ types:
     type: string
     enum: [ HTTP, HTTPS ]
     description: The http scheme to use
+  IpProtocol:
+    type: string
+    enum: [ IPv4 ]
   ReadMode:
     type: string
     enum: [RO, RW]
@@ -49,3 +55,18 @@ types:
       When Marathon receives a TASK_LOST status update indicating that the
       agent running the task is gone, this property defines whether Marathon
       will launch the task on another node or not. Defaults to WAIT_FOREVER"
+  MesosTaskState:
+    type: string
+    enum:
+      - TASK_ERROR
+      - TASK_FAILED
+      - TASK_FINISHED
+      - TASK_KILLED
+      - TASK_KILLING
+      - TASK_RUNNING
+      - TASK_STAGING
+      - TASK_STARTING
+      - TASK_UNREACHABLE
+      - TASK_UNREACHABLE
+      - TASK_GONE
+      - TASK_DROPPED

--- a/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
+++ b/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
@@ -39,6 +39,9 @@ types:
   IpProtocol:
     type: string
     enum: [ IPv4 ]
+  PersistenceId:
+    type: string
+    pattern: ^([^#]+)[#]([^#]+)[#]([^#]+)$
   ReadMode:
     type: string
     enum: [RO, RW]

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -18,7 +18,7 @@ import play.api.libs.json._
 
 object EntityMarshallers {
   import Directives.complete
-  import mesosphere.marathon.api.v2.json.Formats._
+  //  import mesosphere.marathon.api.v2.json.Formats._
   import mesosphere.marathon.raml.MetricsConversion._
 
   private val jsonStringUnmarshaller =

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -18,7 +18,7 @@ import play.api.libs.json._
 
 object EntityMarshallers {
   import Directives.complete
-  //  import mesosphere.marathon.api.v2.json.Formats._
+  import mesosphere.marathon.api.v2.json.Formats._
   import mesosphere.marathon.raml.MetricsConversion._
 
   private val jsonStringUnmarshaller =

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -10,13 +10,11 @@ import akka.util.ByteString
 import com.wix.accord.{ Failure, RuleViolation, Success, Validator }
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import mesosphere.marathon.api.v2.Validation
-import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.state.AppDefinition
 import play.api.libs.json._
 
 object EntityMarshallers {
   import Directives.complete
-  //import mesosphere.marathon.api.v2.json.Formats._
   import mesosphere.marathon.raml.MetricsConversion._
 
   private val jsonStringUnmarshaller =

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -15,6 +15,7 @@ import play.api.libs.json._
 
 object EntityMarshallers {
   import Directives.complete
+  import mesosphere.marathon.api.v2.json.Formats._
   import mesosphere.marathon.raml.MetricsConversion._
 
   private val jsonStringUnmarshaller =
@@ -100,7 +101,8 @@ object EntityMarshallers {
   implicit val jsValueMarshaller = playJsonMarshaller[JsValue]
   implicit val wixResultMarshaller = playJsonMarshaller[com.wix.accord.Failure](Validation.failureWrites)
   implicit val messageMarshaller = playJsonMarshaller[Rejections.Message]
-  implicit val appInfoMarshaller = playJsonMarshaller[raml.AppInfo]
+  //implicit val appInfoMarshaller = playJsonMarshaller[raml.AppInfo]
+  implicit val appInfoMarshaller = playJsonMarshaller[mesosphere.marathon.core.appinfo.AppInfo]
   implicit val infoMarshaller = playJsonMarshaller[raml.MarathonInfo]
   implicit val infoUnmarshaller = playJsonUnmarshaller[raml.MarathonInfo]
   implicit val metricsMarshaller = internalToRamlJsonMarshaller[TickMetricSnapshot, raml.Metrics]

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -16,7 +16,7 @@ import play.api.libs.json._
 
 object EntityMarshallers {
   import Directives.complete
-  import mesosphere.marathon.api.v2.json.Formats._
+  //import mesosphere.marathon.api.v2.json.Formats._
   import mesosphere.marathon.raml.MetricsConversion._
 
   private val jsonStringUnmarshaller =
@@ -109,7 +109,7 @@ object EntityMarshallers {
   implicit val loggerChangeMarshaller = playJsonMarshaller[raml.LoggerChange]
   implicit val loggerChangeUnmarshaller = playJsonUnmarshaller[raml.LoggerChange]
   implicit val stringMapMarshaller = playJsonMarshaller[Map[String, String]]
-  implicit val pluginDefinitionsMarshaller = playJsonMarshaller[PluginDefinitions]
+  implicit val pluginDefinitionsMarshaller = playJsonMarshaller[raml.PluginDefinitions]
 
   private def validEntityRaml[A, B](um: FromEntityUnmarshaller[A])(
     implicit

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -10,8 +10,6 @@ import akka.util.ByteString
 import com.wix.accord.{ Failure, RuleViolation, Success, Validator }
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import mesosphere.marathon.api.v2.Validation
-import mesosphere.marathon.core.appinfo.AppInfo
-import mesosphere.marathon.raml.{ LoggerChange, MarathonInfo, Metrics }
 import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.state.AppDefinition
 import play.api.libs.json._
@@ -104,12 +102,12 @@ object EntityMarshallers {
   implicit val jsValueMarshaller = playJsonMarshaller[JsValue]
   implicit val wixResultMarshaller = playJsonMarshaller[com.wix.accord.Failure](Validation.failureWrites)
   implicit val messageMarshaller = playJsonMarshaller[Rejections.Message]
-  implicit val appInfoMarshaller = playJsonMarshaller[AppInfo]
-  implicit val infoMarshaller = playJsonMarshaller[MarathonInfo]
-  implicit val infoUnmarshaller = playJsonUnmarshaller[MarathonInfo]
-  implicit val metricsMarshaller = internalToRamlJsonMarshaller[TickMetricSnapshot, Metrics]
-  implicit val loggerChangeMarshaller = playJsonMarshaller[LoggerChange]
-  implicit val loggerChangeUnmarshaller = playJsonUnmarshaller[LoggerChange]
+  implicit val appInfoMarshaller = playJsonMarshaller[raml.AppInfo]
+  implicit val infoMarshaller = playJsonMarshaller[raml.MarathonInfo]
+  implicit val infoUnmarshaller = playJsonUnmarshaller[raml.MarathonInfo]
+  implicit val metricsMarshaller = internalToRamlJsonMarshaller[TickMetricSnapshot, raml.Metrics]
+  implicit val loggerChangeMarshaller = playJsonMarshaller[raml.LoggerChange]
+  implicit val loggerChangeUnmarshaller = playJsonUnmarshaller[raml.LoggerChange]
   implicit val stringMapMarshaller = playJsonMarshaller[Map[String, String]]
   implicit val pluginDefinitionsMarshaller = playJsonMarshaller[PluginDefinitions]
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -88,8 +88,9 @@ class AppsController(
     authorized(CreateRunSpec, app).apply {
       onSuccess(create) { (plan, appInfo) =>
         //TODO: post ApiPostEvent
-        val ramlAppInfo = raml.AppInfo(app = raml.Raml.toRaml(appInfo.app))
-        complete((StatusCodes.Created, Seq(Headers.`Marathon-Deployment-Id`(plan.id)), ramlAppInfo))
+        //val ramlAppInfo = raml.AppInfo(app = raml.Raml.toRaml(appInfo.app))
+        //complete((StatusCodes.Created, Seq(Headers.`Marathon-Deployment-Id`(plan.id)), ramlAppInfo))
+        complete((StatusCodes.Created, Seq(Headers.`Marathon-Deployment-Id`(plan.id)), appInfo))
       }
     }
   }
@@ -106,8 +107,9 @@ class AppsController(
           reject(Rejections.EntityNotFound.app(appId))
         case Some(info) =>
           authorized(ViewResource, info.app).apply {
-            val ramlAppInfo = raml.AppInfo(app = raml.Raml.toRaml(info.app))
-            complete(ramlAppInfo)
+            //val ramlAppInfo = raml.AppInfo(app = raml.Raml.toRaml(info.app))
+            //complete(ramlAppInfo)
+            complete(Json.obj("app" -> info))
           }
       }
     }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -86,9 +86,10 @@ class AppsController(
       }
     }
     authorized(CreateRunSpec, app).apply {
-      onSuccess(create) { (plan, app) =>
+      onSuccess(create) { (plan, appInfo) =>
         //TODO: post ApiPostEvent
-        complete((StatusCodes.Created, Seq(Headers.`Marathon-Deployment-Id`(plan.id)), app))
+        val ramlAppInfo = raml.AppInfo(app = raml.Raml.toRaml(appInfo.app))
+        complete((StatusCodes.Created, Seq(Headers.`Marathon-Deployment-Id`(plan.id)), ramlAppInfo))
       }
     }
   }
@@ -105,7 +106,8 @@ class AppsController(
           reject(Rejections.EntityNotFound.app(appId))
         case Some(info) =>
           authorized(ViewResource, info.app).apply {
-            complete(Json.obj("app" -> info))
+            val ramlAppInfo = raml.AppInfo(app = raml.Raml.toRaml(info.app))
+            complete(ramlAppInfo)
           }
       }
     }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/InfoController.scala
@@ -7,7 +7,6 @@ import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.api.akkahttp.Controller
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.plugin.auth.{ Authenticator, AuthorizedResource, Authorizer, ViewResource }
-import mesosphere.marathon.raml.{ HttpConfig, MarathonConfig, MarathonInfo, ZooKeeperConfig }
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
 import mesosphere.util.state.MesosLeaderInfo
 
@@ -27,7 +26,7 @@ case class InfoController(
   import mesosphere.marathon.api.akkahttp.Directives._
   import mesosphere.marathon.api.akkahttp.EntityMarshallers._
 
-  val marathonConfig = MarathonConfig(
+  val marathonConfig = raml.MarathonConfig(
     config.mesosMaster.get,
     config.mesosFailoverTimeout.get,
     config.frameworkName.get,
@@ -50,7 +49,7 @@ case class InfoController(
     config.availableFeatures.toIndexedSeq
   )
 
-  val zookeeperConfig = ZooKeeperConfig(
+  val zookeeperConfig = raml.ZooKeeperConfig(
     s"zk://${config.zkHosts}${config.zkPath}",
     config.zooKeeperTimeout(),
     config.zooKeeperConnectionTimeout(),
@@ -58,7 +57,7 @@ case class InfoController(
     config.maxVersions()
   )
 
-  val httpConfig = HttpConfig(config.httpPort(), config.httpsPort())
+  val httpConfig = raml.HttpConfig(config.httpPort(), config.httpsPort())
 
   @SuppressWarnings(Array("all")) // async/await
   def info(): Route =
@@ -68,7 +67,7 @@ case class InfoController(
           async {
             val frameworkId = await(frameworkIdRepository.get()).map(_.id)
 
-            MarathonInfo(
+            raml.MarathonInfo(
               BuildInfo.name,
               BuildInfo.version,
               BuildInfo.buildref,

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PluginsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PluginsController.scala
@@ -8,6 +8,7 @@ import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.plugin.auth.AuthorizedResource.Plugins
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.plugin.http.HttpRequestHandler
+import mesosphere.marathon.raml.Raml
 
 /**
   * The PluginsController can list all available installed plugins,
@@ -39,7 +40,18 @@ class PluginsController(
     * GET /v2/plugins
     * @return plugin definitions for all available plugins
     */
-  def plugins: Route = complete(definitions)
+  def plugins: Route = {
+    val plugins: Seq[raml.PluginDefinition] = definitions.plugins.map { internal =>
+      raml.PluginDefinition(
+        id = internal.id,
+        plugin = internal.plugin,
+        implementation = internal.implementation,
+        tags = internal.tags.getOrElse(Nil).toIndexedSeq,
+        additionalProperties = internal.info)
+    }
+    val ramlPluginDefinitions = raml.PluginDefinitions(plugins = plugins)
+    complete(ramlPluginDefinitions)
+  }
 
   /**
     * METHOD /v2/plugins/{pluginId}/{path}

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PluginsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PluginsController.scala
@@ -47,7 +47,7 @@ class PluginsController(
         plugin = internal.plugin,
         implementation = internal.implementation,
         tags = internal.tags.getOrElse(Nil).toIndexedSeq,
-        additionalProperties = internal.info)
+        additionalProperties = internal.info.get) //Bug: this should be info: Option[JsObject] = internal.info
     }
     val ramlPluginDefinitions = raml.PluginDefinitions(plugins = plugins)
     complete(ramlPluginDefinitions)

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PluginsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PluginsController.scala
@@ -2,13 +2,14 @@ package mesosphere.marathon
 package api.akkahttp.v2
 
 import akka.http.scaladsl.server.Route
-import mesosphere.marathon.api.akkahttp.{ Controller, HttpPluginFacade }
+import mesosphere.marathon.api.akkahttp.{Controller, HttpPluginFacade}
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.plugin.auth.AuthorizedResource.Plugins
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.plugin.http.HttpRequestHandler
 import mesosphere.marathon.raml.Raml
+import play.api.libs.json.JsObject
 
 /**
   * The PluginsController can list all available installed plugins,
@@ -47,7 +48,7 @@ class PluginsController(
         plugin = internal.plugin,
         implementation = internal.implementation,
         tags = internal.tags.getOrElse(Nil).toIndexedSeq,
-        additionalProperties = internal.info.get) //Bug: this should be info: Option[JsObject] = internal.info
+        additionalProperties = internal.info.getOrElse(JsObject(Seq.empty))) //Bug: this should be info: Option[JsObject] = internal.info
     }
     val ramlPluginDefinitions = raml.PluginDefinitions(plugins = plugins)
     complete(ramlPluginDefinitions)

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PluginsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PluginsController.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package api.akkahttp.v2
 
 import akka.http.scaladsl.server.Route
-import mesosphere.marathon.api.akkahttp.{Controller, HttpPluginFacade}
+import mesosphere.marathon.api.akkahttp.{ Controller, HttpPluginFacade }
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.plugin.auth.AuthorizedResource.Plugins

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -5,14 +5,25 @@ import akka.http.scaladsl.model.{HttpEntity, StatusCodes, Uri}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import mesosphere.UnitTest
 import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
-import mesosphere.marathon.core.appinfo.{AppInfo, AppInfoService, TaskCounts}
+import mesosphere.marathon.core.appinfo._
+import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
+import mesosphere.marathon.core.health.Health
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.plugin.PluginManager
-import mesosphere.marathon.state.{AppDefinition, Identifiable, VersionInfo}
+import mesosphere.marathon.core.readiness.{HttpResponse, ReadinessCheckResult}
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.Task.LaunchedEphemeral
+import mesosphere.marathon.core.task.state.NetworkInfo
+import mesosphere.marathon.raml.ReadinessCheck
+import mesosphere.marathon.state.{AppDefinition, Identifiable, TaskFailure, VersionInfo}
 import mesosphere.marathon.test.SettableClock
+import org.apache.mesos.{Protos => mesos}
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class AppsControllerTest extends UnitTest with ScalatestRouteTest {
 
@@ -43,16 +54,94 @@ class AppsControllerTest extends UnitTest with ScalatestRouteTest {
   }
 
   "accessing an app with authentication returns an app" in {
+
+    Given("an app with full information")
     import mesosphere.marathon.state.PathId._
 
     val f = new Fixture()
     val appD = AppDefinition(id = "/a".toRootPath, versionInfo = VersionInfo.OnlyVersion(f.clock.now()))
     val taskCounts = TaskCounts(0, 3, 2, 1)
     val deployments = Seq(Identifiable("foo"), Identifiable("bar"))
+    val readinessCheckResults = Seq(
+      ReadinessCheckResult(name = "alice", taskId = Task.Id("marathon-task-1"), ready = true, lastResponse = None),
+      ReadinessCheckResult(name = "bob", taskId = Task.Id("marathon-task-2"), ready = false, lastResponse = Some(HttpResponse(400, "application/json", "{}")))
+    )
+    val lastFailure = TaskFailure(
+      appId = appD.id,
+      taskId = mesos.TaskID.newBuilder().setValue("marathon-task-2").build(),
+      state = mesos.TaskState.TASK_FAILED,
+      message = "exit 1",
+      host = "rack-1",
+      version = f.clock.now(),
+      timestamp = f.clock.now(),
+      slaveId = Some(mesos.SlaveID.newBuilder().setValue("agent-1").build())
+    )
+    val taskLifeTime = Some(TaskLifeTime(42.0, 40.0))
+    val taskStatsByVersion = TaskStatsByVersion(
+      maybeStartedAfterLastScaling = Some(TaskStats(taskCounts, taskLifeTime)),
+      maybeWithLatestConfig = Some(TaskStats(taskCounts, taskLifeTime)),
+      maybeWithOutdatedConfig = Some(TaskStats(taskCounts, taskLifeTime)),
+      maybeTotalSummary = Some(TaskStats(taskCounts, taskLifeTime))
+    )
+    val health = Health(
+      instanceId = Instance.Id("a.instance-1c023367-a90b-11e7-9e80-9238e089ec23"),
+      firstSuccess = Some(f.clock.now()),
+      lastSuccess = Some(f.clock.now()),
+      lastFailure = Some(f.clock.now()),
+      lastFailureCause = Some("unknown"),
+      consecutiveFailures = 0
+    )
+    val attribute = mesos.Attribute.newBuilder()
+      .setName("foo")
+      .setType(mesos.Value.Type.TEXT)
+      .setText(mesos.Value.Text.newBuilder().setValue("bar"))
+      .build()
+    val agentInfo = AgentInfo(
+      host = "rack-1",
+      agentId = Some("agent-1"),
+      attributes = Seq(attribute)
+    )
+    val mesosTaskStatus = mesos.TaskStatus.newBuilder()
+      .setTaskId(mesos.TaskID.newBuilder().setValue("marathon-task-2").build())
+      .setState(mesos.TaskState.TASK_RUNNING)
+      .build()
+    val mesosIpAddress = mesos.NetworkInfo.IPAddress.newBuilder().setIpAddress("127.0.0.1").build()
+    val taskStatus = Task.Status(
+      stagedAt = f.clock.now() - 5.minutes,
+      startedAt = Some(f.clock.now()),
+      mesosStatus = Some(mesosTaskStatus),
+      condition = Condition.Running,
+      networkInfo = NetworkInfo("other-host", Seq(8080), Seq(mesosIpAddress))
+    )
+    val ephermeralTask = LaunchedEphemeral(
+      taskId = Task.Id("marathon-task-1"),
+      runSpecVersion = f.clock.now(),
+      status = taskStatus
+    )
+    val tasks = Seq(
+      EnrichedTask(
+        appId = appD.id,
+        task = ephermeralTask,
+        agentInfo = agentInfo,
+        healthCheckResults =  Seq(health),
+        servicePorts = Seq(80, 433)
+      )
+//      EnrichedTask(
+//        appD.id,
+//        task: Task,
+//        agentInfo = agentInfo,
+//        healthCheckResults = Nil,
+//        servicePorts = Nil)
+//      )
+    )
     val appInfo = AppInfo(
       app = appD,
+      maybeTasks = Some(tasks),
       maybeCounts = Some(taskCounts),
-      maybeDeployments = Some(deployments)
+      maybeDeployments = Some(deployments),
+      maybeReadinessCheckResults = Some(readinessCheckResults),
+      maybeLastTaskFailure = Some(lastFailure),
+      maybeTaskStats = Some(taskStatsByVersion)
     )
     f.appInfoService.selectApp(any, any, any) returns Future.successful(Some(appInfo))
 
@@ -94,7 +183,82 @@ class AppsControllerTest extends UnitTest with ScalatestRouteTest {
           |    "tasksRunning" : 3,
           |    "tasksHealthy" : 2,
           |    "tasksUnhealthy" : 1,
-          |    "deployments" : [ { "id" : "foo" }, { "id" : "bar" } ]
+          |    "deployments" : [ { "id" : "foo" }, { "id" : "bar" } ],
+          |    "readinessCheckResults" : [ {
+          |      "name" : "alice",
+          |      "taskId" : "marathon-task-1",
+          |      "ready" : true
+          |    }, {
+          |      "name" : "bob",
+          |      "taskId" : "marathon-task-2",
+          |      "ready" : false,
+          |      "lastResponse" : {
+          |        "status" : 400,
+          |        "contentType" : "application/json",
+          |        "body" : "{}"
+          |      }
+          |    } ],
+          |    "tasks" : [ {
+          |      "ipAddresses" : [ {
+          |        "ipAddress" : "127.0.0.1",
+          |        "protocol" : "IPv4"
+          |      } ],
+          |      "stagedAt" : "2015-04-09T12:25:00.000Z",
+          |      "state" : "TASK_RUNNING",
+          |      "ports" : [ 8080 ],
+          |      "startedAt" : "2015-04-09T12:30:00.000Z",
+          |      "version" : "2015-04-09T12:30:00.000Z",
+          |      "id" : "marathon-task-1",
+          |      "appId" : "/a",
+          |      "slaveId" : "agent-1",
+          |      "host" : "rack-1",
+          |      "servicePorts" : [ 80, 433 ],
+          |      "healthCheckResults" : [ {
+          |        "alive" : false,
+          |        "consecutiveFailures" : 0,
+          |        "firstSuccess" : "2015-04-09T12:30:00.000Z",
+          |        "lastFailure" : "2015-04-09T12:30:00.000Z",
+          |        "lastSuccess" : "2015-04-09T12:30:00.000Z",
+          |        "lastFailureCause" : "unknown",
+          |        "instanceId" : "a.instance-1c023367-a90b-11e7-9e80-9238e089ec23"
+          |      } ]
+          |    } ],
+          |    "lastTaskFailure" : {
+          |      "appId" : "/a",
+          |      "host" : "rack-1",
+          |      "message" : "exit 1",
+          |      "state" : "TASK_FAILED",
+          |      "taskId" : "marathon-task-2",
+          |      "timestamp" : "2015-04-09T12:30:00.000Z",
+          |      "version" : "2015-04-09T12:30:00.000Z",
+          |      "slaveId" : "agent-1"
+          |    },
+          |    "taskStats" : {
+          |      "startedAfterLastScaling" : {
+          |        "stats" : {
+          |          "counts" : { "staged" : 0, "running" : 3, "healthy" : 2, "unhealthy" : 1 },
+          |          "lifeTime" : { "averageSeconds" : 42, "medianSeconds" : 40 }
+          |        }
+          |      },
+          |      "withLatestConfig" : {
+          |        "stats" : {
+          |          "counts" : { "staged" : 0, "running" : 3, "healthy" : 2, "unhealthy" : 1 },
+          |          "lifeTime" : { "averageSeconds" : 42, "medianSeconds" : 40 }
+          |        }
+          |      },
+          |      "withOutdatedConfig" : {
+          |        "stats" : {
+          |          "counts" : { "staged" : 0, "running" : 3, "healthy" : 2, "unhealthy" : 1 },
+          |          "lifeTime" : { "averageSeconds" : 42, "medianSeconds" : 40 }
+          |        }
+          |      },
+          |      "totalSummary" : {
+          |        "stats" : {
+          |          "counts" : { "staged" : 0, "running" : 3, "healthy" : 2, "unhealthy" : 1 },
+          |          "lifeTime" : { "averageSeconds" : 42, "medianSeconds" : 40 }
+          |        }
+          |      }
+          |    }
           |  }
           |}
         """.stripMargin

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -1,39 +1,92 @@
 package mesosphere.marathon
 package api.akkahttp.v2
 
+import akka.http.scaladsl.model.{HttpEntity, StatusCodes, Uri}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import mesosphere.UnitTest
-import mesosphere.marathon.api.TestAuthFixture
-import mesosphere.marathon.core.appinfo.AppInfoService
+import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
+import mesosphere.marathon.core.appinfo.{AppInfo, AppInfoService}
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager
+import mesosphere.marathon.state.{ AppDefinition, VersionInfo }
 import mesosphere.marathon.test.SettableClock
+
+import scala.concurrent.Future
 
 class AppsControllerTest extends UnitTest with ScalatestRouteTest {
 
   case class Fixture(
-                      clock: SettableClock = new SettableClock(),
-                      auth: TestAuthFixture = new TestAuthFixture(),
-                      appInfoService: AppInfoService = mock[AppInfoService],
-                      configArgs: Seq[String] = Seq("--enable_features", "external_volumes"),
-                      groupManager: GroupManager = mock[GroupManager]) {
+      clock: SettableClock = new SettableClock(),
+      auth: TestAuthFixture = new TestAuthFixture(),
+      service: MarathonSchedulerService = mock[MarathonSchedulerService],
+      appInfoService: AppInfoService = mock[AppInfoService],
+      configArgs: Seq[String] = Seq("--enable_features", "external_volumes"),
+      groupManager: GroupManager = mock[GroupManager]) {
     val config: AllConf = AllConf.withTestConfig(configArgs: _*)
 
     implicit val authenticator = auth.auth
-    implicit val authorizer = auth.auth
 
     implicit val electionService: ElectionService = mock[ElectionService]
 
-    when(electionService.isLeader).thenReturn(true)
+    electionService.isLeader returns true
 
     val appsController = new AppsController(
       clock = clock,
       eventBus = system.eventStream,
+      service = service,
       appInfoService = appInfoService,
       config = config,
       groupManager = groupManager,
       pluginManager = PluginManager.None
     )
+  }
+
+  "accessing an app with authentication returns an app" in {
+    import mesosphere.marathon.state.PathId._
+
+    val f = new Fixture()
+    val appD = AppDefinition(id = "/a".toRootPath, versionInfo = VersionInfo.OnlyVersion(f.clock.now()))
+    f.appInfoService.selectApp(any, any, any) returns Future.successful(Some(AppInfo(appD)))
+
+    When("we try to fetch an app")
+    Get(Uri./.withPath(Uri.Path("/a")), HttpEntity.Empty) ~> f.appsController.route ~> check {
+      Then("we receive a response with the app info")
+      status should be(StatusCodes.OK)
+      val expected =
+        """
+          |{
+          |  "app" : {
+          |    "id" : "/a",
+          |    "backoffFactor" : 1.15,
+          |    "backoffSeconds" : 1,
+          |    "cpus" : 1,
+          |    "disk" : 0,
+          |    "executor" : "",
+          |    "instances" : 1,
+          |    "labels" : { },
+          |    "maxLaunchDelaySeconds" : 3600,
+          |    "mem" : 128,
+          |    "gpus" : 0,
+          |    "networks" : [ {
+          |      "mode" : "host"
+          |    } ],
+          |    "portDefinitions" : [ ],
+          |    "requirePorts" : false,
+          |    "upgradeStrategy" : {
+          |      "maximumOverCapacity" : 1,
+          |      "minimumHealthCapacity" : 1
+          |    },
+          |    "version" : "2015-04-09T12:30:00Z",
+          |    "killSelection" : "YOUNGEST_FIRST",
+          |    "unreachableStrategy" : {
+          |      "inactiveAfterSeconds" : 0,
+          |      "expungeAfterSeconds" : 0
+          |    }
+          |  }
+          |}
+        """.stripMargin
+      JsonTestHelper.assertThatJsonString(responseAs[String]).correspondsToJsonString(expected)
+    }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -1,11 +1,11 @@
 package mesosphere.marathon
 package api.akkahttp.v2
 
-import akka.http.scaladsl.model.{HttpEntity, StatusCodes, Uri}
+import akka.http.scaladsl.model.{ HttpEntity, StatusCodes, Uri }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import mesosphere.UnitTest
-import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
-import mesosphere.marathon.core.appinfo.{AppInfo, AppInfoService}
+import mesosphere.marathon.api.{ JsonTestHelper, TestAuthFixture }
+import mesosphere.marathon.core.appinfo.{ AppInfo, AppInfoService }
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -1,0 +1,39 @@
+package mesosphere.marathon
+package api.akkahttp.v2
+
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import mesosphere.UnitTest
+import mesosphere.marathon.api.TestAuthFixture
+import mesosphere.marathon.core.appinfo.AppInfoService
+import mesosphere.marathon.core.election.ElectionService
+import mesosphere.marathon.core.group.GroupManager
+import mesosphere.marathon.core.plugin.PluginManager
+import mesosphere.marathon.test.SettableClock
+
+class AppsControllerTest extends UnitTest with ScalatestRouteTest {
+
+  case class Fixture(
+                      clock: SettableClock = new SettableClock(),
+                      auth: TestAuthFixture = new TestAuthFixture(),
+                      appInfoService: AppInfoService = mock[AppInfoService],
+                      configArgs: Seq[String] = Seq("--enable_features", "external_volumes"),
+                      groupManager: GroupManager = mock[GroupManager]) {
+    val config: AllConf = AllConf.withTestConfig(configArgs: _*)
+
+    implicit val authenticator = auth.auth
+    implicit val authorizer = auth.auth
+
+    implicit val electionService: ElectionService = mock[ElectionService]
+
+    when(electionService.isLeader).thenReturn(true)
+
+    val appsController = new AppsController(
+      clock = clock,
+      eventBus = system.eventStream,
+      appInfoService = appInfoService,
+      config = config,
+      groupManager = groupManager,
+      pluginManager = PluginManager.None
+    )
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -1,10 +1,10 @@
 package mesosphere.marathon
 package api.akkahttp.v2
 
-import akka.http.scaladsl.model.{HttpEntity, StatusCodes, Uri}
+import akka.http.scaladsl.model.{ HttpEntity, StatusCodes, Uri }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import mesosphere.UnitTest
-import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
+import mesosphere.marathon.api.{ JsonTestHelper, TestAuthFixture }
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.election.ElectionService
@@ -13,14 +13,14 @@ import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.plugin.PluginManager
-import mesosphere.marathon.core.readiness.{HttpResponse, ReadinessCheckResult}
+import mesosphere.marathon.core.readiness.{ HttpResponse, ReadinessCheckResult }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.LaunchedEphemeral
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.raml.ReadinessCheck
-import mesosphere.marathon.state.{AppDefinition, Identifiable, TaskFailure, VersionInfo}
+import mesosphere.marathon.state.{ AppDefinition, Identifiable, TaskFailure, VersionInfo }
 import mesosphere.marathon.test.SettableClock
-import org.apache.mesos.{Protos => mesos}
+import org.apache.mesos.{ Protos => mesos }
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -123,16 +123,16 @@ class AppsControllerTest extends UnitTest with ScalatestRouteTest {
         appId = appD.id,
         task = ephermeralTask,
         agentInfo = agentInfo,
-        healthCheckResults =  Seq(health),
+        healthCheckResults = Seq(health),
         servicePorts = Seq(80, 433)
       )
-//      EnrichedTask(
-//        appD.id,
-//        task: Task,
-//        agentInfo = agentInfo,
-//        healthCheckResults = Nil,
-//        servicePorts = Nil)
-//      )
+    //      EnrichedTask(
+    //        appD.id,
+    //        task: Task,
+    //        agentInfo = agentInfo,
+    //        healthCheckResults = Nil,
+    //        servicePorts = Nil)
+    //      )
     )
     val appInfo = AppInfo(
       app = appD,


### PR DESCRIPTION
Summary:
This change forces us to define all API models in RAML and not convert from internal models straight to HTML entities but always to RAML models first. 

JIRA issues: MARATHON-7803
