### PR TITLE
Use given matched resources when building Mesos protobufs for pods

### DIFF
--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -88,6 +88,7 @@ object TaskGroupBuilder extends StrictLogging {
 
   // This method just double-checks that the matched resources are exactly
   // what is needed and in right quantities.
+  @SuppressWarnings(Array("ComparingFloatingPointTypes"))
   private[this] def verifyResources(pod: PodDefinition, matchedResources: Seq[mesos.Resource]): Unit = {
     val cpus = pod.executorResources.cpus + pod.containers.map(_.resources.cpus).sum
     val mem = pod.executorResources.mem + pod.containers.map(_.resources.mem).sum
@@ -102,7 +103,7 @@ object TaskGroupBuilder extends StrictLogging {
     assert(cpus == matchedCpus)
     assert(mem == matchedMem)
     assert(disk == matchedDisk)
-    assert(gpus == matchedGpus)
+    assert(gpus.toDouble == matchedGpus)
   }
 
   // The resource match provides us with a list of host ports.

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -121,46 +121,49 @@ object TaskGroupBuilder extends StrictLogging {
     // Find a CPU resource for the given quantity if possible, and remove the resource from the resource list.
     def consumeCpus(quantity: Double): Option[mesos.Resource] = {
       consume(cpus, BigDecimal(quantity)).map {
-        case (resources, resource) =>
-          cpus = resources
-          resource
+        case (leftResources, consumedResource) =>
+          cpus = leftResources
+          consumedResource
       }
     }
 
     // Find a MEM resource for the given quantity if possible, and remove the resource from the resource list.
     def consumeMem(quantity: Double): Option[mesos.Resource] = {
       consume(mem, BigDecimal(quantity)).map {
-        case (resources, resource) =>
-          mem = resources
-          resource
+        case (leftResources, consumedResource) =>
+          mem = leftResources
+          consumedResource
       }
     }
 
     // Find a DISK resource for the given quantity if possible, and remove the resource from the resource list.
     def consumeDisk(quantity: Double): Option[mesos.Resource] = {
       consume(disk, BigDecimal(quantity)) map {
-        case (resources, resource) =>
-          disk = resources
-          resource
+        case (leftResources, consumedResource) =>
+          disk = leftResources
+          consumedResource
       }
     }
 
     // Find a GPU resource for the given quantity if possible, and remove the resource from the resource list.
     def consumeGpus(quantity: Double): Option[mesos.Resource] = {
       consume(gpus, BigDecimal(quantity)).map {
-        case (resources, resource) =>
-          gpus = resources
-          resource
+        case (leftResources, consumedResource) =>
+          gpus = leftResources
+          consumedResource
       }
     }
 
+    // Find a resource with exactly the given quantity among the provided resources.
     private def consume(
       resources: List[(BigDecimal, mesos.Resource)],
       quantity: BigDecimal): Option[(List[(BigDecimal, mesos.Resource)], mesos.Resource)] =
       if (quantity <= BigDecimal(0)) {
         None
       } else {
-        resources.partition(_._1 != quantity) match {
+        resources.partition {
+          case (resourceQuantity, _) => resourceQuantity != quantity
+        } match {
           case (_, Nil) =>
             throw new IllegalStateException("failed to find a resource with the given quantity")
           case (left, pair :: right) =>

--- a/tests/system/pods/ephemeral-volume-pod.json
+++ b/tests/system/pods/ephemeral-volume-pod.json
@@ -35,7 +35,7 @@
       },
       "exec": {
         "command": {
-          "shell": "sleep 2; while true; do cat ./etc/clock; if [ $? -eq 1 ]; then exit; fi; sleep 1; done"
+          "shell": "while [ ! -f ./etc/clock ]; do sleep 1; done && while true; do cat ./etc/clock; if [ $? -eq 1 ]; then exit; fi; sleep 1; done"
         }
       },
       "volumeMounts": [


### PR DESCRIPTION
Previously, passed resources were ignored, and we just constructed new
resource protobufs based on a pod definition.

JIRA issues: [MARATHON-8110](https://jira.mesosphere.com/browse/MARATHON-8110)