### PR TITLE
Fix flaky `GracefulTaskKillIntegrationTest`

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -207,7 +207,8 @@ private class DeploymentActor(
 
     Done
   }.recover {
-    case NonFatal(error) => logger.warn(s"Error in stopping runSpec ${runSpec.id}", error);
+    case NonFatal(error) =>
+      logger.warn(s"Error in stopping runSpec ${runSpec.id}", error);
       Done
   }
 

--- a/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
@@ -41,7 +41,7 @@ class GracefulTaskKillIntegrationTest extends AkkaIntegrationTest with EmbeddedM
       val taskId = marathon.tasks(app.id.toPath).value.head.id
 
       When("a task of an app is killed")
-      marathon.killTask(app.id.toPath, taskId) should be(OK)
+      marathon.killTask(app.id.toPath, taskId, scale = true) should be(OK)
       val taskKillSentTimestamp = Timestamp.now()
 
       val taskKilledEvent = waitForEventWith(
@@ -73,7 +73,7 @@ class GracefulTaskKillIntegrationTest extends AkkaIntegrationTest with EmbeddedM
       val taskId = marathon.tasks(app.id.toPath).value.head.id
 
       When("a task of an app is killed")
-      marathon.killTask(app.id.toPath, taskId) should be(OK)
+      marathon.killTask(app.id.toPath, taskId, scale = true) should be(OK)
       val taskKillSentTimestamp = Timestamp.now()
 
       val taskKilledEvent = waitForEventWith(


### PR DESCRIPTION
Summary:
Fix flaky `GracefulTaskKillIntegrationTest` by scaling down when killing tasks. Otherwise we have a race condition where a new task is started before the test is finished which leads to a failure during clean up. The underlying race condition will be fixed in another PR.