### PR TITLE
Updated SI tests MoM-EE definitions

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -631,9 +631,13 @@ def add_acs_resource(resource):
 
 
 def add_dcos_marathon_user_acls(user='root'):
+    add_service_account_user_acls(service_account='dcos_marathon', user=user)
+
+
+def add_service_account_user_acls(service_account, user='root'):
     resource = 'dcos:mesos:master:task:user:{}'.format(user)
     add_acs_resource(resource)
-    set_service_account_permissions('dcos_marathon', resource, action='create')
+    set_service_account_permissions(service_account, resource, action='create')
 
 
 def get_marathon_endpoint(path, marathon_name='marathon'):

--- a/tests/system/fixtures/mom-ee-disabled-1.3.json
+++ b/tests/system/fixtures/mom-ee-disabled-1.3.json
@@ -2,7 +2,7 @@
   "id": "/marathon-user-ee",
   "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-disabled-1-3 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --zk zk://master.mesos:2181/universe/marathon-user-ee-1-3",
   "cpus": 2,
-  "mem": 1536,
+  "mem": 2048,
   "disk": 0,
   "instances": 1,
   "constraints": [
@@ -12,12 +12,13 @@
     ]
   ],
   "container": {
-    "type": "DOCKER",
+    "type": "MESOS",
     "docker": {
       "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
-      "network": "HOST",
+      "pullConfig": {
+        "secret": "config-json"
+      },
       "privileged": false,
-      "parameters": [],
       "forcePullImage": false
     },
     "volumes": [
@@ -29,31 +30,42 @@
     ]
   },
   "env": {
-    "JVM_OPTS": "-Xms256m -Xmx768m",
+    "JVM_OPTS": "-Xms256m -Xmx2g",
     "MESOS_NATIVE_JAVA_LIBRARY": "/opt/mesosphere/lib/libmesos.so",
     "PLUGIN_ACS_URL": "http://master.mesos",
     "PLUGIN_AUTHN_MODE": "disabled",
     "PLUGIN_FRAMEWORK_TYPE": "marathon"
+  },
+  "labels": {
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_NAME": "marathon-user-ee-disabled-1-3",
+    "DCOS_SERVICE_PORT_INDEX": "0"
   },
   "healthChecks": [
     {
       "path": "/ping",
       "protocol": "HTTP",
       "portIndex": 0,
-      "gracePeriodSeconds": 120,
+      "gracePeriodSeconds": 1800,
       "intervalSeconds": 10,
       "timeoutSeconds": 5,
       "maxConsecutiveFailures": 3,
       "ignoreHttp1xx": false
     }
   ],
-  "ports": [
-    0,
-    0
-  ],
-  "fetch": [
+  "secrets": {
+    "config-json": {
+      "source": "docker-credentials"
+    }
+  },
+  "portDefinitions": [
     {
-      "uri": "file:///home/core/docker.tar.gz"
+      "port": 0,
+      "name": "http"
+    },
+    {
+      "port": 0,
+      "name": "libprocess"
     }
   ]
 }

--- a/tests/system/fixtures/mom-ee-disabled-1.4.json
+++ b/tests/system/fixtures/mom-ee-disabled-1.4.json
@@ -25,7 +25,7 @@
   },
   "env": {
     "JVM_OPTS": "-Xms256m -Xmx2g",
-    "PLUGIN_ACS_URL": "https://master.mesos",
+    "PLUGIN_ACS_URL": "http://master.mesos",
     "PLUGIN_AUTHN_MODE": "disabled",
     "PLUGIN_FRAMEWORK_TYPE": "marathon"
   },

