### PR TITLE
Import `user_billy` fixture in order to run SI tests.

### DIFF
--- a/tests/system/marathon_auth_common_tests.py
+++ b/tests/system/marathon_auth_common_tests.py
@@ -27,7 +27,8 @@ def test_non_authorized_user():
             error = exec_info.value
             assert str(error) == "You are not authorized to perform this operation"
 
-
+# NOTE:  this is a common test file.   All test suites which import this common
+# set of tests will need to `from fixtures import user_billy` for this fixture to work.
 @pytest.mark.skipif("shakedown.ee_version() is None")
 def test_authorized_non_super_user(user_billy):
     with shakedown.dcos_user('billy', 'billy'):

--- a/tests/system/marathon_auth_common_tests.py
+++ b/tests/system/marathon_auth_common_tests.py
@@ -27,7 +27,8 @@ def test_non_authorized_user():
             error = exec_info.value
             assert str(error) == "You are not authorized to perform this operation"
 
-# NOTE:  this is a common test file.   All test suites which import this common
+
+# NOTE:  this is a common test file. All test suites which import this common
 # set of tests will need to `from fixtures import user_billy` for this fixture to work.
 @pytest.mark.skipif("shakedown.ee_version() is None")
 def test_authorized_non_super_user(user_billy):

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -25,7 +25,7 @@ import marathon_common_tests
 import marathon_pods_tests
 
 from shakedown import dcos_version_less_than, marthon_version_less_than, required_masters, required_public_agents # NOQA
-from fixtures import wait_for_marathon_and_cleanup, events_to_file # NOQA
+from fixtures import wait_for_marathon_and_cleanup, events_to_file, user_billy # NOQA
 
 # the following lines essentially do:
 #     from dcos_service_marathon_tests import test_*


### PR DESCRIPTION
Summary:
import is needed in order to have the fixture injected.  Added notes to the common file.

JIRA issues:  MARATHON-7892
