### PR TITLE
Add IPv6 support for mesos health checks

### DIFF
--- a/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+++ b/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
@@ -481,6 +481,11 @@
             "description": "Protocol of the requests to be performed. One of HTTP, HTTPS, TCP, COMMAND, MESOS_HTTP, MESOS_HTTPS or MESOS_TCP.",
             "enum": ["HTTP", "HTTPS", "TCP", "COMMAND", "MESOS_HTTP", "MESOS_HTTPS", "MESOS_TCP"]
           },
+          "ipProtocol": {
+            "type": "string",
+            "description": "Protocol of the requests to be performed. One of HTTP, HTTPS, TCP, COMMAND, MESOS_HTTP, MESOS_HTTPS or MESOS_TCP.",
+            "enum": ["IPv4", "IPv6"]
+          },
           "timeoutSeconds": {
             "type": "integer",
             "description": "Number of seconds after which a health check is considered a failure regardless of the response.",

--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -137,6 +137,7 @@ types:
         default: HTTP
       ipProtocol?:
         type: strings.IpProtocol
+        default: IPv4
       timeoutSeconds?:
         type: integer
         format: int32

--- a/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
+++ b/docs/docs/rest-api/public/api/v2/types/healthCheck.raml
@@ -135,6 +135,8 @@ types:
       protocol?:
         type: AppHealthCheckProtocol
         default: HTTP
+      ipProtocol?:
+        type: strings.IpProtocol
       timeoutSeconds?:
         type: integer
         format: int32

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependency {
     val Alpakka  = "0.8"
     val Chaos = "0.10.0"
     val Guava = "19.0"
-    val Mesos = "1.4.0"
+    val Mesos = "1.5.0-health-check-ipv6"
     // Version of Mesos to use in Dockerfile.
     val MesosDebian = "1.4.0-2.0.1"
     val OpenJDK = "openjdk:8u121-jdk"

--- a/src/main/java/mesosphere/marathon/Protos.java
+++ b/src/main/java/mesosphere/marathon/Protos.java
@@ -173,6 +173,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1109,7 +1112,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new Constraint(input, extensionRegistry);
+        return new Constraint(input, extensionRegistry);
       }
     };
 
@@ -1277,6 +1280,15 @@ public final class Protos {
      */
     com.google.protobuf.ByteString
         getPortNameBytes();
+
+    /**
+     * <code>optional .mesosphere.marathon.HealthCheckDefinition.IpProtocol ipProtocol = 13 [default = IPv4];</code>
+     */
+    boolean hasIpProtocol();
+    /**
+     * <code>optional .mesosphere.marathon.HealthCheckDefinition.IpProtocol ipProtocol = 13 [default = IPv4];</code>
+     */
+    mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol getIpProtocol();
   }
   /**
    * Protobuf type {@code mesosphere.marathon.HealthCheckDefinition}
@@ -1302,6 +1314,7 @@ public final class Protos {
       port_ = 0;
       delaySeconds_ = 15;
       portName_ = "";
+      ipProtocol_ = 1;
     }
 
     @java.lang.Override
@@ -1314,6 +1327,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1406,6 +1422,17 @@ public final class Protos {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000800;
               portName_ = bs;
+              break;
+            }
+            case 104: {
+              int rawValue = input.readEnum();
+              mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol value = mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(13, rawValue);
+              } else {
+                bitField0_ |= 0x00001000;
+                ipProtocol_ = rawValue;
+              }
               break;
             }
           }
@@ -1565,6 +1592,96 @@ public final class Protos {
       }
 
       // @@protoc_insertion_point(enum_scope:mesosphere.marathon.HealthCheckDefinition.Protocol)
+    }
+
+    /**
+     * Protobuf enum {@code mesosphere.marathon.HealthCheckDefinition.IpProtocol}
+     */
+    public enum IpProtocol
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>IPv4 = 1;</code>
+       */
+      IPv4(1),
+      /**
+       * <code>IPv6 = 2;</code>
+       */
+      IPv6(2),
+      ;
+
+      /**
+       * <code>IPv4 = 1;</code>
+       */
+      public static final int IPv4_VALUE = 1;
+      /**
+       * <code>IPv6 = 2;</code>
+       */
+      public static final int IPv6_VALUE = 2;
+
+
+      public final int getNumber() {
+        return value;
+      }
+
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
+      public static IpProtocol valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static IpProtocol forNumber(int value) {
+        switch (value) {
+          case 1: return IPv4;
+          case 2: return IPv6;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<IpProtocol>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          IpProtocol> internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<IpProtocol>() {
+              public IpProtocol findValueByNumber(int number) {
+                return IpProtocol.forNumber(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        return getDescriptor().getValues().get(ordinal());
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return mesosphere.marathon.Protos.HealthCheckDefinition.getDescriptor().getEnumTypes().get(1);
+      }
+
+      private static final IpProtocol[] VALUES = values();
+
+      public static IpProtocol valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int value;
+
+      private IpProtocol(int value) {
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:mesosphere.marathon.HealthCheckDefinition.IpProtocol)
     }
 
     private int bitField0_;
@@ -1833,6 +1950,22 @@ public final class Protos {
       }
     }
 
+    public static final int IPPROTOCOL_FIELD_NUMBER = 13;
+    private int ipProtocol_;
+    /**
+     * <code>optional .mesosphere.marathon.HealthCheckDefinition.IpProtocol ipProtocol = 13 [default = IPv4];</code>
+     */
+    public boolean hasIpProtocol() {
+      return ((bitField0_ & 0x00001000) == 0x00001000);
+    }
+    /**
+     * <code>optional .mesosphere.marathon.HealthCheckDefinition.IpProtocol ipProtocol = 13 [default = IPv4];</code>
+     */
+    public mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol getIpProtocol() {
+      mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol result = mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol.valueOf(ipProtocol_);
+      return result == null ? mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol.IPv4 : result;
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -1891,6 +2024,9 @@ public final class Protos {
       if (((bitField0_ & 0x00000800) == 0x00000800)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 12, portName_);
       }
+      if (((bitField0_ & 0x00001000) == 0x00001000)) {
+        output.writeEnum(13, ipProtocol_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -1944,6 +2080,10 @@ public final class Protos {
       }
       if (((bitField0_ & 0x00000800) == 0x00000800)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(12, portName_);
+      }
+      if (((bitField0_ & 0x00001000) == 0x00001000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(13, ipProtocol_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2020,6 +2160,10 @@ public final class Protos {
         result = result && getPortName()
             .equals(other.getPortName());
       }
+      result = result && (hasIpProtocol() == other.hasIpProtocol());
+      if (hasIpProtocol()) {
+        result = result && ipProtocol_ == other.ipProtocol_;
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -2079,6 +2223,10 @@ public final class Protos {
       if (hasPortName()) {
         hash = (37 * hash) + PORTNAME_FIELD_NUMBER;
         hash = (53 * hash) + getPortName().hashCode();
+      }
+      if (hasIpProtocol()) {
+        hash = (37 * hash) + IPPROTOCOL_FIELD_NUMBER;
+        hash = (53 * hash) + ipProtocol_;
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -2238,6 +2386,8 @@ public final class Protos {
         bitField0_ = (bitField0_ & ~0x00000400);
         portName_ = "";
         bitField0_ = (bitField0_ & ~0x00000800);
+        ipProtocol_ = 1;
+        bitField0_ = (bitField0_ & ~0x00001000);
         return this;
       }
 
@@ -2314,6 +2464,10 @@ public final class Protos {
           to_bitField0_ |= 0x00000800;
         }
         result.portName_ = portName_;
+        if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
+          to_bitField0_ |= 0x00001000;
+        }
+        result.ipProtocol_ = ipProtocol_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2395,6 +2549,9 @@ public final class Protos {
           bitField0_ |= 0x00000800;
           portName_ = other.portName_;
           onChanged();
+        }
+        if (other.hasIpProtocol()) {
+          setIpProtocol(other.getIpProtocol());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -3041,6 +3198,42 @@ public final class Protos {
         onChanged();
         return this;
       }
+
+      private int ipProtocol_ = 1;
+      /**
+       * <code>optional .mesosphere.marathon.HealthCheckDefinition.IpProtocol ipProtocol = 13 [default = IPv4];</code>
+       */
+      public boolean hasIpProtocol() {
+        return ((bitField0_ & 0x00001000) == 0x00001000);
+      }
+      /**
+       * <code>optional .mesosphere.marathon.HealthCheckDefinition.IpProtocol ipProtocol = 13 [default = IPv4];</code>
+       */
+      public mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol getIpProtocol() {
+        mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol result = mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol.valueOf(ipProtocol_);
+        return result == null ? mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol.IPv4 : result;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.HealthCheckDefinition.IpProtocol ipProtocol = 13 [default = IPv4];</code>
+       */
+      public Builder setIpProtocol(mesosphere.marathon.Protos.HealthCheckDefinition.IpProtocol value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00001000;
+        ipProtocol_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .mesosphere.marathon.HealthCheckDefinition.IpProtocol ipProtocol = 13 [default = IPv4];</code>
+       */
+      public Builder clearIpProtocol() {
+        bitField0_ = (bitField0_ & ~0x00001000);
+        ipProtocol_ = 1;
+        onChanged();
+        return this;
+      }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
@@ -3071,7 +3264,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new HealthCheckDefinition(input, extensionRegistry);
+        return new HealthCheckDefinition(input, extensionRegistry);
       }
     };
 
@@ -3218,6 +3411,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4568,7 +4764,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ReadinessCheckDefinition(input, extensionRegistry);
+        return new ReadinessCheckDefinition(input, extensionRegistry);
       }
     };
 
@@ -4693,6 +4889,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5907,7 +6106,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ObsoleteIpAddress(input, extensionRegistry);
+        return new ObsoleteIpAddress(input, extensionRegistry);
       }
     };
 
@@ -5984,6 +6183,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6680,7 +6882,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ObsoleteDiscoveryInfo(input, extensionRegistry);
+        return new ObsoleteDiscoveryInfo(input, extensionRegistry);
       }
     };
 
@@ -6810,6 +7012,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7986,7 +8191,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new NetworkDefinition(input, extensionRegistry);
+        return new NetworkDefinition(input, extensionRegistry);
       }
     };
 
@@ -8660,6 +8865,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       int mutable_bitField1_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -16026,7 +16234,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ServiceDefinition(input, extensionRegistry);
+        return new ServiceDefinition(input, extensionRegistry);
       }
     };
 
@@ -16110,6 +16318,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -16656,7 +16867,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new UnreachableStrategy(input, extensionRegistry);
+        return new UnreachableStrategy(input, extensionRegistry);
       }
     };
 
@@ -16723,6 +16934,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -17226,7 +17440,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new Json(input, extensionRegistry);
+        return new Json(input, extensionRegistry);
       }
     };
 
