### PR TITLE
Make flake8 compliant by not having naked expects

### DIFF
--- a/src/test/python/app_mock.py
+++ b/src/test/python/app_mock.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
             os.system("ps -a | grep $(lsof -ti :{})".format(port))
         else:
             logging.exception("Socket.error in the main thread: ")
-    except:
+    except Exception:
         logging.exception("Exception in the main thread: ")
     finally:
         logging.info("Closing the server...")

--- a/tests/scale/common.py
+++ b/tests/scale/common.py
@@ -93,7 +93,7 @@ def time_deployment(test=""):
             deployment_count = len(deployments)
             if deployment_count > 0:
                 time.sleep(1)
-        except:
+        except Exception:
             wait_for_service_endpoint('marathon-user')
             pass
 
@@ -226,7 +226,7 @@ def instance_test_app(test_obj):
         launch_results = test_obj.launch_results
         try:
             launch_apps(test_obj)
-        except:
+        except Exception:
             # service unavail == wait for marathon
             launch_results.failed('Failure to launched (but we still will wait for deploys)')
             wait_for_marathon_up(test_obj)
@@ -312,7 +312,7 @@ def undeployment_wait(test_obj=None):
             if deployment_count > 0:
                 time.sleep(1)
                 failure_count = 0
-        except:
+        except Exception:
             failure_count += 1
             # consecutive failures great than x
             if failure_count > 10 and test_obj is not None:
@@ -527,7 +527,7 @@ def get_cluster_metadata():
 
     try:
         version = ee_version()
-    except:
+    except Exception:
         version = None
 
     resources = available_resources()
@@ -583,7 +583,7 @@ def uninstall_mom():
             dcos_client = mesos.DCOSClient()
             dcos_client.shutdown_framework(framework_id)
             time.sleep(2)
-    except:
+    except Exception:
         pass
 
     removed = False
@@ -620,7 +620,7 @@ def wait_for_marathon_up(test_obj=None, timeout=60 * 5):
 def quiet_wait_for_marathon_up(test_obj=None, timeout=60 * 5):
     try:
         wait_for_marathon_up(test_obj, timeout)
-    except:
+    except Exception:
         pass
 
 

--- a/tests/scale/over-provision.py
+++ b/tests/scale/over-provision.py
@@ -18,6 +18,6 @@ for agent in private_agents:
         run_command(agent, "sudo rm -f /var/lib/mesos/slave/meta/slaves/latest")
         try:
             start_agent(agent)
-        except:
+        except Exception:
             time.sleep(1)
             start_agent(agent)

--- a/tests/scale/test_root_marathon_scale.py
+++ b/tests/scale/test_root_marathon_scale.py
@@ -132,7 +132,7 @@ def teardown_module(module):
     create_scale_graph(stats, metadata)
     try:
         delete_all_apps_wait()
-    except:
+    except Exception:
         pass
 
 

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -119,7 +119,7 @@ def cluster_info(mom_name='marathon-user'):
                 client = marathon.create_client()
                 about = client.get_about()
                 print("Marathon MoM version: {}".format(about.get("version")))
-            except:
+            except Exception:
                 print("Marathon MoM not present")
     else:
         print("Marathon MoM not present")
@@ -196,7 +196,7 @@ def ensure_mom():
         try:
             shakedown.install_package_and_wait('marathon')
             shakedown.deployment_wait()
-        except:
+        except Exception:
             pass
 
         if not shakedown.wait_for_service_endpoint('marathon-user'):
@@ -248,7 +248,7 @@ def wait_for_task(service, task, timeout_sec=120):
         response = None
         try:
             response = shakedown.get_service_task(service, task)
-        except:
+        except Exception:
             pass
 
         if response is not None and response['state'] == 'TASK_RUNNING':
@@ -267,7 +267,7 @@ def clear_pods():
         for pod in pods:
             client.remove_pod(pod["id"], True)
         shakedown.deployment_wait()
-    except:
+    except Exception:
         pass
 
 
