### PR TITLE
Fix copy paste error in V2Controller

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/akkahttp/V2Controller.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/V2Controller.scala
@@ -37,7 +37,7 @@ class V2Controller(
         queueController.route
       } ~
       pathPrefix("tasks") {
-        queueController.route
+        tasksController.route
       }
   }
 }


### PR DESCRIPTION
Summary:
Fix copy-paste error in V2Controller definition.

JIRA issues:
