### PR TITLE
Do not set unconditionally DiskInfo.metadata when dealing with volumes

### DIFF
--- a/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
@@ -148,17 +148,17 @@ class VolumeTest extends UnitTest {
     }
 
     "validating that DiskSource asMesos converts to an Option Mesos Protobuffer" in {
-      DiskSource(DiskType.Root, None, None, Map.empty, None).asMesos shouldBe None
-      val Some(pathDisk) = DiskSource(DiskType.Path, Some("/path/to/folder"), None, Map.empty, None).asMesos
+      DiskSource(DiskType.Root, None, None, None, None).asMesos shouldBe None
+      val Some(pathDisk) = DiskSource(DiskType.Path, Some("/path/to/folder"), None, None, None).asMesos
       pathDisk.getPath.getRoot shouldBe "/path/to/folder"
       pathDisk.getType shouldBe Source.Type.PATH
 
-      val Some(mountDisk) = DiskSource(DiskType.Mount, Some("/path/to/mount"), None, Map.empty, None).asMesos
+      val Some(mountDisk) = DiskSource(DiskType.Mount, Some("/path/to/mount"), None, None, None).asMesos
       mountDisk.getMount.getRoot shouldBe "/path/to/mount"
       mountDisk.getType shouldBe Source.Type.MOUNT
 
       val Some(pathCsiDisk) = DiskSource(DiskType.Path, Some("/path/to/folder"),
-        Some("csiPathDisk"), Map("pathKey" -> "pathValue"), Some("pathProfile")).asMesos
+        Some("csiPathDisk"), Some(Map("pathKey" -> "pathValue")), Some("pathProfile")).asMesos
       pathCsiDisk.getPath.getRoot shouldBe "/path/to/folder"
       pathCsiDisk.getType shouldBe Source.Type.PATH
       pathCsiDisk.getId shouldBe "csiPathDisk"
@@ -168,7 +168,7 @@ class VolumeTest extends UnitTest {
       pathCsiDisk.getProfile shouldBe "pathProfile"
 
       val Some(mountCsiDisk) = DiskSource(DiskType.Mount, Some("/path/to/mount"),
-        Some("csiMountDisk"), Map("mountKey" -> "mountValue"), Some("mountProfile")).asMesos
+        Some("csiMountDisk"), Some(Map("mountKey" -> "mountValue")), Some("mountProfile")).asMesos
       mountCsiDisk.getMount.getRoot shouldBe "/path/to/mount"
       mountCsiDisk.getType shouldBe Source.Type.MOUNT
       mountCsiDisk.getId shouldBe "csiMountDisk"
@@ -178,13 +178,13 @@ class VolumeTest extends UnitTest {
       mountCsiDisk.getProfile shouldBe "mountProfile"
 
       a[IllegalArgumentException] shouldBe thrownBy {
-        DiskSource(DiskType.Root, Some("/path"), None, Map.empty, None).asMesos
+        DiskSource(DiskType.Root, Some("/path"), None, None, None).asMesos
       }
       a[IllegalArgumentException] shouldBe thrownBy {
-        DiskSource(DiskType.Path, None, None, Map.empty, None).asMesos
+        DiskSource(DiskType.Path, None, None, None, None).asMesos
       }
       a[IllegalArgumentException] shouldBe thrownBy {
-        DiskSource(DiskType.Mount, None, None, Map.empty, None).asMesos
+        DiskSource(DiskType.Mount, None, None, None, None).asMesos
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VolumeTest.scala
@@ -152,10 +152,16 @@ class VolumeTest extends UnitTest {
       val Some(pathDisk) = DiskSource(DiskType.Path, Some("/path/to/folder"), None, None, None).asMesos
       pathDisk.getPath.getRoot shouldBe "/path/to/folder"
       pathDisk.getType shouldBe Source.Type.PATH
+      pathDisk.hasId shouldBe false
+      pathDisk.hasMetadata shouldBe false
+      pathDisk.hasProfile shouldBe false
 
       val Some(mountDisk) = DiskSource(DiskType.Mount, Some("/path/to/mount"), None, None, None).asMesos
       mountDisk.getMount.getRoot shouldBe "/path/to/mount"
       mountDisk.getType shouldBe Source.Type.MOUNT
+      pathDisk.hasId shouldBe false
+      pathDisk.hasMetadata shouldBe false
+      pathDisk.hasProfile shouldBe false
 
       val Some(pathCsiDisk) = DiskSource(DiskType.Path, Some("/path/to/folder"),
         Some("csiPathDisk"), Some(Map("pathKey" -> "pathValue")), Some("pathProfile")).asMesos

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -704,9 +704,9 @@ class ResourceMatcherTest extends UnitTest with Inside {
 
       resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
       resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch.scalarMatch("disk").get.consumed.toSet shouldBe Set(
-        DiskResourceMatch.Consumption(1024.0, "*", None, None, DiskSource(DiskType.Path, Some("/path2"), None, Map.empty, None),
+        DiskResourceMatch.Consumption(1024.0, "*", None, None, DiskSource(DiskType.Path, Some("/path2"), None, None, None),
           Some(VolumeWithMount(persistentVolume, mount))),
-        DiskResourceMatch.Consumption(476.0, "*", None, None, DiskSource(DiskType.Path, Some("/path2"), None, Map.empty, None),
+        DiskResourceMatch.Consumption(476.0, "*", None, None, DiskSource(DiskType.Path, Some("/path2"), None, None, None),
           Some(VolumeWithMount(persistentVolume, mount))))
     }
 


### PR DESCRIPTION
Summary:
Marathon set metadata to an empty map even if metadata was not present
in resource offers at all.

JIRA issues: MARATHON-8073