### PR TITLE
 Define version and versions route in pods controller. 

### DIFF
--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -77,6 +77,13 @@
               This operation will create a deployment. The operation finishes, if the deployment succeeds.
               You can query the deployments endoint with this id to see the status of the deployment.
             type: string
+      404:
+        description: No pod found with this `id`.
+        body:
+          application/json:
+            type: error.Error
+            example: |
+              { "message": "Pod '/not_existent' does not exist" }
 
   put:
     is: [ secured, jsonValidator, objectValidator, objectLocator ]
@@ -124,6 +131,13 @@
         body:
           application/json:
             type: pod.Pod
+      404:
+        description: No pod found with this `id`.
+        body:
+          application/json:
+            type: error.Error
+            example: |
+              { "message": "Pod '/not_existent' does not exist" }
 
 /{id}::status:
   description: |
@@ -145,6 +159,13 @@
         body:
           application/json:
             type: podStatus.PodStatus
+      404:
+        description: No pod found with this `id`.
+        body:
+          application/json:
+            type: error.Error
+            example: |
+              { "message": "Pod '/not_existent' does not exist" }
 
 /{id}::versions:
   description: |

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -131,13 +131,6 @@
         body:
           application/json:
             type: pod.Pod
-      404:
-        description: No pod found with this `id`.
-        body:
-          application/json:
-            type: error.Error
-            example: |
-              { "message": "Pod '/not_existent' does not exist" }
 
 /{id}::status:
   description: |
@@ -159,13 +152,6 @@
         body:
           application/json:
             type: podStatus.PodStatus
-      404:
-        description: No pod found with this `id`.
-        body:
-          application/json:
-            type: error.Error
-            example: |
-              { "message": "Pod '/not_existent' does not exist" }
 
 /{id}::versions:
   description: |

--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -77,13 +77,6 @@
               This operation will create a deployment. The operation finishes, if the deployment succeeds.
               You can query the deployments endoint with this id to see the status of the deployment.
             type: string
-      404:
-        description: No pod found with this `id`.
-        body:
-          application/json:
-            type: error.Error
-            example: |
-              { "message": "Pod '/not_existent' does not exist" }
 
   put:
     is: [ secured, jsonValidator, objectValidator, objectLocator ]

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/Rejections.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/Rejections.scala
@@ -20,16 +20,16 @@ object Rejections {
     private def readableVersion(version: Option[Timestamp]) = version.fold("")(v => s" in version $v")
 
     def noApp(id: PathId, version: Option[Timestamp] = None): EntityNotFound = {
-      EntityNotFound(Message(s"App '$id' does not exist ${readableVersion(version)}"))
+      EntityNotFound(Message(s"App '$id' does not exist${readableVersion(version)}"))
     }
     def noGroup(id: PathId, version: Option[Timestamp] = None): EntityNotFound = {
-      EntityNotFound(Message(s"Group '$id' does not exist ${readableVersion(version)}"))
+      EntityNotFound(Message(s"Group '$id' does not exist${readableVersion(version)}"))
     }
     def noLeader(): EntityNotFound = {
       EntityNotFound(Message("There is no leader"))
     }
-    def noPod(id: PathId): EntityNotFound = {
-      EntityNotFound(Message(s"Pod '$id' does not exist"))
+    def noPod(id: PathId, version: Option[Timestamp] = None): EntityNotFound = {
+      EntityNotFound(Message(s"Pod '$id' does not exist${readableVersion(version)}"))
     }
 
     def queueApp(appId: PathId): EntityNotFound = {

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/Rejections.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/Rejections.scala
@@ -31,6 +31,9 @@ object Rejections {
     def noPod(id: PathId, version: Option[Timestamp] = None): EntityNotFound = {
       EntityNotFound(Message(s"Pod '$id' does not exist${readableVersion(version)}"))
     }
+    def noPod(id: PathId, version: String): EntityNotFound = {
+      EntityNotFound(Message(s"Pod '$id' does not exist in version $version"))
+    }
 
     def queueApp(appId: PathId): EntityNotFound = {
       EntityNotFound(Message(s"Application $appId not found in tasks queue."))

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
@@ -170,7 +170,6 @@ class PodsController(
       }
     }
 
-  @SuppressWarnings(Array("all")) // async/await
   def status(podId: PathId): Route =
     authenticated.apply { implicit identity =>
       podManager.find(podId) match {
@@ -180,8 +179,8 @@ class PodsController(
           authorized(ViewRunSpec, pod).apply {
             onSuccess(podStatusService.selectPodStatus(podId)) { maybeStatus =>
               // If selectPodStatus returns None this is a bug since find(podId) already verifies that the pod exists.
-              // We don't filter the pods with an authentication since we check for authorization before.
-              val status: raml.PodStatus = maybeStatus.get
+              // We don't filter the pods with an authorization since we check for authorization before.
+              val status: raml.PodStatus = maybeStatus.getOrElse(throw new IllegalStateException(s"Status for pod '$podId' was none even though pod existed at start of request."))
               complete((StatusCodes.OK, status))
             }
           }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
@@ -152,7 +152,6 @@ class PodsController(
       }
     }
 
-  @SuppressWarnings(Array("OptionGet"))
   def status(podId: PathId): Route =
     authenticated.apply { implicit identity =>
       podManager.find(podId) match {

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
@@ -186,7 +186,18 @@ class PodsController(
       }
     }
 
-  def versions(podId: PathId): Route = ???
+  def versions(podId: PathId): Route =
+    authenticated.apply { implicit identity =>
+      podManager.find(podId) match {
+        case None =>
+          reject(Rejections.EntityNotFound.noPod(podId))
+        case Some(pod) =>
+          authorized(ViewRunSpec, pod).apply {
+            val versions = podManager.versions(podId).runWith(Sink.seq)
+            complete(versions)
+          }
+      }
+    }
 
   def version(podId: PathId, v: String): Route = ???
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
@@ -25,7 +25,7 @@ import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.event.PodEvent
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.{ PodDefinition, PodManager }
-import mesosphere.marathon.raml.{ PodConversion, Raml }
+import mesosphere.marathon.raml.{ PodConversion, PodStatusConversion, Raml }
 import mesosphere.marathon.util.SemanticVersion
 
 import async.Async._
@@ -165,6 +165,23 @@ class PodsController(
               // We don't filter the pods with an authorization since we check for authorization before.
               val status: raml.PodStatus = maybeStatus.getOrElse(throw new IllegalStateException(s"Status for pod '$podId' was none even though pod existed at start of request."))
               complete((StatusCodes.OK, status))
+            }
+          }
+      }
+    }
+
+  @SuppressWarnings(Array("all")) // async/await
+  def status(podId: PathId): Route =
+    authenticated.apply { implicit identity =>
+      podManager.find(podId) match {
+        case None =>
+          reject(Rejections.EntityNotFound.noPod(podId))
+        case Some(pod) =>
+          authorized(ViewRunSpec, pod).apply {
+            onSuccess(podStatusService.selectPodStatus(podId)) { maybeStatus =>
+              val status = maybeStatus.get // If selectPodStatus returns None this is a bug.
+              val ramlStatus = PodStatusConversion.podInstanceStatusRamlWriter.write(status)
+              complete("")
             }
           }
       }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
@@ -169,23 +169,6 @@ class PodsController(
       }
     }
 
-  def status(podId: PathId): Route =
-    authenticated.apply { implicit identity =>
-      podManager.find(podId) match {
-        case None =>
-          reject(Rejections.EntityNotFound.noPod(podId))
-        case Some(pod) =>
-          authorized(ViewRunSpec, pod).apply {
-            onSuccess(podStatusService.selectPodStatus(podId)) { maybeStatus =>
-              // If selectPodStatus returns None this is a bug since find(podId) already verifies that the pod exists.
-              // We don't filter the pods with an authorization since we check for authorization before.
-              val status: raml.PodStatus = maybeStatus.getOrElse(throw new IllegalStateException(s"Status for pod '$podId' was none even though pod existed at start of request."))
-              complete((StatusCodes.OK, status))
-            }
-          }
-      }
-    }
-
   def versions(podId: PathId): Route =
     authenticated.apply { implicit identity =>
       podManager.find(podId) match {

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/PodsController.scala
@@ -25,7 +25,7 @@ import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.event.PodEvent
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.{ PodDefinition, PodManager }
-import mesosphere.marathon.raml.{ PodConversion, PodStatusConversion, Raml }
+import mesosphere.marathon.raml.{ PodConversion, Raml }
 import mesosphere.marathon.util.SemanticVersion
 
 import async.Async._
@@ -179,9 +179,10 @@ class PodsController(
         case Some(pod) =>
           authorized(ViewRunSpec, pod).apply {
             onSuccess(podStatusService.selectPodStatus(podId)) { maybeStatus =>
-              val status = maybeStatus.get // If selectPodStatus returns None this is a bug.
-              val ramlStatus = PodStatusConversion.podInstanceStatusRamlWriter.write(status)
-              complete("")
+              // If selectPodStatus returns None this is a bug since find(podId) already verifies that the pod exists.
+              // We don't filter the pods with an authentication since we check for authorization before.
+              val status: raml.PodStatus = maybeStatus.get
+              complete((StatusCodes.OK, status))
             }
           }
       }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/QueueController.scala
@@ -31,6 +31,7 @@ class QueueController(
     val authorizer: Authorizer
 ) extends Controller with StrictLogging {
 
+  // format: OFF
   override val route = {
     asLeader(electionService) {
       authenticated.apply { implicit identity =>
@@ -39,14 +40,17 @@ class QueueController(
             list
           }
         } ~
+        delete {
           pathPrefix(AppPathIdLike) { appId =>
-            (path("delay") & delete) {
+            path("delay") {
               reset(appId)
             }
           }
+        }
       }
     }
   }
+  // format: ON
 
   @SuppressWarnings(Array("all")) // async/await
   private def list(implicit identity: Identity): Route = {

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/GroupsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/GroupsControllerTest.scala
@@ -4,13 +4,11 @@ package api.akkahttp.v2
 import akka.http.scaladsl.model.Uri.{ Path, Query }
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.Accept
-import akka.http.scaladsl.server.{ MalformedQueryParamRejection, Rejection }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.stream.scaladsl.Source
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.UnitTest
 import mesosphere.marathon.api.{ GroupApiService, TestAuthFixture, TestGroupManagerFixture }
-import mesosphere.marathon.api.akkahttp.Rejections.EntityNotFound
 import mesosphere.marathon.api.akkahttp.{ Headers, Rejections }
 import mesosphere.marathon.core.appinfo.{ AppInfo, GroupInfo, GroupInfoService }
 import mesosphere.marathon.core.deployment.DeploymentPlan
@@ -33,6 +31,22 @@ class GroupsControllerTest extends UnitTest with ScalatestRouteTest with Inside 
   implicit val identity: Identity = new Identity {}
 
   "Group detail" should {
+
+    // Entity not found test cases
+    {
+      val f = new FixtureWithRealGroupManager(authorized = false)
+      behave like unknownEntity(forRoute = f.groupsController.route, withRequest = Delete("/groupname"), withMessage = "Group '/groupname' does not exist")
+
+      val infoService = mock[GroupInfoService]
+      infoService.selectGroup(any, any, any, any) returns Future.successful(None)
+      infoService.selectGroupVersion(any, any, any, any) returns Future.successful(None)
+      val g = new Fixture(infoService = infoService)
+
+      behave like unknownEntity(forRoute = g.groupsController.route, withRequest = Get("/unknown-group"), withMessage = "Group '/unknown-group' does not exist")
+      behave like unknownEntity(forRoute = g.groupsController.route, withRequest = Get("/groupname/versions/2017-10-30T16:08:53.852Z"), withMessage = "Group '/groupname' does not exist in version 2017-10-30T16:08:53.852Z")
+    }
+
+    // Unauthenticated access test cases
     {
       val controller = Fixture(authenticated = false).groupsController
       behave like unauthenticatedRoute(forRoute = controller.route, withRequest = Get(Uri./).addHeader(Accept(MediaTypes.`text/plain`)))
@@ -57,16 +71,6 @@ class GroupsControllerTest extends UnitTest with ScalatestRouteTest with Inside 
       Get(Uri./.withPath(Path("/"))) ~> f.groupsController.route ~> check {
         status should be(StatusCodes.OK)
         (Json.parse(responseAs[String]) \ "id").get shouldEqual JsString("/")
-      }
-    }
-
-    "rejects with group not found for nonexisting group" in {
-      val infoService = mock[GroupInfoService]
-      infoService.selectGroup(eq(PathId("/groupname")), any, any, any) returns Future.successful(None)
-      val f = new Fixture(infoService = infoService)
-
-      Get(Uri./.withPath(Path("/groupname"))) ~> f.groupsController.route ~> check {
-        rejection should be (EntityNotFound.noGroup("groupname".toRootPath))
       }
     }
   }
@@ -127,16 +131,6 @@ class GroupsControllerTest extends UnitTest with ScalatestRouteTest with Inside 
         )
       }
     }
-
-    "reject for app and version that does not exist" in {
-      val infoService = mock[GroupInfoService]
-      infoService.selectGroupVersion(any, any, any, any) returns Future.successful(None)
-      val f = new Fixture(infoService = infoService)
-
-      Get(Uri./.withPath(Path("/groupname/versions/2017-10-30T16:08:53.852Z"))) ~> f.groupsController.route ~> check {
-        rejection should be (EntityNotFound.noGroup("groupname".toRootPath, Some(Timestamp("2017-10-30T16:08:53.852Z"))))
-      }
-    }
   }
 
   "Create a group" should {
@@ -193,11 +187,6 @@ class GroupsControllerTest extends UnitTest with ScalatestRouteTest with Inside 
   }
 
   "Delete Group" should {
-    "authenticated delete without authorization leads to a 404 if the resource doesn't exist" in new FixtureWithRealGroupManager(authorized = false) {
-      Delete(Uri./.withPath(Path("/groupname"))) ~> groupsController.route ~> check {
-        rejection should be (Rejections.EntityNotFound.noGroup(PathId("/groupname")))
-      }
-    }
 
     "delete group" in new Fixture {
       groupManager.updateRootEither(org.mockito.Matchers.eq(PathId("/groupname").parent), any, any, org.mockito.Matchers.eq(false), any) returns Future.successful(Right(DeploymentPlan.empty.copy(id = "plan", version = Timestamp.zero)))
@@ -211,6 +200,7 @@ class GroupsControllerTest extends UnitTest with ScalatestRouteTest with Inside 
       }
     }
 
+    // Unauthenticated access test cases
     {
       val controller = Fixture(authenticated = false).groupsController
       behave like unauthenticatedRoute(forRoute = controller.route, withRequest = Delete(Uri./.withPath(Path("/groupname"))))

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
@@ -41,6 +41,7 @@ class PodsControllerTest extends UnitTest with ScalatestRouteTest with RouteBeha
       }
     }
 
+    // Unauthenticated access test cases
     {
       val controller = Fixture(authenticated = false).controller()
       behave like unauthenticatedRoute(forRoute = controller.route, withRequest = Head(Uri./))
@@ -51,6 +52,7 @@ class PodsControllerTest extends UnitTest with ScalatestRouteTest with RouteBeha
       behave like unauthenticatedRoute(forRoute = controller.route, withRequest = Get("/mypod::status"))
     }
 
+    // Unauthorized access test cases
     {
       val f = Fixture(authorized = false)
       val controller = f.controller()
@@ -75,6 +77,7 @@ class PodsControllerTest extends UnitTest with ScalatestRouteTest with RouteBeha
       behave like unauthorizedRoute(forRoute = controller.route, withRequest = Get("/mypod::status"))
     }
 
+    // Entity not found test cases
     {
       val f = Fixture()
       val controller = f.controller()

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
@@ -85,14 +85,20 @@ class PodsControllerTest extends UnitTest with ScalatestRouteTest with RouteBeha
     {
       val f = Fixture()
       val controller = f.controller()
-      f.podManager.find(any).returns(None)
+      val mypodId = PathId("mypod")
+      val podDefinition = PodDefinition(id = mypodId)
+
+      f.podManager.find(eq(PathId("unknown-pod"))).returns(None)
+      f.podManager.find(eq(mypodId)).returns(Some(podDefinition))
+
       f.podManager.version(any, any).returns(Future.successful(None))
       def unknownPod(withRequest: HttpRequest, withMessage: String) = unknownEntity(controller.route, withRequest, withMessage)
 
       behave like unknownPod(withRequest = Delete("/unknown-pod"), withMessage = "Pod 'unknown-pod' does not exist")
       behave like unknownPod(withRequest = Get("/unknown-pod"), withMessage = "Pod 'unknown-pod' does not exist")
       behave like unknownPod(withRequest = Get("/unknown-pod::versions"), withMessage = "Pod 'unknown-pod' does not exist")
-      behave like unknownPod(withRequest = Get("/unknown-pod::versions/2015-04-09T12:30:00.000Z"), withMessage = "Pod 'unknown-pod' does not exist in version 2015-04-09T12:30:00.000Z")
+      behave like unknownPod(withRequest = Get("/mypod::versions/2015-04-09T12:30:00.000Z"), withMessage = "Pod 'mypod' does not exist in version 2015-04-09T12:30:00.000Z")
+      behave like unknownPod(withRequest = Get("/mypod::versions/unparsable-datetime"), withMessage = "Pod 'mypod' does not exist in version unparsable-datetime")
     }
 
     "be able to create a simple single-container pod from docker image w/ shell command" in {

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
@@ -572,7 +572,7 @@ class PodsControllerTest extends UnitTest with ScalatestRouteTest with RouteBeha
         jsonResponse should have(podId("mypod"))
       }
     }
-    
+
     "update a simple single-container pod from docker image w/ shell command" in {
       implicit val podSystem = mock[PodManager]
       val f = Fixture()

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/RouteBehaviours.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/RouteBehaviours.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import mesosphere.UnitTest
 import mesosphere.marathon.api.akkahttp.AuthDirectives.{ NotAuthenticated, NotAuthorized }
+import mesosphere.marathon.api.akkahttp.Rejections.{ EntityNotFound, Message }
 import org.scalatest.Inside
 
 trait RouteBehaviours extends ScalatestRouteTest with Inside { this: UnitTest =>
@@ -34,6 +35,16 @@ trait RouteBehaviours extends ScalatestRouteTest with Inside { this: UnitTest =>
           case NotAuthorized(response) =>
             response.status should be(StatusCodes.Unauthorized)
         }
+      }
+    }
+  }
+
+  def unknownPod(forRoute: Route, withRequest: HttpRequest): Unit = {
+    s"reject ${withRequest.method.value} of ${withRequest.uri} for unknown pod" in {
+      When(s"we try to fetch from $forRoute")
+      withRequest ~> forRoute ~> check {
+        Then("we receive a entity not found rejection")
+        rejection should be(EntityNotFound(Message("Pod 'unknown-pod' does not exist")))
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/RouteBehaviours.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/RouteBehaviours.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package api.akkahttp.v2
 
-import akka.http.scaladsl.model.{ HttpRequest, StatusCodes, Uri }
+import akka.http.scaladsl.model.{ HttpRequest, StatusCodes }
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import mesosphere.UnitTest
@@ -39,12 +39,12 @@ trait RouteBehaviours extends ScalatestRouteTest with Inside { this: UnitTest =>
     }
   }
 
-  def unknownPod(forRoute: Route, withRequest: HttpRequest): Unit = {
-    s"reject ${withRequest.method.value} of ${withRequest.uri} for unknown pod" in {
+  def unknownEntity(forRoute: Route, withRequest: HttpRequest, withMessage: String): Unit = {
+    s"reject ${withRequest.method.value} of ${withRequest.uri} for entity not found: $withMessage" in {
       When(s"we try to fetch from $forRoute")
       withRequest ~> forRoute ~> check {
-        Then("we receive a entity not found rejection")
-        rejection should be(EntityNotFound(Message("Pod 'unknown-pod' does not exist")))
+        Then(s"we receive a entity not found: $withMessage")
+        rejection should be(EntityNotFound(Message(withMessage)))
       }
     }
   }


### PR DESCRIPTION
Summary:
This implements and tests the version endpoint for pods. I also introduced a test behaviour for unknown entities which should simplify testing. It has been refactored for leader and queue controller tests but another refactoring may be required for the apps controller test.

Depends on #5762.

JIRA issues: MARATHON-7879
