### PR TITLE
Instance.isReserved must return true if there is at least one Reserved task

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -34,7 +34,7 @@ case class Instance(
   val runSpecId: PathId = instanceId.runSpecId
   val isLaunched: Boolean = state.condition.isActive
 
-  def isReserved: Boolean = state.condition == Condition.Reserved
+  def isReserved: Boolean = tasksMap.values.exists(_.status.condition == Condition.Reserved)
   def isCreated: Boolean = state.condition == Condition.Created
   def isError: Boolean = state.condition == Condition.Error
   def isFailed: Boolean = state.condition == Condition.Failed

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -34,7 +34,9 @@ case class Instance(
   val runSpecId: PathId = instanceId.runSpecId
   val isLaunched: Boolean = state.condition.isActive
 
+  // An instance has to be considered as Reserved if at least one of its tasks is Reserved.
   def isReserved: Boolean = tasksMap.values.exists(_.status.condition == Condition.Reserved)
+
   def isCreated: Boolean = state.condition == Condition.Created
   def isError: Boolean = state.condition == Condition.Error
   def isFailed: Boolean = state.condition == Condition.Failed

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -45,6 +45,9 @@ object InstanceUpdater extends StrictLogging {
             logger.info("all tasks of {} are terminal, requesting to expunge", updated.instanceId)
             InstanceUpdateEffect.Expunge(updated, events)
           } else {
+            // If the updated task is Reserved, it means that the real task reached a Terminal state,
+            // which in turn means that the task managed to get up and running, which means that
+            // its persistent volume(s) had been created, and therefore they must never be destroyed/unreserved.
             if (updatedTask.status.condition == Condition.Reserved) {
               val suspendedState = Reservation.State.Suspended(timeout = None)
               val suspended = updated.copy(reservation = updated.reservation.map(_.copy(state = suspendedState)))

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -42,6 +42,7 @@ object InstanceUpdater extends StrictLogging {
           val updated: Instance = updatedInstance(instance, updatedTask, now)
           val events = eventsGenerator.events(updated, Some(updatedTask), now, previousCondition = Some(instance.state.condition))
           if (updated.tasksMap.values.forall(_.isTerminal)) {
+            // all task can be terminal only if the instance doesn't have any persistent volumes
             logger.info("all tasks of {} are terminal, requesting to expunge", updated.instanceId)
             InstanceUpdateEffect.Expunge(updated, events)
           } else {

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
@@ -95,8 +95,7 @@ private[jobs] object OverdueTasksActor {
 
     private[this] def overdueReservations(now: Timestamp, instances: Seq[Instance]): Seq[Instance] = {
       instances.filter { instance =>
-        val reservedTasks = instance.tasksMap.values.filter(_.status.condition == Condition.Reserved)
-        reservedTasks.nonEmpty && instance.reservation.exists(_.state.timeout.exists(_.deadline <= now))
+        instance.isReserved && instance.reservation.exists(_.state.timeout.exists(_.deadline <= now))
       }
     }
   }


### PR DESCRIPTION
There is a race condition in task status updates handling in case of pods.
If a pod has two or more containers and terminal states are sent to Marathon
not one right after another, but with some delay, Marathon launches a new pod
without waiting till all the previous tasks reach a terminal state. It is somewhat
benign in case of ephemeral pods, but it is severe in case of pods with
persistent volumes.

JIRA issues:
https://jira.mesosphere.com/browse/MARATHON_EE-1817
https://jira.mesosphere.com/browse/MARATHON_EE-1820