### PR TITLE
Ignore offers from non-home regions

### DIFF
--- a/src/main/scala/mesosphere/marathon/HomeRegionProvider.scala
+++ b/src/main/scala/mesosphere/marathon/HomeRegionProvider.scala
@@ -1,0 +1,5 @@
+package mesosphere.marathon
+
+trait HomeRegionProvider {
+  def getHomeRegion(): Option[String]
+}

--- a/src/main/scala/mesosphere/marathon/HomeRegionProvider.scala
+++ b/src/main/scala/mesosphere/marathon/HomeRegionProvider.scala
@@ -1,5 +1,9 @@
 package mesosphere.marathon
 
+/**
+  * Returns value of home region for Marathon. This is strongly connected with Marathon being region aware.
+  * The value is used for region-aware scheduling.
+  */
 trait HomeRegionProvider {
   def getHomeRegion(): Option[String]
 }

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -47,6 +47,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
 
     // MesosHeartbeatMonitor decorates MarathonScheduler
     bind(classOf[MarathonScheduler]).in(Scopes.SINGLETON)
+    bind(classOf[HomeRegionProvider]).to(classOf[MarathonScheduler]).in(Scopes.SINGLETON)
     bind(classOf[Scheduler]).annotatedWith(Names.named(MesosHeartbeatMonitor.BASE)).toProvider(getProvider(classOf[MarathonScheduler]))
     bind(classOf[Scheduler]).to(classOf[MesosHeartbeatMonitor]).in(Scopes.SINGLETON)
 

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -25,7 +25,7 @@ class MarathonScheduler @Inject() (
     taskStatusProcessor: TaskStatusUpdateProcessor,
     frameworkIdRepository: FrameworkIdRepository,
     mesosLeaderInfo: MesosLeaderInfo,
-    config: MarathonConf) extends Scheduler {
+    config: MarathonConf) extends Scheduler with HomeRegionProvider {
 
   private[this] val log = LoggerFactory.getLogger(getClass.getName)
 

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -52,7 +52,8 @@ class CoreModuleImpl @Inject() (
   clock: Clock,
   scheduler: Provider[DeploymentService],
   instanceUpdateSteps: Seq[InstanceChangeHandler],
-  taskStatusUpdateProcessor: TaskStatusUpdateProcessor
+  taskStatusUpdateProcessor: TaskStatusUpdateProcessor,
+  marathonScheduler: MarathonScheduler
 )
     extends CoreModule {
 
@@ -99,7 +100,8 @@ class CoreModuleImpl @Inject() (
   private[this] lazy val offerMatcherManagerModule = new OfferMatcherManagerModule(
     // infrastructure
     clock, random, marathonConf, actorSystem.scheduler,
-    leadershipModule
+    leadershipModule,
+    marathonScheduler
   )
 
   private[this] lazy val offerMatcherReconcilerModule =
@@ -144,7 +146,8 @@ class CoreModuleImpl @Inject() (
 
     // external guice dependencies
     taskTrackerModule.instanceTracker,
-    launcherModule.taskOpFactory
+    launcherModule.taskOpFactory,
+    marathonScheduler
   )
 
   // PLUGINS

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -53,7 +53,7 @@ class CoreModuleImpl @Inject() (
   scheduler: Provider[DeploymentService],
   instanceUpdateSteps: Seq[InstanceChangeHandler],
   taskStatusUpdateProcessor: TaskStatusUpdateProcessor,
-  marathonScheduler: Provider[MarathonScheduler]
+  homeRegionProvider: Provider[HomeRegionProvider]
 )
     extends CoreModule {
 
@@ -101,7 +101,7 @@ class CoreModuleImpl @Inject() (
     // infrastructure
     clock, random, marathonConf, actorSystem.scheduler,
     leadershipModule,
-    marathonScheduler
+    homeRegionProvider
   )
 
   private[this] lazy val offerMatcherReconcilerModule =
@@ -147,7 +147,7 @@ class CoreModuleImpl @Inject() (
     // external guice dependencies
     taskTrackerModule.instanceTracker,
     launcherModule.taskOpFactory,
-    marathonScheduler
+    homeRegionProvider
   )
 
   // PLUGINS

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -53,7 +53,7 @@ class CoreModuleImpl @Inject() (
   scheduler: Provider[DeploymentService],
   instanceUpdateSteps: Seq[InstanceChangeHandler],
   taskStatusUpdateProcessor: TaskStatusUpdateProcessor,
-  marathonScheduler: MarathonScheduler
+  marathonScheduler: Provider[MarathonScheduler]
 )
     extends CoreModule {
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -4,6 +4,7 @@ package core.launchqueue
 import java.time.Clock
 
 import akka.actor.{ ActorRef, Props }
+import com.google.inject.Provider
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.launcher.InstanceOpFactory
 import mesosphere.marathon.core.launchqueue.impl._
@@ -23,7 +24,7 @@ class LaunchQueueModule(
     maybeOfferReviver: Option[OfferReviver],
     taskTracker: InstanceTracker,
     taskOpFactory: InstanceOpFactory,
-    scheduler: MarathonScheduler) {
+    scheduler: Provider[MarathonScheduler]) {
 
   private[this] val offerMatchStatisticsActor: ActorRef = {
     leadershipModule.startWhenLeader(OfferMatchStatisticsActor.props(), "offerMatcherStatistics")

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -22,7 +22,8 @@ class LaunchQueueModule(
     subOfferMatcherManager: OfferMatcherManager,
     maybeOfferReviver: Option[OfferReviver],
     taskTracker: InstanceTracker,
-    taskOpFactory: InstanceOpFactory) {
+    taskOpFactory: InstanceOpFactory,
+    scheduler: MarathonScheduler) {
 
   private[this] val offerMatchStatisticsActor: ActorRef = {
     leadershipModule.startWhenLeader(OfferMatchStatisticsActor.props(), "offerMatcherStatistics")
@@ -38,7 +39,8 @@ class LaunchQueueModule(
         maybeOfferReviver,
         taskTracker,
         rateLimiterActor,
-        offerMatchStatisticsActor)(runSpec, count)
+        offerMatchStatisticsActor,
+        scheduler)(runSpec, count)
     val props = LaunchQueueActor.props(config, offerMatchStatisticsActor, runSpecActorProps)
     leadershipModule.startWhenLeader(props, "launchQueue")
   }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -24,7 +24,7 @@ class LaunchQueueModule(
     maybeOfferReviver: Option[OfferReviver],
     taskTracker: InstanceTracker,
     taskOpFactory: InstanceOpFactory,
-    scheduler: Provider[MarathonScheduler]) {
+    homeRegionProvider: Provider[HomeRegionProvider]) {
 
   private[this] val offerMatchStatisticsActor: ActorRef = {
     leadershipModule.startWhenLeader(OfferMatchStatisticsActor.props(), "offerMatcherStatistics")
@@ -41,7 +41,7 @@ class LaunchQueueModule(
         taskTracker,
         rateLimiterActor,
         offerMatchStatisticsActor,
-        scheduler)(runSpec, count)
+        homeRegionProvider)(runSpec, count)
     val props = LaunchQueueActor.props(config, offerMatchStatisticsActor, runSpecActorProps)
     leadershipModule.startWhenLeader(props, "launchQueue")
   }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -6,6 +6,7 @@ import java.time.Clock
 import akka.Done
 import akka.actor._
 import akka.event.LoggingReceive
+import com.google.inject.Provider
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.instance.Instance
@@ -36,7 +37,7 @@ private[launchqueue] object TaskLauncherActor {
     instanceTracker: InstanceTracker,
     rateLimiterActor: ActorRef,
     offerMatchStatisticsActor: ActorRef,
-    scheduler: MarathonScheduler)(
+    scheduler: Provider[MarathonScheduler])(
     runSpec: RunSpec,
     initialCount: Int): Props = {
     Props(new TaskLauncherActor(
@@ -88,7 +89,7 @@ private class TaskLauncherActor(
 
     private[this] var runSpec: RunSpec,
     private[this] var instancesToLaunch: Int,
-    scheduler: MarathonScheduler) extends Actor with StrictLogging with Stash {
+    scheduler: Provider[MarathonScheduler]) extends Actor with StrictLogging with Stash {
   // scalastyle:on parameter.number
 
   private[this] var inFlightInstanceOperations = Map.empty[Instance.Id, Cancellable]

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -37,7 +37,7 @@ private[launchqueue] object TaskLauncherActor {
     instanceTracker: InstanceTracker,
     rateLimiterActor: ActorRef,
     offerMatchStatisticsActor: ActorRef,
-    scheduler: Provider[MarathonScheduler])(
+    homeRegionProvider: Provider[HomeRegionProvider])(
     runSpec: RunSpec,
     initialCount: Int): Props = {
     Props(new TaskLauncherActor(
@@ -46,7 +46,7 @@ private[launchqueue] object TaskLauncherActor {
       clock, taskOpFactory,
       maybeOfferReviver,
       instanceTracker, rateLimiterActor, offerMatchStatisticsActor,
-      runSpec, initialCount, scheduler))
+      runSpec, initialCount, homeRegionProvider))
   }
 
   sealed trait Requests
@@ -89,7 +89,7 @@ private class TaskLauncherActor(
 
     private[this] var runSpec: RunSpec,
     private[this] var instancesToLaunch: Int,
-    scheduler: Provider[MarathonScheduler]) extends Actor with StrictLogging with Stash {
+    homeRegionProvider: Provider[HomeRegionProvider]) extends Actor with StrictLogging with Stash {
   // scalastyle:on parameter.number
 
   private[this] var inFlightInstanceOperations = Map.empty[Instance.Id, Cancellable]
@@ -425,7 +425,7 @@ private class TaskLauncherActor(
   private[this] object OfferMatcherRegistration {
     private[this] val myselfAsOfferMatcher: OfferMatcher = {
       //set the precedence only, if this app is resident
-      new ActorOfferMatcher(self, runSpec.residency.map(_ => runSpec.id), scheduler)(context.system.scheduler)
+      new ActorOfferMatcher(self, runSpec.residency.map(_ => runSpec.id), homeRegionProvider)(context.system.scheduler)
     }
     private[this] var registeredAsMatcher = false
 

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/OfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/OfferMatcher.scala
@@ -4,6 +4,7 @@ package core.matcher.base
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launcher.InstanceOp
 import mesosphere.marathon.state.PathId
+import org.apache.mesos.Protos.Offer
 import org.apache.mesos.{ Protos => Mesos }
 
 import scala.concurrent.Future
@@ -78,4 +79,10 @@ trait OfferMatcher {
     * If the filter matches, the offer matcher manager has higher priority than other matchers.
     */
   def precedenceFor: Option[PathId] = None
+
+  /**
+    * To allow offer routing optimization based on the offer contents.
+    * If matcher is not interested in these offers, such offer's won't be even received via matchOffer.
+    */
+  def isInterestedIn(offer: Offer): Boolean = true
 }

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package core.matcher.base.util
 
 import akka.actor.ActorRef
+import com.google.inject.Provider
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.MatchedInstanceOps
@@ -17,7 +18,7 @@ import scala.concurrent.{ Future, Promise }
   * @param actorRef Reference to actor that matches offers.
   * @param precedenceFor Defines which matcher receives offers first. See [[mesosphere.marathon.core.matcher.base.OfferMatcher.precedenceFor]].
   */
-class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[PathId], marathonScheduler: MarathonScheduler)(implicit scheduler: akka.actor.Scheduler)
+class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[PathId], marathonScheduler: Provider[MarathonScheduler])(implicit scheduler: akka.actor.Scheduler)
     extends OfferMatcher with StrictLogging {
 
   def matchOffer(offer: Offer): Future[MatchedInstanceOps] = {
@@ -30,7 +31,7 @@ class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[P
 
   override def isInterestedIn(offer: Offer) = {
     def isFromHomeRegion(offer: Offer): Boolean = {
-      !offer.hasDomain || !offer.getDomain.hasFaultDomain || marathonScheduler.getHomeRegion.forall(_ == offer.getDomain.getFaultDomain.getRegion.getName)
+      !offer.hasDomain || !offer.getDomain.hasFaultDomain || marathonScheduler.get().getHomeRegion.forall(_ == offer.getDomain.getFaultDomain.getRegion.getName)
     }
 
     isFromHomeRegion(offer)

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
@@ -18,7 +18,7 @@ import scala.concurrent.{ Future, Promise }
   * @param actorRef Reference to actor that matches offers.
   * @param precedenceFor Defines which matcher receives offers first. See [[mesosphere.marathon.core.matcher.base.OfferMatcher.precedenceFor]].
   */
-class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[PathId], marathonScheduler: Provider[MarathonScheduler])(implicit scheduler: akka.actor.Scheduler)
+class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[PathId], homeRegionProvider: Provider[HomeRegionProvider])(implicit scheduler: akka.actor.Scheduler)
     extends OfferMatcher with StrictLogging {
 
   def matchOffer(offer: Offer): Future[MatchedInstanceOps] = {
@@ -31,7 +31,7 @@ class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[P
 
   override def isInterestedIn(offer: Offer) = {
     def isFromHomeRegion(offer: Offer): Boolean = {
-      !offer.hasDomain || !offer.getDomain.hasFaultDomain || marathonScheduler.get().getHomeRegion.forall(_ == offer.getDomain.getFaultDomain.getRegion.getName)
+      !offer.hasDomain || !offer.getDomain.hasFaultDomain || homeRegionProvider.get().getHomeRegion.forall(_ == offer.getDomain.getFaultDomain.getRegion.getName)
     }
 
     isFromHomeRegion(offer)

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -4,6 +4,7 @@ package core.matcher.manager
 import java.time.Clock
 
 import akka.actor.{ ActorRef, Scheduler }
+import com.google.inject.Provider
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.util.ActorOfferMatcher
@@ -22,7 +23,7 @@ class OfferMatcherManagerModule(
     offerMatcherConfig: OfferMatcherManagerConfig,
     scheduler: Scheduler,
     leadershipModule: LeadershipModule,
-    marathonScheduler: MarathonScheduler,
+    marathonScheduler: Provider[MarathonScheduler],
     actorName: String = "offerMatcherManager") {
 
   private[this] lazy val offersWanted: Subject[Boolean] = BehaviorSubject[Boolean](false)

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -23,7 +23,7 @@ class OfferMatcherManagerModule(
     offerMatcherConfig: OfferMatcherManagerConfig,
     scheduler: Scheduler,
     leadershipModule: LeadershipModule,
-    marathonScheduler: Provider[MarathonScheduler],
+    homeRegionProvider: Provider[HomeRegionProvider],
     actorName: String = "offerMatcherManager") {
 
   private[this] lazy val offersWanted: Subject[Boolean] = BehaviorSubject[Boolean](false)
@@ -41,6 +41,6 @@ class OfferMatcherManagerModule(
     * offers.
     */
   val globalOfferMatcherWantsOffers: Observable[Boolean] = offersWanted
-  val globalOfferMatcher: OfferMatcher = new ActorOfferMatcher(offerMatcherMultiplexer, None, marathonScheduler)(scheduler)
+  val globalOfferMatcher: OfferMatcher = new ActorOfferMatcher(offerMatcherMultiplexer, None, homeRegionProvider)(scheduler)
   val subOfferMatcherManager: OfferMatcherManager = new OfferMatcherManagerDelegate(offerMatcherMultiplexer)
 }

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -22,6 +22,7 @@ class OfferMatcherManagerModule(
     offerMatcherConfig: OfferMatcherManagerConfig,
     scheduler: Scheduler,
     leadershipModule: LeadershipModule,
+    marathonScheduler: MarathonScheduler,
     actorName: String = "offerMatcherManager") {
 
   private[this] lazy val offersWanted: Subject[Boolean] = BehaviorSubject[Boolean](false)
@@ -39,6 +40,6 @@ class OfferMatcherManagerModule(
     * offers.
     */
   val globalOfferMatcherWantsOffers: Observable[Boolean] = offersWanted
-  val globalOfferMatcher: OfferMatcher = new ActorOfferMatcher(offerMatcherMultiplexer, None)(scheduler)
+  val globalOfferMatcher: OfferMatcher = new ActorOfferMatcher(offerMatcherMultiplexer, None, marathonScheduler)(scheduler)
   val subOfferMatcherManager: OfferMatcherManager = new OfferMatcherManagerDelegate(offerMatcherMultiplexer)
 }

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
@@ -174,7 +174,7 @@ private[impl] class OfferMatcherManagerActor private (
       .map(_.getDisk.getPersistence.getId)
       .collect { case LocalVolumeId(volumeId) => volumeId.runSpecId }
       .toSet
-    val (reserved, normal) = matchers.toSeq.partition(_.precedenceFor.exists(appReservations))
+    val (reserved, normal) = matchers.toSeq.filter(_.isInterestedIn(offer)).partition(_.precedenceFor.exists(appReservations))
     //1 give the offer to the matcher waiting for a reservation
     //2 give the offer to anybody else
     //3 randomize both lists to be fair

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -264,6 +264,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     lazy val instanceOpFactory: InstanceOpFactory = mock[InstanceOpFactory]
     lazy val config = MarathonTestHelper.defaultConfig()
     lazy val parentActor = newTestActor()
+    lazy val scheduler = mock[MarathonScheduler]
 
     lazy val module: LaunchQueueModule = new LaunchQueueModule(
       config,
@@ -272,7 +273,8 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       subOfferMatcherManager = offerMatcherManager,
       maybeOfferReviver = None,
       instanceTracker,
-      instanceOpFactory
+      instanceOpFactory,
+      scheduler
     )
 
     def launchQueue = module.launchQueue

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 
 import java.time.Clock
 
+import com.google.inject.Provider
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.instance.TestInstanceBuilder
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
@@ -264,7 +265,9 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     lazy val instanceOpFactory: InstanceOpFactory = mock[InstanceOpFactory]
     lazy val config = MarathonTestHelper.defaultConfig()
     lazy val parentActor = newTestActor()
-    lazy val scheduler = mock[MarathonScheduler]
+    lazy val scheduler = new Provider[MarathonScheduler] {
+      override def get() = mock[MarathonScheduler]
+    }
 
     lazy val module: LaunchQueueModule = new LaunchQueueModule(
       config,

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -265,8 +265,8 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     lazy val instanceOpFactory: InstanceOpFactory = mock[InstanceOpFactory]
     lazy val config = MarathonTestHelper.defaultConfig()
     lazy val parentActor = newTestActor()
-    lazy val scheduler = new Provider[MarathonScheduler] {
-      override def get() = mock[MarathonScheduler]
+    lazy val homeRegionProvider = new Provider[HomeRegionProvider] {
+      override def get() = mock[HomeRegionProvider]
     }
 
     lazy val module: LaunchQueueModule = new LaunchQueueModule(
@@ -277,7 +277,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       maybeOfferReviver = None,
       instanceTracker,
       instanceOpFactory,
-      scheduler
+      homeRegionProvider
     )
 
     def launchQueue = module.launchQueue

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -71,14 +71,15 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       instanceTracker: InstanceTracker = mock[InstanceTracker],
       offerReviver: OfferReviver = mock[OfferReviver],
       rateLimiterActor: TestProbe = TestProbe(),
-      offerMatchStatisticsActor: TestProbe = TestProbe()) {
+      offerMatchStatisticsActor: TestProbe = TestProbe(),
+      scheduler: MarathonScheduler = mock[MarathonScheduler]) {
 
     def createLauncherRef(instances: Int, appToLaunch: AppDefinition = f.app): ActorRef = {
       val props = TaskLauncherActor.props(
         launchQueueConfig,
         offerMatcherManager, clock, instanceOpFactory,
         maybeOfferReviver = Some(offerReviver),
-        instanceTracker, rateLimiterActor.ref, offerMatchStatisticsActor.ref) _
+        instanceTracker, rateLimiterActor.ref, offerMatchStatisticsActor.ref, scheduler) _
       system.actorOf(props(appToLaunch, instances))
     }
 
@@ -300,7 +301,8 @@ class TaskLauncherActorTest extends AkkaUnitTest {
           offerMatcherManager, clock, instanceOpFactory,
           maybeOfferReviver = None,
           instanceTracker, rateLimiterActor.ref, offerMatchStatisticsActor.ref,
-          f.app, instancesToLaunch = 1
+          f.app, instancesToLaunch = 1,
+          mock[MarathonScheduler]
         ) {
           override protected def scheduleTaskOperationTimeout(
             context: ActorContext, message: InstanceOpRejected): Cancellable = {

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -75,8 +75,8 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       rateLimiterActor: TestProbe = TestProbe(),
       offerMatchStatisticsActor: TestProbe = TestProbe(),
       homeRegionProvider: Provider[HomeRegionProvider] = new Provider[HomeRegionProvider] {
-          override def get() = mock[HomeRegionProvider]
-        }) {
+        override def get() = mock[HomeRegionProvider]
+      }) {
 
     def createLauncherRef(instances: Int, appToLaunch: AppDefinition = f.app): ActorRef = {
       val props = TaskLauncherActor.props(
@@ -299,9 +299,6 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       Mockito.when(instanceOpFactory.matchOfferRequest(m.any())).thenReturn(f.launchResult)
 
       var scheduleCalled = false
-      val homeRegionProvider = new Provider[HomeRegionProvider] {
-        override def get() = mock[HomeRegionProvider]
-      }
       val props = Props(
         new TaskLauncherActor(
           launchQueueConfig,

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -6,6 +6,7 @@ import akka.pattern.ask
 import akka.testkit.TestProbe
 import com.google.inject.Provider
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.HomeRegionProvider
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
@@ -73,16 +74,16 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       offerReviver: OfferReviver = mock[OfferReviver],
       rateLimiterActor: TestProbe = TestProbe(),
       offerMatchStatisticsActor: TestProbe = TestProbe(),
-      scheduler: Provider[MarathonScheduler] = new Provider[MarathonScheduler] {
-        override def get() = mock[MarathonScheduler]
-      }) {
+      homeRegionProvider: Provider[HomeRegionProvider] = new Provider[HomeRegionProvider] {
+          override def get() = mock[HomeRegionProvider]
+        }) {
 
     def createLauncherRef(instances: Int, appToLaunch: AppDefinition = f.app): ActorRef = {
       val props = TaskLauncherActor.props(
         launchQueueConfig,
         offerMatcherManager, clock, instanceOpFactory,
         maybeOfferReviver = Some(offerReviver),
-        instanceTracker, rateLimiterActor.ref, offerMatchStatisticsActor.ref, scheduler) _
+        instanceTracker, rateLimiterActor.ref, offerMatchStatisticsActor.ref, homeRegionProvider) _
       system.actorOf(props(appToLaunch, instances))
     }
 
@@ -298,8 +299,8 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       Mockito.when(instanceOpFactory.matchOfferRequest(m.any())).thenReturn(f.launchResult)
 
       var scheduleCalled = false
-      val marathonScheduler = new Provider[MarathonScheduler] {
-        override def get() = mock[MarathonScheduler]
+      val homeRegionProvider = new Provider[HomeRegionProvider] {
+        override def get() = mock[HomeRegionProvider]
       }
       val props = Props(
         new TaskLauncherActor(
@@ -308,7 +309,7 @@ class TaskLauncherActorTest extends AkkaUnitTest {
           maybeOfferReviver = None,
           instanceTracker, rateLimiterActor.ref, offerMatchStatisticsActor.ref,
           f.app, instancesToLaunch = 1,
-          marathonScheduler
+          homeRegionProvider
         ) {
           override protected def scheduleTaskOperationTimeout(
             context: ActorContext, message: InstanceOpRejected): Cancellable = {

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
@@ -4,6 +4,7 @@ package core.matcher.base.util
 import akka.actor.ActorRef
 import akka.testkit.TestActor.AutoPilot
 import akka.testkit.{ TestActor, TestProbe }
+import com.google.inject.Provider
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.matcher.base.OfferMatcher.MatchedInstanceOps
 import mesosphere.marathon.test.MarathonTestHelper
@@ -28,7 +29,9 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         })
         val offer = MarathonTestHelper.makeBasicOffer().build()
 
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, mock[MarathonScheduler])(scheduler)
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[MarathonScheduler] {
+          override def get() = mock[MarathonScheduler]
+        })(scheduler)
         val offerMatch: MatchedInstanceOps = offerMatcher.matchOffer(offer).futureValue
 
         offerMatch.offerId should not be (offer.getId)

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
@@ -19,7 +19,7 @@ import org.apache.mesos.Protos.{ DomainInfo, FrameworkID, Offer, SlaveID, OfferI
 class ActorOfferMatcherTest extends AkkaUnitTest {
   "The ActorOfferMatcher" when {
     "receives remote region offer" should {
-      "say is not interested when from non-home region" in {
+      "say is not interested when from non-home region" in new Fixture {
         val marathonScheduler = mock[MarathonScheduler]
         marathonScheduler.getHomeRegion returns Some("home")
         val probe = TestProbe()
@@ -30,7 +30,7 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         offerMatcher.isInterestedIn(offerWithFaultRegion("remote")) should be (false)
       }
 
-      "say is interested when from home region" in {
+      "say is interested when from home region" in new Fixture {
         val marathonScheduler = mock[MarathonScheduler]
         marathonScheduler.getHomeRegion returns Some("home")
         val probe = TestProbe()
@@ -41,7 +41,7 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         offerMatcher.isInterestedIn(offerWithFaultRegion("home")) should be (true)
       }
 
-      "say is interested when fault region not set" in {
+      "say is interested when fault region not set" in new Fixture {
         val marathonScheduler = mock[MarathonScheduler]
         marathonScheduler.getHomeRegion returns Some("home")
         val probe = TestProbe()
@@ -52,6 +52,7 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         offerMatcher.isInterestedIn(offerWithoutFaultRegion()) should be (true)
       }
     }
+
     "asking the actor" should {
       "find a match in time" in {
         val probe = TestProbe()
@@ -77,7 +78,9 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         offerMatch.offerId.getValue should be("other")
       }
     }
+  }
 
+  class Fixture {
     def offerWithFaultRegion(faultRegion: String) = {
       Offer.newBuilder()
         .setId(MesosOfferIdProto.newBuilder().setValue(UUID.randomUUID().toString))

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
@@ -20,32 +20,32 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
   "The ActorOfferMatcher" when {
     "receives remote region offer" should {
       "say is not interested when from non-home region" in new Fixture {
-        val marathonScheduler = mock[MarathonScheduler]
-        marathonScheduler.getHomeRegion returns Some("home")
+        val homeRegionProvider = mock[HomeRegionProvider]
+        homeRegionProvider.getHomeRegion returns Some("home")
         val probe = TestProbe()
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[MarathonScheduler] {
-          override def get() = marathonScheduler
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[HomeRegionProvider] {
+          override def get() = homeRegionProvider
         })(scheduler)
 
         offerMatcher.isInterestedIn(offerWithFaultRegion("remote")) should be (false)
       }
 
       "say is interested when from home region" in new Fixture {
-        val marathonScheduler = mock[MarathonScheduler]
-        marathonScheduler.getHomeRegion returns Some("home")
+        val homeRegionProvider = mock[HomeRegionProvider]
+        homeRegionProvider.getHomeRegion returns Some("home")
         val probe = TestProbe()
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[MarathonScheduler] {
-          override def get() = marathonScheduler
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[HomeRegionProvider] {
+          override def get() = homeRegionProvider
         })(scheduler)
 
         offerMatcher.isInterestedIn(offerWithFaultRegion("home")) should be (true)
       }
 
       "say is interested when fault region not set" in new Fixture {
-        val marathonScheduler = mock[MarathonScheduler]
-        marathonScheduler.getHomeRegion returns Some("home")
+        val homeRegionProvider = mock[HomeRegionProvider]
+        homeRegionProvider.getHomeRegion returns Some("home")
         val probe = TestProbe()
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[MarathonScheduler] {
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[HomeRegionProvider] {
           override def get() = mock[MarathonScheduler]
         })(scheduler)
 
@@ -69,8 +69,8 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         })
         val offer = MarathonTestHelper.makeBasicOffer().build()
 
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[MarathonScheduler] {
-          override def get() = mock[MarathonScheduler]
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[HomeRegionProvider] {
+          override def get() = mock[HomeRegionProvider]
         })(scheduler)
         val offerMatch: MatchedInstanceOps = offerMatcher.matchOffer(offer).futureValue
 

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
@@ -28,7 +28,7 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         })
         val offer = MarathonTestHelper.makeBasicOffer().build()
 
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None)(scheduler)
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, mock[MarathonScheduler])(scheduler)
         val offerMatch: MatchedInstanceOps = offerMatcher.matchOffer(offer).futureValue
 
         offerMatch.offerId should not be (offer.getId)

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
@@ -1,6 +1,8 @@
 package mesosphere.marathon
 package core.matcher.base.util
 
+import java.util.UUID
+
 import akka.actor.ActorRef
 import akka.testkit.TestActor.AutoPilot
 import akka.testkit.{ TestActor, TestProbe }
@@ -10,9 +12,46 @@ import mesosphere.marathon.core.matcher.base.OfferMatcher.MatchedInstanceOps
 import mesosphere.marathon.test.MarathonTestHelper
 import mesosphere.mesos.protos.Implicits._
 import mesosphere.mesos.protos.OfferID
+import org.apache.mesos.Protos.DomainInfo.FaultDomain
+import org.apache.mesos.Protos.DomainInfo.FaultDomain.{ RegionInfo, ZoneInfo }
+import org.apache.mesos.Protos.{ DomainInfo, FrameworkID, Offer, SlaveID, OfferID => MesosOfferIdProto }
 
 class ActorOfferMatcherTest extends AkkaUnitTest {
   "The ActorOfferMatcher" when {
+    "receives remote region offer" should {
+      "say is not interested when from non-home region" in {
+        val marathonScheduler = mock[MarathonScheduler]
+        marathonScheduler.getHomeRegion returns Some("home")
+        val probe = TestProbe()
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[MarathonScheduler] {
+          override def get() = marathonScheduler
+        })(scheduler)
+
+        offerMatcher.isInterestedIn(offerWithFaultRegion("remote")) should be (false)
+      }
+
+      "say is interested when from home region" in {
+        val marathonScheduler = mock[MarathonScheduler]
+        marathonScheduler.getHomeRegion returns Some("home")
+        val probe = TestProbe()
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[MarathonScheduler] {
+          override def get() = marathonScheduler
+        })(scheduler)
+
+        offerMatcher.isInterestedIn(offerWithFaultRegion("home")) should be (true)
+      }
+
+      "say is interested when fault region not set" in {
+        val marathonScheduler = mock[MarathonScheduler]
+        marathonScheduler.getHomeRegion returns Some("home")
+        val probe = TestProbe()
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[MarathonScheduler] {
+          override def get() = mock[MarathonScheduler]
+        })(scheduler)
+
+        offerMatcher.isInterestedIn(offerWithoutFaultRegion()) should be (true)
+      }
+    }
     "asking the actor" should {
       "find a match in time" in {
         val probe = TestProbe()
@@ -37,6 +76,28 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         offerMatch.offerId should not be (offer.getId)
         offerMatch.offerId.getValue should be("other")
       }
+    }
+
+    def offerWithFaultRegion(faultRegion: String) = {
+      Offer.newBuilder()
+        .setId(MesosOfferIdProto.newBuilder().setValue(UUID.randomUUID().toString))
+        .setFrameworkId(FrameworkID.newBuilder().setValue("notanidframework"))
+        .setSlaveId(SlaveID.newBuilder().setValue(s"slave1"))
+        .setHostname("hostname")
+        .setDomain(DomainInfo.newBuilder()
+          .setFaultDomain(FaultDomain.newBuilder()
+            .setRegion(RegionInfo.newBuilder().setName(faultRegion))
+            .setZone(ZoneInfo.newBuilder().setName("zone")))
+        ).build()
+    }
+
+    def offerWithoutFaultRegion() = {
+      Offer.newBuilder()
+        .setId(MesosOfferIdProto.newBuilder().setValue(UUID.randomUUID().toString))
+        .setFrameworkId(FrameworkID.newBuilder().setValue("notanidframework"))
+        .setSlaveId(SlaveID.newBuilder().setValue(s"slave1"))
+        .setHostname("hostname")
+        .build()
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
@@ -210,6 +210,21 @@ class OfferMatcherManagerActorTest extends AkkaUnitTest with Eventually {
       Then("OfferMatcher not interested in offer should not receive any offer")
       verify(matcherMock, times(0)).matchOffer(any)
     }
+
+    "receive offer when interested in that offer" in new Fixture {
+      Given("OfferMatcher not interested in offer")
+      val offer1 = offer()
+      val offerMatch1 = Promise[OfferMatcher.MatchedInstanceOps]
+      offerMatcherManager.underlyingActor.launchTokens = 100
+      val matcherMock = matcher(isInterestedIn = true)
+      offerMatcherManager.underlyingActor.matchers += matcherMock
+
+      When("Offer is sent to MatcherManager")
+      offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer1, offerMatch1)
+
+      Then("OfferMatcher not interested in offer should not receive any offer")
+      verify(matcherMock, times(1)).matchOffer(any)
+    }
   }
 
   implicit val timeout = Timeout(3, TimeUnit.SECONDS)

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
@@ -27,41 +27,69 @@ import scala.concurrent.duration._
 class OfferMatcherManagerActorTest extends AkkaUnitTest with Eventually {
 
   "OfferMatcherManagerActor" should {
-    "The list of OfferMatchers is random without precedence" in {
+    "The list of OfferMatchers is random without precedence" in new Fixture {
       Given("OfferMatcher with num normal matchers")
       val num = 5
-      val f = new Fixture
       val appId = PathId("/some/app")
-      val manager = f.offerMatcherManager
-      val matchers = 1.to(num).map(_ => f.matcher())
+      val manager = offerMatcherManager
+      val matchers = 1.to(num).map(_ => matcher())
       matchers.map { matcher => manager ? OfferMatcherManagerDelegate.AddOrUpdateMatcher(matcher) }
 
       When("The list of offer matchers is fetched")
-      val orderedMatchers = manager.underlyingActor.offerMatchers(f.reservedOffer(appId))
+      val orderedMatchers = manager.underlyingActor.offerMatchers(reservedOffer(appId))
 
       Then("The list is sorted in the correct order")
       orderedMatchers should have size num.toLong
       orderedMatchers should contain theSameElementsAs matchers
     }
 
-    "The list of OfferMatchers is sorted by precedence" in {
+    "The list of OfferMatchers is sorted by precedence" in new Fixture {
       Given("OfferMatcher with num precedence and num normal matchers, registered in mixed order")
       val num = 5
-      val f = new Fixture
       val appId = PathId("/some/app")
-      val manager = f.offerMatcherManager
-      1.to(num).flatMap(_ => Seq(f.matcher(), f.matcher(Some(appId)))).map { matcher =>
+      val manager = offerMatcherManager
+      1.to(num).flatMap(_ => Seq(matcher(), matcher(Some(appId)))).map { matcher =>
         manager ? OfferMatcherManagerDelegate.AddOrUpdateMatcher(matcher)
       }
 
       When("The list of offer matchers is fetched")
-      val sortedMatchers = manager.underlyingActor.offerMatchers(f.reservedOffer(appId))
+      val sortedMatchers = manager.underlyingActor.offerMatchers(reservedOffer(appId))
 
       Then("The list is sorted in the correct order")
       sortedMatchers should have size 2 * num.toLong
       val (left, right) = sortedMatchers.splitAt(num)
       left.count(_.precedenceFor.isDefined) should be(num)
       right.count(_.precedenceFor.isDefined) should be(0)
+    }
+
+    "The list of offer matchers does not contain offer matcher not interested in offer" in new Fixture {
+      Given("OfferMatcher not interested in offer")
+      val offer1 = offer()
+      val offerMatch1 = Promise[OfferMatcher.MatchedInstanceOps]
+      offerMatcherManager.underlyingActor.launchTokens = 100
+      val matcherMock = matcher(isInterestedIn = false)
+      offerMatcherManager.underlyingActor.matchers += matcherMock
+
+      When("The list of offer matchers is fetched")
+      val availableMatchers = offerMatcherManager.underlyingActor.offerMatchers(offer())
+
+      Then("OfferMatcher not interested in offer should not be in the list")
+      availableMatchers.isEmpty should be (true)
+    }
+
+    "The list of offer matchers contains offer matcher interested in offer" in new Fixture {
+      Given("OfferMatcher not interested in offer")
+      val offer1 = offer()
+      val offerMatch1 = Promise[OfferMatcher.MatchedInstanceOps]
+      offerMatcherManager.underlyingActor.launchTokens = 100
+      val matcherMock = matcher(isInterestedIn = true)
+      offerMatcherManager.underlyingActor.matchers += matcherMock
+
+      When("The list of offer matchers is fetched")
+      val availableMatchers = offerMatcherManager.underlyingActor.offerMatchers(offer())
+
+      Then("OfferMatcher not interested in offer should not receive any offer")
+      availableMatchers should contain only (matcherMock)
     }
 
     "queue offers, if the maximum number of offer matchers is busy" in new Fixture {
@@ -194,36 +222,6 @@ class OfferMatcherManagerActorTest extends AkkaUnitTest with Eventually {
 
       Then("offer-1 is declined, since the actor did not respond in time")
       offerMatch1.future.futureValue.opsWithSource should be('empty)
-    }
-
-    "not send offers to matchers that are not interested" in new Fixture {
-      Given("OfferMatcher not interested in offer")
-      val offer1 = offer()
-      val offerMatch1 = Promise[OfferMatcher.MatchedInstanceOps]
-      offerMatcherManager.underlyingActor.launchTokens = 100
-      val matcherMock = matcher(isInterestedIn = false)
-      offerMatcherManager.underlyingActor.matchers += matcherMock
-
-      When("Offer is sent to MatcherManager")
-      offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer1, offerMatch1)
-
-      Then("OfferMatcher not interested in offer should not receive any offer")
-      verify(matcherMock, times(0)).matchOffer(any)
-    }
-
-    "receive offer when interested in that offer" in new Fixture {
-      Given("OfferMatcher not interested in offer")
-      val offer1 = offer()
-      val offerMatch1 = Promise[OfferMatcher.MatchedInstanceOps]
-      offerMatcherManager.underlyingActor.launchTokens = 100
-      val matcherMock = matcher(isInterestedIn = true)
-      offerMatcherManager.underlyingActor.matchers += matcherMock
-
-      When("Offer is sent to MatcherManager")
-      offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer1, offerMatch1)
-
-      Then("OfferMatcher not interested in offer should not receive any offer")
-      verify(matcherMock, times(1)).matchOffer(any)
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -4,6 +4,7 @@ package core.matcher.manager.impl
 import java.util.UUID
 import java.time.Clock
 
+import com.google.inject.Provider
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
@@ -51,7 +52,9 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val clock: Clock = Clock.systemUTC()
     val random: Random.type = Random
     val leaderModule: LeadershipModule = AlwaysElectedLeadershipModule.forRefFactory(system)
-    val marathonScheduler = mock[MarathonScheduler]
+    val marathonScheduler = new Provider[MarathonScheduler] {
+      override def get() = mock[MarathonScheduler]
+    }
     val config: OfferMatcherManagerConfig = new OfferMatcherManagerConfig {
       verify()
     }

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -52,14 +52,14 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val clock: Clock = Clock.systemUTC()
     val random: Random.type = Random
     val leaderModule: LeadershipModule = AlwaysElectedLeadershipModule.forRefFactory(system)
-    val marathonScheduler = new Provider[MarathonScheduler] {
-      override def get() = mock[MarathonScheduler]
+    val homeRegionProvider = new Provider[HomeRegionProvider] {
+      override def get() = mock[HomeRegionProvider]
     }
     val config: OfferMatcherManagerConfig = new OfferMatcherManagerConfig {
       verify()
     }
     val module: OfferMatcherManagerModule =
-      new OfferMatcherManagerModule(clock, random, config, system.scheduler, leaderModule, marathonScheduler,
+      new OfferMatcherManagerModule(clock, random, config, system.scheduler, leaderModule, homeRegionProvider,
         actorName = UUID.randomUUID().toString)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -51,11 +51,12 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val clock: Clock = Clock.systemUTC()
     val random: Random.type = Random
     val leaderModule: LeadershipModule = AlwaysElectedLeadershipModule.forRefFactory(system)
+    val marathonScheduler = mock[MarathonScheduler]
     val config: OfferMatcherManagerConfig = new OfferMatcherManagerConfig {
       verify()
     }
     val module: OfferMatcherManagerModule =
-      new OfferMatcherManagerModule(clock, random, config, system.scheduler, leaderModule,
+      new OfferMatcherManagerModule(clock, random, config, system.scheduler, leaderModule, marathonScheduler,
         actorName = UUID.randomUUID().toString)
   }
 


### PR DESCRIPTION
Summary:
Until the remote region support is finished we want to be able to pre-filter all offers from remote regions and ignore them.
This logic will be adjusted we move further with remote regions.

JIRA issues: MARATHON_EE-1662
