### PR TITLE
Switch AuthorizationAction to Contravariance for 1.4

### DIFF
--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/AuthorizedAction.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/AuthorizedAction.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.plugin.{ Group, RunSpec }
   *
   * @tparam R the type of the resource.
   */
-sealed trait AuthorizedAction[+R]
+sealed trait AuthorizedAction[-R]
 
 /**
   * The following objects will be passed to the Authorizer when an action affects an application, in order to identify
@@ -35,4 +35,3 @@ case object CreateResource extends AuthorizedAction[AuthorizedResource]
 case object UpdateResource extends AuthorizedAction[AuthorizedResource]
 case object DeleteResource extends AuthorizedAction[AuthorizedResource]
 case object ViewResource extends AuthorizedAction[AuthorizedResource]
-

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -277,7 +277,7 @@ class GroupsResource @Inject() (
       val maybeExistingGroup = result(groupManager.group(group.id))
       val updatedGroup = groupUpdate.apply(group, newVersion)
 
-      maybeExistingGroup.fold(checkAuthorization(CreateRunSpec, updatedGroup))(checkAuthorization(UpdateGroup, _))
+      maybeExistingGroup.fold(checkAuthorization(CreateGroup, updatedGroup))(checkAuthorization(UpdateGroup, _))
 
       rootGroup.putGroup(updatedGroup, newVersion)
     }


### PR DESCRIPTION
Switch AuthorizationAction to Contravariance for 1.4

Summary:
Switch to enforce the appropriate resource authorization. 

Read: https://jira.mesosphere.com/browse/MARATHON-7974

After merge... this will need a new marathon-dcos-plugin release for the next release of marathon 1.4.x

JIRA issues: MARATHON-7974