### PR TITLE
Complete deployment after it was removed to avoid race condition

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/DeploymentModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/DeploymentModule.scala
@@ -31,7 +31,7 @@ class DeploymentModule(
     eventBus: EventStream,
     readinessCheckExecutor: ReadinessCheckExecutor,
     deploymentRepository: DeploymentRepository,
-    deploymentActorProps: (ActorRef, Promise[Done], KillService, SchedulerActions, DeploymentPlan, InstanceTracker, LaunchQueue, HealthCheckManager, EventStream, ReadinessCheckExecutor) => Props = DeploymentActor.props)(implicit val mat: Materializer) {
+    deploymentActorProps: (ActorRef, KillService, SchedulerActions, DeploymentPlan, InstanceTracker, LaunchQueue, HealthCheckManager, EventStream, ReadinessCheckExecutor) => Props = DeploymentActor.props)(implicit val mat: Materializer) {
 
   private[this] val deploymentManagerActorRef: ActorRef = {
     val props = DeploymentManagerActor.props(

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -25,6 +25,7 @@ import org.mockito.stubbing.Answer
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.util.Success
 
 // TODO: this is NOT a unit test. the DeploymentActor create child actors that cannot be mocked in the current
 // setup which makes the test overly complicated because events etc have to be mocked for these.
@@ -52,10 +53,9 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       InstanceChanged(instanceId, app.version, app.id, condition, instance)
     }
 
-    def deploymentActor(manager: ActorRef, promise: Promise[Done], plan: DeploymentPlan) = system.actorOf(
+    def deploymentActor(manager: ActorRef, plan: DeploymentPlan) = system.actorOf(
       DeploymentActor.props(
         manager,
-        promise,
         killService,
         scheduler,
         plan,
@@ -134,12 +134,12 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
         }
       })
 
-      deploymentActor(managerProbe.ref, Promise[Done](), plan)
+      deploymentActor(managerProbe.ref, plan)
       plan.steps.zipWithIndex.foreach {
         case (step, num) => managerProbe.expectMsg(7.seconds, DeploymentStepInfo(plan, step, num + 1))
       }
 
-      managerProbe.expectMsg(5.seconds, DeploymentFinished(plan))
+      managerProbe.expectMsg(5.seconds, DeploymentFinished(plan, Success(Done)))
 
       withClue(killService.killed.mkString(",")) {
         killService.killed should contain(instance1_2.instanceId) // killed due to scale down
@@ -179,8 +179,11 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
         }
       })
 
-      deploymentActor(managerProbe.ref, promise, plan)
-      promise.future.futureValue should be (Done)
+      deploymentActor(managerProbe.ref, plan)
+      plan.steps.zipWithIndex.foreach {
+        case (step, num) => managerProbe.expectMsg(5.seconds, DeploymentStepInfo(plan, step, num + 1))
+      }
+      managerProbe.expectMsg(5.seconds, DeploymentFinished(plan, Success(Done)))
 
       killService.killed should contain(instance1_1.instanceId)
       killService.killed should contain(instance1_2.instanceId)
@@ -189,7 +192,6 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
     "Restart suspended app" in new Fixture {
       val managerProbe = TestProbe()
-      val promise = Promise[Done]()
 
       val app = AppDefinition(id = PathId("/app1"), cmd = Some("cmd"), instances = 0)
       val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo/bar"), Map(app.id -> app))))
@@ -203,8 +205,11 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       tracker.specInstancesSync(app.id) returns Seq.empty[Instance]
       queue.addAsync(app, 2) returns Future.successful(Done)
 
-      deploymentActor(managerProbe.ref, promise, plan)
-      promise.future.futureValue should be (Done)
+      deploymentActor(managerProbe.ref, plan)
+      plan.steps.zipWithIndex.foreach {
+        case (step, num) => managerProbe.expectMsg(5.seconds, DeploymentStepInfo(plan, step, num + 1))
+      }
+      managerProbe.expectMsg(5.seconds, DeploymentFinished(plan, Success(Done)))
     }
 
     "Scale with tasksToKill" in new Fixture {
@@ -225,13 +230,13 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
       tracker.specInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2, instance1_3))
 
-      deploymentActor(managerProbe.ref, Promise[Done](), plan)
+      deploymentActor(managerProbe.ref, plan)
 
       plan.steps.zipWithIndex.foreach {
         case (step, num) => managerProbe.expectMsg(5.seconds, DeploymentStepInfo(plan, step, num + 1))
       }
 
-      managerProbe.expectMsg(5.seconds, DeploymentFinished(plan))
+      managerProbe.expectMsg(5.seconds, DeploymentFinished(plan, Success(Done)))
 
       killService.numKilled should be(1)
       killService.killed should contain(instance1_2.instanceId)

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Success
 
 class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with GroupCreation with Eventually {
 
@@ -69,7 +70,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
       awaitCond(manager.underlyingActor.runningDeployments.contains(plan.id), 5.seconds)
       manager.underlyingActor.runningDeployments(plan.id).status should be(DeploymentStatus.Deploying)
 
-      manager ! DeploymentFinished(plan)
+      manager ! DeploymentFinished(plan, Success(Done))
       awaitCond(manager.underlyingActor.runningDeployments.isEmpty, 5.seconds)
     }
 
@@ -206,7 +207,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
 
     // A method that returns dummy props. Used to control the deployments progress. Otherwise the tests become racy
     // and depending on when DeploymentActor sends DeploymentFinished message.
-    val deploymentActorProps: (Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Props = (_, _, _, _, _, _, _, _, _, _) => TestActor.props(new LinkedBlockingDeque())
+    val deploymentActorProps: (Any, Any, Any, Any, Any, Any, Any, Any, Any) => Props = (_, _, _, _, _, _, _, _, _) => TestActor.props(new LinkedBlockingDeque())
 
     def deploymentManager(): TestActorRef[DeploymentManagerActor] = TestActorRef (
       DeploymentManagerActor.props(

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -5,19 +5,19 @@ import java.time.{ OffsetDateTime, ZoneOffset }
 import com.google.protobuf.TextFormat
 import mesosphere.UnitTest
 import mesosphere.marathon.api.serialization.PortDefinitionSerializer
-import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
-import mesosphere.marathon.core.pod.{BridgeNetwork, ContainerNetwork}
+import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
+import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
-import mesosphere.marathon.raml.{App, Resources}
-import mesosphere.marathon.state.Container.{Docker, PortMapping}
+import mesosphere.marathon.raml.{ App, Resources }
+import mesosphere.marathon.state.Container.{ Docker, PortMapping }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
-import mesosphere.marathon.state.{AppDefinition, Container, PathId, Timestamp, _}
+import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.test.MarathonTestHelper
-import mesosphere.marathon.{Protos, _}
-import mesosphere.mesos.protos.{Resource, _}
+import mesosphere.marathon.{ Protos, _ }
+import mesosphere.mesos.protos.{ Resource, _ }
 import org.apache.mesos.Protos.TaskInfo
 import org.apache.mesos.{ Protos => MesosProtos }
 


### PR DESCRIPTION
Summary:
The `DeploymentActor` is sending a `DeploymentFinishd` messaged to the
`DeploymentManagerActor` *and* fulfills a promis for the
`MarathonSchedulerActor` which triggers events. This can lead to a race
condition. The scheduler might anounce a finished deployment while it's
still in the queue of active deployments. This change has the manager
fulfill the promise *after* the deployment was removed from the queue.
Thus we avoid the race condition.

Backported from #5939 

JIRA issues: MARATHON-8039
