### PR TITLE
Transfers bytes in proxy and flush after each write.  (#5829)

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
@@ -10,13 +10,13 @@ import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 
 import akka.Done
 import akka.http.scaladsl.model.StatusCodes._
+import com.google.common.io.Closeables
 import com.google.inject.Inject
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.io.IO
 import mesosphere.marathon.stream.Implicits._
-import org.apache.commons.io.IOUtils
-import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
@@ -29,7 +29,7 @@ class LeaderProxyFilter @Inject() (
     httpConf: HttpConf,
     electionService: ElectionService,
     @Named(ModuleNames.HOST_PORT) myHostPort: String,
-    forwarder: RequestForwarder) extends Filter {
+    forwarder: RequestForwarder) extends Filter with StrictLogging {
 
   import LeaderProxyFilter._
 
@@ -70,16 +70,16 @@ class LeaderProxyFilter @Inject() (
         val currentLeaderData = electionService.leaderHostPort
 
         if (weAreLeader || currentLeaderData.exists(_ != myHostPort)) {
-          log.info("Leadership info is consistent again!")
+          logger.info("Leadership info is consistent again!")
           result = true
           retries = 0
         } else if (retries >= 0) {
           // as long as we are not flagged as elected yet, the leadership transition is still
           // taking place and we hold back any requests.
-          log.info(s"Waiting for consistent leadership state. Are we leader?: $weAreLeader, leader: $currentLeaderData")
+          logger.info(s"Waiting for consistent leadership state. Are we leader?: $weAreLeader, leader: $currentLeaderData")
           sleep()
         } else {
-          log.error(
+          logger.error(
             s"inconsistent leadership state, refusing request for ourselves at $myHostPort. " +
               s"Are we leader?: $weAreLeader, leader: $currentLeaderData")
         }
@@ -98,7 +98,7 @@ class LeaderProxyFilter @Inject() (
           response.addHeader(LeaderProxyFilter.HEADER_MARATHON_LEADER, buildUrl(myHostPort).toString)
           chain.doFilter(request, response)
         } else if (leaderDataOpt.forall(_ == myHostPort)) { // either not leader or ourselves
-          log.info(
+          logger.info(
             "Do not proxy to myself. Waiting for consistent leadership state. " +
               s"Are we leader?: false, leader: $leaderDataOpt")
           if (waitForConsistentLeadership()) {
@@ -128,8 +128,6 @@ class LeaderProxyFilter @Inject() (
 }
 
 object LeaderProxyFilter {
-  private val log = LoggerFactory.getLogger(getClass.getName)
-
   val HEADER_MARATHON_LEADER: String = "X-Marathon-Leader"
   val ERROR_STATUS_NO_CURRENT_LEADER: String = "Could not determine the current leader"
 }
@@ -145,7 +143,7 @@ class JavaUrlConnectionRequestForwarder @Inject() (
   @Named(JavaUrlConnectionRequestForwarder.NAMED_LEADER_PROXY_SSL_CONTEXT) sslContext: SSLContext,
   leaderProxyConf: LeaderProxyConf,
   @Named(ModuleNames.HOST_PORT) myHostPort: String)
-    extends RequestForwarder {
+    extends RequestForwarder with StrictLogging {
 
   import JavaUrlConnectionRequestForwarder._
 
@@ -201,7 +199,7 @@ class JavaUrlConnectionRequestForwarder @Inject() (
         headerValues <- Option(request.getHeaders(name))
         headerValue <- headerValues.seq
       } {
-        log.debug(s"addRequestProperty $name: $headerValue")
+        logger.debug(s"addRequestProperty $name: $headerValue")
         leaderConnection.addRequestProperty(name, headerValue)
       }
 
@@ -262,32 +260,32 @@ class JavaUrlConnectionRequestForwarder @Inject() (
           IO.using(remote.getInputStream) { connectionInput => copy(connectionInput, output) }
         } catch {
           case e: IOException =>
-            log.debug("got exception response, this is maybe an error code", e)
+            logger.debug("got exception response, this is maybe an error code", e)
             IO.using(remote.getErrorStream) { connectionError => copy(connectionError, output) }
         }
       }
     }
 
-    log.info(s"Proxying request to ${request.getMethod} $url from $myHostPort")
+    logger.info(s"Proxying request to ${request.getMethod} $url from $myHostPort")
 
     try {
       if (hasProxyLoop) {
-        log.error("Prevent proxy cycle, rejecting request")
+        logger.error("Prevent proxy cycle, rejecting request")
         response.sendError(BadGateway.intValue, ERROR_STATUS_LOOP)
       } else {
         val leaderConnection: HttpURLConnection = createAndConfigureConnection(url)
         try {
           copyRequestToConnection(leaderConnection, request) match {
             case Failure(ex: ConnectException) =>
-              log.error(ERROR_STATUS_CONNECTION_REFUSED, ex)
+              logger.error(ERROR_STATUS_CONNECTION_REFUSED, ex)
               response.sendError(BadGateway.intValue, ERROR_STATUS_CONNECTION_REFUSED)
               return
             case Failure(ex: SocketTimeoutException) =>
-              log.error(ERROR_STATUS_GATEWAY_TIMEOUT, ex)
+              logger.error(ERROR_STATUS_GATEWAY_TIMEOUT, ex)
               response.sendError(GatewayTimeout.intValue, ERROR_STATUS_GATEWAY_TIMEOUT)
               return
             case Failure(ex) =>
-              log.error(ERROR_STATUS_BAD_CONNECTION, ex)
+              logger.error(ERROR_STATUS_BAD_CONNECTION, ex)
               response.sendError(InternalServerError.intValue)
               return
             case Success(_) => // ignore
@@ -297,32 +295,29 @@ class JavaUrlConnectionRequestForwarder @Inject() (
             () => cloneResponseEntity(leaderConnection, response)
           )
         } finally {
-          Try(leaderConnection.getInputStream.close())
-          Try(leaderConnection.getErrorStream.close())
+          Closeables.closeQuietly(leaderConnection.getInputStream())
+          Closeables.closeQuietly(leaderConnection.getErrorStream())
         }
       }
     } finally {
-      Try(request.getInputStream.close())
-      Try(response.getOutputStream.close())
+      Closeables.closeQuietly(request.getInputStream())
+      Closeables.close(response.getOutputStream(), true)
     }
 
   }
 
   def copy(nullableIn: InputStream, nullableOut: OutputStream): Unit = {
     try {
-      for {
-        in <- Option(nullableIn)
-        out <- Option(nullableOut)
-      } IOUtils.copy(in, out)
+      // Note: This method blocks. That means it never returns if the request is for an SSE stream.
+      IO.transfer(Option(nullableIn), Option(nullableOut))
     } catch {
       case e: UnknownServiceException =>
-        log.warn("unexpected unknown service exception", e)
+        logger.warn("unexpected unknown service exception", e)
     }
   }
 }
 
-object JavaUrlConnectionRequestForwarder {
-  private val log = LoggerFactory.getLogger(getClass)
+object JavaUrlConnectionRequestForwarder extends StrictLogging {
 
   /** Header for proxy loop detection. Simply "Via" is ignored by the URL connection.*/
   val HEADER_VIA: String = "X-Marathon-Via"
@@ -339,11 +334,11 @@ object JavaUrlConnectionRequestForwarder {
 
     forwardHeaders() match {
       case Failure(ex: SocketTimeoutException) =>
-        log.error(ERROR_STATUS_GATEWAY_TIMEOUT, ex)
+        logger.error(ERROR_STATUS_GATEWAY_TIMEOUT, ex)
         response.sendError(GatewayTimeout.intValue, ERROR_STATUS_GATEWAY_TIMEOUT)
       case Failure(ex) =>
         // early detection of proxy failure, before we commit the status code to the response stream
-        log.warn("failed to proxy response headers from leader", ex)
+        logger.warn("failed to proxy response headers from leader", ex)
         response.sendError(BadGateway.intValue, ERROR_STATUS_BAD_CONNECTION)
       case Success(_) =>
         forwardEntity()

--- a/src/main/scala/mesosphere/marathon/api/WebJarServlet.scala
+++ b/src/main/scala/mesosphere/marathon/api/WebJarServlet.scala
@@ -5,7 +5,7 @@ import java.net.URI
 import javax.servlet.http.{ HttpServlet, HttpServletRequest, HttpServletResponse }
 
 import mesosphere.marathon.io.IO
-import org.apache.commons.io.IOUtils
+import com.google.common.io.{ ByteStreams, Closeables }
 import org.slf4j.LoggerFactory
 
 class WebJarServlet extends HttpServlet {
@@ -19,8 +19,10 @@ class WebJarServlet extends HttpServlet {
         resp.setContentType(mime)
         resp.setContentLength(stream.available())
         resp.setStatus(200)
-        IOUtils.copy(stream, resp.getOutputStream)
-        IOUtils.closeQuietly(stream)
+        val out = resp.getOutputStream
+        ByteStreams.copy(stream, out)
+        out.flush()
+        Closeables.closeQuietly(stream)
       } getOrElse {
         resp.sendError(404)
       }

--- a/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
@@ -2,9 +2,7 @@ package mesosphere.marathon
 package integration
 
 import java.io.File
-
 import mesosphere.AkkaIntegrationTest
-import mesosphere.marathon.integration.facades.MarathonFacade
 import mesosphere.marathon.integration.facades.MarathonFacade.extractDeploymentIds
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.raml.{ App, AppUpdate }
@@ -16,10 +14,6 @@ import scala.concurrent.duration._
   * Do not add tests to this class. See the notes in [[NonDestructiveLeaderIntegrationTest]].
   */
 abstract class LeaderIntegrationTest extends AkkaIntegrationTest with MarathonClusterTest {
-
-  protected def nonLeader(leader: String): MarathonFacade = {
-    marathonFacades.find(!_.url.contains(leader)).get
-  }
 
   protected def leadingServerProcess(leader: String): LocalMarathon =
     (additionalMarathons :+ marathonServer).find(_.client.url.contains(leader)).getOrElse(

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -861,10 +861,6 @@ trait MarathonClusterTest extends Suite with StrictLogging with ZookeeperServerT
     super.afterAll()
   }
 
-  def nonLeader(leader: ITLeaderResult): MarathonFacade = {
-    marathonFacades.find(!_.url.contains(leader.port.toString)).get
-  }
-
   override def cleanUp(): Unit = {
     Future.sequence(marathonServer.start() +: additionalMarathons.map(_.start())).futureValue
     super.cleanUp()


### PR DESCRIPTION
Summary:
The proxy was broken for the event stream. Our copy method is blocking
as is `com.google.common.io.ByteStreams.copy`. Thus we would never flush
the output stream and the client would not receive any data. This patch
reintroduces the old transfer method with flushes after each write.

This diff should be followed up with an asynchronous copying so that no
threads are blocked.

JIRA issues: MARATHON-7919