### PR TITLE
Remove duplicate imports and unused prameters.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/akkahttp/Headers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/Headers.scala
@@ -16,14 +16,14 @@ object Headers {
     override def renderInRequests(): Boolean = false
   }
 
-  final case class `X-Marathon-Leader`(hostPort: String) extends CustomHeader {
+  case class `X-Marathon-Leader`(hostPort: String) extends CustomHeader {
     override def name(): String = "X-Marathon-Leader"
     override def value: String = hostPort
     override def renderInRequests = false
     override def renderInResponses = true
   }
 
-  final case class `X-Marathon-Via`(via: String) extends CustomHeader {
+  case class `X-Marathon-Via`(via: String) extends CustomHeader {
     override def name(): String = "X-Marathon-Via"
     override def value: String = via
     override def renderInRequests = false

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -8,45 +8,27 @@ import akka.event.EventStream
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import akka.http.scaladsl.model.headers.Location
-import akka.http.scaladsl.model.{ StatusCodes, Uri }
-import akka.http.scaladsl.model.headers.Location
 import akka.http.scaladsl.server.{ Directive1, Rejection, RejectionError, Route }
-import mesosphere.marathon.api.akkahttp.AuthDirectives.NotAuthorized
 import mesosphere.marathon.api.akkahttp.PathMatchers.ExistingRunSpecId
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import mesosphere.marathon.api.TaskKiller
 import mesosphere.marathon.api.akkahttp.AuthDirectives.NotAuthorized
 import mesosphere.marathon.api.v2.{ AppHelpers, AppNormalization, InfoEmbedResolver, LabelSelectorParsers }
-import mesosphere.marathon.api.akkahttp.{ Controller, EntityMarshallers }
 import mesosphere.marathon.api.v2.AppHelpers.{ appNormalization, appUpdateNormalization, authzSelector }
-import mesosphere.marathon.api.v2.Validation.validateOrThrow
-import mesosphere.marathon.api.v2.AppHelpers.{ appNormalization, appUpdateNormalization, authzSelector }
-import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.deployment.DeploymentPlan
-import mesosphere.marathon.core.event.ApiPostEvent
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.plugin.auth.{ Authorizer, CreateRunSpec, DeleteRunSpec, Identity, UpdateRunSpec, ViewResource, ViewRunSpec, Authenticator => MarathonAuthenticator }
-import mesosphere.marathon.plugin.auth.{ Authorizer, CreateRunSpec, Identity, ViewResource, Authenticator => MarathonAuthenticator }
 import mesosphere.marathon.state.{ AppDefinition, Identifiable, PathId }
 import play.api.libs.json.Json
-import PathId._
-import mesosphere.marathon.plugin.auth.{ Authorizer, CreateRunSpec, DeleteRunSpec, Identity, UpdateRunSpec, ViewResource, ViewRunSpec, Authenticator => MarathonAuthenticator }
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Sink
-import play.api.libs.json._
 import mesosphere.marathon.core.election.ElectionService
-import mesosphere.marathon.core.task.Task.{ Id => TaskId }
-import PathMatchers._
 import mesosphere.marathon.api.TaskKiller
 import mesosphere.marathon.core.event.ApiPostEvent
-import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.health.HealthCheckManager
-import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.core.task.Task.{ Id => TaskId }
 import PathMatchers._
@@ -56,7 +38,7 @@ import mesosphere.marathon.raml.EnrichedTaskConversion._
 
 import scala.async.Async._
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Success }
 import scala.util.control.NonFatal
 
 class AppsController(
@@ -81,7 +63,7 @@ class AppsController(
   import Directives._
 
   private implicit lazy val validateApp = AppDefinition.validAppDefinition(config.availableFeatures)(pluginManager)
-  private implicit lazy val updateValidator = AppValidation.validateCanonicalAppUpdateAPI(config.availableFeatures, () => normalizationConfig.defaultNetworkName)
+  //  private implicit lazy val updateValidator = AppValidation.validateCanonicalAppUpdateAPI(config.availableFeatures, () => normalizationConfig.defaultNetworkName)
 
   import AppHelpers._
   import EntityMarshallers._

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/GroupsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/GroupsController.scala
@@ -4,19 +4,14 @@ package v2
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server.{ Directive1, Route }
-import mesosphere.marathon.api.akkahttp.PathMatchers.GroupPathIdLike
 import mesosphere.marathon.api.v2.{ AppHelpers, PodsResource }
 import mesosphere.marathon.core.appinfo.{ AppInfo, GroupInfo, GroupInfoService, Selector }
-import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.plugin.auth.{ Authorizer, Identity, ViewGroup, Authenticator => MarathonAuthenticator }
 import mesosphere.marathon.state.{ Group, PathId }
 import play.api.libs.json.Json
-import akka.http.scaladsl.server.Route
-import mesosphere.marathon.api.akkahttp.PathMatchers.{ AppPathIdLike, GroupPathIdLike }
+import mesosphere.marathon.api.akkahttp.PathMatchers.GroupPathIdLike
 import mesosphere.marathon.core.appinfo.GroupInfoService
 import mesosphere.marathon.core.election.ElectionService
-import mesosphere.marathon.plugin.auth.{ Authorizer, Authenticator => MarathonAuthenticator }
-import mesosphere.marathon.state.PathId
 
 import scala.concurrent.ExecutionContext
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
@@ -121,7 +121,7 @@ class TasksController(
         }
       }
   }
-  private def getTasksByAppId(instanceIdsToAppId: Map[Id, PathId])(implicit identity: Identity): Future[Map[PathId, Seq[Instance]]] = {
+  private def getTasksByAppId(instanceIdsToAppId: Map[Id, PathId]): Future[Map[PathId, Seq[Instance]]] = {
     val maybeInstances = Future.sequence(instanceIdsToAppId.view
       .map { case (instanceId, _) => instanceTracker.instancesBySpec.map(_.instance(instanceId)) })
     maybeInstances.map(i => i.flatten

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -22,7 +22,7 @@ import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, UpdateRunSpe
 import mesosphere.marathon.raml.AnyToRaml
 import mesosphere.marathon.raml.EnrichedTask._
 import mesosphere.marathon.raml.EnrichedTaskConversion._
-import mesosphere.marathon.state.{ AppDefinition, PathId }
+import mesosphere.marathon.state.PathId
 import mesosphere.marathon.stream.Implicits._
 import org.slf4j.LoggerFactory
 import play.api.libs.json.Json

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -105,7 +105,7 @@ class CoreModuleImpl @Inject() (
 
   private[this] lazy val offerMatcherManagerModule = new OfferMatcherManagerModule(
     // infrastructure
-    clock, random, marathonConf, actorSystem.scheduler,
+    clock, random, marathonConf,
     leadershipModule,
     () => marathonScheduler.getLocalRegion
   )

--- a/src/main/scala/mesosphere/marathon/core/election/ElectionModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/ElectionModule.scala
@@ -4,7 +4,6 @@ package core.election
 import akka.actor.{ ActorSystem, Cancellable }
 import akka.event.EventStream
 import akka.stream.scaladsl.Source
-import java.util.concurrent.ExecutorService
 import mesosphere.marathon.core.base.CrashStrategy
 import mesosphere.marathon.util.LifeCycledCloseable
 import scala.concurrent.ExecutionContext

--- a/src/main/scala/mesosphere/marathon/core/launcher/LauncherModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/LauncherModule.scala
@@ -25,7 +25,7 @@ class LauncherModule(
 
   lazy val offerProcessor: OfferProcessor =
     new OfferProcessorImpl(
-      conf, clock,
+      conf,
       offerMatcher, taskLauncher, stateOpProcessor,
       offerStreamInput
     )

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -1,8 +1,6 @@
 package mesosphere.marathon
 package core.launcher.impl
 
-import java.time.Clock
-
 import akka.Done
 import akka.stream.scaladsl.SourceQueue
 import com.typesafe.scalalogging.StrictLogging
@@ -51,7 +49,7 @@ import scala.util.control.NonFatal
   * }}}
   */
 private[launcher] class OfferProcessorImpl(
-    conf: OfferProcessorConfig, clock: Clock,
+    conf: OfferProcessorConfig,
     offerMatcher: OfferMatcher,
     taskLauncher: TaskLauncher,
     stateOpProcessor: InstanceStateOpProcessor,

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -4,7 +4,6 @@ package core.launchqueue
 import java.time.Clock
 
 import akka.actor.{ ActorRef, Props }
-import com.google.inject.Provider
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.launcher.InstanceOpFactory
 import mesosphere.marathon.core.launchqueue.impl._

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -3,7 +3,7 @@ package core.matcher.manager
 
 import java.time.Clock
 
-import akka.actor.{ ActorRef, Scheduler }
+import akka.actor.ActorRef
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.util.ActorOfferMatcher
@@ -21,7 +21,6 @@ import scala.util.Random
 class OfferMatcherManagerModule(
     clock: Clock, random: Random,
     offerMatcherConfig: OfferMatcherManagerConfig,
-    scheduler: Scheduler,
     leadershipModule: LeadershipModule,
     localRegion: () => Option[Region],
     actorName: String = "offerMatcherManager") {

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/PathMatchersTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/PathMatchersTest.scala
@@ -91,7 +91,7 @@ class PathMatchersTest extends UnitTest with GroupCreation with ScalatestRouteTe
     }
 
     "match only path until :: even when it is not followed by keyword" in {
-      PodsPathIdLike(Path(s"test/group/pods_id::other")) shouldBe Matched(Path(s"::other"), Tuple1(s"test/group/pods_id"))
+      PodsPathIdLike(Path("test/group/pods_id::other")) shouldBe Matched(Path(s"::other"), Tuple1("test/group/pods_id"))
     }
 
     "considers empty paths as non-matches" in {

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -45,7 +45,7 @@ class OfferProcessorImplTest extends UnitTest {
       taskLauncher: TaskLauncher = mock[TaskLauncher],
       stateOpProcessor: InstanceStateOpProcessor = mock[InstanceStateOpProcessor]) {
     val offerProcessor = new OfferProcessorImpl(
-      conf, clock, offerMatcher, taskLauncher, stateOpProcessor,
+      conf, offerMatcher, taskLauncher, stateOpProcessor,
       NoopSourceQueue()
     )
   }

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -56,7 +56,7 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       verify()
     }
     val module: OfferMatcherManagerModule =
-      new OfferMatcherManagerModule(clock, random, config, system.scheduler, leaderModule, () => None,
+      new OfferMatcherManagerModule(clock, random, config, leaderModule, () => None,
         actorName = UUID.randomUUID().toString)
   }
 


### PR DESCRIPTION
Summary:
Following `sbt scapegoat` this removes quite a lot of unused imports and
parameters. This makes the linter output a little easier to comprehend.
