### PR TITLE
 Validate groups in tests.

### DIFF
--- a/src/test/scala/mesosphere/marathon/api/akkahttp/PathMatchersTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/PathMatchersTest.scala
@@ -14,9 +14,9 @@ class PathMatchersTest extends UnitTest with GroupCreation with ScalatestRouteTe
   import PathId.StringPathId
 
   class PathMatchersTestFixture {
-    val app1 = AppDefinition("/test/group1/app1".toPath)
-    val app2 = AppDefinition("/test/group2/app2".toPath)
-    val app3 = AppDefinition("/test/group2/restart".toPath)
+    val app1 = AppDefinition("/test/group1/app1".toPath, cmd = Some("sleep"))
+    val app2 = AppDefinition("/test/group2/app2".toPath, cmd = Some("sleep"))
+    val app3 = AppDefinition("/test/group2/restart".toPath, cmd = Some("sleep"))
     val rootGroup = createRootGroup(
       groups = Set(
         createGroup("/test".toPath, groups = Set(

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/TasksControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/TasksControllerTest.scala
@@ -363,7 +363,7 @@ class TasksControllerTest extends UnitTest with ScalatestRouteTest with Inside w
     "list (txt) tasks with less ports than the current app version" in new Fixture {
       // Regression test for #234
       Given("one app with one task with less ports than required")
-      val app = AppDefinition("/foo".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(0)))
+      val app = AppDefinition("/foo".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(0)), cmd = Some("sleep"))
       val instance = TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance()
 
       val tasksByApp = InstanceTracker.InstancesBySpec.forInstances(instance)
@@ -386,8 +386,8 @@ class TasksControllerTest extends UnitTest with ScalatestRouteTest with Inside w
     "see only apps you are authorized to see" in {
       // Regression test for #234
       Given("one app with one task with less ports than required")
-      val authorizedApp = AppDefinition("/foo".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(0)))
-      val notAuthorizedApp = AppDefinition("/foo2".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(0)))
+      val authorizedApp = AppDefinition("/foo".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(0)), cmd = Some("sleep"))
+      val notAuthorizedApp = AppDefinition("/foo2".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(0)), cmd = Some("sleep"))
       val instance = TestInstanceBuilder.newBuilder(authorizedApp.id).addTaskRunning().getInstance()
       val notAuthorizedInstance = TestInstanceBuilder.newBuilder(notAuthorizedApp.id).addTaskRunning().getInstance()
       val f = Fixture(authFn = resource => {

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -78,10 +78,10 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       Raml.fromRaml(normalized)
     }
 
-    def prepareApp(app: App, groupManager: GroupManager, validate: Boolean = true): (Array[Byte], DeploymentPlan) = {
+    def prepareApp(app: App, groupManager: GroupManager, validate: Boolean = true, enabledFeatures: Set[String] = Set.empty): (Array[Byte], DeploymentPlan) = {
       val normed = normalize(app)
       val appDef = Raml.fromRaml(normed)
-      val rootGroup = createRootGroup(Map(appDef.id -> appDef), validate = validate)
+      val rootGroup = createRootGroup(Map(appDef.id -> appDef), validate = validate, enabledFeatures = enabledFeatures)
       val plan = DeploymentPlan(rootGroup, rootGroup)
       val body = Json.stringify(Json.toJson(normed)).getBytes("UTF-8")
       groupManager.updateApp(any, any, any, any, any) returns Future.successful(plan)
@@ -189,7 +189,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       val app = App(
         id = "/app", cmd = Some("cmd"), container = Option(container),
         secrets = Map("pullConfigSecret" -> SecretDef("/config")))
-      val (body, plan) = prepareApp(app, groupManager)
+      val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
       clock += 5.seconds
@@ -210,7 +210,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       val app = App(
         id = "/app", cmd = Some("cmd"), container = Option(container),
         secrets = Map("pullConfigSecret" -> SecretDef("/config")))
-      val (body, plan) = prepareApp(app, groupManager)
+      val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
       clock += 5.seconds
@@ -659,7 +659,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       val app = App(id = "/app", cmd = Some("cmd"),
         secrets = Map[String, SecretDef]("foo" -> SecretDef("/bar")),
         env = Map[String, EnvVarValueOrSecret]("NAMED_FOO" -> raml.EnvVarSecret("foo")))
-      val (body, plan) = prepareApp(app, groupManager)
+      val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
       clock += 5.seconds
@@ -705,7 +705,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       val app = App(id = "/app", cmd = Some("cmd"),
         secrets = Map[String, SecretDef]("foo" -> SecretDef("/bar")),
         container = Some(raml.Container(`type` = EngineType.Mesos, volumes = Seq(AppSecretVolume("/path", "foo")))))
-      val (body, plan) = prepareApp(app, groupManager)
+      val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
       clock += 5.seconds
@@ -735,7 +735,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
       val app = App(id = "/app", cmd = Some("cmd"),
         secrets = Map[String, SecretDef]("foo" -> SecretDef("/bar")),
         env = Map[String, EnvVarValueOrSecret]("NAMED_FOO" -> raml.EnvVarSecret("foo")))
-      val (body, _) = prepareApp(app, groupManager)
+      val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
       clock += 5.seconds
@@ -758,7 +758,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation {
         container = Option(containers),
         secrets = Map("bar" -> SecretDef("foo"))
       )
-      val (body, _) = prepareApp(app, groupManager)
+      val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
       clock += 5.seconds

--- a/src/test/scala/mesosphere/marathon/api/v2/DeploymentsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/DeploymentsResourceTest.scala
@@ -26,7 +26,7 @@ class DeploymentsResourceTest extends UnitTest with GroupCreation {
       Given("An unauthenticated request")
       auth.authenticated = false
       val req = auth.request
-      val app = AppDefinition(PathId("/test"))
+      val app = AppDefinition(PathId("/test"), cmd = Some("sleep"))
       val targetGroup = createRootGroup(apps = Map(app.id -> app))
       val deployment = DeploymentStepInfo(DeploymentPlan(createRootGroup(), targetGroup), DeploymentStep(Seq.empty), 1)
       service.listRunningDeployments() returns Future.successful(Seq(deployment))
@@ -47,7 +47,7 @@ class DeploymentsResourceTest extends UnitTest with GroupCreation {
       auth.authenticated = true
       auth.authorized = false
       val req = auth.request
-      val app = AppDefinition(PathId("/test"))
+      val app = AppDefinition(PathId("/test"), cmd = Some("sleep"))
       val targetGroup = createRootGroup(apps = Map(app.id -> app))
       val deployment = DeploymentStepInfo(DeploymentPlan(createRootGroup(), targetGroup), DeploymentStep(Seq.empty), 1)
       service.listRunningDeployments() returns Future.successful(Seq(deployment))

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -151,7 +151,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation {
 
     "access without authorization is denied if the resource exists" in new FixtureWithRealGroupManager {
       Given("A real group manager with one app")
-      val app = AppDefinition("/a".toRootPath)
+      val app = AppDefinition("/a".toRootPath, cmd = Some("sleep"))
       val rootGroup = createRootGroup(apps = Map(app.id -> app))
 
       Given("An unauthorized request")
@@ -251,7 +251,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation {
     "Creation of a group with same path as an existing app should be prohibited (fixes #3385)" in new FixtureWithRealGroupManager(
       initialRoot = {
       val app = AppDefinition("/group/app".toRootPath)
-      createRootGroup(groups = Set(createGroup("/group".toRootPath, Map(app.id -> app))))
+      createRootGroup(groups = Set(createGroup("/group".toRootPath, Map(app.id -> app), validate = false)), validate = false)
     }
     ) {
       Given("A real group manager with one app")

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -78,9 +78,13 @@ class ModelValidationTest extends UnitTest with GroupCreation {
       val rootGroup = createRootGroup(groups = Set(createGroup("/test".toPath, groups = Set(
         createGroup("/test/group1".toPath, Map(
           validApp.id -> validApp,
-          invalidApp.id -> invalidApp)
+          invalidApp.id -> invalidApp),
+          validate = false
         ),
-        createGroup("/test/group2".toPath)))))
+        createGroup("/test/group2".toPath, validate = false)),
+        validate = false)),
+        validate = false
+      )
 
       validate(rootGroup)(RootGroup.rootGroupValidator(Set())) match {
         case Success => fail()

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -75,7 +75,8 @@ class ModelValidationTest extends UnitTest with GroupCreation {
     "Validators should not produce 'value' string at the end of description." in {
       val validApp = AppDefinition("/test/group1/valid".toPath, cmd = Some("foo"))
       val invalidApp = AppDefinition("/test/group1/invalid".toPath)
-      val rootGroup = createRootGroup(groups = Set(createGroup("/test".toPath, groups = Set(
+      val rootGroup = createRootGroup(
+        groups = Set(createGroup("/test".toPath, groups = Set(
         createGroup("/test/group1".toPath, Map(
           validApp.id -> validApp,
           invalidApp.id -> invalidApp),

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -77,13 +77,13 @@ class ModelValidationTest extends UnitTest with GroupCreation {
       val invalidApp = AppDefinition("/test/group1/invalid".toPath)
       val rootGroup = createRootGroup(
         groups = Set(createGroup("/test".toPath, groups = Set(
-        createGroup("/test/group1".toPath, Map(
-          validApp.id -> validApp,
-          invalidApp.id -> invalidApp),
-          validate = false
-        ),
-        createGroup("/test/group2".toPath, validate = false)),
-        validate = false)),
+          createGroup("/test/group1".toPath, Map(
+            validApp.id -> validApp,
+            invalidApp.id -> invalidApp),
+            validate = false
+          ),
+          createGroup("/test/group2".toPath, validate = false)),
+          validate = false)),
         validate = false
       )
 

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -51,7 +51,7 @@ class TasksResourceTest extends UnitTest with GroupCreation {
     "list (txt) tasks with less ports than the current app version" in new Fixture {
       // Regression test for #234
       Given("one app with one task with less ports than required")
-      val app = AppDefinition("/foo".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(0)))
+      val app = AppDefinition("/foo".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(0)), cmd = Some("sleep"))
 
       val instance = TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance()
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/DeploymentFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/DeploymentFormatsTest.scala
@@ -110,7 +110,7 @@ class DeploymentFormatsTest extends UnitTest with GroupCreation {
 
   def genTimestamp = Timestamp.now()
 
-  def genApp = AppDefinition(id = genId)
+  def genApp = AppDefinition(id = genId, cmd = Some("sleep"))
 
   def genStep = DeploymentStep(actions = Seq(
     StartApplication(genApp, genInt),
@@ -122,13 +122,13 @@ class DeploymentFormatsTest extends UnitTest with GroupCreation {
   def genGroup(children: Set[Group] = Set.empty) = {
     val app1 = genApp
     val app2 = genApp
-    createGroup(genId, apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genId), version = genTimestamp)
+    createGroup(genId, apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genId), version = genTimestamp, validate = false)
   }
 
   def genRootGroup(children: Set[Group] = Set.empty) = {
     val app1 = genApp
     val app2 = genApp
-    createRootGroup(apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genId), version = genTimestamp)
+    createRootGroup(apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genId), version = genTimestamp, validate = false)
   }
 
   def genGroupUpdate(children: Set[GroupUpdate] = Set.empty) =

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoServiceTest.scala
@@ -217,9 +217,9 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
       Given("a nested group with access to only nested app /group/app1")
       val f = new Fixture
       val rootId = PathId.empty
-      val rootApp = AppDefinition(PathId("/app"))
-      val nestedApp1 = AppDefinition(PathId("/group/app1"))
-      val nestedApp2 = AppDefinition(PathId("/group/app2"))
+      val rootApp = AppDefinition(PathId("/app"), cmd = Some("sleep"))
+      val nestedApp1 = AppDefinition(PathId("/group/app1"), cmd = Some("sleep"))
+      val nestedApp2 = AppDefinition(PathId("/group/app2"), cmd = Some("sleep"))
       val nestedGroup = createGroup(PathId("/group"), Map(nestedApp1.id -> nestedApp1, nestedApp2.id -> nestedApp2))
       val rootGroup = createRootGroup(Map(rootApp.id -> rootApp), groups = Set(nestedGroup))
 
@@ -256,10 +256,10 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
     }
   }
 
-  private val app1: AppDefinition = AppDefinition(PathId("/test1"))
+  private val app1: AppDefinition = AppDefinition(PathId("/test1"), cmd = Some("sleep"))
   val someApps = {
-    val app2 = AppDefinition(PathId("/test2"))
-    val app3 = AppDefinition(PathId("/test3"))
+    val app2 = AppDefinition(PathId("/test2"), cmd = Some("sleep"))
+    val app3 = AppDefinition(PathId("/test3"), cmd = Some("sleep"))
     Map(
       app1.id -> app1,
       app2.id -> app2,
@@ -268,8 +268,8 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
   }
 
   val someNestedApps = {
-    val nestedApp1 = AppDefinition(PathId("/nested/test1"))
-    val nestedApp2 = AppDefinition(PathId("/nested/test2"))
+    val nestedApp1 = AppDefinition(PathId("/nested/test1"), cmd = Some("sleep"))
+    val nestedApp2 = AppDefinition(PathId("/nested/test2"), cmd = Some("sleep"))
     Map(
       (nestedApp1.id, nestedApp1),
       (nestedApp2.id, nestedApp2)
@@ -286,13 +286,13 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
     ))
 
   val nestedGroup = {
-    val app1 = AppDefinition(PathId("/app1"))
-    val visibleApp1 = AppDefinition(PathId("/visible/app1"))
-    val visibleGroupApp1 = AppDefinition(PathId("/visible/group/app1"))
-    val secureApp1 = AppDefinition(PathId("/secure/app1"))
-    val secureGroupApp1 = AppDefinition(PathId("/secure/group/app1"))
-    val otherApp1 = AppDefinition(PathId("/other/app1"))
-    val otherGroupApp1 = AppDefinition(PathId("/other/group/app1"))
+    val app1 = AppDefinition(PathId("/app1"), cmd = Some("sleep"))
+    val visibleApp1 = AppDefinition(PathId("/visible/app1"), cmd = Some("sleep"))
+    val visibleGroupApp1 = AppDefinition(PathId("/visible/group/app1"), cmd = Some("sleep"))
+    val secureApp1 = AppDefinition(PathId("/secure/app1"), cmd = Some("sleep"))
+    val secureGroupApp1 = AppDefinition(PathId("/secure/group/app1"), cmd = Some("sleep"))
+    val otherApp1 = AppDefinition(PathId("/other/app1"), cmd = Some("sleep"))
+    val otherGroupApp1 = AppDefinition(PathId("/other/group/app1"), cmd = Some("sleep"))
 
     createRootGroup(Map(app1.id -> app1), groups = Set(
       createGroup(PathId("/visible"), Map(visibleApp1.id -> visibleApp1), groups = Set(

--- a/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
@@ -22,13 +22,13 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       Given("a group of four apps with some simple dependencies")
       val aId = "/test/database/a".toPath
       val bId = "/test/service/b".toPath
-      val cId = "/c".toPath
-      val dId = "/d".toPath
+      val cId = "/test/c".toPath
+      val dId = "/test/d".toPath
 
-      val a = AppDefinition(aId)
-      val b = AppDefinition(bId, dependencies = Set(aId))
-      val c = AppDefinition(cId, dependencies = Set(aId))
-      val d = AppDefinition(dId, dependencies = Set(bId))
+      val a = AppDefinition(aId, cmd = Some("sleep"))
+      val b = AppDefinition(bId, dependencies = Set(aId), cmd = Some("sleep"))
+      val c = AppDefinition(cId, dependencies = Set(aId), cmd = Some("sleep"))
+      val d = AppDefinition(dId, dependencies = Set(bId), cmd = Some("sleep"))
 
       val rootGroup = createRootGroup(groups = Set(createGroup(
         id = "/test".toPath,
@@ -61,11 +61,11 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       val eId = "/e".toPath
       val fId = "/f".toPath
 
-      val a = AppDefinition(aId, dependencies = Set(bId, cId))
-      val b = AppDefinition(bId, dependencies = Set(cId))
-      val c = AppDefinition(cId, dependencies = Set(dId))
-      val d = AppDefinition(dId)
-      val e = AppDefinition(eId)
+      val a = AppDefinition(aId, dependencies = Set(bId, cId), cmd = Some("sleep"))
+      val b = AppDefinition(bId, dependencies = Set(cId), cmd = Some("sleep"))
+      val c = AppDefinition(cId, dependencies = Set(dId), cmd = Some("sleep"))
+      val d = AppDefinition(dId, cmd = Some("sleep"))
+      val e = AppDefinition(eId, cmd = Some("sleep"))
 
       val rootGroup = createRootGroup(
         apps = Map(a.id -> a, b.id -> b, c.id -> c, d.id -> d, e.id -> e)
@@ -86,7 +86,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
     }
 
     "start from empty group" in {
-      val app = AppDefinition("/app".toPath, instances = 2)
+      val app = AppDefinition("/group/app".toPath, instances = 2, cmd = Some("sleep"))
       val from = createRootGroup(groups = Set(createGroup("/group".toPath, Map.empty, groups = Set.empty)))
       val to = createRootGroup(groups = Set(createGroup("/group".toPath, Map(app.id -> app))))
       val plan = DeploymentPlan(from, to)
@@ -96,12 +96,12 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
     }
 
     "start from running group" in {
-      val app1 = AppDefinition("/app".toPath, Some("sleep 10"))
-      val app2 = AppDefinition("/app2".toPath, Some("cmd2"))
-      val app3 = AppDefinition("/app3".toPath, Some("cmd3"))
-      val updatedApp1 = AppDefinition("/app".toPath, Some("sleep 30"))
-      val updatedApp2 = AppDefinition("/app2".toPath, Some("cmd2"), instances = 10)
-      val app4 = AppDefinition("/app4".toPath, Some("cmd4"))
+      val app1 = AppDefinition("app".toPath, Some("sleep 10"))
+      val app2 = AppDefinition("app2".toPath, Some("cmd2"))
+      val app3 = AppDefinition("app3".toPath, Some("cmd3"))
+      val updatedApp1 = AppDefinition("app".toPath, Some("sleep 30"))
+      val updatedApp2 = AppDefinition("app2".toPath, Some("cmd2"), instances = 10)
+      val app4 = AppDefinition("app4".toPath, Some("cmd4"))
       val apps = Map(app1.id -> app1, app2.id -> app2, app3.id -> app3)
       val update = Map(updatedApp1.id -> updatedApp1, updatedApp2.id -> updatedApp2, app4.id -> app4)
 
@@ -119,16 +119,16 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
 
     "can compute affected app ids" in {
       val versionInfo = VersionInfo.forNewConfig(Timestamp(10))
-      val app: AppDefinition = AppDefinition("/app".toPath, Some("sleep 10"), versionInfo = versionInfo)
-      val app2: AppDefinition = AppDefinition("/app2".toPath, Some("cmd2"), versionInfo = versionInfo)
-      val app3: AppDefinition = AppDefinition("/app3".toPath, Some("cmd3"), versionInfo = versionInfo)
-      val unchanged: AppDefinition = AppDefinition("/unchanged".toPath, Some("unchanged"), versionInfo = versionInfo)
+      val app: AppDefinition = AppDefinition("/group/app".toPath, Some("sleep 10"), versionInfo = versionInfo)
+      val app2: AppDefinition = AppDefinition("/group/app2".toPath, Some("cmd2"), versionInfo = versionInfo)
+      val app3: AppDefinition = AppDefinition("/group/app3".toPath, Some("cmd3"), versionInfo = versionInfo)
+      val unchanged: AppDefinition = AppDefinition("/group/unchanged".toPath, Some("unchanged"), versionInfo = versionInfo)
 
       val apps = Map(app.id -> app, app2.id -> app2, app3.id -> app3, unchanged.id -> unchanged)
 
       val updatedApp = app.copy(cmd = Some("sleep 30"))
       val updatedApp2 = app2.copy(instances = 10)
-      val updatedApp4 = AppDefinition("/app4".toPath, Some("cmd4"))
+      val updatedApp4 = AppDefinition("/group/app4".toPath, Some("cmd4"))
       val update = Map(
         updatedApp.id -> updatedApp,
         updatedApp2.id -> updatedApp2,
@@ -140,7 +140,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       val to = createRootGroup(groups = Set(createGroup("/group".toPath, update)))
       val plan = DeploymentPlan(from, to)
 
-      plan.affectedRunSpecIds should equal(Set("/app".toPath, "/app2".toPath, "/app3".toPath, "/app4".toPath))
+      plan.affectedRunSpecIds should equal(Set("/group/app".toPath, "/group/app2".toPath, "/group/app3".toPath, "/group/app4".toPath))
       plan.isAffectedBy(plan) should equal(right = true)
       plan.isAffectedBy(DeploymentPlan(from, from)) should equal(right = false)
     }
@@ -271,8 +271,8 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
         AppDefinition(appId, Some("app1"), instances = 1, upgradeStrategy = strategy) ->
           AppDefinition(appId, Some("app2"), instances = 3, upgradeStrategy = strategy)
 
-      val toStop = AppDefinition("/test/service/toStop".toPath, instances = 1, dependencies = Set(mongoId))
-      val toStart = AppDefinition("/test/service/toStart".toPath, instances = 2, dependencies = Set(serviceId))
+      val toStop = AppDefinition("/test/service/to-stop".toPath, instances = 1, dependencies = Set(mongoId), cmd = Some("sleep"))
+      val toStart = AppDefinition("/test/service/to-start".toPath, instances = 2, dependencies = Set(serviceId), cmd = Some("sleep"))
 
       val from = createRootGroup(groups = Set(createGroup("/test".toPath, groups = Set(
         createGroup("/test/database".toPath, Map(mongo._1.id -> mongo._1)),
@@ -367,23 +367,21 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
     "ScaleApplication step is created with TasksToKill" in {
       Given("a group with one app")
       val aId = "/test/some/a".toPath
-      val oldApp = AppDefinition(aId, versionInfo = VersionInfo.forNewConfig(Timestamp(10)))
+      val oldAppA = AppDefinition(aId, versionInfo = VersionInfo.forNewConfig(Timestamp(10)), cmd = Some("sleep"))
 
       When("A deployment plan is generated")
       val originalGroup = createRootGroup(groups = Set(createGroup(
         id = "/test".toPath,
-        apps = Map(oldApp.id -> oldApp),
         groups = Set(
-          createGroup("/test/some".toPath, Map(oldApp.id -> oldApp))
+          createGroup("/test/some".toPath, Map(oldAppA.id -> oldAppA))
         )
       )))
 
-      val newApp = oldApp.copy(instances = 5)
+      val newAppA = oldAppA.copy(instances = 5)
       val targetGroup = createRootGroup(groups = Set(createGroup(
         id = "/test".toPath,
-        apps = Map(newApp.id -> newApp),
         groups = Set(
-          createGroup("/test/some".toPath, Map(newApp.id -> newApp))
+          createGroup("/test/some".toPath, Map(newAppA.id -> newAppA))
         )
       )))
 
@@ -396,7 +394,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
 
       Then("DeploymentSteps should include ScaleApplication w/ tasksToKill")
       plan.steps should not be empty
-      plan.steps.head.actions.head shouldEqual ScaleApplication(newApp, 5, Some(Seq(instanceToKill)))
+      plan.steps.head.actions.head shouldEqual ScaleApplication(newAppA, 5, Some(Seq(instanceToKill)))
     }
 
     "Deployment plan allows valid updates for resident tasks" in {
@@ -432,14 +430,16 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
     def residentApp(id: String, volumes: Seq[PersistentVolume]): AppDefinition = {
       AppDefinition(
         id = PathId(id),
+        cmd = Some("foo"),
         container = Some(Container.Mesos(volumes)),
-        residency = Some(Residency(123, Protos.ResidencyDefinition.TaskLostBehavior.RELAUNCH_AFTER_TIMEOUT))
+        residency = Some(Residency(123, Protos.ResidencyDefinition.TaskLostBehavior.RELAUNCH_AFTER_TIMEOUT)),
+        unreachableStrategy = UnreachableDisabled
       )
     }
     val vol1 = persistentVolume("foo")
     val vol2 = persistentVolume("bla")
     val vol3 = persistentVolume("test")
-    val validResident = residentApp("/app1", Seq(vol1, vol2)).copy(upgradeStrategy = zero)
+    val validResident = residentApp("/test/app1", Seq(vol1, vol2)).copy(upgradeStrategy = zero)
     val rootGroup = createRootGroup(groups = Set(createGroup(PathId("/test"), apps = Map(validResident.id -> validResident))))
     val marathonConf = MarathonTestHelper.defaultConfig()
     val validator = DeploymentPlan.deploymentPlanValidator()

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -216,7 +216,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val version2 = VersionInfo.forNewConfig(Timestamp(1000))
       val app1New = app1.copy(instances = 2, versionInfo = version2)
 
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app1New.id -> app1New))))
+      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/fobar"), Map(app1New.id -> app1New))))
 
       val instance1_1 = TestInstanceBuilder.newBuilder(app1.id, version = app1.version).addTaskRunning(startedAt = Timestamp.zero).getInstance()
       val instance1_2 = TestInstanceBuilder.newBuilder(app1.id, version = app1.version).addTaskRunning(startedAt = Timestamp(500)).getInstance()

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -216,7 +216,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val version2 = VersionInfo.forNewConfig(Timestamp(1000))
       val app1New = app1.copy(instances = 2, versionInfo = version2)
 
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/fobar"), Map(app1New.id -> app1New))))
+      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app1New.id -> app1New))))
 
       val instance1_1 = TestInstanceBuilder.newBuilder(app1.id, version = app1.version).addTaskRunning(startedAt = Timestamp.zero).getInstance()
       val instance1_2 = TestInstanceBuilder.newBuilder(app1.id, version = app1.version).addTaskRunning(startedAt = Timestamp(500)).getInstance()

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -72,11 +72,11 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
   "DeploymentActor" should {
     "Deploy" in new Fixture {
       val managerProbe = TestProbe()
-      val app1 = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 2)
-      val app2 = AppDefinition(id = PathId("/app2"), cmd = Some("cmd"), instances = 1)
-      val app3 = AppDefinition(id = PathId("/app3"), cmd = Some("cmd"), instances = 1)
-      val app4 = AppDefinition(id = PathId("/app4"), cmd = Some("cmd"))
-      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo/bar"), Map(
+      val app1 = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2)
+      val app2 = AppDefinition(id = PathId("/foo/app2"), cmd = Some("cmd"), instances = 1)
+      val app3 = AppDefinition(id = PathId("/foo/app3"), cmd = Some("cmd"), instances = 1)
+      val app4 = AppDefinition(id = PathId("/foo/app4"), cmd = Some("cmd"))
+      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(
         app1.id -> app1,
         app2.id -> app2,
         app4.id -> app4))))
@@ -85,7 +85,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val app1New = app1.copy(instances = 1, versionInfo = version2)
       val app2New = app2.copy(instances = 2, cmd = Some("otherCmd"), versionInfo = version2)
 
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo/bar"), Map(
+      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(
         app1New.id -> app1New,
         app2New.id -> app2New,
         app3.id -> app3))))
@@ -154,13 +154,13 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
     "Restart app" in new Fixture {
       val managerProbe = TestProbe()
       val promise = Promise[Done]()
-      val app = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 2)
-      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo/bar"), Map(app.id -> app))))
+      val app = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2)
+      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
 
       val version2 = VersionInfo.forNewConfig(Timestamp(1000))
       val appNew = app.copy(cmd = Some("cmd new"), versionInfo = version2)
 
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo/bar"), Map(appNew.id -> appNew))))
+      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(appNew.id -> appNew))))
 
       val instance1_1 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp.zero).getInstance()
       val instance1_2 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp(1000)).getInstance()
@@ -192,12 +192,12 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val managerProbe = TestProbe()
       val promise = Promise[Done]()
 
-      val app = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 0)
-      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo/bar"), Map(app.id -> app))))
+      val app = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 0)
+      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
 
       val version2 = VersionInfo.forNewConfig(Timestamp(1000))
       val appNew = app.copy(cmd = Some("cmd new"), versionInfo = version2)
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo/bar"), Map(appNew.id -> appNew))))
+      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(appNew.id -> appNew))))
 
       val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
@@ -210,13 +210,13 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
     "Scale with tasksToKill" in new Fixture {
       val managerProbe = TestProbe()
-      val app1 = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 3)
-      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo/bar"), Map(app1.id -> app1))))
+      val app1 = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 3)
+      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app1.id -> app1))))
 
       val version2 = VersionInfo.forNewConfig(Timestamp(1000))
       val app1New = app1.copy(instances = 2, versionInfo = version2)
 
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo/bar"), Map(app1New.id -> app1New))))
+      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app1New.id -> app1New))))
 
       val instance1_1 = TestInstanceBuilder.newBuilder(app1.id, version = app1.version).addTaskRunning(startedAt = Timestamp.zero).getInstance()
       val instance1_2 = TestInstanceBuilder.newBuilder(app1.id, version = app1.version).addTaskRunning(startedAt = Timestamp(500)).getInstance()

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
@@ -43,7 +43,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Deployment" in {
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath)
+      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"))
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -58,7 +58,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Finished deployment" in {
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath)
+      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"))
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -76,7 +76,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Conflicting not forced deployment" in {
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath)
+      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"))
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -98,7 +98,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Conflicting forced deployment" in {
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath)
+      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"))
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -120,7 +120,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Multiple conflicting forced deployments" in {
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath)
+      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"))
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -171,7 +171,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
       val manager = f.deploymentManager()
       implicit val timeout = Timeout(1.minute)
 
