### PR TITLE
Change `Int.MaxValue` to 8 for maximum concurrency during loading in …

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/storage/repository/Repository.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/repository/Repository.scala
@@ -56,3 +56,7 @@ trait VersionedRepository[Id, T] extends ReadOnlyVersionedRepository[Id, T] with
   // Removes _only_ the current value, leaving all history in place.
   def deleteCurrent(id: Id): Future[Done]
 }
+
+object RepositoryConstants {
+  val maxConcurrency = 8
+}

--- a/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
@@ -10,6 +10,7 @@ import akka.stream.scaladsl.Source
 import akka.{ Done, NotUsed }
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.Protos
+import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.core.storage.repository.impl.PersistenceStoreRepository
 import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
 import mesosphere.marathon.metrics.Metrics
@@ -137,7 +138,7 @@ class DeploymentRepositoryImpl[K, C, S](
   override def ids(): Source[String, NotUsed] = repo.ids()
 
   override def all(): Source[DeploymentPlan, NotUsed] =
-    repo.ids().mapAsync(Int.MaxValue)(get).collect { case Some(g) => g }
+    repo.ids().mapAsync(RepositoryConstants.maxConcurrency)(get).collect { case Some(g) => g }
 
   @SuppressWarnings(Array("all")) // async/await
   override def get(id: String): Future[Option[DeploymentPlan]] = async { // linter:ignore UnnecessaryElseBranch
@@ -150,6 +151,6 @@ class DeploymentRepositoryImpl[K, C, S](
   }
 
   private[storage] def lazyAll(): Source[StoredPlan, NotUsed] =
-    repo.ids().mapAsync(Int.MaxValue)(repo.get).collect { case Some(g) => g }
+    repo.ids().mapAsync(RepositoryConstants.maxConcurrency)(repo.get).collect { case Some(g) => g }
 }
 


### PR DESCRIPTION
…… (#5677)

…DeploymentRepository.

Summary:
As discussed in #5676 and #5659, we should introduce a restriction on the amount of simultaneous calls. Therefore we change Int.MaxValue to 8 for maximum concurrency during DeploymentRepository.

backport of #5677 