### PR TITLE
Perf optimize /v2/apps json writes. (~20% faster)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ sandboxes.tar.gz
 tests/performance/results
 ci.log
 ci.tar.gz
+*.jfr

--- a/benchmark/src/main/scala/mesosphere/marathon/json/JsonFormatBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/json/JsonFormatBenchmark.scala
@@ -1,0 +1,116 @@
+package mesosphere.marathon
+package json
+
+import java.util.concurrent.TimeUnit
+
+import mesosphere.marathon.api.v2.json.AppAndGroupFormats
+import mesosphere.marathon.core.appinfo.{AppInfo, EnrichedTask}
+import mesosphere.marathon.core.condition.Condition
+import mesosphere.marathon.core.instance.Instance.AgentInfo
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.Task.{LaunchedOnReservation, Reservation, Status}
+import mesosphere.marathon.core.task.state.NetworkInfo
+import mesosphere.marathon.state.{AppDefinition, EnvVarString, PathId, Timestamp}
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import play.api.libs.json.Json
+
+/**
+  * This benchmark focuses on the CPU time of [[AppAndGroupFormats.ExtendedAppInfoWrites]].
+  *
+  * GET /v2/apps?embed=apps.tasks is slow over a large number of apps (840 in our case).
+  *
+  * marathon-lb hammers this endpoint relentlessly. Json writing dominates CPU.
+  *
+  * Run with: {{{
+  *   benchmark/jmh:run -t1 -f1 -wi 5 -i 10 .*JsonFormatBenchmark
+  * }}}
+  *
+  * Or with Java Flight Recorder profiling: {{{
+  *   benchmark/jmh:run -prof jmh.extras.JFR -t1 -f1 -wi 5 -i 20 .*JsonFormatBenchmark
+  * }}}
+  */
+@State(Scope.Benchmark)
+object JsonFormatBenchmark extends AppAndGroupFormats {
+
+  /**
+    * Attempts to represent a real world-ish [[AppInfo]],
+    * with particular focus on accurately representing sizes of json objects,
+    * which translate to expensive scala Maps.
+    */
+  val realisticAppInfo: AppInfo = {
+
+    /**
+      * Taken from our dev cluster with: {{{
+      *   curl /v2/apps | jq '[.apps[].env | length] | add / length'
+      * }}}
+      */
+    val numEnvVars = 70
+
+    /**
+      * Taken from our dev cluster with: {{{
+      *   curl /v2/apps | jq '[.apps[].labels | length] | add / length'
+      * }}}
+      */
+    val numLabels = 11
+
+    val appId = PathId("benchmark/app/definition")
+
+    AppInfo(
+      app = AppDefinition(
+        id = appId,
+        env = 0.to(numEnvVars).map(i => ("KEY_" * 10) + i -> EnvVarString(("VALUE_" * 10) + i)).toMap,
+        labels = 0.to(numLabels).map(i => ("KEY_" * 10) + i -> (("VALUE_" * 10) + i)).toMap
+      ),
+      maybeTasks = Some(
+        Seq(
+          EnrichedTask(
+            appId,
+            task = LaunchedOnReservation(
+              taskId = Task.Id("benchmark_app_definition.2e251a11-af74-11e7-8e35-12ebe3d150b4"),
+              runSpecVersion = Timestamp.now(),
+              status = Status(
+                stagedAt = Timestamp.now(),
+                startedAt = Some(Timestamp.now()),
+                mesosStatus = None,
+                condition = Condition.Running,
+                networkInfo = NetworkInfo(
+                  hostName = "mesos-slave-i-039b610609702bc8a.mesos-dev.us-east-1e.example.com",
+                  hostPorts = Seq(30000),
+                  ipAddresses = Seq.empty
+                )
+              ),
+              reservation = Reservation(
+                volumeIds = Seq.empty,
+                state = Reservation.State.Launched
+              )
+            ),
+            agentInfo = AgentInfo(
+              host = "mesos-slave-i-039b610609702bc8a.mesos-dev.us-east-1e.example.com",
+              agentId = None,
+              region = None,
+              zone = None,
+              attributes = Seq.empty
+            ),
+            healthCheckResults = Seq.empty
+          )
+        )
+      )
+    )
+  }
+}
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+@Fork(1)
+class JsonFormatBenchmark {
+
+  import JsonFormatBenchmark._
+
+  @Benchmark
+  def appInfo(hole: Blackhole): Unit = {
+    val json = Json.toJson(realisticAppInfo)
+    hole.consume(json)
+  }
+}
+

