### PR TITLE
Create leader controller for Akka HTTP refactoring.

### DIFF
--- a/docs/docs/rest-api/public/api/v2/leader.raml
+++ b/docs/docs/rest-api/public/api/v2/leader.raml
@@ -6,6 +6,7 @@ get:
       description: The host and port of the current leading master.
       body:
         application/json:
+          type: info.LeaderInfo
           example: |
             {
                 "leader": "marathon.globalcorp.com:8080"

--- a/docs/docs/rest-api/public/api/v2/leader.raml
+++ b/docs/docs/rest-api/public/api/v2/leader.raml
@@ -15,6 +15,7 @@ get:
       description: If there is no current leader.
       body:
         application/json:
+          type: strings.Message
           example: |
             {
               "message":"There is no leader"

--- a/docs/docs/rest-api/public/api/v2/types/info.raml
+++ b/docs/docs/rest-api/public/api/v2/types/info.raml
@@ -1,4 +1,9 @@
 types:
+  LeaderInfo:
+    type: object
+    properties:
+      leader: string
+
   MarathonConfig:
     type: object
     properties:

--- a/docs/docs/rest-api/public/api/v2/types/info.raml
+++ b/docs/docs/rest-api/public/api/v2/types/info.raml
@@ -1,3 +1,5 @@
+#%RAML 1.0 Library
+
 types:
   LeaderInfo:
     type: object

--- a/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
+++ b/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
@@ -49,3 +49,8 @@ types:
       When Marathon receives a TASK_LOST status update indicating that the
       agent running the task is gone, this property defines whether Marathon
       will launch the task on another node or not. Defaults to WAIT_FOREVER"
+
+  Message:
+    type: object
+    properties:
+      message: string

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
@@ -6,10 +6,10 @@ import java.time.Clock
 import akka.actor.ActorSystem
 import akka.event.EventStream
 import com.google.inject.AbstractModule
-import com.google.inject.{Provides, Scopes, Singleton}
+import com.google.inject.{ Provides, Scopes, Singleton }
 import com.typesafe.config.Config
 import mesosphere.chaos.http.HttpConf
-import mesosphere.marathon.api.{MarathonHttpService, TaskKiller}
+import mesosphere.marathon.api.{ MarathonHttpService, TaskKiller }
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
@@ -61,7 +61,7 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     val eventsController = new EventsController(conf, eventBus)
     val infoController = InfoController(mesosLeaderInfo, storageModule.frameworkIdRepository, conf)
     val pluginsController = new PluginsController(pluginManager.plugins[HttpRequestHandler], pluginManager.definitions)
-    val leaderController = LeaderController(electionService)
+    val leaderController = LeaderController(electionService, storageModule.runtimeConfigurationRepository)
     val v2Controller = new V2Controller(appsController, eventsController, pluginsController, infoController, leaderController)
 
     new AkkaHttpMarathonService(

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
@@ -6,16 +6,16 @@ import java.time.Clock
 import akka.actor.ActorSystem
 import akka.event.EventStream
 import com.google.inject.AbstractModule
-import com.google.inject.{ Provides, Scopes, Singleton }
+import com.google.inject.{Provides, Scopes, Singleton}
 import com.typesafe.config.Config
 import mesosphere.chaos.http.HttpConf
-import mesosphere.marathon.api.{ MarathonHttpService, TaskKiller }
+import mesosphere.marathon.api.{MarathonHttpService, TaskKiller}
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.api.akkahttp.v2.{ AppsController, EventsController, InfoController, PluginsController }
+import mesosphere.marathon.api.akkahttp.v2._
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.http.HttpRequestHandler
@@ -61,7 +61,8 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     val eventsController = new EventsController(conf, eventBus)
     val infoController = InfoController(mesosLeaderInfo, storageModule.frameworkIdRepository, conf)
     val pluginsController = new PluginsController(pluginManager.plugins[HttpRequestHandler], pluginManager.definitions)
-    val v2Controller = new V2Controller(appsController, eventsController, pluginsController, infoController)
+    val leaderController = LeaderController(electionService)
+    val v2Controller = new V2Controller(appsController, eventsController, pluginsController, infoController, leaderController)
 
     new AkkaHttpMarathonService(
       conf,

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -151,6 +151,7 @@ object EntityMarshallers {
   implicit val appInfoMarshaller = playJsonMarshaller[AppInfo]
   implicit val infoMarshaller = playJsonMarshaller[MarathonInfo]
   implicit val infoUnmarshaller = playJsonUnmarshaller[MarathonInfo]
+  implicit val leaderInfoMarshaller = playJsonMarshaller[raml.LeaderInfo]
   implicit val metricsMarshaller = internalToRamlJsonMarshaller[TickMetricSnapshot, Metrics]
   implicit val loggerChangeMarshaller = playJsonMarshaller[LoggerChange]
   implicit val loggerChangeUnmarshaller = playJsonUnmarshaller[LoggerChange]

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -147,11 +147,12 @@ object EntityMarshallers {
 
   implicit val jsValueMarshaller = playJsonMarshaller[JsValue]
   implicit val wixResultMarshaller = playJsonMarshaller[com.wix.accord.Failure](Validation.failureWrites)
-  implicit val messageMarshaller = playJsonMarshaller[Rejections.Message]
+  implicit val rejectionMessageMarshaller = playJsonMarshaller[Rejections.Message]
   implicit val appInfoMarshaller = playJsonMarshaller[AppInfo]
   implicit val infoMarshaller = playJsonMarshaller[MarathonInfo]
   implicit val infoUnmarshaller = playJsonUnmarshaller[MarathonInfo]
   implicit val leaderInfoMarshaller = playJsonMarshaller[raml.LeaderInfo]
+  implicit val messageMarshaller = playJsonMarshaller[raml.Message]
   implicit val metricsMarshaller = internalToRamlJsonMarshaller[TickMetricSnapshot, Metrics]
   implicit val loggerChangeMarshaller = playJsonMarshaller[LoggerChange]
   implicit val loggerChangeUnmarshaller = playJsonUnmarshaller[LoggerChange]

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/LeaderDirectives.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/LeaderDirectives.scala
@@ -43,9 +43,9 @@ object LeaderDirectives extends StrictLogging {
   val HostPort: Regex = """^(.*):(\d+)$""".r
   val FilterHeaders: Set[String] = Set("Host", "Connection", "Timeout-Access")
 
-  private[LeaderDirectives] case class ProxyToLeader(request: HttpRequest, localHostPort: String, leaderHost: String) extends Rejection
-  private[LeaderDirectives] case object NoLeader extends Rejection
-  private[LeaderDirectives] case object ProxyLoop extends Rejection
+  case class ProxyToLeader(request: HttpRequest, localHostPort: String, leaderHost: String) extends Rejection
+  case object NoLeader extends Rejection
+  case object ProxyLoop extends Rejection
 
   def handleNonLeader(implicit actorSystem: ActorSystem, materializer: Materializer): PartialFunction[Rejection, Route] = {
     case ProxyLoop => complete(StatusCodes.BadGateway -> "Detected proxy loop")

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/Rejections.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/Rejections.scala
@@ -14,10 +14,10 @@ object Rejections {
   val defaultEntityNotFoundMessage = Message("Entity was not found")
   case class EntityNotFound(message: Message = defaultEntityNotFoundMessage) extends Rejection
   object EntityNotFound {
-    def app(id: PathId, version: Option[Timestamp] = None): EntityNotFound = {
+    def noApp(id: PathId, version: Option[Timestamp] = None): EntityNotFound = {
       EntityNotFound(Message(s"App '$id' does not exist" + version.fold("")(v => s" in version $v")))
     }
-    def leader(): EntityNotFound = {
+    def noLeader(): EntityNotFound = {
       EntityNotFound(Message("There is no leader"))
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/Rejections.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/Rejections.scala
@@ -17,5 +17,8 @@ object Rejections {
     def app(id: PathId, version: Option[Timestamp] = None): EntityNotFound = {
       EntityNotFound(Message(s"App '$id' does not exist" + version.fold("")(v => s" in version $v")))
     }
+    def leader(): EntityNotFound = {
+      EntityNotFound(Message("There is no leader"))
+    }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/V2Controller.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/V2Controller.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package api.akkahttp
 
 import akka.http.scaladsl.server.Route
-import v2.{ AppsController, EventsController, InfoController, PluginsController }
+import v2._
 
 /**
   * Dispatches to various v2 controller routes
@@ -11,7 +11,8 @@ class V2Controller(
     appsController: AppsController,
     eventsController: EventsController,
     pluginsController: PluginsController,
-    infoController: InfoController
+    infoController: InfoController,
+    leaderController: LeaderController
 ) extends Controller {
   import Directives._
   override val route: Route = {
@@ -26,6 +27,9 @@ class V2Controller(
       } ~
       pathPrefix("info") {
         infoController.route
+      } ~
+      pathPrefix("leader") {
+        leaderController.route
       }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -102,7 +102,7 @@ class AppsController(
 
       onSuccess(appInfoService.selectApp(appId, authzSelector, resolvedEmbed)) {
         case None =>
-          reject(Rejections.EntityNotFound.app(appId))
+          reject(Rejections.EntityNotFound.noApp(appId))
         case Some(info) =>
           authorized(ViewResource, info.app).apply {
             complete(Json.obj("app" -> info))

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
@@ -34,12 +34,10 @@ case class LeaderController(
     }
 
   def deleteLeader(): Route =
-    authenticated.apply { implicit identity =>
-      authorized(UpdateResource, AuthorizedResource.SystemConfig).apply {
-        parameters('backup.?, 'restore.?) { (backup, restore) =>
-          // This follows the LeaderResource implementation. Seems like a bug to me. Why should we not proxy the request?
-          if (electionService.isLeader) {
-
+    asLeader(electionService) {
+      authenticated.apply { implicit identity =>
+        authorized(UpdateResource, AuthorizedResource.SystemConfig).apply {
+          parameters('backup.?, 'restore.?) { (backup, restore) =>
             //TODO: validate backup and restore parameters
             complete {
               async {
@@ -48,8 +46,6 @@ case class LeaderController(
                 raml.Message("Leadership abdicated")
               }
             }
-          } else {
-            reject(Rejections.EntityNotFound.leader())
           }
         }
       }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
@@ -33,6 +33,7 @@ case class LeaderController(
       }
     }
 
+  @SuppressWarnings(Array("all")) // async/await
   def deleteLeader(): Route =
     asLeader(electionService) {
       authenticated.apply { implicit identity =>

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
@@ -30,7 +30,7 @@ case class LeaderController(
     authenticated.apply { implicit identity =>
       authorized(ViewResource, AuthorizedResource.SystemConfig).apply {
         electionService.leaderHostPort match {
-          case None => reject(Rejections.EntityNotFound.leader())
+          case None => reject(Rejections.EntityNotFound.noLeader())
           case Some(leader) => complete(raml.LeaderInfo(leader))
         }
       }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
@@ -1,0 +1,43 @@
+package mesosphere.marathon
+package api.akkahttp.v2
+
+import akka.http.scaladsl.server.Route
+import mesosphere.marathon.api.akkahttp.{ Controller, Rejections }
+import mesosphere.marathon.core.election.ElectionService
+import mesosphere.marathon.plugin.auth.{ Authenticator, AuthorizedResource, Authorizer, ViewResource }
+import com.typesafe.scalalogging.StrictLogging
+import scala.concurrent.ExecutionContext
+
+case class LeaderController(val electionService: ElectionService)(
+    implicit
+    val authenticator: Authenticator,
+    val authorizer: Authorizer) extends Controller with StrictLogging {
+
+  import mesosphere.marathon.api.akkahttp.Directives._
+  import mesosphere.marathon.api.akkahttp.EntityMarshallers._
+
+  def leaderInfo(): Route =
+    authenticated.apply { implicit identity =>
+      authorized(ViewResource, AuthorizedResource.SystemConfig).apply {
+        electionService.leaderHostPort match {
+          case None => reject(Rejections.EntityNotFound.leader())
+          case Some(leader) => complete(raml.LeaderInfo(leader))
+        }
+      }
+    }
+
+  def deleteLeader(): Route = ???
+
+  override val route: Route = {
+    get {
+      pathEndOrSingleSlash {
+        leaderInfo()
+      }
+    } ~
+    delete {
+      pathEndOrSingleSlash {
+        deleteLeader()
+      }
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/LeaderControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/LeaderControllerTest.scala
@@ -1,0 +1,96 @@
+package mesosphere.marathon
+package api.akkahttp.v2
+
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import mesosphere.UnitTest
+import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
+import mesosphere.marathon.api.akkahttp.AuthDirectives.{NotAuthenticated, NotAuthorized}
+import mesosphere.marathon.api.akkahttp.Rejections.EntityNotFound
+import mesosphere.marathon.core.election.ElectionService
+import mesosphere.marathon.storage.repository.RuntimeConfigurationRepository
+import org.scalatest.Inside
+
+class LeaderControllerTest extends UnitTest with ScalatestRouteTest with Inside {
+
+  "LeaderResource" should {
+    "return the leader info" in {
+      Given("a leader has been elected")
+      val f = new Fixture()
+      val controller = f.leaderController()
+      f.electionService.leaderHostPort returns(Some("new.leader.com"))
+
+      When("we try to fetch the info")
+      Get(Uri./) ~> controller.route ~> check {
+        Then("we receive all info")
+        status should be(StatusCodes.OK)
+        val expected =
+          """{
+            |  "leader": "new.leader.com"
+            |}""".stripMargin
+        JsonTestHelper.assertThatJsonString(responseAs[String]).correspondsToJsonString(expected)
+      }
+    }
+
+    "return 404 if no leader has been elected" in {
+      Given("no leader has been elected")
+      val f = new Fixture()
+      val controller = f.leaderController()
+      f.electionService.leaderHostPort returns(None)
+
+      When("we try to fetch the info")
+      Get(Uri./) ~> controller.route ~> check {
+        Then("we receive EntityNotFound response")
+        rejection shouldBe an[EntityNotFound]
+        inside(rejection) {
+          case EntityNotFound(message) =>
+            message.message should be("There is no leader")
+        }
+      }
+    }
+
+    "access without authentication is denied" in {
+      Given("An unauthenticated request")
+      val f = new Fixture(authenticated = false)
+      val controller = f.leaderController()
+
+      When("we try to get the leader info")
+      Get(Uri./) ~> controller.route ~> check {
+        Then("we receive a NotAuthenticated response")
+        rejection shouldBe a[NotAuthenticated]
+        inside(rejection) {
+          case NotAuthenticated(response) =>
+            response.status should be(StatusCodes.Forbidden)
+        }
+      }
+    }
+
+    "access without authorization is denied" in {
+      Given("An unauthenticated request")
+      val f = new Fixture(authorized = false)
+      val controller = f.leaderController()
+
+      When("we try to get the leader info")
+      Get(Uri./) ~> controller.route ~> check {
+        Then("we receive a NotAuthenticated response")
+        rejection shouldBe a[NotAuthorized]
+        inside(rejection) {
+          case NotAuthorized(response) =>
+            response.status should be(StatusCodes.Unauthorized)
+        }
+      }
+    }
+  }
+
+  class Fixture(authenticated: Boolean = true, authorized: Boolean = true) {
+    val electionService = mock[ElectionService]
+
+    val auth = new TestAuthFixture()
+    auth.authenticated = authenticated
+    auth.authorized = authorized
+    implicit val authenticator = auth.auth
+
+    val config = AllConf.withTestConfig()
+    def leaderController() = new LeaderController(electionService)
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/LeaderControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/LeaderControllerTest.scala
@@ -1,15 +1,18 @@
 package mesosphere.marathon
 package api.akkahttp.v2
 
-import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.Done
+import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import mesosphere.UnitTest
-import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
-import mesosphere.marathon.api.akkahttp.AuthDirectives.{NotAuthenticated, NotAuthorized}
+import mesosphere.marathon.api.{ JsonTestHelper, TestAuthFixture }
+import mesosphere.marathon.api.akkahttp.AuthDirectives.{ NotAuthenticated, NotAuthorized }
 import mesosphere.marathon.api.akkahttp.Rejections.EntityNotFound
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.storage.repository.RuntimeConfigurationRepository
 import org.scalatest.Inside
+
+import scala.concurrent.Future
 
 class LeaderControllerTest extends UnitTest with ScalatestRouteTest with Inside {
 
@@ -18,7 +21,7 @@ class LeaderControllerTest extends UnitTest with ScalatestRouteTest with Inside 
       Given("a leader has been elected")
       val f = new Fixture()
       val controller = f.leaderController()
-      f.electionService.leaderHostPort returns(Some("new.leader.com"))
+      f.electionService.leaderHostPort returns (Some("new.leader.com"))
 
       When("we try to fetch the info")
       Get(Uri./) ~> controller.route ~> check {
@@ -36,7 +39,7 @@ class LeaderControllerTest extends UnitTest with ScalatestRouteTest with Inside 
       Given("no leader has been elected")
       val f = new Fixture()
       val controller = f.leaderController()
-      f.electionService.leaderHostPort returns(None)
+      f.electionService.leaderHostPort returns (None)
 
       When("we try to fetch the info")
       Get(Uri./) ~> controller.route ~> check {
@@ -80,10 +83,50 @@ class LeaderControllerTest extends UnitTest with ScalatestRouteTest with Inside 
         }
       }
     }
+
+    "abdicate leadership" in {
+      Given("the host is not leader")
+      val f = new Fixture()
+      val controller = f.leaderController()
+      f.electionService.isLeader returns (true)
+      f.runtimeRepo.store(raml.RuntimeConfiguration(Some("s3://mybucket/foo"), None)) returns (Future.successful(Done))
+
+      When("we try to abdicate")
+      Delete("/?backup=s3://mybucket/foo") ~> controller.route ~> check {
+        Then("we abdicate")
+        verify(f.electionService, once).abdicateLeadership()
+
+        And("receive HTTP ok")
+        status should be(StatusCodes.OK)
+        val expected =
+          """{
+            |  "message": "Leadership abdicated"
+            |}""".stripMargin
+        JsonTestHelper.assertThatJsonString(responseAs[String]).correspondsToJsonString(expected)
+      }
+    }
+
+    "not abdicate leadership" in {
+      Given("the host is not leader")
+      val f = new Fixture()
+      val controller = f.leaderController()
+      f.electionService.isLeader returns (false)
+
+      When("we try to abdicate")
+      Delete(Uri./) ~> controller.route ~> check {
+        Then("we receive EntityNotFound response")
+        rejection shouldBe an[EntityNotFound]
+        inside(rejection) {
+          case EntityNotFound(message) =>
+            message.message should be("There is no leader")
+        }
+      }
+    }
   }
 
   class Fixture(authenticated: Boolean = true, authorized: Boolean = true) {
     val electionService = mock[ElectionService]
+    val runtimeRepo = mock[RuntimeConfigurationRepository]
 
     val auth = new TestAuthFixture()
     auth.authenticated = authenticated
@@ -91,6 +134,6 @@ class LeaderControllerTest extends UnitTest with ScalatestRouteTest with Inside 
     implicit val authenticator = auth.auth
 
     val config = AllConf.withTestConfig()
-    def leaderController() = new LeaderController(electionService)
+    def leaderController() = new LeaderController(electionService, runtimeRepo)
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/LeaderControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/LeaderControllerTest.scala
@@ -2,13 +2,13 @@ package mesosphere.marathon
 package api.akkahttp.v2
 
 import akka.Done
-import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import mesosphere.{UnitTest, ValidationTestLike}
-import mesosphere.marathon.api.{JsonTestHelper, TestAuthFixture}
+import mesosphere.{ UnitTest, ValidationTestLike }
+import mesosphere.marathon.api.{ JsonTestHelper, TestAuthFixture }
 import mesosphere.marathon.api.akkahttp.EntityMarshallers.ValidationFailed
-import mesosphere.marathon.api.akkahttp.AuthDirectives.{NotAuthenticated, NotAuthorized}
-import mesosphere.marathon.api.akkahttp.LeaderDirectives.{NoLeader, ProxyToLeader}
+import mesosphere.marathon.api.akkahttp.AuthDirectives.{ NotAuthenticated, NotAuthorized }
+import mesosphere.marathon.api.akkahttp.LeaderDirectives.{ NoLeader, ProxyToLeader }
 import mesosphere.marathon.api.akkahttp.Rejections.EntityNotFound
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.storage.repository.RuntimeConfigurationRepository
@@ -115,12 +115,13 @@ class LeaderControllerTest extends UnitTest with ScalatestRouteTest with Inside 
       f.electionService.isLeader returns (true)
 
       When("we try to abdicate")
-      Delete("/?backup=norealuri") ~> controller.route ~> check {
+      Delete("/?backup=norealuri&restore=alsowrong") ~> controller.route ~> check {
         Then("then the request should be rejected")
         rejection shouldBe a[ValidationFailed]
         inside(rejection) {
           case ValidationFailed(failure) =>
             failure should haveViolations("/" -> "Invalid URI or unsupported scheme: norealuri")
+            failure should haveViolations("/" -> "Invalid URI or unsupported scheme: alsowrong")
         }
       }
     }


### PR DESCRIPTION
Summary:
We reimplement the `LeaderResource` as an Akka HTTP `LeaderController`.
The response is modelled in RAML. New tests for leader abdication have
been added.

JIRA issues: MARATHON-7303
