### PR TITLE
Remove link to deprecated artifact store

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -42,11 +42,6 @@ layout: default
                 </a>
             </li>
             <li>
-                <a href="{{ site.baseurl }}/docs/artifact-store.html">
-                    Artifact Store
-                </a>
-            </li>
-            <li>
                 <a href="{{ site.baseurl }}/docs/auth-access-ctrl.html">
                     Authorization and Access Control
                 </a>


### PR DESCRIPTION
The artifact store was deprecated with Marathon 1.4 and has been removed in version 1.5.0.

Summary:
The artifact store was deprecated with Marathon 1.4 and has been removed in 1.5.0. This commit removes a link that survived somehow.