### PR TITLE
Using MarathonPollerObserver on perf tests

### DIFF
--- a/tests/performance/config/perf-driver/environments/dcluster.yml
+++ b/tests/performance/config/perf-driver/environments/dcluster.yml
@@ -19,3 +19,6 @@ define:
   # We are going to launch marathon ourselves, therefore we are defining
   # `marathon_url` to point to localhost
   marathon_url: http://127.0.0.1:8080
+
+  # The host name where to connect for the JMX endpoint
+  jmx_host: 127.0.0.1

--- a/tests/performance/config/perf-driver/measure/measure-failedDeployments.yml
+++ b/tests/performance/config/perf-driver/measure/measure-failedDeployments.yml
@@ -37,4 +37,4 @@ trackers:
   # tracking session
   - class: tracker.CountTracker
     metric: failedDeployments
-    events: MarathonDeploymentFailedEvent
+    events: MarathonDeploymentFailedEvent MarathonDeploymentRequestFailedEvent

--- a/tests/performance/config/perf-driver/observers/observer-jmx.yml
+++ b/tests/performance/config/perf-driver/observers/observer-jmx.yml
@@ -24,7 +24,7 @@ observers:
   # The events observer is subscribing to the
   - class: observer.JMXObserver
     connect:
-      host: 127.0.0.1
+      host: "{{jmx_host}}"
       port: "{{jmx_port}}"
 
     # Extract the specified values from the specified MBeans

--- a/tests/performance/config/perf-driver/observers/observer-marathon-poller.yml
+++ b/tests/performance/config/perf-driver/observers/observer-marathon-poller.yml
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------- #
 # Configuration Fragment : Server-Side-Events Observer        #
 # ----------------------------------------------------------- #
-# This fragment installs an observer that attaches to the     #
-# marathon's SSE event stream and forwards the events in the  #
-# internal event bus.
+# This fragment installs a poller observer that is checking   #
+# the status of the deployed applications and creates         #
+# synthetic deployment events if something changes.           #
 # ----------------------------------------------------------- #
 
 # Observer configuration
@@ -12,4 +12,5 @@ observers:
 
   # The events observer is subscribing to the
   - class: observer.MarathonPollerObserver
-    url: "{{marathon_url}}/v2/events"
+    url: "{{marathon_url}}"
+

--- a/tests/performance/config/perf-driver/policies/test-1-apps-n-instances.yml
+++ b/tests/performance/config/perf-driver/policies/test-1-apps-n-instances.yml
@@ -56,12 +56,15 @@ policies:
           pre_value: intertest
 
         events:
-
           # Wait until marathon is started before continuing with the tests
           start: MarathonStartedEvent:single
-
           # We advance to next values every time we receive a deployment completion
           advance: MarathonDeploymentSuccessEvent MarathonDeploymentFailedEvent
+
+        advance_condition:
+          # A deployment of an app shouldn't take more than 30 seconds. We put
+          # the double just to be on the safe side.
+          timeout: 60s
 
 
 # Channel configuration

--- a/tests/performance/config/perf-driver/policies/test-n-apps-1-instances.yml
+++ b/tests/performance/config/perf-driver/policies/test-n-apps-1-instances.yml
@@ -63,6 +63,10 @@ policies:
         advance_condition:
           events: "apps"
 
+          # It shouldn't take more than 100 seconds to deploy worst case of apps
+          # so we are using the double just to be on the safe side.
+          timeout: 200s
+
         tasks:
           pre_value: intertest
 

--- a/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
+++ b/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
@@ -21,7 +21,8 @@ include:
 
   # Use marathon's SSE endpoint to measure our metrics
   - observers/observer-marathon-http-timing.yml
-  - observers/observer-marathon-sse.yml
+  # - observers/observer-marathon-sse.yml
+  - observers/observer-marathon-poller.yml
   - observers/observer-jmx.yml
 
   # Measure the given metrics

--- a/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
+++ b/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
@@ -21,7 +21,6 @@ include:
 
   # Use marathon's SSE endpoint to measure our metrics
   - observers/observer-marathon-http-timing.yml
-  # - observers/observer-marathon-sse.yml
   - observers/observer-marathon-poller.yml
   - observers/observer-jmx.yml
 

--- a/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
+++ b/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
@@ -21,7 +21,8 @@ include:
 
   # Use marathon's SSE endpoint to measure our metrics
   - observers/observer-marathon-http-timing.yml
-  - observers/observer-marathon-sse.yml
+  # - observers/observer-marathon-sse.yml
+  - observers/observer-marathon-poller.yml
   - observers/observer-jmx.yml
 
   # Measure the given metrics

--- a/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
+++ b/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
@@ -21,7 +21,6 @@ include:
 
   # Use marathon's SSE endpoint to measure our metrics
   - observers/observer-marathon-http-timing.yml
-  # - observers/observer-marathon-sse.yml
   - observers/observer-marathon-poller.yml
   - observers/observer-jmx.yml
 

--- a/tests/performance/scripts/dcluster_deploy.sh
+++ b/tests/performance/scripts/dcluster_deploy.sh
@@ -20,8 +20,9 @@ if [ -z "$CLUSTER_CONFIG" ]; then
   exit 253
 fi
 
-# Launch a cluster
-marathon-dcluster \
+# Launch a cluster (we use `eval` to expand $DCLUSTER_ARGS)
+eval marathon-dcluster \
   --detach $CLUSTER_CONFIG \
   --marathon $MARATHON_VERSION \
-  --marathon_image $MARATHON_IMAGE
+  --marathon_image $MARATHON_IMAGE \
+  $DCLUSTER_ARGS


### PR DESCRIPTION
This PR introduces a few fixes to the performance tests:

1. Uses [`MarathonPollerObserver`](http://dcos-performance-test-driver.readthedocs.io/en/latest/classes/Observers.html#marathonpollerobserver) instead of subscribing to the SSE event stream. This is creating synthetic "Deployment Success" events deep-diffing the `/groups` endpoint.
2. Adds support for running the tests in a container instead of in the host machine. The main problem here is that marathon is no longer on `127.0.0.1` but on a particular named host. To accommodate this:
    1. The `jmx_host` is now configurable
    2. The `DCLUSTER_ARGS` is introduced to allow arbitrary flags to be passed to the [`marathon-dcluster`](https://github.com/wavesoft/marathon-dcluster#configuration) script, namely the `--network` configuration. You can check the [launch script](https://github.com/mesosphere/marathon-perf-testing/blob/master/run-marathon-perf-tests.sh#L61) for more details on this.

_The performance infrastructure is currently using this branch (`ic/fix/perf-tests`) for testing. Until we merge this branch I am going to periodically rebase this PR_