### PR TITLE
Run system integration tests at specific time.

### DIFF
--- a/Jenkinsfile.disabled.si
+++ b/Jenkinsfile.disabled.si
@@ -10,7 +10,8 @@ node('py36') {
     // DC/OS EE: channel="testing/pull/1296", for strict, permissive or disabled clusters
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
-            pipelineTriggers([cron('0 */8 * * *')]),
+            // Run pipeline at 1:00, 7:00, 13:00 and 19:00.
+            pipelineTriggers([cron('0 1,7,13,19 * * *')]),
             parameters([
                     string(name: 'channel',
                             defaultValue: 'testing/pull/1296',

--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -10,7 +10,8 @@ node('py36') {
     // DC/OS EE: channel="testing/pull/1296", for strict, permissive or disabled clusters
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
-            pipelineTriggers([cron('0 */8 * * *')]),
+            // Run pipeline at 0:00, 6:00, 12:00 and 18:00.
+            pipelineTriggers([cron('0 0,6,12,18 * * *')]),
             parameters([
                     string(name: 'channel',
                             defaultValue: 'testing/pull/1739',

--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -10,7 +10,8 @@ node('py36') {
     // DC/OS EE: channel="testing/pull/1296", for strict, permissive or disabled clusters
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
-            pipelineTriggers([cron('0 */8 * * *')]),
+            // Run pipeline at 2:00, 8:00, 14:00 and 20:00.
+            pipelineTriggers([cron('0 2,8,14,20 * * *')]),
             parameters([
                     string(name: 'channel',
                             defaultValue: 'testing/pull/1296',

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -10,7 +10,8 @@ node('py36') {
     // DC/OS EE: channel="testing/pull/1296", for strict, permissive or disabled clusters
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
-            pipelineTriggers([cron('0 */8 * * *')]),
+            // Run pipeline at 3:00, 9:00, 15:00 and 21:00.
+            pipelineTriggers([cron('0 3,9,15,21 * * *')]),
             parameters([
                     string(name: 'channel',
                             defaultValue: 'testing/pull/1296',


### PR DESCRIPTION
Summary:
We start the SI clusters a specific times so that they won't overlap
with each other and with clusters for Metronome tests.

JIRA issues: MARATHON-8094