### PR TITLE
Cover all pod creation tests.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
@@ -43,6 +43,7 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     podManager: PodManager,
     pluginManager: PluginManager,
     marathonSchedulerService: MarathonSchedulerService,
+    marathonScheduler: MarathonScheduler,
     storageModule: StorageModule,
     mesosLeaderInfo: MesosLeaderInfo,
     appTasksRes: mesosphere.marathon.api.v2.AppTasksResource,
@@ -79,8 +80,8 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
     val leaderController = LeaderController(electionService, storageModule.runtimeConfigurationRepository)
     val queueController = new QueueController(clock, launchQueue, electionService)
     val tasksController = new TasksController(instanceTracker, groupManager, healthCheckManager, taskKiller, electionService)
-    val podsController = new PodsController(conf, electionService, podManager, groupManager, pluginManager, eventBus, clock)
     val groupsController = new GroupsController(electionService, groupInfoService, groupManager, groupApiService, conf)
+    val podsController = new PodsController(conf, electionService, podManager, groupManager, pluginManager, eventBus, marathonScheduler, clock)
 
     val v2Controller = new V2Controller(
       appsController,

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
@@ -63,9 +63,9 @@ class PodsController(
       (extractClientIP & forceParameter) { (clientIp, force) =>
         extractRequest { req =>
           entity(as[raml.Pod]) { podDef =>
-            normalized(podDef, podNormalizer) { normalizedPodDef =>
-              assumeValid(podDefValidator().apply(podDef)) {
-                val normalizedPodDef = podNormalizer.normalized(podDef)
+            assumeValid(podDefValidator().apply(podDef)) {
+              val normalizedPodDef = podNormalizer.normalized(podDef)
+              normalized(podDef, podNormalizer) { normalizedPodDef =>
                 val pod = Raml.fromRaml(normalizedPodDef).copy(version = clock.now())
                 assumeValid(PodsValidation.pluginValidators(pluginManager).apply(pod)) {
                   authorized(CreateRunSpec, pod).apply {

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
@@ -69,7 +69,7 @@ class PodsController(
                 val pod = Raml.fromRaml(normalizedPodDef).copy(version = clock.now())
                 assumeValid(PodsValidation.pluginValidators(pluginManager).apply(pod)) {
                   authorized(CreateRunSpec, pod).apply {
-                    val p = async {
+                    val planF = async {
                       val deployment = await(podManager.create(pod, force))
 
                       // TODO: How should we get the ip?
@@ -78,7 +78,7 @@ class PodsController(
 
                       deployment
                     }
-                    onSuccess(p) { plan =>
+                    onSuccess(planF) { plan =>
                       val ramlPod = PodConversion.podRamlWriter.write(pod)
                       val responseHeaders = Seq(
                         Location(Uri(pod.id.toString)),

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
@@ -4,7 +4,7 @@ package api.akkahttp.v2
 import java.time.Clock
 
 import akka.event.EventStream
-import akka.http.scaladsl.model.{ Uri, StatusCodes }
+import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import akka.http.scaladsl.model.headers.Location
 import akka.http.scaladsl.server.Route
 import mesosphere.marathon.api.akkahttp.{ Controller, Headers }
@@ -14,6 +14,7 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, CreateRunSpec }
 import mesosphere.marathon.state.PathId
 import akka.http.scaladsl.server.PathMatchers
+import com.wix.accord.Validator
 import mesosphere.marathon.api.v2.PodNormalization
 import mesosphere.marathon.api.v2.validation.PodsValidation
 import mesosphere.marathon.core.election.ElectionService
@@ -21,6 +22,7 @@ import mesosphere.marathon.core.event.PodEvent
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.PodManager
 import mesosphere.marathon.raml.{ PodConversion, Raml }
+import mesosphere.marathon.util.SemanticVersion
 
 import async.Async._
 import scala.concurrent.ExecutionContext
@@ -32,6 +34,7 @@ class PodsController(
     val groupManager: GroupManager,
     val pluginManager: PluginManager,
     val eventBus: EventStream,
+    val scheduler: MarathonScheduler,
     val clock: Clock)(
     implicit
     val authorizer: Authorizer,
@@ -43,6 +46,11 @@ class PodsController(
 
   val podNormalizer = PodNormalization.apply(PodNormalization.Configuration(
     config.defaultNetworkName.get))
+
+  def podDefValidator(): Validator[raml.Pod] =
+    PodsValidation.podValidator(
+      config.availableFeatures,
+      scheduler.mesosMasterVersion().getOrElse(SemanticVersion(0, 0, 0)), config.defaultNetworkName.get)
 
   def capability(): Route =
     authenticated.apply { implicit identity =>
@@ -56,26 +64,28 @@ class PodsController(
         extractRequest { req =>
           entity(as[raml.Pod]) { podDef =>
             normalized(podDef, podNormalizer) { normalizedPodDef =>
-              val normalizedPodDef = podNormalizer.normalized(podDef)
-              val pod = Raml.fromRaml(normalizedPodDef).copy(version = clock.now())
-              assumeValid(PodsValidation.pluginValidators(pluginManager).apply(pod)) {
-                authorized(CreateRunSpec, pod).apply {
-                  val p = async {
-                    val deployment = await(podManager.create(pod, force))
+              assumeValid(podDefValidator().apply(podDef)) {
+                val normalizedPodDef = podNormalizer.normalized(podDef)
+                val pod = Raml.fromRaml(normalizedPodDef).copy(version = clock.now())
+                assumeValid(PodsValidation.pluginValidators(pluginManager).apply(pod)) {
+                  authorized(CreateRunSpec, pod).apply {
+                    val p = async {
+                      val deployment = await(podManager.create(pod, force))
 
-                    // TODO: How should we get the ip?
-                    val ip = clientIp.getAddress().toString
-                    eventBus.publish(PodEvent(ip, req.uri.toString(), PodEvent.Created))
+                      // TODO: How should we get the ip?
+                      val ip = clientIp.getAddress().toString
+                      eventBus.publish(PodEvent(ip, req.uri.toString(), PodEvent.Created))
 
-                    deployment
-                  }
-                  onSuccess(p) { plan =>
-                    val ramlPod = PodConversion.podRamlWriter.write(pod)
-                    val responseHeaders = Seq(
-                      Location(Uri(pod.id.toString)),
-                      Headers.`Marathon-Deployment-Id`(plan.id)
-                    )
-                    complete((StatusCodes.Created, responseHeaders, ramlPod))
+                      deployment
+                    }
+                    onSuccess(p) { plan =>
+                      val ramlPod = PodConversion.podRamlWriter.write(pod)
+                      val responseHeaders = Seq(
+                        Location(Uri(pod.id.toString)),
+                        Headers.`Marathon-Deployment-Id`(plan.id)
+                      )
+                      complete((StatusCodes.Created, responseHeaders, ramlPod))
+                    }
                   }
                 }
               }

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
@@ -80,6 +80,13 @@ class PodsControllerTest extends UnitTest with ScalatestRouteTest with RouteBeha
         HavePropertyMatchResult(matches, "networkmode", Some(mode.value), maybeMode)
       }
     }
+    def podContainerWithEnvSecret(secret: String) = new HavePropertyMatcher[JsValue, Option[String]] {
+      override def apply(actual: JsValue) = {
+        val maybeSecret = (actual \ "containers" \ 0 \ "environment" \ "vol" \ "secret").asOpt[String]
+        val matches = maybeSecret.contains(secret)
+        HavePropertyMatchResult(matches, "podContainerSecret", Some(secret), maybeSecret)
+      }
+    }
 
     "be able to create a simple single-container pod from docker image w/ shell command" in {
       val f = Fixture(configArgs = Seq("--default_network_name", "blah")) // should not be injected into host network spec
@@ -277,24 +284,40 @@ class PodsControllerTest extends UnitTest with ScalatestRouteTest with RouteBeha
       }
     }
 
-    //    "The secrets feature is enabled and create pod (that uses env secret refs on container level) succeeds" in {
-    //      implicit val podSystem = mock[PodManager]
-    //      val f = Fixture(configArgs = Seq("--default_network_name", "blah", "--enable_features", Features.SECRETS)) // should not be injected into host network spec
-    //
-    //      podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
-    //
-    //      val response = f.podsResource.create(podSpecJsonWithEnvRefSecretOnContainerLevel.getBytes(), force = false, f.auth.request)
-    //
-    //      withClue(s"response body: ${response.getEntity}") {
-    //        response.getStatus should be(201)
-    //        val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
-    //        parsedResponse should be (defined)
-    //        val maybePod = parsedResponse.map(_.as[Pod])
-    //        maybePod should be (defined) // validate that we DID get back a pod definition
-    //        val pod = maybePod.get
-    //        pod.containers(0).environment("vol") shouldBe EnvVarSecret("secret1")
-    //      }
-    //    }
+    "The secrets feature is enabled and create pod (that uses env secret refs on container level) succeeds" in {
+      val f = Fixture(configArgs = Seq("--default_network_name", "blah", "--enable_features", Features.SECRETS)) // should not be injected into host network spec
+      val controller = f.controller()
+
+      val deploymentPlan = DeploymentPlan.empty
+      f.podManager.create(any, eq(false)).returns(Future.successful(deploymentPlan))
+
+      val podSpecJsonWithEnvRefSecretOnContainerLevel = """
+                                                          | { "id": "/mypod", "networks": [ { "mode": "host" } ], "containers":
+                                                          |   [
+                                                          |     { "name": "webapp",
+                                                          |       "resources": { "cpus": 0.03, "mem": 64 },
+                                                          |       "image": { "kind": "DOCKER", "id": "busybox" },
+                                                          |       "exec": { "command": { "shell": "sleep 1" } },
+                                                          |       "environment": { "vol": { "secret": "secret1" } }
+                                                          |     }
+                                                          |   ],
+                                                          |   "secrets": { "secret1": { "source": "/path/to/my/secret" } }
+                                                          |  }
+                                                        """.stripMargin
+      val entity = HttpEntity(podSpecJsonWithEnvRefSecretOnContainerLevel).withContentType(ContentTypes.`application/json`)
+      val request = Post(Uri./.withQuery(Query("force" -> "false")))
+        .withEntity(entity)
+        .withHeaders(`Remote-Address`(RemoteAddress(InetAddress.getByName("192.168.3.12"))))
+
+      request ~> controller.route ~> check {
+        response.status should be(StatusCodes.Created)
+
+        val jsonResponse = Json.parse(responseAs[String])
+        jsonResponse should have (
+          podContainerWithEnvSecret("secret1")
+        )
+      }
+    }
 
     //    "The secrets feature is enabled and create pod (that uses file based secrets) succeeds" in {
     //      implicit val podSystem = mock[PodManager]

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
@@ -92,31 +92,6 @@ class PodsControllerTest extends UnitTest with ScalatestRouteTest with RouteBeha
       }
     }
 
-    "handle normalization errors" in {
-      val f = Fixture()
-      val controller = f.controller()
-
-      val deploymentPlan = DeploymentPlan.empty
-      f.podManager.create(any, eq(false)).returns(Future.successful(deploymentPlan))
-
-      val podSpecJsonWithUnresolvableNetworkName =
-        """
-          | { "id": "/mypod", "networks": [ { "mode": "container" } ], "containers": [
-          |   { "name": "webapp",
-          |     "resources": { "cpus": 0.03, "mem": 64 },
-          |     "image": { "kind": "DOCKER", "id": "busybox" },
-          |     "exec": { "command": { "shell": "sleep 1" } } } ] }
-        """.stripMargin
-      val entity = HttpEntity(podSpecJsonWithUnresolvableNetworkName).withContentType(ContentTypes.`application/json`)
-      val request = Post(Uri./.withQuery(Query("force" -> "false")))
-        .withEntity(entity)
-        .withHeaders(`Remote-Address`(RemoteAddress(InetAddress.getByName("192.168.3.12"))))
-
-      request ~> controller.route ~> check {
-        response.status should be(StatusCodes.UnprocessableEntity)
-      }
-    }
-
     "be able to create a simple single-container pod with bridge network" in {
       val f = Fixture(configArgs = Seq("--default_network_name", "blah"))
       val controller = f.controller()

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
@@ -209,19 +209,39 @@ class PodsControllerTest extends UnitTest with ScalatestRouteTest with RouteBeha
       }
     }
 
-    //    "The secrets feature is NOT enabled and create pod (that uses env secret refs) fails" in {
-    //      implicit val podSystem = mock[PodManager]
-    //      val f = Fixture(configArgs = Seq("--default_network_name", "blah")) // should not be injected into host network spec
-    //
-    //      podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
-    //
-    //      val response = f.podsResource.create(podSpecJsonWithEnvRefSecret.getBytes(), force = false, f.auth.request)
-    //
-    //      withClue(s"response body: ${response.getEntity}") {
-    //        response.getStatus should be(422)
-    //        response.getEntity.toString should include("Feature secrets is not enabled")
-    //      }
-    //    }
+    "The secrets feature is NOT enabled and create pod (that uses env secret refs) fails" in {
+      val f = Fixture(configArgs = Seq("--default_network_name", "blah")) // should not be injected into host network spec
+      val controller = f.controller()
+
+      val deploymentPlan = DeploymentPlan.empty
+      f.podManager.create(any, eq(false)).returns(Future.successful(deploymentPlan))
+
+      val podSpecJsonWithEnvRefSecret = """
+                                          | { "id": "/mypod", "networks": [ { "mode": "host" } ], "containers":
+                                          |   [
+                                          |     { "name": "webapp",
+                                          |       "resources": { "cpus": 0.03, "mem": 64 },
+                                          |       "image": { "kind": "DOCKER", "id": "busybox" },
+                                          |       "exec": { "command": { "shell": "sleep 1" } }
+                                          |     }
+                                          |   ],
+                                          |   "environment": { "vol": { "secret": "secret1" } },
+                                          |   "secrets": { "secret1": { "source": "/foo" } }
+                                          |  }
+                                        """.stripMargin
+      val entity = HttpEntity(podSpecJsonWithEnvRefSecret).withContentType(ContentTypes.`application/json`)
+      val request = Post(Uri./.withQuery(Query("force" -> "false")))
+        .withEntity(entity)
+        .withHeaders(`Remote-Address`(RemoteAddress(InetAddress.getByName("192.168.3.12"))))
+
+      request ~> controller.route ~> check {
+        rejection shouldBe a[ValidationFailed]
+        inside(rejection) {
+          case ValidationFailed(failure) =>
+            failure should haveViolations("/secrets" -> "Feature secrets is not enabled. Enable with --enable_features secrets)")
+        }
+      }
+    }
 
     //    "The secrets feature is NOT enabled and create pod (that uses env secret refs on container level) fails" in {
     //      implicit val podSystem = mock[PodManager]

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/ResponseMatchers.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/ResponseMatchers.scala
@@ -1,0 +1,89 @@
+package mesosphere.marathon
+package api.akkahttp.v2
+
+import mesosphere.UnitTest
+import org.scalatest.matchers.{ HavePropertyMatchResult, HavePropertyMatcher }
+import play.api.libs.json.{ JsNumber, JsObject, JsValue }
+
+trait ResponseMatchers { this: UnitTest =>
+
+  /**
+    * Have property matcher for pods executor resources.
+    *
+    * @param cpus expected CPUs
+    * @param mem expected memory
+    * @param disk expected disk
+    * @return Match result.
+    */
+  def executorResources(cpus: Double, mem: Double, disk: Double) = new HavePropertyMatcher[JsValue, Option[JsValue]] {
+    override def apply(actual: JsValue) = {
+      val maybeActual = (actual \ "executorResources").toOption
+      val expected = JsObject(Seq("cpus" -> JsNumber(cpus), "mem" -> JsNumber(mem), "disk" -> JsNumber(disk)))
+      val matches = maybeActual.contains(expected)
+      HavePropertyMatchResult(matches, "executorResources", Some(expected), maybeActual)
+    }
+  }
+
+  /**
+    * Have property matcher verifying that no networkname has been defined.
+    */
+  val noDefinedNetworkname = new HavePropertyMatcher[JsValue, Option[JsValue]] {
+    override def apply(actual: JsValue) = {
+      val actualNetworkname = (actual \ "networks" \ 0 \ "name").toOption
+      val matches = !actualNetworkname.isDefined
+      HavePropertyMatchResult(matches, "networkname", None, actualNetworkname)
+    }
+  }
+
+  /**
+    * Have property matcher for network name of pod.
+    * @param name Expected name of network
+    * @return Match result
+    */
+  def definedNetworkname(name: String) = new HavePropertyMatcher[JsValue, Option[String]] {
+    override def apply(actual: JsValue) = {
+      val maybeNetworkname = (actual \ "networks" \ 0 \ "name").asOpt[String]
+      val matches = maybeNetworkname.contains(name)
+      HavePropertyMatchResult(matches, "networkname", Some(name), maybeNetworkname)
+    }
+  }
+
+  /**
+    * Have property matcher for network mode of pod.
+    * @param mode Expected mode.
+    * @return Match result
+    */
+  def networkMode(mode: raml.NetworkMode) = new HavePropertyMatcher[JsValue, Option[String]] {
+    override def apply(actual: JsValue) = {
+      val maybeMode = (actual \ "networks" \ 0 \ "mode").asOpt[String]
+      val matches = maybeMode.contains(mode.value)
+      HavePropertyMatchResult(matches, "networkmode", Some(mode.value), maybeMode)
+    }
+  }
+
+  /**
+    * Have property matcher for pod environment secret.
+    * @param secret Expected secret
+    * @return Match result
+    */
+  def podContainerWithEnvSecret(secret: String) = new HavePropertyMatcher[JsValue, Option[String]] {
+    override def apply(actual: JsValue) = {
+      val maybeSecret = (actual \ "containers" \ 0 \ "environment" \ "vol" \ "secret").asOpt[String]
+      val matches = maybeSecret.contains(secret)
+      HavePropertyMatchResult(matches, "podContainerSecret", Some(secret), maybeSecret)
+    }
+  }
+
+  /**
+    * Have property matcher for file based secret.
+    * @param secret Expected secret
+    * @return Match result
+    */
+  def podWithFileBasedSecret(secret: String) = new HavePropertyMatcher[JsValue, Option[String]] {
+    override def apply(actual: JsValue) = {
+      val maybeSecret = (actual \ "volumes" \ 0 \ "secret").asOpt[String]
+      val matches = maybeSecret.contains(secret)
+      HavePropertyMatchResult(matches, "podContainerSecret", Some(secret), maybeSecret)
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -288,7 +288,6 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
       val response = f.podsResource.create(podSpecJsonWithContainerNetworking.getBytes(), force = false, f.auth.request)
       response.getStatus shouldBe 422
       response.getEntity.toString should include(NetworkValidationMessages.NetworkNameMustBeSpecified)
-      println(response.getEntity.toString)
     }
 
     "create a pod with custom executor resource declaration" in {

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -288,6 +288,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
       val response = f.podsResource.create(podSpecJsonWithContainerNetworking.getBytes(), force = false, f.auth.request)
       response.getStatus shouldBe 422
       response.getEntity.toString should include(NetworkValidationMessages.NetworkNameMustBeSpecified)
+      println(response.getEntity.toString)
     }
 
     "create a pod with custom executor resource declaration" in {


### PR DESCRIPTION
Summary:
Follow up to #5731. Cover all other cases from `PodsResourceTest` and introduce have property matcher for JSON responses.

JIRA issues: MARATHON-7873
