### PR TITLE
Backport a bunch of IT fixes around `PortAllocator`

### DIFF
--- a/src/test/python/app_mock.py
+++ b/src/test/python/app_mock.py
@@ -45,8 +45,7 @@ def make_handler(appId, version, url):
             self.send_header('Content-type', 'text/html')
             self.end_headers()
 
-            marathonId = os.getenv("MARATHON_APP_ID", "NO_MARATHON_APP_ID_SET")
-            msg = "Pong {}".format(marathonId)
+            msg = "Pong {}".format(appId)
 
             self.wfile.write(byte_type(msg, "UTF-8"))
             return

--- a/src/test/resources/detect-routable-ip.sh
+++ b/src/test/resources/detect-routable-ip.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Script which returns your primary IP; works on Mac OS X and Linux
+#
+
+case $(uname) in
+  Darwin)
+    ifconfig $(route -n get default | grep interface | awk '{print $2}') | egrep "inet\b" | awk '{print $2}'
+    ;;
+  Linux)
+    ip -o addr | egrep -v 'inet6|/32' | grep global | head -1 | awk '{print $4}' | cut -f1 -d/
+    ;;
+  *)
+    # Unknown operating system; default to 127.0.0.1
+    echo "127.0.0.1"
+esac

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -200,11 +200,12 @@ class AppDeployIntegrationTest
 
   test("create a simple app with a Marathon HTTP health check using port instead of portIndex") {
     Given("a new app")
+    val port = mesosCluster.randomAgentPort()
     val app = appProxy(testBasePath / s"http-app-${UUID.randomUUID()}", "v1", instances = 1, healthCheck = None).
       copy(
-        portDefinitions = PortDefinitions(31000),
+        portDefinitions = PortDefinitions(port),
         requirePorts = true,
-        healthChecks = Set(marathonHttpHealthCheck.copy(port = Some(31000)))
+        healthChecks = Set(marathonHttpHealthCheck.copy(port = Some(port)))
       )
     val check = appProxyCheck(app.id, "v1", true)
 

--- a/src/test/scala/mesosphere/marathon/integration/LeadershipAbdicationIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/LeadershipAbdicationIntegrationTest.scala
@@ -25,7 +25,7 @@ class LeadershipAbdicationIntegrationTest extends LeaderIntegrationTest {
   // we need the same amount of additional marathon instances, like we abdicate afterwards.
   override val numAdditionalMarathons = abdicationLoops
 
-  override val mesosNumSlaves = 1
+  override lazy val mesosNumSlaves = 1
 
   test("Abdicating a leader does not kill a running task which is currently involved in a deployment") {
     Given("a new app with an impossible constraint")

--- a/src/test/scala/mesosphere/marathon/integration/NetworkPartitionIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/NetworkPartitionIntegrationTest.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
   */
 @SerialIntegrationTest
 class NetworkPartitionIntegrationTest extends AkkaIntegrationFunTest
-    with EmbeddedMarathonMesosClusterTest with Eventually {
+    with EmbeddedMarathonTest with Eventually {
 
   override implicit def patienceConfig = PatienceConfig(timeout = Span(50, Seconds), interval = Span(1, Second))
   override lazy val mesosNumMasters = 1

--- a/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.Inside
 import scala.concurrent.duration._
 
 @SerialIntegrationTest
-class TaskUnreachableIntegrationTest extends AkkaIntegrationFunTest with EmbeddedMarathonMesosClusterTest with Inside {
+class TaskUnreachableIntegrationTest extends AkkaIntegrationFunTest with EmbeddedMarathonTest with Inside {
 
   override lazy val mesosNumMasters = 1
   override lazy val mesosNumSlaves = 2

--- a/src/test/scala/mesosphere/marathon/integration/facades/MesosFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MesosFacade.scala
@@ -86,4 +86,9 @@ class MesosFacade(url: String, waitTime: Duration = 30.seconds)(implicit val sys
     val pipeline = sendReceive
     result(pipeline(Post(s"$url/terminate", s"frameworkId=$frameworkId")), waitTime)
   }
+
+  def teardown(frameworkId: String): HttpResponse = {
+    val pipeline = sendReceive
+    result(pipeline(Post(s"$url/teardown", s"frameworkId=$frameworkId")), waitTime)
+  }
 }

--- a/src/test/scala/mesosphere/marathon/integration/facades/MesosFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MesosFacade.scala
@@ -31,6 +31,7 @@ object MesosFacade {
 
   case class ITResources(resources: Map[String, ITResourceValue]) {
     def isEmpty: Boolean = resources.isEmpty || resources.values.forall(_.isEmpty)
+    def nonEmpty: Boolean = !isEmpty
 
     override def toString: String = {
       "{" + resources.toSeq.sortBy(_._1).map {

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -31,7 +31,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.mesos.Protos
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
-import org.scalatest.time.{ Milliseconds, Minutes, Seconds, Span }
+import org.scalatest.time.{ Milliseconds, Span }
 import org.scalatest.{ BeforeAndAfterAll, Suite }
 import play.api.libs.json.Json
 

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -654,7 +654,7 @@ trait LocalMarathonTest
   *
   * This should be used for simple tests that do not require multiple masters.
   */
-trait EmbeddedMarathonTest extends Suite with StrictLogging with ZookeeperServerTest with MesosLocalTest with LocalMarathonTest
+trait EmbeddedMarathonTest extends Suite with StrictLogging with ZookeeperServerTest with MesosClusterTest with LocalMarathonTest
 
 /**
   * Trait that has one Marathon instance, zk, and a Mesos cluster ready to go.
@@ -669,7 +669,7 @@ trait EmbeddedMarathonMesosClusterTest extends Suite with StrictLogging with Zoo
   *
   * It provides multiple Marathon instances. This allows e.g. leadership rotation.
   */
-trait MarathonClusterTest extends Suite with StrictLogging with ZookeeperServerTest with MesosLocalTest with LocalMarathonTest {
+trait MarathonClusterTest extends Suite with StrictLogging with ZookeeperServerTest with MesosClusterTest with LocalMarathonTest {
   val numAdditionalMarathons = 2
   lazy val additionalMarathons = 0.until(numAdditionalMarathons).map { _ =>
     LocalMarathon(autoStart = false, suiteName = suiteName, masterUrl = mesosMasterUrl,

--- a/src/test/scala/mesosphere/marathon/integration/setup/MesosTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MesosTest.scala
@@ -8,16 +8,18 @@ import akka.actor.{ ActorSystem, Scheduler }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.stream.Materializer
+import mesosphere.marathon.Seq
 import mesosphere.marathon.integration.facades.MesosFacade
 import mesosphere.marathon.util.Retry
 import mesosphere.util.PortAllocator
 import org.apache.commons.io.FileUtils
+import org.scalatest.Suite
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ BeforeAndAfterAll, Suite }
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.sys.process.Process
+import scala.sys.process.ProcessBuilder
 import scala.util.Try
 import scala.async.Async._
 
@@ -26,128 +28,6 @@ case class MesosConfig(
   containerizers: String = "mesos",
   isolation: Option[String] = None,
   imageProviders: Option[String] = None)
-
-/**
-  * Runs a mesos-local on a ephemeral port
-  *
-  * close() should be called when the server is no longer necessary
-  */
-case class MesosLocal(
-    suiteName: String,
-    numSlaves: Int = 1,
-    autoStart: Boolean = true,
-    config: MesosConfig = MesosConfig(),
-    waitForStart: FiniteDuration = 30.seconds)(implicit
-  system: ActorSystem,
-    mat: Materializer,
-    ctx: ExecutionContext,
-    scheduler: Scheduler) extends AutoCloseable {
-  lazy val port = PortAllocator.ephemeralPort()
-  lazy val masterUrl = s"127.0.0.1:$port"
-
-  private def write(dir: File, fileName: String, content: String): String = {
-    val file = File.createTempFile(fileName, "", dir)
-    file.deleteOnExit()
-    FileUtils.write(file, content)
-    file.setReadable(true)
-    file.getAbsolutePath
-  }
-
-  private lazy val mesosWorkDir = {
-    val tmp = Files.createTempDirectory("mesos-local").toFile
-    tmp.deleteOnExit()
-    tmp
-  }
-
-  private lazy val mesosEnv = {
-    val credentialsPath = write(mesosWorkDir, fileName = "credentials", content = "principal1 secret1")
-    val aclsPath = write(mesosWorkDir, fileName = "acls.json", content =
-      """
-        |{
-        |  "run_tasks": [{
-        |    "principals": { "type": "ANY" },
-        |    "users": { "type": "ANY" }
-        |  }],
-        |  "register_frameworks": [{
-        |    "principals": { "type": "ANY" },
-        |    "roles": { "type": "ANY" }
-        |  }],
-        |  "reserve_resources": [{
-        |    "roles": { "type": "ANY" },
-        |    "principals": { "type": "ANY" },
-        |    "resources": { "type": "ANY" }
-        |  }],
-        |  "create_volumes": [{
-        |    "roles": { "type": "ANY" },
-        |    "principals": { "type": "ANY" },
-        |    "volume_types": { "type": "ANY" }
-        |  }]
-        |}
-      """.stripMargin)
-
-    Seq(
-      "MESOS_WORK_DIR" -> mesosWorkDir.getAbsolutePath,
-      "MESOS_RUNTIME_DIR" -> new File(mesosWorkDir, "runtime").getAbsolutePath,
-      "MESOS_LAUNCHER" -> "posix",
-      "MESOS_CONTAINERIZERS" -> config.containerizers,
-      "MESOS_LAUNCHER" -> config.launcher,
-      "MESOS_ROLES" -> "public,foo",
-      "MESOS_ACLS" -> s"file://$aclsPath",
-      "MESOS_CREDENTIALS" -> s"file://$credentialsPath",
-      "MESOS_SYSTEMD_ENABLE_SUPPORT" -> "false",
-      "MESOS_SWITCH_USER" -> "false") ++
-      config.isolation.map("MESOS_ISOLATION" -> _).to[Seq] ++
-      config.imageProviders.map("MESOS_IMAGE_PROVIDERS" -> _).to[Seq]
-  }
-
-  private def create(): Process = {
-    val process = Process(
-      s"mesos-local --ip=127.0.0.1 --port=$port --work_dir=${mesosWorkDir.getAbsolutePath}",
-      cwd = None, mesosEnv: _*)
-    process.run(ProcessOutputToLogStream(s"$suiteName-MesosLocal-$port"))
-  }
-
-  private var mesosLocal = Option.empty[Process]
-
-  if (autoStart) {
-    start()
-  }
-
-  def start(): Future[Done] = {
-    if (mesosLocal.isEmpty) {
-      mesosLocal = Some(create())
-    }
-    Retry(s"mesos-local-$port", Int.MaxValue, maxDelay = waitForStart) {
-      Http(system).singleRequest(Get(s"http://localhost:$port/version")).map { result =>
-        if (result.status.isSuccess()) {
-          Done
-        } else {
-          throw new Exception(s"Mesos-local-$port not available")
-        }
-      }
-    }
-  }
-
-  def stop(): Unit = {
-    mesosLocal.foreach { process =>
-      process.destroy()
-    }
-    mesosLocal = Option.empty[Process]
-  }
-
-  def clean(): Unit = {
-    val client = new MesosFacade(masterUrl)
-    while (client.state.value.agents.exists(agent => !agent.usedResources.isEmpty || agent.reservedResourcesByRole.nonEmpty)) {
-      client.frameworkIds().value.foreach(client.terminate)
-    }
-  }
-
-  override def close(): Unit = {
-    Try(clean())
-    Try(stop())
-    Try(FileUtils.deleteDirectory(mesosWorkDir))
-  }
-}
 
 case class MesosCluster(
     suiteName: String,
@@ -165,14 +45,21 @@ case class MesosCluster(
   require(quorumSize > 0 && quorumSize <= numMasters)
 
   lazy val masters = 0.until(numMasters).map { i =>
-    Mesos(master = true, Seq(
+    Master(extraArgs = Seq(
       "--slave_ping_timeout=1secs",
       "--max_slave_ping_timeouts=4",
       s"--quorum=$quorumSize"))
   }
 
   lazy val agents = 0.until(numSlaves).map { i =>
-    Mesos(master = false, Seq(s"--hostname=$i"))
+    // We can add additional resources constraints for our test clusters here.
+    // IMPORTANT: we give each cluster's agent it's own port range! Otherwise every mesos will offer the same port range
+    // to it's marathon, leading to multiple tasks (from different IT suits) trying to use the same port!
+    // First-come-first-served task will bind successfully where the others will fail leading to a lot inconsistency and
+    // flakiness in tests.
+    Agent(resources = new Resources(ports = PortAllocator.portsRange()), extraArgs = Seq(
+      s"--attributes=node:$i" // uniquely identify each agent node, useful for constraint matching
+    ))
   }
 
   if (autoStart) {
@@ -186,8 +73,10 @@ case class MesosCluster(
   }
 
   def waitForLeader(): Future[String] = async {
+    val firstMaster = s"http://${masters.head.ip}:${masters.head.port}"
     val result = Retry("wait for leader", maxAttempts = Int.MaxValue, maxDelay = waitForLeaderTimeout) {
-      Http().singleRequest(Get(s"http://localhost:${masters.head.port}/redirect")).map { result =>
+      Http().singleRequest(Get(firstMaster + "/redirect")).map { result =>
+        result.discardEntityBytes() // forget about the body
         if (result.status.isFailure()) {
           throw new Exception(s"Couldn't determine leader: $result")
         }
@@ -195,7 +84,17 @@ case class MesosCluster(
       }
     }
 
-    await(result).headers.find(_.lowercaseName() == "location").map(_.value()).get
+    def maybeFixURI(uri: String): String = {
+      // some versions of mesos issue redirects with broken Location headers; fix them here
+      if (uri.indexOf("//") == 0) {
+        "http:" + uri
+      } else {
+        uri
+      }
+    }
+
+    val location = await(result).headers.find(_.lowercaseName() == "location").map(_.value()).getOrElse(firstMaster)
+    maybeFixURI(location)
   }
 
   def stop(): Unit = {
@@ -204,7 +103,7 @@ case class MesosCluster(
   }
 
   private def defaultContainerizers: String = {
-    if (sys.env.getOrElse("RUN_DOCKER_INTEGRATION_TESTS", "false") == "true") {
+    if (sys.env.getOrElse("RUN_DOCKER_INTEGRATION_TESTS", "true") == "true") {
       "docker,mesos"
     } else {
       "mesos"
@@ -259,18 +158,26 @@ case class MesosCluster(
       config.imageProviders.map("MESOS_IMAGE_PROVIDERS" -> _).to[Seq]
   }
 
-  case class Mesos(master: Boolean, extraArgs: Seq[String]) extends AutoCloseable {
+  // format: OFF
+  case class Resources(cpus: Option[Int] = None, mem: Option[Int] = None, ports: (Int, Int)) {
+    // Generates mesos-agent resource string e.g. "cpus:2;mem:124;ports:[10000-110000]"
+    def resourceString(): String = {
+      s"""
+         |${cpus.fold("")(c => s"cpus:$c;")}
+         |${mem.fold("")(m => s"mem:$m;")}
+         |${ports match {case (f, t) => s"ports:[$f-$t]"}}
+       """.stripMargin.replaceAll("[\n\r]", "");
+    }
+  }
+  // format: ON
+
+  trait Mesos extends AutoCloseable {
+    val extraArgs: Seq[String]
+    val ip = IP.routableIPv4
     val port = PortAllocator.ephemeralPort()
-    private val workDir = Files.createTempDirectory(s"mesos-master$port").toFile
-    private val processBuilder = Process(
-      command = Seq(
-      "mesos",
-      if (master) "master" else "slave",
-      "--ip=127.0.0.1",
-      s"--port=$port",
-      if (master) s"--zk=$masterUrl" else s"--master=$masterUrl",
-      s"--work_dir=${workDir.getAbsolutePath}") ++ extraArgs,
-      cwd = None, extraEnv = mesosEnv(workDir): _*)
+    val workDir: File
+    val processBuilder: ProcessBuilder
+    val processName: String
     private var process = Option.empty[Process]
 
     if (autoStart) {
@@ -287,8 +194,7 @@ case class MesosCluster(
     }
 
     private def create(): Process = {
-      val name = if (master) "Master" else "Agent"
-      processBuilder.run(ProcessOutputToLogStream(s"$suiteName-Mesos$name-$port"))
+      processBuilder.run(ProcessOutputToLogStream(s"$suiteName-Mesos$processName-$port"))
     }
 
     override def close(): Unit = {
@@ -297,11 +203,46 @@ case class MesosCluster(
     }
   }
 
+  // format: OFF
+  case class Master(extraArgs: Seq[String]) extends Mesos {
+    override val workDir = Files.createTempDirectory(s"mesos-master$port").toFile
+    override val processBuilder = Process(
+      command = Seq(
+      "mesos",
+      "master",
+      s"--ip=$ip",
+      s"--hostname=$ip",
+      s"--port=$port",
+      s"--zk=$masterUrl",
+      s"--work_dir=${workDir.getAbsolutePath}") ++ extraArgs,
+      cwd = None, extraEnv = mesosEnv(workDir): _*)
+
+    val processName: String = "Master"
+  }
+
+  case class Agent(resources: Resources, extraArgs: Seq[String]) extends Mesos {
+    override val workDir = Files.createTempDirectory(s"mesos-agent$port").toFile
+    override val processBuilder = Process(
+      command = Seq(
+        "mesos",
+        "agent",
+        s"--ip=$ip",
+        s"--hostname=$ip",
+        s"--port=$port",
+        s"--resources=${resources.resourceString()}",
+        s"--master=$masterUrl",
+        s"--work_dir=${workDir.getAbsolutePath}") ++ extraArgs,
+      cwd = None, extraEnv = mesosEnv(workDir): _*)
+
+    override val processName = "Agent"
+  }
+  // format: ON
+
+  def state = new MesosFacade(Await.result(waitForLeader(), waitForLeaderTimeout)).state
+
   def clean(): Unit = {
     val client = new MesosFacade(Await.result(waitForLeader(), waitForLeaderTimeout))
-    while (client.state.value.agents.exists(agent => !agent.usedResources.isEmpty || agent.reservedResourcesByRole.nonEmpty)) {
-      client.frameworkIds().value.foreach(client.terminate)
-    }
+    MesosTest.clean(client)
   }
 
   override def close(): Unit = {
@@ -309,12 +250,46 @@ case class MesosCluster(
     agents.foreach(_.close())
     masters.foreach(_.close())
   }
+
+  // Get a random port from a random agent from the port range that was given to the agent during initialisation
+  // This is useful for integration tests that need to bind to an accessible port. It still can happen that the
+  // requested port is already bound but the chances should be slim. If not - blame @kjeschkies. Integration test
+  // suites should not use the same port twice in their tests.
+  def randomAgentPort(): Int = {
+    import scala.util.Random
+    val (min, max) = Random.shuffle(agents).head.resources.ports
+    val range = min to max
+    range(Random.nextInt(range.length))
+  }
 }
+// format: ON
 
 trait MesosTest {
   def mesos: MesosFacade
   val mesosMasterUrl: String
   def cleanMesos(): Unit
+}
+
+object MesosTest {
+  def clean(client: MesosFacade, cleanTimeout: Duration = 5.minutes)(implicit ec: ExecutionContext, s: Scheduler): Unit = {
+
+    Retry("teardown marathon", maxDuration = cleanTimeout, minDelay = 0.25.second, maxDelay = 2.second) {
+      client.frameworkIds().value.map(client.teardown(_)).foreach { response =>
+        val status = response.status.intValue
+        if (status == 200) Done
+        else throw new IllegalStateException(s"server returned status $status")
+      }
+
+      val agents = client.state.value.agents
+      agents.find(a => !a.usedResources.isEmpty || a.reservedResourcesByRole.nonEmpty).foreach { agent =>
+        throw new IllegalStateException(
+          s"agent allocated on agent ${agent.id}: " +
+            s"used = ${agent.usedResources}, reserved = ${agent.reservedResourcesByRole}")
+      }
+
+      Future.successful(Done)
+    }
+  }
 }
 
 trait SimulatedMesosTest extends MesosTest {
@@ -324,38 +299,6 @@ trait SimulatedMesosTest extends MesosTest {
   }
   def cleanMesos(): Unit = {}
   val mesosMasterUrl = ""
-}
-
-trait MesosLocalTest extends Suite with ScalaFutures with MesosTest with BeforeAndAfterAll {
-  implicit val system: ActorSystem
-  implicit val mat: Materializer
-  implicit val ctx: ExecutionContext
-  implicit val scheduler: Scheduler
-  lazy val mesosConfig = MesosConfig()
-
-  val mesosNumSlaves = 1
-
-  lazy val mesosLocalServer = MesosLocal(
-    suiteName = suiteName,
-    autoStart = false,
-    waitForStart = patienceConfig.timeout.toMillis.milliseconds,
-    config = mesosConfig,
-    numSlaves = mesosNumSlaves)
-  lazy val port = mesosLocalServer.port
-  lazy val mesosMasterUrl = mesosLocalServer.masterUrl
-  lazy val mesos = new MesosFacade(s"http://$mesosMasterUrl")
-
-  override def cleanMesos(): Unit = mesosLocalServer.clean()
-
-  abstract override def beforeAll(): Unit = {
-    super.beforeAll()
-    mesosLocalServer.start().futureValue
-  }
-
-  abstract override def afterAll(): Unit = {
-    mesosLocalServer.close()
-    super.afterAll()
-  }
 }
 
 trait MesosClusterTest extends Suite with ZookeeperServerTest with MesosTest with ScalaFutures {
@@ -384,5 +327,24 @@ trait MesosClusterTest extends Suite with ZookeeperServerTest with MesosTest wit
   abstract override def afterAll(): Unit = {
     mesosCluster.close()
     super.afterAll()
+  }
+}
+
+object IP {
+  import sys.process._
+
+  lazy val routableIPv4: String =
+    sys.env.getOrElse("MESOSTEST_IP_ADDRESS", inferRoutableIP)
+
+  private def detectIpScript = {
+    val resource = getClass.getClassLoader.getResource("detect-routable-ip.sh")
+    Option(resource).flatMap { f => Option(f.getFile) }.getOrElse {
+      throw new RuntimeException(
+        s"Couldn't find file for detect-routable-ip.sh resource; is ${resource}. Are you running from a JAR?")
+    }
+  }
+
+  private def inferRoutableIP: String = {
+    Seq("bash", detectIpScript).!!.trim
   }
 }

--- a/src/test/scala/mesosphere/marathon/integration/setup/WaitTestSupport.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/WaitTestSupport.scala
@@ -27,4 +27,10 @@ object WaitTestSupport extends Eventually {
       if (!fn) throw new RuntimeException(s"$description not satisfied")
     }
   }
+
+  def waitUntil(description: String)(fn: => Boolean)(implicit patienceConfig: PatienceConfig): Unit = {
+    eventually {
+      if (!fn) throw new RuntimeException(s"$description not satisfied")
+    }
+  }
 }

--- a/src/test/scala/mesosphere/util/PortAllocator.scala
+++ b/src/test/scala/mesosphere/util/PortAllocator.scala
@@ -1,11 +1,12 @@
 package mesosphere.util
 
-import java.net.{ InetSocketAddress, ServerSocket }
+import java.net.ServerSocket
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.annotation.tailrec
+import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
 object PortAllocator extends StrictLogging {
@@ -14,24 +15,13 @@ object PortAllocator extends StrictLogging {
   // The Internet Assigned Numbers Authority (IANA) suggests the range 49152 to 65535  for dynamic or private ports.
   // Many Linux kernels use the port range 32768 to 61000.
 
-  // From http://mesos.apache.org/documentation/latest/port-mapping-isolator/
-  // Mesos provides two ranges of ports to containers:
-  //
-  // • OS allocated “ephemeral” ports are assigned by the OS in a range specified for each container by Mesos.
-  // • Mesos allocated “non-ephemeral” ports are acquired by a framework using the same Mesos resource offer mechanism
-  //   used for cpu, memory etc. for allocation to executors/tasks as required.
-  //
-  // Additionally, the host itself will require ephemeral ports for network communication. You need to configure these
-  // three non-overlapping port ranges on the host.
-
   // We reserve 1000 ephemeral ports for Marathon/Zk/Mesos Master/Mesos Agent processes to listen on:
   val EPHEMERAL_PORT_START = 32768
   val EPHEMERAL_PORT_MAX = EPHEMERAL_PORT_START + 1000
   // and use the rest of the range as ports resources for mesos agents to offer e.g. --resources="ports:[10000-110000]"
-  // IMPORTANT: These two ranges should NOT overlap with each other and with the operating system's ephemeral port range
-  // define in ci/set_port_range.sh!
+  // IMPORTANT: These two ranges should NOT overlap!
   val PORT_RANGE_START = EPHEMERAL_PORT_MAX + 1
-  val PORT_RANGE_MAX = 60000 // 60001 - 61000 is reserved for port 0 random allocation. See ci/set_port_range.sh.
+  val PORT_RANGE_MAX = 65535
 
   // We use 2 different atomic counters: one for ephemeral ports and one for port ranges.
   private val ephemeralPorts: AtomicInteger = new AtomicInteger(EPHEMERAL_PORT_START)
@@ -42,35 +32,31 @@ object PortAllocator extends StrictLogging {
   // out of free ephemeral ports a RuntimeException is thrown.
   @tailrec
   private def freeSocket(): ServerSocket = {
-    def tryOpenSocket(port: Int): ServerSocket = {
-      val socket = new ServerSocket()
-      socket.setReuseAddress(false)
-      socket.bind(new InetSocketAddress("localhost", port))
-      socket
-    }
-
     val port = ephemeralPorts.incrementAndGet()
     if (port > EPHEMERAL_PORT_MAX) throw new RuntimeException("Out of ephemeral ports.")
-
-    Try(tryOpenSocket(port)) match {
-      case Success(socket) =>
-        // We can't return a port if we couldn't close it successfully: theoretically it would then
-        // stay bound until (after a timeout) the underlying OS decides that it's free. Hence we should
-        // return only successfully closed ports and retry if closing fails.
-        Try(socket.close()) match {
-          case Success(_) => socket
-          case Failure(ex) =>
-            logger.warn(s"Failed to close allocator's socket on port $port because: ${ex.getMessage}")
-            freeSocket()
-        }
+    Try(new ServerSocket(port)) match {
+      case Success(v) => v
       case Failure(ex) =>
-        logger.warn(s"Failed to provide an ephemeral port $port because: ${ex.getMessage}. Will retry again...")
+        logger.warn(s"Failed to provide an ephemeral port because of ${ex.getMessage}. Will retry again...")
         freeSocket()
     }
   }
 
+  private def closeSocket(socket: ServerSocket) = {
+    try { socket.close() }
+    catch { case NonFatal(ex) => logger.debug(s"Failed to close port allocator's socket because ${ex.getMessage}") }
+  }
+
   def ephemeralPort(): Int = {
     val socket = freeSocket()
+    closeSocket(socket)
     socket.getLocalPort
+  }
+
+  def portsRange(step: Int = 100): (Int, Int) = {
+    val from = rangePorts.getAndAdd(step + 1) // port resources in mesos are inclusive
+    val to = from + step
+    if (to > PORT_RANGE_MAX) throw new RuntimeException("Port range is depleted.")
+    (from, to)
   }
 }


### PR DESCRIPTION
Summary:
A bunch of 1.5 commits were used here. It wasn't possible to cherry-pick them directly because of other changes to base IT classes missing so I had to add them manually:
- every test suite gets it's own port range
- `app_mock.py` got revisited with handling SIGTERM properly and reusing socket address
- `ForwardService` is killed gracefully