### PR TITLE
Script for manually running perf tests against DC/OS

### DIFF
--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -89,3 +89,28 @@ The "thin cluster" deployed consists of 6 Mesos agents (with overcommitted resou
 #### Environment variables
 
 * `PARTIAL_TESTS` _[Optional]_ : A comma-separated list with the names of the tests to run. If missing the full set of tests will run.
+
+## Running Manually
+
+You can run the same tests manually using the `manual_*.sh` scripts. These scripts do not submit the results to reporting services, nor require complete configuration.
+
+This section describes the usage and requirements of each script.
+
+### `manual_run_dcos.sh` - Run tests against a DC/OS cluster
+
+Runs the tests against a DC/OS cluster. The script accepts the cluster URL as the first argument and an optional list of tests to run.
+
+The script will use `dcos-cli` to first log-in on the cluster and obtain an authentication ID. Example:
+
+```
+./manual_run_dcos.sh http://my.cluster.url [path/to/test.yml ...]
+```
+
+#### Requirements
+
+* dcos-cli
+* python3
+* python3-pip
+* docker
+* docker-compose
+

--- a/tests/performance/config/perf-driver/common/config-common.yml
+++ b/tests/performance/config/perf-driver/common/config-common.yml
@@ -17,4 +17,4 @@ config:
 define:
 
   # The version specification we are using when writing the reponrts
-  versionspec: "{{meta:ref|date(%Y%m%d)}}-{{meta:version|safepath(meta:branch)|'unversioned'}}-{{meta:env}}-{{meta:test}}"
+  versionspec: "{{meta:ref|date(%Y%m%d%H%M)}}-{{meta:version|safepath(meta:branch)|'unversioned'}}-{{meta:env}}-{{meta:test}}"

--- a/tests/performance/config/perf-driver/environments/env-ci.yml
+++ b/tests/performance/config/perf-driver/environments/env-ci.yml
@@ -1,0 +1,16 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : CI Environment                     #
+# ----------------------------------------------------------- #
+# This fragment instructs the driver to report the results to #
+# a remote services such as S3 and DataDog                    #
+# ----------------------------------------------------------- #
+
+# Fragments to include
+# ===========================
+include:
+
+  # Create the following reports
+  - ../reporters/report-raw.yml
+  - ../reporters/report-csv.yml
+  - ../reporters/report-s3.yml
+  - ../reporters/report-datadog.yml

--- a/tests/performance/config/perf-driver/environments/env-local.yml
+++ b/tests/performance/config/perf-driver/environments/env-local.yml
@@ -1,0 +1,15 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Local Environment                  #
+# ----------------------------------------------------------- #
+# This fragment instructs the driver to report to files,      #
+# using the raw and plot reporters.
+# ----------------------------------------------------------- #
+
+# Fragments to include
+# ===========================
+include:
+
+  # Create the following reports
+  - ../reporters/report-raw.yml
+  - ../reporters/report-csv.yml
+  - ../reporters/report-plot.yml

--- a/tests/performance/config/perf-driver/environments/opt-jmx.yml
+++ b/tests/performance/config/perf-driver/environments/opt-jmx.yml
@@ -1,0 +1,18 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : JMX-Supported Environment          #
+# ----------------------------------------------------------- #
+# Include this fragment if you want to enable JMX-Related     #
+# observer and metric collection.                             #
+# ----------------------------------------------------------- #
+
+# Fragments to include
+# ===========================
+include:
+
+  # Enable the JMX observer
+  - ../observers/observer-jmx.yml
+
+  # Enable JMX Metrics
+  - ../measure/measure-jmx-threadCount.yml
+  - ../measure/measure-jmx-usedMemory.yml
+  - ../measure/measure-jmx-cpuUsage.yml

--- a/tests/performance/config/perf-driver/environments/target-cluster-custom.yml
+++ b/tests/performance/config/perf-driver/environments/target-cluster-custom.yml
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------- #
-# Configuration Fragment : Cluster Environment                #
+# Configuration Fragment : Custom DC/OS Cluster Target        #
 # ----------------------------------------------------------- #
 # This fragment instructs the driver to use the marathon      #
-# exposed from an enterprise cluster. As part of it's setup   #
-# sequence, the driver will authenticate to the cluster with  #
-# the default superuser account.                              #
+# exposed from an enterprise cluster. In contrast to other    #
+# cluster targets it requires the auth token to be given by   #
+# the user.                                                   #
 # ----------------------------------------------------------- #
 
 # Global test configuration
@@ -18,10 +18,15 @@ config:
       desc: The URL to the deployed DC/OS cluster
       required: yes
 
+  # We also require the user to provide his authentication token
+    - name: dcos_auth_token
+      desc: The authentication token to use for contacting the DC/OS cluster
+      required: yes
+
 # Test Metadata
 # ===========================
 meta:
-  env: extern-cluster-ee
+  env: extern-cluster-custom
 
 # Definitions
 # ===========================
@@ -29,13 +34,3 @@ define:
 
   # Define `marathon_url` as part of the cluster URL
   marathon_url: "{{base_url}}/marathon"
-
-# One-time tasks
-# ===========================
-tasks:
-
-  # Authenticate to the cluster during the setup phase of the tests
-  - class: tasks.auth.AuthEE
-    password: deleteme
-    user: bootstrapuser
-    at: setup

--- a/tests/performance/config/perf-driver/environments/target-cluster-ee.yml
+++ b/tests/performance/config/perf-driver/environments/target-cluster-ee.yml
@@ -1,0 +1,41 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Enterprise DC/OS Cluster Target    #
+# ----------------------------------------------------------- #
+# This fragment instructs the driver to use the marathon      #
+# exposed from an enterprise cluster. As part of it's setup   #
+# sequence, the driver will authenticate to the cluster with  #
+# the default superuser account.                              #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # We require the following definitions to be present (might be defined by
+  # other fragments, or must be given by the user)
+  definitions:
+    - name: base_url
+      desc: The URL to the deployed DC/OS cluster
+      required: yes
+
+# Test Metadata
+# ===========================
+meta:
+  env: extern-cluster-ee
+
+# Definitions
+# ===========================
+define:
+
+  # Define `marathon_url` as part of the cluster URL
+  marathon_url: "{{base_url}}/marathon"
+
+# One-time tasks
+# ===========================
+tasks:
+
+  # Authenticate to the cluster during the setup phase of the tests
+  - class: tasks.auth.AuthEE
+    password: deleteme
+    user: bootstrapuser
+    at: setup

--- a/tests/performance/config/perf-driver/environments/target-cluster-oss.yml
+++ b/tests/performance/config/perf-driver/environments/target-cluster-oss.yml
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------- #
-# Configuration Fragment : Cluster Environment                #
+# Configuration Fragment : Open-Source DC/OS Cluster Target   #
 # ----------------------------------------------------------- #
 # This fragment instructs the driver to use the marathon      #
 # exposed from an enterprise cluster. As part of it's setup   #

--- a/tests/performance/config/perf-driver/environments/target-dcluster.yml
+++ b/tests/performance/config/perf-driver/environments/target-dcluster.yml
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------- #
-# Configuration Fragment : Local Marathon Environment         #
+# Configuration Fragment : "Thin" Local Cluster Target        #
 # ----------------------------------------------------------- #
 # This fragment instructs the driver to launch marathon with  #
 # it's own mesos simulator (locally). This fragment assumes   #
@@ -22,3 +22,4 @@ define:
 
   # The host name where to connect for the JMX endpoint
   jmx_host: 127.0.0.1
+  jmx_port: 9010

--- a/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
+++ b/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
@@ -22,7 +22,6 @@ include:
   # Use marathon's SSE endpoint to measure our metrics
   - observers/observer-marathon-http-timing.yml
   - observers/observer-marathon-poller.yml
-  - observers/observer-jmx.yml
 
   # Measure the given metrics
   - measure/measure-deploymentTime.yml
@@ -30,12 +29,3 @@ include:
   - measure/measure-httpRequestTime.yml
   - measure/measure-failedDeployments.yml
   - measure/measure-groupsResponseTime.yml
-  - measure/measure-jmx-threadCount.yml
-  - measure/measure-jmx-usedMemory.yml
-  - measure/measure-jmx-cpuUsage.yml
-
-  # Create the following reports
-  - reporters/report-raw.yml
-  - reporters/report-csv.yml
-  - reporters/report-s3.yml
-  - reporters/report-datadog.yml

--- a/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
+++ b/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
@@ -22,7 +22,6 @@ include:
   # Use marathon's SSE endpoint to measure our metrics
   - observers/observer-marathon-http-timing.yml
   - observers/observer-marathon-poller.yml
-  - observers/observer-jmx.yml
 
   # Measure the given metrics
   - measure/measure-deploymentTime.yml
@@ -30,12 +29,3 @@ include:
   - measure/measure-httpRequestTime.yml
   - measure/measure-failedDeployments.yml
   - measure/measure-groupsResponseTime.yml
-  - measure/measure-jmx-threadCount.yml
-  - measure/measure-jmx-usedMemory.yml
-  - measure/measure-jmx-cpuUsage.yml
-
-  # Create the following reports
-  - reporters/report-raw.yml
-  - reporters/report-csv.yml
-  - reporters/report-s3.yml
-  - reporters/report-datadog.yml

--- a/tests/performance/manual_run_dcos.sh
+++ b/tests/performance/manual_run_dcos.sh
@@ -11,6 +11,10 @@ if ! which dcos >/dev/null; then
   echo "ERROR: Please install the DC/OS CLI before using this tool"
   exit 1
 fi
+if ! which dcos-perf-test-driver >/dev/null; then
+  echo "ERROR: Please install the DC/OS Performance Test Driver before using this tool"
+  exit 1
+fi
 
 # Use DC/OS CLI to login if no authentication token was given
 if [ -z "$DCOS_AUTH_TOKEN" ]; then

--- a/tests/performance/manual_run_dcos.sh
+++ b/tests/performance/manual_run_dcos.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # This script runs the scale tests on a DC/OS cluster specified by the user
 
-# Current directory
-BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
 # Require a cluster URL
 [ -z "$1" ] && echo -e "Usage: $0 <cluster> [<test file> ...]" && exit 1
 CLUSTER_URL=$1
@@ -19,8 +16,8 @@ fi
 if [ -z "$DCOS_AUTH_TOKEN" ]; then
 
   # If DC/OS CLI is already configured to this cluster skip the setup step
-  if [ "$CLUSTER_URL" != $(dcos config show core.dcos_url) ]; then
-    dcos cluster setup $CLUSTER_URL
+  if [ "$CLUSTER_URL" != "$(dcos config show core.dcos_url)" ]; then
+    dcos cluster setup "$CLUSTER_URL"
   fi
 
   DCOS_AUTH_TOKEN=$(dcos config show core.dcos_acs_token)
@@ -40,7 +37,7 @@ for TEST in $TESTS; do
   dcos-perf-test-driver \
     ./config/perf-driver/environments/target-cluster-custom.yml \
     ./config/perf-driver/environments/env-local.yml \
-    ./$TEST \
+    "./$TEST" \
     -M "version=${DCOS_VERSION}" \
     -M "marathon=${MARATHON_VERSION}" \
     -D "dcos_auth_token=${DCOS_AUTH_TOKEN}" \

--- a/tests/performance/manual_run_dcos.sh
+++ b/tests/performance/manual_run_dcos.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# This script runs the scale tests on a DC/OS cluster specified by the user
+
+# Current directory
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Require a cluster URL
+[ -z "$1" ] && echo -e "Usage: $0 <cluster> [<test file> ...]" && exit 1
+CLUSTER_URL=$1
+shift
+
+# We need the CLI, so ask the user
+if ! which dcos >/dev/null; then
+  echo "ERROR: Please install the DC/OS CLI before using this tool"
+  exit 1
+fi
+
+# Use DC/OS CLI to login if no authentication token was given
+if [ -z "$DCOS_AUTH_TOKEN" ]; then
+
+  # If DC/OS CLI is already configured to this cluster skip the setup step
+  if [ "$CLUSTER_URL" != $(dcos config show core.dcos_url) ]; then
+    dcos cluster setup $CLUSTER_URL
+  fi
+
+  DCOS_AUTH_TOKEN=$(dcos config show core.dcos_acs_token)
+  [ -z "$DCOS_AUTH_TOKEN" ] \
+    && echo "ERROR: Unable to obtain a DC/OS authentication token. Did you log-in?" \
+    && exit 1
+fi
+
+# Collect some useful metadata
+DCOS_VERSION=$(dcos --version | grep dcos.version | awk -F'=' '{print $2}')
+MARATHON_VERSION=$(dcos marathon --version | awk '{print $3}')
+
+# If the user hasn't specified any test files, run them all
+TESTS=$*
+[ -z "$TESTS" ] && TESTS=$(ls config/perf-driver/test-*.yml)
+for TEST in $TESTS; do
+  dcos-perf-test-driver \
+    ./config/perf-driver/environments/target-cluster-custom.yml \
+    ./config/perf-driver/environments/env-local.yml \
+    ./$TEST \
+    -M "version=${DCOS_VERSION}" \
+    -M "marathon=${MARATHON_VERSION}" \
+    -D "dcos_auth_token=${DCOS_AUTH_TOKEN}" \
+    -D "base_url=${CLUSTER_URL}"
+done

--- a/tests/performance/scripts/dcluster_run.sh
+++ b/tests/performance/scripts/dcluster_run.sh
@@ -50,7 +50,9 @@ for TEST_CONFIG in $TESTS_DIR/test-*.yml; do
 
   # Launch the performance test driver with the correct arguments
   eval dcos-perf-test-driver \
-    $TESTS_DIR/environments/dcluster.yml \
+    $TESTS_DIR/environments/target-dcluster.yml \
+    $TESTS_DIR/environments/env-ci.yml \
+    $TESTS_DIR/environments/opt-jmx.yml \
     $TEST_CONFIG \
     -M "version=${MARATHON_VERSION}" \
     -M "mesos=${MESOS_VERSION}" \


### PR DESCRIPTION
This commit introduces the `manual_run_dcos.sh` that can be used to run
the performance tests against an already deployed DC/OS cluster.

_Part of JIRA: DCOS-20295_