--- a/tests/system/fixtures/mom-ee-disabled-1.4.json
+++ b/tests/system/fixtures/mom-ee-disabled-1.4.json
@@ -1,6 +1,6 @@
 {
   "id": "/marathon-user-ee",
-  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-disabled-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --zk zk://master.mesos:2181/universe/marathon-user-ee",
+  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-disabled-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --zk zk://master.mesos:2181/universe/marathon-user-ee-1-4",
   "cpus": 2,
   "mem": 2048,
   "disk": 0,
@@ -12,20 +12,27 @@
     ]
   ],
   "container": {
-    "type": "DOCKER",
+    "type": "MESOS",
     "docker": {
       "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
-      "network": "HOST",
+      "pullConfig": {
+        "secret": "config-json"
+      },
       "privileged": false,
-      "parameters": [],
       "forcePullImage": false
-    }
+    },
+    "volumes": []
   },
   "env": {
     "JVM_OPTS": "-Xms256m -Xmx2g",
     "PLUGIN_ACS_URL": "https://master.mesos",
     "PLUGIN_AUTHN_MODE": "disabled",
     "PLUGIN_FRAMEWORK_TYPE": "marathon"
+  },
+  "labels": {
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_NAME": "marathon-user-ee-disabled-1-4",
+    "DCOS_SERVICE_PORT_INDEX": "0"
   },
   "healthChecks": [
     {
@@ -39,6 +46,11 @@
       "ignoreHttp1xx": false
     }
   ],
+  "secrets": {
+    "config-json": {
+      "source": "docker-credentials"
+    }
+  },
   "portDefinitions": [
     {
       "port": 0,
@@ -47,11 +59,6 @@
     {
       "port": 0,
       "name": "libprocess"
-    }
-  ],
-  "fetch": [
-    {
-      "uri": "file:///home/core/docker.tar.gz"
     }
   ]
 }

--- a/tests/system/fixtures/mom-ee-disabled-1.5.json
+++ b/tests/system/fixtures/mom-ee-disabled-1.5.json
@@ -12,20 +12,27 @@
     ]
   ],
   "container": {
-    "type": "DOCKER",
+    "type": "MESOS",
     "docker": {
       "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
-      "network": "HOST",
+      "pullConfig": {
+        "secret": "config-json"
+      },
       "privileged": false,
-      "parameters": [],
       "forcePullImage": false
-    }
+    },
+    "volumes": []
   },
   "env": {
     "JVM_OPTS": "-Xms256m -Xmx2g",
     "PLUGIN_ACS_URL": "https://master.mesos",
     "PLUGIN_AUTHN_MODE": "disabled",
     "PLUGIN_FRAMEWORK_TYPE": "marathon"
+  },
+  "labels": {
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_NAME": "marathon-user-ee-disabled-1-5",
+    "DCOS_SERVICE_PORT_INDEX": "0"
   },
   "healthChecks": [
     {
@@ -39,6 +46,11 @@
       "ignoreHttp1xx": false
     }
   ],
+  "secrets": {
+    "config-json": {
+      "source": "docker-credentials"
+    }
+  },
   "portDefinitions": [
     {
       "port": 0,
@@ -47,11 +59,6 @@
     {
       "port": 0,
       "name": "libprocess"
-    }
-  ],
-  "fetch": [
-    {
-      "uri": "file:///home/core/docker.tar.gz"
     }
   ]
 }

--- a/tests/system/fixtures/mom-ee-disabled-1.5.json
+++ b/tests/system/fixtures/mom-ee-disabled-1.5.json
@@ -25,7 +25,7 @@
   },
   "env": {
     "JVM_OPTS": "-Xms256m -Xmx2g",
-    "PLUGIN_ACS_URL": "https://master.mesos",
+    "PLUGIN_ACS_URL": "http://master.mesos",
     "PLUGIN_AUTHN_MODE": "disabled",
     "PLUGIN_FRAMEWORK_TYPE": "marathon"
   },

--- a/tests/system/fixtures/mom-ee-permissive-1.3.json
+++ b/tests/system/fixtures/mom-ee-permissive-1.3.json
@@ -2,7 +2,7 @@
   "id": "/marathon-user-ee",
   "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-permissive-1-3 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee-1-3 --mesos_authentication --mesos_authentication_principal marathon_user_ee",
   "cpus": 2,
