### PR TITLE
Migrate UnreachableStrategy to migrate saved and running Instances as…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,23 @@
+## Changes from 1.5.1 to 1.5.2 (unreleased)
+Bugfix release
+
+### Fixed issues
+- [MARATHON-7790](https://jira.mesosphere.com/browse/MARATHON-7790) Migrate UnreachableStrategy Saved in Instances
+
+### 1.5.1 New Behavior
+#### Migrating unreachableStrategy - running instances
+
+If you already migrated your apps and pods to the new default behavior for `UnreachableStrategy`, you also should consider to migrate the running instances as well.
+
+To change the `unreachableStrategy` of all running instances, set the environment variable `MIGRATION_1_4_6_UNREACHABLE_STRATEGY` to `true`, which leads to the following behavior during migration:
+
+When opting in to the unreachable migration step
+1) all instances that had a config of `UnreachableStrategy(300 seconds, 600 seconds)` (previous default) are migrated to have `UnreachableStrategy(0 seconds, 0 seconds)`
+2) all instances that had a config of `UnreachableStrategy(1 second, x seconds)` are migrated to have `UnreachableStrategy(0 seconds, x seconds)`
+3) all instances that had a config of `UnreachableStrategy(1 second, 2 seconds)` are migrated to have `UnreachableStrategy(0 seconds, 0 seconds)`
+
+**Note**: If you set this variable after upgrading to 1.4.9, it will have no effect.
+
 ## Changes from 1.5.0 to 1.5.1
 Bugfix release
 

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -66,6 +66,9 @@ class Migration(
       },
       StorageVersions(1, 5, 0, StorageVersion.StorageFormat.PERSISTENCE_STORE) -> (() =>
         MigrationTo15(this).migrate()
+      ),
+      StorageVersions(1, 5, 2, StorageVersion.StorageFormat.PERSISTENCE_STORE) -> (() =>
+        new MigrationTo152(instanceRepo).migrate()
       )
     )
 

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo146.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo146.scala
@@ -43,7 +43,7 @@ object MigrationTo146 extends StrictLogging {
     *
     * @return migrated app
     */
-  private def changeUnreachableStrategy(unreachableStrategy: UnreachableStrategy): UnreachableStrategy = {
+  private[migration] def changeUnreachableStrategy(unreachableStrategy: UnreachableStrategy): UnreachableStrategy = {
     unreachableStrategy match {
       // migrate previous `hack` to achieve fastest replacement - case 3
       case UnreachableEnabled(inactiveAfter, expungeAfter) if inactiveAfter == 1.seconds && expungeAfter == 2.seconds =>

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo152.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo152.scala
@@ -1,0 +1,61 @@
+package mesosphere.marathon
+package storage.migration
+
+import akka.Done
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Flow, Keep, Sink }
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.state._
+import mesosphere.marathon.storage.migration.MigrationTo146.Environment
+import mesosphere.marathon.storage.repository.InstanceRepository
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+@SuppressWarnings(Array("ClassNames"))
+class MigrationTo152(instanceRepository: InstanceRepository)(implicit ctx: ExecutionContext, mat: Materializer) extends StrictLogging {
+
+  def migrate(): Future[Done] = {
+    MigrationTo152.migrateUnreachableInstances(instanceRepository)(Environment(sys.env), ctx, mat)
+  }
+}
+
+object MigrationTo152 extends StrictLogging {
+
+  private def changeUnreachableStrategyForInstances(instance: Instance): Instance = {
+    instance.copy(unreachableStrategy = MigrationTo146.changeUnreachableStrategy(instance.unreachableStrategy))
+  }
+
+  def migrateUnreachableInstances(instanceRepository: InstanceRepository)(implicit env: Environment, ctx: ExecutionContext, mat: Materializer): Future[Done] = {
+    logger.info("Starting unreachable strategy migration to 1.5.2")
+
+    val instanceSink =
+      Flow[Instance]
+        .mapAsync(Int.MaxValue)(instanceRepository.store)
+        .toMat(Sink.ignore)(Keep.right)
+
+    // we stick to already present migration indicating env variable to not confuse users
+    val migrateUnreachableStrategyWanted = env.vars.getOrElse(MigrationTo146.MigrateUnreachableStrategyEnvVar, "false")
+
+    if (migrateUnreachableStrategyWanted == "true") {
+      instanceRepository.all()
+        .via(instanceMigrationFlow)
+        .runWith(instanceSink)
+        .andThen {
+          case _ =>
+            logger.info("Finished 1.5.2 migration for unreachable strategy for instances")
+        }
+    } else {
+      logger.info("No unreachable strategy migration to 1.5.2 wanted")
+      Future.successful(Done)
+    }
+  }
+
+  val instanceMigrationFlow =
+    Flow[Instance]
+      .filter(_.unreachableStrategy != UnreachableDisabled)
+      .map { instance =>
+        logger.info(s"Migrate unreachable strategy for instance: ${instance.instanceId}")
+        changeUnreachableStrategyForInstances(instance)
+      }
+}

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo152Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo152Test.scala
@@ -1,0 +1,53 @@
+package mesosphere.marathon
+package storage.migration
+
+import akka.Done
+import akka.stream.scaladsl.Source
+import akka.stream.{ ActorMaterializer, Materializer }
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
+import mesosphere.marathon.state._
+import mesosphere.marathon.storage.migration.MigrationTo146.Environment
+import mesosphere.marathon.storage.repository.InstanceRepository
+import mesosphere.marathon.test.GroupCreation
+
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+
+class MigrationTo152Test extends AkkaUnitTest with GroupCreation with StrictLogging {
+
+  "Migration to 1.5.2" should {
+    "do nothing if env var is not configured" in new Fixture {
+      MigrationTo152.migrateUnreachableInstances(instanceRepository)(env, ctx, mat).futureValue
+      verify(instanceRepository, never).all()
+      verify(instanceRepository, never).store(_: Instance)
+    }
+
+    "do migration if env var is configured" in new Fixture(Map(MigrationTo146.MigrateUnreachableStrategyEnvVar -> "true")) {
+      MigrationTo152.migrateUnreachableInstances(instanceRepository)(env, ctx, mat).futureValue
+      val targetInstance = instance.copy(unreachableStrategy = UnreachableEnabled(0.seconds, 5.seconds)) // case 2
+      val targetInstance2 = instance2.copy(unreachableStrategy = UnreachableEnabled(0.seconds, 0.seconds)) // case 1
+      val targetInstance3 = instance3.copy(unreachableStrategy = UnreachableEnabled(0.seconds, 0.seconds)) // case 3
+
+      logger.info(s"Migration instances ($instance, $instance2, $instance3) ")
+      verify(instanceRepository, once).all()
+      verify(instanceRepository, once).store(targetInstance)
+      verify(instanceRepository, once).store(targetInstance2)
+      verify(instanceRepository, once).store(targetInstance3)
+    }
+  }
+
+  private class Fixture(val environment: Map[String, String] = Map.empty) {
+    val instanceRepository: InstanceRepository = mock[InstanceRepository]
+    implicit lazy val env = Environment(environment)
+    implicit lazy val mat: Materializer = ActorMaterializer()
+    implicit lazy val ctx: ExecutionContextExecutor = system.dispatcher
+    val instance = TestInstanceBuilder.emptyInstance(instanceId = Instance.Id.forRunSpec(PathId("/app"))).copy(unreachableStrategy = UnreachableEnabled(1.seconds, 5.seconds))
+    val instance2 = TestInstanceBuilder.emptyInstance(instanceId = Instance.Id.forRunSpec(PathId("/app2"))).copy(unreachableStrategy = UnreachableEnabled(5.minutes, 10.minutes))
+    val instance3 = TestInstanceBuilder.emptyInstance(instanceId = Instance.Id.forRunSpec(PathId("/app3"))).copy(unreachableStrategy = UnreachableEnabled(1.seconds, 2.seconds))
+    instanceRepository.all() returns Source(Seq(instance, instance2, instance3))
+    instanceRepository.store(any) returns Future.successful(Done)
+  }
+
+}


### PR DESCRIPTION
… well (#5659)

Summary:
The migration for a new default in the unreachable strategy does not migrate the values for running instances. Each instance saves a copy of the strategy which has to be migrated as well. This PR fixes this behavior.

JIRA issues:
https://jira.mesosphere.com/browse/MARATHON-7790

backport of #5659