### PR TITLE
 Compute transitive apps by id index lazily. 

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/DependencyGraphBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/DependencyGraphBenchmark.scala
@@ -54,18 +54,14 @@ object DependencyGraphBenchmark {
 
     val subGroups: Map[GroupKey, Group] = groupIds.map { groupId =>
       val id = s"/supergroup-${superGroupId}/group-${groupId}".toPath
-      id -> Group(
-        id = id,
-        transitiveAppsById = appDefs,
-        transitivePodsById = Map.empty)
+      id -> Group(id = id)
     }(breakOut)
 
     val id = s"/supergroup-${superGroupId}".toPath
     id -> Group(
       id = id,
-      groupsById = subGroups,
-      transitiveAppsById = subGroups.flatMap(_._2.transitiveAppsById)(breakOut),
-      transitivePodsById = Map.empty)
+      groupsById = subGroups
+    )
   }(breakOut)
 
   val rootGroup = RootGroup(
@@ -79,13 +75,8 @@ object DependencyGraphBenchmark {
             id = superGroupId,
             groupsById = superGroup.groupsById.map {
               case (id, subGroup) =>
-                id -> Group(
-                  id = id,
-                  transitiveAppsById = subGroup.transitiveAppsById.mapValues(_.copy(versionInfo = version2)),
-                  transitivePodsById = Map.empty)
-            },
-            transitiveAppsById = superGroup.groupsById.flatMap { case (_, group) => group.transitiveAppsById.mapValues(_.copy(versionInfo = version2)) },
-            transitivePodsById = Map.empty
+                id -> Group(id = id)
+            }
           )
         } else {
           superGroupId -> superGroup

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
@@ -86,14 +86,14 @@ class GroupBenchmark {
 @Fork(1)
 class GroupManagerBenchmark extends GroupBenchmark {
 
-  @Benchmark
-  def updateVersionInfoForChangedApps(hole: Blackhole): Unit = {
-    println(rootGroup.groupsById.keys)
-    val newRootGroup = GroupVersioningUtil.updateVersionInfoForChangedApps(
-      Timestamp (2),
-      rootGroup, upgraded)
-    hole.consume(newRootGroup)
-  }
+  //  @Benchmark
+  //  def updateVersionInfoForChangedApps(hole: Blackhole): Unit = {
+  //    println(rootGroup.groupsById.keys)
+  //    val newRootGroup = GroupVersioningUtil.updateVersionInfoForChangedApps(
+  //      Timestamp (2),
+  //      rootGroup, upgraded)
+  //    hole.consume(newRootGroup)
+  //  }
 
   @Benchmark
   def assignDynamicServicePorts(hole: Blackhole): Unit = {

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
@@ -86,14 +86,13 @@ class GroupBenchmark {
 @Fork(1)
 class GroupManagerBenchmark extends GroupBenchmark {
 
-  //  @Benchmark
-  //  def updateVersionInfoForChangedApps(hole: Blackhole): Unit = {
-  //    println(rootGroup.groupsById.keys)
-  //    val newRootGroup = GroupVersioningUtil.updateVersionInfoForChangedApps(
-  //      Timestamp (2),
-  //      rootGroup, upgraded)
-  //    hole.consume(newRootGroup)
-  //  }
+  @Benchmark
+  def updateVersionInfoForChangedApps(hole: Blackhole): Unit = {
+    val newRootGroup = GroupVersioningUtil.updateVersionInfoForChangedApps(
+      Timestamp (2),
+      rootGroup, upgraded)
+    hole.consume(newRootGroup)
+  }
 
   @Benchmark
   def assignDynamicServicePorts(hole: Blackhole): Unit = {

--- a/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
@@ -78,9 +78,7 @@ object UpdateGroupStructureOp {
       pods = Map.empty,
       groupsById = groupsById,
       dependencies = groupUpdate.dependencies.fold(Set.empty[PathId])(_.map(PathId(_).normalize)),
-      version = version,
-      transitiveAppsById = appsById ++ groupsById.values.flatMap(_.transitiveAppsById),
-      transitivePodsById = Map.empty // we don't support updates to pods via group-update operations
+      version = version
     )
   }
 
@@ -126,9 +124,7 @@ object UpdateGroupStructureOp {
       pods = current.pods,
       groupsById = effectiveGroups,
       dependencies = effectiveDependencies,
-      version = timestamp,
-      transitiveAppsById = effectiveApps ++ effectiveGroups.values.flatMap(_.transitiveAppsById),
-      transitivePodsById = current.pods ++ effectiveGroups.values.flatMap(_.transitivePodsById))
+      version = timestamp)
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -18,9 +18,10 @@ class Group(
     val pods: Map[PathId, PodDefinition] = defaultPods,
     val groupsById: Map[Group.GroupKey, Group] = defaultGroups,
     val dependencies: Set[PathId] = defaultDependencies,
-    val version: Timestamp = defaultVersion,
-    val transitiveAppsById: Map[AppDefinition.AppKey, AppDefinition],
-    val transitivePodsById: Map[PathId, PodDefinition]) extends IGroup {
+    val version: Timestamp = defaultVersion) extends IGroup {
+
+  lazy val transitiveAppsById: Map[AppDefinition.AppKey, AppDefinition] = apps ++ groupsById.values.flatMap(_.transitiveAppsById)
+  lazy val transitivePodsById: Map[PathId, PodDefinition] = pods ++ groupsById.values.flatMap(_.transitivePodsById)
 
   def app(appId: PathId): Option[AppDefinition] = transitiveAppsById.get(appId)
   def pod(podId: PathId): Option[PodDefinition] = transitivePodsById.get(podId)
@@ -81,13 +82,11 @@ object Group {
     pods: Map[PathId, PodDefinition] = Group.defaultPods,
     groupsById: Map[Group.GroupKey, Group] = Group.defaultGroups,
     dependencies: Set[PathId] = Group.defaultDependencies,
-    version: Timestamp = Group.defaultVersion,
-    transitiveAppsById: Map[AppDefinition.AppKey, AppDefinition],
-    transitivePodsById: Map[PathId, PodDefinition]): Group =
-    new Group(id, apps, pods, groupsById, dependencies, version, transitiveAppsById, transitivePodsById)
+    version: Timestamp = Group.defaultVersion): Group =
+    new Group(id, apps, pods, groupsById, dependencies, version)
 
   def empty(id: PathId): Group =
-    Group(id = id, version = Timestamp(0), transitiveAppsById = Map.empty, transitivePodsById = Map.empty)
+    Group(id = id, version = Timestamp(0))
 
   def defaultApps: Map[AppDefinition.AppKey, AppDefinition] = Map.empty
   val defaultPods = Map.empty[PathId, PodDefinition]

--- a/src/main/scala/mesosphere/marathon/state/RootGroup.scala
+++ b/src/main/scala/mesosphere/marathon/state/RootGroup.scala
@@ -28,9 +28,7 @@ class RootGroup(
   pods,
   groupsById,
   dependencies,
-  version,
-  apps ++ groupsById.values.flatMap(_.transitiveAppsById),
-  pods ++ groupsById.values.flatMap(_.transitivePodsById)) {
+  version) {
   require(
     groupsById.forall {
       case (_, _: RootGroup) => false
@@ -112,9 +110,9 @@ class RootGroup(
             pods = oldParent.pods,
             groupsById = oldParent.groupsById + (result.id -> result),
             dependencies = oldParent.dependencies,
-            version = version,
-            transitiveAppsById = oldParent.transitiveAppsById -- oldGroup.transitiveAppsById.keys ++ newGroup.transitiveAppsById,
-            transitivePodsById = oldParent.transitivePodsById -- oldGroup.transitivePodsById.keys ++ newGroup.transitivePodsById)
+            version = version)
+          // transitiveAppsById = oldParent.transitiveAppsById -- oldGroup.transitiveAppsById.keys ++ newGroup.transitiveAppsById,
+          // transitivePodsById = oldParent.transitivePodsById -- oldGroup.transitivePodsById.keys ++ newGroup.transitivePodsById)
           rebuildTree(tail, newParent)
       }
     }
@@ -158,9 +156,9 @@ class RootGroup(
         pods = group.pods,
         groupsById = group.groupsById.map { case (subGroupId, subGroup) => subGroupId -> updateApps(subGroup) },
         dependencies = group.dependencies,
-        version = version,
-        transitiveAppsById = group.transitiveAppsById.map { case (appId, appDef) => appId -> app(appDef) },
-        transitivePodsById = group.transitivePodsById)
+        version = version)
+      //        transitiveAppsById = group.transitiveAppsById.map { case (appId, appDef) => appId -> app(appDef) },
+      //        transitivePodsById = group.transitivePodsById)
     }
     val oldGroup = group(groupId).getOrElse(Group.empty(groupId))
     val newGroup = updateApps(oldGroup)
@@ -193,9 +191,9 @@ class RootGroup(
       pods = oldGroup.pods,
       groupsById = oldGroup.groupsById,
       dependencies = oldGroup.dependencies,
-      version = version,
-      transitiveAppsById = oldGroup.transitiveAppsById -- oldApps.keys ++ newApps,
-      transitivePodsById = oldGroup.transitivePodsById)
+      version = version)
+    //      transitiveAppsById = oldGroup.transitiveAppsById -- oldApps.keys ++ newApps,
+    //      transitivePodsById = oldGroup.transitivePodsById)
     putGroup(newGroup, version)
   }
 
@@ -223,9 +221,9 @@ class RootGroup(
       pods = oldGroup.pods,
       groupsById = oldGroup.groupsById,
       dependencies = newDependencies,
-      version = version,
-      transitiveAppsById = oldGroup.transitiveAppsById,
-      transitivePodsById = oldGroup.transitivePodsById
+      version = version
+    //      transitiveAppsById = oldGroup.transitiveAppsById,
+    //      transitivePodsById = oldGroup.transitivePodsById
     )
     putGroup(newGroup, version)
   }