--- a/build.sbt
+++ b/build.sbt
@@ -321,6 +321,5 @@ lazy val benchmark = (project in file("benchmark"))
   .dependsOn(marathon % "compile->compile; test->test")
   .settings(
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit),
-    libraryDependencies ++= Dependencies.benchmark,
-    generatorType in Jmh := "asm"
+    libraryDependencies ++= Dependencies.benchmark
   )

--- a/src/main/scala/mesosphere/marathon/raml/EnvVarConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/EnvVarConversion.scala
@@ -8,17 +8,17 @@ import scala.collection.immutable.Map
 trait EnvVarConversion {
   implicit val envVarRamlWrites: Writes[Map[String, state.EnvVarValue], Map[String, EnvVarValueOrSecret]] =
     Writes {
-      _.map {
-        case (name, state.EnvVarString(v)) => name -> EnvVarValue(v)
-        case (name, state.EnvVarSecretRef(secret: String)) => name -> EnvVarSecret(secret)
+      _.mapValues {
+        case (state.EnvVarString(v)) => EnvVarValue(v)
+        case (state.EnvVarSecretRef(secret: String)) => EnvVarSecret(secret)
       }
     }
 
   implicit val envVarReads: Reads[Map[String, EnvVarValueOrSecret], Map[String, state.EnvVarValue]] =
     Reads {
-      _.map {
-        case (name, EnvVarValue(v)) => name -> state.EnvVarString(v)
-        case (name, EnvVarSecret(secret: String)) => name -> state.EnvVarSecretRef(secret)
+      _.mapValues {
+        case EnvVarValue(v) => state.EnvVarString(v)
+        case EnvVarSecret(secret: String) => state.EnvVarSecretRef(secret)
       }
     }
 


### PR DESCRIPTION
Perf optimize /v2/apps json writes. (~20% faster)

## Problem
marathon-lb likes to hammer `GET /v2/apps?embed=apps.tasks`, which is driving the load average of our cluster up to 25.

This is driven by 3 factors.
1. We have 840 apps on the cluster, resulting in a 7 MB json response body.
2. We run 20 marathon-lb instances, far more than the recommended 2 (https://github.com/mesosphere/marathon-lb/issues/282).
3. play-json writes are expensive.

Our Ops team manages 1 and 2 which are beyond my control, so this change optimizes 3 (the play-json writes) a bit.

## Optimizing Json Writes
Profiling shows that json writes dominate CPU time, particularly generating scala Maps.

The worst offender is `EnvVarConversion.envVarRamlWrites`, which makes an unnecessary copy of the `"env"` map. Replacing `.map` with `.mapValues` produces a view instead of a copy and avoids rehashing the keys. This nets a cool 20% improvement over our typical use case.

![hot methods](https://user-images.githubusercontent.com/663139/33358607-99dd79a0-d497-11e7-930d-0135614f5654.png)

### Results
Before:
```
marathon(before)> benchmark/jmh:run -t1 -f3 -wi 10 -i 30 .*JsonFormatBenchmark
[info] Benchmark                     Mode  Cnt   Score   Error   Units
[info] JsonFormatBenchmark.appInfo  thrpt   90  32.456 ± 0.688  ops/ms
```

After:
```
marathon(perf-optimize-json)> benchmark/jmh:run -t1 -f3 -wi 10 -i 30 .*JsonFormatBenchmark
[info] Benchmark                     Mode  Cnt   Score   Error   Units
[info] JsonFormatBenchmark.appInfo  thrpt   90  41.079 ± 0.613  ops/ms
```

## jmh "asm"
This also reverts a change in https://github.com/mesosphere/marathon/commit/94efcee727612559ca227af4adce3a458281ee2c to set the jmh generator from "asm" back to the default. When set to "asm", sbt fails with https://gist.github.com/htmldoug/cbf820af93f89c4516893eb8ba4a163a and I can't get the benchmarks to run at all. Happy to set it back if someone can get it working.

## JIRA issues
None filed or searched for. I'm unfamiliar with your process. Holler if you need me to create some.