### PR TITLE
Expose `containerPort` as `$PORT_NAME` env vars

### DIFF
--- a/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
+++ b/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
@@ -87,10 +87,11 @@ object EnvironmentHelper {
           env += (s"PORT_$generatedPort" -> generatedPort.toString)
       }
 
-      requestedPorts.map(_.name).zip(effectivePorts).foreach {
-        case (Some(portName), Some(effectivePort)) =>
+      requestedPorts.zip(effectivePorts).foreach {
+        case (PortRequest(Some(portName), _), Some(effectivePort)) =>
           env += (s"PORT_${portName.toUpperCase}" -> effectivePort.toString)
-        // TODO(jdef) port name envvars for generated container ports
+        case (PortRequest(Some(portName), port), None) =>
+          env += (s"PORT_${portName.toUpperCase}" -> port.toString)
         case _ =>
       }
 

--- a/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
+++ b/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
@@ -87,11 +87,13 @@ object EnvironmentHelper {
           env += (s"PORT_$generatedPort" -> generatedPort.toString)
       }
 
-      requestedPorts.zip(effectivePorts).foreach {
-        case (PortRequest(Some(portName), _), Some(effectivePort)) =>
+      requestedPorts.zip(effectivePorts).zipWithIndex.foreach {
+        case ((PortRequest(Some(portName), _), Some(effectivePort)), _) =>
           env += (s"PORT_${portName.toUpperCase}" -> effectivePort.toString)
-        case (PortRequest(Some(portName), port), None) =>
+        case ((PortRequest(Some(portName), port), None), _) if port != AppDefinition.RandomPortValue =>
           env += (s"PORT_${portName.toUpperCase}" -> port.toString)
+        case ((PortRequest(Some(portName), port), None), portIndex) if port == AppDefinition.RandomPortValue =>
+          env += (s"PORT_${portName.toUpperCase}" -> generatedPorts(portIndex).toString)
         case _ =>
       }
 

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitorTest.scala
@@ -23,14 +23,14 @@ class UnreachableReservedOfferMonitorTest extends AkkaUnitTest with Inside {
   val appId = "/test".toRootPath
   val agentInfo = AgentInfo("host", Some("deadbeef-S01"), Nil)
 
-  def reservationFor(instance: Instance, frameworkId: FrameworkId = myFrameworkId) = {
+  def reservationFor(instance: Instance) = {
     val labels = TaskLabels.labelsForTask(myFrameworkId, instance.tasksMap.values.head.taskId).labels
     MarathonTestHelper.reservation(principal = "marathon", labels)
   }
 
-  def reservedResource(instance: Instance, frameworkId: FrameworkId = myFrameworkId) = {
+  def reservedResource(instance: Instance) = {
     MarathonTestHelper.scalarResource(
-      "disk", 2, role = "marathon", reservation = Some(reservationFor(instance, frameworkId)))
+      "disk", 2, role = "marathon", reservation = Some(reservationFor(instance)))
   }
 
   def lookupForInstances(instances: Seq[Instance]) =

--- a/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
@@ -83,7 +83,7 @@ class GracefulTaskKillIntegrationTest extends AkkaIntegrationFunTest with Embedd
 
     // the task_killed event should occur instantly or at least smaller as taskKillGracePeriod,
     // because the app terminates shortly
-    waitedForTaskKilledEvent.toMillis should be < taskKillGracePeriod.toMillis withClue s"the task kill event took longer than the task kill grace period"
+    waitedForTaskKilledEvent.toMillis should be < taskKillGracePeriod.toMillis withClue "the task kill event took longer than the task kill grace period"
   }
 
   def healthCheck = MarathonHttpHealthCheck(

--- a/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/LeaderIntegrationTest.scala
@@ -258,7 +258,7 @@ class KeepAppsRunningDuringAbdicationIntegrationTest extends LeaderIntegrationTe
     newClient.app(app.id).value.app.instances should be(1) withClue "Previously started app did not survive the abdication"
     val newInstances = newClient.tasks(app.id).value
     newInstances should have size 1 withClue "Previously started one instance did not survive the abdication"
-    newInstances(0).id should be(oldInstances(0).id) withClue "During abdication we started a new instance, instead keeping the old one."
+    newInstances.head.id should be(oldInstances.head.id) withClue "During abdication we started a new instance, instead keeping the old one."
 
     // allow ZK session for former leader to timeout before proceeding
     Thread.sleep((zkTimeout * 2.5).toLong)

--- a/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -125,7 +125,7 @@ class MesosAppIntegrationTest
     Given("a pod with two tasks that are health checked")
     val podId = testBasePath / "healthypod"
     val containerDir = "/opt/marathon"
-    def appMockCommand(port: String) = s"""echo APP PROXY $$MESOS_TASK_ID RUNNING; /opt/marathon/python/app_mock.py """ +
+    def appMockCommand(port: String) = """echo APP PROXY $$MESOS_TASK_ID RUNNING; /opt/marathon/python/app_mock.py """ +
       s"""$port $podId v1 http://127.0.0.1:${healthEndpoint.localAddress.getPort}/health$podId/v1"""
 
     val pod = PodDefinition(

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -267,7 +267,6 @@ trait MarathonTest extends Suite with StrictLogging with ScalaFutures with Befor
     logger.info(s"Starting health check endpoint on port $port.")
     val server = Http().bindAndHandle(route, "localhost", port).futureValue
     logger.info(s"Listening for health events on $port")
-    logger.info(s"Listening for health events on $port")
     server
   }
 
@@ -321,7 +320,7 @@ trait MarathonTest extends Suite with StrictLogging with ScalaFutures with Befor
     val projectDir = sys.props.getOrElse("user.dir", ".")
     val containerDir = "/opt/marathon"
 
-    val cmd = Some(s"""echo APP PROXY $$MESOS_TASK_ID RUNNING; /opt/marathon/python/app_mock.py """ +
+    val cmd = Some("""echo APP PROXY $$MESOS_TASK_ID RUNNING; /opt/marathon/python/app_mock.py """ +
       s"""$$PORT0 $appId $versionId http://127.0.0.1:${healthEndpoint.localAddress.getPort}/health$appId/$versionId""")
 
     AppDefinition(

--- a/src/test/scala/mesosphere/marathon/util/WorkQueueTest.scala
+++ b/src/test/scala/mesosphere/marathon/util/WorkQueueTest.scala
@@ -4,6 +4,7 @@ package util
 import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicInteger
 
+import akka.Done
 import com.twitter.util.CountDownLatch
 import mesosphere.UnitTest
 import org.scalatest.Inside
@@ -17,7 +18,7 @@ class WorkQueueTest extends UnitTest with Inside {
   "WorkQueue" should {
     "return a failure if the Future returning thunk throws an exception" in {
       val queue = WorkQueue("test", maxConcurrent = 1, maxQueueLength = Int.MaxValue)
-      val r = queue {
+      val r: Future[Done] = queue {
         throw new RuntimeException("le failure")
       }
       inside(Try(r.futureValue)) {

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1643,6 +1643,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     assert("8080" == env("PORT_HTTP"))
 
     val port1 = env("PORT1")
+    assert(port1.toInt > 0)
     assert(port1 == env(s"PORT_${port1}"))
     assert(port1 == env("PORT_JABBER"))
   }

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1639,7 +1639,6 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     val env: Map[String, String] =
       command.getEnvironment.getVariablesList.toList.map(v => v.getName -> v.getValue).toMap
 
-    logger.info(env.mkString("\n"))
     assert("8080" == env("PORT_8080"))
     assert("8080" == env("PORT_HTTP"))
 

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1625,7 +1625,7 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
             network = Some(DockerInfo.Network.USER),
             portMappings = Seq(
               PortMapping(containerPort = 8080, hostPort = None, servicePort = 9000, protocol = "tcp", name = Some("http")),
-              PortMapping(containerPort = 8081, hostPort = None, servicePort = 9001, protocol = "tcp", name = Some("jabber"))
+              PortMapping(containerPort = 0, hostPort = None, servicePort = 9001, protocol = "tcp", name = Some("jabber"))
             )
           )),
           ipAddress = Some(IpAddress(networkName = Some("dcos"))),
@@ -1639,10 +1639,13 @@ class TaskBuilderTest extends MarathonSpec with Matchers {
     val env: Map[String, String] =
       command.getEnvironment.getVariablesList.toList.map(v => v.getName -> v.getValue).toMap
 
+    logger.info(env.mkString("\n"))
     assert("8080" == env("PORT_8080"))
-    assert("8081" == env("PORT_8081"))
     assert("8080" == env("PORT_HTTP"))
-    assert("8081" == env("PORT_JABBER"))
+
+    val port1 = env("PORT1")
+    assert(port1 == env(s"PORT_${port1}"))
+    assert(port1 == env("PORT_JABBER"))
   }
 
   test("PortsEnvWithBothPortsAndMappings") {


### PR DESCRIPTION
when using docker user networking (and not `hostPorts` exist). This part of code went missing from 1.3 to 1.4.

Also had to fix a bunch of scalalint complains - otherwise it wouldn't compile.

JIRA: COPS-2072