### PR TITLE
Fix for event stream tests with multimaster

### DIFF
--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -42,7 +42,7 @@ def events_to_file():
         shakedown.run_command(leader_ip,
             '(curl --compressed -H "Cache-Control: no-cache" -H "Accept: text/event-stream" ' +
             '-H "Authorization: token={}" '.format(shakedown.dcos_acs_token()) +
-            '-o events.txt -k https://marathon.mesos:8443/v2/events; echo $? > events.exitcode) &'.format(leader_ip))
+            '-o events.txt -k https://marathon.mesos:8443/v2/events; echo $? > events.exitcode) &')
 
     # Otherwise marathon runs on HTTP mode on port 8080
     else:

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -39,14 +39,16 @@ def events_to_file():
 
     # In strict mode marathon runs in SSL mode on port 8443 and requires authentication
     if shakedown.ee_version() == 'strict':
-        shakedown.run_command(leader_ip,
+        shakedown.run_command(
+            leader_ip,
             '(curl --compressed -H "Cache-Control: no-cache" -H "Accept: text/event-stream" ' +
             '-H "Authorization: token={}" '.format(shakedown.dcos_acs_token()) +
             '-o events.txt -k https://marathon.mesos:8443/v2/events; echo $? > events.exitcode) &')
 
     # Otherwise marathon runs on HTTP mode on port 8080
     else:
-        shakedown.run_command(leader_ip,
+        shakedown.run_command(
+            leader_ip,
             '(curl --compressed -H "Cache-Control: no-cache" -H "Accept: text/event-stream" '
             '-o events.txt http://marathon.mesos:8080/v2/events; echo $? > events.exitcode) &')
 

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -33,26 +33,27 @@ def wait_for_marathon_user_and_cleanup():
 
 @pytest.fixture(scope="function")
 def events_to_file():
+    leader_ip = shakedown.marathon_leader_ip()
     print("entering events_to_file fixture")
-    shakedown.run_command_on_master('rm events.txt')
+    shakedown.run_command(leader_ip, 'rm events.txt')
 
     # In strict mode marathon runs in SSL mode on port 8443 and requires authentication
     if shakedown.ee_version() == 'strict':
-        shakedown.run_command_on_master(
+        shakedown.run_command(leader_ip,
             '(curl --compressed -H "Cache-Control: no-cache" -H "Accept: text/event-stream" ' +
             '-H "Authorization: token={}" '.format(shakedown.dcos_acs_token()) +
-            '-o events.txt -k https://leader.mesos:8443/v2/events; echo $? > events.exitcode) &')
+            '-o events.txt -k https://marathon.mesos:8443/v2/events; echo $? > events.exitcode) &'.format(leader_ip))
 
     # Otherwise marathon runs on HTTP mode on port 8080
     else:
-        shakedown.run_command_on_master(
+        shakedown.run_command(leader_ip,
             '(curl --compressed -H "Cache-Control: no-cache" -H "Accept: text/event-stream" '
-            '-o events.txt http://leader.mesos:8080/v2/events; echo $? > events.exitcode) &')
+            '-o events.txt http://marathon.mesos:8080/v2/events; echo $? > events.exitcode) &')
 
     yield
-    shakedown.kill_process_on_host(shakedown.master_ip(), '[c]url')
-    shakedown.run_command_on_master('rm events.txt')
-    shakedown.run_command_on_master('rm events.exitcode')
+    shakedown.kill_process_on_host(leader_ip, '[c]url')
+    shakedown.run_command(leader_ip, 'rm events.txt')
+    shakedown.run_command(leader_ip, 'rm events.exitcode')
     print("exiting events_to_file fixture")
 
 

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -120,12 +120,14 @@ def test_event_channel_for_pods():
     client.add_pod(pod_def)
     common.deployment_wait(service_id=pod_id)
 
+    leader_ip = shakedown.marathon_leader_ip()
+
     # look for created
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_deployment_message():
-        status, stdout = shakedown.run_command_on_master('cat events.exitcode')
+        status, stdout = shakedown.run_command(leader_ip, 'cat events.exitcode')
         assert str(stdout).strip() == '', "SSE stream disconnected (CURL exit code is {})".format(stdout.strip())
-        status, stdout = shakedown.run_command_on_master('cat events.txt')
+        status, stdout = shakedown.run_command(leader_ip, 'cat events.txt')
         assert 'event_stream_attached' in stdout, "event_stream_attached event has not been produced"
         assert 'pod_created_event' in stdout, "pod_created_event event has not been produced"
         assert 'deployment_step_success' in stdout, "deployment_step_success event has not beed produced"

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -141,7 +141,7 @@ def test_event_channel_for_pods():
     # look for updated
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_update_message():
-        status, stdout = shakedown.run_command_on_master('cat events.txt')
+        status, stdout = shakedown.run_command(leader_ip, 'cat events.txt')
         assert 'pod_updated_event' in stdout, 'pod_update_event event has not been produced'
 
     check_update_message()

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -216,13 +216,13 @@ def test_event_channel():
     client.add_app(app_def)
     shakedown.deployment_wait(app_id=app_id)
 
-    master_ip = shakedown.master_ip()
+    leader_ip = shakedown.marathon_leader_ip()
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_deployment_message():
-        status, stdout = shakedown.run_command_on_master('cat events.exitcode')
+        status, stdout = shakedown.run_command(leader_ip, 'cat events.exitcode')
         assert str(stdout).strip() == '', "SSE stream disconnected (CURL exit code is {})".format(stdout.strip())
-        status, stdout = shakedown.run_command(master_ip, 'cat events.txt')
+        status, stdout = shakedown.run_command(leader_ip, 'cat events.txt')
         assert 'event_stream_attached' in stdout, "event_stream_attached event has not been found"
         assert 'deployment_info' in stdout, "deployment_info event has not been found"
         assert 'deployment_step_success' in stdout, "deployment_step_success has not been found"
@@ -233,7 +233,7 @@ def test_event_channel():
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_kill_message():
-        status, stdout = shakedown.run_command(master_ip, 'cat events.txt')
+        status, stdout = shakedown.run_command(leader_ip, 'cat events.txt')
         assert 'KILLED' in stdout, "KILLED event has not been found"
 
     check_kill_message()


### PR DESCRIPTION
Summary:
Event stream tests were failing after switch to multimaster. The reason for that is that all the commands were talking to (mesos) master but there are multiple masters now so the commands might be executed on different nodes. Now I do the curl always on marathon leader to make that deterministic.

JIRA issues: MARATHON-7943
