### PR TITLE
Reduced overall IT runtime limit to 30.minutes

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -26,7 +26,7 @@ val PACKAGE_DOCS_DIR: Path = pwd / 'target / "universal-docs"
 @main
 def compileAndTest(): Unit = utils.stage("Compile and Test") {
 
-  def run(cmd: String *) = utils.runWithTimeout(1.hour)(cmd)
+  def run(cmd: String *) = utils.runWithTimeout(30.minutes)(cmd)
 
   run("sbt", "clean", "test", "integration:test", "scapegoat")
 

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -29,7 +29,7 @@ import mesosphere.util.PortAllocator
 import org.apache.commons.io.FileUtils
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
-import org.scalatest.time.{ Milliseconds, Span }
+import org.scalatest.time.{ Milliseconds, Minutes, Seconds, Span }
 import org.scalatest.{ BeforeAndAfterAll, Suite }
 import play.api.libs.json.{ JsObject, Json }
 
@@ -452,7 +452,9 @@ trait MarathonTest extends HealthCheckEndpoint with StrictLogging with ScalaFutu
     //do not fail here, since the require statements will ensure a correct setup and fail otherwise
     Try(waitForDeployment(eventually(marathon.deleteGroup(testBasePath, force = true))))
 
-    WaitTestSupport.waitUntil("clean slate in Mesos", patienceConfig.timeout.toMillis.millis) {
+    val cleanUpPatienceConfig = WaitTestSupport.PatienceConfig(timeout = Span(1, Minutes), interval = Span(1, Seconds))
+
+    WaitTestSupport.waitUntil("clean slate in Mesos") {
       val occupiedAgents = mesos.state.value.agents.filter { agent => agent.usedResources.nonEmpty || agent.reservedResourcesByRole.nonEmpty }
       occupiedAgents.foreach { agent =>
         import mesosphere.marathon.integration.facades.MesosFormats._
@@ -461,7 +463,7 @@ trait MarathonTest extends HealthCheckEndpoint with StrictLogging with ScalaFutu
         logger.info(s"""Waiting for blank slate Mesos...\n "used_resources": "$usedResources"\n"reserved_resources": "$reservedResources"""")
       }
       occupiedAgents.isEmpty
-    }
+    }(cleanUpPatienceConfig)
 
     val apps = marathon.listAppsInBaseGroup
     require(apps.value.isEmpty, s"apps weren't empty: ${apps.entityPrettyJsonString}")


### PR DESCRIPTION
Summary:
Reduced overall IT runtime limit to 30.minutes since our build times are now ~13min. Additionally `MarathonTest.cleanUp` timeout is reduced to 1.minutes with
interval of 1.second. Calling it excessively (every 15ms for 5min) doesn't make much sense and is
one of the reasons for the log explosion.