### PR TITLE
Benchmark and speed up service port assignment by up to three magnitu…

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,3 +4,26 @@ within SBT.
 See here for more details:
 [SBT-JMH](https://github.com/ktoso/sbt-jmh)
 [JMS-Samples](http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/)
+
+## Flamegraphs
+
+[Flamegraphs](http://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html) are a
+great tool to figure out where processing time is spent. You can create one by
+following these steps
+
+### Prerequisites
+
+You should have [jfr-flame-graph](https://github.com/chrishantha/jfr-flame-graph)
+and [FlameGraph](https://github.com/brendangregg/FlameGraph) installed or rather
+runnable on you machine.
+
+You also need the environment variable `FLAMEGRAPH_DIR` set to the path of the
+FlameGraph by Brandan Gregg.
+
+### Creating Flamegraphs
+
+1. Create a flight record of the benchmark run by passing `-prof jmh.extras.JFR`
+  to the run, e.g. `sbt "benchmark/jmh:run -prof jmh.extras.JFR -i 1 -wi 3 -f1
+  -t1 .*GroupManagerBenchmark"`. This will produce a `.jfr` file in the
+  benchmark folder.
+2. Create a flamegraph SVG file with `<path to jfr-flame-graph>/create_flamegraph.sh -f  <path to jfr file> -i > flamegraph.svg`.

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
@@ -1,0 +1,104 @@
+package mesosphere.marathon
+package upgrade
+
+import java.util.concurrent.TimeUnit
+
+import mesosphere.marathon.core.group.impl.AssignDynamicServiceLogic
+import mesosphere.marathon.core.pod.{ BridgeNetwork, MesosContainer }
+import mesosphere.marathon.raml.{ Endpoint, Image, ImageType, Resources }
+import mesosphere.marathon.state.Container
+import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.state._
+import mesosphere.marathon.core.pod.PodDefinition
+import org.openjdk.jmh.annotations.{ Group => _, _ }
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.collection.breakOut
+
+@State(Scope.Benchmark)
+class GroupBenchmark {
+
+  val version = VersionInfo.forNewConfig(Timestamp(1))
+
+  def makeApp(path: PathId) =
+    AppDefinition(
+      id = path,
+      labels = Map("ID" -> path.toString),
+      versionInfo = version,
+      networks = Seq(BridgeNetwork()),
+      container = Some(
+        Container.Docker(Nil, "alpine", List(Container.PortMapping(2015, Some(0), 10000, "tcp", Some("thing")))))
+    )
+
+  def makePod(path: PathId) =
+    PodDefinition(
+      id = path,
+      networks = Seq(BridgeNetwork()),
+      labels = Map("ID" -> path.toString),
+      versionInfo = version,
+
+      containers = Seq(
+        MesosContainer(
+          "container-1",
+          resources = Resources(1.0),
+          image = Some(Image(ImageType.Docker, "alpine")),
+          endpoints = List(
+            Endpoint(
+              "service",
+              Some(2015),
+              Some(0),
+              Seq("tcp"))))))
+
+  @Param(value = Array("100", "500", "1000", "2500", "5000"))
+  var numberOfSavedApps: Int = _
+  lazy val ids = 0 until numberOfSavedApps
+
+  @Param(value = Array("5", "15"))
+  var numberOfGroups: Int = _
+  lazy val groupIds = 0 until numberOfGroups
+
+  lazy val childGroupPaths: Vector[PathId] = groupIds.map { groupId =>
+    s"group-$groupId".toRootPath
+  }(breakOut)
+
+  lazy val rootGroup: RootGroup = fillRootGroup()
+
+  // Create apps and add them to their groups
+  def fillRootGroup(): RootGroup = {
+    var tmpGroup = RootGroup()
+    ids.foreach { appId =>
+      val groupPath = childGroupPaths(appId % numberOfGroups)
+      val path = groupPath / s"app-${appId}"
+      val app = makeApp(path)
+      tmpGroup = tmpGroup.updateApp(path, (maybeApp) => app) // because we create an app, you know.
+    }
+    tmpGroup
+  }
+
+  def upgraded = {
+    val appId = childGroupPaths(0) / s"app-$numberOfSavedApps"
+    rootGroup.updateApp(appId, (maybeApp) => makeApp(appId))
+  }
+}
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+class GroupManagerBenchmark extends GroupBenchmark {
+
+  @Benchmark
+  def updateVersionInfoForChangedApps(hole: Blackhole): Unit = {
+    println(rootGroup.groupsById.keys)
+    val newRootGroup = GroupVersioningUtil.updateVersionInfoForChangedApps(
+      Timestamp (2),
+      rootGroup, upgraded)
+    hole.consume(newRootGroup)
+  }
+
+  @Benchmark
+  def assignDynamicServicePorts(hole: Blackhole): Unit = {
+    val portRange = 10000 until 20000
+    val newRootGroup = AssignDynamicServiceLogic.assignDynamicServicePorts(portRange, rootGroup, upgraded)
+    hole.consume(newRootGroup)
+  }
+}


### PR DESCRIPTION
…des. (#5787)

Summary:
As @zen-dog found a big performance degradation when Marathon has already 5000 apps and a new app is added. He found that `GroupManagerImpl.assignDynamicServicePorts` had an exponential runtime.

The benchmark and flamegraph showed that most time was spend in copying and building the `RootGroup` after the update. It also seems that we update all apps even when the get the same port assigned again. This change introduces a filter so that only apps that are new or changed are updated in the `RootGroup`.

You can run the benchmark with
```
sbt "benchmark/jmh:run -i 1 -wi 3 -f1 -t1 .*GroupManagerBenchmark"
```

This is only a fix for small app updates. If many apps are updated at once we will still hit this bottleneck. We should look into the creation of `transitiveAppsById` and `transitivePodsById`
which take up most of the runtime.

JIRA issues: MARATHON_EE-1770, MARATHON_EE-1764