### PR TITLE
 Report execution times of update requests.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
@@ -150,13 +150,15 @@ class GroupManagerImpl(
             deploymentPlanCreationTimer.stop()
 
             logger.info(s"Computed new deployment plan for ${plan.targetIdsString}:\n$plan")
+            val storeRootGroupVersionTimer = timers.startSubTimer("StoreRootGroup")
             await(groupRepository.storeRootVersion(plan.target, plan.createdOrUpdatedApps, plan.createdOrUpdatedPods))
+            storeRootGroupVersionTimer.stop()
 
             await(deploymentService.get().deploy(plan, force))
 
-            val storeRootGroupVersionTimer = timers.startSubTimer("StoreRootGroup")
+            val storeRootGroupTimer = timers.startSubTimer("StoreRootGroup")
             await(groupRepository.storeRoot(plan.target, plan.createdOrUpdatedApps, plan.deletedApps, plan.createdOrUpdatedPods, plan.deletedPods))
-            storeRootGroupVersionTimer.stop()
+            storeRootGroupTimer.stop()
 
             logger.info(s"Updated groups/apps/pods according to plan ${plan.id} for ${plan.targetIdsString}")
             logger.info(s"DeploymentPlanId=${plan.id} $timers")

--- a/src/main/scala/mesosphere/marathon/metrics/MultiTimer.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/MultiTimer.scala
@@ -20,9 +20,11 @@ object MultiTimer {
     }
 
     def duration(): Option[FiniteDuration] = {
-      end.flatMap { endTime =>
-        start.map(endTime - _)
-      }.map(FiniteDuration(_, TimeUnit.NANOSECONDS))
+      (end, start) match {
+        case (Some(endTime), Some(startTime)) =>
+          Some(FiniteDuration(endTime - startTime, TimeUnit.NANOSECONDS))
+        case _ => None
+      }
     }
 
     override def toString: String = duration().fold(s"$label=N/A"){ d => s"$label=${d.toMillis}ms" }
@@ -34,8 +36,9 @@ class MultiTimer {
 
   val subTimers: ArrayBuffer[MultiTimer.Timer] = ArrayBuffer.empty
 
-  def subTimer(label: String): MultiTimer.Timer = {
+  def startSubTimer(label: String): MultiTimer.Timer = {
     val timer = new metrics.MultiTimer.Timer(label)
+    timer.begin()
     subTimers += timer
     return timer
   }

--- a/src/main/scala/mesosphere/marathon/metrics/MultiTimer.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/MultiTimer.scala
@@ -1,0 +1,45 @@
+package mesosphere.marathon
+package metrics
+
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration.FiniteDuration
+
+object MultiTimer {
+  case class Timer(label: String) {
+
+    var start: Option[Long] = None
+    var end: Option[Long] = None
+
+    def begin(): Unit = {
+      start = Some(System.nanoTime())
+    }
+
+    def stop(): Unit = {
+      end = Some(System.nanoTime())
+    }
+
+    def duration(): Option[FiniteDuration] = {
+      end.flatMap { endTime =>
+        start.map(endTime - _)
+      }.map(FiniteDuration(_, TimeUnit.NANOSECONDS))
+    }
+
+    override def toString: String = duration().fold(s"$label=N/A"){ d => s"$label=${d.toMillis}ms" }
+
+  }
+}
+
+class MultiTimer {
+
+  val subTimers: ArrayBuffer[MultiTimer.Timer] = ArrayBuffer.empty
+
+  def subTimer(label: String): MultiTimer.Timer = {
+    val timer = new metrics.MultiTimer.Timer(label)
+    subTimers += timer
+    return timer
+  }
+
+  override def toString: String = subTimers.mkString(", ")
+
+}

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -15,7 +15,8 @@ import mesosphere.marathon.core.storage.repository.impl.PersistenceStoreVersione
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
 import mesosphere.marathon.core.storage.store.impl.cache.{ LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore }
 import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
-import mesosphere.marathon.state.{ AppDefinition, Group, RootGroup, PathId, Timestamp }
+import mesosphere.marathon.metrics.MultiTimer
+import mesosphere.marathon.state.{ AppDefinition, Group, PathId, RootGroup, Timestamp }
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.util.{ RichLock, toRichFuture }
 
@@ -277,18 +278,25 @@ class StoredGroupRepositoryImpl[K, C, S](
   override def storeRoot(rootGroup: RootGroup, updatedApps: Seq[AppDefinition], deletedApps: Seq[PathId],
     updatedPods: Seq[PodDefinition], deletedPods: Seq[PathId]): Future[Done] =
     async {
+      val timers = new MultiTimer()
+
+      val storedGroupCreation = timers.startSubTimer("CreateStoredGroup")
       val storedGroup = StoredGroup(rootGroup)
       beforeStore match {
         case Some(preStore) =>
           await(preStore(storedGroup))
         case _ =>
       }
+      storedGroupCreation.stop()
+
       val promise = Promise[RootGroup]()
       val oldRootFuture = lock {
         val old = rootFuture
         rootFuture = promise.future
         old
       }
+
+      val storeAndDeleteAppsAndPods = timers.startSubTimer("StoreAndDeleteAppsAndPods")
       val storeAppFutures = updatedApps.map(appRepository.store)
       val storePodFutures = updatedPods.map(podRepository.store)
       val deleteAppFutures = deletedApps.map(appRepository.deleteCurrent)
@@ -297,6 +305,7 @@ class StoredGroupRepositoryImpl[K, C, S](
       val storedPods = await(Future.sequence(storePodFutures).asTry)
       await(Future.sequence(deleteAppFutures).recover { case NonFatal(e) => Done })
       await(Future.sequence(deletePodFutures).recover { case NonFatal(e) => Done })
+      storeAndDeleteAppsAndPods.stop()
 
       def revertRoot(ex: Throwable): Done = {
         promise.completeWith(oldRootFuture)
@@ -305,7 +314,12 @@ class StoredGroupRepositoryImpl[K, C, S](
 
       (storedApps, storedPods) match {
         case (Success(_), Success(_)) =>
+
+          val storeRoot = timers.startSubTimer("StoreRoot")
           val storedRoot = await(storedRepo.store(storedGroup).asTry)
+          storeRoot.stop()
+          logger.info(s"RootGroupVersion=${rootGroup.version} $timers")
+
           storedRoot match {
             case Success(_) =>
               addToVersionCache(None, rootGroup)
@@ -333,20 +347,31 @@ class StoredGroupRepositoryImpl[K, C, S](
   @SuppressWarnings(Array("all")) // async/await
   override def storeRootVersion(rootGroup: RootGroup, updatedApps: Seq[AppDefinition], updatedPods: Seq[PodDefinition]): Future[Done] =
     async {
+      val timers = new MultiTimer()
+
+      val storedGroupCreation = timers.startSubTimer("CreateStoredGroup")
       val storedGroup = StoredGroup(rootGroup)
       beforeStore match {
         case Some(preStore) =>
           await(preStore(storedGroup))
         case _ =>
       }
+      storedGroupCreation.stop()
 
+      val storeAppsAndPods = timers.startSubTimer("StoreAppsAndPods")
       val storeAppFutures = updatedApps.map(appRepository.store)
       val storePodFutures = updatedPods.map(podRepository.store)
       val storedApps = await(Future.sequence(Seq(storeAppFutures, storePodFutures).flatten).asTry)
+      storeAppsAndPods.stop()
 
       storedApps match {
         case Success(_) =>
+
+          val storeRoot = timers.startSubTimer("StoreRoot")
           val storedRoot = await(storedRepo.storeVersion(storedGroup).asTry)
+          storeRoot.stop()
+          logger.info(s"RootGroupVersion=${rootGroup.version} $timers")
+
           storedRoot match {
             case Success(_) =>
               addToVersionCache(None, rootGroup)

--- a/src/main/scala/mesosphere/marathon/util/WorkQueue.scala
+++ b/src/main/scala/mesosphere/marathon/util/WorkQueue.scala
@@ -112,6 +112,13 @@ case class WorkQueue(name: String, maxConcurrent: Int, maxQueueLength: Int) exte
       }
     }
   }
+
+  /**
+    * @return size a tuple (queue.size(), openSlotCount)
+    */
+  def stats(): (Int, Int) = synchronized {
+    (queue.size, openSlotsCount)
+  }
 }
 
 /**

--- a/src/test/scala/mesosphere/marathon/metrics/MultiTimerTest.scala
+++ b/src/test/scala/mesosphere/marathon/metrics/MultiTimerTest.scala
@@ -1,0 +1,26 @@
+package mesosphere.marathon
+package metrics
+
+import mesosphere.UnitTest
+
+class MultiTimerTest extends UnitTest {
+
+  "The multi timer" should {
+    "return a proper formatted string" in {
+      val timer = new MultiTimer()
+
+      val subTimerOne = new MultiTimer.Timer("one")
+      subTimerOne.start = Some(10000000)
+      subTimerOne.end = Some(50000000)
+      timer.subTimers += subTimerOne
+
+      val subTimerTwo = new MultiTimer.Timer("two")
+      subTimerTwo.start = Some(40000000)
+      subTimerTwo.end = Some(42000000)
+      timer.subTimers += subTimerTwo
+
+      val actual = timer.toString
+      actual should be("one=40ms, two=2ms")
+    }
+  }
+}


### PR DESCRIPTION
Summary:
We want to have a better understand where time is psent when the root
group is updated. This patch introduces measurements for most sub-steps.

The log line looks like

```
DeploymentPlanId=... ChangeRootGroup=0ms,..., MakeDeploymentPlan=0ms, StoreRootGroup=20ms
```