### PR TITLE
Do not log port when config is invalid.

### DIFF
--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -1,6 +1,5 @@
 package mesosphere.marathon
 
-import java.lang.Thread.UncaughtExceptionHandler
 import java.net.URI
 
 import akka.actor.ActorSystem
@@ -31,11 +30,9 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
 
   SLF4JBridgeHandler.removeHandlersForRootLogger()
   SLF4JBridgeHandler.install()
-  Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler {
-    override def uncaughtException(thread: Thread, throwable: Throwable): Unit = {
-      logger.error(s"Terminating ${cliConf.httpPort()} due to uncaught exception in thread ${thread.getName}:${thread.getId}", throwable)
-      Runtime.getRuntime.asyncExit()(ExecutionContexts.global)
-    }
+  Thread.setDefaultUncaughtExceptionHandler((thread: Thread, throwable: Throwable) => {
+    logger.error(s"Terminating due to uncaught exception in thread ${thread.getName}:${thread.getId}", throwable)
+    Runtime.getRuntime.asyncExit()(ExecutionContexts.global)
   })
 
   private val EnvPrefix = "MARATHON_CMD_"


### PR DESCRIPTION
When the configuration is invalid config might be `null` so it
will cause NPE when we try to log it. This patch removes logging
of a port that causes NPE.

JIRA issues: MARATHON-7998
