### PR TITLE
Network name with underscore is accepted by Marathon MARATHON-7851

### DIFF
--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -78,6 +78,5 @@ def pinger_container_app():
 def fake_framework():
     return load_app('fake-framework')
 
-
-def external_volume_mesos_app():
-    return load_app('external-volume-mesos-app')
+def network_name_underscore_app():
+    return load_app('network-name-underscore-app')

--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -78,5 +78,6 @@ def pinger_container_app():
 def fake_framework():
     return load_app('fake-framework')
 
+
 def network_name_underscore_app():
     return load_app('network-name-underscore-app')

--- a/tests/system/apps/network-name-underscore-app.json
+++ b/tests/system/apps/network-name-underscore-app.json
@@ -1,5 +1,5 @@
 {
-  "id": "/resident-docker-app",
+  "id": "/network-name-underscore-app",
   "instances": 1,
   "cpus": 0.1,
   "mem": 128,

--- a/tests/system/apps/network-name-underscore-app.json
+++ b/tests/system/apps/network-name-underscore-app.json
@@ -1,0 +1,16 @@
+{
+  "id": "/resident-docker-app",
+  "instances": 1,
+  "cpus": 0.1,
+  "mem": 128,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "nginx"
+    }
+  },
+  "networks": [{
+    "mode": "container",
+    "name": "network_name_with_underscore"
+  }]
+}

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -1077,6 +1077,20 @@ def test_vip_docker_bridge_mode(marathon_service_name):
 
     http_output_check()
 
+def test_network_name_with_underscore_is_deployed():
+    """Tests that application containing network name with underscore is accepted
+        by Marathon service.  We do not assert that the app is deployed because that
+        would require to create that network prior to running tests."""
+
+    app_def = apps.network_name_underscore_app()
+    client = marathon.create_client()
+    # add_app call already asserts that marathon returned response with new deployment
+    client.add_app(app_def)
+
+    # the deployment will never be finished so we have to cleanup after ourselves
+    client.remove_app(app_def['id'], True)
+    shakedown.deployment_wait(timedelta(minutes=5).total_seconds())
+
 
 def requires_marathon_version(version):
     """This python module is for testing root and MoM marathons.   The @marathon_1_5

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -1077,6 +1077,7 @@ def test_vip_docker_bridge_mode(marathon_service_name):
 
     http_output_check()
 
+@shakedown.dcos_1_10
 def test_network_name_with_underscore_is_deployed():
     """Tests that application containing network name with underscore is accepted
         by Marathon service.  We do not assert that the app is deployed because that

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -1077,6 +1077,7 @@ def test_vip_docker_bridge_mode(marathon_service_name):
 
     http_output_check()
 
+
 @shakedown.dcos_1_10
 def test_network_name_with_underscore_is_deployed():
     """Tests that application containing network name with underscore is accepted


### PR DESCRIPTION
Summary:
Verify that network name with underscore is accepted by marathon - we had a breaking change in on of the previous versions of Marathon and some of our customers rely on this behavior.

JIRA issues: MARATHON-7851
