### PR TITLE
Document how to run Marathon Docker image on Mac.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Or run it without zookeeper container:
 When using Docker on Mac you have to use a [special address](https://docs.docker.com/docker-for-mac/networking/#there-is-no-docker0-bridge-on-macos) instead of `localhost`:
 
     docker run -p 8080:8080 --hostname $(hostname) -P mesosphere/marathon:v1.6.335 \
-        --master docker.for.mac.host.internal:505 \
+        --master docker.for.mac.host.internal:5050 \
         --zk zk://docker.for.mac.host.internal:2181/marathon
 
 If you want to inspect the contents of the Docker container:

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ Or run it without zookeeper container:
 
 When using Docker on Mac you have to use a [special address](https://docs.docker.com/docker-for-mac/networking/#there-is-no-docker0-bridge-on-macos) instead of `localhost`:
 
-    docker run --network host --hostname $(hostname) mesosphere/marathon:v1.6.335 \
-        --master zk://docker.for.mac.host.internal:2181/mesos \
+    docker run -p 8080:8080 --hostname $(hostname) -P mesosphere/marathon:v1.6.335 \
+        --master docker.for.mac.host.internal:505 \
         --zk zk://docker.for.mac.host.internal:2181/marathon
 
 If you want to inspect the contents of the Docker container:

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Or run it without zookeeper container:
 
     docker run marathon:{version} --master local --zk zk://localhost:2181/marathon
 
-On Mac you have to use a special address instead of `localhost`:
+When using Docker on Mac you have to use a [special address](https://docs.docker.com/docker-for-mac/networking/#there-is-no-docker0-bridge-on-macos) instead of `localhost`:
 
     docker run --network host --hostname $(hostname) mesosphere/marathon:v1.6.335 \
         --master zk://docker.for.mac.host.internal:2181/mesos \

--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ Or run it without zookeeper container:
 
     docker run marathon:{version} --master local --zk zk://localhost:2181/marathon
 
+On Mac you have to use a special address instead of `localhost`:
+
+    docker run --network host --hostname $(hostname) mesosphere/marathon:v1.6.335 \
+        --master zk://docker.for.mac.host.internal:2181/mesos \
+        --zk zk://docker.for.mac.host.internal:2181/marathon
+
 If you want to inspect the contents of the Docker container:
 
     docker run -it --entrypoint=/bin/bash marathon:{version} -s


### PR DESCRIPTION
Summary:
This change explains how to run the Marathon Docker image on Mac with a local
running ZooKeeper and Mesos master. No ZooKeeper or Mesos Docker
container is required.