### PR TITLE
Store a flag node in ZK to indicate that Marathon performs data migration

### DIFF
--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -89,3 +89,11 @@ class ResolveArtifactsCanceledException(msg: String) extends DeploymentFailedExc
 class StoreCommandFailedException(msg: String, cause: Throwable = null) extends Exception(msg, cause)
 @SuppressWarnings(Array("NullAssignment"))
 class MigrationFailedException(msg: String, cause: Throwable = null) extends Exception(msg, cause)
+
+/**
+  * Instances of this exception class are expected to be used to cancel
+  * an on-going migration. It is imperative to throw such an exception
+  * before writing anything to a persistence store.
+  */
+case class MigrationCancelledException(msg: String, cause: Throwable)
+  extends mesosphere.marathon.Exception(msg, cause)

--- a/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
@@ -205,4 +205,15 @@ trait PersistenceStore[K, Category, Serialized] extends OpenableOnce {
     * Make sure that store read operations return up-to-date values.
     */
   def sync(): Future[Done]
+
+  /**
+    * Mark migration as started. It is supposed to be used to ensure that
+    * no other Marathon instance performs migration at the same time.
+    */
+  def startMigration(): Future[Done]
+
+  /**
+    * Mark migration as completed. It does the opposite of what [[startMigration]] does.
+    */
+  def endMigration(): Future[Done]
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
@@ -187,6 +187,10 @@ case class LazyCachingPersistenceStore[K, Category, Serialized](
 
   override def sync(): Future[Done] = store.sync()
 
+  override def startMigration(): Future[Done] = store.startMigration()
+
+  override def endMigration(): Future[Done] = store.endMigration()
+
   override def toString: String = s"LazyCachingPersistenceStore($store)"
 }
 
@@ -372,6 +376,10 @@ case class LazyVersionCachingPersistentStore[K, Category, Serialized](
   override def restore(): ScalaSink[BackupItem, Future[Done]] = store.restore()
 
   override def sync(): Future[Done] = store.sync()
+
+  override def startMigration(): Future[Done] = store.startMigration()
+
+  override def endMigration(): Future[Done] = store.endMigration()
 
   override def toString: String = s"LazyVersionCachingPersistenceStore($store)"
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
@@ -206,6 +206,10 @@ class LoadTimeCachingPersistenceStore[K, Category, Serialized](
 
   override def sync(): Future[Done] = store.sync()
 
+  override def startMigration(): Future[Done] = store.startMigration()
+
+  override def endMigration(): Future[Done] = store.endMigration()
+
   override def versions[Id, V](id: Id)(implicit ir: IdResolver[Id, V, Category, K]): Source[OffsetDateTime, NotUsed] =
     store.versions(id)
 

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/memory/InMemoryPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/memory/InMemoryPersistenceStore.scala
@@ -1,23 +1,23 @@
 package mesosphere.marathon
 package core.storage.store.impl.memory
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream }
 import java.time.OffsetDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.stream.Materializer
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.util.ByteString
-import akka.{Done, NotUsed}
+import akka.{ Done, NotUsed }
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.core.storage.backup.BackupItem
-import mesosphere.marathon.core.storage.store.impl.{BasePersistenceStore, CategorizedKey}
+import mesosphere.marathon.core.storage.store.impl.{ BasePersistenceStore, CategorizedKey }
 import mesosphere.marathon.io.IO
-import mesosphere.marathon.storage.migration.{Migration, StorageVersions}
+import mesosphere.marathon.storage.migration.{ Migration, StorageVersions }
 import mesosphere.marathon.util.Lock
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.reflect.ClassTag
 
 case class RamId(category: String, id: String, version: Option[OffsetDateTime])
@@ -150,7 +150,7 @@ class InMemoryPersistenceStore(implicit
     Future.successful(Done)
   }
 
-  private[this] val migrationInProgress: AtomicBoolean = new AtomicBoolean()(false)
+  private[this] val migrationInProgress: AtomicBoolean = new AtomicBoolean(false)
 
   override def startMigration(): Future[Done] = {
     require(isOpen, "the store must be opened before it can be used")

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -15,14 +15,14 @@ import mesosphere.marathon.storage.StorageConfig
 import mesosphere.marathon.storage.repository._
 import mesosphere.marathon.util.toRichFuture
 
-import scala.async.Async.{async, await}
+import scala.async.Async.{ async, await }
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
 import mesosphere.marathon.raml.RuntimeConfiguration
 
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 /**
   * @param persistenceStore Optional "new" PersistenceStore for new migrations, the repositories

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo15.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo15.scala
@@ -61,8 +61,11 @@ private[migration] object MigrationTo15 {
     AppsResource.appNormalization(AppsResource.NormalizationConfig(
       enabledFeatures, new AppNormalization.Config {
       override def defaultNetworkName: Option[String] =
-        env.vars.get(DefaultNetworkNameForMigratedApps).orElse(networkName).orElse(throw SerializationFailedException(
-          MigrationFailedMissingNetworkEnvVar))
+        env.vars.get(DefaultNetworkNameForMigratedApps)
+          .orElse(networkName)
+          .orElse(throw MigrationCancelledException(
+            "Migration cancelled due to misconfiguration",
+            SerializationFailedException(MigrationFailedMissingNetworkEnvVar)))
       override def mesosBridgeName =
         mbn
     }))

--- a/src/test/scala/mesosphere/marathon/integration/MigrationInterruptedIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MigrationInterruptedIntegrationTest.scala
@@ -1,0 +1,46 @@
+package mesosphere.marathon
+package integration
+
+import mesosphere.AkkaIntegrationTest
+import mesosphere.marathon.integration.setup.{ LocalMarathon, MesosClusterTest, ZookeeperServerTest }
+import org.scalatest.concurrent.Eventually
+
+import scala.concurrent.Await
+
+@IntegrationTest
+class MigrationInterruptedIntegrationTest
+    extends AkkaIntegrationTest
+    with MesosClusterTest
+    with ZookeeperServerTest
+    with Eventually {
+
+  "Marathon" should {
+    "fail to start if migration was interrupted" in {
+      Given("there is a migration flag in ZooKeeper")
+      val namespace = s"marathon-$suiteName"
+      val path = s"/$namespace/state/migration-in-progress"
+      val client = zkClient()
+      try {
+        val returnedPath = Await.result(client.create(path, creatingParentsIfNeeded = true), patienceConfig.timeout)
+        returnedPath should equal (path)
+      } finally {
+        client.close()
+      }
+
+      When("Marathon starts up and becomes a leader")
+      val marathonServer = LocalMarathon(autoStart = false, suiteName = suiteName, masterUrl = mesosMasterUrl,
+        zkUrl = s"zk://${zkServer.connectUri}/$namespace")
+      marathonServer.create()
+
+      Then("it fails to start")
+      try {
+        eventually {
+          marathonServer.isRunning() should be(false)
+        } withClue "Marathon did not suicide because of lingering migration flag."
+        marathonServer.exitValue().get should be > 0 withClue "Marathon exited with 0 instead of an error code > 0."
+      } finally {
+        marathonServer.stop().futureValue
+      }
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
@@ -88,13 +88,17 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
       val migrate = f.migration
 
       mockedStore.isOpen returns true
+      mockedStore.startMigration() returns Future.successful(Done)
       mockedStore.storageVersion() returns Future.successful(None)
       mockedStore.setStorageVersion(any) returns Future.successful(Done)
+      mockedStore.endMigration() returns Future.successful(Done)
 
       migrate.migrate()
 
+      verify(mockedStore).startMigration()
       verify(mockedStore).storageVersion()
       verify(mockedStore).setStorageVersion(StorageVersions.current)
+      verify(mockedStore).endMigration()
       noMoreInteractions(mockedStore)
     }
 
@@ -107,10 +111,16 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
       mockedStore.isOpen returns true
       val currentPersistenceVersion =
         StorageVersions.current.toBuilder.setFormat(StorageVersion.StorageFormat.PERSISTENCE_STORE).build()
+
+      mockedStore.startMigration() returns Future.successful(Done)
       mockedStore.storageVersion() returns Future.successful(Some(currentPersistenceVersion))
+      mockedStore.endMigration() returns Future.successful(Done)
+
       migrate.migrate()
 
+      verify(mockedStore).startMigration()
       verify(mockedStore).storageVersion()
+      verify(mockedStore).endMigration()
       noMoreInteractions(mockedStore)
     }
 
@@ -123,6 +133,8 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
 
       Given("An unsupported storage version")
       val unsupportedVersion = StorageVersions(0, 2, 0)
+
+      mockedStore.startMigration() returns Future.successful(Done)
       mockedStore.storageVersion() returns Future.successful(Some(unsupportedVersion))
 
       When("migrate is called for that version")
@@ -131,7 +143,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
       }
 
       Then("Migration exits with a readable error message")
-      ex.getMessage should equal (s"Migration from versions < ${minVersion.str} are not supported. Your version: ${unsupportedVersion.str}")
+      ex.getMessage should equal(s"Migration from versions < ${minVersion.str} are not supported. Your version: ${unsupportedVersion.str}")
     }
 
     "migrate throws an error for versions > current" in {
@@ -142,6 +154,8 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
 
       Given("An unsupported storage version")
       val unsupportedVersion = StorageVersions(Int.MaxValue, Int.MaxValue, Int.MaxValue, StorageVersion.StorageFormat.PERSISTENCE_STORE)
+
+      mockedStore.startMigration() returns Future.successful(Done)
       mockedStore.storageVersion() returns Future.successful(Some(unsupportedVersion))
 
       When("migrate is called for that version")
@@ -150,11 +164,13 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
       }
 
       Then("Migration exits with a readable error message")
-      ex.getMessage should equal (s"Migration from ${unsupportedVersion.str} is not supported as it is newer than ${StorageVersions.current.str}.")
+      ex.getMessage should equal(s"Migration from ${unsupportedVersion.str} is not supported as it is newer than ${StorageVersions.current.str}.")
     }
 
     "migrations are executed sequentially" in {
       val mockedStore = mock[PersistenceStore[_, _, _]]
+
+      mockedStore.startMigration() returns Future.successful(Done)
       mockedStore.storageVersion() returns Future.successful(Some(StorageVersions(1, 4, 0, StorageVersion.StorageFormat.PERSISTENCE_STORE)))
       mockedStore.versions(any)(any) returns Source.empty
       mockedStore.ids()(any) returns Source.empty
@@ -164,6 +180,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
       mockedStore.store(any, any)(any, any) returns Future.successful(Done)
       mockedStore.store(any, any, any)(any, any) returns Future.successful(Done)
       mockedStore.setStorageVersion(any) returns Future.successful(Done)
+      mockedStore.endMigration() returns Future.successful(Done)
 
       val f = new Fixture(mockedStore)
 
@@ -174,7 +191,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
       migrate.groupRepository.storeRoot(any, any, any, any, any) returns Future.successful(Done)
       migrate.serviceDefinitionRepo.getVersions(any) returns Source.empty
       val result = migrate.migrate()
-      result should be ('nonEmpty)
+      result should be('nonEmpty)
       result should contain theSameElementsInOrderAs migrate.migrations.map(_._1)
     }
 
@@ -192,11 +209,12 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
       )
       val f = new Fixture(mockedStore, migration)
 
+      mockedStore.startMigration() returns Future.successful(Done)
       mockedStore.storageVersion() returns Future.successful(
         Some(StorageVersions(1, 4, 0, StorageVersion.StorageFormat.PERSISTENCE_STORE))
       )
-
       mockedStore.setStorageVersion(any) returns Future.successful(Done)
+      mockedStore.endMigration() returns Future.successful(Done)
 
       val result = f.migration.migrateAsync()
 
@@ -210,8 +228,49 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
 
       migrationDone.success(Done)
 
-      eventually { f.scheduler.taskCount shouldBe 0 }
+      eventually {
+        f.scheduler.taskCount shouldBe 0
+      }
       result.futureValue shouldBe List(version)
+    }
+
+    "throw an error if migration is in progress already" in {
+      val mockedStore = mock[PersistenceStore[_, _, _]]
+      val f = new Fixture(mockedStore)
+      mockedStore.startMigration() throws new StoreCommandFailedException("Migration is already in progress")
+
+      val migrate = f.migration
+
+      val thrown = the[StoreCommandFailedException] thrownBy migrate.migrate()
+      thrown.getMessage should equal("Migration is already in progress")
+
+      verify(mockedStore).startMigration()
+      noMoreInteractions(mockedStore)
+    }
+
+    "throw an error and remove a migration flag if migration gets cancelled" in {
+      val mockedStore = mock[PersistenceStore[_, _, _]]
+      val version = StorageVersions(1, 4, 2, StorageVersion.StorageFormat.PERSISTENCE_STORE)
+      val failingMigration: MigrationAction = (version,
+        () => Future.failed(MigrationCancelledException("Migration cancelled", new Exception("Failed to do something"))))
+      val f = new Fixture(mockedStore, List(failingMigration))
+
+      mockedStore.startMigration() returns Future.successful(Done)
+      mockedStore.storageVersion() returns Future.successful(
+        Some(StorageVersions(1, 4, 0, StorageVersion.StorageFormat.PERSISTENCE_STORE)))
+      mockedStore.endMigration() returns Future.successful(Done)
+
+      val migration = f.migration
+
+      val thrown = the[MigrationFailedException] thrownBy migration.migrate()
+      thrown.getMessage should equal("Migration cancelled")
+      thrown.getCause shouldBe a[Exception]
+      thrown.getCause.getMessage should equal("Failed to do something")
+
+      verify(mockedStore).startMigration()
+      verify(mockedStore).storageVersion()
+      verify(mockedStore).endMigration()
+      noMoreInteractions(mockedStore)
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo15Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo15Test.scala
@@ -80,10 +80,11 @@ class MigrationTo15Test extends AkkaUnitTest with RecoverMethods with GroupCreat
         title in new Fixture {
           val sd: Protos.ServiceDefinition = f(this)
 
-          recoverToExceptionIf[SerializationFailedException] {
+          recoverToExceptionIf[MigrationCancelledException] {
             migrateSingleAppF(sd)
           }.map { ex =>
-            ex.getMessage should be(MigrationFailedMissingNetworkEnvVar)
+            ex.getCause shouldBe a[SerializationFailedException]
+            ex.getCause.getMessage should be(MigrationFailedMissingNetworkEnvVar)
           }.futureValue
         }
       }


### PR DESCRIPTION
Summary:
 - Store a flag node in ZK to indicate that Marathon performs data migration
 - Delete the flag if migration gets cancelled
 - An integration test to ensure that Marathon fails to start in presence of
   the migration flag

It is a backport of #5610

JIRA issues: MARATHON-7788