### PR TITLE
Rename Jenkins node to include correct Debian version.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ ansiColor('xterm') {
       user_is_authorized(master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#marathon-dev')
     }
   }
-  node('JenkinsMarathonCI-Debian8-2018-02-09') {
+  node('JenkinsMarathonCI-Debian9-2018-02-09') {
     stage("Run Pipeline") {
       try {
         checkout scm

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 ansiColor('xterm') {
-  node('JenkinsMarathonCI-Debian8-2018-02-09') {
+  node('JenkinsMarathonCI-Debian9-2018-02-09') {
 
     properties([
       parameters([

--- a/ami/AMI.md
+++ b/ami/AMI.md
@@ -11,5 +11,5 @@ Here is an example on how to install Mesos 1.5.0 using maws (https://github.com/
 
 ```bash
 $(maws login "Team 10")
-AWS_PROFILE=273854932432_Mesosphere-PowerUser packer build -color -var 'ami_name=JenkinsMarathonCI-Debian9-2018-02-02' -var 'mesos_version=1.5.0-2.0.1' marathon-jenkins-ami.json
+AWS_PROFILE=273854932432_Mesosphere-PowerUser packer build -color -var 'ami_name=JenkinsMarathonCI-Debian9-$(date +%Y-%m-%d)' -var 'mesos_version=1.5.0-2.0.1' marathon-jenkins-ami.json
 ```

--- a/ami/AMI.md
+++ b/ami/AMI.md
@@ -11,5 +11,5 @@ Here is an example on how to install Mesos 1.5.0 using maws (https://github.com/
 
 ```bash
 $(maws login "Team 10")
-AWS_PROFILE=273854932432_Mesosphere-PowerUser packer build -color -var 'ami_name=JenkinsMarathonCI-Debian8-2018-02-02' -var 'mesos_version=1.5.0-2.0.1' marathon-jenkins-ami.json
+AWS_PROFILE=273854932432_Mesosphere-PowerUser packer build -color -var 'ami_name=JenkinsMarathonCI-Debian9-2018-02-02' -var 'mesos_version=1.5.0-2.0.1' marathon-jenkins-ami.json
 ```


### PR DESCRIPTION
Summary:
We use Debian 9 as a base image not Debian 8.