### PR TITLE
AppsController split: replace multiple apps method

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -197,6 +197,6 @@ object EntityMarshallers {
       complete(StatusCodes.UnprocessableEntity -> failure)
   }
 
-  def entityUnmarshallerToMessageUnmarshaller[T](um: FromEntityUnmarshaller[T]): FromMessageUnmarshaller[T] =
+  implicit def entityUnmarshallerToMessageUnmarshaller[T](um: FromEntityUnmarshaller[T]): FromMessageUnmarshaller[T] =
     Unmarshaller.withMaterializer { implicit ec ⇒ implicit mat ⇒ request ⇒ um(request.entity) }
 }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -158,6 +158,7 @@ class AppsController(
   }
 
   private def patchSingle(appId: PathId)(implicit identity: Identity): Route = ???
+
   private[this] def updateMultiple(partialUpdate: Boolean, allowCreation: Boolean)(implicit identity: Identity): Route = {
     val version = clock.now()
     (forceParameter & entity(as(appUpdatesUnmarshaller(partialUpdate)))) { (force, appUpdates) =>
@@ -204,7 +205,6 @@ class AppsController(
     case Failure(ex) =>
       throw ex
   }
-
 
   private def putSingle(appId: PathId)(implicit identity: Identity): Route = ???
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -197,7 +197,7 @@ class AppsController(
     case Failure(_: AppNotFoundException) =>
       reject(
         maybeAppId.map { appId =>
-          Rejections.EntityNotFound.app(appId)
+          Rejections.EntityNotFound.noApp(appId)
         } getOrElse Rejections.EntityNotFound()
       )
     case Failure(RejectionError(rejection)) =>

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -165,9 +165,9 @@ class AppsController(
       def updateGroup(rootGroup: RootGroup): RootGroup = appUpdates.foldLeft(rootGroup) { (group, update) =>
         update.id.map(PathId(_)) match {
           case Some(id) =>
-            val res = Try(group.updateApp(id, AppHelpers.updateOrCreate(id, _, update, partialUpdate, allowCreation, clock.now(), marathonSchedulerService), version))
-            res.get
-          case None => group
+            group.updateApp(id, AppHelpers.updateOrCreate(id, _, update, partialUpdate, allowCreation, clock.now(), marathonSchedulerService), version)
+          case None =>
+            group
         }
       }
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -8,6 +8,7 @@ import akka.event.EventStream
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{ Directive1, Rejection, RejectionError, Route }
 import mesosphere.marathon.api.v2.{ AppHelpers, AppNormalization, InfoEmbedResolver, LabelSelectorParsers }
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.deployment.DeploymentPlan
@@ -18,6 +19,7 @@ import mesosphere.marathon.state.{ AppDefinition, Identifiable, PathId }
 import play.api.libs.json.Json
 import PathId._
 import mesosphere.marathon.state._
+import play.api.libs.json._
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.task.Task.{ Id => TaskId }
 import PathMatchers._

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -10,6 +10,11 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.{ Directive1, Rejection, RejectionError, Route }
 import mesosphere.marathon.api.v2.{ AppHelpers, AppNormalization, InfoEmbedResolver, LabelSelectorParsers }
+import mesosphere.marathon.api.akkahttp.{ Controller, EntityMarshallers }
+import mesosphere.marathon.api.v2.AppHelpers.{ appNormalization, appUpdateNormalization, authzSelector }
+import mesosphere.marathon.api.v2.Validation.validateOrThrow
+import mesosphere.marathon.api.v2.AppHelpers.{ appNormalization, appUpdateNormalization, authzSelector }
+import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.group.GroupManager
@@ -62,6 +67,7 @@ class AppsController(
   import Directives._
 
   private implicit lazy val validateApp = AppDefinition.validAppDefinition(config.availableFeatures)(pluginManager)
+  private implicit lazy val updateValidator = AppValidation.validateCanonicalAppUpdateAPI(config.availableFeatures, () => normalizationConfig.defaultNetworkName)
 
   import AppHelpers._
   import EntityMarshallers._
@@ -289,4 +295,7 @@ class AppsController(
 
   private implicit val validateAndNormalizeApp: Normalization[raml.App] =
     appNormalization(config.availableFeatures, normalizationConfig)(AppNormalization.withCanonizedIds())
+
+  private implicit val validateAndNormalizeAppUpdate: Normalization[raml.AppUpdate] =
+    appUpdateNormalization(config.availableFeatures, normalizationConfig)(AppNormalization.withCanonizedIds())
 }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -25,8 +25,19 @@ import mesosphere.marathon.api.TaskKiller
 import mesosphere.marathon.core.event.ApiPostEvent
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker
+import mesosphere.marathon.core.health.HealthCheckManager
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.task.tracker.InstanceTracker
+import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
+import mesosphere.marathon.core.task.Task.{ Id => TaskId }
+import PathMatchers._
+import mesosphere.marathon.raml.DeploymentResult
+import mesosphere.marathon.raml.EnrichedTaskConversion._
+import mesosphere.marathon.raml.AnyToRaml
 
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success, Try }
+import scala.util.control.NonFatal
 
 class AppsController(
     val clock: Clock,

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -1901,7 +1901,6 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
           | }
           ]""".stripMargin.getBytes("UTF-8")
 
-      When("The application is updated")
       val entity = HttpEntity(body).withContentType(ContentTypes.`application/json`)
       Put(Uri./, entity) ~> route ~> check {
         Then("The application is updated")

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -1852,5 +1852,62 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
         (appJson \ "fetch" \ 0 \ "destPath" get) should be(JsString("bash.copy"))
       }
     }
+
+    "Replace multiple existing applications" in new Fixture {
+      Given("An app and group")
+      val app1Id = "/app1"
+      val app2Id = "/app2"
+
+      val newApp1Cmd = "bla1"
+      val newApp2Cmd = "bla2"
+      val apps = Seq(App(
+        id = app1Id,
+        cmd = Some("cmd1")
+      ), App(
+        id = app2Id,
+        cmd = Some("cmd1")
+      )
+      )
+
+      val normed = apps.map(normalize)
+      val appDefs = normed.map(Raml.fromRaml(_))
+      val rootGroup = createRootGroup(
+        appDefs.map { appDef =>
+        appDef.id -> appDef
+      }.toMap
+      )
+      val plan = DeploymentPlan(rootGroup, rootGroup)
+      groupManager.updateRoot(any, any, any, any, any) answers { args =>
+        val fn = args(1).asInstanceOf[RootGroup => RootGroup]
+        val updated = fn(rootGroup)
+        updated.app(PathId(app1Id)).get.cmd.get shouldEqual newApp1Cmd
+        updated.app(PathId(app2Id)).get.cmd.get shouldEqual newApp2Cmd
+        Future.successful(plan)
+      }
+      groupManager.rootGroup() returns rootGroup
+      groupManager.app(appDefs(0).id) returns Some(appDefs(0))
+      groupManager.app(appDefs(1).id) returns Some(appDefs(1))
+
+      When("The application is updated")
+      val body =
+        s"""[
+          | {
+          |   "id": "$app1Id",
+          |   "cmd": "$newApp1Cmd"
+          | },
+          | {
+          |   "id": "$app2Id",
+          |   "cmd": "$newApp2Cmd"
+          | }
+          ]""".stripMargin.getBytes("UTF-8")
+
+      When("The application is updated")
+      val entity = HttpEntity(body).withContentType(ContentTypes.`application/json`)
+      Put(Uri./, entity) ~> route ~> check {
+        Then("The application is updated")
+        status shouldEqual StatusCodes.OK
+        header[Headers.`Marathon-Deployment-Id`] should not be 'empty
+      }
+    }
   }
 }


### PR DESCRIPTION
Summary: Migration of apps resource to akka http. This PR only implements replaceMultipleApps method, so it should be easier to review it. Full implementation of AppsController is available at #5522.

JIRA issues: MARATHON-7299