### PR TITLE
Remove obsolete cosmos labels

### DIFF
--- a/tests/scale/mom.json
+++ b/tests/scale/mom.json
@@ -52,8 +52,7 @@
     "DCOS_PACKAGE_FRAMEWORK_NAME": "marathon-user",
     "DCOS_SERVICE_PORT_INDEX": "0",
     "DCOS_PACKAGE_VERSION": "v1.3.5",
-    "DCOS_PACKAGE_NAME": "marathon",
-    "DCOS_PACKAGE_IS_FRAMEWORK": "true"
+    "DCOS_PACKAGE_NAME": "marathon"
   },
   "portDefinitions": [
     {

--- a/tests/system/test_marathon_on_marathon.py
+++ b/tests/system/test_marathon_on_marathon.py
@@ -72,8 +72,6 @@ def test_ui_registration_requirement():
             for label in task['labels']:
                 if label['key'] == 'DCOS_PACKAGE_NAME':
                     assert label['value'] == 'marathon'
-                if label['key'] == 'DCOS_PACKAGE_IS_FRAMEWORK':
-                    assert label['value'] == 'true'
                 if label['key'] == 'DCOS_SERVICE_NAME':
                     assert label['value'] == 'marathon-user'
 


### PR DESCRIPTION
Summary: Removed test usage of a label that is not used in cosmos any longer.

JIRA issues: MARATHON_EE-1519