### PR TITLE
Contravariance Security fix

### DIFF
--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/AuthorizedAction.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/AuthorizedAction.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.plugin.{ Group, RunSpec }
   *
   * @tparam R the type of the resource.
   */
-sealed trait AuthorizedAction[+R]
+sealed trait AuthorizedAction[-R]
 
 /**
   * The following objects will be passed to the Authorizer when an action affects an application, in order to identify

--- a/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
+++ b/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
@@ -33,7 +33,7 @@ class GroupApiService(groupManager: GroupManager)(implicit authorizer: Authorize
       case Some(version) =>
         val targetVersion = Timestamp(version)
         groupManager.group(group.id, targetVersion)
-            .map(_.getOrElse(throw new IllegalArgumentException(s"Group ${group.id} not available in version $targetVersion")))
+          .map(_.getOrElse(throw new IllegalArgumentException(s"Group ${group.id} not available in version $targetVersion")))
           .filter(checkAuthorizationOrThrow(ViewGroup, _))
           .map(g => Some(rootGroup.putGroup(g, newVersion)))
       case None => Future.successful(None)

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -425,7 +425,7 @@ class AppsController(
   private def getVersion(appId: PathId, version: Timestamp)(implicit identity: Identity): Route = {
     onSuccess(groupManager.appVersion(appId, version.toOffsetDateTime)) {
       case Some(app) =>
-        authorized(ViewRunSpec, app, Rejections.EntityNotFound.noApp(appId)).apply {
+        authorized(ViewRunSpec, app).apply {
           complete(app.toRaml)
         }
       case None =>

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -36,6 +36,7 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Sink
 import play.api.libs.json.Json
 import PathMatchers.forceParameter
+import mesosphere.marathon.plugin.auth.AuthorizedResource.SystemConfig
 
 import scala.async.Async._
 import scala.concurrent.{ ExecutionContext, Future }
@@ -144,7 +145,7 @@ class AppsController(
         case None =>
           reject(Rejections.EntityNotFound.noApp(appId))
         case Some(info) =>
-          authorized(ViewResource, info.app).apply {
+          authorized(ViewResource, SystemConfig).apply {
             complete(Json.obj("app" -> info))
           }
       }
@@ -410,7 +411,7 @@ class AppsController(
 
   private def listVersions(appId: PathId)(implicit identity: Identity): Route = {
     val versions = groupManager.appVersions(appId).runWith(Sink.seq)
-    authorized(ViewRunSpec, groupManager.app(appId), Rejections.EntityNotFound.noApp(appId)).apply {
+    authorized(ViewRunSpec, groupManager.runSpec(appId).get, Rejections.EntityNotFound.noApp(appId)).apply {
       onSuccess(versions) { versions =>
         complete(VersionList(versions))
       }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
@@ -125,7 +125,9 @@ class TasksController(
       .groupBy(instance => instance.instanceId.runSpecId)
       .map { case (appId, instances) => appId -> instances.to[Seq] }(collection.breakOut))
   }
+
   private def isAuthorized(appIds: Iterable[PathId])(implicit identity: Identity): Boolean = appIds.forall(id => authorizer.isAuthorized(identity, UpdateRunSpec, id))
+
   private def tryParseTaskIds(taskIds: TasksToDelete): Either[Rejection, Map[Id, PathId]] = {
     val maybeInstanceIdToAppId: Try[Map[Id, PathId]] = Try(taskIds.ids.map { id =>
       try { Task.Id(id).instanceId -> Task.Id.runSpecId(id) }


### PR DESCRIPTION
Contravariance Security fix

Summary:
Please read the desc of https://jira.mesosphere.com/browse/MARATHON-7974

I don't know if we will keep the Contravariance `[-R]` on Auth... however this definitely showed 5 locations in Marathon where security just plain didn't work.   The typing wasn't changed and there were no tests to confirm.     This PR fixes all but 1 issue which requires someone with more context of the code to fix.


*Needs* Fix needed for TaskController.  Line 129 `authorizer.isAuthorized(identity, UpdateRunSpec, id)`   can NOT be correct.   The "resource" is a `PathId` and needs to be a `RunSpec`.    Also it appears that it should have the `DeleteRunSpec` permission to me.   @alenkacz you were the last to write this code... could you that a look and update this branch? 

JIRA issues: MARATHON-7974

