### PR TITLE
Move reservation info from tasks to instances

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/json/JsonFormatBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/json/JsonFormatBenchmark.scala
@@ -88,7 +88,9 @@ object JsonFormatBenchmark extends AppAndGroupFormats {
               zone = None,
               attributes = Seq.empty
             ),
-            healthCheckResults = Seq.empty
+            healthCheckResults = Seq.empty,
+            servicePorts = Seq.empty,
+            reservation = None
           )
         )
       )

--- a/benchmark/src/main/scala/mesosphere/marathon/json/JsonFormatBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/json/JsonFormatBenchmark.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.appinfo.{ AppInfo, EnrichedTask }
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.Task.{ LaunchedOnReservation, Reservation, Status }
+import mesosphere.marathon.core.task.Task.Status
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{ AppDefinition, EnvVarString, PathId, Timestamp }
 import org.openjdk.jmh.annotations._
@@ -66,7 +66,7 @@ object JsonFormatBenchmark extends AppAndGroupFormats {
         Seq(
           EnrichedTask(
             appId,
-            task = LaunchedOnReservation(
+            task = Task(
               taskId = Task.Id("benchmark_app_definition.2e251a11-af74-11e7-8e35-12ebe3d150b4"),
               runSpecVersion = Timestamp.now(),
               status = Status(
@@ -79,10 +79,6 @@ object JsonFormatBenchmark extends AppAndGroupFormats {
                   hostPorts = Seq(30000),
                   ipAddresses = Seq.empty
                 )
-              ),
-              reservation = Reservation(
-                volumeIds = Seq.empty,
-                state = Reservation.State.Launched
               )
             ),
             agentInfo = AgentInfo(

--- a/docs/docs/rest-api/public/api/v2/examples/app_tasks.json
+++ b/docs/docs/rest-api/public/api/v2/examples/app_tasks.json
@@ -5,7 +5,7 @@
       "host": "srv7.hw.ca1.mesosphere.com",
       "id": "minecraft_survival-world.instance-564bd685-4c30-11e5-98c1-be5b2935a987",
       "ports": [
-      31756
+        31756
       ],
       "slaveId": "agent0",
       "stagedAt": "2015-08-26T20:23:39.463Z",

--- a/docs/docs/rest-api/public/api/v2/types/task.raml
+++ b/docs/docs/rest-api/public/api/v2/types/task.raml
@@ -6,29 +6,6 @@ uses:
 
 types:
 
-  Timeout:
-    type: object
-    properties:
-      initiated: datetime
-      deadline: datetime
-      reason:
-        type: string
-        enum:
-          - RelaunchEscalationTimeout
-          - ReservationTimeout
-
-  State:
-    type: object
-    properties:
-      name: string
-      timeout?: Timeout
-
-  Reservation:
-    type: object
-    properties:
-      volumeIds: LocalVolumeId[]
-      state: State
-
   NetworkInfoIPAddress:
     type: object
     properties:

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -308,7 +308,10 @@ class AppsController(
         val healthStatuses = await(healthCheckManager.statuses(appId))
         instances.flatMap { instance =>
           val health = healthStatuses.getOrElse(instance.instanceId, Nil)
-          instance.tasksMap.values.map { task => EnrichedTask(appId, task, instance.agentInfo, health) }
+          instance.tasksMap.values.map { task =>
+            EnrichedTask(
+              appId, task, instance.agentInfo, health, reservation = instance.reservation)
+          }
         }
       }
     }
@@ -333,7 +336,7 @@ class AppsController(
             val killInstances = async {
               val instances = await(taskKiller.kill(appId, findToKill, wipe = true))
               instances.map { instance =>
-                EnrichedTask(appId, instance.appTask, instance.agentInfo, Nil)
+                EnrichedTask(appId, instance.appTask, instance.agentInfo, Nil, reservation = instance.reservation)
               }
             }
 
@@ -344,7 +347,7 @@ class AppsController(
             val killInstances = async {
               val instances = await(taskKiller.kill(appId, findToKill, wipe = false))
               instances.map { instance =>
-                EnrichedTask(appId, instance.appTask, instance.agentInfo, Nil)
+                EnrichedTask(appId, instance.appTask, instance.agentInfo, Nil, reservation = instance.reservation)
               }
             }
 
@@ -380,7 +383,9 @@ class AppsController(
               val instances = await(taskKiller.kill(appId, findToKill, wipe = true))
               val healthStatuses = await(healthCheckManager.statuses(appId))
               instances.headOption.map { instance =>
-                EnrichedTask(appId, instance.appTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil))
+                EnrichedTask(
+                  appId, instance.appTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil),
+                  reservation = instance.reservation)
               }
             }
 
@@ -395,7 +400,9 @@ class AppsController(
               val instances = await(taskKiller.kill(appId, findToKill, wipe = false))
               val healthStatuses = await(healthCheckManager.statuses(appId))
               instances.headOption.map { instance =>
-                EnrichedTask(appId, instance.appTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil))
+                EnrichedTask(
+                  appId, instance.appTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil),
+                  reservation = instance.reservation)
               }
             }
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -309,8 +309,7 @@ class AppsController(
         instances.flatMap { instance =>
           val health = healthStatuses.getOrElse(instance.instanceId, Nil)
           instance.tasksMap.values.map { task =>
-            EnrichedTask(
-              appId, task, instance.agentInfo, health, reservation = instance.reservation)
+            EnrichedTask(instance, task, health)
           }
         }
       }
@@ -336,7 +335,7 @@ class AppsController(
             val killInstances = async {
               val instances = await(taskKiller.kill(appId, findToKill, wipe = true))
               instances.map { instance =>
-                EnrichedTask(appId, instance.appTask, instance.agentInfo, Nil, reservation = instance.reservation)
+                EnrichedTask(instance, instance.appTask, Nil)
               }
             }
 
@@ -347,7 +346,7 @@ class AppsController(
             val killInstances = async {
               val instances = await(taskKiller.kill(appId, findToKill, wipe = false))
               instances.map { instance =>
-                EnrichedTask(appId, instance.appTask, instance.agentInfo, Nil, reservation = instance.reservation)
+                EnrichedTask(instance, instance.appTask, Nil)
               }
             }
 
@@ -383,9 +382,7 @@ class AppsController(
               val instances = await(taskKiller.kill(appId, findToKill, wipe = true))
               val healthStatuses = await(healthCheckManager.statuses(appId))
               instances.headOption.map { instance =>
-                EnrichedTask(
-                  appId, instance.appTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil),
-                  reservation = instance.reservation)
+                EnrichedTask(instance, instance.appTask, healthStatuses.getOrElse(instance.instanceId, Nil))
               }
             }
 
@@ -400,9 +397,7 @@ class AppsController(
               val instances = await(taskKiller.kill(appId, findToKill, wipe = false))
               val healthStatuses = await(healthCheckManager.statuses(appId))
               instances.headOption.map { instance =>
-                EnrichedTask(
-                  appId, instance.appTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil),
-                  reservation = instance.reservation)
+                EnrichedTask(instance, instance.appTask, healthStatuses.getOrElse(instance.instanceId, Nil))
               }
             }
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
@@ -175,14 +175,10 @@ class TasksController(
         case (appId, instance) => isAuthorized(appId) && isInterestingInstance(instance.state.condition)
       }
       .flatMap {
-        case (appId, instance) => instance.tasksMap.values.map(t => EnrichedTask(
-          appId,
-          t,
-          instance.agentInfo,
-          instancesHealth.getOrElse(instance.instanceId, Nil),
-          appToPorts.getOrElse(appId, Nil),
-          reservation = instance.reservation
-        ))
+        case (appId, instance) => instance.tasksMap.values.map { task =>
+          EnrichedTask(instance, task, instancesHealth.getOrElse(instance.instanceId, Nil),
+            appToPorts.getOrElse(appId, Nil))
+        }
       }.to[Seq]
   }
 
@@ -211,9 +207,7 @@ class TasksController(
       .flatten
 
     killedTasks.flatMap { instance =>
-      instance.tasksMap.valuesIterator.map { task =>
-        EnrichedTask(task.runSpecId, task, instance.agentInfo, Seq.empty, reservation = instance.reservation)
-      }
+      instance.tasksMap.valuesIterator.map { task => EnrichedTask(instance, task, Nil) }
     }.to[Seq]
   }
 

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/TasksController.scala
@@ -180,7 +180,8 @@ class TasksController(
           t,
           instance.agentInfo,
           instancesHealth.getOrElse(instance.instanceId, Nil),
-          appToPorts.getOrElse(appId, Nil)
+          appToPorts.getOrElse(appId, Nil),
+          reservation = instance.reservation
         ))
       }.to[Seq]
   }
@@ -211,7 +212,7 @@ class TasksController(
 
     killedTasks.flatMap { instance =>
       instance.tasksMap.valuesIterator.map { task =>
-        EnrichedTask(task.runSpecId, task, instance.agentInfo, Seq.empty)
+        EnrichedTask(task.runSpecId, task, instance.agentInfo, Seq.empty, reservation = instance.reservation)
       }
     }.to[Seq]
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -71,7 +71,9 @@ class AppTasksResource @Inject() (
       val health = result(healthCheckManager.statuses(id))
       instancesBySpec.specInstances(id).flatMap { instance =>
         instance.tasksMap.values.map { task =>
-          EnrichedTask(id, task, instance.agentInfo, health.getOrElse(instance.instanceId, Nil))
+          EnrichedTask(
+            id, task, instance.agentInfo, health.getOrElse(instance.instanceId, Nil),
+            reservation = instance.reservation)
         }
       }
     }(collection.breakOut)
@@ -120,7 +122,9 @@ class AppTasksResource @Inject() (
         val healthStatuses = await(healthCheckManager.statuses(pathId))
         val enrichedTasks: Seq[EnrichedTask] = instances.map { instance =>
           val killedTask = instance.appTask
-          val enrichedTask = EnrichedTask(pathId, killedTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil))
+          val enrichedTask = EnrichedTask(
+            pathId, killedTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil),
+            reservation = instance.reservation)
           enrichedTask
         }
         ok(jsonObjString("tasks" -> enrichedTasks.toRaml))
@@ -167,7 +171,9 @@ class AppTasksResource @Inject() (
             unknownTask(id)
           case Some(instance) =>
             val killedTask = instance.appTask
-            val enrichedTask = EnrichedTask(pathId, killedTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil))
+            val enrichedTask = EnrichedTask(
+              pathId, killedTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil),
+              reservation = instance.reservation)
             ok(jsonObjString("task" -> enrichedTask.toRaml))
         }
       }.recover {

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -71,9 +71,7 @@ class AppTasksResource @Inject() (
       val health = result(healthCheckManager.statuses(id))
       instancesBySpec.specInstances(id).flatMap { instance =>
         instance.tasksMap.values.map { task =>
-          EnrichedTask(
-            id, task, instance.agentInfo, health.getOrElse(instance.instanceId, Nil),
-            reservation = instance.reservation)
+          EnrichedTask(instance, task, health.getOrElse(instance.instanceId, Nil))
         }
       }
     }(collection.breakOut)
@@ -122,10 +120,7 @@ class AppTasksResource @Inject() (
         val healthStatuses = await(healthCheckManager.statuses(pathId))
         val enrichedTasks: Seq[EnrichedTask] = instances.map { instance =>
           val killedTask = instance.appTask
-          val enrichedTask = EnrichedTask(
-            pathId, killedTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil),
-            reservation = instance.reservation)
-          enrichedTask
+          EnrichedTask(instance, killedTask, healthStatuses.getOrElse(instance.instanceId, Nil))
         }
         ok(jsonObjString("tasks" -> enrichedTasks.toRaml))
       }.recover {
@@ -171,9 +166,7 @@ class AppTasksResource @Inject() (
             unknownTask(id)
           case Some(instance) =>
             val killedTask = instance.appTask
-            val enrichedTask = EnrichedTask(
-              pathId, killedTask, instance.agentInfo, healthStatuses.getOrElse(instance.instanceId, Nil),
-              reservation = instance.reservation)
+            val enrichedTask = EnrichedTask(instance, killedTask, healthStatuses.getOrElse(instance.instanceId, Nil))
             ok(jsonObjString("task" -> enrichedTask.toRaml))
         }
       }.recover {

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -79,14 +79,8 @@ class TasksResource @Inject() (
         tasks = instance.tasksMap.values
       } yield {
         tasks.map { task =>
-          EnrichedTask(
-            appId,
-            task,
-            instance.agentInfo,
-            health.getOrElse(instance.instanceId, Nil),
-            appToPorts.getOrElse(appId, Nil),
-            reservation = instance.reservation
-          )
+          EnrichedTask(instance, task, health.getOrElse(instance.instanceId, Nil),
+            appToPorts.getOrElse(appId, Nil))
         }
       }
       enrichedTasks.flatten
@@ -149,7 +143,7 @@ class TasksResource @Inject() (
         })).flatten
       ok(jsonObjString("tasks" -> killed.flatMap { instance =>
         instance.tasksMap.valuesIterator.map { task =>
-          EnrichedTask(task.runSpecId, task, instance.agentInfo, Seq.empty, reservation = instance.reservation).toRaml
+          EnrichedTask(instance, task, Nil).toRaml
         }
       }))
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -84,7 +84,8 @@ class TasksResource @Inject() (
             task,
             instance.agentInfo,
             health.getOrElse(instance.instanceId, Nil),
-            appToPorts.getOrElse(appId, Nil)
+            appToPorts.getOrElse(appId, Nil),
+            reservation = instance.reservation
           )
         }
       }
@@ -148,7 +149,7 @@ class TasksResource @Inject() (
         })).flatten
       ok(jsonObjString("tasks" -> killed.flatMap { instance =>
         instance.tasksMap.valuesIterator.map { task =>
-          EnrichedTask(task.runSpecId, task, instance.agentInfo, Seq.empty).toRaml
+          EnrichedTask(task.runSpecId, task, instance.agentInfo, Seq.empty, reservation = instance.reservation).toRaml
         }
       }))
     }

