### PR TITLE
Add deployment failure reason to event.

### DIFF
--- a/docs/docs/rest-api/public/api/v2/events.raml
+++ b/docs/docs/rest-api/public/api/v2/events.raml
@@ -16,6 +16,11 @@ get:
         description:
             Specify subscribed event types.
             You can specify this parameter multiple times with different values.
+    plan-format:
+        required: false
+        description:
+            Indicate whether to receive "light" events or full events including
+            deployment plans. Defaults to full events.
 
   responses:
     200:

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -289,7 +289,7 @@ class MarathonSchedulerActor private (
     logger.error(s"Deployment ${plan.id}:${plan.version} of ${plan.targetIdsString} failed", reason)
     Future.sequence(plan.affectedRunSpecIds.map(launchQueue.asyncPurge))
       .recover { case NonFatal(error) => logger.warn(s"Error during async purge: planId=${plan.id} for ${plan.targetIdsString}", error); Done }
-      .foreach { _ => eventBus.publish(core.event.DeploymentFailed(plan.id, plan)) }
+      .foreach { _ => eventBus.publish(core.event.DeploymentFailed(plan.id, plan, reason = Some(reason.getMessage()))) }
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -293,12 +293,19 @@ trait EventFormats {
     )
   }
   implicit lazy val LightDeploymentFailedWrites: Writes[DeploymentFailed] = Writes { event =>
-    Json.obj(
+    val serializedEvent = Json.obj(
       "id" -> event.id,
       "plan" -> LightDeploymentPlanWrites.writes(event.plan),
       "eventType" -> "deployment_failed",
       "timestamp" -> Timestamp.now().toString
     )
+
+    event.reason match {
+      case Some(reason) =>
+        serializedEvent ++ Json.obj("reason" -> reason)
+      case None =>
+        serializedEvent
+    }
   }
   implicit lazy val LightDeploymentStatusWrites: Writes[DeploymentStatus] = Writes { event =>
     Json.obj(

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActor.scala
@@ -147,7 +147,7 @@ class DeploymentManagerActor(
       sender() ! cancelDeployment(plan.id)
 
     case DeploymentFinished(plan, result) =>
-      runningDeployments.remove(plan.id).map { deploymentInfo =>
+      runningDeployments.remove(plan.id).foreach { deploymentInfo =>
         logger.info(s"Removing ${plan.id} for ${plan.targetIdsString} from list of running deployments")
         deploymentStatus -= plan.id
         deploymentRepository.delete(plan.id)
@@ -189,7 +189,7 @@ class DeploymentManagerActor(
       waitForCanceledConflicts(plan, conflicts)
 
     case FailedRepositoryOperation(plan, reason) if isScheduledDeployment(plan.id) =>
-      runningDeployments.remove(plan.id).map(info => info.promise.failure(reason))
+      runningDeployments.remove(plan.id).foreach(info => info.promise.failure(reason))
   }
 
   private def giveUpConflictingDeployment(plan: DeploymentPlan, origSender: ActorRef): Future[Done] = {

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -187,7 +187,8 @@ case class DeploymentFailed(
     id: String,
     plan: DeploymentPlan,
     eventType: String = "deployment_failed",
-    timestamp: String = Timestamp.now().toString) extends UpgradeEvent
+    timestamp: String = Timestamp.now().toString,
+    reason: Option[String] = None) extends UpgradeEvent
 
 case class DeploymentStatus(
     plan: DeploymentPlan,


### PR DESCRIPTION
Summary:
Currently we do not send the reason for a deployment failure along with
the event. This makes debugging hard. This change introduces an optional
reason message.