### PR TITLE
Do not start more instances than needed

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -302,9 +302,9 @@ private class TaskLauncherActor(
   }
 
   private[this] def replyWithQueuedInstanceCount(): Unit = {
-    val instancesLaunched = instanceMap.values.count(_.isLaunched)
+    val instancesLaunched = instanceMap.values.count(instance => instance.isLaunched || instance.isReserved)
     val instancesLaunchesInFlight = inFlightInstanceOperations.keys
-      .count(instanceId => instanceMap.get(instanceId).exists(_.isLaunched))
+      .count(instanceId => instanceMap.get(instanceId).exists(instance => instance.isLaunched || instance.isReserved))
     sender() ! QueuedInstanceInfo(
       runSpec,
       inProgress = instancesToLaunch > 0 || inFlightInstanceOperations.nonEmpty,

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -41,10 +41,10 @@ private[tracker] class InstanceTrackerDelegate(
 
   // TODO(jdef) support pods when counting launched instances
   override def countLaunchedSpecInstancesSync(appId: PathId): Int =
-    instancesBySpecSync.specInstances(appId).count(_.isLaunched)
+    instancesBySpecSync.specInstances(appId).count(instance => instance.isLaunched || instance.isReserved)
   override def countLaunchedSpecInstances(appId: PathId): Future[Int] = {
     import mesosphere.marathon.core.async.ExecutionContexts.global
-    instancesBySpec().map(_.specInstances(appId).count(_.isLaunched))
+    instancesBySpec().map(_.specInstances(appId).count(instance => instance.isLaunched || instance.isReserved))
   }
 
   override def hasSpecInstancesSync(appId: PathId): Boolean = instancesBySpecSync.hasSpecInstances(appId)

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -120,7 +120,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       And("our app gets a backoff delay")
       val patienceConfig: WaitTestSupport.PatienceConfig = WaitTestSupport.PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))
       WaitTestSupport.waitUntil("queue item") {
-        val queue: List[ITQueueItem] = marathon.launchQueue().value.queue
+        val queue: List[ITQueueItem] = marathon.launchQueueForAppId(app.id.toPath).value
         queue should have size 1
         queue.map(_.delay.overdue) should contain(false)
         true

--- a/src/test/scala/mesosphere/marathon/integration/EventsIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/EventsIntegrationTest.scala
@@ -1,8 +1,6 @@
 package mesosphere.marathon
 package integration
 
-import java.util.UUID
-
 import akka.stream.scaladsl.Sink
 import mesosphere.AkkaIntegrationTest
 import mesosphere.marathon.integration.setup._
@@ -15,9 +13,7 @@ import scala.concurrent.duration._
 @IntegrationTest
 class EventsIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
-  before(cleanUp())
-
-  def appId(): PathId = testBasePath / s"app-${UUID.randomUUID}"
+  def appId(suffix: String): PathId = testBasePath / s"app-$suffix"
 
   "Filter events" should {
     "receive only app deployment event" in {
@@ -36,7 +32,7 @@ class EventsIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTes
         .runWith(Sink.head)
 
       When("the app is created")
-      val app = appProxy(appId(), "v1", instances = 1, healthCheck = None)
+      val app = appProxy(appId("with-one-deployment-event"), "v1", instances = 1, healthCheck = None)
       val result = marathon.createAppV2(app)
 
       And("we wait for deployment")

--- a/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GracefulTaskKillIntegrationTest.scala
@@ -41,7 +41,7 @@ class GracefulTaskKillIntegrationTest extends AkkaIntegrationTest with EmbeddedM
       val taskId = marathon.tasks(app.id.toPath).value.head.id
 
       When("a task of an app is killed")
-      marathon.killTask(app.id.toPath, taskId) should be(OK)
+      marathon.killTask(app.id.toPath, taskId, scale = true) should be(OK)
       val taskKillSentTimestamp = Timestamp.now()
 
       val taskKilledEvent = waitForEventWith(
@@ -73,7 +73,7 @@ class GracefulTaskKillIntegrationTest extends AkkaIntegrationTest with EmbeddedM
       val taskId = marathon.tasks(app.id.toPath).value.head.id
 
       When("a task of an app is killed")
-      marathon.killTask(app.id.toPath, taskId) should be(OK)
+      marathon.killTask(app.id.toPath, taskId, scale = true) should be(OK)
       val taskKillSentTimestamp = Timestamp.now()
 
       val taskKilledEvent = waitForEventWith(

--- a/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
@@ -15,9 +15,6 @@ class GroupDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
 
   import PathId._
 
-  //clean up state before running the test case
-  before(cleanUp())
-
   val appIdCount = new AtomicInteger()
   val groupIdCount = new AtomicInteger()
 
@@ -74,7 +71,7 @@ class GroupDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       Then("The group is deleted")
       result should be(OK)
       // only expect the test base group itself
-      marathon.listGroupsInBaseGroup.value.filter { group => group.id != testBasePath } should be('empty)
+      marathon.listGroupsInBaseGroup.value.map(_.id) should not contain (group.id)
     }
 
     "delete a non existing group should give a 404 http response" in {

--- a/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
@@ -9,9 +9,6 @@ import mesosphere.marathon.state.PathId
 @IntegrationTest
 class ReadinessCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
-  //clean up state before running the test case
-  before(cleanUp())
-
   private val ramlHealthCheck = AppHealthCheck(
     protocol = AppHealthCheckProtocol.Http,
     gracePeriodSeconds = 20,

--- a/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ReadinessCheckIntegrationTest.scala
@@ -5,10 +5,9 @@ import mesosphere.AkkaIntegrationTest
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.raml.{ AppHealthCheck, AppHealthCheckProtocol, AppUpdate, PortDefinition, ReadinessCheck }
 import mesosphere.marathon.state.PathId
-import org.scalatest.concurrent.Eventually
 
 @IntegrationTest
-class ReadinessCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Eventually {
+class ReadinessCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
   //clean up state before running the test case
   before(cleanUp())

--- a/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
@@ -21,13 +21,6 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
 
   private[this] val log = LoggerFactory.getLogger(getClass)
 
-  //clean up state before running the test case
-  before(cleanUp())
-
-  // Any test in this suite that restarts an existing task can fail because of: https://issues.apache.org/jira/browse/MESOS-7752
-  // TL;DR: we are reusing taskIds for resident task, which triggers a race condition in mesos by reusing the executor of the
-  // previous task. Though reusing taskIds is discouraged it should be possible for tasks after a terminal task status.
-  // Solution: either mesos fixes the bug or we walk away from reusing taskIds which is somewhat non-trivial on our side.
   "ResidentTaskIntegrationTest" should {
     "resident task can be deployed and write to persistent volume" in new Fixture {
       Given("An app that writes into a persistent volume")
@@ -85,11 +78,6 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
       When("the app is suspended")
       suspendSuccessfully(PathId(app.id))
 
-      And("we wait for a while")
-      // FIXME: we need to retry starting tasks since there is a race-condition in Mesos,
-      // probably related to our recycling of the task ID (but unconfirmed)
-      Thread.sleep(2000L)
-
       And("a new task is started that checks for the previously written file")
       // deploy a new version that checks for the data written the above step
       val update = marathon.updateApp(
@@ -108,7 +96,10 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
     }
 
     "resident task is launched completely on reserved resources" in new Fixture {
-      Given("A resident app")
+      Given("A clean state of the cluster since we check reserved resources")
+      cleanUp()
+
+      And("A resident app")
       val app = residentApp(
         id = appId("resident-task-is-launched-completely-on-reserved-resources"))
 
@@ -177,10 +168,7 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
       val app = createSuccessfully(
         residentApp(
           id = appId("restart-resident-app-with-five-instances"),
-          instances = 5,
-          // FIXME: we need to retry starting tasks since there is a race-condition in Mesos,
-          // probably related to our recycling of the task ID (but unconfirmed)
-          backoffDuration = 300.milliseconds
+          instances = 5
         )
       )
 
@@ -188,7 +176,7 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
       val newVersion = restartSuccessfully(app) withClue ("The app did not restart.")
       val all = allTasks(PathId(app.id))
 
-      log.info("tasks after relaunch: {}", all.mkString(";"))
+      logger.info("tasks after relaunch: {}", all.mkString(";"))
 
       Then("no extra task was created")
       all.size shouldBe 5
@@ -216,7 +204,7 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
       val newVersion = updateSuccessfully(PathId(app.id), AppUpdate(cmd = Some("sleep 1234"))).toString
       val all = allTasks(PathId(app.id))
 
-      log.info("tasks after config change: {}", all.mkString(";"))
+      logger.info("tasks after config change: {}", all.mkString(";"))
 
       Then("no extra task was created")
       all should have size 5

--- a/src/test/scala/mesosphere/marathon/integration/SystemResourceIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/SystemResourceIntegrationTest.scala
@@ -4,18 +4,12 @@ package integration
 import akka.http.scaladsl.model.MediaTypes
 import mesosphere.AkkaIntegrationTest
 import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
-import org.slf4j.LoggerFactory
 
 /**
   * Integration tests for non-app / non-pod end points such as /ping and /metrics
   */
 @IntegrationTest
 class SystemResourceIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
-
-  private[this] val log = LoggerFactory.getLogger(getClass)
-
-  //clean up state before running the test case
-  before(cleanUp())
 
   "Marathon" should {
     "responses to a ping" in {

--- a/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -824,9 +824,12 @@ trait LocalMarathonTest extends MarathonTest with ScalaFutures
   * trait that has marathon, zk, and a mesos ready to go
   */
 trait EmbeddedMarathonTest extends Suite with StrictLogging with ZookeeperServerTest with MesosClusterTest with LocalMarathonTest {
-  // disable failover timeout to assist with cleanup ops; terminated marathons are immediately removed from mesos's
-  // list of frameworks
-  override def marathonArgs: Map[String, String] = Map("failover_timeout" -> "0")
+  /* disable failover timeout to assist with cleanup ops; terminated marathons are immediately removed from mesos's
+   * list of frameworks
+   *
+   * Until https://issues.apache.org/jira/browse/MESOS-8171 is resolved, we cannot set this value to 0.
+   */
+  override def marathonArgs: Map[String, String] = Map("failover_timeout" -> "1")
 }
 
 /**


### PR DESCRIPTION
When determining how many instances to launch during deployments
and scale checks, do account for `isReserved` instances, otherwise
Marathon starts extra instances in case of apps and pods with
persistent volumes.

It is a cherry-pick of 311b176 with fixes of flaky tests.

JIRA issues: MARATHON-7751