### PR TITLE
List tasks as txt

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -17,12 +17,13 @@ object EndpointsHelper {
     * `{host-address-list}` is a delimited list of `{agent}:{hostPort}` tuples.
     * The contents of `{address-list}` are sorted for deterministic output.
     */
-  def appsToEndpointString(
-    instancesMap: InstancesBySpec,
-    apps: Seq[AppDefinition],
-    delimiter: String = "\t"): String = {
+  def appsToEndpointString(data: ListTasks): String = {
 
+    val delimiter = "\t"
     val sb = new StringBuilder
+    val apps = data.apps
+    val instancesMap = data.instancesMap
+
     apps.foreach { app =>
       val instances = instancesMap.specInstances(app.id)
       val cleanId = app.id.safePath
@@ -55,4 +56,5 @@ object EndpointsHelper {
     sb.toString()
   }
 
+  case class ListTasks(instancesMap: InstancesBySpec, apps: Seq[AppDefinition])
 }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/Directives.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/Directives.scala
@@ -2,7 +2,8 @@ package mesosphere.marathon
 package api.akkahttp
 
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.model.{ DateTime, HttpHeader, HttpMethods, HttpProtocols }
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives.extractRequest
 import akka.http.scaladsl.server.{ Directive, Directive0, Route, Directives => AkkaDirectives }
 import com.wix.accord.{ Failure, Success, Result => ValidationResult }
 
@@ -40,6 +41,24 @@ object Directives extends AuthDirectives with LeaderDirectives with AkkaDirectiv
       headers += `Access-Control-Max-Age`(1.day.toSeconds)
 
       respondWithHeaders (headers.result())
+    }
+  }
+
+  def accepts(mediaType: MediaType): Directive0 = {
+    extractRequest.flatMap { request =>
+      request.header[Accept] match {
+        case Some(accept) if accept.mediaRanges.exists(range => range.matches(mediaType)) => pass
+        case _ => reject
+      }
+    }
+  }
+
+  def acceptsAnything: Directive0 = {
+    extractRequest.flatMap { request =>
+      request.header[Accept] match {
+        case None => pass
+        case _ => reject
+      }
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
@@ -55,12 +55,12 @@ class TasksController(
           (accepts(MediaTypes.`text/plain`) & pathEndOrSingleSlash) {
             listTasksTxt()
           } ~
-          (accepts(MediaTypes.`application/json`) & pathEndOrSingleSlash) {
-            listTasksJson()
-          } ~
-          acceptsAnything {
-            listTasksJson() // when no accept header present, json is the default choice
-          }
+            (accepts(MediaTypes.`application/json`) & pathEndOrSingleSlash) {
+              listTasksJson()
+            } ~
+            acceptsAnything {
+              listTasksJson() // when no accept header present, json is the default choice
+            }
         }
       }
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -4,7 +4,7 @@ package api.v2
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{Context, MediaType, Response}
+import javax.ws.rs.core.{ Context, MediaType, Response }
 
 import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api._

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -4,8 +4,9 @@ package api.v2
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{ Context, MediaType, Response }
+import javax.ws.rs.core.{Context, MediaType, Response}
 
+import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api._
 import mesosphere.marathon.core.appinfo.EnrichedTask
 import mesosphere.marathon.core.async.ExecutionContexts.global
@@ -86,7 +87,7 @@ class AppTasksResource @Inject() (
     result(async {
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { app =>
-        ok(EndpointsHelper.appsToEndpointString(instancesBySpec, Seq(app)))
+        ok(EndpointsHelper.appsToEndpointString(ListTasks(instancesBySpec, Seq(app))))
       }
     })
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.{ Context, MediaType, Response }
 
+import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api.{ EndpointsHelper, MarathonMediaType, TaskKiller, _ }
 import mesosphere.marathon.core.appinfo.EnrichedTask
 import mesosphere.marathon.core.async.ExecutionContexts
@@ -104,8 +105,7 @@ class TasksResource @Inject() (
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       val rootGroup = groupManager.rootGroup()
       val appsToEndpointString = EndpointsHelper.appsToEndpointString(
-        instancesBySpec,
-        rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut)
+        ListTasks(instancesBySpec, rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut))
       )
       ok(appsToEndpointString)
     })

--- a/src/test/scala/mesosphere/marathon/api/EndpointsHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/EndpointsHelperTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package api
 
 import mesosphere.UnitTest
+import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.AgentInfo
@@ -54,17 +55,17 @@ class EndpointsHelperTest extends UnitTest {
 
   def endpointsWithoutServicePorts(app: AppDefinition): Unit = {
     "handle single instance without service ports" in {
-      val report = EndpointsHelper.appsToEndpointString(instances(app, Seq(1)), Seq(app))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1)), Seq(app)))
       val expected = "foo\t \tagent1\t\n"
       report should equal(expected)
     }
     "handle multiple instances, same agent, without service ports" in {
-      val report = EndpointsHelper.appsToEndpointString(instances(app, Seq(2)), Seq(app))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2)), Seq(app)))
       val expected = "foo\t \tagent1\tagent1\t\n"
       report should equal(expected)
     }
     "handle multiple instances, different agents, without service ports" in {
-      val report = EndpointsHelper.appsToEndpointString(instances(app, Seq(2, 1, 2)), Seq(app))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2, 1, 2)), Seq(app)))
       val expected = "foo\t \tagent1\tagent1\tagent2\tagent3\tagent3\t\n"
       report should equal(expected)
     }