@@ -17294,6 +17508,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -17801,7 +18018,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ResourceRoles(input, extensionRegistry);
+        return new ResourceRoles(input, extensionRegistry);
       }
     };
 
@@ -17873,6 +18090,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -18442,7 +18662,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ContainerInfo(input, extensionRegistry);
+        return new ContainerInfo(input, extensionRegistry);
       }
     };
 
@@ -18614,6 +18834,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -18933,6 +19156,9 @@ public final class Protos {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -19102,6 +19328,9 @@ public final class Protos {
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
           this();
+          if (extensionRegistry == null) {
+            throw new java.lang.NullPointerException();
+          }
           int mutable_bitField0_ = 0;
           com.google.protobuf.UnknownFieldSet.Builder unknownFields =
               com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -19912,7 +20141,7 @@ public final class Protos {
               com.google.protobuf.CodedInputStream input,
               com.google.protobuf.ExtensionRegistryLite extensionRegistry)
               throws com.google.protobuf.InvalidProtocolBufferException {
-              return new ImagePullConfig(input, extensionRegistry);
+            return new ImagePullConfig(input, extensionRegistry);
           }
         };
 
@@ -20049,6 +20278,9 @@ public final class Protos {
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
           this();
+          if (extensionRegistry == null) {
+            throw new java.lang.NullPointerException();
+          }
           int mutable_bitField0_ = 0;
           com.google.protobuf.UnknownFieldSet.Builder unknownFields =
               com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -21286,7 +21518,7 @@ public final class Protos {
               com.google.protobuf.CodedInputStream input,
               com.google.protobuf.ExtensionRegistryLite extensionRegistry)
               throws com.google.protobuf.InvalidProtocolBufferException {
-              return new ObsoleteDockerPortMapping(input, extensionRegistry);
+            return new ObsoleteDockerPortMapping(input, extensionRegistry);
           }
         };
 
@@ -22977,7 +23209,7 @@ public final class Protos {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-            return new DockerInfo(input, extensionRegistry);
+          return new DockerInfo(input, extensionRegistry);
         }
       };
 
@@ -23140,6 +23372,9 @@ public final class Protos {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -24325,7 +24560,7 @@ public final class Protos {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-            return new MesosDockerInfo(input, extensionRegistry);
+          return new MesosDockerInfo(input, extensionRegistry);
         }
       };
 
@@ -24507,6 +24742,9 @@ public final class Protos {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -25818,7 +26056,7 @@ public final class Protos {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-            return new MesosAppCInfo(input, extensionRegistry);
+          return new MesosAppCInfo(input, extensionRegistry);
         }
       };
 
@@ -25971,6 +26209,9 @@ public final class Protos {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -27372,7 +27613,7 @@ public final class Protos {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-            return new PortMapping(input, extensionRegistry);
+          return new PortMapping(input, extensionRegistry);
         }
       };
 
@@ -29105,7 +29346,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ExtendedContainerInfo(input, extensionRegistry);
+        return new ExtendedContainerInfo(input, extensionRegistry);
       }
     };
 
@@ -29338,6 +29579,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -29543,6 +29787,9 @@ public final class Protos {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -30492,7 +30739,7 @@ public final class Protos {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-            return new PersistentVolumeInfo(input, extensionRegistry);
+          return new PersistentVolumeInfo(input, extensionRegistry);
         }
       };
 
@@ -30609,6 +30856,9 @@ public final class Protos {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -31700,7 +31950,7 @@ public final class Protos {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-            return new ExternalVolumeInfo(input, extensionRegistry);
+          return new ExternalVolumeInfo(input, extensionRegistry);
         }
       };
 
@@ -31767,6 +32017,9 @@ public final class Protos {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -32270,7 +32523,7 @@ public final class Protos {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-            return new SecretVolumeInfo(input, extensionRegistry);
+          return new SecretVolumeInfo(input, extensionRegistry);
         }
       };
 
@@ -34021,7 +34274,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new Volume(input, extensionRegistry);
+        return new Volume(input, extensionRegistry);
       }
     };
 
@@ -34117,6 +34370,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -34912,7 +35168,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new StorageVersion(input, extensionRegistry);
+        return new StorageVersion(input, extensionRegistry);
       }
     };
 
@@ -34980,6 +35236,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -35489,7 +35748,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new UpgradeStrategyDefinition(input, extensionRegistry);
+        return new UpgradeStrategyDefinition(input, extensionRegistry);
       }
     };
 
@@ -35732,6 +35991,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -35917,6 +36179,9 @@ public final class Protos {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
         int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -36573,7 +36838,7 @@ public final class Protos {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
-            return new AppReference(input, extensionRegistry);
+          return new AppReference(input, extensionRegistry);
         }
       };
 
@@ -39147,7 +39412,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new GroupDefinition(input, extensionRegistry);
+        return new GroupDefinition(input, extensionRegistry);
       }
     };
 
@@ -39308,6 +39573,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -40747,7 +41015,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new DeploymentPlanDefinition(input, extensionRegistry);
+        return new DeploymentPlanDefinition(input, extensionRegistry);
       }
     };
 
@@ -40906,6 +41174,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -42510,7 +42781,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new TaskFailure(input, extensionRegistry);
+        return new TaskFailure(input, extensionRegistry);
       }
     };
 
@@ -42622,6 +42893,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -43416,7 +43690,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ZKStoreEntry(input, extensionRegistry);
+        return new ZKStoreEntry(input, extensionRegistry);
       }
     };
 
@@ -43484,6 +43758,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -44081,7 +44358,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new ResidencyDefinition(input, extensionRegistry);
+        return new ResidencyDefinition(input, extensionRegistry);
       }
     };
 
@@ -44159,6 +44436,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -44815,7 +45095,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new Secret(input, extensionRegistry);
+        return new Secret(input, extensionRegistry);
       }
     };
 
@@ -44901,6 +45181,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -45781,7 +46064,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new EnvVarReference(input, extensionRegistry);
+        return new EnvVarReference(input, extensionRegistry);
       }
     };
 
@@ -45844,6 +46127,9 @@ public final class Protos {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -46343,7 +46629,7 @@ public final class Protos {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-          return new EnvVarSecretRef(input, extensionRegistry);
+        return new EnvVarSecretRef(input, extensionRegistry);
       }
     };
 
