### PR TITLE
Create the migration flag only while migrations are performed

### DIFF
--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -5,19 +5,19 @@ import java.time.{ OffsetDateTime, ZoneOffset }
 import com.google.protobuf.TextFormat
 import mesosphere.UnitTest
 import mesosphere.marathon.api.serialization.PortDefinitionSerializer
-import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
-import mesosphere.marathon.core.pod.{BridgeNetwork, ContainerNetwork}
+import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
+import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
-import mesosphere.marathon.raml.{App, Resources}
-import mesosphere.marathon.state.Container.{Docker, PortMapping}
+import mesosphere.marathon.raml.{ App, Resources }
+import mesosphere.marathon.state.Container.{ Docker, PortMapping }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
-import mesosphere.marathon.state.{AppDefinition, Container, PathId, Timestamp, _}
+import mesosphere.marathon.state.{ AppDefinition, Container, PathId, Timestamp, _ }
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.test.MarathonTestHelper
-import mesosphere.marathon.{Protos, _}
-import mesosphere.mesos.protos.{Resource, _}
+import mesosphere.marathon.{ Protos, _ }
+import mesosphere.mesos.protos.{ Resource, _ }
 import org.apache.mesos.Protos.TaskInfo
 import org.apache.mesos.{ Protos => MesosProtos }
 


### PR DESCRIPTION
Currently, the flag is created unconditionally for the duration of
checking the current version in ZK and performing migrations if necessary.
There is no need to create the flag for the duration of checking
the current version, it should be created only if and when there is
a need to perform migrations.

It is a backport of ffeab0c906eaa318921cb07e566394e2aff7acb4

JIRA issues:
https://jira.mesosphere.com/browse/MARATHON-8044