### PR TITLE
Configure probot/stale to mark pull requests as stale.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This pull request has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This pull request has been automatically closed because it has not had any
+  activity in the last sixty days. Feel free to re-open it if you deem it
+  important.

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/SystemControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/SystemControllerTest.scala
@@ -1,0 +1,5 @@
+package mesosphere.marathon.api.akkahttp
+
+class SystemControllerTest {
+
+}

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/SystemControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/SystemControllerTest.scala
@@ -1,5 +1,0 @@
-package mesosphere.marathon.api.akkahttp
-
-class SystemControllerTest {
-
-}


### PR DESCRIPTION
Summary:
This uses [probot](https://probot.github.io/apps/stale/) to manage our pull requests.
When a pull request has seen no activity in the last seven days it is marked as staled.
A stale PR is closed after sixty days without any activity.
