### PR TITLE
Stabilized ITs by removing excessive usage of `cleanUp` method

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -19,7 +19,6 @@ import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.storage.repository.{ DeploymentRepository, GroupRepository }
 import mesosphere.util.state._
-import org.apache.mesos.Scheduler
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.FiniteDuration

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -1,7 +1,5 @@
 package mesosphere.marathon
 
-import javax.inject.Inject
-
 import akka.event.EventStream
 import mesosphere.marathon.core.base._
 import mesosphere.marathon.core.event.{ SchedulerRegisteredEvent, _ }

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -9,7 +9,7 @@ import akka.stream.scaladsl.Sink
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.deployment.{ DeploymentManager, DeploymentPlan, ScalingProposition }
 import mesosphere.marathon.core.election.{ ElectionService, LocalLeadershipEvent }
-import mesosphere.marathon.core.event.{ AppTerminatedEvent, DeploymentSuccess }
+import mesosphere.marathon.core.event.{ DeploymentSuccess }
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.AgentInfo

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/Directives.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/Directives.scala
@@ -3,7 +3,7 @@ package api.akkahttp
 
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.{ Directive, Directive0, Directive1, Route, Directives => AkkaDirectives }
+import akka.http.scaladsl.server.{ Directive0, Directive1, Directives => AkkaDirectives }
 import com.wix.accord.{ Failure, Success, Validator, Result => ValidationResult }
 import com.wix.accord.dsl._
 import mesosphere.marathon.core.instance.Instance

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -11,7 +11,6 @@ import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, FromMessageUnm
 import akka.util.ByteString
 import com.wix.accord.Descriptions.{ Generic, Path }
 import com.wix.accord.{ Failure, RuleViolation, Success, Validator }
-import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.appinfo.AppInfo
 import mesosphere.marathon.plugin.PathId