@@ -72,17 +73,17 @@ class EndpointsHelperTest extends UnitTest {
 
   def endpointsWithSingleDynamicServicePorts(app: AppDefinition): Unit = {
     "handle single instance with 1 service port" in {
-      val report = EndpointsHelper.appsToEndpointString(instances(app, Seq(1)), Seq(app))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1)), Seq(app)))
       val expected = "foo\t80\tagent1:1010\t\n"
       report should equal(expected)
     }
     "handle multiple instances, same agent, with 1 service port" in {
-      val report = EndpointsHelper.appsToEndpointString(instances(app, Seq(2)), Seq(app))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2)), Seq(app)))
       val expected = "foo\t80\tagent1:1010\tagent1:1020\t\n"
       report should equal(expected)
     }
     "handle multiple instances, different agents, with 1 service port" in {
-      val report = EndpointsHelper.appsToEndpointString(instances(app, Seq(2, 1, 2)), Seq(app))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2, 1, 2)), Seq(app)))
       val expected = "foo\t80\tagent1:1010\tagent1:1020\tagent2:1010\tagent3:1010\tagent3:1020\t\n"
       report should equal(expected)
     }
@@ -90,12 +91,12 @@ class EndpointsHelperTest extends UnitTest {
 
   def endpointsWithSingleStaticServicePorts(app: AppDefinition, servicePort: Int, hostPort: Int): Unit = {
     s"handle single instance with 1 (static) service port $servicePort and host port $hostPort" in {
-      val report = EndpointsHelper.appsToEndpointString(instances(app, Seq(1)), Seq(app))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1)), Seq(app)))
       val expected = s"foo\t$servicePort\tagent1:$hostPort\t\n"
       report should equal(expected)
     }
     s"handle multiple instances, different agents, with 1 (static) service port $servicePort and host port $hostPort" in {
-      val report = EndpointsHelper.appsToEndpointString(instances(app, Seq(1, 1, 1)), Seq(app))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1, 1, 1)), Seq(app)))
       val expected = s"foo\t$servicePort\tagent1:$hostPort\tagent2:$hostPort\tagent3:$hostPort\t\n"
       report should equal(expected)
     }

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/RouteBehaviours.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/RouteBehaviours.scala
@@ -10,8 +10,8 @@ import org.scalatest.Inside
 
 trait RouteBehaviours extends ScalatestRouteTest with Inside { this: UnitTest =>
 
-  def unauthenticatedRoute(forRoute: Route, withRequest: HttpRequest): Unit = {
-    s"deny access to ${withRequest.method.value} of ${withRequest.uri} without authentication" in {
+  def unauthenticatedRoute(forRoute: Route, withRequest: HttpRequest, customText: String = ""): Unit = {
+    s"deny access to ${withRequest.method.value} of ${withRequest.uri} without authentication $customText" in {
       When("we try to fetch the info")
       withRequest ~> forRoute ~> check {
         Then("we receive a NotAuthenticated response")

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/TasksControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/TasksControllerTest.scala
@@ -144,6 +144,7 @@ class TasksControllerTest extends UnitTest with ScalatestRouteTest with Inside w
       {
         val controller = Fixture(authenticated = false).controller
         behave like unauthenticatedRoute(forRoute = controller.route, withRequest = Get(Uri./))
+        behave like unauthenticatedRoute(forRoute = controller.route, withRequest = Get(Uri./).addHeader(Accept(MediaTypes.`application/json`)), " using text/json")
       }
 
       "see tasks only for application to which is authorized to see" in {

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/TasksControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/TasksControllerTest.scala
@@ -137,6 +137,11 @@ class TasksControllerTest extends UnitTest with ScalatestRouteTest with Inside w
       behave like unauthenticatedRoute(forRoute = controller.route, withRequest = Get(Uri./))
     }
 
+    {
+      val controller = Fixture(authenticated = false).controller
+      behave like unauthenticatedRoute(forRoute = controller.route, withRequest = Get(Uri./).addHeader(Accept(MediaTypes.`application/json`)), " using text/json")
+    }
+
     "see tasks only for application to which is authorized to see" in {
       val clock = new SettableClock()
       val authorizedApp = AppDefinition(id = "/app".toPath, instances = 1)
@@ -175,14 +180,14 @@ class TasksControllerTest extends UnitTest with ScalatestRouteTest with Inside w
       val rootGroup = createRootGroup(apps = Map(app.id -> app))
       groupManager.rootGroup() returns rootGroup
 
-      assert(app.servicePorts.size > instance.appTask.status.networkInfo.hostPorts.size)
+      app.servicePorts.size should be > instance.appTask.status.networkInfo.hostPorts.size
 
       When("Getting the txt tasks index")
       Get(Uri./).addHeader(Accept(MediaTypes.`text/plain`)) ~> controller.route ~> check {
         Then("The status should be 200")
         status should be(StatusCodes.OK)
 
-        responseAs[String] should include (s"${app.id.safePath}\t${app.servicePorts.head}")
+        responseAs[String] should include (s"foo\t0")
       }
     }
 
@@ -208,8 +213,8 @@ class TasksControllerTest extends UnitTest with ScalatestRouteTest with Inside w
         Then("The status should be 200")
         status should be(StatusCodes.OK)
 
-        responseAs[String] should include (s"${authorizedApp.id.safePath}")
-        responseAs[String] should not include (s"${notAuthorizedApp.id.safePath}")
+        responseAs[String] should include (s"foo")
+        responseAs[String] should not include (s"foo2")
       }
     }
 


### PR DESCRIPTION
List tasks as txt

Summary:
Last part of TasksController rewrite using Akka.HTTP. Prints out tasks in plaintext.

JIRA issues: MARATHON-7308
