### PR TITLE
 Use Marathon's AWS Account to launch test clusters. 

### DIFF
--- a/Jenkinsfile.disabled.si
+++ b/Jenkinsfile.disabled.si
@@ -23,8 +23,7 @@ node('py36') {
       try {
         checkout scm
         withCredentials(
-          [ [$class: 'FileBinding', credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b', variable: 'CLI_TEST_SSH_KEY'],
-            [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '7155bd15-767d-4ae3-a375-e0d74c90a2c4', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+          [ [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'mesosphere-ci-marathon', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
             [$class: 'FileBinding', credentialsId: '11fcc957-5156-4470-ae34-d433da88248a', variable: 'DOT_SHAKEDOWN'],
             [$class: 'StringBinding', credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d', variable: 'DOCKER_HUB_USERNAME'],
             [$class: 'StringBinding', credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825', variable: 'DOCKER_HUB_PASSWORD']

--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -24,7 +24,7 @@ node('py36') {
         checkout scm
         withCredentials(
           [ [$class: 'FileBinding', credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b', variable: 'CLI_TEST_SSH_KEY'],
-            [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '7155bd15-767d-4ae3-a375-e0d74c90a2c4', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+            [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'mesosphere-ci-marathon', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
             [$class: 'FileBinding', credentialsId: '11fcc957-5156-4470-ae34-d433da88248a', variable: 'DOT_SHAKEDOWN'],
             [$class: 'StringBinding', credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d', variable: 'DOCKER_HUB_USERNAME'],
             [$class: 'StringBinding', credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825', variable: 'DOCKER_HUB_PASSWORD']

--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -23,8 +23,7 @@ node('py36') {
       try {
         checkout scm
         withCredentials(
-          [ [$class: 'FileBinding', credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b', variable: 'CLI_TEST_SSH_KEY'],
-            [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'mesosphere-ci-marathon', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+          [ [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'mesosphere-ci-marathon', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
             [$class: 'FileBinding', credentialsId: '11fcc957-5156-4470-ae34-d433da88248a', variable: 'DOT_SHAKEDOWN'],
             [$class: 'StringBinding', credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d', variable: 'DOCKER_HUB_USERNAME'],
             [$class: 'StringBinding', credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825', variable: 'DOCKER_HUB_PASSWORD']

--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -23,8 +23,7 @@ node('py36') {
       try {
         checkout scm
         withCredentials(
-          [ [$class: 'FileBinding', credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b', variable: 'CLI_TEST_SSH_KEY'],
-            [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '7155bd15-767d-4ae3-a375-e0d74c90a2c4', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+          [ [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'mesosphere-ci-marathon', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
             [$class: 'FileBinding', credentialsId: '11fcc957-5156-4470-ae34-d433da88248a', variable: 'DOT_SHAKEDOWN'],
             [$class: 'StringBinding', credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d', variable: 'DOCKER_HUB_USERNAME'],
             [$class: 'StringBinding', credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825', variable: 'DOCKER_HUB_PASSWORD']

--- a/Jenkinsfile.pr.si
+++ b/Jenkinsfile.pr.si
@@ -10,9 +10,8 @@ node('py36') {
         checkout scm
         withCredentials([
             usernamePassword(credentialsId: 'a7ac7f84-64ea-4483-8e66-bb204484e58f', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USER'),
-            [$class: 'FileBinding', credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b', variable: 'CLI_TEST_SSH_KEY'],
             [$class: 'FileBinding', credentialsId: '11fcc957-5156-4470-ae34-d433da88248a', variable: 'DOT_SHAKEDOWN'],
-            [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '7155bd15-767d-4ae3-a375-e0d74c90a2c4', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+            [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'mesosphere-ci-marathon', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
             string(credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d', variable: 'DOCKER_HUB_USERNAME'),
             string(credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825', variable: 'DOCKER_HUB_PASSWORD')
           ]) {

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -23,8 +23,7 @@ node('py36') {
       try {
         checkout scm
         withCredentials(
-          [ [$class: 'FileBinding', credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b', variable: 'CLI_TEST_SSH_KEY'],
-            [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '7155bd15-767d-4ae3-a375-e0d74c90a2c4', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+          [ [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'mesosphere-ci-marathon', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
             [$class: 'FileBinding', credentialsId: '11fcc957-5156-4470-ae34-d433da88248a', variable: 'DOT_SHAKEDOWN'],
             [$class: 'StringBinding', credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d', variable: 'DOCKER_HUB_USERNAME'],
             [$class: 'StringBinding', credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825', variable: 'DOCKER_HUB_PASSWORD']

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -12,9 +12,6 @@ fi
 CHANNEL="$1"
 VARIANT="$2"
 
-JOB_NAME_SANITIZED=$(echo "$JOB_NAME" | tr -c '[:alnum:]-' '-')
-DEPLOYMENT_NAME="$JOB_NAME_SANITIZED-$(date +%s)"
-
 if [ "$VARIANT" == "open" ]; then
   TEMPLATE="https://s3.amazonaws.com/downloads.dcos.io/dcos/${CHANNEL}/cloudformation/multi-master.cloudformation.json"
 else

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -51,9 +51,7 @@ if ! ./dcos-launch wait; then
 fi
 
 # Extract SSH key
-CLI_TEST_SSH_KEY="$DEPLOYMENT_NAME.pem"
 jq -r .ssh_private_key cluster_info.json > "$CLI_TEST_SSH_KEY"
-export CLI_TEST_SSH_KEY
 
 # Return dcos_url
 echo "http://$(./dcos-launch describe | jq -r ".masters[0].public_ip")/"

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -16,7 +16,7 @@ JOB_NAME_SANITIZED=$(echo "$JOB_NAME" | tr -c '[:alnum:]-' '-')
 DEPLOYMENT_NAME="$JOB_NAME_SANITIZED-$(date +%s)"
 
 if [ "$VARIANT" == "open" ]; then
-  TEMPLATE="https://downloads.dcos.io/dcos/${CHANNEL}/cloudformation/multi-master.cloudformation.json"
+  TEMPLATE="https://s3.amazonaws.com/downloads.dcos.io/dcos/${CHANNEL}/cloudformation/multi-master.cloudformation.json"
 else
   TEMPLATE="https://s3.amazonaws.com/downloads.mesosphere.io/dcos-enterprise-aws-advanced/${CHANNEL}/${VARIANT}/cloudformation/ee.multi-master.cloudformation.json"
 fi

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -16,7 +16,7 @@ JOB_NAME_SANITIZED=$(echo "$JOB_NAME" | tr -c '[:alnum:]-' '-')
 DEPLOYMENT_NAME="$JOB_NAME_SANITIZED-$(date +%s)"
 
 if [ "$VARIANT" == "open" ]; then
-  TEMPLATE="https://s3.amazonaws.com/downloads.dcos.io/dcos/${CHANNEL}/cloudformation/multi-master.cloudformation.json"
+  TEMPLATE="https://downloads.dcos.io/dcos/${CHANNEL}/cloudformation/multi-master.cloudformation.json"
 else
   TEMPLATE="https://s3.amazonaws.com/downloads.mesosphere.io/dcos-enterprise-aws-advanced/${CHANNEL}/${VARIANT}/cloudformation/ee.multi-master.cloudformation.json"
 fi
@@ -35,9 +35,9 @@ template_url: $TEMPLATE
 deployment_name: $DEPLOYMENT_NAME
 provider: aws
 aws_region: us-west-2
+key_helper: true
 template_parameters:
     DefaultInstanceType: m4.large
-    KeyName: default
     AdminLocation: 0.0.0.0/0
     PublicSlaveInstanceCount: 1
     SlaveInstanceCount: 5
@@ -49,6 +49,11 @@ fi
 if ! ./dcos-launch wait; then
   exit 3
 fi
+
+# Extract SSH key
+CLI_TEST_SSH_KEY="$DEPLOYMENT_NAME.pem"
+jq -r .ssh_private_key cluster_info.json > "$CLI_TEST_SSH_KEY"
+export CLI_TEST_SSH_KEY
 
 # Return dcos_url
 echo "http://$(./dcos-launch describe | jq -r ".masters[0].public_ip")/"

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -58,8 +58,6 @@ export CLI_TEST_SSH_KEY
 DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )
 CLUSTER_LAUNCH_CODE=$?
 export DCOS_URL
-./dcos-launch delete
-exit $?
 case $CLUSTER_LAUNCH_CODE in
   0)
       cp -f "$DOT_SHAKEDOWN" "$HOME/.shakedown"

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -53,8 +53,9 @@ function download-diagnostics-bundle {
 }
 
 # Launch cluster and run tests if launch was successful.
-CLI_TEST_SSH_KEY="$DEPLOYMENT_NAME.pem"
+CLI_TEST_SSH_KEY="$(pwd)/$DEPLOYMENT_NAME.pem"
 export CLI_TEST_SSH_KEY
+exit 1
 DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )
 CLUSTER_LAUNCH_CODE=$?
 export DCOS_URL

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -58,6 +58,8 @@ export CLI_TEST_SSH_KEY
 DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )
 CLUSTER_LAUNCH_CODE=$?
 export DCOS_URL
+./dcos-launch delete
+exit $?
 case $CLUSTER_LAUNCH_CODE in
   0)
       cp -f "$DOT_SHAKEDOWN" "$HOME/.shakedown"

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -55,7 +55,6 @@ function download-diagnostics-bundle {
 # Launch cluster and run tests if launch was successful.
 CLI_TEST_SSH_KEY="$(pwd)/$DEPLOYMENT_NAME.pem"
 export CLI_TEST_SSH_KEY
-exit 1
 DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )
 CLUSTER_LAUNCH_CODE=$?
 export DCOS_URL

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -48,6 +48,8 @@ function download-diagnostics-bundle {
 }
 
 # Launch cluster and run tests if launch was successful.
+CLI_TEST_SSH_KEY="$DEPLOYMENT_NAME.pem"
+export CLI_TEST_SSH_KEY
 DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )
 CLUSTER_LAUNCH_CODE=$?
 export DCOS_URL

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -12,6 +12,11 @@ fi
 CHANNEL="$1"
 VARIANT="$2"
 
+JOB_NAME_SANITIZED=$(echo "$JOB_NAME" | tr -c '[:alnum:]-' '-')
+DEPLOYMENT_NAME="$JOB_NAME_SANITIZED-$(date +%s)"
+export DEPLOYMENT_NAME
+
+
 function create-junit-xml {
     local testsuite_name=$1
     local testcase_name=$2

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -56,9 +56,9 @@ case $CLUSTER_LAUNCH_CODE in
       cp -f "$DOT_SHAKEDOWN" "$HOME/.shakedown"
       (cd tests && make init test)
       SI_CODE=$?
-      if [ ${SI_CODE} -gt 0 ]; then
-        download-diagnostics-bundle
-      fi
+      # if [ ${SI_CODE} -gt 0 ]; then
+      #  download-diagnostics-bundle
+      # fi
       ./dcos-launch delete
       exit "$SI_CODE" # Propagate return code.
       ;;

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -48,9 +48,9 @@ function download-diagnostics-bundle {
 }
 
 # Launch cluster and run tests if launch was successful.
-DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT")
+DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )
 CLUSTER_LAUNCH_CODE=$?
-export DCOS_URL=$(tail -1 "$DCOS_URL")
+export DCOS_URL
 case $CLUSTER_LAUNCH_CODE in
   0)
       cp -f "$DOT_SHAKEDOWN" "$HOME/.shakedown"

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -48,8 +48,9 @@ function download-diagnostics-bundle {
 }
 
 # Launch cluster and run tests if launch was successful.
-export DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )
+DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT")
 CLUSTER_LAUNCH_CODE=$?
+export DCOS_URL=$(tail -1 "$DCOS_URL")
 case $CLUSTER_LAUNCH_CODE in
   0)
       cp -f "$DOT_SHAKEDOWN" "$HOME/.shakedown"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,7 +20,6 @@ build:
 	flake8 --count --max-line-length=120 system
 
 test:
-	cat "$(CLI_TEST_SSH_KEY)"
 	pipenv run shakedown \
       --stdout all \
       --stdout-inline \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,7 +20,7 @@ build:
 	flake8 --count --max-line-length=120 system
 
 test:
-	cat$(CLI_TEST_SSH_KEY)
+	cat $(CLI_TEST_SSH_KEY)
 	pipenv run shakedown \
       --stdout all \
       --stdout-inline \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,7 +20,7 @@ build:
 	flake8 --count --max-line-length=120 system
 
 test:
-	cat $(CLI_TEST_SSH_KEY)
+	cat "$(CLI_TEST_SSH_KEY)"
 	pipenv run shakedown \
       --stdout all \
       --stdout-inline \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,6 +20,7 @@ build:
 	flake8 --count --max-line-length=120 system
 
 test:
+	echo $(CLI_TEST_SSH_KEY)
 	pipenv run shakedown \
       --stdout all \
       --stdout-inline \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,7 +20,7 @@ build:
 	flake8 --count --max-line-length=120 system
 
 test:
-	echo $(CLI_TEST_SSH_KEY)
+	cat$(CLI_TEST_SSH_KEY)
 	pipenv run shakedown \
       --stdout all \
       --stdout-inline \


### PR DESCRIPTION
Summary:
This migrates our system integration tests to our own AWS account. It will also use temporary
SSH keys instead of a fixed pair.

Additionally cluster launch failures are marked as stable again. There was a bug before.

JIRA issues: MARATHON_EE-1802
