### PR TITLE
Region-aware capability in marathon

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
@@ -82,6 +82,10 @@ object MarathonSchedulerDriver {
     frameworkInfoBuilder.addCapabilities(Capability.newBuilder().setType(Capability.Type.PARTITION_AWARE))
     log.info("PARTITION_AWARE feature enabled.")
 
+    // Enables region awareness in Mesos to receive offers from other regions
+    frameworkInfoBuilder.addCapabilities(Capability.newBuilder().setType(Capability.Type.REGION_AWARE))
+    log.info("REGION_AWARE feature enabled")
+
     val frameworkInfo = frameworkInfoBuilder.build()
 
     log.debug("Start creating new driver")

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -179,7 +179,7 @@ class MarathonSchedulerTest extends AkkaUnitTest {
 
       marathonScheduler.registered(driver, frameworkId, masterInfo)
 
-      marathonScheduler.getDefaultRegion shouldEqual Some(regionName)
+      marathonScheduler.getHomeRegion shouldEqual Some(regionName)
     }
 
     "Store default region when reregistered" in new Fixture {
@@ -206,7 +206,7 @@ class MarathonSchedulerTest extends AkkaUnitTest {
 
       marathonScheduler.reregistered(driver, masterInfo)
 
-      marathonScheduler.getDefaultRegion shouldEqual Some(regionName)
+      marathonScheduler.getHomeRegion shouldEqual Some(regionName)
 
     }
   }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -11,8 +11,10 @@ import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.storage.repository.{ AppRepository, FrameworkIdRepository }
 import mesosphere.marathon.test.MarathonTestHelper
 import mesosphere.util.state.{ FrameworkId, MutableMesosLeaderInfo }
+import org.apache.mesos.Protos.DomainInfo.FaultDomain.{ RegionInfo, ZoneInfo }
 import org.apache.mesos.Protos._
 import org.apache.mesos.SchedulerDriver
+import org.apache.mesos.Protos.DomainInfo.FaultDomain
 
 import scala.concurrent.Future
 
@@ -146,6 +148,66 @@ class MarathonSchedulerTest extends AkkaUnitTest {
       Then("Suicide is called with removing the framework id")
       suicideCalled should be(defined)
       suicideCalled.get should be (true)
+    }
+
+    "Store default region when registered" in new Fixture {
+      val driver = mock[SchedulerDriver]
+      val frameworkId = FrameworkID.newBuilder
+        .setValue("some_id")
+        .build()
+
+      val regionName = "some_region"
+
+      val masterInfo = MasterInfo.newBuilder()
+        .setId("")
+        .setIp(0)
+        .setPort(5050)
+        .setHostname("some_host")
+        .setDomain(
+          DomainInfo.newBuilder()
+            .setFaultDomain(
+              FaultDomain.newBuilder()
+                .setRegion(RegionInfo.newBuilder().setName(regionName).build())
+                .setZone(ZoneInfo.newBuilder().setName("some_zone").build())
+                .build()
+            )
+            .build()
+        )
+        .build()
+
+      frameworkIdRepository.store(any) returns Future.successful(Done)
+
+      marathonScheduler.registered(driver, frameworkId, masterInfo)
+
+      marathonScheduler.getDefaultRegion shouldEqual Some(regionName)
+    }
+
+    "Store default region when reregistered" in new Fixture {
+      val driver = mock[SchedulerDriver]
+
+      val regionName = "some_region"
+
+      val masterInfo = MasterInfo.newBuilder()
+        .setId("")
+        .setIp(0)
+        .setPort(5050)
+        .setHostname("some_host")
+        .setDomain(
+          DomainInfo.newBuilder()
+            .setFaultDomain(
+              FaultDomain.newBuilder()
+                .setRegion(RegionInfo.newBuilder().setName(regionName).build())
+                .setZone(ZoneInfo.newBuilder().setName("some_zone").build())
+                .build()
+            )
+            .build()
+        )
+        .build()
+
+      marathonScheduler.reregistered(driver, masterInfo)
+
+      marathonScheduler.getDefaultRegion shouldEqual Some(regionName)
+
     }
   }
 }


### PR DESCRIPTION
Summary: added region-aware capability and store the default region in a MarathonScheduler

JIRA issues: MARATHON_EE-1663
