### PR TITLE
Wire marathon scheduler manually, not via guice

### DIFF
--- a/src/main/scala/mesosphere/marathon/HomeRegionProvider.scala
+++ b/src/main/scala/mesosphere/marathon/HomeRegionProvider.scala
@@ -1,9 +1,0 @@
-package mesosphere.marathon
-
-/**
-  * Returns value of home region for Marathon. This is strongly connected with Marathon being region aware.
-  * The value is used for region-aware scheduling.
-  */
-trait HomeRegionProvider {
-  def getHomeRegion(): Option[String]
-}

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -45,9 +45,6 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
     bind(classOf[LeaderProxyConf]).toInstance(conf)
     bind(classOf[ZookeeperConf]).toInstance(conf)
 
-    // MesosHeartbeatMonitor decorates MarathonScheduler
-    bind(classOf[Scheduler]).to(classOf[MesosHeartbeatMonitor]).in(Scopes.SINGLETON)
-
     bind(classOf[MarathonSchedulerDriverHolder]).in(Scopes.SINGLETON)
     bind(classOf[SchedulerDriverFactory]).to(classOf[MesosSchedulerDriverFactory]).in(Scopes.SINGLETON)
     bind(classOf[MarathonSchedulerService]).in(Scopes.SINGLETON)

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -46,9 +46,6 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
     bind(classOf[ZookeeperConf]).toInstance(conf)
 
     // MesosHeartbeatMonitor decorates MarathonScheduler
