### PR TITLE
 Application specific override for GPU scheduling behavior

### DIFF
--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -250,7 +250,7 @@ object ResourceMatcher extends StrictLogging {
 
     val checkGpuSchedulingBehaviour: Boolean = {
       val applicationSpecificGpuBehavior = runSpec.labels.get("GPU_SCHEDULING_BEHAVIOR")
-        .filter(behavior => Set(GpuSchedulingBehavior.Restricted, GpuSchedulingBehavior.Unrestricted).contains(behavior))
+        .filter(behavior => validBehaviors.contains(behavior))
       val availableGPUs = groupedResources.getOrElse(Resource.GPUS, Nil).foldLeft(0.0)(_ + _.getScalar.getValue)
       val gpuResourcesAreWasted = availableGPUs > 0 && runSpec.resources.gpus == 0
       applicationSpecificGpuBehavior.getOrElse(conf.gpuSchedulingBehavior()) match {
@@ -576,4 +576,6 @@ object ResourceMatcher extends StrictLogging {
           s"Not all basic resources satisfied: $basicResourceString")
     }
   }
+
+  private val validBehaviors = Set(GpuSchedulingBehavior.Restricted, GpuSchedulingBehavior.Unrestricted)
 }

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -249,9 +249,11 @@ object ResourceMatcher extends StrictLogging {
     }
 
     val checkGpuSchedulingBehaviour: Boolean = {
+      val applicationSpecificGpuBehavior = runSpec.labels.get("GPU_SCHEDULING_BEHAVIOR")
+        .filter(behavior => Set(GpuSchedulingBehavior.Restricted, GpuSchedulingBehavior.Unrestricted).contains(behavior))
       val availableGPUs = groupedResources.getOrElse(Resource.GPUS, Nil).foldLeft(0.0)(_ + _.getScalar.getValue)
       val gpuResourcesAreWasted = availableGPUs > 0 && runSpec.resources.gpus == 0
-      conf.gpuSchedulingBehavior() match {
+      applicationSpecificGpuBehavior.getOrElse(conf.gpuSchedulingBehavior()) match {
         case GpuSchedulingBehavior.Undefined =>
           if (gpuResourcesAreWasted) {
             addOnMatch(() => logger.warn(s"Runspec [${runSpec.id}] doesn't require any GPU resources but " +

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -267,7 +267,7 @@ object ResourceMatcher extends StrictLogging {
             noOfferMatchReasons += NoOfferMatchReason.DeclinedScarceResources
             false
           } else {
-            addOnMatch(() => logger.warn(s"Runspec [${runSpec.id}] doesn't require any GPU resources but " +
+            addOnMatch(() => logger.info(s"Runspec [${runSpec.id}] doesn't require any GPU resources but " +
               "will be launched on an agent with GPU resources due to required persistent volume."))
             true
           }

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -1181,17 +1181,22 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch].reasons.head shouldEqual DeclinedScarceResources
     }
 
-    "correctly match offers in case of app specific override and no Persistent Volume involved" in {
+  }
 
-      val overrideCases = Table(
-        ("gpu_scheduling_behavior", "GPU_SCHEDULING_BEHAVIOR", "expected"),
-        ("unrestricted", Some("restricted"), "NoMatch"),
-        ("unrestricted", None, "Match"),
-        ("restricted", Some("unrestricted"), "Match"),
-        ("restricted", None, "NoMatch")
-      )
+  "ResourceMatcher" should {
 
-      forAll(overrideCases) { (gpuSchedulingBehavior, overrideLabel, expected) =>
+    val overrideCases = Table(
+      ("gpu_scheduling_behavior", "GPU_SCHEDULING_BEHAVIOR", "expected"),
+      ("unrestricted", Some("restricted"), "NoMatch"),
+      ("unrestricted", None, "Match"),
+      ("restricted", Some("unrestricted"), "Match"),
+      ("restricted", None, "NoMatch")
+    )
+
+    forAll(overrideCases) { (gpuSchedulingBehavior, overrideLabel, expected) =>
+
+      s"return a $expected in case of ${overrideLabel.getOrElse("no")} override of $gpuSchedulingBehavior behavior and no Persistent Volume involved" in {
+
         val gpuConfig = AllConf.withTestConfig(
           "--draining_seconds", "300",
           "--gpu_scheduling_behavior", gpuSchedulingBehavior,


### PR DESCRIPTION
https://github.com/mesosphere/marathon/pull/6051 needs to be merged first!

 Application specific override for GPU scheduling behavior

Summary: Implemented an application-specific GPU scheduling behavior override

JIRA issues: MARATHON-8089