### PR TITLE
Set a constant time for task status updates in InstanceTest. (#5538)

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.condition.Condition._
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{ Timestamp, UnreachableStrategy }
+import mesosphere.marathon.state.UnreachableStrategy
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
@@ -107,17 +107,17 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
     def tasks(statuses: Seq[Condition]): Map[Task.Id, Task] =
       statuses.map { status =>
         val taskId = Task.Id.forRunSpec(id)
-        val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(status, taskId, Timestamp.now())
-        val task = TestTaskBuilder.Helper.minimalTask(taskId, Timestamp.now(), mesosStatus, status)
+        val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(status, taskId, clock.now())
+        val task = TestTaskBuilder.Helper.minimalTask(taskId, clock.now(), mesosStatus, status)
         task.taskId -> task
       }(collection.breakOut)
 
     def instanceWith(condition: Condition, conditions: Seq[Condition]): (Instance, Map[Task.Id, Task]) = {
       val currentTasks = tasks(conditions.map(_ => condition))
       val newTasks = tasks(conditions)
-      val state = Instance.InstanceState(None, currentTasks, Timestamp.now(), UnreachableStrategy.default())
+      val state = Instance.InstanceState(None, currentTasks, clock.now(), UnreachableStrategy.default())
       val instance = Instance(Instance.Id.forRunSpec(id), agentInfo, state, currentTasks,
-        runSpecVersion = Timestamp.now(), UnreachableStrategy.default())
+        runSpecVersion = clock.now(), UnreachableStrategy.default())
       (instance, newTasks)
     }
   }


### PR DESCRIPTION
Summary:
The UnreachableStrategy defaults were change to zero. since we used the
current time as status update times the was a small race condition
since we could hit the inactive threshold.