### PR TITLE
Enable successful SI Test runs with cluster of agents with different core counts

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -220,6 +220,12 @@ def restart_master_node():
     shakedown.run_command_on_master("sudo /sbin/shutdown -r now")
 
 
+def cpus_on_agent(hostname):
+    """Detects number of cores on an agent"""
+    status, output = shakedown.run_command_on_agent(hostname, "cat /proc/cpuinfo | grep processor | wc -l", noisy=False)
+    return int(output)
+
+
 def systemctl_master(command='restart'):
     shakedown.run_command_on_master('sudo systemctl {} dcos-mesos-master'.format(command))
 

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -643,11 +643,12 @@ def test_pinned_task_does_not_scale_to_unpinned_host():
     app_def = apps.sleep_app()
     app_id = app_def['id']
 
-    # the size of cpus is designed to be greater than 1/2 of a node
-    # such that only 1 task can land on the node. 
-    app_def['cpus'] = 1.5
     host = common.ip_other_than_mom()
     print('Constraint set to host: {}'.format(host))
+    # the size of cpus is designed to be greater than 1/2 of a node
+    # such that only 1 task can land on the node.
+    cores = common.cpus_on_agent(host)
+    app_def['cpus'] = cores - 0.5
     common.pin_to_host(app_def, host)
 
     client = marathon.create_client()

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -648,7 +648,7 @@ def test_pinned_task_does_not_scale_to_unpinned_host():
     # the size of cpus is designed to be greater than 1/2 of a node
     # such that only 1 task can land on the node.
     cores = common.cpus_on_agent(host)
-    app_def['cpus'] = cores - 0.5
+    app_def['cpus'] = max(0.6, cores - 0.5)
     common.pin_to_host(app_def, host)
 
     client = marathon.create_client()

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -642,7 +642,10 @@ def test_pinned_task_does_not_scale_to_unpinned_host():
 
     app_def = apps.sleep_app()
     app_id = app_def['id']
-    app_def['cpus'] = 3.5
+
+    # the size of cpus is designed to be greater than 1/2 of a node
+    # such that only 1 task can land on the node. 
+    app_def['cpus'] = 1.5
     host = common.ip_other_than_mom()
     print('Constraint set to host: {}'.format(host))
     common.pin_to_host(app_def, host)


### PR DESCRIPTION
Enable successful SI Test runs with cluster of agents with different core counts

Summary:
The test was originally written assuming an agent core count of 4 which has been true for years.   Based on cost cutting measures the latest clusters are made of 2 core agents.   However CCM still creates the 4 core count agents.   This change allows this test to pass for changes in the agent core count.

JIRA issues:
??