@@ -603,7 +603,7 @@ def set_service_account_permissions(service_account, resource='dcos:superuser', 
         else:
             print("Unexpected HTTP error: {}".format(e.response))
             raise
-    except:
+    except Exception:
         print("Unexpected error:", sys.exc_info()[0])
         raise
 
@@ -625,7 +625,7 @@ def add_acs_resource(resource):
         else:
             print("Unexpected HTTP error: {}, {}".format(e.response, e.response.text))
             raise
-    except:
+    except Exception:
         print("Unexpected error:", sys.exc_info()[0])
         raise
 

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -808,7 +808,7 @@ def test_unhealthy_app_can_be_rolled_back():
 
     try:
         shakedown.deployment_wait()
-    except:
+    except Exception:
         client.rollback_deployment(deployment_id)
         shakedown.deployment_wait()
 

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -161,7 +161,7 @@ def test_remove_pod():
 
     try:
         client.show_pod(pod_id)
-    except:
+    except Exception:
         pass
     else:
         assert False, "The pod has not been removed"

--- a/tests/system/scripts/pinger.py
+++ b/tests/system/scripts/pinger.py
@@ -93,7 +93,7 @@ def make_handler():
                     return self.handle_relay()
                 else:
                     return self.handle_ping()
-            except:
+            except Exception:
                 logging.exception('Could not handle GET request')
                 raise
 
@@ -101,7 +101,7 @@ def make_handler():
             try:
                 logging.debug("Got POST request")
                 return self.handle_ping()
-            except:
+            except Exception:
                 logging.exception('Could not handle POST request')
                 raise
 

--- a/tests/system/test_marathon_on_marathon.py
+++ b/tests/system/test_marathon_on_marathon.py
@@ -46,7 +46,7 @@ def teardown_module(module):
     with shakedown.marathon_on_marathon():
         try:
             common.clean_up_marathon()
-        except:
+        except Exception:
             pass
 
     shakedown.uninstall_package_and_wait('marathon')
@@ -243,7 +243,7 @@ def test_framework_unavailable_on_mom():
 
     try:
         shakedown.wait_for_service_endpoint('pyfw', 15)
-    except:
+    except Exception:
         pass
     else:
         assert False, 'MoM shoud NOT create a service endpoint'

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -67,7 +67,7 @@ def mom_ee_image(version):
     image_name = 'MOM_EE_{}'.format(version)
     try:
         os.environ[image_name]
-    except:
+    except Exception:
         default_image = DEFAULT_MOM_IMAGES[image_name]
         print('No environment override found for MoM-EE  v{}. Using default image {}'.format(version, default_image))
         return default_image

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -127,7 +127,7 @@ def test_marathon_delete_leader_and_check_apps(marathon_service_name):
 
     try:
         client.get_app(app_id)
-    except:
+    except Exception:
         pass
     else:
         assert False, "The application resurrected"
@@ -143,7 +143,7 @@ def test_marathon_delete_leader_and_check_apps(marathon_service_name):
     # check if app definition is still not there
     try:
         client.get_app(app_id)
-    except:
+    except Exception:
         pass
     else:
         assert False, "The application resurrected"


### PR DESCRIPTION
making flake8 compliant by not having naked expects

Summary:
* Newly added Python linter complaining about bare except
* All `except:` replaced with `except:  Exception` making it sooooo much better :) 

```
$ flake8 --max-line-length=120 tests/system
tests/system/common.py:122:13: E722 do not use bare except'
tests/system/common.py:199:9: E722 do not use bare except'
tests/system/common.py:251:9: E722 do not use bare except'
tests/system/common.py:270:5: E722 do not use bare except'
tests/system/common.py:606:5: E722 do not use bare except'
tests/system/common.py:628:5: E722 do not use bare except'
tests/system/marathon_common_tests.py:811:5: E722 do not use bare except'
tests/system/marathon_pods_tests.py:164:5: E722 do not use bare except'
tests/system/test_marathon_on_marathon.py:49:9: E722 do not use bare except'
tests/system/test_marathon_on_marathon.py:246:5: E722 do not use bare except'
tests/system/test_marathon_on_marathon_ee.py:70:5: E722 do not use bare except'
tests/system/test_marathon_root.py:130:5: E722 do not use bare except'
tests/system/test_marathon_root.py:146:5: E722 do not use bare except'
tests/system/scripts/pinger.py:96:13: E722 do not use bare except'
tests/system/scripts/pinger.py:104:13: E722 do not use bare except'
```

JIRA issues:
