### PR TITLE
More accurate parsing of the Mesos task info in SI tests MARATHON-7958

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -753,3 +753,13 @@ def running_task_status(task_statuses):
             return task_status
 
     assert False, "Did not find a TASK_RUNNING status in task statuses: %s" % (task_statuses,)
+
+
+def task_by_name(tasks, name):
+    """ Find mesos task by its name
+    """
+    for task in tasks:
+        if task['name'] == name:
+            return
+
+    assert False, "Did not find task with name %s in this list of tasks: %s" % (name, tasks,)

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -742,7 +742,7 @@ def marathon_leadership_changed(original_leader):
 def running_status_network_info(task_statuses):
     """ From a given list of statuses retrieved from mesos API it returns network info of running task.
     """
-    return running_task_status['container_status']['network_infos'][0]
+    return running_task_status(task_statuses)['container_status']['network_infos'][0]
 
 
 def running_task_status(task_statuses):
@@ -759,7 +759,9 @@ def task_by_name(tasks, name):
     """ Find mesos task by its name
     """
     for task in tasks:
+        print(task['name'])
+        print(name)
         if task['name'] == name:
-            return
+            return task
 
     assert False, "Did not find task with name %s in this list of tasks: %s" % (name, tasks,)

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -759,8 +759,6 @@ def task_by_name(tasks, name):
     """ Find mesos task by its name
     """
     for task in tasks:
-        print(task['name'])
-        print(name)
         if task['name'] == name:
             return task
 

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -742,8 +742,14 @@ def marathon_leadership_changed(original_leader):
 def running_status_network_info(task_statuses):
     """ From a given list of statuses retrieved from mesos API it returns network info of running task.
     """
+    return running_task_status['container_status']['network_infos'][0]
+
+
+def running_task_status(task_statuses):
+    """ From a given list of statuses retrieved from mesos API it returns status of running task.
+    """
     for task_status in task_statuses:
         if task_status['state'] == "TASK_RUNNING":
-            return task_status['container_status']['network_infos'][0]
+            return task_status
 
     assert False, "Did not found a TASK_RUNNING status in task statuses: %s" % (task_statuses,)

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -752,4 +752,4 @@ def running_task_status(task_statuses):
         if task_status['state'] == "TASK_RUNNING":
             return task_status
 
