### PR TITLE
Use three agents for SI test clusters.

### DIFF
--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -42,7 +42,7 @@ template_parameters:
     DefaultInstanceType: m4.large
     AdminLocation: 0.0.0.0/0
     PublicSlaveInstanceCount: 1
-    SlaveInstanceCount: 5
+    SlaveInstanceCount: 3
     LicenseKey: $DCOS_LICENSE
 EOF
 


### PR DESCRIPTION
Summary:
Our system integration test cluster would sometimes not launch because
the AWS account ran out of resources. Currently a multi-node cluster requires
ten EC2 instances and three Elastic Load Balancers. With this change we
should only require eight instances per cluster.