### PR TITLE
Fix flaky tests for apps and pods with persistent volumes

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -790,3 +790,26 @@ async def find_event(event_type, event_stream):
 
 async def assert_event(event_type, event_stream, within=10):
     await asyncio.wait_for(find_event(event_type, event_stream), within)
+
+
+def kill_process_on_host(hostname, pattern):
+    """ Kill the process matching pattern at ip
+
+        :param hostname: the hostname or ip address of the host on which the process will be killed
+        :param pattern: a regular expression matching the name of the process to kill
+        :return: True if at least one process got killed or terminated on its own, and False otherwise
+    """
+
+    status, stdout = shakedown.run_command_on_agent(hostname, "ps aux | grep -v grep | grep '{}'".format(pattern))
+    pids = [p.strip().split()[1] for p in stdout.splitlines()]
+    killed_some = False
+
+    for pid in pids:
+        status, stdout = shakedown.run_command_on_agent(hostname, "sudo kill -9 {}".format(pid))
+        if status:
+            killed_some = True
+            print("Killed pid: {}".format(pid))
+        else:
+            print("Unable to killed pid: {}".format(pid))
+
+    return killed_some

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -797,7 +797,7 @@ def kill_process_on_host(hostname, pattern):
 
         :param hostname: the hostname or ip address of the host on which the process will be killed
         :param pattern: a regular expression matching the name of the process to kill
-        :return: True if at least one process gets killed, or False otherwise
+        :return: IDs of processes that got either killed or terminated on their own
     """
 
     cmd = "ps aux | grep -v grep | grep '{}' | awk '{{ print $2 }}' | tee >(xargs sudo kill -9)".format(pattern)
@@ -805,7 +805,6 @@ def kill_process_on_host(hostname, pattern):
     pids = [p.strip() for p in stdout.splitlines()]
     if pids:
         print("Killed pids: {}".format(", ".join(pids)))
-        return True
     else:
         print("Killed no pids")
-        return False
+    return pids

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -797,7 +797,7 @@ def kill_process_on_host(hostname, pattern):
 
         :param hostname: the hostname or ip address of the host on which the process will be killed
         :param pattern: a regular expression matching the name of the process to kill
-        :return: True if at least one process got killed or terminated on its own, and False otherwise
+        :return: True if at least one process gets killed, or False otherwise
     """
 
     status, stdout = shakedown.run_command_on_agent(hostname, "ps aux | grep -v grep | grep '{}'".format(pattern))
@@ -810,6 +810,6 @@ def kill_process_on_host(hostname, pattern):
             killed_some = True
             print("Killed pid: {}".format(pid))
         else:
-            print("Unable to killed pid: {}".format(pid))
+            print("Unable to kill pid: {}".format(pid))
 
     return killed_some

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -223,7 +223,7 @@ def test_task_failure_recovers():
     old_task_id = tasks[0]['id']
     host = tasks[0]['host']
 
-    shakedown.kill_process_on_host(host, '[s]leep 1000')
+    common.kill_process_on_host(host, '[s]leep 1000')
     shakedown.deployment_wait()
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
@@ -623,7 +623,7 @@ def test_pinned_task_recovers_on_host():
     shakedown.deployment_wait()
     tasks = client.get_tasks(app_def["id"])
 
-    shakedown.kill_process_on_host(host, '[s]leep')
+    common.kill_process_on_host(host, '[s]leep')
     shakedown.deployment_wait()
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
@@ -768,8 +768,8 @@ def test_app_with_persistent_volume_recovers():
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def kill_task(host, pattern):
-        killed = common.kill_process_on_host(host, pattern)
-        assert killed, "no task got killed on {} for pattern {}".format(host, pattern)
+        pids = common.kill_process_on_host(host, pattern)
+        assert len(pids) != 0, "no task got killed on {} for pattern {}".format(host, pattern)
 
     kill_task(host, '[h]ttp\\.server')
 

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -771,7 +771,7 @@ def test_app_with_persistent_volume_recovers():
         killed = common.kill_process_on_host(host, pattern)
         assert killed, "no task got killed on {} for pattern {}".format(host, pattern)
 
-    kill_task(host, '[h]ttp.server')
+    kill_task(host, '[h]ttp\\.server')
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_task_recovery():

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -766,7 +766,12 @@ def test_app_with_persistent_volume_recovers():
 
     check_task(cmd, target_data='hello\n')
 
-    shakedown.kill_process_on_host(host, '[h]ttp.server')
+    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
+    def kill_task(host, pattern):
+        killed = common.kill_process_on_host(host, pattern)
+        assert killed, "no task got killed on {} for pattern {}".format(host, pattern)
+
+    kill_task(host, '[h]ttp.server')
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_task_recovery():

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -545,7 +545,12 @@ def test_pod_with_persistent_volume_recovers():
     task_id1 = tasks[0]['id']
     task_id2 = tasks[1]['id']
 
-    shakedown.kill_process_on_host(host, '[h]ttp.server')
+    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
+    def kill_task(host, pattern):
+        killed = common.kill_process_on_host(host, pattern)
+        assert killed, "no task got killed on {} for pattern {}".format(host, pattern)
+
+    kill_task(host, '[h]ttp.server')
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def wait_for_pod_recovery():

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -550,7 +550,7 @@ def test_pod_with_persistent_volume_recovers():
         killed = common.kill_process_on_host(host, pattern)
         assert killed, "no task got killed on {} for pattern {}".format(host, pattern)
 
-    kill_task(host, '[h]ttp.server')
+    kill_task(host, '[h]ttp\\.server')
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def wait_for_pod_recovery():

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -547,8 +547,8 @@ def test_pod_with_persistent_volume_recovers():
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def kill_task(host, pattern):
-        killed = common.kill_process_on_host(host, pattern)
-        assert killed, "no task got killed on {} for pattern {}".format(host, pattern)
+        pids = common.kill_process_on_host(host, pattern)
+        assert len(pids) != 0, "no task got killed on {} for pattern {}".format(host, pattern)
 
     kill_task(host, '[h]ttp\\.server')
 

--- a/tests/system/test_marathon_on_marathon.py
+++ b/tests/system/test_marathon_on_marathon.py
@@ -119,7 +119,7 @@ def test_mom_when_mom_process_killed():
         tasks = client.get_tasks(app_id)
         original_task_id = tasks[0]['id']
 
-        shakedown.kill_process_on_host(common.ip_of_mom(), 'marathon-assembly')
+        common.kill_process_on_host(common.ip_of_mom(), 'marathon-assembly')
         shakedown.wait_for_task('marathon', 'marathon-user', 300)
         shakedown.wait_for_service_endpoint('marathon-user')
 


### PR DESCRIPTION
They were flaky because every once in a while `kill` managed to
finish before an app/pod task(s) got to start, and hence not killing
anything, and therefore there was no need to launch a replacement
task.

JIRA issues:
https://jira.mesosphere.com/browse/MARATHON-8045