### PR TITLE
Do not send contradicting deployment events for cancellation.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -161,10 +161,8 @@ class MarathonSchedulerActor private (
       }
 
     case cmd @ CancelDeployment(plan) =>
-      deploymentManager.cancel(plan).onComplete{
-        case Success(d) => self ! cmd.answer
-        case Failure(e) => logger.error(s"Failed to cancel a deployment ${plan.id} due to: ", e)
-      }
+      // The deployment manager will respond via the plan future/promise
+      deploymentManager.cancel(plan)
 
     case cmd @ Deploy(plan, force) =>
       deploy(sender(), cmd)


### PR DESCRIPTION
Summary:
When a deployment is cancelled by the `MarathonSchedulerActor` it will
trigger a `deployment_success` event. However, the
`DelploymentManagerActor` will trigger a `deployment_failed` event for
the same deployment. This change removes the first event so that a user
will recieve only one event. Ideally we would send a
`deployment_cancelled` event instead. That would break the API, though.