### PR TITLE
Integration test for network name with underscore MARATHON-7851

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -809,6 +809,20 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       waitForDeployment(result)
       waitForStatusUpdates("TASK_FAILED")
     }
+
+    "create a simple app with network name with underscore should succees" in {
+      Given("a new app")
+      val app = appProxy(appId(Some("network-name-with-underscore")), "v1", instances = 1, healthCheck = None).copy(networks = Seq(Network(mode = NetworkMode.Container, name = Some("network_name_with_underscore"))))
+
+      When("The app is deployed")
+      val result = marathon.createAppV2(app)
+
+      Then("The app is created")
+      result should be(Created)
+      extractDeploymentIds(result) should have size 1
+      waitForDeployment(result)
+      waitForStatusUpdates("TASK_RUNNING")
+    }
   }
 
   private val ramlHealthCheck = AppHealthCheck(


### PR DESCRIPTION
Summary:
We introduced a breaking change in 1.5 that disallowed underscore in network names. This is verifying on integration test level that deploying an app with underscore in network name works. I even changed the regular expression validation back and verified that the test fails then...

JIRA issues: MARATHON-7851
