### PR TITLE
Update docs with valid examples for fetch URIs

### DIFF
--- a/docs/docs/application-basics.md
+++ b/docs/docs/application-basics.md
@@ -36,7 +36,7 @@ When you define and launch an application, Marathon hands over execution to Meso
 
 To run any non-trivial application, you typically depend on a collection of resources: files and/or archives of files. 
 To manage resource allocation, Marathon uses the [Mesos fetcher](http://mesos.apache.org/documentation/latest/fetcher/) 
-do the legwork in terms of downloading (and potentially) extracting resources.
+to do the legwork in terms of downloading (and potentially) extracting resources.
 
 Before we dive into this topic, let's have a look at an example:
 
@@ -58,10 +58,10 @@ Before we dive into this topic, let's have a look at an example:
 
 What the example above does: before executing the `cmd`, download the resource `https://example.com/app/cool-script.sh` 
 (via Mesos) and make it available in the application task's sandbox. You can check that these have been downloaded by 
-visiting the Mesos UI and clicking into a Mesos worker node's sandbox where you should now find `cool-script.sh`.
+visiting the Mesos UI and clicking into a Mesos agent node's sandbox where you should now find `cool-script.sh`.
 
 As of Mesos v0.22 and above, the fetcher code does not make downloaded files executable by default.
- In the example above, we should provide the field `"executable": true` to tell Mesos change the fetch result to 
+ In the example above, we provided the field `"executable": true` to tell Mesos change the fetch result to 
  executable for every user. If the `"executable"` field is `"true"`, the `"extract"` field is ignored and has no effect.
 
 As already mentioned above, Marathon also [knows how to handle](https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/mesos/TaskBuilder.scala) 
@@ -79,8 +79,7 @@ first attempt to unpack/extract resources with the following file extensions:
 To prevent this behaviour, field `"extract": false` must be provided.
 
 And how this looks in practice shows you the following example: let's assume you have an application executable in a zip
- file at `https://example.com/app.zip`. This zip file contains the script `cool-script.sh` and that's what you 
- want to execute. Here's how:
+ file at `https://example.com/app.zip`. This zip file contains the script `cool-script.sh` and that's what you want to execute. Here's how:
 
 ```json
 {
@@ -102,7 +101,8 @@ Note that in contrast to the example `basic-1` we now have a `cmd` that looks as
 Additionally, if you want to use a fetcher cache, `"cache": true` field must be specified. If a URI is encountered 
 for the first time (for the same user), it is first downloaded into the cache, then copied to the sandbox directory 
 from there. If the same URI is encountered again, and a corresponding cache file is resident in the cache or 
-still en route into the cache, then downloading is omitted and the fetcher proceeds directly to copying from the cache. 
+still en route into the cache, then downloading is omitted and the fetcher proceeds directly to copying from the cache.
+Caching is working locally on every agent, so if the task is restarted on a different node, resources will be fetched again.
 
 ```json
 {
@@ -120,7 +120,7 @@ still en route into the cache, then downloading is omitted and the fetcher proce
 }
 ```
 
-It's also possible to specify path and name of the destination where fetched resource will be stored:
+It's also possible to specify path and name of the destination where the fetched resource will be stored:
 
 ```json
 {
@@ -138,7 +138,7 @@ It's also possible to specify path and name of the destination where fetched res
 }
 ```
 
-Note also that you can specify many resources, not only one. So, for example, you could provide a git repository
+Note also that you can specify many resources, not just one. So, for example, you could provide a git repository
  and some resources from a CDN as follows:
 
 ```json

--- a/docs/docs/application-basics.md
+++ b/docs/docs/application-basics.md
@@ -34,28 +34,39 @@ When you define and launch an application, Marathon hands over execution to Meso
 
 ## Using Resources in Applications
 
-To run any non-trivial application, you typically depend on a collection of resources: files and/or archives of files. To manage resource allocation, Marathon has the concept of URIs. URIs use the Mesos fetcher to do the legwork in terms of downloading (and potentially) extracting resources.
+To run any non-trivial application, you typically depend on a collection of resources: files and/or archives of files. 
+To manage resource allocation, Marathon uses the [Mesos fetcher](http://mesos.apache.org/documentation/latest/fetcher/) 
+do the legwork in terms of downloading (and potentially) extracting resources.
 
 Before we dive into this topic, let's have a look at an example:
 
 ```json
 {
     "id": "basic-1", 
-    "cmd": "`chmod u+x cool-script.sh && ./cool-script.sh`",
+    "cmd": "`./cool-script.sh`",
     "cpus": 0.1,
     "mem": 10.0,
     "instances": 1,
-    "uris": [
-        "https://example.com/app/cool-script.sh"
+    "fetch": [
+        {
+          "uri": "https://example.com/app/cool-script.sh",
+          "executable": true
+        }
     ]
 }
 ```
 
-What the example above does: before executing the `cmd`, download the resource `https://example.com/app/cool-script.sh` (via Mesos) and make it available in the application task's sandbox. You can check that these have been downloaded by visiting the Mesos UI and clicking into a Mesos worker node's sandbox where you should now find `cool-script.sh`.
+What the example above does: before executing the `cmd`, download the resource `https://example.com/app/cool-script.sh` 
+(via Mesos) and make it available in the application task's sandbox. You can check that these have been downloaded by 
+visiting the Mesos UI and clicking into a Mesos worker node's sandbox where you should now find `cool-script.sh`.
 
-**Note:** As of Mesos v0.22 and above, the fetcher code does not make downloaded files executable by default. In the example above, `cmd` first makes the file executable.
+As of Mesos v0.22 and above, the fetcher code does not make downloaded files executable by default.
+ In the example above, we should provide the field `"executable": true` to tell Mesos change the fetch result to 
+ executable for every user. If the `"executable"` field is `"true"`, the `"extract"` field is ignored and has no effect.
 
-As already mentioned above, Marathon also [knows how to handle](https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/mesos/TaskBuilder.scala) application resources that reside in archives. Currently, Marathon will (via Mesos and before executing the `cmd`) first attempt to unpack/extract resources with the following file extensions:
+As already mentioned above, Marathon also [knows how to handle](https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/mesos/TaskBuilder.scala) 
+application resources that reside in archives. By default, Marathon will (via Mesos and before executing the `cmd`) 
+first attempt to unpack/extract resources with the following file extensions:
 
 * `.tgz`
 * `.tar.gz`
@@ -65,7 +76,11 @@ As already mentioned above, Marathon also [knows how to handle](https://github.c
 * `.tar.xz`
 * `.zip`
 
-And how this looks in practice shows you the following example: let's assume you have an application executable in a zip file at `https://example.com/app.zip`. This zip file contains the script `cool-script.sh` and that's what you want to execute. Here's how:
+To prevent this behaviour, field `"extract": false` must be provided.
+
+And how this looks in practice shows you the following example: let's assume you have an application executable in a zip
+ file at `https://example.com/app.zip`. This zip file contains the script `cool-script.sh` and that's what you 
+ want to execute. Here's how:
 
 ```json
 {
@@ -74,21 +89,78 @@ And how this looks in practice shows you the following example: let's assume you
     "cpus": 0.1,
     "mem": 10.0,
     "instances": 1,
-    "uris": [
-        "https://example.com/app.zip"
+    "fetch": [
+        {
+          "uri": "https://example.com/app.zip"
+        }
     ]
 }
 ```
 
 Note that in contrast to the example `basic-1` we now have a `cmd` that looks as follows: `app/cool-script.sh`. This stems from the fact that when the zip file gets downloaded and extracted, a directory `app` according to the file name `app.zip` is created where the content of the zip file is extracted into.
 
-Note also that you can specify many resources, not only one. So, for example, you could provide a git repository and some resources from a CDN as follows:
+Additionally, if you want to use a fetcher cache, `"cache": true` field must be specified. If a URI is encountered 
+for the first time (for the same user), it is first downloaded into the cache, then copied to the sandbox directory 
+from there. If the same URI is encountered again, and a corresponding cache file is resident in the cache or 
+still en route into the cache, then downloading is omitted and the fetcher proceeds directly to copying from the cache. 
+
+```json
+{
+    "id": "basic-3", 
+    "cmd": "app/cool-script.sh",
+    "cpus": 0.1,
+    "mem": 10.0,
+    "instances": 1,
+    "fetch": [
+        {
+          "uri": "https://example.com/app.zip",
+          "cache": true
+        }
+    ]
+}
+```
+
+It's also possible to specify path and name of the destination where fetched resource will be stored:
+
+```json
+{
+    "id": "basic-4", 
+    "cmd": "./cool-script.sh",
+    "cpus": 0.1,
+    "mem": 10.0,
+    "instances": 1,
+    "fetch": [
+        {
+          "uri": "https://example.com/some-script.sh",
+          "destPath": "cool-script.sh"
+        }
+    ]
+}
+```
+
+Note also that you can specify many resources, not only one. So, for example, you could provide a git repository
+ and some resources from a CDN as follows:
 
 ```json
 {
     ...
-    "uris": [
-        "https://git.example.com/repo-app.zip", "https://cdn.example.net/my-file.jpg", "https://cdn.example.net/my-other-file.css"
+    "fetch": [
+        {
+          "uri": "https://git.example.com/repo-app.zip"
+        },
+        {
+          "uri": "https://git.example.com/docs-bundle.zip",
+          "extract": false
+        },
+        {
+          "uri": "https://cdn.example.net/my-file.jpg",
+          "cache": false
+        },
+        {
+          "uri": "https://cdn.example.net/my-other-file.css",
+          "cache": true
+        }
+          
     ]
     ...
 }

--- a/docs/docs/event-bus.md
+++ b/docs/docs/event-bus.md
@@ -76,7 +76,7 @@ Fired every time Marathon receives an API request that modifies an app (create, 
     "upgradeStrategy": {
         "minimumHealthCapacity": 1.0
     },
-    "uris": [],
+    "fetch": [],
     "user": null,
     "version": "2014-09-09T05:57:50.866Z"
   }
@@ -420,7 +420,7 @@ Fired when a new http callback subscriber is added or removed:
           "upgradeStrategy": {
               "minimumHealthCapacity": 1.0
           },
-          "uris": [],
+          "fetch": [],
           "user": null,
           "version": "2014-09-09T05:57:50.866Z"
         }
@@ -485,7 +485,7 @@ Fired when a new http callback subscriber is added or removed:
           "upgradeStrategy": {
               "minimumHealthCapacity": 1.0
           },
-          "uris": [],
+          "fetch": [],
           "user": null,
           "version": "2014-09-09T05:57:50.866Z"
         }
@@ -550,7 +550,7 @@ Fired when a new http callback subscriber is added or removed:
           "upgradeStrategy": {
               "minimumHealthCapacity": 1.0
           },
-          "uris": [],
+          "fetch": [],
           "user": null,
           "version": "2014-09-09T05:57:50.866Z"
         }

--- a/docs/docs/marathon-ui.md
+++ b/docs/docs/marathon-ui.md
@@ -94,7 +94,7 @@ as failing.
 
 #### Staged
 A task is staged when a launch request has been submitted to the cluster, but
-has not been reported as running yet. Fetching the specified "uris" in the app
+has not been reported as running yet. Fetching the specified "fetch" in the app
 definition or the docker images happens before Mesos reports the task as
 running.
 

--- a/docs/docs/native-docker-private-registry.md
+++ b/docs/docs/native-docker-private-registry.md
@@ -210,11 +210,13 @@ the `uris` field of your app. The `docker.tar.gz` file should include the `.dock
 
 #### Step 2:  Add URI path to app definition
 
-1.  Add the path to the archive file login credentials to the `uris` parameter of your app definition.
+1.  Add the path to the archive file login credentials to the `fetch` parameter of your app definition.
 
-    ```bash
-    "uris": [
-       "file:///etc/docker.tar.gz"
+    ```json
+    "fetch": [
+      {
+        "uri": "file:///etc/docker.tar.gz"
+      }
     ]
     ```
 
@@ -233,8 +235,10 @@ the `uris` field of your app. The `docker.tar.gz` file should include the `.dock
           "network": "HOST"
         }
       },
-      "uris":  [
-          "file:///etc/docker.tar.gz"
+      "fetch": [
+        {
+          "uri": "file:///etc/docker.tar.gz"
+        }
       ]
     }
     ```

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -126,7 +126,11 @@ See the detailed docs on
   "instances": 2,
   "mem": 32.0,
   "ports": [0],
-  "uris": ["http://downloads.mesosphere.com/misc/toggle.tgz"]
+  "fetch": [
+    {
+      "uri": "http://downloads.mesosphere.com/misc/toggle.tgz"
+    }
+  ]
 }
 ```
 
@@ -151,7 +155,11 @@ See the detailed docs on
   "instances": 2,
   "mem": 32.0,
   "ports": [0],
-  "uris": ["http://downloads.mesosphere.com/misc/toggle.tgz"]
+  "fetch": [
+    {
+      "uri": "http://downloads.mesosphere.com/misc/toggle.tgz"
+    }
+  ]
 }
 ```
 
@@ -179,7 +187,11 @@ To enable this feature for marathon versions prior to `0.7.4`, start Marathon wi
   "instances": 2,
   "mem": 32.0,
   "ports": [0],
-  "uris": ["http://downloads.mesosphere.com/misc/toggle.tgz"]
+  "fetch": [
+    {
+      "uri": "http://downloads.mesosphere.com/misc/toggle.tgz"
+    }
+  ]
 }
 ```
 
