### PR TITLE
Automated Community Release Process

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -33,7 +33,6 @@ ansiColor('xterm') {
             sh """docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"""
             sh """sudo -E ci/pipeline release $params.version $params.gitsha $params.latest"""
           }
-        }
       } finally {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')
         junit allowEmptyResults: true, testResults: 'target/test-reports/*integration/*.xml'

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -32,7 +32,9 @@ ansiColor('xterm') {
             string(credentialsId: '4551c307-10ae-40f9-a0ac-f1bb44206b5b',variable: 'DOCKER_HUB_EMAIL'),
         ]) {
           sh """docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD} -e ${DOCKER_HUB_EMAIL}"""
-          sh """sudo -E ci/pipeline release $params.version $params.gitsha $params.latest"""
+          sshagent (credentials: ['0f7ec9c9-99b2-4797-9ed5-625572d5931d']) {
+            sh """sudo -E ci/pipeline release $params.version $params.gitsha $params.latest"""
+          }
         }
       } finally {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,0 +1,51 @@
+#!/usr/bin/env groovy
+
+ansiColor('xterm') {
+  node('JenkinsMarathonCI-Debian8-2017-10-23') {
+
+    properties([
+      parameters([
+        string(name: 'gitsha',
+          defaultValue: '',
+          description: 'Git Commit SHA to Build and Release (ex. 167d7fb86 or 167)'
+        ),
+        string(name: 'version',
+          defaultValue: '',
+          description: 'Community Release Version (ex. v1.5.2)'
+        ),
+        string(name: 'latest',
+          defaultValue: 'False',
+          description: 'True if docker mesosphere/marathon:latest should be pushed'
+        )]
+      )
+    ])
+
+    stage("Run Pipeline") {
+      try {
+        checkout scm
+        withCredentials([
+            usernamePassword(credentialsId: 'a7ac7f84-64ea-4483-8e66-bb204484e58f', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USER'),
+            string(credentialsId: '3f0dbb48-de33-431f-b91c-2366d2f0e1cf',variable: 'AWS_ACCESS_KEY_ID'),
+            string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY'),
+            string(credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d',variable: 'DOCKER_HUB_USERNAME'),
+            string(credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825',variable: 'DOCKER_HUB_PASSWORD'),
+            string(credentialsId: '4551c307-10ae-40f9-a0ac-f1bb44206b5b',variable: 'DOCKER_HUB_EMAIL'),
+        ]) {
+          sh """docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD} -e ${DOCKER_HUB_EMAIL}"""
+          sh """sudo -E ci/pipeline release $params.version $params.gitsha $params.latest"""
+        }
+      } finally {
+        junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')
+        junit allowEmptyResults: true, testResults: 'target/test-reports/*integration/*.xml'
+        publishHTML([
+            allowMissing: true, alwaysLinkToLastBuild: false, keepAll: true,
+            reportDir: 'target/scala-2.12/scapegoat-report', reportFiles: 'scapegoat.html',
+            reportName: 'Scapegoat Report', reportTitles: ''
+        ])
+        archive includes: "sandboxes.tar.gz"
+        archive includes: "ci-${env.BUILD_TAG}.log.tar.gz"
+        archive includes: "ci-${env.BUILD_TAG}.log"  // Only in case the build was  aborted and the logs weren't zipped
+      }
+    }
+  }
+}

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -27,14 +27,11 @@ ansiColor('xterm') {
             usernamePassword(credentialsId: 'a7ac7f84-64ea-4483-8e66-bb204484e58f', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USER'),
             string(credentialsId: '3f0dbb48-de33-431f-b91c-2366d2f0e1cf',variable: 'AWS_ACCESS_KEY_ID'),
             string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY'),
-            string(credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d',variable: 'DOCKER_HUB_USERNAME'),
-            string(credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825',variable: 'DOCKER_HUB_PASSWORD'),
-            string(credentialsId: '4551c307-10ae-40f9-a0ac-f1bb44206b5b',variable: 'DOCKER_HUB_EMAIL'),
         ]) {
-          sh """docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD} -e ${DOCKER_HUB_EMAIL}"""
           sshagent (credentials: ['0f7ec9c9-99b2-4797-9ed5-625572d5931d']) {
+          withDockerRegistry([credentialsId: 'docker-hub-credentials']) {
             sh """sudo -E ci/pipeline release $params.version $params.gitsha $params.latest"""
-          }
+          }}
         }
       } finally {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -13,7 +13,7 @@ ansiColor('xterm') {
           defaultValue: '',
           description: 'Community Release Version (ex. v1.5.2)'
         ),
-        boolean(name: 'latest',
+        booleanParam(name: 'latest',
           defaultValue: false,
           description: 'True if docker mesosphere/marathon:latest should be pushed'
         )]

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -29,10 +29,11 @@ ansiColor('xterm') {
             string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY'),
             string(credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d',variable: 'DOCKER_HUB_USERNAME'),
             string(credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825',variable: 'DOCKER_HUB_PASSWORD'),
-          ]) {
-            sh """docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"""
-            sh """sudo -E ci/pipeline release $params.version $params.gitsha $params.latest"""
-          }
+            string(credentialsId: '4551c307-10ae-40f9-a0ac-f1bb44206b5b',variable: 'DOCKER_HUB_EMAIL'),
+        ]) {
+          sh """docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD} -e ${DOCKER_HUB_EMAIL}"""
+          sh """sudo -E ci/pipeline release $params.version $params.gitsha $params.latest"""
+        }
       } finally {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')
         junit allowEmptyResults: true, testResults: 'target/test-reports/*integration/*.xml'

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -27,8 +27,10 @@ ansiColor('xterm') {
             usernamePassword(credentialsId: 'a7ac7f84-64ea-4483-8e66-bb204484e58f', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USER'),
             string(credentialsId: '3f0dbb48-de33-431f-b91c-2366d2f0e1cf',variable: 'AWS_ACCESS_KEY_ID'),
             string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY'),
-        ]) {
-          withDockerRegistry([credentialsId: 'docker-hub-credentials', url: 'https://index.docker.io/v1/']) {
+            string(credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d',variable: 'DOCKER_HUB_USERNAME'),
+            string(credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825',variable: 'DOCKER_HUB_PASSWORD'),
+          ]) {
+            sh """docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"""
             sh """sudo -E ci/pipeline release $params.version $params.gitsha $params.latest"""
           }
         }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -13,8 +13,8 @@ ansiColor('xterm') {
           defaultValue: '',
           description: 'Community Release Version (ex. v1.5.2)'
         ),
-        string(name: 'latest',
-          defaultValue: 'False',
+        boolean(name: 'latest',
+          defaultValue: false,
           description: 'True if docker mesosphere/marathon:latest should be pushed'
         )]
       )

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -27,12 +27,10 @@ ansiColor('xterm') {
             usernamePassword(credentialsId: 'a7ac7f84-64ea-4483-8e66-bb204484e58f', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USER'),
             string(credentialsId: '3f0dbb48-de33-431f-b91c-2366d2f0e1cf',variable: 'AWS_ACCESS_KEY_ID'),
             string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY'),
-            string(credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d',variable: 'DOCKER_HUB_USERNAME'),
-            string(credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825',variable: 'DOCKER_HUB_PASSWORD'),
-            string(credentialsId: '4551c307-10ae-40f9-a0ac-f1bb44206b5b',variable: 'DOCKER_HUB_EMAIL'),
         ]) {
-          sh """docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD} -e ${DOCKER_HUB_EMAIL}"""
-          sh """sudo -E ci/pipeline release $params.version $params.gitsha $params.latest"""
+          withDockerRegistry([credentialsId: 'docker-hub-credentials', url: 'https://index.docker.io/v1/']) {
+            sh """sudo -E ci/pipeline release $params.version $params.gitsha $params.latest"""
+          }
         }
       } finally {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')

--- a/ci/awsClient.sc
+++ b/ci/awsClient.sc
@@ -70,6 +70,8 @@ def doesS3FileExist(path: S3Path): Boolean = {
  *  compare the sha1 sums because they change for each build of the same commit.
  *  However, our artifact names are unique for each commit.
  *
+ *  @param uploadFile path of the file to be uploaded to S3.
+ *  @param s3path S3 path to upload file to on S3.
  *  @return Artifact description if it was uploaded. None otherwise.
  */
 def archiveArtifact(uploadFile: Path, s3path: S3Path): Option[Artifact] = {
@@ -84,6 +86,9 @@ def archiveArtifact(uploadFile: Path, s3path: S3Path): Option[Artifact] = {
 /**
  *  Uploads marathon artifacts to the default bucket, using the env var credentials.
  *  Upload process creates the sha1 file
+ *
+ *  @param uploadFile path of the file to be uploaded to S3.
+ *  @param s3path S3 path to upload file to on S3.
  */
 def uploadFileAndSha(uploadFile: Path, s3path: S3Path): Artifact = {
   val shaFile = fileUtil.writeSha1ForFile(uploadFile)

--- a/ci/awsClient.sc
+++ b/ci/awsClient.sc
@@ -40,9 +40,9 @@ case class Artifact(path: S3Path, sha1: String) {
 }
 
 /**
- * builds = snapshots / builds, milestones, releases
+ * builds =  builds, milestones, releases
  */
-def s3PathFor(buildLocation: String = "snapshots") : S3Path = {
+def s3PathFor(buildLocation: String = "builds") : S3Path = {
   S3Path(
     sys.env.getOrElse("S3_BUCKET", "downloads.mesosphere.io"),
     Path(sys.env.getOrElse("S3_PATH" , s"/marathon/$buildLocation")))

--- a/ci/awsClient.sc
+++ b/ci/awsClient.sc
@@ -39,9 +39,14 @@ case class Artifact(path: S3Path, sha1: String) {
   def downloadUrl: String = s"$base/${path.bucket}/${path.key}"
 }
 
-val S3_PREFIX = S3Path(
-  sys.env.getOrElse("S3_BUCKET", "downloads.mesosphere.io"),
-  Path(sys.env.getOrElse("S3_PATH" , "/marathon/snapshots")))
+/**
+ * builds = snapshots / builds, milestones, releases
+ */
+def s3PathFor(buildLocation: String = "snapshots") : S3Path = {
+  S3Path(
+    sys.env.getOrElse("S3_BUCKET", "downloads.mesosphere.io"),
+    Path(sys.env.getOrElse("S3_PATH" , s"/marathon/$buildLocation")))
+}
 
 /**
  *  Returns AWS S3 client.
@@ -67,32 +72,32 @@ def doesS3FileExist(path: S3Path): Boolean = {
  *
  *  @return Artifact description if it was uploaded. None otherwise.
  */
-def archiveArtifact(uploadFile: Path): Option[Artifact] = {
+def archiveArtifact(uploadFile: Path, s3path: S3Path): Option[Artifact] = {
   // is already uploaded.
-  if(doesS3FileExist(S3_PREFIX / uploadFile.last)) {
-    println(s"Skipping File: ${uploadFile.last} already exists on S3 at ${S3_PREFIX / uploadFile.last}")
+  if(doesS3FileExist(s3path / uploadFile.last)) {
+    println(s"Skipping File: ${uploadFile.last} already exists on S3 at ${s3path / uploadFile.last}")
     None
   } else
-    Some(uploadFileAndSha(uploadFile))
+    Some(uploadFileAndSha(uploadFile, s3path))
 }
 
 /**
  *  Uploads marathon artifacts to the default bucket, using the env var credentials.
  *  Upload process creates the sha1 file
  */
-def uploadFileAndSha(uploadFile: Path): Artifact = {
+def uploadFileAndSha(uploadFile: Path, s3path: S3Path): Artifact = {
   val shaFile = fileUtil.writeSha1ForFile(uploadFile)
 
-  upload(uploadFile)
-  upload(shaFile)
-  Artifact(S3_PREFIX / uploadFile.last, read(shaFile))
+  upload(uploadFile, s3path)
+  upload(shaFile, s3path)
+  Artifact(s3path / uploadFile.last, read(shaFile))
 }
 
 /**
  * Uploads file to default bucket.
  */
-def upload(file: Path): Unit = {
-  uploadFileToS3(file, S3_PREFIX / file.last)
+def upload(file: Path, s3path: S3Path): Unit = {
+  uploadFileToS3(file, s3path / file.last)
 }
 
 /**

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -65,6 +65,7 @@ def zipLogs(logFileName: String = "ci.log"): Unit = {
  * Upload Marathon tgz tarballs, its sha1 checksum and docs to S3.
  *
  * @param version The version to upload.
+ * @param buildLocation subfolder location to upload tarball to.  Example: "builds"
  * @return Artifact description if it was uploaded.
  */
 def uploadTarballPackagesToS3(version: String, buildLocation: String): Option[awsClient.Artifact] = utils.stage("Upload Tarball Packages") {
@@ -95,14 +96,14 @@ def createTarballPackages(): String = utils.stage("Package Tarballs") {
   // we need to regex this string because we do have colored output in the `sbt version` command
   val VersionLineRegex = "^.*(\\d+\\.\\d+\\.\\d+[-A-Za-z\\d]+).*$".r
   // release version example v1.5.2
-  val releaseVersionLineRegex = "^.*(\\d+\\.\\d+\\.\\d+).*$".r
+  val ReleaseVersionLineRegex = "^.*(\\d+\\.\\d+\\.\\d+).*$".r
 
   // Nothing is what it seems. This is a poor man's way to extract the version
   // from sbt's console output until we run our Ammonite scripts in sbt.
   val lastLine = result.out.lines.last
   val version = lastLine match {
     case VersionLineRegex(v) => v
-    case releaseVersionLineRegex(v) => v
+    case ReleaseVersionLineRegex(v) => v
     case _ =>
         val commit = %%('git, "log", "--pretty=format:%h", "-n1").out.lines.last
         s"unknown version in commit $commit with version: $lastLine"
@@ -254,9 +255,8 @@ def release(requestVersion: String, gitSha: String, latest: String = "False"): U
   %('git, "tag", "-a", tagVersion, "-m", tagVersion)
   val version = build()
 
-  // Uploads
   uploadTarballPackagesToS3(version, s"releases/$releaseVersion")
-  // push docker
+
   %('docker, "push", s"mesosphere/marathon:$tagVersion")
 
   if (latest.toUpperCase == "TRUE") {
@@ -266,7 +266,6 @@ def release(requestVersion: String, gitSha: String, latest: String = "False"): U
     println("Docker image mesosphere/marathon:latest NOT updated")
   }
 
-  // push tags
   %('git, "push", "--tags")
 
   // TODO: Publish swagger files.

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -267,7 +267,8 @@ def release(requestVersion: String, gitSha: String, latest: Boolean = false): Un
     println("Docker image mesosphere/marathon:latest NOT updated")
   }
 
-  %('git, "push", "--tags")
+  // TODO: git push fails currently b/c jenkins isn't authorized to push to GH
+  // %('git, "push", "--tags")
 
   // TODO: Publish swagger files.
   // TODO: Publish native packages to unstable.

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -29,7 +29,7 @@ val PACKAGE_DOCS_DIR: Path = pwd / 'target / "universal-docs"
 @main
 def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") {
 
-  def run(cmd: String *) = utils.runWithTimeoutAndCleanup(30.minutes, logFileName)(cmd)
+  def run(cmd: String *) = utils.withCleanUp {utils.runWithTimeout(30.minutes, logFileName)(cmd)}
 
   run("sbt", "clean", "test", "integration:test", "scapegoat")
 
@@ -44,7 +44,6 @@ def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") 
 
 @main
 def checkSystemIntegrationTests(logFileName: String): Unit = {
-  // TODO: (kgs)  There is NO need to kill processes for this!
   def run(cmd: String *) = utils.runWithTimeout(30.minutes, logFileName)(cmd)
   run("flake8", "--count", "--max-line-length=120", "tests/system", "src/test/python")
 }
@@ -65,7 +64,7 @@ def zipLogs(logFileName: String = "ci.log"): Unit = {
  * Upload Marathon tgz tarballs, its sha1 checksum and docs to S3.
  *
  * @param version The version to upload.
- * @param buildLocation subfolder location to upload tarball to.  Example: "builds"
+ * @param buildLocation subfolder location to upload tarball to. Example: "builds"
  * @return Artifact description if it was uploaded.
  */
 def uploadTarballPackagesToS3(version: String, buildLocation: String): Option[awsClient.Artifact] = utils.stage("Upload Tarball Packages") {
@@ -198,7 +197,7 @@ def master(): Unit = {
   val version = build()
 
   // Uploads
-  val maybeArtifact = uploadTarballPackagesToS3(version, "snapshots")
+  val maybeArtifact = uploadTarballPackagesToS3(version, "builds")
   maybeArtifact.foreach { artifact =>
     updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
   }
@@ -214,7 +213,7 @@ def pr(): Unit = asPullRequest {
   val version = build()
 
   // Uploads
-  val artifact = uploadTarballPackagesToS3(version, "snapshots")
+  val artifact = uploadTarballPackagesToS3(version, "builds")
   (version, artifact)
 }
 
@@ -242,13 +241,15 @@ def jenkins(): Unit = {
  *  1. tarball with version details
  *  2. release of docker with that version
  *  3. git tag of version (pushed to server)
- *
+ * @param requestVersion The version attempting to be released v1.4.6
+ * @param gitSha The git commit sha.  This can be shorthand (ex. 0e1)
+ * @param latest Boolean to indicat if the Docker latest should be updated to this version.
  * @return Version and artifact description of Marathon build.
  */
 @main
-def release(requestVersion: String, gitSha: String, latest: String = "False"): Unit = {
+def release(requestVersion: String, gitSha: String, latest: Boolean = false): Unit = {
 
-  val releaseVersion = cleanVersion(requestVersion)
+  val releaseVersion = withoutVersionPrefix(requestVersion)
   val tagVersion = s"v$releaseVersion"
   println(s"Releasing version: $releaseVersion ")
   %('git, "checkout", gitSha)
@@ -259,7 +260,7 @@ def release(requestVersion: String, gitSha: String, latest: String = "False"): U
 
   %('docker, "push", s"mesosphere/marathon:$tagVersion")
 
-  if (latest.toUpperCase == "TRUE") {
+  if (latest) {
     %('docker, "tag", s"mesosphere/marathon:$tagVersion", "mesosphere/marathon:latest")
     %('docker, "push", "mesosphere/marathon:latest")
   } else {
@@ -272,7 +273,7 @@ def release(requestVersion: String, gitSha: String, latest: String = "False"): U
   // TODO: Publish native packages to unstable.
 }
 
-def cleanVersion(releaseVersion: String): String = {
+def withoutVersionPrefix(releaseVersion: String): String = {
     if(releaseVersion.toLowerCase.startsWith("v"))
       releaseVersion.substring(1)
     else

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -184,8 +184,7 @@ def buildDockerAndLinuxPackages(): Unit = {
 
     // create test docker images and tests packages
     val testPath = pwd/'tests/'package
-    %('make, "all")(testPath)
-    %('amm, "test.sc", "all")(testPath)
+    %('make, "test")(testPath)
   }
 }
 

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -17,6 +17,7 @@ import $file.provision
 import $file.upgrade
 import $file.utils
 
+
 val PACKAGE_DIR: Path = pwd / 'target / 'universal
 val PACKAGE_DOCS_DIR: Path = pwd / 'target / "universal-docs"
 
@@ -28,7 +29,7 @@ val PACKAGE_DOCS_DIR: Path = pwd / 'target / "universal-docs"
 @main
 def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") {
 
-  def run(cmd: String *) = utils.runWithTimeout(30.minutes, logFileName)(cmd)
+  def run(cmd: String *) = utils.runWithTimeoutAndCleanup(30.minutes, logFileName)(cmd)
 
   run("sbt", "clean", "test", "integration:test", "scapegoat")
 
@@ -43,6 +44,7 @@ def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") 
 
 @main
 def checkSystemIntegrationTests(logFileName: String): Unit = {
+  // TODO: (kgs)  There is NO need to kill processes for this!
   def run(cmd: String *) = utils.runWithTimeout(30.minutes, logFileName)(cmd)
   run("flake8", "--count", "--max-line-length=120", "tests/system", "src/test/python")
 }
@@ -60,21 +62,21 @@ def zipLogs(logFileName: String = "ci.log"): Unit = {
 
 @main
 /**
- * Upload Marathon tgz tarballs, its cha1 checksum and docs to S3.
+ * Upload Marathon tgz tarballs, its sha1 checksum and docs to S3.
  *
  * @param version The version to upload.
  * @return Artifact description if it was uploaded.
  */
-def uploadTarballPackagesToS3(version: String): Option[awsClient.Artifact] = utils.stage("Upload Tarball Packages") {
+def uploadTarballPackagesToS3(version: String, buildLocation: String): Option[awsClient.Artifact] = utils.stage("Upload Tarball Packages") {
   import scala.collection.breakOut
 
   // Upload docs
   val docsPath = PACKAGE_DOCS_DIR / s"marathon-docs-$version.tgz"
-  awsClient.upload(docsPath)
+  awsClient.upload(docsPath, awsClient.s3PathFor(buildLocation))
 
   // Upload Marathon
   PACKAGE_DIR.toIO.listFiles.filter(f => f.getName.endsWith(".tgz"))
-    .headOption.flatMap(file => awsClient.archiveArtifact(Path(file)))
+    .headOption.flatMap(file => awsClient.archiveArtifact(Path(file), awsClient.s3PathFor(buildLocation)))
 }
 
 /**
@@ -92,14 +94,18 @@ def createTarballPackages(): String = utils.stage("Package Tarballs") {
   // ending with random characters
   // we need to regex this string because we do have colored output in the `sbt version` command
   val VersionLineRegex = "^.*(\\d+\\.\\d+\\.\\d+[-A-Za-z\\d]+).*$".r
+  // release version example v1.5.2
+  val releaseVersionLineRegex = "^.*(\\d+\\.\\d+\\.\\d+).*$".r
 
   // Nothing is what it seems. This is a poor man's way to extract the version
   // from sbt's console output until we run our Ammonite scripts in sbt.
-  val version = result.out.lines.last match {
+  val lastLine = result.out.lines.last
+  val version = lastLine match {
     case VersionLineRegex(v) => v
+    case releaseVersionLineRegex(v) => v
     case _ =>
         val commit = %%('git, "log", "--pretty=format:%h", "-n1").out.lines.last
-        s"unkown version in commit $commit"
+        s"unknown version in commit $commit with version: $lastLine"
   }
   println(s"Built tarballs for Marathon $version.")
   version
@@ -168,11 +174,19 @@ def build(): String = {
   }
 
   val version = createTarballPackages()
+  buildDockerAndLinuxPackages()
+  version
+}
+
+def buildDockerAndLinuxPackages(): Unit = {
   utils.stage("Package Docker Image, Debian and RedHat Packages") {
     %('sbt, "docker:publishLocal", "packageLinux")
-  }
 
-  version
+    // create test docker images and tests packages
+    val testPath = pwd/'tests/'package
+    %('make, "all")(testPath)
+    %('amm, "test.sc", "all")(testPath)
+  }
 }
 
 /**
@@ -183,7 +197,7 @@ def master(): Unit = {
   val version = build()
 
   // Uploads
-  val maybeArtifact = uploadTarballPackagesToS3(version)
+  val maybeArtifact = uploadTarballPackagesToS3(version, "snapshots")
   maybeArtifact.foreach { artifact =>
     updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
   }
@@ -199,7 +213,7 @@ def pr(): Unit = asPullRequest {
   val version = build()
 
   // Uploads
-  val artifact = uploadTarballPackagesToS3(version)
+  val artifact = uploadTarballPackagesToS3(version, "snapshots")
   (version, artifact)
 }
 
@@ -220,4 +234,48 @@ def loop(): Unit = {
 def jenkins(): Unit = {
   if(utils.isPullRequest) pr()
   else master()
+}
+
+/**
+ * Executes the Community Release which includes:
+ *  1. tarball with version details
+ *  2. release of docker with that version
+ *  3. git tag of version (pushed to server)
+ *
+ * @return Version and artifact description of Marathon build.
+ */
+@main
+def release(requestVersion: String, gitSha: String, latest: String = "False"): Unit = {
+
+  val releaseVersion = cleanVersion(requestVersion)
+  val tagVersion = s"v$releaseVersion"
+  println(s"Releasing version: $releaseVersion ")
+  %('git, "checkout", gitSha)
+  %('git, "tag", "-a", tagVersion, "-m", tagVersion)
+  val version = build()
+
+  // Uploads
+  uploadTarballPackagesToS3(version, s"releases/$releaseVersion")
+  // push docker
+  %('docker, "push", s"mesosphere/marathon:$tagVersion")
+
+  if (latest.toUpperCase == "TRUE") {
+    %('docker, "tag", s"mesosphere/marathon:$tagVersion", "mesosphere/marathon:latest")
+    %('docker, "push", "mesosphere/marathon:latest")
+  } else {
+    println("Docker image mesosphere/marathon:latest NOT updated")
+  }
+
+  // push tags
+  %('git, "push", "--tags")
+
+  // TODO: Publish swagger files.
+  // TODO: Publish native packages to unstable.
+}
+
+def cleanVersion(releaseVersion: String): String = {
+    if(releaseVersion.toLowerCase.startsWith("v"))
+      releaseVersion.substring(1)
+    else
+      releaseVersion
 }

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -88,7 +88,6 @@ def runWithTimeout(timeout: FiniteDuration, logFileName: String)(commands: Seq[S
     .redirectOutput(ProcessBuilder.Redirect.appendTo(ciLogFile(logFileName)))
     .start()
 
-  try {
     val exited = buildProcess.waitFor(timeout.length, timeout.unit)
 
     if (exited) {
@@ -103,6 +102,20 @@ def runWithTimeout(timeout: FiniteDuration, logFileName: String)(commands: Seq[S
       val cmd = commands.mkString(" ")
       throw new java.util.concurrent.TimeoutException(s"'$cmd' timed out after $timeout.")
     }
+}
+
+/**
+ * Run a process with given commands and time out it runs too long.
+ *
+ * @param timeout The maximum time to wait.
+ * @param logFileName Name of file which collects all logs.
+ * @param commands The commands that are executed in a process. E.g. "sbt",
+ *  "compile".
+ */
+def runWithTimeoutAndCleanup(timeout: FiniteDuration, logFileName: String)(commands: Seq[String]): Unit = {
+
+  try {
+    runWithTimeout(timeout, logFileName)(commands)
   } finally {
     // This also cleans forked SBT processes.
     provision.killStaleTestProcesses()

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -104,7 +104,7 @@ def runWithTimeout(timeout: FiniteDuration, logFileName: String)(commands: Seq[S
     }
 }
 
-def withCleanUp[T](block: => Unit): Unit = {
+def withCleanUp[T](block: => T): T = {
   try { block }
   finally { provision.killStaleTestProcesses() }
 }

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -104,22 +104,9 @@ def runWithTimeout(timeout: FiniteDuration, logFileName: String)(commands: Seq[S
     }
 }
 
-/**
- * Run a process with given commands and time out it runs too long.
- *
- * @param timeout The maximum time to wait.
- * @param logFileName Name of file which collects all logs.
- * @param commands The commands that are executed in a process. E.g. "sbt",
- *  "compile".
- */
-def runWithTimeoutAndCleanup(timeout: FiniteDuration, logFileName: String)(commands: Seq[String]): Unit = {
-
-  try {
-    runWithTimeout(timeout, logFileName)(commands)
-  } finally {
-    // This also cleans forked SBT processes.
-    provision.killStaleTestProcesses()
-  }
+def withCleanUp[T](block: => Unit): Unit = {
+  try { block }
+  finally { provision.killStaleTestProcesses() }
 }
 
 /**

--- a/tests/package/Makefile
+++ b/tests/package/Makefile
@@ -43,4 +43,7 @@ target/ubuntu-upstart.built: ubuntu-upstart/Dockerfile ubuntu-upstart/mesos-vers
 	cd ubuntu-upstart && docker build . -t marathon-package-test:ubuntu-upstart
 	touch $@
 
+test:
+	amm test.sc all
+
 all: target/mesos.built target/debian-systemv.built target/debian-systemd.built target/centos-systemd.built target/centos-systemv.built target/ubuntu-upstart.built

--- a/tests/package/Makefile
+++ b/tests/package/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all default
+.PHONY: all default test clean
 .SECONDARY:
 
 default: all
@@ -43,7 +43,7 @@ target/ubuntu-upstart.built: ubuntu-upstart/Dockerfile ubuntu-upstart/mesos-vers
 	cd ubuntu-upstart && docker build . -t marathon-package-test:ubuntu-upstart
 	touch $@
 
-test:
+test: | all
 	amm test.sc all
 
 all: target/mesos.built target/debian-systemv.built target/debian-systemd.built target/centos-systemd.built target/centos-systemv.built target/ubuntu-upstart.built


### PR DESCRIPTION
Automated Community Release Process

Summary:
* Full build and testing
* Docker and Linux Binary Builds with Testing
* Landing in the Release Folder on S3

This has been tested against building 1.5 and 1.6. 
It changes our releases defined here:  https://wiki.mesosphere.com/display/MARATHON/Release+a+1.5.x+Version+of+Marathon
and automates steps 1, 2, 3

We still need to add in native linux releases and mom-ee releases.
The rest will remain manual.

JIRA issues:  MARATHON-7902

