### PR TITLE
Test network name with underscore in controller

### DIFF
--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -348,6 +348,25 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
       }
     }
 
+    "Allow creating app with network name with underscore" in new Fixture {
+      Given("An app with a Docker config.json")
+      val container = RamlContainer(
+        `type` = EngineType.Mesos,
+        docker = Option(DockerContainer(
+          image = "private/image")))
+      val app = App(
+        id = "/app", cmd = Some("cmd"), container = Option(container),
+        networks = Seq(Network(name = Some("name_with_underscore"), mode = NetworkMode.Container)))
+      val (body, plan) = prepareApp(app, groupManager)
+
+      When("The create request is made")
+      clock += 5.seconds
+      val entity = HttpEntity(body).withContentType(ContentTypes.`application/json`)
+      Post(Uri./, entity) ~> route ~> check {
+        status shouldEqual StatusCodes.Created withClue s"body: ${ByteString(body).utf8String}, response: ${responseAs[String]}"
+      }
+    }
+
     "Do partial update with patch methods" in new Fixture {
       Given("An app")
       val id = "/app"

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -349,11 +349,11 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
     }
 
     "Allow creating app with network name with underscore" in new Fixture {
-      Given("An app with a Docker config.json")
+      Given("An app with a network name with underscore")
       val container = RamlContainer(
         `type` = EngineType.Mesos,
         docker = Option(DockerContainer(
-          image = "private/image")))
+          image = "image")))
       val app = App(
         id = "/app", cmd = Some("cmd"), container = Option(container),
         networks = Seq(Network(name = Some("name_with_underscore"), mode = NetworkMode.Container)))

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -1581,11 +1581,11 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
     }
 
     "Allow creating app with network name with underscore" in new Fixture {
-      Given("An app with a Docker config.json")
+      Given("An app with a network name with underscore")
       val container = RamlContainer(
         `type` = EngineType.Mesos,
         docker = Option(DockerContainer(
-          image = "private/image")))
+          image = "image")))
       val app = App(
         id = "/app", cmd = Some("cmd"), container = Option(container),
         networks = Seq(Network(name = Some("name_with_underscore"), mode = NetworkMode.Container)))

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -1579,5 +1579,24 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       (appJson \ "fetch" \ 0 \ "cache" get) should be(JsBoolean(false))
       (appJson \ "fetch" \ 0 \ "destPath" get) should be(JsString("bash.copy"))
     }
+
+    "Allow creating app with network name with underscore" in new Fixture {
+      Given("An app with a Docker config.json")
+      val container = RamlContainer(
+        `type` = EngineType.Mesos,
+        docker = Option(DockerContainer(
+          image = "private/image")))
+      val app = App(
+        id = "/app", cmd = Some("cmd"), container = Option(container),
+        networks = Seq(Network(name = Some("name_with_underscore"), mode = NetworkMode.Container)))
+      val (body, plan) = prepareApp(app, groupManager)
+
+      When("The create request is made")
+      clock += 5.seconds
+      val response = appsResource.create(body, force = false, auth.request)
+
+      Then("It is successful")
+      assert(response.getStatus == 201, s"body=${new String(body)}, response=${response.getEntity.asInstanceOf[String]}")
+    }
   }
 }


### PR DESCRIPTION
Summary:
Verify that network name with underscore is accepted by marathon - we had a breaking change in on of the previous versions of Marathon and some of our customers rely on this behavior.

JIRA issues: MARATHON-7851