### PR TITLE
 Update MoM-EE image to `v1.5.1_1.10.0` in SI tests

### DIFF
--- a/tests/system/fixtures/mom-ee-disabled-1.5.json
+++ b/tests/system/fixtures/mom-ee-disabled-1.5.json
@@ -1,6 +1,6 @@
 {
   "id": "/marathon-user-ee",
-  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-disabled-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --zk zk://master.mesos:2181/universe/marathon-user-ee",
+  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-disabled-1-5 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_instances_per_offer 1 --mesos_leader_ui_url /mesos --zk zk://master.mesos:2181/universe/marathon-user-ee",
   "cpus": 2,
   "mem": 2048,
   "disk": 0,

--- a/tests/system/fixtures/mom-ee-disabled-1.5.json
+++ b/tests/system/fixtures/mom-ee-disabled-1.5.json
@@ -1,0 +1,57 @@
+{
+  "id": "/marathon-user-ee",
+  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-disabled-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --zk zk://master.mesos:2181/universe/marathon-user-ee",
+  "cpus": 2,
+  "mem": 2048,
+  "disk": 0,
+  "instances": 1,
+  "constraints": [
+    [
+      "hostname",
+      "UNIQUE"
+    ]
+  ],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
+      "network": "HOST",
+      "privileged": false,
+      "parameters": [],
+      "forcePullImage": false
+    }
+  },
+  "env": {
+    "JVM_OPTS": "-Xms256m -Xmx2g",
+    "PLUGIN_ACS_URL": "https://master.mesos",
+    "PLUGIN_AUTHN_MODE": "disabled",
+    "PLUGIN_FRAMEWORK_TYPE": "marathon"
+  },
+  "healthChecks": [
+    {
+      "path": "/ping",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 1800,
+      "intervalSeconds": 10,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "name": "http"
+    },
+    {
+      "port": 0,
+      "name": "libprocess"
+    }
+  ],
+  "fetch": [
+    {
+      "uri": "file:///home/core/docker.tar.gz"
+    }
+  ]
+}

