### PR TITLE
Model EnrichedTask in RAML.

### DIFF
--- a/docs/docs/rest-api/public/api/api.raml
+++ b/docs/docs/rest-api/public/api/api.raml
@@ -7,6 +7,7 @@ baseUri: ../
 
 uses:
   app: v2/types/app.raml
+  enrichedTask: v2/types/enrichedTask.raml
   error: v2/types/error.raml
   info: v2/types/info.raml
   queue: v2/types/queue.raml

--- a/docs/docs/rest-api/public/api/v2/types/enrichedTask.raml
+++ b/docs/docs/rest-api/public/api/v2/types/enrichedTask.raml
@@ -30,7 +30,7 @@ types:
       ipAddresses?: IpAddr[]
       ports?: numbers.Port[]
       servicePorts?: numbers.Port[]
-      slaveId: string
+      slaveId?: string
       state: strings.MesosTaskState
       stagedAt?: string
       startedAt?: string

--- a/docs/docs/rest-api/public/api/v2/types/enrichedTask.raml
+++ b/docs/docs/rest-api/public/api/v2/types/enrichedTask.raml
@@ -1,0 +1,38 @@
+#%RAML 1.0 Library
+uses:
+  health: healthCheck.raml
+  numbers: numberTypes.raml
+  strings: stringTypes.raml
+
+types:
+  # Not to be confused with network.IpAddress
+  IpAddr:
+    type: object
+    properties:
+      ipAddress: string
+      protocol: strings.IpProtocol
+
+  LocalVolumeId:
+    type: object
+    properties:
+      runSpecId: strings.PathId
+      containerPath: string
+      uuid: string
+      persistensId: strings.PersistenceId
+
+  EnrichedTask:
+    type: object
+    properties:
+      appId: strings.PathId
+      healthCheckResults?: health.Health[]
+      host: string
+      id: string
+      ipAddresses?: IpAddr[]
+      ports?: numbers.Port[]
+      servicePorts?: numbers.Port[]
+      slaveId: string
+      state: strings.MesosTaskState
+      stagedAt?: string
+      startedAt?: string
+      version?: string
+      localVolumes?: LocalVolumeId[]

--- a/docs/docs/rest-api/public/api/v2/types/enrichedTask.raml
+++ b/docs/docs/rest-api/public/api/v2/types/enrichedTask.raml
@@ -18,7 +18,7 @@ types:
       runSpecId: strings.PathId
       containerPath: string
       uuid: string
-      persistensId: strings.PersistenceId
+      persistenceId: strings.PersistenceId
 
   EnrichedTask:
     type: object

--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -148,3 +148,15 @@ types:
         description: Amount of time to wait until starting the health checks.
         minimum: 0
         default: 15
+  Health:
+    type: object
+    properties:
+      alive: boolean
+      consecutiveFailures:
+        type: number
+        format: int32
+      firstSuccess?: string
+      instanceId: strings.InstanceId
+      lastSuccess?: string
+      lastFailure?: string
+      lastFailureCause?: string

--- a/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
+++ b/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
@@ -33,6 +33,12 @@ types:
     type: string
     enum: [ HTTP, HTTPS ]
     description: The http scheme to use
