### PR TITLE
Edited logs to print `runSpecId` in all relevant deployment log lines

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -281,14 +281,14 @@ class MarathonSchedulerActor private (
   }
 
   def deploymentSuccess(plan: DeploymentPlan): Unit = {
-    logger.info(s"Deployment ${plan.id}:${plan.version} of ${plan.target.id} finished")
+    logger.info(s"Deployment ${plan.id}:${plan.version} of ${plan.targetIdsString} finished")
     eventBus.publish(DeploymentSuccess(plan.id, plan))
   }
 
   def deploymentFailed(plan: DeploymentPlan, reason: Throwable): Unit = {
-    logger.error(s"Deployment ${plan.id}:${plan.version} of ${plan.target.id} failed", reason)
+    logger.error(s"Deployment ${plan.id}:${plan.version} of ${plan.targetIdsString} failed", reason)
     Future.sequence(plan.affectedRunSpecIds.map(launchQueue.asyncPurge))
-      .recover { case NonFatal(error) => logger.warn(s"Error during async purge: planId=${plan.id}", error); Done }
+      .recover { case NonFatal(error) => logger.warn(s"Error during async purge: planId=${plan.id} for ${plan.targetIdsString}", error); Done }
       .foreach { _ => eventBus.publish(core.event.DeploymentFailed(plan.id, plan)) }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
@@ -186,6 +186,8 @@ case class DeploymentPlan(
       } else " NO STEPS"
     s"DeploymentPlan id=$id,$version$stepString\n"
   }
+
+  def targetIdsString = affectedRunSpecIds.mkString(", ")
 }
 
 object DeploymentPlan {

--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
@@ -123,11 +123,11 @@ class GroupManagerImpl(
             Validation.validateOrThrow(to)(RootGroup.rootGroupValidator(config.availableFeatures))
             val plan = DeploymentPlan(from, to, version, toKill)
             Validation.validateOrThrow(plan)(DeploymentPlan.deploymentPlanValidator())
-            logger.info(s"Computed new deployment plan:\n$plan")
+            logger.info(s"Computed new deployment plan for ${plan.targetIdsString}:\n$plan")
             await(groupRepository.storeRootVersion(plan.target, plan.createdOrUpdatedApps, plan.createdOrUpdatedPods))
             await(deploymentService.get().deploy(plan, force))
             await(groupRepository.storeRoot(plan.target, plan.createdOrUpdatedApps, plan.deletedApps, plan.createdOrUpdatedPods, plan.deletedPods))
-            logger.info(s"Updated groups/apps/pods according to plan ${plan.id}")
+            logger.info(s"Updated groups/apps/pods according to plan ${plan.id} for ${plan.targetIdsString}")
             // finally update the root under the write lock.
             root := Option(plan.target)
             Right(plan)
@@ -137,7 +137,7 @@ class GroupManagerImpl(
 
     maybeDeploymentPlan.onComplete {
       case Success(Right(plan)) =>
-        logger.info(s"Deployment ${plan.id}:${plan.version} for ${plan.target.id} acknowledged. Waiting to get processed")
+        logger.info(s"Deployment ${plan.id}:${plan.version} for ${plan.targetIdsString} acknowledged. Waiting to get processed")
         eventStream.publish(GroupChangeSuccess(id, version.toString))
       case Success(Left(_)) =>
         ()

--- a/src/main/scala/mesosphere/marathon/upgrade/GroupVersioningUtil.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/GroupVersioningUtil.scala
@@ -28,17 +28,17 @@ object GroupVersioningUtil {
     def updateAppVersionInfo(maybeOldApp: Option[AppDefinition], newApp: AppDefinition): AppDefinition = {
       val newVersionInfo = maybeOldApp match {
         case None =>
-          log.info(s"[${newApp.id}]: new app detected")
+          log.info(s"${newApp.id}: new app detected")
           VersionInfo.forNewConfig(newVersion = version)
         case Some(oldApp) =>
           if (oldApp.isUpgrade(newApp)) {
-            log.info(s"[${newApp.id}]: upgrade detected for app (oldVersion ${oldApp.versionInfo})")
+            log.info(s"${newApp.id}: upgrade detected for app (oldVersion ${oldApp.versionInfo})")
             oldApp.versionInfo.withConfigChange(newVersion = version)
           } else if (oldApp.isOnlyScaleChange(newApp)) {
-            log.info(s"[${newApp.id}]: scaling op detected for app (oldVersion ${oldApp.versionInfo})")
+            log.info(s"${newApp.id}: scaling op detected for app (oldVersion ${oldApp.versionInfo})")
             oldApp.versionInfo.withScaleOrRestartChange(newVersion = version)
           } else if (oldApp.versionInfo != newApp.versionInfo && newApp.versionInfo == VersionInfo.NoVersion) {
-            log.info(s"[${newApp.id}]: restart detected for app (oldVersion ${oldApp.versionInfo})")
+            log.info(s"${newApp.id}: restart detected for app (oldVersion ${oldApp.versionInfo})")
             oldApp.versionInfo.withScaleOrRestartChange(newVersion = version)
           } else {
             oldApp.versionInfo


### PR DESCRIPTION
Summary:
This should allow us to grep logs for some `runSpecId` and get all relevant deployment lines. Also complete deployment plan is  only printed once - this should further improve log readability.