### PR TITLE
Fixes v1.5 migration issue with args only apps

### DIFF
--- a/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
@@ -323,7 +323,7 @@ trait AppConversion extends DefaultConversions with ConstraintConversion with En
       args = if (service.hasCmd && service.getCmd.getArgumentsCount > 0) service.getCmd.getArgumentsList.to[Seq] else App.DefaultArgs,
       backoffFactor = service.whenOrElse(_.hasBackoffFactor, _.getBackoffFactor, App.DefaultBackoffFactor),
       backoffSeconds = service.whenOrElse(_.hasBackoff, b => (b.getBackoff / 1000L).toInt, App.DefaultBackoffSeconds),
-      cmd = if (service.hasCmd && service.getCmd.hasValue) Option(service.getCmd.getValue) else App.DefaultCmd,
+      cmd = if (service.hasCmd && service.getCmd.getArgumentsCount == 0 && service.getCmd.hasValue) Option(service.getCmd.getValue) else App.DefaultCmd,
       constraints = service.whenOrElse(_.getConstraintsCount > 0, _.getConstraintsList.map(_.toRaml[Seq[String]])(collection.breakOut), App.DefaultConstraints),
       container = service.when(_.hasContainer, _.getContainer.toRaml).orElse(App.DefaultContainer),
       cpus = resourcesMap.getOrElse(Resource.CPUS, App.DefaultCpus),

--- a/src/test/scala/mesosphere/marathon/raml/AppConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/AppConversionTest.scala
@@ -52,6 +52,19 @@ class AppConversionTest extends UnitTest with ValidationTestLike {
     portDefinitions = state.PortDefinitions(1, 2, 3),
     unreachableStrategy = state.UnreachableDisabled
   )
+  private lazy val argsOnlyApp = AppDefinition(
+    id = PathId("/args-only-app"),
+    args = Seq("whatever", "one", "two", "three")
+  )
+  private lazy val simpleDockerApp = AppDefinition(
+    id = PathId("/simple-docker-app"),
+    container = Some(state.Container.Docker(image = "foo/bla"))
+  )
+  private lazy val dockerWithArgsApp = AppDefinition(
+    id = PathId("/docker-with-args-app"),
+    args = Seq("whatever", "one", "two", "three"),
+    container = Some(state.Container.Docker(image = "foo/bla"))
+  )
 
   def convertToRamlAndBack(app: AppDefinition): Unit = {
     s"app ${app.id.toString} is written to json and can be read again via formats" in {
@@ -93,6 +106,15 @@ class AppConversionTest extends UnitTest with ValidationTestLike {
 
     behave like convertToRamlAndBack(hostApp)
     behave like convertToProtobufThenToRAML(hostApp)
+
+    behave like convertToRamlAndBack(argsOnlyApp)
+    behave like convertToProtobufThenToRAML(argsOnlyApp)
+
+    behave like convertToRamlAndBack(simpleDockerApp)
+    behave like convertToProtobufThenToRAML(simpleDockerApp)
+
+    behave like convertToRamlAndBack(dockerWithArgsApp)
+    behave like convertToProtobufThenToRAML(dockerWithArgsApp)
 
     "convert legacy service definitions to RAML" in {
       val legacy = Protos.ServiceDefinition.newBuilder()

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo15Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo15Test.scala
@@ -55,10 +55,11 @@ class MigrationTo15Test extends AkkaUnitTest with RecoverMethods with GroupCreat
       }
 
       "without cmd and container but with args defined" in new Fixture {
-        val basicArgsService = basicCommandApp.copy(cmd = None, args = Seq("sleep", "42")).toProto
+        val basicArgsApp = basicCommandApp.copy(cmd = None, args = Seq("sleep", "42"))
+        val basicArgsService = basicArgsApp.toProto
 
         val migratedApp = migrateSingleApp(basicArgsService)
-        migratedApp should be(basicCommandApp)
+        migratedApp should be(basicArgsApp)
       }
 
       "mesos container, host networking" in new Fixture {

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo15Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo15Test.scala
@@ -54,6 +54,13 @@ class MigrationTo15Test extends AkkaUnitTest with RecoverMethods with GroupCreat
         migrateSingleApp(sd) should be(expected)
       }
 
+      "without cmd and container but with args defined" in new Fixture {
+        val basicArgsService = basicCommandApp.copy(cmd = None, args = Seq("sleep", "42")).toProto
+
+        val migratedApp = migrateSingleApp(basicArgsService)
+        migratedApp should be(basicCommandApp)
+      }
+
       "mesos container, host networking" in new Fixture {
         val sd = withContainer { containerInfo =>
           containerInfo.setType(Mesos.ContainerInfo.Type.MESOS)


### PR DESCRIPTION
Summary:
Protobuf-to-RAML conversion introduced a regression in the interpretation of CommandInfo's content (args vs cmd), which was already properly handled in AppDefinition.mergeFromProto.
Tests added to prevent regressions on cmd/args/container consistency.

JIRA issues: MARATHON-8015