-  "mem": 1536,
+    "mem": 2048,
   "disk": 0,
   "instances": 1,
   "constraints": [
@@ -12,12 +12,13 @@
     ]
   ],
   "container": {
-    "type": "DOCKER",
+      "type": "MESOS",
     "docker": {
       "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
-      "network": "HOST",
+        "pullConfig": {
+          "secret": "config-json"
+        },
       "privileged": false,
-      "parameters": [],
       "forcePullImage": false
     },
     "volumes": [
@@ -29,10 +30,10 @@
     ]
   },
   "env": {
-    "JVM_OPTS": "-Xms256m -Xmx768m",
+    "JVM_OPTS": "-Xms256m -Xmx2g",
     "DCOS_STRICT_SECURITY_ENABLED": "false",
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL_TOFILE": {
-      "secret": "service-credential"
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": {
+        "secret": "service-account"
     },
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_MODULES": "file:///opt/mesosphere/etc/mesos-scheduler-modules/dcos_authenticatee_module.json",
@@ -43,12 +44,17 @@
     "MESOS_NATIVE_JAVA_LIBRARY": "/opt/mesosphere/lib/libmesos.so",
     "PLUGIN_ACS_URL": "http://master.mesos"
   },
+  "labels": {
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_NAME": "marathon-user-ee-permissive-1-3",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  },
   "healthChecks": [
     {
       "path": "/ping",
       "protocol": "HTTP",
       "portIndex": 0,
-      "gracePeriodSeconds": 120,
+        "gracePeriodSeconds": 1800,
       "intervalSeconds": 10,
       "timeoutSeconds": 5,
       "maxConsecutiveFailures": 3,
@@ -56,17 +62,23 @@
     }
   ],
   "secrets": {
-    "service-credential": {
-      "source": "my-secret"
+      "service-account": {
+        "source": "service-credentials"
+      },
+      "config-json": {
+        "source": "docker-credentials"
     }
   },
-  "ports": [
-    0,
-    0
-  ],
-  "fetch": [
+    "portDefinitions": [
     {
-      "uri": "file:///home/core/docker.tar.gz"
+        "name": "http",
+        "port": 0
+      },
+      {
+        "name": "libprocess",
+        "port": 0
     }
-  ]
+    ],
+    "requirePorts": false,
+    "networks": []
 }

--- a/tests/system/fixtures/mom-ee-permissive-1.3.json
+++ b/tests/system/fixtures/mom-ee-permissive-1.3.json
@@ -2,7 +2,7 @@
   "id": "/marathon-user-ee",
   "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-permissive-1-3 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee-1-3 --mesos_authentication --mesos_authentication_principal marathon_user_ee",
   "cpus": 2,
-    "mem": 2048,
+  "mem": 2048,
   "disk": 0,
   "instances": 1,
   "constraints": [

--- a/tests/system/fixtures/mom-ee-permissive-1.4.json
+++ b/tests/system/fixtures/mom-ee-permissive-1.4.json
@@ -1,6 +1,6 @@
 {
   "id": "/marathon-user-ee",
-  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-permissive-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
+  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-permissive-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee-1-4 --mesos_authentication --mesos_authentication_principal marathon_user_ee",
   "cpus": 2,
   "mem": 2048,
   "disk": 0,
@@ -12,20 +12,22 @@
     ]
   ],
   "container": {
-    "type": "DOCKER",
+    "type": "MESOS",
     "docker": {
       "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
-      "network": "HOST",
+      "pullConfig": {
+        "secret": "config-json"
+      },
       "privileged": false,
-      "parameters": [],
       "forcePullImage": false
-    }
+    },
+    "volumes": []
   },
   "env": {
     "JVM_OPTS": "-Xms256m -Xmx2g",
     "DCOS_STRICT_SECURITY_ENABLED": "false",
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL_TOFILE": {
-      "secret": "service-credential"
+      "DCOS_SERVICE_ACCOUNT_CREDENTIAL": {
+        "secret": "service-account"
     },
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_MODULES": "{\"libraries\":[{\"file\":\"/opt/libmesos-bundle/lib/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
@@ -37,6 +39,11 @@
     "PLUGIN_AUTHN_MODE": "dcos/jwt+anonymous",
     "PLUGIN_FRAMEWORK_TYPE": "marathon"
   },
+  "labels": {
+        "DCOS_SERVICE_SCHEME": "http",
+        "DCOS_SERVICE_NAME": "marathon-user-ee-permissive-1-4",
+        "DCOS_SERVICE_PORT_INDEX": "0"
+      },
   "healthChecks": [
     {
       "path": "/ping",
@@ -50,23 +57,23 @@
     }
   ],
   "secrets": {
-    "service-credential": {
-      "source": "my-secret"
+      "service-account": {
+        "source": "service-credentials"
+      },
+      "config-json": {
+        "source": "docker-credentials"
     }
   },
   "portDefinitions": [
     {
-      "port": 0,
-      "name": "http"
+        "name": "http",
+        "port": 0
     },
     {
-      "port": 0,
-      "name": "libprocess"
+        "name": "libprocess",
+        "port": 0
     }
   ],
-  "fetch": [
-    {
-      "uri": "file:///home/core/docker.tar.gz"
-    }
-  ]
+    "requirePorts": false,
+    "networks": []
 }

--- a/tests/system/fixtures/mom-ee-permissive-1.5.json
+++ b/tests/system/fixtures/mom-ee-permissive-1.5.json
@@ -1,72 +1,79 @@
 {
-  "id": "/marathon-user-ee",
-  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-permissive-1-5 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_instances_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
-  "cpus": 2,
-  "mem": 2048,
-  "disk": 0,
-  "instances": 1,
-  "constraints": [
-    [
-      "hostname",
-      "UNIQUE"
-    ]
-  ],
-  "container": {
-    "type": "DOCKER",
-    "docker": {
-      "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
-      "network": "HOST",
-      "privileged": false,
-      "parameters": [],
-      "forcePullImage": false
-    }
-  },
-  "env": {
-    "JVM_OPTS": "-Xms256m -Xmx2g",
-    "DCOS_STRICT_SECURITY_ENABLED": "false",
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL_TOFILE": {
-      "secret": "service-credential"
+    "id": "/marathon-user-ee",
+    "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-permissive-1-5 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_instances_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee-1-5 --mesos_authentication --mesos_authentication_principal marathon_user_ee",
+    "cpus": 2,
+    "mem": 2048,
+    "disk": 0,
+    "instances": 1,
+    "constraints": [
+      [
+        "hostname",
+        "UNIQUE"
+      ]
+    ],
+    "container": {
+      "type": "MESOS",
+      "docker": {
+        "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
+        "pullConfig": {
+          "secret": "config-json"
+        },
+        "privileged": false,
+        "forcePullImage": false
+      },
+      "volumes": []
     },
-    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
-    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"/opt/libmesos-bundle/lib/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
-    "LIBPROCESS_SSL_ENABLED": "false",
-    "LIBPROCESS_SSL_SUPPORT_DOWNGRADE": "true",
-    "LIBPROCESS_SSL_REQUIRE_CERT": "false",
-    "LIBPROCESS_SSL_VERIFY_CERT": "false",
-    "PLUGIN_ACS_URL": "http://master.mesos",
-    "PLUGIN_AUTHN_MODE": "dcos/jwt+anonymous",
-    "PLUGIN_FRAMEWORK_TYPE": "marathon"
-  },
-  "healthChecks": [
-    {
-      "path": "/ping",
-      "protocol": "HTTP",
-      "portIndex": 0,
-      "gracePeriodSeconds": 1800,
-      "intervalSeconds": 10,
-      "timeoutSeconds": 5,
-      "maxConsecutiveFailures": 3,
-      "ignoreHttp1xx": false
-    }
-  ],
-  "secrets": {
-    "service-credential": {
-      "source": "my-secret"
-    }
-  },
-  "portDefinitions": [
-    {
-      "port": 0,
-      "name": "http"
+    "env": {
+      "JVM_OPTS": "-Xms256m -Xmx2g",
+      "DCOS_STRICT_SECURITY_ENABLED": "false",
+      "DCOS_SERVICE_ACCOUNT_CREDENTIAL": {
+        "secret": "service-account"
+      },
+      "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+      "MESOS_MODULES": "{\"libraries\":[{\"file\":\"/opt/libmesos-bundle/lib/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+      "LIBPROCESS_SSL_ENABLED": "false",
+      "LIBPROCESS_SSL_SUPPORT_DOWNGRADE": "true",
+      "LIBPROCESS_SSL_REQUIRE_CERT": "false",
+      "LIBPROCESS_SSL_VERIFY_CERT": "false",
+      "PLUGIN_ACS_URL": "http://master.mesos",
+      "PLUGIN_AUTHN_MODE": "dcos/jwt+anonymous",
+      "PLUGIN_FRAMEWORK_TYPE": "marathon"
     },
-    {
-      "port": 0,
-      "name": "libprocess"
-    }
-  ],
-  "fetch": [
-    {
-      "uri": "file:///home/core/docker.tar.gz"
-    }
-  ]
-}
+    "labels": {
+        "DCOS_SERVICE_SCHEME": "http",
+        "DCOS_SERVICE_NAME": "marathon-user-ee-permissive-1-5",
+        "DCOS_SERVICE_PORT_INDEX": "0"
+    },
+    "healthChecks": [
+      {
+        "path": "/ping",
+        "protocol": "HTTP",
+        "portIndex": 0,
+        "gracePeriodSeconds": 1800,
+        "intervalSeconds": 10,
+        "timeoutSeconds": 5,
+        "maxConsecutiveFailures": 3,
+        "ignoreHttp1xx": false
+      }
+    ],
+    "secrets": {
+      "service-account": {
+        "source": "service-credentials"
+      },
+      "config-json": {
+        "source": "docker-credentials"
+      }
+    },
+    "portDefinitions": [
+      {
+        "name": "http",
+        "port": 0
+      },
+      {
+        "name": "libprocess",
+        "port": 0
+      }
+    ],
+    "requirePorts": false,
+    "networks": []
+  }

--- a/tests/system/fixtures/mom-ee-strict-1.3.json
+++ b/tests/system/fixtures/mom-ee-strict-1.3.json
@@ -2,9 +2,10 @@
   "id": "/marathon-user-ee",
   "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-strict-1-3 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee-1-3 --mesos_authentication --mesos_authentication_principal marathon_user_ee",
   "cpus": 2,
-  "mem": 1536,
+  "mem": 2048,
   "disk": 0,
   "instances": 1,
+  "user": "root",
   "constraints": [
     [
       "hostname",
@@ -12,12 +13,13 @@
     ]
   ],
   "container": {
-    "type": "DOCKER",
+    "type": "MESOS",
     "docker": {
       "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
-      "network": "HOST",
+      "pullConfig": {
+        "secret": "config-json"
+      },
       "privileged": false,
-      "parameters": [],
       "forcePullImage": false
     },
     "volumes": [
@@ -29,10 +31,10 @@
     ]
   },
   "env": {
-    "JVM_OPTS": "-Xms256m -Xmx768m",
+    "JVM_OPTS": "-Xms256m -Xmx2g",
     "DCOS_STRICT_SECURITY_ENABLED": "true",
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL_TOFILE": {
-      "secret": "service-credential"
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": {
+      "secret": "service-account"
     },
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_MODULES": "file:///opt/mesosphere/etc/mesos-scheduler-modules/dcos_authenticatee_module.json",
@@ -43,12 +45,17 @@
     "MESOS_NATIVE_JAVA_LIBRARY": "/opt/mesosphere/lib/libmesos.so",
     "PLUGIN_ACS_URL": "https://master.mesos"
   },
+  "labels": {
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_NAME": "marathon-user-ee-strict-1-3",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  },
   "healthChecks": [
     {
       "path": "/ping",
       "protocol": "HTTP",
       "portIndex": 0,
-      "gracePeriodSeconds": 120,
+      "gracePeriodSeconds": 1800,
       "intervalSeconds": 10,
       "timeoutSeconds": 5,
       "maxConsecutiveFailures": 3,
@@ -56,17 +63,21 @@
     }
   ],
   "secrets": {
-    "service-credential": {
-      "source": "my-secret"
+    "service-account": {
+      "source": "service-credentials"
+    },
+    "config-json": {
+      "source": "docker-credentials"
     }
   },
-  "ports": [
-    0,
-    0
-  ],
-  "fetch": [
+  "portDefinitions": [
     {
-      "uri": "file:///home/core/docker.tar.gz"
+      "port": 0,
+      "name": "http"
+    },
+    {
+      "port": 0,
+      "name": "libprocess"
     }
   ]
 }

--- a/tests/system/fixtures/mom-ee-strict-1.4.json
+++ b/tests/system/fixtures/mom-ee-strict-1.4.json
@@ -1,10 +1,11 @@
 {
   "id": "/marathon-user-ee",
-  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-strict-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee --mesos_authentication --mesos_authentication_principal marathon_user_ee",
+  "cmd": "cd $MESOS_SANDBOX && LIBPROCESS_PORT=$PORT1 && /marathon/bin/start --default_accepted_resource_roles \"*\" --enable_features \"vips,task_killing,external_volumes,secrets,gpu_resources\" --framework_name marathon-user-ee-strict-1-4 --hostname $LIBPROCESS_IP --http_port $PORT0 --master zk://master.mesos:2181/mesos --max_tasks_per_offer 1 --mesos_leader_ui_url /mesos --mesos_role marathon-user-ee  --zk zk://master.mesos:2181/universe/marathon-user-ee-1-4 --mesos_authentication --mesos_authentication_principal marathon_user_ee",
   "cpus": 2,
   "mem": 2048,
   "disk": 0,
   "instances": 1,
+  "user": "root",
   "constraints": [
     [
       "hostname",
@@ -12,20 +13,22 @@
     ]
   ],
   "container": {
-    "type": "DOCKER",
+    "type": "MESOS",
     "docker": {
       "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
-      "network": "HOST",
+      "pullConfig": {
+        "secret": "config-json"
+      },
       "privileged": false,
-      "parameters": [],
       "forcePullImage": false
-    }
+    },
+    "volumes": []
   },
   "env": {
     "JVM_OPTS": "-Xms256m -Xmx2g",
     "DCOS_STRICT_SECURITY_ENABLED": "true",
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL_TOFILE": {
-      "secret": "service-credential"
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": {
+        "secret": "service-account"
     },
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_MODULES": "{\"libraries\":[{\"file\":\"/opt/libmesos-bundle/lib/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
@@ -36,6 +39,11 @@
     "PLUGIN_ACS_URL": "https://master.mesos",
     "PLUGIN_AUTHN_MODE": "dcos/jwt",
     "PLUGIN_FRAMEWORK_TYPE": "marathon"
+  },
+  "labels": {
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_NAME": "marathon-user-ee-strict-1-4",
+    "DCOS_SERVICE_PORT_INDEX": "0"
   },
   "healthChecks": [
     {
@@ -50,8 +58,11 @@
     }
   ],
   "secrets": {
-    "service-credential": {
-      "source": "my-secret"
+    "service-account": {
+      "source": "service-credentials"
+    },
+    "config-json": {
+      "source": "docker-credentials"
     }
   },
   "portDefinitions": [
@@ -62,11 +73,6 @@
     {
       "port": 0,
       "name": "libprocess"
-    }
-  ],
-  "fetch": [
-    {
-      "uri": "file:///home/core/docker.tar.gz"
     }
   ]
 }

--- a/tests/system/fixtures/mom-ee-strict-1.5.json
+++ b/tests/system/fixtures/mom-ee-strict-1.5.json
@@ -5,6 +5,7 @@
   "mem": 2048,
   "disk": 0,
   "instances": 1,
+  "user": "root",
   "constraints": [
     [
       "hostname",
@@ -12,20 +13,22 @@
     ]
   ],
   "container": {
-    "type": "DOCKER",
+    "type": "MESOS",
     "docker": {
       "image": "mesosphere/marathon-dcos-ee:__FILL_IN_VERSION_HERE__",
-      "network": "HOST",
+      "pullConfig": {
+        "secret": "config-json"
+      },
       "privileged": false,
-      "parameters": [],
       "forcePullImage": false
-    }
+    },
+    "volumes": []
   },
   "env": {
     "JVM_OPTS": "-Xms256m -Xmx2g",
     "DCOS_STRICT_SECURITY_ENABLED": "true",
-    "DCOS_SERVICE_ACCOUNT_CREDENTIAL_TOFILE": {
-      "secret": "service-credential"
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": {
+      "secret": "service-account"
     },
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_MODULES": "{\"libraries\":[{\"file\":\"/opt/libmesos-bundle/lib/libdcos_security.so\",\"modules\":[{\"name\":\"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
@@ -36,6 +39,11 @@
     "PLUGIN_ACS_URL": "https://master.mesos",
     "PLUGIN_AUTHN_MODE": "dcos/jwt",
     "PLUGIN_FRAMEWORK_TYPE": "marathon"
+  },
+  "labels": {
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_NAME": "marathon-user-ee-strict-1-5",
+    "DCOS_SERVICE_PORT_INDEX": "0"
   },
   "healthChecks": [
     {
@@ -50,8 +58,11 @@
     }
   ],
   "secrets": {
-    "service-credential": {
-      "source": "my-secret"
+    "service-account": {
+      "source": "service-credentials"
+    },
+    "config-json": {
+      "source": "docker-credentials"
     }
   },
   "portDefinitions": [
@@ -62,11 +73,6 @@
     {
       "port": 0,
       "name": "libprocess"
-    }
-  ],
-  "fetch": [
-    {
-      "uri": "file:///home/core/docker.tar.gz"
     }
   ]
 }

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -220,6 +220,7 @@ def cleanup():
     if common.has_secret(MOM_EE_DOCKER_CONFIG_SECRET_NAME):
         common.delete_secret(MOM_EE_DOCKER_CONFIG_SECRET_NAME)
 
+
 def setup_function(function):
     if is_mom_ee_deployed():
         remove_mom_ee()

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -9,6 +9,7 @@ import fixtures
 import os
 import pytest
 import shakedown
+import json
 
 from dcos import http
 from shakedown import marathon
@@ -18,7 +19,8 @@ from utils import get_resource
 
 MOM_EE_NAME = 'marathon-user-ee'
 MOM_EE_SERVICE_ACCOUNT = 'marathon_user_ee'
-MOM_EE_SECRET_NAME = 'my-secret'
+MOM_EE_SERVICE_ACCOUNT_SECRET_NAME = 'service-credentials'
+MOM_EE_DOCKER_CONFIG_SECRET_NAME = 'docker-credentials'
 
 PRIVATE_KEY_FILE = 'private-key.pem'
 PUBLIC_KEY_FILE = 'public-key.pem'
@@ -82,8 +84,14 @@ def assert_mom_ee(version, security_mode='permissive'):
     ensure_prerequisites_installed()
     ensure_service_account()
     ensure_permissions()
-    ensure_secret(strict=True if security_mode == 'strict' else False)
-    ensure_docker_credentials()
+    ensure_sa_secret(strict=True if security_mode == 'strict' else False)
+    ensure_docker_config_secret()
+
+    # In strict mode all tasks are started as user `nobody` by default. However we start
+    # MoM-EE as 'root' and for that we need to give root marathon ACLs to start
+    # tasks as 'root'.
+    if security_mode == 'strict':
+        common.add_dcos_marathon_user_acls()
 
     # Deploy MoM-EE in permissive mode
     app_def_file = '{}/mom-ee-{}-{}.json'.format(fixtures.fixtures_dir(), security_mode, version)
@@ -179,24 +187,27 @@ def ensure_permissions():
     assert req.json()['array'][0]['url'] == expected, "Service account permissions couldn't be set"
 
 
-def ensure_secret(strict=False):
-    if common.has_secret(MOM_EE_SECRET_NAME):
-        common.delete_secret(MOM_EE_SECRET_NAME)
-    common.create_sa_secret(MOM_EE_SECRET_NAME, MOM_EE_SERVICE_ACCOUNT, strict)
-    assert common.has_secret(MOM_EE_SECRET_NAME)
+def ensure_sa_secret(strict=False):
+    if common.has_secret(MOM_EE_SERVICE_ACCOUNT_SECRET_NAME):
+        common.delete_secret(MOM_EE_SERVICE_ACCOUNT_SECRET_NAME)
+    common.create_sa_secret(MOM_EE_SERVICE_ACCOUNT_SECRET_NAME, MOM_EE_SERVICE_ACCOUNT, strict)
+    assert common.has_secret(MOM_EE_SERVICE_ACCOUNT_SECRET_NAME)
 
 
-def ensure_docker_credentials():
+def ensure_docker_config_secret():
     # Docker username and password should be passed  as environment variables `DOCKER_HUB_USERNAME`
     # and `DOCKER_HUB_PASSWORD` (usually by jenkins)
     assert 'DOCKER_HUB_USERNAME' in os.environ, "Couldn't find docker hub username. $DOCKER_HUB_USERNAME is not set"
     assert 'DOCKER_HUB_PASSWORD' in os.environ, "Couldn't find docker hub password. $DOCKER_HUB_PASSWORD is not set"
 
+    if common.has_secret(MOM_EE_DOCKER_CONFIG_SECRET_NAME):
+        common.delete_secret(MOM_EE_DOCKER_CONFIG_SECRET_NAME)
+
     username = os.environ['DOCKER_HUB_USERNAME']
     password = os.environ['DOCKER_HUB_PASSWORD']
-
-    common.create_docker_credentials_file(username, password)
-    common.copy_docker_credentials_file(shakedown.get_private_agents())
+    config_json = common.create_docker_pull_config_json(username, password)
+    common.create_secret(MOM_EE_DOCKER_CONFIG_SECRET_NAME, value=json.dumps(config_json))
+    assert common.has_secret(MOM_EE_DOCKER_CONFIG_SECRET_NAME)
 
 
 def cleanup():
@@ -204,9 +215,10 @@ def cleanup():
         remove_mom_ee()
     if common.has_service_account(MOM_EE_SERVICE_ACCOUNT):
         common.delete_service_account(MOM_EE_SERVICE_ACCOUNT)
-    if common.has_secret(MOM_EE_SECRET_NAME):
-        common.delete_secret(MOM_EE_SECRET_NAME)
-
+    if common.has_secret(MOM_EE_SERVICE_ACCOUNT_SECRET_NAME):
+        common.delete_secret(MOM_EE_SERVICE_ACCOUNT_SECRET_NAME)
+    if common.has_secret(MOM_EE_DOCKER_CONFIG_SECRET_NAME):
+        common.delete_secret(MOM_EE_DOCKER_CONFIG_SECRET_NAME)
 
 def setup_function(function):
     if is_mom_ee_deployed():


### PR DESCRIPTION
Summary:
Now we are using:
- EBS (environment based secrets) to provide mom-ee service credentials
- `Docker.pullConfig` feature to pull MoM-EE images (instead of uploading docker credentials to all agents)
- `MESOS` containerizer instead of `DOCKER`
- setting `DCOS_SERVICE_*` labels properly to help admin router find MoM-EE as recommended in the docs

JIRA issues: MARATHON_EE-1696
