### PR TITLE
Do sync before reading from or writing to ZooKeeper

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -16,6 +16,7 @@ import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.heartbeat._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.leadership.LeadershipCoordinator
+import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.stream.Sink
@@ -64,6 +65,7 @@ trait DeploymentService {
   * Wrapper class for the scheduler
   */
 class MarathonSchedulerService @Inject() (
+  persistenceStore: PersistenceStore[_, _, _],
   leadershipCoordinator: LeadershipCoordinator,
   config: MarathonConf,
   electionService: ElectionService,
@@ -198,6 +200,9 @@ class MarathonSchedulerService @Inject() (
   override def startLeadership(): Unit = synchronized {
     log.info("As new leader running the driver")
 
+    // allow interactions with the persistence store
+    persistenceStore.open()
+
     refreshCachesAndDoMigration()
 
     // run all pre-driver callbacks
@@ -273,6 +278,9 @@ class MarathonSchedulerService @Inject() (
   override def stopLeadership(): Unit = synchronized {
     // invoked by election service upon loss of leadership (state transitioned to Idle)
     log.info("Lost leadership")
+
+    // disallow any interaction with the persistence storage
+    persistenceStore.close()
 
     leadershipCoordinator.stop()
 

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -22,6 +22,7 @@ import mesosphere.marathon.core.leadership.{ LeadershipCoordinator, LeadershipMo
 import mesosphere.marathon.core.plugin.{ PluginDefinitions, PluginManager }
 import mesosphere.marathon.core.pod.PodManager
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
+import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.{ InstanceCreationHandler, InstanceTracker, TaskStateOpProcessor }
@@ -112,6 +113,12 @@ class CoreGuiceModule(config: Config) extends AbstractModule {
   @Provides
   @Singleton
   def materializer(coreModule: CoreModule): Materializer = coreModule.actorsModule.materializer
+
+  @Provides
+  @Singleton
+  def providePersistenceStore(coreModule: CoreModule): PersistenceStore[_, _, _] = {
+    coreModule.storageModule.persistenceStore
+  }
 
   @Provides
   @Singleton

--- a/src/main/scala/mesosphere/marathon/core/group/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/GroupManager.scala
@@ -21,7 +21,19 @@ import scala.collection.immutable.Seq
   */
 trait GroupManager {
 
+  /**
+    * Get a root group, fetching it from a persistence store if necessary.
+    *
+    * @return a root group
+    */
   def rootGroup(): RootGroup
+
+  /**
+    * Get a root group.
+    *
+    * @return a root group if it has been fetched already, otherwise [[None]]
+    */
+  def rootGroupOption(): Option[RootGroup]
 
   /**
     * Get all available versions for given group identifier.

--- a/src/main/scala/mesosphere/marathon/core/group/GroupManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/GroupManagerModule.scala
@@ -9,7 +9,7 @@ import kamon.metric.instrument.Time
 import mesosphere.marathon.core.group.impl.GroupManagerImpl
 import mesosphere.marathon.storage.repository.GroupRepository
 
-import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.ExecutionContext
 
 /**
   * Provides a [[GroupManager]] implementation.
@@ -20,16 +20,7 @@ class GroupManagerModule(
     groupRepo: GroupRepository)(implicit ctx: ExecutionContext, eventStream: EventStream) {
 
   val groupManager: GroupManager = {
-    val groupManager = new GroupManagerImpl(config, Await.result(groupRepo.root(), config.zkTimeoutDuration), groupRepo, scheduler)
-
-    // We've already released metrics using these names, so we can't use the Metrics.* methods
-    Kamon.metrics.gauge("service.mesosphere.marathon.app.count")(
-      groupManager.rootGroup().transitiveApps.size.toLong
-    )
-
-    Kamon.metrics.gauge("service.mesosphere.marathon.group.count")(
-      groupManager.rootGroup().transitiveGroupsById.size.toLong
-    )
+    val groupManager = new GroupManagerImpl(config, None, groupRepo, scheduler)
 
     val startedAt = System.currentTimeMillis()
     Kamon.metrics.gauge("service.mesosphere.marathon.uptime", Time.Milliseconds)(

--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
@@ -2,12 +2,14 @@ package mesosphere.marathon
 package core.group.impl
 
 import java.time.OffsetDateTime
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Provider
 
 import akka.event.EventStream
 import akka.stream.scaladsl.Source
 import akka.{ Done, NotUsed }
 import com.typesafe.scalalogging.StrictLogging
+import kamon.Kamon
 import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.event.{ GroupChangeFailed, GroupChangeSuccess }
@@ -22,13 +24,13 @@ import mesosphere.marathon.util.{ LockedVar, WorkQueue }
 import scala.async.Async._
 import scala.collection.immutable.Seq
 import scala.collection.mutable
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success }
 
 class GroupManagerImpl(
     config: GroupManagerConfig,
-    initialRoot: RootGroup,
+    initialRoot: Option[RootGroup],
     groupRepository: GroupRepository,
     deploymentService: Provider[DeploymentService])(implicit eventStream: EventStream, ctx: ExecutionContext) extends GroupManager with StrictLogging {
   /**
@@ -45,7 +47,22 @@ class GroupManagerImpl(
     */
   private[this] val root = LockedVar(initialRoot)
 
-  override def rootGroup(): RootGroup = root.get()
+  @SuppressWarnings(Array("OptionGet"))
+  override def rootGroup(): RootGroup =
+    root.get() match { // linter:ignore:UseGetOrElseNotPatMatch
+      case None =>
+        root.update {
+          case None =>
+            val group = Await.result(groupRepository.root(), config.zkTimeoutDuration)
+            registerMetrics()
+            Some(group)
+          case group =>
+            group
+        }.get
+      case Some(group) => group
+    }
+
+  override def rootGroupOption(): Option[RootGroup] = root.get()
 
   override def versions(id: PathId): Source[Timestamp, NotUsed] = {
     groupRepository.rootVersions().mapAsync(Int.MaxValue) { version =>
@@ -105,7 +122,7 @@ class GroupManagerImpl(
         await(groupRepository.storeRoot(plan.target, plan.createdOrUpdatedApps, plan.deletedApps, plan.createdOrUpdatedPods, plan.deletedPods))
         logger.info(s"Updated groups/apps/pods according to plan ${plan.id}")
         // finally update the root under the write lock.
-        root := plan.target
+        root := Option(plan.target)
         plan
       }
     }
@@ -195,11 +212,32 @@ class GroupManagerImpl(
 
   @SuppressWarnings(Array("all")) // async/await
   override def invalidateGroupCache(): Future[Done] = async {
+    root := None
+
     // propagation of reset group caches on repository is needed,
     // because manager and repository are holding own caches
     await(groupRepository.invalidateGroupCache())
-    val currentRoot = await(groupRepository.root())
-    root := currentRoot
+
+    // force fetching of the root group from the group repository
+    rootGroup()
     Done
+  }
+
+  private[this] val metricsRegistered: AtomicBoolean = new AtomicBoolean(false)
+  private[this] def registerMetrics(): Unit = {
+    if (metricsRegistered.compareAndSet(false, true)) {
+      // We've already released metrics using these names, so we can't use the Metrics.* methods
+      Kamon.metrics.gauge("service.mesosphere.marathon.app.count") {
+        rootGroupOption().foldLeft(0L) { (_, group) =>
+          group.transitiveApps.size.toLong
+        }
+      }
+
+      Kamon.metrics.gauge("service.mesosphere.marathon.group.count") {
+        rootGroupOption().foldLeft(0L) { (_, group) =>
+          group.transitiveGroupsById.size.toLong
+        }
+      }
+    }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
@@ -9,6 +9,7 @@ import akka.stream.scaladsl.{ Sink, Source }
 import akka.{ Done, NotUsed }
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.core.storage.backup.BackupItem
+import mesosphere.marathon.util.Openable
 
 import scala.concurrent.Future
 
@@ -83,7 +84,7 @@ import scala.concurrent.Future
   * @tparam Category The persistence store's category type.
   * @tparam Serialized The serialized format for the persistence store.
   */
-trait PersistenceStore[K, Category, Serialized] {
+trait PersistenceStore[K, Category, Serialized] extends Openable {
   /**
     * Get a list of all of the Ids of the given Value Types
     */
@@ -199,4 +200,9 @@ trait PersistenceStore[K, Category, Serialized] {
     * @return a sink that can be used to restore the complete state.
     */
   def restore(): Sink[BackupItem, Future[Done]]
+
+  /**
+    * Make sure that store read operations return up-to-date values.
+    */
+  def sync(): Future[Done]
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
@@ -44,6 +44,10 @@ case class LazyCachingPersistenceStore[K, Category, Serialized](
   private[this] val getHitCounters = TrieMap.empty[Category, Counter]
   private[this] val idsHitCounters = TrieMap.empty[Category, Counter]
 
+  override def open(): Unit = store.open()
+  override def close(): Unit = store.close()
+  override def isOpen: Boolean = store.isOpen
+
   override def storageVersion(): Future[Option[StorageVersion]] = store.storageVersion()
 
   override def setStorageVersion(storageVersion: StorageVersion): Future[Done] =
@@ -181,6 +185,8 @@ case class LazyCachingPersistenceStore[K, Category, Serialized](
 
   override def restore(): ScalaSink[BackupItem, Future[Done]] = store.restore()
 
+  override def sync(): Future[Done] = store.sync()
+
   override def toString: String = s"LazyCachingPersistenceStore($store)"
 }
 
@@ -189,6 +195,10 @@ case class LazyVersionCachingPersistentStore[K, Category, Serialized](
     config: VersionCacheConfig = VersionCacheConfig.Default)(implicit
   mat: Materializer,
     ctx: ExecutionContext) extends PersistenceStore[K, Category, Serialized] with StrictLogging {
+
+  override def open(): Unit = store.open()
+  override def close(): Unit = store.close()
+  override def isOpen: Boolean = store.isOpen
 
   private[store] val versionCache = TrieMap.empty[(Category, K), Set[OffsetDateTime]]
   private[store] val versionedValueCache = TrieMap.empty[(K, OffsetDateTime), Option[Any]]
@@ -360,6 +370,8 @@ case class LazyVersionCachingPersistentStore[K, Category, Serialized](
   override def backup(): Source[BackupItem, NotUsed] = store.backup()
 
   override def restore(): ScalaSink[BackupItem, Future[Done]] = store.restore()
+
+  override def sync(): Future[Done] = store.sync()
 
   override def toString: String = s"LazyVersionCachingPersistenceStore($store)"
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
@@ -50,6 +50,10 @@ class LoadTimeCachingPersistenceStore[K, Category, Serialized](
   private[store] var valueCache: Future[TrieMap[K, Either[Serialized, Any]]] =
     Future.failed(new NotActiveException())
 
+  override def open(): Unit = store.open()
+  override def close(): Unit = store.close()
+  override def isOpen: Boolean = store.isOpen
+
   override def storageVersion(): Future[Option[StorageVersion]] = store.storageVersion()
 
   override def setStorageVersion(storageVersion: StorageVersion): Future[Done] =
@@ -199,6 +203,8 @@ class LoadTimeCachingPersistenceStore[K, Category, Serialized](
   override def backup(): Source[BackupItem, NotUsed] = store.backup()
 
   override def restore(): Sink[BackupItem, Future[Done]] = store.restore()
+
+  override def sync(): Future[Done] = store.sync()
 
   override def versions[Id, V](id: Id)(implicit ir: IdResolver[Id, V, Category, K]): Source[OffsetDateTime, NotUsed] =
     store.versions(id)

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/memory/InMemoryPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/memory/InMemoryPersistenceStore.scala
@@ -27,38 +27,54 @@ class InMemoryPersistenceStore(implicit
   protected val mat: Materializer,
   ctx: ExecutionContext)
     extends BasePersistenceStore[RamId, String, Identity] {
+
   val entries = TrieMap[RamId, Identity]()
   val version = Lock(StorageVersions.current.toBuilder)
 
   override def storageVersion(): Future[Option[StorageVersion]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     Future.successful(Some(version(_.build())))
   }
 
   override def setStorageVersion(storageVersion: StorageVersion): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     version(_.mergeFrom(storageVersion))
     Future.successful(Done)
   }
 
   override protected def rawIds(category: String): Source[RamId, NotUsed] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     val ids = entries.keySet.filter(_.category == category)
     // we need to list the id even if there is no current version.
     Source(ids.groupBy(_.id).flatMap(_._2.headOption))
   }
 
-  override protected[store] def rawGet(k: RamId): Future[Option[Identity]] =
+  override protected[store] def rawGet(k: RamId): Future[Option[Identity]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     Future.successful(entries.get(k))
+  }
 
   override protected def rawDelete(k: RamId, version: OffsetDateTime): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     entries.remove(k.copy(version = Some(version)))
     Future.successful(Done)
   }
 
   override protected def rawStore[V](k: RamId, v: Identity): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     entries.put(k, v)
     Future.successful(Done)
   }
 
   override protected def rawVersions(id: RamId): Source[OffsetDateTime, NotUsed] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     val versions = entries.collect {
       case (RamId(category, rid, Some(v)), _) if category == id.category && id.id == rid => v
     }(collection.breakOut)
@@ -66,20 +82,29 @@ class InMemoryPersistenceStore(implicit
   }
 
   override protected def rawDeleteCurrent(k: RamId): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     entries.remove(k)
     Future.successful(Done)
   }
 
   override protected def rawDeleteAll(k: RamId): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     val toRemove = entries.keySet.filter(id => k.category == id.category && k.id == id.id)
     toRemove.foreach(entries.remove)
     Future.successful(Done)
   }
 
-  override protected[store] def allKeys(): Source[CategorizedKey[String, RamId], NotUsed] =
+  override protected[store] def allKeys(): Source[CategorizedKey[String, RamId], NotUsed] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     Source(entries.keySet.filter(_.version.isEmpty).map(id => CategorizedKey(id.category, id))(collection.breakOut))
+  }
 
   override def backup(): Source[BackupItem, NotUsed] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     Source.fromIterator(() => entries.iterator.map {
       case (key, value) =>
         BackupItem(key.category, key.id, key.version, ByteString(InMemoryPersistenceStore.objectToByteArray(value.value)))
@@ -92,6 +117,8 @@ class InMemoryPersistenceStore(implicit
   }
 
   override def restore(): Sink[BackupItem, Future[Done]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     def store(item: BackupItem): Done = {
       InMemoryPersistenceStore.byteArrayToObject[AnyRef](item.data.toArray) match {
         case Some(value) => entries.put(RamId(item.category, item.key, item.version), Identity(value))
@@ -114,6 +141,12 @@ class InMemoryPersistenceStore(implicit
       }
       .prepend { Source.single(clean()) }
       .toMat(Sink.ignore)(Keep.right)
+  }
+
+  override def sync(): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
+    Future.successful(Done)
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -5,17 +5,20 @@ import akka.actor.{ ActorSystem, Scheduler }
 import akka.stream.Materializer
 import mesosphere.marathon.core.base.LifecycleState
 import mesosphere.marathon.core.storage.backup.PersistentStoreBackup
+import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.cache.LoadTimeCachingPersistenceStore
 import mesosphere.marathon.storage.migration.{ Migration, ServiceDefinitionRepository }
 import mesosphere.marathon.storage.repository._
 
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
+import scala.language.existentials
 
 /**
   * Provides the repositories for all persistable entities.
   */
 trait StorageModule {
+  val persistenceStore: PersistenceStore[_, _, _]
   val instanceRepository: InstanceRepository
   val deploymentRepository: DeploymentRepository
   val taskFailureRepository: TaskFailureRepository
@@ -65,6 +68,7 @@ object StorageModule {
           taskFailureRepository, frameworkIdRepository, ServiceDefinitionRepository.zkRepository(store), runtimeConfigurationRepository, backup, config)
 
         StorageModuleImpl(
+          store,
           instanceRepository,
           deploymentRepository,
           taskFailureRepository,
@@ -100,6 +104,7 @@ object StorageModule {
           taskFailureRepository, frameworkIdRepository, ServiceDefinitionRepository.inMemRepository(store), runtimeConfigurationRepository, backup, config)
 
         StorageModuleImpl(
+          store,
           instanceRepository,
           deploymentRepository,
           taskFailureRepository,
@@ -115,6 +120,7 @@ object StorageModule {
 }
 
 private[storage] case class StorageModuleImpl(
+  persistenceStore: PersistenceStore[_, _, _],
   instanceRepository: InstanceRepository,
   deploymentRepository: DeploymentRepository,
   taskFailureRepository: TaskFailureRepository,

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -100,6 +100,12 @@ class Migration(
 
   @SuppressWarnings(Array("all")) // async/await
   def migrateAsync(): Future[Seq[StorageVersion]] = async {
+    // Before reading to and writing from the storage, let's ensure that
+    // no stale values are read from the persistence store.
+    // Although in case of ZK it is done at the time of creation of CuratorZK,
+    // it is better to be safe than sorry.
+    await(persistenceStore.sync())
+
     val config = await(runtimeConfigurationRepository.get()).getOrElse(RuntimeConfiguration())
     // before backup/restore called, reset the runtime configuration
     await(runtimeConfigurationRepository.store(RuntimeConfiguration(None, None)))

--- a/src/main/scala/mesosphere/marathon/util/Openable.scala
+++ b/src/main/scala/mesosphere/marathon/util/Openable.scala
@@ -1,0 +1,34 @@
+package mesosphere.marathon
+package util
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+  * This trait is meant to be used to mark a resource object as open or close.
+  * A resource can be marked as open or close only once. Also, it can be closed
+  * only when it is open.
+  */
+trait Openable {
+  protected val opened = new AtomicBoolean(false)
+  protected val wasEverOpened = new AtomicBoolean(false)
+
+  /** Mark an object as open. */
+  def open(): Unit = {
+    if (wasEverOpened.compareAndSet(false, true)) {
+      opened.set(true)
+    } else {
+      throw new IllegalStateException("it was opened before")
+    }
+  }
+
+  /** Mark an object as closed. */
+  def close(): Unit = {
+    val wasOpened = opened.compareAndSet(true, false)
+    if (!wasOpened) {
+      throw new IllegalStateException("attempt to close while not being opened")
+    }
+  }
+
+  /** This method returns true, if the object is open at the moment. */
+  def isOpen: Boolean = opened.get()
+}

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -14,6 +14,7 @@ import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.heartbeat._
 import mesosphere.marathon.core.leadership.LeadershipCoordinator
+import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
@@ -59,6 +60,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
   case class Fixture() {
     val probe: TestProbe = TestProbe()
     val heartbeatProbe: TestProbe = TestProbe()
+    val persistenceStore: PersistenceStore[_, _, _] = mock[PersistenceStore[_, _, _]]
     val leadershipCoordinator: LeadershipCoordinator = mock[LeadershipCoordinator]
     val healthCheckManager: HealthCheckManager = mock[HealthCheckManager]
     val config: MarathonConf = mockConfig
@@ -87,6 +89,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
   "MarathonSchedulerService" should {
     "Start timer when elected" in new Fixture {
       val schedulerService = new MarathonSchedulerService(
+        persistenceStore,
         leadershipCoordinator,
         config,
         electionService,
@@ -110,6 +113,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
     "Cancel timer when defeated" in new Fixture {
       val driver = mock[SchedulerDriver]
       val schedulerService = new MarathonSchedulerService(
+        persistenceStore,
         leadershipCoordinator,
         config,
         electionService,
@@ -138,6 +142,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
     "throw in start leadership when migration fails" in new Fixture {
 
       val schedulerService = new MarathonSchedulerService(
+        persistenceStore,
         leadershipCoordinator,
         config,
         electionService,
@@ -171,6 +176,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
       val driverFactory = mock[SchedulerDriverFactory]
 
       val schedulerService = new MarathonSchedulerService(
+        persistenceStore,
         leadershipCoordinator,
         config,
         electionService,
@@ -199,6 +205,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
       val driverFactory = mock[SchedulerDriverFactory]
 
       val schedulerService = new MarathonSchedulerService(
+        persistenceStore,
         leadershipCoordinator,
         config,
         electionService,
@@ -231,6 +238,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
       val driverFactory = mock[SchedulerDriverFactory]
 
       val schedulerService = new MarathonSchedulerService(
+        persistenceStore,
         leadershipCoordinator,
         config,
         electionService,

--- a/src/test/scala/mesosphere/marathon/core/election/impl/PseudoElectionServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/election/impl/PseudoElectionServiceTest.scala
@@ -1,4 +1,3 @@
-
 package mesosphere.marathon
 package core.election.impl
 

--- a/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ Future, Promise }
 class GroupManagerTest extends AkkaUnitTest with GroupCreation {
   class Fixture(
       val servicePortsRange: Range = 1000.until(20000),
-      val initialRoot: RootGroup = RootGroup.empty) {
+      val initialRoot: Option[RootGroup] = Some(RootGroup.empty)) {
     val config = AllConf.withTestConfig("--local_port_min", servicePortsRange.start.toString, "--local_port_max", (servicePortsRange.end + 1).toString)
     val groupRepository = mock[GroupRepository]
     val deploymentService = mock[DeploymentService]
@@ -29,6 +29,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       override def get(): DeploymentService = deploymentService
     })(eventStream, ExecutionContexts.global)
   }
+
   "applications with port definitions" when {
     "apps with port definitions should map dynamic ports to a non-0 value" in new Fixture(10.to(20)) {
       val app = AppDefinition("/app".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(1)))
@@ -240,6 +241,10 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
   behave like withContainerNetworking("mesos", Container.Mesos())
 
   "GroupManager" should {
+    "return None as a root group, if the initial group has not been passed to it" in new Fixture(initialRoot = None) {
+      groupManager.rootGroupOption() shouldBe None
+    }
+
     "Don't store invalid groups" in new Fixture {
 
       val app1 = AppDefinition("/app1".toPath)
@@ -309,10 +314,10 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       verify(groupRepository).storeRootVersion(groupWithVersionInfo, Seq(appWithVersionInfo), Nil)
     }
 
-    "Expunge removed apps from appRepo" in new Fixture(initialRoot = {
+    "Expunge removed apps from appRepo" in new Fixture(initialRoot = Option({
       val app: AppDefinition = AppDefinition("/app1".toPath, cmd = Some("sleep 3"), portDefinitions = Seq.empty)
       createRootGroup(Map(app.id -> app), version = Timestamp(1))
-    }) {
+    })) {
       val groupEmpty = createRootGroup(version = Timestamp(1))
 
       deploymentService.deploy(any, any) returns Future.successful(Done)

--- a/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
@@ -33,6 +33,27 @@ private[storage] trait PersistenceStoreTest { this: AkkaUnitTest =>
     um: Unmarshaller[Serialized, TestClass1]): Unit = {
 
     name should {
+      "is open" in {
+        val store = newStore
+        store.isOpen shouldBe true
+      }
+      "cannot be opened twice" in {
+        val store = newStore
+        val thrown = the[IllegalStateException] thrownBy store.open()
+        thrown.getMessage shouldBe "it was opened before"
+      }
+      "cannot be reopened" in {
+        val store = newStore
+        store.close()
+        val thrown = the[IllegalStateException] thrownBy store.open()
+        thrown.getMessage shouldBe "it was opened before"
+      }
+      "cannot be closed twice" in {
+        val store = newStore
+        store.close()
+        val thrown = the[IllegalStateException] thrownBy store.close()
+        thrown.getMessage shouldBe "attempt to close while not being opened"
+      }
       "have no ids" in {
         val store = newStore
         store.ids().runWith(Sink.seq).futureValue should equal(Nil)

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/InMemoryPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/InMemoryPersistenceStoreTest.scala
@@ -23,6 +23,12 @@ trait InMemoryTestClass1Serialization {
 class InMemoryPersistenceStoreTest extends AkkaUnitTest with PersistenceStoreTest
     with InMemoryStoreSerialization with InMemoryTestClass1Serialization {
 
-  behave like basicPersistenceStore("InMemoryPersistenceStore", new InMemoryPersistenceStore())
-  behave like backupRestoreStore("InMemoryPersistenceStore", new InMemoryPersistenceStore())
+  def inMemoryStore: InMemoryPersistenceStore = {
+    val store = new InMemoryPersistenceStore()
+    store.open()
+    store
+  }
+
+  behave like basicPersistenceStore("InMemoryPersistenceStore", inMemoryStore)
+  behave like backupRestoreStore("InMemoryPersistenceStore", inMemoryStore)
 }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
@@ -23,18 +23,24 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
     with InMemoryStoreSerialization with InMemoryTestClass1Serialization {
 
   private def cachedInMemory = {
-    LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
+    store
   }
 
-  private def withLazyVersionCaching = LazyVersionCachingPersistentStore(cachedInMemory)
+  private def withLazyVersionCaching = {
+    val store = LazyVersionCachingPersistentStore(new InMemoryPersistenceStore())
+    store.open()
+    store
+  }
 
-  def zkStore: ZkPersistenceStore = {
+  private def cachedZk = {
     val root = UUID.randomUUID().toString
     val client = zkClient(namespace = Some(root))
-    new ZkPersistenceStore(client, Duration.Inf, 8)
+    val store = LazyCachingPersistenceStore(new ZkPersistenceStore(client, Duration.Inf, 8))
+    store.open()
+    store
   }
-
-  private def cachedZk = LazyCachingPersistenceStore(zkStore)
 
   behave like basicPersistenceStore("LazyCache(InMemory)", cachedInMemory)
   behave like basicPersistenceStore("LazyCache(Zk)", cachedZk)

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
@@ -25,12 +25,14 @@ class LoadTimeCachingPersistenceStoreTest extends AkkaUnitTest
 
   private def cachedInMemory = {
     val store = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
     store.preDriverStarts.futureValue
     store
   }
 
   private def cachedZk = {
     val store = new LoadTimeCachingPersistenceStore(zkStore)
+    store.open()
     store.preDriverStarts.futureValue
     store
   }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -61,7 +61,9 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
   def defaultStore: ZkPersistenceStore = {
     val root = UUID.randomUUID().toString
     val client = zkClient(namespace = Some(root))
-    new ZkPersistenceStore(client, Duration.Inf)
+    val store = new ZkPersistenceStore(client, Duration.Inf)
+    store.open()
+    store
   }
 
   behave like basicPersistenceStore("ZookeeperPersistenceStore", defaultStore)

--- a/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
@@ -66,6 +66,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       testScan: Option[() => Future[ScanDone]] = None)(
       testCompact: Option[(Set[PathId], Map[PathId, Set[OffsetDateTime]], Set[PathId], Map[PathId, Set[OffsetDateTime]], Set[OffsetDateTime]) => Future[CompactDone]] = None) {
     val store = new InMemoryPersistenceStore()
+    store.open()
     val appRepo = AppRepository.inMemRepository(store)
     val podRepo = PodRepository.inMemRepository(store)
     val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -426,6 +427,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
     "actually running" should {
       "ignore scan errors on roots" in {
         val store = new InMemoryPersistenceStore()
+        store.open()
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = mock[StoredGroupRepositoryImpl[RamId, String, Identity]]
@@ -438,6 +440,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore scan errors on apps" in {
         val store = new InMemoryPersistenceStore()
+        store.open()
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -453,6 +456,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore scan errors on pods" in {
         val store = new InMemoryPersistenceStore()
+        store.open()
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = mock[PodRepositoryImpl[RamId, String, Identity]]
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -468,6 +472,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore errors when compacting" in {
         val store = new InMemoryPersistenceStore()
+        store.open()
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)

--- a/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
@@ -120,7 +120,10 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
         noMoreInteractions(appRepo)
       }
       "retrieve a historical version" in {
-        val appRepo = AppRepository.inMemRepository(new InMemoryPersistenceStore())
+        val store = new InMemoryPersistenceStore()
+        store.open()
+
+        val appRepo = AppRepository.inMemRepository(store)
         val repo = createRepo(appRepo, mock[PodRepository], 2)
 
         val app1 = AppDefinition("app1".toRootPath)
@@ -145,6 +148,7 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
 
   def createInMemRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     val store = new InMemoryPersistenceStore()
+    store.open()
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }
 
@@ -156,16 +160,19 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
 
   def createZkRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     val store = zkStore
+    store.open()
     GroupRepository.zkRepository(store, appRepository, podRepository)
   }
 
   def createLazyCachingRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }
 
   def createLoadCachingRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     val store = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
     store.preDriverStarts.futureValue
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }

--- a/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
@@ -33,6 +33,7 @@ class PodRepositoryTest extends AkkaUnitTest {
     implicit val ctx = ExecutionContexts.global
 
     val store = new InMemoryPersistenceStore()
+    store.open()
     val repo = PodRepository.inMemRepository(store)
   }
 }

--- a/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
@@ -149,11 +149,14 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
   }
 
   def createInMemRepo(): AppRepository = {
-    AppRepository.inMemRepository(new InMemoryPersistenceStore())
+    val store = new InMemoryPersistenceStore()
+    store.open()
+    AppRepository.inMemRepository(store)
   }
 
   def createLoadTimeCachingRepo(): AppRepository = {
     val cached = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
+    cached.open()
     cached.preDriverStarts.futureValue
     AppRepository.inMemRepository(cached)
   }
@@ -162,15 +165,20 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
     val root = UUID.randomUUID().toString
     val rootClient = zkClient(namespace = Some(root))
     val store = new ZkPersistenceStore(rootClient, Duration.Inf)
+    store.open()
     AppRepository.zkRepository(store)
   }
 
   def createLazyCachingRepo(): AppRepository = {
-    AppRepository.inMemRepository(LazyCachingPersistenceStore(new InMemoryPersistenceStore()))
+    val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
+    AppRepository.inMemRepository(store)
   }
 
   def createLazyVersionCachingRepo(): AppRepository = {
-    AppRepository.inMemRepository(LazyVersionCachingPersistentStore(new InMemoryPersistenceStore()))
+    val store = LazyVersionCachingPersistentStore(new InMemoryPersistenceStore())
+    store.open()
+    AppRepository.inMemRepository(store)
   }
 
   behave like basic("InMemoryPersistence", createInMemRepo)

--- a/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
@@ -42,21 +42,28 @@ class SingletonRepositoryTest extends AkkaUnitTest with ZookeeperServerTest {
   }
 
   def createInMemRepo(): FrameworkIdRepository = {
-    FrameworkIdRepository.inMemRepository(new InMemoryPersistenceStore())
+    val store = new InMemoryPersistenceStore()
+    store.open()
+    FrameworkIdRepository.inMemRepository(store)
   }
 
   def createLoadTimeCachingRepo(): FrameworkIdRepository = {
     val cached = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
+    cached.open()
     cached.preDriverStarts.futureValue
     FrameworkIdRepository.inMemRepository(cached)
   }
 
   def createZKRepo(): FrameworkIdRepository = {
-    FrameworkIdRepository.zkRepository(new ZkPersistenceStore(zkClient(), 10.seconds))
+    val store = new ZkPersistenceStore(zkClient(), 10.seconds)
+    store.open()
+    FrameworkIdRepository.zkRepository(store)
   }
 
   def createLazyCachingRepo(): FrameworkIdRepository = {
-    FrameworkIdRepository.inMemRepository(LazyCachingPersistenceStore(new InMemoryPersistenceStore()))
+    val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
+    FrameworkIdRepository.inMemRepository(store)
   }
 
   behave like basic("InMemoryPersistence", createInMemRepo())

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -25,7 +25,12 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
   val TEST_APP_NAME = PathId("/foo")
 
   case class Fixture() {
-    implicit val state: InstanceRepository = spy(InstanceRepository.inMemRepository(new InMemoryPersistenceStore()))
+    val store: InMemoryPersistenceStore = {
+      val store = new InMemoryPersistenceStore()
+      store.open()
+      store
+    }
+    implicit val state: InstanceRepository = spy(InstanceRepository.inMemRepository(store))
     val config: AllConf = MarathonTestHelper.defaultConfig()
     implicit val clock: SettableClock = new SettableClock()
     val taskTrackerModule: InstanceTrackerModule = MarathonTestHelper.createTaskTrackerModule(

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -335,7 +335,11 @@ object MarathonTestHelper {
     store: Option[InstanceRepository] = None)(implicit mat: Materializer): InstanceTrackerModule = {
 
     implicit val ctx = ExecutionContexts.global
-    val instanceRepo = store.getOrElse(InstanceRepository.inMemRepository(new InMemoryPersistenceStore()))
+    val instanceRepo = store.getOrElse {
+      val store = new InMemoryPersistenceStore()
+      store.open()
+      InstanceRepository.inMemRepository(store)
+    }
     val updateSteps = Seq.empty[InstanceChangeHandler]
 
     new InstanceTrackerModule(clock, defaultConfig(), leadershipModule, instanceRepo, updateSteps) {


### PR DESCRIPTION
In addition to that,

- Prevent any access to the persistence storage while
  not being a leader, which means that Marathon reads from
  and writes to ZK only after it becomes a leader.
- Register service.mesosphere.marathon.app.count and
  service.mesosphere.marathon.app.count metrics once
  the root group gets loaded for the first time

JIRA issues:
https://jira.mesosphere.com/browse/MARATHON-7763
https://jira.mesosphere.com/browse/MARATHON-7785

It is a cherry-pick of https://github.com/mesosphere/marathon/commit/5137ed9949c98f0c759bd2ba2b6ce6f8cd4d60db