-      val app = AppDefinition("app".toRootPath)
+      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"))
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
       val plan = DeploymentPlan(oldGroup, newGroup)

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanRevertTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanRevertTest.scala
@@ -55,7 +55,7 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
     }
   }
   private[this] def removeApp(appId: String) = Deployment(s"remove app '$appId'", _.removeApp(appId.toRootPath))
-  private[this] def addApp(appId: String) = Deployment(s"add app '$appId'", _.updateApp(appId.toRootPath, _ => AppDefinition(appId.toRootPath), Timestamp.now()))
+  private[this] def addApp(appId: String) = Deployment(s"add app '$appId'", _.updateApp(appId.toRootPath, _ => AppDefinition(appId.toRootPath, cmd = Some("sleep")), Timestamp.now()))
   private[this] def addGroup(groupId: String) = Deployment(s"add group '$groupId'", _.makeGroup(groupId.toRootPath))
   private[this] def removeGroup(groupId: String) = Deployment(s"remove group '$groupId'", _.removeGroup(groupId.toRootPath))
 
@@ -130,8 +130,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
       Given("an unrelated group")
       val unrelatedGroup = {
         val id = "unrelated".toRootPath
-        val app1 = AppDefinition(id / "app1")
-        val app2 = AppDefinition(id / "app2")
+        val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+        val app2 = AppDefinition(id / "app2", cmd = Some("sleep"))
         createGroup(
           id,
           apps = Map(
@@ -156,8 +156,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
       Given("an existing group with apps")
       val changeme = {
         val id = "changeme".toRootPath
-        val app1 = AppDefinition(id / "app1")
-        val app2 = AppDefinition(id / "app2")
+        val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+        val app2 = AppDefinition(id / "app2", cmd = Some("sleep"))
         createGroup(
           id,
           apps = Map(
@@ -197,8 +197,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
       Given("a group")
       val changeme = {
         val id = "changeme".toRootPath
-        val app1 = AppDefinition(id / "app1")
-        val app2 = AppDefinition(id / "app2")
+        val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+        val app2 = AppDefinition(id / "app2", cmd = Some("sleep"))
         createGroup(
           id,
           apps = Map(
@@ -223,8 +223,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
       Given("an existing group with apps")
       val existingGroup = {
         val id = "changeme".toRootPath
-        val app1 = AppDefinition(id / "app1")
-        val app2 = AppDefinition(id / "app2")
+        val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+        val app2 = AppDefinition(id / "app2", cmd = Some("sleep"))
         createGroup(
           id,
           dependencies = Set(
@@ -261,8 +261,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
 
     val existingGroup = {
       val id = "changeme".toRootPath
-      val app1 = AppDefinition(id / "app1")
-      val app2 = AppDefinition(id / "app2")
+      val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+      val app2 = AppDefinition(id / "app2", cmd = Some("sleep"))
       createGroup(
         id,
         dependencies = Set(
@@ -299,7 +299,7 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
             createGroup("othergroup3".toRootPath),
             {
               val id = "other".toRootPath
-              val app4 = AppDefinition(id / "app4")
+              val app4 = AppDefinition(id / "app4", cmd = Some("sleep"))
               createGroup(
                 id,
                 apps = Map(app4.id -> app4) // app4 was added
@@ -307,8 +307,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
             },
             {
               val id = "changeme".toRootPath
-              val app1 = AppDefinition(id / "app1")
-              val app3 = AppDefinition(id / "app3")
+              val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+              val app3 = AppDefinition(id / "app3", cmd = Some("sleep"))
               createGroup(
                 id,
                 dependencies = Set(
@@ -348,8 +348,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
             },
             {
               val id = "changeme".toRootPath
-              val app1 = AppDefinition(id / "app1")
-              val app2 = AppDefinition(id / "app2")
+              val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+              val app2 = AppDefinition(id / "app2", cmd = Some("sleep"))
               createGroup(
                 id,
                 dependencies = Set(
@@ -379,8 +379,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
             createGroup("othergroup3".toRootPath),
             {
               val id = "changeme".toRootPath
-              val app1 = AppDefinition(id / "app1")
-              val app2 = AppDefinition(id / "app2")
+              val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+              val app2 = AppDefinition(id / "app2", cmd = Some("sleep"))
               createGroup(
                 id,
                 dependencies = Set(
@@ -411,8 +411,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
             createGroup("othergroup3".toRootPath),
             {
               val id = "changeme".toRootPath
-              val app1 = AppDefinition(id / "app1")
-              val app2 = AppDefinition(id / "app2")
+              val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+              val app2 = AppDefinition(id / "app2", cmd = Some("sleep"))
               createGroup(
                 id,
                 dependencies = Set(
@@ -447,8 +447,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
               createGroup("othergroup3".toRootPath),
               {
                 val id = "changeme".toRootPath
-                val app1 = AppDefinition(id / "app1")
-                val app2 = AppDefinition(id / "app2")
+                val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+                val app2 = AppDefinition(id / "app2", cmd = Some("sleep"))
                 createGroup(
                   id,
                   dependencies = Set(
@@ -491,11 +491,11 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
             createGroup("othergroup3".toRootPath),
             {
               val id = "changeme".toRootPath
-              val app1 = AppDefinition(id / "app1")
-              val app2 = AppDefinition(id / "app2")
-              val appBA = AppDefinition(id / "some" / "b" / "a")
-              val appBB = AppDefinition(id / "some" / "b" / "b")
-              val appBC = AppDefinition(id / "some" / "b" / "c")
+              val app1 = AppDefinition(id / "app1", cmd = Some("sleep"))
+              val app2 = AppDefinition(id / "app2", cmd = Some("sleep"))
+              val appBA = AppDefinition(id / "some" / "b" / "a", cmd = Some("sleep"))
+              val appBB = AppDefinition(id / "some" / "b" / "b", cmd = Some("sleep"))
+              val appBC = AppDefinition(id / "some" / "b" / "c", cmd = Some("sleep"))
               createGroup(
                 id,
                 dependencies = Set(

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
@@ -28,9 +28,11 @@ class DVDIProviderRootGroupValidationTest extends UnitTest with GroupCreation {
             apps = Map(
               app1.id -> app1,
               app2.id -> app2
-            )
+            ),
+            validate = false
           )
-        )
+        ),
+        validate = false
       )
 
       f.checkResult(
@@ -51,9 +53,11 @@ class DVDIProviderRootGroupValidationTest extends UnitTest with GroupCreation {
             apps = Map(
               app1.id -> app1,
               app2.id -> app2
-            )
+            ),
+            validate = false
           )
-        )
+        ),
+        validate = false
       )
 
       f.checkResult(

--- a/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
@@ -37,7 +37,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
 
     "Don't store invalid groups" in new Fixture {
       val app1 = AppDefinition("/app1".toPath)
-      val rootGroup = createRootGroup(Map(app1.id -> app1), groups = Set(createGroup("/app1".toPath)))
+      val rootGroup = createRootGroup(Map(app1.id -> app1), groups = Set(createGroup("/app1".toPath)), validate = false)
 
       groupRepository.root() returns Future.successful(createRootGroup())
 
@@ -49,8 +49,8 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
     }
 
     "return multiple apps when asked" in {
-      val app1 = AppDefinition("/app1".toPath)
-      val app2 = AppDefinition("/app2".toPath)
+      val app1 = AppDefinition("/app1".toPath, cmd = Some("sleep"))
+      val app2 = AppDefinition("/app2".toPath, cmd = Some("sleep"))
       val rootGroup = createRootGroup(Map(app1.id -> app1, app2.id -> app2))
       val f = new Fixture(initialRoot = Some(rootGroup))
 

--- a/src/test/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogicTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogicTest.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.test.GroupCreation
 class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
   "applications with port definitions" when {
     "apps with port definitions should map dynamic ports to a non-0 value" in {
-      val app = AppDefinition("/app".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(1)))
+      val app = AppDefinition("/app".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(1)), cmd = Some("sleep"))
       val rootGroup = createRootGroup(Map(app.id -> app))
       val update = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), createRootGroup(), rootGroup)
       update.apps(app.id).portDefinitions.size should equal(2)
@@ -19,9 +19,9 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
     }
 
     "multiple apps are assigned dynamic app ports" should {
-      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(1, 2, 3))
-      val app3 = AppDefinition("/app3".toPath, portDefinitions = PortDefinitions(0, 2, 0))
+      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0), cmd = Some("sleep"))
+      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(1, 2, 3), cmd = Some("sleep"))
+      val app3 = AppDefinition("/app3".toPath, portDefinitions = PortDefinitions(0, 2, 0), cmd = Some("sleep"))
       val rootGroup = createRootGroup(Map(
         app1.id -> app1,
         app2.id -> app2,
@@ -40,8 +40,8 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
 
     //regression for #2743
     "should reassign dynamic service ports specified in the container" in {
-      val app = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 11))
-      val updatedApp = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 0, 11))
+      val app = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 11), cmd = Some("sleep"))
+      val updatedApp = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 0, 11), cmd = Some("sleep"))
       val from = createRootGroup(Map(app.id -> app))
       val to = createRootGroup(Map(updatedApp.id -> updatedApp))
       val update = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), from, to)
@@ -50,8 +50,8 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
 
     "Already taken ports will not be used" in {
       val servicePortsRange = 10.to(20)
-      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(0, 2, 0))
+      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0), cmd = Some("sleep"))
+      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(0, 2, 0), cmd = Some("sleep"))
       val rootGroup = createRootGroup(Map(
         app1.id -> app1,
         app2.id -> app2
@@ -63,7 +63,7 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
 
     // Regression test for #2868
     "Don't assign duplicated service ports" in {
-      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 10))
+      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 10), cmd = Some("sleep"))
       val rootGroup = createRootGroup(Map(app1.id -> app1))
       val update = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), createRootGroup(), rootGroup)
 
@@ -72,10 +72,10 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
     }
 
     "Assign unique service ports also when adding a dynamic service port to an app" in {
-      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 11))
+      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(10, 11), cmd = Some("sleep"))
       val originalGroup = createRootGroup(Map(app1.id -> app1))
 
-      val updatedApp1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
+      val updatedApp1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0), cmd = Some("sleep"))
       val updatedGroup = createRootGroup(Map(updatedApp1.id -> updatedApp1))
       val result = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), originalGroup, updatedGroup)
 
@@ -84,8 +84,8 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
     }
 
     "If there are not enough ports, a PortExhausted exception is thrown" in {
-      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0))
-      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(0, 0, 0))
+      val app1 = AppDefinition("/app1".toPath, portDefinitions = PortDefinitions(0, 0, 0), cmd = Some("sleep"))
+      val app2 = AppDefinition("/app2".toPath, portDefinitions = PortDefinitions(0, 0, 0), cmd = Some("sleep"))
       val rootGroup = createRootGroup(Map(
         app1.id -> app1,
         app2.id -> app2
@@ -112,7 +112,7 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
         )
         )
         val virtualNetwork = Seq(ContainerNetwork(name = "whatever"))
