### PR TITLE
Send Instance health changed event when the overall status changed

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
@@ -1,0 +1,92 @@
+package mesosphere.marathon
+package core.health.impl
+
+import akka.actor.{ Actor, Props }
+import akka.event.EventStream
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.event.InstanceHealthChanged
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor._
+import mesosphere.marathon.core.health.{ Health, HealthCheck }
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.state.{ PathId, Timestamp }
+
+class AppHealthCheckActor(eventBus: EventStream) extends Actor with StrictLogging {
+  private var healthChecks: Map[ApplicationKey, Set[HealthCheck]] = Map.empty
+  private var healthCheckStates: Map[InstanceKey, Map[HealthCheck, Option[Health]]] =
+    Map.empty
+
+  private def computeGlobalHealth(instanceHealthResults: Map[HealthCheck, Option[Health]]): Option[Boolean] = {
+    val instanceHealthResultsSet = instanceHealthResults.values.toSet
+    val healthy = instanceHealthResultsSet.forall(x => x.fold(false)(_.alive))
+    val unhealthy = instanceHealthResultsSet.forall(_.nonEmpty) && !healthy
+    (healthy, unhealthy) match {
+      case (true, _) => Some(true)
+      case (_, true) => Some(false)
+      case _ => Option.empty[Boolean]
+    }
+  }
+
+  private def notifyHealthChanged(applicationKey: ApplicationKey, instanceId: Instance.Id,
+    healthiness: Option[Boolean]): Unit = {
+    logger.debug(s"Instance global health status changed to healthiness=$healthiness " +
+      s"for instance $applicationKey $instanceId")
+    eventBus.publish(InstanceHealthChanged(
+      instanceId, applicationKey.version, applicationKey.appId, healthiness))
+  }
+
+  private def healthCheckExists(applicationKey: ApplicationKey, healthCheck: HealthCheck): Boolean =
+    healthChecks.contains(applicationKey) && healthChecks(applicationKey).contains(healthCheck)
+
+  override def receive: Receive = {
+    case AddHealthCheck(appKey, healthCheck) =>
+      healthChecks = healthChecks +
+        (appKey -> (healthChecks.getOrElse(appKey, Set.empty) + healthCheck))
+      logger.debug(s"Add healthcheck $healthCheck to instance ${appKey.appId} ${appKey.version}")
+
+    case RemoveHealthCheck(appKey, healthCheck) =>
+      logger.debug(s"Remove healthcheck $healthCheck from instance ${appKey.appId} ${appKey.version}")
+
+      healthChecks = healthChecks +
+        (appKey -> (healthChecks.getOrElse(appKey, Set.empty) - healthCheck))
+
+      healthCheckStates = healthCheckStates.map(kv => {
+        val newHealthChecks = kv._2.filter(x => x._1 != healthCheck)
+        (kv._1, newHealthChecks)
+      })
+
+    case HealthCheckStatusChanged(appKey, healthCheck, health) =>
+      if (healthCheckExists(appKey, healthCheck)) {
+        logger.debug(s"Healthcheck status changed to $health for health check $healthCheck of " +
+          s"instance ${appKey.appId} ${appKey.version} ${health.instanceId}")
+
+        val instanceKey = InstanceKey(appKey, health.instanceId)
+        val currentInstanceHealthResults = healthCheckStates.getOrElse(instanceKey, {
+          healthChecks.getOrElse(appKey, Set.empty).map(x => (x, Option.empty[Health])).toMap
+        })
+
+        val newInstanceHealthResults = currentInstanceHealthResults + (healthCheck -> Some(health))
+
+        val currentInstanceGlobalHealth = computeGlobalHealth(currentInstanceHealthResults)
+        val newInstanceGlobalHealth = computeGlobalHealth(newInstanceHealthResults)
+
+        if (currentInstanceGlobalHealth != newInstanceGlobalHealth)
+          notifyHealthChanged(appKey, health.instanceId, newInstanceGlobalHealth)
+
+        healthCheckStates = healthCheckStates +
+          (instanceKey -> newInstanceHealthResults)
+      }
+  }
+}
+
+object AppHealthCheckActor {
+  case class ApplicationKey(appId: PathId, version: Timestamp)
+  case class InstanceKey(applicationKey: ApplicationKey, instanceId: Instance.Id)
+
+  def props(eventBus: EventStream): Props = Props(new AppHealthCheckActor(eventBus))
+
+  case class AddHealthCheck(appKey: ApplicationKey, healthCheck: HealthCheck)
+  case class RemoveHealthCheck(appKey: ApplicationKey, healthCheck: HealthCheck)
+  case class HealthCheckStatusChanged(
+    appKey: ApplicationKey,
+    healthCheck: HealthCheck, health: Health)
+}

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -2,26 +2,27 @@ package mesosphere.marathon
 package core.health.impl
 
 import akka.Done
