### PR TITLE
Uppercase letters are disallowed in secret names

### DIFF
--- a/tests/system/apps/private-ucr-docker-app.json
+++ b/tests/system/apps/private-ucr-docker-app.json
@@ -15,7 +15,7 @@
   },
   "secrets": {
     "pullConfigSecret": {
-      "source": "/pullConfig"
+      "source": "/pullconfig"
     }
   }
 }

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -84,7 +84,7 @@ def test_create_pod_with_private_image():
     username = os.environ['DOCKER_HUB_USERNAME']
     password = os.environ['DOCKER_HUB_PASSWORD']
 
-    secret_name = "pullConfig"
+    secret_name = "pullconfig"
     secret_value_json = common.create_docker_pull_config_json(username, password)
     secret_value = json.dumps(secret_value_json)
 

--- a/tests/system/pods/private-docker-pod.json
+++ b/tests/system/pods/private-docker-pod.json
@@ -28,7 +28,7 @@
   ],
   "secrets": {
     "pullConfigSecret": {
-      "source": "/pullConfig"
+      "source": "/pullconfig"
     }
   }
 }

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -437,7 +437,7 @@ def test_private_repository_mesos_app():
     username = os.environ['DOCKER_HUB_USERNAME']
     password = os.environ['DOCKER_HUB_PASSWORD']
 
-    secret_name = "pullConfig"
+    secret_name = "pullconfig"
     secret_value_json = common.create_docker_pull_config_json(username, password)
     secret_value = json.dumps(secret_value_json)
 


### PR DESCRIPTION
Summary:
Uppercase letters are disallowed in secret names. See https://jira.mesosphere.com/browse/DCOS-16368

JIRA issues: MARATHON-7966