-        val app = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = Some(container), networks = virtualNetwork)
+        val app = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = Some(container), networks = virtualNetwork, cmd = Some("sleep"))
         val rootGroup = createRootGroup(Map(app.id -> app))
         val updatedGroup = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
         val updatedApp = updatedGroup.transitiveApps.head
@@ -132,8 +132,8 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
         )
         ))
         val virtualNetwork = Seq(ContainerNetwork(name = "whatever"))
-        val app1 = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = c1, networks = virtualNetwork)
-        val app2 = AppDefinition("/app2".toPath, portDefinitions = Seq(), container = c2, networks = virtualNetwork)
+        val app1 = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = c1, networks = virtualNetwork, cmd = Some("sleep"))
+        val app2 = AppDefinition("/app2".toPath, portDefinitions = Seq(), container = c2, networks = virtualNetwork, cmd = Some("sleep"))
         val rootGroup = createRootGroup(Map(
           app1.id -> app1,
           app2.id -> app2
@@ -156,8 +156,8 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
           PortMapping(containerPort = 8082, hostPort = Some(0))
         )
         ))
-        val bridgeModeApp = AppDefinition("/bridgemodeapp".toPath, container = bridgeModeContainer, networks = Seq(BridgeNetwork()))
-        val userModeApp = AppDefinition("/usermodeapp".toPath, container = userModeContainer, networks = Seq(ContainerNetwork("whatever")))
+        val bridgeModeApp = AppDefinition("/bridgemodeapp".toPath, container = bridgeModeContainer, networks = Seq(BridgeNetwork()), cmd = Some("sleep"))
+        val userModeApp = AppDefinition("/usermodeapp".toPath, container = userModeContainer, networks = Seq(ContainerNetwork("whatever")), cmd = Some("sleep"))
         val fromGroup = createRootGroup(Map(bridgeModeApp.id -> bridgeModeApp))
         val toGroup = createRootGroup(Map(
           bridgeModeApp.id -> bridgeModeApp,
@@ -180,7 +180,7 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
           PortMapping()
         )
         ))