-import akka.actor.{ ActorRef, ActorRefFactory }
+import akka.actor.{ActorRef, ActorRefFactory}
 import akka.event.EventStream
 import akka.pattern.ask
 import akka.stream.Materializer
 import akka.util.Timeout
 import mesosphere.marathon.core.async.ExecutionContexts.global
-import mesosphere.marathon.core.event.{ AddHealthCheck, RemoveHealthCheck }
+import mesosphere.marathon.core.event.{AddHealthCheck, RemoveHealthCheck}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health._
-import mesosphere.marathon.core.health.impl.HealthCheckActor.{ AppHealth, GetAppHealth, GetInstanceHealth }
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor.ApplicationKey
+import mesosphere.marathon.core.health.impl.HealthCheckActor.{AppHealth, GetAppHealth, GetInstanceHealth}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
+import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
 import mesosphere.util.RWLock
 import org.apache.mesos.Protos.TaskStatus
 
 import scala.async.Async._
-import scala.collection.immutable.{ Map, Seq }
+import scala.collection.immutable.{Map, Seq}
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -39,6 +40,8 @@ class MarathonHealthCheckManager(
 
   protected[this] var appHealthChecks: RWLock[mutable.Map[PathId, Map[Timestamp, Set[ActiveHealthCheck]]]] =
     RWLock(mutable.Map.empty.withDefaultValue(Map.empty.withDefaultValue(Set.empty)))
+
+  protected[this] var appHealthChecksActor: ActorRef = actorRefFactory.actorOf(AppHealthCheckActor.props(eventBus))
 
   override def list(appId: PathId): Set[HealthCheck] =
     listActive(appId).map(_.healthCheck)
@@ -63,9 +66,12 @@ class MarathonHealthCheckManager(
         log.info(s"Adding health check for app [${app.id}] and version [${app.version}]: [$healthCheck]")
 
         val ref = actorRefFactory.actorOf(
-          HealthCheckActor.props(app, killService, healthCheck, instanceTracker, eventBus))
+          HealthCheckActor.props(app, appHealthChecksActor, killService, healthCheck, instanceTracker, eventBus))
         val newHealthChecksForApp =
           healthChecksForApp + ActiveHealthCheck(healthCheck, ref)
+
+        appHealthChecksActor ! AppHealthCheckActor.AddHealthCheck(
+          ApplicationKey(app.id, app.version), healthCheck)
 
         healthCheck match {
           case _: MesosHealthCheck =>
@@ -109,6 +115,9 @@ class MarathonHealthCheckManager(
       } else {
         currentHealthChecksForApp + (appVersion -> newHealthChecksForVersion)
       }
+
+      appHealthChecksActor ! AppHealthCheckActor.RemoveHealthCheck(
+        ApplicationKey(appId, appVersion), healthCheck)
 
       if (newHealthChecksForApp.isEmpty) ahcs -= appId
       else ahcs += (appId -> newHealthChecksForApp)

--- a/src/test/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActorTest.scala
@@ -1,0 +1,133 @@
+package mesosphere.marathon
+package core.health.impl
+
+import akka.testkit.TestProbe
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.event.InstanceHealthChanged
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{AddHealthCheck, ApplicationKey, HealthCheckStatusChanged, RemoveHealthCheck}
+import mesosphere.marathon.core.health.{Health, MarathonHttpHealthCheck, PortReference}
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.state.Timestamp
+
+class AppHealthCheckActorTest extends AkkaUnitTest {
+  class Fixture {
+    val appId = "/test".toPath
+    val appVersion = Timestamp(1)
+    val appKey = ApplicationKey(appId, appVersion)
+    val hcPort80 = MarathonHttpHealthCheck(portIndex = Some(PortReference(80)))
+    val hcPort443 = MarathonHttpHealthCheck(portIndex = Some(PortReference(443)))
+    val instances = List(
+      Instance.Id("instance1"),
+      Instance.Id("instance2"),
+      Instance.Id("instance3")
+    )
+  }
+
+  "AppHealthCheckActor" should {
+    "send status changed event when all instances are healthy" in {
+      val f = new Fixture
+      val systemLog = TestProbe()
+
+      val actor = system.actorOf(AppHealthCheckActor.props(system.eventStream))
+      system.eventStream.subscribe(systemLog.ref, classOf[InstanceHealthChanged])
+
+      actor ! AddHealthCheck(f.appKey, f.hcPort80)
+      actor ! AddHealthCheck(f.appKey, f.hcPort443)
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort80)
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort443)
+
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances.head, f.appKey.version, f.appKey.appId, Some(true)))
+    }
+
+    "send status changed event when one instance becomes unhealthy" in {
+      val f = new Fixture
+      val systemLog = TestProbe()
+
+      val actor = system.actorOf(AppHealthCheckActor.props(system.eventStream))
+      system.eventStream.subscribe(systemLog.ref, classOf[InstanceHealthChanged])
+
+      actor ! AddHealthCheck(f.appKey, f.hcPort80)
+      actor ! AddHealthCheck(f.appKey, f.hcPort443)
+
+      // all health checks pass once
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      // and suddenly one fails
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(8))))
+
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort80)
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort443)
+
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances.head, f.appKey.version, f.appKey.appId, Some(true)))
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances.head, f.appKey.version, f.appKey.appId, Some(false)))
+    }
+
+    "not send status changed even when health check is not registered" in {
+      val f = new Fixture
+      val systemLog = TestProbe()
+
+      val actor = system.actorOf(AppHealthCheckActor.props(system.eventStream))
+      system.eventStream.subscribe(systemLog.ref, classOf[InstanceHealthChanged])
+
+      // all health checks pass once
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      systemLog.expectNoMsg()
+    }
+
+    "send status changed event when several instances become healthy" in {
+      val f = new Fixture
+      val systemLog = TestProbe()
+
+      val actor = system.actorOf(AppHealthCheckActor.props(system.eventStream))
+      system.eventStream.subscribe(systemLog.ref, classOf[InstanceHealthChanged])
+
+      actor ! AddHealthCheck(f.appKey, f.hcPort80)
+      actor ! AddHealthCheck(f.appKey, f.hcPort443)
+
+      // all health checks pass once
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances(1), lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances.head, f.appKey.version, f.appKey.appId, Some(true)))
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances(1), lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances(1), f.appKey.version, f.appKey.appId, Some(true)))
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances(2), lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances(2), lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances(2), f.appKey.version, f.appKey.appId, Some(true)))
+
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort80)
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort443)
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
@@ -36,6 +36,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
 
     val instanceBuilder = TestInstanceBuilder.newBuilder(appId, version = appVersion).addTaskRunning()
     val instance = instanceBuilder.getInstance()
