### PR TITLE
Correct links to Mesos getting started and tutorial.

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -20,8 +20,8 @@ Marathon runs atop Apache Mesos. You can install Mesos via your system's package
 Current builds and instructions on how to set up repositories for major Linux distributions are available on the Mesosphere [downloads page](http://mesosphere.com/downloads/).
 
 If you want to build Mesos from source, see the
-Mesos [Getting Started](http://mesos.apache.org/gettingstarted/) page or the
-[Mesosphere tutorial](http://mesosphere.com/2013/08/01/distributed-fault-tolerant-framework-apache-mesos/)
+Mesos [Getting Started](http://mesos.apache.org/getting-started/) page or the
+[Mesosphere tutorial](https://mesosphere.com/blog/distributed-fault-tolerant-framework-apache-mesos-html/)
 for details. Running `make install` will install Mesos in `/usr/local`.
 
 #### Install Marathon

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -20,7 +20,7 @@ Marathon runs atop Apache Mesos. You can install Mesos via your system's package
 Current builds and instructions on how to set up repositories for major Linux distributions are available on the Mesosphere [downloads page](http://mesosphere.com/downloads/).
 
 If you want to build Mesos from source, see the
-Mesos [Getting Started](http://mesos.apache.org/getting-started/) page or the
+Mesos [Getting Started](https://mesos.apache.org/getting-started/) page or the
 [Mesosphere tutorial](https://mesosphere.com/blog/distributed-fault-tolerant-framework-apache-mesos-html/)
 for details. Running `make install` will install Mesos in `/usr/local`.
 


### PR DESCRIPTION
Summary:
This fixes two links in our getting started page.

JIRA issues: MARATHON-7869
