### PR TITLE
fix IS constraint for pods

### DIFF
--- a/project/RamlTypeGenerator.scala
+++ b/project/RamlTypeGenerator.scala
@@ -52,6 +52,7 @@ object RamlTypeGenerator {
 
   val SeqClass = RootClass.newClass("scala.collection.immutable.Seq")
   val SetClass = RootClass.newClass("Set")
+  val IterableClass = RootClass.newClass("Iterable")
 
   def TYPE_SEQ(typ: Type): Type = SeqClass TYPE_OF typ
 
@@ -219,6 +220,7 @@ object RamlTypeGenerator {
           VAL("StringToValue") withType(TYPE_MAP(StringClass, name)) withFlags(Flags.PRIVATE) := REF("Map") APPLY(sortedValues.map { enumValue =>
             TUPLE(LIT(enumValue), REF(underscoreToCamel(camelify(enumValue))))
           }),
+          DEF("all", IterableClass TYPE_OF name) := REF("StringToValue") DOT "values",
           DEF("fromString", TYPE_OPTION(name)) withParams(PARAM("v", StringClass)) := REF("StringToValue") DOT "get" APPLY(REF("v"))
         ) ++ default.map { defaultValue =>
           VAL("DefaultValue") withType(name) := REF(underscoreToCamel(camelify(defaultValue)))

--- a/src/main/scala/mesosphere/marathon/raml/ConstraintConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/ConstraintConversion.scala
@@ -11,6 +11,7 @@ trait ConstraintConversion {
       case ConstraintOperator.Like => Protos.Constraint.Operator.LIKE
       case ConstraintOperator.Unlike => Protos.Constraint.Operator.UNLIKE
       case ConstraintOperator.MaxPer => Protos.Constraint.Operator.MAX_PER
+      case ConstraintOperator.Is => Protos.Constraint.Operator.IS
     }
 
     val builder = Protos.Constraint.newBuilder().setField(raml.fieldName).setOperator(operator)
@@ -46,6 +47,7 @@ trait ConstraintConversion {
       case Protos.Constraint.Operator.LIKE => ConstraintOperator.Like
       case Protos.Constraint.Operator.UNLIKE => ConstraintOperator.Unlike
       case Protos.Constraint.Operator.MAX_PER => ConstraintOperator.MaxPer
+      case Protos.Constraint.Operator.IS => ConstraintOperator.Is
     }
     Constraint(c.getField, operator, if (c.hasValue) Some(c.getValue) else None)
   }

--- a/src/test/scala/mesosphere/marathon/raml/ConstraintConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/ConstraintConversionTest.scala
@@ -4,20 +4,34 @@ package raml
 import mesosphere.UnitTest
 
 class ConstraintConversionTest extends UnitTest {
-  "ConstraintConversion" should {
-    "A Constraint can be transformed into a Seq[String]" in {
-      Given("A constraint proto")
-      val constraint = Protos.Constraint.newBuilder()
-        .setField("foo")
-        .setOperator(Protos.Constraint.Operator.GROUP_BY)
-        .setValue("test")
-        .build()
-
-      When("The constraint is be converted")
-      val seq = constraint.toRaml[Seq[String]]
-
-      Then("The constraint is a correct string sequence")
-      seq should be(Seq("foo", "GROUP_BY", "test"))
+  def checkConstraintConversion(constraints: Constraint*): Unit = {
+    "all constraint operators are checked" in {
+      constraints.map(_.operator).toSet shouldBe ConstraintOperator.all.toSet withClue (
+        "We need to ensure that a case for every constraint operator is checked")
     }
+
+    constraints.foreach { constraint =>
+      s"convert ${constraint.operator} to and from array form, and protobuf format losslessly" in {
+        // pods use the RAML constraint operator, while apps use the array format
+        // We convert through all of these representations and back, making sure that no information is lost
+        val roundTripped = constraint.fromRaml[Protos.Constraint]
+          .toRaml[Seq[String]]
+          .fromRaml[Protos.Constraint]
+          .toRaml[Constraint]
+
+        roundTripped shouldBe constraint
+      }
+    }
+  }
+
+  "ConstraintConversion" should {
+    checkConstraintConversion(
+      Constraint("foo", ConstraintOperator.GroupBy, Some("test")),
+      Constraint("foo", ConstraintOperator.Is, Some("test")),
+      Constraint("@hostname", ConstraintOperator.Unique, None),
+      Constraint("rack", ConstraintOperator.MaxPer, Some("3")),
+      Constraint("@hostname", ConstraintOperator.Unlike, Some("regex")),
+      Constraint("@hostname", ConstraintOperator.Like, Some("regex")),
+      Constraint("@hostname", ConstraintOperator.Cluster, None))
   }
 }


### PR DESCRIPTION
Pods use a different serialization mechanism for constraints. When implementing the IS operator, this conversion method wasn't updated.

Add additional tests to improve coverage

JIRA Issues: MARATHON_EE-1667