-    assert False, "Did not found a TASK_RUNNING status in task statuses: %s" % (task_statuses,)
+    assert False, "Did not find a TASK_RUNNING status in task statuses: %s" % (task_statuses,)

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -737,3 +737,13 @@ def marathon_leadership_changed(original_leader):
     """
     __marathon_leadership_changed_in_marathon_api(original_leader)
     __marathon_leadership_changed_in_mesosDNS(original_leader)
+
+
+def running_status_network_info(task_statuses):
+    """ From a given list of statuses retrieved from mesos API it returns network info of running task.
+    """
+    for task_status in task_statuses:
+        if task_status['state'] == "TASK_RUNNING":
+            return task_status['container_status']['network_infos'][0]
+
+    pytest.fail("did not found a TASK_RUNNING status in task statuses: %s" %(task_statuses,))

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -746,4 +746,4 @@ def running_status_network_info(task_statuses):
         if task_status['state'] == "TASK_RUNNING":
             return task_status['container_status']['network_infos'][0]
 
-    pytest.fail("did not found a TASK_RUNNING status in task statuses: %s" %(task_statuses,))
+    assert False, "Did not found a TASK_RUNNING status in task statuses: %s" % (task_statuses,)

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -454,7 +454,7 @@ def test_pod_with_container_bridge_network():
     common.deployment_wait(service_id=pod_id)
 
     task = common.get_pod_tasks(pod_id)[0]
-    network_info = task['statuses'][0]['container_status']['network_infos'][0]
+    network_info = common.running_status_network_info(task[0]['statuses'])
     assert network_info['name'] == "mesos-bridge", \
         "The network is {}, but mesos-bridge was expected".format(network_info['name'])
 

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -425,7 +425,7 @@ def test_pod_with_container_network():
 
     tasks = common.get_pod_tasks(pod_id)
 
-    network_info = tasks[0]['statuses'][0]['container_status']['network_infos'][0]
+    network_info = common.running_status_network_info(tasks[0]['statuses'])
     assert network_info['name'] == "dcos", \
         "The network name is {}, but 'dcos' was expected".format(network_info['name'])
 

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -399,8 +399,8 @@ def test_pod_health_check():
     common.deployment_wait(service_id=pod_id)
 
     tasks = common.get_pod_tasks(pod_id)
-    c1_health = tasks[0]['statuses'][0]['healthy']
-    c2_health = tasks[1]['statuses'][0]['healthy']
+    c1_health = common.running_task_status(tasks[0]['statuses'])['healthy']
+    c2_health = common.running_task_status(tasks[2]['statuses'])['healthy']
 
     assert c1_health, "One of the pod's tasks is unhealthy"
     assert c2_health, "One of the pod's tasks is unhealthy"

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -421,9 +421,9 @@ def test_pod_with_container_network():
     client.add_pod(pod_def)
     common.deployment_wait(service_id=pod_id)
 
-    tasks = common.get_pod_tasks(pod_id)
+    task = common.task_by_name(common.get_pod_tasks(pod_id), "nginx")
 
-    network_info = common.running_status_network_info(tasks[0]['statuses'])
+    network_info = common.running_status_network_info(task['statuses'])
     assert network_info['name'] == "dcos", \
         "The network name is {}, but 'dcos' was expected".format(network_info['name'])
 
@@ -451,7 +451,7 @@ def test_pod_with_container_bridge_network():
     client.add_pod(pod_def)
     common.deployment_wait(service_id=pod_id)
 
-    task = common.get_pod_tasks(pod_id)[0]
+    task = common.task_by_name(common.get_pod_tasks(pod_id), "nginx")
     network_info = common.running_status_network_info(task[0]['statuses'])
     assert network_info['name'] == "mesos-bridge", \
         "The network is {}, but mesos-bridge was expected".format(network_info['name'])

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -400,7 +400,7 @@ def test_pod_health_check():
 
     tasks = common.get_pod_tasks(pod_id)
     c1_health = common.running_task_status(tasks[0]['statuses'])['healthy']
-    c2_health = common.running_task_status(tasks[2]['statuses'])['healthy']
+    c2_health = common.running_task_status(tasks[1]['statuses'])['healthy']
 
     assert c1_health, "One of the pod's tasks is unhealthy"
     assert c2_health, "One of the pod's tasks is unhealthy"

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -452,7 +452,7 @@ def test_pod_with_container_bridge_network():
     common.deployment_wait(service_id=pod_id)
 
     task = common.task_by_name(common.get_pod_tasks(pod_id), "nginx")
-    network_info = common.running_status_network_info(task[0]['statuses'])
+    network_info = common.running_status_network_info(task['statuses'])
     assert network_info['name'] == "mesos-bridge", \
         "The network is {}, but mesos-bridge was expected".format(network_info['name'])
 

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -399,11 +399,9 @@ def test_pod_health_check():
     common.deployment_wait(service_id=pod_id)
 
     tasks = common.get_pod_tasks(pod_id)
-    c1_health = common.running_task_status(tasks[0]['statuses'])['healthy']
-    c2_health = common.running_task_status(tasks[1]['statuses'])['healthy']
-
-    assert c1_health, "One of the pod's tasks is unhealthy"
-    assert c2_health, "One of the pod's tasks is unhealthy"
+    for task in tasks:
+        health = common.running_task_status(task['statuses'])['healthy']
+        assert health, "One of the pod's tasks (%s) is unhealthy" % (task['name'])
 
 
 @shakedown.dcos_1_9


### PR DESCRIPTION
Summary:
Some parts of mesos task info were queries out of first task status but that is not possible anymore because Mesos started sending TASK_STARTING status. We need to explicitly ask for STATUS_RUNNING for this to work.

JIRA issues: MARATHON-7958, MARATHON-7959