### PR TITLE
Use leader IP as DCOS_URL

### DIFF
--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -59,9 +59,10 @@ export DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )
 CLUSTER_LAUNCH_CODE=$?
 case $CLUSTER_LAUNCH_CODE in
   0)
-      use-leader-ip-as-dcos-url
       cp -f "$DOT_SHAKEDOWN" "$HOME/.shakedown"
-      (cd tests && make init test)
+      (cd tests && make init)
+      use-leader-ip-as-dcos-url
+      (cd tests && make test)
       SI_CODE=$?
       if [ ${SI_CODE} -gt 0 ]; then
         download-diagnostics-bundle

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -50,7 +50,7 @@ function download-diagnostics-bundle {
 # We need to use master (leader) public IP as DCOS_URL not just random master public IP.
 # Tests that introduce network partition never partition cluster leader node.
 function use-leader-ip-as-dcos-url {
-    LEADER_PUBLIC_IP=`for id in $(dcos node --json | jq --raw-output '.[] | select(.type == "master (leader)") | .ip'); do dcos node ssh --option StrictHostKeyChecking=no --option LogLevel=quiet --master-proxy --private-ip=$id "curl -s ifconfig.co" ; done 2>/dev/null`
+    LEADER_PUBLIC_IP=`for id in $(dcos node --json | jq --raw-output '.[] | select(.type == "master (leader)") | .ip'); do dcos node ssh --option StrictHostKeyChecking=no --option LogLevel=quiet --master-proxy --private-ip=$id "curl -s ifconfig.co" ; done`
     export DCOS_URL="http://$LEADER_PUBLIC_IP/"
 }
 


### PR DESCRIPTION
Summary:
Right now we use just random master IP as DCOS_URL. There are some tests that partition the whole cluster and it might happen, that we partition out the node that we actually use to do our API queries against.

At the same time, we NEVER partition master leader (mesos leader).

By this change I just make sure, that we always use leader IP as DCOS_URL instead of any IP.

JIRA issues: MARATHON-7965
