### PR TITLE
[RFC] Use explicit RAML conversion instead of implicits.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -17,12 +17,13 @@ import mesosphere.marathon.core.appinfo.AppInfo
 import mesosphere.marathon.plugin.PathId
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfoWithStatistics
 import mesosphere.marathon.core.plugin.PluginDefinitions
+import mesosphere.marathon.raml.AppConversion
 import mesosphere.marathon.state.AppDefinition
 import play.api.libs.json._
 
 import scala.collection.breakOut
 
-object EntityMarshallers {
+object EntityMarshallers extends AppConversion {
   import Directives.complete
   import mesosphere.marathon.api.v2.json.Formats._
   import mesosphere.marathon.raml.MetricsConversion._
@@ -130,7 +131,7 @@ object EntityMarshallers {
         // however since this is an update, the user isn't required to specify an ID as part of the definition so we do
         // some hackery here to pass initial JSON parsing.
         val app = (jsObj + ("id" -> JsString(appId.toString))).as[raml.App]
-        appNormalization.normalized(app).toRaml[raml.AppUpdate]
+        asRaml(appNormalization.normalized(app))
       }
   }.handleValidationErrors
 
@@ -144,7 +145,7 @@ object EntityMarshallers {
       // this is a complete replacement of the app as we know it, so parse and normalize as if we're dealing
       // with a brand new app because the rules are different (for example, many fields are non-optional with brand-new apps).
       // the version is thrown away in toUpdate so just pass `zero` for now.
-      playJsonUnmarshaller[Seq[raml.App]].map(_.map(app => appNormalization.normalized(app).toRaml[raml.AppUpdate]))
+      playJsonUnmarshaller[Seq[raml.App]].map(_.map(app => asRaml(appNormalization.normalized(app))))
   }
 
   implicit val jsValueMarshaller = playJsonMarshaller[JsValue]

--- a/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
@@ -5,9 +5,9 @@ import mesosphere.marathon.raml._
 import mesosphere.marathon.state.{ FetchUri, PathId }
 import mesosphere.marathon.stream.Implicits._
 
-object AppNormalization {
+object AppNormalization extends UnreachableStrategyConversion {
 
-  import Apps._
+  import mesosphere.marathon.raml.Apps._
   import NetworkNormalization.Networks
   import Normalization._
 
@@ -298,7 +298,7 @@ object AppNormalization {
 
     val defaultUnreachable: UnreachableStrategy = {
       val hasPersistentVols = app.container.exists(_.volumes.existsAn[AppPersistentVolume])
-      state.UnreachableStrategy.default(hasPersistentVols).toRaml
+      asRaml(state.UnreachableStrategy.default(hasPersistentVols))
     }
 
     // requirePorts only applies for host-mode networking

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -16,8 +16,6 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.raml.AnyToRaml
-import mesosphere.marathon.raml.EnrichedTask._
 import mesosphere.marathon.raml.EnrichedTaskConversion._
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.state.PathId._
@@ -52,13 +50,13 @@ class AppTasksResource @Inject() (
           val groupPath = gid.toRootPath
           val maybeGroup = groupManager.group(groupPath)
           withAuthorization(ViewGroup, maybeGroup, unknownGroup(groupPath)) { group =>
-            ok(jsonObjString("tasks" -> runningTasks(group.transitiveAppIds, instancesBySpec).toRaml))
+            ok(jsonObjString("tasks" -> runningTasks(group.transitiveAppIds, instancesBySpec).map(asRaml)))
           }
         case _ =>
           val appId = id.toRootPath
           val maybeApp = groupManager.app(appId)
           withAuthorization(ViewRunSpec, maybeApp, unknownApp(appId)) { _ =>
-            ok(jsonObjString("tasks" -> runningTasks(Set(appId), instancesBySpec).toRaml))
+            ok(jsonObjString("tasks" -> runningTasks(Set(appId), instancesBySpec).map(asRaml)))
           }
       }
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -18,7 +18,6 @@ import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec }
-import mesosphere.marathon.raml.AnyToRaml
 import mesosphere.marathon.raml.EnrichedTask._
 import mesosphere.marathon.raml.EnrichedTaskConversion._
 import mesosphere.marathon.state.{ AppDefinition, PathId }
@@ -94,7 +93,7 @@ class TasksResource @Inject() (
 
     val enrichedTasks: Iterable[EnrichedTask] = result(futureEnrichedTasks)
     ok(jsonObjString(
-      "tasks" -> enrichedTasks.toIndexedSeq.toRaml
+      "tasks" -> enrichedTasks.toIndexedSeq.map(asRaml)
     ))
   }
 
@@ -150,7 +149,7 @@ class TasksResource @Inject() (
         })).flatten
       ok(jsonObjString("tasks" -> killed.flatMap { instance =>
         instance.tasksMap.valuesIterator.map { task =>
-          EnrichedTask(task.runSpecId, task, instance.agentInfo, Seq.empty).toRaml
+          asRaml(EnrichedTask(task.runSpecId, task, instance.agentInfo, Seq.empty))
         }
       }))
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -445,7 +445,7 @@ trait AppAndGroupFormats {
         info.maybeCounts.map(TaskCountsWrites.writes(_).as[JsObject]),
         info.maybeDeployments.map(deployments => Json.obj("deployments" -> deployments)),
         info.maybeReadinessCheckResults.map(readiness => Json.obj("readinessCheckResults" -> readiness)),
-        info.maybeTasks.map(tasks => Json.obj("tasks" -> Raml.toRaml(tasks))),
+        info.maybeTasks.map(tasks => Json.obj("tasks" -> tasks.map(asRaml))),
         info.maybeLastTaskFailure.map(lastFailure => Json.obj("lastTaskFailure" -> lastFailure)),
         info.maybeTaskStats.map(taskStats => Json.obj("taskStats" -> taskStats))
       ).flatten

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -7,11 +7,11 @@ import com.fasterxml.uuid.{ EthernetAddress, Generators }
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance.{ AgentInfo, InstanceState }
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.{ MarathonState, PathId, Timestamp, UnreachableStrategy, UnreachableDisabled, UnreachableEnabled }
+import mesosphere.marathon.state.{ MarathonState, PathId, Timestamp, UnreachableDisabled, UnreachableEnabled, UnreachableStrategy }
 import mesosphere.marathon.tasks.OfferUtil
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.Placed
-import mesosphere.marathon.raml.Raml
+import mesosphere.marathon.raml.UnreachableStrategyConversion
 import org.apache._
 import org.apache.mesos.Protos.Attribute
 import play.api.libs.json._
@@ -348,7 +348,7 @@ object Instance {
       (__ \ "runSpecVersion").write[Timestamp] ~
       (__ \ "state").write[InstanceState] ~
       (__ \ "unreachableStrategy").write[raml.UnreachableStrategy]
-    ) { (i) => (i.instanceId, i.agentInfo, i.tasksMap, i.runSpecVersion, i.state, Raml.toRaml(i.unreachableStrategy)) }
+    ) { (i) => (i.instanceId, i.agentInfo, i.tasksMap, i.runSpecVersion, i.state, UnreachableStrategyConversion.asRaml(i.unreachableStrategy)) }
   }
 
   implicit val unreachableStrategyReads: Reads[Instance] = {
@@ -361,7 +361,7 @@ object Instance {
       (__ \ "unreachableStrategy").readNullable[raml.UnreachableStrategy]
     ) { (instanceId, agentInfo, tasksMap, runSpecVersion, state, maybeUnreachableStrategy) =>
         val unreachableStrategy = maybeUnreachableStrategy.
-          map(Raml.fromRaml(_)).getOrElse(UnreachableStrategy.default())
+          map(UnreachableStrategyConversion.fromRaml).getOrElse(UnreachableStrategy.default())
         new Instance(instanceId, agentInfo, state, tasksMap, runSpecVersion, unreachableStrategy)
       }
   }

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -4,7 +4,7 @@ package core.pod
 // scalastyle:off
 import mesosphere.marathon.api.v2.PodNormalization
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.raml.{ Endpoint, ExecutorResources, Pod, Raml, Resources }
+import mesosphere.marathon.raml.{ Endpoint, ExecutorResources, NetworkConversion, Pod, PodConversion, Raml, Resources }
 import mesosphere.marathon.state._
 import play.api.libs.json.Json
 
