### PR TITLE
Benchmark and speed up group validation.

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -4,6 +4,7 @@ package state
 import java.util.concurrent.TimeUnit
 
 import mesosphere.marathon.core.pod.BridgeNetwork
+import mesosphere.marathon.api.v2.Validation
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
@@ -24,7 +25,8 @@ class GroupBenchmark {
         Container.Docker(Nil, "alpine", List(Container.PortMapping(2015, Some(0), 10000, "tcp", Some("thing")))))
     )
 
-  @Param(value = Array("2", "10", "100", "1000"))
+  //@Param(value = Array("2", "10", "100", "1000"))
+  @Param(value = Array("2", "10", "100"))
   var appsPerGroup: Int = _
   lazy val appIds = 0 until appsPerGroup
 
@@ -76,5 +78,10 @@ class RootGroupBenchmark extends GroupBenchmark {
   def buildRootGroup(hole: Blackhole): Unit = {
     val root = fillRootGroup()
     hole.consume(root)
+  }
+
+  @Benchmark
+  def validateRootGroup(hole: Blackhole): Unit = {
+    Validation.validateOrThrow(rootGroup)(RootGroup.rootGroupValidator(Set.empty))
   }
 }

--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -25,8 +25,7 @@ class GroupBenchmark {
         Container.Docker(Nil, "alpine", List(Container.PortMapping(2015, Some(0), 10000, "tcp", Some("thing")))))
     )
 
-  //@Param(value = Array("2", "10", "100", "1000"))
-  @Param(value = Array("2", "10", "100"))
+  @Param(value = Array("2", "10", "100", "1000"))
   var appsPerGroup: Int = _
   lazy val appIds = 0 until appsPerGroup
 

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -453,17 +453,6 @@ object AppDefinition extends GeneralPurposeCombinators {
       app.dependencies is every(PathId.pathIdValidator)
     } and validBasicAppDefinition(enabledFeatures) and pluginValidators
 
