### PR TITLE
Switch AuthorizationAction to Contravariance 

### DIFF
--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/AuthorizedAction.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/AuthorizedAction.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.plugin.{ Group, RunSpec }
   *
   * @tparam R the type of the resource.
   */
-sealed trait AuthorizedAction[+R]
+sealed trait AuthorizedAction[-R]
 
 /**
   * The following objects will be passed to the Authorizer when an action affects an application, in order to identify

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -277,7 +277,7 @@ class GroupsResource @Inject() (
 
       maybeExistingGroup match {
         case Some(existingGroup) => checkAuthorization(UpdateGroup, existingGroup)
-        case None => checkAuthorization(CreateRunSpec, updatedGroup)
+        case None => checkAuthorization(CreateGroup, updatedGroup)
       }
 
       updatedGroup


### PR DESCRIPTION
Switch AuthorizationAction to Contravariance

Summary:
Switch to enforce the appropriate resource authorization.  Required for Metronome.  Already tested with Metronome.

Read: https://jira.mesosphere.com/browse/MARATHON-7974


JIRA issues: MARATHON-7974
