### PR TITLE
Bump Coursier to 1.0.0-RC13

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.4")
 addSbtPlugin("de.johoop" % "cpd4sbt" % "1.2.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.25")
 addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.10.6")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
 
 libraryDependencies ++= Seq(
   "org.raml" % "raml-parser-2" % "1.0.0",
@@ -32,3 +32,5 @@ libraryDependencies ++= Seq(
 
 sbtPlugin := true
 
+// Needed for jdeb dependency of sbt-native-packager
+classpathTypes += "maven-plugin"


### PR DESCRIPTION
A classpathTypes setting is required to resolve an issue with
sbt-native-packager/jdeb and newer Coursier versions. Upgrading here and
providing the fix for people that have a newer version of Coursier
loaded globally