### PR TITLE
Abdicate leadership via API after a delay

### DIFF
--- a/docs/docs/rest-api/public/api/v2/leader.raml
+++ b/docs/docs/rest-api/public/api/v2/leader.raml
@@ -50,6 +50,10 @@ delete:
       required: false
       description: URI to restore zk state.
       example: file:///var/backup/marathon/backup
+    delay?:
+      required: false
+      description: Delay, in milliseconds, after which to abdicate leadership (default: 500)
+      example: "1000"
   responses:
     200:
       description: The abdication message from the current leader.
@@ -57,7 +61,7 @@ delete:
         application/json:
           example: |
             {
-                "message": "Leadership abdicated"
+                "message": "Leadership will be abdicated in 500ms"
             }
     404:
       description: If there is no current leader.

--- a/docs/docs/rest-api/public/api/v2/leader.raml
+++ b/docs/docs/rest-api/public/api/v2/leader.raml
@@ -50,10 +50,6 @@ delete:
       required: false
       description: URI to restore zk state.
       example: file:///var/backup/marathon/backup
-    delay?:
-      required: false
-      description: Delay, in milliseconds, after which to abdicate leadership (default: 500)
-      example: "1000"
   responses:
     200:
       description: The abdication message from the current leader.
@@ -61,7 +57,7 @@ delete:
         application/json:
           example: |
             {
-                "message": "Leadership will be abdicated in 500ms"
+                "message": "Leadership abdicated"
             }
     404:
       description: If there is no current leader.

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -125,6 +125,10 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
   @Singleton
   def provideActorSystem(): ActorSystem = actorSystem
 
+  @Provides
+  @Singleton
+  def provideActorScheduler(): Scheduler = actorSystem.scheduler
+
   /* Reexports the `akka.actor.ActorSystem` as `akka.actor.ActorRefFactory`. It doesn't work automatically. */
   @Provides
   @Singleton

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/AkkaHttpModule.scala
@@ -78,7 +78,7 @@ class AkkaHttpModule(conf: MarathonConf with HttpConf) extends AbstractModule {
       electionService.leadershipTransitionEvents)
     val infoController = InfoController(mesosLeaderInfo, storageModule.frameworkIdRepository, conf)
     val pluginsController = new PluginsController(pluginManager.plugins[HttpRequestHandler], pluginManager.definitions)
-    val leaderController = LeaderController(electionService, storageModule.runtimeConfigurationRepository)
+    val leaderController = LeaderController(electionService, storageModule.runtimeConfigurationRepository, actorSystem.scheduler)
     val queueController = new QueueController(clock, launchQueue, electionService)
     val tasksController = new TasksController(instanceTracker, groupManager, healthCheckManager, taskKiller, electionService)
     val groupsController = new GroupsController(electionService, groupInfoService, groupManager, groupApiService, conf)

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
@@ -53,7 +53,7 @@ case class LeaderController(
                   scheduler.scheduleOnce(LeaderResource.abdicationDelay) {
                     electionService.abdicateLeadership()
                   }
-                  raml.Message(s"Leadership abdicated")
+                  raml.Message("Leadership abdicated")
                 }
               }
             }

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/LeaderController.scala
@@ -4,7 +4,7 @@ package api.akkahttp.v2
 import akka.actor.Scheduler
 import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.api.v2.Validation
+import mesosphere.marathon.api.v2.{ LeaderResource, Validation }
 import mesosphere.marathon.api.akkahttp.{ Controller, Rejections }
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.plugin.auth._
@@ -50,10 +50,10 @@ case class LeaderController(
               complete {
                 async {
                   await(runtimeConfigRepo.store(RuntimeConfiguration(backup, restore)))
-                  scheduler.scheduleOnce(delay.millis) {
+                  scheduler.scheduleOnce(LeaderResource.abdicationDelay) {
                     electionService.abdicateLeadership()
                   }
-                  raml.Message(s"Leadership will be abdicated in ${delay}ms")
+                  raml.Message(s"Leadership abdicated")
                 }
               }
             }

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package api.v2
 
+import akka.actor.Scheduler
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs.core.{ Context, Response }
 import javax.ws.rs._
@@ -14,6 +15,8 @@ import mesosphere.marathon.storage.repository.RuntimeConfigurationRepository
 import mesosphere.marathon.raml.RuntimeConfiguration
 import Validation._
 import mesosphere.marathon.stream.UriIO
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 @Path("v2/leader")
 class LeaderResource @Inject() (
@@ -21,7 +24,8 @@ class LeaderResource @Inject() (
     val config: MarathonConf with HttpConf,
     val runtimeConfigRepo: RuntimeConfigurationRepository,
     val authenticator: Authenticator,
-    val authorizer: Authorizer)
+    val authorizer: Authorizer,
+    val scheduler: Scheduler)(implicit executionContext: ExecutionContext)
   extends RestResource with AuthResource {
 
   @GET
@@ -41,16 +45,19 @@ class LeaderResource @Inject() (
   def delete(
     @QueryParam("backup") backupNullable: String,
     @QueryParam("restore") restoreNullable: String,
+    @QueryParam("delay") delayOrDefault: Long,
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
     withAuthorization(UpdateResource, AuthorizedResource.Leader) {
       if (electionService.isLeader) {
         assumeValid {
+          val delay = if (delayOrDefault == 0) 500.millis else delayOrDefault.millis
           val backup = validateOrThrow(Option(backupNullable))(optional(UriIO.valid))
           val restore = validateOrThrow(Option(restoreNullable))(optional(UriIO.valid))
           result(runtimeConfigRepo.store(RuntimeConfiguration(backup, restore)))
 
-          electionService.abdicateLeadership()
-          ok(jsonObjString("message" -> "Leadership abdicated"))
+          scheduler.scheduleOnce(delay) { electionService.abdicateLeadership() }
+
+          ok(jsonObjString("message" -> s"Leadership will be abdicated in ${delay}ms"))
         }
       } else {
         notFound("There is no leader")

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -59,7 +59,7 @@ class LeaderResource @Inject() (
 
           scheduler.scheduleOnce(LeaderResource.abdicationDelay) { electionService.abdicateLeadership() }
 
-          ok(jsonObjString("message" -> s"Leadership abdicated"))
+          ok(jsonObjString("message" -> "Leadership abdicated"))
         }
       } else {
         notFound("There is no leader")

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/LeaderControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/LeaderControllerTest.scala
@@ -4,6 +4,7 @@ package api.akkahttp.v2
 import akka.Done
 import akka.http.scaladsl.model.{ StatusCodes, Uri }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import mesosphere.marathon.api.v2.LeaderResource
 import mesosphere.marathon.test.{ SettableClock, SimulatedScheduler }
 import mesosphere.{ UnitTest, ValidationTestLike }
 import mesosphere.marathon.api.{ JsonTestHelper, TestAuthFixture }
@@ -18,7 +19,7 @@ import scala.concurrent.duration._
 
 class LeaderControllerTest extends UnitTest with ScalatestRouteTest with Inside with ValidationTestLike with RouteBehaviours {
 
-  "LeaderResource" should {
+  "LeaderController" should {
 
     // Unauthenticated access test cases
     {
@@ -146,7 +147,7 @@ class LeaderControllerTest extends UnitTest with ScalatestRouteTest with Inside 
         Then("we receive a 200 response")
         status should be(StatusCodes.OK)
         verify(f.electionService, times(0)).abdicateLeadership()
-        f.clock += 500.millis
+        f.clock += LeaderResource.abdicationDelay
         verify(f.electionService, times(1)).abdicateLeadership()
       }
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/LeaderResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/LeaderResourceTest.scala
@@ -27,7 +27,7 @@ class LeaderResourceTest extends UnitTest {
       index.getStatus should be(f.auth.NotAuthenticatedStatus)
 
       When("we try to delete the current leader")
-      val delete = resource.delete(null, null, 0, f.auth.request)
+      val delete = resource.delete(null, null, f.auth.request)
       Then("we receive a NotAuthenticated response")
       delete.getStatus should be(f.auth.NotAuthenticatedStatus)
     }
@@ -45,7 +45,7 @@ class LeaderResourceTest extends UnitTest {
       index.getStatus should be(f.auth.UnauthorizedStatus)
 
       When("we try to delete the current leader")
-      val delete = resource.delete(null, null, 0, f.auth.request)
+      val delete = resource.delete(null, null, f.auth.request)
       Then("we receive a Unauthorized response")
       delete.getStatus should be(f.auth.UnauthorizedStatus)
     }
@@ -60,7 +60,7 @@ class LeaderResourceTest extends UnitTest {
       f.runtimeRepo.store(any).returns(Future.successful(Done))
 
       When("we try to delete the current leader")
-      val delete = resource.delete(null, null, 0, f.auth.request)
+      val delete = resource.delete(null, null, f.auth.request)
       Then("we receive a authorized response")
       delete.getStatus should be(200)
       verify(f.electionService, times(0)).abdicateLeadership()


### PR DESCRIPTION
This brings back behavior we previously had with Marathon 1.5.

When abdication is requested via the API, if marathon exits too quickly, it will shut down before the HTTP response is delivered to the client, leading in the appearance of a failed request.

JIRA Issues: MARATHON-8037