### PR TITLE
Define build loop target and unique ci log name. (#5690)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-ansiColor('gnome-terminal') {
+ansiColor('xterm') {
   node('JenkinsMarathonCI-Debian8-2017-10-06') {
     stage("Run Pipeline") {
       try {
@@ -16,8 +16,8 @@ ansiColor('gnome-terminal') {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')
         junit allowEmptyResults: true, testResults: 'target/test-reports/*integration/*.xml'
         archive includes: 'sandboxes.tar.gz'
-        archive includes: 'ci.tar.gz'
-        archive includes: 'ci.log'  // Only in case the build was  aborted and the logs weren't zipped
+        archive includes: 'ci-*.tar.gz'
+        archive includes: 'ci-*.log'  // Only in case the build was  aborted and the logs weren't zipped
       }
     }
   }

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -22,11 +22,13 @@ val PACKAGE_DOCS_DIR: Path = pwd / 'target / "universal-docs"
 
 /**
  * Compile Marathon and run unit and integration tests followed by scapegoat.
+ *
+ * @param logFileName Name of file which collects logs.
  */
 @main
-def compileAndTest(): Unit = utils.stage("Compile and Test") {
+def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") {
 
-  def run(cmd: String *) = utils.runWithTimeout(1.hour)(cmd)
+  def run(cmd: String *) = utils.runWithTimeout(30.minutes, logFileName)(cmd)
 
   run("sbt", "clean", "test", "integration:test", "scapegoat")
 
@@ -36,10 +38,15 @@ def compileAndTest(): Unit = utils.stage("Compile and Test") {
   run("sbt", "plugin-interface/compile")
 }
 
+/**
+ * Compresses sandboxes and logs.
+ *
+ * @param logFileName Name of log file.
+ */
 @main
-def zipLogs(): Unit = {
+def zipLogs(logFileName: String = "ci.log"): Unit = {
   Try(%("tar", "-zcf", "sandboxes.tar.gz", "sandboxes"))
-  Try(%("tar", "-zcf", "ci.tar.gz", "--remove-files", "ci.log"))
+  Try(%("tar", "-zcf", s"$logFileName.tar.gz", "--remove-files", logFileName))
 }
 
 @main
@@ -143,10 +150,11 @@ def updateDcosImage(version: String, artifactUrl: String, sha1: String): Unit = 
 /**
  * Run the main pipeline.
  *
+ * @param publish Indicates whether a package should be published or not.
  * @return Version and artifact description of Marathon build.
  */
 @main
-def run(): (String, Option[awsClient.Artifact]) = {
+def run(publish: Boolean = false): (String, Option[awsClient.Artifact]) = {
   utils.stage("Provision") {
 
     // Set port range for random port 0 allocation.
@@ -156,15 +164,16 @@ def run(): (String, Option[awsClient.Artifact]) = {
     provision.installMesos()
   }
 
+  val logFileName = s"ci-${sys.env.getOrElse("BUILD_TAG", "run")}.log"
   try {
-    compileAndTest()
+    compileAndTest(logFileName)
   } finally {
-    zipLogs()    // Try to archive ci and sandbox logs in any case
+    zipLogs(logFileName)    // Try to archive ci and sandbox logs in any case
   }
 
   val (version, maybeArtifact) = createAndUploadPackages()
 
-  if(utils.isMasterBuild) {
+  if(publish) {
     maybeArtifact.foreach { artifact =>
       updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
     }
@@ -183,6 +192,12 @@ def jenkins(): Unit = {
   if(utils.isPullRequest) {
     asPullRequest { run() }
   } else {
-    run()
+    run(publish = utils.isMasterBuild)
   }
 }
+
+/**
+ * The target for our loop builds on Jenkins.
+ */
+@main
+def loop(): Unit = run(publish = false)

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -66,13 +66,14 @@ def uploadTarballToS3(): Option[awsClient.Artifact] = utils.stage("Upload Packag
 /**
  * Packages Marathon and uploads its artifacts alongside sha1 checksum to S3.
  *
+ * @param snapshot Indicates whether we want to upload the snapshot.
  * @return Version and artifact description of Marathon build.
  */
-def createAndUploadPackages(): (String, Option[awsClient.Artifact]) = {
+def createAndUploadPackages(snapshot: Boolean = true): (String, Option[awsClient.Artifact]) = {
   val version = createPackages()
   val docsPath = PACKAGE_DOCS_DIR / s"marathon-docs-$version.tgz"
-  val artifact = uploadTarballToS3()
-  awsClient.upload(docsPath)
+  val artifact = if(snapshot) uploadTarballToS3() else None
+  if(snapshot) awsClient.upload(docsPath)
 
   createDockerAndLinux()
   (version, artifact)
@@ -151,10 +152,11 @@ def updateDcosImage(version: String, artifactUrl: String, sha1: String): Unit = 
  * Run the main pipeline.
  *
  * @param publish Indicates whether a package should be published or not.
+ * @param snapshot Indicates whether the run should upload snapshots.
  * @return Version and artifact description of Marathon build.
  */
 @main
-def run(publish: Boolean = false): (String, Option[awsClient.Artifact]) = {
+def run(publish: Boolean = false, snapshot: Boolean = true): (String, Option[awsClient.Artifact]) = {
   utils.stage("Provision") {
 
     // Set port range for random port 0 allocation.
@@ -171,7 +173,7 @@ def run(publish: Boolean = false): (String, Option[awsClient.Artifact]) = {
     zipLogs(logFileName)    // Try to archive ci and sandbox logs in any case
   }
 
-  val (version, maybeArtifact) = createAndUploadPackages()
+  val (version, maybeArtifact) = createAndUploadPackages(snapshot)
 
   if(publish) {
     maybeArtifact.foreach { artifact =>
@@ -190,7 +192,7 @@ def run(publish: Boolean = false): (String, Option[awsClient.Artifact]) = {
 @main
 def jenkins(): Unit = {
   if(utils.isPullRequest) {
-    asPullRequest { run() }
+    asPullRequest { run(publish = false, snapshot = true) }
   } else {
     run(publish = utils.isMasterBuild)
   }
@@ -200,4 +202,4 @@ def jenkins(): Unit = {
  * The target for our loop builds on Jenkins.
  */
 @main
-def loop(): Unit = run(publish = false)
+def loop(): Unit = run(publish = false, snapshot = false)

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -11,7 +11,7 @@ import java.io.File
 
 import $file.provision
 
-def ciLogFile(name: String = "ci.log"): File = {
+def ciLogFile(name: String): File = {
   val log = new File(name)
   if (!log.exists())
     log.createNewFile()
@@ -65,17 +65,18 @@ def stage[T](name: String)(block: => T): T = {
  * Run a process with given commands and time out it runs too long.
  *
  * @param timeout The maximum time to wait.
+ * @param logFileName Name of file which collects all logs.
  * @param commands The commands that are executed in a process. E.g. "sbt",
  *  "compile".
  */
-def runWithTimeout(timeout: FiniteDuration)(commands: Seq[String]): Unit = {
+def runWithTimeout(timeout: FiniteDuration, logFileName: String)(commands: Seq[String]): Unit = {
 
   val builder = new java.lang.ProcessBuilder()
   val buildProcess = builder
     .directory(new java.io.File(pwd.toString))
     .command(commands.asJava)
     .inheritIO()
-    .redirectOutput(ProcessBuilder.Redirect.appendTo(ciLogFile()))
+    .redirectOutput(ProcessBuilder.Redirect.appendTo(ciLogFile(logFileName)))
     .start()
 
   try {


### PR DESCRIPTION
Summary:
The ci logs included logs of another run because the ci.log file would
not always be removed. This introduces a unique name per builds.