### PR TITLE
Pass instance id to offer matcher.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -78,7 +78,7 @@ class InstanceOpFactoryImpl(
 
     matchedOffer match {
       case matches: ResourceMatchResponse.Match =>
-        val instanceId = Instance.Id.forRunSpec(pod.id)
+        val instanceId = request.instanceId
         val taskIds = pod.containers.map { container =>
           Task.Id.forInstanceId(instanceId, Some(container))
         }
@@ -96,14 +96,14 @@ class InstanceOpFactoryImpl(
   }
 
   private[this] def inferNormalTaskOp(app: AppDefinition, request: InstanceOpFactory.Request): OfferMatchResult = {
-    val InstanceOpFactory.Request(runSpec, offer, instances, _, localRegion) = request
+    val InstanceOpFactory.Request(runSpec, offer, instances, _, instanceId, localRegion) = request
 
     val matchResponse =
       RunSpecOfferMatcher.matchOffer(app, offer, instances.values.toIndexedSeq,
         config.defaultAcceptedResourceRolesSet, config, schedulerPlugins, localRegion)
     matchResponse match {
       case matches: ResourceMatchResponse.Match =>
-        val taskId = Task.Id.forRunSpec(app.id)
+        val taskId = Task.Id.forInstanceId(instanceId, None)
         val taskBuilder = new TaskBuilder(app, taskId, config, runSpecTaskProc)
         val (taskInfo, networkInfo) = taskBuilder.build(request.offer, matches.resourceMatch, None)
         val task = Task(
@@ -125,10 +125,7 @@ class InstanceOpFactoryImpl(
   }
 
   private[this] def inferForResidents(spec: RunSpec, request: InstanceOpFactory.Request): OfferMatchResult = {
-    val InstanceOpFactory.Request(runSpec, offer, instances, additionalLaunches, localRegion) = request
-
-    val needToLaunch = additionalLaunches > 0 && request.hasWaitingReservations
-    val needToReserve = request.numberOfWaitingReservations < additionalLaunches
+    val InstanceOpFactory.Request(runSpec, offer, instances, _, instanceId, localRegion) = request
 
     /* *
      * If an offer HAS reservations/volumes that match our run spec, handling these has precedence
@@ -145,7 +142,7 @@ class InstanceOpFactoryImpl(
      *  - schedule a ReserveAndCreate TaskOp
      */
 
-    def maybeLaunchOnReservation: Option[OfferMatchResult] = if (needToLaunch) {
+    def maybeLaunchOnReservation: Option[OfferMatchResult] = if (request.needToLaunch) {
       logger.debug(s"Need to launch on reservation for ${runSpec.id}, version ${runSpec.version}")
       val maybeVolumeMatch = PersistentVolumeMatcher.matchVolumes(offer, request.reserved)
 
@@ -180,7 +177,7 @@ class InstanceOpFactoryImpl(
       }
     } else None
 
-    def maybeReserveAndCreateVolumes: Option[OfferMatchResult] = if (needToReserve) {
+    def maybeReserveAndCreateVolumes: Option[OfferMatchResult] = if (request.needToReserve) {
       logger.debug(s"Need to reserve for ${runSpec.id}, version ${runSpec.version}")
       val configuredRoles = if (runSpec.acceptedResourceRoles.isEmpty) {
         config.defaultAcceptedResourceRolesSet

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -326,7 +326,9 @@ private class TaskLauncherActor(
     case ActorOfferMatcher.MatchOffer(offer, promise) =>
       logger.debug(s"Matching offer ${offer.getId} and need to launch $instancesToLaunch tasks.")
       val reachableInstances = instanceMap.filterNotAs{ case (_, instance) => instance.state.condition.isLost }
-      val matchRequest = InstanceOpFactory.Request(runSpec, offer, reachableInstances, instancesToLaunch, localRegion())
+
+      val instanceId = Instance.Id.forRunSpec(runSpec.id)
+      val matchRequest = InstanceOpFactory.Request(runSpec, offer, reachableInstances, instancesToLaunch, instanceId, localRegion())
       instanceOpFactory.matchOfferRequest(matchRequest) match {
         case matched: OfferMatchResult.Match =>
           logger.debug(s"Matched offer ${offer.getId} for run spec ${runSpec.id}, ${runSpec.version}.")

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -18,7 +18,7 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.integration.setup.WaitTestSupport
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.MarathonTestHelper
-import org.mockito.Matchers
+import org.mockito.{ ArgumentCaptor, Matchers }
 
 import scala.concurrent.duration._
 
@@ -170,8 +170,10 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       val matchedTasks = matchFuture.futureValue
 
       Then("the offer gets passed to the task factory and respects the answer")
-      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1)
-      verify(instanceOpFactory).matchOfferRequest(request)
+      val argument = ArgumentCaptor.forClass(classOf[InstanceOpFactory.Request])
+      verify(instanceOpFactory).matchOfferRequest(argument.capture())
+      argument.getValue.runSpec should be(app)
+
       matchedTasks.offerId should equal(offer.getId)
       matchedTasks.opsWithSource should equal(Seq.empty)
 
@@ -196,8 +198,10 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       val matchedTasks = matchFuture.futureValue
 
       Then("the offer gets passed to the task factory and respects the answer")
-      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1)
-      verify(instanceOpFactory).matchOfferRequest(request)
+      val argument = ArgumentCaptor.forClass(classOf[InstanceOpFactory.Request])
+      verify(instanceOpFactory).matchOfferRequest(argument.capture())
+      argument.getValue.runSpec should be(app)
+
       matchedTasks.offerId should equal(offer.getId)
       launchedTaskInfos(matchedTasks) should equal(Seq(mesosTask))
 
@@ -241,7 +245,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val app = MarathonTestHelper.makeBasicApp().copy(id = PathId("/app"))
 
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    val runspecId = PathId("/test")
+    val runspecId = app.id
     val instance = TestInstanceBuilder.newBuilder(runspecId).addTaskWithBuilder().taskRunning().build().getInstance()
     val task: Task = instance.appTask
 

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -26,6 +26,7 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.test.MarathonTestHelper
 import org.mockito
 import org.mockito.{ ArgumentCaptor, Mockito }
+import org.scalatest.Inside
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Promise
@@ -40,7 +41,7 @@ import scala.concurrent.duration._
   * * tracking task status
   * * timeout for task launching feedback
   */
-class TaskLauncherActorTest extends AkkaUnitTest {
+class TaskLauncherActorTest extends AkkaUnitTest with Inside {
 
   import org.mockito.{ Matchers => m }
 
@@ -194,8 +195,14 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       assert(counts.instancesLeftToLaunch == 0)
 
       Mockito.verify(instanceTracker).instancesBySpecSync
-      val matchRequest = InstanceOpFactory.Request(f.app, offer, Map.empty, additionalLaunches = 1)
-      Mockito.verify(instanceOpFactory).matchOfferRequest(matchRequest)
+      val captor = ArgumentCaptor.forClass(classOf[InstanceOpFactory.Request])
+      Mockito.verify(instanceOpFactory).matchOfferRequest(captor.capture())
+      inside(captor.getValue) {
+        case InstanceOpFactory.Request(actualApp, actualOffer, passedInstances, 1, _, None) =>
+          actualApp should be(f.app)
+          actualOffer should be(offer)
+          passedInstances should be('empty)
+      }
       verifyClean()
     }
 
@@ -284,8 +291,14 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       assert(counts.instancesLeftToLaunch == 1)
 
       Mockito.verify(instanceTracker).instancesBySpecSync
-      val matchRequest = InstanceOpFactory.Request(f.app, offer, Map.empty, additionalLaunches = 1)
-      Mockito.verify(instanceOpFactory).matchOfferRequest(matchRequest)
+      val captor = ArgumentCaptor.forClass(classOf[InstanceOpFactory.Request])
+      Mockito.verify(instanceOpFactory).matchOfferRequest(captor.capture())
+      inside(captor.getValue) {
+        case InstanceOpFactory.Request(actualApp, actualOffer, passedInstances, 1, _, None) =>
+          actualApp should be(f.app)
+          actualOffer should be(offer)
+          passedInstances should be('empty)
+      }
       verifyClean()
     }
 
@@ -328,8 +341,14 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       assert(scheduleCalled)
 
       Mockito.verify(instanceTracker).instancesBySpecSync
-      val matchRequest = InstanceOpFactory.Request(f.app, offer, Map.empty, additionalLaunches = 1)
-      Mockito.verify(instanceOpFactory).matchOfferRequest(matchRequest)
+      val captor = ArgumentCaptor.forClass(classOf[InstanceOpFactory.Request])
+      Mockito.verify(instanceOpFactory).matchOfferRequest(captor.capture())
+      inside(captor.getValue) {
+        case InstanceOpFactory.Request(actualApp, actualOffer, passedInstances, 1, _, None) =>
+          actualApp should be(f.app)
+          actualOffer should be(offer)
+          passedInstances should be('empty)
+      }
       verifyClean()
     }
 
@@ -354,8 +373,14 @@ class TaskLauncherActorTest extends AkkaUnitTest {
       assert(counts.instancesLeftToLaunch == 0)
 
       Mockito.verify(instanceTracker).instancesBySpecSync
-      val matchRequest = InstanceOpFactory.Request(f.app, offer, Map.empty, additionalLaunches = 1)
-      Mockito.verify(instanceOpFactory).matchOfferRequest(matchRequest)
+      val captor = ArgumentCaptor.forClass(classOf[InstanceOpFactory.Request])
+      Mockito.verify(instanceOpFactory).matchOfferRequest(captor.capture())
+      inside(captor.getValue) {
+        case InstanceOpFactory.Request(actualApp, actualOffer, passedInstances, 1, _, None) =>
+          actualApp should be(f.app)
+          actualOffer should be(offer)
+          passedInstances should be('empty)
+      }
       verifyClean()
     }
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
@@ -35,7 +35,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       val app: AppDefinition = AppDefinition(id = appId, portDefinitions = List())
       val runningInstances = Map(instance.instanceId -> instance)
 
-      val request = InstanceOpFactory.Request(app, offer, runningInstances, additionalLaunches = 1)
+      val request = InstanceOpFactory.Request(app, offer, runningInstances, additionalLaunches = 1, instanceId = Instance.Id.forRunSpec(app.id))
       val matchResult = f.instanceOpFactory.matchOfferRequest(request)
 
       val matched = inside(matchResult) {
@@ -80,7 +80,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       val offer = f.insufficientOffer
 
       When("We infer the instanceOp")
-      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1)
+      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1, instanceId = Instance.Id.forRunSpec(app.id))
       val matchResult = f.instanceOpFactory.matchOfferRequest(request)
 
       Then("NoMatch is returned because there are already 2 launched tasks")
@@ -94,7 +94,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       val offer = f.offer
 
       When("We infer the taskOp")
-      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1)
+      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1, instanceId = Instance.Id.forRunSpec(app.id))
       val matchResult = f.instanceOpFactory.matchOfferRequest(request)
 
       Then("A Match with Launch is inferred")
@@ -111,7 +111,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       val offer = f.insufficientOffer
 
       When("We infer the taskOp")
-      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1)
+      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1, instanceId = Instance.Id.forRunSpec(app.id))
       val matchResult = f.instanceOpFactory.matchOfferRequest(request)
 
       Then("NoMatch is returned")
@@ -125,7 +125,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       val offer = f.offer
 
       When("We infer the taskOp")
-      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1)
+      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1, instanceId = Instance.Id.forRunSpec(app.id))
       val matchResult = f.instanceOpFactory.matchOfferRequest(request)
 
       Then("A NoMatch is returned because there is not enough disk space")
@@ -139,7 +139,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       val offer = f.offerWithSpaceForLocalVolume
 
       When("We infer the taskOp")
-      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1)
+      val request = InstanceOpFactory.Request(app, offer, Map.empty, additionalLaunches = 1, instanceId = Instance.Id.forRunSpec(app.id))
       val matchResult = f.instanceOpFactory.matchOfferRequest(request)
 
       Then("A Match with ReserveAndCreateVolumes is returned")
@@ -166,7 +166,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
         reservedInstance))
 
       When("We infer the taskOp")
-      val request = InstanceOpFactory.Request(app, offer, runningInstances, additionalLaunches = 1)
+      val request = InstanceOpFactory.Request(app, offer, runningInstances, additionalLaunches = 1, instanceId = Instance.Id.forRunSpec(app.id))
       val matchResult = f.instanceOpFactory.matchOfferRequest(request)
 
       Then("A Match with a Launch is returned")
@@ -196,7 +196,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       val offer = f.offerWithVolumes(runningTaskId, offeredVolumeId)
 
       When("We infer the taskOp")
-      val request = InstanceOpFactory.Request(app, offer, Instance.instancesById(runningInstances), additionalLaunches = 1)
+      val request = InstanceOpFactory.Request(app, offer, Instance.instancesById(runningInstances), additionalLaunches = 1, instanceId = Instance.Id.forRunSpec(app.id))
       val matchResult = f.instanceOpFactory.matchOfferRequest(request)
 
       Then("A None is returned because there is already a launched Task")
@@ -221,7 +221,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       val updatedAgentId = "updatedAgentId"
       val offer = f.offerWithVolumes(taskId, updatedHostName, updatedAgentId, volumeId)
 
-      val request = InstanceOpFactory.Request(app, offer, Map(existingReservedInstance.instanceId -> existingReservedInstance), additionalLaunches = 1)
+      val request = InstanceOpFactory.Request(app, offer, Map(existingReservedInstance.instanceId -> existingReservedInstance), additionalLaunches = 1, instanceId = Instance.Id.forRunSpec(app.id))
       val result = f.instanceOpFactory.matchOfferRequest(request)
 
       inside(result) {


### PR DESCRIPTION
Summary:
Our mid term goal is to generate the instance id in the business logic
and push it towards the task launch layer. This is the first step to
generate the id in the task launcher instead of the offer matcher.

The next step should pass the id to the task launcher instead of
generating it there.