### PR TITLE
First step in making launch cluster run on mac

### DIFF
--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -21,7 +21,12 @@ fi
 echo "Workspace: ${WORKSPACE}"
 echo "Using: ${TEMPLATE}"
 
-apt-get update && apt-get install -y -t jessie-backports gettext-base wget
+PLATFORM=`uname`
+if [ "$PLATFORM" == 'Darwin' ]; then
+    brew install gettext
+else
+    apt-get update && apt-get install -y -t jessie-backports gettext-base wget
+fi
 wget 'https://downloads.dcos.io/dcos-test-utils/bin/linux/dcos-launch' && chmod +x dcos-launch
 
 


### PR DESCRIPTION
Summary:
Do not use apt on mac, use homebrew instead.

JIRA issues:
