### PR TITLE
Migration from joda-time to java.time

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,8 +27,6 @@ object Dependencies {
     aws % "compile",
     chaos % "compile",
     mesos % "compile",
-    jodaTime % "compile",
-    jodaConvert % "compile",
     jerseyServlet % "compile",
     jerseyMultiPart % "compile",
     jettyEventSource % "compile",
@@ -95,8 +93,6 @@ object Dependency {
     val AsyncAwait = "0.9.6"
     val Jersey = "1.18.6"
     val JettyServlets = "9.3.6.v20151106"
-    val JodaTime = "2.9.9"
-    val JodaConvert = "1.8.1"
     val UUIDGenerator = "3.1.4"
     val JGraphT = "0.9.3"
     val Diffson = "2.0.2"
@@ -140,8 +136,6 @@ object Dependency {
   val jerseyServlet =  "com.sun.jersey" % "jersey-servlet" % V.Jersey
   val jettyEventSource = "org.eclipse.jetty" % "jetty-servlets" % V.JettyServlets
   val jerseyMultiPart =  "com.sun.jersey.contribs" % "jersey-multipart" % V.Jersey
-  val jodaTime = "joda-time" % "joda-time" % V.JodaTime
-  val jodaConvert = "org.joda" % "joda-convert" % V.JodaConvert
   val uuidGenerator = "com.fasterxml.uuid" % "java-uuid-generator" % V.UUIDGenerator
   val jGraphT = "org.javabits.jgrapht" % "jgrapht-core" % V.JGraphT
   val beanUtils = "commons-beanutils" % "commons-beanutils" % "1.9.3"

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -1,11 +1,11 @@
 package mesosphere.marathon
 package state
 
-import java.time.{ Instant, OffsetDateTime }
+import java.time.format.DateTimeFormatter
+import java.time.{ OffsetDateTime, Instant, ZoneOffset, Duration }
 import java.util.concurrent.TimeUnit
 
 import org.apache.mesos
-import org.joda.time.{ DateTime, DateTimeZone }
 
 import scala.concurrent.duration.FiniteDuration
 import scala.language.implicitConversions
@@ -14,30 +14,30 @@ import scala.math.Ordered
 /**
   * An ordered wrapper for UTC timestamps.
   */
-abstract case class Timestamp private (private val utcDateTime: DateTime) extends Ordered[Timestamp] {
+abstract case class Timestamp private (private val instant: Instant) extends Ordered[Timestamp] {
   def toOffsetDateTime: OffsetDateTime =
     OffsetDateTime.ofInstant(
-      Instant.ofEpochMilli(utcDateTime.toInstant.getMillis),
-      utcDateTime.getZone.toTimeZone.toZoneId)
+      instant,
+      ZoneOffset.UTC)
 
-  def compare(that: Timestamp): Int = this.utcDateTime compareTo that.utcDateTime
+  def compare(that: Timestamp): Int = this.instant compareTo that.instant
 
-  def before(that: Timestamp): Boolean = (this.utcDateTime compareTo that.utcDateTime) < 0
-  def after(that: Timestamp): Boolean = (this.utcDateTime compareTo that.utcDateTime) > 0
+  def before(that: Timestamp): Boolean = (this.instant compareTo that.instant) < 0
+  def after(that: Timestamp): Boolean = (this.instant compareTo that.instant) > 0
   def youngerThan(that: Timestamp): Boolean = this.after(that)
   def olderThan(that: Timestamp): Boolean = this.before(that)
 
-  override def toString: String = utcDateTime.toString
+  override def toString: String = Timestamp.formatter.format(instant)
 
-  def toDateTime: DateTime = utcDateTime
+  def toInstant: Instant = instant
 
-  def millis: Long = toDateTime.getMillis
+  def millis: Long = toInstant.toEpochMilli
   def micros: Long = TimeUnit.MILLISECONDS.toMicros(millis)
   def nanos: Long = TimeUnit.MILLISECONDS.toNanos(millis)
 
   def until(other: Timestamp): FiniteDuration = {
-    val millis = other.utcDateTime.getMillis - utcDateTime.getMillis
-    FiniteDuration(millis, TimeUnit.MILLISECONDS)
+    val duration = Duration.between(this.instant, other.instant)
+    FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
   }
 
   /**
@@ -45,41 +45,40 @@ abstract case class Timestamp private (private val utcDateTime: DateTime) extend
     */
   def expired(other: Timestamp, by: FiniteDuration): Boolean = this.until(other) > by
 
-  def +(duration: FiniteDuration): Timestamp = Timestamp(utcDateTime.getMillis + duration.toMillis)
-  def -(duration: FiniteDuration): Timestamp = Timestamp(utcDateTime.getMillis - duration.toMillis)
+  def +(duration: FiniteDuration): Timestamp = Timestamp(instant.plusMillis(duration.toMillis))
+  def -(duration: FiniteDuration): Timestamp = Timestamp(instant.minusMillis(duration.toMillis))
 }
 
 object Timestamp {
   def apply(offsetDateTime: OffsetDateTime): Timestamp =
-    apply(offsetDateTime.toInstant.toEpochMilli)
+    apply(offsetDateTime.toInstant)
 
   /**
     * Returns a new Timestamp representing the instant that is the supplied
     * dateTime converted to UTC.
     */
-  def apply(dateTime: DateTime): Timestamp = new Timestamp(dateTime.toDateTime(DateTimeZone.UTC)) {} // linter:ignore TypeToType
+  def apply(instant: Instant): Timestamp = new Timestamp(instant) {} // linter:ignore TypeToType
 
   /**
     * Returns a new Timestamp representing the instant that is the supplied
     * number of milliseconds after the epoch.
     */
-  def apply(ms: Long): Timestamp = Timestamp(new DateTime(ms))
+  def apply(ms: Long): Timestamp = Timestamp(Instant.ofEpochMilli(ms))
 
   /**
     * Returns a new Timestamp representing the supplied time.
     *
     * See the Joda time documentation for a description of acceptable formats:
-    * http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTimeParser()
     */
-  def apply(time: String): Timestamp = Timestamp(DateTime.parse(time))
+  def apply(time: String): Timestamp = Timestamp(OffsetDateTime.parse(time))
 
   /**
     * Returns a new Timestamp representing the current instant.
     */
-  def now(): Timestamp = Timestamp(System.currentTimeMillis)
+  def now(): Timestamp = Timestamp(Instant.now())
 
   def now(clock: java.time.Clock): Timestamp =
-    Timestamp(clock.millis())
+    Timestamp(Instant.now(clock))
 
   def zero: Timestamp = Timestamp(0)
 
@@ -98,4 +97,9 @@ object Timestamp {
   def fromTaskStatus(taskStatus: mesos.Protos.TaskStatus): Timestamp = {
     apply(TimeUnit.SECONDS.toMillis(taskStatus.getTimestamp.toLong))
   }
+
+  /*
+   * .toString in java.time is truncating zeros in millis part, so we use custom formatter to keep them
+   */
+  private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
 }

--- a/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
+++ b/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
@@ -87,10 +87,11 @@ object EnvironmentHelper {
           env += (s"PORT_$generatedPort" -> generatedPort.toString)
       }
 
-      requestedPorts.map(_.name).zip(effectivePorts).foreach {
-        case (Some(portName), Some(effectivePort)) =>
+      requestedPorts.zip(effectivePorts).foreach {
+        case (PortRequest(Some(portName), _), Some(effectivePort)) =>
           env += (s"PORT_${portName.toUpperCase}" -> effectivePort.toString)
-        // TODO(jdef) port name envvars for generated container ports
+        case (PortRequest(Some(portName), port), None) =>
+          env += (s"PORT_${portName.toUpperCase}" -> port.toString)
         case _ =>
       }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -619,7 +619,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           implicit val podManager = PodManagerImpl(groupManager)
           val f = Fixture()
 
-          val response = f.podsResource.version("/id", "2008", f.auth.request)
+          val response = f.podsResource.version("/id", "2008-01-01T12:00:00Z", f.auth.request)
           withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_NOT_FOUND)
             response.getEntity.toString should be ("{\"message\":\"Pod '/id' does not exist\"}")

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskLifeTimeTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskLifeTimeTest.scala
@@ -1,15 +1,16 @@
 package mesosphere.marathon
 package core.appinfo
 
+import java.time.{ OffsetDateTime, ZoneOffset }
+
 import mesosphere.UnitTest
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.instance.{ Instance, LegacyAppInstance, TestTaskBuilder }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{ PathId, Timestamp, UnreachableStrategy }
-import org.joda.time.DateTime
 
 class TaskLifeTimeTest extends UnitTest {
-  private[this] val now: Timestamp = Timestamp(new DateTime(2015, 4, 9, 12, 30))
+  private[this] val now: Timestamp = Timestamp(OffsetDateTime.of(2015, 4, 9, 12, 30, 0, 0, ZoneOffset.UTC))
   private[this] val runSpecId = PathId("/test")
   private[this] val agentInfo = AgentInfo(host = "host", agentId = Some("agent"), attributes = Nil)
   private[this] def newTaskId(): Task.Id = {

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskStatsByVersionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskStatsByVersionTest.scala
@@ -1,13 +1,14 @@
 package mesosphere.marathon
 package core.appinfo
 
+import java.time.{ OffsetDateTime, ZoneOffset }
+
 import mesosphere.UnitTest
 import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.instance.{ Instance, LegacyAppInstance, TestTaskBuilder }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{ PathId, Timestamp, UnreachableStrategy, VersionInfo }
-import org.joda.time.DateTime
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
@@ -85,7 +86,7 @@ class TaskStatsByVersionTest extends UnitTest {
 
     }
   }
-  private[this] val now: Timestamp = Timestamp(new DateTime(2015, 4, 9, 12, 30))
+  private[this] val now: Timestamp = Timestamp(OffsetDateTime.of(2015, 4, 9, 12, 30, 0, 0, ZoneOffset.UTC))
   private val lastScalingAt: Timestamp = now - 10.seconds
   private val intermediaryScalingAt: Timestamp = now - 20.seconds
   private val lastConfigChangeAt: Timestamp = now - 100.seconds

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceFormatTest.scala
@@ -15,9 +15,9 @@ class InstanceFormatTest extends UnitTest {
       |{
       |  "instanceId": { "idString": "app.instance-1337" },
       |  "tasksMap": {},
-      |  "runSpecVersion": "2015-01-01",
+      |  "runSpecVersion": "2015-01-01T12:00:00Z",
       |  "agentInfo": { "host": "localhost", "attributes": [] },
-      |  "state": { "since": "2015-01-01", "condition": { "str": "Running" } }
+      |  "state": { "since": "2015-01-01T12:00:00Z", "condition": { "str": "Running" } }
       |}""".stripMargin).as[JsObject]
 
   "Instance.instanceFormat" should {

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -1,6 +1,8 @@
 package mesosphere.marathon
 package core.task.bus
 
+import java.time.{ OffsetDateTime, ZoneOffset }
+
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.update._
 import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
@@ -9,7 +11,6 @@ import mesosphere.marathon.core.task.{ Task, TaskCondition }
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import org.apache.mesos.Protos.TaskStatus.Reason
 import org.apache.mesos.Protos.{ TaskState, TaskStatus }
-import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
 class TaskStatusUpdateTestHelper(val operation: InstanceUpdateOperation, val effect: InstanceUpdateEffect) {
@@ -47,7 +48,7 @@ object TaskStatusUpdateTestHelper {
     new TaskStatusUpdateTestHelper(operation, effect)
 
   lazy val defaultInstance = TestInstanceBuilder.newBuilder(PathId("/app")).addTaskStaged().getInstance()
-  lazy val defaultTimestamp = Timestamp.apply(new DateTime(2015, 2, 3, 12, 30, 0, 0))
+  lazy val defaultTimestamp = Timestamp(OffsetDateTime.of(2015, 2, 3, 12, 30, 0, 0, ZoneOffset.UTC))
 
   def taskLaunchFor(instance: Instance) = {
     val operation = InstanceUpdateOperation.LaunchEphemeral(instance)

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -6,12 +6,12 @@ import java.util.UUID
 import mesosphere.AkkaIntegrationTest
 import mesosphere.marathon.api.RestResource
 import mesosphere.marathon.integration.facades.MarathonFacade._
-import mesosphere.marathon.integration.facades.{ITDeployment, ITEnrichedTask, ITQueueItem}
+import mesosphere.marathon.integration.facades.{ ITDeployment, ITEnrichedTask, ITQueueItem }
 import mesosphere.marathon.integration.setup._
-import mesosphere.marathon.raml.{App, AppHealthCheck, AppHealthCheckProtocol, AppUpdate, CommandCheck, Container, ContainerPortMapping, DockerContainer, EngineType, Network, NetworkMode, NetworkProtocol}
+import mesosphere.marathon.raml.{ App, AppHealthCheck, AppHealthCheckProtocol, AppUpdate, CommandCheck, Container, ContainerPortMapping, DockerContainer, EngineType, Network, NetworkMode, NetworkProtocol }
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{PathId, Timestamp}
-import org.scalatest.time.{Millis, Seconds, Span}
+import mesosphere.marathon.state.{ PathId, Timestamp }
+import org.scalatest.time.{ Millis, Seconds, Span }
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._

--- a/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
@@ -1,11 +1,10 @@
 package mesosphere.marathon
 package state
 
-import java.time.Instant
+import java.time.{ Instant, OffsetDateTime, ZoneOffset }
 import java.time.temporal.ChronoUnit
 
 import mesosphere.UnitTest
-import org.joda.time.{ DateTime, DateTimeZone }
 
 import scala.concurrent.duration._
 
@@ -46,7 +45,7 @@ class TimestampTest extends UnitTest {
       }
       "independent of timezone" in {
         val t1 = Timestamp(1024)
-        val t2 = Timestamp(new DateTime(1024).toDateTime(DateTimeZone.forOffsetHours(2))) // linter:ignore TypeToType
+        val t2 = Timestamp(OffsetDateTime.ofInstant(Instant.ofEpochMilli(1024), ZoneOffset.ofHours(2))) // linter:ignore TypeToType
 
         (t1 == t2) shouldBe true
         (t1.hashCode == t2.hashCode) shouldBe true

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1,5 +1,7 @@
 package mesosphere.mesos
 
+import java.time.{ OffsetDateTime, ZoneOffset }
+
 import com.google.protobuf.TextFormat
 import mesosphere.UnitTest
 import mesosphere.marathon.api.serialization.PortDefinitionSerializer
@@ -18,7 +20,6 @@ import mesosphere.marathon.{ Protos, _ }
 import mesosphere.mesos.protos.{ Resource, _ }
 import org.apache.mesos.Protos.TaskInfo
 import org.apache.mesos.{ Protos => MesosProtos }
-import org.joda.time.{ DateTime, DateTimeZone }
 
 import scala.concurrent.duration._
 
@@ -1370,7 +1371,7 @@ class TaskBuilderTest extends UnitTest {
     }
 
     "TaskContextEnv empty when no taskId given" in {
-      val version = VersionInfo.forNewConfig(Timestamp(new DateTime(2015, 2, 3, 12, 30, DateTimeZone.UTC)))
+      val version = VersionInfo.forNewConfig(Timestamp(OffsetDateTime.of(2015, 2, 3, 12, 30, 0, 0, ZoneOffset.UTC)))
       val runSpec = AppDefinition(
         id = PathId("/app"),
         versionInfo = version
@@ -1381,7 +1382,7 @@ class TaskBuilderTest extends UnitTest {
     }
 
     "TaskContextEnv minimal" in {
-      val version = VersionInfo.forNewConfig(Timestamp(new DateTime(2015, 2, 3, 12, 30, DateTimeZone.UTC)))
+      val version = VersionInfo.forNewConfig(Timestamp(OffsetDateTime.of(2015, 2, 3, 12, 30, 0, 0, ZoneOffset.UTC)))
       val runSpec = AppDefinition(
         id = PathId("/app"),
         versionInfo = version
@@ -1403,7 +1404,7 @@ class TaskBuilderTest extends UnitTest {
     }
 
     "TaskContextEnv all fields" in {
-      val version = VersionInfo.forNewConfig(Timestamp(new DateTime(2015, 2, 3, 12, 30, DateTimeZone.UTC)))
+      val version = VersionInfo.forNewConfig(Timestamp(OffsetDateTime.of(2015, 2, 3, 12, 30, 0, 0, ZoneOffset.UTC)))
       val runSpecId = PathId("/app")
       val runSpec = AppDefinition(
         id = runSpecId,


### PR DESCRIPTION
Summary: joda-time removed from the project and underlying implementation of Timestamp is changed from joda.DateTime to java.time.Instant

JIRA issues: MARATHON-7914

(cherry picked from commit f2147a2)