### PR TITLE
Backport of OffsetDateTime json serialization is different form Timestamp serialization

### DIFF
--- a/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
@@ -1,7 +1,11 @@
 package mesosphere.marathon
 package raml
 
+import java.time.OffsetDateTime
+
+import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.stream.Implicits._
+import play.api.libs.json.JsString
 
 /**
   * All conversions for standard scala types.
@@ -15,6 +19,8 @@ trait DefaultConversions {
   implicit val doubleIdentityWrites: Writes[Double, Double] = identityConversion[Double]
   implicit val stringIdentityWrites: Writes[String, String] = identityConversion[String]
   implicit val booleanIdentityWrites: Writes[Boolean, Boolean] = identityConversion[Boolean]
+
+  implicit val timestampWrites: Writes[Timestamp, String] = Writes { _.toString }
 
   implicit def optionConversion[A, B](implicit writer: Writes[A, B]): Writes[Option[A], Option[B]] = Writes { option =>
     option.map(writer.write)
@@ -36,5 +42,8 @@ trait DefaultConversions {
     map.map {
       case (k, v) => key.write(k) -> value.write(v)
     }
+  }
+  implicit object OffsetDateTimeWrite extends play.api.libs.json.Writes[OffsetDateTime] {
+    def writes(o: OffsetDateTime) = JsString(o.format(Timestamp.formatter))
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -101,5 +101,5 @@ object Timestamp {
   /*
    * .toString in java.time is truncating zeros in millis part, so we use custom formatter to keep them
    */
-  private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
+  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -619,7 +619,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           implicit val podManager = PodManagerImpl(groupManager)
           val f = Fixture()
 
-          val response = f.podsResource.version("/id", "2008-01-01T12:00:00Z", f.auth.request)
+          val response = f.podsResource.version("/id", "2008-01-01T12:00:00.000Z", f.auth.request)
           withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_NOT_FOUND)
             response.getEntity.toString should be ("{\"message\":\"Pod '/id' does not exist\"}")

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceFormatTest.scala
@@ -15,9 +15,9 @@ class InstanceFormatTest extends UnitTest {
       |{
       |  "instanceId": { "idString": "app.instance-1337" },
       |  "tasksMap": {},
-      |  "runSpecVersion": "2015-01-01T12:00:00Z",
+      |  "runSpecVersion": "2015-01-01T12:00:00.000Z",
       |  "agentInfo": { "host": "localhost", "attributes": [] },
-      |  "state": { "since": "2015-01-01T12:00:00Z", "condition": { "str": "Running" } }
+      |  "state": { "since": "2015-01-01T12:00:00.000Z", "condition": { "str": "Running" } }
       |}""".stripMargin).as[JsObject]
 
   "Instance.instanceFormat" should {

--- a/src/test/scala/mesosphere/marathon/raml/DefaultConversionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/DefaultConversionsTest.scala
@@ -4,10 +4,14 @@ package raml
 import java.util
 
 import mesosphere.UnitTest
+import mesosphere.marathon.state.Timestamp
+import play.api.libs.json.Json
 
 class DefaultConversionsTest extends UnitTest with DefaultConversions {
 
   implicit val intToStringWrites: Writes[Int, String] = Writes { _.toString }
+
+  import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
 
   "DefaultConversions" should {
     "identity can be converted automatically" in {
@@ -33,6 +37,11 @@ class DefaultConversionsTest extends UnitTest with DefaultConversions {
 
     "A map conversion is applied automatically" in {
       Map(1 -> 1, 2 -> 2).toRaml[Map[String, String]] should be (Map("1" -> "1", "2" -> "2"))
+    }
+
+    "serialize versions in the same way" in {
+      val timestamp = Timestamp("2018-01-05T18:27:50.690Z")
+      Json.toJson(timestamp.toRaml) should be (Json.toJson(timestamp.toOffsetDateTime))
     }
   }
 }


### PR DESCRIPTION

Summary: added a formatting to every usage of OffsetDateTime to keep string representation consistent across Timestamp and OffsetDateTime

JIRA issues: MARATHON-8005