### PR TITLE
Stabilize scheduler test

### DIFF
--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -453,7 +453,6 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
       answer.cmd should equal(Deploy(plan))
       answer.reason.isInstanceOf[AppLockedException] should be(true)
     } finally {
-      //      system.eventStream.unsubscribe(probe.ref)
       stopActor(schedulerActor)
     }
   }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -445,16 +445,11 @@ class MarathonSchedulerActorTest extends MarathonActorSupport
     try {
       schedulerActor ! LocalLeadershipEvent.ElectedAsLeader
 
-      // should fail...
-      val answer2 = expectMsgType[DeploymentStarted]
-      //      answer2.cmd should equal(Deploy(plan))
-      //      answer2.reason.isInstanceOf[AppLockedException] should be(true)
-
       schedulerActor ! Deploy(plan)
 
       // This indicates that the deployment is already running,
       // which means it has successfully been restarted
-      val answer = expectMsgType[CommandFailed]
+      val answer = expectMsgType[CommandFailed](30.seconds)
       answer.cmd should equal(Deploy(plan))
       answer.reason.isInstanceOf[AppLockedException] should be(true)
     } finally {


### PR DESCRIPTION
Summary:
`MarathonSchedulerActorTest` has been flaky lately. This patch tries to stabilize it.
The loop does not show this issue anymore.
