### PR TITLE
Fixing handling iptables in partitioning SI tests

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -233,6 +233,7 @@ def save_iptables(host, filename='iptables.rules'):
         host,
         'if [ ! -e {} ] ; then sudo iptables-save > {} ; fi'.format(filename, filename))
 
+
 def restore_iptables(host, filename='iptables.rules'):
     """ Reconnect a previously partitioned node to the network
         :param hostname: host or IP of the machine to partition from the cluster

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -231,7 +231,7 @@ def save_iptables(host, filename='iptables.rules'):
 
     shakedown.run_command_on_agent(
         host,
-        'if [ ! -e {} ] ; then sudo iptables -L > /dev/null && sudo iptables-save > {} ; fi'.format(filename, filename))
+        'if [ ! -e {} ] ; then sudo iptables-save > {} ; fi'.format(filename, filename))
 
 def restore_iptables(host, filename='iptables.rules'):
     """ Reconnect a previously partitioned node to the network
@@ -240,7 +240,7 @@ def restore_iptables(host, filename='iptables.rules'):
 
     shakedown.run_command_on_agent(
         host,
-        'if [ -e {} ]; then sudo iptables-restore < {} && rm {} ; fi'.format(filename, filename, filename))
+        'if [ -e {} ]; then sudo iptables-restore < {} && sudo rm {} ; fi'.format(filename, filename, filename))
 
 
 @contextlib.contextmanager

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -533,7 +533,7 @@ def test_task_gets_restarted_due_to_network_split():
     port = tasks[0]['ports'][0]
 
     # introduce a network partition
-    with shakedown.iptable_rules(host):
+    with common.iptable_rules(host):
         common.block_port(host, port)
         time.sleep(10)
 
@@ -863,7 +863,7 @@ def test_marathon_when_disconnected_from_zk():
     tasks = client.get_tasks(app_def["id"])
     original_task_id = tasks[0]['id']
 
-    with shakedown.iptable_rules(host):
+    with common.iptable_rules(host):
         common.block_port(host, 2181)
         time.sleep(10)
 

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -12,9 +12,7 @@ import os
 import pytest
 import retrying
 import shakedown
-import time
 import uuid
-import contextlib
 
 from dcos import marathon, errors
 from datetime import timedelta
@@ -182,8 +180,6 @@ def test_marathon_master_partition_leader_change(marathon_service_name):
         common.marathon_leadership_changed(original_leader)
         # Make sure marathon is available
         shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
-
-
 
 
 @shakedown.public_agents(1)

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -14,6 +14,7 @@ import retrying
 import shakedown
 import time
 import uuid
+import contextlib
 
 from dcos import marathon, errors
 from datetime import timedelta
@@ -160,15 +161,13 @@ def test_marathon_zk_partition_leader_change(marathon_service_name):
     original_leader = common.get_marathon_leader_not_on_master_leader_node()
 
     # blocking zk on marathon leader (not master leader)
-    with shakedown.iptable_rules(original_leader):
+    with common.iptable_rules(original_leader):
         common.block_port(original_leader, 2181, direction='INPUT')
         common.block_port(original_leader, 2181, direction='OUTPUT')
-        #  time of the zk block, the duration must be greater than all the default ZK timeout values in Marathon
-        time.sleep(20)
-
-    shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
-
-    common.marathon_leadership_changed(original_leader)
+        #  Wait for a leader change before restoring  iptables rules
+        common.marathon_leadership_changed(original_leader)
+        # Make sure marathon is available
+        shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
 
 
 @shakedown.masters(3)
@@ -177,14 +176,14 @@ def test_marathon_master_partition_leader_change(marathon_service_name):
     original_leader = common.get_marathon_leader_not_on_master_leader_node()
 
     # blocking outbound connection to mesos master
-    with shakedown.iptable_rules(original_leader):
+    with common.iptable_rules(original_leader):
         common.block_port(original_leader, 5050, direction='OUTPUT')
-        #  time of the master block
-        time.sleep(timedelta(minutes=1.5).total_seconds())
+        #  Wait for a leader change before restoring  iptables rules
+        common.marathon_leadership_changed(original_leader)
+        # Make sure marathon is available
+        shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
 
-    shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
 
-    common.marathon_leadership_changed(original_leader)
 
 
 @shakedown.public_agents(1)
@@ -371,9 +370,7 @@ def test_marathon_backup_and_check_apps(marathon_service_name):
 
     # Abdicate the leader with backup
     original_leader = shakedown.marathon_leader_ip()
-    print('leader: {}'.format(original_leader))
     url = 'v2/leader?backup={}'.format(backup_url1)
-    print('DELETE {}'.format(url))
     common.delete_marathon_path(url)
 
     shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())


### PR DESCRIPTION
- Iptables rules are now stored in a temp files with a unique name
- Added missing `sudo` when removing this file
- Refactored the tests to remove `time.sleep` - we now wait directly for leadership change before restoring the iptables rules

Related JIRA issues: MARATHON-7965
