### PR TITLE
Allow underscore for network names, not endpoint name 1.5.1.1 backport

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/network.raml
+++ b/docs/docs/rest-api/public/api/v2/types/network.raml
@@ -12,8 +12,7 @@ types:
       Endpoints may also be advertised outside of a cluster.
     properties:
       name:
-        type: string
-        pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+        type: strings.Name
         maxLength: 63
         minLength: 1
         description: |
@@ -67,9 +66,8 @@ types:
     type: object
     properties:
       name?:
-        type: strings.Name
-        description: |
-          Defines the name of the container network to join.
+        type: strings.NetworkName
+        description:   Defines the name of the container network to join.
           Not for use with `host` mode networking.
       mode?:
         type: NetworkMode

--- a/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
+++ b/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
@@ -5,6 +5,11 @@ types:
     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
     maxLength: 63
     minLength: 1
+  NetworkName:
+    type: string
+    pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+    maxLength: 63
+    minLength: 1
   LegacyName:
     type: string
     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/NetworkValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/NetworkValidation.scala
@@ -9,18 +9,7 @@ import mesosphere.marathon.raml.{ Network, NetworkMode }
 
 @SuppressWarnings(Array("all")) // wix breaks stuff
 trait NetworkValidation {
-  import NameValidation._
   import Validation._
-
-  implicit val modelNetworkValidator: Validator[pod.Network] = new Validator[pod.Network] {
-    val containerNetworkValidator: Validator[pod.ContainerNetwork] = validator[pod.ContainerNetwork] { net =>
-      net.name is valid(validName)
-    }
-    override def apply(net: pod.Network): Result = net match {
-      case ct: pod.ContainerNetwork => validate(ct)(containerNetworkValidator)
-      case _ => Success // remaining network types don't have validation yet
-    }
-  }
 
   /** changes here should be reflected in [[modelNetworksValidator]] */
   implicit val ramlNetworksValidator: Validator[Seq[Network]] =

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -573,7 +573,6 @@ object AppDefinition extends GeneralPurposeCombinators {
     // constraints are only validated in RAML layer
     appDef.unreachableStrategy is valid
     appDef.networks is valid(NetworkValidation.modelNetworksValidator)
-    appDef.networks is every(NetworkValidation.modelNetworkValidator)
   } and ExternalVolumes.validApp and EnvVarValue.validApp
 
   @SuppressWarnings(Array("TraversableHead"))

--- a/src/test/scala/mesosphere/marathon/api/v2/json/NetworkTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/NetworkTest.scala
@@ -1,0 +1,26 @@
+package mesosphere.marathon
+package api.v2.json
+
+import mesosphere.marathon.core.pod.{ ContainerNetwork, Network }
+import mesosphere.{ UnitTest, ValidationTestLike }
+import mesosphere.marathon.raml
+import mesosphere.marathon.raml.Raml
+import play.api.libs.json._
+
+class NetworkTest extends UnitTest with ValidationTestLike {
+  def toJsonAndBack(c: Network): Network = {
+    Raml.fromRaml(
+      Json.toJson(Raml.toRaml(c)).as[raml.Network])
+  }
+
+  "it should not allow network names with special chars" in {
+    a[JsResultException] shouldBe thrownBy {
+      toJsonAndBack(ContainerNetwork(name = "invalid^name"))
+    }
+  }
+
+  "it should allow network names with underscores, numbers" in {
+    val original = ContainerNetwork(name = "network_1-ops")
+    toJsonAndBack(original) shouldBe original
+  }
+}


### PR DESCRIPTION
Allow underscore for network names, not endpoint name 1.5.1.1 backport

backport of 7a92637 (#5686)

allow underscore for network names, not endpoint name
JIRA Issue: MARATHON-7848
