### PR TITLE
Add akka http queue controller

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
@@ -5,19 +5,17 @@ import java.time.Clock
 
 import akka.actor.ActorSystem
 import akka.event.EventStream
-import com.google.inject.AbstractModule
-import com.google.inject.{ Provides, Scopes, Singleton }
+import com.google.inject.{ AbstractModule, Provides, Scopes, Singleton }
 import com.typesafe.config.Config
 import mesosphere.chaos.http.HttpConf
-import mesosphere.marathon.api.{ MarathonHttpService, TaskKiller }
+import mesosphere.marathon.api.MarathonHttpService
+import mesosphere.marathon.api.akkahttp.v2._
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
+import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.api.akkahttp.v2.{ AppsController, EventsController, InfoController, PluginsController }
-import mesosphere.marathon.core.health.HealthCheckManager
-import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.http.HttpRequestHandler
 import mesosphere.marathon.storage.StorageModule
 import mesosphere.util.state.MesosLeaderInfo
@@ -40,7 +38,8 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     marathonSchedulerService: MarathonSchedulerService,
     storageModule: StorageModule,
     mesosLeaderInfo: MesosLeaderInfo,
-    appTasksRes: mesosphere.marathon.api.v2.AppTasksResource)(implicit
+    appTasksRes: mesosphere.marathon.api.v2.AppTasksResource,
+    launchQueue: LaunchQueue)(implicit
     actorSystem: ActorSystem,
     authenticator: Authenticator,
     authorizer: Authorizer,
@@ -61,7 +60,13 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     val eventsController = new EventsController(conf, eventBus)
     val infoController = InfoController(mesosLeaderInfo, storageModule.frameworkIdRepository, conf)
     val pluginsController = new PluginsController(pluginManager.plugins[HttpRequestHandler], pluginManager.definitions)
-    val v2Controller = new V2Controller(appsController, eventsController, pluginsController, infoController)
+    val queueController = new QueueController(clock, launchQueue)
+    val v2Controller = new V2Controller(
+      appsController,
+      eventsController,
+      pluginsController,
+      infoController,
+      queueController)
 
     new AkkaHttpMarathonService(
       conf,

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
@@ -60,7 +60,7 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     val eventsController = new EventsController(conf, eventBus)
     val infoController = InfoController(mesosLeaderInfo, storageModule.frameworkIdRepository, conf)
     val pluginsController = new PluginsController(pluginManager.plugins[HttpRequestHandler], pluginManager.definitions)
-    val queueController = new QueueController(clock, launchQueue)
+    val queueController = new QueueController(clock, launchQueue, electionService)
 
     val v2Controller = new V2Controller(
       appsController,

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
@@ -61,6 +61,7 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     val infoController = InfoController(mesosLeaderInfo, storageModule.frameworkIdRepository, conf)
     val pluginsController = new PluginsController(pluginManager.plugins[HttpRequestHandler], pluginManager.definitions)
     val queueController = new QueueController(clock, launchQueue)
+
     val v2Controller = new V2Controller(
       appsController,
       eventsController,

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -1,6 +1,8 @@
 package mesosphere.marathon
 package api.akkahttp
 
+import java.time.Clock
+
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.model.StatusCodes
@@ -13,6 +15,7 @@ import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.appinfo.{ AppInfo, EnrichedTask }
 import mesosphere.marathon.plugin.PathId
+import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfoWithStatistics
 import mesosphere.marathon.raml.{ LoggerChange, MarathonInfo, Metrics }
 import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.state.AppDefinition
@@ -150,12 +153,12 @@ object EntityMarshallers {
   implicit val messageMarshaller = playJsonMarshaller[Rejections.Message]
   implicit val appInfoMarshaller = playJsonMarshaller[AppInfo]
   implicit val infoMarshaller = playJsonMarshaller[MarathonInfo]
-  implicit val infoUnmarshaller = playJsonUnmarshaller[MarathonInfo]
   implicit val metricsMarshaller = internalToRamlJsonMarshaller[TickMetricSnapshot, Metrics]
   implicit val loggerChangeMarshaller = playJsonMarshaller[LoggerChange]
   implicit val loggerChangeUnmarshaller = playJsonUnmarshaller[LoggerChange]
   implicit val stringMapMarshaller = playJsonMarshaller[Map[String, String]]
   implicit val pluginDefinitionsMarshaller = playJsonMarshaller[PluginDefinitions]
+  implicit val queueMarashaller = internalToRamlJsonMarshaller[(Seq[QueuedInstanceInfoWithStatistics], Boolean, Clock), raml.Queue]
   implicit val deploymentResultMarshaller = playJsonMarshaller[raml.DeploymentResult]
   implicit val enrichedTaskMarshaller = playJsonMarshaller[EnrichedTask]
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/PathMatchers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/PathMatchers.scala
@@ -26,7 +26,7 @@ object PathMatchers {
     catch { case _: IllegalArgumentException => None }
   )
 
-  private val marathonApiKeywords = Set("restart", "tasks", "versions")
+  private val marathonApiKeywords = Set("restart", "tasks", "versions", "delay")
 
   /**
     * Matches everything what's coming before api keywords as PathId

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/Rejections.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/Rejections.scala
@@ -12,10 +12,15 @@ object Rejections {
   }
 
   val defaultEntityNotFoundMessage = Message("Entity was not found")
+
   case class EntityNotFound(message: Message = defaultEntityNotFoundMessage) extends Rejection
   object EntityNotFound {
     def app(id: PathId, version: Option[Timestamp] = None): EntityNotFound = {
       EntityNotFound(Message(s"App '$id' does not exist" + version.fold("")(v => s" in version $v")))
+    }
+
+    def queueApp(appId: PathId): EntityNotFound = {
+      EntityNotFound(Message(s"Application $appId not found in tasks queue."))
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/V2Controller.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/V2Controller.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package api.akkahttp
 
 import akka.http.scaladsl.server.Route
-import v2.{ AppsController, EventsController, InfoController, PluginsController }
+import v2._
 
 /**
   * Dispatches to various v2 controller routes
@@ -11,7 +11,8 @@ class V2Controller(
     appsController: AppsController,
     eventsController: EventsController,
     pluginsController: PluginsController,
-    infoController: InfoController
+    infoController: InfoController,
+    queueController: QueueController
 ) extends Controller {
   import Directives._
   override val route: Route = {
@@ -26,6 +27,9 @@ class V2Controller(
       } ~
       pathPrefix("info") {
         infoController.route
+      } ~
+      pathPrefix("queue") {
+        queueController.route
       }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
@@ -4,17 +4,22 @@ package api.akkahttp.v2
 import java.time.Clock
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{ StatusCodes }
 import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.api.akkahttp.Controller
 import mesosphere.marathon.api.akkahttp.Directives.{ asLeader, authenticated, get, parameters, pathEndOrSingleSlash, _ }
+import mesosphere.marathon.api.akkahttp.EntityMarshallers._
+import mesosphere.marathon.api.akkahttp.PathMatchers.AppPathIdLike
+import mesosphere.marathon.api.akkahttp.{ Controller, Rejections }
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, Identity, ViewRunSpec }
-import mesosphere.marathon.api.akkahttp.EntityMarshallers._
+import mesosphere.marathon.plugin.auth.{ Authenticator, _ }
+import mesosphere.marathon.state.PathId
 
 import scala.async.Async._
+import scala.collection.immutable.Seq
 import scala.concurrent.{ ExecutionContext, Future }
+import mesosphere.marathon.api.akkahttp.Directives._
 
 class QueueController(
     clock: Clock,
@@ -34,22 +39,41 @@ class QueueController(
           pathEndOrSingleSlash {
             list
           }
-        }
+        } ~
+          pathPrefix(AppPathIdLike) { appId =>
+            (path("delay") & delete) {
+              reset(appId)
+            }
+          }
       }
     }
   }
 
   private def list(implicit identity: Identity): Route = {
-    def listAsync(): Future[Seq[LaunchQueue.QueuedInstanceInfoWithStatistics]] = async {
+    def listWithStatisticsAsync(): Future[Seq[LaunchQueue.QueuedInstanceInfoWithStatistics]] = async {
       val info = await(launchQueue.listWithStatisticsAsync)
       info.filter(t => t.inProgress && authorizer.isAuthorized(identity, ViewRunSpec, t.runSpec))
     }
 
     parameters('embed.*) { embed =>
       val embedLastUnusedOffers = embed.exists(_ == QueueController.EmbedLastUnusedOffers)
-      onSuccess(listAsync) { info =>
-        val result = (info, embedLastUnusedOffers, clock)
-        complete(result)
+      onSuccess(listWithStatisticsAsync) { info =>
+        complete((info, embedLastUnusedOffers, clock))
+      }
+    }
+  }
+
+  private def reset(appId: PathId)(implicit identity: Identity): Route = {
+    onSuccess(launchQueue.listAsync) { apps =>
+      val maybeApp = apps.find(_.runSpec.id == appId).map(_.runSpec)
+
+      maybeApp match {
+        case Some(app) =>
+          authorized(UpdateRunSpec, app).apply {
+            launchQueue.resetDelay(app)
+            complete(StatusCodes.NoContent)
+          }
+        case None => reject(Rejections.EntityNotFound.queueApp(appId))
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
@@ -7,13 +7,14 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.api.akkahttp.Controller
-import mesosphere.marathon.api.akkahttp.Directives.{asLeader, authenticated, get, parameters, pathEndOrSingleSlash, _}
+import mesosphere.marathon.api.akkahttp.Directives.{ asLeader, authenticated, get, parameters, pathEndOrSingleSlash, _ }
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, Identity, ViewRunSpec}
+import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, Identity, ViewRunSpec }
+import mesosphere.marathon.api.akkahttp.EntityMarshallers._
 
 import scala.async.Async._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 class QueueController(
     clock: Clock,
@@ -46,8 +47,9 @@ class QueueController(
 
     parameters('embed.*) { embed =>
       val embedLastUnusedOffers = embed.exists(_ == QueueController.EmbedLastUnusedOffers)
-      onComplete(listAsync) { info =>
-        complete("TODO")
+      onSuccess(listAsync) { info =>
+        val result = (info, embedLastUnusedOffers, clock)
+        complete(result)
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
@@ -49,6 +49,7 @@ class QueueController(
     }
   }
 
+  @SuppressWarnings(Array("all")) // async/await
   private def list(implicit identity: Identity): Route = {
     def listWithStatisticsAsync(): Future[Seq[LaunchQueue.QueuedInstanceInfoWithStatistics]] = async {
       val info = await(launchQueue.listWithStatisticsAsync)

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
@@ -19,7 +19,6 @@ import mesosphere.marathon.state.PathId
 import scala.async.Async._
 import scala.collection.immutable.Seq
 import scala.concurrent.{ ExecutionContext, Future }
-import mesosphere.marathon.api.akkahttp.Directives._
 
 class QueueController(
     clock: Clock,
@@ -57,7 +56,7 @@ class QueueController(
     }
 
     parameters('embed.*) { embed =>
-      val embedLastUnusedOffers = embed.exists(_ == QueueController.EmbedLastUnusedOffers)
+      val embedLastUnusedOffers = embed.toSeq.contains(QueueController.EmbedLastUnusedOffers)
       onSuccess(listWithStatisticsAsync) { info =>
         complete((info, embedLastUnusedOffers, clock))
       }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
@@ -1,0 +1,58 @@
+package mesosphere.marathon
+package api.akkahttp.v2
+
+import java.time.Clock
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.Route
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.api.akkahttp.Controller
+import mesosphere.marathon.api.akkahttp.Directives.{asLeader, authenticated, get, parameters, pathEndOrSingleSlash, _}
+import mesosphere.marathon.core.election.ElectionService
+import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, Identity, ViewRunSpec}
+
+import scala.async.Async._
+import scala.concurrent.{ExecutionContext, Future}
+
+class QueueController(
+    clock: Clock,
+    launchQueue: LaunchQueue)(
+    implicit
+    val actorSystem: ActorSystem,
+    val executionContext: ExecutionContext,
+    val authenticator: Authenticator,
+    val authorizer: Authorizer,
+    val electionService: ElectionService
+) extends Controller with StrictLogging {
+
+  override val route = {
+    asLeader(electionService) {
+      authenticated.apply { implicit identity =>
+        get {
+          pathEndOrSingleSlash {
+            list
+          }
+        }
+      }
+    }
+  }
+
+  private def list(implicit identity: Identity): Route = {
+    def listAsync(): Future[Seq[LaunchQueue.QueuedInstanceInfoWithStatistics]] = async {
+      val info = await(launchQueue.listWithStatisticsAsync)
+      info.filter(t => t.inProgress && authorizer.isAuthorized(identity, ViewRunSpec, t.runSpec))
+    }
+
+    parameters('embed.*) { embed =>
+      val embedLastUnusedOffers = embed.exists(_ == QueueController.EmbedLastUnusedOffers)
+      onComplete(listAsync) { info =>
+        complete("TODO")
+      }
+    }
+  }
+}
+
+object QueueController {
+  val EmbedLastUnusedOffers = "lastUnusedOffers"
+}

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
@@ -22,13 +22,13 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 class QueueController(
     clock: Clock,
-    launchQueue: LaunchQueue)(
+    launchQueue: LaunchQueue,
+    val electionService: ElectionService)(
     implicit
     val actorSystem: ActorSystem,
     val executionContext: ExecutionContext,
     val authenticator: Authenticator,
-    val authorizer: Authorizer,
-    val electionService: ElectionService
+    val authorizer: Authorizer
 ) extends Controller with StrictLogging {
 
   override val route = {
@@ -56,7 +56,7 @@ class QueueController(
     }
 
     parameters('embed.*) { embed =>
-      val embedLastUnusedOffers = embed.toSeq.contains(QueueController.EmbedLastUnusedOffers)
+      val embedLastUnusedOffers = embed.toSeq.contains(QueueController.EmbedLastUnusedOffersParameter)
       onSuccess(listWithStatisticsAsync) { info =>
         complete((info, embedLastUnusedOffers, clock))
       }
@@ -80,5 +80,5 @@ class QueueController(
 }
 
 object QueueController {
-  val EmbedLastUnusedOffers = "lastUnusedOffers"
+  val EmbedLastUnusedOffersParameter = "lastUnusedOffers"
 }

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
@@ -1,0 +1,227 @@
+package mesosphere.marathon
+package api.akkahttp.v2
+
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.UnitTest
+import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
+import mesosphere.marathon.api.akkahttp.AuthDirectives.NotAuthenticated
+import mesosphere.marathon.core.election.ElectionService
+import mesosphere.marathon.core.launcher.OfferMatchResult
+import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfoWithStatistics
+import mesosphere.marathon.raml.{App, Raml}
+import mesosphere.marathon.state.{AppDefinition, VersionInfo}
+import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
+import mesosphere.mesos.NoOfferMatchReason
+import org.scalatest.Inside
+import mesosphere.marathon.state.PathId._
+import play.api.libs.json._
+
+import scala.concurrent.duration._
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+
+class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside with StrictLogging {
+
+  implicit val appDefReader: Reads[AppDefinition] = Reads { js =>
+    val ramlApp = js.as[App]
+    val appDef: AppDefinition = Raml.fromRaml(ramlApp)
+    // assume that any json we generate is canonical and valid
+    JsSuccess(appDef)
+  }
+
+  "QueueController" should {
+    "deny access withouth authentication" in {
+      Given("an unauthenticated request")
+      val f = new Fixture(authenticated = false)
+
+      When("we try to fetch the queue")
+      Get(Uri./) ~> f.controller.route ~> check {
+        Then("we receive a NotAuthenticated response")
+        rejection shouldBe a[NotAuthenticated]
+        inside(rejection) {
+          case NotAuthenticated(response) =>
+            response.status should be(StatusCodes.Forbidden)
+        }
+      }
+    }
+
+    "return an empty json array if nothing in the queue" in {
+      Given("an authenticated request")
+      val f = new Fixture(authenticated = true)
+
+      When("we try to fetch the queue")
+      Get(Uri./) ~> f.controller.route ~> check {
+        Then("we receive an empty json array")
+        status should be(StatusCodes.OK)
+
+        val expected =
+          """{
+            |  "queue" : [ ]
+            |}""".stripMargin
+        JsonTestHelper.assertThatJsonString(responseAs[String]).correspondsToJsonString(expected)
+      }
+    }
+
+    "return a well formatted json response if there is an app in the queue" in {
+      Given("an authenticated request")
+      val f = new Fixture(authenticated = true)
+
+      And("an existing app in the queue")
+      val app = AppDefinition(id = "app".toRootPath, acceptedResourceRoles = Set("*"), versionInfo = VersionInfo.forNewConfig(f.clock.now()))
+      val noMatch = OfferMatchResult.NoMatch(app, MarathonTestHelper.makeBasicOffer().build(), Seq(NoOfferMatchReason.InsufficientCpus), f.clock.now())
+      f.launchQueue.listWithStatisticsAsync returns Future.successful(Seq(
+        QueuedInstanceInfoWithStatistics(
+          app, inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
+          backOffUntil = f.clock.now() + 100.seconds, startedAt = f.clock.now(),
+          rejectSummaryLastOffers = Map(NoOfferMatchReason.InsufficientCpus -> 1),
+          rejectSummaryLaunchAttempt = Map(NoOfferMatchReason.InsufficientCpus -> 3), processedOffersCount = 3, unusedOffersCount = 1,
+          lastMatch = None, lastNoMatch = None, lastNoMatches = Seq(noMatch)
+        )
+      ))
+
+      When("we try to fetch the queue")
+      Get(Uri./) ~> f.controller.route ~> check {
+        Then("we receive an empty json array")
+        status should be(StatusCodes.OK)
+
+        val expected =
+          """{
+            |  "queue" : [ {
+            |    "count" : 23,
+            |    "delay" : {
+            |      "timeLeftSeconds" : 100,
+            |      "overdue" : false
+            |    },
+            |    "since" : "2015-04-09T12:30:00Z",
+            |    "processedOffersSummary" : {
+            |      "processedOffersCount" : 3,
+            |      "unusedOffersCount" : 1,
+            |      "rejectSummaryLastOffers" : [ {
+            |        "reason" : "UnfulfilledRole",
+            |        "declined" : 0,
+            |        "processed" : 1
+            |      }, {
+            |        "reason" : "UnfulfilledConstraint",
+            |        "declined" : 0,
+            |        "processed" : 1
+            |      }, {
+            |        "reason" : "NoCorrespondingReservationFound",
+            |        "declined" : 0,
+            |        "processed" : 1
+            |      }, {
+            |        "reason" : "InsufficientCpus",
+            |        "declined" : 1,
+            |        "processed" : 1
+            |      }, {
+            |        "reason" : "InsufficientMemory",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientDisk",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientGpus",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientPorts",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      } ],
+            |      "rejectSummaryLaunchAttempt" : [ {
+            |        "reason" : "UnfulfilledRole",
+            |        "declined" : 0,
+            |        "processed" : 3
+            |      }, {
+            |        "reason" : "UnfulfilledConstraint",
+            |        "declined" : 0,
+            |        "processed" : 3
+            |      }, {
+            |        "reason" : "NoCorrespondingReservationFound",
+            |        "declined" : 0,
+            |        "processed" : 3
+            |      }, {
+            |        "reason" : "InsufficientCpus",
+            |        "declined" : 3,
+            |        "processed" : 3
+            |      }, {
+            |        "reason" : "InsufficientMemory",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientDisk",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientGpus",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientPorts",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      } ]
+            |    },
+            |    "app" : {
+            |      "id" : "/app",
+            |      "acceptedResourceRoles" : [ "*" ],
+            |      "backoffFactor" : 1.15,
+            |      "backoffSeconds" : 1,
+            |      "cpus" : 1,
+            |      "disk" : 0,
+            |      "executor" : "",
+            |      "instances" : 1,
+            |      "labels" : { },
+            |      "maxLaunchDelaySeconds" : 3600,
+            |      "mem" : 128,
+            |      "gpus" : 0,
+            |      "networks" : [ {
+            |        "mode" : "host"
+            |      } ],
+            |      "portDefinitions" : [ ],
+            |      "requirePorts" : false,
+            |      "upgradeStrategy" : {
+            |        "maximumOverCapacity" : 1,
+            |        "minimumHealthCapacity" : 1
+            |      },
+            |      "version" : "2015-04-09T12:30:00Z",
+            |      "versionInfo" : {
+            |        "lastScalingAt" : "2015-04-09T12:30:00Z",
+            |        "lastConfigChangeAt" : "2015-04-09T12:30:00Z"
+            |      },
+            |      "killSelection" : "YOUNGEST_FIRST",
+            |      "unreachableStrategy" : {
+            |        "inactiveAfterSeconds" : 0,
+            |        "expungeAfterSeconds" : 0
+            |      }
+            |    }
+            |  } ]
+            |}""".stripMargin
+
+        JsonTestHelper.assertThatJsonString(responseAs[String]).correspondsToJsonString(expected)
+      }
+    }
+  }
+
+  class Fixture(authenticated: Boolean = true, authorized: Boolean = true) {
+
+    val clock: SettableClock = new SettableClock()
+    val launchQueue: LaunchQueue = mock[LaunchQueue]
+    launchQueue.listWithStatisticsAsync returns Future.successful(Seq.empty)
+
+    val authFixture = new TestAuthFixture()
+    authFixture.authenticated = authenticated
+    authFixture.authorized = authorized
+
+    implicit val electionService = mock[ElectionService]
+    electionService.isLeader returns true
+
+    implicit val authenticator = authFixture.auth
+
+    val controller = new QueueController(clock, launchQueue)
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
@@ -1,36 +1,27 @@
 package mesosphere.marathon
 package api.akkahttp.v2
 
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.UnitTest
-import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
 import mesosphere.marathon.api.akkahttp.AuthDirectives.NotAuthenticated
+import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.launcher.OfferMatchResult
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfoWithStatistics
-import mesosphere.marathon.raml.{App, Raml}
+import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{AppDefinition, VersionInfo}
 import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
 import mesosphere.mesos.NoOfferMatchReason
 import org.scalatest.Inside
-import mesosphere.marathon.state.PathId._
-import play.api.libs.json._
 
-import scala.concurrent.duration._
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside with StrictLogging {
-
-  implicit val appDefReader: Reads[AppDefinition] = Reads { js =>
-    val ramlApp = js.as[App]
-    val appDef: AppDefinition = Raml.fromRaml(ramlApp)
-    // assume that any json we generate is canonical and valid
-    JsSuccess(appDef)
-  }
 
   "QueueController" should {
     "deny access withouth authentication" in {
@@ -70,17 +61,7 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
       val f = new Fixture(authenticated = true)
 
       And("an existing app in the queue")
-      val app = AppDefinition(id = "app".toRootPath, acceptedResourceRoles = Set("*"), versionInfo = VersionInfo.forNewConfig(f.clock.now()))
-      val noMatch = OfferMatchResult.NoMatch(app, MarathonTestHelper.makeBasicOffer().build(), Seq(NoOfferMatchReason.InsufficientCpus), f.clock.now())
-      f.launchQueue.listWithStatisticsAsync returns Future.successful(Seq(
-        QueuedInstanceInfoWithStatistics(
-          app, inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
-          backOffUntil = f.clock.now() + 100.seconds, startedAt = f.clock.now(),
-          rejectSummaryLastOffers = Map(NoOfferMatchReason.InsufficientCpus -> 1),
-          rejectSummaryLaunchAttempt = Map(NoOfferMatchReason.InsufficientCpus -> 3), processedOffersCount = 3, unusedOffersCount = 1,
-          lastMatch = None, lastNoMatch = None, lastNoMatches = Seq(noMatch)
-        )
-      ))
+      f.launchQueue.listWithStatisticsAsync returns Future.successful(queueInfoWithStatistics(f))
 
       When("we try to fetch the queue")
       Get(Uri./) ~> f.controller.route ~> check {
@@ -205,6 +186,185 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
         JsonTestHelper.assertThatJsonString(responseAs[String]).correspondsToJsonString(expected)
       }
     }
+
+    "return a well formatted json with lastUnusedOffers response if there is an app in the queue" in {
+      Given("an authenticated request")
+      val f = new Fixture(authenticated = true)
+
+      And("an existing app in the queue")
+      f.launchQueue.listWithStatisticsAsync returns Future.successful(queueInfoWithStatistics(f))
+
+      When("we try to fetch the queue")
+      Get("/?embed=lastUnusedOffers") ~> f.controller.route ~> check {
+        Then("we receive an empty json array")
+        status should be(StatusCodes.OK)
+
+        val expected =
+          """{
+            |  "queue" : [ {
+            |    "count" : 23,
+            |    "delay" : {
+            |      "timeLeftSeconds" : 100,
+            |      "overdue" : false
+            |    },
+            |    "since" : "2015-04-09T12:30:00Z",
+            |    "processedOffersSummary" : {
+            |      "processedOffersCount" : 3,
+            |      "unusedOffersCount" : 1,
+            |      "rejectSummaryLastOffers" : [ {
+            |        "reason" : "UnfulfilledRole",
+            |        "declined" : 0,
+            |        "processed" : 1
+            |      }, {
+            |        "reason" : "UnfulfilledConstraint",
+            |        "declined" : 0,
+            |        "processed" : 1
+            |      }, {
+            |        "reason" : "NoCorrespondingReservationFound",
+            |        "declined" : 0,
+            |        "processed" : 1
+            |      }, {
+            |        "reason" : "InsufficientCpus",
+            |        "declined" : 1,
+            |        "processed" : 1
+            |      }, {
+            |        "reason" : "InsufficientMemory",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientDisk",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientGpus",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientPorts",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      } ],
+            |      "rejectSummaryLaunchAttempt" : [ {
+            |        "reason" : "UnfulfilledRole",
+            |        "declined" : 0,
+            |        "processed" : 3
+            |      }, {
+            |        "reason" : "UnfulfilledConstraint",
+            |        "declined" : 0,
+            |        "processed" : 3
+            |      }, {
+            |        "reason" : "NoCorrespondingReservationFound",
+            |        "declined" : 0,
+            |        "processed" : 3
+            |      }, {
+            |        "reason" : "InsufficientCpus",
+            |        "declined" : 3,
+            |        "processed" : 3
+            |      }, {
+            |        "reason" : "InsufficientMemory",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientDisk",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientGpus",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      }, {
+            |        "reason" : "InsufficientPorts",
+            |        "declined" : 0,
+            |        "processed" : 0
+            |      } ]
+            |    },
+            |    "lastUnusedOffers" : [ {
+            |      "offer" : {
+            |        "id" : "1",
+            |        "hostname" : "localhost",
+            |        "agentId" : "slave0",
+            |        "resources" : [ {
+            |          "name" : "cpus",
+            |          "role" : "*",
+            |          "scalar" : 4
+            |        }, {
+            |          "name" : "gpus",
+            |          "role" : "*",
+            |          "scalar" : 0
+            |        }, {
+            |          "name" : "mem",
+            |          "role" : "*",
+            |          "scalar" : 16000
+            |        }, {
+            |          "name" : "disk",
+            |          "role" : "*",
+            |          "scalar" : 1
+            |        }, {
+            |          "name" : "ports",
+            |          "role" : "*",
+            |          "ranges" : [ {
+            |            "begin" : 31000,
+            |            "end" : 32000
+            |          } ]
+            |        } ],
+            |        "attributes" : [ ]
+            |      },
+            |      "reason" : [ "InsufficientCpus" ],
+            |      "timestamp" : "2015-04-09T12:30:00Z"
+            |    } ],
+            |    "app" : {
+            |      "id" : "/app",
+            |      "acceptedResourceRoles" : [ "*" ],
+            |      "backoffFactor" : 1.15,
+            |      "backoffSeconds" : 1,
+            |      "cpus" : 1,
+            |      "disk" : 0,
+            |      "executor" : "",
+            |      "instances" : 1,
+            |      "labels" : { },
+            |      "maxLaunchDelaySeconds" : 3600,
+            |      "mem" : 128,
+            |      "gpus" : 0,
+            |      "networks" : [ {
+            |        "mode" : "host"
+            |      } ],
+            |      "portDefinitions" : [ ],
+            |      "requirePorts" : false,
+            |      "upgradeStrategy" : {
+            |        "maximumOverCapacity" : 1,
+            |        "minimumHealthCapacity" : 1
+            |      },
+            |      "version" : "2015-04-09T12:30:00Z",
+            |      "versionInfo" : {
+            |        "lastScalingAt" : "2015-04-09T12:30:00Z",
+            |        "lastConfigChangeAt" : "2015-04-09T12:30:00Z"
+            |      },
+            |      "killSelection" : "YOUNGEST_FIRST",
+            |      "unreachableStrategy" : {
+            |        "inactiveAfterSeconds" : 0,
+            |        "expungeAfterSeconds" : 0
+            |      }
+            |    }
+            |  } ]
+            |}""".stripMargin
+        logger.info(responseAs[String])
+        JsonTestHelper.assertThatJsonString(responseAs[String]).correspondsToJsonString(expected)
+      }
+    }
+  }
+
+  def queueInfoWithStatistics(f: Fixture): Seq[LaunchQueue.QueuedInstanceInfoWithStatistics] = {
+    val app = AppDefinition(id = "app".toRootPath, acceptedResourceRoles = Set("*"), versionInfo = VersionInfo.forNewConfig(f.clock.now()))
+    val noMatch = OfferMatchResult.NoMatch(app, MarathonTestHelper.makeBasicOffer().build(), Seq(NoOfferMatchReason.InsufficientCpus), f.clock.now())
+    Seq(
+      QueuedInstanceInfoWithStatistics(
+        app, inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
+        backOffUntil = f.clock.now() + 100.seconds, startedAt = f.clock.now(),
+        rejectSummaryLastOffers = Map(NoOfferMatchReason.InsufficientCpus -> 1),
+        rejectSummaryLaunchAttempt = Map(NoOfferMatchReason.InsufficientCpus -> 3), processedOffersCount = 3, unusedOffersCount = 1,
+        lastMatch = None, lastNoMatch = None, lastNoMatches = Seq(noMatch)
+      )
+    )
   }
 
   class Fixture(authenticated: Boolean = true, authorized: Boolean = true) {

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
@@ -1,21 +1,21 @@
 package mesosphere.marathon
 package api.akkahttp.v2
 
-import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.UnitTest
-import mesosphere.marathon.api.akkahttp.AuthDirectives.{NotAuthenticated, NotAuthorized}
+import mesosphere.marathon.api.akkahttp.AuthDirectives.{ NotAuthenticated, NotAuthorized }
 import mesosphere.marathon.api.akkahttp.Rejections.EntityNotFound
-import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
+import mesosphere.marathon.api.{ JsonTestHelper, TestAuthFixture }
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.launcher.OfferMatchResult
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.core.launchqueue.LaunchQueue.{QueuedInstanceInfo, QueuedInstanceInfoWithStatistics}
+import mesosphere.marathon.core.launchqueue.LaunchQueue.{ QueuedInstanceInfo, QueuedInstanceInfoWithStatistics }
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{AppDefinition, VersionInfo}
-import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
+import mesosphere.marathon.state.{ AppDefinition, VersionInfo }
+import mesosphere.marathon.test.{ MarathonTestHelper, SettableClock }
 import mesosphere.mesos.NoOfferMatchReason
 import org.scalatest.Inside
 
@@ -467,11 +467,11 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
     authFixture.authenticated = authenticated
     authFixture.authorized = authorized
 
-    implicit val electionService = mock[ElectionService]
+    val electionService = mock[ElectionService]
     electionService.isLeader returns true
 
     implicit val authenticator = authFixture.auth
 
-    val controller = new QueueController(clock, launchQueue)
+    val controller = new QueueController(clock, launchQueue, electionService)
   }
 }


### PR DESCRIPTION
Summary:
Added queue controller implementation with authentication and authorisation. Respective tests were ported from the `QueueResourceTest` class.

JIRA issues: MARATHON-7307, MARATHON-7088