### PR TITLE
Improve the docs for private docker registries

### DIFF
--- a/docs/docs/native-docker-private-registry.md
+++ b/docs/docs/native-docker-private-registry.md
@@ -4,7 +4,7 @@ title: Using a Private Docker Registry
 
 # Using a Private Docker Registry
 
-As of Marathon 1.5, you can upload your private Docker registry credentials to a secret store, then reference them in your app or pod definition. This functionality is only available if you are using the Mesos containerizer. If you are using the Docker containerizer, follow [these instructions](#docker-containerizer) to use a private Docker registry.
+As of Marathon 1.5, you can upload your private Docker registry credentials to a secret store, then reference them in your app or pod definition. This functionality is only available if you are using the Mesos containerizer. If you are using the Docker containerizer, follow [these instructions](#docker-containerizer) to use a private Docker registry. If you want to learn how to configure credentials to pull images from the Amazon Elastic Container Registry (AWS ECR) please refer to [this blog post](https://aws.amazon.com/blogs/apn/automating-ecr-authentication-on-marathon-with-the-amazon-ecr-credential-helper/).
 
 ## Step 1: Create a Credentials File
 


### PR DESCRIPTION
Summary:
Added a link that explains how to setup credentials when trying to pull images from AWS ECR (Elastic Container Registry).

JIRA issues: MARATHON-4333