+    val appHealthCheckActor = TestProbe()
 
     val task: Task = instance.appTask
 
@@ -44,7 +45,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
 
     def actor(healthCheck: HealthCheck) = TestActorRef[HealthCheckActor](
       Props(
-        new HealthCheckActor(app, killService, healthCheck, tracker, system.eventStream)
+        new HealthCheckActor(app, appHealthCheckActor.ref, killService, healthCheck, tracker, system.eventStream)
       )
     )
 
@@ -52,6 +53,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
       Props(
         new HealthCheckActor(
           app,
+          appHealthCheckActor.ref,
           killService,
           MarathonHttpHealthCheck(portIndex = Some(PortReference(0))),
           tracker,

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -250,12 +250,12 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
 
       // reconcile starts health checks of task 1
       val captured1 = captureEvents.forBlock {
-        assert(hcManager.list(appId) == Set.empty[HealthCheck])
         currentAppVersion = startTask_i(1)
+        assert(hcManager.list(appId) == Set.empty[HealthCheck])
         groupManager.appVersion(currentAppVersion.id, currentAppVersion.version.toOffsetDateTime) returns Future.successful(Some(currentAppVersion))
         hcManager.reconcile(Seq(currentAppVersion)).futureValue
       }
-      assert(captured1.map(_.eventType) == Vector("add_health_check_event"))
+      assert(captured1.map(_.eventType).count(_ == "add_health_check_event") == 1)
       assert(hcManager.list(appId) == healthChecks(1)) // linter:ignore:UnlikelyEquality
 
       // reconcile leaves health check running
@@ -271,7 +271,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
         groupManager.appVersion(currentAppVersion.id, currentAppVersion.version.toOffsetDateTime) returns Future.successful(Some(currentAppVersion))
         hcManager.reconcile(Seq(currentAppVersion)).futureValue
       }
-      assert(captured3.map(_.eventType) == Vector("add_health_check_event", "add_health_check_event"))
+      assert(captured3.map(_.eventType).count(_ == "add_health_check_event") == 2)
       assert(hcManager.list(appId) == healthChecks(1) ++ healthChecks(2)) // linter:ignore:UnlikelyEquality
 
       // reconcile stops health checks which are not current and which are without tasks


### PR DESCRIPTION
Before this fix, during a deployment triggered by a restart, the old
instances of an app were killed before the new ones were healthy. This
was due to the "instance_health_changed_event" event sent too early to
the ReadinessBehavior instance (when the first health check reported to be
healthy instead of ALL health checks).

The aim of this fix is to aggregate the results of health checks and
maintain a global instance health state which is Some(true) if all health
checks of a given instances report healthy, Some(false) if all health checks
report unhealthy and Option.empty if there is at least one unreported result.
The "instance_health_changed_event" event is now sent only when there is a
transition between those 3 states.

This commit relates to those tickets: MARATHON-7609, MARATHON-2683.