@@ -109,7 +109,7 @@ object PodDefinition {
     Raml.fromRaml(Json.parse(proto.getJson).as[Pod])
   }
 
-  val DefaultExecutorResources: Resources = ExecutorResources().fromRaml
+  val DefaultExecutorResources: Resources = PodConversion.fromRaml(ExecutorResources())
   val DefaultId = PathId.empty
   val DefaultUser = Option.empty[String]
   val DefaultEnv = Map.empty[String, EnvVarValue]
@@ -121,7 +121,7 @@ object PodDefinition {
   val DefaultConstraints = Set.empty[Protos.Constraint]
   val DefaultVersion = Timestamp.now()
   val DefaultVolumes = Seq.empty[Volume]
-  val DefaultNetworks: Seq[Network] = PodNormalization.DefaultNetworks.map(_.fromRaml)
+  val DefaultNetworks: Seq[Network] = PodNormalization.DefaultNetworks.map(NetworkConversion.fromRaml)
   val DefaultBackoffStrategy = BackoffStrategy()
   val DefaultUpgradeStrategy = AppDefinition.DefaultUpgradeStrategy
   val DefaultUnreachableStrategy = UnreachableStrategy.default(resident = false)

--- a/src/main/scala/mesosphere/marathon/raml/ConstraintConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/ConstraintConversion.scala
@@ -50,7 +50,7 @@ trait ConstraintConversion {
     Constraint(c.getField, operator, Option(c.getValue))
   }
 
-  implicit val constraintToSeqStringWrites: Writes[Protos.Constraint, Seq[String]] = Writes { constraint =>
+  def constraintProtosToStringSeq(constraint: Protos.Constraint): Seq[String] = {
     val builder = Seq.newBuilder[String]
     builder += constraint.getField
     builder += constraint.getOperator.name

--- a/src/main/scala/mesosphere/marathon/raml/ContainerConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/ContainerConversion.scala
@@ -94,7 +94,7 @@ trait ContainerConversion extends HealthCheckConversion with VolumeConversion wi
     }
   }
 
-  implicit val pullConfigReads: Reads[DockerPullConfig, state.Container.DockerPullConfig] = Reads {
+  def fromRaml(config: DockerPullConfig): state.Container.DockerPullConfig = config match {
     case DockerPullConfig(secret) => state.Container.DockerPullConfig(secret)
   }
 
@@ -118,7 +118,7 @@ trait ContainerConversion extends HealthCheckConversion with VolumeConversion wi
           image = docker.image,
           portMappings = portMappings, // assumed already normalized, see AppNormalization
           credential = docker.credential.map(c => state.Container.Credential(principal = c.principal, secret = c.secret)),
-          pullConfig = docker.pullConfig.map(_.fromRaml),
+          pullConfig = docker.pullConfig.map(fromRaml),
           forcePullImage = docker.forcePullImage
         )
       case (EngineType.Mesos, None, Some(appc)) =>

--- a/src/main/scala/mesosphere/marathon/raml/EnrichedTaskConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/EnrichedTaskConversion.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.core.task.Task
 
 object EnrichedTaskConversion extends HealthConversion with DefaultConversions {
 
-  implicit val localVolumeIdWrites: Writes[Task.LocalVolumeId, LocalVolumeId] = Writes { localVolumeId =>
+  def asRaml(localVolumeId: Task.LocalVolumeId): LocalVolumeId = {
     LocalVolumeId(
       runSpecId = localVolumeId.runSpecId.toRaml,
       containerPath = localVolumeId.containerPath,
@@ -15,7 +15,7 @@ object EnrichedTaskConversion extends HealthConversion with DefaultConversions {
     )
   }
 
-  implicit val enrichedTaskRamlWrite: Writes[core.appinfo.EnrichedTask, EnrichedTask] = Writes { enrichedTask =>
+  def asRaml(enrichedTask: core.appinfo.EnrichedTask): EnrichedTask = {
     val task: Task = enrichedTask.task
 
     val (startedAt, stagedAt, ports, version) =
@@ -28,12 +28,12 @@ object EnrichedTaskConversion extends HealthConversion with DefaultConversions {
     val ipAddresses = task.status.networkInfo.ipAddresses.toRaml
 
     val localVolumes = task.reservationWithVolumes.fold(Seq.empty[LocalVolumeId]) { reservation =>
-      reservation.volumeIds.toRaml
+      reservation.volumeIds.map(asRaml)
     }
 
     EnrichedTask(
       appId = enrichedTask.appId.toRaml,
-      healthCheckResults = enrichedTask.healthCheckResults.toRaml,
+      healthCheckResults = enrichedTask.healthCheckResults.map(asRaml),
       host = enrichedTask.agentInfo.host,
       id = task.taskId.idString,
       ipAddresses = ipAddresses,

--- a/src/main/scala/mesosphere/marathon/raml/HealthConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/HealthConversion.scala
@@ -14,4 +14,8 @@ trait HealthConversion extends DefaultConversions {
       lastFailureCause = health.lastFailureCause
     )
   }
+
+  def asRaml(health: core.health.Health): Health = {
+    health.toRaml
+  }
 }

--- a/src/main/scala/mesosphere/marathon/raml/KillSelectionConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/KillSelectionConversion.scala
@@ -6,7 +6,7 @@ package raml
   */
 trait KillSelectionConversion {
 
-  implicit val ramlKillSelectionRead = Reads[KillSelection, state.KillSelection] {
+  def fromRaml(raml: KillSelection): state.KillSelection = raml match {
     case KillSelection.OldestFirst => state.KillSelection.OldestFirst
     case KillSelection.YoungestFirst => state.KillSelection.YoungestFirst
   }

--- a/src/main/scala/mesosphere/marathon/raml/NetworkConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/NetworkConversion.scala
@@ -10,19 +10,18 @@ trait NetworkConversion {
 
   import NetworkConversionMessages._
 
-  implicit val networkRamlReader: Reads[Network, pod.Network] =
-    Reads { raml =>
-      raml.mode match {
-        case NetworkMode.Host => pod.HostNetwork
-        case NetworkMode.ContainerBridge => pod.BridgeNetwork(raml.labels)
-        case NetworkMode.Container => pod.ContainerNetwork(
-          // we expect validation to catch this problem first. but it's possible that migration
-          // also runs into this problem so we handle it explicitly.
-          raml.name.getOrElse(throw SerializationFailedException(ContainerNetworkRequiresName)),
-          raml.labels
-        )
-      }
+  def fromRaml(raml: Network): pod.Network = {
+    raml.mode match {
+      case NetworkMode.Host => pod.HostNetwork
+      case NetworkMode.ContainerBridge => pod.BridgeNetwork(raml.labels)
+      case NetworkMode.Container => pod.ContainerNetwork(
+        // we expect validation to catch this problem first. but it's possible that migration
+        // also runs into this problem so we handle it explicitly.
+        raml.name.getOrElse(throw SerializationFailedException(ContainerNetworkRequiresName)),
+        raml.labels
+      )
     }
+  }
 
   implicit val networkRamlWriter: Writes[pod.Network, Network] = Writes {
     case cnet: pod.ContainerNetwork =>

--- a/src/main/scala/mesosphere/marathon/raml/ReadinessConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/ReadinessConversions.scala
@@ -25,7 +25,7 @@ trait ReadinessConversions {
     )
   }
 
-  implicit val readinessProtocolReads: Reads[HttpScheme, core.readiness.ReadinessCheck.Protocol] = Reads {
+  def fromRaml(protocol: HttpScheme): core.readiness.ReadinessCheck.Protocol = protocol match {
     case HttpScheme.Http => core.readiness.ReadinessCheck.Protocol.HTTP
     case HttpScheme.Https => core.readiness.ReadinessCheck.Protocol.HTTPS
   }
@@ -33,7 +33,7 @@ trait ReadinessConversions {
   implicit val appReadinessRamlReader: Reads[ReadinessCheck, core.readiness.ReadinessCheck] = Reads { check =>
     core.readiness.ReadinessCheck(
       name = check.name,
-      protocol = check.protocol.fromRaml,
+      protocol = fromRaml(check.protocol),
       path = check.path,
       portName = check.portName,
       interval = check.intervalSeconds.seconds,

--- a/src/main/scala/mesosphere/marathon/raml/UnreachableStrategyConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/UnreachableStrategyConversion.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
   */
 trait UnreachableStrategyConversion {
 
-  implicit val ramlUnreachableStrategyRead = Reads[UnreachableStrategy, state.UnreachableStrategy] {
+  def fromRaml(model: UnreachableStrategy): state.UnreachableStrategy = model match {
     case strategy: UnreachableEnabled =>
       state.UnreachableEnabled(
         inactiveAfter = strategy.inactiveAfterSeconds.seconds,
@@ -17,7 +17,7 @@ trait UnreachableStrategyConversion {
       state.UnreachableDisabled
   }
 
-  implicit val ramlUnreachableStrategyWrite = Writes[state.UnreachableStrategy, UnreachableStrategy]{
+  def asRaml(model: state.UnreachableStrategy): UnreachableStrategy = model match {
     case strategy: state.UnreachableEnabled =>
       UnreachableEnabled(
         inactiveAfterSeconds = strategy.inactiveAfter.toSeconds,

--- a/src/main/scala/mesosphere/marathon/raml/UpgradeStrategyConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/UpgradeStrategyConversion.scala
@@ -1,0 +1,12 @@
+package mesosphere.marathon
+package raml
+
+trait UpgradeStrategyConversion {
+
+  def asRaml(strategy: state.UpgradeStrategy): UpgradeStrategy = {
+    UpgradeStrategy(strategy.maximumOverCapacity, strategy.minimumHealthCapacity)
+  }
+
+}
+
+object UpgradeStrategyConversion extends UpgradeStrategyConversion

--- a/src/main/scala/mesosphere/marathon/raml/package.scala
+++ b/src/main/scala/mesosphere/marathon/raml/package.scala
@@ -2,15 +2,9 @@ package mesosphere.marathon
 
 package object raml extends RamlConversions {
 
-  implicit class AnyToRaml[A](val a: A) extends AnyVal {
+  private[raml] implicit class AnyToRaml[A](val a: A) extends AnyVal {
     def toRaml[B](implicit writes: Writes[A, B]): B = {
       writes.write(a)
-    }
-  }
-
-  implicit class AnyFromRaml[A](val a: A) extends AnyVal {
-    def fromRaml[B](implicit reads: Reads[A, B]): B = {
-      reads.read(a)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/KillSelection.scala
+++ b/src/main/scala/mesosphere/marathon/state/KillSelection.scala
@@ -1,6 +1,8 @@
 package mesosphere.marathon
 package state
 
+import mesosphere.marathon.raml.KillSelectionConversion
+
 /**
   * Defines a kill selection for tasks. See [[mesosphere.marathon.core.deployment.ScalingProposition]].
   */
@@ -27,7 +29,7 @@ object KillSelection {
       Protos.KillSelection.OldestFirst
   }
 
-  lazy val DefaultKillSelection: KillSelection = raml.KillSelection.DefaultValue.fromRaml
+  lazy val DefaultKillSelection: KillSelection = KillSelectionConversion.fromRaml(raml.KillSelection.DefaultValue)
 
   private[this] val proto2Model = Map(
     Protos.KillSelection.YoungestFirst -> YoungestFirst,

--- a/src/main/scala/mesosphere/marathon/state/Residency.scala
+++ b/src/main/scala/mesosphere/marathon/state/Residency.scala
@@ -3,13 +3,14 @@ package state
 
 import com.wix.accord.dsl._
 import mesosphere.marathon.Protos.ResidencyDefinition.TaskLostBehavior
+import mesosphere.marathon.raml.RamlConversions
 
 case class Residency(relaunchEscalationTimeoutSeconds: Long, taskLostBehavior: TaskLostBehavior)
 
 object Residency {
   def default: Residency = Residency(defaultRelaunchEscalationTimeoutSeconds, defaultTaskLostBehaviour)
 
-  def defaultTaskLostBehaviour: TaskLostBehavior = raml.AppResidency.DefaultTaskLostBehavior.fromRaml
+  def defaultTaskLostBehaviour: TaskLostBehavior = RamlConversions.fromRaml(raml.AppResidency.DefaultTaskLostBehavior)
   def defaultRelaunchEscalationTimeoutSeconds: Long = raml.AppResidency.DefaultRelaunchEscalationTimeoutSeconds
 
   implicit val residencyValidator = validator[Residency] { residency =>

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo15.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo15.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.api.v2.{ AppNormalization, AppHelpers }
 import mesosphere.marathon.core.async.ExecutionContexts
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.zk.ZkPersistenceStore
-import mesosphere.marathon.raml.Raml
+import mesosphere.marathon.raml.RamlConversions
 import mesosphere.marathon.state.{ AppDefinition, PathId, RootGroup }
 import mesosphere.marathon.storage.repository.GroupRepository
 
@@ -125,7 +125,7 @@ private[migration] object MigrationTo15 {
     import Normalization._
     val rawRaml = Raml.toRaml(service)
     val normalizedApp = rawRaml.normalize
-    val appDef = normalizedApp.fromRaml
+    val appDef = RamlConversions.fromRaml(normalizedApp)
     // fixup version since it's intentionally lost in the conversion from App to AppDefinition
     appDef.copy(versionInfo = AppDefinition.versionInfoFrom(service))
   }

--- a/src/main/scala/mesosphere/mesos/ScalarMatchResult.scala
+++ b/src/main/scala/mesosphere/mesos/ScalarMatchResult.scala
@@ -173,7 +173,7 @@ case class DiskResourceNoMatch(
   def requestedStringification(requested: Either[Double, PersistentVolume]): String = requested match {
     case Left(value) => s"disk:root:${value}"
     case Right(vol) =>
-      val constraintsJson: Seq[Seq[String]] = vol.persistent.constraints.map(_.toRaml[Seq[String]])(collection.breakOut)
+      val constraintsJson: Seq[Seq[String]] = vol.persistent.constraints.map(constraintProtosToStringSeq)(collection.breakOut)
       s"disk:${vol.persistent.`type`.toString}:${vol.persistent.size}:[${constraintsJson.mkString(",")}]"
   }
 

--- a/src/test/scala/mesosphere/marathon/api/ConstraintTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/ConstraintTest.scala
@@ -23,7 +23,7 @@ class ConstraintTest extends UnitTest {
 
   implicit val constraintWrites: Writes[Constraint] = Writes { c =>
     import mesosphere.marathon.raml._
-    val converted = c.toRaml[Seq[String]]
+    val converted = constraintProtosToStringSeq(c)
     JsArray(converted.map(JsString))
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -87,7 +87,7 @@ class AppDefinitionFormatsTest extends UnitTest
       (r1 \ "container").asOpt[String] should equal (None)
       (r1 \ "healthChecks").asOpt[Seq[AppHealthCheck]] should be (empty)
       (r1 \ "dependencies").asOpt[Set[PathId]] should be (empty)
-      (r1 \ "upgradeStrategy").as[UpgradeStrategy] should equal (DefaultUpgradeStrategy.toRaml)
+      (r1 \ "upgradeStrategy").as[UpgradeStrategy] should equal (UpgradeStrategyConversion.asRaml(DefaultUpgradeStrategy))
       (r1 \ "residency").asOpt[String] should equal (None)
       (r1 \ "secrets").asOpt[Map[String, SecretDef]] should be (empty)
       (r1 \ "taskKillGracePeriodSeconds").asOpt[Long] should equal (DefaultTaskKillGracePeriod)

--- a/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
@@ -91,7 +91,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         |  "localVolumes" : []
         |}
       """.stripMargin
-      JsonTestHelper.assertThatJsonOf(f.taskWithoutIp.toRaml).correspondsToJsonString(json)
+      JsonTestHelper.assertThatJsonOf(asRaml(f.taskWithoutIp)).correspondsToJsonString(json)
     }
 
     "JSON serialization of a Task with multiple IPs" in {
@@ -122,7 +122,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         |  "localVolumes" : []
         |}
       """.stripMargin
-      JsonTestHelper.assertThatJsonOf(f.taskWithMultipleIPs.toRaml).correspondsToJsonString(json)
+      JsonTestHelper.assertThatJsonOf(asRaml(f.taskWithMultipleIPs)).correspondsToJsonString(json)
     }
 
     "JSON serialization of a Task with reserved local volumes" in {
@@ -155,7 +155,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         |  ]
         |}
       """.stripMargin
-      JsonTestHelper.assertThatJsonOf(f.taskWithLocalVolumes.toRaml).correspondsToJsonString(json)
+      JsonTestHelper.assertThatJsonOf(asRaml(f.taskWithLocalVolumes)).correspondsToJsonString(json)
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/raml/ConstraintConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/ConstraintConversionTest.scala
@@ -14,7 +14,7 @@ class ConstraintConversionTest extends UnitTest {
         .build()
 
       When("The constraint is be converted")
-      val seq = constraint.toRaml[Seq[String]]
+      val seq = constraintProtosToStringSeq(constraint)
 
       Then("The constraint is a correct string sequence")
       seq should be(Seq("foo", "GROUP_BY", "test"))

--- a/src/test/scala/mesosphere/marathon/raml/UnreachableStrategyConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/UnreachableStrategyConversionTest.scala
@@ -19,7 +19,7 @@ class UnreachableStrategyConversionTest extends UnitTest {
     "read from RAML" in {
       val raml = UnreachableEnabled()
 
-      val result: state.UnreachableStrategy = UnreachableStrategyConversion.ramlUnreachableStrategyRead(raml)
+      val result: state.UnreachableStrategy = UnreachableStrategyConversion.fromRaml(raml)
 
       result shouldBe (state.UnreachableStrategy.default(resident = false))
     }
@@ -28,7 +28,7 @@ class UnreachableStrategyConversionTest extends UnitTest {
   it should {
     val strategy = state.UnreachableEnabled(inactiveAfter = 10.minutes, expungeAfter = 20.minutes)
 
-    val raml = UnreachableStrategyConversion.ramlUnreachableStrategyWrite(strategy).
+    val raml = UnreachableStrategyConversion.fromRaml(strategy).
       asInstanceOf[UnreachableEnabled]
 
     behave like convertToProtobufThenToRAML(


### PR DESCRIPTION
Summary:
This leverages method overloading instead of implicits. This way it is
much easier to find the implementation of a conversion and their usages.
It should also speed up compilation since searching for implicits takes
the longest time.
