### PR TITLE
capital M for `Data Migration` in docs

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -137,7 +137,7 @@ layout: default
             </li>
             <li>
                 <a href="{{ site.baseurl }}/docs/data-migration.html">
-                    Data migration
+                    Data Migration
                 </a>
             </li>
             <li>

--- a/docs/docs/data-migration.md
+++ b/docs/docs/data-migration.md
@@ -1,8 +1,8 @@
 ---
-title: Data migration
+title: Data Migration
 ---
 
-# Data migration
+# Data Migration
 
 Marathon stores its data in ZooKeeper. When you upgrade Marathon, your data will be migrated, because different versions of Marathon can have different data layouts in ZooKeeper. When a newer version of Marathon becomes leader for the first time, it moves the data in ZooKeeper to the new layout.
 


### PR DESCRIPTION
In order to align the `Data Migration` section with the other headlines, the M should be capitalized.