### PR TITLE
Status parameter is not required on the tasks endpoint

### DIFF
--- a/docs/docs/rest-api/public/api/v2/tasks.raml
+++ b/docs/docs/rest-api/public/api/v2/tasks.raml
@@ -5,7 +5,7 @@ get:
   queryParameters:
     status:
       required: false
-      description: Filter the list of tasks by status
+      description: Filter the list of tasks by status. If status is not specified, tasks with any status will be included.
       enum: [ running, staging ]
   responses:
     200:

--- a/docs/docs/rest-api/public/api/v2/tasks.raml
+++ b/docs/docs/rest-api/public/api/v2/tasks.raml
@@ -1,9 +1,10 @@
 get:
   description:
-    List all running tasks.
+    List all tasks.
   is: [ secured ]
   queryParameters:
     status:
+      required: false
       description: Filter the list of tasks by status
       enum: [ running, staging ]
   responses:


### PR DESCRIPTION
Status parameter is not required on the tasks endpoint

Summary:
Small fix for the tasks endpoint RAML documentation. If status parameter is not provided, task of all statuses are returned. If you don't believe me, feel free to test it out here :) https://soak.mesosphere.com/service/marathon/v2/tasks

JIRA issues: MARATHON-7308