--- a/tests/system/fixtures/mom-ee-permissive-1.5.json
+++ b/tests/system/fixtures/mom-ee-permissive-1.5.json
@@ -1,7 +1,7 @@
 {
   "id": "/marathon-user-ee",
-  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-permissive-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
-  "cpus": 2,
+  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-permissive-1-5 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_instances_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
+  "cpus": 1,
   "mem": 2048,
   "disk": 0,
   "instances": 1,

--- a/tests/system/fixtures/mom-ee-permissive-1.5.json
+++ b/tests/system/fixtures/mom-ee-permissive-1.5.json
@@ -1,0 +1,72 @@
+{
+  "id": "/marathon-user-ee",
+  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-permissive-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
+  "cpus": 2,
+  "mem": 2048,
+  "disk": 0,
+  "instances": 1,
+  "constraints": [
+    [
+      "hostname",
+      "UNIQUE"
+    ]
+  ],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
+      "network": "HOST",
+      "privileged": false,
+      "parameters": [],
+      "forcePullImage": false
+    }
+  },
+  "env": {
+    "JVM_OPTS": "-Xms256m -Xmx2g",
+    "DCOS_STRICT_SECURITY_ENABLED": "false",
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL_TOFILE": {
+      "secret": "service-credential"
+    },
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"/opt/libmesos-bundle/lib/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "LIBPROCESS_SSL_ENABLED": "false",
+    "LIBPROCESS_SSL_SUPPORT_DOWNGRADE": "true",
+    "LIBPROCESS_SSL_REQUIRE_CERT": "false",
+    "LIBPROCESS_SSL_VERIFY_CERT": "false",
+    "PLUGIN_ACS_URL": "http://master.mesos",
+    "PLUGIN_AUTHN_MODE": "dcos/jwt+anonymous",
+    "PLUGIN_FRAMEWORK_TYPE": "marathon"
+  },
+  "healthChecks": [
+    {
+      "path": "/ping",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 1800,
+      "intervalSeconds": 10,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "secrets": {
+    "service-credential": {
+      "source": "my-secret"
+    }
+  },
+  "portDefinitions": [
+    {
+      "port": 0,
+      "name": "http"
+    },
+    {
+      "port": 0,
+      "name": "libprocess"
+    }
+  ],
+  "fetch": [
+    {
+      "uri": "file:///home/core/docker.tar.gz"
+    }
+  ]
+}

--- a/tests/system/fixtures/mom-ee-strict-1.5.json
+++ b/tests/system/fixtures/mom-ee-strict-1.5.json
@@ -1,6 +1,6 @@
 {
   "id": "/marathon-user-ee",
-  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-strict-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
+  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-strict-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_instances_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
   "cpus": 2,
   "mem": 2048,
   "disk": 0,

--- a/tests/system/fixtures/mom-ee-strict-1.5.json
+++ b/tests/system/fixtures/mom-ee-strict-1.5.json
@@ -1,6 +1,6 @@
 {
   "id": "/marathon-user-ee",
-  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-strict-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_instances_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
+  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-strict-1-5 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_instances_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
   "cpus": 2,
   "mem": 2048,
   "disk": 0,

--- a/tests/system/fixtures/mom-ee-strict-1.5.json
+++ b/tests/system/fixtures/mom-ee-strict-1.5.json
@@ -1,0 +1,72 @@
+{
+  "id": "/marathon-user-ee",
+  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-strict-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
+  "cpus": 2,
+  "mem": 2048,
+  "disk": 0,
+  "instances": 1,
+  "constraints": [
+    [
+      "hostname",
+      "UNIQUE"
+    ]
+  ],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
+      "network": "HOST",
+      "privileged": false,
+      "parameters": [],
+      "forcePullImage": false
+    }
+  },
+  "env": {
+    "JVM_OPTS": "-Xms256m -Xmx2g",
+    "DCOS_STRICT_SECURITY_ENABLED": "true",
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL_TOFILE": {
+      "secret": "service-credential"
+    },
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"/opt/libmesos-bundle/lib/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "LIBPROCESS_SSL_ENABLED": "true",
+    "LIBPROCESS_SSL_SUPPORT_DOWNGRADE": "false",
+    "LIBPROCESS_SSL_REQUIRE_CERT": "false",
+    "LIBPROCESS_SSL_VERIFY_CERT": "false",
+    "PLUGIN_ACS_URL": "https://master.mesos",
+    "PLUGIN_AUTHN_MODE": "dcos/jwt",
+    "PLUGIN_FRAMEWORK_TYPE": "marathon"
+  },
+  "healthChecks": [
+    {
+      "path": "/ping",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 1800,
+      "intervalSeconds": 10,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "secrets": {
+    "service-credential": {
+      "source": "my-secret"
+    }
+  },
+  "portDefinitions": [
+    {
+      "port": 0,
+      "name": "http"
+    },
+    {
+      "port": 0,
+      "name": "libprocess"
+    }
+  ],
+  "fetch": [
+    {
+      "uri": "file:///home/core/docker.tar.gz"
+    }
+  ]
+}

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -26,7 +26,7 @@ PUBLIC_KEY_FILE = 'public-key.pem'
 DEFAULT_MOM_IMAGES = {
     'MOM_EE_1.4': 'v1.4.7_1.9.8',
     'MOM_EE_1.3': '1.3.13_1.1.5',
-    'MOM_EE_1.5': 'v1.5.0_1.10.0-rc1'
+    'MOM_EE_1.5': 'v1.5.0_1.10.0'
 }
 
 
@@ -51,6 +51,7 @@ def remove_mom_ee():
     ]
     for mom_ee in mom_ee_versions:
         endpoint = mom_ee_endpoint(mom_ee[0], mom_ee[1])
+        print('Checking endpoint: {}'.format(endpoint))
         if shakedown.service_available_predicate(endpoint):
             print('Removing {}...'.format(endpoint))
             with shakedown.marathon_on_marathon(name=endpoint):

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -26,7 +26,7 @@ PUBLIC_KEY_FILE = 'public-key.pem'
 DEFAULT_MOM_IMAGES = {
     'MOM_EE_1.4': 'v1.4.7_1.9.8',
     'MOM_EE_1.3': '1.3.13_1.1.5',
-    'MOM_EE_1.5': 'v1.5.0_1.10.0'
+    'MOM_EE_1.5': 'v1.5.1_1.10.0'
 }
 
 

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -26,7 +26,7 @@ PUBLIC_KEY_FILE = 'public-key.pem'
 DEFAULT_MOM_IMAGES = {
     'MOM_EE_1.4': 'v1.4.7_1.9.8',
     'MOM_EE_1.3': '1.3.13_1.1.5',
-    'MOM_EE_1.5': 'TIM_SET_YOUR_TAG_HERE'
+    'MOM_EE_1.5': 'v1.5.0_1.10.0-rc1'
 }
 
 

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -24,9 +24,9 @@ PRIVATE_KEY_FILE = 'private-key.pem'
 PUBLIC_KEY_FILE = 'public-key.pem'
 
 DEFAULT_MOM_IMAGES = {
+    'MOM_EE_1.5': 'v1.5.1_1.10.0',
     'MOM_EE_1.4': 'v1.4.7_1.9.8',
-    'MOM_EE_1.3': '1.3.13_1.1.5',
-    'MOM_EE_1.5': 'v1.5.1_1.10.0'
+    'MOM_EE_1.3': '1.3.13_1.1.5'
 }
 
 

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -25,7 +25,8 @@ PUBLIC_KEY_FILE = 'public-key.pem'
 
 DEFAULT_MOM_IMAGES = {
     'MOM_EE_1.4': 'v1.4.7_1.9.8',
-    'MOM_EE_1.3': '1.3.13_1.1.5'
+    'MOM_EE_1.3': '1.3.13_1.1.5',
+    'MOM_EE_1.5': 'TIM_SET_YOUR_TAG_HERE'
 }
 
 
@@ -38,6 +39,9 @@ def is_mom_ee_deployed():
 
 def remove_mom_ee():
     mom_ee_versions = [
+        ('1.5', 'strict'),
+        ('1.5', 'permissive'),
+        ('1.5', 'disabled'),
         ('1.4', 'strict'),
         ('1.4', 'permissive'),
         ('1.4', 'disabled'),
@@ -100,6 +104,7 @@ def assert_mom_ee(version, security_mode='permissive'):
 @pytest.mark.skipif('shakedown.required_private_agents(2)')
 @pytest.mark.skipif("shakedown.ee_version() != 'strict'")
 @pytest.mark.parametrize("version,security_mode", [
+    ('1.5', 'strict'),
     ('1.4', 'strict'),
     ('1.3', 'strict')
 ])
@@ -112,6 +117,8 @@ def test_strict_mom_ee(version, security_mode):
 @pytest.mark.skipif('shakedown.required_private_agents(2)')
 @pytest.mark.skipif("shakedown.ee_version() != 'permissive'")
 @pytest.mark.parametrize("version,security_mode", [
+    ('1.5', 'permissive'),
+    ('1.5', 'disabled'),
     ('1.4', 'permissive'),
     ('1.4', 'disabled'),
     ('1.3', 'permissive'),
@@ -126,6 +133,7 @@ def test_permissive_mom_ee(version, security_mode):
 @pytest.mark.skipif('shakedown.required_private_agents(2)')
 @pytest.mark.skipif("shakedown.ee_version() != 'disabled'")
 @pytest.mark.parametrize("version,security_mode", [
+    ('1.5', 'disabled'),
     ('1.4', 'disabled'),
     ('1.3', 'disabled')
 ])


### PR DESCRIPTION
Summary:
- Update MoM-EE image to `v1.5.1_1.10.0` in SI tests. Replaced `max_tasks_per_offer` parameter with `max_instances_per_offer` for 1.5 MoM-EE definitions