### PR TITLE
marathon releases should publish libs

### DIFF
--- a/ci/awsClient.sc
+++ b/ci/awsClient.sc
@@ -94,6 +94,8 @@ def uploadFileAndSha(uploadFile: Path, s3path: S3Path): Artifact = {
   val shaFile = fileUtil.writeSha1ForFile(uploadFile)
 
   upload(uploadFile, s3path)
+  println(s"Sha1 for file: ${uploadFile}")
+  %('cat, shaFile)
   upload(shaFile, s3path)
   Artifact(s3path / uploadFile.last, read(shaFile))
 }

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -358,6 +358,7 @@ def release(requestVersion: String, gitSha: String, latest: Boolean = false): Un
     println("Docker image mesosphere/marathon:latest NOT updated")
   }
 
+  // publishing to the nexus repository.  This artifact is used by metronome.
   %('sbt, "publish")
 
   // TODO: git push fails currently b/c jenkins isn't authorized to push to GH

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -286,8 +286,6 @@ def master(): Unit = {
   maybeArtifact.foreach { artifact =>
     updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
   }
-  // TODO: Publish swagger files.
-  // TODO: Publish native packages to unstable.
 }
 
 /**
@@ -360,9 +358,88 @@ def release(requestVersion: String, gitSha: String, latest: Boolean = false): Un
     println("Docker image mesosphere/marathon:latest NOT updated")
   }
 
+  %('sbt, "publish")
+
   // TODO: git push fails currently b/c jenkins isn't authorized to push to GH
   // %('git, "push", "--tags")
 
   // TODO: Publish swagger files.
-  // TODO: Publish native packages to stable.
+}
+
+/**
+  * Given tagName v1.5.1, and rev DEADBEEF, we would assert that v1.5.0 is a direct ancestor of rev DEADBEEF
+  * this ensures that a v1.5.1 release can NOT happen on a branch that had a v1.6.0 release.
+  *
+  * Also, we assert that rev contains new commits since the last release. If the proposal is to tag v1.5.1 with same
+  * revision as v1.5.0, then we fail, saying that there v1.5.0 points to the commit porposed for v1.5.1
+  *
+  * @param tagName The tag name / version we are going to tag. eg v1.5.1
+  * @param gitSha The commit sha / rev that will be tagged.
+  */
+def assertPriorVersionIsAncestor(tagName: String, gitSha: String): Unit = {
+  utils.priorPatchVersion(tagName).foreach { prior =>
+    val revs = %%("git", "rev-list", "--format=oneline", s"${gitSha}..${prior}").out.string
+    if(revs.trim.nonEmpty) {
+      println(s"Error! ${prior} is not a direct ancestor of proposed commit ${gitSha} for ${tagName}!")
+      sys.exit(1)
+    }
+
+    val commitsSinceLast = %%("git", "rev-list", "--format=oneline", s"${prior}..${gitSha}").out.string
+    if(commitsSinceLast.trim.isEmpty) {
+      println(s"Error! ${prior} points to proposed commit ${gitSha} for ${tagName}!")
+      sys.exit(1)
+    }
+  }
+}
+
+def withoutVersionPrefix(releaseVersion: String): String = {
+    if(releaseVersion.toLowerCase.startsWith("v"))
+      releaseVersion.substring(1)
+    else
+      releaseVersion
+}
+
+def uploadLinuxPackagesToRepos(tagName: String): Unit = {
+  val pkgserverUser = sys.env.getOrElse("PKG_SSH_USER", {
+    throw new IllegalStateException("PKG_SSH_USER environment variable must be set")
+  })
+  val pkgserverHost = sys.env.getOrElse("PKG_SSH_HOST", {
+    throw new IllegalStateException("PKG_SSH_HOST environment variable must be set")
+  })
+
+  // Note - the key is expected to be provided via an SSH agent
+  utils.printStageTitle(s"Uploading native packages")
+  %("rsync", "-avz",
+    (pwd / 'target / 'packages) + "/",
+    s"${pkgserverUser}@${pkgserverHost}:repo/incoming/marathon-${tagName}/")
+
+  val pkgType = if (tagName.toLowerCase contains "rc")
+    "-testing"
+  else
+    ""
+
+  val mappings = Seq(
+    "systemd" -> s"debian/jessie${pkgType}",
+    "systemd" -> s"ubuntu/yakkety${pkgType}",
+    "systemd" -> s"ubuntu/xenial${pkgType}",
+    "systemd" -> s"ubuntu/wily${pkgType}",
+    "systemd" -> s"ubuntu/vivid${pkgType}",
+    "upstart" -> s"ubuntu/trusty${pkgType}",
+    "upstart" -> s"ubuntu/precise${pkgType}",
+    "systemv" -> s"el${pkgType}/6",
+    "systemd" -> s"el${pkgType}/7")
+
+  val copyCommands = mappings.map { case (packageType, path) =>
+    s"cp $$HOME/repo/incoming/marathon-${tagName}/${packageType}-marathon* " +
+    s"$$HOME/repo/incoming/${path}/"
+  }.mkString(";")
+
+  utils.printStageTitle("Distributing packages to distros")
+  %("ssh", s"${pkgserverUser}@${pkgserverHost}", "bash",
+    "-e", "-x", "-c",
+    utils.escapeCmdArg(List(
+      copyCommands,
+      s"rm -rf $$HOME/repo/incoming/marathon-${tagName}").mkString("\n")))
+
+  utils.printStageTitle("All done")
 }


### PR DESCRIPTION
marathon releases should publish libs

Summary:
Marathon releases to publish to nexus the marathon libs.   At a minimum metronome uses these.     It should be part of our automated release process.

Also it is more convenient to get the SHA of the uploaded tarball from the test logs.

JIRA issues:  MARATHON_EE-1752

