### PR TITLE
Adding SI tests for Hybrid Cloud

### DIFF
--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -89,3 +89,34 @@ def ipv6_healthcheck():
         For more information about the nc options just run `docker run alpine nc --help`
     """
     return load_app('ipv6-healthcheck')
+
+def faultdomain_app(region=None, zone=None, instances=1, constraints=[]):
+    """
+    This is a dynamic app definition based on the faultdomain-base-app. It modifies it by appending
+    the name, zone and region configuration as given
+
+    :param region: The region to start this app in
+    :param zone: The zone to start this app in
+    :param instances: The number of instances in this app
+    :param constraints: Other constraints to append
+    :return: Returns the App Definition
+    """
+    app = load_app('faultdomain-base-app')
+    app['instances'] = instances
+
+    # Append region constraint
+    if not region is None:
+        app['constraints'] += [
+            ["@region", "IS", str(region)]
+        ]
+
+    # Append zone constraint
+    if not zone is None:
+        app['constraints'] += [
+            ["@zone", "IS", str(zone)]
+        ]
+
+    # Append misc constraints
+    app['constraints'] += constraints
+
+    return app

--- a/tests/system/apps/faultdomain-base-app.json
+++ b/tests/system/apps/faultdomain-base-app.json
@@ -1,0 +1,8 @@
+{
+  "id": "/fault-domain",
+  "cmd": "sleep 1200",
+  "instances": 1,
+  "cpus": 0.01,
+  "mem": 32,
+  "constraints": []
+}

--- a/tests/system/utils.py
+++ b/tests/system/utils.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 
-from dcos import http, util
+from dcos import http, util, mesos
 from dcos.errors import DCOSException
 
 
@@ -39,3 +39,114 @@ def get_resource(resource):
                 raise Exception
         except Exception:
             raise DCOSException("Can't read from resource: {0}. Please check that it exists.".format(resource))
+
+class FaultDomain:
+    """
+    High-level representation of a fault domain
+    """
+    def __init__(self, config):
+        # Make sure config is a dict
+        if not type(config) is dict:
+            config = {}
+
+        # Extract fault domain
+        fault_domain = config.get('fault_domain', {})
+
+        # Extract zone/region
+        self.zone = fault_domain.get('zone', {}).get('name', 'default')
+        self.region = fault_domain.get('region', {}).get('name', 'default')
+
+
+def get_cluster_local_domain():
+    """Contacts the DC/OS mesos master and returns it's faultDomain configuration (aka "local domain")
+    """
+    master = mesos.get_master()
+    return FaultDomain(master.state().get('domain', {}))
+
+def get_cluster_slave_domains():
+    """Returns a dictionary with the slave IDs in the cluster and their corresponding
+       fault domain information
+    """
+    slave_domains = {}
+
+    # Populate slave_domains with the ID and the corresponding domain for each slave
+    master = mesos.get_master()
+    for slave in master.slaves():
+        slave_domains[slave['id']] = FaultDomain(slave._short_state.get('domain', None))
+    return slave_domains
+
+def get_all_cluster_regions():
+    """Returns a dictionary with all the regions and their zones in the cluster
+    """
+    domain_regions = {}
+
+    # Populate all the domain zones and regions found in the cluster
+    for domain in get_cluster_slave_domains().values():
+        if not domain.region in domain_regions:
+            domain_regions[domain.region] = []
+        if not domain.zone in domain_regions[domain.region]:
+            domain_regions[domain.region].append(domain.zone)
+
+    # Return dictionary
+    return domain_regions
+
+def get_biggest_cluster_region():
+    """Returns a tuple with the name of the biggest region in the cluster and the zones in it
+    """
+    biggest_region = None
+    biggest_region_zones = []
+
+    for (region, zones) in get_all_cluster_regions().items():
+        if len(zones) > len(biggest_region_zones):
+            biggest_region_zones = zones
+            biggest_region = region
+
+    return (biggest_region, biggest_region_zones)
+
+def get_app_domains(app):
+    """Returns a list of all te fault domains used by the tasks of the specified app
+    """
+    tasks = app.get('tasks', [])
+    slave_domains = get_cluster_slave_domains()
+
+    assert len(tasks) > 0, "App %s did not launch any tasks on mesos" % (app['id'],)
+
+    # Collect the FaultDomain objects from all the agents where the tasks are running
+    domains = []
+    for task in tasks:
+        domains.append(slave_domains[task['slaveId']])
+
+    return domains
+
+def get_used_regions_and_zones(domains):
+    """Returns tuple with the sets of the used regions and zones from the given list
+       of FaultDomain object instances (ex. obtained by get_app_domains())"""
+    used_regions = set()
+    used_zones = set()
+
+    for domain in domains:
+        used_regions.add(domain.region)
+        used_zones.add(domain.zone)
+
+    return (used_regions, used_zones)
+
+def count_agents_in_faultdomains(regions=None, zones=None):
+    """Return the number of agents that belong on the specified region and/or zone
+    """
+    counter = 0
+
+    # Make sure to always operate on iterable
+    if type(regions) is str:
+        regions = [regions]
+    if type(zones) is str:
+        zones = [zones]
+
+    # Increment counter for the agents that pass the checks
+    for domain in get_cluster_slave_domains().values():
+        if not regions is None and not domain.region in regions:
+            continue
+        if not zones is None and not domain.zone in zones:
+            continue
+        counter += 1
+
+    return counter


### PR DESCRIPTION
This PR introduces hybrid-cloud System Integration tests:

- `marathon_common_tests.py::test_faultdomains_default` : Checks the behaviour of launching an app without fault domain constraints
- `marathon_common_tests.py::test_faultdomains_region_only` : Checks the behaviour of launching an app with only `region` fixed 
- `marathon_common_tests.py::test_faultdomains_region_and_zone` : Checks the behaviour of launching an app with `region` and `zone` fixed
- `marathon_common_tests.py::test_faultdomains_distribute` : Checks the behaviour of the `GROUP_BY` constraints

These tests are discovering the zones and regions of the cluster by asking the cluster's mesos leader. When launching a DC/OS cluster make sure that there is at least 1 remote region, bigger than the local region, having at least 2 zones each. For example:

```yaml
fault_domain_helper:
  LocalZone:
    num_zones: 2
    num_private_agents: 2
    local: true
  RemoteZone:
    num_zones: 3
    num_public_agents: 1
    num_private_agents: 2
```

## WIP Items

* [ ] Modify `dcos-launch` to start a multi-zone cluster on EE by default
* [ ] Figure out other constraints that needs to be