### PR TITLE
Fix network_infos retrieval after Mesos update

### DIFF
--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -519,7 +519,7 @@ def test_pod_with_persistent_volume():
 
     tasks = common.get_pod_tasks(pod_id)
 
-    host = tasks[0]['statuses'][0]['container_status']['network_infos'][0]['ip_addresses'][0]['ip_address']
+    host = common.running_status_network_info(tasks[0]['statuses'])['ip_addresses'][0]['ip_address']
     port1 = tasks[0]['discovery']['ports']['ports'][0]["number"]
     port2 = tasks[1]['discovery']['ports']['ports'][0]["number"]
     dir1 = tasks[0]['container']['volumes'][0]['container_path']


### PR DESCRIPTION
Summary:
Mesos bump changes the format of the statuses returned - it started returning status STARTING which does not contain network infos. So wherever we access statuses[0] we don't get the running status as we are expecting.

JIRA issues:
