### PR TITLE
Changed default of UnreachableEnabled to (0,0) (#5523)

### DIFF
--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -761,13 +761,13 @@
           "properties": {
             "inactiveAfterSeconds": {
               "type": "integer",
-              "description": "If an instance is unreachable for longer than inactiveAfter seconds it is marked as inactive. This will trigger a new instance launch. The original task is not expunged yet. Must be less than expungeAfterSeconds.",
-              "minimum": 1
+              "description": "If an instance is unreachable for longer than inactiveAfter seconds it is marked as inactive. This will trigger a new instance launch. The original task is not expunged yet. Must be less than or equal to expungeAfterSeconds.",
+              "minimum": 0
             },
             "expungeAfterSeconds": {
               "type": "number",
-              "description": "If an instance is unreachable for longer than unreachableExpungeAfter seconds it will be expunged.  That means it will be killed if it ever comes back. Instances are usually marked as unreachable before they are expunged but they don't have to. This value is required to be greater than inactiveAfterSeconds.\n\nIf the instance has any persistent volumes associated with it, then they will be destroyed and associated data will be deleted.\n\nDefault is 7 days (604800 seconds).",
-              "minimum": 2
+              "description": "If an instance is unreachable for longer than expungeAfterSeconds it will be expunged.  That means it will be killed if it ever comes back. Instances are usually marked as unreachable before they are expunged but they don't have to. This value is required to be greater than inactiveAfterSeconds unless both are zero.\n\nIf the instance has any persistent volumes associated with it, then they will be destroyed and associated data will be deleted.\n\nDefault is 0 seconds.",
+              "minimum": 0
             }
           }
         }

--- a/docs/docs/rest-api/public/api/v2/types/unreachableStrategy.raml
+++ b/docs/docs/rest-api/public/api/v2/types/unreachableStrategy.raml
@@ -10,23 +10,23 @@ types:
       inactiveAfterSeconds?:
         type: integer
         format: int64
-        default: 300
+        default: 0
         minimum: 0
         description: |
           If an instance is unreachable for longer than inactiveAfter seconds it is marked
           as inactive. This will trigger a new instance launch. The original task is not
-          expunged yet. Must be less than expungeAfterSeconds.
+          expunged yet. Must be less than or equal to expungeAfterSeconds.
 
-          The default value is set to 5 minutes (300 seconds).
+          The default value is set to 0 seconds.
 
       expungeAfterSeconds?:
         type: integer
         format: int64
-        default: 600
+        default: 0
         minimum: 0
         description: |
-          If an instance is unreachable for longer than unreachableExpungeAfter seconds it will be expunged.  That means
+          If an instance is unreachable for longer than expungeAfterSeconds it will be expunged.  That means
           it will be killed if it ever comes back. Instances are usually marked as unreachable before they are expunged
-          but they don't have to. This value is required to be greater than inactiveAfterSeconds.
+          but they don't have to. This value is required to be greater than or equal to inactiveAfterSeconds.
 
-          The default value is set to 10 minutes (600 seconds).
+          The default value is set to 0 seconds.

--- a/src/main/scala/mesosphere/marathon/state/UnreachableStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/state/UnreachableStrategy.scala
@@ -30,8 +30,8 @@ case class UnreachableEnabled(
       build
 }
 object UnreachableEnabled {
-  val DefaultInactiveAfter: FiniteDuration = 5.minutes
-  val DefaultExpungeAfter: FiniteDuration = 10.minutes
+  val DefaultInactiveAfter: FiniteDuration = 0.seconds
+  val DefaultExpungeAfter: FiniteDuration = 0.seconds
   val default = UnreachableEnabled()
 
   implicit val unreachableEnabledValidator = validator[UnreachableEnabled] { strategy =>

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.core.instance.update.{ InstanceUpdateOperation, Insta
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.{ AgentInfoPlaceholder, AgentTestDefaults, NetworkInfoPlaceholder }
-import mesosphere.marathon.state.{ PathId, Timestamp, UnreachableStrategy }
+import mesosphere.marathon.state.{ PathId, Timestamp, UnreachableEnabled, UnreachableStrategy }
 import org.apache.mesos
 
 import scala.collection.immutable.Seq
@@ -40,8 +40,9 @@ case class TestInstanceBuilder(
   def addTaskLost(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskLost(since, containerName).build()
 
-  def addTaskUnreachable(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
-    addTaskWithBuilder().taskUnreachable(since, containerName).build()
+  def addTaskUnreachable(since: Timestamp = now, containerName: Option[String] = None, unreachableStrategy: UnreachableStrategy = UnreachableEnabled()): TestInstanceBuilder =
+    this.copy(instance = instance.copy(unreachableStrategy = unreachableStrategy)) // we need to update the unreachable strategy first before adding an unreachable task
+      .addTaskWithBuilder().taskUnreachable(since, containerName).build()
 
   def addTaskUnreachableInactive(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskUnreachableInactive(since, containerName).build()

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -28,7 +28,7 @@ import org.mockito.{ ArgumentCaptor, Mockito }
 import org.scalatest.GivenWhenThen
 
 import scala.collection.immutable.Seq
-import scala.concurrent.{ Await, Promise }
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 /**
@@ -166,7 +166,6 @@ class TaskLauncherActorTest extends MarathonSpec with GivenWhenThen {
     val launcherRef = createLauncherRef(instances = 1, constraintApp)
     launcherRef ! RateLimiterActor.DelayUpdate(constraintApp, clock.now())
 
-    val promise = Promise[MatchedInstanceOps]
     Await.result(launcherRef ? ActorOfferMatcher.MatchOffer(clock.now() + 1.seconds, offer), 3.seconds).asInstanceOf[MatchedInstanceOps]
 
     Mockito.verify(instanceTracker).instancesBySpecSync

--- a/src/test/scala/mesosphere/marathon/integration/NetworkPartitionIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/NetworkPartitionIntegrationTest.scala
@@ -5,8 +5,10 @@ import mesosphere.AkkaIntegrationFunTest
 import mesosphere.marathon.integration.facades.ITEnrichedTask
 import mesosphere.marathon.integration.setup._
 
+import mesosphere.marathon.state.UnreachableEnabled
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{ Second, Seconds, Span }
+import scala.concurrent.duration._
 
 /**
   * Integration test to simulate the issues discovered a verizon where a network partition caused Marathon to be
@@ -46,7 +48,7 @@ class NetworkPartitionIntegrationTest extends AkkaIntegrationFunTest
 
   test("Loss of ZK and Loss of Slave will not kill the task when slave comes back") {
     Given("a new app")
-    val app = appProxy(testBasePath / "app", "v1", instances = 1, healthCheck = None)
+    val app = appProxy(testBasePath / "app", "v1", instances = 1, healthCheck = None).copy(unreachableStrategy = UnreachableEnabled(5.minutes, 10.minutes))
     waitForDeployment(marathon.createAppV2(app))
     val task = waitForTasks(app.id, 1).head
 


### PR DESCRIPTION
Summary:
Most users would expect the same behavior in terms of unreachable task as marathon had before introducing the unreachableStrategy.
Therefore this patch re-introduces the old behavior as default configuration.

Test Plan:
sbt test
sbt integration:test

Reviewers: meln1k, timcharper, kensipe

Subscribers: marathon-dev, marathon-team

JIRA Issues: MARATHON-7576

Differential Revision: https://phabricator.mesosphere.com/D1072