### PR TITLE
Publish Docker tags, native packages and jar.

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -263,15 +263,29 @@ def release(args: String*): Unit = {
 
   %('git, "checkout", config.version.commit)
 
-  buildDockerAndLinuxPackages()
-  if (config.runTests)
-    testDockerAndLinuxPackages()
+  val targets = config.targets.toSet
 
-  config.targets.distinct.foreach {
+  if (targets.contains(ReleaseTarget.LinuxPackages) ||
+      targets.contains(ReleaseTarget.DockerTag) ||
+      targets.contains(ReleaseTarget.DockerLatest)) {
+      buildDockerAndLinuxPackages()
+      if (config.runTests)
+        testDockerAndLinuxPackages()
+  }
+
+  targets.foreach {
     case ReleaseTarget.S3Package =>
       releases.copyTarballBuildsToReleases(config.version)
-    case other =>
-      println(s"Target ${other.name} is not supported yet. Skipping...")
+    case ReleaseTarget.LinuxPackages =>
+      releases.uploadLinuxPackagesToRepos(config.version.toTagString)
+    case ReleaseTarget.DockerTag =>
+      %('docker, "push", s"mesosphere/marathon:${config.version.toTagString}")
+    case ReleaseTarget.DockerLatest =>
+      %('docker, "tag", s"mesosphere/marathon:${config.version.toTagString}", "mesosphere/marathon:latest")
+      %('docker, "push", "mesosphere/marathon:latest")
+    case ReleaseTarget.JARArtifact =>
+      // publishing to the nexus repository.  This artifact is used by metronome.
+      %('sbt, "publish")
   }
 
   githubClient.tag(config.version.commit, config.version.toTagString)

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -265,13 +265,10 @@ def release(args: String*): Unit = {
 
   val targets = config.targets.toSet
 
-  if (targets.contains(ReleaseTarget.LinuxPackages) ||
-      targets.contains(ReleaseTarget.DockerTag) ||
-      targets.contains(ReleaseTarget.DockerLatest)) {
-      buildDockerAndLinuxPackages()
-      if (config.runTests)
-        testDockerAndLinuxPackages()
-  }
+  build(config.runTests)
+  buildDockerAndLinuxPackages()
+  if (config.runTests)
+    testDockerAndLinuxPackages()
 
   targets.foreach {
     case ReleaseTarget.S3Package =>


### PR DESCRIPTION
Summary:
This patch enables the new release pipeline to publish tags of the
Docker image, native Linux packages and the JAR file.

Depends on #5996.

JIRA issues: MARATHON_EE-1842, MARATHON_EE-1846, MARATHON_EE-1844