### PR TITLE
Refactor Openable trait

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -201,7 +201,7 @@ class MarathonSchedulerService @Inject() (
     log.info("As new leader running the driver")
 
     // allow interactions with the persistence store
-    persistenceStore.open()
+    persistenceStore.markOpen()
 
     refreshCachesAndDoMigration()
 
@@ -280,7 +280,7 @@ class MarathonSchedulerService @Inject() (
     log.info("Lost leadership")
 
     // disallow any interaction with the persistence storage
-    persistenceStore.close()
+    persistenceStore.markClosed()
 
     leadershipCoordinator.stop()
 

--- a/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
@@ -9,7 +9,7 @@ import akka.stream.scaladsl.{ Sink, Source }
 import akka.{ Done, NotUsed }
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.core.storage.backup.BackupItem
-import mesosphere.marathon.util.Openable
+import mesosphere.marathon.util.OpenableOnce
 
 import scala.concurrent.Future
 
@@ -84,7 +84,7 @@ import scala.concurrent.Future
   * @tparam Category The persistence store's category type.
   * @tparam Serialized The serialized format for the persistence store.
   */
-trait PersistenceStore[K, Category, Serialized] extends Openable {
+trait PersistenceStore[K, Category, Serialized] extends OpenableOnce {
   /**
     * Get a list of all of the Ids of the given Value Types
     */

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
@@ -44,8 +44,8 @@ case class LazyCachingPersistenceStore[K, Category, Serialized](
   private[this] val getHitCounters = TrieMap.empty[Category, Counter]
   private[this] val idsHitCounters = TrieMap.empty[Category, Counter]
 
-  override def open(): Unit = store.open()
-  override def close(): Unit = store.close()
+  override def markOpen(): Unit = store.markOpen()
+  override def markClosed(): Unit = store.markClosed()
   override def isOpen: Boolean = store.isOpen
 
   override def storageVersion(): Future[Option[StorageVersion]] = store.storageVersion()
@@ -196,8 +196,8 @@ case class LazyVersionCachingPersistentStore[K, Category, Serialized](
   mat: Materializer,
     ctx: ExecutionContext) extends PersistenceStore[K, Category, Serialized] with StrictLogging {
 
-  override def open(): Unit = store.open()
-  override def close(): Unit = store.close()
+  override def markOpen(): Unit = store.markOpen()
+  override def markClosed(): Unit = store.markClosed()
   override def isOpen: Boolean = store.isOpen
 
   private[store] val versionCache = TrieMap.empty[(Category, K), Set[OffsetDateTime]]

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
@@ -50,8 +50,8 @@ class LoadTimeCachingPersistenceStore[K, Category, Serialized](
   private[store] var valueCache: Future[TrieMap[K, Either[Serialized, Any]]] =
     Future.failed(new NotActiveException())
 
-  override def open(): Unit = store.open()
-  override def close(): Unit = store.close()
+  override def markOpen(): Unit = store.markOpen()
+  override def markClosed(): Unit = store.markClosed()
   override def isOpen: Boolean = store.isOpen
 
   override def storageVersion(): Future[Option[StorageVersion]] = store.storageVersion()

--- a/src/main/scala/mesosphere/marathon/util/Openable.scala
+++ b/src/main/scala/mesosphere/marathon/util/Openable.scala
@@ -8,12 +8,12 @@ import java.util.concurrent.atomic.AtomicBoolean
   * A resource can be marked as open or close only once. Also, it can be closed
   * only when it is open.
   */
-trait Openable {
+trait OpenableOnce {
   protected val opened = new AtomicBoolean(false)
   protected val wasEverOpened = new AtomicBoolean(false)
 
   /** Mark an object as open. */
-  def open(): Unit = {
+  def markOpen(): Unit = {
     if (wasEverOpened.compareAndSet(false, true)) {
       opened.set(true)
     } else {
@@ -22,7 +22,7 @@ trait Openable {
   }
 
   /** Mark an object as closed. */
-  def close(): Unit = {
+  def markClosed(): Unit = {
     val wasOpened = opened.compareAndSet(true, false)
     if (!wasOpened) {
       throw new IllegalStateException("attempt to close while not being opened")

--- a/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
@@ -39,19 +39,19 @@ private[storage] trait PersistenceStoreTest { this: AkkaUnitTest =>
       }
       "cannot be opened twice" in {
         val store = newStore
-        val thrown = the[IllegalStateException] thrownBy store.open()
+        val thrown = the[IllegalStateException] thrownBy store.markOpen()
         thrown.getMessage shouldBe "it was opened before"
       }
       "cannot be reopened" in {
         val store = newStore
-        store.close()
-        val thrown = the[IllegalStateException] thrownBy store.open()
+        store.markClosed()
+        val thrown = the[IllegalStateException] thrownBy store.markOpen()
         thrown.getMessage shouldBe "it was opened before"
       }
       "cannot be closed twice" in {
         val store = newStore
-        store.close()
-        val thrown = the[IllegalStateException] thrownBy store.close()
+        store.markClosed()
+        val thrown = the[IllegalStateException] thrownBy store.markClosed()
         thrown.getMessage shouldBe "attempt to close while not being opened"
       }
       "have no ids" in {

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/InMemoryPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/InMemoryPersistenceStoreTest.scala
@@ -25,7 +25,7 @@ class InMemoryPersistenceStoreTest extends AkkaUnitTest with PersistenceStoreTes
 
   def inMemoryStore: InMemoryPersistenceStore = {
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
     store
   }
 

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
@@ -24,13 +24,13 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
 
   private def cachedInMemory = {
     val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     store
   }
 
   private def withLazyVersionCaching = {
     val store = LazyVersionCachingPersistentStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     store
   }
 
@@ -38,7 +38,7 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
     val root = UUID.randomUUID().toString
     val client = zkClient(namespace = Some(root))
     val store = LazyCachingPersistenceStore(new ZkPersistenceStore(client, Duration.Inf, 8))
-    store.open()
+    store.markOpen()
     store
   }
 

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
@@ -25,14 +25,14 @@ class LoadTimeCachingPersistenceStoreTest extends AkkaUnitTest
 
   private def cachedInMemory = {
     val store = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     store.preDriverStarts.futureValue
     store
   }
 
   private def cachedZk = {
     val store = new LoadTimeCachingPersistenceStore(zkStore)
-    store.open()
+    store.markOpen()
     store.preDriverStarts.futureValue
     store
   }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -62,7 +62,7 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
     val root = UUID.randomUUID().toString
     val client = zkClient(namespace = Some(root))
     val store = new ZkPersistenceStore(client, Duration.Inf)
-    store.open()
+    store.markOpen()
     store
   }
 

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
@@ -26,7 +26,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
   class Fixture(
       persistenceStore: PersistenceStore[_, _, _] = {
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
         store
       },
       fakeMigrations: List[MigrationAction] = List.empty) {

--- a/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
@@ -66,7 +66,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       testScan: Option[() => Future[ScanDone]] = None)(
       testCompact: Option[(Set[PathId], Map[PathId, Set[OffsetDateTime]], Set[PathId], Map[PathId, Set[OffsetDateTime]], Set[OffsetDateTime]) => Future[CompactDone]] = None) {
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
     val appRepo = AppRepository.inMemRepository(store)
     val podRepo = PodRepository.inMemRepository(store)
     val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -427,7 +427,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
     "actually running" should {
       "ignore scan errors on roots" in {
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = mock[StoredGroupRepositoryImpl[RamId, String, Identity]]
@@ -440,7 +440,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore scan errors on apps" in {
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -456,7 +456,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore scan errors on pods" in {
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = mock[PodRepositoryImpl[RamId, String, Identity]]
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
@@ -472,7 +472,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "ignore errors when compacting" in {
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)

--- a/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
@@ -121,7 +121,7 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
       }
       "retrieve a historical version" in {
         val store = new InMemoryPersistenceStore()
-        store.open()
+        store.markOpen()
 
         val appRepo = AppRepository.inMemRepository(store)
         val repo = createRepo(appRepo, mock[PodRepository], 2)
@@ -148,7 +148,7 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
 
   def createInMemRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }
 
@@ -160,19 +160,19 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
 
   def createZkRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     val store = zkStore
-    store.open()
+    store.markOpen()
     GroupRepository.zkRepository(store, appRepository, podRepository)
   }
 
   def createLazyCachingRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }
 
   def createLoadCachingRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter
     val store = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     store.preDriverStarts.futureValue
     GroupRepository.inMemRepository(store, appRepository, podRepository)
   }

--- a/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
@@ -33,7 +33,7 @@ class PodRepositoryTest extends AkkaUnitTest {
     implicit val ctx = ExecutionContexts.global
 
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
     val repo = PodRepository.inMemRepository(store)
   }
 }

--- a/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
@@ -150,13 +150,13 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
 
   def createInMemRepo(): AppRepository = {
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
     AppRepository.inMemRepository(store)
   }
 
   def createLoadTimeCachingRepo(): AppRepository = {
     val cached = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
-    cached.open()
+    cached.markOpen()
     cached.preDriverStarts.futureValue
     AppRepository.inMemRepository(cached)
   }
@@ -165,19 +165,19 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
     val root = UUID.randomUUID().toString
     val rootClient = zkClient(namespace = Some(root))
     val store = new ZkPersistenceStore(rootClient, Duration.Inf)
-    store.open()
+    store.markOpen()
     AppRepository.zkRepository(store)
   }
 
   def createLazyCachingRepo(): AppRepository = {
     val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     AppRepository.inMemRepository(store)
   }
 
   def createLazyVersionCachingRepo(): AppRepository = {
     val store = LazyVersionCachingPersistentStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     AppRepository.inMemRepository(store)
   }
 

--- a/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
@@ -43,26 +43,26 @@ class SingletonRepositoryTest extends AkkaUnitTest with ZookeeperServerTest {
 
   def createInMemRepo(): FrameworkIdRepository = {
     val store = new InMemoryPersistenceStore()
-    store.open()
+    store.markOpen()
     FrameworkIdRepository.inMemRepository(store)
   }
 
   def createLoadTimeCachingRepo(): FrameworkIdRepository = {
     val cached = new LoadTimeCachingPersistenceStore(new InMemoryPersistenceStore())
-    cached.open()
+    cached.markOpen()
     cached.preDriverStarts.futureValue
     FrameworkIdRepository.inMemRepository(cached)
   }
 
   def createZKRepo(): FrameworkIdRepository = {
     val store = new ZkPersistenceStore(zkClient(), 10.seconds)
-    store.open()
+    store.markOpen()
     FrameworkIdRepository.zkRepository(store)
   }
 
   def createLazyCachingRepo(): FrameworkIdRepository = {
     val store = LazyCachingPersistenceStore(new InMemoryPersistenceStore())
-    store.open()
+    store.markOpen()
     FrameworkIdRepository.inMemRepository(store)
   }
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -27,7 +27,7 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
   case class Fixture() {
     val store: InMemoryPersistenceStore = {
       val store = new InMemoryPersistenceStore()
-      store.open()
+      store.markOpen()
       store
     }
     implicit val state: InstanceRepository = spy(InstanceRepository.inMemRepository(store))

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -337,7 +337,7 @@ object MarathonTestHelper {
     implicit val ctx = ExecutionContexts.global
     val instanceRepo = store.getOrElse {
       val store = new InMemoryPersistenceStore()
-      store.open()
+      store.markOpen()
       InstanceRepository.inMemRepository(store)
     }
     val updateSteps = Seq.empty[InstanceChangeHandler]


### PR DESCRIPTION
- Rename its open() and close() methods to markOpen() and markClosed()
  respectively, because the former are too generic.
- Rename Opeable to OpenableOnce because it better reflects what
  it does.
