### PR TITLE
Introduce jekyll plugin to redirect old marathon rest api documentation to new one

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,6 +15,9 @@ sass:
   sass_dir: _sass
   style: :compressed
 
+plugins:
+  - jekyll-redirect-from
+
 baseurl: "/marathon"
 highlighter: rouge
 lsi: false

--- a/docs/docs/rest-api.md
+++ b/docs/docs/rest-api.md
@@ -1,0 +1,5 @@
+---
+title: REST API		
+redirect_to:
+  - http://mesosphere.github.io/marathon/api-console/index.html
+---


### PR DESCRIPTION
Summary:
We removed the old deprecated rest api in during the release of Marathon 1.5

To keep old URIs and google search results working, this PR introduces a redirect from the old URI to the new raml based rest documentation.