### PR TITLE
Retry querying content of Pods with persistent volumes.

### DIFF
--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -514,9 +514,8 @@ def test_pod_with_persistent_volume():
     def assert_volume_content(host, port, directory):
         cmd = "curl {}:{}/{}/foo".format(host, port, directory)
         run, data = shakedown.run_command_on_master(cmd)
-        assert run, "{} did not succeed".format(cmd)
+        assert run, "{} did not succeed on {}:{}".format(cmd, host, port)
         assert data == 'hello\n', "'{}' was not equal to hello\\n".format(data)
-
 
     assert_volume_content(host, port1, dir1)
     assert_volume_content(host, port2, dir2)


### PR DESCRIPTION
Summary:
This should avoid a race condition when the pod that does not echo into
the volume is up and running while the other is not. So the first curl
would end up with an empty response. Health checks could be an
alternative.

JIRA issues: MARATHON-8053