### PR TITLE
Publish scapegoat report.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,11 @@ ansiColor('gnome-terminal') {
       } finally {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')
         junit allowEmptyResults: true, testResults: 'target/test-reports/*integration/*.xml'
+        publishHTML([
+            allowMissing: true, alwaysLinkToLastBuild: false, keepAll: true,
+            reportDir: 'target/scala-2.12/scapegoat-report', reportFiles: 'scapegoat.html',
+            reportName: 'Scapegoat Report', reportTitles: ''
+        ])
         archive includes: 'sandboxes.tar.gz'
         archive includes: 'ci.tar.gz'
         archive includes: 'ci.log'  // Only in case the build was  aborted and the logs weren't zipped


### PR DESCRIPTION
Summary:
This should allow easier investigation of failed tests. Sometimes
scapegoat failures are hidden.