### PR TITLE
Switch AuthorizationAction to Contravariance for 1.5

### DIFF
--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/AuthorizedAction.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/AuthorizedAction.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.plugin.{ Group, RunSpec }
   *
   * @tparam R the type of the resource.
   */
-sealed trait AuthorizedAction[+R]
+sealed trait AuthorizedAction[-R]
 
 /**
   * The following objects will be passed to the Authorizer when an action affects an application, in order to identify

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -17,7 +17,7 @@ import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager
-import mesosphere.marathon.plugin.auth.{ Authenticator => MarathonAuthenticator, Authorizer, CreateRunSpec, Identity, ViewResource }
+import mesosphere.marathon.plugin.auth.{ Authorizer, CreateRunSpec, Identity, ViewResource, ViewRunSpec, Authenticator => MarathonAuthenticator }
 import mesosphere.marathon.state.{ AppDefinition, Identifiable, PathId }
 import play.api.libs.json.Json
 import PathId._
@@ -105,7 +105,7 @@ class AppsController(
         case None =>
           reject(Rejections.EntityNotFound.app(appId))
         case Some(info) =>
-          authorized(ViewResource, info.app).apply {
+          authorized(ViewRunSpec, info.app).apply {
             complete(Json.obj("app" -> info))
           }
       }

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -333,7 +333,7 @@ class GroupsResource @Inject() (
       val updatedGroup: Group = Raml.fromRaml(
         GroupConversion(groupUpdate, group, newVersion) -> appConversionFunc)
 
-      maybeExistingGroup.fold(checkAuthorization(CreateRunSpec, updatedGroup))(checkAuthorization(UpdateGroup, _))
+      maybeExistingGroup.fold(checkAuthorization(UpdateGroup, updatedGroup))(checkAuthorization(UpdateGroup, _))
 
       rootGroup.putGroup(updatedGroup, newVersion)
     }


### PR DESCRIPTION
Switch AuthorizationAction to Contravariance for 1.5

Summary:
Switch to enforce the appropriate resource authorization. 

Read: https://jira.mesosphere.com/browse/MARATHON-7974

After merge... this will need a new marathon-dcos-plugin release for the next release of marathon 1.5.x

JIRA issues: MARATHON-7974