### PR TITLE
Workaround MESOS-8171 by setting failover_timeout to non-zero in tests

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -826,7 +826,7 @@ trait LocalMarathonTest extends MarathonTest with ScalaFutures
 trait EmbeddedMarathonTest extends Suite with StrictLogging with ZookeeperServerTest with MesosClusterTest with LocalMarathonTest {
   // disable failover timeout to assist with cleanup ops; terminated marathons are immediately removed from mesos's
   // list of frameworks
-  override def marathonArgs: Map[String, String] = Map("failover_timeout" -> "0")
+  override def marathonArgs: Map[String, String] = Map("failover_timeout" -> "1")
 }
 
 /**

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -824,8 +824,12 @@ trait LocalMarathonTest extends MarathonTest with ScalaFutures
   * trait that has marathon, zk, and a mesos ready to go
   */
 trait EmbeddedMarathonTest extends Suite with StrictLogging with ZookeeperServerTest with MesosClusterTest with LocalMarathonTest {
-  // disable failover timeout to assist with cleanup ops; terminated marathons are immediately removed from mesos's
-  // list of frameworks
+  /* disable failover timeout to assist with cleanup ops; terminated marathons are immediately removed from mesos's
+   * list of frameworks
+   *
+   * Until https://issues.apache.org/jira/browse/MESOS-8171 is resolved, we cannot set this value to 0.
+   */
+
   override def marathonArgs: Map[String, String] = Map("failover_timeout" -> "1")
 }
 


### PR DESCRIPTION
JIRA Issues: MARATHON-7793