-        val app1 = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = c1, networks = Seq(ContainerNetwork("whatever")))
+        val app1 = AppDefinition("/app1".toPath, portDefinitions = Seq(), container = c1, networks = Seq(ContainerNetwork("whatever")), cmd = Some("sleep"))
         val rootGroup = createRootGroup(Map(app1.id -> app1))
         val update = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
         update.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
@@ -196,7 +196,7 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
           PortMapping(containerPort = 9000, hostPort = Some(10555), servicePort = 81, protocol = "udp")
         )
         )
-        val app1 = AppDefinition("/app1".toPath, container = Some(container), networks = Seq(ContainerNetwork("foo")))
+        val app1 = AppDefinition("/app1".toPath, container = Some(container), networks = Seq(ContainerNetwork("foo")), cmd = Some("sleep"))
         val rootGroup = createRootGroup(Map(app1.id -> app1))
         val update = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
         update.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
@@ -209,6 +209,7 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
 
         val app1 = AppDefinition(
           id = "/app1".toPath,
+          cmd = Some("sleep"),
           container = Some(container)
         )
         val rootGroup = createRootGroup(Map(app1.id -> app1))
@@ -221,9 +222,9 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
     }
   }
 
-  behave like withContainerNetworking("docker-docker", Container.Docker())
-  behave like withContainerNetworking("mesos-docker", Container.MesosDocker())
-  behave like withContainerNetworking("mesos-appc", Container.MesosAppC())
+  behave like withContainerNetworking("docker-docker", Container.Docker(image = "foobar"))
+  behave like withContainerNetworking("mesos-docker", Container.MesosDocker(image = "foobar"))
+  behave like withContainerNetworking("mesos-appc", Container.MesosAppC(image = "foobar"))
   behave like withContainerNetworking("mesos", Container.Mesos())
 
 }