@@ -25,7 +24,6 @@ import scala.collection.breakOut
 object EntityMarshallers {
   import Directives.complete
   import mesosphere.marathon.api.v2.json.Formats._
-  import mesosphere.marathon.raml.MetricsConversion._
 
   private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -17,9 +17,6 @@ import scala.concurrent.duration._
 @IntegrationTest
 class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
-  //clean up state before running the test case
-  before(cleanUp())
-
   def appId(suffix: Option[String] = None): PathId = testBasePath / s"app-${suffix.getOrElse(UUID.randomUUID)}"
 
   "AppDeploy" should {
@@ -79,7 +76,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       deployment2 should be(OK)
 
       And("BUT our app still has a backoff delay")
-      val queueAfterScaling: List[ITQueueItem] = marathon.launchQueue().value.queue
+      val queueAfterScaling: List[ITQueueItem] = marathon.launchQueueForAppId(app.id.toPath).value
       queueAfterScaling should have size 1
       queueAfterScaling.map(_.delay.overdue) should contain(false)
     }
@@ -118,7 +115,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
 
       And("our app gets a backoff delay")
       WaitTestSupport.waitUntil("queue item") {
-        val queue: List[ITQueueItem] = marathon.launchQueue().value.queue
+        val queue: List[ITQueueItem] = marathon.launchQueueForAppId(app.id.toPath).value
         queue should have size 1
         queue.map(_.delay.overdue) should contain(false)
         true
@@ -275,9 +272,8 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       waitForDeployment(create)
 
       Then("the list of running app tasks can be fetched")
-      val apps = marathon.listAppsInBaseGroup
-      apps should be(OK)
-      apps.value should have size 1
+      val apps = marathon.listAppsInBaseGroupForAppId(app.id.toPath).value
+      apps should have size 1
 
       val tasksResult: RestResult[List[ITEnrichedTask]] = marathon.tasks(app.id.toPath)
       tasksResult should be(OK)
@@ -314,7 +310,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       val delete = marathon.deleteApp(id, force = true)
       delete should be(OK)
       waitForDeployment(delete)
-      marathon.listAppsInBaseGroup.value should have size 0
+      marathon.listAppsInBaseGroupForAppId(id).value should have size 0
     }
 
     "an unhealthy app fails to deploy because health checks takes too long to pass" in {
@@ -345,7 +341,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       val delete = marathon.deleteApp(id, force = true)
       delete should be(OK)
       waitForDeployment(delete)
-      marathon.listAppsInBaseGroup.value should have size 0
+      marathon.listAppsInBaseGroupForAppId(id).value should have size 0
     }
 
     "update an app" in {
@@ -570,7 +566,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       waitForDeployment(delete)
 
       Then("All instances of the app get restarted")
-      marathon.listAppsInBaseGroup.value should have size 0
+      marathon.listAppsInBaseGroupForAppId(app.id.toPath).value should have size 0
     }
 
     "create and deploy an app with two tasks" in {
@@ -608,7 +604,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       deploymentSuccess.info("id") should be(deploymentId)
 
       Then("after that deployments should be empty")
-      val event: RestResult[List[ITDeployment]] = marathon.listDeploymentsForBaseGroup()
+      val event: RestResult[List[ITDeployment]] = marathon.listDeploymentsForPathId(appIdPath)
       event.value should be('empty)
 
       Then("Both tasks respond to http requests")
@@ -635,7 +631,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       val deploymentId = extractDeploymentIds(create).head
 
       Then("the deployment gets created")
-      WaitTestSupport.validFor("deployment visible", 1.second)(marathon.listDeploymentsForBaseGroup().value.size == 1)
+      WaitTestSupport.validFor("deployment visible", 1.second)(marathon.listDeploymentsForPathId(id).value.size == 1)
 
       When("the deployment is forcefully removed")
       val delete = marathon.deleteDeployment(deploymentId, force = true)
@@ -643,7 +639,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
 
       Then("the deployment should be gone")
       waitForEvent("deployment_failed")
-      marathon.listDeploymentsForBaseGroup().value should have size 0
+      marathon.listDeploymentsForPathId(id).value should have size 0
 
       Then("the app should still be there")
       marathon.app(id) should be(OK)
@@ -661,7 +657,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       val deploymentId = extractDeploymentIds(create).head
 
       Then("the deployment gets created")
-      WaitTestSupport.validFor("deployment visible", 5.second)(marathon.listDeploymentsForBaseGroup().value.size == 1)
+      WaitTestSupport.validFor("deployment visible", 5.second)(marathon.listDeploymentsForPathId(id).value.size == 1)
 
       When("the deployment is rolled back")
       val delete = marathon.deleteDeployment(deploymentId, force = false)
@@ -677,7 +673,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
 
       Then("no more deployment in the queue")
       WaitTestSupport.waitUntil("Deployments get removed from the queue") {
-        marathon.listDeploymentsForBaseGroup().value.isEmpty
+        marathon.listDeploymentsForPathId(id).value.isEmpty
       }
 
       Then("the app should also be gone")

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -194,7 +194,10 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
     }
 
     "create a simple app with a Marathon HTTP health check using port instead of portIndex" in {
-      Given("a new app")
+      Given("A clean cluster (since we need a concrete port that should be free)")
+      cleanUp()
+
+      And("a new app")
       val port = mesosCluster.randomAgentPort()
       val app = appProxy(appId(Some("with-marathon-http-health-check-using-port")), "v1", instances = 1, healthCheck = None).
         copy(

--- a/src/test/scala/mesosphere/marathon/integration/EventsIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/EventsIntegrationTest.scala
@@ -1,8 +1,6 @@
 package mesosphere.marathon
 package integration
 
-import java.util.UUID
-
 import akka.stream.scaladsl.Sink
 import mesosphere.AkkaIntegrationTest
 import mesosphere.marathon.integration.setup._
@@ -15,9 +13,7 @@ import scala.concurrent.duration._
 @IntegrationTest
 class EventsIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
-  before(cleanUp())
-
-  def appId(): PathId = testBasePath / s"app-${UUID.randomUUID}"
+  def appId(suffix: String): PathId = testBasePath / s"app-$suffix"
 
   "Filter events" should {
     "receive only app deployment event" in {
@@ -36,7 +32,7 @@ class EventsIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTes
         .runWith(Sink.head)
 
       When("the app is created")
-      val app = appProxy(appId(), "v1", instances = 1, healthCheck = None)
+      val app = appProxy(appId("with-one-deployment-event"), "v1", instances = 1, healthCheck = None)
       val result = marathon.createAppV2(app)
 
       And("we wait for deployment")

--- a/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
@@ -15,9 +15,6 @@ class GroupDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
 
   import PathId._
 
-  //clean up state before running the test case
-  before(cleanUp())
-
   val appIdCount = new AtomicInteger()
   val groupIdCount = new AtomicInteger()
 
@@ -74,7 +71,7 @@ class GroupDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       Then("The group is deleted")
       result should be(OK)
       // only expect the test base group itself
-      marathon.listGroupsInBaseGroup.value.filter { group => group.id != testBasePath } should be('empty)
+      marathon.listGroupsInBaseGroup.value.exists { g => g.id == group.id } shouldBe false
     }
 
     "delete a non existing group should give a 404 http response" in {

--- a/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
@@ -71,7 +71,7 @@ class GroupDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       Then("The group is deleted")
       result should be(OK)
       // only expect the test base group itself
-      marathon.listGroupsInBaseGroup.value.exists { g => g.id == group.id } shouldBe false
+      marathon.listGroupsInBaseGroup.value.map(_.id) should not contain (group.id)
     }
 
     "delete a non existing group should give a 404 http response" in {

--- a/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -22,8 +22,6 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
   // run as root in a Linux environment. They have to be explicitly enabled through an env variable.
   val envVar = "RUN_MESOS_INTEGRATION_TESTS"
 
-  val currentAppId = new AtomicInteger()
-
   // Configure Mesos to provide the Mesos containerizer with Docker image support.
   override lazy val mesosConfig = MesosConfig(
     launcher = "linux",
@@ -31,7 +29,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
     imageProviders = Some("docker"))
 
   private[this] def simplePod(podId: String): PodDefinition = PodDefinition(
-    id = testBasePath / s"$podId-${currentAppId.incrementAndGet()}",
+    id = testBasePath / s"$podId",
     containers = Seq(
       MesosContainer(
         name = "task1",
@@ -43,14 +41,11 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
     instances = 1
   )
 
-  //clean up state before running the test case
-  before(cleanUp())
-
   "MesosApp" should {
     "deploy a simple Docker app using the Mesos containerizer" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a new Docker app")
       val app = App(
-        id = (testBasePath / s"mesos-docker-app-${currentAppId.incrementAndGet()}").toString,
+        id = (testBasePath / s"mesos-simple-docker-app").toString,
         cmd = Some("sleep 600"),
         container = Some(Container(`type` = EngineType.Mesos, docker = Some(DockerContainer(image = "busybox")))),
         cpus = 0.2,
@@ -71,7 +66,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
     "deploy a simple Docker app that uses Entrypoint/Cmd using the Mesos containerizer" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a new Docker app the uses 'Cmd' in its Dockerfile")
       val app = raml.App(
-        id = (testBasePath / s"mesos-docker-app-${currentAppId.incrementAndGet()}").toString,
+        id = (testBasePath / s"mesos-docker-app-with-entrypoint").toString,
         container = Some(raml.Container(`type` = raml.EngineType.Mesos, docker = Some(raml.DockerContainer(
           image = "hello-world")))),
         cpus = 0.1, mem = 32.0,
@@ -90,7 +85,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
 
     "deploy a simple pod" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a pod with a single task")
-      val pod = simplePod("simplepod")
+      val pod = simplePod("simple-pod-with-single-task")
 
       When("The pod is deployed")
       val createResult = marathon.createPodV2(pod)
@@ -120,7 +115,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       val projectDir = sys.props.getOrElse("user.dir", ".")
 
       Given("a pod with two tasks that are health checked")
-      val podId = testBasePath / s"healthypod-${currentAppId.incrementAndGet()}"
+      val podId = testBasePath / "healthy-pod-with-two-tasks"
       val containerDir = "/opt/marathon"
 
       def appMockCommand(port: String) = """echo APP PROXY $$MESOS_TASK_ID RUNNING; /opt/marathon/python/app_mock.py """ +
@@ -197,7 +192,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
 
     "deploy a pod with Entrypoint/Cmd" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("A pod using the 'hello' image that sets Cmd in its Dockerfile")
-      val pod = simplePod("simplepod").copy(
+      val pod = simplePod("simple-pod-with-hello-image-and-cmd").copy(
         containers = Seq(MesosContainer(
           name = "hello",
           resources = raml.Resources(cpus = 0.1, mem = 32.0),
@@ -216,7 +211,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
 
     "deleting a group deletes pods deployed in the group" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a deployed pod")
-      val pod = simplePod("simplepod")
+      val pod = simplePod("simple-pod-is-deleted-with-group")
       val createResult = marathon.createPodV2(pod)
       createResult should be(Created)
       waitForDeployment(createResult)
@@ -238,7 +233,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
 
     "list pod versions" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a new pod")
-      val pod = simplePod("simplepod")
+      val pod = simplePod("simple-pod-with-versions")
       val createResult = marathon.createPodV2(pod)
       createResult should be(Created)
       waitForDeployment(createResult)
@@ -255,7 +250,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
 
     "correctly version pods" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a new pod")
-      val pod = simplePod("simplepod")
+      val pod = simplePod("simple-pod-with-version-after-update")
       val createResult = marathon.createPodV2(pod)
       createResult should be(Created)
       //Created
@@ -289,7 +284,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
     "stop (forcefully delete) a pod deployment" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a pod with constraints that cannot be fulfilled")
       val constraint = Protos.Constraint.newBuilder().setField("nonExistent").setOperator(Protos.Constraint.Operator.CLUSTER).setValue("na").build()
-      val pod = simplePod("simplepod").copy(
+      val pod = simplePod("simple-pod-with-impossible-constraints-force-delete").copy(
         constraints = Set(constraint)
       )
 
@@ -318,7 +313,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
     "rollback a pod deployment" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a pod with constraints that cannot be fulfilled")
       val constraint = Protos.Constraint.newBuilder().setField("nonExistent").setOperator(Protos.Constraint.Operator.CLUSTER).setValue("na").build()
-      val pod = simplePod("simplepod").copy(
+      val pod = simplePod("simple-pod-with-impossible-constraints-rollback").copy(
         constraints = Set(constraint)
       )
 
@@ -353,8 +348,8 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
 
     "delete pod instances" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a new pod with 2 instances")
-      val pod = simplePod("simplepod").copy(
-        instances = 3
+      val pod = simplePod("simple-pod-with-two-instances-delete").copy(
+        instances = 2
       )
 
       When("The pod is created")
@@ -366,7 +361,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       Then("Three instances should be running")
       val status1 = marathon.status(pod.id)
       status1 should be(OK)
-      status1.value.instances should have size 3
+      status1.value.instances should have size 2
 
       When("An instance is deleted")
       val instanceId = status1.value.instances.head.id
@@ -377,7 +372,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       waitForStatusUpdates("TASK_KILLED", "TASK_RUNNING")
       val status2 = marathon.status(pod.id)
       status2 should be(OK)
-      status2.value.instances.filter(_.status == raml.PodInstanceState.Stable) should have size 3
+      status2.value.instances.filter(_.status == raml.PodInstanceState.Stable) should have size 2
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
@@ -10,9 +10,6 @@ import org.scalatest.concurrent.Eventually
 @IntegrationTest
 class ReadinessCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Eventually {
 
-  //clean up state before running the test case
-  before(cleanUp())
-
   private val ramlHealthCheck = AppHealthCheck(
     protocol = AppHealthCheckProtocol.Http,
     gracePeriodSeconds = 20,

--- a/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
@@ -19,15 +19,6 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
 
   import Fixture._
 
-  private[this] val log = LoggerFactory.getLogger(getClass)
-
-  //clean up state before running the test case
-  before(cleanUp())
-
-  // Any test in this suite that restarts an existing task can fail because of: https://issues.apache.org/jira/browse/MESOS-7752
-  // TL;DR: we are reusing taskIds for resident task, which triggers a race condition in mesos by reusing the executor of the
-  // previous task. Though reusing taskIds is discouraged it should be possible for tasks after a terminal task status.
-  // Solution: either mesos fixes the bug or we walk away from reusing taskIds which is somewhat non-trivial on our side.
   "ResidentTaskIntegrationTest" should {
     "resident task can be deployed and write to persistent volume" in new Fixture {
       Given("An app that writes into a persistent volume")
@@ -108,7 +99,10 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
     }
 
     "resident task is launched completely on reserved resources" in new Fixture {
-      Given("A resident app")
+      Given("A clean state of the cluster since we check reserved resources")
+      cleanUp()
+
+      And("A resident app")
       val app = residentApp(
         id = appId("resident-task-is-launched-completely-on-reserved-resources"))
 
@@ -188,7 +182,7 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
       val newVersion = restartSuccessfully(app) withClue ("The app did not restart.")
       val all = allTasks(PathId(app.id))
 
-      log.info("tasks after relaunch: {}", all.mkString(";"))
+      logger.info("tasks after relaunch: {}", all.mkString(";"))
 
       Then("no extra task was created")
       all.size shouldBe 5
@@ -216,7 +210,7 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
       val newVersion = updateSuccessfully(PathId(app.id), AppUpdate(cmd = Some("sleep 1234"))).toString
       val all = allTasks(PathId(app.id))
 
-      log.info("tasks after config change: {}", all.mkString(";"))
+      logger.info("tasks after config change: {}", all.mkString(";"))
 
       Then("no extra task was created")
       all should have size 5

--- a/src/test/scala/mesosphere/marathon/integration/SystemResourceIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/SystemResourceIntegrationTest.scala
@@ -12,11 +12,6 @@ import org.slf4j.LoggerFactory
 @IntegrationTest
 class SystemResourceIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
-  private[this] val log = LoggerFactory.getLogger(getClass)
-
-  //clean up state before running the test case
-  before(cleanUp())
-
   "Marathon" should {
     "responses to a ping" in {
 

--- a/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -236,6 +236,11 @@ class MarathonFacade(
     res.map(_.map(Raml.fromRaml(_))).map(_.filter(pod => isInBaseGroup(pod.id)))
   }
 
+  def listPodsInBaseGroupByPodId(podId: PathId): RestResult[Seq[PodDefinition]] = {
+    val res = result(requestFor[Seq[Pod]](Get(s"$url/v2/pods")), waitTime)
+    res.map(_.map(Raml.fromRaml(_))).map(_.filter(_.id == podId))
+  }
+
   def pod(id: PathId): RestResult[PodDefinition] = {
     requireInBaseGroup(id)
     val res = result(requestFor[Pod](Get(s"$url/v2/pods$id")), waitTime)

--- a/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -25,9 +25,9 @@ import mesosphere.marathon.raml.{ App, AppUpdate, GroupInfo, GroupUpdate, Pod, P
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.util.Retry
-import org.slf4j.LoggerFactory
 import play.api.libs.functional.syntax._
 import play.api.libs.json.JsArray
+import mesosphere.marathon.state.PathId._
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Await.result
@@ -173,18 +173,23 @@ class MarathonFacade(
 
   def listAppsInBaseGroup: RestResult[List[App]] = {
     val res = result(requestFor[ITListAppsResult](Get(s"$url/v2/apps")), waitTime)
-    res.map(_.apps.filterAs(app => isInBaseGroup(PathId(app.id)))(collection.breakOut))
+    res.map(_.apps.filterAs(app => isInBaseGroup(app.id.toPath))(collection.breakOut))
+  }
+
+  def listAppsInBaseGroupForAppId(appId: PathId): RestResult[List[App]] = {
+    val res = result(requestFor[ITListAppsResult](Get(s"$url/v2/apps")), waitTime)
+    res.map(_.apps.filterAs(app => isInBaseGroup(app.id.toPath) && app.id.toPath == appId)(collection.breakOut))
   }
 
   def app(id: PathId): RestResult[ITAppDefinition] = {
     requireInBaseGroup(id)
     val getUrl: String = s"$url/v2/apps$id"
-    LoggerFactory.getLogger(getClass).info(s"get url = $getUrl")
+    logger.info(s"get url = $getUrl")
     result(requestFor[ITAppDefinition](Get(getUrl)), waitTime)
   }
 
   def createAppV2(app: App): RestResult[App] = {
-    requireInBaseGroup(PathId(app.id))
+    requireInBaseGroup(app.id.toPath)
     result(requestFor[App](Post(s"$url/v2/apps", app)), waitTime)
   }
 
@@ -196,7 +201,7 @@ class MarathonFacade(
   def updateApp(id: PathId, app: AppUpdate, force: Boolean = false): RestResult[ITDeploymentResult] = {
     requireInBaseGroup(id)
     val putUrl: String = s"$url/v2/apps$id?force=$force"
-    LoggerFactory.getLogger(getClass).info(s"put url = $putUrl")
+    logger.info(s"put url = $putUrl")
 
     result(requestFor[ITDeploymentResult](Put(putUrl, app)), waitTime)
   }
@@ -204,7 +209,7 @@ class MarathonFacade(
   def patchApp(id: PathId, app: AppUpdate, force: Boolean = false): RestResult[ITDeploymentResult] = {
     requireInBaseGroup(id)
     val putUrl: String = s"$url/v2/apps$id?force=$force"
-    LoggerFactory.getLogger(getClass).info(s"put url = $putUrl")
+    logger.info(s"put url = $putUrl")
 
     result(requestFor[ITDeploymentResult](Patch(putUrl, app)), waitTime)
   }
@@ -281,9 +286,6 @@ class MarathonFacade(
   }
 
   //apps tasks resource --------------------------------------
-
-  private val log = LoggerFactory.getLogger(getClass)
-
   def tasks(appId: PathId): RestResult[List[ITEnrichedTask]] = {
     requireInBaseGroup(appId)
     val res = result(requestFor[ITListTasks](Get(s"$url/v2/apps$appId/tasks")), waitTime)
@@ -358,6 +360,15 @@ class MarathonFacade(
     }
   }
 
+  def listDeploymentsForPathId(pathId: PathId): RestResult[List[ITDeployment]] = {
+    result(requestFor[List[ITDeployment]](Get(s"$url/v2/deployments")), waitTime).map { deployments =>
+      deployments.filter { deployment =>
+        deployment.affectedApps.map(PathId(_)).contains(pathId) ||
+          deployment.affectedPods.map(PathId(_)).contains(pathId)
+      }
+    }
+  }
+
   def deleteDeployment(id: String, force: Boolean = false): RestResult[HttpResponse] = {
     result(request(Delete(s"$url/v2/deployments/$id?force=$force")), waitTime)
   }
@@ -401,6 +412,11 @@ class MarathonFacade(
   //launch queue ------------------------------------------
   def launchQueue(): RestResult[ITLaunchQueue] = {
     result(requestFor[ITLaunchQueue](Get(s"$url/v2/queue")), waitTime)
+  }
+
+  def launchQueueForAppId(appId: PathId): RestResult[List[ITQueueItem]] = {
+    val res = result(requestFor[ITLaunchQueue](Get(s"$url/v2/queue")), waitTime)
+    res.map(_.queue.filterAs(q => q.app.id.toPath == appId)(collection.breakOut))
   }
 
   //resources -------------------------------------------


### PR DESCRIPTION
Summary:
- we used to call `cleanUp` between individual tests in some test suites. It's removed now (with one explicit exception
  in `ResidentTaskIntegrationTest`)
- every test should be a snow flake in a sense that it is independent of what else happens on the cluster which e.g. includes
  unique app names
- added a few helper methods in the `MarathonFacade` class to e.g. fetch deployment for a specific app
- fixed a few unused imports