### PR TITLE
Changes to offer and reservation operations to support CSI volumes

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
@@ -123,7 +123,7 @@ object ContainerSerializer {
 }
 
 object VolumeSerializer {
-  def toProto(volumeWithMount: VolumeWithMount): Protos.Volume = {
+  def toProto(volumeWithMount: VolumeWithMount[Volume]): Protos.Volume = {
     val volume = volumeWithMount.volume
     val mount = volumeWithMount.mount
     val mode = VolumeMount.readOnlyToProto(mount.readOnly)

--- a/src/main/scala/mesosphere/marathon/core/launcher/InstanceOpFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/InstanceOpFactory.scala
@@ -2,7 +2,9 @@ package mesosphere.marathon
 package core.launcher
 
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.state.{ Region, RunSpec }
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.state.{ DiskSource, Region, RunSpec }
+import mesosphere.mesos.protos.ResourceProviderID
 import mesosphere.util.state.FrameworkId
 import org.apache.mesos.{ Protos => Mesos }
 
@@ -38,4 +40,17 @@ object InstanceOpFactory {
     def numberOfWaitingReservations: Int = reserved.size
     def isForResidentRunSpec: Boolean = runSpec.isResident
   }
+
+  /**
+    * A task local volume with all information which is necessary for a volume creation
+    * upon offer receive.
+    *
+    * @param providerId an optional resource provider ID
+    * @param source     a disk source from an offer received
+    * @param volume     a task local volume
+    */
+  case class OfferedVolume(
+      providerId: Option[ResourceProviderID],
+      source: DiskSource,
+      volume: Task.LocalVolume)
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -3,11 +3,9 @@ package core.launcher.impl
 
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
-import mesosphere.marathon.core.launcher.InstanceOp
+import mesosphere.marathon.core.launcher.{ InstanceOp, InstanceOpFactory }
 import mesosphere.marathon.core.matcher.base.util.OfferOperationFactory
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.Task.LocalVolume
-import mesosphere.marathon.state.DiskSource
 import org.apache.mesos.{ Protos => Mesos }
 
 class InstanceOpFactoryHelper(
@@ -78,7 +76,7 @@ class InstanceOpFactoryHelper(
     reservationLabels: ReservationLabels,
     newState: InstanceUpdateOperation.Reserve,
     resources: Seq[Mesos.Resource],
-    localVolumes: Seq[(Option[String], DiskSource, LocalVolume)]): InstanceOp.ReserveAndCreateVolumes = {
+    localVolumes: Seq[InstanceOpFactory.OfferedVolume]): InstanceOp.ReserveAndCreateVolumes = {
 
     def createOperations =
       offerOperationFactory.reserve(reservationLabels, resources) ++

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -80,11 +80,9 @@ class InstanceOpFactoryHelper(
     resources: Seq[Mesos.Resource],
     localVolumes: Seq[(Option[String], DiskSource, LocalVolume)]): InstanceOp.ReserveAndCreateVolumes = {
 
-    def createOperations = Seq(
-      offerOperationFactory.reserve(reservationLabels, resources),
-      offerOperationFactory.createVolumes(
-        reservationLabels,
-        localVolumes))
+    def createOperations =
+      offerOperationFactory.reserve(reservationLabels, resources) ++
+        offerOperationFactory.createVolumes(reservationLabels, localVolumes)
 
     InstanceOp.ReserveAndCreateVolumes(newState, resources, createOperations)
   }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -78,7 +78,7 @@ class InstanceOpFactoryHelper(
     reservationLabels: ReservationLabels,
     newState: InstanceUpdateOperation.Reserve,
     resources: Seq[Mesos.Resource],
-    localVolumes: Seq[(DiskSource, LocalVolume)]): InstanceOp.ReserveAndCreateVolumes = {
+    localVolumes: Seq[(Option[String], DiskSource, LocalVolume)]): InstanceOp.ReserveAndCreateVolumes = {
 
     def createOperations = Seq(
       offerOperationFactory.reserve(reservationLabels, resources),

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -317,8 +317,10 @@ class InstanceOpFactoryImpl(
 
     val localVolumes: Seq[(DiskSource, Task.LocalVolume)] =
       resourceMatch.localVolumes.map {
-        case (source, volume, mount) =>
-          (source, Task.LocalVolume(Task.LocalVolumeId(runSpec.id, volume, mount), volume, mount))
+        case (source, volumeWithMount) =>
+          (source, Task.LocalVolume(
+            Task.LocalVolumeId(runSpec.id, volumeWithMount.volume, volumeWithMount.mount),
+            volumeWithMount.volume, volumeWithMount.mount))
       }
 
     val persistentVolumeIds = localVolumes.map { case (_, localVolume) => localVolume.id }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -19,7 +19,7 @@ import mesosphere.marathon.plugin.{ ApplicationSpec, PodSpec }
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
-import mesosphere.mesos.{ NoOfferMatchReason, PersistentVolumeMatcher, ResourceMatchResponse, ResourceMatcher, RunSpecOfferMatcher, TaskBuilder, TaskGroupBuilder }
+import mesosphere.mesos.{ DiskResourceMatch, NoOfferMatchReason, PersistentVolumeMatcher, ResourceMatchResponse, ResourceMatcher, RunSpecOfferMatcher, TaskBuilder, TaskGroupBuilder }
 import mesosphere.util.state.FrameworkId
 import org.apache.mesos.Protos.{ ExecutorInfo, TaskGroupInfo, TaskInfo }
 import org.apache.mesos.{ Protos => Mesos }
@@ -315,15 +315,14 @@ class InstanceOpFactoryImpl(
     offer: Mesos.Offer,
     resourceMatch: ResourceMatcher.ResourceMatch): InstanceOp = {
 
-    val localVolumes: Seq[(Option[String], DiskSource, Task.LocalVolume)] =
+    val localVolumes: Seq[InstanceOpFactory.OfferedVolume] =
       resourceMatch.localVolumes.map {
-        case (providerId, source, volumeWithMount) =>
-          (providerId, source, Task.LocalVolume(
-            Task.LocalVolumeId(runSpec.id, volumeWithMount.volume, volumeWithMount.mount),
-            volumeWithMount.volume, volumeWithMount.mount))
+        case DiskResourceMatch.ConsumedVolume(providerId, source, VolumeWithMount(volume, mount)) =>
+          val localVolume = Task.LocalVolume(Task.LocalVolumeId(runSpec.id, volume, mount), volume, mount)
+          InstanceOpFactory.OfferedVolume(providerId, source, localVolume)
       }
 
-    val persistentVolumeIds = localVolumes.map { case (_, _, localVolume) => localVolume.id }
+    val persistentVolumeIds = localVolumes.map(_.volume.id)
     val now = clock.now()
     val timeout = Task.Reservation.Timeout(
       initiated = now,

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -315,15 +315,15 @@ class InstanceOpFactoryImpl(
     offer: Mesos.Offer,
     resourceMatch: ResourceMatcher.ResourceMatch): InstanceOp = {
 
-    val localVolumes: Seq[(DiskSource, Task.LocalVolume)] =
+    val localVolumes: Seq[(Option[String], DiskSource, Task.LocalVolume)] =
       resourceMatch.localVolumes.map {
-        case (source, volumeWithMount) =>
-          (source, Task.LocalVolume(
+        case (providerId, source, volumeWithMount) =>
+          (providerId, source, Task.LocalVolume(
             Task.LocalVolumeId(runSpec.id, volumeWithMount.volume, volumeWithMount.mount),
             volumeWithMount.volume, volumeWithMount.mount))
       }
 
-    val persistentVolumeIds = localVolumes.map { case (_, localVolume) => localVolume.id }
+    val persistentVolumeIds = localVolumes.map { case (_, _, localVolume) => localVolume.id }
     val now = clock.now()
     val timeout = Task.Reservation.Timeout(
       initiated = now,

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactory.scala
@@ -47,84 +47,99 @@ class OfferOperationFactory(
       .build()
   }
 
-  def reserve(reservationLabels: ReservationLabels, resources: Seq[Mesos.Resource]): Mesos.Offer.Operation = {
-    val reservedResources = resources.map { resource =>
-
-      val reservation = ReservationInfo.newBuilder()
-        .setLabels(reservationLabels.mesosLabels)
-        .setPrincipal(principal)
-
-      Mesos.Resource.newBuilder(resource)
-        .setRole(role)
-        .setReservation(reservation)
-        .build()
+  private def getProviderId(resource: Mesos.Resource): Option[String] = {
+    if (resource.hasProviderId && resource.getProviderId.hasValue) {
+      Some(resource.getProviderId.getValue)
+    } else {
+      None
     }
+  }
 
-    val reserve = Mesos.Offer.Operation.Reserve.newBuilder()
-      .addAllResources(reservedResources.asJava)
-      .build()
+  def reserve(reservationLabels: ReservationLabels, resources: Seq[Mesos.Resource]): Seq[Mesos.Offer.Operation] = {
 
-    Mesos.Offer.Operation.newBuilder()
-      .setType(Mesos.Offer.Operation.Type.RESERVE)
-      .setReserve(reserve)
-      .build()
+    // Mesos requires that there is an operation per each resource provider ID
+    resources.groupBy(getProviderId).values.map { resources =>
+      val reservedResources = resources.map { resource =>
+
+        val reservation = ReservationInfo.newBuilder()
+          .setLabels(reservationLabels.mesosLabels)
+          .setPrincipal(principal)
+
+        Mesos.Resource.newBuilder(resource)
+          .setRole(role)
+          .setReservation(reservation)
+          .build()
+      }
+
+      val reserve = Mesos.Offer.Operation.Reserve.newBuilder()
+        .addAllResources(reservedResources.asJava)
+        .build()
+
+      Mesos.Offer.Operation.newBuilder()
+        .setType(Mesos.Offer.Operation.Type.RESERVE)
+        .setReserve(reserve)
+        .build()
+    }.to[Seq]
   }
 
   def createVolumes(
     reservationLabels: ReservationLabels,
-    localVolumes: Seq[(Option[String], DiskSource, LocalVolume)]): Mesos.Offer.Operation = {
+    localVolumes: Seq[(Option[String], DiskSource, LocalVolume)]): Seq[Mesos.Offer.Operation] = {
 
-    val volumes: Seq[Mesos.Resource] = localVolumes.map {
-      case (providerId, source, vol) =>
-        val disk = {
-          val persistence = Mesos.Resource.DiskInfo.Persistence.newBuilder().setId(vol.id.idString)
-          principalOpt.foreach(persistence.setPrincipal)
+    // Mesos requires that there is an operation per each resource provider ID
+    localVolumes.groupBy(_._1).values.map { localVolumes =>
+      val volumes: Seq[Mesos.Resource] = localVolumes.map {
+        case (providerId, source, vol) =>
+          val disk = {
+            val persistence = Mesos.Resource.DiskInfo.Persistence.newBuilder().setId(vol.id.idString)
+            principalOpt.foreach(persistence.setPrincipal)
 
-          // Pod volumes have names, whereas app volumes do not. Since pod persistent volumes are created
-          // in the executor container, a persistent volume name is used as its name on the Mesos end. In this case
-          // all the corresponding volume mounts refer to the volume by its name. On the other hand, in case of apps,
-          // volumes do not have names, and since persistent volumes are not shared in this case, the mount path
-          // is used instead.
-          val name = vol.persistentVolume.name.getOrElse(vol.mount.mountPath)
+            // Pod volumes have names, whereas app volumes do not. Since pod persistent volumes are created
+            // in the executor container, a persistent volume name is used as its name on the Mesos end. In this case
+            // all the corresponding volume mounts refer to the volume by its name. On the other hand, in case of apps,
+            // volumes do not have names, and since persistent volumes are not shared in this case, the mount path
+            // is used instead.
+            val name = vol.persistentVolume.name.getOrElse(vol.mount.mountPath)
 
-          val mode = VolumeMount.readOnlyToProto(vol.mount.readOnly)
-          val volume = Mesos.Volume.newBuilder()
-            .setContainerPath(name)
-            .setMode(mode)
+            val mode = VolumeMount.readOnlyToProto(vol.mount.readOnly)
+            val volume = Mesos.Volume.newBuilder()
+              .setContainerPath(name)
+              .setMode(mode)
 
-          val builder = Mesos.Resource.DiskInfo.newBuilder()
-            .setPersistence(persistence)
-            .setVolume(volume)
-          source.asMesos.foreach(builder.setSource)
-          builder
-        }
+            val builder = Mesos.Resource.DiskInfo.newBuilder()
+              .setPersistence(persistence)
+              .setVolume(volume)
+            source.asMesos.foreach(builder.setSource)
+            builder
+          }
 
-        val reservation = Mesos.Resource.ReservationInfo.newBuilder()
-          .setLabels(reservationLabels.mesosLabels)
-        principalOpt.foreach(reservation.setPrincipal)
+          val reservation = Mesos.Resource.ReservationInfo.newBuilder()
+            .setLabels(reservationLabels.mesosLabels)
+          principalOpt.foreach(reservation.setPrincipal)
 
-        val builder = Mesos.Resource.newBuilder()
-          .setName("disk")
-          .setType(Mesos.Value.Type.SCALAR)
-          .setScalar(Mesos.Value.Scalar.newBuilder().setValue(vol.persistentVolume.persistent.size.toDouble).build())
-          .setRole(role)
-          .setReservation(reservation)
-          .setDisk(disk)
+          val builder = Mesos.Resource.newBuilder()
+            .setName("disk")
+            .setType(Mesos.Value.Type.SCALAR)
+            .setScalar(Mesos.Value.Scalar.newBuilder().setValue(vol.persistentVolume.persistent.size.toDouble).build())
+            .setRole(role)
+            .setReservation(reservation)
+            .setDisk(disk)
 
-        providerId.foreach { providerIdValue =>
-          val providerIdProto = Mesos.ResourceProviderID.newBuilder().setValue(providerIdValue).build()
-          builder.setProviderId(providerIdProto)
-        }
+          providerId.foreach { providerIdValue =>
+            val providerIdProto = Mesos.ResourceProviderID.newBuilder().setValue(providerIdValue).build()
+            builder.setProviderId(providerIdProto)
+          }
 
-        builder.build()
-    }
+          builder.build()
+      }
 
-    val create = Mesos.Offer.Operation.Create.newBuilder()
-      .addAllVolumes(volumes.asJava)
+      val create = Mesos.Offer.Operation.Create.newBuilder()
+        .addAllVolumes(volumes.asJava)
 
-    Mesos.Offer.Operation.newBuilder()
-      .setType(Mesos.Offer.Operation.Type.CREATE)
-      .setCreate(create)
-      .build()
+      Mesos.Offer.Operation.newBuilder()
+        .setType(Mesos.Offer.Operation.Type.CREATE)
+        .setCreate(create)
+        .build()
+    }.to[Seq]
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -135,8 +135,10 @@ case class AppDefinition(
 
   override val diskForPersistentVolumes: Double = persistentVolumes.map(_.persistent.size).sum.toDouble
 
-  private[state] val persistentVolumesWithMounts: Seq[VolumeWithMount] =
-    container.map(_.volumes.collect { case vm @ VolumeWithMount(_: PersistentVolume, _) => vm }).getOrElse(Seq.empty)
+  private[state] val persistentVolumesWithMounts: Seq[VolumeWithMount[PersistentVolume]] =
+    container.map(_.volumes.collect {
+      case vm @ VolumeWithMount(_: PersistentVolume, _) => vm.asInstanceOf[VolumeWithMount[PersistentVolume]]
+    }).getOrElse(Seq.empty)
 
   def toProto: Protos.ServiceDefinition = {
     val commandInfo = TaskBuilder.commandInfo(

--- a/src/main/scala/mesosphere/marathon/state/Container.scala
+++ b/src/main/scala/mesosphere/marathon/state/Container.scala
@@ -13,7 +13,7 @@ sealed trait Container extends Product with Serializable {
   import Container.{ Docker, PortMapping }
 
   def portMappings: Seq[PortMapping]
-  val volumes: Seq[VolumeWithMount]
+  val volumes: Seq[VolumeWithMount[Volume]]
 
   // TODO(nfnt): Remove this field and use type matching instead.
   def docker: Option[Docker] = {
@@ -29,29 +29,29 @@ sealed trait Container extends Product with Serializable {
   def servicePorts: Seq[Int] =
     portMappings.map(_.servicePort)
 
-  def copyWith(portMappings: Seq[PortMapping] = portMappings, volumes: Seq[VolumeWithMount] = volumes): Container
+  def copyWith(portMappings: Seq[PortMapping] = portMappings, volumes: Seq[VolumeWithMount[Volume]] = volumes): Container
 }
 
 object Container {
 
   case class Mesos(
-      volumes: Seq[VolumeWithMount] = Seq.empty,
+      volumes: Seq[VolumeWithMount[Volume]] = Seq.empty,
       override val portMappings: Seq[PortMapping] = Nil
   ) extends Container {
 
-    override def copyWith(portMappings: Seq[PortMapping] = portMappings, volumes: Seq[VolumeWithMount] = volumes) =
+    override def copyWith(portMappings: Seq[PortMapping] = portMappings, volumes: Seq[VolumeWithMount[Volume]] = volumes) =
       copy(portMappings = portMappings, volumes = volumes)
   }
 
   case class Docker(
-      volumes: Seq[VolumeWithMount] = Seq.empty,
+      volumes: Seq[VolumeWithMount[Volume]] = Seq.empty,
       image: String = "",
       override val portMappings: Seq[PortMapping] = Nil,
       privileged: Boolean = false,
       parameters: Seq[Parameter] = Nil,
       forcePullImage: Boolean = false) extends Container {
 
-    override def copyWith(portMappings: Seq[PortMapping] = portMappings, volumes: Seq[VolumeWithMount] = volumes) =
+    override def copyWith(portMappings: Seq[PortMapping] = portMappings, volumes: Seq[VolumeWithMount[Volume]] = volumes) =
       copy(portMappings = portMappings, volumes = volumes)
   }
 
@@ -97,14 +97,14 @@ object Container {
   case class DockerPullConfig(secret: String)
 
   case class MesosDocker(
-      volumes: Seq[VolumeWithMount] = Seq.empty,
+      volumes: Seq[VolumeWithMount[Volume]] = Seq.empty,
       image: String = "",
       override val portMappings: Seq[PortMapping] = Nil,
       credential: Option[Credential] = None,
       pullConfig: Option[DockerPullConfig] = None,
       forcePullImage: Boolean = false) extends Container {
 
-    override def copyWith(portMappings: Seq[PortMapping] = portMappings, volumes: Seq[VolumeWithMount] = volumes) =
+    override def copyWith(portMappings: Seq[PortMapping] = portMappings, volumes: Seq[VolumeWithMount[Volume]] = volumes) =
       copy(portMappings = portMappings, volumes = volumes)
   }
 
@@ -115,14 +115,14 @@ object Container {
   }
 
   case class MesosAppC(
-      volumes: Seq[VolumeWithMount] = Seq.empty,
+      volumes: Seq[VolumeWithMount[Volume]] = Seq.empty,
       image: String = "",
       override val portMappings: Seq[PortMapping] = Nil,
       id: Option[String] = None,
       labels: Map[String, String] = Map.empty[String, String],
       forcePullImage: Boolean = false) extends Container {
 
-    override def copyWith(portMappings: Seq[PortMapping] = portMappings, volumes: Seq[VolumeWithMount] = volumes) =
+    override def copyWith(portMappings: Seq[PortMapping] = portMappings, volumes: Seq[VolumeWithMount[Volume]] = volumes) =
       copy(portMappings = portMappings, volumes = volumes)
   }
 

--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -72,24 +72,22 @@ object VolumeMount {
   def readOnlyToProto(readOnly: Boolean): Mode = if (readOnly) Mode.RO else Mode.RW
 }
 
-case class VolumeWithMount(volume: Volume, mount: VolumeMount)
+case class VolumeWithMount[+A <: Volume](volume: A, mount: VolumeMount)
 
 object VolumeWithMount {
-  def apply(volumeName: Option[String], proto: Protos.Volume): VolumeWithMount =
+  def apply(volumeName: Option[String], proto: Protos.Volume): VolumeWithMount[Volume] =
     new VolumeWithMount(volume = Volume(volumeName, proto), mount = VolumeMount(volumeName, proto))
 
-  def apply(volume: Volume, mount: VolumeMount): VolumeWithMount =
-    new VolumeWithMount(volume = volume, mount = mount)
-
-  def validVolumeWithMount(enabledFeatures: Set[String]): Validator[VolumeWithMount] = validator[VolumeWithMount] { vm =>
-    vm.volume is Volume.validVolume(enabledFeatures)
-    vm.mount is VolumeMount.validVolumeMount
-    vm.volume match {
-      case _: PersistentVolume =>
-        vm.mount is PersistentVolume.validPersistentVolumeMount
-      case _ =>
+  def validVolumeWithMount(enabledFeatures: Set[String]): Validator[VolumeWithMount[Volume]] =
+    validator[VolumeWithMount[Volume]] { vm =>
+      vm.volume is Volume.validVolume(enabledFeatures)
+      vm.mount is VolumeMount.validVolumeMount
+      vm.volume match {
+        case _: PersistentVolume =>
+          vm.mount is PersistentVolume.validPersistentVolumeMount
+        case _ =>
+      }
     }
-  }
 }
 
 /**

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -352,13 +352,13 @@ object ResourceMatcher extends StrictLogging {
         case nextAllocation :: restAllocations =>
           val (matcher, nextAllocationSize) = nextAllocation match {
             case Left(size) => ({ _: Protos.Resource => true }, size)
-            case Right(vm) =>
+            case Right(VolumeWithMount(volume, _)) =>
               def matcher(resource: Protos.Resource): Boolean = {
-                VolumeConstraints.meetsAllConstraints(resource, vm.volume.persistent.constraints) &&
-                  matchesProfileName(vm.volume.persistent.profileName, resource)
+                VolumeConstraints.meetsAllConstraints(resource, volume.persistent.constraints) &&
+                  matchesProfileName(volume.persistent.profileName, resource)
               }
 
-              (matcher _, vm.volume.persistent.size.toDouble)
+              (matcher _, volume.persistent.size.toDouble)
           }
 
           findDiskGroupMatches(nextAllocationSize, orderedResources, orderedResources, matcher) match {

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -36,7 +36,7 @@ object ResourceMatcher extends StrictLogging {
         portsMatch.resources
 
     // TODO - this assumes that volume matches are one resource to one volume, which should be correct, but may not be.
-    val localVolumes: Seq[(DiskSource, PersistentVolume, VolumeMount)] =
+    val localVolumes: Seq[(DiskSource, VolumeWithMount[PersistentVolume])] =
       scalarMatches.collect { case r: DiskResourceMatch => r.volumes }.flatten
   }
 
@@ -148,27 +148,25 @@ object ResourceMatcher extends StrictLogging {
     val diskMatch = if (needToReserveDisk) {
       val volumes = runSpec.persistentVolumes
       val mounts = runSpec.persistentVolumeMounts
-      val (namedVolumes, namedMounts) =
-        if (volumes.exists(_.name.isEmpty) && volumes.length == mounts.length) {
-          // Give temporary names to volumes and mounts to ease volume mount matching in [[findMatches]].
-          // Since application volumes are not named, and there is 1:1 mapping between application volumes and
-          // volume mounts, and 1:many mapping between pod ones, in order to make it easier to find a volume
-          // corresponding to a volume mount in [[findMatches]], temporary names are assigned to volumes
-          // and volume mounts.
-          val indexedVolumes = volumes.zipWithIndex.map { case (v, i) => v.copy(name = Some(i.toString)) }
-          val indexedMounts = mounts.zipWithIndex.map { case (m, i) => m.copy(volumeName = Some(i.toString)) }
-          (indexedVolumes, indexedMounts)
-        } else {
-          (volumes, mounts)
-        }
+      val volumesWithMounts = runSpec match {
+        case _: AppDefinition =>
+          volumes.zip(mounts).map {
+            case (volume, mount) => VolumeWithMount(volume, mount)
+          }
+        case _: PodDefinition =>
+          volumes.map { volume =>
+            val mountPath = volume.name.getOrElse(throw new IllegalStateException("Failed to retrieve a volume name"))
+            val mount = VolumeMount(volume.name, mountPath, readOnly = false)
+            VolumeWithMount(volume, mount)
+          }
+      }
       diskResourceMatch(
         runSpec,
         runSpec.resources.disk,
-        namedVolumes,
-        namedMounts,
+        volumesWithMounts,
         ScalarMatchResult.Scope.IncludingLocalVolumes)
     } else {
-      diskResourceMatch(runSpec, runSpec.resources.disk, Nil, Nil, ScalarMatchResult.Scope.ExcludingLocalVolumes)
+      diskResourceMatch(runSpec, runSpec.resources.disk, Nil, ScalarMatchResult.Scope.ExcludingLocalVolumes)
     }
 
     val scalarMatchResults = (
@@ -330,8 +328,7 @@ object ResourceMatcher extends StrictLogging {
     groupedResources: Map[Role, Seq[Protos.Resource]], selector: ResourceSelector)(
     runSpec: RunSpec,
     scratchDisk: Double,
-    volumes: Seq[PersistentVolume],
-    volumeMounts: Seq[VolumeMount],
+    volumesWithMounts: Seq[VolumeWithMount[PersistentVolume]],
     scope: ScalarMatchResult.Scope = ScalarMatchResult.Scope.NoneDisk): Seq[ScalarMatchResult] = {
 
     def matchesProfileName(profileName: Option[String], resource: Protos.Resource): Boolean = {
@@ -344,7 +341,7 @@ object ResourceMatcher extends StrictLogging {
     @tailrec
     def findMatches(
       diskType: DiskType,
-      pendingAllocations: List[Either[Double, PersistentVolume]],
+      pendingAllocations: List[Either[Double, VolumeWithMount[PersistentVolume]]],
       resourcesRemaining: List[SourceResources],
       resourcesConsumed: List[DiskResourceMatch.Consumption] = Nil): Either[DiskResourceNoMatch, DiskResourceMatch] = {
       val orderedResources = prioritizeDiskResources(diskType, resourcesRemaining)
@@ -355,13 +352,13 @@ object ResourceMatcher extends StrictLogging {
         case nextAllocation :: restAllocations =>
           val (matcher, nextAllocationSize) = nextAllocation match {
             case Left(size) => ({ _: Protos.Resource => true }, size)
-            case Right(v) =>
+            case Right(vm) =>
               def matcher(resource: Protos.Resource): Boolean = {
-                VolumeConstraints.meetsAllConstraints(resource, v.persistent.constraints) &&
-                  matchesProfileName(v.persistent.profileName, resource)
+                VolumeConstraints.meetsAllConstraints(resource, vm.volume.persistent.constraints) &&
+                  matchesProfileName(vm.volume.persistent.profileName, resource)
               }
 
-              (matcher _, v.persistent.size.toDouble)
+              (matcher _, vm.volume.persistent.size.toDouble)
           }
 
           findDiskGroupMatches(nextAllocationSize, orderedResources, orderedResources, matcher) match {
@@ -370,18 +367,8 @@ object ResourceMatcher extends StrictLogging {
                 DiskResourceNoMatch(resourcesConsumed, resourcesRemaining.flatMap(_.resources), nextAllocation, scope))
             case Some((source, generalConsumptions, decrementedResources)) =>
               val consumptions = generalConsumptions.map { c =>
-                val volume = nextAllocation.right.toOption
-                val mount = volume.flatMap { volume =>
-                  volumeMounts.find(_.volumeName == volume.name)
-                }
-                val (volumeToPass, mountToPass) = runSpec match {
-                  case _: AppDefinition =>
-                    // strip off temporary names
-                    (volume.map(_.copy(name = None)), mount.map(_.copy(volumeName = None)))
-                  case _: PodDefinition =>
-                    (volume, mount)
-                }
-                DiskResourceMatch.Consumption(c, source, volumeToPass, mountToPass)
+                val volumeWithMount = nextAllocation.right.toOption
+                DiskResourceMatch.Consumption(c, source, volumeWithMount)
               }
 
               findMatches(
@@ -404,7 +391,7 @@ object ResourceMatcher extends StrictLogging {
       */
     @tailrec
     def findMountMatches(
-      pendingAllocations: List[PersistentVolume],
+      pendingAllocations: List[VolumeWithMount[PersistentVolume]],
       resources: List[Protos.Resource],
       resourcesConsumed: List[DiskResourceMatch.Consumption] = Nil): Either[DiskResourceNoMatch, DiskResourceMatch] = {
       pendingAllocations match {
@@ -413,33 +400,22 @@ object ResourceMatcher extends StrictLogging {
         case nextAllocation :: restAllocations =>
           resources.find { resource =>
             val resourceSize = resource.getScalar.getValue
-            VolumeConstraints.meetsAllConstraints(resource, nextAllocation.persistent.constraints) &&
-              (resourceSize >= nextAllocation.persistent.size) &&
-              (resourceSize <= nextAllocation.persistent.maxSize.getOrElse(Long.MaxValue)) &&
-              matchesProfileName(nextAllocation.persistent.profileName, resource)
+            VolumeConstraints.meetsAllConstraints(resource, nextAllocation.volume.persistent.constraints) &&
+              (resourceSize >= nextAllocation.volume.persistent.size) &&
+              (resourceSize <= nextAllocation.volume.persistent.maxSize.getOrElse(Long.MaxValue)) &&
+              matchesProfileName(nextAllocation.volume.persistent.profileName, resource)
           } match {
             case Some(matchedResource) =>
               val consumedAmount = matchedResource.getScalar.getValue
-              val grownVolume =
-                nextAllocation.copy(
-                  persistent = nextAllocation.persistent.copy(
-                    size = consumedAmount.toLong))
-              val volumeMount = volumeMounts.find(_.volumeName == grownVolume.name)
-              val (volumeToPass, mountToPass) = runSpec match {
-                case _: AppDefinition =>
-                  // strip off temporary names
-                  (grownVolume.copy(name = None), volumeMount.map(_.copy(volumeName = None)))
-                case _: PodDefinition =>
-                  (grownVolume, volumeMount)
-              }
+              val grownVolumeWithMount = nextAllocation.copy(volume = nextAllocation.volume.copy(
+                persistent = nextAllocation.volume.persistent.copy(size = consumedAmount.toLong)))
               val consumption =
                 DiskResourceMatch.Consumption(
                   consumedAmount,
                   role = matchedResource.getRole,
                   reservation = if (matchedResource.hasReservation) Option(matchedResource.getReservation) else None,
                   source = DiskSource.fromMesos(matchedResource.getDiskSourceOption),
-                  Some(volumeToPass),
-                  mountToPass)
+                  Some(grownVolumeWithMount))
 
               findMountMatches(
                 restAllocations,
@@ -458,17 +434,17 @@ object ResourceMatcher extends StrictLogging {
     }.withDefault(_ => Nil)
 
     val scratchDiskRequest = if (scratchDisk > 0.0) Some(Left(scratchDisk)) else None
-    val requestedResourcesByType: Map[DiskType, Seq[Either[Double, PersistentVolume]]] =
-      (scratchDiskRequest ++ volumes.map(Right(_)).toList).groupBy {
+    val requestedResourcesByType: Map[DiskType, Seq[Either[Double, VolumeWithMount[PersistentVolume]]]] =
+      (scratchDiskRequest ++ volumesWithMounts.map(Right(_)).toList).groupBy {
         case Left(_) => DiskType.Root
-        case Right(p) => p.persistent.`type`
+        case Right(vm) => vm.volume.persistent.`type`
       }.map { case (k, v) => k -> v.to[Seq] }
 
     requestedResourcesByType.keys.map { diskType =>
       val withBiggestRequestsFirst =
         requestedResourcesByType(diskType).
           toList.
-          sortBy({ r => r.right.map(_.persistent.size.toDouble).merge })(implicitly[Ordering[Double]].reverse)
+          sortBy({ r => r.right.map(_.volume.persistent.size.toDouble).merge })(implicitly[Ordering[Double]].reverse)
 
       val resources: List[Protos.Resource] = resourcesByType(diskType).filterAs(selector(_))(collection.breakOut)
 

--- a/src/main/scala/mesosphere/mesos/ScalarMatchResult.scala
+++ b/src/main/scala/mesosphere/mesos/ScalarMatchResult.scala
@@ -1,7 +1,7 @@
 package mesosphere.mesos
 
 import mesosphere.marathon.raml._
-import mesosphere.marathon.state.{ DiskSource, DiskType, PersistentVolume, VolumeMount }
+import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.ResourceUtil
 import mesosphere.mesos.protos.{ Resource, ScalarResource }
 import org.apache.mesos.Protos
@@ -109,7 +109,7 @@ case class DiskResourceMatch(
 
   def consumedResources: Seq[Protos.Resource] = {
     consumed.map {
-      case DiskResourceMatch.Consumption(value, role, reservation, source, _, _) =>
+      case DiskResourceMatch.Consumption(value, role, reservation, source, _) =>
         import mesosphere.mesos.protos.Implicits._
         val builder = ScalarResource(resourceName, value, role).toBuilder
         reservation.foreach(builder.setReservation)
@@ -126,9 +126,9 @@ case class DiskResourceMatch(
     * return all volumes for this disk resource match
     * Distinct because a persistentVolume may be associated with multiple resources.
     */
-  def volumes: Seq[(DiskSource, PersistentVolume, VolumeMount)] =
+  def volumes: Seq[(DiskSource, VolumeWithMount[PersistentVolume])] =
     consumed.collect {
-      case d @ DiskResourceMatch.Consumption(_, _, _, _, Some(volume), Some(mount)) => (d.source, volume, mount)
+      case d @ DiskResourceMatch.Consumption(_, _, _, _, Some(volumeWithMount)) => (d.source, volumeWithMount)
     }.toList.distinct
 
   override def toString: String = {
@@ -140,20 +140,18 @@ object DiskResourceMatch {
   /** A (potentially partial) consumption of a scalar resource. */
   case class Consumption(consumedValue: Double, role: String,
       reservation: Option[ReservationInfo], source: DiskSource,
-      persistentVolume: Option[PersistentVolume],
-      volumeMount: Option[VolumeMount]) extends ScalarMatchResult.Consumption {
+      persistentVolumeWithMount: Option[VolumeWithMount[PersistentVolume]]) extends ScalarMatchResult.Consumption {
 
-    def requested: Either[Double, PersistentVolume] =
-      persistentVolume.map(Right(_)).getOrElse(Left(consumedValue))
+    def requested: Either[Double, VolumeWithMount[PersistentVolume]] =
+      persistentVolumeWithMount.map(Right(_)).getOrElse(Left(consumedValue))
   }
-  type ApplyFn = ((Double, String, Option[ReservationInfo], DiskSource, Option[PersistentVolume], Option[VolumeMount]) => Consumption)
+  type ApplyFn = ((Double, String, Option[ReservationInfo], DiskSource, Option[VolumeWithMount[PersistentVolume]]) => Consumption)
   object Consumption extends ApplyFn {
     def apply(
       c: GeneralScalarMatch.Consumption,
       source: Option[DiskInfo.Source],
-      persistentVolume: Option[PersistentVolume],
-      volumeMount: Option[VolumeMount]): Consumption = {
-      Consumption(c.consumedValue, c.role, c.reservation, DiskSource.fromMesos(source), persistentVolume, volumeMount)
+      persistentVolumeWithMount: Option[VolumeWithMount[PersistentVolume]]): Consumption = {
+      Consumption(c.consumedValue, c.role, c.reservation, DiskSource.fromMesos(source), persistentVolumeWithMount)
     }
   }
 
@@ -162,21 +160,22 @@ object DiskResourceMatch {
 case class DiskResourceNoMatch(
     consumed: Seq[DiskResourceMatch.Consumption],
     resourcesRemaining: Seq[Protos.Resource],
-    failedWith: Either[Double, PersistentVolume],
+    failedWith: Either[Double, VolumeWithMount[PersistentVolume]],
     scope: ScalarMatchResult.Scope) extends ScalarMatchResult {
 
   import ResourceUtil.RichResource
 
   def resourceName: String = Resource.DISK
   def requiredValue: Double = {
-    failedWith.right.map(_.persistent.size.toDouble).merge + consumed.foldLeft(0.0)(_ + _.consumedValue)
+    failedWith.right.map(_.volume.persistent.size.toDouble).merge + consumed.foldLeft(0.0)(_ + _.consumedValue)
   }
 
-  def requestedStringification(requested: Either[Double, PersistentVolume]): String = requested match {
-    case Left(value) => s"disk:root:${value}"
-    case Right(vol) =>
-      val constraintsJson: Seq[Seq[String]] = vol.persistent.constraints.map(_.toRaml[Seq[String]])(collection.breakOut)
-      s"disk:${vol.persistent.`type`.toString}:${vol.persistent.size}:[${constraintsJson.mkString(",")}]"
+  def requestedStringification(requested: Either[Double, VolumeWithMount[PersistentVolume]]): String = requested match {
+    case Left(value) => s"disk:root:$value"
+    case Right(vm) =>
+      val constraintsJson: Seq[Seq[String]] =
+        vm.volume.persistent.constraints.map(_.toRaml[Seq[String]])(collection.breakOut)
+      s"disk:${vm.volume.persistent.`type`.toString}:${vm.volume.persistent.size}:[${constraintsJson.mkString(",")}]"
   }
 
   def matches: Boolean = false

--- a/src/main/scala/mesosphere/mesos/protos/ResourceProviderID.scala
+++ b/src/main/scala/mesosphere/mesos/protos/ResourceProviderID.scala
@@ -1,0 +1,15 @@
+package mesosphere.mesos.protos
+
+import org.apache.mesos.Protos
+
+case class ResourceProviderID(value: String)
+
+object ResourceProviderID {
+  def fromResourceProto(resource: Protos.Resource): Option[ResourceProviderID] = {
+    if (resource.hasProviderId && resource.getProviderId.hasValue) {
+      Some(ResourceProviderID(resource.getProviderId.getValue))
+    } else {
+      None
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
@@ -676,7 +676,8 @@ class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
       )
 
       // scalastyle:off magic.number
-      def hostVolume(hostPath: String = "/etc/foo", mountPath: String = "/test", readOnly: Boolean = false): VolumeWithMount[Volume] =
+      def hostVolume(hostPath: String = "/etc/foo", mountPath: String = "/test",
+        readOnly: Boolean = false): VolumeWithMount[HostVolume] =
         VolumeWithMount(
           volume = HostVolume(name = None, hostPath = hostPath),
           mount = VolumeMount(volumeName = None, mountPath = mountPath, readOnly = readOnly))

--- a/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
@@ -676,19 +676,19 @@ class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
       )
 
       // scalastyle:off magic.number
-      def hostVolume(hostPath: String = "/etc/foo", mountPath: String = "/test", readOnly: Boolean = false): VolumeWithMount =
+      def hostVolume(hostPath: String = "/etc/foo", mountPath: String = "/test", readOnly: Boolean = false): VolumeWithMount[Volume] =
         VolumeWithMount(
           volume = HostVolume(name = None, hostPath = hostPath),
           mount = VolumeMount(volumeName = None, mountPath = mountPath, readOnly = readOnly))
 
-      def persistentVolume(size: Long = 10, mountPath: String = "test", readOnly: Boolean = false): VolumeWithMount =
+      def persistentVolume(size: Long = 10, mountPath: String = "test", readOnly: Boolean = false): VolumeWithMount[PersistentVolume] =
         VolumeWithMount(
           volume = PersistentVolume(name = None, persistent = PersistentVolumeInfo(size)),
           mount = VolumeMount(volumeName = None, mountPath = mountPath, readOnly = readOnly))
 
       val zero = UpgradeStrategy(0, 0)
 
-      def residentApp(id: String, volumes: Seq[VolumeWithMount]): AppDefinition = {
+      def residentApp(id: String, volumes: Seq[VolumeWithMount[PersistentVolume]]): AppDefinition = {
         AppDefinition(
           id = PathId(id),
           cmd = Some("test"),

--- a/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
@@ -429,7 +429,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       mount = VolumeMount(volumeName = None, mountPath = path, readOnly = false))
     val zero = UpgradeStrategy(0, 0)
 
-    def residentApp(id: String, volumes: Seq[VolumeWithMount]): AppDefinition = {
+    def residentApp(id: String, volumes: Seq[VolumeWithMount[PersistentVolume]]): AppDefinition = {
       AppDefinition(
         id = PathId(id),
         cmd = Some("foo"),

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
@@ -8,6 +8,7 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.test.MarathonTestHelper
+import mesosphere.mesos.protos.ResourceProviderID
 import org.apache.mesos.{ Protos => Mesos }
 
 class OfferOperationFactoryTest extends UnitTest {
@@ -75,35 +76,64 @@ class OfferOperationFactoryTest extends UnitTest {
 
       Given("a factory without principal")
       val factory = new OfferOperationFactory(Some("principal"), Some("role"))
-      val task = MarathonTestHelper.makeOneCPUTask(f.taskId)
-      val volumes = Seq(f.localVolume("mount"))
-      val resource = MarathonTestHelper.scalarResource("disk", 1024)
+      val volume1 = f.localVolume("mount1")
+      val volume2 = f.localVolume("mount2")
+      val volumes = Seq(volume1, volume2)
 
       When("We create a reserve operation")
-      val offeredVolumes = volumes.map(v => InstanceOpFactory.OfferedVolume(None, DiskSource.root, v))
+      val offeredVolume1 = InstanceOpFactory.OfferedVolume(None, DiskSource.root, volume1)
+      val offeredVolume2 =
+        InstanceOpFactory.OfferedVolume(Some(ResourceProviderID("pID")), DiskSource.root, volume2)
+      val offeredVolumes = Seq(offeredVolume1, offeredVolume2)
       val operations = factory.createVolumes(f.reservationLabels, offeredVolumes)
 
       Then("The operation is as expected")
-      operations.length shouldEqual 1
-      val operation = operations.head
-      operation.getType shouldEqual Mesos.Offer.Operation.Type.CREATE
-      operation.hasCreate shouldEqual true
-      operation.getCreate.getVolumesCount shouldEqual volumes.size
+      operations.length shouldEqual 2
+
+      val (operationWithProviderId, operationWithoutProviderId) =
+        if (operations.head.getCreate.getVolumesList.exists(_.hasProviderId)) {
+          (operations.head, operations.last)
+        } else {
+          (operations.last, operations.head)
+        }
+
+      operationWithProviderId.getType shouldEqual Mesos.Offer.Operation.Type.CREATE
+      operationWithProviderId.hasCreate shouldEqual true
+      operationWithProviderId.getCreate.getVolumesCount shouldEqual 1
+      operationWithProviderId.getCreate.getVolumesList.exists(_.hasProviderId) shouldEqual true
+
+      operationWithoutProviderId.getType shouldEqual Mesos.Offer.Operation.Type.CREATE
+      operationWithoutProviderId.hasCreate shouldEqual true
+      operationWithoutProviderId.getCreate.getVolumesCount shouldEqual 1
+      operationWithoutProviderId.getCreate.getVolumesList.exists(_.hasProviderId) shouldEqual false
 
       And("The volumes are correct")
-      val volume = operation.getCreate.getVolumes(0)
-      val originalVolume = volumes.head
-      volume.getName shouldEqual "disk"
-      volume.getRole shouldEqual "role"
-      volume.getScalar.getValue shouldEqual 10
-      volume.hasReservation shouldEqual true
-      volume.getReservation.getPrincipal shouldEqual "principal"
-      volume.hasDisk shouldEqual true
-      volume.getDisk.hasPersistence shouldEqual true
-      volume.getDisk.getPersistence.getId shouldEqual originalVolume.id.idString
-      volume.getDisk.hasVolume shouldEqual true
-      volume.getDisk.getVolume.getContainerPath shouldEqual originalVolume.mount.mountPath
-      volume.getDisk.getVolume.getMode shouldEqual Mesos.Volume.Mode.RW
+      val volumeWithProviderId = operationWithProviderId.getCreate.getVolumes(0)
+      val originalVolume = volume2
+      volumeWithProviderId.getName shouldEqual "disk"
+      volumeWithProviderId.getRole shouldEqual "role"
+      volumeWithProviderId.getScalar.getValue shouldEqual 10
+      volumeWithProviderId.hasReservation shouldEqual true
+      volumeWithProviderId.getReservation.getPrincipal shouldEqual "principal"
+      volumeWithProviderId.hasDisk shouldEqual true
+      volumeWithProviderId.getDisk.hasPersistence shouldEqual true
+      volumeWithProviderId.getDisk.getPersistence.getId shouldEqual volume2.id.idString
+      volumeWithProviderId.getDisk.hasVolume shouldEqual true
+      volumeWithProviderId.getDisk.getVolume.getContainerPath shouldEqual volume2.mount.mountPath
+      volumeWithProviderId.getDisk.getVolume.getMode shouldEqual Mesos.Volume.Mode.RW
+
+      val volumeWithoutProviderId = operationWithoutProviderId.getCreate.getVolumes(0)
+      volumeWithoutProviderId.getName shouldEqual "disk"
+      volumeWithoutProviderId.getRole shouldEqual "role"
+      volumeWithoutProviderId.getScalar.getValue shouldEqual 10
+      volumeWithoutProviderId.hasReservation shouldEqual true
+      volumeWithoutProviderId.getReservation.getPrincipal shouldEqual "principal"
+      volumeWithoutProviderId.hasDisk shouldEqual true
+      volumeWithoutProviderId.getDisk.hasPersistence shouldEqual true
+      volumeWithoutProviderId.getDisk.getPersistence.getId shouldEqual volume1.id.idString
+      volumeWithoutProviderId.getDisk.hasVolume shouldEqual true
+      volumeWithoutProviderId.getDisk.getVolume.getContainerPath shouldEqual volume1.mount.mountPath
+      volumeWithoutProviderId.getDisk.getVolume.getMode shouldEqual Mesos.Volume.Mode.RW
     }
   }
   class Fixture {

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
@@ -77,7 +77,7 @@ class OfferOperationFactoryTest extends UnitTest {
       val resource = MarathonTestHelper.scalarResource("disk", 1024)
 
       When("We create a reserve operation")
-      val operation = factory.createVolumes(f.reservationLabels, volumes.map(v => (DiskSource.root, v)))
+      val operation = factory.createVolumes(f.reservationLabels, volumes.map(v => (None, DiskSource.root, v)))
 
       Then("The operation is as expected")
       operation.getType shouldEqual Mesos.Offer.Operation.Type.CREATE

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package core.matcher.base.util
 
 import mesosphere.UnitTest
+import mesosphere.marathon.core.launcher.InstanceOpFactory
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state._
@@ -79,7 +80,8 @@ class OfferOperationFactoryTest extends UnitTest {
       val resource = MarathonTestHelper.scalarResource("disk", 1024)
 
       When("We create a reserve operation")
-      val operations = factory.createVolumes(f.reservationLabels, volumes.map(v => (None, DiskSource.root, v)))
+      val offeredVolumes = volumes.map(v => InstanceOpFactory.OfferedVolume(None, DiskSource.root, v))
+      val operations = factory.createVolumes(f.reservationLabels, offeredVolumes)
 
       Then("The operation is as expected")
       operations.length shouldEqual 1

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
@@ -50,9 +50,11 @@ class OfferOperationFactoryTest extends UnitTest {
       val task = MarathonTestHelper.makeOneCPUTask(f.taskId)
 
       When("We create a reserve operation")
-      val operation = factory.reserve(f.reservationLabels, task.getResourcesList.to[Seq])
+      val operations = factory.reserve(f.reservationLabels, task.getResourcesList.to[Seq])
 
       Then("The operation is as expected")
+      operations.length shouldEqual 1
+      val operation = operations.head
       operation.getType shouldEqual Mesos.Offer.Operation.Type.RESERVE
       operation.hasReserve shouldEqual true
       operation.getReserve.getResourcesCount shouldEqual task.getResourcesCount
@@ -77,9 +79,11 @@ class OfferOperationFactoryTest extends UnitTest {
       val resource = MarathonTestHelper.scalarResource("disk", 1024)
 
       When("We create a reserve operation")
-      val operation = factory.createVolumes(f.reservationLabels, volumes.map(v => (None, DiskSource.root, v)))
+      val operations = factory.createVolumes(f.reservationLabels, volumes.map(v => (None, DiskSource.root, v)))
 
       Then("The operation is as expected")
+      operations.length shouldEqual 1
+      val operation = operations.head
       operation.getType shouldEqual Mesos.Offer.Operation.Type.CREATE
       operation.hasCreate shouldEqual true
       operation.getCreate.getVolumesCount shouldEqual volumes.size

--- a/src/test/scala/mesosphere/marathon/raml/VolumeConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/VolumeConversionTest.scala
@@ -3,12 +3,13 @@ package raml
 
 import mesosphere.UnitTest
 import mesosphere.marathon.api.serialization.VolumeSerializer
+import mesosphere.marathon.state.Volume
 
 class VolumeConversionTest extends UnitTest {
 
-  def convertToProtobufThenToRAML(volume: => state.VolumeWithMount, raml: => AppVolume): Unit = {
+  def convertToProtobufThenToRAML(volumeWithMount: => state.VolumeWithMount[Volume], raml: => AppVolume): Unit = {
     "convert to protobuf, then to RAML" in {
-      val proto = VolumeSerializer.toProto(volume)
+      val proto = VolumeSerializer.toProto(volumeWithMount)
       val proto2Raml = proto.toRaml
       proto2Raml should be(raml)
     }

--- a/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
@@ -10,21 +10,21 @@ import org.apache.mesos.Protos.Resource.DiskInfo.Source
 class VolumeTest extends UnitTest {
   import mesosphere.marathon.test.MarathonTestHelper.constraint
 
-  def survivesProtobufSerializationRoundtrip(title: => String, volume: => VolumeWithMount): Unit = {
+  def survivesProtobufSerializationRoundtrip(title: => String, volumeWithMount: => VolumeWithMount[Volume]): Unit = {
     s"$title survives protobuf serialization round-trip" in {
-      val protobuf = VolumeSerializer.toProto(volume)
+      val protobuf = VolumeSerializer.toProto(volumeWithMount)
       val resurrected = VolumeWithMount(None, protobuf)
-      resurrected should be(volume)
+      resurrected should be(volumeWithMount)
     }
   }
 
-  def persistent(info: PersistentVolumeInfo, mountPath: String = "cpath", readOnly: Boolean = false): VolumeWithMount = {
+  def persistent(info: PersistentVolumeInfo, mountPath: String = "cpath", readOnly: Boolean = false): VolumeWithMount[PersistentVolume] = {
     val volume = PersistentVolume(None, info)
     val mount = VolumeMount(None, mountPath, readOnly)
     VolumeWithMount(volume, mount)
   }
 
-  def external(info: ExternalVolumeInfo, mountPath: String = "cpath", readOnly: Boolean = false): VolumeWithMount = {
+  def external(info: ExternalVolumeInfo, mountPath: String = "cpath", readOnly: Boolean = false): VolumeWithMount[ExternalVolume] = {
     val volume = ExternalVolume(None, info)
     val mount = VolumeMount(None, mountPath, readOnly)
     VolumeWithMount(volume, mount)

--- a/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
@@ -148,23 +148,23 @@ class VolumeTest extends UnitTest {
     }
 
     "validating that DiskSource asMesos converts to an Option Mesos Protobuffer" in {
-      DiskSource(DiskType.Root, None).asMesos shouldBe None
-      val Some(pathDisk) = DiskSource(DiskType.Path, Some("/path/to/folder")).asMesos
+      DiskSource(DiskType.Root, None, None, None).asMesos shouldBe None
+      val Some(pathDisk) = DiskSource(DiskType.Path, Some("/path/to/folder"), None, None).asMesos
       pathDisk.getPath.getRoot shouldBe "/path/to/folder"
       pathDisk.getType shouldBe Source.Type.PATH
 
-      val Some(mountDisk) = DiskSource(DiskType.Mount, Some("/path/to/mount")).asMesos
+      val Some(mountDisk) = DiskSource(DiskType.Mount, Some("/path/to/mount"), None, None).asMesos
       mountDisk.getMount.getRoot shouldBe "/path/to/mount"
       mountDisk.getType shouldBe Source.Type.MOUNT
 
       a[IllegalArgumentException] shouldBe thrownBy {
-        DiskSource(DiskType.Root, Some("/path")).asMesos
+        DiskSource(DiskType.Root, Some("/path"), None, None).asMesos
       }
       a[IllegalArgumentException] shouldBe thrownBy {
-        DiskSource(DiskType.Path, None).asMesos
+        DiskSource(DiskType.Path, None, None, None).asMesos
       }
       a[IllegalArgumentException] shouldBe thrownBy {
-        DiskSource(DiskType.Mount, None).asMesos
+        DiskSource(DiskType.Mount, None, None, None).asMesos
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
@@ -157,6 +157,26 @@ class VolumeTest extends UnitTest {
       mountDisk.getMount.getRoot shouldBe "/path/to/mount"
       mountDisk.getType shouldBe Source.Type.MOUNT
 
+      val Some(pathCsiDisk) = DiskSource(DiskType.Path, Some("/path/to/folder"),
+        Some("csiPathDisk"), Map("pathKey" -> "pathValue"), Some("pathProfile")).asMesos
+      pathCsiDisk.getPath.getRoot shouldBe "/path/to/folder"
+      pathCsiDisk.getType shouldBe Source.Type.PATH
+      pathCsiDisk.getId shouldBe "csiPathDisk"
+      pathCsiDisk.getMetadata.getLabelsCount shouldBe 1
+      pathCsiDisk.getMetadata.getLabels(0).getKey shouldBe "pathKey"
+      pathCsiDisk.getMetadata.getLabels(0).getValue shouldBe "pathValue"
+      pathCsiDisk.getProfile shouldBe "pathProfile"
+
+      val Some(mountCsiDisk) = DiskSource(DiskType.Mount, Some("/path/to/mount"),
+        Some("csiMountDisk"), Map("mountKey" -> "mountValue"), Some("mountProfile")).asMesos
+      mountCsiDisk.getMount.getRoot shouldBe "/path/to/mount"
+      mountCsiDisk.getType shouldBe Source.Type.MOUNT
+      mountCsiDisk.getId shouldBe "csiMountDisk"
+      mountCsiDisk.getMetadata.getLabelsCount shouldBe 1
+      mountCsiDisk.getMetadata.getLabels(0).getKey shouldBe "mountKey"
+      mountCsiDisk.getMetadata.getLabels(0).getValue shouldBe "mountValue"
+      mountCsiDisk.getProfile shouldBe "mountProfile"
+
       a[IllegalArgumentException] shouldBe thrownBy {
         DiskSource(DiskType.Root, Some("/path"), None, Map.empty, None).asMesos
       }

--- a/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
@@ -148,23 +148,23 @@ class VolumeTest extends UnitTest {
     }
 
     "validating that DiskSource asMesos converts to an Option Mesos Protobuffer" in {
-      DiskSource(DiskType.Root, None, None, None).asMesos shouldBe None
-      val Some(pathDisk) = DiskSource(DiskType.Path, Some("/path/to/folder"), None, None).asMesos
+      DiskSource(DiskType.Root, None, None, Map.empty, None).asMesos shouldBe None
+      val Some(pathDisk) = DiskSource(DiskType.Path, Some("/path/to/folder"), None, Map.empty, None).asMesos
       pathDisk.getPath.getRoot shouldBe "/path/to/folder"
       pathDisk.getType shouldBe Source.Type.PATH
 
-      val Some(mountDisk) = DiskSource(DiskType.Mount, Some("/path/to/mount"), None, None).asMesos
+      val Some(mountDisk) = DiskSource(DiskType.Mount, Some("/path/to/mount"), None, Map.empty, None).asMesos
       mountDisk.getMount.getRoot shouldBe "/path/to/mount"
       mountDisk.getType shouldBe Source.Type.MOUNT
 
       a[IllegalArgumentException] shouldBe thrownBy {
-        DiskSource(DiskType.Root, Some("/path"), None, None).asMesos
+        DiskSource(DiskType.Root, Some("/path"), None, Map.empty, None).asMesos
       }
       a[IllegalArgumentException] shouldBe thrownBy {
-        DiskSource(DiskType.Path, None, None, None).asMesos
+        DiskSource(DiskType.Path, None, None, Map.empty, None).asMesos
       }
       a[IllegalArgumentException] shouldBe thrownBy {
-        DiskSource(DiskType.Mount, None, None, None).asMesos
+        DiskSource(DiskType.Mount, None, None, Map.empty, None).asMesos
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/tasks/ResourceUtilTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/ResourceUtilTest.scala
@@ -47,8 +47,8 @@ class ResourceUtilTest extends UnitTest {
       val reservationInfo = ReservationInfo.newBuilder().setPrincipal("principal").build()
 
       val disk = DiskInfo.newBuilder().setPersistence(Persistence.newBuilder().setId("persistenceId")).build()
-      val resourceWithReservation = MTH.scalarResource("disk", 1024, "role", Some(reservationInfo), Some(disk))
-      val resourceWithoutReservation = MTH.scalarResource("disk", 1024, "role", None, None)
+      val resourceWithReservation = MTH.scalarResource("disk", 1024, "role", None, Some(reservationInfo), Some(disk))
+      val resourceWithoutReservation = MTH.scalarResource("disk", 1024, "role", None, None, None)
 
       // simple case: Only exact match contained
 
@@ -109,8 +109,8 @@ class ResourceUtilTest extends UnitTest {
       val labels = Protos.Labels.newBuilder().addLabels(Protos.Label.newBuilder().setKey("key").setValue("value"))
       val reservationInfo2 = ReservationInfo.newBuilder().setPrincipal("principal").setLabels(labels).build()
 
-      val resourceWithReservation1 = MTH.scalarResource("disk", 1024, "role", Some(reservationInfo1), None)
-      val resourceWithReservation2 = MTH.scalarResource("disk", 1024, "role", Some(reservationInfo2), None)
+      val resourceWithReservation1 = MTH.scalarResource("disk", 1024, "role", None, Some(reservationInfo1), None)
+      val resourceWithReservation2 = MTH.scalarResource("disk", 1024, "role", None, Some(reservationInfo2), None)
 
       // simple case: Only exact match contained
 
@@ -161,7 +161,7 @@ class ResourceUtilTest extends UnitTest {
 
     "display resources indicates reservation" in {
       val reservationInfo = ReservationInfo.newBuilder().setPrincipal("principal").build()
-      val resource = MTH.scalarResource("disk", 1024, "role", Some(reservationInfo), None)
+      val resource = MTH.scalarResource("disk", 1024, "role", None, Some(reservationInfo), None)
       val resourceString = ResourceUtil.displayResources(Seq(resource), maxRanges = 10)
       resourceString should equal("disk(role, RESERVED for principal) 1024.0")
     }
@@ -169,7 +169,7 @@ class ResourceUtilTest extends UnitTest {
     "display resources displays disk and reservation info" in {
       val reservationInfo = ReservationInfo.newBuilder().setPrincipal("principal").build()
       val disk = DiskInfo.newBuilder().setPersistence(Persistence.newBuilder().setId("persistenceId")).build()
-      val resource = MTH.scalarResource("disk", 1024, "role", Some(reservationInfo), Some(disk))
+      val resource = MTH.scalarResource("disk", 1024, "role", None, Some(reservationInfo), Some(disk))
       val resourceString = ResourceUtil.displayResources(Seq(resource), maxRanges = 10)
       resourceString should equal("disk(role, RESERVED for principal, diskId persistenceId) 1024.0")
     }

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -28,6 +28,7 @@ import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.InstanceRepository
 import mesosphere.marathon.stream.Implicits._
+import mesosphere.mesos.protos
 import mesosphere.mesos.protos.{ FrameworkID, OfferID, Range, RangesResource, Resource, ScalarResource, SlaveID }
 import mesosphere.mesos.protos.Implicits._
 import mesosphere.util.state.FrameworkId
@@ -191,7 +192,8 @@ object MarathonTestHelper {
 
   def scalarResource(
     name: String, d: Double, role: String = ResourceRole.Unreserved,
-    reservation: Option[ReservationInfo] = None, disk: Option[DiskInfo] = None): Mesos.Resource = {
+    providerId: Option[protos.ResourceProviderID] = None, reservation: Option[ReservationInfo] = None,
+    disk: Option[DiskInfo] = None): Mesos.Resource = {
 
     val builder = Mesos.Resource
       .newBuilder()
@@ -200,6 +202,10 @@ object MarathonTestHelper {
       .setScalar(Value.Scalar.newBuilder().setValue(d))
       .setRole(role)
 
+    providerId.foreach { providerId =>
+      val proto = Mesos.ResourceProviderID.newBuilder().setValue(providerId.value)
+      builder.setProviderId(proto)
+    }
     reservation.foreach(builder.setReservation)
     disk.foreach(builder.setDisk)
 

--- a/src/test/scala/mesosphere/mesos/ResourceMatchTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatchTest.scala
@@ -17,7 +17,7 @@ class ResourceMatchTest extends UnitTest {
         scalarMatches = Seq(
           GeneralScalarMatch(
             "mem", 128.0,
-            consumed = Seq(GeneralScalarMatch.Consumption(128.0, "role1", reservation = Some(memReservation))),
+            consumed = Seq(GeneralScalarMatch.Consumption(128.0, "role1", None, reservation = Some(memReservation))),
             scope = ScalarMatchResult.Scope.NoneDisk
           )
         ),

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -181,7 +181,7 @@ class ResourceMatcherTest extends UnitTest with Inside {
       )
       res.scalarMatch(Resource.DISK).get.consumed.toSet should be(
         Set(
-          DiskResourceMatch.Consumption(2.0, ResourceRole.Unreserved, Some(diskReservation), DiskSource.root, None, None)
+          DiskResourceMatch.Consumption(2.0, ResourceRole.Unreserved, Some(diskReservation), DiskSource.root, None)
         )
       )
 
@@ -241,7 +241,7 @@ class ResourceMatcherTest extends UnitTest with Inside {
       res.scalarMatch(Resource.DISK).get.consumed.toSet should be(
         Set(
           DiskResourceMatch.Consumption(
-            2.0, ResourceRole.Unreserved, reservation = Some(diskReservation), DiskSource.root, None, None)
+            2.0, ResourceRole.Unreserved, reservation = Some(diskReservation), DiskSource.root, None)
         )
       )
 
@@ -702,9 +702,9 @@ class ResourceMatcherTest extends UnitTest with Inside {
       resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
       resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch.scalarMatch("disk").get.consumed.toSet shouldBe Set(
         DiskResourceMatch.Consumption(1024.0, "*", None, DiskSource(DiskType.Path, Some("/path2")),
-          Some(persistentVolume), Some(mount)),
+          Some(VolumeWithMount(persistentVolume, mount))),
         DiskResourceMatch.Consumption(476.0, "*", None, DiskSource(DiskType.Path, Some("/path2")),
-          Some(persistentVolume), Some(mount)))
+          Some(VolumeWithMount(persistentVolume, mount))))
     }
 
     "match disk enforces constraints" in {
@@ -784,7 +784,7 @@ class ResourceMatcherTest extends UnitTest with Inside {
         case matches: ResourceMatchResponse.Match =>
           matches.resourceMatch.scalarMatches.collectFirst {
             case m: DiskResourceMatch =>
-              (m.consumedValue, m.consumed.head.persistentVolume.get.persistent.size)
+              (m.consumedValue, m.consumed.head.persistentVolumeWithMount.get.volume.persistent.size)
           } shouldBe Some((1024, 1024))
       }
 

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -169,19 +169,19 @@ class ResourceMatcherTest extends UnitTest with Inside {
       res.scalarMatches should have size 3
       res.scalarMatch(Resource.CPUS).get.consumed.toSet should be(
         Set(
-          GeneralScalarMatch.Consumption(1.0, "marathon", reservation = Some(cpuReservation)),
-          GeneralScalarMatch.Consumption(1.0, "marathon", reservation = Some(cpuReservation2))
+          GeneralScalarMatch.Consumption(1.0, "marathon", None, reservation = Some(cpuReservation)),
+          GeneralScalarMatch.Consumption(1.0, "marathon", None, reservation = Some(cpuReservation2))
         )
       )
 
       res.scalarMatch(Resource.MEM).get.consumed.toSet should be(
         Set(
-          GeneralScalarMatch.Consumption(128.0, ResourceRole.Unreserved, reservation = Some(memReservation))
+          GeneralScalarMatch.Consumption(128.0, ResourceRole.Unreserved, None, reservation = Some(memReservation))
         )
       )
       res.scalarMatch(Resource.DISK).get.consumed.toSet should be(
         Set(
-          DiskResourceMatch.Consumption(2.0, ResourceRole.Unreserved, Some(diskReservation), DiskSource.root, None)
+          DiskResourceMatch.Consumption(2.0, ResourceRole.Unreserved, None, Some(diskReservation), DiskSource.root, None)
         )
       )
 
@@ -228,20 +228,20 @@ class ResourceMatcherTest extends UnitTest with Inside {
       res.scalarMatches should have size 3
       res.scalarMatch(Resource.CPUS).get.consumed.toSet should be(
         Set(
-          GeneralScalarMatch.Consumption(1.0, "marathon", reservation = Some(cpuReservation)),
-          GeneralScalarMatch.Consumption(1.0, "marathon", reservation = Some(cpuReservation2))
+          GeneralScalarMatch.Consumption(1.0, "marathon", None, reservation = Some(cpuReservation)),
+          GeneralScalarMatch.Consumption(1.0, "marathon", None, reservation = Some(cpuReservation2))
         )
       )
 
       res.scalarMatch(Resource.MEM).get.consumed.toSet should be(
         Set(
-          GeneralScalarMatch.Consumption(128.0, ResourceRole.Unreserved, reservation = Some(memReservation))
+          GeneralScalarMatch.Consumption(128.0, ResourceRole.Unreserved, None, reservation = Some(memReservation))
         )
       )
       res.scalarMatch(Resource.DISK).get.consumed.toSet should be(
         Set(
           DiskResourceMatch.Consumption(
-            2.0, ResourceRole.Unreserved, reservation = Some(diskReservation), DiskSource.root, None)
+            2.0, ResourceRole.Unreserved, None, reservation = Some(diskReservation), DiskSource.root, None)
         )
       )
 
@@ -701,9 +701,9 @@ class ResourceMatcherTest extends UnitTest with Inside {
 
       resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
       resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch.scalarMatch("disk").get.consumed.toSet shouldBe Set(
-        DiskResourceMatch.Consumption(1024.0, "*", None, DiskSource(DiskType.Path, Some("/path2"), None, None),
+        DiskResourceMatch.Consumption(1024.0, "*", None, None, DiskSource(DiskType.Path, Some("/path2"), None, Map.empty, None),
           Some(VolumeWithMount(persistentVolume, mount))),
-        DiskResourceMatch.Consumption(476.0, "*", None, DiskSource(DiskType.Path, Some("/path2"), None, None),
+        DiskResourceMatch.Consumption(476.0, "*", None, None, DiskSource(DiskType.Path, Some("/path2"), None, Map.empty, None),
           Some(VolumeWithMount(persistentVolume, mount))))
     }
 

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -701,9 +701,9 @@ class ResourceMatcherTest extends UnitTest with Inside {
 
       resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
       resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch.scalarMatch("disk").get.consumed.toSet shouldBe Set(
-        DiskResourceMatch.Consumption(1024.0, "*", None, DiskSource(DiskType.Path, Some("/path2")),
+        DiskResourceMatch.Consumption(1024.0, "*", None, DiskSource(DiskType.Path, Some("/path2"), None, None),
           Some(VolumeWithMount(persistentVolume, mount))),
-        DiskResourceMatch.Consumption(476.0, "*", None, DiskSource(DiskType.Path, Some("/path2")),
+        DiskResourceMatch.Consumption(476.0, "*", None, DiskSource(DiskType.Path, Some("/path2"), None, None),
           Some(VolumeWithMount(persistentVolume, mount))))
     }
 


### PR DESCRIPTION
- Reservation fields like `DiskInfo.Source.{id,metadata}` and `Resource.provider_id` have to be preserved when dealing with offer operations.
- Parametrize `VolumeWithMount` type in order to simplify code in a few places.
- Offer operations must be grouped by resource provider ID, otherwise operations get dropped by Mesos.