### PR TITLE
Serialize events only once.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
@@ -32,6 +32,7 @@ class EventModule(
       Props(
         new HttpEventStreamActor(
           electionService,
+          eventBus,
           new HttpEventStreamActorMetrics(),
           handleStreamProps)
       ),

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActor.scala
@@ -2,11 +2,12 @@ package mesosphere.marathon
 package core.event.impl.stream
 
 import akka.actor._
+import akka.event.EventStream
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.election.{ ElectionService, LeadershipTransition }
 import mesosphere.marathon.core.event.MarathonEvent
 import mesosphere.marathon.core.event.impl.stream.HttpEventStreamActor._
 import mesosphere.marathon.metrics.{ ApiMetric, Metrics, SettableGauge }
-import org.slf4j.LoggerFactory
 
 import scala.util.Try
 
@@ -30,20 +31,22 @@ class HttpEventStreamActorMetrics() {
   */
 class HttpEventStreamActor(
     electionService: ElectionService,
+    stream: EventStream,
     metrics: HttpEventStreamActorMetrics,
     handleStreamProps: HttpEventStreamHandle => Props)
-  extends Actor {
+  extends Actor with StrictLogging {
   //map from handle to actor
   private[impl] var streamHandleActors = Map.empty[HttpEventStreamHandle, ActorRef]
-  private[this] val log = LoggerFactory.getLogger(getClass)
 
   override def preStart(): Unit = {
     metrics.numberOfStreams.setValue(0)
     electionService.subscribe(self)
+    stream.subscribe(self, classOf[MarathonEvent])
   }
 
   override def postStop(): Unit = {
     electionService.unsubscribe(self)
+    stream.unsubscribe(self)
     metrics.numberOfStreams.setValue(0)
   }
 
@@ -62,6 +65,7 @@ class HttpEventStreamActor(
       handleLeadership,
       cleanupHandlerActors,
       newConnectionBehaviour,
+      handleEvents,
       warnAboutUnknownMessages
     ).reduceLeft {
       // Prevent fatal warning about deriving type Any as type parameter
@@ -74,7 +78,7 @@ class HttpEventStreamActor(
   /** Immediately close new connections. */
   private[this] def rejectingNewConnections: Receive = {
     case HttpEventStreamConnectionOpen(handle) =>
-      log.warn("Ignoring open connection request. Closing handle.")
+      logger.warn("Ignoring open connection request. Closing handle.")
       Try(handle.close())
   }
 
@@ -82,7 +86,7 @@ class HttpEventStreamActor(
   private[this] def acceptingNewConnections: Receive = {
     case HttpEventStreamConnectionOpen(handle) =>
       metrics.numberOfStreams.setValue(streamHandleActors.size.toLong)
-      log.info(s"Add EventStream Handle as event listener: $handle. Current nr of streams: ${streamHandleActors.size}")
+      logger.info(s"Add EventStream Handle as event listener: $handle. Current nr of streams: ${streamHandleActors.size}")
       val actor = context.actorOf(handleStreamProps(handle), handle.id)
       context.watch(actor)
       streamHandleActors += handle -> actor
@@ -91,12 +95,12 @@ class HttpEventStreamActor(
   /** Switch behavior according to leadership changes. */
   private[this] def handleLeadership: Receive = {
     case LeadershipTransition.Standby =>
-      log.info("Now standing by. Closing existing handles and rejecting new.")
+      logger.info("Now standing by. Closing existing handles and rejecting new.")
       context.become(standby)
       streamHandleActors.keys.foreach(removeHandler)
 
     case LeadershipTransition.ElectedAsLeaderAndReady =>
-      log.info("Became active. Accepting event streaming requests.")
+      logger.info("Became active. Accepting event streaming requests.")
       context.become(active)
   }
 
@@ -112,7 +116,7 @@ class HttpEventStreamActor(
       context.stop(actor)
       streamHandleActors -= handle
       metrics.numberOfStreams.setValue(streamHandleActors.size.toLong)
-      log.info(s"Removed EventStream Handle as event listener: $handle. " +
+      logger.info(s"Removed EventStream Handle as event listener: $handle. " +
         s"Current nr of listeners: ${streamHandleActors.size}")
     }
   }
@@ -120,14 +124,23 @@ class HttpEventStreamActor(
   private[this] def unexpectedTerminationOfHandlerActor(actor: ActorRef): Unit = {
     streamHandleActors.find(_._2 == actor).foreach {
       case (handle, ref) =>
-        log.error(s"Actor terminated unexpectedly: $handle")
+        logger.error(s"Actor terminated unexpectedly: $handle")
         streamHandleActors -= handle
         metrics.numberOfStreams.setValue(streamHandleActors.size.toLong)
     }
   }
 
+  def handleEvents: Receive = {
+    case event: MarathonEvent =>
+      logger.info(s"### handle $event")
+      // Broadcast events to all handle actors.
+      streamHandleActors.valuesIterator.foreach { actor: ActorRef =>
+        actor ! event
+      }
+  }
+
   private[this] def warnAboutUnknownMessages: Receive = {
-    case message: Any => log.warn(s"Received unexpected message $message")
+    case message: Any => logger.warn(s"Received unexpected message $message")
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActor.scala
@@ -23,13 +23,11 @@ class HttpEventStreamHandleActor(
   private[impl] var outstanding = Seq.empty[MarathonEvent]
 
   override def preStart(): Unit = {
-    stream.subscribe(self, classOf[MarathonEvent])
     stream.publish(EventStreamAttached(handle.remoteAddress))
   }
 
   override def postStop(): Unit = {
     logger.info(s"Stop actor $handle")
-    stream.unsubscribe(self)
     stream.publish(EventStreamDetached(handle.remoteAddress))
     Try(handle.close()) //ignore, if this fails
   }

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServlet.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServlet.scala
@@ -27,7 +27,7 @@ class HttpEventSSEHandle(request: HttpServletRequest, emitter: Emitter) extends 
 
   private val subscribedEventTypes = request.getParameterMap.getOrDefault("event_type", Array.empty).toSet
 
-  private val useLightWeightEvents = request.getParameterMap.getOrDefault("plan-format", Array.empty).contains("light")
+  override val useLightWeightEvents = request.getParameterMap.getOrDefault("plan-format", Array.empty).contains("light")
 
   def subscribed(eventType: String): Boolean = {
     subscribedEventTypes.isEmpty || subscribedEventTypes.contains(eventType)

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServlet.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServlet.scala
@@ -6,14 +6,12 @@ import javax.servlet.http.{ Cookie, HttpServletRequest, HttpServletResponse }
 
 import akka.actor.ActorRef
 import mesosphere.marathon.api.RequestFacade
-import mesosphere.marathon.api.v2.json.Formats.{ eventToJson }
-import mesosphere.marathon.core.event.{ EventConf, MarathonEvent }
+import mesosphere.marathon.core.event.EventConf
 import mesosphere.marathon.core.event.impl.stream.HttpEventStreamActor._
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.plugin.http.HttpResponse
 import org.eclipse.jetty.servlets.EventSource.Emitter
 import org.eclipse.jetty.servlets.{ EventSource, EventSourceServlet }
-import play.api.libs.json.Json
 
 import scala.concurrent.{ Await, blocking }
 
@@ -39,10 +37,8 @@ class HttpEventSSEHandle(request: HttpServletRequest, emitter: Emitter) extends 
 
   override def close(): Unit = emitter.close()
 
-  override def sendEvent(event: MarathonEvent): Unit = {
-    if (subscribed(event.eventType)) blocking(emitter.event(event.eventType, Json.stringify(
-      eventToJson(event, useLightWeightEvents)
-    )))
+  override def sendEvent(event: SerializedMarathonEvent): Unit = {
+    if (subscribed(event.eventType)) blocking(emitter.event(event.eventType, event.payload))
   }
 
   override def toString: String = s"HttpEventSSEHandle($id on $remoteAddress on event types from $subscribedEventTypes)"

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/AppsDirectivesTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/AppsDirectivesTest.scala
@@ -4,12 +4,9 @@ package api.akkahttp
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.{ Path, Query }
 import akka.http.scaladsl.server.MalformedQueryParamRejection
-import akka.http.scaladsl.server.PathMatcher.{ Matched, Unmatched }
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import mesosphere.UnitTest
-import mesosphere.marathon.state.{ AppDefinition, PathId }
-import mesosphere.marathon.test.GroupCreation
 
 class AppsDirectivesTest extends UnitTest with ScalatestRouteTest {
   import AppsDirectives._

--- a/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/akkahttp/v2/PodsControllerTest.scala
@@ -24,7 +24,7 @@ import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.{ PodDefinition, PodManager }
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.core.pod.PodManager
-import mesosphere.marathon.raml.{ FixedPodScalingPolicy, LocalVolumeId, PersistentVolumeInfo, PersistentVolumeType, PodPersistentVolume, VolumeMount }
+import mesosphere.marathon.raml.{ PersistentVolumeInfo, PersistentVolumeType, PodPersistentVolume, VolumeMount }
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.util.SemanticVersion

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -15,7 +15,6 @@ import mesosphere.marathon.state.{ PathId, _ }
 import mesosphere.marathon.test.{ GroupCreation, SettableClock }
 import org.mockito.Matchers
 import org.mockito.Mockito._
-import play.api.libs.json.Json
 
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventSSEHandleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventSSEHandleTest.scala
@@ -5,7 +5,7 @@ import java.util.Collections
 import javax.servlet.http.HttpServletRequest
 
 import mesosphere.UnitTest
-import mesosphere.marathon.core.event.{ Subscribe, Unsubscribe }
+import mesosphere.marathon.core.event.impl.stream.HttpEventStreamActor.SerializedMarathonEvent
 import mesosphere.marathon.stream.Implicits._
 import org.eclipse.jetty.servlets.EventSource.Emitter
 
@@ -59,6 +59,6 @@ class HttpEventSSEHandleTest extends UnitTest {
     }
   }
 
-  val subscribed = Subscribe("client IP", "callback URL")
-  val unsubscribe = Unsubscribe("client IP", "callback URL")
+  val subscribed = SerializedMarathonEvent(eventType = "subscribe_event", payload = "{}")
+  val unsubscribe = SerializedMarathonEvent(eventType = "unsubscribed_event", payload = "{}")
 }

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActorTest.scala
@@ -19,7 +19,7 @@ class HttpEventStreamActorTest extends AkkaUnitTest with ImplicitSender {
       metrics: HttpEventStreamActorMetrics = new HttpEventStreamActorMetrics()) {
     def handleStreamProps(handle: HttpEventStreamHandle) = Props(new HttpEventStreamHandleActor(handle, stream, 1))
     val streamActor: TestActorRef[HttpEventStreamActor] = TestActorRef(Props(
-      new HttpEventStreamActor(electionService, metrics, handleStreamProps)
+      new HttpEventStreamActor(electionService, stream, metrics, handleStreamProps)
     ))
   }
 

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActorTest.scala
@@ -8,7 +8,8 @@ import akka.actor.Props
 import akka.event.EventStream
 import akka.testkit.{ EventFilter, ImplicitSender, TestActorRef }
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.event.{ EventStreamAttached, EventStreamDetached, MarathonEvent, Subscribe }
+import mesosphere.marathon.core.event.impl.stream.HttpEventStreamActor.SerializedMarathonEvent
+import mesosphere.marathon.core.event.{ EventStreamAttached, EventStreamDetached, Subscribe }
 
 import scala.concurrent.duration._
 
@@ -24,20 +25,20 @@ class HttpEventStreamHandleActorTest extends AkkaUnitTest with ImplicitSender {
     "A message send to the handle actor will be transferred to the stream handle" in new Fixture {
       Given("A handler that will postpone sending until latch is hit")
       val latch = new CountDownLatch(1)
-      handle.sendEvent(any[MarathonEvent]) answers (_ => latch.countDown())
+      handle.sendEvent(any[SerializedMarathonEvent]) answers (_ => latch.countDown())
 
       When("The event is send to the actor, the outstanding messages is 1")
       handleActor ! EventStreamAttached("remote")
 
       Then("We need to wait for the future to succeed")
       awaitCond(latch.getCount == 0)
-      verify(handle, times(1)).sendEvent(any[MarathonEvent])
+      verify(handle, times(1)).sendEvent(any[SerializedMarathonEvent])
     }
 
     "If the consumer is slow and maxOutstanding limit is reached, messages get dropped" in new Fixture {
       Given("A handler that will postpone the sending")
       val latch = new CountDownLatch(1)
-      handle.sendEvent(any[MarathonEvent]) answers (_ => latch.await())
+      handle.sendEvent(any[SerializedMarathonEvent]) answers (_ => latch.await())
       val filter = EventFilter(pattern = "Ignore event.*", occurrences = 1)
 
       When("More than the max size of outstanding events is send to the actor")
@@ -52,7 +53,7 @@ class HttpEventStreamHandleActorTest extends AkkaUnitTest with ImplicitSender {
 
     "If the handler throws an EOF exception, the actor stops acting" in new Fixture {
       Given("A handler that will postpone the sending")
-      handle.sendEvent(any[MarathonEvent]) answers { _ => throw new EOFException() }
+      handle.sendEvent(any[SerializedMarathonEvent]) answers { _ => throw new EOFException() }
       val filter = EventFilter(pattern = "Received EOF.*", occurrences = 1)
 
       When("An event is send to actor")
@@ -68,7 +69,7 @@ class HttpEventStreamHandleActorTest extends AkkaUnitTest with ImplicitSender {
       var events = List.empty[String]
       val handle = mock[HttpEventStreamHandle]
       val stream = mock[EventStream]
-      handle.sendEvent(any[MarathonEvent]) answers { args => events ::= args(0).asInstanceOf[MarathonEvent].eventType; latch.await() }
+      handle.sendEvent(any[SerializedMarathonEvent]) answers { args => events ::= args(0).asInstanceOf[SerializedMarathonEvent].eventType; latch.await() }
       val handleActor: TestActorRef[HttpEventStreamHandleActor] = TestActorRef(Props(
         new HttpEventStreamHandleActor(handle, stream, 50)
       ))

--- a/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -145,15 +145,16 @@ class MarathonFacade(
     * Connects to the Marathon SSE endpoint. Future completes when the http connection is established. Events are
     * streamed via the materializable-once Source.
     */
-  def events(eventsType: String*): Future[Source[ITEvent, NotUsed]] = {
+  def events(eventsType: Seq[String] = Seq.empty, lightweight: Boolean = false): Future[Source[ITEvent, NotUsed]] = {
 
     import EventUnmarshalling.fromEventStream
     val mapper = new ObjectMapper() with ScalaObjectMapper
     mapper.registerModule(DefaultScalaModule)
 
     val eventsFilter = Query(eventsType.map(eventType => "event_type" -> eventType): _*)
+    val planFormat = if (lightweight) eventsFilter.+:("plan-format" -> "light") else eventsFilter
 
-    Http().singleRequest(Get(akka.http.scaladsl.model.Uri(s"$url/v2/events").withQuery(eventsFilter))
+    Http().singleRequest(Get(akka.http.scaladsl.model.Uri(s"$url/v2/events").withQuery(planFormat))
       .withHeaders(Accept(MediaType.text("event-stream"))))
       .flatMap { response =>
         AkkaUnmarshal(response).to[Source[ServerSentEvent, NotUsed]]


### PR DESCRIPTION
Summary:
Currently each SSE handle is serializing the events. This
is a small overhead. It should be enough to serialize them
once and then broadcast to each handle actor.

The next step is to replace the `HttpEventStreamHandleActor`
with an Akka stream so that we do not have to deal with
slow consumers.

JIRA issues: MARATHON-8035
