### PR TITLE
Report error and warning count from flake8.

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -44,7 +44,7 @@ def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") 
 @main
 def checkSystemIntegrationTests(logFileName: String): Unit = {
   def run(cmd: String *) = utils.runWithTimeout(30.minutes, logFileName)(cmd)
-  run("flake8", "--max-line-length=120", "tests/system")
+  run("flake8", "--count", "--max-line-length=120", "tests/system")
 }
 
 /**


### PR DESCRIPTION
Summary:
Some builds such as in #5702 have been confsing because the fail without
any apparent issue in the stderr logs. This change reports the flake8
error count to stderr. We should think about a better style reporting
for shakedown and flake8.