### PR TITLE
Expose `containerPort` as `$PORT_NAME` env vars

### DIFF
--- a/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
+++ b/src/main/scala/mesosphere/mesos/EnvironmentHelper.scala
@@ -87,11 +87,13 @@ object EnvironmentHelper {
           env += (s"PORT_$generatedPort" -> generatedPort.toString)
       }
 
-      requestedPorts.zip(effectivePorts).foreach {
-        case (PortRequest(Some(portName), _), Some(effectivePort)) =>
+      requestedPorts.zip(effectivePorts).zipWithIndex.foreach {
+        case ((PortRequest(Some(portName), _), Some(effectivePort)), _) =>
           env += (s"PORT_${portName.toUpperCase}" -> effectivePort.toString)
-        case (PortRequest(Some(portName), port), None) =>
+        case ((PortRequest(Some(portName), port), None), _) if port != AppDefinition.RandomPortValue =>
           env += (s"PORT_${portName.toUpperCase}" -> port.toString)
+        case ((PortRequest(Some(portName), port), None), portIndex) if port == AppDefinition.RandomPortValue =>
+          env += (s"PORT_${portName.toUpperCase}" -> generatedPorts(portIndex).toString)
         case _ =>
       }
 

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1638,7 +1638,7 @@ class TaskBuilderTest extends UnitTest {
 
               portMappings = Seq(
                 PortMapping(containerPort = 8080, hostPort = None, servicePort = 9000, protocol = "tcp", name = Some("http")),
-                PortMapping(containerPort = 8081, hostPort = None, servicePort = 9001, protocol = "tcp", name = Some("jabber"))
+                PortMapping(containerPort = 0, hostPort = None, servicePort = 9001, protocol = "tcp", name = Some("jabber"))
               )
             ))
           ),
@@ -1652,9 +1652,11 @@ class TaskBuilderTest extends UnitTest {
         command.getEnvironment.getVariablesList.toList.map(v => v.getName -> v.getValue).toMap
 
       assert("8080" == env("PORT_8080"))
-      assert("8081" == env("PORT_8081"))
       assert("8080" == env("PORT_HTTP"))
-      assert("8081" == env("PORT_JABBER"))
+
+      val port1 = env("PORT1")
+      assert(port1 == env(s"PORT_${port1}"))
+      assert(port1 == env("PORT_JABBER"))
     }
 
     "PortsEnvWithBothPortsAndMappings" in {

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1655,6 +1655,7 @@ class TaskBuilderTest extends UnitTest {
       assert("8080" == env("PORT_HTTP"))
 
       val port1 = env("PORT1")
+      assert(port1.toInt > 0)
       assert(port1 == env(s"PORT_${port1}"))
       assert(port1 == env("PORT_JABBER"))
     }


### PR DESCRIPTION
for randomly generated ports correctly.

JIRA: COPS-2072
