### PR TITLE
Fix errors in flake8

### DIFF
--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -4,11 +4,9 @@ import common
 import pytest
 import retrying
 import shakedown
-import time
 
 from datetime import timedelta
-from dcos import packagemanager, marathon, cosmos
-from dcos.errors import DCOSException
+from dcos import packagemanager, cosmos
 
 
 PACKAGE_NAME = 'marathon'


### PR DESCRIPTION
Not used imports. Flake8 started reporting them probably after the python got updated in the AMI ... ?