### PR TITLE
Optimize `v2/groups` request performance

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -1,5 +1,6 @@
 package mesosphere.marathon
 
+import mesosphere.marathon.core.appinfo.AppInfoConfig
 import mesosphere.marathon.core.deployment.DeploymentConfig
 import mesosphere.marathon.core.event.EventConf
 import mesosphere.marathon.core.flow.{ LaunchTokenConfig, ReviveOffersConfig }
@@ -36,7 +37,7 @@ trait MarathonConf
   with LeaderProxyConf with MarathonSchedulerServiceConfig with OfferMatcherManagerConfig with OfferProcessorConfig
   with PluginManagerConfiguration with ReviveOffersConfig with StorageConf with KillConfig
   with TaskJobsConfig with TaskStatusUpdateConfig with InstanceTrackerConfig with DeploymentConfig with ZookeeperConf
-  with MatcherConf {
+  with MatcherConf with AppInfoConfig {
 
   lazy val mesosMaster = opt[String](
     "master",

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerServiceConfig.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerServiceConfig.scala
@@ -10,4 +10,11 @@ trait MarathonSchedulerServiceConfig extends ScallopConf {
     hidden = true,
     default = Some(10000))
 
+  lazy val schedulerActionsExecutionContextSize = opt[Int](
+    "scheduler_actions_execution_context_size",
+    default = Some(8),
+    hidden = true,
+    descr = "INTERNAL TUNING PARAMETER: Scheduler actions component's execution context thread pool size"
+  )
+
 }

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerServiceConfig.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerServiceConfig.scala
@@ -12,7 +12,7 @@ trait MarathonSchedulerServiceConfig extends ScallopConf {
 
   lazy val schedulerActionsExecutionContextSize = opt[Int](
     "scheduler_actions_execution_context_size",
-    default = Some(8),
+    default = Some(Runtime.getRuntime().availableProcessors()),
     hidden = true,
     descr = "INTERNAL TUNING PARAMETER: Scheduler actions component's execution context thread pool size"
   )

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -35,9 +35,10 @@ import mesosphere.marathon.core.task.termination.TaskTerminationModule
 import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.storage.StorageModule
+import mesosphere.util.NamedExecutionContext
 import mesosphere.util.state.MesosLeaderInfo
-import scala.concurrent.ExecutionContext
 
+import scala.concurrent.ExecutionContext
 import scala.util.Random
 
 /**
@@ -81,7 +82,7 @@ class CoreModuleImpl @Inject() (
   )
 
   // TASKS
-  val storageExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(8))
+  val storageExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(8, "storage-module")
   override lazy val taskTrackerModule =
     new InstanceTrackerModule(clock, marathonConf, leadershipModule,
       storageModule.instanceRepository, instanceUpdateSteps)(actorsModule.materializer)
@@ -199,7 +200,7 @@ class CoreModuleImpl @Inject() (
 
   // GROUP MANAGER
 
-  val groupManagerExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(8))
+  val groupManagerExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(8, "group-manager-module")
   override lazy val groupManagerModule: GroupManagerModule = new GroupManagerModule(
     marathonConf,
     scheduler,
@@ -261,7 +262,7 @@ class CoreModuleImpl @Inject() (
   //
   // TODO: this can be removed when MarathonSchedulerActor becomes a core component
 
-  val schedulerActionsExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(8))
+  val schedulerActionsExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(8, "scheduler-actions")
   override lazy val schedulerActions: SchedulerActions = new SchedulerActions(
     storageModule.groupRepository,
     healthModule.healthCheckManager,

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -15,7 +15,7 @@ import mesosphere.marathon.core.deployment.DeploymentModule
 import mesosphere.marathon.core.election._
 import mesosphere.marathon.core.event.EventModule
 import mesosphere.marathon.core.flow.FlowModule
-import mesosphere.marathon.core.group.GroupManagerModule
+import mesosphere.marathon.core.group.{ GroupManagerConfig, GroupManagerModule }
 import mesosphere.marathon.core.health.HealthModule
 import mesosphere.marathon.core.heartbeat.MesosHeartbeatMonitor
 import mesosphere.marathon.core.history.HistoryModule
@@ -34,7 +34,7 @@ import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
 import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
-import mesosphere.marathon.storage.StorageModule
+import mesosphere.marathon.storage.{ StorageConf, StorageModule }
 import mesosphere.util.NamedExecutionContext
 import mesosphere.util.state.MesosLeaderInfo
 
@@ -82,7 +82,7 @@ class CoreModuleImpl @Inject() (
   )
 
   // TASKS
-  val storageExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(8, "storage-module")
+  val storageExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(marathonConf.asInstanceOf[StorageConf].storageExecutionContextSize(), "storage-module")
   override lazy val taskTrackerModule =
     new InstanceTrackerModule(clock, marathonConf, leadershipModule,
       storageModule.instanceRepository, instanceUpdateSteps)(actorsModule.materializer)
@@ -200,7 +200,7 @@ class CoreModuleImpl @Inject() (
 
   // GROUP MANAGER
 
-  val groupManagerExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(8, "group-manager-module")
+  val groupManagerExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(marathonConf.asInstanceOf[GroupManagerConfig].groupManagerExecutionContextSize(), "group-manager-module")
   override lazy val groupManagerModule: GroupManagerModule = new GroupManagerModule(
     marathonConf,
     scheduler,
@@ -262,7 +262,7 @@ class CoreModuleImpl @Inject() (
   //
   // TODO: this can be removed when MarathonSchedulerActor becomes a core component
 
-  val schedulerActionsExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(8, "scheduler-actions")
+  val schedulerActionsExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(marathonConf.asInstanceOf[MarathonSchedulerServiceConfig].schedulerActionsExecutionContextSize(), "scheduler-actions")
   override lazy val schedulerActions: SchedulerActions = new SchedulerActions(
     storageModule.groupRepository,
     healthModule.healthCheckManager,

--- a/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoConfig.scala
@@ -1,0 +1,21 @@
+package mesosphere.marathon
+package core.appinfo
+
+import org.rogach.scallop.ScallopConf
+
+trait AppInfoConfig extends ScallopConf {
+
+  lazy val appInfoModuleExecutionContextSize = opt[Int](
+    "app_info_module_execution_context_size",
+    default = Some(8),
+    hidden = true,
+    descr = "INTERNAL TUNING PARAMETER: AppInfo module's execution context thread pool size"
+  )
+
+  lazy val defaultInfoServiceExecutionContextSize = opt[Int](
+    "default_info_service_execution_context_size",
+    default = Some(8),
+    hidden = true,
+    descr = "INTERNAL TUNING PARAMETER: DefaultInfo service's execution context thread pool size"
+  )
+}

--- a/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoConfig.scala
@@ -7,14 +7,14 @@ trait AppInfoConfig extends ScallopConf {
 
   lazy val appInfoModuleExecutionContextSize = opt[Int](
     "app_info_module_execution_context_size",
-    default = Some(8),
+    default = Some(Runtime.getRuntime().availableProcessors()),
     hidden = true,
     descr = "INTERNAL TUNING PARAMETER: AppInfo module's execution context thread pool size"
   )
 
   lazy val defaultInfoServiceExecutionContextSize = opt[Int](
     "default_info_service_execution_context_size",
-    default = Some(8),
+    default = Some(Runtime.getRuntime().availableProcessors()),
     hidden = true,
     descr = "INTERNAL TUNING PARAMETER: DefaultInfo service's execution context thread pool size"
   )

--- a/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoModule.scala
@@ -22,7 +22,7 @@ class AppInfoModule @Inject() (
     marathonSchedulerService: MarathonSchedulerService,
     taskFailureRepository: TaskFailureRepository) {
 
-  val ec = NamedExecutionContext.fixedThreadPoolExecutionContext(32, "app-info-module")
+  val ec = NamedExecutionContext.fixedThreadPoolExecutionContext(8, "app-info-module")
 
   private[this] val appInfoBaseData = () => new AppInfoBaseData(
     clock, taskTracker, healthCheckManager, marathonSchedulerService, taskFailureRepository, groupManager)(ec)

--- a/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoModule.scala
@@ -2,7 +2,6 @@ package mesosphere.marathon
 package core.appinfo
 
 import java.time.Clock
-import java.util.concurrent.Executors
 
 import com.google.inject.Inject
 import mesosphere.marathon.core.appinfo.impl.{ AppInfoBaseData, DefaultInfoService }
@@ -10,8 +9,7 @@ import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.storage.repository.TaskFailureRepository
-
-import scala.concurrent.ExecutionContext
+import mesosphere.util.NamedExecutionContext
 
 /**
   * Provides a service to query information related to apps.
@@ -24,7 +22,7 @@ class AppInfoModule @Inject() (
     marathonSchedulerService: MarathonSchedulerService,
     taskFailureRepository: TaskFailureRepository) {
 
-  val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(32))
+  val ec = NamedExecutionContext.fixedThreadPoolExecutionContext(32, "app-info-module")
 
   private[this] val appInfoBaseData = () => new AppInfoBaseData(
     clock, taskTracker, healthCheckManager, marathonSchedulerService, taskFailureRepository, groupManager)(ec)

--- a/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoModule.scala
@@ -2,14 +2,16 @@ package mesosphere.marathon
 package core.appinfo
 
 import java.time.Clock
+import java.util.concurrent.Executors
 
 import com.google.inject.Inject
-import mesosphere.marathon.MarathonSchedulerService
 import mesosphere.marathon.core.appinfo.impl.{ AppInfoBaseData, DefaultInfoService }
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.storage.repository.TaskFailureRepository
+
+import scala.concurrent.ExecutionContext
 
 /**
   * Provides a service to query information related to apps.
@@ -21,8 +23,11 @@ class AppInfoModule @Inject() (
     healthCheckManager: HealthCheckManager,
     marathonSchedulerService: MarathonSchedulerService,
     taskFailureRepository: TaskFailureRepository) {
+
+  val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(32))
+
   private[this] val appInfoBaseData = () => new AppInfoBaseData(
-    clock, taskTracker, healthCheckManager, marathonSchedulerService, taskFailureRepository, groupManager)
+    clock, taskTracker, healthCheckManager, marathonSchedulerService, taskFailureRepository, groupManager)(ec)
 
   def appInfoService: AppInfoService = infoService
   def groupInfoService: GroupInfoService = infoService

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -68,6 +68,7 @@ class AppInfoBaseData(
     instanceTracker.instancesBySpec()
   }
 
+  @SuppressWarnings(Array("OptionGet", "TryGet"))
   def appInfoFuture(app: AppDefinition, embeds: Set[AppInfo.Embed]): Future[AppInfo] = async {
     val appData = new AppData(app)
 

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -3,6 +3,7 @@ package core.appinfo.impl
 
 import java.time.Clock
 
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.appinfo.{ AppInfo, EnrichedTask, TaskCounts, TaskStatsByVersion }
 import mesosphere.marathon.core.deployment.{ DeploymentPlan, DeploymentStepInfo }
 import mesosphere.marathon.core.group.GroupManager
@@ -14,7 +15,6 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.raml.{ PodInstanceState, PodInstanceStatus, PodState, PodStatus, Raml }
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.TaskFailureRepository
-import org.slf4j.LoggerFactory
 
 import scala.async.Async.{ async, await }
 import scala.collection.immutable.{ Map, Seq }
@@ -28,11 +28,9 @@ class AppInfoBaseData(
     healthCheckManager: HealthCheckManager,
     deploymentService: DeploymentService,
     taskFailureRepository: TaskFailureRepository,
-    groupManager: GroupManager)(implicit ec: ExecutionContext) {
+    groupManager: GroupManager)(implicit ec: ExecutionContext) extends StrictLogging {
 
-  import AppInfoBaseData._
-
-  if (log.isDebugEnabled) log.debug(s"new AppInfoBaseData $this")
+  logger.debug(s"new AppInfoBaseData $this")
 
   lazy val runningDeployments: Future[Seq[DeploymentStepInfo]] = deploymentService.listRunningDeployments()
 
@@ -47,7 +45,7 @@ class AppInfoBaseData(
   }
 
   lazy val runningDeploymentsByAppFuture: Future[Map[PathId, Seq[Identifiable]]] = {
-    log.debug("Retrieving running deployments")
+    logger.debug("Retrieving running deployments")
 
     val allRunningDeploymentsFuture: Future[Seq[DeploymentPlan]] = runningDeployments.map(_.map(_.plan))
 
@@ -66,7 +64,7 @@ class AppInfoBaseData(
   }
 
   lazy val instancesByRunSpecFuture: Future[InstanceTracker.InstancesBySpec] = {
-    log.debug("Retrieve tasks")
+    logger.debug("Retrieve tasks")
     instanceTracker.instancesBySpec()
   }
 
@@ -105,7 +103,7 @@ class AppInfoBaseData(
       .map(_.specInstances(app.id).toVector)
 
     lazy val healthByInstanceIdFuture: Future[Map[Instance.Id, Seq[Health]]] = {
-      log.debug(s"retrieving health counts for app [${app.id}]")
+      logger.debug(s"retrieving health counts for app [${app.id}]")
       healthCheckManager.statuses(app.id)
     }.recover {
       case NonFatal(e) => throw new RuntimeException(s"while retrieving health counts for app [${app.id}]", e)
@@ -121,7 +119,7 @@ class AppInfoBaseData(
     }
 
     lazy val taskCountsFuture: Future[TaskCounts] = {
-      log.debug(s"calculating task counts for app [${app.id}]")
+      logger.debug(s"calculating task counts for app [${app.id}]")
       for {
         tasks <- tasksForStats
       } yield TaskCounts(tasks)
@@ -130,14 +128,14 @@ class AppInfoBaseData(
     }
 
     lazy val taskStatsFuture: Future[TaskStatsByVersion] = {
-      log.debug(s"calculating task stats for app [${app.id}]")
+      logger.debug(s"calculating task stats for app [${app.id}]")
       for {
         tasks <- tasksForStats
       } yield TaskStatsByVersion(app.versionInfo, tasks)
     }
 
     lazy val enrichedTasksFuture: Future[Seq[EnrichedTask]] = {
-      log.debug(s"assembling rich tasks for app [${app.id}]")
+      logger.debug(s"assembling rich tasks for app [${app.id}]")
       def statusesToEnrichedTasks(instances: Seq[Instance], statuses: Map[Instance.Id, collection.Seq[Health]]): Seq[EnrichedTask] = {
         instances.map { instance =>
           EnrichedTask(instance, instance.appTask, statuses.getOrElse(instance.instanceId, Nil).to[Seq])
@@ -153,7 +151,7 @@ class AppInfoBaseData(
     }
 
     lazy val maybeLastTaskFailureFuture: Future[Option[TaskFailure]] = {
-      log.debug(s"retrieving last task failure for app [${app.id}]")
+      logger.debug(s"retrieving last task failure for app [${app.id}]")
       taskFailureRepository.get(app.id)
     }.recover {
       case NonFatal(e) => throw new RuntimeException(s"while retrieving last task failure for app [${app.id}]", e)
@@ -161,37 +159,36 @@ class AppInfoBaseData(
   }
 
   @SuppressWarnings(Array("all")) // async/await
-  def podStatus(podDef: PodDefinition): Future[PodStatus] =
-    async { // linter:ignore UnnecessaryElseBranch
-      val now = clock.now().toOffsetDateTime
-      val instances = await(instancesByRunSpecFuture).specInstances(podDef.id)
-      val specByVersion: Map[Timestamp, Option[PodDefinition]] = await(Future.sequence(
-        // TODO(jdef) if repositories ever support a bulk-load interface, use it here
-        instances.map(_.runSpecVersion).distinct.map { version =>
-          groupManager.podVersion(podDef.id, version.toOffsetDateTime).map(version -> _)
-        }
-      )).toMap
-      val instanceStatus = instances.flatMap { inst => podInstanceStatus(inst)(specByVersion.apply) }
-      val statusSince = if (instanceStatus.isEmpty) now else instanceStatus.map(_.statusSince).max
-      val state = await(podState(podDef.instances, instanceStatus, isPodTerminating(podDef.id)))
+  def podStatus(podDef: PodDefinition): Future[PodStatus] = async { // linter:ignore UnnecessaryElseBranch
+    val now = clock.now().toOffsetDateTime
+    val instances = await(instancesByRunSpecFuture).specInstances(podDef.id)
+    val specByVersion: Map[Timestamp, Option[PodDefinition]] = await(Future.sequence(
+      // TODO(jdef) if repositories ever support a bulk-load interface, use it here
+      instances.map(_.runSpecVersion).distinct.map { version =>
+        groupManager.podVersion(podDef.id, version.toOffsetDateTime).map(version -> _)
+      }
+    )).toMap
+    val instanceStatus = instances.flatMap { inst => podInstanceStatus(inst)(specByVersion.apply) }
+    val statusSince = if (instanceStatus.isEmpty) now else instanceStatus.map(_.statusSince).max
+    val state = await(podState(podDef.instances, instanceStatus, isPodTerminating(podDef.id)))
 
-      // TODO(jdef) pods need termination history
-      PodStatus(
-        id = podDef.id.toString,
-        spec = Raml.toRaml(podDef),
-        instances = instanceStatus,
-        status = state,
-        statusSince = statusSince,
-        lastUpdated = now,
-        lastChanged = statusSince
-      )
-    }
+    // TODO(jdef) pods need termination history
+    PodStatus(
+      id = podDef.id.toString,
+      spec = Raml.toRaml(podDef),
+      instances = instanceStatus,
+      status = state,
+      statusSince = statusSince,
+      lastUpdated = now,
+      lastChanged = statusSince
+    )
+  }
 
   def podInstanceStatus(instance: Instance)(f: Timestamp => Option[PodDefinition]): Option[PodInstanceStatus] = {
     val maybePodSpec: Option[PodDefinition] = f(instance.runSpecVersion)
 
     if (maybePodSpec.isEmpty)
-      log.warn(s"failed to generate pod instance status for instance ${instance.instanceId}, " +
+      logger.warn(s"failed to generate pod instance status for instance ${instance.instanceId}, " +
         s"pod version ${instance.runSpecVersion} failed to load from persistent store")
 
     maybePodSpec.map { pod => Raml.toRaml(pod -> instance) }
@@ -220,8 +217,4 @@ class AppInfoBaseData(
       }
       state
     }
-}
-
-object AppInfoBaseData {
-  private val log = LoggerFactory.getLogger(getClass)
 }

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
@@ -1,8 +1,6 @@
 package mesosphere.marathon
 package core.appinfo.impl
 
-import java.util.concurrent.Executors
-
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.appinfo.AppInfo.Embed
 import mesosphere.marathon.core.appinfo._
@@ -11,18 +9,18 @@ import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.raml.PodStatus
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
-import org.slf4j.LoggerFactory
+import mesosphere.util.NamedExecutionContext
 
 import scala.async.Async.{ async, await }
 import scala.collection.immutable.Seq
 import scala.collection.mutable
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 private[appinfo] class DefaultInfoService(
     groupManager: GroupManager,
     newBaseData: () => AppInfoBaseData) extends AppInfoService with GroupInfoService with PodStatusService with StrictLogging {
 
-  implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(16))
+  implicit val ec = NamedExecutionContext.fixedThreadPoolExecutionContext(16, "default-info-service")
 
   @SuppressWarnings(Array("all")) // async/await
   override def selectPodStatus(id: PathId, selector: PodSelector): Future[Option[PodStatus]] =

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
@@ -20,7 +20,7 @@ private[appinfo] class DefaultInfoService(
     groupManager: GroupManager,
     newBaseData: () => AppInfoBaseData) extends AppInfoService with GroupInfoService with PodStatusService with StrictLogging {
 
-  implicit val ec = NamedExecutionContext.fixedThreadPoolExecutionContext(16, "default-info-service")
+  implicit val ec = NamedExecutionContext.fixedThreadPoolExecutionContext(8, "default-info-service")
 
   @SuppressWarnings(Array("all")) // async/await
   override def selectPodStatus(id: PathId, selector: PodSelector): Future[Option[PodStatus]] =
@@ -164,7 +164,7 @@ private[appinfo] class DefaultInfoService(
 
   private[this] def resolvePodInfos(
     specs: Seq[RunSpec],
-    baseData: AppInfoBaseData = newBaseData()): Future[Seq[PodStatus]] = Future.sequence(specs.collect {
+    baseData: AppInfoBaseData): Future[Seq[PodStatus]] = Future.sequence(specs.collect {
     case pod: PodDefinition =>
       baseData.podStatus(pod)
   })

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
@@ -9,18 +9,16 @@ import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.raml.PodStatus
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
-import mesosphere.util.NamedExecutionContext
 
 import scala.async.Async.{ async, await }
 import scala.collection.immutable.Seq
 import scala.collection.mutable
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 private[appinfo] class DefaultInfoService(
     groupManager: GroupManager,
-    newBaseData: () => AppInfoBaseData) extends AppInfoService with GroupInfoService with PodStatusService with StrictLogging {
-
-  implicit val ec = NamedExecutionContext.fixedThreadPoolExecutionContext(8, "default-info-service")
+    newBaseData: () => AppInfoBaseData)(implicit ec: ExecutionContext)
+  extends AppInfoService with GroupInfoService with PodStatusService with StrictLogging {
 
   @SuppressWarnings(Array("all")) // async/await
   override def selectPodStatus(id: PathId, selector: PodSelector): Future[Option[PodStatus]] =

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
@@ -1,6 +1,9 @@
 package mesosphere.marathon
 package core.appinfo.impl
 
+import java.util.concurrent.Executors
+
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.appinfo.AppInfo.Embed
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.group.GroupManager
@@ -13,14 +16,14 @@ import org.slf4j.LoggerFactory
 import scala.async.Async.{ async, await }
 import scala.collection.immutable.Seq
 import scala.collection.mutable
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 private[appinfo] class DefaultInfoService(
     groupManager: GroupManager,
-    newBaseData: () => AppInfoBaseData) extends AppInfoService with GroupInfoService with PodStatusService {
-  import mesosphere.marathon.core.async.ExecutionContexts.global
+    newBaseData: () => AppInfoBaseData) extends AppInfoService with GroupInfoService with PodStatusService with StrictLogging {
 
   private[this] val log = LoggerFactory.getLogger(getClass)
+  implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(16))
 
   @SuppressWarnings(Array("all")) // async/await
   override def selectPodStatus(id: PathId, selector: PodSelector): Future[Option[PodStatus]] =

--- a/src/main/scala/mesosphere/marathon/core/group/GroupManagerConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/GroupManagerConfig.scala
@@ -24,7 +24,7 @@ trait GroupManagerConfig extends ScallopConf {
 
   lazy val groupManagerExecutionContextSize = opt[Int](
     "group_manager_execution_context_size",
-    default = Some(8),
+    default = Some(Runtime.getRuntime().availableProcessors()),
     hidden = true,
     descr = "INTERNAL TUNING PARAMETER: Group manager module's execution context thread pool size"
   )

--- a/src/main/scala/mesosphere/marathon/core/group/GroupManagerConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/GroupManagerConfig.scala
@@ -22,6 +22,13 @@ trait GroupManagerConfig extends ScallopConf {
     hidden = true,
     default = Some(10.seconds.toMillis.toInt))
 
+  lazy val groupManagerExecutionContextSize = opt[Int](
+    "group_manager_execution_context_size",
+    default = Some(8),
+    hidden = true,
+    descr = "INTERNAL TUNING PARAMETER: Group manager module's execution context thread pool size"
+  )
+
   def availableFeatures: Set[String]
   def localPortMin: ScallopOption[Int]
   def localPortMax: ScallopOption[Int]

--- a/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
@@ -46,7 +46,7 @@ trait StorageConf extends ZookeeperConf with BackupConf {
 
   lazy val storageExecutionContextSize = opt[Int](
     "storage_execution_context_size",
-    default = Some(8),
+    default = Some(Runtime.getRuntime().availableProcessors()),
     hidden = true,
     descr = "INTERNAL TUNING PARAMETER: Storage module's execution context thread pool size"
   )

--- a/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
@@ -44,6 +44,13 @@ trait StorageConf extends ZookeeperConf with BackupConf {
     prefix = "disable_"
   )
 
+  lazy val storageExecutionContextSize = opt[Int](
+    "storage_execution_context_size",
+    default = Some(8),
+    hidden = true,
+    descr = "INTERNAL TUNING PARAMETER: Storage module's execution context thread pool size"
+  )
+
   def defaultNetworkName: ScallopOption[String]
 
   def availableFeatures: Set[String]

--- a/src/main/scala/mesosphere/util/ThreadPoolContext.scala
+++ b/src/main/scala/mesosphere/util/ThreadPoolContext.scala
@@ -1,7 +1,8 @@
 package mesosphere.util
 
-import java.util.concurrent.Executors
+import java.util.concurrent.{ ExecutorService, Executors, ThreadFactory }
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import mesosphere.marathon.core.async.ContextPropagatingExecutionContextWrapper
 
 import scala.concurrent.ExecutionContext
@@ -18,5 +19,21 @@ object ThreadPoolContext {
   implicit lazy val ioContext = ContextPropagatingExecutionContextWrapper(
     ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(numberOfThreads))
   )
+}
 
+object NamedExecutionContext {
+
+  /**
+    * Returns an execution context backed by a fixed thread pool. All threads in the pool are prefixed with `namePrefix`
+    * e.g. `slow-io-pool-thread-1`.
+    *
+    * @param numThreads number of threads in the pol
+    * @param namePrefix thread name prefix
+    * @return execution context
+    */
+  def fixedThreadPoolExecutionContext(numThreads: Int, namePrefix: String): ExecutionContext = {
+    val factory: ThreadFactory = new ThreadFactoryBuilder().setNameFormat(s"$namePrefix-thread-%d").build()
+    val executorService: ExecutorService = Executors.newFixedThreadPool(numThreads, factory)
+    ExecutionContext.fromExecutorService(executorService)
+  }
 }

--- a/src/main/scala/mesosphere/util/ThreadPoolContext.scala
+++ b/src/main/scala/mesosphere/util/ThreadPoolContext.scala
@@ -27,7 +27,7 @@ object NamedExecutionContext {
     * Returns an execution context backed by a fixed thread pool. All threads in the pool are prefixed with `namePrefix`
     * e.g. `slow-io-pool-thread-1`.
     *
-    * @param numThreads number of threads in the pol
+    * @param numThreads number of threads in the pool
     * @param namePrefix thread name prefix
     * @return execution context
     */

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -36,6 +36,8 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
     lazy val taskFailureRepository = mock[TaskFailureRepository]
     lazy val groupManager = mock[GroupManager]
 
+    import mesosphere.marathon.core.async.ExecutionContexts.global
+
     lazy val baseData = new AppInfoBaseData(
       clock,
       instanceTracker,

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoServiceTest.scala
@@ -248,6 +248,8 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
     lazy val groupManager = mock[GroupManager]
     lazy val baseData = mock[AppInfoBaseData]
     def newBaseData(): AppInfoBaseData = baseData
+
+    import mesosphere.marathon.core.async.ExecutionContexts.global
     lazy val infoService = new DefaultInfoService(groupManager, newBaseData)
 
     def verifyNoMoreInteractions(): Unit = {


### PR DESCRIPTION
Improved `v2/groups?embed...` requests performance by introducing dedicated thread pools for fetching info instead of using the `ForkJoinPool`. 
Additionally introduces dedicated execution context for `GroupManagerModule`, `StorageModule` and `SchedulerActions` components.

[Benchmark](https://github.com/wg/wrk) results master:
```
Running 1m test @ http://localhost:8080/v2/groups?embed=...
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.17s   354.93ms   2.00s    70.33%
    Req/Sec     0.12      0.33     1.00     87.76%
  237 requests in 1.00m, 217.12MB read
  Socket errors: connect 0, read 0, write 0, timeout 146
Requests/sec:      3.95
Transfer/sec:      3.62MB
``` 

This branch:
```
Running 1m test @ http://localhost:8080/v2/groups?embed=...
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   249.39ms   62.67ms 580.40ms   65.82%
    Req/Sec     4.01      1.82    10.00     85.60%
  2403 requests in 1.00m, 2.15GB read
Requests/sec:     40.00
Transfer/sec:     36.64MB
```
**Summary**: 10x throughput, 5x latency and 5x std. deviation improvement.

JIRA: COPS-2224