### PR TITLE
Add support for Graphite reporter interval parameter

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -320,8 +320,8 @@ The Web Site flags control the behavior of Marathon's web site, including the us
     Enabling this might noticeably degrade performance but it helps finding performance problems.
     These measurements can be disabled with --disable_metrics. Other metrics are not affected.
 * <span class="label label-default">v0.13.0</span> `--reporter_graphite` (Optional. Default: disabled):
-    Report metrics to [Graphite](http://graphite.wikidot.com) as defined by the given URL.
-    Example: `tcp://localhost:2003?prefix=marathon-test&interval=10`
+    Report metrics to [Graphite](http://graphite.wikidot.com) (StatsD) as defined by the given URL.
+    Example: `udp://localhost:2003?prefix=marathon-test&interval=10`
     The URL can have several parameters to refine the functionality.
     * prefix: (Default: None) the prefix for all metrics
     * interval: (Default: 10) the interval to report to graphite in seconds


### PR DESCRIPTION
Also, fix documentation for graphite reporter: tcp is not allowed. Log a warning if a protocol other than udp is specified.

Backport of 5a789e7

JIRA issues: MARATHON-8080, MARATHON-8079
