### PR TITLE
Add publishing of the plugin interfaces to the release

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -361,6 +361,7 @@ def release(requestVersion: String, gitSha: String, latest: Boolean = false): Un
   // publishing to the nexus repository.  This artifact is used by metronome.
   %('sbt, "publish")
 
+  %('sbt, "project plugin-interface", "publish")
   // TODO: git push fails currently b/c jenkins isn't authorized to push to GH
   // %('git, "push", "--tags")
 


### PR DESCRIPTION
Add publishing of the plugin interfaces to the release

Summary:
plugin project needs to be released in the release process

