### PR TITLE
Use new Jenkins Debian Stretch node with Python 3.6.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 ansiColor('xterm') {
-  node('JenkinsMarathonCI-Debian8-2017-10-23') {
+  node('JenkinsMarathonCI-Debian8-2018-01-02') {
     stage("Run Pipeline") {
       try {
         checkout scm

--- a/ami/AMI.md
+++ b/ami/AMI.md
@@ -8,9 +8,7 @@ Documentation on provisioning new AMI for jenkins: https://wiki.mesosphere.com/d
 Mesos version used by marathon: https://github.com/mesosphere/marathon/blob/master/project/Dependencies.scala#L87
 
 ```bash
-packer build -color \
-    -var 'aws_access_key=%AWS_ACCESS_KEY' \
-    -var 'aws_secret_key=%AWS_SECRET_KEY' \
+AWS_PROFILE=%AWS_PROFILE packer build -color \
     -var 'ami_name=%AMI_NAME' \
     -var 'mesos_version=%MESOS_VERSION' \
     marathon-jenkins-ami.json

--- a/ami/install.bash
+++ b/ami/install.bash
@@ -1,47 +1,45 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Enable Jessie backports to install the latest Java JRE.
-cat <<EOF >>/etc/apt/sources.list
-
-# Debian backports
-deb http://httpredir.debian.org/debian jessie-backports main
-EOF
+apt-get install -y dirmngr
 
 # Add sbt repo.
 echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
 
 # Add Docker repo.
-echo "deb https://apt.dockerproject.org/repo debian-jessie main" | tee -a /etc/apt/sources.list.d/docker.list
+echo "deb https://apt.dockerproject.org/repo debian-stretch main" | tee -a /etc/apt/sources.list.d/docker.list
 apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 
 # Add Mesos repo.
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
-  echo "deb http://repos.mesosphere.com/debian jessie-unstable main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
-  echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
-  echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
-
-  apt-get -y update
+  echo "deb http://repos.mesosphere.com/debian stretch-unstable main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+  echo "deb http://repos.mesosphere.com/debian stretch-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+  echo "deb http://repos.mesosphere.com/debian stretch main" | tee -a /etc/apt/sources.list.d/mesosphere.list
+apt-get -y update
 
 # Add github.com to known hosts
 ssh-keyscan github.com >> /home/admin/.ssh/known_hosts
 ssh-keyscan github.com >> /root/.ssh/known_hosts
 
 # Install dependencies
-apt install -t jessie-backports -y openjdk-8-jdk
-update-java-alternatives -s java-1.8.0-openjdk-amd64
-
 apt-get install -y \
         build-essential \
         curl \
         docker-engine \
         git \
-        npm \
-        python3.6 \
-        python3-pip \
-        rpm \
-        sbt
+        openjdk-8-jdk \
+        libssl-dev \
+        sbt \
+        zlib1g-dev
+
+# Download, compile and install Python 3.6.2
+wget https://www.python.org/ftp/python/3.6.2/Python-3.6.2.tgz
+tar xvf Python-3.6.2.tgz && cd Python-3.6.2/
+./configure --enable-optimizations
+make -j
+sudo make altinstall
+cd ../ && rm -r Python-3.6.2
 
 # Download (but don't install) Mesos and its dependencies.
 # The CI task will install Mesos later.

--- a/ami/install.bash
+++ b/ami/install.bash
@@ -41,6 +41,13 @@ make -j
 sudo make altinstall
 cd ../ && rm -r Python-3.6.2
 
+# Install pip
+wget https://bootstrap.pypa.io/get-pip.py
+python3 get-pip.py
+
+# Install falke8
+pip3 install flake8
+
 # Download (but don't install) Mesos and its dependencies.
 # The CI task will install Mesos later.
 apt-get install -y --force-yes --no-install-recommends mesos=$MESOS_VERSION
@@ -62,9 +69,6 @@ curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq
 
 # Install Ammonite
 curl -L -o /usr/local/bin/amm https://github.com/lihaoyi/Ammonite/releases/download/0.8.2/2.12-0.8.2 && sudo chmod +x /usr/local/bin/amm
-
-# Install falke8
-pip3 install flake8
 
 # Warmup ivy2 cache. Note: `sbt` is later executed with `sudo` and Debian `sudo` modifies $HOME
 # so we need ivy2 cache in `/root`

--- a/ami/install.bash
+++ b/ami/install.bash
@@ -38,6 +38,7 @@ apt-get install -y \
         docker-engine \
         git \
         npm \
+        python3.6 \
         python3-pip \
         rpm \
         sbt

--- a/ami/marathon-jenkins-ami.json
+++ b/ami/marathon-jenkins-ami.json
@@ -12,11 +12,12 @@
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
-    "source_ami": "ami-9d6c128a",
+    "source_ami": "ami-f6e6948c",
     "instance_type": "m4.xlarge",
     "vpc_id": "vpc-f46c7c8d",
     "subnet_id": "subnet-1d724531",
     "ssh_username": "admin",
+    "run_tags": {"created_by": "jenkins"},
     "ami_name": "{{user `ami_name`}}",
     "ami_users": ["633059600857", "540164828399"],
     "ami_block_device_mappings": [{

--- a/ami/marathon-jenkins-ami.json
+++ b/ami/marathon-jenkins-ami.json
@@ -9,8 +9,6 @@
   },
   "builders": [{
     "type": "amazon-ebs",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
     "source_ami": "ami-f6e6948c",
     "instance_type": "m4.xlarge",
@@ -21,7 +19,7 @@
     "ami_name": "{{user `ami_name`}}",
     "ami_users": ["633059600857", "540164828399"],
     "ami_block_device_mappings": [{
-      "device_name": "/dev/xvda",
+      "device_name": "xvda",
       "volume_type": "gp2",
       "volume_size": 40,
       "delete_on_termination": true


### PR DESCRIPTION
Summary:
Python 3.6 is required for asynchronous system integration tests.
