### PR TITLE
Store a flag node in ZK to indicate that Marathon performs data migration

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
@@ -175,4 +175,15 @@ trait PersistenceStore[K, Category, Serialized] extends OpenableOnce {
     * Make sure that store read operations return up-to-date values.
     */
   def sync(): Future[Done]
+
+  /**
+    * Mark migration as started. It is supposed to be used to ensure that
+    * no other Marathon instance performs migration at the same time.
+    */
+  def startMigration(): Future[Done]
+
+  /**
+    * Mark migration as completed. It does the opposite of what [[startMigration]] does.
+    */
+  def endMigration(): Future[Done]
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
@@ -178,6 +178,10 @@ case class LazyCachingPersistenceStore[K, Category, Serialized](
 
   override def sync(): Future[Done] = store.sync()
 
+  override def startMigration(): Future[Done] = store.startMigration()
+
+  override def endMigration(): Future[Done] = store.endMigration()
+
   override def toString: String = s"LazyCachingPersistenceStore($store)"
 }
 
@@ -352,6 +356,10 @@ case class LazyVersionCachingPersistentStore[K, Category, Serialized](
     store.setStorageVersion(storageVersion)
 
   override def sync(): Future[Done] = store.sync()
+
+  override def startMigration(): Future[Done] = store.startMigration()
+
+  override def endMigration(): Future[Done] = store.endMigration()
 
   override def toString: String = s"LazyVersionCachingPersistenceStore($store)"
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
@@ -204,5 +204,9 @@ class LoadTimeCachingPersistenceStore[K, Category, Serialized](
 
   override def sync(): Future[Done] = store.sync()
 
+  override def startMigration(): Future[Done] = store.startMigration()
+
+  override def endMigration(): Future[Done] = store.endMigration()
+
   override def toString: String = s"LoadTimeCachingPersistenceStore($store)"
 }

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -303,4 +303,42 @@ class ZkPersistenceStore(
       }
     }
   }
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def startMigration(): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
+    async {
+      await(client.create("/migration-in-progress").asTry) match {
+        case Success(_) =>
+          Done
+        case Failure(e: KeeperException.NodeExistsException) =>
+          throw new StoreCommandFailedException(
+            "Migration is already in progress; /migration-in-progress node already exists", e)
+        case Failure(e: KeeperException) =>
+          throw new StoreCommandFailedException("Failed to start migration", e)
+        case Failure(e) =>
+          throw e
+      }
+    }
+  }
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def endMigration(): Future[Done] = {
+    require(isOpen, "the store must be opened before it can be used")
+
+    async {
+      await(client.delete("/migration-in-progress").asTry) match {
+        case Success(_) =>
+          Done
+        case Failure(e: KeeperException.NoNodeException) =>
+          throw new StoreCommandFailedException(
+            "Migration has not been started; /migration-in-progress node does not exist", e)
+        case Failure(e: KeeperException) =>
+          throw new StoreCommandFailedException("Failed to end migration", e)
+        case Failure(e) =>
+          throw e
+      }
+    }
+  }
 }

--- a/src/test/scala/mesosphere/marathon/integration/MigrationInterruptedIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MigrationInterruptedIntegrationTest.scala
@@ -1,0 +1,46 @@
+package mesosphere.marathon
+package integration
+
+import mesosphere.AkkaIntegrationTest
+import mesosphere.marathon.integration.setup.{ LocalMarathon, MesosClusterTest, ZookeeperServerTest }
+import org.scalatest.concurrent.Eventually
+
+import scala.concurrent.Await
+
+@IntegrationTest
+class MigrationInterruptedIntegrationTest
+    extends AkkaIntegrationTest
+    with MesosClusterTest
+    with ZookeeperServerTest
+    with Eventually {
+
+  "Marathon" should {
+    "fail to start if migration was interrupted" in {
+      Given("there is a migration flag in ZooKeeper")
+      val namespace = s"marathon-$suiteName"
+      val path = s"/$namespace/state/migration-in-progress"
+      val client = zkClient()
+      try {
+        val returnedPath = Await.result(client.create(path, creatingParentsIfNeeded = true), patienceConfig.timeout)
+        returnedPath should equal (path)
+      } finally {
+        client.close()
+      }
+
+      When("Marathon starts up and becomes a leader")
+      val marathonServer = LocalMarathon(autoStart = false, suiteName = suiteName, masterUrl = mesosMasterUrl,
+        zkUrl = s"zk://${zkServer.connectUri}/$namespace")
+      marathonServer.create()
+
+      Then("it fails to start")
+      try {
+        eventually {
+          marathonServer.isRunning() should be(false)
+        } withClue "Marathon did not suicide because of lingering migration flag."
+        marathonServer.exitValue().get should be > 0 withClue "Marathon exited with 0 instead of an error code > 0."
+      } finally {
+        marathonServer.stop()
+      }
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -128,14 +128,17 @@ case class LocalMarathon(
     Process(cmd, workDir, sys.env.toSeq: _*)
   }
 
-  private def create(): Process = {
-    processBuilder.run(ProcessOutputToLogStream(s"$suiteName-LocalMarathon-$httpPort"))
+  def create(): Process = {
+    marathon.getOrElse {
+      val process = processBuilder.run(ProcessOutputToLogStream(s"$suiteName-LocalMarathon-$httpPort"))
+      marathon = Some(process)
+      process
+    }
   }
 
   def start(): Future[Done] = {
-    if (marathon.isEmpty) {
-      marathon = Some(create())
-    }
+    create()
+
     val port = conf.get("http_port").orElse(conf.get("https_port")).map(_.toInt).getOrElse(httpPort)
     val future = Retry(s"marathon-$port", maxAttempts = Int.MaxValue, minDelay = 1.milli, maxDelay = 5.seconds, maxDuration = 90.seconds) {
       async {


### PR DESCRIPTION
Summary:
 - Store a flag node in ZK to indicate that Marathon performs data migration
 - Add an integration test to ensure that Marathon fails to start in presence of the migration flag

It is a backport of #5610

JIRA issues: MARATHON-7788