### PR TITLE
Allow to kill tasks during a deployment

### DIFF
--- a/docs/docs/rest-api/public/api/v2/apps.raml
+++ b/docs/docs/rest-api/public/api/v2/apps.raml
@@ -489,11 +489,11 @@
       # Kill tasks of an application
       #
       delete:
-        description: Kill tasks that belong to the application `app_id`
+        description: Kill tasks that belong to the application `app_id`. If an upgrade is currently running, the tasks will be killed nonetheless, and eventually new tasks will be started.
         is: [ secured, deployable ]
         queryParameters:
           host:
-            description: all tasks of that application on the supplied slave are killed
+            description: all tasks of that application on the supplied agent are killed
           scale:
             description: If `scale=true` is specified, then the application is scaled down by the number of killed tasks. Only possible if `wipe=false` or not specified.
             default: "false"
@@ -521,7 +521,7 @@
         # Delete a single task
         #
         delete:
-          description: Kill the task with ID `task_id` that belongs to the application `app_id`.
+          description: Kill the task with ID `task_id` that belongs to the application `app_id`. If an upgrade is currently running, the task will be killed nonetheless, and eventually new tasks will be started.
           is: [ secured, deployable ]
           queryParameters:
             scale:

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -15,7 +15,6 @@ import mesosphere.marathon.core.deployment.{DeploymentManager, DeploymentPlan, D
 import mesosphere.marathon.core.election.{ElectionCandidate, ElectionService}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.heartbeat._
-import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.leadership.LeadershipCoordinator
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
@@ -132,12 +131,6 @@ class MarathonSchedulerService @Inject() (
 
   def getApp(appId: PathId, version: Timestamp): Option[AppDefinition] = {
     Await.result(groupManager.appVersion(appId, version.toOffsetDateTime), config.zkTimeoutDuration)
-  }
-
-  def killInstances(
-    appId: PathId,
-    instances: Seq[Instance]): Unit = {
-    schedulerActor ! KillTasks(appId, instances)
   }
 
   //Begin Service interface

--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -21,7 +21,6 @@ import scala.util.control.NonFatal
 class TaskKiller @Inject() (
     instanceTracker: InstanceTracker,
     groupManager: GroupManager,
-    service: MarathonSchedulerService,
     val config: MarathonConf,
     val authenticator: Authenticator,
     val authorizer: Authorizer,
@@ -45,7 +44,7 @@ class TaskKiller @Inject() (
             val expunged = await(expunge(foundInstances))
             val killed = await(killService.killInstances(activeInstances, KillReason.KillingTasksViaApi))
           } else {
-            if (activeInstances.nonEmpty) service.killInstances(runSpecId, activeInstances)
+            val killed = await(killService.killInstances(activeInstances, KillReason.KillingTasksViaApi))
           }
           // Return killed *and* expunged instances.
           // The user only cares that all instances won't exist eventually. That's why we send all instances back and

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -72,8 +72,9 @@ private[launcher] class OfferProcessorImpl(
   private def warnOnZeroResource(offer: Offer): Unit = {
     val resourcesWithZeroValues = offer
       .getResourcesList.asScala
-      .collect { case resource if resource.getScalar.getValue.ceil.toLong == 0 =>
-        resource.getName
+      .collect {
+        case resource if resource.getScalar.getValue.ceil.toLong == 0 =>
+          resource.getName
       }
     if (resourcesWithZeroValues.nonEmpty) {
       logger.warn(s"Offer ${offer.getId.getValue} has zero-valued resources: ${resourcesWithZeroValues.mkString(", ")}")

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -90,6 +90,7 @@ class TaskKillerTest extends UnitTest {
       val tasksToKill = Seq(instance)
       when(f.groupManager.runSpec(appId)).thenReturn(Some(AppDefinition(appId)))
       when(f.tracker.specInstances(appId)).thenReturn(Future.successful(tasksToKill))
+      when(f.killService.killInstances(tasksToKill, KillReason.KillingTasksViaApi)).thenReturn(Future(Done))
 
       val result = f.taskKiller.kill(appId, { tasks =>
         tasks should equal(tasksToKill)
@@ -97,7 +98,7 @@ class TaskKillerTest extends UnitTest {
       })
 
       result.futureValue shouldEqual tasksToKill
-      verify(f.service, times(1)).killInstances(appId, tasksToKill)
+      verify(f.killService, times(1)).killInstances(tasksToKill, KillReason.KillingTasksViaApi)
     }
 
     "Kill and scale w/o force should fail if there is a deployment" in {
@@ -154,7 +155,6 @@ class TaskKillerTest extends UnitTest {
 
   class Fixture {
     val tracker: InstanceTracker = mock[InstanceTracker]
-    val service: MarathonSchedulerService = mock[MarathonSchedulerService]
     val killService: KillService = mock[KillService]
     val groupManager: GroupManager = mock[GroupManager]
 
@@ -162,7 +162,7 @@ class TaskKillerTest extends UnitTest {
     when(config.zkTimeoutDuration).thenReturn(1.second)
 
     val taskKiller: TaskKiller = new TaskKiller(
-      tracker, groupManager, service, config, auth.auth, auth.auth, killService)
+      tracker, groupManager, config, auth.auth, auth.auth, killService)
   }
 
 }

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -29,6 +29,7 @@ class TaskKillerTest extends UnitTest {
       val appId = PathId("invalid")
       when(f.tracker.specInstances(appId)).thenReturn(Future.successful(Seq.empty))
       when(f.groupManager.runSpec(appId)).thenReturn(Some(AppDefinition(appId)))
+      when(f.killService.killInstances(Seq.empty[Instance], KillReason.KillingTasksViaApi)).thenReturn(Future.successful(Done))
 
       val result = f.taskKiller.kill(appId, (tasks) => Seq.empty[Instance]).futureValue
       result.isEmpty shouldEqual true

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -25,8 +25,8 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
 
   case class Fixture(
       auth: TestAuthFixture = new TestAuthFixture,
-      service: MarathonSchedulerService = mock[MarathonSchedulerService],
-      instanceTracker: InstanceTracker = mock[InstanceTracker],
+    instanceTracker: InstanceTracker = mock[InstanceTracker],
+      stateOpProcessor: InstanceStateOpProcessor = mock[InstanceStateOpProcessor],
       taskKiller: TaskKiller = mock[TaskKiller],
       healthCheckManager: HealthCheckManager = mock[HealthCheckManager],
       config: MarathonConf = mock[MarathonConf],
@@ -47,15 +47,14 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
 
   case class FixtureWithRealTaskKiller(
       auth: TestAuthFixture = new TestAuthFixture,
-      service: MarathonSchedulerService = mock[MarathonSchedulerService],
-      instanceTracker: InstanceTracker = mock[InstanceTracker],
+    instanceTracker: InstanceTracker = mock[InstanceTracker],
       healthCheckManager: HealthCheckManager = mock[HealthCheckManager],
       config: MarathonConf = mock[MarathonConf],
       groupManager: GroupManager = mock[GroupManager]) {
     val identity = auth.identity
     val killService = mock[KillService]
     val taskKiller = new TaskKiller(
-      instanceTracker, groupManager, service, config, auth.auth, auth.auth, killService)
+      instanceTracker, groupManager, config, auth.auth, auth.auth, killService)
     val appsTaskResource = new AppTasksResource(
       instanceTracker,
       taskKiller,

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -29,7 +29,6 @@ import scala.concurrent.duration._
 class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
   case class Fixture(
       auth: TestAuthFixture = new TestAuthFixture,
-      service: MarathonSchedulerService = mock[MarathonSchedulerService],
       instanceTracker: InstanceTracker = mock[InstanceTracker],
       taskKiller: TaskKiller = mock[TaskKiller],
       config: MarathonConf = mock[MarathonConf],
@@ -297,7 +296,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       val body = s"""{"ids": ["$taskId1", "$taskId2", "$taskId3"]}""".getBytes
 
       override val taskKiller = new TaskKiller(
-        instanceTracker, groupManager, service, config, auth.auth, auth.auth, killService)
+        instanceTracker, groupManager, config, auth.auth, auth.auth, killService)
       override val taskResource = new TasksResource(
         instanceTracker,
         taskKiller,


### PR DESCRIPTION
Killing tasks via the API is now always directly processed by the KillService. Before, when the `wipe` flag was not specified as `true`, killing tasks was indirected via the MarathonSchedulerService, and silently failed if the associated app was locked by a deployment, even if `force=true` was specified. With this patch, it is possible to kill tasks even if they are subject of a running deployment.

JIRA issues: MARATHON-1686