### PR TITLE
Change `Int.MaxValue` to 8 for maximum concurrency during migration (…

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -191,6 +191,7 @@ class Migration(
 
 object Migration {
   val StorageVersionName = "internal:storage:version"
+  val maxConcurrency = 8
   val statusLoggingInterval = 10.seconds
 
   type MigrationAction = (StorageVersion, () => Future[Any])

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo142.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo142.scala
@@ -18,7 +18,7 @@ class MigrationTo142(appRepository: AppRepository)(implicit
   import MigrationTo142.migrationFlow
   val sink =
     Flow[AppDefinition]
-      .mapAsync(Int.MaxValue)(appRepository.store)
+      .mapAsync(Migration.maxConcurrency)(appRepository.store)
       .toMat(Sink.ignore)(Keep.right)
 
   def migrate(): Future[Done] = {

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo146.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo146.scala
@@ -63,12 +63,12 @@ object MigrationTo146 extends StrictLogging {
     logger.info("Starting unreachable strategy migration to 1.4.6")
     val appSink =
       Flow[AppDefinition]
-        .mapAsync(Int.MaxValue)(appRepository.store)
+        .mapAsync(Migration.maxConcurrency)(appRepository.store)
         .toMat(Sink.ignore)(Keep.right)
 
     val podSink =
       Flow[PodDefinition]
-        .mapAsync(Int.MaxValue)(podRepository.store)
+        .mapAsync(Migration.maxConcurrency)(podRepository.store)
         .toMat(Sink.ignore)(Keep.right)
 
     val migrateUnreachableStrategyWanted = env.vars.getOrElse(MigrationTo146.MigrateUnreachableStrategyEnvVar, "false")

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo15.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo15.scala
@@ -91,7 +91,7 @@ private[migration] object MigrationTo15 {
   /**
     * load roots from the group repository, the flow always ends with the current root
     */
-  def loadRootsFlow(groupRepository: GroupRepository) = Flow[OffsetDateTime].mapAsync(Int.MaxValue) { version =>
+  def loadRootsFlow(groupRepository: GroupRepository) = Flow[OffsetDateTime].mapAsync(Migration.maxConcurrency) { version =>
     groupRepository.rootVersion(version)
   }.collect {
     case Some(root) => root

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo152.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo152.scala
@@ -31,7 +31,7 @@ object MigrationTo152 extends StrictLogging {
 
     val instanceSink =
       Flow[Instance]
-        .mapAsync(Int.MaxValue)(instanceRepository.store)
+        .mapAsync(Migration.maxConcurrency)(instanceRepository.store)
         .toMat(Sink.ignore)(Keep.right)
 
     // we stick to already present migration indicating env variable to not confuse users


### PR DESCRIPTION
…#5676)

Summary:
As discussed in #5659, we should introduce a restriction on the amount of simultaneous calls. Therefore we change Int.MaxValue to 8 for maximum concurrency during migration.