@@ -236,7 +248,7 @@ that you quote the "*" correctly)
 ### Using constraints
 
 You can use constraints to restrict where to run the tasks for your apps. See
-[constraints]({ site.baseurl }}/docs/constraints.html) for details.
+[constraints]({{ site.baseurl }}/docs/constraints.html) for details.
 
 The advantage of using constraints to restrict where tasks run is that you only have to provide appropriate attributes on the Mesos agents.
 
@@ -262,5 +274,3 @@ Often, multiple instances of legacy applications cannot be run concurrently. The
     "maximumOverCapacity": 0
   }
 ```
-
-

--- a/examples/Play.json
+++ b/examples/Play.json
@@ -4,7 +4,9 @@
   "mem": 512,
   "cpus": 1.0,
   "instances": 1,
-  "uris": [
-    "http://downloads.mesosphere.com/tutorials/PlayHello.zip"
+  "fetch": [
+    {
+      "uri": "http://downloads.mesosphere.com/tutorials/PlayHello.zip"
+    }
   ]
 }

--- a/examples/Rails.json
+++ b/examples/Rails.json
@@ -4,8 +4,11 @@
   "mem": 100,
   "cpus": 1.0,
   "instances": 1,
-  "uris": [
-    "http://downloads.mesosphere.com/tutorials/RailsHello.tgz"
+  "fetch": [
+    {
+      "uri": "http://downloads.mesosphere.com/tutorials/RailsHello.tgz"
+    }
+
   ],
   "env": {
     "RAILS_ENV": "production"

--- a/examples/Tomcat.json
+++ b/examples/Tomcat.json
@@ -4,8 +4,12 @@
   "mem": 512,
   "cpus": 1.0,
   "instances": 1,
-  "uris": [
-    "http://www-us.apache.org/dist/tomcat/tomcat-7/v7.0.69/bin/apache-tomcat-7.0.69.tar.gz",
-    "https://gwt-examples.googlecode.com/files/Calendar.war"
+  "fetch": [
+    {
+      "uri": "https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.69/bin/apache-tomcat-7.0.69.tar.gz"
+    },
+    {
+      "uri": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/gwt-examples/Calendar.war"
+    }
   ]
 }


### PR DESCRIPTION
Summary: Updated the docs to use the fetch field instead of uris, and provided comprehensive examples.

JIRA issues: MARATHON-8078

