### PR TITLE
Docs: Add multiple protocol specification

### DIFF
--- a/docs/docs/networking.md
+++ b/docs/docs/networking.md
@@ -473,6 +473,8 @@ The default is `tcp`:
   }
 ```
 
+It is possible to specify multiple protocols by using a comma as a separator: `udp,tcp` (note the lack of spaces).
+
 ##### Specifying Service Ports
 
 By default, Marathon will create associated service ports for each of these declared mappings and dynamically assign them values.


### PR DESCRIPTION
Summary:
This specific option did not exist in the documentation, however it does work.

It is available in the DC/OS documentation though: https://docs.mesosphere.com/1.10/deploying-services/service-ports/#definitions

Note that without spaces it seems not to work.