### PR TITLE
Rename to AgentMaintenance, add it to queue stats

### DIFF
--- a/src/main/scala/mesosphere/mesos/NoOfferMatchReason.scala
+++ b/src/main/scala/mesosphere/mesos/NoOfferMatchReason.scala
@@ -12,7 +12,7 @@ object NoOfferMatchReason {
   case object InsufficientPorts extends NoOfferMatchReason
   case object UnfulfilledRole extends NoOfferMatchReason
   case object UnfulfilledConstraint extends NoOfferMatchReason
-  case object AgentUnavailable extends NoOfferMatchReason
+  case object AgentMaintenance extends NoOfferMatchReason
   case object NoCorrespondingReservationFound extends NoOfferMatchReason
 
   /**
@@ -24,6 +24,7 @@ object NoOfferMatchReason {
     UnfulfilledRole,
     UnfulfilledConstraint,
     NoCorrespondingReservationFound,
+    AgentMaintenance,
     InsufficientCpus,
     InsufficientMemory,
     InsufficientDisk,

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -228,7 +228,7 @@ object ResourceMatcher extends StrictLogging {
         val result = Availability.offerAvailable(offer, conf.drainingTime)
         noOfferMatchReasons += NoOfferMatchReason.UnfulfilledConstraint
         // Add unavailability to noOfferMatchReasons
-        noOfferMatchReasons += NoOfferMatchReason.AgentUnavailable
+        noOfferMatchReasons += NoOfferMatchReason.AgentMaintenance
         logger.info(
           s"Offer [${offer.getId.getValue}]. Agent [${offer.getSlaveId}] on host [${offer.getHostname}] unavailable.\n"
         )


### PR DESCRIPTION
Summary:
AgentMaintenance seems like a better name for the offer rejection.
Also it is not included in rejection stats in queue - I think the reason for that is that it was missing in reasonFunnel.

JIRA issues: MARATHON-7999
