### PR TITLE
Changelog note about scala 2.12

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 The Sentry Raven log appender has been updated to version 8.0.x. Users that have enabled the Sentry Raven appender will need to update their configuration according to the [sentry migration guide](https://docs.sentry.io/clients/java/migration/).
 
+#### Scala 2.12
+
+Marathon 1.6.0 is compiled using Scala 2.12. This means that plugins which were compiled using scala 2.11 will fail marathon startup due to binary incompatibility between scala 2.11 and 2.12.
+
 ### Deprecations
 
 #### /v2/schema route is Deprecated

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ The Sentry Raven log appender has been updated to version 8.0.x. Users that have
 
 #### Scala 2.12
 
-Marathon 1.6.0 is compiled using Scala 2.12. This means that plugins which were compiled using scala 2.11 will fail marathon startup due to binary incompatibility between scala 2.11 and 2.12.
+Marathon 1.6.0 is compiled using Scala 2.12. This means that plugins which were compiled using Scala 2.11 will make Marathon failed during startup due to binary incompatibility between Scala 2.11 and 2.12.
 
 ### Deprecations
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ The Sentry Raven log appender has been updated to version 8.0.x. Users that have
 
 #### Scala 2.12
 
-Marathon 1.6.0 is compiled using Scala 2.12. This means that plugins which were compiled using Scala 2.11 will make Marathon failed during startup due to binary incompatibility between Scala 2.11 and 2.12.
+Marathon 1.6.0 is compiled using Scala 2.12. This means that plugins which were compiled using Scala 2.11 will make Marathon fail during startup due to binary incompatibility between Scala 2.11 and 2.12.
 
 ### Deprecations
 


### PR DESCRIPTION
Summary: Added a warning about broken binary compatibility for plugins which were compiled using scala 2.11

JIRA issues: MARATHON-8072

