### PR TITLE
Updated mesos debian package to `1.1.3-2.0.1`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,9 +77,9 @@ object Dependency {
     val Chaos = "0.8.7"
     val Guava = "19.0"
     // FIXME (gkleiman): reenable deprecation checks after Mesos 1.0.0-rc2 deprecations are handled
-    val Mesos = "1.1.0"
+    val Mesos = "1.1.3"
     // Version of Mesos to use in Dockerfile.
-    val MesosDebian = "1.1.0-2.0.107.debian81"
+    val MesosDebian = "1.1.3-2.0.1"
     val Akka = "2.4.17"
     val AsyncAwait = "0.9.6"
     val Spray = "1.3.4"


### PR DESCRIPTION
 and mesos dependency to 1.1.3. This fixes failing `MesosAppIntegrationTests*` that use mesos containerizer and docker images.