### PR TITLE
Fix Logstash grok pattern for https log lines

### DIFF
--- a/tools/elk/conf/filter-marathon-1.4.x.conf
+++ b/tools/elk/conf/filter-marathon-1.4.x.conf
@@ -29,7 +29,7 @@ filter {
     remove_tag => ["unclassified"]
   }
   grok {
-    match => {"message" => "^%{IP:httpHost} - (?<user>%{WORD}|-).*\"(?<method>GET|PUT|DELETE|POST|HEAD)\s+//(?<authority>[^/]+)%{URIPATH:uri}(?:%{URIPARAM:params})?.*?\" %{POSINT:httpStatus:int} %{POSINT:size:int}"}
+    match => {"message" => "^%{IP:httpHost} - (?<user>%{WORD}|-)[^\"]*\"(?<method>GET|PUT|DELETE|POST|HEAD)\s+(http:|https:|)//(?<authority>[^/]+)%{URIPATH:uri}(?:%{URIPARAM:params})?.*?\" %{POSINT:httpStatus:int} %{POSINT:size:int}"}
     add_field => {"class" => "http"}
     add_field => {"class2" => "response"}
     tag_on_failure => []


### PR DESCRIPTION
If https is enabled, then the http request log lines include a protocol in the accessed URI. The grok pattern is adjusted to accept this.