### PR TITLE
 OffsetDateTime json serialization is different form Timestamp serialization

### DIFF
--- a/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
@@ -1,10 +1,13 @@
 package mesosphere.marathon
 package raml
 
+import java.time.OffsetDateTime
+
 import mesosphere.marathon.core.instance
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.stream.Implicits._
 import org.apache.mesos.{ Protos => mesos }
+import play.api.libs.json.JsString
 
 import scala.collection.breakOut
 
@@ -60,4 +63,9 @@ trait DefaultConversions {
       .getOrElse(throw new IllegalArgumentException(s"$name is an unknown protocol"))
     IpAddr(ipAddress.getIpAddress, protocol)
   }
+
+  implicit object OffsetDateTimeWrite extends play.api.libs.json.Writes[OffsetDateTime] {
+    def writes(o: OffsetDateTime) = JsString(o.format(Timestamp.formatter))
+  }
+
 }

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -104,5 +104,5 @@ object Timestamp {
   /*
    * .toString in java.time is truncating zeros in millis part, so we use custom formatter to keep them
    */
-  private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
+  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
 }

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/AppsControllerTest.scala
@@ -237,7 +237,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,
@@ -459,7 +459,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,
@@ -532,7 +532,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,
@@ -646,7 +646,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,
@@ -716,7 +716,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,
@@ -788,7 +788,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,
@@ -874,7 +874,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,
@@ -966,7 +966,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,
@@ -1101,7 +1101,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,
@@ -1196,7 +1196,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,
@@ -1346,7 +1346,7 @@ class AppsControllerTest extends UnitTest with GroupCreation with ScalatestRoute
                          |    "maximumOverCapacity" : 1,
                          |    "minimumHealthCapacity" : 1
                          |  },
-                         |  "version" : "2015-04-09T12:30:05Z",
+                         |  "version" : "2015-04-09T12:30:05.000Z",
                          |  "killSelection" : "YOUNGEST_FIRST",
                          |  "unreachableStrategy" : {
                          |    "inactiveAfterSeconds" : 0,

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/GroupsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/GroupsControllerTest.scala
@@ -179,7 +179,7 @@ class GroupsControllerTest extends UnitTest with ScalatestRouteTest with Inside 
       Post(Uri./.withPath(Path("/newgroup")), entity) ~> f.groupsController.route ~> check {
         responseAs[String] should be ("""{
                                         |  "deploymentId" : "plan",
-                                        |  "version" : "1970-01-01T00:00:00Z"
+                                        |  "version" : "1970-01-01T00:00:00.000Z"
                                         |}""".stripMargin)
       }
     }
@@ -194,7 +194,7 @@ class GroupsControllerTest extends UnitTest with ScalatestRouteTest with Inside 
         header[Headers.`Marathon-Deployment-Id`] should be(Some(Headers.`Marathon-Deployment-Id`("plan")))
         responseAs[String] should be ("""{
                                         |  "deploymentId" : "plan",
-                                        |  "version" : "1970-01-01T00:00:00Z"
+                                        |  "version" : "1970-01-01T00:00:00.000Z"
                                         |}""".stripMargin)
       }
     }

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/QueueControllerTest.scala
@@ -80,7 +80,7 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
             |      "timeLeftSeconds" : 100,
             |      "overdue" : false
             |    },
-            |    "since" : "2015-04-09T12:30:00Z",
+            |    "since" : "2015-04-09T12:30:00.000Z",
             |    "processedOffersSummary" : {
             |      "processedOffersCount" : 3,
             |      "unusedOffersCount" : 1,
@@ -181,10 +181,10 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
             |        "maximumOverCapacity" : 1,
             |        "minimumHealthCapacity" : 1
             |      },
-            |      "version" : "2015-04-09T12:30:00Z",
+            |      "version" : "2015-04-09T12:30:00.000Z",
             |      "versionInfo" : {
-            |        "lastScalingAt" : "2015-04-09T12:30:00Z",
-            |        "lastConfigChangeAt" : "2015-04-09T12:30:00Z"
+            |        "lastScalingAt" : "2015-04-09T12:30:00.000Z",
+            |        "lastConfigChangeAt" : "2015-04-09T12:30:00.000Z"
             |      },
             |      "killSelection" : "YOUNGEST_FIRST",
             |      "unreachableStrategy" : {
@@ -219,7 +219,7 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
             |      "timeLeftSeconds" : 100,
             |      "overdue" : false
             |    },
