### PR TITLE
Open the persistence store before taking a backup using CLI

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/storage/backup/Backup.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/backup/Backup.scala
@@ -40,8 +40,10 @@ abstract class BackupRestoreAction extends StrictLogging {
     import mesosphere.marathon.core.async.ExecutionContexts.global
     try {
       val storageModule = StorageModule(conf, LifecycleState.WatchingJVM)
+      storageModule.persistenceStore.markOpen()
       val backup = storageModule.persistentStoreBackup
       Await.result(fn(backup), Duration.Inf)
+      storageModule.persistenceStore.markClosed()
       logger.info("Action complete.")
     } catch {
       case NonFatal(ex) =>


### PR DESCRIPTION
And close it once finished. This addresses the "IllegalArgumentException:
requirement failed: the store must be opened before it can be used".

This is a cherry-pick of 9a7ca56

JIRA issues:
https://jira.mesosphere.com/browse/MARATHON-8112