### PR TITLE
Move auth tests to common test behaviours.

### DIFF
--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
@@ -58,7 +58,7 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
 
       When("we try to fetch the queue")
       Get(Uri./) ~> f.controller.route ~> check {
-        Then("weder receive an empty json array")
+        Then("we receive an empty json array")
         status should be(StatusCodes.OK)
 
         val expected =

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
@@ -2,11 +2,10 @@ package mesosphere.marathon
 package api.akkahttp.v2
 
 import akka.http.scaladsl.model.{ StatusCodes, Uri }
-import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.UnitTest
-import mesosphere.marathon.api.akkahttp.AuthDirectives.{ NotAuthenticated, NotAuthorized }
+import mesosphere.marathon.api.akkahttp.AuthDirectives.NotAuthorized
 import mesosphere.marathon.api.akkahttp.Rejections.EntityNotFound
 import mesosphere.marathon.api.{ JsonTestHelper, TestAuthFixture }
 import mesosphere.marathon.core.election.ElectionService
@@ -23,37 +22,14 @@ import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside with StrictLogging {
+class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside with RouteBehaviours with StrictLogging {
 
   "QueueController" should {
-    "deny access without authentication for getting queue info" in {
-      Given("an unauthenticated request")
-      val f = new Fixture(authenticated = false)
 
-      When("we try to fetch the queue")
-      Get(Uri./) ~> f.controller.route ~> check {
-        Then("we receive a NotAuthenticated response")
-        rejection shouldBe a[NotAuthenticated]
-        inside(rejection) {
-          case NotAuthenticated(response) =>
-            response.status should be(StatusCodes.Forbidden)
-        }
-      }
-    }
-
-    "deny access without authentication for reseting backoff delay" in {
-      Given("an unauthenticated request")
-      val f = new Fixture(authenticated = false)
-
-      When("we try to fetch the queue")
-      Delete("/unknown/delay") ~> f.controller.route ~> check {
-        Then("we receive a NotAuthenticated response")
-        rejection shouldBe a[NotAuthenticated]
-        inside(rejection) {
-          case NotAuthenticated(response) =>
-            response.status should be(StatusCodes.Forbidden)
-        }
-      }
+    {
+      val controller = Fixture(authenticated = false).controller
+      behave like unauthenticatedRoute(forRoute = controller.route, withRequest = Get(Uri./))
+      behave like unauthenticatedRoute(forRoute = controller.route, withRequest = Delete("/unknown/delay"))
     }
 
     "return an empty json array if nothing in the queue" in {
@@ -82,7 +58,7 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
 
       When("we try to fetch the queue")
       Get(Uri./) ~> f.controller.route ~> check {
-        Then("we receive an empty json array")
+        Then("weder receive an empty json array")
         status should be(StatusCodes.OK)
 
         val expected =
@@ -456,7 +432,7 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
     )
   }
 
-  class Fixture(authenticated: Boolean = true, authorized: Boolean = true) {
+  case class Fixture(authenticated: Boolean = true, authorized: Boolean = true) {
 
     val clock: SettableClock = new SettableClock()
     val launchQueue: LaunchQueue = mock[LaunchQueue]

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/RouteBehaviours.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/RouteBehaviours.scala
@@ -1,0 +1,41 @@
+package mesosphere.marathon
+package api.akkahttp.v2
+
+import akka.http.scaladsl.model.{ HttpRequest, StatusCodes, Uri }
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import mesosphere.UnitTest
+import mesosphere.marathon.api.akkahttp.AuthDirectives.{ NotAuthenticated, NotAuthorized }
+import org.scalatest.Inside
+
+trait RouteBehaviours extends ScalatestRouteTest with Inside { this: UnitTest =>
+
+  def unauthenticatedRoute(forRoute: Route, withRequest: HttpRequest): Unit = {
+    s"deny access to ${withRequest.method.value} of ${withRequest.uri} without authentication" in {
+      When("we try to fetch the info")
+      withRequest ~> forRoute ~> check {
+        Then("we receive a NotAuthenticated response")
+        rejection shouldBe a[NotAuthenticated]
+        inside(rejection) {
+          case NotAuthenticated(response) =>
+            response.status should be(StatusCodes.Forbidden)
+        }
+      }
+    }
+  }
+
+  def unauthorizedRoute(forRoute: Route, withRequest: HttpRequest): Unit = {
+    s"deny access to ${withRequest.method.value} of ${withRequest.uri} without authorization" in {
+      When("we try to fetch the info")
+      withRequest ~> forRoute ~> check {
+        Then("we receive a NotAuthenticated response")
+        rejection shouldBe a[NotAuthorized]
+        inside(rejection) {
+          case NotAuthorized(response) =>
+            response.status should be(StatusCodes.Unauthorized)
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Summary:
Many new controllers have test to verify authentication and
authorization behaviours. This change moves them into a common ScalaTest
behaviour.
