### PR TITLE
Truncate app and pod ids in logs.

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -6,6 +6,7 @@ import java.util.Objects
 import com.typesafe.scalalogging.StrictLogging
 import com.wix.accord._
 import com.wix.accord.dsl._
+import mesosphere.util.summarize
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.core.pod.PodDefinition
@@ -110,15 +111,6 @@ class Group(
 
   override def hashCode(): Int = Objects.hash(id, apps, pods, groupsById, dependencies, version)
 
-  private def summarize[T](iterator: Iterator[T]): String = {
-    val s = new StringBuilder
-    s ++= "Seq("
-    s ++= iterator.take(3).toSeq.mkString(", ")
-    if (iterator.hasNext)
-      s ++= s", ... ${iterator.length} more"
-    s ++= ")"
-    s.toString
-  }
   override def toString = {
     val summarizedApps = summarize(apps.valuesIterator.map(_.id))
     val summarizedPods = summarize(pods.valuesIterator.map(_.id))

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -10,6 +10,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.{ Done, NotUsed }
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.util.summarize
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.storage.repository.impl.PersistenceStoreVersionedRepository
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
@@ -316,16 +317,19 @@ class StoredGroupRepositoryImpl[K, C, S](
               revertRoot(ex)
           }
         case (Failure(ex), Success(_)) =>
-          logger.error("Unable to store updated apps or pods: " +
-            s"${updatedApps.map(_.id).mkString} ${updatedPods.map(_.id).mkString}", ex)
+          val summarizedApps = summarize(updatedApps.toIterator.map(_.id))
+          val summarizedPods = summarize(updatedPods.toIterator.map(_.id))
+          logger.error(s"Unable to store updated apps or pods: $summarizedApps $summarizedPods", ex)
           revertRoot(ex)
         case (Success(_), Failure(ex)) =>
-          logger.error("Unable to store updated apps or pods: " +
-            s"${updatedApps.map(_.id).mkString} ${updatedPods.map(_.id).mkString}", ex)
+          val summarizedApps = summarize(updatedApps.toIterator.map(_.id))
+          val summarizedPods = summarize(updatedPods.toIterator.map(_.id))
+          logger.error(s"Unable to store updated apps or pods: $summarizedApps $summarizedPods", ex)
           revertRoot(ex)
         case (Failure(ex), Failure(_)) =>
-          logger.error("Unable to store updated apps or pods: " +
-            s"${updatedApps.map(_.id).mkString} ${updatedPods.map(_.id).mkString}", ex)
+          val summarizedApps = summarize(updatedApps.toIterator.map(_.id))
+          val summarizedPods = summarize(updatedPods.toIterator.map(_.id))
+          logger.error(s"Unable to store updated apps or pods: $summarizedApps $summarizedPods", ex)
           revertRoot(ex)
       }
     }
@@ -356,7 +360,9 @@ class StoredGroupRepositoryImpl[K, C, S](
               throw ex
           }
         case Failure(ex) =>
-          logger.error(s"Unable to store updated apps/pods ${Seq(updatedApps, updatedPods).flatten.map(_.id).mkString}", ex)
+          val summarizedApps = summarize(updatedApps.toIterator.map(_.id))
+          val summarizedPods = summarize(updatedPods.toIterator.map(_.id))
+          logger.error(s"Unable to store updated apps or pods: $summarizedApps $summarizedPods", ex)
           throw ex
       }
     }

--- a/src/main/scala/mesosphere/util/package.scala
+++ b/src/main/scala/mesosphere/util/package.scala
@@ -6,6 +6,27 @@ import scala.annotation.tailrec
 import scala.concurrent.duration.Duration
 
 package object util {
+
+  /**
+    * Truncates the string output of a long list.
+    *
+    * This should be used to reduce the size of logging ids etc.
+    *
+    * @param it The iterable that will be truncated.
+    * @param showFirst The number of items that should be shown in string.
+    * @tparam T
+    * @return String representation of truncated sequence.
+    */
+  def summarize[T](it: Iterator[T], showFirst: Int = 3): String = {
+    val s = new StringBuilder
+    s ++= "Seq("
+    s ++= it.take(showFirst).toSeq.mkString(", ")
+    if (it.hasNext)
+      s ++= s", ... ${it.length} more"
+    s ++= ")"
+    s.toString
+  }
+
   implicit class DurationToHumanReadable(val d: Duration) extends AnyVal {
     def toHumanReadable: String = {
       import TimeUnit._


### PR DESCRIPTION
Summary:
As we've seen in other cases it is not cheap to log all app and pod ids.
This extends the work of #5857 to other cases.

JIRA issues: MARATHON-7990