### PR TITLE
Verify SSL connection for events integration test with CA from DC/OS.

### DIFF
--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -51,4 +51,4 @@ fi
 jq -r .ssh_private_key cluster_info.json > "$CLI_TEST_SSH_KEY"
 
 # Return dcos_url
-echo "http://$(./dcos-launch describe | jq -r ".masters[0].public_ip")/"
+echo "$(./dcos-launch describe | jq -r ".masters[0].public_ip")"

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -55,7 +55,14 @@ function download-diagnostics-bundle {
 # Launch cluster and run tests if launch was successful.
 CLI_TEST_SSH_KEY="$(pwd)/$DEPLOYMENT_NAME.pem"
 export CLI_TEST_SSH_KEY
-DCOS_URL=$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )
+
+if [ "$VARIANT" == "strict" ]; then
+  DCOS_URL="https://$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )"
+  wget --no-check-certificate -O tests/system/fixtures/dcos-ca.crt $DCOS_URL/ca/dcos-ca.crt
+else
+  DCOS_URL="http://$( ./ci/launch_cluster.sh "$CHANNEL" "$VARIANT" | tail -1 )"
+fi
+
 CLUSTER_LAUNCH_CODE=$?
 export DCOS_URL
 case $CLUSTER_LAUNCH_CODE in

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -40,7 +40,7 @@ async def sse_events():
     headers = {'Authorization': 'token={}'.format(shakedown.dcos_acs_token()),
                'Accept': 'text/event-stream'}
     async with aiohttp.ClientSession(headers=headers) as session:
-        async with session.get(url) as response:
+        async with session.get(url, verify_ssl=False) as response:
             async def internal_generator():
                 client = SSEClient(response.content)
                 async for event in client.events():

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -4,7 +4,9 @@ import json
 import os.path
 import pytest
 import shakedown
+import ssl
 from datetime import timedelta
+from pathlib import Path
 from sseclient.async import SSEClient
 from urllib.parse import urljoin
 
@@ -34,13 +36,32 @@ def wait_for_marathon_user_and_cleanup():
     print("exiting wait_for_marathon_user_and_cleanup fixture")
 
 
+def get_ssl_context():
+    """Looks for the DC/OS certificate in the fixtures folder.
+
+    Returns:
+        None if ca file does not exist.
+        SSLContext with file.
+
+    """
+    cafile = Path(fixtures_dir(), 'dcos-ca.crt')
+    if cafile.is_file():
+        print(f'Provide certificate {cafile}')
+        ssl_context = ssl.create_default_context(cafile=cafile)
+        return ssl_context
+    else:
+        return None
+
 @pytest.fixture
 async def sse_events():
     url = urljoin(shakedown.dcos_url(), 'service/marathon/v2/events')
     headers = {'Authorization': 'token={}'.format(shakedown.dcos_acs_token()),
                'Accept': 'text/event-stream'}
+
+    ssl_context = get_ssl_context()
+    verify_ssl = ssl_context is not None
     async with aiohttp.ClientSession(headers=headers) as session:
-        async with session.get(url, verify_ssl=False) as response:
+        async with session.get(url, verify_ssl=verify_ssl, ssl_context=ssl_context) as response:
             async def internal_generator():
                 client = SSEClient(response.content)
                 async for event in client.events():

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -52,6 +52,7 @@ def get_ssl_context():
     else:
         return None
 
+
 @pytest.fixture
 async def sse_events():
     url = urljoin(shakedown.dcos_url(), 'service/marathon/v2/events')

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -46,7 +46,7 @@ def get_ssl_context():
     """
     cafile = Path(fixtures_dir(), 'dcos-ca.crt')
     if cafile.is_file():
-        print(f'Provide certificate {cafile}')
+        print(f'Provide certificate {cafile}') # NOQA E999
         ssl_context = ssl.create_default_context(cafile=cafile)
         return ssl_context
     else:

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -487,8 +487,8 @@ def test_pod_health_failed_check():
     tasks = common.get_pod_tasks(pod_id)
     for new_task in tasks:
         new_task_id = new_task['id']
-        assert new_task_id != initial_id1, f"Task {task_id} has not been restarted" # noqa E999
-        assert new_task_id != initial_id2, f"Task {task_id} has not been restarted"
+        assert new_task_id != initial_id1, f"Task {new_task_id} has not been restarted"
+        assert new_task_id != initial_id2, f"Task {new_task_id} has not been restarted"
 
 
 @common.marathon_1_6


### PR DESCRIPTION
Summary:
All requests that require an SSL verification fail because the CA file is not loaded. With this
change we'll download the certificate and provide it to the event stream client for strict clusters.
