### PR TITLE
Refactored `SchedulerActions` object

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -8,7 +8,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.deployment._
 import mesosphere.marathon.core.deployment.impl.DeploymentActor.{ Cancel, Fail, NextStep }
 import mesosphere.marathon.core.deployment.impl.DeploymentManagerActor.DeploymentFinished
-import mesosphere.marathon.core.event.{ DeploymentStatus, DeploymentStepFailure, DeploymentStepSuccess }
+import mesosphere.marathon.core.event.{ AppTerminatedEvent, DeploymentStatus, DeploymentStepFailure, DeploymentStepSuccess }
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launchqueue.LaunchQueue
@@ -186,20 +186,29 @@ private class DeploymentActor(
   }
 
   @SuppressWarnings(Array("all")) /* async/await */
-  def stopRunnable(runnableSpec: RunSpec): Future[Done] = async {
-    logger.debug(s"Stop runnable $runnableSpec")
-    val instances = await(instanceTracker.specInstances(runnableSpec.id))
+  def stopRunnable(runSpec: RunSpec): Future[Done] = async {
+    logger.debug(s"Stop runnable $runSpec")
+    healthCheckManager.removeAllFor(runSpec.id)
+
+    // Purging launch queue
+    await(launchQueue.asyncPurge(runSpec.id))
+
+    val instances = await(instanceTracker.specInstances(runSpec.id))
     val launchedInstances = instances.filter(_.isLaunched)
-    // TODO: the launch queue is purged in stopRunnable, but it would make sense to do that before calling kill(tasks)
+
+    logger.info(s"Killing all instances of ${runSpec.id}: ${launchedInstances.map(_.instanceId)}")
     await(killService.killInstances(launchedInstances, KillReason.DeletingApp))
 
-    logger.debug(s"Killed all remaining tasks: ${launchedInstances.map(_.instanceId)}")
+    launchQueue.resetDelay(runSpec)
 
-    // Note: This is an asynchronous call. We do NOT wait for the run spec to stop. If we do, the DeploymentActorTest
-    // fails.
-    scheduler.stopRunSpec(runnableSpec)
+    // The tasks will be removed from the InstanceTracker when their termination
+    // was confirmed by Mesos via a task update.
+    eventBus.publish(AppTerminatedEvent(runSpec.id))
 
     Done
+  }.recover {
+    case NonFatal(error) => logger.warn(s"Error in stopping runSpec ${runSpec.id}", error);
+      Done
   }
 
   def restartRunnable(run: RunSpec, status: DeploymentStatus): Future[Done] = {

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -26,20 +26,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 class SchedulerActionsTest extends AkkaUnitTest {
   "SchedulerActions" should {
 
-    "Reset rate limiter if application is stopped" in {
-      val f = new Fixture
-      val app = AppDefinition(id = PathId("/myapp"))
-
-      f.queue.asyncPurge(eq(app.id)) returns Future.successful(Done)
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty[Instance])
-
-      f.scheduler.stopRunSpec(app).futureValue(1.second)
-
-      verify(f.queue).asyncPurge(app.id)
-      verify(f.queue).resetDelay(app)
-      verifyNoMoreInteractions(f.queue)
-    }
-
     "Task reconciliation sends known running and staged tasks and empty list" in {
       val f = new Fixture
       val app = AppDefinition(id = PathId("/myapp"))

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -119,6 +119,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
       val plan = DeploymentPlan(origGroup, targetGroup)
 
+      queue.asyncPurge(any) returns Future.successful(Done)
       scheduler.startRunSpec(any) returns Future.successful(Done)
       tracker.specInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2))
       tracker.specInstancesSync(app2.id) returns Seq(instance2_1)
@@ -146,7 +147,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
         killService.killed should contain(instance2_1.instanceId) // killed due to config change
         killService.killed should contain(instance4_1.instanceId) // killed because app4 does not exist anymore
         killService.numKilled should be(3)
-        verify(scheduler).stopRunSpec(app4.copy(instances = 0))
+        verify(queue).resetDelay(app4.copy(instances = 0))
       }
     }
 


### PR DESCRIPTION
Summary:
Removed `stopRunnable` method completely and moved missing parts to the `DeploymentActor`. Partially that code (killing instances) was called twice between those two.