-    bind(classOf[MarathonScheduler]).in(Scopes.SINGLETON)
-    bind(classOf[HomeRegionProvider]).to(classOf[MarathonScheduler]).in(Scopes.SINGLETON)
-    bind(classOf[Scheduler]).annotatedWith(Names.named(MesosHeartbeatMonitor.BASE)).toProvider(getProvider(classOf[MarathonScheduler]))
     bind(classOf[Scheduler]).to(classOf[MesosHeartbeatMonitor]).in(Scopes.SINGLETON)
 
     bind(classOf[MarathonSchedulerDriverHolder]).in(Scopes.SINGLETON)

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -25,7 +25,7 @@ class MarathonScheduler(
     taskStatusProcessor: TaskStatusUpdateProcessor,
     frameworkIdRepository: FrameworkIdRepository,
     mesosLeaderInfo: MesosLeaderInfo,
-    config: MarathonConf) extends Scheduler with HomeRegionProvider {
+    config: MarathonConf) extends Scheduler {
 
   private[this] val log = LoggerFactory.getLogger(getClass.getName)
 

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory
 import scala.concurrent._
 import scala.util.control.NonFatal
 
-class MarathonScheduler @Inject() (
+class MarathonScheduler(
     eventBus: EventStream,
     offerProcessor: OfferProcessor,
     taskStatusProcessor: TaskStatusUpdateProcessor,

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -15,7 +15,6 @@ import mesosphere.marathon.core.deployment.DeploymentManager
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
-import mesosphere.marathon.core.heartbeat.MesosHeartbeatMonitor
 import mesosphere.marathon.core.instance.update.InstanceChangeHandler
 import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.launchqueue.LaunchQueue
@@ -238,9 +237,9 @@ class CoreGuiceModule(config: Config) extends AbstractModule {
   @Singleton
   def schedulerActions(coreModule: CoreModule): SchedulerActions = coreModule.schedulerActions
 
-  @Provides @Singleton @Named(MesosHeartbeatMonitor.BASE)
-  def heartbeatMonitorScheduler(coreModule: CoreModule): Scheduler = coreModule.marathonScheduler
-
   @Provides @Singleton
   def marathonScheduler(coreModule: CoreModule): MarathonScheduler = coreModule.marathonScheduler
+
+  @Provides @Singleton
+  def scheduler(coreModule: CoreModule): Scheduler = coreModule.mesosHeartbeatMonitor
 }

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -15,6 +15,7 @@ import mesosphere.marathon.core.deployment.DeploymentManager
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
+import mesosphere.marathon.core.heartbeat.MesosHeartbeatMonitor
 import mesosphere.marathon.core.instance.update.InstanceChangeHandler
 import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.launchqueue.LaunchQueue
@@ -34,6 +35,7 @@ import mesosphere.marathon.plugin.http.HttpRequestHandler
 import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.storage.repository._
 import mesosphere.marathon.util.WorkQueue
+import org.apache.mesos.Scheduler
 import org.eclipse.jetty.servlets.EventSourceServlet
 
 import scala.collection.immutable
@@ -235,4 +237,10 @@ class CoreGuiceModule(config: Config) extends AbstractModule {
   @Provides
   @Singleton
   def schedulerActions(coreModule: CoreModule): SchedulerActions = coreModule.schedulerActions
+
+  @Provides @Singleton @Named(MesosHeartbeatMonitor.BASE)
+  def heartbeatMonitorScheduler(coreModule: CoreModule): Scheduler = coreModule.marathonScheduler
+
+  @Provides @Singleton
+  def marathonScheduler(coreModule: CoreModule): MarathonScheduler = coreModule.marathonScheduler
 }

--- a/src/main/scala/mesosphere/marathon/core/CoreModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModule.scala
@@ -9,6 +9,7 @@ import mesosphere.marathon.core.election.ElectionModule
 import mesosphere.marathon.core.event.EventModule
 import mesosphere.marathon.core.group.GroupManagerModule
 import mesosphere.marathon.core.health.HealthModule
+import mesosphere.marathon.core.heartbeat.MesosHeartbeatMonitor
 import mesosphere.marathon.core.history.HistoryModule
 import mesosphere.marathon.core.launcher.LauncherModule
 import mesosphere.marathon.core.launchqueue.LaunchQueueModule
@@ -47,4 +48,6 @@ trait CoreModule {
   def taskTerminationModule: TaskTerminationModule
   def deploymentModule: DeploymentModule
   def schedulerActions: SchedulerActions
+  def marathonScheduler: MarathonScheduler
+  def mesosHeartbeatMonitor: MesosHeartbeatMonitor
 }

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -104,7 +104,7 @@ class CoreModuleImpl @Inject() (
     // infrastructure
     clock, random, marathonConf, actorSystem.scheduler,
     leadershipModule,
-    () => marathonScheduler
+    () => marathonScheduler.getHomeRegion
   )
 
   private[this] lazy val offerMatcherReconcilerModule =
@@ -150,7 +150,7 @@ class CoreModuleImpl @Inject() (
     // external guice dependencies
     taskTrackerModule.instanceTracker,
     launcherModule.taskOpFactory,
-    () => marathonScheduler
+    () => marathonScheduler.getHomeRegion
   )
 
   // PLUGINS

--- a/src/main/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitor.scala
+++ b/src/main/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitor.scala
@@ -22,8 +22,7 @@ import org.slf4j.LoggerFactory
   * @see org.apache.mesos.Scheduler
   * @see org.apache.mesos.SchedulerDriver
   */
-class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) heartbeatActor: ActorRef
-) extends Scheduler {
+class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) heartbeatActor: ActorRef) extends Scheduler {
 
   import MesosHeartbeatMonitor._
 
@@ -141,8 +140,6 @@ class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEART
 }
 
 object MesosHeartbeatMonitor {
-  final val BASE = "mesosHeartbeatMonitor.base"
-
   final val DEFAULT_HEARTBEAT_INTERVAL_MS = 15000L
   final val DEFAULT_HEARTBEAT_FAILURE_THRESHOLD = 5
 

--- a/src/main/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitor.scala
+++ b/src/main/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitor.scala
@@ -22,9 +22,7 @@ import org.slf4j.LoggerFactory
   * @see org.apache.mesos.Scheduler
   * @see org.apache.mesos.SchedulerDriver
   */
-class MesosHeartbeatMonitor @Inject() (
-    @Named(MesosHeartbeatMonitor.BASE) scheduler: Scheduler,
-    @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) heartbeatActor: ActorRef
+class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) heartbeatActor: ActorRef
 ) extends Scheduler {
 
   import MesosHeartbeatMonitor._

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -24,7 +24,7 @@ class LaunchQueueModule(
     maybeOfferReviver: Option[OfferReviver],
     taskTracker: InstanceTracker,
     taskOpFactory: InstanceOpFactory,
-    homeRegionProvider: () => HomeRegionProvider) {
+    homeRegion: () => Option[String]) {
 
   private[this] val offerMatchStatisticsActor: ActorRef = {
     leadershipModule.startWhenLeader(OfferMatchStatisticsActor.props(), "offerMatcherStatistics")
@@ -41,7 +41,7 @@ class LaunchQueueModule(
         taskTracker,
         rateLimiterActor,
         offerMatchStatisticsActor,
-        homeRegionProvider)(runSpec, count)
+        homeRegion)(runSpec, count)
     val props = LaunchQueueActor.props(config, offerMatchStatisticsActor, runSpecActorProps)
     leadershipModule.startWhenLeader(props, "launchQueue")
   }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -24,7 +24,7 @@ class LaunchQueueModule(
     maybeOfferReviver: Option[OfferReviver],
     taskTracker: InstanceTracker,
     taskOpFactory: InstanceOpFactory,
-    homeRegionProvider: Provider[HomeRegionProvider]) {
+    homeRegionProvider: () => HomeRegionProvider) {
 
   private[this] val offerMatchStatisticsActor: ActorRef = {
     leadershipModule.startWhenLeader(OfferMatchStatisticsActor.props(), "offerMatcherStatistics")

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -37,7 +37,7 @@ private[launchqueue] object TaskLauncherActor {
     instanceTracker: InstanceTracker,
     rateLimiterActor: ActorRef,
     offerMatchStatisticsActor: ActorRef,
-    homeRegionProvider: () => HomeRegionProvider)(
+    homeRegion: () => Option[String])(
     runSpec: RunSpec,
     initialCount: Int): Props = {
     Props(new TaskLauncherActor(
@@ -46,7 +46,7 @@ private[launchqueue] object TaskLauncherActor {
       clock, taskOpFactory,
       maybeOfferReviver,
       instanceTracker, rateLimiterActor, offerMatchStatisticsActor,
-      runSpec, initialCount, homeRegionProvider))
+      runSpec, initialCount, homeRegion))
   }
 
   sealed trait Requests
@@ -89,7 +89,7 @@ private class TaskLauncherActor(
 
     private[this] var runSpec: RunSpec,
     private[this] var instancesToLaunch: Int,
-    homeRegionProvider: () => HomeRegionProvider) extends Actor with StrictLogging with Stash {
+    homeRegion: () => Option[String]) extends Actor with StrictLogging with Stash {
   // scalastyle:on parameter.number
 
   private[this] var inFlightInstanceOperations = Map.empty[Instance.Id, Cancellable]
@@ -425,7 +425,7 @@ private class TaskLauncherActor(
   private[this] object OfferMatcherRegistration {
     private[this] val myselfAsOfferMatcher: OfferMatcher = {
       //set the precedence only, if this app is resident
-      new ActorOfferMatcher(self, runSpec.residency.map(_ => runSpec.id), homeRegionProvider)
+      new ActorOfferMatcher(self, runSpec.residency.map(_ => runSpec.id), homeRegion)
     }
     private[this] var registeredAsMatcher = false
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -37,7 +37,7 @@ private[launchqueue] object TaskLauncherActor {
     instanceTracker: InstanceTracker,
     rateLimiterActor: ActorRef,
     offerMatchStatisticsActor: ActorRef,
-    homeRegionProvider: Provider[HomeRegionProvider])(
+    homeRegionProvider: () => HomeRegionProvider)(
     runSpec: RunSpec,
     initialCount: Int): Props = {
     Props(new TaskLauncherActor(
@@ -89,7 +89,7 @@ private class TaskLauncherActor(
 
     private[this] var runSpec: RunSpec,
     private[this] var instancesToLaunch: Int,
-    homeRegionProvider: Provider[HomeRegionProvider]) extends Actor with StrictLogging with Stash {
+    homeRegionProvider: () => HomeRegionProvider) extends Actor with StrictLogging with Stash {
   // scalastyle:on parameter.number
 
   private[this] var inFlightInstanceOperations = Map.empty[Instance.Id, Cancellable]

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
@@ -18,7 +18,7 @@ import scala.concurrent.{ Future, Promise }
   * @param actorRef Reference to actor that matches offers.
   * @param precedenceFor Defines which matcher receives offers first. See [[mesosphere.marathon.core.matcher.base.OfferMatcher.precedenceFor]].
   */
-class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[PathId], homeRegionProvider: Provider[HomeRegionProvider])(implicit scheduler: akka.actor.Scheduler)
+class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[PathId], homeRegionProvider: () => HomeRegionProvider)(implicit scheduler: akka.actor.Scheduler)
     extends OfferMatcher with StrictLogging {
 
   def matchOffer(offer: Offer): Future[MatchedInstanceOps] = {
@@ -31,7 +31,7 @@ class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[P
 
   override def isInterestedIn(offer: Offer) = {
     def isFromHomeRegion(offer: Offer): Boolean = {
-      !offer.hasDomain || !offer.getDomain.hasFaultDomain || homeRegionProvider.get().getHomeRegion.forall(_ == offer.getDomain.getFaultDomain.getRegion.getName)
+      !offer.hasDomain || !offer.getDomain.hasFaultDomain || homeRegionProvider().getHomeRegion.forall(_ == offer.getDomain.getFaultDomain.getRegion.getName)
     }
 
     isFromHomeRegion(offer)

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
@@ -18,7 +18,7 @@ import scala.concurrent.{ Future, Promise }
   * @param actorRef Reference to actor that matches offers.
   * @param precedenceFor Defines which matcher receives offers first. See [[mesosphere.marathon.core.matcher.base.OfferMatcher.precedenceFor]].
   */
-class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[PathId], homeRegionProvider: () => HomeRegionProvider)
+class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[PathId], homeRegion: () => Option[String])
     extends OfferMatcher with StrictLogging {
 
   def matchOffer(offer: Offer): Future[MatchedInstanceOps] = {
@@ -31,7 +31,7 @@ class ActorOfferMatcher(actorRef: ActorRef, override val precedenceFor: Option[P
 
   override def isInterestedIn(offer: Offer) = {
     def isFromHomeRegion(offer: Offer): Boolean = {
-      !offer.hasDomain || !offer.getDomain.hasFaultDomain || homeRegionProvider().getHomeRegion.forall(_ == offer.getDomain.getFaultDomain.getRegion.getName)
+      !offer.hasDomain || !offer.getDomain.hasFaultDomain || homeRegion().forall(_ == offer.getDomain.getFaultDomain.getRegion.getName)
     }
 
     isFromHomeRegion(offer)

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -23,7 +23,7 @@ class OfferMatcherManagerModule(
     offerMatcherConfig: OfferMatcherManagerConfig,
     scheduler: Scheduler,
     leadershipModule: LeadershipModule,
-    homeRegionProvider: Provider[HomeRegionProvider],
+    homeRegionProvider: () => HomeRegionProvider,
     actorName: String = "offerMatcherManager") {
 
   private[this] lazy val offersWanted: Subject[Boolean] = BehaviorSubject[Boolean](false)

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -23,7 +23,7 @@ class OfferMatcherManagerModule(
     offerMatcherConfig: OfferMatcherManagerConfig,
     scheduler: Scheduler,
     leadershipModule: LeadershipModule,
-    homeRegionProvider: () => HomeRegionProvider,
+    homeRegion: () => Option[String],
     actorName: String = "offerMatcherManager") {
 
   private[this] lazy val offersWanted: Subject[Boolean] = BehaviorSubject[Boolean](false)
@@ -41,6 +41,6 @@ class OfferMatcherManagerModule(
     * offers.
     */
   val globalOfferMatcherWantsOffers: Observable[Boolean] = offersWanted
-  val globalOfferMatcher: OfferMatcher = new ActorOfferMatcher(offerMatcherMultiplexer, None, homeRegionProvider)
+  val globalOfferMatcher: OfferMatcher = new ActorOfferMatcher(offerMatcherMultiplexer, None, homeRegion)
   val subOfferMatcherManager: OfferMatcherManager = new OfferMatcherManagerDelegate(offerMatcherMultiplexer)
 }

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -265,9 +265,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     lazy val instanceOpFactory: InstanceOpFactory = mock[InstanceOpFactory]
     lazy val config = MarathonTestHelper.defaultConfig()
     lazy val parentActor = newTestActor()
-    lazy val homeRegionProvider = new Provider[HomeRegionProvider] {
-      override def get() = mock[HomeRegionProvider]
-    }
+    lazy val homeRegionProvider = mock[HomeRegionProvider]
 
     lazy val module: LaunchQueueModule = new LaunchQueueModule(
       config,
@@ -277,7 +275,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       maybeOfferReviver = None,
       instanceTracker,
       instanceOpFactory,
-      homeRegionProvider
+      () => homeRegionProvider
     )
 
     def launchQueue = module.launchQueue

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -262,7 +262,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     lazy val instanceOpFactory: InstanceOpFactory = mock[InstanceOpFactory]
     lazy val config = MarathonTestHelper.defaultConfig()
     lazy val parentActor = newTestActor()
-    lazy val homeRegionProvider = mock[HomeRegionProvider]
+    lazy val homeRegion = () => None
 
     lazy val module: LaunchQueueModule = new LaunchQueueModule(
       config,
@@ -272,7 +272,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       maybeOfferReviver = None,
       instanceTracker,
       instanceOpFactory,
-      () => homeRegionProvider
+      homeRegion
     )
 
     def launchQueue = module.launchQueue

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -6,7 +6,6 @@ import akka.pattern.ask
 import akka.testkit.TestProbe
 import com.google.inject.Provider
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.HomeRegionProvider
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
@@ -74,14 +73,14 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       offerReviver: OfferReviver = mock[OfferReviver],
       rateLimiterActor: TestProbe = TestProbe(),
       offerMatchStatisticsActor: TestProbe = TestProbe(),
-      homeRegionProvider: () => HomeRegionProvider = () => mock[HomeRegionProvider]) {
+      homeRegion: () => Option[String] = () => None) {
 
     def createLauncherRef(instances: Int, appToLaunch: AppDefinition = f.app): ActorRef = {
       val props = TaskLauncherActor.props(
         launchQueueConfig,
         offerMatcherManager, clock, instanceOpFactory,
         maybeOfferReviver = Some(offerReviver),
-        instanceTracker, rateLimiterActor.ref, offerMatchStatisticsActor.ref, homeRegionProvider) _
+        instanceTracker, rateLimiterActor.ref, offerMatchStatisticsActor.ref, homeRegion) _
       system.actorOf(props(appToLaunch, instances))
     }
 
@@ -304,7 +303,7 @@ class TaskLauncherActorTest extends AkkaUnitTest {
           maybeOfferReviver = None,
           instanceTracker, rateLimiterActor.ref, offerMatchStatisticsActor.ref,
           f.app, instancesToLaunch = 1,
-          homeRegionProvider
+          homeRegion
         ) {
           override protected def scheduleTaskOperationTimeout(
             context: ActorContext, message: InstanceOpRejected): Cancellable = {

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -74,9 +74,7 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       offerReviver: OfferReviver = mock[OfferReviver],
       rateLimiterActor: TestProbe = TestProbe(),
       offerMatchStatisticsActor: TestProbe = TestProbe(),
-      homeRegionProvider: Provider[HomeRegionProvider] = new Provider[HomeRegionProvider] {
-        override def get() = mock[HomeRegionProvider]
-      }) {
+      homeRegionProvider: () => HomeRegionProvider = () => mock[HomeRegionProvider]) {
 
     def createLauncherRef(instances: Int, appToLaunch: AppDefinition = f.app): ActorRef = {
       val props = TaskLauncherActor.props(

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
@@ -20,28 +20,22 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
   "The ActorOfferMatcher" when {
     "receives remote region offer" should {
       "say is not interested when from non-home region" in new Fixture {
-        val homeRegionProvider = mock[HomeRegionProvider]
-        homeRegionProvider.getHomeRegion returns Some("home")
         val probe = TestProbe()
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => homeRegionProvider)
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => Some("home"))
 
         offerMatcher.isInterestedIn(offerWithFaultRegion("remote")) should be (false)
       }
 
       "say is interested when from home region" in new Fixture {
-        val homeRegionProvider = mock[HomeRegionProvider]
-        homeRegionProvider.getHomeRegion returns Some("home")
         val probe = TestProbe()
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => homeRegionProvider)
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => Some("home"))
 
         offerMatcher.isInterestedIn(offerWithFaultRegion("home")) should be (true)
       }
 
       "say is interested when fault region not set" in new Fixture {
-        val homeRegionProvider = mock[HomeRegionProvider]
-        homeRegionProvider.getHomeRegion returns Some("home")
         val probe = TestProbe()
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => homeRegionProvider)
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => Some("home"))
 
         offerMatcher.isInterestedIn(offerWithoutFaultRegion()) should be (true)
       }
@@ -63,7 +57,7 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         })
         val offer = MarathonTestHelper.makeBasicOffer().build()
 
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => mock[HomeRegionProvider])
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => None)
         val offerMatch: MatchedInstanceOps = offerMatcher.matchOffer(offer).futureValue
 
         offerMatch.offerId should not be (offer.getId)

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcherTest.scala
@@ -23,9 +23,7 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         val homeRegionProvider = mock[HomeRegionProvider]
         homeRegionProvider.getHomeRegion returns Some("home")
         val probe = TestProbe()
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[HomeRegionProvider] {
-          override def get() = homeRegionProvider
-        })(scheduler)
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => homeRegionProvider)(scheduler)
 
         offerMatcher.isInterestedIn(offerWithFaultRegion("remote")) should be (false)
       }
@@ -34,9 +32,7 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         val homeRegionProvider = mock[HomeRegionProvider]
         homeRegionProvider.getHomeRegion returns Some("home")
         val probe = TestProbe()
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[HomeRegionProvider] {
-          override def get() = homeRegionProvider
-        })(scheduler)
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => homeRegionProvider)(scheduler)
 
         offerMatcher.isInterestedIn(offerWithFaultRegion("home")) should be (true)
       }
@@ -45,9 +41,7 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         val homeRegionProvider = mock[HomeRegionProvider]
         homeRegionProvider.getHomeRegion returns Some("home")
         val probe = TestProbe()
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[HomeRegionProvider] {
-          override def get() = mock[MarathonScheduler]
-        })(scheduler)
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => homeRegionProvider)(scheduler)
 
         offerMatcher.isInterestedIn(offerWithoutFaultRegion()) should be (true)
       }
@@ -69,9 +63,7 @@ class ActorOfferMatcherTest extends AkkaUnitTest {
         })
         val offer = MarathonTestHelper.makeBasicOffer().build()
 
-        val offerMatcher = new ActorOfferMatcher(probe.ref, None, new Provider[HomeRegionProvider] {
-          override def get() = mock[HomeRegionProvider]
-        })(scheduler)
+        val offerMatcher = new ActorOfferMatcher(probe.ref, None, () => mock[HomeRegionProvider])(scheduler)
         val offerMatch: MatchedInstanceOps = offerMatcher.matchOffer(offer).futureValue
 
         offerMatch.offerId should not be (offer.getId)

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -52,14 +52,12 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val clock: Clock = Clock.systemUTC()
     val random: Random.type = Random
     val leaderModule: LeadershipModule = AlwaysElectedLeadershipModule.forRefFactory(system)
-    val homeRegionProvider = new Provider[HomeRegionProvider] {
-      override def get() = mock[HomeRegionProvider]
-    }
+    val homeRegionProvider = mock[HomeRegionProvider]
     val config: OfferMatcherManagerConfig = new OfferMatcherManagerConfig {
       verify()
     }
     val module: OfferMatcherManagerModule =
-      new OfferMatcherManagerModule(clock, random, config, system.scheduler, leaderModule, homeRegionProvider,
+      new OfferMatcherManagerModule(clock, random, config, system.scheduler, leaderModule, () => homeRegionProvider,
         actorName = UUID.randomUUID().toString)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -52,12 +52,11 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val clock: Clock = Clock.systemUTC()
     val random: Random.type = Random
     val leaderModule: LeadershipModule = AlwaysElectedLeadershipModule.forRefFactory(system)
-    val homeRegionProvider = mock[HomeRegionProvider]
     val config: OfferMatcherManagerConfig = new OfferMatcherManagerConfig {
       verify()
     }
     val module: OfferMatcherManagerModule =
-      new OfferMatcherManagerModule(clock, random, config, system.scheduler, leaderModule, () => homeRegionProvider,
+      new OfferMatcherManagerModule(clock, random, config, system.scheduler, leaderModule, () => None,
         actorName = UUID.randomUUID().toString)
   }
 


### PR DESCRIPTION
Summary:
Follow-up for my previous review - this time just removing MarathonScheduler being wired as a guice dependency - now it is instantiated manually. 

JIRA issues:
