### PR TITLE
Change terminal color in Jenkins job to xterm.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-ansiColor('gnome-terminal') {
+ansiColor('xterm') {
   node('JenkinsMarathonCI-Debian8-2017-10-23') {
     stage("Run Pipeline") {
       try {


### PR DESCRIPTION
Summary:
This should avoid this weird effect of a partial dark background in the console view of a Jenkins job.
