### PR TITLE
Create the migration flag only while migrations are performed

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -132,9 +132,10 @@ class Migration(
   def runMigrations(version: Protos.StorageVersion, backupCreated: Boolean = false): Future[Seq[StorageVersion]] =
     async {
       if (!backupCreated && config.backupLocation.isDefined) {
-        logger.info("Backup current state")
+        logger.info("Making a backup of the current state")
         await(backup.backup(config.backupLocation.get))
-        logger.info("Backup finished. Apply migration.")
+        logger.info(s"The backup has been saved to ${config.backupLocation}")
+        logger.info("Going to apply the migration steps.")
       }
       val result = await(applyMigrationSteps(version))
       await(storeCurrentVersion())

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -119,31 +119,26 @@ class Migration(
     // step 2: restore state from given backup
     await(config.restore.map(uri => backup.restore(new URI(uri))).getOrElse(Future.successful(Done)))
 
-    // mark migration as started
-    await(persistenceStore.startMigration())
-
-    // run the migration, to ensure we can operate on the zk state
-    await(migrateStorage(backupCreated = config.backup.isDefined || config.restore.isDefined).asTry) match {
-      case Success(result) =>
-        // mark migration as completed
-        await(persistenceStore.endMigration())
-
-        logger.info(s"Migration successfully applied for version ${StorageVersions.current.str}")
-        result
-      case Failure(ex: MigrationCancelledException) =>
-        logger.error(ex.getMessage)
-
-        // mark migration as completed
-        await(persistenceStore.endMigration())
-
-        throw new MigrationFailedException("Migration cancelled", ex.getCause)
-      case Failure(ex) =>
-        throw ex
-    }
+    // last step: run the migration, to ensure we can operate on the zk state
+    val result = await(migrateStorage(backupCreated = config.backup.isDefined || config.restore.isDefined))
+    logger.info(s"Migration successfully applied for version ${StorageVersions.current.str}")
+    result
   }
 
   def migrate(): Seq[StorageVersion] =
     Await.result(migrateAsync(), Duration.Inf)
+
+  def runMigrations(version: Protos.StorageVersion, backupCreated: Boolean = false): Future[Seq[StorageVersion]] =
+    async {
+      if (!backupCreated && config.backupLocation.isDefined) {
+        logger.info("Backup current state")
+        await(backup.backup(config.backupLocation.get))
+        logger.info("Backup finished. Apply migration.")
+      }
+      val result = await(applyMigrationSteps(version))
+      await(storeCurrentVersion())
+      result
+    }
 
   @SuppressWarnings(Array("all")) // async/await
   def migrateStorage(backupCreated: Boolean = false): Future[Seq[StorageVersion]] = {
@@ -161,20 +156,30 @@ class Migration(
             s" than ${StorageVersions.current.str}."
           throw new MigrationFailedException(msg)
         case Some(version) if version < currentBuildVersion =>
-          if (!backupCreated && config.backupLocation.isDefined) {
-            logger.info("Backup current state")
-            await(backup.backup(config.backupLocation.get))
-            logger.info("Backup finished. Apply migration.")
+          // mark migration as started
+          await(persistenceStore.startMigration())
+          await(runMigrations(version, backupCreated).asTry) match {
+            case Success(result) =>
+              // mark migration as completed
+              await(persistenceStore.endMigration())
+              result
+            case Failure(ex: MigrationCancelledException) =>
+              // mark migration as completed
+              await(persistenceStore.endMigration())
+              throw ex
+            case Failure(ex) =>
+              throw ex
           }
-          val result = await(applyMigrationSteps(version))
-          await(storeCurrentVersion())
-          result
         case Some(version) if version == currentBuildVersion =>
           logger.info("No migration necessary, already at the current version")
           Nil
         case _ =>
           logger.info("No migration necessary, no version stored")
+          // mark migration as started
+          await(persistenceStore.startMigration())
           await(storeCurrentVersion())
+          // mark migration as completed
+          await(persistenceStore.endMigration())
           Nil
       }
       migrations

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -128,6 +128,7 @@ class Migration(
   def migrate(): Seq[StorageVersion] =
     Await.result(migrateAsync(), Duration.Inf)
 
+  @SuppressWarnings(Array("all")) // async/await
   def runMigrations(version: Protos.StorageVersion, backupCreated: Boolean = false): Future[Seq[StorageVersion]] =
     async {
       if (!backupCreated && config.backupLocation.isDefined) {

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
@@ -111,16 +111,11 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
       mockedStore.isOpen returns true
       val currentPersistenceVersion =
         StorageVersions.current.toBuilder.setFormat(StorageVersion.StorageFormat.PERSISTENCE_STORE).build()
-
-      mockedStore.startMigration() returns Future.successful(Done)
       mockedStore.storageVersion() returns Future.successful(Some(currentPersistenceVersion))
-      mockedStore.endMigration() returns Future.successful(Done)
 
       migrate.migrate()
 
-      verify(mockedStore).startMigration()
       verify(mockedStore).storageVersion()
-      verify(mockedStore).endMigration()
       noMoreInteractions(mockedStore)
     }
 
@@ -236,13 +231,16 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
       val mockedStore = mock[PersistenceStore[_, _, _]]
       val f = new Fixture(mockedStore)
       mockedStore.startMigration() throws new StoreCommandFailedException("Migration is already in progress")
+      mockedStore.storageVersion() returns Future.successful(Some(StorageVersions(1, 4, 0, StorageVersion.StorageFormat.PERSISTENCE_STORE)))
 
       val migrate = f.migration
 
-      val thrown = the[StoreCommandFailedException] thrownBy migrate.migrate()
-      thrown.getMessage should equal("Migration is already in progress")
+      val thrown = the[MigrationFailedException] thrownBy migrate.migrate()
+      thrown.getMessage should equal("Migration Failed: Migration is already in progress")
+      thrown.getCause shouldBe a[StoreCommandFailedException]
 
       verify(mockedStore).startMigration()
+      verify(mockedStore).storageVersion()
       noMoreInteractions(mockedStore)
     }
 
@@ -260,7 +258,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
 
       val migration = f.migration
 
-      val thrown = the[MigrationFailedException] thrownBy migration.migrate()
+      val thrown = the[MigrationCancelledException] thrownBy migration.migrate()
       thrown.getMessage should equal("Migration cancelled")
       thrown.getCause shouldBe a[Exception]
       thrown.getCause.getMessage should equal("Failed to do something")


### PR DESCRIPTION
Currently, the flag is created unconditionally for the duration of
checking the current version in ZK and performing migrations if necessary.
There is no need to create the flag for the duration of checking
the current version, it should be created only if and when there is
a need to perform migrations.

JIRA issues:
https://jira.mesosphere.com/browse/MARATHON-8044