### PR TITLE
 Retrieve all status in pods controller. 

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -152,6 +152,7 @@ object EntityMarshallers {
   implicit val podDefSeqMarshaller = playJsonMarshaller[Seq[raml.Pod]]
   implicit val podDefUnmarshaller = playJsonUnmarshaller[raml.Pod]
   implicit val podStatus = playJsonMarshaller[raml.PodStatus]
+  implicit val podStatuses = playJsonMarshaller[Seq[raml.PodStatus]]
   implicit val leaderInfoMarshaller = playJsonMarshaller[raml.LeaderInfo]
   implicit val messageMarshaller = playJsonMarshaller[raml.Message]
   implicit val infoMarshaller = playJsonMarshaller[raml.MarathonInfo]

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/EntityMarshallers.scala
@@ -15,7 +15,7 @@ import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.appinfo.AppInfo
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfoWithStatistics
 import mesosphere.marathon.core.plugin.PluginDefinitions
-import mesosphere.marathon.state.{ AppDefinition, Group, PathId, Timestamp }
+import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import play.api.libs.json._
 
 import scala.collection.breakOut

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
@@ -152,6 +152,7 @@ class PodsController(
       }
     }
 
+  @SuppressWarnings(Array("OptionGet"))
   def status(podId: PathId): Route =
     authenticated.apply { implicit identity =>
       podManager.find(podId) match {

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
@@ -5,7 +5,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import akka.http.scaladsl.model.MediaTypes.`text/plain`
 import akka.http.scaladsl.model.{ MediaTypes, StatusCodes }
-import akka.http.scaladsl.server.{ MalformedQueryParamRejection, Rejection, Route }
+import akka.http.scaladsl.server.{ Rejection, Route }
 import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -203,8 +203,6 @@ class GroupsResource @Inject() (
     body: Array[Byte],
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
 
-    import mesosphere.marathon.core.async.ExecutionContexts.global
-
     assumeValid {
       val validatedId = validateOrThrow(id.toRootPath)
       val raw = Json.parse(body).as[raml.GroupUpdate]
@@ -281,8 +279,6 @@ class GroupsResource @Inject() (
     update: raml.GroupUpdate,
     force: Boolean)(implicit identity: Identity): (DeploymentPlan, PathId) = {
     val version = Timestamp.now()
-
-    import mesosphere.marathon.core.async.ExecutionContexts.global
 
     val effectivePath = update.id.map(PathId(_).canonicalPath(id)).getOrElse(id)
     val deployment = result(groupManager.updateRoot(


### PR DESCRIPTION
Summary:
Fetch and filter statuses for all pods. Depends on #5761.

JIRA issues: MARATHON-7880
