### PR TITLE
Expose `containerPort` as `$PORT_NAME` env vars

### DIFF
--- a/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
+++ b/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
@@ -87,10 +87,11 @@ object EnvironmentHelper {
           env += (s"PORT_$generatedPort" -> generatedPort.toString)
       }
 
-      requestedPorts.map(_.name).zip(effectivePorts).foreach {
-        case (Some(portName), Some(effectivePort)) =>
+      requestedPorts.zip(effectivePorts).foreach {
+        case (PortRequest(Some(portName), _), Some(effectivePort)) =>
           env += (s"PORT_${portName.toUpperCase}" -> effectivePort.toString)
-        // TODO(jdef) port name envvars for generated container ports
+        case (PortRequest(Some(portName), port), None) =>
+          env += (s"PORT_${portName.toUpperCase}" -> port.toString)
         case _ =>
       }
 

--- a/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
+++ b/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
@@ -87,11 +87,13 @@ object EnvironmentHelper {
           env += (s"PORT_$generatedPort" -> generatedPort.toString)
       }
 
-      requestedPorts.zip(effectivePorts).foreach {
-        case (PortRequest(Some(portName), _), Some(effectivePort)) =>
+      requestedPorts.zip(effectivePorts).zipWithIndex.foreach {
+        case ((PortRequest(Some(portName), _), Some(effectivePort)), _) =>
           env += (s"PORT_${portName.toUpperCase}" -> effectivePort.toString)
-        case (PortRequest(Some(portName), port), None) =>
+        case ((PortRequest(Some(portName), port), None), _) if port != AppDefinition.RandomPortValue =>
           env += (s"PORT_${portName.toUpperCase}" -> port.toString)
+        case ((PortRequest(Some(portName), port), None), portIndex) if port == AppDefinition.RandomPortValue =>
+          env += (s"PORT_${portName.toUpperCase}" -> generatedPorts(portIndex).toString)
         case _ =>
       }
 

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1,25 +1,25 @@
 package mesosphere.mesos
 
-import java.time.{ OffsetDateTime, ZoneOffset }
+import java.time.{OffsetDateTime, ZoneOffset}
 
 import com.google.protobuf.TextFormat
 import mesosphere.UnitTest
 import mesosphere.marathon.api.serialization.PortDefinitionSerializer
-import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
-import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
+import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.pod.{BridgeNetwork, ContainerNetwork}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
-import mesosphere.marathon.raml.{ App, Resources }
-import mesosphere.marathon.state.Container.{ Docker, PortMapping }
+import mesosphere.marathon.raml.{App, Resources}
+import mesosphere.marathon.state.Container.{Docker, PortMapping}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
-import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
+import mesosphere.marathon.state.{AppDefinition, Container, PathId, Timestamp, _}
 import mesosphere.marathon.stream.Implicits._
-import mesosphere.marathon.test.{ MarathonTestHelper, SettableClock }
-import mesosphere.marathon.{ Protos, _ }
-import mesosphere.mesos.protos.{ Resource, _ }
+import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
+import mesosphere.marathon.{Protos, _}
+import mesosphere.mesos.protos.{Resource, _}
 import org.apache.mesos.Protos.TaskInfo
-import org.apache.mesos.{ Protos => MesosProtos }
+import org.apache.mesos.{Protos => MesosProtos}
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
@@ -1628,6 +1628,34 @@ class TaskBuilderTest extends UnitTest {
       assert("1001" == env("PORT_8081"))
       assert("1000" == env("PORT_HTTP"))
       assert("1001" == env("PORT_JABBER"))
+    }
+
+    "PortsEnvWithOnlyMappingsAndUserNetworking" in {
+      val command =
+        TaskBuilder.commandInfo(
+          runSpec = AppDefinition(
+            id = runSpecId,
+            networks = Seq(ContainerNetwork("dcos")), container = Some(Docker(
+
+              portMappings = Seq(
+                PortMapping(containerPort = 8080, hostPort = None, servicePort = 9000, protocol = "tcp", name = Some("http")),
+                PortMapping(containerPort = 8081, hostPort = None, servicePort = 9001, protocol = "tcp", name = Some("jabber"))
+              )
+            ))
+          ),
+          taskId = Some(Task.Id("task-123")),
+          host = Some("host.mega.corp"),
+          hostPorts = Seq(None, None),
+          envPrefix = None
+        )
+
+      val env: Map[String, String] =
+        command.getEnvironment.getVariablesList.toList.map(v => v.getName -> v.getValue).toMap
+
+      assert("8080" == env("PORT_8080"))
+      assert("8081" == env("PORT_8081"))
+      assert("8080" == env("PORT_HTTP"))
+      assert("8081" == env("PORT_JABBER"))
     }
 
     "PortsEnvWithBothPortsAndMappings" in {

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1639,7 +1639,7 @@ class TaskBuilderTest extends UnitTest {
 
               portMappings = Seq(
                 PortMapping(containerPort = 8080, hostPort = None, servicePort = 9000, protocol = "tcp", name = Some("http")),
-                PortMapping(containerPort = 8081, hostPort = None, servicePort = 9001, protocol = "tcp", name = Some("jabber"))
+                PortMapping(containerPort = 0, hostPort = None, servicePort = 9001, protocol = "tcp", name = Some("jabber"))
               )
             ))
           ),
@@ -1653,9 +1653,11 @@ class TaskBuilderTest extends UnitTest {
         command.getEnvironment.getVariablesList.toList.map(v => v.getName -> v.getValue).toMap
 
       assert("8080" == env("PORT_8080"))
-      assert("8081" == env("PORT_8081"))
       assert("8080" == env("PORT_HTTP"))
-      assert("8081" == env("PORT_JABBER"))
+
+      val port1 = env("PORT1")
+      assert(port1 == env(s"PORT_${port1}"))
+      assert(port1 == env("PORT_JABBER"))
     }
 
     "PortsEnvWithBothPortsAndMappings" in {

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1656,6 +1656,7 @@ class TaskBuilderTest extends UnitTest {
       assert("8080" == env("PORT_HTTP"))
 
       val port1 = env("PORT1")
+      assert(port1.toInt > 0)
       assert(port1 == env(s"PORT_${port1}"))
       assert(port1 == env("PORT_JABBER"))
     }


### PR DESCRIPTION
when using docker user networking (and not `hostPorts` exist). This part of code went missing from 1.3 to 1.4.

JIRA: COPS-2072
