### PR TITLE
Document proper usage of env cmd vars

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -16,7 +16,9 @@ These flags control the core functionality of the Marathon server.
 
 ### Note - Command Line Flags May Be Specified Using Environment Variables
 
-The core functionality flags can be also set by environment variable `MARATHON_OPTION_NAME` (the option name with a `MARATHON_` prefix added to it), for example `MARATHON_MASTER` for `--master` option.  Please note that command line options precede environment variables.  This means that if the `MARATHON_MASTER` environment variable is set and `--master` is supplied on the command line, then the environment variable is ignored.
+The core functionality flags can be also set by environment variable `MARATHON_CMD_OPTION_NAME` (the option name with a `MARATHON_CMD_` prefix added to it), for example `MARATHON_CMD_MASTER` for `--master` option.  Please note that command line options precede environment variables.  This means that if the `MARATHON_CMD_MASTER` environment variable is set and `--master` is supplied on the command line, then the environment variable is ignored. 
+
+For versions of Marathon prior to 1.4 the prefix for option name was just `MARATHON_`. In newer versions that is not supported anymore.
 
 ### Required Flags
 


### PR DESCRIPTION
Summary:
In version 1.4 a breaking change was introduced for the way how env vars for CMD parameters are named and this was not documented so far. This PR adds this documentation. See this old ticket https://jira.mesosphere.com/browse/MARATHON_EE-569 and this code in `Main.scala` https://github.com/mesosphere/marathon/commit/f6fccc35f4bd6ce4dad2b43aab9b0f862299643a#diff-d9fbeb18eb73de0292d5767e79e5da8e
