### PR TITLE
Backport 1.5 - Properly read secret volumes from protobufs

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -35,6 +35,10 @@ object Volume {
         external = ExternalVolumeInfo.fromProto(proto.getExternal),
         mode = proto.getMode
       )
+    else if (proto.hasSecret)
+      SecretVolume(
+        proto.getContainerPath,
+        proto.getSecret.getSecret)
     else
       DockerVolume(
         containerPath = proto.getContainerPath,

--- a/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
@@ -61,6 +61,10 @@ class VolumeTest extends UnitTest {
       hostPath = "/host/path",
       mode = Mode.RW
     )
+
+    val secretVol = SecretVolume(
+      containerPath = "secret-path",
+      secret = "secret-name")
   }
   object Fixture extends Fixture
 
@@ -72,6 +76,7 @@ class VolumeTest extends UnitTest {
     behave like survivesProtobufSerializationRoundtrip("ext vol w/o size", external(Fixture.extVolNoSize))
     behave like survivesProtobufSerializationRoundtrip("ext vol w/ size", external(Fixture.extVolWithSize))
     behave like survivesProtobufSerializationRoundtrip("host vol", Fixture.hostVol)
+    behave like survivesProtobufSerializationRoundtrip("secret vol", Fixture.secretVol)
 
     "validating PersistentVolumeInfo constraints accepts an empty constraint list" in new Fixture {
       validate(rootVolNoConstraints).isSuccess shouldBe true


### PR DESCRIPTION
When a secret volume was posted to Marathon, it would write it
properly, but when reading it back from the persistence layer it would
drop the secret and result in an invalid app

JIRA Issue: MARATHON_EE-1768, MARATHON_EE-1762