### PR TITLE
Using stretch-slim as the new upstream for the docker image

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,7 +86,6 @@ object Dependency {
     val Mesos = "1.5.0"
     // Version of Mesos to use in Dockerfile.
     val MesosDebian = "1.5.0-2.0.1"
-    val OpenJDK = "openjdk:8u121-jdk"
     val Akka = "2.5.7"
     val AkkaHttp = "10.0.11"
     val ApacheCommonsCompress = "1.13"


### PR DESCRIPTION
This commit is switching the docker base image to `stretch-slim` in order to use the `GLIBCXX_3.4.21` required by mesos `1.5.0`. A few minor tweaks to the docker RUN script had to be done to accommodate this.