### PR TITLE
Change `Int.MaxValue` to 8 for maximum concurrency during migration (…

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -260,6 +260,7 @@ class Migration(
 
 object Migration {
   val StorageVersionName = "internal:storage:version"
+  val maxConcurrency = 8
 }
 
 object StorageVersions {

--- a/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_2.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_2.scala
@@ -6,6 +6,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{ Flow, Keep, Sink }
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.state._
+import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.storage.repository.AppRepository
 
 import scala.concurrent.{ ExecutionContext, Future }

--- a/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_2.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_2.scala
@@ -18,7 +18,7 @@ class MigrationTo_1_4_2(appRepository: AppRepository)(implicit
   import MigrationTo_1_4_2.migrationFlow
   val sink =
     Flow[AppDefinition]
-      .mapAsync(Int.MaxValue)(appRepository.store)
+      .mapAsync(Migration.maxConcurrency)(appRepository.store)
       .toMat(Sink.ignore)(Keep.right)
 
   def migrate(): Future[Done] = {

--- a/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_6.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_6.scala
@@ -6,6 +6,7 @@ import akka.stream.scaladsl.{ Flow, Keep, Sink }
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.state._
+import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.storage.repository.{ AppRepository, PodRepository }
 
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_6.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_6.scala
@@ -63,12 +63,12 @@ object MigrationTo_1_4_6 extends StrictLogging {
   def migrateUnreachableApps(appRepository: AppRepository, podRepository: PodRepository)(implicit env: Environment, ctx: ExecutionContext, mat: Materializer): Future[Done] = {
     val appSink =
       Flow[AppDefinition]
-        .mapAsync(Int.MaxValue)(appRepository.store)
+        .mapAsync(Migration.maxConcurrency)(appRepository.store)
         .toMat(Sink.ignore)(Keep.right)
 
     val podSink =
       Flow[PodDefinition]
-        .mapAsync(Int.MaxValue)(podRepository.store)
+        .mapAsync(Migration.maxConcurrency)(podRepository.store)
         .toMat(Sink.ignore)(Keep.right)
 
     val migrateUnreachableStrategyWanted = env.vars.getOrElse(MigrationTo_1_4_6.MigrateUnreachableStrategyEnvVar, "false")

--- a/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_9.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_9.scala
@@ -30,7 +30,7 @@ object MigrationTo_1_4_9 extends StrictLogging {
 
     val instanceSink =
       Flow[Instance]
-        .mapAsync(Int.MaxValue)(instanceRepository.store)
+        .mapAsync(Migration.maxConcurrency)(instanceRepository.store)
         .toMat(Sink.ignore)(Keep.right)
 
     // we stick to already present migration indicating env variable to not confuse users

--- a/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_9.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/legacy/MigrationTo_1_4_9.scala
@@ -6,6 +6,7 @@ import akka.stream.scaladsl.{ Flow, Keep, Sink }
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state._
+import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.storage.migration.legacy.MigrationTo_1_4_6.Environment
 import mesosphere.marathon.storage.repository.InstanceRepository
 


### PR DESCRIPTION
…#5676)

Summary:
As discussed in #5659, we should introduce a restriction on the amount of simultaneous calls. Therefore we change Int.MaxValue to 8 for maximum concurrency during migration.

backport of #5676