### PR TITLE
Backport of #5929 to 1.4: Scaling to zero takes too much time in case of non-scaling related runspec changes

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -47,6 +47,7 @@ trait RunSpec extends plugin.RunSpec {
   def isUpgrade(to: RunSpec): Boolean
   def needsRestart(to: RunSpec): Boolean
   def isOnlyScaleChange(to: RunSpec): Boolean
+  def isScaledToZero: Boolean = instances == 0
   val versionInfo: VersionInfo
   val container = Option.empty[Container]
   val cmd = Option.empty[String]

--- a/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/DeploymentPlan.scala
@@ -255,7 +255,7 @@ object DeploymentPlan {
             Some(ScaleApplication(newSpec, newSpec.instances))
 
           // Scale-only change.
-          case Some(oldSpec) if oldSpec.isOnlyScaleChange(newSpec) =>
+          case Some(oldSpec) if oldSpec.isOnlyScaleChange(newSpec) || newSpec.isScaledToZero =>
             Some(ScaleApplication(newSpec, newSpec.instances, toKill.get(newSpec.id)))
 
           // Update or restart an existing run spec.


### PR DESCRIPTION
Summary: Deployment plan now treats scale to 0 instances change as scale-only change regardless other changes in the runspec

JIRA issues: MARATHON-8011

(cherry picked from commit 46c9ad1)