--- a/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
@@ -67,7 +67,7 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       val offer = MarathonTestHelper.offerWithVolumes(taskId, localVolumeIdLaunched)
 
       And("a bogus app")
-      val app = AppDefinition(appId)
+      val app = AppDefinition(appId, cmd = Some("sleep"))
       f.groupRepository.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
       And("no tasks")
       f.taskTracker.instancesBySpec()(any) returns Future.successful(InstancesBySpec.empty)
@@ -125,7 +125,7 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       val offer = MarathonTestHelper.offerWithVolumes(taskId, localVolumeIdLaunched)
 
       And("a matching bogus app")
-      val app = AppDefinition(appId)
+      val app = AppDefinition(appId, cmd = Some("sleep"))
       f.groupRepository.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
       And("a matching bogus task")
       f.taskTracker.instancesBySpec()(any) returns Future.successful(

--- a/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
@@ -14,8 +14,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
   "A Group" should {
     "can find a group by its path" in {
       Given("an existing group with two subgroups")
-      val app1 = AppDefinition("/test/group1/app1".toPath)
-      val app2 = AppDefinition("/test/group2/app2".toPath)
+      val app1 = AppDefinition("/test/group1/app1".toPath, cmd = Some("sleep"))
+      val app2 = AppDefinition("/test/group2/app2".toPath, cmd = Some("sleep"))
       val current = createRootGroup(
         groups = Set(
           createGroup("/test".toPath, groups = Set(
@@ -32,8 +32,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "can not find a group if its not existing" in {
       Given("an existing group with two subgroups")
-      val app1 = AppDefinition("/test/group1/app1".toPath)
-      val app2 = AppDefinition("/test/group2/app2".toPath)
+      val app1 = AppDefinition("/test/group1/app1".toPath, cmd = Some("sleep"))
+      val app2 = AppDefinition("/test/group2/app2".toPath, cmd = Some("sleep"))
       val current = createRootGroup(
         groups = Set(
           createGroup("/test".toPath, groups = Set(
@@ -62,8 +62,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "can make groups specified by a path" in {
       Given("a group with subgroups")
-      val app1 = AppDefinition("/test/group1/app1".toPath)
-      val app2 = AppDefinition("/test/group2/app2".toPath)
+      val app1 = AppDefinition("/test/group1/app1".toPath, cmd = Some("sleep"))
+      val app2 = AppDefinition("/test/group2/app2".toPath, cmd = Some("sleep"))
       val current = createRootGroup(
         groups = Set(
           createGroup("/test".toPath, groups = Set(
@@ -223,14 +223,14 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "can turn a group with group dependencies into a dependency graph" in {
       Given("a group with subgroups and dependencies")
-      val redisApp = AppDefinition("/test/database/redis/r1".toPath)
-      val memcacheApp = AppDefinition("/test/database/memcache/c1".toPath)
-      val mongoApp = AppDefinition("/test/database/mongo/m1".toPath)
-      val serviceApp1 = AppDefinition("/test/service/service1/s1".toPath)
-      val serviceApp2 = AppDefinition("/test/service/service2/s2".toPath)
-      val frontendApp1 = AppDefinition("/test/frontend/app1/a1".toPath)
-      val frontendApp2 = AppDefinition("/test/frontend/app2/a2".toPath)
-      val cacheApp = AppDefinition("/test/cache/c1/c1".toPath)
+      val redisApp = AppDefinition("/test/database/redis/r1".toPath, cmd = Some("sleep"))
+      val memcacheApp = AppDefinition("/test/database/memcache/c1".toPath, cmd = Some("sleep"))
+      val mongoApp = AppDefinition("/test/database/mongo/m1".toPath, cmd = Some("sleep"))
+      val serviceApp1 = AppDefinition("/test/service/service1/s1".toPath, cmd = Some("sleep"))
+      val serviceApp2 = AppDefinition("/test/service/service2/s2".toPath, cmd = Some("sleep"))
+      val frontendApp1 = AppDefinition("/test/frontend/app1/a1".toPath, cmd = Some("sleep"))
+      val frontendApp2 = AppDefinition("/test/frontend/app2/a2".toPath, cmd = Some("sleep"))
+      val cacheApp = AppDefinition("/test/cache/c1/c1".toPath, cmd = Some("sleep"))
       val current: RootGroup = createRootGroup(
         groups = Set(
           createGroup("/test".toPath, groups = Set(
@@ -277,14 +277,14 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "can turn a group with app dependencies into a dependency graph" in {
       Given("a group with subgroups and dependencies")
-      val redisApp = AppDefinition("/test/database/redis".toPath)
-      val memcacheApp = AppDefinition("/test/database/memcache".toPath, dependencies = Set("/test/database/mongo".toPath, "/test/database/redis".toPath))
-      val mongoApp = AppDefinition("/test/database/mongo".toPath, dependencies = Set("/test/database/redis".toPath))
-      val serviceApp1 = AppDefinition("/test/service/srv1".toPath, dependencies = Set("/test/database/memcache".toPath))
-      val serviceApp2 = AppDefinition("/test/service/srv2".toPath, dependencies = Set("/test/database/mongo".toPath, "/test/service/srv1".toPath))
-      val frontendApp1 = AppDefinition("/test/frontend/app1".toPath, dependencies = Set("/test/service/srv2".toPath))
-      val frontendApp2 = AppDefinition("/test/frontend/app2".toPath, dependencies = Set("/test/service/srv2".toPath, "/test/database/mongo".toPath, "/test/frontend/app1".toPath))
-      val cacheApp = AppDefinition("/test/cache/cache1".toPath)
+      val redisApp = AppDefinition("/test/database/redis".toPath, cmd = Some("sleep"))
+      val memcacheApp = AppDefinition("/test/database/memcache".toPath, dependencies = Set("/test/database/mongo".toPath, "/test/database/redis".toPath), cmd = Some("sleep"))
+      val mongoApp = AppDefinition("/test/database/mongo".toPath, dependencies = Set("/test/database/redis".toPath), cmd = Some("sleep"))
+      val serviceApp1 = AppDefinition("/test/service/srv1".toPath, dependencies = Set("/test/database/memcache".toPath), cmd = Some("sleep"))
+      val serviceApp2 = AppDefinition("/test/service/srv2".toPath, dependencies = Set("/test/database/mongo".toPath, "/test/service/srv1".toPath), cmd = Some("sleep"))
+      val frontendApp1 = AppDefinition("/test/frontend/app1".toPath, dependencies = Set("/test/service/srv2".toPath), cmd = Some("sleep"))
+      val frontendApp2 = AppDefinition("/test/frontend/app2".toPath, dependencies = Set("/test/service/srv2".toPath, "/test/database/mongo".toPath, "/test/frontend/app1".toPath), cmd = Some("sleep"))
+      val cacheApp = AppDefinition("/test/cache/cache1".toPath, cmd = Some("sleep"))
       //has no dependencies
       val current: RootGroup = createRootGroup(
         groups = Set(
@@ -330,14 +330,14 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "can turn a group without dependencies into a dependency graph" in {
       Given("a group with subgroups and dependencies")
-      val redisApp = AppDefinition("/test/database/redis/r1".toPath)
-      val memcacheApp = AppDefinition("/test/database/memcache/m1".toPath)
-      val mongoApp = AppDefinition("/test/database/mongo/m1".toPath)
-      val serviceApp1 = AppDefinition("/test/service/service1/srv1".toPath)
-      val serviceApp2 = AppDefinition("/test/service/service2/srv2".toPath)
-      val frontendApp1 = AppDefinition("/test/frontend/app1/a1".toPath)
-      val frontendApp2 = AppDefinition("/test/frontend/app2/a2".toPath)
-      val cacheApp1 = AppDefinition("/test/cache/c1/cache1".toPath)
+      val redisApp = AppDefinition("/test/database/redis/r1".toPath, cmd = Some("sleep"))
+      val memcacheApp = AppDefinition("/test/database/memcache/m1".toPath, cmd = Some("sleep"))
+      val mongoApp = AppDefinition("/test/database/mongo/m1".toPath, cmd = Some("sleep"))
+      val serviceApp1 = AppDefinition("/test/service/service1/srv1".toPath, cmd = Some("sleep"))
+      val serviceApp2 = AppDefinition("/test/service/service2/srv2".toPath, cmd = Some("sleep"))
+      val frontendApp1 = AppDefinition("/test/frontend/app1/a1".toPath, cmd = Some("sleep"))
+      val frontendApp2 = AppDefinition("/test/frontend/app2/a2".toPath, cmd = Some("sleep"))
+      val cacheApp1 = AppDefinition("/test/cache/c1/cache1".toPath, cmd = Some("sleep"))
       val current: RootGroup = createRootGroup(
         groups = Set(
           createGroup("/test".toPath, groups = Set(
@@ -369,18 +369,18 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "detects a cyclic dependency graph" in {
       Given("a group with cyclic dependencies")
-      val mongoApp = AppDefinition("/test/database/mongo/m1".toPath, dependencies = Set("/test/service".toPath))
-      val serviceApp1 = AppDefinition("/test/service/service1/srv1".toPath, dependencies = Set("/test/database".toPath))
+      val mongoApp = AppDefinition("/test/database/mongo/m1".toPath, dependencies = Set("/test/service".toPath), cmd = Some("sleep"))
+      val serviceApp1 = AppDefinition("/test/service/service1/srv1".toPath, dependencies = Set("/test/database".toPath), cmd = Some("sleep"))
       val current: RootGroup = createRootGroup(
         groups = Set(
           createGroup("/test".toPath, groups = Set(
             createGroup("/test/database".toPath, groups = Set(
-              createGroup("/test/database/mongo".toPath, Map(mongoApp.id -> mongoApp))
-            )),
+              createGroup("/test/database/mongo".toPath, Map(mongoApp.id -> mongoApp), validate = false)
+            ), validate = false),
             createGroup("/test/service".toPath, groups = Set(
-              createGroup("/test/service/service1".toPath, Map(serviceApp1.id -> serviceApp1))
-            ))
-          ))))
+              createGroup("/test/service/service1".toPath, Map(serviceApp1.id -> serviceApp1), validate = false)
+            ), validate = false)
+          ))), validate = false)
 
       Then("the cycle is detected")
       current.hasNonCyclicDependencies should equal(false)
@@ -399,7 +399,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
       When("App is updated")
       val app = AppDefinition("/test/service/test/app".toPath, cmd = Some("Foobar"))
-      val rootGroup = createRootGroup(Map(app.id -> app))
+      val rootGroup = createRootGroup()
       val updatedGroup = rootGroup.updateApp(app.id, { a => app }, Timestamp.zero)
       val ids = updatedGroup.transitiveGroupsById.keys
 
@@ -410,10 +410,10 @@ class RootGroupTest extends UnitTest with GroupCreation {
     "relative dependencies should be resolvable" in {
       Given("a group with an app having relative dependency")
       val app1 = AppDefinition("app1".toPath, cmd = Some("foo"))
-      val app2 = AppDefinition("app2".toPath, cmd = Some("bar"), dependencies = Set("../app1".toPath))
+      val app2 = AppDefinition("/group/subgroup/app2".toPath, cmd = Some("bar"), dependencies = Set("../app1".toPath))
       val rootGroup = createRootGroup(groups = Set(
-        createGroup("group".toPath, apps = Map(app1.id -> app1),
-          groups = Set(createGroup("subgroup".toPath, Map(app2.id -> app2))))
+        createGroup("/group".toPath, apps = Map(app1.id -> app1),
+          groups = Set(createGroup("/group/subgroup".toPath, Map(app2.id -> app2))))
       ))
 
       When("group is validated")
@@ -427,8 +427,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("Group with nested app of wrong path")
       val app = AppDefinition(PathId("/root"), cmd = Some("test"))
       val invalid = createRootGroup(groups = Set(
-        createGroup(PathId("nested"), apps = Map(app.id -> app))
-      ))
+        createGroup(PathId("nested"), apps = Map(app.id -> app), validate = false)
+      ), validate = false)
 
       When("group is validated")
       val invalidResult = validate(invalid)(RootGroup.rootGroupValidator(Set()))
@@ -441,9 +441,9 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("Group with nested app of wrong path")
       val invalid = createRootGroup(groups = Set(
         createGroup(PathId("nested"), groups = Set(
-          createGroup(PathId("/root"))
-        ))
-      ))
+          createGroup(PathId("/root"), validate = false)
+        ), validate = false)
+      ), validate = false)
 
       When("group is validated")
       val invalidResult = validate(invalid)(RootGroup.rootGroupValidator(Set()))
@@ -455,7 +455,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
     "Root Group with app in wrong group is not valid (Regression for #4901)" in {
       Given("Group with nested app of wrong path")
       val app = AppDefinition(PathId("/foo/bla"), cmd = Some("test"))
-      val invalid = createRootGroup(apps = Map(app.id -> app))
+      val invalid = createRootGroup(apps = Map(app.id -> app), validate = false)
 
       When("group is validated")
       val invalidResult = validate(invalid)(RootGroup.rootGroupValidator(Set()))
@@ -468,7 +468,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("Group with nested app of wrong path")
       val app = AppDefinition(PathId("/nested/foo"), cmd = Some("test"))
       val valid = createRootGroup(groups = Set(
-        createGroup(PathId("nested"), apps = Map(app.id -> app))
+        createGroup(PathId("/nested"), apps = Map(app.id -> app))
       ))
 
       When("group is validated")
@@ -480,7 +480,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "should receive a non-root Group with nested groups as an updated and properly propagate transitiveAppsById" in {
       val appPath = "/domain/developers/gitlab/git".toPath
-      val app = AppDefinition(appPath)
+      val app = AppDefinition(appPath, cmd = Some("sleep"))
 
       val groupUpdate = createGroup(
         PathId("/domain/developers"),
@@ -496,7 +496,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "should receive a non-root Group with nested groups as an updated and properly propagate transitiveAppsByI2 2" in {
       val appPath = "/domain/developers/gitlab/git".toPath
-      val app = AppDefinition(appPath)
+      val app = AppDefinition(appPath, cmd = Some("sleep"))
 
       val groupUpdate = createGroup(
         PathId("/domain"),
@@ -514,7 +514,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "should receive a non-root Group without nested groups as an updated and properly propagate transitiveAppsById 3" in {
       val appPath = "/domain/developers/gitlab/git".toPath
-      val app = AppDefinition(appPath)
+      val app = AppDefinition(appPath, cmd = Some("sleep"))
 
       val groupUpdate = createGroup(
         PathId("/domain/developers/gitlab"),

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo15Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo15Test.scala
@@ -305,7 +305,7 @@ class MigrationTo15Test extends AkkaUnitTest with RecoverMethods with GroupCreat
       }
       "migrate all apps in the current root group" in new Fixture {
         val singleAppRoot = createRootGroup(
-          apps = Map(basicCommandApp.id -> AppDefinition(id = basicCommandApp.id, versionInfo = basicCommandApp.versionInfo)),
+          apps = Map(basicCommandApp.id -> AppDefinition(id = basicCommandApp.id, versionInfo = basicCommandApp.versionInfo, cmd = Some("sleep"))),
           pods = Map.empty,
           groups = Set.empty,
           dependencies = Set.empty,
@@ -336,7 +336,7 @@ class MigrationTo15Test extends AkkaUnitTest with RecoverMethods with GroupCreat
           version = Timestamp.zero
         )
         val singleAppRoot = createRootGroup(
-          apps = Map(basicCommandApp.id -> AppDefinition(id = basicCommandApp.id, versionInfo = basicCommandApp.versionInfo)),
+          apps = Map(basicCommandApp.id -> AppDefinition(id = basicCommandApp.id, versionInfo = basicCommandApp.versionInfo, cmd = Some("sleep"))),
           pods = Map.empty,
           groups = Set.empty,
           dependencies = Set.empty,

--- a/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
@@ -209,8 +209,8 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(5)()()
         f.actor.setState(Scanning, UpdatedEntities())
         val deployPromise = Promise[Done]()
-        val app1 = AppDefinition("a".toRootPath)
-        val app2 = AppDefinition("b".toRootPath)
+        val app1 = AppDefinition("a".toRootPath, cmd = Some("sleep"))
+        val app2 = AppDefinition("b".toRootPath, cmd = Some("sleep"))
         val root1 = createRootGroup(Map("a".toRootPath -> app1))
         val root2 = createRootGroup(Map("b".toRootPath -> app2))
         f.actor ! StorePlan(DeploymentPlan(root1, root2, Timestamp.now()), deployPromise)
@@ -232,8 +232,8 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(5)()(compactWaitOnSem(compactedAppIds, compactedAppVersions,
           compactedPodIds, compactedPodVersions, compactedRoots, sem))
         f.actor.setState(Scanning, UpdatedEntities())
-        val app1 = AppDefinition("a".toRootPath)
-        val app2 = AppDefinition("b".toRootPath)
+        val app1 = AppDefinition("a".toRootPath, cmd = Some("sleep"))
+        val app2 = AppDefinition("b".toRootPath, cmd = Some("sleep"))
         val pod1 = PodDefinition("p1".toRootPath)
         val pod2 = PodDefinition("p2".toRootPath)
         val root1 = createRootGroup(Map("a".toRootPath -> app1), Map(pod1.id -> pod1))
@@ -393,8 +393,8 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(2)()()
         f.actor.setState(Compacting, BlockedEntities())
         val promise = Promise[Done]()
-        val app1 = AppDefinition("a".toRootPath)
-        val app2 = AppDefinition("b".toRootPath)
+        val app1 = AppDefinition("a".toRootPath, cmd = Some("sleep"))
+        val app2 = AppDefinition("b".toRootPath, cmd = Some("sleep"))
         val root1 = createRootGroup(Map("a".toRootPath -> app1))
         val root2 = createRootGroup(Map("b".toRootPath -> app2))
         f.actor ! StorePlan(DeploymentPlan(root1, root2, Timestamp.now()), promise)
@@ -405,12 +405,12 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "block plans with deleted roots until compaction completes" in {
         val f = Fixture(2)()()
-        val app1 = AppDefinition("a".toRootPath)
+        val app1 = AppDefinition("a".toRootPath, cmd = Some("sleep"))
         val root1 = createRootGroup(Map("a".toRootPath -> app1))
 
         f.actor.setState(Compacting, BlockedEntities(rootsDeleting = Set(root1.version.toOffsetDateTime)))
         val promise = Promise[Done]()
-        val app2 = AppDefinition("b".toRootPath)
+        val app2 = AppDefinition("b".toRootPath, cmd = Some("sleep"))
         val root2 = createRootGroup(Map("b".toRootPath -> app2))
         f.actor ! StorePlan(DeploymentPlan(root1, root2, Timestamp.now()), promise)
         // internally we send two more messages as StorePlan in compacting is the same as StoreRoot x 2
@@ -528,10 +528,10 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "delete unused apps, pods, and roots" in {
         val f = Fixture(1)()()
-        val dApp1 = AppDefinition("a".toRootPath)
-        val dApp2 = AppDefinition("b".toRootPath)
+        val dApp1 = AppDefinition("a".toRootPath, cmd = Some("sleep"))
+        val dApp2 = AppDefinition("b".toRootPath, cmd = Some("sleep"))
         val dApp1V2 = dApp1.copy(versionInfo = VersionInfo.OnlyVersion(Timestamp(7)))
-        val app3 = AppDefinition("c".toRootPath)
+        val app3 = AppDefinition("c".toRootPath, cmd = Some("sleep"))
         f.appRepo.store(dApp1).futureValue
         f.appRepo.storeVersion(dApp2).futureValue
         f.appRepo.store(app3)

--- a/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
+++ b/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
@@ -12,11 +12,12 @@ trait GroupCreation {
     groups: Set[Group] = Set.empty,
     dependencies: Set[PathId] = Group.defaultDependencies,
     version: Timestamp = Group.defaultVersion,
-    validate: Boolean = true): RootGroup = {
+    validate: Boolean = true,
+    enabledFeatures: Set[String] = Set.empty): RootGroup = {
     val group = RootGroup(apps, pods, groups.map(group => group.id -> group)(collection.breakOut), dependencies, version)
 
     if (validate) {
-      val validation = accord.validate(group)(RootGroup.rootGroupValidator(Set("secrets")))
+      val validation = accord.validate(group)(RootGroup.rootGroupValidator(enabledFeatures))
       assert(validation.isSuccess, s"Provided test root group was not valid: ${validation.toString}")
     }
 
@@ -30,7 +31,8 @@ trait GroupCreation {
     groups: Set[Group] = Set.empty,
     dependencies: Set[PathId] = Group.defaultDependencies,
     version: Timestamp = Group.defaultVersion,
-    validate: Boolean = true): Group = {
+    validate: Boolean = true,
+    enabledFeatures: Set[String] = Set.empty): Group = {
     val groupsById: Map[Group.GroupKey, Group] = groups.map(group => group.id -> group)(collection.breakOut)
     val group = Group(
       id,
@@ -43,7 +45,7 @@ trait GroupCreation {
       pods ++ groupsById.values.flatMap(_.transitivePodsById))
 
     if (validate) {
-      val validation = accord.validate(group)(Group.validGroup(id.parent, Set("secrets")))
+      val validation = accord.validate(group)(Group.validGroup(id.parent, enabledFeatures))
       assert(validation.isSuccess, s"Provided test group was not valid: ${validation.toString}")
     }
 

--- a/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
+++ b/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
@@ -16,7 +16,7 @@ trait GroupCreation {
     val group = RootGroup(apps, pods, groups.map(group => group.id -> group)(collection.breakOut), dependencies, version)
 
     if (validate) {
-      val validation = accord.validate(group)(RootGroup.rootGroupValidator(Set()))
+      val validation = accord.validate(group)(RootGroup.rootGroupValidator(Set("secrets")))
       assert(validation.isSuccess, s"Provided test root group was not valid: ${validation.toString}")
     }
 
@@ -43,7 +43,7 @@ trait GroupCreation {
       pods ++ groupsById.values.flatMap(_.transitivePodsById))
 
     if (validate) {
-      val validation = accord.validate(group)(Group.validGroup(id.parent, Set()))
+      val validation = accord.validate(group)(Group.validGroup(id.parent, Set("secrets")))
       assert(validation.isSuccess, s"Provided test group was not valid: ${validation.toString}")
     }
 


### PR DESCRIPTION
Summary:
Some of the group definitions we use are not valid. This change
introduces a validation for each test group to avoud confusion about
proper group definitions.
