### PR TITLE
AppsController split: `kill tasks` method

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/akkahttp/Directives.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/Directives.scala
@@ -3,7 +3,7 @@ package api.akkahttp
 
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{ DateTime, HttpHeader, HttpMethods, HttpProtocols }
-import akka.http.scaladsl.server.{ Directive, Directive0, Route, Directives => AkkaDirectives }
+import akka.http.scaladsl.server.{ Directive, Directive0, Directive1, MalformedQueryParamRejection, Route, Directives => AkkaDirectives }
 import com.wix.accord.{ Failure, Success, Result => ValidationResult }
 
 import scala.concurrent.duration._
@@ -76,4 +76,30 @@ object Directives extends AuthDirectives with LeaderDirectives with AkkaDirectiv
       case Success => f(Unit)
     }
   }
+
+  def extractTaskKillingMode: Directive1[TaskKillingMode] =
+    (parameter("scale".as[Boolean].?(false)) & parameter("wipe".as[Boolean].?(false))).tflatMap {
+      case (scale, wipe) =>
+        if (scale && wipe) {
+          reject(MalformedQueryParamRejection("scale, wipe", "You cannot use scale and wipe at the same time."))
+        } else if (scale) {
+          provide(TaskKillingMode.Scale)
+        } else if (wipe) {
+          provide(TaskKillingMode.Wipe)
+        } else {
+          provide(TaskKillingMode.KillWithoutWipe)
+        }
+    }
+
+  sealed trait TaskKillingMode
+  object TaskKillingMode {
+
+    case object Scale extends TaskKillingMode
+
+    case object KillWithoutWipe extends TaskKillingMode
+
+    case object Wipe extends TaskKillingMode
+
+  }
+
 }

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/DirectivesTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/DirectivesTest.scala
@@ -1,0 +1,44 @@
+package mesosphere.marathon
+package api.akkahttp
+
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.{ Path, Query }
+import akka.http.scaladsl.server.MalformedQueryParamRejection
+import akka.http.scaladsl.server.PathMatcher.{ Matched, Unmatched }
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import mesosphere.UnitTest
+import mesosphere.marathon.state.{ AppDefinition, PathId }
+import mesosphere.marathon.test.GroupCreation
+
+class DirectivesTest extends UnitTest with ScalatestRouteTest {
+  import Directives._
+
+  def objectName(obj: AnyRef) = obj.getClass.getName
+
+  val route = extractTaskKillingMode { mode =>
+    complete(objectName(mode))
+  }
+
+  "Directives" should {
+    "extract scale killing mode from request" in {
+      Get().withUri(Uri./.withQuery(Query("scale" -> "true"))) ~> route ~> check {
+        responseAs[String] shouldEqual objectName(TaskKillingMode.Scale)
+      }
+    }
+    "extract wipe killing mode from request" in {
+      Get().withUri(Uri./.withQuery(Query("wipe" -> "true"))) ~> route ~> check {
+        responseAs[String] shouldEqual objectName(TaskKillingMode.Wipe)
+      }
+    }
+    "extract killWithoutWipe killing mode from request" in {
+      Get().withUri(Uri./) ~> route ~> check {
+        responseAs[String] shouldEqual objectName(TaskKillingMode.KillWithoutWipe)
+      }
+    }
+    "reject when scale and wipe are both true" in {
+      Get().withUri(Uri./.withQuery(Query("wipe" -> "true", "scale" -> "true"))) ~> route ~> check {
+        rejection shouldBe a[MalformedQueryParamRejection]
+      }
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -2206,5 +2206,63 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
         header[Headers.`Marathon-Deployment-Id`] should not be 'empty
       }
     }
+    "Kill tasks and scale" in new Fixture {
+      val app = AppDefinition(id = PathId("/app"))
+      val rootGroup = createRootGroup(Map(app.id -> app))
+      val plan = DeploymentPlan(rootGroup, rootGroup)
+      groupManager.app(PathId("/app")) returns Some(app)
+
+      groupManager.rootGroup() returns rootGroup
+      taskKiller.killAndScale(any, any, any)(any) returns Future.successful(plan)
+      taskKiller.kill(any, any, any)(any) returns Future.successful(Seq.empty)
+
+      val entity = HttpEntity.Empty
+
+      val uri = Uri./.withPath(Path(app.id.toString) / "tasks").withQuery(Query("scale" -> "true", "host" -> "*"))
+
+      Delete(uri, entity) ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+        header[Headers.`Marathon-Deployment-Id`] should not be 'empty
+      }
+    }
+
+    "Kill tasks and wipe" in new Fixture {
+      val app = AppDefinition(id = PathId("/app"))
+      val rootGroup = createRootGroup(Map(app.id -> app))
+      val plan = DeploymentPlan(rootGroup, rootGroup)
+      groupManager.app(PathId("/app")) returns Some(app)
+
+      groupManager.rootGroup() returns rootGroup
+      taskKiller.killAndScale(any, any, any)(any) returns Future.successful(plan)
+      taskKiller.kill(any, any, any)(any) returns Future.successful(Seq.empty)
+
+      val entity = HttpEntity.Empty
+
+      val uri = Uri./.withPath(Path(app.id.toString) / "tasks").withQuery(Query("wipe" -> "true", "host" -> "*"))
+
+      Delete(uri, entity) ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+    }
+
+    "Just Kill tasks" in new Fixture {
+      val app = AppDefinition(id = PathId("/app"))
+      val rootGroup = createRootGroup(Map(app.id -> app))
+      val plan = DeploymentPlan(rootGroup, rootGroup)
+      groupManager.app(PathId("/app")) returns Some(app)
+
+      groupManager.rootGroup() returns rootGroup
+      taskKiller.killAndScale(any, any, any)(any) returns Future.successful(plan)
+      taskKiller.kill(any, any, any)(any) returns Future.successful(Seq.empty)
+
+      val entity = HttpEntity.Empty
+
+      val uri = Uri./.withPath(Path(app.id.toString) / "tasks").withQuery(Query("host" -> "*"))
+
+      Delete(uri, entity) ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+      }
+    }
+
   }
 }


### PR DESCRIPTION
AppsController split: `kill tasks` method

Summary: splitting of the big apps controller pr, this time `kill tasks` method

JIRA issues: MARATHON-7299