--- a/src/main/scala/mesosphere/marathon/core/appinfo/EnrichedTask.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/EnrichedTask.scala
@@ -4,7 +4,7 @@ package core.appinfo
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.Instance.AgentInfo
-import mesosphere.marathon.core.instance.Reservation
+import mesosphere.marathon.core.instance.{ Instance, Reservation }
 import mesosphere.marathon.state.PathId
 
 case class EnrichedTask(
@@ -12,5 +12,13 @@ case class EnrichedTask(
     task: Task,
     agentInfo: AgentInfo,
     healthCheckResults: Seq[Health],
-    servicePorts: Seq[Int] = Nil,
-    reservation: Option[Reservation] = None)
+    servicePorts: Seq[Int],
+    reservation: Option[Reservation])
+
+object EnrichedTask {
+  def apply(instance: Instance, task: Task, healthCheckResults: Seq[Health],
+    servicePorts: Seq[Int] = Nil): EnrichedTask = {
+    new EnrichedTask(instance.runSpecId, task, instance.agentInfo, healthCheckResults, servicePorts = servicePorts,
+      reservation = instance.reservation)
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/appinfo/EnrichedTask.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/EnrichedTask.scala
@@ -4,6 +4,7 @@ package core.appinfo
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.Instance.AgentInfo
+import mesosphere.marathon.core.instance.Reservation
 import mesosphere.marathon.state.PathId
 
 case class EnrichedTask(
@@ -11,4 +12,5 @@ case class EnrichedTask(
     task: Task,
     agentInfo: AgentInfo,
     healthCheckResults: Seq[Health],
-    servicePorts: Seq[Int] = Nil)
+    servicePorts: Seq[Int] = Nil,
+    reservation: Option[Reservation] = None)

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -147,7 +147,10 @@ class AppInfoBaseData(
       log.debug(s"assembling rich tasks for app [${app.id}]")
       def statusesToEnrichedTasks(instances: Seq[Instance], statuses: Map[Instance.Id, collection.Seq[Health]]): Seq[EnrichedTask] = {
         instances.map { instance =>
-          EnrichedTask(app.id, instance.appTask, instance.agentInfo, statuses.getOrElse(instance.instanceId, Seq.empty[Health]).to[Seq])
+          EnrichedTask(
+            app.id, instance.appTask, instance.agentInfo,
+            statuses.getOrElse(instance.instanceId, Seq.empty[Health]).to[Seq],
+            reservation = instance.reservation)
         }
       }
 

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -147,10 +147,7 @@ class AppInfoBaseData(
       log.debug(s"assembling rich tasks for app [${app.id}]")
       def statusesToEnrichedTasks(instances: Seq[Instance], statuses: Map[Instance.Id, collection.Seq[Health]]): Seq[EnrichedTask] = {
         instances.map { instance =>
-          EnrichedTask(
-            app.id, instance.appTask, instance.agentInfo,
-            statuses.getOrElse(instance.instanceId, Seq.empty[Health]).to[Seq],
-            reservation = instance.reservation)
+          EnrichedTask(instance, instance.appTask, statuses.getOrElse(instance.instanceId, Nil).to[Seq])
         }
       }
 

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -51,7 +51,7 @@ case class Instance(
   def isDropped: Boolean = state.condition == Condition.Dropped
   def isTerminated: Boolean = state.condition.isTerminal
   def isActive: Boolean = state.condition.isActive
-  def hasReservation = reservation.isDefined
+  def hasReservation: Boolean = reservation.isDefined
 
   override def mergeFromProto(message: Protos.Json): Instance = {
     Json.parse(message.getJson).as[Instance]

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -28,7 +28,8 @@ case class Instance(
     state: InstanceState,
     tasksMap: Map[Task.Id, Task],
     runSpecVersion: Timestamp,
-    unreachableStrategy: UnreachableStrategy) extends MarathonState[Protos.Json, Instance] with Placed {
+    unreachableStrategy: UnreachableStrategy,
+    reservation: Option[Reservation]) extends MarathonState[Protos.Json, Instance] with Placed {
 
   val runSpecId: PathId = instanceId.runSpecId
   val isLaunched: Boolean = state.condition.isActive
@@ -50,11 +51,7 @@ case class Instance(
   def isDropped: Boolean = state.condition == Condition.Dropped
   def isTerminated: Boolean = state.condition.isTerminal
   def isActive: Boolean = state.condition.isActive
-  def hasReservation =
-    tasksMap.values.exists {
-      case _: Task.ReservedTask => true
-      case _ => false
-    }
+  def hasReservation = reservation.isDefined
 
   override def mergeFromProto(message: Protos.Json): Instance = {
     Json.parse(message.getJson).as[Instance]
@@ -339,6 +336,7 @@ object Instance {
   implicit val idFormat: Format[Instance.Id] = Json.format[Instance.Id]
   implicit val instanceConditionFormat: Format[Condition] = Condition.conditionFormat
   implicit val instanceStateFormat: Format[InstanceState] = Json.format[InstanceState]
+  implicit val reservationFormat: Format[Reservation] = Reservation.reservationFormat
 
   implicit val instanceJsonWrites: Writes[Instance] = {
     (
@@ -347,22 +345,27 @@ object Instance {
       (__ \ "tasksMap").write[Map[Task.Id, Task]] ~
       (__ \ "runSpecVersion").write[Timestamp] ~
       (__ \ "state").write[InstanceState] ~
-      (__ \ "unreachableStrategy").write[raml.UnreachableStrategy]
-    ) { (i) => (i.instanceId, i.agentInfo, i.tasksMap, i.runSpecVersion, i.state, Raml.toRaml(i.unreachableStrategy)) }
+      (__ \ "unreachableStrategy").write[raml.UnreachableStrategy] ~
+      (__ \ "reservation").writeNullable[Reservation]
+    ) { (i) =>
+        val unreachableStrategy = Raml.toRaml(i.unreachableStrategy)
+        (i.instanceId, i.agentInfo, i.tasksMap, i.runSpecVersion, i.state, unreachableStrategy, i.reservation)
+      }
   }
 
-  implicit val unreachableStrategyReads: Reads[Instance] = {
+  implicit val instanceJsonReads: Reads[Instance] = {
     (
       (__ \ "instanceId").read[Instance.Id] ~
       (__ \ "agentInfo").read[AgentInfo] ~
       (__ \ "tasksMap").read[Map[Task.Id, Task]] ~
       (__ \ "runSpecVersion").read[Timestamp] ~
       (__ \ "state").read[InstanceState] ~
-      (__ \ "unreachableStrategy").readNullable[raml.UnreachableStrategy]
-    ) { (instanceId, agentInfo, tasksMap, runSpecVersion, state, maybeUnreachableStrategy) =>
+      (__ \ "unreachableStrategy").readNullable[raml.UnreachableStrategy] ~
+      (__ \ "reservation").readNullable[Reservation]
+    ) { (instanceId, agentInfo, tasksMap, runSpecVersion, state, maybeUnreachableStrategy, reservation) =>
         val unreachableStrategy = maybeUnreachableStrategy.
           map(Raml.fromRaml(_)).getOrElse(UnreachableStrategy.default())
-        new Instance(instanceId, agentInfo, state, tasksMap, runSpecVersion, unreachableStrategy)
+        new Instance(instanceId, agentInfo, state, tasksMap, runSpecVersion, unreachableStrategy, reservation)
       }
   }
 
@@ -399,6 +402,6 @@ object LegacyAppInstance {
     val tasksMap = Map(task.taskId -> task)
     val state = Instance.InstanceState(None, tasksMap, since, unreachableStrategy)
 
-    new Instance(task.taskId.instanceId, agentInfo, state, tasksMap, task.runSpecVersion, unreachableStrategy)
+    new Instance(task.taskId.instanceId, agentInfo, state, tasksMap, task.runSpecVersion, unreachableStrategy, None)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/instance/LocalVolume.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/LocalVolume.scala
@@ -10,7 +10,7 @@ import play.api.libs.json._
 case class LocalVolume(id: LocalVolumeId, persistentVolume: PersistentVolume, mount: VolumeMount)
 
 case class LocalVolumeId(runSpecId: PathId, name: String, uuid: String) {
-  import LocalVolumeId._
+  import LocalVolumeId.delimiter
   lazy val idString = runSpecId.safePath + delimiter + name + delimiter + uuid
 
   override def toString: String = s"LocalVolume [$idString]"

--- a/src/main/scala/mesosphere/marathon/core/instance/LocalVolume.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/LocalVolume.scala
@@ -11,7 +11,7 @@ case class LocalVolume(id: LocalVolumeId, persistentVolume: PersistentVolume, mo
 
 case class LocalVolumeId(runSpecId: PathId, name: String, uuid: String) {
   import LocalVolumeId.delimiter
-  lazy val idString = runSpecId.safePath + delimiter + name + delimiter + uuid
+  lazy val idString: String = runSpecId.safePath + delimiter + name + delimiter + uuid
 
   override def toString: String = s"LocalVolume [$idString]"
 }
@@ -31,13 +31,13 @@ object LocalVolumeId {
     case _ => None
   }
 
-  implicit val localVolumeIdReader = (
+  implicit val localVolumeIdReader: Reads[LocalVolumeId] = (
     (__ \ "runSpecId").read[PathId] and
     (__ \ "containerPath").read[String] and
     (__ \ "uuid").read[String]
   )((id, path, uuid) => LocalVolumeId(id, path, uuid))
 
-  implicit val localVolumeIdWriter = Writes[LocalVolumeId] { localVolumeId =>
+  implicit val localVolumeIdWriter: Writes[LocalVolumeId] = Writes[LocalVolumeId] { localVolumeId =>
     JsObject(Seq(
       "runSpecId" -> Json.toJson(localVolumeId.runSpecId),
       "containerPath" -> Json.toJson(localVolumeId.name),

--- a/src/main/scala/mesosphere/marathon/core/instance/LocalVolume.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/LocalVolume.scala
@@ -1,0 +1,48 @@
+package mesosphere.marathon
+package core.instance
+
+import com.fasterxml.uuid.{ EthernetAddress, Generators }
+import mesosphere.marathon.api.v2.json.Formats._
+import mesosphere.marathon.state.{ PathId, PersistentVolume, VolumeMount }
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class LocalVolume(id: LocalVolumeId, persistentVolume: PersistentVolume, mount: VolumeMount)
+
+case class LocalVolumeId(runSpecId: PathId, name: String, uuid: String) {
+  import LocalVolumeId._
+  lazy val idString = runSpecId.safePath + delimiter + name + delimiter + uuid
+
+  override def toString: String = s"LocalVolume [$idString]"
+}
+
+object LocalVolumeId {
+  private val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
+  private val delimiter = "#"
+  private val LocalVolumeEncoderRE = s"^([^$delimiter]+)[$delimiter]([^$delimiter]+)[$delimiter]([^$delimiter]+)$$".r
+
+  def apply(runSpecId: PathId, volume: PersistentVolume, mount: VolumeMount): LocalVolumeId = {
+    val name = volume.name.getOrElse(mount.mountPath)
+    LocalVolumeId(runSpecId, name, uuidGenerator.generate().toString)
+  }
+
+  def unapply(id: String): Option[(LocalVolumeId)] = id match {
+    case LocalVolumeEncoderRE(runSpec, name, uuid) => Some(LocalVolumeId(PathId.fromSafePath(runSpec), name, uuid))
+    case _ => None
+  }
+
+  implicit val localVolumeIdReader = (
+    (__ \ "runSpecId").read[PathId] and
+    (__ \ "containerPath").read[String] and
+    (__ \ "uuid").read[String]
+  )((id, path, uuid) => LocalVolumeId(id, path, uuid))
+
+  implicit val localVolumeIdWriter = Writes[LocalVolumeId] { localVolumeId =>
+    JsObject(Seq(
+      "runSpecId" -> Json.toJson(localVolumeId.runSpecId),
+      "containerPath" -> Json.toJson(localVolumeId.name),
+      "uuid" -> Json.toJson(localVolumeId.uuid),
+      "persistenceId" -> Json.toJson(localVolumeId.idString)
+    ))
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/instance/Reservation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Reservation.scala
@@ -1,0 +1,96 @@
+package mesosphere.marathon
+package core.instance
+
+import mesosphere.marathon.api.v2.json.Formats._
+import mesosphere.marathon.state.Timestamp
+import play.api.libs.json._
+
+/**
+  * Represents a reservation for all resources that are needed for launching a task
+  * and associated persistent local volumes.
+  */
+case class Reservation(volumeIds: Seq[LocalVolumeId], state: Reservation.State)
+
+object Reservation {
+  /**
+    * A timeout that eventually leads to a state transition
+    *
+    * @param initiated When this timeout was setup
+    * @param deadline When this timeout should become effective
+    * @param reason The reason why this timeout was set up
+    */
+  case class Timeout(initiated: Timestamp, deadline: Timestamp, reason: Timeout.Reason)
+
+  object Timeout {
+    sealed trait Reason
+    object Reason {
+      /** A timeout because the task could not be relaunched */
+      case object RelaunchEscalationTimeout extends Reason
+      /** A timeout because we got no ack for reserved resources or persistent volumes */
+      case object ReservationTimeout extends Reason
+    }
+
+    implicit object ReasonFormat extends Format[Timeout.Reason] {
+      override def reads(json: JsValue): JsResult[Timeout.Reason] = {
+        json.validate[String].map {
+          case "RelaunchEscalationTimeout" => Reason.RelaunchEscalationTimeout
+          case "ReservationTimeout" => Reason.ReservationTimeout
+        }
+      }
+
+      override def writes(o: Timeout.Reason): JsValue = {
+        JsString(o.toString)
+      }
+    }
+
+    implicit val timeoutFormat: Format[Timeout] = Json.format[Timeout]
+  }
+
+  sealed trait State extends Product with Serializable {
+    /** Defines when this state should time out and for which reason */
+    def timeout: Option[Timeout]
+  }
+
+  object State {
+    /** A newly reserved resident task */
+    case class New(timeout: Option[Timeout]) extends State
+    /** A launched resident task, never has a timeout */
+    case object Launched extends State {
+      override def timeout: Option[Timeout] = None
+    }
+    /** A resident task that has been running before but terminated and can be relaunched */
+    case class Suspended(timeout: Option[Timeout]) extends State
+    /** A resident task whose reservation and persistent volumes are being destroyed */
+    case class Garbage(timeout: Option[Timeout]) extends State
+    /** An unknown resident task created because of unknown reservations/persistent volumes */
+    case class Unknown(timeout: Option[Timeout]) extends State
+
+    implicit object StateFormat extends Format[State] {
+      override def reads(json: JsValue): JsResult[State] = {
+        implicit val timeoutFormat: Format[Timeout] = Timeout.timeoutFormat
+        (json \ "timeout").validateOpt[Timeout].flatMap { timeout =>
+          (json \ "name").validate[String].map {
+            case "new" => New(timeout)
+            case "launched" => Launched
+            case "suspended" => Suspended(timeout)
+            case "garbage" => Garbage(timeout)
+            case _ => Unknown(timeout)
+          }
+        }
+      }
+
+      override def writes(o: State): JsValue = {
+        val timeout = Json.toJson(o.timeout)
+        o match {
+          case _: New => JsObject(Seq("name" -> JsString("new"), "timeout" -> timeout))
+          case Launched => JsObject(Seq("name" -> JsString("launched"), "timeout" -> timeout))
+          case _: Suspended => JsObject(Seq("name" -> JsString("suspended"), "timeout" -> timeout))
+          case _: Garbage => JsObject(Seq("name" -> JsString("garbage"), "timeout" -> timeout))
+          case _: Unknown => JsObject(Seq("name" -> JsString("unknown"), "timeout" -> timeout))
+        }
+      }
+    }
+  }
+
+  implicit val reservationFormat = Json.format[Reservation]
+}

--- a/src/main/scala/mesosphere/marathon/core/instance/Reservation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Reservation.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.state.Timestamp
 import play.api.libs.json._
 
 /**
-  * Represents a reservation for all resources that are needed for launching a task
+  * Represents a reservation for all resources that are needed for launching an instance
   * and associated persistent local volumes.
   */
 case class Reservation(volumeIds: Seq[LocalVolumeId], state: Reservation.State)
@@ -24,7 +24,7 @@ object Reservation {
   object Timeout {
     sealed trait Reason
     object Reason {
-      /** A timeout because the task could not be relaunched */
+      /** A timeout because the instance could not be relaunched */
       case object RelaunchEscalationTimeout extends Reason
       /** A timeout because we got no ack for reserved resources or persistent volumes */
       case object ReservationTimeout extends Reason
@@ -52,17 +52,17 @@ object Reservation {
   }
 
   object State {
-    /** A newly reserved resident task */
+    /** A newly reserved resident instance */
     case class New(timeout: Option[Timeout]) extends State
-    /** A launched resident task, never has a timeout */
+    /** A launched resident instance, never has a timeout */
     case object Launched extends State {
       override def timeout: Option[Timeout] = None
     }
-    /** A resident task that has been running before but terminated and can be relaunched */
+    /** A resident instance that has been running before but terminated and can be relaunched */
     case class Suspended(timeout: Option[Timeout]) extends State
-    /** A resident task whose reservation and persistent volumes are being destroyed */
+    /** A resident instance whose reservation and persistent volumes are being destroyed */
     case class Garbage(timeout: Option[Timeout]) extends State
-    /** An unknown resident task created because of unknown reservations/persistent volumes */
+    /** An unknown resident instance created because of unknown reservations/persistent volumes */
     case class Unknown(timeout: Option[Timeout]) extends State
 
     implicit object StateFormat extends Format[State] {
@@ -92,5 +92,5 @@ object Reservation {
     }
   }
 
-  implicit val reservationFormat = Json.format[Reservation]
+  implicit val reservationFormat: OFormat[Reservation] = Json.format[Reservation]
 }

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -36,7 +36,7 @@ object InstanceUpdater extends StrictLogging {
     val now = op.now
     val taskId = Task.Id(op.mesosStatus.getTaskId)
     instance.tasksMap.get(taskId).map { task =>
-      val taskEffect = task.update(TaskUpdateOperation.MesosUpdate(op.condition, op.mesosStatus, now))
+      val taskEffect = task.update(instance, TaskUpdateOperation.MesosUpdate(op.condition, op.mesosStatus, now))
       taskEffect match {
         case TaskUpdateEffect.Update(updatedTask) =>
           val updated: Instance = updatedInstance(instance, updatedTask, now)
@@ -93,7 +93,7 @@ object InstanceUpdater extends StrictLogging {
           val status = op.statuses.getOrElse(
             newTaskId,
             throw new IllegalStateException("failed to retrieve a task status"))
-          task.update(TaskUpdateOperation.LaunchOnReservation(newTaskId, op.runSpecVersion, status))
+          task.update(instance, TaskUpdateOperation.LaunchOnReservation(newTaskId, op.runSpecVersion, status))
       }
 
       val nonUpdates = taskEffects.filter {

--- a/src/main/scala/mesosphere/marathon/core/launcher/InstanceOpFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/InstanceOpFactory.scala
@@ -1,8 +1,7 @@
 package mesosphere.marathon
 package core.launcher
 
-import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.instance.{ Instance, LocalVolume }
 import mesosphere.marathon.state.{ DiskSource, Region, RunSpec }
 import mesosphere.mesos.protos.ResourceProviderID
 import mesosphere.util.state.FrameworkId
@@ -52,5 +51,5 @@ object InstanceOpFactory {
   case class OfferedVolume(
       providerId: Option[ResourceProviderID],
       source: DiskSource,
-      volume: Task.LocalVolume)
+      volume: LocalVolume)
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/InstanceOpFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/InstanceOpFactory.scala
@@ -14,8 +14,8 @@ trait InstanceOpFactory {
     * Match an offer request.
     *
     * @param request the offer request.
-    * @return Either this request results in a Match with some InstanceOp or a NoMatch
-    *         which describes why this offer request could not be matched.
+    * @return        either this request results in a Match with some InstanceOp or a NoMatch
+    *                which describes why this offer request could not be matched
     */
   def matchOfferRequest(request: InstanceOpFactory.Request): OfferMatchResult
 
@@ -23,12 +23,12 @@ trait InstanceOpFactory {
 
 object InstanceOpFactory {
   /**
-    * @param runSpec the related run specification definition
-    * @param offer the offer to match against
-    * @param instanceMap a map of running tasks or reservations for the given run spec,
-    *              needed to check constraints and handle resident tasks
+    * @param runSpec            the related run specification definition
+    * @param offer              the offer to match against
+    * @param instanceMap        a map of running tasks or reservations for the given run spec,
+    *                           needed to check constraints and handle resident tasks
     * @param additionalLaunches the number of additional launches that has been requested
-    * @param localRegion region where mesos master is running
+    * @param localRegion        region where mesos master is running
     */
   case class Request(runSpec: RunSpec, offer: Mesos.Offer, instanceMap: Map[Instance.Id, Instance],
       additionalLaunches: Int, localRegion: Option[Region] = None) {
@@ -41,12 +41,12 @@ object InstanceOpFactory {
   }
 
   /**
-    * A task local volume with all information which is necessary for a volume creation
+    * An instance local volume with all information which is necessary for a volume creation
     * upon offer receive.
     *
     * @param providerId an optional resource provider ID
     * @param source     a disk source from an offer received
-    * @param volume     a task local volume
+    * @param volume     a instance local volume
     */
   case class OfferedVolume(
       providerId: Option[ResourceProviderID],

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.launcher.impl
 
-import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.{ Instance, LocalVolume }
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.launcher.{ InstanceOp, InstanceOpFactory }
 import mesosphere.marathon.core.matcher.base.util.OfferOperationFactory
@@ -16,7 +16,7 @@ class InstanceOpFactoryHelper(
 
   def launchEphemeral(
     taskInfo: Mesos.TaskInfo,
-    newTask: Task.LaunchedEphemeral,
+    newTask: Task,
     instance: Instance): InstanceOp.LaunchTask = {
 
     assume(newTask.taskId.mesosTaskId == taskInfo.getTaskId, "marathon task id and mesos task id must be equal")

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.launcher.impl
 
-import mesosphere.marathon.core.instance.{ Instance, LocalVolume }
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.launcher.{ InstanceOp, InstanceOpFactory }
 import mesosphere.marathon.core.matcher.base.util.OfferOperationFactory

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance.{ AgentInfo, InstanceState }
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
-import mesosphere.marathon.core.instance._
+import mesosphere.marathon.core.instance.{ Instance, LegacyAppInstance, LocalVolume, LocalVolumeId, Reservation }
 import mesosphere.marathon.core.launcher.{ InstanceOp, InstanceOpFactory, OfferMatchResult }
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.PodDefinition
@@ -85,7 +85,6 @@ class InstanceOpFactoryImpl(
         val (executorInfo, groupInfo, hostPorts) = TaskGroupBuilder.build(pod, request.offer,
           instanceId, taskIds, builderConfig, runSpecTaskProc, matches.resourceMatch, None)
 
-        // TODO(jdef) no support for resident tasks inside pods for the MVP
         val agentInfo = Instance.AgentInfo(request.offer)
         val taskIDs: Seq[Task.Id] = groupInfo.getTasksList.map { t => Task.Id(t.getTaskId) }(collection.breakOut)
         val instance = ephemeralPodInstance(pod, agentInfo, taskIDs, hostPorts, instanceId)

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance.{ AgentInfo, InstanceState }
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
-import mesosphere.marathon.core.instance.{ Instance, LegacyAppInstance }
+import mesosphere.marathon.core.instance._
 import mesosphere.marathon.core.launcher.{ InstanceOp, InstanceOpFactory, OfferMatchResult }
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.PodDefinition
@@ -107,7 +107,7 @@ class InstanceOpFactoryImpl(
         val taskId = Task.Id.forRunSpec(app.id)
         val taskBuilder = new TaskBuilder(app, taskId, config, runSpecTaskProc)
         val (taskInfo, networkInfo) = taskBuilder.build(request.offer, matches.resourceMatch, None)
-        val task = Task.LaunchedEphemeral(
+        val task = Task(
           taskId = Task.Id(taskInfo.getTaskId),
           runSpecVersion = runSpec.version,
           status = Task.Status(
@@ -318,17 +318,18 @@ class InstanceOpFactoryImpl(
     val localVolumes: Seq[InstanceOpFactory.OfferedVolume] =
       resourceMatch.localVolumes.map {
         case DiskResourceMatch.ConsumedVolume(providerId, source, VolumeWithMount(volume, mount)) =>
-          val localVolume = Task.LocalVolume(Task.LocalVolumeId(runSpec.id, volume, mount), volume, mount)
+          val localVolume = LocalVolume(LocalVolumeId(runSpec.id, volume, mount), volume, mount)
           InstanceOpFactory.OfferedVolume(providerId, source, localVolume)
       }
 
     val persistentVolumeIds = localVolumes.map(_.volume.id)
     val now = clock.now()
-    val timeout = Task.Reservation.Timeout(
+    val timeout = Reservation.Timeout(
       initiated = now,
       deadline = now + config.taskReservationTimeout().millis,
-      reason = Task.Reservation.Timeout.Reason.ReservationTimeout
-    )
+      reason = Reservation.Timeout.Reason.ReservationTimeout)
+    val state = Reservation.State.New(timeout = Some(timeout))
+    val reservation = Reservation(persistentVolumeIds, state)
     val agentInfo = Instance.AgentInfo(offer)
 
     val (reservationLabels, stateOp) = runSpec match {
@@ -342,10 +343,8 @@ class InstanceOpFactoryImpl(
         // there was always a 1:1 correlation from reservation to taskId)
         val taskId = Task.Id.forRunSpec(runSpec.id)
         val reservationLabels = TaskLabels.labelsForTask(frameworkId, taskId)
-        val reservation = Task.Reservation(persistentVolumeIds, Task.Reservation.State.New(timeout = Some(timeout)))
-        val task = Task.Reserved(
+        val task = Task(
           taskId = taskId,
-          reservation = reservation,
           status = Task.Status(
             stagedAt = now,
             condition = Condition.Reserved,
@@ -353,6 +352,7 @@ class InstanceOpFactoryImpl(
           ),
           runSpecVersion = runSpec.version
         )
+
         val instance = Instance(
           instanceId = task.taskId.instanceId,
           agentInfo = agentInfo,
@@ -364,7 +364,8 @@ class InstanceOpFactoryImpl(
           ),
           tasksMap = Map(task.taskId -> task),
           runSpecVersion = runSpec.version,
-          unreachableStrategy = runSpec.unreachableStrategy
+          unreachableStrategy = runSpec.unreachableStrategy,
+          reservation = Some(reservation)
         )
         val stateOp = InstanceUpdateOperation.Reserve(instance)
         (reservationLabels, stateOp)
@@ -379,12 +380,10 @@ class InstanceOpFactoryImpl(
         val reservationLabels = TaskLabels.labelsForTask(
           frameworkId,
           taskIds.headOption.getOrElse(throw new IllegalStateException("pod does not have any container")))
-        val reservation = Task.Reservation(persistentVolumeIds, Task.Reservation.State.New(timeout = Some(timeout)))
 
         val tasks = taskIds.map { taskId =>
-          Task.Reserved(
+          Task(
             taskId = taskId,
-            reservation = reservation,
             status = Task.Status(
               stagedAt = now,
               condition = Condition.Reserved,
@@ -394,6 +393,7 @@ class InstanceOpFactoryImpl(
             runSpecVersion = runSpec.version
           )
         }
+
         val instance = Instance(
           instanceId = instanceId,
           agentInfo = agentInfo,
@@ -405,7 +405,8 @@ class InstanceOpFactoryImpl(
           ),
           tasksMap = tasks.map(t => t.taskId -> t)(collection.breakOut),
           runSpecVersion = runSpec.version,
-          unreachableStrategy = runSpec.unreachableStrategy
+          unreachableStrategy = runSpec.unreachableStrategy,
+          reservation = Some(reservation)
         )
         val stateOp = InstanceUpdateOperation.Reserve(instance)
         (reservationLabels, stateOp)
@@ -478,7 +479,7 @@ object InstanceOpFactoryImpl {
         val networkInfo = taskNetworkInfos.getOrElse(
           taskId,
           throw new IllegalStateException("failed to retrieve a task network info"))
-        val task = Task.LaunchedEphemeral(
+        val task = Task(
           taskId = taskId,
           runSpecVersion = pod.version,
           status = Task.Status(stagedAt = since, condition = Condition.Created, networkInfo = networkInfo)
@@ -486,7 +487,8 @@ object InstanceOpFactoryImpl {
         task.taskId -> task
       }(collection.breakOut),
       runSpecVersion = pod.version,
-      unreachableStrategy = pod.unreachableStrategy
+      unreachableStrategy = pod.unreachableStrategy,
+      reservation = None
     )
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLabels.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLabels.scala
@@ -39,5 +39,4 @@ object TaskLabels {
   }
 
   def labelKeysForReservations: Set[String] = Set(FRAMEWORK_ID_LABEL, TASK_ID_LABEL)
-
 }

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
@@ -167,17 +167,17 @@ private[impl] class OfferMatcherManagerActor private (
   def updateOffersWanted(): Unit = offersWantedObserver.onNext(offersWanted)
 
   def offerMatchers(offer: Offer): Queue[OfferMatcher] = {
-    //the persistence id of a volume encodes the app id
-    //we use this information as filter criteria
+    // the persistence id of a volume encodes the app id
+    // we use this information as filter criteria
     val reservations: Set[PathId] = offer.getResourcesList.view
       .filter(r => r.hasDisk && r.getDisk.hasPersistence && r.getDisk.getPersistence.hasId)
       .map(_.getDisk.getPersistence.getId)
       .collect { case LocalVolumeId(volumeId) => volumeId.runSpecId }
       .toSet
     val (reserved, normal) = matchers.toSeq.partition(_.precedenceFor.exists(reservations))
-    //1 give the offer to the matcher waiting for a reservation
-    //2 give the offer to anybody else
-    //3 randomize both lists to be fair
+    // 1. give the offer to the matcher waiting for a reservation
+    // 2. give the offer to anybody else
+    // 3. randomize both lists to be fair
     (random.shuffle(reserved) ++ random.shuffle(normal)).to[Queue]
   }
 

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
@@ -7,12 +7,12 @@ import akka.actor.{ Actor, Cancellable, Props }
 import akka.event.LoggingReceive
 import akka.pattern.pipe
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.instance.LocalVolumeId
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.{ InstanceOpWithSource, MatchedInstanceOps }
 import mesosphere.marathon.core.matcher.base.util.ActorOfferMatcher
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerConfig
 import mesosphere.marathon.core.matcher.manager.impl.OfferMatcherManagerActor.{ CleanUpOverdueOffers, MatchOfferData, UnprocessedOffer }
-import mesosphere.marathon.core.task.Task.LocalVolumeId
 import mesosphere.marathon.metrics.{ Metrics, ServiceMetric, SettableGauge }
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.stream.Implicits._
@@ -169,12 +169,12 @@ private[impl] class OfferMatcherManagerActor private (
   def offerMatchers(offer: Offer): Queue[OfferMatcher] = {
     //the persistence id of a volume encodes the app id
     //we use this information as filter criteria
-    val appReservations: Set[PathId] = offer.getResourcesList.view
+    val reservations: Set[PathId] = offer.getResourcesList.view
       .filter(r => r.hasDisk && r.getDisk.hasPersistence && r.getDisk.getPersistence.hasId)
       .map(_.getDisk.getPersistence.getId)
       .collect { case LocalVolumeId(volumeId) => volumeId.runSpecId }
       .toSet
-    val (reserved, normal) = matchers.toSeq.partition(_.precedenceFor.exists(appReservations))
+    val (reserved, normal) = matchers.toSeq.partition(_.precedenceFor.exists(reservations))
     //1 give the offer to the matcher waiting for a reservation
     //2 give the offer to anybody else
     //3 randomize both lists to be fair

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -8,7 +8,6 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition.Terminal
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.MesosContainer
-import mesosphere.marathon.core.task.Task.Reservation.Timeout.Reason.{ RelaunchEscalationTimeout, ReservationTimeout }
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.core.task.update.{ TaskUpdateEffect, TaskUpdateOperation }
 import mesosphere.marathon.state._
@@ -19,9 +18,7 @@ import org.apache.mesos.{ Protos => MesosProtos }
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.FiniteDuration
-// TODO PODS remove api imports
 import mesosphere.marathon.api.v2.json.Formats._
-import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 /**
@@ -63,17 +60,102 @@ import play.api.libs.json._
   * Marathon will notice spurious tasks in the offer and create the appropriate
   * unreserve operations. See https://github.com/mesosphere/marathon/issues/3223
   */
-sealed trait Task {
-  def taskId: Task.Id
-  def reservationWithVolumes: Option[Task.Reservation]
-  def runSpecVersion: Timestamp
 
-  /** apply the given operation to a task */
-  def update(update: TaskUpdateOperation): TaskUpdateEffect
+case class Task(taskId: Task.Id, runSpecVersion: Timestamp, status: Task.Status) {
+  import Task.log
 
   def runSpecId: PathId = taskId.runSpecId
 
-  def status: Task.Status
+  private[this] def hasStartedRunning: Boolean = status.startedAt.isDefined
+
+  /** apply the given operation to a task */
+  def update(instance: Instance, op: TaskUpdateOperation): TaskUpdateEffect = op match {
+
+    // exceptional case: the task is already terminal. Don't transition in this case.
+    // This might be because the task terminated (e.g. finished) before Marathon issues a kill Request
+    // to Mesos. Mesos will likely send back a TASK_LOST status update, because the task is no longer
+    // known in Mesos. We'll never want to transition from one terminal state to another as a terminal
+    // state should already be distinct enough.
+    // related to https://github.com/mesosphere/marathon/pull/4531
+
+    case op: TaskUpdateOperation if this.isTerminal =>
+      log.warn(s"received $op for terminal $taskId, ignoring")
+      TaskUpdateEffect.Noop
+
+    // case 1: running
+    case TaskUpdateOperation.MesosUpdate(Condition.Running, mesosStatus, now) if !hasStartedRunning =>
+      val updatedNetworkInfo = status.networkInfo.update(mesosStatus)
+      val updatedTask = copy(status = status.copy(
+        mesosStatus = Some(mesosStatus),
+        condition = Condition.Running,
+        startedAt = Some(now),
+        networkInfo = updatedNetworkInfo))
+      TaskUpdateEffect.Update(newState = updatedTask)
+
+    // case 2: terminal; extractor applies specific logic e.g. when an Unreachable task becomes Gone
+    case TaskUpdateOperation.MesosUpdate(newStatus: Terminal, mesosStatus, _) =>
+      val updatedStatus =
+        if (instance.hasReservation) {
+          status.copy(
+            mesosStatus = Some(mesosStatus),
+            // Note the task needs to transition to Reserved, otherwise the instance will not transition to Reserved
+            condition = Condition.Reserved)
+        } else {
+          status.copy(
+            mesosStatus = Some(mesosStatus),
+            condition = newStatus)
+        }
+      val updated = copy(status = updatedStatus)
+      TaskUpdateEffect.Update(updated)
+
+    case update: TaskUpdateOperation.MesosUpdate if status.condition == Condition.Reserved =>
+      // There are small edge cases in which Marathon thinks a resident task is reserved but it is actually running
+      // (restore ZK backup, for example). If Mesos says that it's running, then transition accordingly
+      if (update.condition.isActive) {
+        val updatedStatus = status.copy(startedAt = Some(update.now), mesosStatus = Some(update.taskStatus))
+        val updatedTask = Task(taskId = taskId, status = updatedStatus, runSpecVersion = runSpecVersion)
+        TaskUpdateEffect.Update(updatedTask)
+      } else {
+        TaskUpdateEffect.Noop
+      }
+
+    // case 3: health or state updated
+    case TaskUpdateOperation.MesosUpdate(newStatus, mesosStatus, _) =>
+      // TODO(PODS): strange to use Condition here
+      updatedHealthOrState(status.mesosStatus, mesosStatus).map { newTaskStatus =>
+        val updatedNetworkInfo = status.networkInfo.update(mesosStatus)
+        val updatedStatus = status.copy(
+          mesosStatus = Some(newTaskStatus), condition = newStatus, networkInfo = updatedNetworkInfo)
+        val updatedTask = copy(status = updatedStatus)
+        // TODO(PODS): The instance needs to handle a terminal task via an Update here
+        // Or should we use Expunge in case of a terminal update for resident tasks?
+        TaskUpdateEffect.Update(newState = updatedTask)
+      } getOrElse {
+        log.debug("Ignoring status update for {}. Status did not change.", taskId)
+        TaskUpdateEffect.Noop
+      }
+
+    case TaskUpdateOperation.LaunchOnReservation(newTaskId, newRunSpecVersion, taskStatus) =>
+      val updatedTask = Task(taskId = newTaskId, runSpecVersion = newRunSpecVersion, status = taskStatus)
+      TaskUpdateEffect.Update(updatedTask)
+  }
+
+  /** returns the new status if the health status has been added or changed, or if the state changed */
+  private[this] def updatedHealthOrState(
+    maybeCurrent: Option[MesosProtos.TaskStatus],
+    update: MesosProtos.TaskStatus): Option[MesosProtos.TaskStatus] = {
+    maybeCurrent match {
+      case Some(current) =>
+        val healthy = update.hasHealthy && (!current.hasHealthy || current.getHealthy != update.getHealthy)
+        val changed = healthy || current.getState != update.getState
+        if (changed) {
+          Some(update)
+        } else {
+          None
+        }
+      case None => Some(update)
+    }
+  }
 
   def launchedMesosId: Option[MesosProtos.TaskID] = if (status.condition.isActive) {
     // it doesn't make sense for an inactive task
@@ -99,9 +181,7 @@ sealed trait Task {
 }
 
 object Task {
-
-  // TODO PODs remove api import
-  import mesosphere.marathon.api.v2.json.Formats.PathIdFormat
+  private val log = LoggerFactory.getLogger(getClass)
 
   case class Id(idString: String) extends Ordered[Id] {
     lazy val mesosTaskId: MesosProtos.TaskID = MesosProtos.TaskID.newBuilder().setValue(idString).build()
@@ -243,46 +323,6 @@ object Task {
     def calculateLegacyExecutorId(taskId: String): String = s"marathon-$taskId"
   }
 
-  case class LocalVolume(id: LocalVolumeId, persistentVolume: PersistentVolume, mount: VolumeMount)
-
-  case class LocalVolumeId(runSpecId: PathId, name: String, uuid: String) {
-    import LocalVolumeId._
-    lazy val idString = runSpecId.safePath + delimiter + name + delimiter + uuid
-
-    override def toString: String = s"LocalVolume [$idString]"
-  }
-
-  object LocalVolumeId {
-    private val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
-    private val delimiter = "#"
-    private val LocalVolumeEncoderRE = s"^([^$delimiter]+)[$delimiter]([^$delimiter]+)[$delimiter]([^$delimiter]+)$$".r
-
-    def apply(runSpecId: PathId, volume: PersistentVolume, mount: VolumeMount): LocalVolumeId = {
-      val name = volume.name.getOrElse(mount.mountPath)
-      LocalVolumeId(runSpecId, name, uuidGenerator.generate().toString)
-    }
-
-    def unapply(id: String): Option[(LocalVolumeId)] = id match {
-      case LocalVolumeEncoderRE(runSpec, name, uuid) => Some(LocalVolumeId(PathId.fromSafePath(runSpec), name, uuid))
-      case _ => None
-    }
-
-    implicit val localVolumeIdReader = (
-      (__ \ "runSpecId").read[PathId] and
-      (__ \ "containerPath").read[String] and
-      (__ \ "uuid").read[String]
-    )((id, path, uuid) => LocalVolumeId(id, path, uuid))
-
-    implicit val localVolumeIdWriter = Writes[LocalVolumeId] { localVolumeId =>
-      JsObject(Seq(
-        "runSpecId" -> Json.toJson(localVolumeId.runSpecId),
-        "containerPath" -> Json.toJson(localVolumeId.name),
-        "uuid" -> Json.toJson(localVolumeId.uuid),
-        "persistenceId" -> Json.toJson(localVolumeId.idString)
-      ))
-    }
-  }
-
   /**
     * Contains information about the status of a launched task including timestamps for important
     * state transitions.
@@ -328,303 +368,6 @@ object Task {
     def unapply(state: TaskState): Option[TaskState] = if (isTerminated(state)) Some(state) else None
   }
 
-  /**
-    * A LaunchedEphemeral task is a stateless task that does not consume reserved resources or persistent volumes.
-    */
-  case class LaunchedEphemeral(
-      taskId: Task.Id,
-      runSpecVersion: Timestamp,
-      status: Status) extends Task {
-
-    import LaunchedEphemeral.log
-
-    override def reservationWithVolumes: Option[Reservation] = None
-
-    private[this] def hasStartedRunning: Boolean = status.startedAt.isDefined
-
-    override def update(op: TaskUpdateOperation): TaskUpdateEffect = op match {
-      // exceptional case: the task is already terminal. Don't transition in this case.
-      // This might be because the task terminated (e.g. finished) before Marathon issues a kill Request
-      // to Mesos. Mesos will likely send back a TASK_LOST status update, because the task is no longer
-      // known in Mesos. We'll never want to transition from one terminal state to another as a terminal
-      // state should already be distinct enough.
-      // related to https://github.com/mesosphere/marathon/pull/4531
-      case op: TaskUpdateOperation if this.isTerminal =>
-        log.warn(s"received $op for terminal $taskId, ignoring")
-        TaskUpdateEffect.Noop
-
-      case TaskUpdateOperation.MesosUpdate(Condition.Running, mesosStatus, now) if !hasStartedRunning =>
-        val updatedNetworkInfo = status.networkInfo.update(mesosStatus)
-        val updatedTask = copy(status = status.copy(
-          mesosStatus = Some(mesosStatus),
-          condition = Condition.Running,
-          startedAt = Some(now),
-          networkInfo = updatedNetworkInfo
-        ))
-        TaskUpdateEffect.Update(newState = updatedTask)
-
-      // The Terminal extractor applies specific logic e.g. when an Unreachable task becomes Gone
-      case TaskUpdateOperation.MesosUpdate(newStatus: Terminal, mesosStatus, _) =>
-        val updated = copy(status = status.copy(
-          mesosStatus = Some(mesosStatus),
-          condition = newStatus))
-        TaskUpdateEffect.Update(updated)
-
-      case TaskUpdateOperation.MesosUpdate(newStatus, mesosStatus, _) =>
-        // TODO(PODS): strange to use Condition here
-        updatedHealthOrState(status.mesosStatus, mesosStatus).map { newTaskStatus =>
-          val updatedTask = copy(status = status.copy(
-            mesosStatus = Some(newTaskStatus),
-            condition = newStatus
-          ))
-          // TODO(PODS): The instance needs to handle a terminal task via an Update here
-          // Or should we use Expunge in case of a terminal update for resident tasks?
-          TaskUpdateEffect.Update(newState = updatedTask)
-        } getOrElse {
-          log.debug("Ignoring status update for {}. Status did not change.", taskId)
-          TaskUpdateEffect.Noop
-        }
-    }
-  }
-
-  object LaunchedEphemeral {
-    private val log = LoggerFactory.getLogger(getClass)
-    implicit val launchedEphemeralFormat = Json.format[LaunchedEphemeral]
-  }
-
-  /**
-    * Represents a reservation for all resources that are needed for launching a task
-    * and associated persistent local volumes.
-    */
-  case class Reservation(volumeIds: Seq[LocalVolumeId], state: Reservation.State)
-
-  object Reservation {
-    /**
-      * A timeout that eventually leads to a state transition
-      *
-      * @param initiated When this timeout was setup
-      * @param deadline When this timeout should become effective
-      * @param reason The reason why this timeout was set up
-      */
-    case class Timeout(initiated: Timestamp, deadline: Timestamp, reason: Timeout.Reason)
-
-    object Timeout {
-      sealed trait Reason
-      object Reason {
-        /** A timeout because the task could not be relaunched */
-        case object RelaunchEscalationTimeout extends Reason
-        /** A timeout because we got no ack for reserved resources or persistent volumes */
-        case object ReservationTimeout extends Reason
-      }
-
-      implicit object ReasonFormat extends Format[Timeout.Reason] {
-        override def reads(json: JsValue): JsResult[Timeout.Reason] = {
-          json.validate[String].map {
-            case "RelaunchEscalationTimeout" => RelaunchEscalationTimeout
-            case "ReservationTimeout" => ReservationTimeout
-          }
-        }
-
-        override def writes(o: Timeout.Reason): JsValue = {
-          JsString(o.toString)
-        }
-      }
-      implicit val timeoutFormat = Json.format[Timeout]
-    }
-    sealed trait State extends Product with Serializable {
-      /** Defines when this state should time out and for which reason */
-      def timeout: Option[Timeout]
-    }
-    object State {
-      /** A newly reserved resident task */
-      case class New(timeout: Option[Timeout]) extends State
-      /** A launched resident task, never has a timeout */
-      case object Launched extends State {
-        override def timeout: Option[Timeout] = None
-      }
-      /** A resident task that has been running before but terminated and can be relaunched */
-      case class Suspended(timeout: Option[Timeout]) extends State
-      /** A resident task whose reservation and persistent volumes are being destroyed */
-      case class Garbage(timeout: Option[Timeout]) extends State
-      /** An unknown resident task created because of unknown reservations/persistent volumes */
-      case class Unknown(timeout: Option[Timeout]) extends State
-
-      implicit object StateFormat extends Format[State] {
-        override def reads(json: JsValue): JsResult[State] = {
-          (json \ "timeout").validateOpt[Timeout].flatMap { timeout =>
-            (json \ "name").validate[String].map {
-              case "new" => New(timeout)
-              case "launched" => Launched
-              case "suspended" => Suspended(timeout)
-              case "garbage" => Garbage(timeout)
-              case _ => Unknown(timeout)
-            }
-          }
-        }
-
-        override def writes(o: State): JsValue = {
-          val timeout = Json.toJson(o.timeout)
-          o match {
-            case _: New => JsObject(Seq("name" -> JsString("new"), "timeout" -> timeout))
-            case Launched => JsObject(Seq("name" -> JsString("launched"), "timeout" -> timeout))
-            case _: Suspended => JsObject(Seq("name" -> JsString("suspended"), "timeout" -> timeout))
-            case _: Garbage => JsObject(Seq("name" -> JsString("garbage"), "timeout" -> timeout))
-            case _: Unknown => JsObject(Seq("name" -> JsString("unknown"), "timeout" -> timeout))
-          }
-        }
-      }
-    }
-    implicit val reservationFormat = Json.format[Reservation]
-  }
-
-  sealed trait ReservedTask extends Task {
-    val taskId: Task.Id
-    val reservation: Reservation
-    val status: Status
-    val runSpecVersion: Timestamp
-  }
-
-  /**
-    * A Reserved task carries the information of reserved resources and persistent volumes
-    * and is currently not launched.
-    *
-    * @param taskId The task Id
-    * @param reservation Information about the reserved resources and persistent volumes
-    */
-  case class Reserved(
-      taskId: Task.Id,
-      reservation: Reservation,
-      status: Status,
-      runSpecVersion: Timestamp) extends ReservedTask {
-
-    override def reservationWithVolumes: Option[Reservation] = Some(reservation)
-
-    private def toLaunchedOnReservation(
-      taskId: Task.Id,
-      reservation: Reservation = reservation,
-      status: Status = status,
-      runSpecVersion: Timestamp = runSpecVersion) = {
-      LaunchedOnReservation(
-        taskId = taskId,
-        reservation = reservation,
-        status = status,
-        runSpecVersion = runSpecVersion)
-    }
-
-    override def update(op: TaskUpdateOperation): TaskUpdateEffect = op match {
-      case TaskUpdateOperation.LaunchOnReservation(newTaskId, newRunSpecVersion, taskStatus) =>
-        val updatedTask = toLaunchedOnReservation(
-          taskId = newTaskId,
-          runSpecVersion = newRunSpecVersion,
-          status = taskStatus)
-        TaskUpdateEffect.Update(updatedTask)
-
-      case update: TaskUpdateOperation.MesosUpdate =>
-        /* There are small edge cases in which Marathon thinks a resident task is reserved but it is actually running
-         * (restore ZK backup, for example). If Mesos says that it's running, then transition accordingly */
-        if (update.condition.isActive)
-          TaskUpdateEffect.Update(
-            toLaunchedOnReservation(
-              taskId = taskId,
-              status = status.copy(
-                startedAt = Some(update.now),
-                mesosStatus = Some(update.taskStatus))))
-        else
-          TaskUpdateEffect.Noop
-    }
-  }
-
-  case class LaunchedOnReservation(
-      taskId: Task.Id,
-      runSpecVersion: Timestamp,
-      status: Status,
-      reservation: Reservation) extends ReservedTask {
-
-    import LaunchedOnReservation.log
-
-    override def reservationWithVolumes: Option[Reservation] = Some(reservation)
-
-    private[this] def hasStartedRunning: Boolean = status.startedAt.isDefined
-
-    // TODO(PODS): this is the same def as in LaunchedEphemeral
-    override def update(op: TaskUpdateOperation): TaskUpdateEffect = op match {
-      // exceptional case: the task is already terminal. Don't transition in this case.
-      // This might be because the task terminated (e.g. finished) before Marathon issues a kill Request
-      // to Mesos. Mesos will likely send back a TASK_LOST status update, because the task is no longer
-      // known in Mesos. We'll never want to transition from one terminal state to another as a terminal
-      // state should already be distinct enough.
-      // related to https://github.com/mesosphere/marathon/pull/4531
-      case op: TaskUpdateOperation if this.isTerminal =>
-        log.warn(s"received $op for terminal $taskId, ignoring")
-        TaskUpdateEffect.Noop
-
-      // case 1: now running
-      case TaskUpdateOperation.MesosUpdate(Condition.Running, mesosStatus, now) if !hasStartedRunning =>
-        val updatedNetworkInfo = status.networkInfo.update(mesosStatus)
-        val updated = copy(
-          status = status.copy(
-            startedAt = Some(now),
-            mesosStatus = Some(mesosStatus),
-            condition = Condition.Running,
-            networkInfo = updatedNetworkInfo))
-        TaskUpdateEffect.Update(updated)
-
-      // case 2: terminal
-      case TaskUpdateOperation.MesosUpdate(newStatus: Terminal, mesosStatus, _) =>
-        val updatedTask = Task.Reserved(
-          taskId = taskId,
-          reservation = reservation.copy(state = Task.Reservation.State.Suspended(timeout = None)),
-          status = status.copy(
-            mesosStatus = Some(mesosStatus),
-            // Note the task needs to transition to Reserved, otherwise the instance will not transition to Reserved
-            condition = Condition.Reserved
-          ),
-          runSpecVersion = runSpecVersion
-        )
-        TaskUpdateEffect.Update(updatedTask)
-
-      // case 3: health or state updated
-      case TaskUpdateOperation.MesosUpdate(newStatus, mesosStatus, _) =>
-        updatedHealthOrState(status.mesosStatus, mesosStatus).map { newTaskStatus =>
-          val updatedNetworkInfo = status.networkInfo.update(mesosStatus)
-          val updatedTask = copy(status = status.copy(
-            mesosStatus = Some(newTaskStatus),
-            condition = newStatus,
-            networkInfo = updatedNetworkInfo
-          ))
-          TaskUpdateEffect.Update(newState = updatedTask)
-        } getOrElse {
-          log.debug("Ignoring status update for {}. Status did not change.", taskId)
-          TaskUpdateEffect.Noop
-        }
-    }
-  }
-
-  object LaunchedOnReservation {
-    private val log = LoggerFactory.getLogger(getClass)
-  }
-
-  /** returns the new status if the health status has been added or changed, or if the state changed */
-  private[this] def updatedHealthOrState(
-    maybeCurrent: Option[MesosProtos.TaskStatus],
-    update: MesosProtos.TaskStatus): Option[MesosProtos.TaskStatus] = {
-
-    maybeCurrent match {
-      case Some(current) =>
-        val healthy = update.hasHealthy && (!current.hasHealthy || current.getHealthy != update.getHealthy)
-        val changed = healthy || current.getState != update.getState
-        if (changed) {
-          Some(update)
-        } else {
-          None
-        }
-      case None => Some(update)
-    }
-  }
-
-  def reservedTasks(tasks: Iterable[Task]): Seq[Task.Reserved] =
-    tasks.collect { case r: Task.Reserved => r }(collection.breakOut)
-
   implicit class TaskStatusComparison(val task: Task) extends AnyVal {
     def isReserved: Boolean = task.status.condition == Condition.Reserved
     def isCreated: Boolean = task.status.condition == Condition.Created
@@ -645,37 +388,5 @@ object Task {
     def isActive: Boolean = task.status.condition.isActive
   }
 
-  implicit object TaskFormat extends Format[Task] {
-    private val reservedTaskReader: Reads[ReservedTask] = (
-      (__ \ "taskId").read[Task.Id] ~
-      (__ \ "reservation").read[Reservation] ~
-      (__ \ "status").read[Status] ~
-      (__ \ "runSpecVersion").read[Timestamp]
-    ) { (taskId, reservation, status, runSpecVersion) =>
-        if (status.condition == Condition.Reserved) {
-          Reserved(taskId, reservation, status, runSpecVersion)
-        } else {
-          LaunchedOnReservation(taskId, runSpecVersion, status, reservation)
-        }
-      }
-
-    private val reservedTaskWriter: Writes[ReservedTask] = {
-      (
-        (__ \ "taskId").write[Task.Id] ~
-        (__ \ "reservation").write[Reservation] ~
-        (__ \ "status").write[Status] ~
-        (__ \ "runSpecVersion").write[Timestamp]
-      ) { r =>
-          (r.taskId, r.reservation, r.status, r.runSpecVersion)
-        }
-    }
-    override def reads(json: JsValue): JsResult[Task] = {
-      json.validate(reservedTaskReader).orElse(json.validate[LaunchedEphemeral])
-    }
-
-    override def writes(o: Task): JsValue = o match {
-      case f: LaunchedEphemeral => Json.toJson(f)(LaunchedEphemeral.launchedEphemeralFormat)
-      case r: ReservedTask => Json.toJson(r)(reservedTaskWriter)
-    }
-  }
+  implicit val taskFormat: Format[Task] = Json.format[Task]
 }

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
@@ -96,7 +96,7 @@ private[jobs] object OverdueTasksActor {
     private[this] def overdueReservations(now: Timestamp, instances: Seq[Instance]): Seq[Instance] = {
       instances.filter { instance =>
         val reservedTasks = instance.tasksMap.values.filter(_.status.condition == Condition.Reserved)
-        reservedTasks.nonEmpty && instance.reservation.forall(_.state.timeout.exists(_.deadline <= now))
+        reservedTasks.nonEmpty && instance.reservation.exists(_.state.timeout.exists(_.deadline <= now))
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
@@ -94,11 +94,9 @@ private[jobs] object OverdueTasksActor {
     }
 
     private[this] def overdueReservations(now: Timestamp, instances: Seq[Instance]): Seq[Instance] = {
-      // TODO PODs is an Instance overdue if a single task is overdue? / move reservation to instance level
       instances.filter { instance =>
-        Task.reservedTasks(instance.tasksMap.values).exists { (task: Task.Reserved) =>
-          task.reservation.state.timeout.exists(_.deadline <= now)
-        }
+        val reservedTasks = instance.tasksMap.values.filter(_.status.condition == Condition.Reserved)
+        reservedTasks.nonEmpty && instance.reservation.forall(_.state.timeout.exists(_.deadline <= now))
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/raml/TaskConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/TaskConversion.scala
@@ -2,11 +2,11 @@ package mesosphere.marathon
 package raml
 
 import mesosphere.marathon.core.condition
-import mesosphere.marathon.core.task
+import mesosphere.marathon.core.instance
 
 object TaskConversion extends HealthConversion with DefaultConversions {
 
-  implicit val localVolumeIdWrites: Writes[task.Task.LocalVolumeId, LocalVolumeId] = Writes { localVolumeId =>
+  implicit val localVolumeIdWrites: Writes[instance.LocalVolumeId, LocalVolumeId] = Writes { localVolumeId =>
     LocalVolumeId(
       runSpecId = localVolumeId.runSpecId.toRaml,
       containerPath = localVolumeId.name,
@@ -27,7 +27,7 @@ object TaskConversion extends HealthConversion with DefaultConversions {
 
     val ipAddresses = task.status.networkInfo.ipAddresses.toRaml
 
-    val localVolumes = task.reservationWithVolumes.fold(Seq.empty[LocalVolumeId]) { reservation =>
+    val localVolumes = enrichedTask.reservation.fold(Seq.empty[LocalVolumeId]) { reservation =>
       reservation.volumeIds.toRaml
     }
 

--- a/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
@@ -26,7 +26,6 @@ object PersistentVolumeMatcher {
 
     waitingInstances.toStream
       .flatMap { instance =>
-        // Note this only supports AppDefinition instances with exactly one task
         instance.reservation.flatMap { reservation =>
           resourcesForReservation(reservation).flatMap(rs => Some(VolumeMatch(instance, rs)))
         }

--- a/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
@@ -1,7 +1,6 @@
 package mesosphere.mesos
 
-import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.Task.Reservation
+import mesosphere.marathon.core.instance.{ Instance, Reservation }
 import mesosphere.marathon.stream.Implicits._
 import org.apache.mesos.{ Protos => Mesos }
 
@@ -28,7 +27,7 @@ object PersistentVolumeMatcher {
     waitingInstances.toStream
       .flatMap { instance =>
         // Note this only supports AppDefinition instances with exactly one task
-        instance.tasksMap.values.headOption.flatMap(_.reservationWithVolumes).flatMap { reservation =>
+        instance.reservation.flatMap { reservation =>
           resourcesForReservation(reservation).flatMap(rs => Some(VolumeMatch(instance, rs)))
         }
       }.headOption

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -244,7 +244,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val offer = MarathonTestHelper.makeBasicOffer().build()
     val runspecId = PathId("/test")
     val instance = TestInstanceBuilder.newBuilder(runspecId).addTaskWithBuilder().taskRunning().build().getInstance()
-    val task: Task.LaunchedEphemeral = instance.appTask
+    val task: Task = instance.appTask
 
     val mesosTask = MarathonTestHelper.makeOneCPUTask(task.taskId).build()
     val launch = new InstanceOpFactoryHelper(Some("principal"), Some("role")).

--- a/src/test/scala/mesosphere/marathon/api/EndpointsHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/EndpointsHelperTest.scala
@@ -36,14 +36,14 @@ class EndpointsHelperTest extends UnitTest {
             case (portOption, _) => portOption
           }
           val taskId = Task.Id.forInstanceId(instanceId, None)
-          val task = Task.LaunchedEphemeral(taskId, runSpecVersion = Timestamp.zero, status = Task.Status(
+          val task = Task(taskId, runSpecVersion = Timestamp.zero, status = Task.Status(
             stagedAt = Timestamp.zero, startedAt = None, mesosStatus = None, condition = Condition.Running,
             networkInfo = NetworkInfo(hostname, hostPorts = hostPorts, ipAddresses = ipAddresses)
           ))
           val state = Instance.InstanceState(
             condition = Condition.Running, since = Timestamp.zero, activeSince = None, healthy = None)
           instanceId -> Instance(instanceId, agent,
-            state = state, tasksMap = Map(taskId -> task), Timestamp.zero, UnreachableStrategy.default())
+            state = state, tasksMap = Map(taskId -> task), Timestamp.zero, UnreachableStrategy.default(), None)
         }
     }.toMap
     )

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -31,8 +31,6 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, Identity }
 import mesosphere.marathon.raml.Raml
-//import mesosphere.marathon.raml.{, AppSecretVolume, AppUpdate, ContainerPortMapping, DockerContainer, DockerNetwork,
-//, EngineType, EnvVarValueOrSecret, IpAddress, IpDiscovery, IpDiscoveryPort, Network, NetworkMode,
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.GroupRepository
@@ -98,7 +96,8 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
       Instance.InstanceState(Condition.Running, clock.now(), None, None),
       Map.empty,
       clock.now(),
-      UnreachableDisabled
+      UnreachableDisabled,
+      None
     )
 
     implicit val rejectionHandler: RejectionHandler = AkkaHttpMarathonService.rejectionHandler

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -670,7 +670,8 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
             InstanceState(Condition.Running, Timestamp.now(), Some(Timestamp.now()), None),
             Map.empty,
             runSpecVersion = Timestamp.now(),
-            unreachableStrategy = UnreachableStrategy.default()
+            unreachableStrategy = UnreachableStrategy.default(),
+            None
           )
           killer.kill(any, any, any)(any) returns Future.successful(Seq(instance))
           val response = f.podsResource.killInstance("/id", instance.instanceId.toString, f.auth.request)
@@ -686,12 +687,14 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
             Instance(Instance.Id.forRunSpec("/id1".toRootPath), Instance.AgentInfo("", None, None, None, Nil),
               InstanceState(Condition.Running, Timestamp.now(), Some(Timestamp.now()), None), Map.empty,
               runSpecVersion = Timestamp.now(),
-              unreachableStrategy = UnreachableStrategy.default()
+              unreachableStrategy = UnreachableStrategy.default(),
+              None
             ),
             Instance(Instance.Id.forRunSpec("/id1".toRootPath), Instance.AgentInfo("", None, None, None, Nil),
               InstanceState(Condition.Running, Timestamp.now(), Some(Timestamp.now()), None), Map.empty,
               runSpecVersion = Timestamp.now(),
-              unreachableStrategy = UnreachableStrategy.default()))
+              unreachableStrategy = UnreachableStrategy.default(),
+              None))
 
           val f = Fixture()
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
@@ -81,7 +81,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         |  "stagedAt": "1970-01-01T00:00:01.024Z",
         |  "version": "1970-01-01T00:00:01.024Z",
         |  "slaveId": "abcd-1234",
-        |  "localVolumes" : [ ]
+        |  "localVolumes" : []
         |}
       """.stripMargin
       JsonTestHelper.assertThatJsonOf(f.taskWithoutIp.toRaml).correspondsToJsonString(json)
@@ -112,7 +112,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         |  "stagedAt": "1970-01-01T00:00:01.024Z",
         |  "version": "1970-01-01T00:00:01.024Z",
         |  "slaveId": "abcd-1234",
-        |  "localVolumes" : [ ]
+        |  "localVolumes" : []
         |}
       """.stripMargin
       JsonTestHelper.assertThatJsonOf(f.taskWithMultipleIPs.toRaml).correspondsToJsonString(json)

--- a/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
@@ -36,9 +36,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         .withAgentInfo(agentInfo)
         .addTaskStaging(since = time)
         .getInstance()
-      EnrichedTask(
-        runSpecId, instance.appTask, agentInfo, healthCheckResults = Nil, servicePorts = Nil,
-        reservation = instance.reservation)
+      EnrichedTask(instance, instance.appTask, Nil)
     }
 
     def mesosStatus(taskId: Task.Id) = {
@@ -58,9 +56,7 @@ class EnrichedTaskWritesTest extends UnitTest {
         .addTaskWithBuilder().taskStaging(since = time)
         .withNetworkInfo(networkInfo)
         .build().getInstance()
-      EnrichedTask(
-        runSpecId, instance.appTask, agentInfo, healthCheckResults = Nil, servicePorts = Nil,
-        reservation = instance.reservation)
+      EnrichedTask(instance, instance.appTask, Nil)
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
@@ -190,15 +190,14 @@ object Fixture {
   implicit class TaskImplicits(val task: Task) extends AnyVal {
     def toInstance: Instance = LegacyAppInstance(
       task, AgentInfo(host = "host", agentId = Some("agent"), region = None, zone = None, attributes = Nil),
-      unreachableStrategy = UnreachableStrategy.default(resident = task.reservationWithVolumes.nonEmpty)
-    )
+      unreachableStrategy = UnreachableStrategy.default())
   }
 }
 
 class Fixture {
   val runSpecId = PathId("/test")
   val taskId = Task.Id.forRunSpec(runSpecId)
-  val taskWithoutState = Task.LaunchedEphemeral(
+  val taskWithoutState = Task(
     taskId = taskId,
     runSpecVersion = Timestamp(0),
     status = Task.Status(

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -147,9 +147,9 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
 
       appInfo should be(AppInfo(app, maybeTasks = Some(
         Seq(
-          EnrichedTask(app.id, running1.appTask, running1.agentInfo, Seq.empty, reservation = running1.reservation),
-          EnrichedTask(app.id, running2.appTask, running2.agentInfo, Seq(alive), reservation = running2.reservation),
-          EnrichedTask(app.id, running3.appTask, running3.agentInfo, Seq(unhealthy), reservation = running3.reservation)
+          EnrichedTask(running1, running1.appTask, Nil),
+          EnrichedTask(running2, running2.appTask, Seq(alive)),
+          EnrichedTask(running3, running3.appTask, Seq(unhealthy))
         )
       )))
 

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -147,9 +147,9 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
 
       appInfo should be(AppInfo(app, maybeTasks = Some(
         Seq(
-          EnrichedTask(app.id, running1.appTask, running1.agentInfo, Seq.empty),
-          EnrichedTask(app.id, running2.appTask, running2.agentInfo, Seq(alive)),
-          EnrichedTask(app.id, running3.appTask, running3.agentInfo, Seq(unhealthy))
+          EnrichedTask(app.id, running1.appTask, running1.agentInfo, Seq.empty, reservation = running1.reservation),
+          EnrichedTask(app.id, running2.appTask, running2.agentInfo, Seq(alive), reservation = running2.reservation),
+          EnrichedTask(app.id, running3.appTask, running3.agentInfo, Seq(unhealthy), reservation = running3.reservation)
         )
       )))
 
@@ -400,7 +400,7 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
       val instanceId = Instance.Id.forRunSpec(pod.id)
       val tasks: Map[Task.Id, Task] = pod.containers.map { ct =>
         val taskId = Task.Id.forInstanceId(instanceId, Some(ct))
-        taskId -> Task.LaunchedEphemeral(
+        taskId -> Task(
           taskId = taskId,
           runSpecVersion = pod.version,
           status = Task.Status.apply(
@@ -417,7 +417,8 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
         state = InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default()),
         tasksMap = tasks,
         runSpecVersion = pod.version,
-        unreachableStrategy = UnreachableStrategy.default()
+        unreachableStrategy = UnreachableStrategy.default(),
+        None
       )
     }
 

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehaviorTest.scala
@@ -221,7 +221,7 @@ class ReadinessBehaviorTest extends AkkaUnitTest with Eventually with GroupCreat
       val task = mockTask
       val instance = Instance(
         instanceId, agentInfo, InstanceState(Running, version, Some(version), healthy = Some(true)),
-        Map(task.taskId -> task), runSpecVersion = version, UnreachableStrategy.default())
+        Map(task.taskId -> task), runSpecVersion = version, UnreachableStrategy.default(), None)
       tracker.instance(any) returns Future.successful(Some(instance))
       instance
     }

--- a/src/test/scala/mesosphere/marathon/core/health/HealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/HealthCheckTest.scala
@@ -297,7 +297,7 @@ class HealthCheckTest extends UnitTest {
       val hostName = "hostName"
       val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
       val task = {
-        val t: Task.LaunchedEphemeral = TestTaskBuilder.Helper.runningTaskForApp(app.id)
+        val t: Task = TestTaskBuilder.Helper.runningTaskForApp(app.id)
         val hostPorts = Seq(4321)
         t.copy(status = t.status.copy(networkInfo = NetworkInfo(hostName, hostPorts, ipAddresses = Nil)))
       }

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
@@ -34,7 +34,7 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
       val hostName = InetAddress.getLocalHost.getCanonicalHostName
       val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
       val task = {
-        val t: Task.LaunchedEphemeral = TestTaskBuilder.Helper.runningTaskForApp(appId)
+        val t: Task = TestTaskBuilder.Helper.runningTaskForApp(appId)
         val hostPorts = Seq(socketPort)
         t.copy(status = t.status.copy(networkInfo = NetworkInfo(hostName, hostPorts, ipAddresses = Nil)))
       }
@@ -64,7 +64,7 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
       val hostName = InetAddress.getLocalHost.getCanonicalHostName
       val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
       val task = {
-        val t: Task.LaunchedEphemeral = TestTaskBuilder.Helper.runningTaskForApp(appId)
+        val t: Task = TestTaskBuilder.Helper.runningTaskForApp(appId)
         val hostPorts = Seq(socketPort)
         t.copy(status = t.status.copy(networkInfo = NetworkInfo(hostName, hostPorts, ipAddresses = Nil)))
       }

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
@@ -24,9 +24,8 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
         .zip(startTimestamps)
         .map {
           case (task, startTime) =>
-            val ephemeralTask = task.asInstanceOf[Task.LaunchedEphemeral]
-            val newStatus: Task.Status = ephemeralTask.status.copy(startedAt = startTime)
-            task.taskId -> ephemeralTask.copy(status = newStatus)
+            val newStatus: Task.Status = task.status.copy(startedAt = startTime)
+            task.taskId -> task.copy(status = newStatus)
         }(collection.breakOut)
 
       val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default())
@@ -54,9 +53,8 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
         .zip(startTimestamps)
         .map {
           case (task, startTime) =>
-            val ephemeralTask = task.asInstanceOf[Task.LaunchedEphemeral]
-            val newStatus: Task.Status = ephemeralTask.status.copy(startedAt = startTime)
-            task.taskId -> ephemeralTask.copy(status = newStatus)
+            val newStatus: Task.Status = task.status.copy(startedAt = startTime)
+            task.taskId -> task.copy(status = newStatus)
         }(collection.breakOut)
 
       val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default())
@@ -74,9 +72,8 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
         .zip(startTimestamps)
         .map {
           case (task, startTime) =>
-            val ephemeralTask = task.asInstanceOf[Task.LaunchedEphemeral]
-            val newStatus: Task.Status = ephemeralTask.status.copy(startedAt = startTime)
-            task.taskId -> ephemeralTask.copy(status = newStatus)
+            val newStatus: Task.Status = task.status.copy(startedAt = startTime)
+            task.taskId -> task.copy(status = newStatus)
         }(collection.breakOut)
 
       val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default())

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
@@ -139,7 +139,7 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
       val newTasks = tasks(conditions)
       val state = Instance.InstanceState(None, currentTasks, clock.now(), UnreachableStrategy.default())
       val instance = Instance(Instance.Id.forRunSpec(id), agentInfo, state, currentTasks,
-        runSpecVersion = clock.now(), UnreachableStrategy.default())
+        runSpecVersion = clock.now(), UnreachableStrategy.default(), None)
       (instance, newTasks)
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -33,18 +33,22 @@ case class TestInstanceBuilder(instance: Instance, now: Timestamp = Timestamp.no
   def addTaskResidentLaunched(volumeIds: Seq[LocalVolumeId]): TestInstanceBuilder =
     withReservation(volumeIds).addTaskWithBuilder().taskResidentLaunched().build()
 
-  def addTaskResidentUnreachable(volumeIds: Seq[LocalVolumeId]): TestInstanceBuilder =
-    withReservation(volumeIds).addTaskWithBuilder().taskResidentUnreachable().build()
+  def addTaskUnreachable(volumeIds: Seq[LocalVolumeId]): TestInstanceBuilder =
+    withReservation(volumeIds).addTaskWithBuilder().taskUnreachable().build()
 
-  def addTaskRunning(containerName: Option[String] = None, stagedAt: Timestamp = now, startedAt: Timestamp = now): TestInstanceBuilder =
+  def addTaskRunning(containerName: Option[String] = None, stagedAt: Timestamp = now,
+    startedAt: Timestamp = now): TestInstanceBuilder =
     addTaskWithBuilder().taskRunning(containerName, stagedAt, startedAt).build()
 
   def addTaskLost(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskLost(since, containerName).build()
 
-  def addTaskUnreachable(since: Timestamp = now, containerName: Option[String] = None, unreachableStrategy: UnreachableStrategy = UnreachableEnabled()): TestInstanceBuilder =
-    this.copy(instance = instance.copy(unreachableStrategy = unreachableStrategy)) // we need to update the unreachable strategy first before adding an unreachable task
+  def addTaskUnreachable(since: Timestamp = now, containerName: Option[String] = None,
+    unreachableStrategy: UnreachableStrategy = UnreachableEnabled()): TestInstanceBuilder = {
+    // we need to update the unreachable strategy first before adding an unreachable task
+    this.copy(instance = instance.copy(unreachableStrategy = unreachableStrategy))
       .addTaskWithBuilder().taskUnreachable(since, containerName).build()
+  }
 
   def addTaskUnreachableInactive(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskUnreachableInactive(since, containerName).build()
@@ -82,7 +86,8 @@ case class TestInstanceBuilder(instance: Instance, now: Timestamp = Timestamp.no
   def addTaskStarting(since: Timestamp = now, containerName: Option[String] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskStarting(since, containerName).build()
 
-  def addTaskStaged(stagedAt: Timestamp = now, version: Option[Timestamp] = None, containerName: Option[String] = None): TestInstanceBuilder =
+  def addTaskStaged(stagedAt: Timestamp = now, version: Option[Timestamp] = None,
+    containerName: Option[String] = None): TestInstanceBuilder =
     addTaskWithBuilder().taskStaged(containerName, stagedAt, version).build()
 
   def addTaskWithBuilder(): TestTaskBuilder = TestTaskBuilder.newBuilder(this)
@@ -91,7 +96,7 @@ case class TestInstanceBuilder(instance: Instance, now: Timestamp = Timestamp.no
     this.copy(instance = InstanceUpdater.updatedInstance(instance, task, now + 1.second))
   }
 
-  def getInstance() = instance
+  def getInstance(): Instance = instance
 
   def withAgentInfo(agentInfo: AgentInfo): TestInstanceBuilder = copy(instance = instance.copy(agentInfo = agentInfo))
 
@@ -125,7 +130,8 @@ case class TestInstanceBuilder(instance: Instance, now: Timestamp = Timestamp.no
 
   def stateOpLaunch() = InstanceUpdateOperation.LaunchEphemeral(instance)
 
-  def stateOpUpdate(mesosStatus: mesos.Protos.TaskStatus) = InstanceUpdateOperation.MesosUpdate(instance, mesosStatus, now)
+  def stateOpUpdate(mesosStatus: mesos.Protos.TaskStatus) =
+    InstanceUpdateOperation.MesosUpdate(instance, mesosStatus, now)
 
   def taskLaunchedOp(): InstanceUpdateOperation.LaunchOnReservation = {
     val taskId = instance.appTask.taskId
@@ -148,7 +154,8 @@ case class TestInstanceBuilder(instance: Instance, now: Timestamp = Timestamp.no
 
 object TestInstanceBuilder {
 
-  def emptyInstance(now: Timestamp = Timestamp.now(), version: Timestamp = Timestamp.zero, instanceId: Instance.Id): Instance = Instance(
+  def emptyInstance(now: Timestamp = Timestamp.now(), version: Timestamp = Timestamp.zero,
+    instanceId: Instance.Id): Instance = Instance(
     instanceId = instanceId,
     agentInfo = TestInstanceBuilder.defaultAgentInfo,
     state = InstanceState(Condition.Created, now, None, healthy = None),
@@ -162,11 +169,17 @@ object TestInstanceBuilder {
     host = AgentTestDefaults.defaultHostName,
     agentId = Some(AgentTestDefaults.defaultAgentId), region = None, zone = None, attributes = Seq.empty)
 
-  def newBuilder(runSpecId: PathId, now: Timestamp = Timestamp.now(), version: Timestamp = Timestamp.zero): TestInstanceBuilder = newBuilderWithInstanceId(Instance.Id.forRunSpec(runSpecId), now, version)
+  def newBuilder(runSpecId: PathId, now: Timestamp = Timestamp.now(),
+    version: Timestamp = Timestamp.zero): TestInstanceBuilder =
+    newBuilderWithInstanceId(Instance.Id.forRunSpec(runSpecId), now, version)
 
-  def newBuilderWithInstanceId(instanceId: Instance.Id, now: Timestamp = Timestamp.now(), version: Timestamp = Timestamp.zero): TestInstanceBuilder = TestInstanceBuilder(emptyInstance(now, version, instanceId), now)
+  def newBuilderWithInstanceId(instanceId: Instance.Id, now: Timestamp = Timestamp.now(),
+    version: Timestamp = Timestamp.zero): TestInstanceBuilder =
+    TestInstanceBuilder(emptyInstance(now, version, instanceId), now)
 
-  def newBuilderWithLaunchedTask(runSpecId: PathId, now: Timestamp = Timestamp.now(), version: Timestamp = Timestamp.zero): TestInstanceBuilder = newBuilder(runSpecId, now, version).addTaskLaunched()
+  def newBuilderWithLaunchedTask(runSpecId: PathId, now: Timestamp = Timestamp.now(),
+    version: Timestamp = Timestamp.zero): TestInstanceBuilder =
+    newBuilder(runSpecId, now, version).addTaskLaunched()
 
   @SuppressWarnings(Array("AsInstanceOf"))
   implicit class EnhancedLegacyInstanceImprovement(val instance: Instance) extends AnyVal {

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -41,7 +41,7 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
   def taskReserved(containerName: Option[String] = None) = {
     val instance = instanceBuilder.getInstance()
     val taskId = Task.Id.forInstanceId(instance.instanceId, maybeMesosContainerByName(containerName))
-    this.copy(task = Some(TestTaskBuilder.Helper.minimalReservedTask(instance.instanceId.runSpecId, Some(taskId))))
+    this.copy(task = Some(TestTaskBuilder.Helper.residentReservedTask(instance.instanceId.runSpecId, Some(taskId))))
   }
 
   def taskResidentReserved() = {
@@ -265,16 +265,13 @@ object TestTaskBuilder {
       )
     }
 
-    def minimalReservedTask(appId: PathId, maybeTaskId: Option[Task.Id] = None): Task = {
+    def residentReservedTask(appId: PathId, maybeTaskId: Option[Task.Id] = None): Task = {
       val taskId = maybeTaskId.getOrElse(Task.Id.forRunSpec(appId))
       Task(
         taskId = taskId,
         status = Task.Status(Timestamp.now(), condition = Condition.Reserved, networkInfo = NetworkInfoPlaceholder()),
         runSpecVersion = Timestamp.now())
     }
-
-    def residentReservedTask(appId: PathId, maybeTaskId: Option[Task.Id] = None) =
-      minimalReservedTask(appId, maybeTaskId)
 
     def residentLaunchedTask(appId: PathId, maybeTaskId: Option[Task.Id] = None) = {
       val now = Timestamp.now()

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -397,12 +397,13 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
 
     lazy val appId = PathId("/app")
     lazy val existingInstance: Instance = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
-    lazy val existingTask: Task.LaunchedEphemeral = existingInstance.appTask
+    lazy val existingTask: Task = existingInstance.appTask
 
     lazy val reservedInstance = TestInstanceBuilder.newBuilder(appId).addTaskReserved().getInstance()
-    lazy val existingReservedTask: Task.Reserved = reservedInstance.appTask
+    lazy val existingReservedTask: Task = reservedInstance.appTask
 
-    lazy val reservedLaunchedInstance: Instance = TestInstanceBuilder.newBuilder(appId).addTaskResidentLaunched().getInstance()
+    lazy val reservedLaunchedInstance: Instance = TestInstanceBuilder.
+      newBuilder(appId).addTaskResidentLaunched(Seq.empty).getInstance()
 
     lazy val notExistingInstanceId = Instance.Id.forRunSpec(appId)
     lazy val unreachableInstance = TestInstanceBuilder.newBuilder(appId).addTaskUnreachable().getInstance()

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
@@ -304,9 +304,9 @@ class InstanceUpdaterTest extends UnitTest {
       condition = Condition.Running,
       networkInfo = NetworkInfoPlaceholder()
     )
-    val task = Task.LaunchedEphemeral(taskId, runSpecVersion = clock.now(), status = taskStatus)
+    val task = Task(taskId, runSpecVersion = clock.now(), status = taskStatus)
     val instance = Instance(
       Instance.Id("foobar.instance-baz"), agentInfo, instanceState, Map(taskId -> task), clock.now(),
-      UnreachableStrategy.default())
+      UnreachableStrategy.default(), None)
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -32,8 +32,8 @@ class OfferProcessorImplTest extends UnitTest {
   private[this] val taskInfo2 = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId2, None)).build()
   private[this] val instance1 = TestInstanceBuilder.newBuilderWithInstanceId(instanceId1).addTaskWithBuilder().taskFromTaskInfo(taskInfo1).build().getInstance()
   private[this] val instance2 = TestInstanceBuilder.newBuilderWithInstanceId(instanceId2).addTaskWithBuilder().taskFromTaskInfo(taskInfo2).build().getInstance()
-  private[this] val task1: Task.LaunchedEphemeral = instance1.appTask
-  private[this] val task2: Task.LaunchedEphemeral = instance2.appTask
+  private[this] val task1: Task = instance1.appTask
+  private[this] val task2: Task = instance2.appTask
 
   private[this] val tasks = Seq((taskInfo1, task1, instance1), (taskInfo2, task2, instance2))
   private[this] val arbitraryInstanceUpdateEffect = InstanceUpdateEffect.Noop(instanceId1)
@@ -53,7 +53,7 @@ class OfferProcessorImplTest extends UnitTest {
   object f {
     import org.apache.mesos.{ Protos => Mesos }
     val launch = new InstanceOpFactoryHelper(Some("principal"), Some("role"))
-      .launchEphemeral(_: Mesos.TaskInfo, _: Task.LaunchedEphemeral, _: Instance)
+      .launchEphemeral(_: Mesos.TaskInfo, _: Task, _: Instance)
     val launchWithNewTask = new InstanceOpFactoryHelper(Some("principal"), Some("role"))
       .launchOnReservation(_: Mesos.TaskInfo, _: InstanceUpdateOperation.LaunchOnReservation, _: Instance)
   }
@@ -142,7 +142,7 @@ class OfferProcessorImplTest extends UnitTest {
       val dummySource = new DummySource
       val tasksWithSource = tasks.map {
         case (taskInfo, _, _) =>
-          val dummyInstance = TestInstanceBuilder.newBuilder(appId).addTaskResidentReserved().getInstance()
+          val dummyInstance = TestInstanceBuilder.newBuilder(appId).addTaskResidentReserved(Seq.empty).getInstance()
           val taskId = Task.Id(taskInfo.getTaskId)
           val newTaskId = Task.Id.forResidentTask(taskId)
           val updateOperation = InstanceUpdateOperation.LaunchOnReservation(

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
@@ -25,7 +25,7 @@ class TaskLauncherImplTest extends UnitTest {
   private[this] def launch(taskInfoBuilder: TaskInfo.Builder): InstanceOp.LaunchTask = {
     val taskInfo = taskInfoBuilder.build()
     val instance = TestInstanceBuilder.newBuilderWithInstanceId(instanceId).addTaskWithBuilder().taskFromTaskInfo(taskInfo).build().getInstance()
-    val task: Task.LaunchedEphemeral = instance.appTask
+    val task: Task = instance.appTask
     new InstanceOpFactoryHelper(Some("principal"), Some("role")).launchEphemeral(taskInfo, task, instance)
   }
   private[this] val appId = PathId("/test")

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitorTest.scala
@@ -43,7 +43,7 @@ class UnreachableReservedOfferMonitorTest extends AkkaUnitTest with Inside {
     TestInstanceBuilder.newBuilder(appId).withAgentInfo(agentInfo)
 
   val runningInstance = newBuilder.addTaskResidentLaunched(Seq.empty).getInstance()
-  val unreachableInstance = newBuilder.addTaskResidentUnreachable(Seq.empty).getInstance()
+  val unreachableInstance = newBuilder.addTaskUnreachable(Seq.empty).getInstance()
 
   def reservedOffer(instances: Seq[Instance]) = {
     val b = MarathonTestHelper.makeBasicOffer(role = "marathon").clearResources()

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitorTest.scala
@@ -42,8 +42,8 @@ class UnreachableReservedOfferMonitorTest extends AkkaUnitTest with Inside {
   def newBuilder =
     TestInstanceBuilder.newBuilder(appId).withAgentInfo(agentInfo)
 
-  val runningInstance = newBuilder.addTaskResidentLaunched().getInstance
-  val unreachableInstance = newBuilder.addTaskResidentUnreachable().getInstance
+  val runningInstance = newBuilder.addTaskResidentLaunched(Seq.empty).getInstance()
+  val unreachableInstance = newBuilder.addTaskResidentUnreachable(Seq.empty).getInstance()
 
   def reservedOffer(instances: Seq[Instance]) = {
     val b = MarathonTestHelper.makeBasicOffer(role = "marathon").clearResources()

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -53,10 +53,10 @@ class TaskLauncherActorTest extends AkkaUnitTest {
     import org.apache.mesos.{ Protos => Mesos }
     val app = AppDefinition(id = PathId("/testapp"))
     val marathonInstance = TestInstanceBuilder.newBuilderWithLaunchedTask(app.id, version = app.version, now = Timestamp.now()).getInstance()
-    val marathonTask: Task.LaunchedEphemeral = marathonInstance.appTask
+    val marathonTask: Task = marathonInstance.appTask
     val instanceId = marathonInstance.instanceId
     val task = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId, None)).build()
-    val opFactory = new InstanceOpFactoryHelper(Some("principal"), Some("role")).launchEphemeral(_: Mesos.TaskInfo, _: Task.LaunchedEphemeral, _: Instance)
+    val opFactory = new InstanceOpFactoryHelper(Some("principal"), Some("role")).launchEphemeral(_: Mesos.TaskInfo, _: Task, _: Instance)
     val launch = opFactory(task, marathonTask, marathonInstance)
     val offer = MarathonTestHelper.makeBasicOffer().build()
     val noMatchResult = OfferMatchResult.NoMatch(app, offer, Seq.empty, Timestamp.now())

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package core.matcher.base.util
 
 import mesosphere.UnitTest
+import mesosphere.marathon.core.instance.{ LocalVolume, LocalVolumeId }
 import mesosphere.marathon.core.launcher.InstanceOpFactory
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.task.Task
@@ -145,10 +146,10 @@ class OfferOperationFactoryTest extends UnitTest {
     val role = Some("role")
     val factory = new OfferOperationFactory(principal, role)
 
-    def localVolume(mountPath: String): Task.LocalVolume = {
+    def localVolume(mountPath: String): LocalVolume = {
       val pv = PersistentVolume(None, PersistentVolumeInfo(size = 10))
       val mount = VolumeMount(None, mountPath)
-      Task.LocalVolume(Task.LocalVolumeId(runSpecId, pv, mount), pv, mount)
+      LocalVolume(LocalVolumeId(runSpecId, pv, mount), pv, mount)
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
@@ -8,11 +8,11 @@ import akka.pattern.ask
 import akka.testkit.TestActorRef
 import akka.util.Timeout
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.instance.LocalVolumeId
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.util.ActorOfferMatcher
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerConfig
-import mesosphere.marathon.core.task.Task.LocalVolumeId
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.MarathonTestHelper
 import org.apache.mesos.Protos.Offer

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -45,7 +45,7 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val instanceId = Instance.Id.forRunSpec(runSpecId)
     val launch = new InstanceOpFactoryHelper(
       Some("principal"),
-      Some("role")).launchEphemeral(_: Mesos.TaskInfo, _: Task.LaunchedEphemeral, _: Instance)
+      Some("role")).launchEphemeral(_: Mesos.TaskInfo, _: Task, _: Instance)
   }
 
   class Fixture {
@@ -82,7 +82,7 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     override def matchOffer(offer: Offer): Future[MatchedInstanceOps] = {
       val opsWithSources = matchTasks(offer).map { taskInfo =>
         val instance = TestInstanceBuilder.newBuilderWithInstanceId(F.instanceId).addTaskWithBuilder().taskFromTaskInfo(taskInfo, offer).build().getInstance()
-        val task: Task.LaunchedEphemeral = instance.appTask
+        val task: Task = instance.appTask
         val launch = F.launch(taskInfo, task.copy(taskId = Task.Id(taskInfo.getTaskId)), instance)
         InstanceOpWithSource(Source, launch)
       }(collection.breakOut)

--- a/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
@@ -2,11 +2,10 @@ package mesosphere.marathon
 package core.matcher.reconcile.impl
 
 import mesosphere.UnitTest
-import mesosphere.marathon.core.instance.TestInstanceBuilder
+import mesosphere.marathon.core.instance.{ LocalVolumeId, TestInstanceBuilder }
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.launcher.InstanceOp
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.Task.LocalVolumeId
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.state._

--- a/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckSpecTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckSpecTest.scala
@@ -145,7 +145,7 @@ class ReadinessCheckSpecTest extends UnitTest {
     )
 
     def taskWithPorts = {
-      val task: Task.LaunchedEphemeral = TestTaskBuilder.Helper.runningTaskForApp(appId)
+      val task: Task = TestTaskBuilder.Helper.runningTaskForApp(appId)
       task.copy(status = task.status.copy(networkInfo = NetworkInfo(hostName, hostPorts = Seq(80, 81), ipAddresses = Nil)))
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
@@ -4,9 +4,8 @@ package core.task
 import mesosphere.UnitTest
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.TestTaskBuilder
+import mesosphere.marathon.core.instance.{ Instance, LocalVolumeId, TestTaskBuilder }
 import mesosphere.marathon.core.pod.{ ContainerNetwork, HostNetwork }
-import mesosphere.marathon.core.task.Task.LocalVolumeId
 import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
 import mesosphere.marathon.core.task.state.{ NetworkInfo, NetworkInfoPlaceholder }
 import mesosphere.marathon.core.task.update.{ TaskUpdateEffect, TaskUpdateOperation }
@@ -159,16 +158,17 @@ class TaskTest extends UnitTest with Inside {
 
       val condition = Condition.Reserved
       val taskId = Task.Id.forRunSpec(f.appWithIpAddress.id)
-      val reservation = mock[Task.Reservation]
       val status = Task.Status(f.clock.now, None, None, condition, NetworkInfoPlaceholder())
-      val task = Task.Reserved(taskId, reservation, status, f.clock.now)
+      val task = Task(taskId, f.clock.now, status)
+      val instance = mock[Instance]
+      instance.hasReservation returns true
 
       val mesosStatus = MesosTaskStatusTestHelper.running(taskId)
       val op = TaskUpdateOperation.MesosUpdate(Condition.Running, mesosStatus, f.clock.now)
 
-      inside(task.update(op)) {
+      inside(task.update(instance, op)) {
         case effect: TaskUpdateEffect.Update =>
-          effect.newState shouldBe a[Task.LaunchedOnReservation]
+          effect.newState shouldBe a[Task]
       }
     }
 
@@ -177,12 +177,13 @@ class TaskTest extends UnitTest with Inside {
 
       val condition = Condition.Running
       val taskId = Task.Id.forRunSpec(f.appWithIpAddress.id)
-      val reservation = mock[Task.Reservation]
       val status = Task.Status(
         stagedAt = f.clock.now,
         startedAt = Some(f.clock.now),
         mesosStatus = None, condition, NetworkInfoPlaceholder())
-      val task = Task.LaunchedOnReservation(taskId, f.clock.now, status, reservation)
+      val task = Task(taskId, f.clock.now, status)
+      val instance = mock[Instance]
+      instance.hasReservation returns true
 
       val containerStatus = MarathonTestHelper.containerStatusWithNetworkInfo(f.networkWithOneIp1)
 
@@ -197,7 +198,7 @@ class TaskTest extends UnitTest with Inside {
       task.status.networkInfo.ipAddresses shouldBe Nil
 
       Then("MesosUpdate TASK_RUNNING is applied with containing NetworkInfo")
-      inside(task.update(op)) {
+      inside(task.update(instance, op)) {
         case effect: TaskUpdateEffect.Update =>
           Then("NetworkInfo should be updated")
           effect.newState.status.networkInfo.ipAddresses shouldBe Seq(f.ipAddress1)
@@ -209,12 +210,13 @@ class TaskTest extends UnitTest with Inside {
 
       val condition = Condition.Staging
       val taskId = Task.Id.forRunSpec(f.appWithIpAddress.id)
-      val reservation = mock[Task.Reservation]
       val status = Task.Status(
         stagedAt = f.clock.now,
         startedAt = None,
         mesosStatus = None, condition, NetworkInfoPlaceholder())
-      val task = Task.LaunchedOnReservation(taskId, f.clock.now, status, reservation)
+      val task = Task(taskId, f.clock.now, status)
+      val instance = mock[Instance]
+      instance.hasReservation returns true
 
       val containerStatus = MarathonTestHelper.containerStatusWithNetworkInfo(f.networkWithOneIp1)
 
@@ -229,7 +231,7 @@ class TaskTest extends UnitTest with Inside {
       task.status.networkInfo.ipAddresses shouldBe Nil
 
       Then("MesosUpdate TASK_RUNNING is applied with containing NetworkInfo")
-      inside(task.update(op)) {
+      inside(task.update(instance, op)) {
         case effect: TaskUpdateEffect.Update =>
           Then("NetworkInfo should be updated")
           effect.newState.status.networkInfo.ipAddresses shouldBe Seq(f.ipAddress1)
@@ -241,14 +243,15 @@ class TaskTest extends UnitTest with Inside {
 
       val condition = Condition.Reserved
       val taskId = Task.Id.forRunSpec(f.appWithIpAddress.id)
-      val reservation = mock[Task.Reservation]
       val status = Task.Status(f.clock.now, None, None, condition, NetworkInfoPlaceholder())
-      val task = Task.Reserved(taskId, reservation, status, f.clock.now)
+      val task = Task(taskId, f.clock.now, status)
       val newTaskId = Task.Id.forResidentTask(task.taskId)
+      val instance = mock[Instance]
+      instance.hasReservation returns true
 
       val op = TaskUpdateOperation.LaunchOnReservation(newTaskId, f.clock.now, status)
 
-      val effect = task.update(op)
+      val effect = task.update(instance, op)
 
       effect shouldBe a[TaskUpdateEffect.Update]
     }
@@ -267,38 +270,11 @@ class TaskTest extends UnitTest with Inside {
   }
 
   "json serialization" should {
-    "round trip serialize a LaunchedEphemeral task" in {
+    "round trip serialize a Task" in {
       val f = new Fixture
-      val launchedEphemeral: Task.LaunchedEphemeral = TestTaskBuilder.Helper.minimalRunning(
+      val task: Task = TestTaskBuilder.Helper.minimalRunning(
         f.appWithoutIpAddress.id, Condition.Running, f.clock.now)
-      Json.toJson(launchedEphemeral).as[Task] shouldBe launchedEphemeral
-    }
-
-    "round trip serialize a Reserved task" in {
-      val f = new Fixture
-      val reservedTask: Task.Reserved = TestTaskBuilder.Helper.residentReservedTask(
-        f.appWithoutIpAddress.id,
-        taskReservationState = Task.Reservation.State.New(None),
-        Seq(
-          LocalVolumeId(f.appWithIpAddress.id, "very-path", "deadbeef-1234-0000-0000-000000000000"),
-          LocalVolumeId(f.appWithIpAddress.id, "very-path", "deadbeef-5678-0000-0000-000000000000")
-        )
-      )
-
-      Json.toJson(reservedTask).as[Task] shouldBe reservedTask
-    }
-
-    "round trip serialize a LaunchedOnReservation task" in {
-      val f = new Fixture
-      val launchedTask: Task.LaunchedOnReservation = TestTaskBuilder.Helper.residentLaunchedTask(
-        f.appWithoutIpAddress.id,
-        Seq(
-          LocalVolumeId(f.appWithIpAddress.id, "very-path", "deadbeef-1234-0000-0000-000000000000"),
-          LocalVolumeId(f.appWithIpAddress.id, "very-path", "deadbeef-5678-0000-0000-000000000000")
-        )
-      )
-
-      Json.toJson(launchedTask).as[Task] shouldBe launchedTask
+      Json.toJson(task).as[Task] shouldBe task
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
@@ -169,6 +169,8 @@ class TaskTest extends UnitTest with Inside {
       inside(task.update(instance, op)) {
         case effect: TaskUpdateEffect.Update =>
           effect.newState shouldBe a[Task]
+          effect.newState.status.condition shouldBe Condition.Running
+          effect.newState.status.mesosStatus shouldBe Some(op.taskStatus)
       }
     }
 

--- a/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
@@ -8,11 +8,11 @@ import akka.testkit.TestProbe
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.instance.update.{ InstanceUpdateEffect, InstanceUpdateOperation }
-import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
+import mesosphere.marathon.core.instance.{ Instance, Reservation, TestInstanceBuilder }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
-import mesosphere.marathon.core.task.tracker.{ InstanceTracker, InstanceStateOpProcessor }
+import mesosphere.marathon.core.task.tracker.{ InstanceStateOpProcessor, InstanceTracker }
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.test.MarathonTestHelper
 import org.apache.mesos.SchedulerDriver
@@ -163,11 +163,10 @@ class OverdueTasksActorTest extends AkkaUnitTest {
     }
   }
   private[this] def reservedWithTimeout(appId: PathId, deadline: Timestamp): Instance = {
-    val state = Task.Reservation.State.New(timeout = Some(Task.Reservation.Timeout(
+    val state = Reservation.State.New(timeout = Some(Reservation.Timeout(
       initiated = Timestamp.zero,
       deadline = deadline,
-      reason = Task.Reservation.Timeout.Reason.ReservationTimeout
-    )))
-    TestInstanceBuilder.newBuilder(appId).addTaskWithBuilder().taskResidentReserved(state).build().getInstance()
+      reason = Reservation.Timeout.Reason.ReservationTimeout)))
+    TestInstanceBuilder.newBuilder(appId).addTaskResidentReserved(state).getInstance()
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillActionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillActionTest.scala
@@ -3,8 +3,7 @@ package core.task.termination.impl
 
 import mesosphere.UnitTest
 import mesosphere.marathon.test.SettableClock
-import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
-import mesosphere.marathon.core.task.Task.LocalVolumeId
+import mesosphere.marathon.core.instance.{ Instance, LocalVolumeId, TestInstanceBuilder }
 import mesosphere.marathon.state.PathId
 import org.scalatest.prop.TableDrivenPropertyChecks
 
@@ -15,13 +14,11 @@ class KillActionTest extends UnitTest with TableDrivenPropertyChecks {
 
   lazy val localVolumeId = LocalVolumeId(appId, "unwanted-persistent-volume", "uuid1")
   lazy val residentLaunchedInstance: Instance = TestInstanceBuilder.newBuilder(appId).
-    addTaskResidentLaunched(localVolumeId).
+    addTaskResidentLaunched(Seq(localVolumeId)).
     getInstance()
 
   lazy val residentUnreachableInstance: Instance = TestInstanceBuilder.newBuilder(appId).
-    addTaskWithBuilder().
-    taskResidentUnreachable(localVolumeId).
-    build().
+    addTaskResidentUnreachable(Seq(localVolumeId)).
     getInstance()
 
   lazy val unreachableInstance: Instance = TestInstanceBuilder.newBuilder(appId).addTaskUnreachable().getInstance()

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillActionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillActionTest.scala
@@ -18,7 +18,7 @@ class KillActionTest extends UnitTest with TableDrivenPropertyChecks {
     getInstance()
 
   lazy val residentUnreachableInstance: Instance = TestInstanceBuilder.newBuilder(appId).
-    addTaskResidentUnreachable(Seq(localVolumeId)).
+    addTaskUnreachable(Seq(localVolumeId)).
     getInstance()
 
   lazy val unreachableInstance: Instance = TestInstanceBuilder.newBuilder(appId).addTaskUnreachable().getInstance()

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceStateOpProcessorDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceStateOpProcessorDelegateTest.scala
@@ -120,7 +120,7 @@ class InstanceStateOpProcessorDelegateTest extends AkkaUnitTest {
       val f = new Fixture
       val appId: PathId = PathId("/test")
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(appId).getInstance()
-      val task: Task.LaunchedEphemeral = instance.appTask
+      val task: Task = instance.appTask
       val taskIdString = task.taskId.idString
       val now = f.clock.now()
 
@@ -146,7 +146,7 @@ class InstanceStateOpProcessorDelegateTest extends AkkaUnitTest {
       val f = new Fixture
       val appId: PathId = PathId("/test")
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(appId).getInstance()
-      val task: Task.LaunchedEphemeral = instance.appTask
+      val task: Task = instance.appTask
       val taskId = task.taskId
       val now = f.clock.now()
 

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImplTest.scala
@@ -110,7 +110,7 @@ class PostToEventStreamStepImplTest extends UnitTest {
     val instanceState = InstanceState(Condition.Running, clock.now(), Some(clock.now()), healthy = None)
     val instance = Instance(
       Instance.Id("foobar.instance-baz"), agentInfo, instanceState, Map.empty, clock.now(),
-      UnreachableStrategy.default()
+      UnreachableStrategy.default(), None
     )
     val eventStream = mock[EventStream]
 

--- a/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
@@ -479,7 +479,7 @@ object PodStatusConversionTest {
         activeSince = if (condition == core.condition.Condition.Created) None else Some(since),
         healthy = None),
       tasksMap = Seq[core.task.Task](
-        core.task.Task.LaunchedEphemeral(
+        core.task.Task(
           taskIds.head,
           since,
           core.task.Task.Status(
@@ -492,7 +492,8 @@ object PodStatusConversionTest {
         )
       ).map(t => t.taskId -> t)(collection.breakOut),
       runSpecVersion = pod.version,
-      unreachableStrategy = state.UnreachableStrategy.default()
+      unreachableStrategy = state.UnreachableStrategy.default(),
+      reservation = None
     )
 
     InstanceFixture(since, agentInfo, taskIds, instance)
@@ -500,7 +501,7 @@ object PodStatusConversionTest {
 
   def fakeTask(networks: Seq[Protos.NetworkInfo]) = {
     val taskId = core.task.Task.Id.forRunSpec(PathId.empty)
-    core.task.Task.LaunchedEphemeral(
+    core.task.Task(
       taskId = taskId,
       status = core.task.Task.Status(
         stagedAt = Timestamp.zero,

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
@@ -89,7 +89,7 @@ class AppDefinitionPortAssignmentsTest extends UnitTest {
       val app = MarathonTestHelper.makeBasicApp()
 
       Given("A reserved task")
-      val task = TestTaskBuilder.Helper.minimalReservedTask(app.id, TestTaskBuilder.Helper.taskReservationStateNew, localVolumeIds = Seq.empty)
+      val task = TestTaskBuilder.Helper.minimalReservedTask(app.id)
 
       Then("The port assignments are empty")
       task.status.networkInfo.portAssignments(app, includeUnresolved = true) should be(empty)

--- a/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/AppDefinitionPortAssignmentsTest.scala
@@ -89,7 +89,7 @@ class AppDefinitionPortAssignmentsTest extends UnitTest {
       val app = MarathonTestHelper.makeBasicApp()
 
       Given("A reserved task")
-      val task = TestTaskBuilder.Helper.minimalReservedTask(app.id)
+      val task = TestTaskBuilder.Helper.residentReservedTask(app.id)
 
       Then("The port assignments are empty")
       task.status.networkInfo.portAssignments(app, includeUnresolved = true) should be(empty)

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
@@ -24,7 +24,7 @@ class InstanceOpFactoryHelperTest extends UnitTest {
 
       Given("A non-matching task and taskInfo")
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(f.runSpecId).getInstance()
-      val task: Task.LaunchedEphemeral = instance.appTask
+      val task: Task = instance.appTask
       val taskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forRunSpec(f.runSpecId)).build()
 
       When("We create a launch operation")
@@ -41,7 +41,7 @@ class InstanceOpFactoryHelperTest extends UnitTest {
 
       Given("a task and a taskInfo")
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(f.runSpecId).getInstance()
-      val task: Task.LaunchedEphemeral = instance.appTask
+      val task: Task = instance.appTask
       val taskInfo = MarathonTestHelper.makeOneCPUTask(task.taskId).build()
 
       When("We create a launch operation")

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -492,11 +492,7 @@ object MarathonTestHelper {
     implicit class TaskImprovements(task: Task) {
       def withNetworkInfo(networkInfo: core.task.state.NetworkInfo): Task = {
         val newStatus = task.status.copy(networkInfo = networkInfo)
-        task match {
-          case launchedEphemeral: Task => launchedEphemeral.copy(status = newStatus)
-          case launchedOnReservation: Task => launchedOnReservation.copy(status = newStatus)
-          case reserved: Task => reserved.copy(status = newStatus)
-        }
+        task.copy(status = newStatus)
       }
 
       def withNetworkInfo(hostName: Option[String] = None, hostPorts: Seq[Int] = Nil, networkInfos: scala.collection.Seq[NetworkInfo] = Nil): Task = {
@@ -521,17 +517,7 @@ object MarathonTestHelper {
         withNetworkInfo(networkInfo).withStatus(_.copy(mesosStatus = taskStatus))
       }
 
-      def withStatus[T <: Task](update: Task.Status => Task.Status): T = task match {
-        case launchedEphemeral: Task =>
-          launchedEphemeral.copy(status = update(launchedEphemeral.status)).asInstanceOf[T]
-
-        case launchedOnReservation: Task =>
-          launchedOnReservation.copy(status = update(launchedOnReservation.status)).asInstanceOf[T]
-
-        case reserved: Task =>
-          throw new scala.RuntimeException("Reserved task cannot have a status")
-      }
-
+      def withStatus(update: Task.Status => Task.Status): Task = task.copy(status = update(task.status))
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.Protos.Constraint.Operator
 import mesosphere.marathon.api.JsonTestHelper
 import mesosphere.marathon.core.async.ExecutionContexts
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.{ Instance, LocalVolumeId }
 import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.core.instance.update.InstanceChangeHandler
 import mesosphere.marathon.core.launcher.impl.{ ReservationLabels, TaskLabels }
@@ -383,7 +383,8 @@ object MarathonTestHelper {
     state = InstanceState(Condition.Created, since = clock.now(), None, healthy = None),
     tasksMap = Map.empty[Task.Id, Task],
     runSpecVersion = clock.now(),
-    UnreachableStrategy.default()
+    UnreachableStrategy.default(),
+    None
   )
 
   def createTaskTracker(
@@ -392,7 +393,7 @@ object MarathonTestHelper {
     createTaskTrackerModule(leadershipModule, store).instanceTracker
   }
 
-  def persistentVolumeResources(taskId: Task.Id, localVolumeIds: Task.LocalVolumeId*) = localVolumeIds.map { id =>
+  def persistentVolumeResources(taskId: Task.Id, localVolumeIds: LocalVolumeId*) = localVolumeIds.map { id =>
     Mesos.Resource.newBuilder()
       .setName("disk")
       .setType(Mesos.Value.Type.SCALAR)
@@ -412,14 +413,14 @@ object MarathonTestHelper {
       .build()
   }
 
-  def offerWithVolumes(taskId: Task.Id, localVolumeIds: Task.LocalVolumeId*) = {
+  def offerWithVolumes(taskId: Task.Id, localVolumeIds: LocalVolumeId*) = {
     MarathonTestHelper.makeBasicOffer(
       reservation = Some(TaskLabels.labelsForTask(frameworkId, taskId)),
       role = "test"
     ).addAllResources(persistentVolumeResources(taskId, localVolumeIds: _*).asJava).build()
   }
 
-  def offerWithVolumes(taskId: Task.Id, hostname: String, agentId: String, localVolumeIds: Task.LocalVolumeId*) = {
+  def offerWithVolumes(taskId: Task.Id, hostname: String, agentId: String, localVolumeIds: LocalVolumeId*) = {
     MarathonTestHelper.makeBasicOffer(
       reservation = Some(TaskLabels.labelsForTask(frameworkId, taskId)),
       role = "test"
@@ -428,7 +429,7 @@ object MarathonTestHelper {
       .addAllResources(persistentVolumeResources(taskId, localVolumeIds: _*).asJava).build()
   }
 
-  def offerWithVolumesOnly(taskId: Task.Id, localVolumeIds: Task.LocalVolumeId*) = {
+  def offerWithVolumesOnly(taskId: Task.Id, localVolumeIds: LocalVolumeId*) = {
     MarathonTestHelper.makeBasicOffer()
       .clearResources()
       .addAllResources(persistentVolumeResources(taskId, localVolumeIds: _*).asJava)
@@ -492,9 +493,9 @@ object MarathonTestHelper {
       def withNetworkInfo(networkInfo: core.task.state.NetworkInfo): Task = {
         val newStatus = task.status.copy(networkInfo = networkInfo)
         task match {
-          case launchedEphemeral: Task.LaunchedEphemeral => launchedEphemeral.copy(status = newStatus)
-          case launchedOnReservation: Task.LaunchedOnReservation => launchedOnReservation.copy(status = newStatus)
-          case reserved: Task.Reserved => reserved.copy(status = newStatus)
+          case launchedEphemeral: Task => launchedEphemeral.copy(status = newStatus)
+          case launchedOnReservation: Task => launchedOnReservation.copy(status = newStatus)
+          case reserved: Task => reserved.copy(status = newStatus)
         }
       }
 
@@ -521,13 +522,13 @@ object MarathonTestHelper {
       }
 
       def withStatus[T <: Task](update: Task.Status => Task.Status): T = task match {
-        case launchedEphemeral: Task.LaunchedEphemeral =>
+        case launchedEphemeral: Task =>
           launchedEphemeral.copy(status = update(launchedEphemeral.status)).asInstanceOf[T]
 
-        case launchedOnReservation: Task.LaunchedOnReservation =>
+        case launchedOnReservation: Task =>
           launchedOnReservation.copy(status = update(launchedOnReservation.status)).asInstanceOf[T]
 
-        case reserved: Task.Reserved =>
+        case reserved: Task =>
           throw new scala.RuntimeException("Reserved task cannot have a status")
       }
 

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -4,7 +4,7 @@ import mesosphere.UnitTest
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.Protos.Constraint.Operator
 import mesosphere.marathon._
-import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
+import mesosphere.marathon.core.instance.{ Instance, LocalVolumeId, TestInstanceBuilder }
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
 import mesosphere.marathon.core.task.Task
@@ -825,8 +825,8 @@ class ResourceMatcherTest extends UnitTest with Inside {
           volumes = List(volume))))
 
       // Since offer matcher checks the instance version it's should be >= app.version
-      val instance = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskReserved(
-        Task.LocalVolumeId(app.id, persistentVolume, mount))
+      val instance = TestInstanceBuilder.newBuilder(app.id, version = app.version)
+        .addTaskReserved(Seq(LocalVolumeId(app.id, persistentVolume, mount)))
         .getInstance()
 
       val response = ResourceMatcher.matchResources(
@@ -855,8 +855,8 @@ class ResourceMatcherTest extends UnitTest with Inside {
           volumes = List(volume))))
 
       // Since offer matcher checks the instance version it's should be >= app.version
-      val instance = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskReserved(
-        Task.LocalVolumeId(app.id, persistentVolume, mount))
+      val instance = TestInstanceBuilder.newBuilder(app.id, version = app.version)
+        .addTaskReserved(Seq(LocalVolumeId(app.id, persistentVolume, mount)))
         .getInstance()
 
       val response = ResourceMatcher.matchResources(


### PR DESCRIPTION
Once reservations are moved to instances, it makes sense to get rid of the task polymorphism, since reservations essentially are the only differentiator of different kinds of tasks.

JIRA issues:
https://jira.mesosphere.com/browse/MARATHON_EE-1786
https://jira.mesosphere.com/browse/MARATHON_EE-1787