### PR TITLE
Add license when launching SI tests

### DIFF
--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -25,6 +25,7 @@ node('py36') {
         withCredentials(
           [ [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'mesosphere-ci-marathon', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
             [$class: 'FileBinding', credentialsId: '11fcc957-5156-4470-ae34-d433da88248a', variable: 'DOT_SHAKEDOWN'],
+            [$class: 'StringBinding', credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389', variable: 'DCOS_LICENSE'],
             [$class: 'StringBinding', credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d', variable: 'DOCKER_HUB_USERNAME'],
             [$class: 'StringBinding', credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825', variable: 'DOCKER_HUB_PASSWORD']
           ]) {

--- a/Jenkinsfile.pr.si
+++ b/Jenkinsfile.pr.si
@@ -12,6 +12,7 @@ node('py36') {
             usernamePassword(credentialsId: 'a7ac7f84-64ea-4483-8e66-bb204484e58f', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USER'),
             [$class: 'FileBinding', credentialsId: '11fcc957-5156-4470-ae34-d433da88248a', variable: 'DOT_SHAKEDOWN'],
             [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'mesosphere-ci-marathon', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+            [$class: 'StringBinding', credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389', variable: 'DCOS_LICENSE'],
             string(credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d', variable: 'DOCKER_HUB_USERNAME'),
             string(credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825', variable: 'DOCKER_HUB_PASSWORD')
           ]) {

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -25,6 +25,7 @@ node('py36') {
         withCredentials(
           [ [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'mesosphere-ci-marathon', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
             [$class: 'FileBinding', credentialsId: '11fcc957-5156-4470-ae34-d433da88248a', variable: 'DOT_SHAKEDOWN'],
+            [$class: 'StringBinding', credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389', variable: 'DCOS_LICENSE'],
             [$class: 'StringBinding', credentialsId: '7bdd2775-2911-41ba-918f-59c8ae52326d', variable: 'DOCKER_HUB_USERNAME'],
             [$class: 'StringBinding', credentialsId: '42f2e3fb-3f4f-47b2-a128-10ac6d0f6825', variable: 'DOCKER_HUB_PASSWORD']
           ]) {

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -33,6 +33,8 @@ deployment_name: $DEPLOYMENT_NAME
 provider: aws
 aws_region: us-west-2
 key_helper: true
+dcos_config:
+    license_key_contents: $DCOS_LICENSE
 template_parameters:
     DefaultInstanceType: m4.large
     AdminLocation: 0.0.0.0/0

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -41,6 +41,11 @@ template_parameters:
     LicenseKey: $DCOS_LICENSE
 EOF
 
+if [[ -z `curl $TEMPLATE | grep 'LicenseKey'` ]]; then
+    sed -i '/LicenseKey/d' 'config.yaml'
+    echo 'Removed LicenseKey parameter as it was not in template'
+fi
+
 ./dcos-launch create
 if [ $? -ne 0 ]; then
   echo "Failed to launch a cluster via dcos-launch"

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -33,13 +33,12 @@ deployment_name: $DEPLOYMENT_NAME
 provider: aws
 aws_region: us-west-2
 key_helper: true
-dcos_config:
-    license_key_contents: $DCOS_LICENSE
 template_parameters:
     DefaultInstanceType: m4.large
     AdminLocation: 0.0.0.0/0
     PublicSlaveInstanceCount: 1
     SlaveInstanceCount: 5
+    LicenseKey: $DCOS_LICENSE
 EOF
 
 ./dcos-launch create -L debug

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -42,7 +42,7 @@ template_parameters:
     SlaveInstanceCount: 5
 EOF
 
-if ! ./dcos-launch create; then
+if ! ./dcos-launch create -L debug; then
   exit 2
 fi
 if ! ./dcos-launch wait; then

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -42,7 +42,9 @@ template_parameters:
     SlaveInstanceCount: 5
 EOF
 
-if ! ./dcos-launch create -L debug; then
+./dcos-launch create -L debug
+if [ $? -ne 0 ]; then
+  echo "Failed to launch a cluster via dcos-launch"
   exit 2
 fi
 if ! ./dcos-launch wait; then

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -41,7 +41,7 @@ template_parameters:
     LicenseKey: $DCOS_LICENSE
 EOF
 
-./dcos-launch create -L debug
+./dcos-launch create
 if [ $? -ne 0 ]; then
   echo "Failed to launch a cluster via dcos-launch"
   exit 2


### PR DESCRIPTION
Summary:
License was probably made mandatory for EE versions of DC/OS as was announced by email.
Strict tests passing here https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/system-integration-tests/job/marathon-si-dcos-strict/job/av%252Flicense/3/console

JIRA issues: MARATHON_EE-1830