@@ -261,9 +259,9 @@ class RootGroup(
         case (_, group) => group.id != newApp.id || group.containsApps || group.containsPods
       },
       dependencies = oldGroup.dependencies,
-      version = version,
-      transitiveAppsById = oldGroup.transitiveAppsById + (newApp.id -> newApp),
-      transitivePodsById = oldGroup.transitivePodsById)
+      version = version)
+    //      transitiveAppsById = oldGroup.transitiveAppsById + (newApp.id -> newApp),
+    //      transitivePodsById = oldGroup.transitivePodsById)
     putGroup(newGroup, version)
   }
 
@@ -298,9 +296,9 @@ class RootGroup(
         case (_, group) => group.id != newPod.id || group.containsApps || group.containsPods
       },
       dependencies = oldGroup.dependencies,
-      version = version,
-      transitiveAppsById = oldGroup.transitiveAppsById,
-      transitivePodsById = oldGroup.transitivePodsById + (newPod.id -> newPod))
+      version = version)
+    //      transitiveAppsById = oldGroup.transitiveAppsById,
+    //      transitivePodsById = oldGroup.transitivePodsById + (newPod.id -> newPod))
     putGroup(newGroup, version)
   }
 
@@ -311,9 +309,9 @@ class RootGroup(
       pods = group.pods,
       groupsById = group.groupsById.map { case (subGroupId, subGroup) => subGroupId -> updateVersion(subGroup, version) },
       dependencies = group.dependencies,
-      version = version,
-      transitiveAppsById = group.transitiveAppsById,
-      transitivePodsById = group.transitivePodsById)
+      version = version)
+    //      transitiveAppsById = group.transitiveAppsById,
+    //      transitivePodsById = group.transitivePodsById)
   }
 
   /**
@@ -345,9 +343,9 @@ class RootGroup(
           pods = oldParent.pods,
           groupsById = oldParent.groupsById - oldGroup.id,
           dependencies = oldParent.dependencies,
-          version = version,
-          transitiveAppsById = oldParent.transitiveAppsById -- oldGroup.transitiveAppsById.keys,
-          transitivePodsById = oldParent.transitivePodsById -- oldGroup.transitivePodsById.keys), version)
+          version = version), version)
+      //          transitiveAppsById = oldParent.transitiveAppsById -- oldGroup.transitiveAppsById.keys,
+      //          transitivePodsById = oldParent.transitivePodsById -- oldGroup.transitivePodsById.keys), version)
     }
   }
 
@@ -369,9 +367,9 @@ class RootGroup(
         pods = oldGroup.pods,
         groupsById = oldGroup.groupsById,
         dependencies = oldGroup.dependencies,
-        version = version,
-        transitiveAppsById = oldGroup.transitiveAppsById - oldApp.id,
-        transitivePodsById = oldGroup.transitivePodsById), version)
+        version = version), version)
+      //        transitiveAppsById = oldGroup.transitiveAppsById - oldApp.id,
+      //        transitivePodsById = oldGroup.transitivePodsById), version)
     }
   }
 
@@ -393,9 +391,9 @@ class RootGroup(
         pods = oldGroup.pods - oldPod.id,
         groupsById = oldGroup.groupsById,
         dependencies = oldGroup.dependencies,
-        version = version,
-        transitiveAppsById = oldGroup.transitiveAppsById,
-        transitivePodsById = oldGroup.transitivePodsById - oldPod.id), version)
+        version = version), version)
+      //        transitiveAppsById = oldGroup.transitiveAppsById,
+      //        transitivePodsById = oldGroup.transitivePodsById - oldPod.id), version)
     }
   }
 
@@ -411,9 +409,7 @@ class RootGroup(
         pods = group.pods.map { case (podId, pod) => podId -> pod.copy(versionInfo = VersionInfo.NoVersion) },
         groupsById = group.groupsById.map { case (subGroupId, subGroup) => subGroupId -> in(subGroup) },
         dependencies = group.dependencies,
-        version = Timestamp(0),
-        transitiveAppsById = group.transitiveAppsById.map { case (appId, app) => appId -> app.copy(versionInfo = VersionInfo.NoVersion) },
-        transitivePodsById = group.transitivePodsById.map { case (podId, pod) => podId -> pod.copy(versionInfo = VersionInfo.NoVersion) })
+        version = Timestamp(0))
     }
     RootGroup.fromGroup(in(this))
   }

--- a/src/main/scala/mesosphere/marathon/state/RootGroup.scala
+++ b/src/main/scala/mesosphere/marathon/state/RootGroup.scala
@@ -111,8 +111,6 @@ class RootGroup(
             groupsById = oldParent.groupsById + (result.id -> result),
             dependencies = oldParent.dependencies,
             version = version)
-          // transitiveAppsById = oldParent.transitiveAppsById -- oldGroup.transitiveAppsById.keys ++ newGroup.transitiveAppsById,
-          // transitivePodsById = oldParent.transitivePodsById -- oldGroup.transitivePodsById.keys ++ newGroup.transitivePodsById)
           rebuildTree(tail, newParent)
       }
     }
@@ -157,8 +155,6 @@ class RootGroup(
         groupsById = group.groupsById.map { case (subGroupId, subGroup) => subGroupId -> updateApps(subGroup) },
         dependencies = group.dependencies,
         version = version)
-      //        transitiveAppsById = group.transitiveAppsById.map { case (appId, appDef) => appId -> app(appDef) },
-      //        transitivePodsById = group.transitivePodsById)
     }
     val oldGroup = group(groupId).getOrElse(Group.empty(groupId))
     val newGroup = updateApps(oldGroup)
@@ -192,8 +188,6 @@ class RootGroup(
       groupsById = oldGroup.groupsById,
       dependencies = oldGroup.dependencies,
       version = version)
-    //      transitiveAppsById = oldGroup.transitiveAppsById -- oldApps.keys ++ newApps,
-    //      transitivePodsById = oldGroup.transitivePodsById)
     putGroup(newGroup, version)
   }
 
@@ -222,8 +216,6 @@ class RootGroup(
       groupsById = oldGroup.groupsById,
       dependencies = newDependencies,
       version = version
-    //      transitiveAppsById = oldGroup.transitiveAppsById,
-    //      transitivePodsById = oldGroup.transitivePodsById
     )
     putGroup(newGroup, version)
   }
@@ -260,8 +252,6 @@ class RootGroup(
       },
       dependencies = oldGroup.dependencies,
       version = version)
-    //      transitiveAppsById = oldGroup.transitiveAppsById + (newApp.id -> newApp),
-    //      transitivePodsById = oldGroup.transitivePodsById)
     putGroup(newGroup, version)
   }
 
@@ -297,8 +287,6 @@ class RootGroup(
       },
       dependencies = oldGroup.dependencies,
       version = version)
-    //      transitiveAppsById = oldGroup.transitiveAppsById,
-    //      transitivePodsById = oldGroup.transitivePodsById + (newPod.id -> newPod))
     putGroup(newGroup, version)
   }
 
@@ -310,8 +298,6 @@ class RootGroup(
       groupsById = group.groupsById.map { case (subGroupId, subGroup) => subGroupId -> updateVersion(subGroup, version) },
       dependencies = group.dependencies,
       version = version)
-    //      transitiveAppsById = group.transitiveAppsById,
-    //      transitivePodsById = group.transitivePodsById)
   }
 
   /**
@@ -344,8 +330,6 @@ class RootGroup(
           groupsById = oldParent.groupsById - oldGroup.id,
           dependencies = oldParent.dependencies,
           version = version), version)
-      //          transitiveAppsById = oldParent.transitiveAppsById -- oldGroup.transitiveAppsById.keys,
-      //          transitivePodsById = oldParent.transitivePodsById -- oldGroup.transitivePodsById.keys), version)
     }
   }
 
@@ -368,8 +352,6 @@ class RootGroup(
         groupsById = oldGroup.groupsById,
         dependencies = oldGroup.dependencies,
         version = version), version)
-      //        transitiveAppsById = oldGroup.transitiveAppsById - oldApp.id,
-      //        transitivePodsById = oldGroup.transitivePodsById), version)
     }
   }
 
@@ -392,8 +374,6 @@ class RootGroup(
         groupsById = oldGroup.groupsById,
         dependencies = oldGroup.dependencies,
         version = version), version)
-      //        transitiveAppsById = oldGroup.transitiveAppsById,
-      //        transitivePodsById = oldGroup.transitivePodsById - oldPod.id), version)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -88,9 +88,7 @@ case class StoredGroup(
       pods = pods,
       groupsById = groups,
       dependencies = dependencies,
-      version = Timestamp(version),
-      transitiveAppsById = apps ++ groups.values.flatMap(_.transitiveAppsById),
-      transitivePodsById = pods ++ groups.values.flatMap(_.transitivePodsById)
+      version = Timestamp(version)
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/raml/GroupConversionTesting.scala
+++ b/src/test/scala/mesosphere/marathon/raml/GroupConversionTesting.scala
@@ -22,9 +22,7 @@ trait GroupConversionTesting {
       pods = Map.empty[PathId, PodDefinition], // we never read in pods
       groupsById = groupsById,
       dependencies = group.dependencies.map(_.toPath),
-      version = group.version.map(Timestamp(_)).getOrElse(Timestamp.now()),
-      transitiveAppsById = appsById ++ groupsById.values.flatMap(_.transitiveAppsById),
-      transitivePodsById = groupsById.values.flatMap(_.transitivePodsById)(collection.breakOut)
+      version = group.version.map(Timestamp(_)).getOrElse(Timestamp.now())
     )
   }
 }

--- a/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
+++ b/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
@@ -28,8 +28,6 @@ trait GroupCreation {
       pods,
       groupsById,
       dependencies,
-      version,
-      apps ++ groupsById.values.flatMap(_.transitiveAppsById),
-      pods ++ groupsById.values.flatMap(_.transitivePodsById))
+      version)
   }
 }


### PR DESCRIPTION
Summary:
This is the first step to remove the app and pods index alltorgether.
For now it is caluclated only at one spot.

JIRA issues: MARATHON-7945
