### PR TITLE
Define minimum executor resources.

### DIFF
--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -11,6 +11,7 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.ResourceMatcher.ResourceMatch
 import mesosphere.mesos.protos.Implicits._
+import mesosphere.mesos.protos.ScalarResource
 import org.apache.mesos.Protos.Environment._
 import org.apache.mesos.Protos._
 
@@ -65,7 +66,10 @@ class TaskBuilder(
 
         val info = ExecutorInfo.newBuilder()
           .setExecutorId(ExecutorID.newBuilder().setValue(executorId))
-
+          .addAllResources(Seq(
+            ScalarResource.cpus(0.1),
+            ScalarResource.memory(32.0)
+          ).map(resourceToProto).asJava)
         containerProto.foreach(info.setContainer)
 
         val command =

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -3,23 +3,24 @@ package mesosphere.mesos
 import com.google.protobuf.TextFormat
 import mesosphere.UnitTest
 import mesosphere.marathon.api.serialization.PortDefinitionSerializer
-import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
-import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
+import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.pod.{BridgeNetwork, ContainerNetwork}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
-import mesosphere.marathon.raml.{ App, Resources }
-import mesosphere.marathon.state.Container.{ Docker, PortMapping }
+import mesosphere.marathon.raml.{App, Resources}
+import mesosphere.marathon.state.Container.{Docker, PortMapping}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
-import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
+import mesosphere.marathon.state.{AppDefinition, Container, PathId, Timestamp, _}
 import mesosphere.marathon.stream.Implicits._
-import mesosphere.marathon.test.{ MarathonTestHelper, SettableClock }
-import mesosphere.marathon.{ Protos, _ }
-import mesosphere.mesos.protos.{ Resource, _ }
+import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
+import mesosphere.marathon.{Protos, _}
+import mesosphere.mesos.protos.{Resource, _}
 import org.apache.mesos.Protos.TaskInfo
-import org.apache.mesos.{ Protos => MesosProtos }
-import org.joda.time.{ DateTime, DateTimeZone }
+import org.apache.mesos.{Protos => MesosProtos}
+import org.joda.time.{DateTime, DateTimeZone}
 
+import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 class TaskBuilderTest extends UnitTest {
@@ -990,6 +991,10 @@ class TaskBuilderTest extends UnitTest {
 
       assert(!taskInfo.hasCommand)
       assert(cmd.getValue == "chmod ug+rx '/custom/executor' && exec '/custom/executor' a b c")
+      assert(taskInfo.getExecutor.getResourcesList == Seq(
+        ScalarResource.cpus(0.1),
+        ScalarResource.memory(32.0)
+      ).map(resourceToProto).asJava)
     }
 
     "BuildIfMatchesWithRole" in {


### PR DESCRIPTION
When running a custom executor Mesos will log the following statement

> W1012 14:34:57.062808 20260 validation.cpp:932] Executor 'marathon-app.c15de967-af49-11e7-88c1-020b7e07fc76' for task 'app.c15de967-af49-11e7-88c1-020b7e07fc76' uses less memory (None) than the minimum required (32MB). Please update your executor, as this will be mandatory in future releases.

this PR sets CPU/MEM resources so this statement is not logged.

Refs:
* https://issues.apache.org/jira/browse/MESOS-1807
* https://github.com/apache/mesos/blob/1.4.0/src/master/validation.cpp#L1292-L1314