### PR TITLE
Serialize full and light events only once.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.event
 
-import akka.event.EventStream
+import com.fasterxml.jackson.annotation.JsonIgnore
 import mesosphere.marathon.api.v2.json.Formats.eventToJson
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.health.HealthCheck
@@ -11,12 +11,19 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.core.deployment.{ DeploymentPlan, DeploymentStep }
 import org.apache.mesos.{ Protos => Mesos }
+import play.api.libs.json.Json
 
 import scala.collection.immutable.Seq
 
 sealed trait MarathonEvent {
   val eventType: String
   val timestamp: String
+
+  @JsonIgnore
+  lazy val fullJsonString: String = Json.stringify(eventToJson(this, false))
+
+  @JsonIgnore
+  lazy val lightJsonString: String = Json.stringify(eventToJson(this, true))
 }
 
 // api

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServlet.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServlet.scala
@@ -40,9 +40,10 @@ class HttpEventSSEHandle(request: HttpServletRequest, emitter: Emitter) extends 
   override def close(): Unit = emitter.close()
 
   override def sendEvent(event: MarathonEvent): Unit = {
-    if (subscribed(event.eventType)) blocking(emitter.event(event.eventType, Json.stringify(
-      eventToJson(event, useLightWeightEvents)
-    )))
+    if (subscribed(event.eventType)) {
+      if (useLightWeightEvents) blocking(emitter.event(event.eventType, event.lightJsonString))
+      else blocking(emitter.event(event.eventType, event.fullJsonString))
+    }
   }
 
   override def toString: String = s"HttpEventSSEHandle($id on $remoteAddress on event types from $subscribedEventTypes)"

--- a/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -145,15 +145,16 @@ class MarathonFacade(
     * Connects to the Marathon SSE endpoint. Future completes when the http connection is established. Events are
     * streamed via the materializable-once Source.
     */
-  def events(eventsType: String*): Future[Source[ITEvent, NotUsed]] = {
+  def events(eventsType: Seq[String] = Seq.empty, lightweight: Boolean = false): Future[Source[ITEvent, NotUsed]] = {
 
     import EventUnmarshalling.fromEventStream
     val mapper = new ObjectMapper() with ScalaObjectMapper
     mapper.registerModule(DefaultScalaModule)
 
     val eventsFilter = Query(eventsType.map(eventType => "event_type" -> eventType): _*)
+    val planFormat = if (lightweight) eventsFilter.+:("plan-format" -> "light") else eventsFilter
 
-    Http().singleRequest(Get(akka.http.scaladsl.model.Uri(s"$url/v2/events").withQuery(eventsFilter))
+    Http().singleRequest(Get(akka.http.scaladsl.model.Uri(s"$url/v2/events").withQuery(planFormat))
       .withHeaders(Accept(MediaType.text("event-stream"))))
       .flatMap { response =>
         AkkaUnmarshal(response).to[Source[ServerSentEvent, NotUsed]]


### PR DESCRIPTION
Summary:
Currently each SSE handle is serializing the events. This
is a small overhead. It should be enough to serialize them
once and then broadcast to each handle actor.

The next step is to replace the HttpEventStreamHandleActor
with an Akka stream so that we do not have to deal with
slow consumers.

JIRA issues: MARATHON-8035