### PR TITLE
Correct expected error message for unknown user.

### DIFF
--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -269,8 +269,8 @@ def test_run_app_with_non_existing_user():
     def check_failure_message():
         app = client.get_app(app_def["id"])
         message = app['lastTaskFailure']['message']
-        error = "Failed to get user information for 'bad'"
-        assert error in message, "Launched an app with a non-existing user: {}".format(app['user'])
+        error = "No such user 'bad'"
+        assert error in message, f"Did not receive expected error messsage \"{error}\" but \"{message}\""
 
     check_failure_message()
 

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -270,7 +270,7 @@ def test_run_app_with_non_existing_user():
         app = client.get_app(app_def["id"])
         message = app['lastTaskFailure']['message']
         error = "No such user 'bad'"
-        assert error in message, f"Did not receive expected error messsage \"{error}\" but \"{message}\""
+        assert error in message, f"Did not receive expected error messsage \"{error}\" but \"{message}\"" # noqa E999
 
     check_failure_message()
 


### PR DESCRIPTION
Summary:
A system integration test was expecting the wrong error message. We
probably should make this more agnostic to the actual message.
