### PR TITLE
Do not fail script after error.

### DIFF
--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -71,4 +71,6 @@ fi
 jq -r .ssh_private_key cluster_info.json > "$CLI_TEST_SSH_KEY"
 
 # Return dcos_url
-echo "$(dcos-launch describe | jq -r ".masters[0].public_ip")"
+CLUSTER_IP="$(dcos-launch describe | jq -r ".masters[0].public_ip")"
+echo "Launched cluster with IP $CLUSTER_IP"
+echo "$CLUSTER_IP"

--- a/ci/si_install_deps.sh
+++ b/ci/si_install_deps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x -e -o pipefail
+set -x +e -o pipefail
 
 PLATFORM=$(uname)
 

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -79,11 +79,11 @@ case $CLUSTER_LAUNCH_CODE in
       ;;
   2) exit-as-unstable "Cluster launch failed.";;
   3)
-      dcos-launch delete || true
+      dcos-launch delete
       exit-as-unstable "Cluster did not start in time."
       ;;
   *)
-      dcos-launch delete || true
+      dcos-launch delete
       exit-as-unstable "Unknown error in cluster launch: $CLUSTER_LAUNCH_CODE"
       ;;
 esac

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -x +e -o pipefail
 
 # Two parameters are expected: CHANNEL and VARIANT where CHANNEL is the respective PR and
@@ -51,7 +50,7 @@ function download-diagnostics-bundle {
 	dcos node diagnostics download "${BUNDLE_NAME}" --location=./diagnostics.zip
 }
 
-# Install dependencies
+# Install dependencies and expose new PATH value.
 source ./ci/si_install_deps.sh
 
 # Launch cluster and run tests if launch was successful.
@@ -75,10 +74,16 @@ case $CLUSTER_LAUNCH_CODE in
       if [ ${SI_CODE} -gt 0 ]; then
         download-diagnostics-bundle
       fi
-      dcos-launch delete
+      dcos-launch delete || true
       exit "$SI_CODE" # Propagate return code.
       ;;
   2) exit-as-unstable "Cluster launch failed.";;
-  3) exit-as-unstable "Cluster did not start in time.";;
-  *) exit-as-unstable "Unknown error in cluster launch: $CLUSTER_LAUNCH_CODE";;
+  3)
+      dcos-launch delete || true
+      exit-as-unstable "Cluster did not start in time."
+      ;;
+  *)
+      dcos-launch delete || true
+      exit-as-unstable "Unknown error in cluster launch: $CLUSTER_LAUNCH_CODE"
+      ;;
 esac


### PR DESCRIPTION
Summary:
Sourcing `si_install_deps.sh` set `-e` which means the pipeline script
would abort on an error. However, we have to delete the cluster first
and then exit.
