### PR TITLE
Benchmark and speed up service port assignment by up to three magnitu…

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,3 +4,26 @@ within SBT.
 See here for more details:
 [SBT-JMH](https://github.com/ktoso/sbt-jmh)
 [JMS-Samples](http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/)
+
+## Flamegraphs
+
+[Flamegraphs](http://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html) are a
+great tool to figure out where processing time is spent. You can create one by
+following these steps
+
+### Prerequisites
+
+You should have [jfr-flame-graph](https://github.com/chrishantha/jfr-flame-graph)
+and [FlameGraph](https://github.com/brendangregg/FlameGraph) installed or rather
+runnable on you machine.
+
+You also need the environment variable `FLAMEGRAPH_DIR` set to the path of the
+FlameGraph by Brandan Gregg.
+
+### Creating Flamegraphs
+
+1. Create a flight record of the benchmark run by passing `-prof jmh.extras.JFR`
+  to the run, e.g. `sbt "benchmark/jmh:run -prof jmh.extras.JFR -i 1 -wi 3 -f1
+  -t1 .*GroupManagerBenchmark"`. This will produce a `.jfr` file in the
+  benchmark folder.
+2. Create a flamegraph SVG file with `<path to jfr-flame-graph>/create_flamegraph.sh -f  <path to jfr file> -i > flamegraph.svg`.

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
@@ -1,0 +1,104 @@
+package mesosphere.marathon
+package upgrade
+
+import java.util.concurrent.TimeUnit
+
+import mesosphere.marathon.core.group.impl.AssignDynamicServiceLogic
+import mesosphere.marathon.core.pod.{ BridgeNetwork, MesosContainer }
+import mesosphere.marathon.raml.{ Endpoint, Image, ImageType, Resources }
+import mesosphere.marathon.state.Container
+import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.state._
+import mesosphere.marathon.core.pod.PodDefinition
+import org.openjdk.jmh.annotations.{ Group => _, _ }
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.collection.breakOut
+
+@State(Scope.Benchmark)
+class GroupBenchmark {
+
+  val version = VersionInfo.forNewConfig(Timestamp(1))
+
+  def makeApp(path: PathId) =
+    AppDefinition(
+      id = path,
+      labels = Map("ID" -> path.toString),
+      versionInfo = version,
+      networks = Seq(BridgeNetwork()),
+      container = Some(
+        Container.Docker(Nil, "alpine", List(Container.PortMapping(2015, Some(0), 10000, "tcp", Some("thing")))))
+    )
+
+  def makePod(path: PathId) =
+    PodDefinition(
+      id = path,
+      networks = Seq(BridgeNetwork()),
+      labels = Map("ID" -> path.toString),
+      versionInfo = version,
+
+      containers = Seq(
+        MesosContainer(
+          "container-1",
+          resources = Resources(1.0),
+          image = Some(Image(ImageType.Docker, "alpine")),
+          endpoints = List(
+            Endpoint(
+              "service",
+              Some(2015),
+              Some(0),
+              Seq("tcp"))))))
+
+  @Param(value = Array("100", "500", "1000", "2500", "5000"))
+  var numberOfSavedApps: Int = _
+  lazy val ids = 0 until numberOfSavedApps
+
+  @Param(value = Array("5", "15"))
+  var numberOfGroups: Int = _
+  lazy val groupIds = 0 until numberOfGroups
+
+  lazy val childGroupPaths: Vector[PathId] = groupIds.map { groupId =>
+    s"group-$groupId".toRootPath
+  }(breakOut)
+
+  lazy val rootGroup: RootGroup = fillRootGroup()
+
+  // Create apps and add them to their groups
+  def fillRootGroup(): RootGroup = {
+    var tmpGroup = RootGroup()
+    ids.foreach { appId =>
+      val groupPath = childGroupPaths(appId % numberOfGroups)
+      val path = groupPath / s"app-${appId}"
+      val app = makeApp(path)
+      tmpGroup = tmpGroup.updateApp(path, (maybeApp) => app) // because we create an app, you know.
+    }
+    tmpGroup
+  }
+
+  def upgraded = {
+    val appId = childGroupPaths(0) / s"app-$numberOfSavedApps"
+    rootGroup.updateApp(appId, (maybeApp) => makeApp(appId))
+  }
+}
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+class GroupManagerBenchmark extends GroupBenchmark {
+
+  @Benchmark
+  def updateVersionInfoForChangedApps(hole: Blackhole): Unit = {
+    println(rootGroup.groupsById.keys)
+    val newRootGroup = GroupVersioningUtil.updateVersionInfoForChangedApps(
+      Timestamp (2),
+      rootGroup, upgraded)
+    hole.consume(newRootGroup)
+  }
+
+  @Benchmark
+  def assignDynamicServicePorts(hole: Blackhole): Unit = {
+    val portRange = 10000 until 20000
+    val newRootGroup = AssignDynamicServiceLogic.assignDynamicServicePorts(portRange, rootGroup, upgraded)
+    hole.consume(newRootGroup)
+  }
+}

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
@@ -88,7 +88,6 @@ class GroupManagerBenchmark extends GroupBenchmark {
 
   @Benchmark
   def updateVersionInfoForChangedApps(hole: Blackhole): Unit = {
-    println(rootGroup.groupsById.keys)
     val newRootGroup = GroupVersioningUtil.updateVersionInfoForChangedApps(
       Timestamp (2),
       rootGroup, upgraded)

--- a/src/main/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogic.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogic.scala
@@ -1,0 +1,108 @@
+package mesosphere.marathon
+package core.group.impl
+
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.state._
+
+import scala.collection.immutable.Seq
+
+object AssignDynamicServiceLogic extends StrictLogging {
+
+  /**
+    * Checks whether newApp is new or changed.
+    * @param originalApps A map of the original apps form before the update.
+    * @param newApp The new app that is tested.
+    * @return true if app is new or an updated, false otherwise.
+    */
+  private def changedOrNew(originalApps: Map[AppDefinition.AppKey, AppDefinition], newApp: AppDefinition): Boolean = {
+    originalApps.get(newApp.id).forall { _.isUpgrade(newApp) }
+  }
+
+  private def mergeServicePortsAndPortDefinitions(
+    portDefinitions: Seq[PortDefinition],
+    servicePorts: Seq[Int]): Seq[PortDefinition] =
+    if (portDefinitions.nonEmpty)
+      portDefinitions.zipAll(servicePorts, AppDefinition.RandomPortDefinition, AppDefinition.RandomPortValue).map {
+        case (portDefinition, servicePort) => portDefinition.copy(port = servicePort)
+      }
+    else Seq.empty
+
+  /**
+    * CONTAINS SIDE EFFECTS!!!
+    *
+    * Given some app, replace all service port 0 specifications with an assigned service port.
+    *
+    * Assignment logic is:
+    * 1) First, scan for service ports used in old app, but are not specified in the new app. Use these first.
+    * 2) Second, consume from provided unassignedPortsIterator
+    *
+    * If no ports are assigned, there are no side effects.
+    *
+    * @return The updated app definition with assigned service ports
+    */
+  private def assignPorts(newApp: AppDefinition, oldApp: Option[AppDefinition], portRange: Range,
+    unassignedPortsIterator: Iterator[Int]): AppDefinition = {
+    /* All ports that are already assigned in old app definition, but not used in the new definition
+     * if the app uses dynamic ports (0), it will get always the same ports assigned */
+    val assignedAndAvailable: Seq[Int] =
+      oldApp match {
+        case Some(oldApp) =>
+          oldApp.servicePorts.filter { p: Int => portRange.contains(p) && !newApp.servicePorts.contains(p) }
+        case None => Nil
+      }
+
+    val freePortsIterator = assignedAndAvailable.iterator ++ unassignedPortsIterator
+
+    val servicePorts: Seq[Int] = newApp.servicePorts.map {
+      case 0 =>
+        if (freePortsIterator.hasNext)
+          freePortsIterator.next()
+        else
+          throw new PortRangeExhaustedException(portRange.min, portRange.max)
+      case port => port
+    }
+
+    val updatedContainer = newApp.container.find(_.portMappings.nonEmpty).map { container =>
+      val newMappings = container.portMappings.zip(servicePorts).map {
+        case (portMapping, servicePort) => portMapping.copy(servicePort = servicePort)
+      }
+      container.copyWith(portMappings = newMappings)
+    }
+
+    newApp.copy(
+      portDefinitions = mergeServicePortsAndPortDefinitions(newApp.portDefinitions, servicePorts),
+      container = updatedContainer.orElse(newApp.container))
+  }
+
+  def assignDynamicServicePorts(portRange: Range, from: RootGroup, to: RootGroup): RootGroup = {
+    /* Note: We consider the "from" rootGroup servicePorts as well, since these are reserved for re-use for a specific
+     * app in the case that servicePorts are re-posted all as 0's.
+     */
+    val usedServicePorts: Set[Int] =
+      (from.transitiveApps.iterator ++ to.transitiveApps.iterator).flatMap(_.servicePorts).toSet
+    val unassignedPortsIterator = portRange.iterator
+      .filter { p => !usedServicePorts.contains(p) }
+      .map { port =>
+        logger.debug(s"Take next configured free port: $port")
+        port
+      }
+    val dynamicApps: Iterator[AppDefinition] =
+      to.transitiveApps
+        .iterator
+        .filter { newApp => changedOrNew(from.transitiveAppsById, newApp) }
+        .map {
+          // assign values for service ports that the user has left "blank" (set to zero)
+          case app: AppDefinition if app.hasDynamicServicePorts =>
+            assignPorts(app, from.app(app.id), portRange, unassignedPortsIterator)
+          case app: AppDefinition =>
+            // Always set the ports to service ports, even if we do not have dynamic ports in our port mappings
+            app.copy(
+              portDefinitions = mergeServicePortsAndPortDefinitions(app.portDefinitions, app.servicePorts)
+            )
+        }
+
+    dynamicApps.foldLeft(to) { (rootGroup, app) =>
+      rootGroup.updateApp(app.id, _ => app, app.version)
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
@@ -23,16 +23,16 @@ import mesosphere.marathon.util.{ LockedVar, WorkQueue }
 
 import scala.async.Async._
 import scala.collection.immutable.Seq
-import scala.collection.mutable
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success }
 
 class GroupManagerImpl(
-    config: GroupManagerConfig,
+    val config: GroupManagerConfig,
     initialRoot: Option[RootGroup],
     groupRepository: GroupRepository,
     deploymentService: Provider[DeploymentService])(implicit eventStream: EventStream, ctx: ExecutionContext) extends GroupManager with StrictLogging {
+
   /**
     * All updates to root() should go through this workqueue and the maxConcurrent should always be "1"
     * as we don't allow multiple updates to the root at the same time.
@@ -111,7 +111,10 @@ class GroupManagerImpl(
         logger.info(s"Upgrade root group version:$version with force:$force")
 
         val from = rootGroup()
-        val unversioned = assignDynamicServicePorts(from, change(from))
+        val unversioned = AssignDynamicServiceLogic.assignDynamicServicePorts(
+          Range.inclusive(config.localPortMin(), config.localPortMax()),
+          from,
+          change(from))
         val withVersionedApps = GroupVersioningUtil.updateVersionInfoForChangedApps(version, from, unversioned)
         val withVersionedAppsPods = GroupVersioningUtil.updateVersionInfoForChangedPods(version, from, withVersionedApps)
         Validation.validateOrThrow(withVersionedAppsPods)(RootGroup.rootGroupValidator(config.availableFeatures))
@@ -139,76 +142,6 @@ class GroupManagerImpl(
         eventStream.publish(GroupChangeFailed(id, version.toString, ex.getMessage))
     }
     deployment
-  }
-
-  private[group] def assignDynamicServicePorts(from: RootGroup, to: RootGroup): RootGroup = {
-    val portRange = Range(config.localPortMin(), config.localPortMax())
-    var taken = from.transitiveApps.flatMap(_.servicePorts) ++ to.transitiveApps.flatMap(_.servicePorts)
-
-    def nextGlobalFreePort: Int = {
-      val port = portRange.find(!taken.contains(_))
-        .getOrElse(throw new PortRangeExhaustedException(
-          config.localPortMin(),
-          config.localPortMax()
-        ))
-      logger.info(s"Take next configured free port: $port")
-      taken += port
-      port
-    }
-
-    def mergeServicePortsAndPortDefinitions(
-      portDefinitions: Seq[PortDefinition],
-      servicePorts: Seq[Int]): Seq[PortDefinition] =
-      if (portDefinitions.nonEmpty)
-        portDefinitions.zipAll(servicePorts, AppDefinition.RandomPortDefinition, AppDefinition.RandomPortValue).map {
-          case (portDefinition, servicePort) => portDefinition.copy(port = servicePort)
-        }
-      else Seq.empty
-
-    def assignPorts(app: AppDefinition): AppDefinition = {
-      //all ports that are already assigned in old app definition, but not used in the new definition
-      //if the app uses dynamic ports (0), it will get always the same ports assigned
-      val assignedAndAvailable = mutable.Queue(
-        from.app(app.id)
-          .map(_.servicePorts.filter(p => portRange.contains(p) && !app.servicePorts.contains(p)))
-          .getOrElse(Nil): _*
-      )
-
-      def nextFreeServicePort: Int =
-        if (assignedAndAvailable.nonEmpty) assignedAndAvailable.dequeue()
-        else nextGlobalFreePort
-
-      val servicePorts: Seq[Int] = app.servicePorts.map { port =>
-        if (port == 0) nextFreeServicePort else port
-      }
-
-      val updatedContainer = app.container.find(_.portMappings.nonEmpty).map { container =>
-        val newMappings = container.portMappings.zip(servicePorts).map {
-          case (portMapping, servicePort) => portMapping.copy(servicePort = servicePort)
-        }
-        container.copyWith(portMappings = newMappings)
-      }
-
-      app.copy(
-        portDefinitions = mergeServicePortsAndPortDefinitions(app.portDefinitions, servicePorts),
-        container = updatedContainer.orElse(app.container)
-      )
-    }
-
-    val dynamicApps: Set[AppDefinition] =
-      to.transitiveApps.map {
-        // assign values for service ports that the user has left "blank" (set to zero)
-        case app: AppDefinition if app.hasDynamicServicePorts => assignPorts(app)
-        case app: AppDefinition =>
-          // Always set the ports to service ports, even if we do not have dynamic ports in our port mappings
-          app.copy(
-            portDefinitions = mergeServicePortsAndPortDefinitions(app.portDefinitions, app.servicePorts)
-          )
-      }
-
-    dynamicApps.foldLeft(to) { (rootGroup, app) =>
-      rootGroup.updateApp(app.id, _ => app, app.version)
-    }
   }
 
   @SuppressWarnings(Array("all")) // async/await

--- a/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
@@ -9,7 +9,6 @@ import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.async.ExecutionContexts
 import mesosphere.marathon.core.event.GroupChangeSuccess
 import mesosphere.marathon.core.group.impl.GroupManagerImpl
-import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.GroupRepository
@@ -19,9 +18,10 @@ import scala.concurrent.{ Future, Promise }
 
 class GroupManagerTest extends AkkaUnitTest with GroupCreation {
   class Fixture(
-      val servicePortsRange: Range = 1000.until(20000),
+      val servicePortsRange: Range = 1000.to(20000),
       val initialRoot: Option[RootGroup] = Some(RootGroup.empty)) {
-    val config = AllConf.withTestConfig("--local_port_min", servicePortsRange.start.toString, "--local_port_max", (servicePortsRange.end + 1).toString)
+    val config = AllConf.withTestConfig("--local_port_min", servicePortsRange.min.toString,
+      "--local_port_max", (servicePortsRange.max).toString)
     val groupRepository = mock[GroupRepository]
     val deploymentService = mock[DeploymentService]
     val eventStream = mock[EventStream]
@@ -29,216 +29,6 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       override def get(): DeploymentService = deploymentService
     })(eventStream, ExecutionContexts.global)
   }
-
-  "applications with port definitions" when {
-    "apps with port definitions should map dynamic ports to a non-0 value" in new Fixture(10.to(20)) {
-      val app = AppDefinition("/app".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(1)))
-      val rootGroup = createRootGroup(Map(app.id -> app))
-      val update = groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-      update.apps(app.id).portDefinitions.size should equal(2)
-      update.apps(app.id).portDefinitions should contain(PortDefinition(1))
-      update.apps(app.id).portDefinitions should not contain PortDefinition(0)
-    }
-
-    "multiple apps are assigned dynamic app ports" should {
-      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(1, 2, 3))
-      val app3 = AppDefinition("/app3".toPath, portDefinitions = PortDefinitions(0, 2, 0))
-      val rootGroup = createRootGroup(Map(
-        app1.id -> app1,
-        app2.id -> app2,
-        app3.id -> app3
-      ))
-      "have real ports assigned for all of the original dynamic ports in their definitions" in new Fixture(10.to(20)) {
-        val update = groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-        update.transitiveApps.filter(_.hasDynamicServicePorts) should be(empty)
-      }
-      "consume service ports from the expected range" in new Fixture(10.to(20)) {
-        val update = groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-        update.transitiveApps.flatMap(_.portNumbers.filter(servicePortsRange.contains)) should have size 5
-      }
-    }
-
-    //regression for #2743
-    "should reassign dynamic service ports specified in the container" in new Fixture(10.to(20)) {
-      val app = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 11))
-      val updatedApp = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 0, 11))
-      val from = createRootGroup(Map(app.id -> app))
-      val to = createRootGroup(Map(updatedApp.id -> updatedApp))
-      val update = groupManager.assignDynamicServicePorts(from, to)
-      update.app("/app1".toPath).get.portNumbers should be(Seq(10, 12, 11))
-    }
-
-    "Already taken ports will not be used" in new Fixture(10.to(20)) {
-      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(0, 2, 0))
-      val rootGroup = createRootGroup(Map(
-        app1.id -> app1,
-        app2.id -> app2
-      ))
-      val update = groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-      update.transitiveApps.filter(_.hasDynamicServicePorts) should be(empty)
-      update.transitiveApps.flatMap(_.portNumbers.filter(servicePortsRange.contains)) should have size 5
-    }
-
-    // Regression test for #2868
-    "Don't assign duplicated service ports" in new Fixture(10.to(20)) {
-      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 10))
-      val rootGroup = createRootGroup(Map(app1.id -> app1))
-      val update = groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-
-      val assignedPorts: Set[Int] = update.transitiveApps.flatMap(_.portNumbers)
-      assignedPorts should have size 2
-    }
-
-    "Assign unique service ports also when adding a dynamic service port to an app" in new Fixture(10.to(20)) {
-      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 11))
-      val originalGroup = createRootGroup(Map(app1.id -> app1))
-
-      val updatedApp1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-      val updatedGroup = createRootGroup(Map(updatedApp1.id -> updatedApp1))
-      val result = groupManager.assignDynamicServicePorts(originalGroup, updatedGroup)
-
-      val assignedPorts: Set[Int] = result.transitiveApps.flatMap(_.portNumbers)
-      assignedPorts should have size 3
-    }
-
-    "If there are not enough ports, a PortExhausted exception is thrown" in new Fixture(10.to(14)) {
-      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-      val rootGroup = createRootGroup(Map(
-        app1.id -> app1,
-        app2.id -> app2
-      ))
-      val ex = intercept[PortRangeExhaustedException] {
-        groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-      }
-      ex.minPort should be(10)
-      ex.maxPort should be(15)
-    }
-  }
-
-  def withContainerNetworking(containerization: String, prototype: => Container): Unit = {
-    import Container.PortMapping
-
-    s"withContainerNetworking using $containerization" should {
-      "Assign dynamic service ports specified in the container" in new Fixture(10.to(14)) {
-        val container = prototype.copyWith(portMappings = Seq(
-          PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 0, protocol = "tcp"),
-          PortMapping(containerPort = 9000, hostPort = Some(10555), servicePort = 10555, protocol = "udp"),
-          PortMapping(containerPort = 9001, hostPort = Some(31337), servicePort = 0, protocol = "udp"),
-          PortMapping(containerPort = 9002, hostPort = Some(0), servicePort = 0, protocol = "tcp")
-        )
-        )
-        val virtualNetwork = Seq(ContainerNetwork(name = "whatever"))
-        val app = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = Some(container), networks = virtualNetwork)
-        val rootGroup = createRootGroup(Map(app.id -> app))
-        val updatedGroup = groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-        val updatedApp = updatedGroup.transitiveApps.head
-        updatedApp.hasDynamicServicePorts should be (false)
-        updatedApp.hostPorts should have size 4
-        updatedApp.servicePorts should have size 4
-        updatedApp.servicePorts.filter(servicePortsRange.contains) should have size 3
-      }
-
-      "Assign dynamic service ports specified in multiple containers" in new Fixture(10.to(12)) {
-        val c1 = Some(prototype.copyWith(portMappings = Seq(
-          PortMapping(containerPort = 8080)
-        )
-        ))
-        val c2 = Some(prototype.copyWith(portMappings = Seq(
-          PortMapping(containerPort = 8081)
-        )
-        ))
-        val virtualNetwork = Seq(ContainerNetwork(name = "whatever"))
-        val app1 = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = c1, networks = virtualNetwork)
-        val app2 = AppDefinition("/app2".toPath, portDefinitions = Seq(), container = c2, networks = virtualNetwork)
-        val rootGroup = createRootGroup(Map(
-          app1.id -> app1,
-          app2.id -> app2
-        ))
-        val update = groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-        update.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
-        update.transitiveApps.flatMap(_.hostPorts.flatten.filter(servicePortsRange.contains)) should have size 0 // linter:ignore:AvoidOptionMethod
-        update.transitiveApps.flatMap(_.servicePorts.filter(servicePortsRange.contains)) should have size 2 // linter:ignore:AvoidOptionMethod
-      }
-
-      "Assign dynamic service ports w/ both BRIDGE and USER containers" in new Fixture(0.until(12)) {
-        val bridgeModeContainer = Some(prototype.copyWith(portMappings = Seq(
-          PortMapping(containerPort = 8080, hostPort = Some(0))
-        )
-        ))
-        val userModeContainer = Some(prototype.copyWith(portMappings = Seq(
-          PortMapping(containerPort = 8081),
-          PortMapping(containerPort = 8082, hostPort = Some(0))
-        )
-        ))
-        val bridgeModeApp = AppDefinition("/bridgemodeapp".toPath, container = bridgeModeContainer, networks = Seq(BridgeNetwork()))
-        val userModeApp = AppDefinition("/usermodeapp".toPath, container = userModeContainer, networks = Seq(ContainerNetwork("whatever")))
-        val fromGroup = createRootGroup(Map(bridgeModeApp.id -> bridgeModeApp))
-        val toGroup = createRootGroup(Map(
-          bridgeModeApp.id -> bridgeModeApp,
-          userModeApp.id -> userModeApp
-        ))
-
-        val groupsV1 = groupManager.assignDynamicServicePorts(createRootGroup(), fromGroup)
-        groupsV1.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
-        groupsV1.transitiveApps.flatMap(_.servicePorts.filter(servicePortsRange.contains)) should have size 1
-
-        val groupsV2 = groupManager.assignDynamicServicePorts(groupsV1, toGroup)
-        groupsV2.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
-        val assignedServicePorts = groupsV2.transitiveApps.flatMap(_.servicePorts.filter(servicePortsRange.contains))
-        assignedServicePorts should have size 3
-      }
-
-      "Assign a service port for an app using Docker USER networking with a default port mapping" in new Fixture(10.to(11)) {
-        val c1 = Some(prototype.copyWith(portMappings = Seq(
-          PortMapping()
-        )
-        ))
-        val app1 = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = c1, networks = Seq(ContainerNetwork("whatever")))
-        val rootGroup = createRootGroup(Map(app1.id -> app1))
-        val update = groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-        update.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
-        update.transitiveApps.flatMap(_.hostPorts.flatten) should have size 0 // linter:ignore:AvoidOptionMethod
-        update.transitiveApps.flatMap(_.servicePorts.filter(servicePortsRange.contains)) should have size 1 // linter:ignore:AvoidOptionSize
-      }
-
-      // Regression test for #1365
-      "Export non-dynamic service ports specified in the container to the ports field" in new Fixture(10.to(20)) {
-        val container = prototype.copyWith(portMappings = Seq(
-          PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 80, protocol = "tcp"),
-          PortMapping(containerPort = 9000, hostPort = Some(10555), servicePort = 81, protocol = "udp")
-        )
-        )
-        val app1 = AppDefinition("/app1".toPath, container = Some(container), networks = Seq(ContainerNetwork("foo")))
-        val rootGroup = createRootGroup(Map(app1.id -> app1))
-        val update = groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-        update.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
-        update.transitiveApps.flatMap(_.servicePorts) should equal (Set(80, 81))
-      }
-
-      "Retain the original container definition if port mappings are missing" in new Fixture(10.to(15)) {
-        val container: Container = prototype.copyWith(portMappings = Nil)
-
-        val app1 = AppDefinition(
-          id = "/app1".toPath,
-          container = Some(container)
-        )
-        val rootGroup = createRootGroup(Map(app1.id -> app1))
-
-        val result = groupManager.assignDynamicServicePorts(createRootGroup(), rootGroup)
-        result.apps.size should be(1)
-        val app = result.apps.head._2
-        app.container should be(Some(container))
-      }
-    }
-  }
-
-  behave like withContainerNetworking("docker-docker", Container.Docker())
-  behave like withContainerNetworking("mesos-docker", Container.MesosDocker())
-  behave like withContainerNetworking("mesos-appc", Container.MesosAppC())
-  behave like withContainerNetworking("mesos", Container.Mesos())
 
   "GroupManager" should {
     "return None as a root group, if the initial group has not been passed to it" in new Fixture(initialRoot = None) {
@@ -260,12 +50,8 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
     }
 
     "publishes GroupChangeSuccess with the appropriate GID on successful deployment" in new Fixture {
-      val f = new Fixture
       val app: AppDefinition = AppDefinition("/group/app1".toPath, cmd = Some("sleep 3"), portDefinitions = Seq.empty)
       val group = createGroup("/group".toPath, apps = Map(app.id -> app), version = Timestamp(1))
-      val rootGroup = createRootGroup(
-        version = Timestamp(1),
-        groups = Set(group))
 
       groupRepository.root() returns Future.successful(createRootGroup())
       deploymentService.deploy(any, any) returns Future.successful(Done)

--- a/src/test/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogicTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogicTest.scala
@@ -1,0 +1,229 @@
+package mesosphere.marathon
+package core.group.impl
+
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
+import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.state._
+import mesosphere.marathon.test.GroupCreation
+
+class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
+  "applications with port definitions" when {
+    "apps with port definitions should map dynamic ports to a non-0 value" in {
+      val app = AppDefinition("/app".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(1)))
+      val rootGroup = createRootGroup(Map(app.id -> app))
+      val update = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), createRootGroup(), rootGroup)
+      update.apps(app.id).portDefinitions.size should equal(2)
+      update.apps(app.id).portDefinitions should contain(PortDefinition(1))
+      update.apps(app.id).portDefinitions should not contain PortDefinition(0)
+    }
+
+    "multiple apps are assigned dynamic app ports" should {
+      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
+      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(1, 2, 3))
+      val app3 = AppDefinition("/app3".toPath, portDefinitions = PortDefinitions(0, 2, 0))
+      val rootGroup = createRootGroup(Map(
+        app1.id -> app1,
+        app2.id -> app2,
+        app3.id -> app3
+      ))
+      "have real ports assigned for all of the original dynamic ports in their definitions" in {
+        val update = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), createRootGroup(), rootGroup)
+        update.transitiveApps.filter(_.hasDynamicServicePorts) should be(empty)
+      }
+      "consume service ports from the expected range" in {
+        val servicePortsRange = 10.to(20)
+        val update = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
+        update.transitiveApps.flatMap(_.portNumbers.filter(servicePortsRange.contains)) should have size 5
+      }
+    }
+
+    //regression for #2743
+    "should reassign dynamic service ports specified in the container" in {
+      val app = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 11))
+      val updatedApp = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 0, 11))
+      val from = createRootGroup(Map(app.id -> app))
+      val to = createRootGroup(Map(updatedApp.id -> updatedApp))
+      val update = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), from, to)
+      update.app("/app1".toPath).get.portNumbers should be(Seq(10, 12, 11))
+    }
+
+    "Already taken ports will not be used" in {
+      val servicePortsRange = 10.to(20)
+      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
+      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(0, 2, 0))
+      val rootGroup = createRootGroup(Map(
+        app1.id -> app1,
+        app2.id -> app2
+      ))
+      val update = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
+      update.transitiveApps.filter(_.hasDynamicServicePorts) should be(empty)
+      update.transitiveApps.flatMap(_.portNumbers.filter(servicePortsRange.contains)) should have size 5
+    }
+
+    // Regression test for #2868
+    "Don't assign duplicated service ports" in {
+      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 10))
+      val rootGroup = createRootGroup(Map(app1.id -> app1))
+      val update = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), createRootGroup(), rootGroup)
+
+      val assignedPorts: Set[Int] = update.transitiveApps.flatMap(_.portNumbers)
+      assignedPorts should have size 2
+    }
+
+    "Assign unique service ports also when adding a dynamic service port to an app" in {
+      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 11))
+      val originalGroup = createRootGroup(Map(app1.id -> app1))
+
+      val updatedApp1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
+      val updatedGroup = createRootGroup(Map(updatedApp1.id -> updatedApp1))
+      val result = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), originalGroup, updatedGroup)
+
+      val assignedPorts: Set[Int] = result.transitiveApps.flatMap(_.portNumbers)
+      assignedPorts should have size 3
+    }
+
+    "If there are not enough ports, a PortExhausted exception is thrown" in {
+      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
+      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(0, 0, 0))
+      val rootGroup = createRootGroup(Map(
+        app1.id -> app1,
+        app2.id -> app2
+      ))
+      val ex = intercept[PortRangeExhaustedException] {
+        AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(14), createRootGroup(), rootGroup)
+      }
+      ex.minPort should be(10)
+      ex.maxPort should be(14)
+    }
+  }
+
+  def withContainerNetworking(containerization: String, prototype: => Container): Unit = {
+    import Container.PortMapping
+
+    s"withContainerNetworking using $containerization" should {
+      "Assign dynamic service ports specified in the container" in {
+        val servicePortsRange = 10.to(14)
+        val container = prototype.copyWith(portMappings = Seq(
+          PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 0, protocol = "tcp"),
+          PortMapping(containerPort = 9000, hostPort = Some(10555), servicePort = 10555, protocol = "udp"),
+          PortMapping(containerPort = 9001, hostPort = Some(31337), servicePort = 0, protocol = "udp"),
+          PortMapping(containerPort = 9002, hostPort = Some(0), servicePort = 0, protocol = "tcp")
+        )
+        )
+        val virtualNetwork = Seq(ContainerNetwork(name = "whatever"))
+        val app = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = Some(container), networks = virtualNetwork)
+        val rootGroup = createRootGroup(Map(app.id -> app))
+        val updatedGroup = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
+        val updatedApp = updatedGroup.transitiveApps.head
+        updatedApp.hasDynamicServicePorts should be (false)
+        updatedApp.hostPorts should have size 4
+        updatedApp.servicePorts should have size 4
+        updatedApp.servicePorts.filter(servicePortsRange.contains) should have size 3
+      }
+
+      "Assign dynamic service ports specified in multiple containers" in {
+        val c1 = Some(prototype.copyWith(portMappings = Seq(
+          PortMapping(containerPort = 8080)
+        )
+        ))
+        val c2 = Some(prototype.copyWith(portMappings = Seq(
+          PortMapping(containerPort = 8081)
+        )
+        ))
+        val virtualNetwork = Seq(ContainerNetwork(name = "whatever"))
+        val app1 = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = c1, networks = virtualNetwork)
+        val app2 = AppDefinition("/app2".toPath, portDefinitions = Seq(), container = c2, networks = virtualNetwork)
+        val rootGroup = createRootGroup(Map(
+          app1.id -> app1,
+          app2.id -> app2
+        ))
+        val servicePortsRange = 10.to(12)
+        val update = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
+        update.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
+        update.transitiveApps.flatMap(_.hostPorts.flatten.filter(servicePortsRange.contains)) should have size 0 // linter:ignore:AvoidOptionMethod
+        update.transitiveApps.flatMap(_.servicePorts.filter(servicePortsRange.contains)) should have size 2 // linter:ignore:AvoidOptionMethod
+      }
+
+      "Assign dynamic service ports w/ both BRIDGE and USER containers" in {
+        val servicePortsRange = 0.until(12)
+        val bridgeModeContainer = Some(prototype.copyWith(portMappings = Seq(
+          PortMapping(containerPort = 8080, hostPort = Some(0))
+        )
+        ))
+        val userModeContainer = Some(prototype.copyWith(portMappings = Seq(
+          PortMapping(containerPort = 8081),
+          PortMapping(containerPort = 8082, hostPort = Some(0))
+        )
+        ))
+        val bridgeModeApp = AppDefinition("/bridgemodeapp".toPath, container = bridgeModeContainer, networks = Seq(BridgeNetwork()))
+        val userModeApp = AppDefinition("/usermodeapp".toPath, container = userModeContainer, networks = Seq(ContainerNetwork("whatever")))
+        val fromGroup = createRootGroup(Map(bridgeModeApp.id -> bridgeModeApp))
+        val toGroup = createRootGroup(Map(
+          bridgeModeApp.id -> bridgeModeApp,
+          userModeApp.id -> userModeApp
+        ))
+
+        val groupsV1 = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), fromGroup)
+        groupsV1.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
+        groupsV1.transitiveApps.flatMap(_.servicePorts.filter(servicePortsRange.contains)) should have size 1
+
+        val groupsV2 = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, groupsV1, toGroup)
+        groupsV2.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
+        val assignedServicePorts = groupsV2.transitiveApps.flatMap(_.servicePorts.filter(servicePortsRange.contains))
+        assignedServicePorts should have size 3
+      }
+
+      "Assign a service port for an app using Docker USER networking with a default port mapping" in {
+        val servicePortsRange = 10.to(11)
+        val c1 = Some(prototype.copyWith(portMappings = Seq(
+          PortMapping()
+        )
+        ))
+        val app1 = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = c1, networks = Seq(ContainerNetwork("whatever")))
+        val rootGroup = createRootGroup(Map(app1.id -> app1))
+        val update = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
+        update.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
+        update.transitiveApps.flatMap(_.hostPorts.flatten) should have size 0 // linter:ignore:AvoidOptionMethod
+        update.transitiveApps.flatMap(_.servicePorts.filter(servicePortsRange.contains)) should have size 1 // linter:ignore:AvoidOptionSize
+      }
+
+      // Regression test for #1365
+      "Export non-dynamic service ports specified in the container to the ports field" in {
+        val servicePortsRange = 10.to(20)
+        val container = prototype.copyWith(portMappings = Seq(
+          PortMapping(containerPort = 8080, hostPort = Some(0), servicePort = 80, protocol = "tcp"),
+          PortMapping(containerPort = 9000, hostPort = Some(10555), servicePort = 81, protocol = "udp")
+        )
+        )
+        val app1 = AppDefinition("/app1".toPath, container = Some(container), networks = Seq(ContainerNetwork("foo")))
+        val rootGroup = createRootGroup(Map(app1.id -> app1))
+        val update = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
+        update.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
+        update.transitiveApps.flatMap(_.servicePorts) should equal (Set(80, 81))
+      }
+
+      "Retain the original container definition if port mappings are missing" in {
+        val servicePortsRange = 10.to(15)
+        val container: Container = prototype.copyWith(portMappings = Nil)
+
+        val app1 = AppDefinition(
+          id = "/app1".toPath,
+          container = Some(container)
+        )
+        val rootGroup = createRootGroup(Map(app1.id -> app1))
+
+        val result = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
+        result.apps.size should be(1)
+        val app = result.apps.head._2
+        app.container should be(Some(container))
+      }
+    }
+  }
+
+  behave like withContainerNetworking("docker-docker", Container.Docker())
+  behave like withContainerNetworking("mesos-docker", Container.MesosDocker())
+  behave like withContainerNetworking("mesos-appc", Container.MesosAppC())
+  behave like withContainerNetworking("mesos", Container.Mesos())
+
+}


### PR DESCRIPTION
…des. (#5787)

Summary:
As @zen-dog found a big performance degradation when Marathon has already 5000
apps and a new app is added. He found that `GroupManagerImpl.assignDynamicServicePorts`
had an exponential runtime.

The benchmark and flamegraph showed that most time was spend in copying and
building the `RootGroup` after the update. It also seems that we update all
apps even when the get the same port assigned again. This change introduces a
filter so that only apps that are new or changed are updated in the `RootGroup`.

You can run the benchmark with
```
sbt "benchmark/jmh:run -i 1 -wi 3 -f1 -t1 .*GroupManagerBenchmark"
```

This is only a fix for small app updates. If many apps are updated at once we
will still hit this bottleneck. We should look into the creation of
`transitiveAppsById` and `transitivePodsById` which take up most of the runtime.

JIRA issues: MARATHON_EE-1770, MARATHON_EE-1764