### PR TITLE
Make Marathon leaderchange assertion in SI test stateless.

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -595,7 +595,8 @@ def set_service_account_permissions(service_account, resource='dcos:superuser', 
         print('Granting {} permissions to {}/users/{}'.format(action, resource, service_account))
         url = urljoin(shakedown.dcos_url(), 'acs/api/v1/acls/{}/users/{}/{}'.format(resource, service_account, action))
         req = http.put(url)
-        assert req.status_code == 204, 'Failed to grant permissions to the service account: {}, {}'.format(req, req.text)
+        msg = 'Failed to grant permissions to the service account: {}, {}'.format(req, req.text)
+        assert req.status_code == 204, msg
     except DCOSHTTPException as e:
         if (e.response.status_code == 409):
             print('Service account {} already has {} permissions set'.format(service_account, resource))

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -15,7 +15,6 @@ from shakedown import dcos_version_less_than, marthon_version_less_than, require
 from urllib.parse import urljoin
 
 from fixtures import wait_for_marathon_and_cleanup
-from utils import parse_json
 
 
 PACKAGE_NAME = 'marathon'
@@ -33,7 +32,7 @@ def get_pod_status_url(pod_id):
 
 def get_pod_status(pod_id):
     url = urljoin(DCOS_SERVICE_URL, get_pod_status_url(pod_id))
-    return parse_json(http.get(url))
+    return http.get(url).json()
 
 
 def get_pod_instances_url(pod_id, instance_id):
@@ -50,12 +49,12 @@ def get_pod_versions_url(pod_id, version_id=""):
 
 def get_pod_versions(pod_id):
     url = urljoin(DCOS_SERVICE_URL, get_pod_versions_url(pod_id))
-    return parse_json(http.get(url))
+    return http.get(url).json()
 
 
 def get_pod_version(pod_id, version_id):
     url = urljoin(DCOS_SERVICE_URL, get_pod_versions_url(pod_id, version_id))
-    return parse_json(http.get(url))
+    return http.get(url).json()
 
 
 @shakedown.dcos_1_9

--- a/tests/system/utils.py
+++ b/tests/system/utils.py
@@ -1,8 +1,11 @@
 import os
+import retrying
 import uuid
 
 from dcos import http, util
 from dcos.errors import DCOSException
+import shakedown
+import common
 
 
 def make_id(prefix=None):
@@ -41,5 +44,9 @@ def get_resource(resource):
             raise DCOSException("Can't read from resource: {0}. Please check that it exists.".format(resource))
 
 
-def parse_json(response):
-    return response.json()
+@retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
+def marathon_leadership_changed(original_leader):
+    current_leader = shakedown.marathon_leader_ip()
+    print('leader: {}'.format(current_leader))
+    assert original_leader != current_leader
+


### PR DESCRIPTION
Summary:
The check had side effects which made reasoning hard. So we extract it
into a module and avoid redefinition.
