### PR TITLE
Fix 1.4.6 UnreachableStrategy migration

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo146.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo146.scala
@@ -54,7 +54,7 @@ object MigrationTo146 extends StrictLogging {
         UnreachableEnabled(0.seconds, expungeAfter)
 
       // migrate previous default - case 1
-      case UnreachableEnabled(inactiveAfter, expungeAfter) if inactiveAfter == UnreachableEnabled.DefaultInactiveAfter && expungeAfter == UnreachableEnabled.DefaultExpungeAfter =>
+      case UnreachableEnabled(inactiveAfter, expungeAfter) if inactiveAfter == 5.minutes && expungeAfter == 10.minutes =>
         UnreachableEnabled(0.seconds, 0.seconds)
     }
   }

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo146Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo146Test.scala
@@ -49,7 +49,7 @@ class MigrationTo146Test extends AkkaUnitTest with GroupCreation with StrictLogg
     implicit lazy val mat: Materializer = ActorMaterializer()
     implicit lazy val ctx: ExecutionContextExecutor = system.dispatcher
     val app = AppDefinition(PathId("/app"), unreachableStrategy = UnreachableEnabled(1.seconds, 5.seconds))
-    val app2 = AppDefinition(PathId("/app2"), unreachableStrategy = UnreachableEnabled())
+    val app2 = AppDefinition(PathId("/app2"), unreachableStrategy = UnreachableEnabled(5.minutes, 10.minutes))
     val pod = PodDefinition(PathId("/pod"), unreachableStrategy = UnreachableEnabled(1.seconds, 2.seconds))
     appRepository.all() returns Source(Seq(app, app2))
     appRepository.store(any) returns Future.successful(Done)


### PR DESCRIPTION
As inactiveAfter and expungeAfter defaults to 0 seconds now, we need
to match the old default values to make the migration work.