### PR TITLE
 Replace transitive apps and pods set with an iterable. 

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -24,12 +24,10 @@ class GroupBenchmark {
         Container.Docker(Nil, "alpine", List(Container.PortMapping(2015, Some(0), 10000, "tcp", Some("thing")))))
     )
 
-  //  @Param(value = Array("100", "500", "1000", "2500", "5000"))
-  @Param(value = Array("2", "10", "100"))
+  @Param(value = Array("2", "10", "100", "1000"))
   var appsPerGroup: Int = _
   lazy val appIds = 0 until appsPerGroup
 
-  //  @Param(value = Array("5", "15", "100", "1000"))
   @Param(value = Array("5", "10", "20"))
   var groupDepth: Int = _
   lazy val groupIds = 0 until groupDepth

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
@@ -49,7 +49,7 @@ class GroupBenchmark {
               Some(0),
               Seq("tcp"))))))
 
-  @Param(value = Array("100", "500", "1000", "2500", "5000"))
+  @Param(value = Array("100", "500", "1000", "2500", "5000", "10000"))
   var numberOfSavedApps: Int = _
   lazy val ids = 0 until numberOfSavedApps
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -391,7 +391,7 @@ class SchedulerActions(
   def reconcileTasks(driver: SchedulerDriver): Future[Status] = async {
     val root = await(groupRepository.root())
 
-    val runSpecIds = root.transitiveRunSpecIds
+    val runSpecIds = root.transitiveRunSpecIds.toSet
     val instances = await(instanceTracker.instancesBySpec())
 
     val knownTaskStatuses = runSpecIds.flatMap { runSpecId =>

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -66,7 +66,7 @@ class AppTasksResource @Inject() (
     result(tasksResponse)
   }
 
-  def runningTasks(appIds: Set[PathId], instancesBySpec: InstancesBySpec): Set[EnrichedTask] = {
+  def runningTasks(appIds: Iterable[PathId], instancesBySpec: InstancesBySpec): Seq[EnrichedTask] = {
     appIds.withFilter(instancesBySpec.hasSpecInstances).flatMap { id =>
       val health = result(healthCheckManager.statuses(id))
       instancesBySpec.specInstances(id).flatMap { instance =>
@@ -74,7 +74,7 @@ class AppTasksResource @Inject() (
           EnrichedTask(id, task, instance.agentInfo, health.getOrElse(instance.instanceId, Nil))
         }
       }
-    }
+    }(collection.breakOut)
   }
 
   @GET

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -66,7 +66,7 @@ class AppTasksResource @Inject() (
     result(tasksResponse)
   }
 
-  def runningTasks(appIds: Iterable[PathId], instancesBySpec: InstancesBySpec): Seq[EnrichedTask] = {
+  def runningTasks(appIds: Iterable[PathId], instancesBySpec: InstancesBySpec): Vector[EnrichedTask] = {
     appIds.withFilter(instancesBySpec.hasSpecInstances).flatMap { id =>
       val health = result(healthCheckManager.statuses(id))
       instancesBySpec.specInstances(id).flatMap { instance =>

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
@@ -93,7 +93,7 @@ private[impl] object DVDIProviderValidations extends ExternalVolumeValidations {
   // task instance across the entire cluster.
   override lazy val rootGroup = new Validator[RootGroup] {
     override def apply(rootGroup: RootGroup): Result = {
-      val appsByVolume: Map[String, Set[PathId]] =
+      val appsByVolume: Map[String, Iterable[PathId]] =
         rootGroup.transitiveApps
           .flatMap { app => namesOfMatchingVolumes(app).map(_ -> app.id) }
           .groupBy { case (volumeName, _) => volumeName }
@@ -101,8 +101,8 @@ private[impl] object DVDIProviderValidations extends ExternalVolumeValidations {
 
       val appValid: Validator[AppDefinition] = {
         def volumeNameUnique(appId: PathId): Validator[ExternalVolume] = {
-          def conflictingApps(vol: ExternalVolume): Set[PathId] =
-            appsByVolume.getOrElse(vol.external.name, Set.empty).filter(_ != appId)
+          def conflictingApps(vol: ExternalVolume): Iterable[PathId] =
+            appsByVolume.getOrElse(vol.external.name, Iterable.empty).filter(_ != appId)
 
           isTrue { (vol: ExternalVolume) =>
             val conflictingAppIds = conflictingApps(vol).mkString(", ")

--- a/src/main/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogic.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogic.scala
@@ -79,16 +79,15 @@ object AssignDynamicServiceLogic extends StrictLogging {
      * app in the case that servicePorts are re-posted all as 0's.
      */
     val usedServicePorts: Set[Int] =
-      (from.transitiveApps.iterator ++ to.transitiveApps.iterator).flatMap(_.servicePorts).toSet
+      (from.transitiveApps ++ to.transitiveApps).flatMap(_.servicePorts).toSet
     val unassignedPortsIterator = portRange.iterator
       .filter { p => !usedServicePorts.contains(p) }
       .map { port =>
         logger.debug(s"Take next configured free port: $port")
         port
       }
-    val dynamicApps: Iterator[AppDefinition] =
+    val dynamicApps: Iterable[AppDefinition] =
       to.transitiveApps
-        .iterator
         .filter { newApp => changedOrNew(from, newApp) }
         .map {
           // assign values for service ports that the user has left "blank" (set to zero)

--- a/src/main/scala/mesosphere/marathon/core/pod/impl/PodManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/impl/PodManagerImpl.scala
@@ -14,7 +14,7 @@ import scala.concurrent.Future
 
 case class PodManagerImpl(groupManager: GroupManager) extends PodManager {
 
-  override def ids(): Set[PathId] = groupManager.rootGroup().transitivePodIds
+  override def ids(): Set[PathId] = groupManager.rootGroup().transitivePodIds.toSet
 
   def create(p: PodDefinition, force: Boolean): Future[DeploymentPlan] = {
     def createOrThrow(opt: Option[PodDefinition]) = opt

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -46,13 +46,13 @@ class Group(
 
   private def transitiveAppsIterator(): Iterator[AppDefinition] = apps.valuesIterator ++ groupsById.valuesIterator.flatMap(_.transitiveAppsIterator())
   private def transitiveAppIdsIterator(): Iterator[PathId] = apps.keysIterator ++ groupsById.valuesIterator.flatMap(_.transitiveAppIdsIterator())
-  lazy val transitiveApps: Iterable[AppDefinition] = transitiveAppsIterator().toIterable
-  lazy val transitiveAppIds: Iterable[PathId] = transitiveAppIdsIterator().toIterable
+  lazy val transitiveApps: Iterable[AppDefinition] = transitiveAppsIterator().toVector
+  lazy val transitiveAppIds: Iterable[PathId] = transitiveAppIdsIterator().toVector
 
   private def transitivePodsIterator(): Iterator[PodDefinition] = pods.valuesIterator ++ groupsById.valuesIterator.flatMap(_.transitivePodsIterator())
   private def transitivePodIdsIterator(): Iterator[PathId] = pods.keysIterator ++ groupsById.valuesIterator.flatMap(_.transitivePodIdsIterator())
-  lazy val transitivePods: Iterable[PodDefinition] = transitivePodsIterator().toIterable
-  lazy val transitivePodIds: Iterable[PathId] = transitivePodIdsIterator().toIterable
+  lazy val transitivePods: Iterable[PodDefinition] = transitivePodsIterator().toVector
+  lazy val transitivePodIds: Iterable[PathId] = transitivePodIdsIterator().toVector
 
   lazy val transitiveRunSpecs: Iterable[RunSpec] = transitiveApps ++ transitivePods
   lazy val transitiveRunSpecIds: Iterable[PathId] = transitiveAppIds ++ transitivePodIds

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -46,16 +46,16 @@ class Group(
 
   private def transitiveAppsIterator(): Iterator[AppDefinition] = apps.valuesIterator ++ groupsById.valuesIterator.flatMap(_.transitiveAppsIterator())
   private def transitiveAppIdsIterator(): Iterator[PathId] = apps.keysIterator ++ groupsById.valuesIterator.flatMap(_.transitiveAppIdsIterator())
-  lazy val transitiveApps: Set[AppDefinition] = transitiveAppsIterator().toSet
-  lazy val transitiveAppIds: Set[PathId] = transitiveAppIdsIterator().toSet
+  lazy val transitiveApps: Iterable[AppDefinition] = transitiveAppsIterator().toIterable
+  lazy val transitiveAppIds: Iterable[PathId] = transitiveAppIdsIterator().toIterable
 
   private def transitivePodsIterator(): Iterator[PodDefinition] = pods.valuesIterator ++ groupsById.valuesIterator.flatMap(_.transitivePodsIterator())
   private def transitivePodIdsIterator(): Iterator[PathId] = pods.keysIterator ++ groupsById.valuesIterator.flatMap(_.transitivePodIdsIterator())
-  lazy val transitivePods: Set[PodDefinition] = transitivePodsIterator().toSet
-  lazy val transitivePodIds: Set[PathId] = transitivePodIdsIterator().toSet
+  lazy val transitivePods: Iterable[PodDefinition] = transitivePodsIterator().toIterable
+  lazy val transitivePodIds: Iterable[PathId] = transitivePodIdsIterator().toIterable
 
-  lazy val transitiveRunSpecs: Set[RunSpec] = transitiveApps ++ transitivePods
-  lazy val transitiveRunSpecIds: Set[PathId] = transitiveAppIds ++ transitivePodIds
+  lazy val transitiveRunSpecs: Iterable[RunSpec] = transitiveApps ++ transitivePods
+  lazy val transitiveRunSpecIds: Iterable[PathId] = transitiveAppIds ++ transitivePodIds
 
   def transitiveGroups(): Iterator[(Group.GroupKey, Group)] = groupsById.iterator ++ groupsById.valuesIterator.flatMap(_.transitiveGroups())
   lazy val transitiveGroupsById: Map[Group.GroupKey, Group] = {
@@ -122,7 +122,7 @@ object Group {
 
   private def noAppsAndPodsWithSameId: Validator[Group] =
     isTrue("Applications and Pods may not share the same id") { group =>
-      group.transitiveAppIds.intersect(group.transitivePodIds).isEmpty
+      !group.transitiveAppIds.exists(appId => group.pod(appId).isDefined)
     }
 
   private def noAppsAndGroupsWithSameName: Validator[Group] =

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -20,13 +20,32 @@ class Group(
     val dependencies: Set[PathId] = defaultDependencies,
     val version: Timestamp = defaultVersion) extends IGroup {
 
+  /**
+    * Get app from this group or any child group.
+    *
+    * @param appId The app to retrieve.
+    * @return None if the app was not found or non empty option with app.
+    */
   def app(appId: PathId): Option[AppDefinition] = {
     apps.get(appId) orElse group(appId.parent).flatMap(_.apps.get(appId))
   }
+
+  /**
+    * Get pod from this group or any child group.
+    *
+    * @param podId The pod to retrieve.
+    * @return None if the pod was not found or non empty option with pod.
+    */
   def pod(podId: PathId): Option[PodDefinition] = {
     pods.get(podId) orElse group(podId.parent).flatMap(_.pods.get(podId))
   }
 
+  /**
+    * Get a runnable specification from this group or any child group.
+    *
+    * @param id The path of the run spec to retrieve.
+    * @return None of run spec was not found or non empty option with run spec.
+    */
   def runSpec(id: PathId): Option[RunSpec] = {
     val maybeApp = this.app(id)
     if (maybeApp.isDefined) maybeApp else this.pod(id)
@@ -34,13 +53,17 @@ class Group(
 
   /**
     * Checks whether a runnable spec with the given id exists.
+    *
     * @param id Id of an app or pod.
     * @return True if app or pod exists, false otherwise.
     */
   def exists(id: PathId): Boolean = runSpec(id).isDefined
 
   /**
-    * Find and return the child group for the given path. If no match is found, then returns None
+    * Find and return the child group for the given path.
+    *
+    * @param gid The path of the group for find.
+    * @return None if no group was found or non empty option with group.
     */
   def group(gid: PathId): Option[Group] = transitiveGroupsById.get(gid)
 

--- a/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
@@ -72,7 +72,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       )
 
       When("the group's apps are grouped by the longest outbound path")
-      val partitionedApps = DeploymentPlan.runSpecsGroupedByLongestPath(rootGroup.transitiveAppIds, rootGroup)
+      val partitionedApps = DeploymentPlan.runSpecsGroupedByLongestPath(rootGroup.transitiveAppIds.toSet, rootGroup)
 
       Then("three equivalence classes should be computed")
       partitionedApps should have size 4

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanRevertTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanRevertTest.scala
@@ -37,8 +37,8 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
       val actualAppIds = actual.transitiveAppIds
       val expectedAppIds = expected.transitiveAppIds
 
-      val unexpectedAppIds = actualAppIds -- expectedAppIds
-      val missingAppIds = expectedAppIds -- actualAppIds
+      val unexpectedAppIds = actualAppIds.filter(appId => expected.app(appId).isEmpty)
+      val missingAppIds = expectedAppIds.filter(appId => actual.app(appId).isEmpty)
 
       withClue(s"unexpected apps $unexpectedAppIds, missing apps $missingAppIds: ") {
         actualAppIds should equal(expectedAppIds)

--- a/src/test/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogicTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogicTest.scala
@@ -200,7 +200,7 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
         val rootGroup = createRootGroup(Map(app1.id -> app1))
         val update = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
         update.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
-        update.transitiveApps.flatMap(_.servicePorts) should contain theSameElementsAs(Vector(80, 81))
+        update.transitiveApps.flatMap(_.servicePorts) should contain theSameElementsAs (Vector(80, 81))
       }
 
       "Retain the original container definition if port mappings are missing" in {

--- a/src/test/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogicTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogicTest.scala
@@ -67,7 +67,7 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
       val rootGroup = createRootGroup(Map(app1.id -> app1))
       val update = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), createRootGroup(), rootGroup)
 
-      val assignedPorts: Set[Int] = update.transitiveApps.flatMap(_.portNumbers)
+      val assignedPorts: Iterable[Int] = update.transitiveApps.flatMap(_.portNumbers)
       assignedPorts should have size 2
     }
 
@@ -79,7 +79,7 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
       val updatedGroup = createRootGroup(Map(updatedApp1.id -> updatedApp1))
       val result = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), originalGroup, updatedGroup)
 
-      val assignedPorts: Set[Int] = result.transitiveApps.flatMap(_.portNumbers)
+      val assignedPorts: Iterable[Int] = result.transitiveApps.flatMap(_.portNumbers)
       assignedPorts should have size 3
     }
 
@@ -200,7 +200,7 @@ class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
         val rootGroup = createRootGroup(Map(app1.id -> app1))
         val update = AssignDynamicServiceLogic.assignDynamicServicePorts(servicePortsRange, createRootGroup(), rootGroup)
         update.transitiveApps.filter(_.hasDynamicServicePorts) should be (empty)
-        update.transitiveApps.flatMap(_.servicePorts) should equal (Set(80, 81))
+        update.transitiveApps.flatMap(_.servicePorts) should contain theSameElementsAs(Vector(80, 81))
       }
 
       "Retain the original container definition if port mappings are missing" in {

--- a/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
@@ -164,7 +164,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
       Then("the group with same path has been replaced by the new app definition")
       changed.transitiveGroupsById.keys.map(_.toString) should be(Set("/", "/some"))
-      changed.transitiveAppIds.map(_.toString) should contain theSameElementsAs(Vector("/some/nested"))
+      changed.transitiveAppIds.map(_.toString) should contain theSameElementsAs (Vector("/some/nested"))
 
       Then("the resulting group should be valid when represented in the V2 API model")
       validate(changed)(RootGroup.rootGroupValidator(Set())) should be(Success)
@@ -193,7 +193,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Then("the group with same path has NOT been replaced by the new app definition")
       current.transitiveGroupsById.keys.map(_.toString) should be(
         Set("/", "/some", "/some/nested", "/some/nested/path", "/some/nested/path2"))
-      changed.transitiveAppIds.map(_.toString) should contain theSameElementsAs(Vector("/some/nested", "/some/nested/path2/app"))
+      changed.transitiveAppIds.map(_.toString) should contain theSameElementsAs (Vector("/some/nested", "/some/nested/path2/app"))
 
       Then("the conflict will be detected by our V2 API model validation")
       val result = validate(changed)(RootGroup.rootGroupValidator(Set()))
@@ -225,8 +225,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Then("the group with same path has NOT been replaced by the new app definition")
       current.transitiveGroupsById.keys.map(_.toString) should be(
         Set("/", "/some", "/some/nested", "/some/nested/path", "/some/nested/path2"))
-      changed.transitiveAppIds.map(_.toString) should contain theSameElementsAs(Vector("/some/nested"))
-      changed.transitivePodIds.map(_.toString) should contain theSameElementsAs(Vector("/some/nested/path2/pod"))
+      changed.transitiveAppIds.map(_.toString) should contain theSameElementsAs (Vector("/some/nested"))
+      changed.transitivePodIds.map(_.toString) should contain theSameElementsAs (Vector("/some/nested/path2/pod"))
 
       Then("the conflict will be detected by our V2 API model validation")
       val result = validate(changed)(RootGroup.rootGroupValidator(Set()))
@@ -261,7 +261,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       current.transitiveGroupsById.keys.map(_.toString) should be(
         Set("/", "/some", "/some/nested", "/some/nested/path", "/some/nested/path2"))
       changed.transitiveAppIds.map(_.toString) should be('empty)
-      changed.transitivePodIds.map(_.toString) should contain theSameElementsAs(Vector("/some/nested", "/some/nested/path2/pod"))
+      changed.transitivePodIds.map(_.toString) should contain theSameElementsAs (Vector("/some/nested", "/some/nested/path2/pod"))
 
       Then("the conflict will be detected by our V2 API model validation")
       val result = validate(changed)(RootGroup.rootGroupValidator(Set()))


### PR DESCRIPTION
Summary:
This change builds on top of #5805 and cuts the execution time
of the assign dynamic service ports.

The current master takes ~18ms for 15 groups and 10,000 apps 
in the dynamic port assignment benchmark. This change speeds
it up to <5ms.

I also added a benchmark for building the root group which implies
a lot of `updateApp` calls. Here, the current master takes >97000ms
for building a root group with 20 nested child groups and 1000 apps
each, i.e. building a group with 20,000 apps. This patch speeds up
the building time by two magnitudes to <230ms.

The app, pod and child group access time stays constant while the
master as a linear time in terms of number of groups.

The speed is achieved by removing the build up of an apps and pods
index (`transitiveAppsById` and `transitivePodsById`). The look up
stays constant by leveraging the constant lookup of child groups.

JIRA issues: MARATHON-7946
