### PR TITLE
Add support for Graphite reporter interval parameter

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -330,8 +330,8 @@ The Web Site flags control the behavior of Marathon's web site, including the us
     Enabling this might noticeably degrade performance but it helps finding performance problems.
     These measurements can be disabled with --disable_metrics. Other metrics are not affected.
 * <span class="label label-default">v0.13.0</span> `--reporter_graphite` (Optional. Default: disabled):
-    Report metrics to [Graphite](http://graphite.wikidot.com) as defined by the given URL.
-    Example: `tcp://localhost:2003?prefix=marathon-test&interval=10`
+    Report metrics to [Graphite](http://graphite.wikidot.com) (StatsD) as defined by the given URL.
+    Example: `udp://localhost:2003?prefix=marathon-test&interval=10`
     The URL can have several parameters to refine the functionality.
     * prefix: (Default: None) the prefix for all metrics
     * interval: (Default: 10) the interval to report to graphite in seconds

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon
 import java.net.URI
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri
 import com.google.common.util.concurrent.ServiceManager
 import com.google.inject.{ Guice, Module }
 import com.typesafe.config.{ Config, ConfigFactory }
@@ -61,11 +62,17 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
         """.stripMargin
       }
       val statsd = cliConf.graphite.get.map { urlStr =>
-        val url = new URI(urlStr)
+        val url = Uri(urlStr)
+
+        if (url.scheme.toLowerCase() != "udp") {
+          logger.warn(s"Graphite reporter protocol ${url.scheme} is not supported; using UDP")
+        }
+        val params = url.query()
         s"""
            |kamon.statsd {
-           |  hostname: ${url.getHost}
-           |  port: ${if (url.getPort == -1) 8125 else url.getPort}
+           |  hostname: ${url.authority.host}
+           |  port: ${if (url.authority.port == 0) 8125 else url.authority.port}
+           |  flush-interval: ${params.collectFirst { case ("interval", iv) => iv.toInt }.getOrElse(10)} seconds
            |}
          """.stripMargin
       }


### PR DESCRIPTION
Also, fix documentation for graphite reporter: tcp is not allowed. Log a warning if a protocol other than udp is specified.

JIRA issues: MARATHON-8080, MARATHON-8079