-            |    "since" : "2015-04-09T12:30:00Z",
+            |    "since" : "2015-04-09T12:30:00.000Z",
             |    "processedOffersSummary" : {
             |      "processedOffersCount" : 3,
             |      "unusedOffersCount" : 1,
@@ -330,7 +330,7 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
             |        "attributes" : [ ]
             |      },
             |      "reason" : [ "InsufficientCpus" ],
-            |      "timestamp" : "2015-04-09T12:30:00Z"
+            |      "timestamp" : "2015-04-09T12:30:00.000Z"
             |    } ],
             |    "app" : {
             |      "id" : "/app",
@@ -354,10 +354,10 @@ class QueueControllerTest extends UnitTest with ScalatestRouteTest with Inside w
             |        "maximumOverCapacity" : 1,
             |        "minimumHealthCapacity" : 1
             |      },
-            |      "version" : "2015-04-09T12:30:00Z",
+            |      "version" : "2015-04-09T12:30:00.000Z",
             |      "versionInfo" : {
-            |        "lastScalingAt" : "2015-04-09T12:30:00Z",
-            |        "lastConfigChangeAt" : "2015-04-09T12:30:00Z"
+            |        "lastScalingAt" : "2015-04-09T12:30:00.000Z",
+            |        "lastConfigChangeAt" : "2015-04-09T12:30:00.000Z"
             |      },
             |      "killSelection" : "YOUNGEST_FIRST",
             |      "unreachableStrategy" : {

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/TasksControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/TasksControllerTest.scala
@@ -266,7 +266,7 @@ class TasksControllerTest extends UnitTest with ScalatestRouteTest with Inside w
         And("Should create a deployment")
         responseAs[String] should be ("""{
                                         |  "deploymentId" : "plan",
-                                        |  "version" : "1970-01-01T00:00:00Z"
+                                        |  "version" : "1970-01-01T00:00:00.000Z"
                                         |}""".stripMargin)
 
         And("app1 and app2 is killed with force")

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -618,7 +618,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           implicit val podManager = PodManagerImpl(groupManager)
           val f = Fixture()
 
-          val response = f.podsResource.version("/id", "2008-01-01T12:00:00Z", f.auth.request)
+          val response = f.podsResource.version("/id", "2008-01-01T12:00:00.000Z", f.auth.request)
           withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_NOT_FOUND)
             response.getEntity.toString should be ("{\"message\":\"Pod '/id' does not exist\"}")

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceFormatTest.scala
@@ -15,9 +15,9 @@ class InstanceFormatTest extends UnitTest {
       |{
       |  "instanceId": { "idString": "app.instance-1337" },
       |  "tasksMap": {},
-      |  "runSpecVersion": "2015-01-01T12:00:00Z",
+      |  "runSpecVersion": "2015-01-01T12:00:00.000Z",
       |  "agentInfo": { "host": "localhost", "attributes": [] },
-      |  "state": { "since": "2015-01-01T12:00:00Z", "condition": { "str": "Running" } }
+      |  "state": { "since": "2015-01-01T12:00:00.000Z", "condition": { "str": "Running" } }
       |}""".stripMargin).as[JsObject]
 
   "Instance.instanceFormat" should {

--- a/src/test/scala/mesosphere/marathon/raml/DefaultConversionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/DefaultConversionsTest.scala
@@ -4,6 +4,8 @@ package raml
 import java.util
 
 import mesosphere.UnitTest
+import mesosphere.marathon.state.Timestamp
+import play.api.libs.json.Json
 
 class DefaultConversionsTest extends UnitTest with DefaultConversions {
 
@@ -33,6 +35,11 @@ class DefaultConversionsTest extends UnitTest with DefaultConversions {
 
     "A map conversion is applied automatically" in {
       Map(1 -> 1, 2 -> 2).toRaml[Map[String, String]] should be (Map("1" -> "1", "2" -> "2"))
+    }
+
+    "serialize versions in the same way" in {
+      val timestamp = Timestamp("2018-01-05T18:27:50.690Z")
+      Json.toJson(timestamp.toRaml) should be (Json.toJson(timestamp.toOffsetDateTime))
     }
   }
 }


### PR DESCRIPTION
Summary: added a formatting to every usage of OffsetDateTime to keep string representation consistent across Timestamp and OffsetDateTime

JIRA issues: MARATHON-8005

