### PR TITLE
Use block_iptable_rules_for_seconds.

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -244,8 +244,9 @@ def block_iptable_rules_for_seconds(host, port_number, sleep_seconds, block_inpu
 
 def iptables_block_string(block_input, block_output, port):
     """ Produces a string of iptables blocking command that can be executed on an agent. """
-    str = "sudo iptables -I INPUT -p tcp --dport {} -j DROP;".format(port) if block_input else ""
-    return str + "sudo iptables -I OUTPUT -p tcp --dport {} -j DROP;".format(port) if block_output else ""
+    block_input_str = "sudo iptables -I INPUT -p tcp --dport {} -j DROP;".format(port) if block_input else ""
+    block_output_str = "sudo iptables -I OUTPUT -p tcp --dport {} -j DROP;".format(port) if block_output else ""
+    return block_input_str + block_output_str
 
 
 def wait_for_task(service, task, timeout_sec=120):

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -487,7 +487,7 @@ def test_pod_health_failed_check():
     tasks = common.get_pod_tasks(pod_id)
     for new_task in tasks:
         new_task_id = new_task['id']
-        assert new_task_id != initial_id1, f"Task {task_id} has not been restarted"
+        assert new_task_id != initial_id1, f"Task {task_id} has not been restarted" # noqa E999
         assert new_task_id != initial_id2, f"Task {task_id} has not been restarted"
 
 

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -486,9 +486,9 @@ def test_pod_health_failed_check():
 
     tasks = common.get_pod_tasks(pod_id)
     for new_task in tasks:
-        task_id = new_task['id']
-        assert task_id != initial_id1, f"Task {task_id} has not been restarted"
-        assert task_id != initial_id2, f"Task {task_id} has not been restarted"
+        new_task_id = new_task['id']
+        assert new_task_id != initial_id1, f"Task {task_id} has not been restarted"
+        assert new_task_id != initial_id2, f"Task {task_id} has not been restarted"
 
 
 @common.marathon_1_6

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -481,16 +481,14 @@ def test_pod_health_failed_check():
     container1 = pod['instances'][0]['containers'][0]
     port = container1['endpoints'][0]['allocatedHostPort']
 
-    common.save_iptables(host)
-    common.block_port(host, port)
-    time.sleep(7)
-    common.restore_iptables(host)
+    common.block_iptable_rules_for_seconds(host, port, 7, block_input=True, block_output=False)
     common.deployment_wait(service_id=pod_id)
 
     tasks = common.get_pod_tasks(pod_id)
-    for task in tasks:
-        assert task['id'] != initial_id1, "One of the tasks has not been restarted"
-        assert task['id'] != initial_id2, "One of the tasks has not been restarted"
+    for new_task in tasks:
+        task_id = new_task['id']
+        assert task_id != initial_id1, f"Task {task_id} has not been restarted"
+        assert task_id != initial_id2, f"Task {task_id} has not been restarted"
 
 
 @common.marathon_1_6


### PR DESCRIPTION
Summary:
One system integration test was still using the removed `save_iptables` and
`block_port` logic.
