### PR TITLE
Update test README to reflect changes in DC/OS cli.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -61,13 +61,11 @@ The tests are run with
 make test
 ```
 
-To start a shell in the environment call `pipenv shell`. E.g. to authenticate
-and run a specific test call
+You can also run a specific test module or function with
 
 ```
 pipenv shell
-dcos config set core.dcos_url <dcos url>
-dcos auth login
+dcos cluster setup <dcos ip>
 shakedown test_marathon_root.py::<test name>
 ```
 


### PR DESCRIPTION
Summary:
The new CLI has the `dcos cluster setup` command which is doing the
authentication. This patch reflects these CLI changes in the docs.