### PR TITLE
Do sync before reading from or writing to ZooKeeper

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -206,7 +206,7 @@ class MarathonSchedulerService @Inject() (
     log.info("As new leader running the driver")
 
     // allow interactions with the persistence store
-    persistenceStore.foreach(_.open())
+    persistenceStore.foreach(_.markOpen())
 
     // GroupRepository is holding in memory caches of the root group. The cache is loaded when it is accessed the first time.
     // Actually this is really bad, because each marathon will log the amount of groups during startup through metrics.
@@ -276,7 +276,7 @@ class MarathonSchedulerService @Inject() (
     log.info("Lost leadership")
 
     // disallow any interaction with the persistence storage
-    persistenceStore.foreach(_.close())
+    persistenceStore.foreach(_.markClosed())
 
     leadershipCoordinator.stop()
 

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -20,6 +20,7 @@ import mesosphere.marathon.core.leadership.{ LeadershipCoordinator, LeadershipMo
 import mesosphere.marathon.core.plugin.{ PluginDefinitions, PluginManager }
 import mesosphere.marathon.core.pod.PodManager
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
+import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.task.bus.{ TaskChangeObservables, TaskStatusEmitter }
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.KillService
@@ -116,6 +117,12 @@ class CoreGuiceModule extends AbstractModule {
   @Provides
   @Singleton
   def materializer(coreModule: CoreModule): Materializer = coreModule.actorsModule.materializer
+
+  @Provides
+  @Singleton
+  def providePersistenceStore(coreModule: CoreModule): Option[PersistenceStore[_, _, _]] = {
+    coreModule.storageModule.persistenceStore
+  }
 
   @Provides
   @Singleton

--- a/src/main/scala/mesosphere/marathon/core/election/impl/CuratorElectionService.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/impl/CuratorElectionService.scala
@@ -109,7 +109,7 @@ class CuratorElectionService(
     if (acquiringLeadership.compareAndSet(false, true)) {
       require(leaderLatch.get.isEmpty, "leaderLatch is not empty")
 
-      startCuratorClient()
+      startCuratorClientAndConnect()
       val latch = new LeaderLatch(
         client, config.zooKeeperLeaderPath + "-curator", hostPort)
       latch.addListener(LeaderChangeListener, threadExecutor)
@@ -248,9 +248,11 @@ class CuratorElectionService(
     client
   }
 
-  private def startCuratorClient(): Unit = {
+  private def startCuratorClientAndConnect(): Unit = {
     client.start()
-    client.blockUntilConnected(config.zkTimeoutDuration.toMillis.toInt, TimeUnit.MILLISECONDS)
+    client.blockUntilConnected(
+      client.getZookeeperClient.getConnectionTimeoutMs,
+      TimeUnit.MILLISECONDS)
   }
 
   /**

--- a/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.scaladsl.Source
 import akka.{ Done, NotUsed }
 import mesosphere.marathon.Protos.StorageVersion
+import mesosphere.marathon.util.Openable
 
 import scala.concurrent.Future
 
@@ -81,7 +82,7 @@ import scala.concurrent.Future
   * @tparam Category The persistence store's category type.
   * @tparam Serialized The serialized format for the persistence store.
   */
-trait PersistenceStore[K, Category, Serialized] {
+trait PersistenceStore[K, Category, Serialized] extends Openable {
   /**
     * Get a list of all of the Ids of the given Value Types
     */
@@ -169,4 +170,9 @@ trait PersistenceStore[K, Category, Serialized] {
     *         will fail the future with [[mesosphere.marathon.StoreCommandFailedException]]
     */
   def deleteAll[Id, V](k: Id)(implicit ir: IdResolver[Id, V, Category, K]): Future[Done]
+
+  /**
+    * Make sure that store read operations return up-to-date values.
+    */
+  def sync(): Future[Done]
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.scaladsl.Source
 import akka.{ Done, NotUsed }
 import mesosphere.marathon.Protos.StorageVersion
-import mesosphere.marathon.util.Openable
+import mesosphere.marathon.util.OpenableOnce
 
 import scala.concurrent.Future
 
@@ -82,7 +82,7 @@ import scala.concurrent.Future
   * @tparam Category The persistence store's category type.
   * @tparam Serialized The serialized format for the persistence store.
   */
-trait PersistenceStore[K, Category, Serialized] extends Openable {
+trait PersistenceStore[K, Category, Serialized] extends OpenableOnce {
   /**
     * Get a list of all of the Ids of the given Value Types
     */

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
@@ -44,6 +44,10 @@ case class LazyCachingPersistenceStore[K, Category, Serialized](
   private[this] val getHitCounters = TrieMap.empty[Category, Metrics.Counter]
   private[this] val idsHitCounters = TrieMap.empty[Category, Metrics.Counter]
 
+  override def open(): Unit = store.open()
+  override def close(): Unit = store.close()
+  override def isOpen: Boolean = store.isOpen
+
   override def storageVersion(): Future[Option[StorageVersion]] = store.storageVersion()
 
   override def setStorageVersion(storageVersion: StorageVersion): Future[Done] =
@@ -172,6 +176,8 @@ case class LazyCachingPersistenceStore[K, Category, Serialized](
     version: OffsetDateTime)(implicit ir: IdResolver[Id, V, Category, K]): Future[Done] =
     store.deleteVersion(k, version)
 
+  override def sync(): Future[Done] = store.sync()
+
   override def toString: String = s"LazyCachingPersistenceStore($store)"
 }
 
@@ -181,6 +187,10 @@ case class LazyVersionCachingPersistentStore[K, Category, Serialized](
   mat: Materializer,
     ctx: ExecutionContext,
     metrics: Metrics) extends PersistenceStore[K, Category, Serialized] with StrictLogging {
+
+  override def open(): Unit = store.open()
+  override def close(): Unit = store.close()
+  override def isOpen: Boolean = store.isOpen
 
   private[store] val versionCache = TrieMap.empty[(Category, K), Set[OffsetDateTime]]
   private[store] val versionedValueCache = TrieMap.empty[(K, OffsetDateTime), Option[Any]]
@@ -340,6 +350,8 @@ case class LazyVersionCachingPersistentStore[K, Category, Serialized](
 
   override def setStorageVersion(storageVersion: StorageVersion): Future[Done] =
     store.setStorageVersion(storageVersion)
+
+  override def sync(): Future[Done] = store.sync()
 
   override def toString: String = s"LazyVersionCachingPersistenceStore($store)"
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
@@ -44,8 +44,8 @@ case class LazyCachingPersistenceStore[K, Category, Serialized](
   private[this] val getHitCounters = TrieMap.empty[Category, Metrics.Counter]
   private[this] val idsHitCounters = TrieMap.empty[Category, Metrics.Counter]
 
-  override def open(): Unit = store.open()
-  override def close(): Unit = store.close()
+  override def markOpen(): Unit = store.markOpen()
+  override def markClosed(): Unit = store.markClosed()
   override def isOpen: Boolean = store.isOpen
 
   override def storageVersion(): Future[Option[StorageVersion]] = store.storageVersion()
@@ -188,8 +188,8 @@ case class LazyVersionCachingPersistentStore[K, Category, Serialized](
     ctx: ExecutionContext,
     metrics: Metrics) extends PersistenceStore[K, Category, Serialized] with StrictLogging {
 
-  override def open(): Unit = store.open()
-  override def close(): Unit = store.close()
+  override def markOpen(): Unit = store.markOpen()
+  override def markClosed(): Unit = store.markClosed()
   override def isOpen: Boolean = store.isOpen
 
   private[store] val versionCache = TrieMap.empty[(Category, K), Set[OffsetDateTime]]

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
@@ -49,8 +49,8 @@ class LoadTimeCachingPersistenceStore[K, Category, Serialized](
   private[store] var valueCache: Future[TrieMap[K, Either[Serialized, Any]]] =
     Future.failed(new NotActiveException())
 
-  override def open(): Unit = store.open()
-  override def close(): Unit = store.close()
+  override def markOpen(): Unit = store.markOpen()
+  override def markClosed(): Unit = store.markClosed()
   override def isOpen: Boolean = store.isOpen
 
   override def storageVersion(): Future[Option[StorageVersion]] = store.storageVersion()

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
@@ -49,6 +49,10 @@ class LoadTimeCachingPersistenceStore[K, Category, Serialized](
   private[store] var valueCache: Future[TrieMap[K, Either[Serialized, Any]]] =
     Future.failed(new NotActiveException())
 
+  override def open(): Unit = store.open()
+  override def close(): Unit = store.close()
+  override def isOpen: Boolean = store.isOpen
+
   override def storageVersion(): Future[Option[StorageVersion]] = store.storageVersion()
 
   override def setStorageVersion(storageVersion: StorageVersion): Future[Done] =
@@ -197,6 +201,8 @@ class LoadTimeCachingPersistenceStore[K, Category, Serialized](
     k: Id,
     version: OffsetDateTime)(implicit ir: IdResolver[Id, V, Category, K]): Future[Done] =
     store.deleteVersion(k, version)
+
+  override def sync(): Future[Done] = store.sync()
 
   override def toString: String = s"LoadTimeCachingPersistenceStore($store)"
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/memory/InMemoryPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/memory/InMemoryPersistenceStore.scala
@@ -23,38 +23,54 @@ class InMemoryPersistenceStore(implicit
   protected val metrics: Metrics,
   ctx: ExecutionContext)
     extends BasePersistenceStore[RamId, String, Identity] {
+
   val entries = TrieMap[RamId, Identity]()
   val version = Lock(StorageVersions.current.toBuilder)
 
   override def storageVersion(): Future[Option[StorageVersion]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     Future.successful(Some(version(_.build())))
   }
 
   override def setStorageVersion(storageVersion: StorageVersion): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     version(_.mergeFrom(storageVersion))
     Future.successful(Done)
   }
 
   override protected def rawIds(category: String): Source[RamId, NotUsed] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     val ids = entries.keySet.filter(_.category == category)
     // we need to list the id even if there is no current version.
     Source(ids.groupBy(_.id).flatMap(_._2.headOption))
   }
 
-  override protected[store] def rawGet(k: RamId): Future[Option[Identity]] =
+  override protected[store] def rawGet(k: RamId): Future[Option[Identity]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     Future.successful(entries.get(k))
+  }
 
   override protected def rawDelete(k: RamId, version: OffsetDateTime): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     entries.remove(k.copy(version = Some(version)))
     Future.successful(Done)
   }
 
   override protected def rawStore[V](k: RamId, v: Identity): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     entries.put(k, v)
     Future.successful(Done)
   }
 
   override protected def rawVersions(id: RamId): Source[OffsetDateTime, NotUsed] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     val versions = entries.collect {
       case (RamId(category, rid, Some(v)), _) if category == id.category && id.id == rid => v
     }(collection.breakOut)
@@ -62,16 +78,29 @@ class InMemoryPersistenceStore(implicit
   }
 
   override protected def rawDeleteCurrent(k: RamId): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     entries.remove(k)
     Future.successful(Done)
   }
 
   override protected def rawDeleteAll(k: RamId): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     val toRemove = entries.keySet.filter(id => k.category == id.category && k.id == id.id)
     toRemove.foreach(entries.remove)
     Future.successful(Done)
   }
 
-  override protected[store] def allKeys(): Source[CategorizedKey[String, RamId], NotUsed] =
+  override protected[store] def allKeys(): Source[CategorizedKey[String, RamId], NotUsed] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     Source(entries.keySet.filter(_.version.isEmpty).map(id => CategorizedKey(id.category, id))(collection.breakOut))
+  }
+
+  override def sync(): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
+    Future.successful(Done)
+  }
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -53,6 +53,7 @@ class ZkPersistenceStore(
     scheduler: Scheduler,
     val metrics: Metrics
 ) extends BasePersistenceStore[ZkId, String, ZkSerialized]() with StrictLogging {
+
   private val limitRequests = WorkQueue("ZkPersistenceStore", maxConcurrent = maxConcurrent, maxQueueLength = maxQueued)
 
   private val retryOn: Retry.RetryOnFn = {
@@ -66,7 +67,9 @@ class ZkPersistenceStore(
   }
 
   @SuppressWarnings(Array("all")) // async/await
-  override def storageVersion(): Future[Option[StorageVersion]] =
+  override def storageVersion(): Future[Option[StorageVersion]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     retry("ZkPersistenceStore::storageVersion") {
       async {
         await(client.data(s"/${Migration.StorageVersionName}").asTry) match {
@@ -82,9 +85,12 @@ class ZkPersistenceStore(
         }
       }
     }
+  }
 
   @SuppressWarnings(Array("all")) // async/await
-  override def setStorageVersion(storageVersion: StorageVersion): Future[Done] =
+  override def setStorageVersion(storageVersion: StorageVersion): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     retry(s"ZkPersistenceStore::setStorageVersion($storageVersion)") {
       async {
         val path = s"/${Migration.StorageVersionName}"
@@ -109,9 +115,12 @@ class ZkPersistenceStore(
         }
       }
     }
+  }
 
   @SuppressWarnings(Array("all")) // async/await
   override protected def rawIds(category: String): Source[ZkId, NotUsed] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     val childrenFuture = retry(s"ZkPersistenceStore::ids($category)") {
       async {
         val buckets = await(client.children(s"/$category").recover {
@@ -133,6 +142,8 @@ class ZkPersistenceStore(
 
   @SuppressWarnings(Array("all")) // async/await
   override protected def rawVersions(id: ZkId): Source[OffsetDateTime, NotUsed] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     val unversioned = id.copy(version = None)
     val path = unversioned.path
     val versions = retry(s"ZkPersistenceStore::versions($path)") {
@@ -155,7 +166,9 @@ class ZkPersistenceStore(
   }
 
   @SuppressWarnings(Array("all")) // async/await
-  override protected[store] def rawGet(id: ZkId): Future[Option[ZkSerialized]] =
+  override protected[store] def rawGet(id: ZkId): Future[Option[ZkSerialized]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     retry(s"ZkPersistenceStore::get($id)") {
       async {
         await(client.data(id.path).asTry) match {
@@ -174,9 +187,12 @@ class ZkPersistenceStore(
         }
       }
     }
+  }
 
   @SuppressWarnings(Array("all")) // async/await
-  override protected def rawDelete(id: ZkId, version: OffsetDateTime): Future[Done] =
+  override protected def rawDelete(id: ZkId, version: OffsetDateTime): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     retry(s"ZkPersistenceStore::delete($id, $version)") {
       async {
         await(client.delete(id.copy(version = Some(version)).path).asTry) match {
@@ -188,9 +204,12 @@ class ZkPersistenceStore(
         }
       }
     }
+  }
 
   @SuppressWarnings(Array("all")) // async/await
   override protected def rawDeleteCurrent(id: ZkId): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     retry(s"ZkPersistenceStore::deleteCurrent($id)") {
       async {
         await(client.setData(id.path, data = ByteString()).asTry) match {
@@ -206,6 +225,8 @@ class ZkPersistenceStore(
 
   @SuppressWarnings(Array("all")) // async/await
   override protected def rawStore[V](id: ZkId, v: ZkSerialized): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     retry(s"ZkPersistenceStore::store($id, $v)") {
       async {
         await(client.setData(id.path, v.bytes).asTry) match {
@@ -242,6 +263,8 @@ class ZkPersistenceStore(
 
   @SuppressWarnings(Array("all")) // async/await
   override protected def rawDeleteAll(id: ZkId): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     val unversionedId = id.copy(version = None)
     retry(s"ZkPersistenceStore::delete($unversionedId)") {
       client.delete(unversionedId.path, guaranteed = true, deletingChildrenIfNeeded = true).map(_ => Done).recover {
@@ -253,6 +276,8 @@ class ZkPersistenceStore(
 
   @SuppressWarnings(Array("all")) // async/await
   override protected[store] def allKeys(): Source[CategorizedKey[String, ZkId], NotUsed] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     val sources = retry("ZkPersistenceStore::keys()") {
       async {
         val rootChildren = await(client.children("/").map(_.children))
@@ -261,5 +286,21 @@ class ZkPersistenceStore(
       }
     }
     Source.fromFuture(sources).flatMapConcat(identity).map { k => CategorizedKey(k.category, k) }
+  }
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def sync(): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
+    async {
+      await(client.sync("/").asTry) match {
+        case Success(_) =>
+          Done
+        case Failure(e: KeeperException) =>
+          throw new StoreCommandFailedException("Failed to sync", e)
+        case Failure(e) =>
+          throw e
+      }
+    }
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -53,11 +53,20 @@ class Migration(
     val store = config.store
     store match {
       case s: PersistentStoreManagement with PrePostDriverCallback =>
-        s.preDriverStarts.flatMap(_ => s.initialize()).map(_ => Some(store))
+        s.preDriverStarts
+          .flatMap(_ => s.sync())
+          .map(_ => s.initialize())
+          .map(_ => Some(store))
       case s: PersistentStoreManagement =>
-        s.initialize().map(_ => Some(store))
+        s.sync()
+          .map(_ => s.initialize())
+          .map(_ => Some(store))
       case s: PrePostDriverCallback =>
-        s.preDriverStarts.map(_ => Some(store))
+        s.preDriverStarts
+          .map(_ => s.sync())
+          .map(_ => Some(store))
+      case s: PersistentStore =>
+        s.sync().map(_ => Some(store))
       case _ =>
         Future.successful(Some(store))
     }

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -150,9 +150,7 @@ class Migration(
       // no stale values are read from the persistence store.
       // Although in case of ZK it is done at the time of creation of CuratorZK,
       // it is better to be safe than sorry.
-      persistenceStore.foreach { store =>
-        Await.ready(store.sync(), Duration.Inf)
-      }
+      await(Future.sequence(persistenceStore.map(_.sync()).toList))
 
       // invalidate group cache before migration
       await(groupRepository.invalidateGroupCache())

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -51,6 +51,9 @@ class Migration(
 
   private[migration] lazy val legacyStoreFuture: Future[Option[PersistentStore]] = legacyConfig.map { config =>
     val store = config.store
+    if (!store.isOpen) {
+      store.markOpen()
+    }
     store match {
       case s: PersistentStoreManagement with PrePostDriverCallback =>
         s.preDriverStarts

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/EntityStore.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/EntityStore.scala
@@ -1,5 +1,7 @@
 package mesosphere.marathon.storage.repository.legacy.store
 
+import mesosphere.marathon.util.OpenableOnce
+
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
@@ -9,7 +11,7 @@ import scala.concurrent.Future
   *
   * @tparam T the specific type of entities that are handled by this specific store.
   */
-trait EntityStore[T] {
+trait EntityStore[T] extends OpenableOnce {
 
   type Deserialize = () => T //returns deserialized T value.
   type Update = Deserialize => T //Update function Gets an Read and returns the (modified) T

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/InMemoryStore.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/InMemoryStore.scala
@@ -16,37 +16,55 @@ class InMemoryStore(implicit val ec: ExecutionContext = ExecutionContext.Implici
 
   private[this] val entities = TrieMap.empty[ID, InMemoryEntity]
 
-  override def load(key: ID): Future[Option[PersistentEntity]] = Future.successful{
-    entities.get(key)
+  override def load(key: ID): Future[Option[PersistentEntity]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
+    Future.successful {
+      entities.get(key)
+    }
   }
 
-  override def create(key: ID, content: IndexedSeq[Byte]): Future[PersistentEntity] = Future {
-    if (entities.contains(key)) throw new StoreCommandFailedException(s"Entity with id $key already exists!")
-    val entity = InMemoryEntity(key, 0, content)
-    entities.put(key, entity)
-    entity
+  override def create(key: ID, content: IndexedSeq[Byte]): Future[PersistentEntity] = {
+    require(isOpen, "the store must be opened before it can be used")
+
+    Future {
+      if (entities.contains(key)) throw new StoreCommandFailedException(s"Entity with id $key already exists!")
+      val entity = InMemoryEntity(key, 0, content)
+      entities.put(key, entity)
+      entity
+    }
   }
 
-  override def update(entity: PersistentEntity): Future[PersistentEntity] = Future {
-    entity match {
-      case e @ InMemoryEntity(id, version, _) =>
-        val currentVersion = entities(id)
-        if (currentVersion.version != version) throw new StoreCommandFailedException("Concurrent updates!")
-        val nextVersion = e.withNextVersion
-        if (entities.replace(id, currentVersion, nextVersion)) nextVersion
-        else throw new StoreCommandFailedException("Concurrent updates!")
-      case _ => throw new IllegalArgumentException(s"Wrong entity type: $entity")
+  override def update(entity: PersistentEntity): Future[PersistentEntity] = {
+    require(isOpen, "the store must be opened before it can be used")
+
+    Future {
+      entity match {
+        case e @ InMemoryEntity(id, version, _) =>
+          val currentVersion = entities(id)
+          if (currentVersion.version != version) throw new StoreCommandFailedException("Concurrent updates!")
+          val nextVersion = e.withNextVersion
+          if (entities.replace(id, currentVersion, nextVersion)) nextVersion
+          else throw new StoreCommandFailedException("Concurrent updates!")
+        case _ => throw new IllegalArgumentException(s"Wrong entity type: $entity")
+      }
     }
   }
 
   override def delete(key: ID): Future[Boolean] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     entities.get(key) match {
       case Some(value) => Future.successful(entities.remove(key).isDefined)
       case None => Future.successful(false)
     }
   }
 
-  override def allIds(): Future[Seq[ID]] = Future.successful(entities.keySet.toIndexedSeq)
+  override def allIds(): Future[Seq[ID]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
+    Future.successful(entities.keySet.toIndexedSeq)
+  }
 
   override def sync(): Future[Done] = Future.successful(Done)
 }

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/InMemoryStore.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/InMemoryStore.scala
@@ -1,6 +1,8 @@
 package mesosphere.marathon
 package storage.repository.legacy.store
 
+import akka.Done
+
 import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.Seq
 import scala.concurrent.{ ExecutionContext, Future }
@@ -45,6 +47,8 @@ class InMemoryStore(implicit val ec: ExecutionContext = ExecutionContext.Implici
   }
 
   override def allIds(): Future[Seq[ID]] = Future.successful(entities.keySet.toIndexedSeq)
+
+  override def sync(): Future[Done] = Future.successful(Done)
 }
 
 case class InMemoryEntity(id: String, version: Int, bytes: IndexedSeq[Byte] = Vector.empty) extends PersistentEntity {

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/MesosStateStore.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/MesosStateStore.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package storage.repository.legacy.store
 
+import akka.Done
 import mesosphere.marathon.storage.repository.legacy.store.JavaFutureToFuture.Timeout
 import mesosphere.marathon.stream._
 import org.apache.mesos.state.{ State, Variable }
@@ -75,6 +76,8 @@ class MesosStateStore(state: State, timeout: Duration) extends PersistentStore {
           Seq.empty[ID]
       }
   }
+
+  override def sync(): Future[Done] = Future.successful(Done)
 
   private[this] def entityExists(variable: Variable): Boolean = variable.value().nonEmpty
 

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/MesosStateStore.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/MesosStateStore.scala
@@ -19,6 +19,8 @@ class MesosStateStore(state: State, timeout: Duration) extends PersistentStore {
   import JavaFutureToFuture.futureToFuture
 
   override def load(key: ID): Future[Option[PersistentEntity]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     futureToFuture(state.fetch(key))
       .map(throwOnNull)
       .map { variable => if (entityExists(variable)) Some(MesosStateEntity(key, variable)) else None }
@@ -26,6 +28,8 @@ class MesosStateStore(state: State, timeout: Duration) extends PersistentStore {
   }
 
   override def create(key: ID, content: IndexedSeq[Byte]): Future[PersistentEntity] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     futureToFuture(state.fetch(key))
       .map(throwOnNull)
       .flatMap { variable =>
@@ -35,17 +39,23 @@ class MesosStateStore(state: State, timeout: Duration) extends PersistentStore {
       .recover(mapException(s"Can not create entity with key $key"))
   }
 
-  override def update(entity: PersistentEntity): Future[PersistentEntity] = entity match {
-    case MesosStateEntity(id, v) =>
-      futureToFuture(state.store(v))
-        .recover(mapException(s"Can not update entity with key ${entity.id}"))
-        .map(throwOnNull)
-        .map(MesosStateEntity(id, _))
+  override def update(entity: PersistentEntity): Future[PersistentEntity] = {
+    require(isOpen, "the store must be opened before it can be used")
 
-    case _ => throw new IllegalArgumentException("Can not handle this kind of entity")
+    entity match {
+      case MesosStateEntity(id, v) =>
+        futureToFuture(state.store(v))
+          .recover(mapException(s"Can not update entity with key ${entity.id}"))
+          .map(throwOnNull)
+          .map(MesosStateEntity(id, _))
+
+      case _ => throw new IllegalArgumentException("Can not handle this kind of entity")
+    }
   }
 
   override def delete(key: ID): Future[Boolean] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     futureToFuture(state.fetch(key))
       .map(throwOnNull)
       .flatMap { variable =>
@@ -59,6 +69,8 @@ class MesosStateStore(state: State, timeout: Duration) extends PersistentStore {
   }
 
   override def allIds(): Future[Seq[ID]] = {
+    require(isOpen, "the store must be opened before it can be used")
+
     futureToFuture(state.names())
       .map(_.toIndexedSeq)
       .recover {

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/PersistentStore.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/PersistentStore.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package storage.repository.legacy.store
 
 import akka.Done
+import mesosphere.marathon.util.OpenableOnce
 
 import scala.concurrent.Future
 
@@ -31,7 +32,7 @@ trait PersistentEntity {
 /**
   * Store abstraction for different store implementations.
   */
-trait PersistentStore {
+trait PersistentStore extends OpenableOnce {
 
   type ID = String
 

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/PersistentStore.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/PersistentStore.scala
@@ -80,6 +80,11 @@ trait PersistentStore {
     * @return the list of available identifier.
     */
   def allIds(): Future[Seq[ID]]
+
+  /**
+    * Make sure that store read operations return up-to-date values.
+    */
+  def sync(): Future[Done]
 }
 
 /**

--- a/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/ZKStore.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/legacy/store/ZKStore.scala
@@ -92,6 +92,12 @@ class ZKStore(val client: ZkClient, root: ZNode, compressionConf: CompressionCon
       .recover(exceptionTransform(s"Can not list children of $parent"))
   }
 
+  override def sync(): Future[Done] = {
+    client.apply("/").sync().asScala
+      .map(_ => Done)
+      .recover(exceptionTransform("Failed to sync"))
+  }
+
   private[this] def exceptionTransform[T](errorMessage: => String): PartialFunction[Throwable, T] = {
     case ex: KeeperException => throw new StoreCommandFailedException(errorMessage, ex)
   }

--- a/src/main/scala/mesosphere/marathon/util/Openable.scala
+++ b/src/main/scala/mesosphere/marathon/util/Openable.scala
@@ -1,0 +1,34 @@
+package mesosphere.marathon
+package util
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+  * This trait is meant to be used to mark a resource object as open or close.
+  * A resource can be marked as open or close only once. Also, it can be closed
+  * only when it is open.
+  */
+trait Openable {
+  protected val opened = new AtomicBoolean(false)
+  protected val wasEverOpened = new AtomicBoolean(false)
+
+  /** Mark an object as open. */
+  def open(): Unit = {
+    if (wasEverOpened.compareAndSet(false, true)) {
+      opened.set(true)
+    } else {
+      throw new IllegalStateException("it was opened before")
+    }
+  }
+
+  /** Mark an object as closed. */
+  def close(): Unit = {
+    val wasOpened = opened.compareAndSet(true, false)
+    if (!wasOpened) {
+      throw new IllegalStateException("attempt to close while not being opened")
+    }
+  }
+
+  /** This method returns true, if the object is open at the moment. */
+  def isOpen: Boolean = opened.get()
+}

--- a/src/main/scala/mesosphere/marathon/util/Openable.scala
+++ b/src/main/scala/mesosphere/marathon/util/Openable.scala
@@ -8,12 +8,12 @@ import java.util.concurrent.atomic.AtomicBoolean
   * A resource can be marked as open or close only once. Also, it can be closed
   * only when it is open.
   */
-trait Openable {
+trait OpenableOnce {
   protected val opened = new AtomicBoolean(false)
   protected val wasEverOpened = new AtomicBoolean(false)
 
   /** Mark an object as open. */
-  def open(): Unit = {
+  def markOpen(): Unit = {
     if (wasEverOpened.compareAndSet(false, true)) {
       opened.set(true)
     } else {
@@ -22,7 +22,7 @@ trait Openable {
   }
 
   /** Mark an object as closed. */
-  def close(): Unit = {
+  def markClosed(): Unit = {
     val wasOpened = opened.compareAndSet(true, false)
     if (!wasOpened) {
       throw new IllegalStateException("attempt to close while not being opened")

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -12,6 +12,7 @@ import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.heartbeat._
 import mesosphere.marathon.core.leadership.LeadershipCoordinator
+import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
@@ -63,6 +64,7 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
 
   private[this] var probe: TestProbe = _
   private[this] var heartbeatProbe: TestProbe = _
+  private[this] var persistenceStore: PersistenceStore[_, _, _] = _
   private[this] var leadershipCoordinator: LeadershipCoordinator = _
   private[this] var healthCheckManager: HealthCheckManager = _
   private[this] var config: MarathonConf = _
@@ -81,6 +83,7 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
   before {
     probe = TestProbe()
     heartbeatProbe = TestProbe()
+    persistenceStore = mock[PersistenceStore[_, _, _]]
     leadershipCoordinator = mock[LeadershipCoordinator]
     healthCheckManager = mock[HealthCheckManager]
     config = mockConfig
@@ -105,6 +108,7 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
 
   test("Start timer when elected") {
     val schedulerService = new MarathonSchedulerService(
+      Some(persistenceStore),
       leadershipCoordinator,
       config,
       electionService,
@@ -127,6 +131,7 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
   test("Cancel timer when defeated") {
     val driver = mock[SchedulerDriver]
     val schedulerService = new MarathonSchedulerService(
+      Some(persistenceStore),
       leadershipCoordinator,
       config,
       electionService,
@@ -154,6 +159,7 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
   test("throw in start leadership when migration fails") {
 
     val schedulerService = new MarathonSchedulerService(
+      Some(persistenceStore),
       leadershipCoordinator,
       config,
       electionService,
@@ -186,6 +192,7 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
     val driverFactory = mock[SchedulerDriverFactory]
 
     val schedulerService = new MarathonSchedulerService(
+      Some(persistenceStore),
       leadershipCoordinator,
       config,
       electionService,
@@ -213,6 +220,7 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
     val driverFactory = mock[SchedulerDriverFactory]
 
     val schedulerService = new MarathonSchedulerService(
+      Some(persistenceStore),
       leadershipCoordinator,
       config,
       electionService,
@@ -244,6 +252,7 @@ class MarathonSchedulerServiceTest extends AkkaFunTest {
     val driverFactory = mock[SchedulerDriverFactory]
 
     val schedulerService = new MarathonSchedulerService(
+      Some(persistenceStore),
       leadershipCoordinator,
       config,
       electionService,

--- a/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/GroupManagerActorTest.scala
@@ -381,7 +381,8 @@ class GroupManagerActorTest extends Mockito with Matchers with MarathonSpec with
       groupRepo,
       provider,
       config,
-      eventBus)
+      eventBus,
+      metrics)
 
     lazy val manager = system.actorOf(props)
   }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
@@ -34,19 +34,19 @@ private[storage] trait PersistenceStoreTest { this: AkkaUnitTest =>
       }
       "cannot be opened twice" in {
         val store = newStore
-        val thrown = the[IllegalStateException] thrownBy store.open()
+        val thrown = the[IllegalStateException] thrownBy store.markOpen()
         thrown.getMessage shouldBe "it was opened before"
       }
       "cannot be reopened" in {
         val store = newStore
-        store.close()
-        val thrown = the[IllegalStateException] thrownBy store.open()
+        store.markClosed()
+        val thrown = the[IllegalStateException] thrownBy store.markOpen()
         thrown.getMessage shouldBe "it was opened before"
       }
       "cannot be closed twice" in {
         val store = newStore
-        store.close()
-        val thrown = the[IllegalStateException] thrownBy store.close()
+        store.markClosed()
+        val thrown = the[IllegalStateException] thrownBy store.markClosed()
         thrown.getMessage shouldBe "attempt to close while not being opened"
       }
       "have no ids" in {

--- a/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
@@ -28,6 +28,27 @@ private[storage] trait PersistenceStoreTest { this: AkkaUnitTest =>
     um: Unmarshaller[Serialized, TestClass1]): Unit = {
 
     name should {
+      "is open" in {
+        val store = newStore
+        store.isOpen shouldBe true
+      }
+      "cannot be opened twice" in {
+        val store = newStore
+        val thrown = the[IllegalStateException] thrownBy store.open()
+        thrown.getMessage shouldBe "it was opened before"
+      }
+      "cannot be reopened" in {
+        val store = newStore
+        store.close()
+        val thrown = the[IllegalStateException] thrownBy store.open()
+        thrown.getMessage shouldBe "it was opened before"
+      }
+      "cannot be closed twice" in {
+        val store = newStore
+        store.close()
+        val thrown = the[IllegalStateException] thrownBy store.close()
+        thrown.getMessage shouldBe "attempt to close while not being opened"
+      }
       "have no ids" in {
         val store = newStore
         store.ids().runWith(Sink.seq).futureValue should equal(Nil)

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/InMemoryPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/InMemoryPersistenceStoreTest.scala
@@ -28,7 +28,7 @@ class InMemoryPersistenceStoreTest extends AkkaUnitTest with PersistenceStoreTes
 
   behave like basicPersistenceStore("InMemoryPersistenceStore", {
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
     store
   })
 }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/InMemoryPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/InMemoryPersistenceStoreTest.scala
@@ -26,5 +26,9 @@ class InMemoryPersistenceStoreTest extends AkkaUnitTest with PersistenceStoreTes
 
   implicit val metrics = new Metrics(new MetricRegistry)
 
-  behave like basicPersistenceStore("InMemoryPersistenceStore", new InMemoryPersistenceStore())
+  behave like basicPersistenceStore("InMemoryPersistenceStore", {
+    val store = new InMemoryPersistenceStore()
+    store.open()
+    store
+  })
 }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
@@ -25,12 +25,16 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
 
   private def cachedInMemory = {
     implicit val metrics = new Metrics(new MetricRegistry)
-    LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
+    store
   }
 
   private def withLazyVersionCaching = {
     implicit val metrics = new Metrics(new MetricRegistry)
-    LazyVersionCachingPersistentStore(cachedInMemory)
+    val store = LazyVersionCachingPersistentStore(LazyCachingPersistenceStore(new InMemoryPersistenceStore()))
+    store.open()
+    store
   }
 
   def zkStore: ZkPersistenceStore = {
@@ -43,7 +47,9 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
 
   private def cachedZk = {
     implicit val metrics = new Metrics(new MetricRegistry)
-    LazyCachingPersistenceStore(zkStore)
+    val store = LazyCachingPersistenceStore(zkStore)
+    store.open()
+    store
   }
 
   behave like basicPersistenceStore("LazyCache(InMemory)", cachedInMemory)

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
@@ -26,14 +26,14 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
   private def cachedInMemory = {
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     store
   }
 
   private def withLazyVersionCaching = {
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = LazyVersionCachingPersistentStore(LazyCachingPersistenceStore(new InMemoryPersistenceStore()))
-    store.open()
+    store.markOpen()
     store
   }
 
@@ -48,7 +48,7 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
   private def cachedZk = {
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = LazyCachingPersistenceStore(zkStore)
-    store.open()
+    store.markOpen()
     store
   }
 

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
@@ -29,14 +29,14 @@ class LoadTimeCachingPersistenceStoreTest extends AkkaUnitTest
   private def cachedInMemory = {
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     store.preDriverStarts.futureValue
     store
   }
 
   private def cachedZk = {
     val store = new LoadTimeCachingPersistenceStore(zkStore)
-    store.open()
+    store.markOpen()
     store.preDriverStarts.futureValue
     store
   }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
@@ -29,12 +29,14 @@ class LoadTimeCachingPersistenceStoreTest extends AkkaUnitTest
   private def cachedInMemory = {
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
     store.preDriverStarts.futureValue
     store
   }
 
   private def cachedZk = {
     val store = new LoadTimeCachingPersistenceStore(zkStore)
+    store.open()
     store.preDriverStarts.futureValue
     store
   }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -69,7 +69,9 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
     val root = UUID.randomUUID().toString
     val client = zkClient(namespace = Some(root))
     implicit val metrics = new Metrics(new MetricRegistry)
-    new ZkPersistenceStore(client, Duration.Inf)
+    val store = new ZkPersistenceStore(client, Duration.Inf)
+    store.open()
+    store
   }
 
   behave like basicPersistenceStore("ZookeeperPersistenceStore", defaultStore)
@@ -80,6 +82,7 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
       rootClient.create(s"/$root").futureValue(Timeout(5.seconds))
       implicit val metrics = new Metrics(new MetricRegistry)
       val newStore = new ZkPersistenceStore(rootClient.usingNamespace(root), Duration.Inf)
+      newStore.open()
       val twitterClient = twitterZkClient()
       val legacyStore = new ZKStore(twitterClient, ZNode(twitterClient, s"/$root"), CompressionConf(true, 64 * 1024),
         8, 1024)

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -70,7 +70,7 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
     val client = zkClient(namespace = Some(root))
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = new ZkPersistenceStore(client, Duration.Inf)
-    store.open()
+    store.markOpen()
     store
   }
 
@@ -82,10 +82,11 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
       rootClient.create(s"/$root").futureValue(Timeout(5.seconds))
       implicit val metrics = new Metrics(new MetricRegistry)
       val newStore = new ZkPersistenceStore(rootClient.usingNamespace(root), Duration.Inf)
-      newStore.open()
+      newStore.markOpen()
       val twitterClient = twitterZkClient()
       val legacyStore = new ZKStore(twitterClient, ZNode(twitterClient, s"/$root"), CompressionConf(true, 64 * 1024),
         8, 1024)
+      legacyStore.markOpen()
 
       val version = StorageVersions(Random.nextInt, Random.nextInt, Random.nextInt)
       legacyStore.create(Migration.StorageVersionName, version.toByteArray.toIndexedSeq).futureValue

--- a/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/MarathonStoreTest.scala
@@ -25,6 +25,8 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
 
   test("Fetch") {
     val state = mock[PersistentStore]
+    when(state.isOpen).thenReturn(true)
+
     val variable = mock[PersistentEntity]
     val now = Timestamp.now()
     val appDef = AppDefinition(id = "testApp".toPath, args = Seq("arg"),
@@ -41,6 +43,7 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
 
   test("FetchFail") {
     val state = mock[PersistentStore]
+    when(state.isOpen).thenReturn(true)
 
     when(state.load("app:testApp")).thenReturn(Future.failed(new StoreCommandFailedException("failed")))
 
@@ -56,6 +59,8 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
 
   test("FetchInvalidProto") {
     val state = mock[PersistentStore]
+    when(state.isOpen).thenReturn(true)
+
     val variable = mock[PersistentEntity]
     when(variable.bytes).thenReturn(IndexedSeq[Byte](1, 1, 1))
 
@@ -68,6 +73,8 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
 
   test("Modify") {
     val state = mock[PersistentStore]
+    when(state.isOpen).thenReturn(true)
+
     val variable = mock[PersistentEntity]
     val now = Timestamp.now()
     val appDef = AppDefinition(id = "testApp".toPath, args = Seq("arg"),
@@ -94,6 +101,8 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
 
   test("ModifyFail") {
     val state = mock[PersistentStore]
+    when(state.isOpen).thenReturn(true)
+
     val variable = mock[PersistentEntity]
     val appDef = AppDefinition(id = "testApp".toPath, args = Seq("arg"))
 
@@ -118,6 +127,7 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
 
   test("Expunge") {
     val state = mock[PersistentStore]
+    when(state.isOpen).thenReturn(true)
 
     when(state.delete("app:testApp")).thenReturn(Future.successful(true))
     val store = new MarathonStore[AppDefinition](state, metrics, () => AppDefinition(id = runSpecId), "app:")
@@ -129,6 +139,7 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
 
   test("ExpungeFail") {
     val state = mock[PersistentStore]
+    when(state.isOpen).thenReturn(true)
 
     when(state.delete("app:testApp")).thenReturn(Future.failed(new StoreCommandFailedException("failed")))
 
@@ -143,6 +154,8 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
 
   test("Names") {
     val state = new InMemoryStore
+    val store = new MarathonStore[AppDefinition](state, metrics, () => AppDefinition(id = runSpecId), "app:")
+    store.markOpen()
 
     def populate(key: String, value: Array[Byte]) = {
       state.load(key).futureValue match {
@@ -155,7 +168,6 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
     populate("app:bar", Array())
     populate("no_match", Array())
 
-    val store = new MarathonStore[AppDefinition](state, metrics, () => AppDefinition(id = runSpecId), "app:")
     val res = store.names()
 
     assert(Set("foo", "bar") == Await.result(res, 5.seconds).toSet, "Should return all application keys")
@@ -163,6 +175,7 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
 
   test("NamesFail") {
     val state = mock[PersistentStore]
+    when(state.isOpen).thenReturn(true)
 
     when(state.allIds()).thenReturn(Future.failed(new StoreCommandFailedException("failed")))
 
@@ -174,8 +187,8 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
 
   test("ConcurrentModifications") {
     val state = new InMemoryStore
-
     val store = new MarathonStore[AppDefinition](state, metrics, () => AppDefinition(id = runSpecId), "app:")
+    store.markOpen()
 
     store.store("foo", AppDefinition(id = "foo".toPath, instances = 0)).futureValue
 
@@ -204,6 +217,7 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
     }
 
     val store = new MarathonStore[AppDefinition](state, metrics, () => AppDefinition(id = runSpecId), "app:")
+    store.markOpen()
 
     noException should be thrownBy {
       Await.result(store.names(), 1.second)
@@ -219,6 +233,7 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
     }
 
     val store = new MarathonStore[AppDefinition](state, metrics, () => AppDefinition(id = runSpecId), "app:")
+    store.markOpen()
 
     noException should be thrownBy {
       Await.result(store.names(), 1.second)
@@ -231,6 +246,7 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
     }
 
     val store = new MarathonStore[AppDefinition](state, metrics, () => AppDefinition(id = runSpecId), "app:")
+    store.markOpen()
 
     noException should be thrownBy {
       Await.result(store.names(), 1.second)
@@ -243,6 +259,7 @@ class MarathonStoreTest extends MarathonSpec with Matchers {
     }
 
     val store = new MarathonStore[AppDefinition](state, metrics, () => AppDefinition(id = runSpecId), "app:")
+    store.markOpen()
 
     noException should be thrownBy {
       Await.result(store.names(), 1.second)

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
@@ -92,6 +92,8 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen {
 
       migrate.migrate()
 
+      verify(mockedPersistentStore).isOpen
+      verify(mockedPersistentStore).markOpen()
       verify(mockedPersistentStore).sync()
       verify(mockedPersistentStore, times(2)).load(Migration.StorageVersionName)
       verify(mockedPersistentStore).create(Migration.StorageVersionName, StorageVersions.current.toByteArray.toIndexedSeq)
@@ -124,6 +126,8 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen {
       val migrate = migration(legacyConfig = Some(legacyConfig), persistenceStore = None)
 
       migrate.migrate()
+      verify(mockedPersistentStore).isOpen
+      verify(mockedPersistentStore).markOpen()
       verify(mockedPersistentStore).sync()
       verify(mockedPersistentStore).load(Migration.StorageVersionName)
       noMoreInteractions(mockedPersistentStore)
@@ -202,6 +206,8 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen {
       val migrate = migration(legacyConfig = Some(legacyConfig))
 
       migrate.migrate()
+      verify(mockedPersistentStore).isOpen
+      verify(mockedPersistentStore).markOpen()
       verify(mockedPersistentStore).sync()
       verify(mockedPersistentStore).initialize()
       verify(mockedPersistentStore).close()

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo1_1_5_Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo1_1_5_Test.scala
@@ -226,6 +226,7 @@ class MigrationTo1_1_5_Test extends AkkaUnitTest with Mockito with GroupCreation
   class Fixture {
     implicit val metrics = new Metrics(new MetricRegistry)
     val config = LegacyInMemConfig(maxVersions)
+    config.store.markOpen()
     val oldAppRepo: AppEntityRepository = AppRepository.legacyRepository(config.entityStore[AppDefinition], maxVersions)
     val oldPodRepo: PodEntityRepository = PodRepository.legacyRepository(config.entityStore[PodDefinition], maxVersions)
     val oldGroupRepo: GroupEntityRepository = GroupRepository.legacyRepository(config.entityStore[Group], maxVersions, oldAppRepo, oldPodRepo)

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo1_4_PersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo1_4_PersistenceStoreTest.scala
@@ -33,7 +33,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
     implicit val metrics = new Metrics(new MetricRegistry)
     val persistenceStore = {
       val store = new InMemoryPersistenceStore()
-      store.open()
+      store.markOpen()
       store
     }
     val appRepository = AppRepository.inMemRepository(persistenceStore)
@@ -55,6 +55,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "do nothing if it doesn't exist" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldRepo = FrameworkIdRepository.legacyRepository(config.entityStore[FrameworkId])
 
         val migrator = migration(Some(config))
@@ -66,6 +67,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "migrate an existing value" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldRepo = FrameworkIdRepository.legacyRepository(config.entityStore[FrameworkId])
         val id = FrameworkId(UUID.randomUUID.toString)
         oldRepo.store(id).futureValue
@@ -82,6 +84,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "do nothing if it doesn't exist" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldRepo = EventSubscribersRepository.legacyRepository(config.entityStore[EventSubscribers])
 
         val migrator = migration(Some(config))
@@ -93,6 +96,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "migrate an existing value" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldRepo = EventSubscribersRepository.legacyRepository(config.entityStore[EventSubscribers])
         val subscribers = EventSubscribers(Set(UUID.randomUUID().toString))
         oldRepo.store(subscribers).futureValue
@@ -109,6 +113,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "do nothing if no tasks exist" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldRepo = TaskRepository.legacyRepository(config.entityStore[MarathonTaskState])
 
         val migrator = migration(Some(config))
@@ -121,6 +126,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "migrate all tasks" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldRepo = TaskRepository.legacyRepository(config.entityStore[MarathonTaskState])
         val agentInfo = Instance.AgentInfo("abc", None, Nil)
         def setAgentInfo(builder: MarathonTask.Builder): MarathonTask = {
@@ -164,6 +170,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "do nothing if there are no failures" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldRepo = TaskFailureRepository.legacyRepository(config.entityStore[TaskFailure])
 
         val migrator = migration(Some(config))
@@ -175,6 +182,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "migrate the failures" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldRepo = TaskFailureRepository.legacyRepository(config.entityStore[TaskFailure])
         val failure1 = TaskFailure.empty.copy(appId = "123".toRootPath, timestamp = Timestamp(1))
 
@@ -198,6 +206,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "do nothing if there are no plans" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldRepo = DeploymentRepository.legacyRepository(config.entityStore[DeploymentPlan])
 
         val migrator = migration(Some(config))
@@ -209,6 +218,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "migrate the plans" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldRepo = DeploymentRepository.legacyRepository(config.entityStore[DeploymentPlan])
         val appRepo = AppRepository.legacyRepository(config.entityStore[AppDefinition], maxVersions)
         val podRepo = PodRepository.legacyRepository(config.entityStore[PodDefinition], maxVersions)
@@ -243,6 +253,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
       "store an empty group if there are no groups" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val config = LegacyInMemConfig(maxVersions)
+        config.store.markOpen()
         val oldAppRepo = AppRepository.legacyRepository(config.entityStore[AppDefinition], maxVersions)
         val oldPodRepo = PodRepository.legacyRepository(config.entityStore[PodDefinition], maxVersions)
         val oldRepo = GroupRepository.legacyRepository(config.entityStore[Group], maxVersions, oldAppRepo, oldPodRepo)
@@ -272,6 +283,7 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
         implicit val metrics = new Metrics(new MetricRegistry)
         val oldMax = 3
         val config = LegacyInMemConfig(oldMax)
+        config.store.markOpen()
         val oldAppRepo = AppRepository.legacyRepository(config.entityStore[AppDefinition], oldMax)
         val oldPodRepo = PodRepository.legacyRepository(config.entityStore[PodDefinition], oldMax)
         val oldRepo = GroupRepository.legacyRepository(config.entityStore[Group], oldMax, oldAppRepo, oldPodRepo)

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo1_4_PersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo1_4_PersistenceStoreTest.scala
@@ -31,7 +31,11 @@ class MigrationTo1_4_PersistenceStoreTest extends AkkaUnitTest with Mockito with
 
   def migration(legacyConfig: Option[LegacyStorageConfig] = None, maxVersions: Int = maxVersions): Migration = {
     implicit val metrics = new Metrics(new MetricRegistry)
-    val persistenceStore = new InMemoryPersistenceStore()
+    val persistenceStore = {
+      val store = new InMemoryPersistenceStore()
+      store.open()
+      store
+    }
     val appRepository = AppRepository.inMemRepository(persistenceStore)
     val podRepository = PodRepository.inMemRepository(persistenceStore)
     val groupRepository = GroupRepository.inMemRepository(persistenceStore, appRepository, podRepository)

--- a/src/test/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo0_11Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo0_11Test.scala
@@ -20,6 +20,7 @@ class MigrationTo0_11Test extends MarathonActorSupport with GivenWhenThen with M
     implicit lazy val metrics = new Metrics(new MetricRegistry)
     val maxVersions = 25
     lazy val config = LegacyInMemConfig(maxVersions)
+    config.store.markOpen()
     lazy val migration = new MigrationTo0_11(Some(config))
     lazy val appRepo = AppRepository.legacyRepository(config.entityStore[AppDefinition], maxVersions)
     lazy val podRepo = PodRepository.legacyRepository(config.entityStore[PodDefinition], maxVersions)

--- a/src/test/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo0_13Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo0_13Test.scala
@@ -163,6 +163,7 @@ class MigrationTo0_13Test extends MarathonSpec with MarathonActorSupport with Gi
     val maxVersions = 25
     lazy val config = LegacyInMemConfig(maxVersions)
     lazy val state = config.store
+    state.markOpen()
     implicit lazy val metrics = new Metrics(new MetricRegistry)
     lazy val legacyTaskStore = new LegacyTaskStore(state)
     lazy val taskRepo = TaskRepository.legacyRepository(config.entityStore[MarathonTaskState])

--- a/src/test/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo0_16Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo0_16Test.scala
@@ -23,6 +23,7 @@ class MigrationTo0_16Test extends MarathonActorSupport with GivenWhenThen with M
     val maxVersions = 25
     lazy val config = LegacyInMemConfig(maxVersions)
     lazy val store = config.store
+    store.markOpen()
 
     lazy val appStore = new MarathonStore[AppDefinition](store, metrics, () => AppDefinition(id = PathId("/test")), prefix = "app:")
     lazy val appRepo = new AppEntityRepository(appStore, maxVersions = maxVersions)(ExecutionContext.global, metrics)

--- a/src/test/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo1_2Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo1_2Test.scala
@@ -24,6 +24,7 @@ class MigrationTo1_2Test extends MarathonSpec with GivenWhenThen with Matchers w
     implicit lazy val metrics = new Metrics(new MetricRegistry)
     lazy val config = LegacyInMemConfig(25)
     lazy val store = config.store
+    store.markOpen()
     lazy val taskRepo = TaskRepository.legacyRepository(config.entityStore[MarathonTaskState])
 
     lazy val migration = new MigrationTo1_2(Some(config))

--- a/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
@@ -66,6 +66,8 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       testScan: Option[() => Future[ScanDone]] = None)(
       testCompact: Option[(Set[PathId], Map[PathId, Set[OffsetDateTime]], Set[PathId], Map[PathId, Set[OffsetDateTime]], Set[OffsetDateTime]) => Future[CompactDone]] = None) {
     val store = new InMemoryPersistenceStore()
+    store.open()
+
     val appRepo = AppRepository.inMemRepository(store)
     val podRepo = PodRepository.inMemRepository(store)
     val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -426,6 +428,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
     "actually running" should {
       "ignore scan errors on roots" in {
         val store = new InMemoryPersistenceStore()
+        store.open()
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = mock[StoredGroupRepositoryImpl[RamId, String, Identity]]
@@ -438,6 +441,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore scan errors on apps" in {
         val store = new InMemoryPersistenceStore()
+        store.open()
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -453,6 +457,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore scan errors on pods" in {
         val store = new InMemoryPersistenceStore()
+        store.open()
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = mock[PodRepositoryImpl[RamId, String, Identity]]
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -468,6 +473,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore errors when compacting" in {
         val store = new InMemoryPersistenceStore()
+        store.open()
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)

--- a/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
@@ -66,7 +66,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       testScan: Option[() => Future[ScanDone]] = None)(
       testCompact: Option[(Set[PathId], Map[PathId, Set[OffsetDateTime]], Set[PathId], Map[PathId, Set[OffsetDateTime]], Set[OffsetDateTime]) => Future[CompactDone]] = None) {
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
 
     val appRepo = AppRepository.inMemRepository(store)
     val podRepo = PodRepository.inMemRepository(store)
@@ -428,7 +428,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
     "actually running" should {
       "ignore scan errors on roots" in {
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = mock[StoredGroupRepositoryImpl[RamId, String, Identity]]
@@ -441,7 +441,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore scan errors on apps" in {
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -457,7 +457,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore scan errors on pods" in {
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = mock[PodRepositoryImpl[RamId, String, Identity]]
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -473,7 +473,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore errors when compacting" in {
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)

--- a/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
@@ -129,7 +129,7 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
       "retrieve a historical version" in {
         implicit val metrics = new Metrics(new MetricRegistry)
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
         val appRepo = AppRepository.inMemRepository(store)
         val repo = createRepo(appRepo, mock[PodRepository], 2)
 
@@ -156,7 +156,7 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
   def createInMemRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }
 
@@ -170,21 +170,21 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
   def createZkRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = zkStore
-    store.open()
+    store.markOpen()
     GroupRepository.zkRepository(store, appRepository, podRepository)
   }
 
   def createLazyCachingRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }
 
   def createLoadCachingRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     store.preDriverStarts.futureValue
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }
@@ -193,7 +193,9 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
     implicit val metrics = new Metrics(new MetricRegistry)
     val persistentStore = new InMemoryStore()
     def entityStore(name: String, newState: () => Group): EntityStore[Group] = {
-      new MarathonStore(persistentStore, metrics, newState, name)
+      val store = new MarathonStore(persistentStore, metrics, newState, name)
+      store.markOpen()
+      store
     }
     GroupRepository.legacyRepository(entityStore, maxVersions, appRepository, podRepository)
   }
@@ -203,9 +205,11 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
     val client = twitterZkClient()
     val persistentStore = new ZKStore(client, ZNode(client, s"/${UUID.randomUUID().toString}"),
       CompressionConf(true, 64 * 1024), 8, 1024)
-    persistentStore.initialize().futureValue(Timeout(5.seconds))
     def entityStore(name: String, newState: () => Group): EntityStore[Group] = {
-      new MarathonStore(persistentStore, metrics, newState, name)
+      val store = new MarathonStore(persistentStore, metrics, newState, name)
+      store.markOpen()
+      persistentStore.initialize().futureValue(Timeout(5.seconds))
+      store
     }
     GroupRepository.legacyRepository(entityStore, maxVersions, appRepository, podRepository)
   }

--- a/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
@@ -128,7 +128,9 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
       }
       "retrieve a historical version" in {
         implicit val metrics = new Metrics(new MetricRegistry)
-        val appRepo = AppRepository.inMemRepository(new InMemoryPersistenceStore())
+        val store = new InMemoryPersistenceStore()
+        store.open()
+        val appRepo = AppRepository.inMemRepository(store)
         val repo = createRepo(appRepo, mock[PodRepository], 2)
 
         val app1 = AppDefinition("app1".toRootPath)
@@ -154,6 +156,7 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
   def createInMemRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = new InMemoryPersistenceStore()
+    store.open()
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }
 
@@ -167,18 +170,21 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
   def createZkRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = zkStore
+    store.open()
     GroupRepository.zkRepository(store, appRepository, podRepository)
   }
 
   def createLazyCachingRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }
 
   def createLoadCachingRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
     store.preDriverStarts.futureValue
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }

--- a/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
@@ -36,6 +36,7 @@ class PodRepositoryTest extends AkkaUnitTest with ZookeeperServerTest {
     val root = UUID.randomUUID().toString
     val rootClient = zkClient(namespace = Some(root))
     val store = new ZkPersistenceStore(rootClient, Duration.Inf)
+    store.open()
     val repo = PodRepository.zkRepository(store)
   }
 }

--- a/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
@@ -36,7 +36,7 @@ class PodRepositoryTest extends AkkaUnitTest with ZookeeperServerTest {
     val root = UUID.randomUUID().toString
     val rootClient = zkClient(namespace = Some(root))
     val store = new ZkPersistenceStore(rootClient, Duration.Inf)
-    store.open()
+    store.markOpen()
     val repo = PodRepository.zkRepository(store)
   }
 }

--- a/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
@@ -14,7 +14,7 @@ import mesosphere.marathon.core.storage.store.impl.zk.ZkPersistenceStore
 import mesosphere.marathon.integration.setup.ZookeeperServerTest
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp, VersionInfo }
-import mesosphere.marathon.storage.repository.legacy.store.{ CompressionConf, EntityStore, InMemoryStore, MarathonStore, PersistentStore, ZKStore }
+import mesosphere.marathon.storage.repository.legacy.store.{ CompressionConf, EntityStore, InMemoryStore, MarathonStore, ZKStore }
 import mesosphere.marathon.stream.Sink
 import org.scalatest.GivenWhenThen
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
@@ -150,34 +150,42 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
     }
   }
 
-  def createLegacyRepo(maxVersions: Int, store: PersistentStore): AppRepository = {
+  def createLegacyInMemoryRepo(maxVersions: Int): AppRepository = {
     implicit val metrics = new Metrics(new MetricRegistry)
+    val store = new InMemoryStore()
     def entityStore(name: String, newState: () => AppDefinition): EntityStore[AppDefinition] = {
-      new MarathonStore(store, metrics, newState, name)
+      val marathonStore = new MarathonStore(store, metrics, newState, name)
+      marathonStore.markOpen()
+      marathonStore
     }
     AppRepository.legacyRepository(entityStore, maxVersions)
   }
 
-  def zkStore(): PersistentStore = {
+  def createLegacyZkRepo(maxVersions: Int): AppRepository = {
     implicit val metrics = new Metrics(new MetricRegistry)
     val client = twitterZkClient()
-    val persistentStore = new ZKStore(client, ZNode(client, s"/${UUID.randomUUID().toString}"),
+    val store = new ZKStore(client, ZNode(client, s"/${UUID.randomUUID().toString}"),
       CompressionConf(true, 64 * 1024), 8, 1024)
-    persistentStore.initialize().futureValue(Timeout(5.seconds))
-    persistentStore
+    def entityStore(name: String, newState: () => AppDefinition): EntityStore[AppDefinition] = {
+      val marathonStore = new MarathonStore(store, metrics, newState, name)
+      marathonStore.markOpen()
+      store.initialize().futureValue(Timeout(5.seconds))
+      marathonStore
+    }
+    AppRepository.legacyRepository(entityStore, maxVersions)
   }
 
   def createInMemRepo(maxVersions: Int): AppRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
     AppRepository.inMemRepository(store)
   }
 
   def createLoadTimeCachingRepo(maxVersions: Int): AppRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val cached = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
-    cached.open()
+    cached.markOpen()
     cached.preDriverStarts.futureValue
     AppRepository.inMemRepository(cached)
   }
@@ -187,33 +195,33 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
     val root = UUID.randomUUID().toString
     val rootClient = zkClient(namespace = Some(root))
     val store = new ZkPersistenceStore(rootClient, Duration.Inf)
-    store.open()
+    store.markOpen()
     AppRepository.zkRepository(store)
   }
 
   def createLazyCachingRepo(maxVersions: Int): AppRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     AppRepository.inMemRepository(store)
   }
 
   def createLazyVersionCachingRepo(maxVersions: Int): AppRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val store = LazyVersionCachingPersistentStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     AppRepository.inMemRepository(store)
   }
 
-  behave like basic("InMemEntity", createLegacyRepo(_, new InMemoryStore()))
-  behave like basic("ZkEntity", createLegacyRepo(_, zkStore()))
+  behave like basic("InMemEntity", createLegacyInMemoryRepo)
+  behave like basic("ZkEntity", createLegacyZkRepo)
   behave like basic("InMemoryPersistence", createInMemRepo)
   behave like basic("ZkPersistence", createZKRepo)
   behave like basic("LoadTimeCachingPersistence", createLoadTimeCachingRepo)
   behave like basic("LazyCachingPersistence", createLazyCachingRepo)
 
-  behave like versioned("InMemEntity", createLegacyRepo(_, new InMemoryStore()))
-  behave like versioned("ZkEntity", createLegacyRepo(_, zkStore()))
+  behave like versioned("InMemEntity", createLegacyInMemoryRepo)
+  behave like versioned("ZkEntity", createLegacyZkRepo)
   behave like versioned("InMemoryPersistence", createInMemRepo)
   behave like versioned("ZkPersistence", createZKRepo)
   behave like versioned("LoadTimeCachingPersistence", createLoadTimeCachingRepo)

--- a/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
@@ -169,12 +169,15 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
 
   def createInMemRepo(maxVersions: Int): AppRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
-    AppRepository.inMemRepository(new InMemoryPersistenceStore())
+    val store = new InMemoryPersistenceStore()
+    store.open()
+    AppRepository.inMemRepository(store)
   }
 
   def createLoadTimeCachingRepo(maxVersions: Int): AppRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
     val cached = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
+    cached.open()
     cached.preDriverStarts.futureValue
     AppRepository.inMemRepository(cached)
   }
@@ -184,17 +187,22 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
     val root = UUID.randomUUID().toString
     val rootClient = zkClient(namespace = Some(root))
     val store = new ZkPersistenceStore(rootClient, Duration.Inf)
+    store.open()
     AppRepository.zkRepository(store)
   }
 
   def createLazyCachingRepo(maxVersions: Int): AppRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
-    AppRepository.inMemRepository(LazyCachingPersistenceStore(new InMemoryPersistenceStore()))
+    val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
+    AppRepository.inMemRepository(store)
   }
 
   def createLazyVersionCachingRepo(maxVersions: Int): AppRepository = { // linter:ignore:UnusedParameter
     implicit val metrics = new Metrics(new MetricRegistry)
-    AppRepository.inMemRepository(LazyVersionCachingPersistentStore(new InMemoryPersistenceStore()))
+    val store = LazyVersionCachingPersistentStore(new InMemoryPersistenceStore())
+    store.open()
+    AppRepository.inMemRepository(store)
   }
 
   behave like basic("InMemEntity", createLegacyRepo(_, new InMemoryStore()))

--- a/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
@@ -64,24 +64,31 @@ class SingletonRepositoryTest extends AkkaUnitTest with ZookeeperServerTest {
 
   def createInMemRepo(): FrameworkIdRepository = {
     implicit val metrics = new Metrics(new MetricRegistry)
-    FrameworkIdRepository.inMemRepository(new InMemoryPersistenceStore())
+    val store = new InMemoryPersistenceStore()
+    store.open()
+    FrameworkIdRepository.inMemRepository(store)
   }
 
   def createLoadTimeCachingRepo(): FrameworkIdRepository = {
     implicit val metrics = new Metrics(new MetricRegistry)
     val cached = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
+    cached.open()
     cached.preDriverStarts.futureValue
     FrameworkIdRepository.inMemRepository(cached)
   }
 
   def createZKRepo(): FrameworkIdRepository = {
     implicit val metrics = new Metrics(new MetricRegistry)
-    FrameworkIdRepository.zkRepository(new ZkPersistenceStore(zkClient(), 10.seconds))
+    val store = new ZkPersistenceStore(zkClient(), 10.seconds)
+    store.open()
+    FrameworkIdRepository.zkRepository(store)
   }
 
   def createLazyCachingRepo(): FrameworkIdRepository = {
     implicit val metrics = new Metrics(new MetricRegistry)
-    FrameworkIdRepository.inMemRepository(LazyCachingPersistenceStore(new InMemoryPersistenceStore()))
+    val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
+    store.open()
+    FrameworkIdRepository.inMemRepository(store)
   }
 
   behave like basic("InMemEntity", createLegacyRepo(new InMemoryStore()))

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -36,7 +36,7 @@ class InstanceTrackerImplTest extends AkkaFunTest with MarathonShutdownHookSuppo
 
   before {
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
     state = spy(InstanceRepository.inMemRepository(store))
     val taskTrackerModule = MarathonTestHelper.createTaskTrackerModule(AlwaysElectedLeadershipModule(shutdownHooks), Some(state), metrics)
     instanceTracker = taskTrackerModule.instanceTracker

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -35,7 +35,9 @@ class InstanceTrackerImplTest extends AkkaFunTest with MarathonShutdownHookSuppo
   var state: InstanceRepository = _
 
   before {
-    state = spy(InstanceRepository.inMemRepository(new InMemoryPersistenceStore()))
+    val store = new InMemoryPersistenceStore()
+    store.open()
+    state = spy(InstanceRepository.inMemRepository(store))
     val taskTrackerModule = MarathonTestHelper.createTaskTrackerModule(AlwaysElectedLeadershipModule(shutdownHooks), Some(state), metrics)
     instanceTracker = taskTrackerModule.instanceTracker
     stateOpProcessor = taskTrackerModule.stateOpProcessor

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -319,7 +319,11 @@ object MarathonTestHelper {
 
     implicit val ctx = ExecutionContext.global
     implicit val m = metrics
-    val instanceRepo = store.getOrElse(InstanceRepository.inMemRepository(new InMemoryPersistenceStore()))
+    val instanceRepo = store.getOrElse(InstanceRepository.inMemRepository {
+      val store = new InMemoryPersistenceStore()
+      store.open()
+      store
+    })
     val updateSteps = Seq.empty[InstanceChangeHandler]
 
     new InstanceTrackerModule(clock, metrics, defaultConfig(), leadershipModule, instanceRepo, updateSteps) {

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -321,7 +321,7 @@ object MarathonTestHelper {
     implicit val m = metrics
     val instanceRepo = store.getOrElse(InstanceRepository.inMemRepository {
       val store = new InMemoryPersistenceStore()
-      store.open()
+      store.markOpen()
       store
     })
     val updateSteps = Seq.empty[InstanceChangeHandler]

--- a/src/test/scala/mesosphere/util/state/memory/InMemoryStoreTest.scala
+++ b/src/test/scala/mesosphere/util/state/memory/InMemoryStoreTest.scala
@@ -20,7 +20,9 @@ class InMemoryStoreTest extends PersistentStoreTest {
     update.version should be (read.get.version + 1)
   }
 
-  lazy val persistentStore: PersistentStore = new InMemoryStore
-
+  lazy val persistentStore: PersistentStore = {
+    val store = new InMemoryStore
+    store.markOpen()
+    store
+  }
 }
-

--- a/src/test/scala/mesosphere/util/state/mesos/MesosStateStoreTest.scala
+++ b/src/test/scala/mesosphere/util/state/mesos/MesosStateStoreTest.scala
@@ -28,6 +28,8 @@ class MesosStateStoreTest extends PersistentStoreTest with ZookeeperServerTest {
       TimeUnit.MILLISECONDS,
       s"/${UUID.randomUUID}"
     )
-    new MesosStateStore(state, duration)
+    val store = new MesosStateStore(state, duration)
+    store.markOpen()
+    store
   }
 }


### PR DESCRIPTION
In addition to that,

- Prevent any access to the persistence storage while
  not being a leader, which means that Marathon reads from
  and writes to ZK only after it becomes a leader.
- Register service.mesosphere.marathon.app.count and
  service.mesosphere.marathon.app.count metrics once
  the root group gets loaded for the first time

JIRA tickets:

- https://jira.mesosphere.com/browse/MARATHON-7763
- https://jira.mesosphere.com/browse/MARATHON-7785
