### PR TITLE
Block Mesos port on Marathon master for 100 seconds.

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -365,8 +365,7 @@ def install_enterprise_cli_package():
        command to create secrets, manage service accounts etc.
     """
     print('Installing dcos-enterprise-cli package')
-    stdout, stderr, return_code = shakedown.run_dcos_command('package install dcos-enterprise-cli --cli --yes')
-    assert return_code == 0, "Failed to install dcos-enterprise-cli package"
+    stdout, stderr, return_code = shakedown.run_dcos_command('package install dcos-enterprise-cli --cli --yes', raise_on_error=True)
 
 
 def is_enterprise_cli_package_installed():
@@ -727,8 +726,8 @@ def __marathon_leadership_changed_in_mesosDNS(original_leader):
         We have to retry because mesosDNS checks for changes only every 30s.
     """
     current_leader = shakedown.marathon_leader_ip()
-    print('leader according to MesosDNS: {}'.format(current_leader))
-    assert original_leader != current_leader
+    print(f'leader according to MesosDNS: {current_leader}, original leader: {original_leader}')
+    assert original_leader != current_leader, f'Current leader did not change: original={original_leader}, current={current_leader}'
 
 
 @retrying.retry(wait_exponential_multiplier=1000, wait_exponential_max=30000, retry_on_exception=ignore_exception)

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -365,7 +365,8 @@ def install_enterprise_cli_package():
        command to create secrets, manage service accounts etc.
     """
     print('Installing dcos-enterprise-cli package')
-    stdout, stderr, return_code = shakedown.run_dcos_command('package install dcos-enterprise-cli --cli --yes', raise_on_error=True)
+    cmd = 'package install dcos-enterprise-cli --cli --yes'
+    stdout, stderr, return_code = shakedown.run_dcos_command(cmd, raise_on_error=True)
 
 
 def is_enterprise_cli_package_installed():
@@ -727,7 +728,8 @@ def __marathon_leadership_changed_in_mesosDNS(original_leader):
     """
     current_leader = shakedown.marathon_leader_ip()
     print(f'leader according to MesosDNS: {current_leader}, original leader: {original_leader}')
-    assert original_leader != current_leader, f'Current leader did not change: original={original_leader}, current={current_leader}'
+    error = f'Current leader did not change: original={original_leader}, current={current_leader}'
+    assert original_leader != current_leader, error
 
 
 @retrying.retry(wait_exponential_multiplier=1000, wait_exponential_max=30000, retry_on_exception=ignore_exception)

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -727,8 +727,8 @@ def __marathon_leadership_changed_in_mesosDNS(original_leader):
         We have to retry because mesosDNS checks for changes only every 30s.
     """
     current_leader = shakedown.marathon_leader_ip()
-    print(f'leader according to MesosDNS: {current_leader}, original leader: {original_leader}')
-    error = f'Current leader did not change: original={original_leader}, current={current_leader}'
+    print(f'leader according to MesosDNS: {current_leader}, original leader: {original_leader}') # NOQA E999
+    error = f'Current leader did not change: original={original_leader}, current={current_leader}' # NOQA E999
     assert original_leader != current_leader, error
 
 

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -487,7 +487,7 @@ def test_pod_health_failed_check():
     tasks = common.get_pod_tasks(pod_id)
     for new_task in tasks:
         new_task_id = new_task['id']
-        assert new_task_id != initial_id1, f"Task {new_task_id} has not been restarted"
+        assert new_task_id != initial_id1, f"Task {new_task_id} has not been restarted" # NOQA E999
         assert new_task_id != initial_id2, f"Task {new_task_id} has not been restarted"
 
 

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -487,8 +487,8 @@ def test_pod_health_failed_check():
     tasks = common.get_pod_tasks(pod_id)
     for new_task in tasks:
         new_task_id = new_task['id']
-        assert new_task_id != initial_id1, f"Task {task_id} has not been restarted" # noqa E999
-        assert new_task_id != initial_id2, f"Task {task_id} has not been restarted"
+        assert new_task_id != initial_id1, f"Task {new_task_id} has not been restarted"
+        assert new_task_id != initial_id2, f"Task {new_task_id} has not been restarted"
 
 
 @common.marathon_1_6

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -171,7 +171,9 @@ def test_marathon_master_partition_leader_change(marathon_service_name):
     original_leader = common.get_marathon_leader_not_on_master_leader_node()
 
     # blocking outbound connection to mesos master
-    common.block_iptable_rules_for_seconds(original_leader, 5050, sleep_seconds=60,
+    # Marathon has a Mesos heartbeat interval of 15 seconds. If 5 are missed it
+    # disconnects. Thus we should wait more than 75 seconds.
+    common.block_iptable_rules_for_seconds(original_leader, 5050, sleep_seconds=100,
                                            block_input=False, block_output=True)
 
     common.marathon_leadership_changed(original_leader)


### PR DESCRIPTION
Summary:
Currently a partition test blocks the Mesos port on the Marathon leader
host for 60 seconds. That is not enough to trigger 5 Mesos heartbeat
failures and a following leader election. Thus we set it to 100 seconds.
