### PR TITLE
Rate limit ProcessOutputToLogStream

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/setup/ProcessOutputToLogStream.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ProcessOutputToLogStream.scala
@@ -1,13 +1,40 @@
 package mesosphere.marathon
 package integration.setup
 
-import org.slf4j.LoggerFactory
+import org.slf4j.{ LoggerFactory, Logger }
 
 import scala.sys.process.ProcessLogger
 
-case class ProcessOutputToLogStream(process: String) extends ProcessLogger {
-  val log = LoggerFactory.getLogger(s"mesosphere.marathon.integration.process.$process")
-  override def out(msg: => String): Unit = log.debug(msg)
-  override def err(msg: => String): Unit = log.warn(msg)
+final case class ProcessOutputToLogStream(process: String, maxLinesPerPeriod: Int = 100, periodMillis: Long = 1000L) extends ProcessLogger {
+  private[this] var nextFlush = System.currentTimeMillis() + periodMillis
+  private[this] var callsSinceLastFlush = 0
+  val log: Logger = LoggerFactory.getLogger(s"mesosphere.marathon.integration.process.$process")
+
+  private def rateLimited(msg: String): Boolean = synchronized {
+    val now = System.currentTimeMillis
+    if (now > nextFlush) {
+      val suppressedLines = callsSinceLastFlush - maxLinesPerPeriod
+      if (suppressedLines > 0)
+        log.error(s"ProcessLogger ${process} was rate limited; ${suppressedLines} lines were supressed")
+
+      callsSinceLastFlush = 1
+      nextFlush = now + periodMillis
+      false
+    } else {
+      callsSinceLastFlush += 1
+      callsSinceLastFlush > maxLinesPerPeriod
+    }
+  }
+
+  override def out(getMsg: => String): Unit = if (log.isDebugEnabled()) {
+    val msg = getMsg
+    if (!rateLimited(msg))
+      log.debug(msg)
+  }
+  override def err(getMsg: => String): Unit = if (log.isWarnEnabled()) {
+    val msg = getMsg
+    if (!rateLimited(msg))
+      log.warn(msg)
+  }
   override def buffer[T](f: => T): T = f
 }

--- a/src/test/scala/mesosphere/marathon/integration/setup/ProcessOutputToLogStream.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ProcessOutputToLogStream.scala
@@ -15,7 +15,7 @@ final case class ProcessOutputToLogStream(process: String, maxLinesPerPeriod: In
 
   private def rateLimited(msg: String): Boolean = synchronized {
     val now = System.currentTimeMillis
-    if (now > nextPeriodStart) {
+    if (now >= nextPeriodStart) {
       val suppressedLines = callsThisPeriod - maxLinesPerPeriod
       if (suppressedLines > 0)
         log.error(s"ProcessLogger ${process} was rate limited; ${suppressedLines} lines were supressed")

--- a/src/test/scala/mesosphere/marathon/integration/setup/ProcessOutputToLogStream.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ProcessOutputToLogStream.scala
@@ -1,42 +1,57 @@
 package mesosphere.marathon
 package integration.setup
 
+import java.time.Clock
 import org.slf4j.{ LoggerFactory, Logger }
+import ProcessOutputToLogStream._
 
 import scala.sys.process.ProcessLogger
 import scala.concurrent.duration._
 
-final case class ProcessOutputToLogStream(process: String, maxLinesPerPeriod: Int = 100, period: FiniteDuration = 1.second) extends ProcessLogger {
-  private[this] var nextPeriodStart = System.currentTimeMillis() + periodMillis
-  private[this] var callsThisPeriod = 0
-  private val periodMillis = period.toMillis
+object ProcessOutputToLogStream {
+  /**
+    * Handles rate limiting logic; calling the method `incrementAndCheck` both registers a log line and returns whether
+    * or not the quota has been exceeded.
+    *
+    * Simple periodic quota mechanism. We keep a tally of the number of log lines for each period. When we enter the
+    * next period, we reset. If we exceed the quota for the period, we start returning false.
+    *
+    * @return Whether or not the quota for this period has been exceeded
+    */
+  final class RateLimiter(log: Logger, maxLinesPerPeriod: Int, period: FiniteDuration, clock: Clock) {
+    private val periodMillis = period.toMillis
+    private[this] var nextPeriodStart = System.currentTimeMillis() + periodMillis
+    private[this] var linesThisPeriod = 0
+    def incrementAndCheck(): Boolean = synchronized {
+      val now = clock.millis()
+      if (now >= nextPeriodStart) {
+        val suppressedLines = linesThisPeriod - maxLinesPerPeriod
+        if (suppressedLines > 0)
+          log.error(s"Logger was rate-limited; ${suppressedLines} lines were supressed")
 
-  val log: Logger = LoggerFactory.getLogger(s"mesosphere.marathon.integration.process.$process")
-
-  private def rateLimited(msg: String): Boolean = synchronized {
-    val now = System.currentTimeMillis
-    if (now >= nextPeriodStart) {
-      val suppressedLines = callsThisPeriod - maxLinesPerPeriod
-      if (suppressedLines > 0)
-        log.error(s"ProcessLogger ${process} was rate limited; ${suppressedLines} lines were supressed")
-
-      callsThisPeriod = 1
-      nextPeriodStart = now + periodMillis
-      false
-    } else {
-      callsThisPeriod += 1
-      callsThisPeriod > maxLinesPerPeriod
+        linesThisPeriod = 1
+        nextPeriodStart = now + periodMillis
+        false
+      } else {
+        linesThisPeriod += 1
+        linesThisPeriod > maxLinesPerPeriod
+      }
     }
   }
+}
+
+final case class ProcessOutputToLogStream(process: String, maxLinesPerPeriod: Int = 100, period: FiniteDuration = 1.second) extends ProcessLogger {
+  private val log: Logger = LoggerFactory.getLogger(s"mesosphere.marathon.integration.process.$process")
+  private val rateLimiter = new RateLimiter(log, maxLinesPerPeriod, period, Clock.systemUTC())
 
   override def out(getMsg: => String): Unit = if (log.isDebugEnabled()) {
     val msg = getMsg
-    if (!rateLimited(msg))
+    if (!rateLimiter.incrementAndCheck())
       log.debug(msg)
   }
   override def err(getMsg: => String): Unit = if (log.isWarnEnabled()) {
     val msg = getMsg
-    if (!rateLimited(msg))
+    if (!rateLimiter.incrementAndCheck())
       log.warn(msg)
   }
   override def buffer[T](f: => T): T = f


### PR DESCRIPTION
Sometimes, our sub-processes (such as Mesos), can get in a really tight loop and produce an overwhelming amount of output that overwhelms Jenkins and inhibits the test tear-down code from running.

Looking at a few of such cases, it seems obvious that we can effectively limit it via our ProcessOutputToLogStream logger class.

JIRA Issues: MARATHON-7809