### PR TITLE
Switch to use Debian Slim base image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,7 +177,7 @@ lazy val packagingSettings = Seq(
   dockerRepository := Some("mesosphere"),
   daemonUser in Docker := "root",
   version in Docker := { "v" + (version in Compile).value },
-  dockerBaseImage := "buildpack-deps:jessie-curl",
+  dockerBaseImage := "debian:jessie-slim",
   (defaultLinuxInstallLocation in Docker) := "/marathon",
   dockerCommands := {
     // kind of a work-around; we want our mesos install and jdk install to come earlier so that Docker can cache them
@@ -186,12 +186,15 @@ lazy val packagingSettings = Seq(
     prefixCommands ++
       Seq(Cmd("RUN",
         s"""apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \\
+          |apt-get update -y && \\
+          |apt-get upgrade -y && \\
           |echo "deb http://ftp.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list && \\
           |echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \\
           |echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \\
           |apt-get update && \\
           |
           |# jdk setup
+          |mkdir -p /usr/share/man/man1 && \\
           |apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java=20161107~bpo8+1 && \\
           |/var/lib/dpkg/info/ca-certificates-java.postinst configure && \\
           |ln -svT "/usr/lib/jvm/java-8-openjdk-$$(dpkg --print-architecture)" /docker-java-home && \\

--- a/tests/package/test.sc
+++ b/tests/package/test.sc
@@ -397,7 +397,7 @@ class DockerImageTest extends MesosTest {
     // Round about way of testing this; the HOOK_MARATHON_START file creates an env file which sets this parameter
     implicit val patienceConfig = veryPatient
     eventually {
-      execBash(dockerMarathon.containerId, "curl localhost:8080/v2/info") should include("http://test-host:port")
+      execBash(mesos.containerId, s"curl ${dockerMarathon.ipAddress}:8080/v2/info") should include("http://test-host:port")
     }
   }
 


### PR DESCRIPTION
Backport of 340b3138 (#5666)

This shaves off 40MB from our base image, and reduces the number of
dependencies we pull in (limiting the number of CVE vulnerabilities that
show up in image scans)

Also update package tests as this new docker container will not contain curl

JIRA Issues: MARATHON-7852
