### PR TITLE
Scaling to zero takes too much time in case of non-scaling related runspec changes

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
@@ -246,7 +246,7 @@ object DeploymentPlan {
             Some(ScaleApplication(newSpec, newSpec.instances))
 
           // Scale-only change.
-          case Some(oldSpec) if oldSpec.isOnlyScaleChange(newSpec) =>
+          case Some(oldSpec) if oldSpec.isOnlyScaleChange(newSpec) || newSpec.isScaledToZero =>
             Some(ScaleApplication(newSpec, newSpec.instances, toKill.get(newSpec.id)))
 
           // Update or restart an existing run spec.

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -48,6 +48,7 @@ trait RunSpec extends plugin.RunSpec {
   def isUpgrade(to: RunSpec): Boolean
   def needsRestart(to: RunSpec): Boolean
   def isOnlyScaleChange(to: RunSpec): Boolean
+  def isScaledToZero: Boolean = instances == 0
   val versionInfo: VersionInfo
   val container = Option.empty[Container]
   val cmd = Option.empty[String]


### PR DESCRIPTION
Summary: Deployment plan now treats scale to 0 instances change as scale-only change regardless other changes in the runspec

JIRA issues: MARATHON-8011

Backport of #5929
(cherry picked from commit 46c9ad1)