@@ -46542,176 +46828,179 @@ public final class Protos {
       "rathon.Constraint.Operator\022\r\n\005value\030\003 \001(" +
       "\t\"\\\n\010Operator\022\n\n\006UNIQUE\020\000\022\010\n\004LIKE\020\001\022\013\n\007C" +
       "LUSTER\020\002\022\014\n\010GROUP_BY\020\003\022\n\n\006UNLIKE\020\004\022\013\n\007MA" +
-      "X_PER\020\005\022\006\n\002IS\020\006\"\342\003\n\025HealthCheckDefinitio" +
+      "X_PER\020\005\022\006\n\002IS\020\006\"\325\004\n\025HealthCheckDefinitio" +
       "n\022E\n\010protocol\030\001 \002(\01623.mesosphere.maratho" +
       "n.HealthCheckDefinition.Protocol\022\021\n\tport" +
-      "Index\030\002 \001(\r\022\036\n\022gracePeriodSeconds\030\003 \001(\r:",
+      "Index\030\002 \001(\r\022\036\n\022gracePeriodSeconds\030\003 \001(\r:" +
       "\00215\022\033\n\017intervalSeconds\030\004 \001(\r:\00210\022\032\n\016time" +
       "outSeconds\030\005 \001(\r:\00220\022\017\n\004path\030\006 \001(\t:\001/\022!\n" +
       "\026maxConsecutiveFailures\030\007 \001(\r:\0013\022#\n\007comm" +
       "and\030\010 \001(\0132\022.mesos.CommandInfo\022\034\n\rignoreH" +
       "ttp1xx\030\t \001(\010:\005false\022\014\n\004port\030\n \001(\r\022\030\n\014del" +
-      "aySeconds\030\013 \001(\r:\00215\022\020\n\010portName\030\014 \001(\t\"e\n" +
-      "\010Protocol\022\010\n\004HTTP\020\000\022\007\n\003TCP\020\001\022\013\n\007COMMAND\020" +
-      "\002\022\t\n\005HTTPS\020\003\022\016\n\nMESOS_HTTP\020\004\022\017\n\013MESOS_HT" +
-      "TPS\020\005\022\r\n\tMESOS_TCP\020\006\"\240\002\n\030ReadinessCheckD" +
-      "efinition\022\014\n\004name\030\001 \001(\t\022H\n\010protocol\030\002 \001(",
-      "\01626.mesosphere.marathon.ReadinessCheckDe" +
-      "finition.Protocol\022\014\n\004path\030\003 \001(\t\022\020\n\010portN" +
-      "ame\030\004 \001(\t\022\026\n\016intervalMillis\030\005 \001(\004\022\025\n\rtim" +
-      "eoutMillis\030\006 \001(\004\022\036\n\026httpStatusCodeForRea" +
-      "dy\030\007 \003(\r\022\034\n\024preserveLastResponse\030\010 \001(\010\"\037" +
-      "\n\010Protocol\022\010\n\004HTTP\020\000\022\t\n\005HTTPS\020\001\"\231\001\n\021Obso" +
-      "leteIpAddress\022\016\n\006groups\030\001 \003(\t\022\034\n\006labels\030" +
-      "\002 \003(\0132\014.mesos.Label\022A\n\rdiscoveryInfo\030\003 \001" +
-      "(\0132*.mesosphere.marathon.ObsoleteDiscove" +
-      "ryInfo\022\023\n\013networkName\030\004 \001(\t\"3\n\025ObsoleteD",
-      "iscoveryInfo\022\032\n\005ports\030\001 \003(\0132\013.mesos.Port" +
-      "\"\264\001\n\021NetworkDefinition\0229\n\004mode\030\001 \001(\0162+.m" +
-      "esosphere.marathon.NetworkDefinition.Mod" +
-      "e\022\014\n\004name\030\002 \001(\t\022\034\n\006labels\030\003 \003(\0132\014.mesos." +
-      "Label\"8\n\004Mode\022\013\n\007UNKNOWN\020\000\022\010\n\004HOST\020\001\022\r\n\t" +
-      "CONTAINER\020\002\022\n\n\006BRIDGE\020\003\"\276\013\n\021ServiceDefin" +
-      "ition\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030\002 \002(\0132\022.mesos.C" +
-      "ommandInfo\022\021\n\tinstances\030\003 \002(\r\022\"\n\tresourc" +
-      "es\030\004 \003(\0132\017.mesos.Resource\022\023\n\013description" +
-      "\030\005 \001(\t\022\r\n\005ports\030\006 \003(\r\0224\n\013constraints\030\007 \003",
-      "(\0132\037.mesosphere.marathon.Constraint\022\022\n\010e" +
-      "xecutor\030\010 \002(\t:\000\022>\n\022OBSOLETE_container\030\n " +
-      "\001(\0132\".mesosphere.marathon.ContainerInfo\022" +
-      ")\n\007version\030\013 \001(\t:\0301970-01-01T00:00:00.00" +
-      "0Z\022@\n\014healthChecks\030\014 \003(\0132*.mesosphere.ma" +
-      "rathon.HealthCheckDefinition\022\025\n\007backoff\030" +
-      "\r \001(\003:\0041000\022\033\n\rbackoffFactor\030\016 \001(\001:\0041.15" +
-      "\022G\n\017upgradeStrategy\030\017 \001(\0132..mesosphere.m" +
-      "arathon.UpgradeStrategyDefinition\022\024\n\014dep" +
-      "endencies\030\020 \003(\t\022\021\n\tstoreUrls\030\021 \003(\t\022\034\n\rre",
-      "quire_ports\030\022 \001(\010:\005false\022=\n\tcontainer\030\023 " +
-      "\001(\0132*.mesosphere.marathon.ExtendedContai" +
-      "nerInfo\022 \n\006labels\030\024 \003(\0132\020.mesos.Paramete" +
-      "r\022\037\n\016maxLaunchDelay\030\025 \001(\003:\0073600000\022A\n\025ac" +
-      "ceptedResourceRoles\030\026 \001(\0132\".mesosphere.m" +
-      "arathon.ResourceRoles\022\027\n\017last_scaling_at" +
-      "\030\027 \001(\003\022\035\n\025last_config_change_at\030\030 \001(\003\022B\n" +
-      "\022OBSOLETE_ipAddress\030\031 \001(\0132&.mesosphere.m" +
-      "arathon.ObsoleteIpAddress\022;\n\tresidency\030\032" +
-      " \001(\0132(.mesosphere.marathon.ResidencyDefi",
-      "nition\022$\n\017portDefinitions\030\033 \003(\0132\013.mesos." +
-      "Port\022O\n\030readinessCheckDefinition\030\034 \003(\0132-" +
-      ".mesosphere.marathon.ReadinessCheckDefin" +
-      "ition\022,\n\007secrets\030\035 \003(\0132\033.mesosphere.mara" +
-      "thon.Secret\022>\n\020envVarReferences\030\036 \003(\0132$." +
-      "mesosphere.marathon.EnvVarReference\022\033\n\023t" +
-      "askKillGracePeriod\030\037 \001(\003\022E\n\023unreachableS" +
-      "trategy\030  \001(\0132(.mesosphere.marathon.Unre" +
-      "achableStrategy\022H\n\rkillSelection\030! \001(\0162\"" +
-      ".mesosphere.marathon.KillSelection:\rYoun",
-      "gestFirst\0228\n\010networks\030\" \003(\0132&.mesosphere" +
-      ".marathon.NetworkDefinition\022\033\n\003tty\030# \001(\013" +
-      "2\016.mesos.TTYInfo\"]\n\023UnreachableStrategy\022" +
-      "!\n\024inactiveAfterSeconds\030\001 \001(\004:\003900\022#\n\023ex" +
-      "pungeAfterSeconds\030\002 \001(\004:\006604800\"\024\n\004Json\022" +
-      "\014\n\004json\030\001 \002(\t\"\035\n\rResourceRoles\022\014\n\004role\030\001" +
-      " \003(\t\"1\n\rContainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017" +
-      "\n\007options\030\002 \003(\014\"\356\013\n\025ExtendedContainerInf" +
-      "o\022\'\n\004type\030\001 \002(\0162\031.mesos.ContainerInfo.Ty" +
-      "pe\022,\n\007volumes\030\002 \003(\0132\033.mesosphere.maratho",
-      "n.Volume\022M\n\rport_mappings\030\006 \003(\01326.mesosp" +
-      "here.marathon.ExtendedContainerInfo.Port" +
-      "Mapping\022E\n\006docker\030\003 \001(\01325.mesosphere.mar" +
-      "athon.ExtendedContainerInfo.DockerInfo\022O" +
-      "\n\013mesosDocker\030\004 \001(\0132:.mesosphere.maratho" +
-      "n.ExtendedContainerInfo.MesosDockerInfo\022" +
-      "K\n\tmesosAppC\030\005 \001(\01328.mesosphere.marathon" +
-      ".ExtendedContainerInfo.MesosAppCInfo\032\361\004\n" +
-      "\nDockerInfo\022\r\n\005image\030\001 \002(\t\022G\n\020OBSOLETE_n" +
-      "etwork\030\002 \001(\0162\'.mesos.ContainerInfo.Docke",
-      "rInfo.Network:\004HOST\022o\n\026OBSOLETE_port_map" +
-      "pings\030\003 \003(\0132O.mesosphere.marathon.Extend" +
-      "edContainerInfo.DockerInfo.ObsoleteDocke" +
-      "rPortMapping\022\031\n\nprivileged\030\004 \001(\010:\005false\022" +
-      "$\n\nparameters\030\005 \003(\0132\020.mesos.Parameter\022\030\n" +
-      "\020force_pull_image\030\006 \001(\010\032\236\001\n\017ImagePullCon" +
-      "fig\022X\n\004type\030\001 \002(\0162J.mesosphere.marathon." +
-      "ExtendedContainerInfo.DockerInfo.ImagePu" +
-      "llConfig.Type\022\035\n\006secret\030\002 \001(\0132\r.mesos.Se" +
-      "cret\"\022\n\004Type\022\n\n\006SECRET\020\001\032\235\001\n\031ObsoleteDoc",
-      "kerPortMapping\022\021\n\thost_port\030\001 \001(\r\022\026\n\016con" +
-      "tainer_port\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\014\n\004n" +
-      "ame\030\004 \001(\t\022\034\n\006labels\030\005 \003(\0132\014.mesos.Label\022" +
-      "\027\n\014service_port\030d \001(\r:\0010\032\310\001\n\017MesosDocker" +
-      "Info\022\r\n\005image\030\001 \002(\t\0220\n\025deprecated_creden" +
-      "tial\030\002 \001(\0132\021.mesos.Credential\022\030\n\020force_p" +
-      "ull_image\030\003 \001(\010\022Z\n\013pull_config\030\004 \001(\0132E.m" +
-      "esosphere.marathon.ExtendedContainerInfo" +
-      ".DockerInfo.ImagePullConfig\032b\n\rMesosAppC" +
-      "Info\022\r\n\005image\030\001 \002(\t\022\n\n\002id\030\002 \001(\t\022\034\n\006label",
-      "s\030\003 \003(\0132\014.mesos.Label\022\030\n\020force_pull_imag" +
-      "e\030\004 \001(\010\032\246\001\n\013PortMapping\022\021\n\thost_port\030\001 \001" +
-      "(\r\022\026\n\016container_port\030\002 \002(\r\022\020\n\010protocol\030\003" +
-      " \001(\t\022\014\n\004name\030\004 \001(\t\022\034\n\006labels\030\005 \003(\0132\014.mes" +
-      "os.Label\022\027\n\014service_port\030\006 \001(\r:\0010\022\025\n\rnet" +
-      "work_names\030\007 \003(\t\"\341\004\n\006Volume\022 \n\004mode\030\003 \002(" +
-      "\0162\022.mesos.Volume.Mode\022\026\n\016container_path\030" +
-      "\001 \002(\t\022\021\n\thost_path\030\002 \001(\t\022\033\n\005image\030\004 \001(\0132" +
-      "\014.mesos.Image\022D\n\npersistent\030\005 \001(\01320.meso" +
-      "sphere.marathon.Volume.PersistentVolumeI",
-      "nfo\022@\n\010external\030\006 \001(\0132..mesosphere.marat" +
-      "hon.Volume.ExternalVolumeInfo\022<\n\006secret\030" +
-      "\007 \001(\0132,.mesosphere.marathon.Volume.Secre" +
-      "tVolumeInfo\032\237\001\n\024PersistentVolumeInfo\022\014\n\004" +
-      "size\030\001 \002(\004\0222\n\004type\030\002 \001(\0162$.mesos.Resourc" +
-      "e.DiskInfo.Source.Type\0224\n\013constraints\030\003 " +
-      "\003(\0132\037.mesosphere.marathon.Constraint\022\017\n\007" +
-      "maxSize\030\004 \001(\004\032a\n\022ExternalVolumeInfo\022\014\n\004s" +
-      "ize\030\001 \001(\004\022\014\n\004name\030\002 \002(\t\022\020\n\010provider\030\003 \002(" +
-      "\t\022\035\n\007options\030\004 \003(\0132\014.mesos.Label\032\"\n\020Secr",
-      "etVolumeInfo\022\016\n\006secret\030\001 \002(\t\"\274\001\n\016Storage" +
-      "Version\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n" +
-      "\005patch\030\003 \002(\r\022I\n\006format\030\004 \001(\01621.mesospher" +
-      "e.marathon.StorageVersion.StorageFormat:" +
-      "\006LEGACY\"2\n\rStorageFormat\022\n\n\006LEGACY\020\000\022\025\n\021" +
-      "PERSISTENCE_STORE\020\001\"Z\n\031UpgradeStrategyDe" +
-      "finition\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022" +
-      "\036\n\023maximumOverCapacity\030\002 \001(\001:\0011\"\236\003\n\017Grou" +
-      "pDefinition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t" +
-      "\022?\n\017deprecated_apps\030\003 \003(\0132&.mesosphere.m",
-      "arathon.ServiceDefinition\0222\n\017deprecated_" +
-      "pods\030\010 \003(\0132\031.mesosphere.marathon.Json\0224\n" +
-      "\006groups\030\004 \003(\0132$.mesosphere.marathon.Grou" +
-      "pDefinition\022\024\n\014dependencies\030\005 \003(\t\022?\n\004app" +
-      "s\030\006 \003(\01321.mesosphere.marathon.GroupDefin" +
-      "ition.AppReference\022?\n\004pods\030\007 \003(\01321.mesos" +
-      "phere.marathon.GroupDefinition.AppRefere" +
-      "nce\032+\n\014AppReference\022\n\n\002id\030\001 \002(\t\022\017\n\007versi" +
-      "on\030\002 \002(\t\"\371\001\n\030DeploymentPlanDefinition\022\n\n" +
-      "\002id\030\001 \002(\t\022\021\n\ttimestamp\030\002 \001(\t\022A\n\023deprecat",
-      "ed_original\030\004 \001(\0132$.mesosphere.marathon." +
-      "GroupDefinition\022?\n\021deprecated_target\030\005 \001" +
-      "(\0132$.mesosphere.marathon.GroupDefinition" +
-      "\022\035\n\025original_root_version\030\006 \001(\t\022\033\n\023targe" +
-      "t_root_version\030\007 \001(\t\"\306\001\n\013TaskFailure\022\016\n\006" +
-      "app_id\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.Ta" +
-      "skID\022\037\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n" +
-      "\007message\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007vers" +
-      "ion\030\006 \002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030" +
-      "\010 \001(\0132\016.mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n",
-      "\004name\030\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014" +
-      "\022\031\n\ncompressed\030\004 \001(\010:\005false\"\326\001\n\023Residenc" +
-      "yDefinition\022(\n relaunchEscalationTimeout" +
-      "Seconds\030\001 \001(\003\022S\n\020taskLostBehavior\030\002 \001(\0162" +
-      "9.mesosphere.marathon.ResidencyDefinitio" +
-      "n.TaskLostBehavior\"@\n\020TaskLostBehavior\022\032" +
-      "\n\026RELAUNCH_AFTER_TIMEOUT\020\000\022\020\n\014WAIT_FOREV" +
-      "ER\020\001\"$\n\006Secret\022\n\n\002id\030\001 \002(\t\022\016\n\006source\030\002 \002" +
-      "(\t\"\262\001\n\017EnvVarReference\0227\n\004type\030\001 \002(\0162).m" +
-      "esosphere.marathon.EnvVarReference.Type\022",
-      "\014\n\004name\030\002 \002(\t\0227\n\tsecretRef\030\003 \001(\0132$.mesos" +
-      "phere.marathon.EnvVarSecretRef\"\037\n\004Type\022\013" +
-      "\n\007UNKNOWN\020\000\022\n\n\006SECRET\020\001\"#\n\017EnvVarSecretR" +
-      "ef\022\020\n\010secretId\030\001 \002(\t*3\n\rKillSelection\022\021\n" +
-      "\rYoungestFirst\020\001\022\017\n\013OldestFirst\020\002B\035\n\023mes" +
-      "osphere.marathonB\006Protos"
+      "aySeconds\030\013 \001(\r:\00215\022\020\n\010portName\030\014 \001(\t\022O\n" +
+      "\nipProtocol\030\r \001(\01625.mesosphere.marathon." +
+      "HealthCheckDefinition.IpProtocol:\004IPv4\"e" +
+      "\n\010Protocol\022\010\n\004HTTP\020\000\022\007\n\003TCP\020\001\022\013\n\007COMMAND" +
+      "\020\002\022\t\n\005HTTPS\020\003\022\016\n\nMESOS_HTTP\020\004\022\017\n\013MESOS_H" +
+      "TTPS\020\005\022\r\n\tMESOS_TCP\020\006\" \n\nIpProtocol\022\010\n\004I" +
+      "Pv4\020\001\022\010\n\004IPv6\020\002\"\240\002\n\030ReadinessCheckDefini" +
+      "tion\022\014\n\004name\030\001 \001(\t\022H\n\010protocol\030\002 \001(\01626.m" +
+      "esosphere.marathon.ReadinessCheckDefinit" +
+      "ion.Protocol\022\014\n\004path\030\003 \001(\t\022\020\n\010portName\030\004" +
+      " \001(\t\022\026\n\016intervalMillis\030\005 \001(\004\022\025\n\rtimeoutM" +
+      "illis\030\006 \001(\004\022\036\n\026httpStatusCodeForReady\030\007 " +
+      "\003(\r\022\034\n\024preserveLastResponse\030\010 \001(\010\"\037\n\010Pro" +
+      "tocol\022\010\n\004HTTP\020\000\022\t\n\005HTTPS\020\001\"\231\001\n\021ObsoleteI" +
+      "pAddress\022\016\n\006groups\030\001 \003(\t\022\034\n\006labels\030\002 \003(\013" +
+      "2\014.mesos.Label\022A\n\rdiscoveryInfo\030\003 \001(\0132*." +
+      "mesosphere.marathon.ObsoleteDiscoveryInf" +
+      "o\022\023\n\013networkName\030\004 \001(\t\"3\n\025ObsoleteDiscov" +
+      "eryInfo\022\032\n\005ports\030\001 \003(\0132\013.mesos.Port\"\264\001\n\021" +
+      "NetworkDefinition\0229\n\004mode\030\001 \001(\0162+.mesosp" +
+      "here.marathon.NetworkDefinition.Mode\022\014\n\004" +
+      "name\030\002 \001(\t\022\034\n\006labels\030\003 \003(\0132\014.mesos.Label" +
+      "\"8\n\004Mode\022\013\n\007UNKNOWN\020\000\022\010\n\004HOST\020\001\022\r\n\tCONTA" +
+      "INER\020\002\022\n\n\006BRIDGE\020\003\"\276\013\n\021ServiceDefinition" +
+      "\022\n\n\002id\030\001 \002(\t\022\037\n\003cmd\030\002 \002(\0132\022.mesos.Comman" +
+      "dInfo\022\021\n\tinstances\030\003 \002(\r\022\"\n\tresources\030\004 " +
+      "\003(\0132\017.mesos.Resource\022\023\n\013description\030\005 \001(" +
+      "\t\022\r\n\005ports\030\006 \003(\r\0224\n\013constraints\030\007 \003(\0132\037." +
+      "mesosphere.marathon.Constraint\022\022\n\010execut" +
+      "or\030\010 \002(\t:\000\022>\n\022OBSOLETE_container\030\n \001(\0132\"" +
+      ".mesosphere.marathon.ContainerInfo\022)\n\007ve" +
+      "rsion\030\013 \001(\t:\0301970-01-01T00:00:00.000Z\022@\n" +
+      "\014healthChecks\030\014 \003(\0132*.mesosphere.maratho" +
+      "n.HealthCheckDefinition\022\025\n\007backoff\030\r \001(\003" +
+      ":\0041000\022\033\n\rbackoffFactor\030\016 \001(\001:\0041.15\022G\n\017u" +
+      "pgradeStrategy\030\017 \001(\0132..mesosphere.marath" +
+      "on.UpgradeStrategyDefinition\022\024\n\014dependen" +
+      "cies\030\020 \003(\t\022\021\n\tstoreUrls\030\021 \003(\t\022\034\n\rrequire" +
+      "_ports\030\022 \001(\010:\005false\022=\n\tcontainer\030\023 \001(\0132*" +
+      ".mesosphere.marathon.ExtendedContainerIn" +
+      "fo\022 \n\006labels\030\024 \003(\0132\020.mesos.Parameter\022\037\n\016" +
+      "maxLaunchDelay\030\025 \001(\003:\0073600000\022A\n\025accepte" +
+      "dResourceRoles\030\026 \001(\0132\".mesosphere.marath" +
+      "on.ResourceRoles\022\027\n\017last_scaling_at\030\027 \001(" +
+      "\003\022\035\n\025last_config_change_at\030\030 \001(\003\022B\n\022OBSO" +
+      "LETE_ipAddress\030\031 \001(\0132&.mesosphere.marath" +
+      "on.ObsoleteIpAddress\022;\n\tresidency\030\032 \001(\0132" +
+      "(.mesosphere.marathon.ResidencyDefinitio" +
+      "n\022$\n\017portDefinitions\030\033 \003(\0132\013.mesos.Port\022" +
+      "O\n\030readinessCheckDefinition\030\034 \003(\0132-.meso" +
+      "sphere.marathon.ReadinessCheckDefinition" +
+      "\022,\n\007secrets\030\035 \003(\0132\033.mesosphere.marathon." +
+      "Secret\022>\n\020envVarReferences\030\036 \003(\0132$.mesos" +
+      "phere.marathon.EnvVarReference\022\033\n\023taskKi" +
+      "llGracePeriod\030\037 \001(\003\022E\n\023unreachableStrate" +
+      "gy\030  \001(\0132(.mesosphere.marathon.Unreachab" +
+      "leStrategy\022H\n\rkillSelection\030! \001(\0162\".meso" +
+      "sphere.marathon.KillSelection:\rYoungestF" +
+      "irst\0228\n\010networks\030\" \003(\0132&.mesosphere.mara" +
+      "thon.NetworkDefinition\022\033\n\003tty\030# \001(\0132\016.me" +
+      "sos.TTYInfo\"]\n\023UnreachableStrategy\022!\n\024in" +
+      "activeAfterSeconds\030\001 \001(\004:\003900\022#\n\023expunge" +
+      "AfterSeconds\030\002 \001(\004:\006604800\"\024\n\004Json\022\014\n\004js" +
+      "on\030\001 \002(\t\"\035\n\rResourceRoles\022\014\n\004role\030\001 \003(\t\"" +
+      "1\n\rContainerInfo\022\017\n\005image\030\001 \002(\014:\000\022\017\n\007opt" +
+      "ions\030\002 \003(\014\"\356\013\n\025ExtendedContainerInfo\022\'\n\004" +
+      "type\030\001 \002(\0162\031.mesos.ContainerInfo.Type\022,\n" +
+      "\007volumes\030\002 \003(\0132\033.mesosphere.marathon.Vol" +
+      "ume\022M\n\rport_mappings\030\006 \003(\01326.mesosphere." +
+      "marathon.ExtendedContainerInfo.PortMappi" +
+      "ng\022E\n\006docker\030\003 \001(\01325.mesosphere.marathon" +
+      ".ExtendedContainerInfo.DockerInfo\022O\n\013mes" +
+      "osDocker\030\004 \001(\0132:.mesosphere.marathon.Ext" +
+      "endedContainerInfo.MesosDockerInfo\022K\n\tme" +
+      "sosAppC\030\005 \001(\01328.mesosphere.marathon.Exte" +
+      "ndedContainerInfo.MesosAppCInfo\032\361\004\n\nDock" +
+      "erInfo\022\r\n\005image\030\001 \002(\t\022G\n\020OBSOLETE_networ" +
+      "k\030\002 \001(\0162\'.mesos.ContainerInfo.DockerInfo" +
+      ".Network:\004HOST\022o\n\026OBSOLETE_port_mappings" +
+      "\030\003 \003(\0132O.mesosphere.marathon.ExtendedCon" +
+      "tainerInfo.DockerInfo.ObsoleteDockerPort" +
+      "Mapping\022\031\n\nprivileged\030\004 \001(\010:\005false\022$\n\npa" +
+      "rameters\030\005 \003(\0132\020.mesos.Parameter\022\030\n\020forc" +
+      "e_pull_image\030\006 \001(\010\032\236\001\n\017ImagePullConfig\022X" +
+      "\n\004type\030\001 \002(\0162J.mesosphere.marathon.Exten" +
+      "dedContainerInfo.DockerInfo.ImagePullCon" +
+      "fig.Type\022\035\n\006secret\030\002 \001(\0132\r.mesos.Secret\"" +
+      "\022\n\004Type\022\n\n\006SECRET\020\001\032\235\001\n\031ObsoleteDockerPo" +
+      "rtMapping\022\021\n\thost_port\030\001 \001(\r\022\026\n\016containe" +
+      "r_port\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022\014\n\004name\030\004" +
+      " \001(\t\022\034\n\006labels\030\005 \003(\0132\014.mesos.Label\022\027\n\014se" +
+      "rvice_port\030d \001(\r:\0010\032\310\001\n\017MesosDockerInfo\022" +
+      "\r\n\005image\030\001 \002(\t\0220\n\025deprecated_credential\030" +
+      "\002 \001(\0132\021.mesos.Credential\022\030\n\020force_pull_i" +
+      "mage\030\003 \001(\010\022Z\n\013pull_config\030\004 \001(\0132E.mesosp" +
+      "here.marathon.ExtendedContainerInfo.Dock" +
+      "erInfo.ImagePullConfig\032b\n\rMesosAppCInfo\022" +
+      "\r\n\005image\030\001 \002(\t\022\n\n\002id\030\002 \001(\t\022\034\n\006labels\030\003 \003" +
+      "(\0132\014.mesos.Label\022\030\n\020force_pull_image\030\004 \001" +
+      "(\010\032\246\001\n\013PortMapping\022\021\n\thost_port\030\001 \001(\r\022\026\n" +
+      "\016container_port\030\002 \002(\r\022\020\n\010protocol\030\003 \001(\t\022" +
+      "\014\n\004name\030\004 \001(\t\022\034\n\006labels\030\005 \003(\0132\014.mesos.La" +
+      "bel\022\027\n\014service_port\030\006 \001(\r:\0010\022\025\n\rnetwork_" +
+      "names\030\007 \003(\t\"\341\004\n\006Volume\022 \n\004mode\030\003 \002(\0162\022.m" +
+      "esos.Volume.Mode\022\026\n\016container_path\030\001 \002(\t" +
+      "\022\021\n\thost_path\030\002 \001(\t\022\033\n\005image\030\004 \001(\0132\014.mes" +
+      "os.Image\022D\n\npersistent\030\005 \001(\01320.mesospher" +
+      "e.marathon.Volume.PersistentVolumeInfo\022@" +
+      "\n\010external\030\006 \001(\0132..mesosphere.marathon.V" +
+      "olume.ExternalVolumeInfo\022<\n\006secret\030\007 \001(\013" +
+      "2,.mesosphere.marathon.Volume.SecretVolu" +
+      "meInfo\032\237\001\n\024PersistentVolumeInfo\022\014\n\004size\030" +
+      "\001 \002(\004\0222\n\004type\030\002 \001(\0162$.mesos.Resource.Dis" +
+      "kInfo.Source.Type\0224\n\013constraints\030\003 \003(\0132\037" +
+      ".mesosphere.marathon.Constraint\022\017\n\007maxSi" +
+      "ze\030\004 \001(\004\032a\n\022ExternalVolumeInfo\022\014\n\004size\030\001" +
+      " \001(\004\022\014\n\004name\030\002 \002(\t\022\020\n\010provider\030\003 \002(\t\022\035\n\007" +
+      "options\030\004 \003(\0132\014.mesos.Label\032\"\n\020SecretVol" +
+      "umeInfo\022\016\n\006secret\030\001 \002(\t\"\274\001\n\016StorageVersi" +
+      "on\022\r\n\005major\030\001 \002(\r\022\r\n\005minor\030\002 \002(\r\022\r\n\005patc" +
+      "h\030\003 \002(\r\022I\n\006format\030\004 \001(\01621.mesosphere.mar" +
+      "athon.StorageVersion.StorageFormat:\006LEGA" +
+      "CY\"2\n\rStorageFormat\022\n\n\006LEGACY\020\000\022\025\n\021PERSI" +
+      "STENCE_STORE\020\001\"Z\n\031UpgradeStrategyDefinit" +
+      "ion\022\035\n\025minimumHealthCapacity\030\001 \002(\001\022\036\n\023ma" +
+      "ximumOverCapacity\030\002 \001(\001:\0011\"\236\003\n\017GroupDefi" +
+      "nition\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 \002(\t\022?\n\017d" +
+      "eprecated_apps\030\003 \003(\0132&.mesosphere.marath" +
+      "on.ServiceDefinition\0222\n\017deprecated_pods\030" +
+      "\010 \003(\0132\031.mesosphere.marathon.Json\0224\n\006grou" +
+      "ps\030\004 \003(\0132$.mesosphere.marathon.GroupDefi" +
+      "nition\022\024\n\014dependencies\030\005 \003(\t\022?\n\004apps\030\006 \003" +
+      "(\01321.mesosphere.marathon.GroupDefinition" +
+      ".AppReference\022?\n\004pods\030\007 \003(\01321.mesosphere" +
+      ".marathon.GroupDefinition.AppReference\032+" +
+      "\n\014AppReference\022\n\n\002id\030\001 \002(\t\022\017\n\007version\030\002 " +
+      "\002(\t\"\371\001\n\030DeploymentPlanDefinition\022\n\n\002id\030\001" +
+      " \002(\t\022\021\n\ttimestamp\030\002 \001(\t\022A\n\023deprecated_or" +
+      "iginal\030\004 \001(\0132$.mesosphere.marathon.Group" +
+      "Definition\022?\n\021deprecated_target\030\005 \001(\0132$." +
+      "mesosphere.marathon.GroupDefinition\022\035\n\025o" +
+      "riginal_root_version\030\006 \001(\t\022\033\n\023target_roo" +
+      "t_version\030\007 \001(\t\"\306\001\n\013TaskFailure\022\016\n\006app_i" +
+      "d\030\001 \002(\t\022\036\n\007task_id\030\002 \002(\0132\r.mesos.TaskID\022" +
+      "\037\n\005state\030\003 \002(\0162\020.mesos.TaskState\022\021\n\007mess" +
+      "age\030\004 \001(\t:\000\022\016\n\004host\030\005 \001(\t:\000\022\017\n\007version\030\006" +
+      " \002(\t\022\021\n\ttimestamp\030\007 \002(\t\022\037\n\007slaveId\030\010 \001(\013" +
+      "2\016.mesos.SlaveID\"T\n\014ZKStoreEntry\022\014\n\004name" +
+      "\030\001 \002(\t\022\014\n\004uuid\030\002 \002(\014\022\r\n\005value\030\003 \002(\014\022\031\n\nc" +
+      "ompressed\030\004 \001(\010:\005false\"\326\001\n\023ResidencyDefi" +
+      "nition\022(\n relaunchEscalationTimeoutSecon" +
+      "ds\030\001 \001(\003\022S\n\020taskLostBehavior\030\002 \001(\01629.mes" +
+      "osphere.marathon.ResidencyDefinition.Tas" +
+      "kLostBehavior\"@\n\020TaskLostBehavior\022\032\n\026REL" +
+      "AUNCH_AFTER_TIMEOUT\020\000\022\020\n\014WAIT_FOREVER\020\001\"" +
+      "$\n\006Secret\022\n\n\002id\030\001 \002(\t\022\016\n\006source\030\002 \002(\t\"\262\001" +
+      "\n\017EnvVarReference\0227\n\004type\030\001 \002(\0162).mesosp" +
+      "here.marathon.EnvVarReference.Type\022\014\n\004na" +
+      "me\030\002 \002(\t\0227\n\tsecretRef\030\003 \001(\0132$.mesosphere" +
+      ".marathon.EnvVarSecretRef\"\037\n\004Type\022\013\n\007UNK" +
+      "NOWN\020\000\022\n\n\006SECRET\020\001\"#\n\017EnvVarSecretRef\022\020\n" +
+      "\010secretId\030\001 \002(\t*3\n\rKillSelection\022\021\n\rYoun" +
+      "gestFirst\020\001\022\017\n\013OldestFirst\020\002B\035\n\023mesosphe" +
+      "re.marathonB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -46737,7 +47026,7 @@ public final class Protos {
     internal_static_mesosphere_marathon_HealthCheckDefinition_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mesosphere_marathon_HealthCheckDefinition_descriptor,
-        new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "Port", "DelaySeconds", "PortName", });
+        new java.lang.String[] { "Protocol", "PortIndex", "GracePeriodSeconds", "IntervalSeconds", "TimeoutSeconds", "Path", "MaxConsecutiveFailures", "Command", "IgnoreHttp1Xx", "Port", "DelaySeconds", "PortName", "IpProtocol", });
     internal_static_mesosphere_marathon_ReadinessCheckDefinition_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_mesosphere_marathon_ReadinessCheckDefinition_fieldAccessorTable = new

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -60,7 +60,7 @@ message HealthCheckDefinition {
   optional uint32 delaySeconds = 11 [default = 15];
   // portName and portIndex are exclusive; both must not be set
   optional string portName = 12;
-  optional IpProtocol ipProtocol = 13 [default = IPv4];
+  optional IpProtocol ipProtocol = 13;
 }
 
 message ReadinessCheckDefinition {

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -43,6 +43,10 @@ message HealthCheckDefinition {
     MESOS_HTTPS = 5;
     MESOS_TCP = 6;
   }
+  enum IpProtocol {
+    IPv4 = 1;
+    IPv6 = 2;
+  }
   required Protocol protocol = 1;
   optional uint32 portIndex = 2;
   optional uint32 gracePeriodSeconds = 3 [default = 15];
@@ -56,6 +60,7 @@ message HealthCheckDefinition {
   optional uint32 delaySeconds = 11 [default = 15];
   // portName and portIndex are exclusive; both must not be set
   optional string portName = 12;
+  optional IpProtocol ipProtocol = 13 [default = IPv4];
 }
 
 message ReadinessCheckDefinition {

--- a/src/main/proto/marathon.proto
+++ b/src/main/proto/marathon.proto
@@ -60,7 +60,7 @@ message HealthCheckDefinition {
   optional uint32 delaySeconds = 11 [default = 15];
   // portName and portIndex are exclusive; both must not be set
   optional string portName = 12;
-  optional IpProtocol ipProtocol = 13;
+  optional IpProtocol ipProtocol = 13 [default = IPv4];;
 }
 
 message ReadinessCheckDefinition {

--- a/src/main/proto/mesos/mesos.proto
+++ b/src/main/proto/mesos/mesos.proto
@@ -504,6 +504,8 @@ message HealthCheck {
   // treat return codes between 200 and 399 as success; custom executors
   // may employ a different strategy, e.g. leveraging the `statuses` field.
   message HTTPCheckInfo {
+    optional NetworkInfo.Protocol protocol = 5 [default = IPv4];
+
     // Currently "http" and "https" are supported.
     optional string scheme = 3;
 
@@ -539,6 +541,8 @@ message HealthCheck {
   // Describes a TCP health check, i.e. based on establishing
   // a TCP connection to the specified port.
   message TCPCheckInfo {
+    optional NetworkInfo.Protocol protocol = 2 [default = IPv4];
+
     // Port expected to be open.
     required uint32 port = 1;
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -8,6 +8,7 @@ import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation.{ featureEnabled, _ }
 import mesosphere.marathon.core.externalvolume.ExternalVolumes
+import mesosphere.marathon.core.health.IPv4
 import mesosphere.marathon.raml._
 import mesosphere.marathon.state.{ AppDefinition, PathId, ResourceRole }
 import mesosphere.marathon.stream.Implicits._
@@ -502,11 +503,11 @@ trait AppValidation {
         AppHealthCheckProtocol.MesosHttps,
         AppHealthCheckProtocol.MesosTcp)
 
-      def isMesosHttpTcpHealthCheck: Boolean = allowedProtocols.contains(healthCheck.protocol)
+      def isMesosHttpHealthCheck: Boolean = allowedProtocols.contains(healthCheck.protocol)
       def isDockerContainer = container.exists(c => c.`type` == EngineType.Docker)
-      val hasIpProtocol = healthCheck.ipProtocol.isDefined
+      val hasDefaultIpProtocol = healthCheck.ipProtocol == IpProtocol.Ipv4
 
-      !hasIpProtocol || (isMesosHttpTcpHealthCheck && isDockerContainer)
+      hasDefaultIpProtocol || (isMesosHttpHealthCheck && isDockerContainer)
     }
 
   private val haveAtMostOneMesosHealthCheck: Validator[App] = {

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -554,5 +554,5 @@ object AppValidationMessages {
     "may only specify a single container network when using the Docker container engine"
 
   val HealthCheckIpProtocolLimitation =
-    "Health check ipProtocol can be used only for docker container and mesos http/https/tcp healthcheck"
+    "Health check ipProtocol can only be used for docker container and mesos http/https/tcp healthcheck"
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -553,5 +553,5 @@ object AppValidationMessages {
     "may only specify a single container network when using the Docker container engine"
 
   val HealthCheckIpProtocolLimitation =
-    "Health check ipProtocol can only be used for docker container and mesos http/https/tcp healthcheck"
+    "IPv6 can only be used for container type DOCKER and Mesos http/https/tcp health checks"
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -498,12 +498,10 @@ trait AppValidation {
 
   private def complyWithIpProtocolRules(container: Option[Container]): Validator[AppHealthCheck] =
     isTrue(AppValidationMessages.HealthCheckIpProtocolLimitation) { healthCheck =>
-      val allowedProtocols = Set(
-        AppHealthCheckProtocol.MesosHttp,
-        AppHealthCheckProtocol.MesosHttps,
-        AppHealthCheckProtocol.MesosTcp)
-
-      def isMesosHttpHealthCheck: Boolean = allowedProtocols.contains(healthCheck.protocol)
+      def isMesosHttpHealthCheck: Boolean = healthCheck.protocol match {
+        case AppHealthCheckProtocol.MesosHttp | AppHealthCheckProtocol.MesosHttps | AppHealthCheckProtocol.MesosTcp => true
+        case _ => false
+      }
       def isDockerContainer = container.exists(c => c.`type` == EngineType.Docker)
       val hasDefaultIpProtocol = healthCheck.ipProtocol == IpProtocol.Ipv4
 

--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
@@ -294,6 +294,7 @@ object MesosHttpHealthCheck {
 
   def ipProtocolConversion(ipProtocol: IpProtocol): Protos.HealthCheckDefinition.IpProtocol = ipProtocol match {
     case IPv4 => Protos.HealthCheckDefinition.IpProtocol.IPv4
+    case IPv6 => Protos.HealthCheckDefinition.IpProtocol.IPv6
   }
 
   def ipProtocolToMesosProto(ipProtocol: IpProtocol): NetworkInfo.Protocol = ipProtocol match {

--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
@@ -294,14 +294,11 @@ object MesosHttpHealthCheck {
 
   def ipProtocolConversion(ipProtocol: IpProtocol): Protos.HealthCheckDefinition.IpProtocol = ipProtocol match {
     case IPv4 => Protos.HealthCheckDefinition.IpProtocol.IPv4
-    case IPv6 => Protos.HealthCheckDefinition.IpProtocol.IPv6
-    case _ => throw new IllegalStateException(s"Unsupported protocol in health check: $ipProtocol")
   }
 
   def ipProtocolToMesosProto(ipProtocol: IpProtocol): NetworkInfo.Protocol = ipProtocol match {
     case IPv4 => NetworkInfo.Protocol.IPv4
     case IPv6 => NetworkInfo.Protocol.IPv6
-    case _ => throw new IllegalStateException(s"Unsupported protocol in health check: $ipProtocol")
   }
 
   def mergeFromProto(proto: Protos.HealthCheckDefinition): MesosHttpHealthCheck =
@@ -366,7 +363,6 @@ object MesosTcpHealthCheck {
   def ipProtocolFromProto(ipProtocol: Protos.HealthCheckDefinition.IpProtocol): IpProtocol = ipProtocol match {
     case Protos.HealthCheckDefinition.IpProtocol.IPv4 => IPv4
     case Protos.HealthCheckDefinition.IpProtocol.IPv6 => IPv6
-    case _ => throw new IllegalStateException(s"Unsupported protocol in health check: $ipProtocol")
   }
 
   def mergeFromProto(proto: Protos.HealthCheckDefinition): MesosTcpHealthCheck =

--- a/src/main/scala/mesosphere/marathon/raml/HealthCheckConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/HealthCheckConversion.scala
@@ -166,19 +166,16 @@ trait HealthCheckConversion {
   private def ipProtocolFromRaml(ipProtocol: raml.IpProtocol): mesosphere.marathon.core.health.IpProtocol = ipProtocol match {
     case raml.IpProtocol.Ipv4 => IPv4
     case raml.IpProtocol.Ipv6 => IPv6
-    case _ => throw new IllegalStateException(s"Unsupported protocol in health check: $ipProtocol")
   }
 
   private def ipProtocolToRaml(ipProtocol: mesosphere.marathon.core.health.IpProtocol): raml.IpProtocol = ipProtocol match {
     case IPv4 => raml.IpProtocol.Ipv4
     case IPv6 => raml.IpProtocol.Ipv6
-    case _ => throw new IllegalStateException(s"Unsupported protocol in health check: $ipProtocol")
   }
 
   def ipProtocolFromProtoToRaml(ipProtocol: HealthCheckDefinition.IpProtocol): raml.IpProtocol = ipProtocol match {
     case HealthCheckDefinition.IpProtocol.IPv4 => raml.IpProtocol.Ipv4
     case HealthCheckDefinition.IpProtocol.IPv6 => raml.IpProtocol.Ipv6
-    case _ => throw new IllegalStateException(s"Unsupported protocol in health check: $ipProtocol")
   }
 
   implicit val appHealthCheckRamlReader: Reads[AppHealthCheck, CoreHealthCheck] = Reads { check =>

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
@@ -298,7 +298,7 @@ class AppValidationTest extends UnitTest with ValidationTestLike {
             Set(AppHealthCheck(
               protocol = protocol,
               port = Some(80),
-              ipProtocol = Some(IpProtocol.Ipv6))))
+              ipProtocol = IpProtocol.Ipv6)))
 
           basicValidator(dockerAppWithMesosHttpHealthCheck) should be(aSuccess)
         }
@@ -309,7 +309,7 @@ class AppValidationTest extends UnitTest with ValidationTestLike {
           Set(AppHealthCheck(
             protocol = AppHealthCheckProtocol.Http,
             port = Some(80),
-            ipProtocol = Some(IpProtocol.Ipv6))))
+            ipProtocol = IpProtocol.Ipv6)))
 
         basicValidator(dockerAppWithMarathonHttpHealthCheck) should haveViolations(
           "/healthChecks(0)" -> AppValidationMessages.HealthCheckIpProtocolLimitation)
@@ -335,16 +335,28 @@ class AppValidationTest extends UnitTest with ValidationTestLike {
           docker = Some(DockerContainer(
             image = "xyz")))))
 
-      "should fail even for otherwise supported types" in {
+      "fail even for otherwise supported types" in {
         allowedProtocols.foreach { protocol =>
           val ucrAppWithHealthCheck = ucrApp.copy(healthChecks =
             Set(AppHealthCheck(
               protocol = protocol,
               port = Some(80),
-              ipProtocol = Some(IpProtocol.Ipv6))))
+              ipProtocol = IpProtocol.Ipv6)))
 
           basicValidator(ucrAppWithHealthCheck) should haveViolations(
             "/healthChecks(0)" -> AppValidationMessages.HealthCheckIpProtocolLimitation)
+        }
+      }
+
+      "should pass always for IPv4" in {
+        allowedProtocols.foreach { protocol =>
+          val ucrAppWithHealthCheck = ucrApp.copy(healthChecks =
+            Set(AppHealthCheck(
+              protocol = protocol,
+              port = Some(80),
+              ipProtocol = IpProtocol.Ipv4)))
+
+          basicValidator(ucrAppWithHealthCheck) should be(aSuccess)
         }
       }
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
@@ -305,14 +305,25 @@ class AppValidationTest extends UnitTest with ValidationTestLike {
       }
 
       "fail for Marathon HTTP health check with ip protocol" in {
-        val dockerAppWithMesosHttpHealthCheck = dockerApp.copy(healthChecks =
+        val dockerAppWithMarathonHttpHealthCheck = dockerApp.copy(healthChecks =
           Set(AppHealthCheck(
             protocol = AppHealthCheckProtocol.Http,
             port = Some(80),
             ipProtocol = Some(IpProtocol.Ipv6))))
 
-        basicValidator(dockerAppWithMesosHttpHealthCheck) should haveViolations(
+        basicValidator(dockerAppWithMarathonHttpHealthCheck) should haveViolations(
           "/healthChecks(0)" -> AppValidationMessages.HealthCheckIpProtocolLimitation)
+      }
+
+      "pass validation even when no ipProtocol specified when Mesos HTTP/HTTPS/TCP" in {
+        allowedProtocols.foreach { protocol =>
+          val dockerAppWithMesosHttpHealthCheck = dockerApp.copy(healthChecks =
+            Set(AppHealthCheck(
+              protocol = protocol,
+              port = Some(80))))
+
+          basicValidator(dockerAppWithMesosHttpHealthCheck) should be(aSuccess)
+        }
       }
     }
 
@@ -326,13 +337,13 @@ class AppValidationTest extends UnitTest with ValidationTestLike {
 
       "should fail even for otherwise supported types" in {
         allowedProtocols.foreach { protocol =>
-          val dockerAppWithMesosHttpHealthCheck = ucrApp.copy(healthChecks =
+          val ucrAppWithHealthCheck = ucrApp.copy(healthChecks =
             Set(AppHealthCheck(
               protocol = protocol,
               port = Some(80),
               ipProtocol = Some(IpProtocol.Ipv6))))
 
-          basicValidator(dockerAppWithMesosHttpHealthCheck) should haveViolations(
+          basicValidator(ucrAppWithHealthCheck) should haveViolations(
             "/healthChecks(0)" -> AppValidationMessages.HealthCheckIpProtocolLimitation)
         }
       }

--- a/src/test/scala/mesosphere/marathon/core/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/HealthCheckTest.scala
@@ -17,6 +17,7 @@ import play.api.libs.json.Json
 import scala.concurrent.duration._
 
 class HealthCheckTest extends UnitTest {
+
   "HealthCheck" should {
     "ToProto Marathon HTTP HealthCheck with portIndex" in {
       val healthCheck = MarathonHttpHealthCheck(

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -130,7 +130,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPortIndex)
@@ -146,7 +147,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPort)
@@ -196,7 +198,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPortIndex.copy(protocol = Protocol.MESOS_HTTPS))
@@ -212,7 +215,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPort.copy(protocol = Protocol.MESOS_HTTPS))
@@ -262,7 +266,8 @@ class MesosHealthCheckTest extends UnitTest {
         gracePeriod = 10.seconds,
         interval = 60.seconds,
         maxConsecutiveFailures = 0,
-        port = Some(12345)
+        port = Some(12345),
+        ipProtocol = IPv6
       )
 
       val proto = healthCheck.toProto
@@ -274,6 +279,7 @@ class MesosHealthCheckTest extends UnitTest {
       assert(60 == proto.getIntervalSeconds)
       assert(0 == proto.getMaxConsecutiveFailures)
       assert(12345 == proto.getPort)
+      assert(Protos.HealthCheckDefinition.IpProtocol.IPv6 == proto.getIpProtocol)
     }
 
     "ToProto Mesos TCP HealthCheck with port" in {
@@ -281,7 +287,8 @@ class MesosHealthCheckTest extends UnitTest {
         port = Some(80),
         gracePeriod = 7.seconds,
         interval = 35.seconds,
-        maxConsecutiveFailures = 10
+        maxConsecutiveFailures = 10,
+        ipProtocol = IPv6
       )
 
       val proto = healthCheck.toProto
@@ -291,6 +298,7 @@ class MesosHealthCheckTest extends UnitTest {
       assert(7 == proto.getGracePeriodSeconds)
       assert(35 == proto.getIntervalSeconds)
       assert(10 == proto.getMaxConsecutiveFailures)
+      assert(Protos.HealthCheckDefinition.IpProtocol.IPv6 == proto.getIpProtocol)
     }
 
     "FromProto Mesos HTTP HealthCheck with portIndex" in {
@@ -302,6 +310,7 @@ class MesosHealthCheckTest extends UnitTest {
         .setIntervalSeconds(60)
         .setTimeoutSeconds(10)
         .setMaxConsecutiveFailures(10)
+        .setIpProtocol(Protos.HealthCheckDefinition.IpProtocol.IPv6)
         .build
 
       val mergeResult = HealthCheck.fromProto(proto)
@@ -314,7 +323,8 @@ class MesosHealthCheckTest extends UnitTest {
         interval = 60.seconds,
         timeout = 10.seconds,
         maxConsecutiveFailures = 10,
-        port = None
+        port = None,
+        ipProtocol = IPv6
       )
 
       assert(mergeResult == expectedResult)
@@ -382,6 +392,7 @@ class MesosHealthCheckTest extends UnitTest {
         .setIntervalSeconds(60)
         .setTimeoutSeconds(10)
         .setMaxConsecutiveFailures(10)
+        .setIpProtocol(Protos.HealthCheckDefinition.IpProtocol.IPv6)
         .build
 
       val mergeResult = HealthCheck.fromProto(proto)
@@ -393,7 +404,8 @@ class MesosHealthCheckTest extends UnitTest {
         gracePeriod = 10.seconds,
         interval = 60.seconds,
         timeout = 10.seconds,
-        maxConsecutiveFailures = 10
+        maxConsecutiveFailures = 10,
+        ipProtocol = IPv6
       )
 
       assert(mergeResult == expectedResult)
@@ -542,6 +554,18 @@ class MesosHealthCheckTest extends UnitTest {
 
       val (taskInfo, _) = task.get
       assertHttpHealthCheckProto(taskInfo, 80, "http")
+    }
+
+    "Mesos HTTP HealthCheck toMesos correctly serializes ip protocol" in {
+      import org.apache.mesos.Protos.NetworkInfo
+
+      val protoHealthCheck = MesosHttpHealthCheck(
+        path = Some("/health"),
+        protocol = Protocol.MESOS_HTTP,
+        port = Some(80),
+        ipProtocol = IPv6).toMesos()
+
+      protoHealthCheck.get.getHttp.getProtocol should be(NetworkInfo.Protocol.IPv6)
     }
 
     // Mesos TCP health check
@@ -765,7 +789,8 @@ class MesosHealthCheckTest extends UnitTest {
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
           "portIndex": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosTcpHealthCheckWithPortIndex)
@@ -780,7 +805,8 @@ class MesosHealthCheckTest extends UnitTest {
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
           "port": 80,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosTcpHealthCheckWithPort)

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -130,8 +130,7 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15,
-          "ipProtocol" : "IPv4"
+          "delaySeconds": 15
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPortIndex)
@@ -147,8 +146,7 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15,
-          "ipProtocol" : "IPv4"
+          "delaySeconds": 15
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPort)
@@ -198,8 +196,7 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15,
-          "ipProtocol" : "IPv4"
+          "delaySeconds": 15
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPortIndex.copy(protocol = Protocol.MESOS_HTTPS))
@@ -215,8 +212,7 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15,
-          "ipProtocol" : "IPv4"
+          "delaySeconds": 15
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPort.copy(protocol = Protocol.MESOS_HTTPS))
@@ -267,7 +263,7 @@ class MesosHealthCheckTest extends UnitTest {
         interval = 60.seconds,
         maxConsecutiveFailures = 0,
         port = Some(12345),
-        ipProtocol = IPv6
+        ipProtocol = Some(IPv6)
       )
 
       val proto = healthCheck.toProto
@@ -288,7 +284,7 @@ class MesosHealthCheckTest extends UnitTest {
         gracePeriod = 7.seconds,
         interval = 35.seconds,
         maxConsecutiveFailures = 10,
-        ipProtocol = IPv6
+        ipProtocol = Some(IPv6)
       )
 
       val proto = healthCheck.toProto
@@ -324,7 +320,7 @@ class MesosHealthCheckTest extends UnitTest {
         timeout = 10.seconds,
         maxConsecutiveFailures = 10,
         port = None,
-        ipProtocol = IPv6
+        ipProtocol = Some(IPv6)
       )
 
       assert(mergeResult == expectedResult)
@@ -405,7 +401,7 @@ class MesosHealthCheckTest extends UnitTest {
         interval = 60.seconds,
         timeout = 10.seconds,
         maxConsecutiveFailures = 10,
-        ipProtocol = IPv6
+        ipProtocol = Some(IPv6)
       )
 
       assert(mergeResult == expectedResult)
@@ -563,7 +559,7 @@ class MesosHealthCheckTest extends UnitTest {
         path = Some("/health"),
         protocol = Protocol.MESOS_HTTP,
         port = Some(80),
-        ipProtocol = IPv6).toMesos()
+        ipProtocol = Some(IPv6)).toMesos()
 
       protoHealthCheck.get.getHttp.getProtocol should be(NetworkInfo.Protocol.IPv6)
     }
@@ -789,8 +785,7 @@ class MesosHealthCheckTest extends UnitTest {
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
           "portIndex": 0,
-          "delaySeconds": 15,
-          "ipProtocol" : "IPv4"
+          "delaySeconds": 15
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosTcpHealthCheckWithPortIndex)
@@ -805,8 +800,7 @@ class MesosHealthCheckTest extends UnitTest {
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
           "port": 80,
-          "delaySeconds": 15,
-          "ipProtocol" : "IPv4"
+          "delaySeconds": 15
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosTcpHealthCheckWithPort)

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -60,7 +60,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 3,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(MesosCommandHealthCheck(command = Command("echo healthy")))
@@ -78,7 +79,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 3,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       val expected = MesosCommandHealthCheck(command = Command("echo healthy"))
@@ -130,7 +132,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPortIndex)
@@ -146,7 +149,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPort)
@@ -164,7 +168,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       assert(fromJson(portIndexJson) == mesosHttpHealthCheckWithPortIndex.copy(protocol = Protocol.MESOS_HTTPS))
@@ -179,7 +184,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       assert(fromJson(portJson) == mesosHttpHealthCheckWithPort.copy(protocol = Protocol.MESOS_HTTPS))
@@ -196,7 +202,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPortIndex.copy(protocol = Protocol.MESOS_HTTPS))
@@ -212,7 +219,8 @@ class MesosHealthCheckTest extends UnitTest {
           "intervalSeconds": 60,
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosHttpHealthCheckWithPort.copy(protocol = Protocol.MESOS_HTTPS))
@@ -263,7 +271,7 @@ class MesosHealthCheckTest extends UnitTest {
         interval = 60.seconds,
         maxConsecutiveFailures = 0,
         port = Some(12345),
-        ipProtocol = Some(IPv6)
+        ipProtocol = IPv6
       )
 
       val proto = healthCheck.toProto
@@ -284,7 +292,7 @@ class MesosHealthCheckTest extends UnitTest {
         gracePeriod = 7.seconds,
         interval = 35.seconds,
         maxConsecutiveFailures = 10,
-        ipProtocol = Some(IPv6)
+        ipProtocol = IPv6
       )
 
       val proto = healthCheck.toProto
@@ -320,7 +328,7 @@ class MesosHealthCheckTest extends UnitTest {
         timeout = 10.seconds,
         maxConsecutiveFailures = 10,
         port = None,
-        ipProtocol = Some(IPv6)
+        ipProtocol = IPv6
       )
 
       assert(mergeResult == expectedResult)
@@ -401,7 +409,7 @@ class MesosHealthCheckTest extends UnitTest {
         interval = 60.seconds,
         timeout = 10.seconds,
         maxConsecutiveFailures = 10,
-        ipProtocol = Some(IPv6)
+        ipProtocol = IPv6
       )
 
       assert(mergeResult == expectedResult)
@@ -559,7 +567,7 @@ class MesosHealthCheckTest extends UnitTest {
         path = Some("/health"),
         protocol = Protocol.MESOS_HTTP,
         port = Some(80),
-        ipProtocol = Some(IPv6)).toMesos()
+        ipProtocol = IPv6).toMesos()
 
       protoHealthCheck.get.getHttp.getProtocol should be(NetworkInfo.Protocol.IPv6)
     }
@@ -755,7 +763,8 @@ class MesosHealthCheckTest extends UnitTest {
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
           "portIndex": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       assert(fromJson(portIndexJson) == mesosTcpHealthCheckWithPortIndex)
@@ -769,7 +778,8 @@ class MesosHealthCheckTest extends UnitTest {
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
           "port": 80,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       assert(fromJson(portJson) == mesosTcpHealthCheckWithPort)
@@ -785,7 +795,8 @@ class MesosHealthCheckTest extends UnitTest {
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
           "portIndex": 0,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosTcpHealthCheckWithPortIndex)
@@ -800,7 +811,8 @@ class MesosHealthCheckTest extends UnitTest {
           "timeoutSeconds": 20,
           "maxConsecutiveFailures": 0,
           "port": 80,
-          "delaySeconds": 15
+          "delaySeconds": 15,
+          "ipProtocol" : "IPv4"
         }
       """
       JsonTestHelper.assertThatJsonOf(mesosTcpHealthCheckWithPort)

--- a/src/test/scala/mesosphere/marathon/raml/HealthCheckConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/HealthCheckConversionTest.scala
@@ -127,13 +127,14 @@ class HealthCheckConversionTest extends UnitTest {
 
   "A MesosHttpHealthCheck is converted correctly" when {
     "A core MesosHttpHealthCheck" should {
-      val check = MesosHttpHealthCheck()
+      val check = MesosHttpHealthCheck(ipProtocol = IPv6)
       val raml = check.toRaml[AppHealthCheck]
 
       behave like convertToProtobufThenToRAML(check, raml)
 
       "convert to a RAML AppHealthCheck" in {
         raml.protocol should be(AppHealthCheckProtocol.MesosHttp)
+        raml.ipProtocol should be(Some(mesosphere.marathon.raml.IpProtocol.Ipv6))
         raml.command should be(empty)
         raml.gracePeriodSeconds should be(check.gracePeriod.toSeconds)
         raml.ignoreHttp1xx should be(None)
@@ -147,11 +148,12 @@ class HealthCheckConversionTest extends UnitTest {
     }
     "An AppHealthCheck" should {
       "convert to a MesosHttpHealthCheck" in {
-        val check = AppHealthCheck(protocol = AppHealthCheckProtocol.MesosHttp)
+        val check = AppHealthCheck(protocol = AppHealthCheckProtocol.MesosHttp, ipProtocol = Some(IpProtocol.Ipv6))
         val core = Some(check.fromRaml).collect {
           case c: MesosHttpHealthCheck => c
         }.getOrElse(fail("expected MesosHttpHealthCheck"))
         core.protocol should be(Protos.HealthCheckDefinition.Protocol.MESOS_HTTP)
+        core.ipProtocol should be(IPv6)
         core.gracePeriod should be(check.gracePeriodSeconds.seconds)
         core.delay should be(CoreHealthCheck.DefaultDelay)
         core.interval should be(check.intervalSeconds.seconds)
@@ -183,13 +185,14 @@ class HealthCheckConversionTest extends UnitTest {
 
   "A MesosTcpHealthCheck is converted correctly" when {
     "A MesosTcpHealthCheck" should {
-      val check = MesosTcpHealthCheck()
+      val check = MesosTcpHealthCheck(ipProtocol = IPv6)
       val raml = check.toRaml[AppHealthCheck]
 
       behave like convertToProtobufThenToRAML(check, raml)
 
       "convert to a RAML AppHealthCheck" in {
         raml.protocol should be(AppHealthCheckProtocol.MesosTcp)
+        raml.ipProtocol should be(Some(mesosphere.marathon.raml.IpProtocol.Ipv6))
         raml.command should be(empty)
         raml.gracePeriodSeconds should be(check.gracePeriod.toSeconds)
         raml.ignoreHttp1xx should be(None)
@@ -203,10 +206,11 @@ class HealthCheckConversionTest extends UnitTest {
     }
     "An AppHealthCheck" should {
       "convert to a MesosTcpHealthCheck" in {
-        val check = AppHealthCheck(protocol = AppHealthCheckProtocol.MesosTcp)
+        val check = AppHealthCheck(protocol = AppHealthCheckProtocol.MesosTcp, ipProtocol = Some(IpProtocol.Ipv6))
         val core = Some(check.fromRaml).collect {
           case c: MesosTcpHealthCheck => c
         }.getOrElse(fail("expected MesosTcpHealthCheck"))
+        core.ipProtocol should be(IPv6)
         core.gracePeriod should be(check.gracePeriodSeconds.seconds)
         core.delay should be(CoreHealthCheck.DefaultDelay)
         core.interval should be(check.intervalSeconds.seconds)

--- a/src/test/scala/mesosphere/marathon/raml/HealthCheckConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/HealthCheckConversionTest.scala
@@ -127,7 +127,7 @@ class HealthCheckConversionTest extends UnitTest {
 
   "A MesosHttpHealthCheck is converted correctly" when {
     "A core MesosHttpHealthCheck" should {
-      val check = MesosHttpHealthCheck(ipProtocol = IPv6)
+      val check = MesosHttpHealthCheck(ipProtocol = Some(IPv6))
       val raml = check.toRaml[AppHealthCheck]
 
       behave like convertToProtobufThenToRAML(check, raml)
@@ -153,7 +153,7 @@ class HealthCheckConversionTest extends UnitTest {
           case c: MesosHttpHealthCheck => c
         }.getOrElse(fail("expected MesosHttpHealthCheck"))
         core.protocol should be(Protos.HealthCheckDefinition.Protocol.MESOS_HTTP)
-        core.ipProtocol should be(IPv6)
+        core.ipProtocol should be(Some(IPv6))
         core.gracePeriod should be(check.gracePeriodSeconds.seconds)
         core.delay should be(CoreHealthCheck.DefaultDelay)
         core.interval should be(check.intervalSeconds.seconds)
@@ -185,7 +185,7 @@ class HealthCheckConversionTest extends UnitTest {
 
   "A MesosTcpHealthCheck is converted correctly" when {
     "A MesosTcpHealthCheck" should {
-      val check = MesosTcpHealthCheck(ipProtocol = IPv6)
+      val check = MesosTcpHealthCheck(ipProtocol = Some(IPv6))
       val raml = check.toRaml[AppHealthCheck]
 
       behave like convertToProtobufThenToRAML(check, raml)
@@ -210,7 +210,7 @@ class HealthCheckConversionTest extends UnitTest {
         val core = Some(check.fromRaml).collect {
           case c: MesosTcpHealthCheck => c
         }.getOrElse(fail("expected MesosTcpHealthCheck"))
-        core.ipProtocol should be(IPv6)
+        core.ipProtocol should be(Some(IPv6))
         core.gracePeriod should be(check.gracePeriodSeconds.seconds)
         core.delay should be(CoreHealthCheck.DefaultDelay)
         core.interval should be(check.intervalSeconds.seconds)

--- a/src/test/scala/mesosphere/marathon/raml/HealthCheckConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/HealthCheckConversionTest.scala
@@ -127,14 +127,14 @@ class HealthCheckConversionTest extends UnitTest {
 
   "A MesosHttpHealthCheck is converted correctly" when {
     "A core MesosHttpHealthCheck" should {
-      val check = MesosHttpHealthCheck(ipProtocol = Some(IPv6))
+      val check = MesosHttpHealthCheck(ipProtocol = IPv6)
       val raml = check.toRaml[AppHealthCheck]
 
       behave like convertToProtobufThenToRAML(check, raml)
 
       "convert to a RAML AppHealthCheck" in {
         raml.protocol should be(AppHealthCheckProtocol.MesosHttp)
-        raml.ipProtocol should be(Some(mesosphere.marathon.raml.IpProtocol.Ipv6))
+        raml.ipProtocol should be(mesosphere.marathon.raml.IpProtocol.Ipv6)
         raml.command should be(empty)
         raml.gracePeriodSeconds should be(check.gracePeriod.toSeconds)
         raml.ignoreHttp1xx should be(None)
@@ -148,12 +148,12 @@ class HealthCheckConversionTest extends UnitTest {
     }
     "An AppHealthCheck" should {
       "convert to a MesosHttpHealthCheck" in {
-        val check = AppHealthCheck(protocol = AppHealthCheckProtocol.MesosHttp, ipProtocol = Some(IpProtocol.Ipv6))
+        val check = AppHealthCheck(protocol = AppHealthCheckProtocol.MesosHttp, ipProtocol = IpProtocol.Ipv6)
         val core = Some(check.fromRaml).collect {
           case c: MesosHttpHealthCheck => c
         }.getOrElse(fail("expected MesosHttpHealthCheck"))
         core.protocol should be(Protos.HealthCheckDefinition.Protocol.MESOS_HTTP)
-        core.ipProtocol should be(Some(IPv6))
+        core.ipProtocol should be(IPv6)
         core.gracePeriod should be(check.gracePeriodSeconds.seconds)
         core.delay should be(CoreHealthCheck.DefaultDelay)
         core.interval should be(check.intervalSeconds.seconds)
@@ -185,14 +185,14 @@ class HealthCheckConversionTest extends UnitTest {
 
   "A MesosTcpHealthCheck is converted correctly" when {
     "A MesosTcpHealthCheck" should {
-      val check = MesosTcpHealthCheck(ipProtocol = Some(IPv6))
+      val check = MesosTcpHealthCheck(ipProtocol = IPv6)
       val raml = check.toRaml[AppHealthCheck]
 
       behave like convertToProtobufThenToRAML(check, raml)
 
       "convert to a RAML AppHealthCheck" in {
         raml.protocol should be(AppHealthCheckProtocol.MesosTcp)
-        raml.ipProtocol should be(Some(mesosphere.marathon.raml.IpProtocol.Ipv6))
+        raml.ipProtocol should be(mesosphere.marathon.raml.IpProtocol.Ipv6)
         raml.command should be(empty)
         raml.gracePeriodSeconds should be(check.gracePeriod.toSeconds)
         raml.ignoreHttp1xx should be(None)
@@ -206,11 +206,11 @@ class HealthCheckConversionTest extends UnitTest {
     }
     "An AppHealthCheck" should {
       "convert to a MesosTcpHealthCheck" in {
-        val check = AppHealthCheck(protocol = AppHealthCheckProtocol.MesosTcp, ipProtocol = Some(IpProtocol.Ipv6))
+        val check = AppHealthCheck(protocol = AppHealthCheckProtocol.MesosTcp, ipProtocol = IpProtocol.Ipv6)
         val core = Some(check.fromRaml).collect {
           case c: MesosTcpHealthCheck => c
         }.getOrElse(fail("expected MesosTcpHealthCheck"))
-        core.ipProtocol should be(Some(IPv6))
+        core.ipProtocol should be(IPv6)
         core.gracePeriod should be(check.gracePeriodSeconds.seconds)
         core.delay should be(CoreHealthCheck.DefaultDelay)
         core.interval should be(check.intervalSeconds.seconds)


### PR DESCRIPTION
Summary:
Phase 1 of adding ipv6 support that is needed by our customers. Currently their infra is running on ipv4, only containers will be switched to ipv6.

This PR adds the possibility to specify that Mesos health check should be run on ipv6.

JIRA issues: MARATHON_EE-1713
