### PR TITLE
Tag a commit that was released.

### DIFF
--- a/ci/githubClient.sc
+++ b/ci/githubClient.sc
@@ -47,6 +47,24 @@ def comment(pullNumber: String, msg: String, event: String = "COMMENT"): Unit = 
 }
 
 /**
+ * Creates a lightweight tag for a commit.
+ *
+ * @param commit The commit hash to be tagged.
+ * @param name The name of the tag, e.g. v1.7.42
+ */
+def tag(commit: String, name: String) : Unit = {
+  val fullCommitSha = %%('git, "rev-parse", commit).out.string.trim
+
+  val request = Js.Obj(
+    "ref"  -> Js.Str(s"refs/tags/$name"),
+    "sha" -> Js.Str(fullCommitSha),
+    )
+
+  val path = s"repos/mesosphere/marathon/git/refs"
+  execute(path, request.toString)
+}
+
+/**
  * Reject pull request with pullNumber.
  */
 def reject(

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -273,4 +273,6 @@ def release(args: String*): Unit = {
     case other =>
       println(s"Target ${other.name} is not supported yet. Skipping...")
   }
+
+  githubClient.tag(config.version.commit, config.version.toTagString)
 }


### PR DESCRIPTION
Summary:
Since Jenkins cannot push to the git repository we use Github's API to
create a lightweight tag for community releases. The script accepts
short commit hashes and infers the full hash.

Depends on #5999.

JIRA issues: MARATHON_EE-1843