### PR TITLE
Rescue Billy

### DIFF
--- a/tests/system/marathon_auth_common_tests.py
+++ b/tests/system/marathon_auth_common_tests.py
@@ -8,7 +8,8 @@ import shakedown
 
 from dcos import marathon
 from urllib.parse import urljoin
-from fixtures import user_billy
+from fixtures import user_billy # NOQA
+
 
 @pytest.mark.skipif("shakedown.ee_version() is None")
 def test_non_authenticated_user():
@@ -28,8 +29,8 @@ def test_non_authorized_user():
             assert str(error) == "You are not authorized to perform this operation"
 
 
-@pytest.mark.skipif("shakedown.ee_version() is None")
-def test_authorized_non_super_user(user_billy):
+@pytest.mark.skipif("shakedown.ee_version() is None") # NOQA
+def test_authorized_non_super_user(user_billy): # NOQA
     with shakedown.dcos_user('billy', 'billy'):
         client = marathon.create_client()
         assert len(client.get_apps()) == 0

--- a/tests/system/marathon_auth_common_tests.py
+++ b/tests/system/marathon_auth_common_tests.py
@@ -8,7 +8,7 @@ import shakedown
 
 from dcos import marathon
 from urllib.parse import urljoin
-
+from fixtures import user_billy
 
 @pytest.mark.skipif("shakedown.ee_version() is None")
 def test_non_authenticated_user():

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -148,4 +148,6 @@ def uninstall(service, package=PACKAGE_NAME):
             shakedown.delete_zk_node('/universe/{}'.format(service))
 
     except Exception as e:
+        print("Could not unintall {}".format(PACKAGE_NAME))
+        print(e)
         pass

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -148,6 +148,6 @@ def uninstall(service, package=PACKAGE_NAME):
             shakedown.delete_zk_node('/universe/{}'.format(service))
 
     except Exception as e:
-        print("Could not unintall {}".format(PACKAGE_NAME))
+        print("Could not uninstall {}".format(PACKAGE_NAME))
         print(e)
         pass


### PR DESCRIPTION
It seems `user_billy` fixture was accidentally removed in a previous commit : https://github.com/mesosphere/marathon/compare/e3425ac9376975207799871f75b604550ba1dd5e...99a596785b77cac74173742d58ce7182f0ced328#diff-984c5562f7187dee9e6d3e161c7b52f8L51

This commit re-imports `user_billy` that would hopefully solve the failing SI tests.