+  IpProtocol:
+    type: string
+    enum: [ IPv4 ]
+  PersistenceId:
+    type: string
+    pattern: ^([^#]+)[#]([^#]+)[#]([^#]+)$
   ReadMode:
     type: string
     enum: [RO, RW]

--- a/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
+++ b/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
@@ -1,5 +1,8 @@
 #%RAML 1.0 Library
 types:
+  InstanceId:
+    type: string
+    pattern: ^(.+)\.(instance-|marathon-)([^\.]+)$
   Name:
     type: string
     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -55,3 +58,18 @@ types:
       When Marathon receives a TASK_LOST status update indicating that the
       agent running the task is gone, this property defines whether Marathon
       will launch the task on another node or not. Defaults to WAIT_FOREVER"
+  MesosTaskState:
+    type: string
+    enum:
+      - TASK_ERROR
+      - TASK_FAILED
+      - TASK_FINISHED
+      - TASK_KILLED
+      - TASK_KILLING
+      - TASK_RUNNING
+      - TASK_STAGING
+      - TASK_STARTING
+      - TASK_UNREACHABLE
+      - TASK_UNREACHABLE
+      - TASK_GONE
+      - TASK_DROPPED

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -13,7 +13,6 @@ import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.appinfo.{ AppInfo, EnrichedTask }
 import mesosphere.marathon.plugin.PathId
-import mesosphere.marathon.raml.{ LoggerChange, MarathonInfo, Metrics }
 import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.state.AppDefinition
 import play.api.libs.json._
@@ -149,15 +148,15 @@ object EntityMarshallers {
   implicit val wixResultMarshaller = playJsonMarshaller[com.wix.accord.Failure](Validation.failureWrites)
   implicit val messageMarshaller = playJsonMarshaller[Rejections.Message]
   implicit val appInfoMarshaller = playJsonMarshaller[AppInfo]
-  implicit val infoMarshaller = playJsonMarshaller[MarathonInfo]
-  implicit val infoUnmarshaller = playJsonUnmarshaller[MarathonInfo]
-  implicit val metricsMarshaller = internalToRamlJsonMarshaller[TickMetricSnapshot, Metrics]
-  implicit val loggerChangeMarshaller = playJsonMarshaller[LoggerChange]
-  implicit val loggerChangeUnmarshaller = playJsonUnmarshaller[LoggerChange]
+  implicit val infoMarshaller = playJsonMarshaller[raml.MarathonInfo]
+  implicit val infoUnmarshaller = playJsonUnmarshaller[raml.MarathonInfo]
+  implicit val metricsMarshaller = internalToRamlJsonMarshaller[TickMetricSnapshot, raml.Metrics]
+  implicit val loggerChangeMarshaller = playJsonMarshaller[raml.LoggerChange]
+  implicit val loggerChangeUnmarshaller = playJsonUnmarshaller[raml.LoggerChange]
   implicit val stringMapMarshaller = playJsonMarshaller[Map[String, String]]
   implicit val pluginDefinitionsMarshaller = playJsonMarshaller[PluginDefinitions]
   implicit val deploymentResultMarshaller = playJsonMarshaller[raml.DeploymentResult]
-  implicit val enrichedTaskMarshaller = playJsonMarshaller[EnrichedTask]
+  implicit val enrichedTaskMarshaller = playJsonMarshaller[raml.EnrichedTask]
 
   implicit class FromEntityUnmarshallerOps[T](val um: FromEntityUnmarshaller[T]) extends AnyVal {
     def handleValidationErrors: FromEntityUnmarshaller[T] = um.recover(_ ⇒ _ ⇒ {

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -11,7 +11,7 @@ import com.wix.accord.Descriptions.{ Generic, Path }
 import com.wix.accord.{ Failure, RuleViolation, Success, Validator }
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import mesosphere.marathon.api.v2.Validation
-import mesosphere.marathon.core.appinfo.{ AppInfo, EnrichedTask }
+import mesosphere.marathon.core.appinfo.AppInfo
 import mesosphere.marathon.plugin.PathId
 import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.state.AppDefinition

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -7,7 +7,6 @@ import javax.ws.rs._
 import javax.ws.rs.core.{ Context, MediaType, Response }
 
 import mesosphere.marathon.api._
-import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.core.appinfo.EnrichedTask
 import mesosphere.marathon.core.async.ExecutionContexts.global
 import mesosphere.marathon.core.group.GroupManager

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -17,6 +17,9 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.plugin.auth._
+import mesosphere.marathon.raml.AnyToRaml
+import mesosphere.marathon.raml.EnrichedTask._
+import mesosphere.marathon.raml.EnrichedTaskConversion._
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.state.PathId._
 import org.slf4j.LoggerFactory
@@ -50,13 +53,13 @@ class AppTasksResource @Inject() (
           val groupPath = gid.toRootPath
           val maybeGroup = groupManager.group(groupPath)
           withAuthorization(ViewGroup, maybeGroup, unknownGroup(groupPath)) { group =>
-            ok(jsonObjString("tasks" -> runningTasks(group.transitiveAppIds, instancesBySpec)))
+            ok(jsonObjString("tasks" -> runningTasks(group.transitiveAppIds, instancesBySpec).toRaml))
           }
         case _ =>
           val appId = id.toRootPath
           val maybeApp = groupManager.app(appId)
           withAuthorization(ViewRunSpec, maybeApp, unknownApp(appId)) { _ =>
-            ok(jsonObjString("tasks" -> runningTasks(Set(appId), instancesBySpec)))
+            ok(jsonObjString("tasks" -> runningTasks(Set(appId), instancesBySpec).toRaml))
           }
       }
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -19,7 +19,7 @@ import mesosphere.marathon.core.event.ApiPostEvent
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.raml.{ AppConversion, AppExternalVolume, AppPersistentVolume, Raml }
+import mesosphere.marathon.raml.Raml
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -19,6 +19,9 @@ import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec }
+import mesosphere.marathon.raml.AnyToRaml
+import mesosphere.marathon.raml.EnrichedTask._
+import mesosphere.marathon.raml.EnrichedTaskConversion._
 import mesosphere.marathon.state.{ AppDefinition, PathId }
 import mesosphere.marathon.stream.Implicits._
 import org.slf4j.LoggerFactory
@@ -92,7 +95,7 @@ class TasksResource @Inject() (
 
     val enrichedTasks: Iterable[EnrichedTask] = result(futureEnrichedTasks)
     ok(jsonObjString(
-      "tasks" -> enrichedTasks
+      "tasks" -> enrichedTasks.toIndexedSeq.toRaml
     ))
   }
 
@@ -148,7 +151,7 @@ class TasksResource @Inject() (
         })).flatten
       ok(jsonObjString("tasks" -> killed.flatMap { instance =>
         instance.tasksMap.valuesIterator.map { task =>
-          EnrichedTask(task.runSpecId, task, instance.agentInfo, Seq.empty)
+          EnrichedTask(task.runSpecId, task, instance.agentInfo, Seq.empty).toRaml
         }
       }))
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -7,7 +7,6 @@ import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.{ Context, MediaType, Response }
 
-import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.{ EndpointsHelper, MarathonMediaType, TaskKiller, _ }
 import mesosphere.marathon.core.appinfo.EnrichedTask
 import mesosphere.marathon.core.async.ExecutionContexts

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -2,7 +2,6 @@ package mesosphere.marathon
 package api.v2.json
 
 import mesosphere.marathon.core.appinfo._
-import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.deployment.{ DeploymentAction, DeploymentPlan, DeploymentStep, DeploymentStepInfo }
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health._
@@ -10,7 +9,6 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.plugin.{ PluginDefinition, PluginDefinitions }
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.readiness.{ HttpResponse, ReadinessCheckResult }
-import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.raml.{ Raml }
 import mesosphere.marathon.raml.EnrichedTask._
@@ -19,7 +17,6 @@ import mesosphere.marathon.state._
 import org.apache.mesos.{ Protos => mesos }
 import play.api.libs.json.JsonValidationError
 import play.api.libs.functional.syntax._
-import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json._
 
 import scala.concurrent.duration._
@@ -112,28 +109,6 @@ trait Formats
     (__ \ "hostPorts").format[Seq[Int]] ~
     (__ \ "ipAddresses").format[Seq[mesos.NetworkInfo.IPAddress]]
   )(NetworkInfo(_, _, _), unlift(NetworkInfo.unapply))
-
-  import scala.collection.mutable
-  implicit val TaskWrites: Writes[Task] = Writes { task =>
-    val fields = mutable.HashMap[String, JsValueWrapper](
-      "id" -> task.taskId,
-      "state" -> Condition.toMesosTaskStateOrStaging(task.status.condition)
-    )
-    if (task.isActive) {
-      fields.update("startedAt", task.status.startedAt)
-      fields.update("stagedAt", task.status.stagedAt)
-      fields.update("ports", task.status.networkInfo.hostPorts)
-      fields.update("version", task.runSpecVersion)
-    }
-    if (task.status.networkInfo.ipAddresses.nonEmpty) {
-      fields.update("ipAddresses", task.status.networkInfo.ipAddresses)
-    }
-    task.reservationWithVolumes.foreach { reservation =>
-      fields.update("localVolumes", reservation.volumeIds)
-    }
-
-    Json.obj(fields.to[Seq]: _*)
-  }
 
   implicit lazy val PathIdFormat: Format[PathId] = Format(
     Reads.of[String](Reads.minLength[String](1)).map(PathId(_)),

--- a/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
@@ -8,12 +8,10 @@ import mesosphere.mesos.protos.Implicits._
 
 import scala.concurrent.duration._
 
-trait AppConversion extends ConstraintConversion with EnvVarConversion with HealthCheckConversion
+trait AppConversion extends DefaultConversions with ConstraintConversion with EnvVarConversion with HealthCheckConversion
     with NetworkConversion with ReadinessConversions with SecretConversion with VolumeConversion with UnreachableStrategyConversion with KillSelectionConversion {
 
   import AppConversion._
-
-  implicit val pathIdWrites: Writes[PathId, String] = Writes { _.toString }
 
   implicit val artifactWrites: Writes[FetchUri, Artifact] = Writes { fetch =>
     Artifact(fetch.uri, fetch.extract, fetch.executable, fetch.cache, fetch.outputFile)

--- a/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
@@ -1,7 +1,10 @@
 package mesosphere.marathon
 package raml
 
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.stream.Implicits._
+import org.apache.mesos.{ Protos => mesos }
 
 /**
   * All conversions for standard scala types.
@@ -36,5 +39,20 @@ trait DefaultConversions {
     map.map {
       case (k, v) => key.write(k) -> value.write(v)
     }
+  }
+
+  implicit val timestampWrites: Writes[Timestamp, String] = Writes { _.toString }
+
+  implicit val pathIdWrites: Writes[PathId, String] = Writes { _.toString }
+
+  implicit val instanceIdWrites: Writes[Instance.Id, String] = Writes { _.toString }
+
+  implicit val taskStateWrites: Writes[mesos.TaskState, MesosTaskState] = Writes { taskState =>
+    MesosTaskState.fromString(taskState.name()).get
+  }
+
+  implicit val ipAddressWrites: Writes[mesos.NetworkInfo.IPAddress, IpAddr] = Writes { ipAddress =>
+    val protocol = IpProtocol.fromString(ipAddress.getProtocol.name()).get
+    IpAddr(ipAddress.getIpAddress, protocol)
   }
 }

--- a/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
@@ -50,11 +50,14 @@ trait DefaultConversions {
   implicit val instanceIdWrites: Writes[Instance.Id, String] = Writes { _.toString }
 
   implicit val taskStateWrites: Writes[mesos.TaskState, MesosTaskState] = Writes { taskState =>
-    MesosTaskState.fromString(taskState.name()).get
+    val name = taskState.name()
+    MesosTaskState.fromString(name).getOrElse(throw new IllegalArgumentException(s"$name is an unknown Mesos task state"))
   }
 
   implicit val ipAddressWrites: Writes[mesos.NetworkInfo.IPAddress, IpAddr] = Writes { ipAddress =>
-    val protocol = IpProtocol.fromString(ipAddress.getProtocol.name()).get
+    val name = ipAddress.getProtocol.name()
+    val protocol = IpProtocol.fromString(name)
+      .getOrElse(throw new IllegalArgumentException(s"$name is an unknown protocol"))
     IpAddr(ipAddress.getIpAddress, protocol)
   }
 }

--- a/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
@@ -6,6 +6,8 @@ import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.stream.Implicits._
 import org.apache.mesos.{ Protos => mesos }
 
+import scala.collection.breakOut
+
 /**
   * All conversions for standard scala types.
   */
@@ -28,7 +30,7 @@ trait DefaultConversions {
   }
 
   implicit def javaListToSeqConversion[A, B](implicit writer: Writes[A, B]): Writes[java.util.List[A], Seq[B]] = Writes { list =>
-    list.toSeq.map(writer.write)
+    list.map(writer.write)(breakOut)
   }
 
   implicit def setConversion[A, B](implicit writer: Writes[A, B]): Writes[Set[A], Set[B]] = Writes { set =>

--- a/src/main/scala/mesosphere/marathon/raml/EnrichedTaskConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/EnrichedTaskConversion.scala
@@ -4,7 +4,7 @@ package raml
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.task.Task
 
-object EnrichedTaskConversion extends HealthConversion {
+object EnrichedTaskConversion extends HealthConversion with DefaultConversions {
 
   implicit val localVolumeIdWrites: Writes[Task.LocalVolumeId, LocalVolumeId] = Writes { localVolumeId =>
     LocalVolumeId(

--- a/src/main/scala/mesosphere/marathon/raml/EnrichedTaskConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/EnrichedTaskConversion.scala
@@ -47,10 +47,4 @@ object EnrichedTaskConversion extends HealthConversion with DefaultConversions {
       localVolumes = localVolumes
     )
   }
-
-  /*
-  task.reservationWithVolumes.foreach { reservation =>
-    fields.update("localVolumes", reservation.volumeIds)
-  }
-    */
 }

--- a/src/main/scala/mesosphere/marathon/raml/EnrichedTaskConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/EnrichedTaskConversion.scala
@@ -1,0 +1,41 @@
+package mesosphere.marathon
+package raml
+
+import mesosphere.marathon.core.condition.Condition
+import mesosphere.marathon.core.task.Task
+
+object EnrichedTaskConversion extends HealthConversion {
+
+  implicit val enrichedTaskRamlWriter: Writes[core.appinfo.EnrichedTask, EnrichedTask] = Writes { enrichedTask =>
+    val task: Task = enrichedTask.task
+
+    val (startedAt, stagedAt, ports, version) =
+      if (task.isActive) {
+        (task.status.startedAt, Some(task.status.stagedAt), task.status.networkInfo.hostPorts, Some(task.runSpecVersion))
+      } else {
+        (None, None, Nil, None)
+      }
+
+    EnrichedTask(
+      appId = enrichedTask.appId.toRaml,
+      healthCheckResults = enrichedTask.healthCheckResults.map(_.toRaml),
+      host = enrichedTask.agentInfo.host,
+      id = task.taskId.toString,
+      ipAddresses = task.status.networkInfo.ipAddresses.map(_.toRaml),
+      ports = ports,
+      servicePorts = enrichedTask.servicePorts,
+      slaveId = enrichedTask.agentInfo.agentId,
+      state = Condition.toMesosTaskStateOrStaging(task.status.condition).toRaml,
+      stagedAt = stagedAt.map(_.toRaml),
+      startedAt = startedAt.map(_.toRaml),
+      version = version.map(_.toRaml),
+      localVolumes = Nil
+    )
+  }
+
+  /*
+  task.reservationWithVolumes.foreach { reservation =>
+    fields.update("localVolumes", reservation.volumeIds)
+  }
+    */
+}

--- a/src/main/scala/mesosphere/marathon/raml/HealthConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/HealthConversion.scala
@@ -7,10 +7,10 @@ trait HealthConversion extends DefaultConversions {
     Health(
       alive = health.alive,
       consecutiveFailures = health.consecutiveFailures,
-      firstSuccess = health.firstSuccess.map(_.toString),
+      firstSuccess = health.firstSuccess.toRaml,
       instanceId = health.instanceId.toRaml,
-      lastSuccess = health.lastSuccess.map(_.toString),
-      lastFailure = health.lastFailure.map(_.toString),
+      lastSuccess = health.lastSuccess.toRaml,
+      lastFailure = health.lastFailure.toRaml,
       lastFailureCause = health.lastFailureCause
     )
   }

--- a/src/main/scala/mesosphere/marathon/raml/HealthConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/HealthConversion.scala
@@ -1,0 +1,17 @@
+package mesosphere.marathon
+package raml
+
+trait HealthConversion extends DefaultConversions {
+
+  implicit val healthRamlWriter: Writes[core.health.Health, Health] = Writes { health =>
+    Health(
+      alive = health.alive,
+      consecutiveFailures = health.consecutiveFailures,
+      firstSuccess = health.firstSuccess.map(_.toString),
+      instanceId = health.instanceId.toRaml,
+      lastSuccess = health.lastSuccess.map(_.toString),
+      lastFailure = health.lastFailure.map(_.toString),
+      lastFailureCause = health.lastFailureCause
+    )
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -2,9 +2,7 @@ package mesosphere.marathon
 package api.v2
 
 import mesosphere.UnitTest
-import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.{ JsonTestHelper, TaskKiller, TestAuthFixture }
-import mesosphere.marathon.core.appinfo.EnrichedTask
 import mesosphere.marathon.core.async.ExecutionContexts.global
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -14,7 +14,7 @@ import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.{ InstanceTracker, TaskStateOpProcessor }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ PathId, _ }
-import mesosphere.marathon.test.GroupCreation
+import mesosphere.marathon.test.{ GroupCreation, SettableClock }
 import org.mockito.Matchers
 import org.mockito.Mockito._
 import play.api.libs.json.Json
@@ -164,10 +164,12 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation {
     }
 
     "get tasks" in new Fixture {
+      val clock = new SettableClock()
+
       val appId = PathId("/my/app")
 
-      val instance1 = TestInstanceBuilder.newBuilderWithLaunchedTask(appId).getInstance()
-      val instance2 = TestInstanceBuilder.newBuilderWithLaunchedTask(appId).getInstance()
+      val instance1 = TestInstanceBuilder.newBuilderWithLaunchedTask(appId, clock.now()).getInstance()
+      val instance2 = TestInstanceBuilder.newBuilderWithLaunchedTask(appId, clock.now()).getInstance()
 
       config.zkTimeoutDuration returns 5.seconds
       taskTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.of(InstanceTracker.SpecInstances.forInstances(appId, Seq(instance1, instance2))))
@@ -177,19 +179,42 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation {
       val response = appsTaskResource.indexJson("/my/app", auth.request)
       response.getStatus shouldEqual 200
 
-      def toEnrichedTask(instance: Instance): EnrichedTask = {
-        EnrichedTask(
-          appId = appId,
-          task = instance.appTask,
-          agentInfo = instance.agentInfo,
-          healthCheckResults = Seq(),
-          servicePorts = Seq()
-        )
-      }
+      val expected =
+        s"""
+          |{ "tasks": [
+          |  {
+          |    "appId" : "/my/app",
+          |    "healthCheckResults" : [ ],
+          |    "host" : "host.some",
+          |    "id" : "${instance1.appTask.taskId.idString}",
+          |    "ipAddresses" : [ ],
+          |    "ports" : [ ],
+          |    "servicePorts" : [ ],
+          |    "slaveId" : "agent-1",
+          |    "state" : "TASK_STAGING",
+          |    "stagedAt" : "2015-04-09T12:30:00.000Z",
+          |    "version" : "2015-04-09T12:30:00.000Z",
+          |    "localVolumes" : [ ]
+          |  }, {
+          |    "appId" : "/my/app",
+          |    "healthCheckResults" : [ ],
+          |    "host" : "host.some",
+          |    "id" : "${instance2.appTask.taskId.idString}",
+          |    "ipAddresses" : [ ],
+          |    "ports" : [ ],
+          |    "servicePorts" : [ ],
+          |    "slaveId" : "agent-1",
+          |    "state" : "TASK_STAGING",
+          |    "stagedAt" : "2015-04-09T12:30:00.000Z",
+          |    "version" : "2015-04-09T12:30:00.000Z",
+          |    "localVolumes" : [ ]
+          |  } ]
+          |}
+        """.stripMargin
 
       JsonTestHelper
         .assertThatJsonString(response.getEntity.asInstanceOf[String])
-        .correspondsToJsonOf(Json.obj("tasks" -> Seq(instance1, instance2).map(toEnrichedTask)))
+        .correspondsToJsonString(expected)
     }
 
     "access without authentication is denied" in new Fixture {

--- a/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
@@ -8,13 +8,13 @@ import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.raml.AnyToRaml
+import mesosphere.marathon.raml.EnrichedTask._
+import mesosphere.marathon.raml.EnrichedTaskConversion._
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.stream.Implicits._
 import org.apache.mesos.{ Protos => MesosProtos }
 
 class EnrichedTaskWritesTest extends UnitTest {
-
-  import Formats.EnrichedTaskWrites
 
   class Fixture {
     val time = Timestamp(1024)
@@ -78,14 +78,17 @@ class EnrichedTaskWritesTest extends UnitTest {
         s"""
         |{
         |  "appId": "${f.runSpecId}",
+        |  "healthCheckResults" : [],
         |  "id": "${f.taskWithoutIp.task.taskId.idString}",
+        |  "ipAddresses" : [],
         |  "host": "agent1.mesos",
         |  "state": "TASK_STAGING",
         |  "ports": [],
-        |  "startedAt": null,
+        |  "servicePorts" : [],
         |  "stagedAt": "1970-01-01T00:00:01.024Z",
         |  "version": "1970-01-01T00:00:01.024Z",
-        |  "slaveId": "abcd-1234"
+        |  "slaveId": "abcd-1234",
+        |  "localVolumes" : []
         |}
       """.stripMargin
       JsonTestHelper.assertThatJsonOf(f.taskWithoutIp.toRaml).correspondsToJsonString(json)
@@ -97,6 +100,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         s"""
         |{
         |  "appId": "${f.runSpecId}",
+        |  "healthCheckResults" : [],
         |  "id": "${f.taskWithMultipleIPs.task.taskId.idString}",
         |  "host": "agent1.mesos",
         |  "state": "TASK_STAGING",
@@ -111,10 +115,11 @@ class EnrichedTaskWritesTest extends UnitTest {
         |    }
         |  ],
         |  "ports": [],
-        |  "startedAt": null,
+        |  "servicePorts" : [],
         |  "stagedAt": "1970-01-01T00:00:01.024Z",
         |  "version": "1970-01-01T00:00:01.024Z",
-        |  "slaveId": "abcd-1234"
+        |  "slaveId": "abcd-1234",
+        |  "localVolumes" : []
         |}
       """.stripMargin
       JsonTestHelper.assertThatJsonOf(f.taskWithMultipleIPs.toRaml).correspondsToJsonString(json)
@@ -129,10 +134,13 @@ class EnrichedTaskWritesTest extends UnitTest {
         s"""
         |{
         |  "appId": "${f.runSpecId}",
+        |  "healthCheckResults" : [],
         |  "id": "${task.taskId.idString}",
+        |  "ipAddresses" : [],
         |  "host": "agent1.mesos",
         |  "state" : "TASK_RUNNING",
         |  "ports": [],
+        |  "servicePorts" : [],
         |  "startedAt": "${status.startedAt.value.toString}",
         |  "stagedAt": "${status.stagedAt.toString}",
         |  "version": "${task.runSpecVersion}",

--- a/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.core.appinfo.EnrichedTask
 import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
+import mesosphere.marathon.raml.AnyToRaml
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.stream.Implicits._
 import org.apache.mesos.{ Protos => MesosProtos }
@@ -87,7 +88,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         |  "slaveId": "abcd-1234"
         |}
       """.stripMargin
-      JsonTestHelper.assertThatJsonOf(f.taskWithoutIp).correspondsToJsonString(json)
+      JsonTestHelper.assertThatJsonOf(f.taskWithoutIp.toRaml).correspondsToJsonString(json)
     }
 
     "JSON serialization of a Task with multiple IPs" in {
@@ -116,7 +117,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         |  "slaveId": "abcd-1234"
         |}
       """.stripMargin
-      JsonTestHelper.assertThatJsonOf(f.taskWithMultipleIPs).correspondsToJsonString(json)
+      JsonTestHelper.assertThatJsonOf(f.taskWithMultipleIPs.toRaml).correspondsToJsonString(json)
     }
 
     "JSON serialization of a Task with reserved local volumes" in {
@@ -146,7 +147,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         |  ]
         |}
       """.stripMargin
-      JsonTestHelper.assertThatJsonOf(f.taskWithLocalVolumes).correspondsToJsonString(json)
+      JsonTestHelper.assertThatJsonOf(f.taskWithLocalVolumes.toRaml).correspondsToJsonString(json)
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -13,9 +13,9 @@ import mesosphere.marathon.test.MarathonTestHelper.Implicits._
 import org.apache.mesos
 import org.slf4j.LoggerFactory
 
-case class TestTaskBuilder(
-    task: Option[Task], instanceBuilder: TestInstanceBuilder, now: Timestamp = Timestamp.now()
-) {
+case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuilder) {
+
+  val now = instanceBuilder.now
 
   def taskFromTaskInfo(
     taskInfo: mesos.Protos.TaskInfo,


### PR DESCRIPTION
Summary:
Model the `EnrichedTask` response in RAML. This is the first step of removing the infamous handwritten `Formats.scala`. I used the raw JSON in `EnrickedTaskWritesTest` as examples.

JIRA issues:
