### PR TITLE
Do not start more instances than needed

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
@@ -55,6 +55,7 @@ trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Acto
       val launchedInstances = await(instanceTracker.countLaunchedSpecInstances(runSpec.id))
       val actualSize = await(launchQueue.getAsync(runSpec.id)).fold(launchedInstances)(_.finalInstanceCount)
       val instancesToStartNow = Math.max(scaleTo - actualSize, 0)
+      logger.info(s"launchedInstances=$launchedInstances actualSize=$actualSize")
       logger.debug(s"Sync start instancesToStartNow=$instancesToStartNow appId=${runSpec.id}")
       if (instancesToStartNow > 0) {
         logger.info(s"Reconciling app ${runSpec.id} scaling: queuing $instancesToStartNow new instances")

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
@@ -55,7 +55,6 @@ trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Acto
       val launchedInstances = await(instanceTracker.countLaunchedSpecInstances(runSpec.id))
       val actualSize = await(launchQueue.getAsync(runSpec.id)).fold(launchedInstances)(_.finalInstanceCount)
       val instancesToStartNow = Math.max(scaleTo - actualSize, 0)
-      logger.info(s"launchedInstances=$launchedInstances actualSize=$actualSize")
       logger.debug(s"Sync start instancesToStartNow=$instancesToStartNow appId=${runSpec.id}")
       if (instancesToStartNow > 0) {
         logger.info(s"Reconciling app ${runSpec.id} scaling: queuing $instancesToStartNow new instances")

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -304,9 +304,9 @@ private class TaskLauncherActor(
   }
 
   private[this] def replyWithQueuedInstanceCount(): Unit = {
-    val instancesLaunched = instanceMap.values.count(_.isLaunched)
+    val instancesLaunched = instanceMap.values.count(instance => instance.isLaunched || instance.isReserved)
     val instancesLaunchesInFlight = inFlightInstanceOperations.keys
-      .count(instanceId => instanceMap.get(instanceId).exists(_.isLaunched))
+      .count(instanceId => instanceMap.get(instanceId).exists(instance => instance.isLaunched || instance.isReserved))
     sender() ! QueuedInstanceInfo(
       runSpec,
       inProgress = instancesToLaunch > 0 || inFlightInstanceOperations.nonEmpty,

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -41,10 +41,10 @@ private[tracker] class InstanceTrackerDelegate(
 
   // TODO(jdef) support pods when counting launched instances
   override def countLaunchedSpecInstancesSync(appId: PathId): Int =
-    instancesBySpecSync.specInstances(appId).count(_.isLaunched)
+    instancesBySpecSync.specInstances(appId).count(instance => instance.isLaunched || instance.isReserved)
   override def countLaunchedSpecInstances(appId: PathId): Future[Int] = {
     import mesosphere.marathon.core.async.ExecutionContexts.global
-    instancesBySpec().map(_.specInstances(appId).count(_.isLaunched))
+    instancesBySpec().map(_.specInstances(appId).count(instance => instance.isLaunched || instance.isReserved))
   }
 
   override def hasSpecInstancesSync(appId: PathId): Boolean = instancesBySpecSync.hasSpecInstances(appId)


### PR DESCRIPTION
When determining how many instances to launch during deployments
and scale checks, do account for `isReserved` instances, otherwise
Marathon starts extra instances in case of apps and pods with
persistent volumes.

JIRA issues: MARATHON-7751