### PR TITLE
Skip serializing docker default network.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
@@ -238,6 +238,14 @@ object DockerSerializer {
       case HostNetwork => DockerInfo.Network.HOST // it's the default, but we include here for posterity
       case unsupported => throw SerializationFailedException(s"unsupported docker network type $unsupported")
     }.foreach(builder.setNetwork)
+
+    // The default network mode is OS specific for the mesos agent (`HOST` on Linux and `BRIDGE` on Windows), so
+    // we need to clear the network field and let the agent decide what mode to use. Since the default is `HOST` in
+    // in marathon, if we didn't clear this field, we would by default send `HOST`, which is unsupported on Windows.
+    if (DockerInfo.getDefaultInstance.getNetwork == builder.getNetwork) {
+      builder.clearNetwork
+    }
+
     builder.build
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/serialization/ContainerSerializerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/serialization/ContainerSerializerTest.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.state.Container.PortMapping
 import mesosphere.marathon.state.Container
 
 import scala.collection.JavaConverters._
-import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
+import mesosphere.marathon.core.pod.{ HostNetwork, BridgeNetwork, ContainerNetwork }
 import org.scalatest.Inside
 import org.apache.mesos.{ Protos => Mesos }
 
@@ -54,6 +54,18 @@ class ContainerSerializerTest extends UnitTest with Inside {
           case Seq(portMapping) =>
             portMapping.getHostPort shouldBe 1000
         }
+      }
+      "not serialize the network if it's host mode for the docker container" in {
+        val networks = List(HostNetwork)
+        val container = Container.Docker()
+
+        val result = ContainerSerializer.toMesos(networks, container, "mesos-bridge")
+
+        // We expect the protobuf field to be not set, so we know that it's not serialized.
+        result.getDocker.hasNetwork shouldBe false
+
+        // Make sure we get the correct default value back even though the network isn't serialized.
+        result.getDocker.getNetwork shouldBe (Mesos.ContainerInfo.DockerInfo.Network.HOST)
       }
     }
 


### PR DESCRIPTION
Summary:
The Mesos agent determines the default docker network mode by checking
if the `ContainerInfo::DockerInfo.network()` field is set and setting
the OS specific default. So, we don't serialize the network if it's
the default (`HOST` in this case).

JIRA issues:
[MARATHON-8056](https://jira.mesosphere.com/browse/MARATHON-8056)