### PR TITLE
Block and restore iptables rules on one command

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -226,38 +226,21 @@ def systemctl_master(command='restart'):
     shakedown.run_command_on_master('sudo systemctl {} dcos-mesos-master'.format(command))
 
 
-def save_iptables(host, filename='iptables.rules'):
-    """ Saves iptables firewall rules such they can be restored
-    """
-
-    shakedown.run_command_on_agent(
-        host,
-        'if [ ! -e {} ] ; then sudo iptables-save > {} ; fi'.format(filename, filename))
-
-
-def restore_iptables(host, filename='iptables.rules'):
-    """ Reconnect a previously partitioned node to the network
-        :param hostname: host or IP of the machine to partition from the cluster
-    """
-
-    shakedown.run_command_on_agent(
-        host,
-        'if [ -e {} ]; then sudo iptables-restore < {} && sudo rm {} ; fi'.format(filename, filename, filename))
-
-
-@contextlib.contextmanager
-def iptable_rules(host):
+def block_iptable_rules(host, port_number, sleep_seconds, input=True, output=True):
     filename = 'iptables-{}.rules'.format(uuid.uuid4().hex)
-    save_iptables(host, filename)
-    try:
-        yield
-    finally:
-        # return config to previous state
-        restore_iptables(host, filename)
+    shakedown.run_command_on_agent(
+        host,
+        """if [ ! -e {} ] ; then sudo iptables-save > {} ; fi;
+        {}
+        sleep {};
+        if [ -e {} ]; then sudo iptables-restore < {} && sudo rm {} ; fi"""
+            .format(filename, filename, iptables_block_string(input, output, port_number),
+                    sleep_seconds, filename, filename, filename))
 
 
-def block_port(host, port, direction='INPUT'):
-    shakedown.run_command_on_agent(host, 'sudo iptables -I {} -p tcp --dport {} -j DROP'.format(direction, port))
+def iptables_block_string(input, output, port):
+    str = "sudo iptables -I INPUT -p tcp --dport {} -j DROP;".format(port) if input else ""
+    return str + "sudo iptables -I OUTPUT -p tcp --dport {} -j DROP;".format(port) if output else ""
 
 
 def wait_for_task(service, task, timeout_sec=120):

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -533,7 +533,7 @@ def test_task_gets_restarted_due_to_network_split():
     port = tasks[0]['ports'][0]
 
     # introduce a network partition
-    common.block_iptable_rules(host, port, 10, True, False)
+    common.block_iptable_rules_for_seconds(host, port, sleep_seconds=10, block_input=True, block_output=False)
 
     shakedown.deployment_wait()
 
@@ -861,7 +861,7 @@ def test_marathon_when_disconnected_from_zk():
     tasks = client.get_tasks(app_def["id"])
     original_task_id = tasks[0]['id']
 
-    common.block_iptable_rules(host, 2181, 10, True, False)
+    common.block_iptable_rules_for_seconds(host, 2181, sleep_seconds=10, block_input=True, block_output=False)
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_task_is_back():

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -533,9 +533,7 @@ def test_task_gets_restarted_due_to_network_split():
     port = tasks[0]['ports'][0]
 
     # introduce a network partition
-    with common.iptable_rules(host):
-        common.block_port(host, port)
-        time.sleep(10)
+    common.block_iptable_rules(host, port, 10, True, False)
 
     shakedown.deployment_wait()
 
@@ -863,9 +861,7 @@ def test_marathon_when_disconnected_from_zk():
     tasks = client.get_tasks(app_def["id"])
     original_task_id = tasks[0]['id']
 
-    with common.iptable_rules(host):
-        common.block_port(host, 2181)
-        time.sleep(10)
+    common.block_iptable_rules(host, 2181, 10, True, False)
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_task_is_back():

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -158,7 +158,7 @@ def test_marathon_zk_partition_leader_change(marathon_service_name):
 
     original_leader = common.get_marathon_leader_not_on_master_leader_node()
 
-    common.block_iptable_rules(original_leader, 2181, 30)
+    common.block_iptable_rules_for_seconds(original_leader, 2181, sleep_seconds=30)
 
     common.marathon_leadership_changed(original_leader)
     # Make sure marathon is available
@@ -171,7 +171,8 @@ def test_marathon_master_partition_leader_change(marathon_service_name):
     original_leader = common.get_marathon_leader_not_on_master_leader_node()
 
     # blocking outbound connection to mesos master
-    common.block_iptable_rules(original_leader, 5050, 60, False, True)
+    common.block_iptable_rules_for_seconds(original_leader, 5050, sleep_seconds=60,
+                                           block_input=False, block_output=True)
 
     common.marathon_leadership_changed(original_leader)
     # Make sure marathon is available


### PR DESCRIPTION
Summary:
Doing blocking and restoration in multiple command can cause problems because one of the SSH command might fail. Also if we manage to partition out the master whose IP we use as DCOS_URL, then all subsequent API requests (as well as SSH commands) fail.

This should make it more reliable.

JIRA issues: MARATHON-7965
