### PR TITLE
Collect diagnostics on all exit codes greater than 0

### DIFF
--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -54,7 +54,7 @@ case $CLUSTER_LAUNCH_CODE in
   0)
       ./ci/system_integration.sh "$DCOS_URL"
       SI_CODE=$?
-      if [ ${SI_CODE} -eq 1 ]; then
+      if [ ${SI_CODE} -gt 0 ]; then
         download-diagnostics-bundle
       fi
       ./dcos-launch delete


### PR DESCRIPTION
Summary:
Currently when the code was e.g. 3 then diagnostics bundle was not collected.

