### PR TITLE
Fix Mesos provisioning for 1.4 nodes. (#5509)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,16 +44,7 @@ node('JenkinsMarathonCI-Debian8') {
             currentBuild.displayName = "#${env.BUILD_NUMBER}: ${shortCommit}"
         }
         stage("Provision Jenkins Node") {
-            sh "sudo apt-get -y clean"
-            sh "sudo apt-get -y update"
-            sh "sudo apt-get install -y --force-yes --no-install-recommends curl"
-            sh """if grep -q MesosDebian \$WORKSPACE/project/Dependencies.scala; then
-        MESOS_VERSION=\$(sed -n 's/^.*MesosDebian = "\\(.*\\)"/\\1/p' <\$WORKSPACE/project/Dependencies.scala)
-      else
-        MESOS_VERSION=\$(sed -n 's/^.*mesos=\\(.*\\)&&.*/\\1/p' <\$WORKSPACE/Dockerfile)
-      fi
-      sudo apt-get install -y --force-yes --no-install-recommends mesos=\$MESOS_VERSION
-      """
+            sh "sudo -E ci/provision.sh"
         }
         stageWithCommitStatus("1. Compile") {
           withEnv(['RUN_DOCKER_INTEGRATION_TESTS=true', 'RUN_MESOS_INTEGRATION_TESTS=true']) {

--- a/ci/provision.sh
+++ b/ci/provision.sh
@@ -16,8 +16,5 @@ sudo apt-get -y update
 # Install dependencies.
 sudo apt-get install -y --force-yes --no-install-recommends curl sbt
 
-MESOS_VERSION=$(sed -n 's/^.*MesosDebian = "\(.*\)"/\1/p' < "$WORKSPACE/project/Dependencies.scala")
-if [[ -z $MESOS_VERSION ]]; then
-    MESOS_VERSION=$(sed -n 's/^.*mesos=\(.*\)&&.*/\1/p' < "$WORKSPACE/Dockerfile")
-fi
+MESOS_VERSION=$(sed -n 's/^.*mesos=\([^[:space:]]*\) &&.*/\1/p' < "$WORKSPACE/Dockerfile")
 sudo apt-get install -y --force-yes --no-install-recommends mesos="$MESOS_VERSION"

--- a/ci/provision.sh
+++ b/ci/provision.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+sudo apt-get -y clean
+sudo apt-get -y update
+
+# Add sbt repo.
+echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+
+# Add Mesos repo.
+sudo apt-get install -y lsb-release
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+echo "deb http://repos.mesosphere.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/mesosphere.list
+sudo apt-get -y update
+
+# Install dependencies.
+sudo apt-get install -y --force-yes --no-install-recommends curl sbt
+
+MESOS_VERSION=$(sed -n 's/^.*MesosDebian = "\(.*\)"/\1/p' < "$WORKSPACE/project/Dependencies.scala")
+if [[ -z $MESOS_VERSION ]]; then
+    MESOS_VERSION=$(sed -n 's/^.*mesos=\(.*\)&&.*/\1/p' < "$WORKSPACE/Dockerfile")
+fi
+sudo apt-get install -y --force-yes --no-install-recommends mesos="$MESOS_VERSION"


### PR DESCRIPTION
Summary:
The Mesos installation failed on our 1.4 Jenkins nodes. Apparently we
had to install lsb-release.

Test Plan: PR build

Reviewers: ichernetsky, meln1k

Subscribers: jenkins, marathon-team
