### PR TITLE
Fix flaky `GracefulTaskKillIntegrationTest`

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
@@ -39,7 +39,7 @@ class GracefulTaskKillIntegrationTest extends AkkaIntegrationFunTest with Embedd
 
     When("a task of an app is killed")
     val taskKillSentTimestamp = Timestamp.now()
-    marathon.killTask(app.id, taskId).code should be (200)
+    marathon.killTask(app.id, taskId, scale = true).code should be (200)
 
     val taskKilledEvent = waitForEventWith(
       "status_update_event",
@@ -70,7 +70,7 @@ class GracefulTaskKillIntegrationTest extends AkkaIntegrationFunTest with Embedd
     val taskId = marathon.tasks(app.id).value.head.id
 
     When("a task of an app is killed")
-    marathon.killTask(app.id, taskId).code should be (200)
+    marathon.killTask(app.id, taskId, scale = true).code should be (200)
     val taskKillSentTimestamp = Timestamp.now()
 
     val taskKilledEvent = waitForEventWith(

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -3,22 +3,22 @@ package mesosphere.mesos
 import com.google.protobuf.TextFormat
 import mesosphere.marathon.Protos
 import mesosphere.marathon.api.serialization.PortDefinitionSerializer
-import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.raml.Resources
-import mesosphere.marathon.state.Container.{Docker, PortMapping}
+import mesosphere.marathon.state.Container.{ Docker, PortMapping }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
-import mesosphere.marathon.state.{AppDefinition, Container, PathId, Timestamp, _}
+import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
 import mesosphere.marathon._
 import mesosphere.marathon.stream._
-import mesosphere.marathon.test.{MarathonSpec, MarathonTestHelper}
-import mesosphere.mesos.protos.{Resource, _}
+import mesosphere.marathon.test.{ MarathonSpec, MarathonTestHelper }
+import mesosphere.mesos.protos.{ Resource, _ }
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo
 import org.apache.mesos.Protos.TaskInfo
-import org.apache.mesos.{Protos => MesosProtos}
-import org.joda.time.{DateTime, DateTimeZone}
+import org.apache.mesos.{ Protos => MesosProtos }
+import org.joda.time.{ DateTime, DateTimeZone }
 import org.scalatest.Matchers
 
 import scala.collection.immutable.Seq


### PR DESCRIPTION
Summary:
Fix flaky `GracefulTaskKillIntegrationTest` by scaling down when killing
tasks. Otherwise we have a race condition where a new task
is started before the test is finished which leads to a failure during
clean up. The underlying race condition will be fixed in another PR.