### PR TITLE
Adding the test plus dependencies to the make file

### DIFF
--- a/tests/package/Makefile
+++ b/tests/package/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all default
+.PHONY: all default test clean
 .SECONDARY:
 
 default: all
@@ -13,6 +13,7 @@ clean:
 	cp target/mesos-version $@
 
 target/mesos-version: ../../project/Dependencies.scala
+	mkdir -p target
 	cat ../../project/Dependencies.scala | grep MesosDebian | cut -f 2 -d '"' > $@.tmp
 	[ "$$(wc -l $@.tmp | awk '{print $$1}')" = 1 ]
 	mv $@.tmp $@
@@ -41,5 +42,8 @@ target/centos-systemd.built: centos-systemd/Dockerfile centos-systemd/mesos-vers
 target/ubuntu-upstart.built: ubuntu-upstart/Dockerfile ubuntu-upstart/mesos-version
 	cd ubuntu-upstart && docker build . -t marathon-package-test:ubuntu-upstart
 	touch $@
+
+test: | all
+	amm test.sc all
 
 all: target/mesos.built target/debian-systemv.built target/debian-systemd.built target/centos-systemd.built target/centos-systemv.built target/ubuntu-upstart.built


### PR DESCRIPTION
Adding the test plus dependencies to the make file

Summary:
* Cleaning up make to included testing
* Needed for the automated release pipeline 

JIRA issues:
