### PR TITLE
Fix the failing ipv6 test

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -790,4 +790,3 @@ async def find_event(event_type, event_stream):
 
 async def assert_event(event_type, event_stream, within=10):
     await asyncio.wait_for(find_event(event_type, event_stream), within)
-

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -8,7 +8,6 @@ import time
 import uuid
 import sys
 import retrying
-import contextlib
 
 from datetime import timedelta
 from dcos import http, mesos
@@ -792,13 +791,3 @@ async def find_event(event_type, event_stream):
 async def assert_event(event_type, event_stream, within=10):
     await asyncio.wait_for(find_event(event_type, event_stream), within)
 
-
-@contextlib.contextmanager
-def docker_ipv6_network_fixture(network_name):
-    agents = shakedown.get_agents()
-    network_cmd = f"sudo docker network create --driver=bridge --ipv6 --subnet=fd01::/64 {network_name}"
-    for agent in agents:
-        shakedown.run_command_on_agent(agent, network_cmd)
-    yield
-    for agent in agents:
-        shakedown.run_command_on_agent(agent, f"sudo docker network rm {network_name}")

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -82,3 +82,14 @@ def user_billy():
     shakedown.remove_user_permission(rid='dcos:service:marathon:marathon:services:/', uid='billy', action='full')
     shakedown.remove_user('billy')
     print("exiting user_billy fixture")
+
+
+@pytest.fixture(scope="function")
+def docker_ipv6_network_fixture():
+    agents = shakedown.get_agents()
+    network_cmd = f"sudo docker network create --driver=bridge --ipv6 --subnet=fd01::/64 mesos-docker-ipv6-test"
+    for agent in agents:
+        shakedown.run_command_on_agent(agent, network_cmd)
+    yield
+    for agent in agents:
+        shakedown.run_command_on_agent(agent, f"sudo docker network rm mesos-docker-ipv6-test")

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -1135,7 +1135,7 @@ def test_network_pinger(test_type, get_pinger_app, dns_format, marathon_service_
     http_output_check()
 
 
-# @shakedown.dcos_1_11
+@shakedown.dcos_1_11
 def test_ipv6_healthcheck(docker_ipv6_network_fixture):
     """ There is new feature in DC/OS 1.11 that allows containers running on IPv6 network to be healthchecked from
         Marathon. This tests verifies executing such healthcheck.

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -15,6 +15,7 @@ from datetime import timedelta
 from dcos import http, marathon
 from shakedown import dcos_version_less_than, marthon_version_less_than, required_private_agents # NOQA
 
+
 def test_launch_mesos_container():
     """Launches a Mesos container with a simple command."""
 
@@ -1134,17 +1135,6 @@ def test_network_pinger(test_type, get_pinger_app, dns_format, marathon_service_
     http_output_check()
 
 
-@pytest.fixture(scope="function")
-def docker_ipv6_network_fixture():
-    agents = shakedown.get_agents()
-    network_cmd = f"sudo docker network create --driver=bridge --ipv6 --subnet=fd01::/64 mesos-docker-ipv6-test"
-    for agent in agents:
-        shakedown.run_command_on_agent(agent, network_cmd)
-    yield
-    for agent in agents:
-        shakedown.run_command_on_agent(agent, f"sudo docker network rm mesos-docker-ipv6-test")
-
-
 # @shakedown.dcos_1_11
 def test_ipv6_healthcheck(docker_ipv6_network_fixture):
     """ There is new feature in DC/OS 1.11 that allows containers running on IPv6 network to be healthchecked from
@@ -1164,4 +1154,3 @@ def test_ipv6_healthcheck(docker_ipv6_network_fixture):
         "The number of healthy tasks is {}, but {} was expected".format(app['tasksHealthy'], target_instances_count)
 
     client.remove_app(app['id'], True)
-

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -23,7 +23,7 @@ import marathon_common_tests
 import marathon_pods_tests
 
 from shakedown import dcos_version_less_than, marthon_version_less_than, required_masters, required_public_agents # NOQA F401
-from fixtures import sse_events, wait_for_marathon_and_cleanup, user_billy # NOQA F401
+from fixtures import sse_events, wait_for_marathon_and_cleanup, user_billy, docker_ipv6_network_fixture # NOQA F401
 
 # the following lines essentially do:
 #     from dcos_service_marathon_tests import test_*


### PR DESCRIPTION
Summary:
Example https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/system-integration-tests/job/marathon-si-dcos-permissive/job/master/445/

I run the test locally against my cluster to see it pass.
