### PR TITLE
Increase retry on the v2 leadership query

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -721,7 +721,7 @@ def __marathon_leadership_changed_in_mesosDNS(original_leader):
     assert original_leader != current_leader
 
 
-@retrying.retry(wait_fixed=1000, stop_max_attempt_number=10, retry_on_exception=ignore_exception)
+@retrying.retry(wait_fixed=1000, stop_max_attempt_number=60, retry_on_exception=ignore_exception)
 def __marathon_leadership_changed_in_marathon_api(original_leader):
     """ This method uses Marathon API to figure out that leadership changed.
         We have to retry here because leader election takes time and what might happen is that some nodes might

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -721,7 +721,7 @@ def __marathon_leadership_changed_in_mesosDNS(original_leader):
     assert original_leader != current_leader
 
 
-@retrying.retry(wait_fixed=1000, stop_max_attempt_number=60, retry_on_exception=ignore_exception)
+@retrying.retry(wait_exponential_multiplier=1000, wait_exponential_max=30000, retry_on_exception=ignore_exception)
 def __marathon_leadership_changed_in_marathon_api(original_leader):
     """ This method uses Marathon API to figure out that leadership changed.
         We have to retry here because leader election takes time and what might happen is that some nodes might


### PR DESCRIPTION
Summary:
I have seen a SI test run failed because marathon returned HTTP 502 10 times on v2/leader. Let's try to increase the number of times we retry to see if it helps.

Example of failed run https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/system-integration-tests/job/marathon-si-dcos-open/job/master/365/consoleFull

JIRA issues:
