### PR TITLE
 Persistent volumes for pods — ZK data migration 

### DIFF
--- a/src/main/scala/mesosphere/marathon/BuildInfo.scala
+++ b/src/main/scala/mesosphere/marathon/BuildInfo.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.io.IO
 case object BuildInfo {
   private val marathonJar = "\\bmesosphere\\.marathon\\.marathon-[0-9.]+".r
   lazy val DefaultMajor = 1
-  lazy val DefaultMinor = 5
+  lazy val DefaultMinor = 6
   lazy val DefaultPatch = 0
 
   lazy val DefaultBuildVersion = s"$DefaultMajor.$DefaultMinor.$DefaultPatch-SNAPSHOT"

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -70,7 +70,7 @@ class Migration(
       StorageVersions(1, 5, 2, StorageVersion.StorageFormat.PERSISTENCE_STORE) -> (() =>
         new MigrationTo152(instanceRepo).migrate()
       ),
-      StorageVersions(1, 5, 2, StorageVersion.StorageFormat.PERSISTENCE_STORE) -> (() =>
+      StorageVersions(1, 6, 0, StorageVersion.StorageFormat.PERSISTENCE_STORE) -> (() =>
         new MigrationTo160(instanceRepo, persistenceStore).migrate()
       )
     )

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -69,6 +69,9 @@ class Migration(
       ),
       StorageVersions(1, 5, 2, StorageVersion.StorageFormat.PERSISTENCE_STORE) -> (() =>
         new MigrationTo152(instanceRepo).migrate()
+      ),
+      StorageVersions(1, 5, 2, StorageVersion.StorageFormat.PERSISTENCE_STORE) -> (() =>
+        new MigrationTo160(instanceRepo, persistenceStore).migrate()
       )
     )
 

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
@@ -31,11 +31,7 @@ class MigrationTo160(instanceRepository: InstanceRepository, persistenceStore: P
 object MigrationTo160 extends StrictLogging {
   def migrateReservations(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _])(implicit env: Environment, ctx: ExecutionContext, mat: Materializer): Future[Done] = {
 
-    logger.info("Starting unreachable strategy migration to 1.6.0")
-
-    val migrateUnreachableStrategyWanted = env.vars.getOrElse(MigrationTo146.MigrateUnreachableStrategyEnvVar, "false")
-
-    if (migrateUnreachableStrategyWanted == "true") {
+    logger.info("Starting reservations migration to 1.6.0")
 
       val store: ZkPersistenceStore = {
         persistenceStore match {
@@ -93,9 +89,5 @@ object MigrationTo160 extends StrictLogging {
             instanceRepository.store(updatedInstance)
         }
         .runWith(Sink.ignore)
-    } else {
-      logger.info("No unreachable strategy migration to 1.6.0 wanted")
-      Future.successful(Done)
-    }
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
@@ -45,7 +45,7 @@ object MigrationTo160 extends StrictLogging {
           case lvcps: LazyVersionCachingPersistentStore[_, _, _] =>
             findZkStore(lvcps.store)
           case ltcps: LoadTimeCachingPersistenceStore[_, _, _] =>
-            findZkStore(ltcps)
+            findZkStore(ltcps.store)
           case other =>
             throw MigrationCancelledException(s"expected ZK persistent store, but found ${other.getClass.getName}", new RuntimeException)
         }

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
@@ -3,19 +3,16 @@ package storage.migration
 
 import java.time.OffsetDateTime
 
-import akka.{ Done, NotUsed }
+import akka.Done
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.stream.scaladsl.Sink
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.MigrationCancelledException
-import mesosphere.marathon.core.async.ExecutionContexts
 import mesosphere.marathon.core.instance.{ Instance, Reservation }
 import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.storage.store.impl.cache.{ LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore }
 import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
 import mesosphere.marathon.core.storage.store.impl.zk.{ ZkId, ZkPersistenceStore, ZkSerialized }
-import mesosphere.marathon.storage.migration.MigrationTo146.Environment
 import mesosphere.marathon.storage.repository.InstanceRepository
 import play.api.libs.json.{ JsValue, Json }
 
@@ -25,15 +22,28 @@ import scala.concurrent.{ ExecutionContext, Future }
 class MigrationTo160(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _])(implicit ctx: ExecutionContext, mat: Materializer) extends StrictLogging {
 
   def migrate(): Future[Done] = {
-    MigrationTo160.migrateReservations(instanceRepository, persistenceStore)(Environment(sys.env), ctx, mat)
+    MigrationTo160.migrateReservations(instanceRepository, persistenceStore)
   }
 }
 
 object MigrationTo160 extends StrictLogging {
-  def migrateReservations(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _])(implicit env: Environment, ctx: ExecutionContext, mat: Materializer): Future[Done] = {
+  /**
+    * This function traverse all the instances in the ZK, and moves reservation from task to the instance level
+    *
+    * @param instanceRepository
+    * @param persistenceStore
+    * @param ctx
+    * @param mat
+    * @return
+    */
+  def migrateReservations(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _])(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = {
 
     logger.info("Starting reservations migration to 1.6.0")
 
+    /**
+      * We're trying to find if we have a zookeeper store to make sure that migration will run in production environment
+      * and will be skipped in a unit test.
+      */
     val maybeStore: Option[ZkPersistenceStore] = {
 
       def findZkStore(ps: PersistenceStore[_, _, _]): Option[ZkPersistenceStore] = {
@@ -86,6 +96,11 @@ object MigrationTo160 extends StrictLogging {
         .mapConcat {
           case Some(jsValue) =>
             val instance = jsValue.as[Instance]
+            //prior to 1.6.0, only PVs are supported only with apps,
+            // therefore reservation can only appear in app instances,
+            // and in such of apps, taskMap has only one KV pair.
+            //
+            // We still use .headOption here to handle the case with empty reservation
             val maybeReservationJson = (jsValue \ "tasksMap" \\ "reservation").headOption
 
             maybeReservationJson.map { reservationJson =>

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
@@ -106,15 +106,16 @@ object MigrationTo160 extends StrictLogging {
 
           case _ => Nil
         }
-        .mapConcat { case (reservation, instance) =>
-          instance.reservation.map { reservation =>
-            //do nothing in case instance already contains some reservations, we don't want to not overwrite existing data
-            Nil
-          } getOrElse {
-            //no reservation on the instance level, updating instance with provided reservation
-            val updatedInstance = instance.copy(reservation = Some(reservation))
-            updatedInstance :: Nil
-          }
+        .mapConcat {
+          case (reservation, instance) =>
+            instance.reservation.map { reservation =>
+              //do nothing in case instance already contains some reservations, we don't want to not overwrite existing data
+              Nil
+            } getOrElse {
+              //no reservation on the instance level, updating instance with provided reservation
+              val updatedInstance = instance.copy(reservation = Some(reservation))
+              updatedInstance :: Nil
+            }
         }
         .mapAsync(1) { updatedInstance =>
           instanceRepository.store(updatedInstance)

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
@@ -3,23 +3,23 @@ package storage.migration
 
 import java.time.OffsetDateTime
 
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.MigrationCancelledException
 import mesosphere.marathon.core.async.ExecutionContexts
-import mesosphere.marathon.core.instance.{ Instance, Reservation }
+import mesosphere.marathon.core.instance.{Instance, Reservation}
 import mesosphere.marathon.core.instance.Instance.Id
-import mesosphere.marathon.core.storage.store.impl.cache.LazyCachingPersistenceStore
-import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
-import mesosphere.marathon.core.storage.store.impl.zk.{ ZkId, ZkPersistenceStore, ZkSerialized }
+import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
+import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkPersistenceStore, ZkSerialized}
 import mesosphere.marathon.storage.migration.MigrationTo146.Environment
 import mesosphere.marathon.storage.repository.InstanceRepository
-import play.api.libs.json.{ JsValue, Json }
+import play.api.libs.json.{JsValue, Json}
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 @SuppressWarnings(Array("ClassNames"))
 class MigrationTo160(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _])(implicit ctx: ExecutionContext, mat: Materializer) extends StrictLogging {
@@ -35,19 +35,23 @@ object MigrationTo160 extends StrictLogging {
     logger.info("Starting reservations migration to 1.6.0")
 
     val store: ZkPersistenceStore = {
-      persistenceStore match {
-        case zk: ZkPersistenceStore =>
-          zk
-        case lcps: LazyCachingPersistenceStore[_, _, _] =>
-          lcps.store match {
-            case zk: ZkPersistenceStore =>
-              zk
-            case other =>
-              throw MigrationCancelledException(s"expected ZK persistent store, but found ${other.getClass.getName}", new RuntimeException)
-          }
-        case other =>
-          throw MigrationCancelledException(s"expected ZK persistent store, but found ${other.getClass.getName}", new RuntimeException)
+
+      def findZkStore(ps: PersistenceStore[_, _, _]): ZkPersistenceStore = {
+        ps match {
+          case zk: ZkPersistenceStore =>
+            zk
+          case lcps: LazyCachingPersistenceStore[_, _, _] =>
+            findZkStore(lcps.store)
+          case lvcps: LazyVersionCachingPersistentStore[_, _, _] =>
+            findZkStore(lvcps.store)
+          case ltcps: LoadTimeCachingPersistenceStore[_, _, _] =>
+            findZkStore(ltcps)
+          case other =>
+            throw MigrationCancelledException(s"expected ZK persistent store, but found ${other.getClass.getName}", new RuntimeException)
+        }
       }
+
+      findZkStore(persistenceStore)
     }
 
     implicit val instanceResolver: IdResolver[Instance.Id, JsValue, String, ZkId] =

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
@@ -1,0 +1,101 @@
+package mesosphere.marathon
+package storage.migration
+
+import java.time.OffsetDateTime
+
+import akka.{ Done, NotUsed }
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.MigrationCancelledException
+import mesosphere.marathon.core.async.ExecutionContexts
+import mesosphere.marathon.core.instance.{ Instance, Reservation }
+import mesosphere.marathon.core.instance.Instance.Id
+import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
+import mesosphere.marathon.core.storage.store.impl.zk.{ ZkId, ZkPersistenceStore, ZkSerialized }
+import mesosphere.marathon.storage.migration.MigrationTo146.Environment
+import mesosphere.marathon.storage.repository.InstanceRepository
+import play.api.libs.json.{ JsValue, Json }
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+@SuppressWarnings(Array("ClassNames"))
+class MigrationTo160(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _])(implicit ctx: ExecutionContext, mat: Materializer) extends StrictLogging {
+
+  def migrate(): Future[Done] = {
+    MigrationTo160.migrateReservations(instanceRepository, persistenceStore)(Environment(sys.env), ctx, mat)
+  }
+}
+
+object MigrationTo160 extends StrictLogging {
+  def migrateReservations(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _])(implicit env: Environment, ctx: ExecutionContext, mat: Materializer): Future[Done] = {
+
+    logger.info("Starting unreachable strategy migration to 1.6.0")
+
+    val migrateUnreachableStrategyWanted = env.vars.getOrElse(MigrationTo146.MigrateUnreachableStrategyEnvVar, "false")
+
+    if (migrateUnreachableStrategyWanted == "true") {
+
+      val store: ZkPersistenceStore = {
+        persistenceStore match {
+          case zk: ZkPersistenceStore =>
+            zk
+          case other =>
+            throw MigrationCancelledException(s"expected ZK persistent store, but found ${other.getClass.getName}", new RuntimeException)
+        }
+      }
+
+      implicit val instanceResolver: IdResolver[Instance.Id, JsValue, String, ZkId] =
+        new IdResolver[Instance.Id, JsValue, String, ZkId] {
+          override def toStorageId(id: Id, version: Option[OffsetDateTime]): ZkId =
+            ZkId(category, id.idString, version)
+
+          override val category: String = "instance"
+
+          override def fromStorageId(key: ZkId): Id = Instance.Id(key.id)
+
+          override val hasVersions: Boolean = false
+
+          override def version(v: JsValue): OffsetDateTime = OffsetDateTime.MIN
+        }
+
+      implicit val instanceJsonUnmarshaller: Unmarshaller[ZkSerialized, JsValue] =
+        Unmarshaller.strict {
+          case ZkSerialized(byteString) =>
+            Json.parse(byteString.utf8String)
+        }
+
+      import Reservation.reservationFormat
+      import Instance.instanceJsonReads
+
+      instanceRepository
+        .ids()
+        .mapAsync(1) { instanceId =>
+          store.get(instanceId)
+        }
+        .mapConcat {
+          case Some(jsValue) =>
+            val instance = jsValue.as[Instance]
+            val maybeReservationJson = (jsValue \ "tasksMap" \\ "reservation").headOption
+
+            maybeReservationJson.map { reservationJson =>
+              reservationJson.as[Reservation] -> instance :: Nil
+            } getOrElse {
+              Nil
+            }
+
+          case _ => Nil
+        }
+        .mapAsync(1) {
+          case (reservation, instance) =>
+            val updatedInstance = instance.copy(reservation = Some(reservation))
+            instanceRepository.store(updatedInstance)
+        }
+        .runWith(Sink.ignore)
+    } else {
+      logger.info("No unreachable strategy migration to 1.6.0 wanted")
+      Future.successful(Done)
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/BuildInfoTest.scala
+++ b/src/test/scala/mesosphere/marathon/BuildInfoTest.scala
@@ -7,7 +7,7 @@ class BuildInfoTest extends UnitTest {
   "BuildInfo" should {
     "return a default versions" in {
       BuildInfo.scalaVersion should be("2.x.x")
-      BuildInfo.version should be("1.5.0-SNAPSHOT")
+      BuildInfo.version should be("1.6.0-SNAPSHOT")
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/InfoControllerTest.scala
@@ -34,7 +34,7 @@ class InfoControllerTest extends UnitTest with ScalatestRouteTest with Inside wi
         val expected =
           """{
             |  "name" : "unknown",
-            |  "version" : "1.5.0-SNAPSHOT",
+            |  "version" : "1.6.0-SNAPSHOT",
             |  "buildref" : "unknown",
             |  "elected" : false,
             |  "leader" : "80",

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo160Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo160Test.scala
@@ -1,0 +1,129 @@
+package mesosphere.marathon
+package storage.migration
+
+import java.time.OffsetDateTime
+
+import akka.Done
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.stream.scaladsl.Source
+import akka.stream.{ ActorMaterializer, Materializer }
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.condition.Condition
+import mesosphere.marathon.core.instance.Instance.Id
+import mesosphere.marathon.core.instance.{ Instance, Reservation, TestInstanceBuilder }
+import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
+import mesosphere.marathon.core.storage.store.impl.zk.{ ZkId, ZkPersistenceStore, ZkSerialized }
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
+import mesosphere.marathon.state._
+import mesosphere.marathon.storage.migration.MigrationTo146.Environment
+import mesosphere.marathon.storage.repository.InstanceRepository
+import mesosphere.marathon.test.GroupCreation
+import org.apache.mesos
+import org.apache.mesos.Protos.NetworkInfo.Protocol
+import play.api.libs.json.{ JsValue, Json }
+import play.api.libs.json._
+
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+
+class MigrationTo160Test extends AkkaUnitTest with GroupCreation with StrictLogging {
+
+  "Migration to 1.6.0" should {
+    "do nothing if env var is not configured" in new Fixture {
+      MigrationTo160.migrateReservations(instanceRepository, persistenceStore)(env, ctx, mat).futureValue
+      verify(instanceRepository, never).all()
+      verify(instanceRepository, never).store(_: Instance)
+    }
+
+    "do migration if env var is configured" in new Fixture(Map(MigrationTo146.MigrateUnreachableStrategyEnvVar -> "true")) {
+      MigrationTo160.migrateReservations(instanceRepository, persistenceStore)(env, ctx, mat).futureValue
+      val targetInstance = instance.copy(reservation = Some(Reservation(Nil, Reservation.State.Launched)))
+      val targetInstance2 = instance2.copy(reservation = Some(Reservation(Nil, Reservation.State.Launched)))
+      val targetInstance3 = instance3.copy(reservation = Some(Reservation(Nil, Reservation.State.Launched)))
+
+      logger.info(s"Migration instances ($instance, $instance2, $instance3) ")
+      verify(instanceRepository, once).ids()
+      verify(instanceRepository, once).store(targetInstance)
+      verify(instanceRepository, once).store(targetInstance2)
+      verify(instanceRepository, once).store(targetInstance3)
+    }
+  }
+
+  private class Fixture(val environment: Map[String, String] = Map.empty) {
+
+    implicit val instanceResolver: IdResolver[Instance.Id, JsValue, String, ZkId] =
+      new IdResolver[Instance.Id, JsValue, String, ZkId] {
+        override def toStorageId(id: Id, version: Option[OffsetDateTime]): ZkId =
+          ZkId(category, id.idString, version)
+        override val category: String = "instance"
+        override def fromStorageId(key: ZkId): Id = Instance.Id(key.id)
+        override val hasVersions: Boolean = false
+        override def version(v: JsValue): OffsetDateTime = OffsetDateTime.MIN
+      }
+
+    implicit val instanceJsonUnmarshaller: Unmarshaller[ZkSerialized, JsValue] =
+      Unmarshaller.strict {
+        case ZkSerialized(byteString) =>
+          Json.parse(byteString.utf8String)
+      }
+
+    import Reservation.reservationFormat
+    import Instance.instanceJsonReads
+
+    val instanceRepository: InstanceRepository = mock[InstanceRepository]
+    val persistenceStore: ZkPersistenceStore = mock[ZkPersistenceStore]
+    implicit lazy val env = Environment(environment)
+    implicit lazy val mat: Materializer = ActorMaterializer()
+    implicit lazy val ctx: ExecutionContextExecutor = system.dispatcher
+    val instanceId1 = Instance.Id.forRunSpec(PathId("/app"))
+    val instanceId2 = Instance.Id.forRunSpec(PathId("/app2"))
+    val instanceId3 = Instance.Id.forRunSpec(PathId("/app3"))
+
+    val taskMap = List(
+      Task(
+        Task.Id.forInstanceId(instanceId1, None),
+        Timestamp.now(),
+        Task.Status(
+          stagedAt = Timestamp.now(),
+          condition = Condition.Running,
+          networkInfo = NetworkInfo(
+            "127.0.0.1",
+            8888 :: Nil,
+            mesos.Protos.NetworkInfo.IPAddress.newBuilder()
+              .setProtocol(Protocol.IPv4)
+              .setIpAddress("127.0.0.1")
+              .build() :: Nil)
+        ))
+    ).map(t => t.taskId -> t).toMap
+
+    def legacyInstanceJson(i: Instance): JsValue = {
+      val fieldsMap = Json.toJson(i).asInstanceOf[JsObject].value
+
+      val res = JsObject(fieldsMap.map {
+        case ("tasksMap", taskMap) =>
+          val updatedTaskMap = "tasksMap" -> JsObject(taskMap.asInstanceOf[JsObject].value.mapValues {
+            case task: JsObject =>
+              task + ("reservation" -> Json.toJson(Reservation(Nil, Reservation.State.Launched)).asInstanceOf[JsObject])
+          })
+
+          updatedTaskMap
+
+        case (k, v) => k -> v
+      })
+
+      res
+    }
+
+    val instance = TestInstanceBuilder.emptyInstance(instanceId = instanceId1).copy(tasksMap = taskMap)
+    val instance2 = TestInstanceBuilder.emptyInstance(instanceId = instanceId2).copy(tasksMap = taskMap)
+    val instance3 = TestInstanceBuilder.emptyInstance(instanceId = instanceId3).copy(tasksMap = taskMap)
+    instanceRepository.ids() returns Source(List(instance, instance2, instance3).map(_.instanceId))
+    persistenceStore.get[Instance.Id, JsValue](equalTo(instance.instanceId))(any, any) returns Future(Some(legacyInstanceJson(instance)))
+    persistenceStore.get[Instance.Id, JsValue](equalTo(instance2.instanceId))(any, any) returns Future(Some(legacyInstanceJson(instance2)))
+    persistenceStore.get[Instance.Id, JsValue](equalTo(instance3.instanceId))(any, any) returns Future(Some(legacyInstanceJson(instance3)))
+    instanceRepository.store(any) returns Future.successful(Done)
+  }
+
+}


### PR DESCRIPTION
Summary: added a migration to move residency from the task level to the instance level

JIRA issues: MARATHON_EE-1785

Results of the manual test:
`[zk: localhost:2181(CONNECTED) 1] get /marathon/state/instance/8/postgres.marathon-3b4a55ee-f547-11e7-9abc-22ca52e973a9`
```json
{
   "instanceId":{
      "idString":"postgres.marathon-3b4a55ee-f547-11e7-9abc-22ca52e973a9"
   },
   "agentInfo":{
      "host":"ubuntu",
      "agentId":"197fdeb5-94a8-44ac-90d6-f44de4a6fc6f-S0",
      "attributes":[

      ]
   },
   "tasksMap":{
      "postgres.3b4a55ee-f547-11e7-9abc-22ca52e973a9.304":{
         "taskId":"postgres.3b4a55ee-f547-11e7-9abc-22ca52e973a9.304",
         "reservation":{
            "volumeIds":[
               {
                  "runSpecId":"/postgres",
                  "containerPath":"pgdata",
                  "uuid":"3b4a55ed-f547-11e7-9abc-22ca52e973a9",
                  "persistenceId":"postgres#pgdata#3b4a55ed-f547-11e7-9abc-22ca52e973a9"
               }
            ],
            "state":{
               "name":"suspended",
               "timeout":null
            }
         },
         "status":{
            "stagedAt":"2018-01-09T15:06:35.523Z",
            "mesosStatus":"CjMKMXBvc3RncmVzLjNiNGE1NWVlLWY1NDctMTFlNy05YWJjLTIyY2E1MmU5NzNhOS4zMDQQAyIwQWJub3JtYWwgZXhlY3V0b3IgdGVybWluYXRpb246IHVua25vd24gY29udGFpbmVyKikKJzE5N2ZkZWI1LTk0YTgtNDRhYy05MGQ2LWY0NGRlNGE2ZmM2Zi1TMDFpOOSeNpXWQTozCjFwb3N0Z3Jlcy4zYjRhNTVlZS1mNTQ3LTExZTctOWFiYy0yMmNhNTJlOTczYTkuMzA0SAFQAVoQLb5WpFmSRXKnKFJhfJP/QA==",
            "condition":"Reserved",
            "networkInfo":{
               "hostName":"ubuntu",
               "hostPorts":[
                  31497
               ],
               "ipAddresses":[

               ]
            }
         },
         "runSpecVersion":"2018-01-09T14:13:12.774Z"
      }
   },
   "runSpecVersion":"2018-01-09T14:13:12.774Z",
   "state":{
      "condition":"Reserved",
      "since":"2018-01-09T15:06:35.574Z"
   },
   "unreachableStrategy":"disabled"
}
```
After the migration:
```json
{
   "instanceId":{
      "idString":"postgres.marathon-3b4a55ee-f547-11e7-9abc-22ca52e973a9"
   },
   "agentInfo":{
      "host":"ubuntu",
      "agentId":"197fdeb5-94a8-44ac-90d6-f44de4a6fc6f-S0",
      "attributes":[

      ]
   },
   "tasksMap":{
      "postgres.3b4a55ee-f547-11e7-9abc-22ca52e973a9.307":{
         "taskId":"postgres.3b4a55ee-f547-11e7-9abc-22ca52e973a9.307",
         "runSpecVersion":"2018-01-09T14:13:12.774Z",
         "status":{
            "stagedAt":"2018-01-10T10:42:46.340Z",
            "mesosStatus":"CjMKMXBvc3RncmVzLjNiNGE1NWVlLWY1NDctMTFlNy05YWJjLTIyY2E1MmU5NzNhOS4zMDcQAyIwQWJub3JtYWwgZXhlY3V0b3IgdGVybWluYXRpb246IHVua25vd24gY29udGFpbmVyKikKJzE5N2ZkZWI1LTk0YTgtNDRhYy05MGQ2LWY0NGRlNGE2ZmM2Zi1TMDEqjaCJe5XWQTozCjFwb3N0Z3Jlcy4zYjRhNTVlZS1mNTQ3LTExZTctOWFiYy0yMmNhNTJlOTczYTkuMzA3SAFQAVoQJtOvS7iOS7OLG6/I15XrPg==",
            "condition":"Reserved",
            "networkInfo":{
               "hostName":"ubuntu",
               "hostPorts":[
                  31497
               ],
               "ipAddresses":[

               ]
            }
         }
      }
   },
   "runSpecVersion":"2018-01-09T14:13:12.774Z",
   "state":{
      "condition":"Reserved",
      "since":"2018-01-10T10:42:46.545Z"
   },
   "unreachableStrategy":"disabled",
   "reservation":{
      "volumeIds":[
         {
            "runSpecId":"/postgres",
            "containerPath":"pgdata",
            "uuid":"3b4a55ed-f547-11e7-9abc-22ca52e973a9",
            "persistenceId":"postgres#pgdata#3b4a55ed-f547-11e7-9abc-22ca52e973a9"
         }
      ],
      "state":{
         "name":"suspended",
         "timeout":null
      }
   }
}
```
