### PR TITLE
Print out newline after SHA1 in release jenkins log

### DIFF
--- a/ci/awsClient.sc
+++ b/ci/awsClient.sc
@@ -95,7 +95,8 @@ def uploadFileAndSha(uploadFile: Path, s3path: S3Path): Artifact = {
 
   upload(uploadFile, s3path)
   println(s"Sha1 for file: ${uploadFile}")
-  %('cat, shaFile)
+  val sha1 = %%('cat, shaFile).out.string
+  println(sha1)
   upload(shaFile, s3path)
   Artifact(s3path / uploadFile.last, read(shaFile))
 }


### PR DESCRIPTION
Summary:
Right now the output looks like following. This PR should fix printing out Sha1 as it will be on its own line.

```
Sha1 for file: /home/admin/workspace/marathon-pipelines_master-KUGQBV4N5V3NKHADS432JRQBWEQANSY6GKJXNJL5YAA5IS2RCKNQ/target/universal/marathon-1.6.0-pre-178-gb0f6bda.tgz
de469ae71e634d228fd3d2e8b96e1650f4b0d5b1Uploading /home/admin/workspace/marathon-pipelines_master-KUGQBV4N5V3NKHADS432JRQBWEQANSY6GKJXNJL5YAA5IS2RCKNQ/target/universal/marathon-1.6.0-pre-178-gb0f6bda.tgz.sha1 -> s3://downloads.mesosphere.io/marathon/builds/marathon-1.6.0-pre-178-gb0f6bda.tgz.sha1
```

JIRA issues:
