### PR TITLE
Enhance logs in TaskLauncherActor.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -146,7 +146,7 @@ class InstanceOpFactoryImpl(
      */
 
     def maybeLaunchOnReservation: Option[OfferMatchResult] = if (needToLaunch) {
-      logger.info("Need to launch on reservation.")
+      logger.debug(s"Need to launch on reservation for ${runSpec.id}, version ${runSpec.version}")
       val maybeVolumeMatch = PersistentVolumeMatcher.matchVolumes(offer, request.reserved)
 
       maybeVolumeMatch.map { volumeMatch =>
@@ -180,7 +180,7 @@ class InstanceOpFactoryImpl(
     } else None
 
     def maybeReserveAndCreateVolumes: Option[OfferMatchResult] = if (needToReserve) {
-      logger.info("Need to reserve.")
+      logger.debug(s"Need to reserve for ${runSpec.id}, version ${runSpec.version}")
       val configuredRoles = if (runSpec.acceptedResourceRoles.isEmpty) {
         config.defaultAcceptedResourceRolesSet
       } else {

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -146,6 +146,7 @@ class InstanceOpFactoryImpl(
      */
 
     def maybeLaunchOnReservation: Option[OfferMatchResult] = if (needToLaunch) {
+      logger.info("Need to launch on reservation.")
       val maybeVolumeMatch = PersistentVolumeMatcher.matchVolumes(offer, request.reserved)
 
       maybeVolumeMatch.map { volumeMatch =>
@@ -179,6 +180,7 @@ class InstanceOpFactoryImpl(
     } else None
 
     def maybeReserveAndCreateVolumes: Option[OfferMatchResult] = if (needToReserve) {
+      logger.info("Need to reserve.")
       val configuredRoles = if (runSpec.acceptedResourceRoles.isEmpty) {
         config.defaultAcceptedResourceRolesSet
       } else {

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -237,7 +237,7 @@ private class TaskLauncherActor(
     case change: InstanceChange =>
       change match {
         case update: InstanceUpdated =>
-          logger.debug(s"receiveInstanceUpdate: ${update.id} is ${update.condition}")
+          logger.info(s"receiveInstanceUpdate: ${update.id} is ${update.condition}")
           instanceMap += update.id -> update.instance
 
         case update: InstanceDeleted =>
@@ -269,6 +269,7 @@ private class TaskLauncherActor(
 
   private[this] def receiveAddCount: Receive = {
     case TaskLauncherActor.AddInstances(newRunSpec, addCount) =>
+      logger.info(s"Received add instances for ${newRunSpec.id}, version ${newRunSpec.version} with count $addCount.")
       val configChange = runSpec.isUpgrade(newRunSpec)
       if (configChange || runSpec.needsRestart(newRunSpec) || runSpec.isOnlyScaleChange(newRunSpec)) {
         runSpec = newRunSpec

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -323,13 +323,16 @@ private class TaskLauncherActor(
       promise.trySuccess(MatchedInstanceOps.noMatch(offer.getId))
 
     case ActorOfferMatcher.MatchOffer(offer, promise) =>
+      logger.info(s"Matching offer ${offer.getId} and need to launch $instancesToLaunch tasks.")
       val reachableInstances = instanceMap.filterNotAs{ case (_, instance) => instance.state.condition.isLost }
       val matchRequest = InstanceOpFactory.Request(runSpec, offer, reachableInstances, instancesToLaunch, localRegion())
       instanceOpFactory.matchOfferRequest(matchRequest) match {
         case matched: OfferMatchResult.Match =>
+          logger.info(s"Matched offer ${offer.getId} for run spec ${runSpec.id}, ${runSpec.version}.")
           offerMatchStatisticsActor ! matched
           handleInstanceOp(matched.instanceOp, offer, promise)
         case notMatched: OfferMatchResult.NoMatch =>
+          logger.info(s"Did not match offer ${offer.getId} for run spec ${runSpec.id}, ${runSpec.version}.")
           offerMatchStatisticsActor ! notMatched
           promise.trySuccess(MatchedInstanceOps.noMatch(offer.getId))
       }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -237,7 +237,7 @@ private class TaskLauncherActor(
     case change: InstanceChange =>
       change match {
         case update: InstanceUpdated =>
-          logger.info(s"receiveInstanceUpdate: ${update.id} is ${update.condition}")
+          logger.debug(s"receiveInstanceUpdate: ${update.id} is ${update.condition}")
           instanceMap += update.id -> update.instance
 
         case update: InstanceDeleted =>
@@ -269,7 +269,7 @@ private class TaskLauncherActor(
 
   private[this] def receiveAddCount: Receive = {
     case TaskLauncherActor.AddInstances(newRunSpec, addCount) =>
-      logger.info(s"Received add instances for ${newRunSpec.id}, version ${newRunSpec.version} with count $addCount.")
+      logger.debug(s"Received add instances for ${newRunSpec.id}, version ${newRunSpec.version} with count $addCount.")
       val configChange = runSpec.isUpgrade(newRunSpec)
       if (configChange || runSpec.needsRestart(newRunSpec) || runSpec.isOnlyScaleChange(newRunSpec)) {
         runSpec = newRunSpec
@@ -324,16 +324,16 @@ private class TaskLauncherActor(
       promise.trySuccess(MatchedInstanceOps.noMatch(offer.getId))
 
     case ActorOfferMatcher.MatchOffer(offer, promise) =>
-      logger.info(s"Matching offer ${offer.getId} and need to launch $instancesToLaunch tasks.")
+      logger.debug(s"Matching offer ${offer.getId} and need to launch $instancesToLaunch tasks.")
       val reachableInstances = instanceMap.filterNotAs{ case (_, instance) => instance.state.condition.isLost }
       val matchRequest = InstanceOpFactory.Request(runSpec, offer, reachableInstances, instancesToLaunch, localRegion())
       instanceOpFactory.matchOfferRequest(matchRequest) match {
         case matched: OfferMatchResult.Match =>
-          logger.info(s"Matched offer ${offer.getId} for run spec ${runSpec.id}, ${runSpec.version}.")
+          logger.debug(s"Matched offer ${offer.getId} for run spec ${runSpec.id}, ${runSpec.version}.")
           offerMatchStatisticsActor ! matched
           handleInstanceOp(matched.instanceOp, offer, promise)
         case notMatched: OfferMatchResult.NoMatch =>
-          logger.info(s"Did not match offer ${offer.getId} for run spec ${runSpec.id}, ${runSpec.version}.")
+          logger.debug(s"Did not match offer ${offer.getId} for run spec ${runSpec.id}, ${runSpec.version}.")
           offerMatchStatisticsActor ! notMatched
           promise.trySuccess(MatchedInstanceOps.noMatch(offer.getId))
       }

--- a/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
@@ -176,6 +176,9 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
         )
       )
 
+      val launchedTasks = allTasks(PathId(app.id))
+      launchedTasks should have size 5
+
       When("we restart the app")
       val newVersion = restartSuccessfully(app) withClue ("The app did not restart.")
       val all = allTasks(PathId(app.id))
@@ -200,6 +203,9 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
           instances = 5
         )
       )
+
+      val launchedTasks = allTasks(PathId(app.id))
+      launchedTasks should have size 5
 
       When("we change the config")
       val newVersion = updateSuccessfully(PathId(app.id), AppUpdate(cmd = Some("sleep 1234"))).toString


### PR DESCRIPTION
Summary:
We sometimes do not know when the `TaskLauncherActor` accepts or rejects
offers. This change should help us to debug MARATHON-7751.