### PR TITLE
Scaling to zero takes too much time in case of non-scaling related runspec changes

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
@@ -246,7 +246,7 @@ object DeploymentPlan {
             Some(ScaleApplication(newSpec, newSpec.instances))
 
           // Scale-only change.
-          case Some(oldSpec) if oldSpec.isOnlyScaleChange(newSpec) =>
+          case Some(oldSpec) if oldSpec.isOnlyScaleChange(newSpec) || newSpec.isScaledToZero =>
             Some(ScaleApplication(newSpec, newSpec.instances, toKill.get(newSpec.id)))
 
           // Update or restart an existing run spec.

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -48,6 +48,7 @@ trait RunSpec extends plugin.RunSpec {
   def isUpgrade(to: RunSpec): Boolean
   def needsRestart(to: RunSpec): Boolean
   def isOnlyScaleChange(to: RunSpec): Boolean
+  def isScaledToZero: Boolean = instances == 0
   val versionInfo: VersionInfo
   val container = Option.empty[Container]
   val cmd = Option.empty[String]

--- a/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
@@ -422,6 +422,36 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       Then("The deployment is not valid")
       validate(plan2)(f.validator).isSuccess should be(false)
     }
+
+    "Deployment plan treats change with 0 instances as scale-only change" in {
+      Given("An application update with command and scale changes")
+      val mongoId = "/test/database/mongo".toPath
+      val strategy = UpgradeStrategy(0.75)
+
+      val versionInfo = VersionInfo.forNewConfig(Timestamp(10))
+      val mongo: (AppDefinition, AppDefinition) =
+        AppDefinition(mongoId, Some("mng1"), instances = 4, upgradeStrategy = strategy, versionInfo = versionInfo) ->
+          AppDefinition(mongoId, Some("mng2"), instances = 0, upgradeStrategy = strategy, versionInfo = versionInfo)
+
+      val from = createRootGroup(groups = Set(createGroup(
+        id = "/test".toPath,
+        groups = Set(
+          createGroup("/test/database".toPath, Map(mongo._1.id -> mongo._1))
+        )
+      )
+      ))
+
+      val to = createRootGroup(groups = Set(createGroup("/test".toPath, groups = Set(
+        createGroup("/test/database".toPath, Map(mongo._2.id -> mongo._2))
+      ))))
+
+      When("the deployment plan is computed")
+      val plan = DeploymentPlan(from, to)
+
+      Then("the deployment steps are correct")
+      plan.steps should have size 1
+      plan.steps(0).actions.toSet should equal(Set(ScaleApplication(mongo._2, 0)))
+    }
   }
   class Fixture {
     def persistentVolume(path: String) = VolumeWithMount(

--- a/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
@@ -423,7 +423,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       validate(plan2)(f.validator).isSuccess should be(false)
     }
 
-    "Deployment plan treats change with 0 instances as scale-only change" in {
+    "Deployment plan treats app conf update and scale down to 0 instances as scale-only change" in {
       Given("An application update with command and scale changes")
       val mongoId = "/test/database/mongo".toPath
       val strategy = UpgradeStrategy(0.75)


### PR DESCRIPTION
Summary: Deployment plan now treats scale to 0 instances change as scale-only change regardless other changes in the runspec

JIRA issues: MARATHON-8011
