### PR TITLE
documentation: Fix broken link format

### DIFF
--- a/docs/docs/native-docker-private-registry.md
+++ b/docs/docs/native-docker-private-registry.md
@@ -202,11 +202,9 @@ the `uris` field of your app. The `docker.tar.gz` file should include the `.dock
     $ cp docker.tar.gz /etc/
     ```
 
-      <div class="alert alert-info">
-        <strong>Note:</strong>
-       The URI must be accessible by all nodes that will start your application. You can distribute the file to the local filesystem of all nodes, for example via RSYNC/SCP, or store it on a shared network drive like [Amazon S3](http://aws.amazon.com/s3/). Consider the security implications of your chosen approach carefully.
-      </div>
-
+     <strong>Note:</strong>
+     The URI must be accessible by all nodes that will start your application.
+     You can distribute the file to the local filesystem of all nodes, for example via RSYNC/SCP, or store it on a shared network drive like [Google Cloud Storage](https://cloud.google.com/storage/) or [Amazon S3](https://aws.amazon.com/s3/). Consider the security implications of your chosen approach carefully.
 
 #### Step 2:  Add URI path to app definition
 


### PR DESCRIPTION
Remove div with alert info in favour of pure Markdown

Summary:
I removed div with `alert alert-info` classes because link format is not displayed correctly. I think that it is better to display links correctly on Github and in documentation even without that blue box around that note.