### PR TITLE
Define build loop target and unique ci log name.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,8 +21,8 @@ ansiColor('gnome-terminal') {
             reportName: 'Scapegoat Report', reportTitles: ''
         ])
         archive includes: 'sandboxes.tar.gz'
-        archive includes: '*.tar.gz'
-        archive includes: '*.log'  // Only in case the build was  aborted and the logs weren't zipped
+        archive includes: 'ci-*.tar.gz'
+        archive includes: 'ci-*.log'  // Only in case the build was  aborted and the logs weren't zipped
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,8 +21,8 @@ ansiColor('gnome-terminal') {
             reportName: 'Scapegoat Report', reportTitles: ''
         ])
         archive includes: 'sandboxes.tar.gz'
-        archive includes: 'ci.tar.gz'
-        archive includes: 'ci.log'  // Only in case the build was  aborted and the logs weren't zipped
+        archive includes: '*.tar.gz'
+        archive includes: '*.log'  // Only in case the build was  aborted and the logs weren't zipped
       }
     }
   }

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -163,7 +163,7 @@ def updateDcosImage(version: String, artifactUrl: String, sha1: String): Unit = 
  * @return Version and artifact description of Marathon build.
  */
 @main
-def run(publish: Boolean = true): (String, Option[awsClient.Artifact]) = {
+def run(publish: Boolean = false): (String, Option[awsClient.Artifact]) = {
   utils.stage("Provision") {
 
     // Set port range for random port 0 allocation.
@@ -182,7 +182,7 @@ def run(publish: Boolean = true): (String, Option[awsClient.Artifact]) = {
 
   val (version, maybeArtifact) = createAndUploadPackages()
 
-  if(utils.isMasterBuild && publish) {
+  if(publish) {
     maybeArtifact.foreach { artifact =>
       updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
     }
@@ -201,7 +201,7 @@ def jenkins(): Unit = {
   if(utils.isPullRequest) {
     asPullRequest { run() }
   } else {
-    run()
+    run(publish = utils.isMasterBuild)
   }
 }
 

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -22,11 +22,13 @@ val PACKAGE_DOCS_DIR: Path = pwd / 'target / "universal-docs"
 
 /**
  * Compile Marathon and run unit and integration tests followed by scapegoat.
+ *
+ * @param logFileName Name of file which collects logs.
  */
 @main
-def compileAndTest(): Unit = utils.stage("Compile and Test") {
+def compileAndTest(logFileName: String = "ci.log"): Unit = utils.stage("Compile and Test") {
 
-  def run(cmd: String *) = utils.runWithTimeout(30.minutes)(cmd)
+  def run(cmd: String *) = utils.runWithTimeout(30.minutes, logFileName)(cmd)
 
   run("sbt", "clean", "test", "integration:test", "scapegoat")
 
@@ -45,10 +47,15 @@ def checkSystemIntegrationTests(): Unit = {
   run("flake8", "--max-line-length=120", "tests/system")
 }
 
+/**
+ * Compresses sandboxes and logs.
+ *
+ * @param logFileName Name of log file.
+ */
 @main
-def zipLogs(): Unit = {
+def zipLogs(logFileName: String = "ci.log"): Unit = {
   Try(%("tar", "-zcf", "sandboxes.tar.gz", "sandboxes"))
-  Try(%("tar", "-zcf", "ci.tar.gz", "--remove-files", "ci.log"))
+  Try(%("tar", "-zcf", s"$logFileName.tar.gz", "--remove-files", logFileName))
 }
 
 @main
@@ -152,10 +159,11 @@ def updateDcosImage(version: String, artifactUrl: String, sha1: String): Unit = 
 /**
  * Run the main pipeline.
  *
+ * @param publish Indicates whether a package should be published or not.
  * @return Version and artifact description of Marathon build.
  */
 @main
-def run(): (String, Option[awsClient.Artifact]) = {
+def run(publish: Boolean = true): (String, Option[awsClient.Artifact]) = {
   utils.stage("Provision") {
 
     // Set port range for random port 0 allocation.
@@ -165,15 +173,16 @@ def run(): (String, Option[awsClient.Artifact]) = {
     provision.installMesos()
   }
 
+  val logFileName = s"ci-${sys.env.getOrElse("BUILD_TAG", "run")}.log"
   try {
-    compileAndTest()
+    compileAndTest(logFileName)
   } finally {
-    zipLogs()    // Try to archive ci and sandbox logs in any case
+    zipLogs(logFileName)    // Try to archive ci and sandbox logs in any case
   }
 
   val (version, maybeArtifact) = createAndUploadPackages()
 
-  if(utils.isMasterBuild) {
+  if(utils.isMasterBuild && publish) {
     maybeArtifact.foreach { artifact =>
       updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
     }
@@ -195,3 +204,9 @@ def jenkins(): Unit = {
     run()
   }
 }
+
+/**
+ * The target for our loop builds on Jenkins.
+ */
+@main
+def loop(): Unit = run(publish = false)

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -26,7 +26,7 @@ val PACKAGE_DOCS_DIR: Path = pwd / 'target / "universal-docs"
  * @param logFileName Name of file which collects logs.
  */
 @main
-def compileAndTest(logFileName: String = "ci.log"): Unit = utils.stage("Compile and Test") {
+def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") {
 
   def run(cmd: String *) = utils.runWithTimeout(30.minutes, logFileName)(cmd)
 
@@ -38,12 +38,12 @@ def compileAndTest(logFileName: String = "ci.log"): Unit = utils.stage("Compile 
   run("sbt", "plugin-interface/compile")
 
   // Check system integraion tests.
-  checkSystemIntegrationTests()
+  checkSystemIntegrationTests(logFileName)
 }
 
 @main
-def checkSystemIntegrationTests(): Unit = {
-  def run(cmd: String *) = utils.runWithTimeout(30.minutes)(cmd)
+def checkSystemIntegrationTests(logFileName: String): Unit = {
+  def run(cmd: String *) = utils.runWithTimeout(30.minutes, logFileName)(cmd)
   run("flake8", "--max-line-length=120", "tests/system")
 }
 

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -11,7 +11,7 @@ import java.io.File
 
 import $file.provision
 
-def ciLogFile(name: String = "ci.log"): File = {
+def ciLogFile(name: String): File = {
   val log = new File(name)
   if (!log.exists())
     log.createNewFile()
@@ -69,14 +69,14 @@ def stage[T](name: String)(block: => T): T = {
  * @param commands The commands that are executed in a process. E.g. "sbt",
  *  "compile".
  */
-def runWithTimeout(timeout: FiniteDuration, logFileName: String = "ci.log")(commands: Seq[String]): Unit = {
+def runWithTimeout(timeout: FiniteDuration, logFileName: String)(commands: Seq[String]): Unit = {
 
   val builder = new java.lang.ProcessBuilder()
   val buildProcess = builder
     .directory(new java.io.File(pwd.toString))
     .command(commands.asJava)
     .inheritIO()
-    .redirectOutput(ProcessBuilder.Redirect.appendTo(ciLogFile()))
+    .redirectOutput(ProcessBuilder.Redirect.appendTo(ciLogFile(logFileName)))
     .start()
 
   try {

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -65,10 +65,11 @@ def stage[T](name: String)(block: => T): T = {
  * Run a process with given commands and time out it runs too long.
  *
  * @param timeout The maximum time to wait.
+ * @param logFileName Name of file which collects all logs.
  * @param commands The commands that are executed in a process. E.g. "sbt",
  *  "compile".
  */
-def runWithTimeout(timeout: FiniteDuration)(commands: Seq[String]): Unit = {
+def runWithTimeout(timeout: FiniteDuration, logFileName: String = "ci.log")(commands: Seq[String]): Unit = {
 
   val builder = new java.lang.ProcessBuilder()
   val buildProcess = builder


### PR DESCRIPTION
Summary:
The ci logs included logs of another run because the ci.log file would
not always be removed. This introduces a unique name per builds.