### PR TITLE
Support pragma.serializeOnly in RAML generator

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/pragma.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pragma.raml
@@ -42,5 +42,5 @@ annotationTypes:
   serializeOnly:
     type: nil
     description:  |
-      Mark a type as "serialize-only" for which no de-serialization code will be generated.
+      Mark an object type as "serialize-only" for which no de-serialization code will be generated.
 

--- a/docs/docs/rest-api/public/api/v2/types/pragma.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pragma.raml
@@ -40,7 +40,7 @@ annotationTypes:
       No functional change - only to indicate the use of one type.
       Use only on type level.
   serializeOnly:
-    type: string
+    type: nil
     description:  |
-      Mark a type as "serialize-only" for which no de-serialization code will be genrated.
+      Mark a type as "serialize-only" for which no de-serialization code will be generated.
 

--- a/docs/docs/rest-api/public/api/v2/types/pragma.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pragma.raml
@@ -39,5 +39,8 @@ annotationTypes:
       Mark a type as internal to indicate, that it is not used in the external API.
       No functional change - only to indicate the use of one type.
       Use only on type level.
-
+  serializeOnly:
+    type: string
+    description:  |
+      Mark a type as "serialize-only" for which no de-serialization code will be genrated.
 

--- a/project/src/main/scala/com/mesosphere/RamlTypeGenerator.scala
+++ b/project/src/main/scala/com/mesosphere/RamlTypeGenerator.scala
@@ -131,7 +131,7 @@ object RamlTypeGenerator {
     o.annotations().asScala.exists(_.name() == "(pragma.forceOptional)")
 
   def pragmaSerializeOnly(o: TypeDeclaration): Boolean =
-    o.annotations().exists(_.name() == "(pragma.serializeOnly)")
+    o.annotations().asScala.exists(_.name() == "(pragma.serializeOnly)")
 
   def generateUpdateTypeName(o: ObjectTypeDeclaration): Option[String] =
     if (o.`type`() == "object" && !isUpdateType(o)) {


### PR DESCRIPTION
Summary:
This commit introduces the "(pragma.serializeOnly):" RAML attribute
that can be used in RAML types that have no discriminator, forcing
the generator to materialize only the `writes` part of the Format.

_JIRA issues: [MARATHON-7841](https://jira.mesosphere.com/browse/MARATHON-7841)_

Example input:

```raml
  DeploymentPlan:
    type: object
    (pragma.serializeOnly): ; <-- Used on base class
    properties:
      id:
        type: string
        description: The UUID of the deployment plan

  DeploymentStepInfo:
    type: DeploymentPlan
    properties:
      affectedApps:
        type: array
        items: strings.PathId
        description: The IDs of the apps affected by this deployment

```

Example Output:

```scala
trait DeploymentPlan extends RamlGenerated with Product with Serializable {
  val id: String
}

case class DeploymentStepInfo(id: String, affectedApps: scala.collection.immutable.Seq[String]) extends DeploymentPlan

object DeploymentStepInfo {
  implicit object playJsonFormat extends play.api.libs.json.Format[DeploymentStepInfo] {
    def reads(json: play.api.libs.json.JsValue): play.api.libs.json.JsResult[DeploymentStepInfo] = {
      val id = json.\("id").validate[String](play.api.libs.json.JsPath.read[String])
      val affectedApps = json.\("affectedApps").validate[scala.collection.immutable.Seq[String]](play.api.libs.json.JsPath.read[scala.collection.immutable.Seq[String]])
      val _errors = Seq(("id", id), ("affectedApps", affectedApps)).collect({
        case (field, e:play.api.libs.json.JsError) => e.repath(play.api.libs.json.JsPath.\(field)).asInstanceOf[play.api.libs.json.JsError]
      })
      if (_errors.nonEmpty) _errors.reduceOption[play.api.libs.json.JsError](_.++(_)).getOrElse(_errors.head)
      else play.api.libs.json.JsSuccess(DeploymentStepInfo(id = id.get, original = original.get, target = target.get, steps = steps.get, version = version.get, affectedApps = affectedApps.get, affectedPods = affectedPods.get, currentActions = currentActions.get, currentStep = currentStep.get, totalSteps = totalSteps.get))
    }
    def writes(o: DeploymentStepInfo): play.api.libs.json.JsValue = {
      val id = play.api.libs.json.Json.toJson(o.id)
      val affectedApps = play.api.libs.json.Json.toJson(o.affectedApps)
  }
  val DefaultOriginal: Option[Group] = None
  val DefaultTarget: Option[Group] = None
}

object DeploymentPlan {
  implicit object playJsonFormat extends play.api.libs.json.Writes[DeploymentPlan] {
    def writes(o: DeploymentPlan): play.api.libs.json.JsValue = {
      val id = play.api.libs.json.Json.toJson(o.id)
    }
  }
  val DefaultOriginal: Option[Group] = None
  val DefaultTarget: Option[Group] = None
}
```

Previously, `DeploymentPlan` was becoming:

```scala
object DeploymentPlan {
  val DefaultOriginal: Option[Group] = None
  val DefaultTarget: Option[Group] = None
}
```