-  /**
-    * Validator for apps, which are being part of a group.
-    *
-    * @param base Path of the parent group.
-    * @return
-    */
-  def validNestedAppDefinition(base: PathId, enabledFeatures: Set[String]): Validator[AppDefinition] =
-    validator[AppDefinition] { app =>
-      app.id is PathId.validPathWithBase(base)
-    } and validBasicAppDefinition(enabledFeatures)
-
   private def pluginValidators(implicit pluginManager: PluginManager): Validator[AppDefinition] =
     new Validator[AppDefinition] {
       override def apply(app: AppDefinition): Result = {

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -543,7 +543,7 @@ object AppDefinition extends GeneralPurposeCombinators {
         true
     }
 
-  private def validBasicAppDefinition(enabledFeatures: Set[String]) = validator[AppDefinition] { appDef =>
+  def validBasicAppDefinition(enabledFeatures: Set[String]) = validator[AppDefinition] { appDef =>
     appDef.upgradeStrategy is valid
     appDef.container is optional(Container.validContainer(appDef.networks, enabledFeatures))
     appDef.portDefinitions is PortDefinitions.portDefinitionsValidator

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -165,7 +165,7 @@ object Group extends StrictLogging {
       group.transitiveGroupValues as "groups" is every(
         noAppsAndPodsWithSameId and noAppsAndGroupsWithSameName and noPodsAndGroupsWithSameName
           and isTrue("Group has to be child of groups with parent id") { childGroup =>
-            if (childGroup.id.parent.isRoot) group.groupsById.contains(childGroup.id)
+            if (childGroup.id.parent == group.id) group.groupsById.contains(childGroup.id)
             else {
               group.group(childGroup.id.parent) match {
                 case None => false
@@ -196,7 +196,7 @@ object Group extends StrictLogging {
 
   private def isChildOfParentId(group: Group): Validator[AppDefinition] = {
     isTrue("App has to be child of group with parent id") { app =>
-      if (app.id.parent.isRoot) group.apps.contains(app.id)
+      if (app.id.parent == group.id) group.apps.contains(app.id)
       else {
         group.group(app.id.parent) match {
           case None => false

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -194,13 +194,19 @@ object Group extends StrictLogging {
     }
   }
 
+  /**
+    * An app validator to verify that the app is in a proper child group of group.
+    *
+    * @param group The parent group for all sub groups to check.
+    * @return The validator.
+    */
   private def isChildOfParentId(group: Group): Validator[AppDefinition] = {
     isTrue("App has to be child of group with parent id") { app =>
       if (app.id.parent == group.id) group.apps.contains(app.id)
       else {
         group.group(app.id.parent) match {
           case None => false
-          case Some(parentGroup) => parentGroup.apps.contains(app.id)
+          case Some(childGroup) => childGroup.apps.contains(app.id)
         }
       }
     }

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -161,7 +161,7 @@ object Group extends StrictLogging {
       group is noAppsAndPodsWithSameId
       group is noAppsAndGroupsWithSameName
       group is noPodsAndGroupsWithSameName
-      
+
       group.transitiveGroupValues as "groups" is every(
         noAppsAndPodsWithSameId and noAppsAndGroupsWithSameName and noPodsAndGroupsWithSameName
           and isTrue("Group has to be child of groups with parent id") { childGroup =>

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -153,8 +153,7 @@ object Group extends StrictLogging {
   def validGroup(base: PathId, enabledFeatures: Set[String]): Validator[Group] =
     validator[Group] { group =>
       group.id is validPathWithBase(base)
-      //      group.apps.values as "apps" is every(
-      //        AppDefinition.validNestedAppDefinition(group.id.canonicalPath(base), enabledFeatures))
+
       group.transitiveApps as "apps" is every(
         validator[AppDefinition] { app =>
           group.group(app.id.parent) match {
@@ -162,6 +161,7 @@ object Group extends StrictLogging {
             case Some(parentGroup) => validPathWithBase(parentGroup.id).apply(app.id)
           }
         })
+
       group is noAppsAndPodsWithSameId
       group is noAppsAndGroupsWithSameName
       group is noPodsAndGroupsWithSameName

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -255,7 +255,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Deployment" in withFixture() { f =>
       import f._
       val app = AppDefinition(
-        id = PathId("app1"),
+        id = PathId("/foo/app1"),
         cmd = Some("cmd"),
         instances = 2,
         upgradeStrategy = UpgradeStrategy(0.5),
@@ -321,7 +321,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Deployment fail to acquire lock" in withFixture() { f =>
       import f._
       val app = AppDefinition(
-        id = PathId("app1"),
+        id = PathId("/foo/app1"),
         cmd = Some("cmd"),
         instances = 2,
         upgradeStrategy = UpgradeStrategy(0.5),
@@ -349,7 +349,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Restart deployments after failover" in withFixture() { f =>
       import f._
       val app = AppDefinition(
-        id = PathId("app1"),
+        id = PathId("/foo/app1"),
         cmd = Some("cmd"),
         instances = 2,
         upgradeStrategy = UpgradeStrategy(0.5),
@@ -375,7 +375,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
     "Forced deployment" in withFixture() { f =>
       import f._
-      val app = AppDefinition(id = PathId("app1"), cmd = Some("cmd"), instances = 2, upgradeStrategy = UpgradeStrategy(0.5))
+      val app = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2, upgradeStrategy = UpgradeStrategy(0.5))
       val rootGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
 
       val plan = DeploymentPlan(createRootGroup(), rootGroup, id = Some("d1"))

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -49,7 +49,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
   "MarathonSchedulerActor" should {
     "RecoversDeploymentsAndReconcilesHealthChecksOnStart" in withFixture() { f =>
       import f._
-      val app = AppDefinition(id = "test-app".toPath, instances = 1, cmd = Some("sleep"))
+      val app = AppDefinition(id = "/test-app".toPath, instances = 1, cmd = Some("sleep"))
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
       schedulerActor ! LeadershipTransition.ElectedAsLeaderAndReady
@@ -187,13 +187,13 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
     "ScaleApp" in withFixture() { f =>
       import f._
-      val app = AppDefinition(id = "test-app-scale".toPath, instances = 1, cmd = Some("sleep"))
+      val app = AppDefinition(id = "/test-app-scale".toPath, instances = 1, cmd = Some("sleep"))
 
       queue.get(app.id) returns Some(LaunchQueueTestHelper.zeroCounts)
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
       schedulerActor ! LeadershipTransition.ElectedAsLeaderAndReady
-      schedulerActor ! ScaleRunSpec("test-app-scale".toPath)
+      schedulerActor ! ScaleRunSpec("/test-app-scale".toPath)
 
       eventually {
         verify(queue).add(app, 1)

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -3,7 +3,7 @@ package api.v2
 
 import com.wix.accord._
 import com.wix.accord.dsl._
-import mesosphere.UnitTest
+import mesosphere.{ UnitTest, ValidationTestLike }
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.core.pod.BridgeNetwork
 import mesosphere.marathon.raml.GroupUpdate
@@ -37,7 +37,7 @@ object ModelValidationTest {
     )
 }
 
-class ModelValidationTest extends UnitTest with GroupCreation {
+class ModelValidationTest extends UnitTest with GroupCreation with ValidationTestLike {
 
   import ModelValidationTest._
 
@@ -87,13 +87,17 @@ class ModelValidationTest extends UnitTest with GroupCreation {
         validate = false
       )
 
-      validate(rootGroup)(RootGroup.rootGroupValidator(Set())) match {
+      validate(rootGroup)(RootGroup.rootGroupValidator(Set())) should haveViolations(
+        "/apps//test/group1/invalid" -> "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'."
+      )
+      /*
+      match {
         case Success => fail()
         case f: Failure =>
           val errors = (Json.toJson(f) \ "details").as[Seq[JsObject]]
           errors should have size 1
           (errors.head \ "path").as[String] should be("/groups(0)/groups(0)/apps(1)")
-      }
+      }*/
     }
 
     "PortDefinition should be allowed to contain tcp and udp as protocol." in {

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -90,14 +90,6 @@ class ModelValidationTest extends UnitTest with GroupCreation with ValidationTes
       validate(rootGroup)(RootGroup.rootGroupValidator(Set())) should haveViolations(
         "/apps//test/group1/invalid" -> "AppDefinition must either contain one of 'cmd' or 'args', and/or a 'container'."
       )
-      /*
-      match {
-        case Success => fail()
-        case f: Failure =>
-          val errors = (Json.toJson(f) \ "details").as[Seq[JsObject]]
-          errors should have size 1
-          (errors.head \ "path").as[String] should be("/groups(0)/groups(0)/apps(1)")
-      }*/
     }
 
     "PortDefinition should be allowed to contain tcp and udp as protocol." in {

--- a/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
@@ -96,12 +96,12 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
     }
 
     "start from running group" in {
-      val app1 = AppDefinition("app".toPath, Some("sleep 10"))
-      val app2 = AppDefinition("app2".toPath, Some("cmd2"))
-      val app3 = AppDefinition("app3".toPath, Some("cmd3"))
-      val updatedApp1 = AppDefinition("app".toPath, Some("sleep 30"))
-      val updatedApp2 = AppDefinition("app2".toPath, Some("cmd2"), instances = 10)
-      val app4 = AppDefinition("app4".toPath, Some("cmd4"))
+      val app1 = AppDefinition("/group/app".toPath, Some("sleep 10"))
+      val app2 = AppDefinition("/group/app2".toPath, Some("cmd2"))
+      val app3 = AppDefinition("/group/app3".toPath, Some("cmd3"))
+      val updatedApp1 = AppDefinition("/group/app".toPath, Some("sleep 30"))
+      val updatedApp2 = AppDefinition("/group/app2".toPath, Some("cmd2"), instances = 10)
+      val app4 = AppDefinition("/group/app4".toPath, Some("cmd4"))
       val apps = Map(app1.id -> app1, app2.id -> app2, app3.id -> app3)
       val update = Map(updatedApp1.id -> updatedApp1, updatedApp2.id -> updatedApp2, app4.id -> app4)
 

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
@@ -30,14 +30,11 @@ import mesosphere.marathon.test.{ GroupCreation, MarathonTestHelper }
 import org.apache.mesos.SchedulerDriver
 import org.rogach.scallop.ScallopConf
 import org.scalatest.concurrent.Eventually
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 
 class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with GroupCreation with Eventually {
-
-  private[this] val log = LoggerFactory.getLogger(getClass)
 
   "DeploymentManager" should {
     "Deployment" in {

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
@@ -30,11 +30,14 @@ import mesosphere.marathon.test.{ GroupCreation, MarathonTestHelper }
 import org.apache.mesos.SchedulerDriver
 import org.rogach.scallop.ScallopConf
 import org.scalatest.concurrent.Eventually
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 
 class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with GroupCreation with Eventually {
+
+  private[this] val log = LoggerFactory.getLogger(getClass)
 
   "DeploymentManager" should {
     "Deployment" in {

--- a/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
@@ -33,11 +33,11 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "find an app without a parent" in {
       Given("an existing root group with an app without a parent")
-      val app = AppDefinition("app".toPath, cmd = Some("sleep"))
+      val app = AppDefinition("/app".toPath, cmd = Some("sleep"))
       val current = createRootGroup(apps = Map(app.id -> app))
 
       When("an app with a specific path is requested")
-      val path = PathId("app")
+      val path = PathId("/app")
 
       Then("the group is found")
       current.app(path) should be('defined)

--- a/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
@@ -491,7 +491,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "relative dependencies should be resolvable" in {
       Given("a group with an app having relative dependency")
-      val app1 = AppDefinition("app1".toPath, cmd = Some("foo"))
+      val app1 = AppDefinition("/group/app1".toPath, cmd = Some("foo"))
       val app2 = AppDefinition("/group/subgroup/app2".toPath, cmd = Some("bar"), dependencies = Set("../app1".toPath))
       val rootGroup = createRootGroup(groups = Set(
         createGroup("/group".toPath, apps = Map(app1.id -> app1),


### PR DESCRIPTION
Summary:
Traversing the groups recursively is slower than going over the flattened id.

This also includes a bug fix. The validation of
```
app.id is PathId.validPathWithBase(base)
```
as the based base was always the parent. The same holds up for
```
path is childOf(path.parent)
```

The invalid app definitions in the unit tests have been fixed as well.

Additionally this change introduces more expressive violations paths. See the unit test changes
for details.

JIRA issues: MARATHON_EE-883
