### PR TITLE
Use sliding average window on /metrics endpoint

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -329,6 +329,9 @@ The Web Site flags control the behavior of Marathon's web site, including the us
     Expose the execution time per method via the metrics endpoint (/metrics) using code instrumentation.
     Enabling this might noticeably degrade performance but it helps finding performance problems.
     These measurements can be disabled with --disable_metrics. Other metrics are not affected.
+* <span class="label label-default">v1.6.0</span> `--metrics_averaging_window` (Optional. Default: 30 seconds):
+    Configure the size of the sliding average window that is used to compute the values for the `/metrics` endpoint. Note that this value
+    should be at least double the value of the `kamon.metric.tick-interval` parameter, that is 1 second by default.
 * <span class="label label-default">v0.13.0</span> `--reporter_graphite` (Optional. Default: disabled):
     Report metrics to [Graphite](http://graphite.wikidot.com) (StatsD) as defined by the given URL.
     Example: `udp://localhost:2003?prefix=marathon-test&interval=10`

--- a/docs/docs/metrics.md
+++ b/docs/docs/metrics.md
@@ -4,7 +4,7 @@ title: Metrics
 
 # Metrics
 
-Marathon currently uses [Codahale/Dropwizard Metrics](https://github.com/dropwizard/metrics). You can query
+Marathon currently uses [Kamon.io](http://kamon.io/) for it's metrics. You can query
 the current metrics via the `/metrics` HTTP endpoint or configure the metrics to report periodically to:
 
 * graphite via `--reporter_graphite`.
@@ -122,8 +122,10 @@ expect the names of these metrics to change if the affected code changes.
 
 ### Derived metrics (mean, p99, ...)
 
-Our metrics library calculates derived metrics like "mean" and "p99." However, Marathon provides these metrics for the entire life of of the app and applies an exponential weighting algorithm as a heuristic. For more precise metrics, build your dashboard around "counts" rather than "rates" where possible.
+Our metrics library calculates derived metrics like "mean" and "p99" using a sliding average window algorithm. This means that every time you fetch the `/metrics` endpoint you are looking at the average of the last N seconds. By default the length of the window is 30 seconds, but this can be configured with the `--metrics_averaging_window` flag.
+
+For getting the most accurate results it is recommended to configure your polling interval to the size of the sliding average window.
 
 ### Statsd and derived statistics
 
-Statsd typically creates derived statistics (mean, p99) from mean values Marathon reports. Our codahale metrics package also reports derived statistics. To avoid accidentally aggregating statistics multiple times, be sure you know where you are reporting and computing mean values.
+Statsd typically creates derived statistics (mean, p99) from mean values Marathon reports. Our metrics package also reports derived statistics. To avoid accidentally aggregating statistics multiple times, be sure you know where you are reporting and computing mean values.

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 
 import java.net.URI
+import java.time
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
@@ -116,7 +117,12 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
     }
 
     val injector = Guice.createInjector(modules.asJava)
-    Metrics.start(injector.getInstance(classOf[ActorSystem]))
+    Metrics.start(
+      injector.getInstance(classOf[ActorSystem]),
+      time.Duration.ofSeconds(
+        cliConf.averagingWindow.get.getOrElse(60L)
+      )
+    )
     val services = Seq(
       injector.getInstance(classOf[MarathonHttpService]),
       injector.getInstance(classOf[MarathonSchedulerService]))

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -117,12 +117,7 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
     }
 
     val injector = Guice.createInjector(modules.asJava)
-    Metrics.start(
-      injector.getInstance(classOf[ActorSystem]),
-      time.Duration.ofSeconds(
-        cliConf.averagingWindow.get.getOrElse(60L)
-      )
-    )
+    Metrics.start(injector.getInstance(classOf[ActorSystem]), cliConf)
     val services = Seq(
       injector.getInstance(classOf[MarathonHttpService]),
       injector.getInstance(classOf[MarathonSchedulerService]))

--- a/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
@@ -175,9 +175,11 @@ object Metrics {
   def snapshot(): TickMetricSnapshot = metrics
 
   // Starts collecting snapshots.
-  def start(actorRefFactory: ActorRefFactory, averagingWindow: Duration): Done = {
+  def start(actorRefFactory: ActorRefFactory, config: MetricsReporterConf): Done = {
     class SubscriberActor() extends Actor {
-      val slidingAverageSnapshot: SlidingAverageSnapshot = new SlidingAverageSnapshot(averagingWindow)
+      val slidingAverageSnapshot: SlidingAverageSnapshot = new SlidingAverageSnapshot(
+        Duration.ofSeconds(config.averagingWindow.get.getOrElse(60L))
+      )
 
       override def receive: Actor.Receive = {
         case snapshot: TickMetricSnapshot =>

--- a/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
@@ -178,7 +178,7 @@ object Metrics {
   def start(actorRefFactory: ActorRefFactory, config: MetricsReporterConf): Done = {
     class SubscriberActor() extends Actor {
       val slidingAverageSnapshot: SlidingAverageSnapshot = new SlidingAverageSnapshot(
-        Duration.ofSeconds(config.averagingWindow.get.getOrElse(30L))
+        Duration.ofSeconds(config.averagingWindowSizeSeconds.get.getOrElse(30L))
       )
 
       override def receive: Actor.Receive = {

--- a/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
@@ -178,7 +178,7 @@ object Metrics {
   def start(actorRefFactory: ActorRefFactory, config: MetricsReporterConf): Done = {
     class SubscriberActor() extends Actor {
       val slidingAverageSnapshot: SlidingAverageSnapshot = new SlidingAverageSnapshot(
-        Duration.ofSeconds(config.averagingWindow.get.getOrElse(60L))
+        Duration.ofSeconds(config.averagingWindow.get.getOrElse(30L))
       )
 
       override def receive: Actor.Receive = {

--- a/src/main/scala/mesosphere/marathon/metrics/MetricsReporterConf.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/MetricsReporterConf.scala
@@ -16,5 +16,12 @@ trait MetricsReporterConf extends ScallopConf {
     descr = "URL to dogstatsd agent. e.g. udp://localhost:8125?prefix=marathon-test&tags=marathon&interval=10",
     noshort = true
   )
+
+  lazy val averagingWindow = opt[Long](
+    "metrics_averaging_window",
+    descr = "The length of the average window on metrics (in seconds)",
+    noshort = true
+  )
+
 }
 

--- a/src/main/scala/mesosphere/marathon/metrics/MetricsReporterConf.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/MetricsReporterConf.scala
@@ -17,7 +17,7 @@ trait MetricsReporterConf extends ScallopConf {
     noshort = true
   )
 
-  lazy val averagingWindow = opt[Long](
+  lazy val averagingWindowSizeSeconds = opt[Long](
     "metrics_averaging_window",
     descr = "The length of the average window on metrics (in seconds)",
     noshort = true

--- a/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
@@ -2,23 +2,19 @@ package mesosphere.marathon
 package metrics
 
 import java.time.Duration
-import java.util.logging.Logger
 
-import akka.Done
-import akka.actor.{ Actor, ActorRefFactory, Props }
 import kamon.Kamon
-import kamon.metric.{ Entity, EntitySnapshot }
+import kamon.metric.{Entity, EntitySnapshot}
 import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import kamon.metric.instrument.CollectionContext
-import kamon.util.{ MapMerge, MilliTimestamp }
-import mesosphere.marathon.metrics.Metrics.subscribe
+import kamon.util.{MapMerge, MilliTimestamp}
 
 /**
   * Calculates sliding average entity snapshot
   */
-class SlidingAverageSnapshot(val averagingWindow: Duration) {
-  private val logger: Logger = Logger.getLogger(getClass.getName)
+class SlidingAverageSnapshot(val averagingWindow: Duration) extends StrictLogging {
 
   val collectionContext: CollectionContext = Kamon.metrics.buildDefaultCollectionContext
 
@@ -46,7 +42,7 @@ class SlidingAverageSnapshot(val averagingWindow: Duration) {
 
     // Warn for too low values
     if (fullFrames < 3) {
-      logger.warning(s"SlidingAverageReporter applied over a very small window (${fullFrames} frames), consider" +
+      logger.warn(s"SlidingAverageReporter applied over a very small window (${fullFrames} frames), consider" +
         " increasing averageWindow or decreasing `kamon.metric.tick-interval`!")
     }
 

--- a/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
@@ -1,0 +1,137 @@
+package mesosphere.marathon
+package metrics
+
+import java.time.Duration
+import java.util.logging.Logger
+
+import akka.Done
+import akka.actor.{ Actor, ActorRefFactory, Props }
+import kamon.Kamon
+import kamon.metric.{ Entity, EntitySnapshot }
+import com.typesafe.config.Config
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.instrument.CollectionContext
+import kamon.util.{ MapMerge, MilliTimestamp }
+import mesosphere.marathon.metrics.Metrics.subscribe
+
+/**
+  * Calculates sliding average entity snapshot
+  */
+class SlidingAverageSnapshot(val averagingWindow: Duration) {
+  private val logger: Logger = Logger.getLogger(getClass.getName)
+
+  val collectionContext: CollectionContext = Kamon.metrics.buildDefaultCollectionContext
+
+  /**
+    * The current summarised snapshot
+    */
+  private var currentSnapshot: TickMetricSnapshot = TickMetricSnapshot(MilliTimestamp.now, MilliTimestamp.now, Map.empty)
+
+  /**
+    * A ring buffer that collects the snapshots
+    */
+  private var averageRing: Array[TickMetricSnapshot] = ringFactory(Kamon.config)
+
+  /**
+    * The current index to the average ring buffer
+    */
+  private var averageIndex: Int = 0
+
+  /**
+    * Rebuilds the average ring, based on the current configuration
+    */
+  private def ringFactory(config: Config): Array[TickMetricSnapshot] = {
+    val tickInterval: Long = config.getDuration("kamon.metric.tick-interval").toMillis
+    val fullFrames: Int = (averagingWindow.toMillis.toFloat / tickInterval).ceil.toInt
+
+    // Warn for too low values
+    if (fullFrames < 3) {
+      logger.warning(s"SlidingAverageReporter applied over a very small window (${fullFrames} frames), consider" +
+        s" increasing averageWindow or decreasing `kamon.metric.tick-interval`!")
+    }
+
+    // Create an array with that many free slots, as the full ticks that fit within the duration requested
+    logger.info(s"Initialized sliding average reporter with ${fullFrames} frames")
+    Array.fill(fullFrames){null}
+  }
+
+  /**
+    * Combine all the metrics in the ring buffer and return an
+    * @return
+    */
+  private def combineRingMetrics: TickMetricSnapshot = {
+    var rangeFrom: MilliTimestamp = MilliTimestamp.now
+    var rangeTo: MilliTimestamp = MilliTimestamp.now
+    var combined: Option[Map[Entity, EntitySnapshot]] = None
+
+    // The averageIndex advances every time we insert something on the ring buffer.
+    // Therefore is pointing to the newest entry on the buffer.
+    // Going backwards we find the oldest values until we reach
+
+    // Start processing all the values of the ring buffer in incrementing index
+    // starting fro the oldest (the next value from the current index) to the
+    // newest (the current index).
+    val maxItems: Int = averageRing.length
+    for (i: Int <- 0 until maxItems) {
+      val idx = (averageIndex + i) % maxItems
+      val inst = averageRing(idx)
+
+      // Pass-through null entries
+      combined = inst match {
+        case null => combined
+        case _ => {
+          combined match {
+
+            // Initialize all iteration values at first index
+            case None => {
+              rangeFrom = inst.from
+              rangeTo = inst.to
+              Some(inst.metrics)
+            }
+
+            // Otherwise combine the current metrics and advance the upper range
+            case Some(current) => {
+              rangeTo = inst.to
+              Some(MapMerge.Syntax(current).merge(inst.metrics, (l, r) => l.merge(r, collectionContext)))
+            }
+          }
+        }
+      }
+    }
+
+    // Compose the snapshot from the combined data
+    TickMetricSnapshot(
+      rangeFrom,
+      rangeTo,
+      combined getOrElse Map()
+    )
+  }
+
+  /**
+    * Update the sliding average window with a new frame that should come at fixed intervals,
+    * as configured in `kamon.metric.tick-interval`
+    *
+    * @param snapshot The snaphot received from Kamon
+    * @return Returns the averaged values of the metrics
+    */
+  def updateWithTick(snapshot: TickMetricSnapshot): TickMetricSnapshot = {
+    // Put the tick metrics on the ring buffer
+    averageRing.update(averageIndex, snapshot)
+    averageIndex = (averageIndex + 1) % averageRing.length
+
+    // Update current snapshot and return it
+    currentSnapshot = combineRingMetrics
+    currentSnapshot
+  }
+
+  /**
+    * Collect the current snapshot
+    * @return
+    */
+  def snapshot(): TickMetricSnapshot = currentSnapshot
+
+  /**
+    * Get the size of the ring
+    */
+  def ringSize(): Int = averageRing.length
+}

--- a/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
@@ -64,10 +64,6 @@ class SlidingAverageSnapshot(val averagingWindow: Duration) {
     var rangeTo: MilliTimestamp = MilliTimestamp.now
     var combined: Option[Map[Entity, EntitySnapshot]] = None
 
-    // The averageIndex advances every time we insert something on the ring buffer.
-    // Therefore is pointing to the newest entry on the buffer.
-    // Going backwards we find the oldest values until we reach
-
     // Start processing all the values of the ring buffer in incrementing index
     // starting fro the oldest (the next value from the current index) to the
     // newest (the current index).

--- a/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
@@ -47,7 +47,7 @@ class SlidingAverageSnapshot(val averagingWindow: Duration) {
     // Warn for too low values
     if (fullFrames < 3) {
       logger.warning(s"SlidingAverageReporter applied over a very small window (${fullFrames} frames), consider" +
-        s" increasing averageWindow or decreasing `kamon.metric.tick-interval`!")
+        " increasing averageWindow or decreasing `kamon.metric.tick-interval`!")
     }
 
     // Create an array with that many free slots, as the full ticks that fit within the duration requested

--- a/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
+++ b/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
@@ -2,38 +2,12 @@ package mesosphere.marathon
 package metrics
 
 import java.time.Duration
-import java.util.concurrent.TimeUnit
 
-import akka.actor.{Actor, ActorSystem, Props}
 import com.typesafe.config.ConfigFactory
 import kamon.Kamon
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
-import kamon.metric.instrument.Gauge.CurrentValueCollector
 import kamon.util.MilliTimestamp
 import mesosphere.UnitTest
-
-import scala.concurrent.Await
-
-/**
-  * Since some tests are repeating the same actions, the `SlidingAverageSnapshotTestHandler` trait
-  * provides the interface the test cases can implement
-  */
-trait SlidingAverageSnapshotTestHandler {
-
-  /**
-    * Called when Kamon is initialized
-    * The test handler may now instantiate an instrument
-    */
-  def init(): Unit
-
-  /**
-    * Called on every tick so the test can push their values at known intervals
-    *
-    * @param snapshot The current tickSnapshot from Kamon
-    * @return Return TRUE to keep running or FALSE to complete the test
-    */
-  def tick(snapshot: TickMetricSnapshot): Boolean
-}
 
 class SlidingAverageSnapshotTest extends UnitTest {
 
@@ -45,228 +19,92 @@ class SlidingAverageSnapshotTest extends UnitTest {
         "kamon.metric.tick-interval = 123"
       ).withFallback(ConfigFactory.load()))
 
-      // Initialize sliding average window with 4 frames
+      // Check if the custom configuration had any effect
       val win: SlidingAverageSnapshot = new SlidingAverageSnapshot(Duration.ofMillis(123 * 4))
       win.ringSize shouldBe 4
     }
 
-    "should correctly merge histogram instruments within the averaging window" in {
-      var mostRecentTick: MilliTimestamp = MilliTimestamp.now
-      val metrics: TickMetricSnapshot = SlidingAverageSnapshotTest.runTestAndCollectMetrics(
-        tickIntervalMs = 100,
-        averagingWindowMs = 500,
-        new SlidingAverageSnapshotTestHandler {
-          private var histogram: kamon.metric.instrument.Histogram = _
-          private var index: Int = 0
+    "should correctly operate on empty ring buffer" in {
+      val win: SlidingAverageSnapshot = SlidingAverageSnapshotTest.ringFactory(4)
+      val s: TickMetricSnapshot = win.snapshot()
 
-          // When Kamon is ready, get a histogram
-          override def init(): Unit = {
-            histogram = Kamon.metrics.histogram("someHistogram")
-          }
-
-          // Put 10 samples (x100 ms step = 1 second) and exit on the 11th
-          override def tick(snapshot: TickMetricSnapshot): Boolean = {
-            mostRecentTick = MilliTimestamp.now
-            if (index > 10) false
-            else {
-              histogram.record(index)
-              index += 1
-              true
-            }
-          }
-        }
-      )
-
-      // The the `to` value should be close to our current time (100 ms tolerance)
-      (mostRecentTick.millis - metrics.to.millis).toInt should be < 100
-
-      // Time range from the metrics should be within the averaging window (10 ms tolerance)
-      (metrics.to.millis - metrics.from.millis).toInt should be(490 +- 510)
-
-      // The values in the histogram should contain the last 5 measurements and nothing
-      // from the previous ones
-      metrics.metrics.values.head.histograms.values.head.recordsIterator
-        .toStream.map(v => (v.level, v.count)) should be(Seq(
-        (6, 1), (7, 1), (8, 1), (9, 1), (10, 1)
-      ))
+      // The time span should be zero
+      s.from shouldBe s.to
     }
 
-    "should correctly merge counter instruments within the averaging window" in {
-      var mostRecentTick: MilliTimestamp = MilliTimestamp.now
-      val metrics: TickMetricSnapshot = SlidingAverageSnapshotTest.runTestAndCollectMetrics(
-        tickIntervalMs = 100,
-        averagingWindowMs = 500,
-        new SlidingAverageSnapshotTestHandler {
-          private var counter: kamon.metric.instrument.Counter = _
-          private var index: Int = 0
+    "should correctly operate on half-full ring buffer" in {
+      val win: SlidingAverageSnapshot = SlidingAverageSnapshotTest.ringFactory(4)
+      val ts0: MilliTimestamp = MilliTimestamp.now
+      val ts1: MilliTimestamp = MilliTimestamp(ts0.millis + 100)
+      val s1: TickMetricSnapshot = TickMetricSnapshot(ts0, ts1, Map())
 
-          // When Kamon is ready, get a histogram
-          override def init(): Unit = {
-            counter = Kamon.metrics.counter("someCounter")
-          }
+      // Insert snapshot
+      win.updateWithTick(TickMetricSnapshot(ts0, ts1, Map()))
 
-          // Increment the counter by 10 times over the course of 1 second
-          override def tick(snapshot: TickMetricSnapshot): Boolean = {
-            mostRecentTick = MilliTimestamp.now
-            if (index > 10) false
-            else {
-              counter.increment()
-              index += 1
-              true
-            }
-          }
-        }
-      )
-
-      // The the `to` value should be close to our current time (100 ms tolerance)
-      (mostRecentTick.millis - metrics.to.millis).toInt should be < 100
-
-      // Time range from the metrics should be within the averaging window (10 ms tolerance)
-      (metrics.to.millis - metrics.from.millis).toInt should be(490 +- 510)
-
-      // The counter takes in account the last 5 values in the window
-      metrics.metrics.values.head.counters.head._2.count.toInt should be (5)
+      // The time span should be of the first snapshot
+      val s: TickMetricSnapshot = win.snapshot()
+      s.from shouldBe ts0
+      s.to shouldBe ts1
     }
 
-    "should correctly merge min/max instruments within the averaging window" in {
-      var mostRecentTick: MilliTimestamp = MilliTimestamp.now
-      val metrics: TickMetricSnapshot = SlidingAverageSnapshotTest.runTestAndCollectMetrics(
-        tickIntervalMs = 100,
-        averagingWindowMs = 500,
-        new SlidingAverageSnapshotTestHandler {
-          import scala.concurrent.duration.{FiniteDuration, TimeUnit}
-          private var counter: kamon.metric.instrument.MinMaxCounter = _
-          private var index: Int = 0
+    "should correctly operate on a full ring buffer" in {
+      val win: SlidingAverageSnapshot = SlidingAverageSnapshotTest.ringFactory(4)
+      val ts0: MilliTimestamp = MilliTimestamp.now
+      val ts1: MilliTimestamp = MilliTimestamp(ts0.millis + 100)
+      val ts2: MilliTimestamp = MilliTimestamp(ts1.millis + 100)
+      val ts3: MilliTimestamp = MilliTimestamp(ts2.millis + 100)
+      val ts4: MilliTimestamp = MilliTimestamp(ts3.millis + 100)
 
-          // When Kamon is ready, get a histogram
-          override def init(): Unit = {
-            counter = Kamon.metrics.minMaxCounter(
-              "someCounter",
-              // For our tests we are using the same interval as our tick interval
-              // in order to advance the values on every tick.
-              FiniteDuration(100, TimeUnit.MILLISECONDS)
-            )
-          }
+      // Insert snapshots
+      win.updateWithTick(TickMetricSnapshot(ts0, ts1, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts1, ts2, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts2, ts3, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts3, ts4, Map()))
 
-          // Increment the counter by 10 times over the course of 1 second
-          override def tick(snapshot: TickMetricSnapshot): Boolean = {
-            mostRecentTick = MilliTimestamp.now
-            if (index > 10) false
-            else {
-              counter.increment()
-              index += 1
-              true
-            }
-          }
-        }
-      )
-
-      // The the `to` value should be close to our current time (100 ms tolerance)
-      (mostRecentTick.millis - metrics.to.millis).toInt should be < 100
-
-      // Time range from the metrics should be within the averaging window (10 ms tolerance)
-      (metrics.to.millis - metrics.from.millis).toInt should be(490 +- 510)
-
-      // The counter takes in account the last 5 values in the window
-      // (Note that we had 1 tick in the beginning, before the first `tick` method was called)
-      metrics.metrics.values.head.minMaxCounters.head._2.min.toInt should be (6)
-      metrics.metrics.values.head.minMaxCounters.head._2.max.toInt should be (11)
+      // The time span should at the bounds of the first and last snapshot
+      val s: TickMetricSnapshot = win.snapshot()
+      s.from shouldBe ts0
+      s.to shouldBe ts4
     }
 
-    "should correctly merge gauge instruments within the averaging window" in {
-      var mostRecentTick: MilliTimestamp = MilliTimestamp.now
-      val metrics: TickMetricSnapshot = SlidingAverageSnapshotTest.runTestAndCollectMetrics(
-        tickIntervalMs = 100,
-        averagingWindowMs = 500,
-        new SlidingAverageSnapshotTestHandler {
-          private var index: Int = 0
-          private var gauge: kamon.metric.instrument.Gauge = _
-          private val gaugeValueCollector: CurrentValueCollector = new CurrentValueCollector {
-            override def currentValue: Long = index
-          }
+    "should correctly operate on an overflown ring buffer" in {
+      val win: SlidingAverageSnapshot = SlidingAverageSnapshotTest.ringFactory(4)
+      val ts0: MilliTimestamp = MilliTimestamp.now
+      val ts1: MilliTimestamp = MilliTimestamp(ts0.millis + 100)
+      val ts2: MilliTimestamp = MilliTimestamp(ts1.millis + 100)
+      val ts3: MilliTimestamp = MilliTimestamp(ts2.millis + 100)
+      val ts4: MilliTimestamp = MilliTimestamp(ts3.millis + 100)
+      val ts5: MilliTimestamp = MilliTimestamp(ts4.millis + 100)
 
-          // When Kamon is ready, get a histogram
-          override def init(): Unit = {
-            gauge = Kamon.metrics.gauge("someGauge")(gaugeValueCollector)
-          }
+      // Insert snapshots
+      win.updateWithTick(TickMetricSnapshot(ts0, ts1, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts1, ts2, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts2, ts3, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts3, ts4, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts4, ts5, Map()))
 
-          // Increment the counter by 10 times over the course of 1 second
-          override def tick(snapshot: TickMetricSnapshot): Boolean = {
-            mostRecentTick = MilliTimestamp.now
-            if (index > 10) false
-            else {
-              index += 1
-              true
-            }
-          }
-        }
-      )
-
-      // The the `to` value should be close to our current time (100 ms tolerance)
-      (mostRecentTick.millis - metrics.to.millis).toInt should be < 100
-
-      // Time range from the metrics should be within the averaging window (10 ms tolerance)
-      (metrics.to.millis - metrics.from.millis).toInt should be(490 +- 510)
-
-      // The counter takes in account the last 5 values in the window
-      // (Note that we had 1 tick in the beginning, before the first `tick` method was called)
-      metrics.metrics.values.head.gauges.head._2.recordsIterator
-        .toStream.map(v => (v.level, v.count)) should be(Seq(
-        (7, 1), (8, 1), (9, 1), (10, 1), (11, 1) // (The extra tick)
-      ))
+      // The time span should at the bounds of the last four snapshots
+      val s: TickMetricSnapshot = win.snapshot()
+      s.from shouldBe ts1
+      s.to shouldBe ts5
     }
 
   }
+
 }
 
 object SlidingAverageSnapshotTest {
 
   /**
-    * Helper function to start an actor system, configure Kamon, run the tests and wait for the actor system
-    * to be shut down before returning the metrics collected so far by the averaging window snasphot
+    * Utility function to instantiate a `SlidingAverageSnapshot` class, having the correct
+    * number of frames in it's buffer.
     *
-    * @param tickIntervalMs    How frequently Kamon should call the tick function (in ms)
-    * @param averagingWindowMs How long is the averaging window (in ms)
-    * @param testHandler       The handler for this test case
-    * @return Returns the final
+    * @param frameCount The number of frames desired in the average ring buffer
+    * @return Returns a new instance of `SlidingAverageSnapshot`
     */
-  def runTestAndCollectMetrics(tickIntervalMs: Long,
-                               averagingWindowMs: Long,
-                               testHandler: SlidingAverageSnapshotTestHandler): TickMetricSnapshot = {
-    val system = ActorSystem()
-
-    // Configure Kamon and the averaging window with the arguments given
-    Kamon.start(ConfigFactory
-      .parseString(s"kamon.metric.tick-interval = $tickIntervalMs").withFallback(ConfigFactory.load()))
-    val averagingSnapshot: SlidingAverageSnapshot = new SlidingAverageSnapshot(Duration.ofMillis(averagingWindowMs))
-
-    // The metrics at the end of the test
-    var metrics: TickMetricSnapshot = TickMetricSnapshot(MilliTimestamp.now, MilliTimestamp.now, Map())
-
-    // Now that Kamon is ready we can initialize the test handler
-    testHandler.init()
-
-    // Register an actor that is going to receive TickMetricSnapshots and advance the tests
-    // at the same time, in order to mitigate delay-induced race conditions on the test
-    class SubscriberActor() extends Actor {
-      override def receive: Actor.Receive = {
-        case snapshot: TickMetricSnapshot =>
-          // Collect average from the previous run and call out to start new run
-          metrics = averagingSnapshot.updateWithTick(snapshot)
-          if (!testHandler.tick(snapshot)) system.terminate()
-      }
-    }
-    Kamon.metrics.subscribe(AcceptAllFilter, system.actorOf(Props(new SubscriberActor)))
-
-    // Wait for the system to be terminated (wait a bit more than the test duration)
-    import scala.concurrent.duration._
-    Await.result(system.whenTerminated, 30 seconds)
-
-    // Shut down kamon when done
-    Kamon.shutdown()
-
-    // Return the metrics collected
-    metrics
+  def ringFactory(frameCount: Int): SlidingAverageSnapshot = {
+    val tickInterval: Long = Kamon.config.getDuration("kamon.metric.tick-interval").toMillis
+    new SlidingAverageSnapshot(Duration.ofMillis(tickInterval * frameCount))
   }
 
 }

--- a/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
+++ b/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
@@ -171,6 +171,9 @@ object SlidingAverageSnapshotTest {
     import scala.concurrent.duration._
     Await.result(system.whenTerminated, 30 seconds)
 
+    // Shut down kamon when done
+    Kamon.shutdown()
+
     // Return the metrics collected
     metrics
   }

--- a/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
+++ b/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
@@ -1,4 +1,5 @@
-package mesosphere.marathon.metrics
+package mesosphere.marathon
+package metrics
 
 import java.time.Duration
 import java.util.concurrent.TimeUnit

--- a/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
+++ b/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
@@ -1,0 +1,179 @@
+package mesosphere.marathon.metrics
+
+import java.time.Duration
+
+import akka.actor.{Actor, ActorSystem, Props}
+import com.typesafe.config.ConfigFactory
+import kamon.Kamon
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.util.MilliTimestamp
+import mesosphere.UnitTest
+
+import scala.concurrent.Await
+
+/**
+  * Since some tests are repeating the same actions, the `SlidingAverageSnapshotTestHandler` trait
+  * provides the interface the test cases can implement
+  */
+trait SlidingAverageSnapshotTestHandler {
+
+  /**
+    * Called when Kamon is initialized
+    * The test handler may now instantiate an instrument
+    */
+  def init(): Unit
+
+  /**
+    * Called on every tick so the test can push their values at known intervals
+    *
+    * @param snapshot The current tickSnapshot from Kamon
+    * @return Return TRUE to keep running or FALSE to complete the test
+    */
+  def tick(snapshot: TickMetricSnapshot): Boolean
+}
+
+class SlidingAverageSnapshotTest extends UnitTest {
+
+  "Sliding Average Snapshot" should {
+
+    "should correctly be configured using the `kamon.metric.tick-interval` parameter" in {
+      // Start Kamon with custom parameters
+      Kamon.start(ConfigFactory.parseString(
+        "kamon.metric.tick-interval = 123"
+      ).withFallback(ConfigFactory.load()))
+
+      // Initialize sliding average window with 4 frames
+      val win: SlidingAverageSnapshot = new SlidingAverageSnapshot(Duration.ofMillis(123 * 4))
+      win.ringSize shouldBe 4
+    }
+
+    "should correctly average histograms" in {
+      var mostRecentTick: MilliTimestamp = MilliTimestamp.now
+      val metrics: TickMetricSnapshot = SlidingAverageSnapshotTest.runTestAndCollectMetrics(
+        tickIntervalMs = 100,
+        averagingWindowMs = 500,
+        new SlidingAverageSnapshotTestHandler {
+          private var histogram: kamon.metric.instrument.Histogram = _
+          private var index: Int = 0
+
+          // When Kamon is ready, get a histogram
+          override def init(): Unit = {
+            histogram = Kamon.metrics.histogram("someHistogram")
+          }
+
+          // Put 10 samples (x100 ms step = 1 second) and exit on the 11th
+          override def tick(snapshot: TickMetricSnapshot): Boolean = {
+            mostRecentTick = MilliTimestamp.now
+            if (index > 10) false
+            else {
+              histogram.record(index)
+              index += 1
+              true
+            }
+          }
+        }
+      )
+
+      // The the `to` value should be close to our current time (100 ms tolerance)
+      (mostRecentTick.millis - metrics.to.millis).toInt should be < 100
+
+      // Time range from the metrics should be within the averaging window (10 ms tolerance)
+      (metrics.to.millis - metrics.from.millis).toInt should be(490 +- 510)
+
+      // The values in the histogram should contain the last 5 measurements and nothing
+      // from the previous ones
+      metrics.metrics.values.head.histograms.values.head.recordsIterator
+        .toStream.map(v => (v.level, v.count)) should be(Seq(
+        (6, 1), (7, 1), (8, 1), (9, 1), (10, 1)
+      ))
+    }
+
+    "should monotonically increase counters" in {
+      var mostRecentTick: MilliTimestamp = MilliTimestamp.now
+      val metrics: TickMetricSnapshot = SlidingAverageSnapshotTest.runTestAndCollectMetrics(
+        tickIntervalMs = 100,
+        averagingWindowMs = 500,
+        new SlidingAverageSnapshotTestHandler {
+          private var counter: kamon.metric.instrument.Counter = _
+          private var index: Int = 0
+
+          // When Kamon is ready, get a histogram
+          override def init(): Unit = {
+            counter = Kamon.metrics.counter("someCounter")
+          }
+
+          // Increment the counter by 10 times over the course of 1 second
+          override def tick(snapshot: TickMetricSnapshot): Boolean = {
+            mostRecentTick = MilliTimestamp.now
+            if (index > 10) false
+            else {
+              counter.increment()
+              index += 1
+              true
+            }
+          }
+        }
+      )
+
+      // The the `to` value should be close to our current time (100 ms tolerance)
+      (mostRecentTick.millis - metrics.to.millis).toInt should be < 100
+
+      // Time range from the metrics should be within the averaging window (10 ms tolerance)
+      (metrics.to.millis - metrics.from.millis).toInt should be(490 +- 510)
+
+      // The values in the histogram should contain the last 5 measurements and nothing
+      // from the previous ones
+      metrics.metrics.values.head.counters.head._2.count.toInt should be (10)
+    }
+
+  }
+}
+
+object SlidingAverageSnapshotTest {
+
+  /**
+    * Helper function to start an actor system, configure Kamon, run the tests and wait for the actor system
+    * to be shut down before returning the metrics collected so far by the averaging window snasphot
+    *
+    * @param tickIntervalMs    How frequently Kamon should call the tick function (in ms)
+    * @param averagingWindowMs How long is the averaging window (in ms)
+    * @param testHandler       The handler for this test case
+    * @return Returns the final
+    */
+  def runTestAndCollectMetrics(tickIntervalMs: Long,
+                               averagingWindowMs: Long,
+                               testHandler: SlidingAverageSnapshotTestHandler): TickMetricSnapshot = {
+    val system = ActorSystem()
+
+    // Configure Kamon and the averaging window with the arguments given
+    Kamon.start(ConfigFactory
+      .parseString(s"kamon.metric.tick-interval = $tickIntervalMs").withFallback(ConfigFactory.load()))
+    val averagingSnapshot: SlidingAverageSnapshot = new SlidingAverageSnapshot(Duration.ofMillis(averagingWindowMs))
+
+    // The metrics at the end of the test
+    var metrics: TickMetricSnapshot = TickMetricSnapshot(MilliTimestamp.now, MilliTimestamp.now, Map())
+
+    // Now that Kamon is ready we can initialize the test handler
+    testHandler.init()
+
+    // Register an actor that is going to receive TickMetricSnapshots and advance the tests
+    // at the same time, in order to mitigate delay-induced race conditions on the test
+    class SubscriberActor() extends Actor {
+      override def receive: Actor.Receive = {
+        case snapshot: TickMetricSnapshot =>
+          // Collect average from the previous run and call out to start new run
+          metrics = averagingSnapshot.updateWithTick(snapshot)
+          if (!testHandler.tick(snapshot)) system.terminate()
+      }
+    }
+    Kamon.metrics.subscribe(AcceptAllFilter, system.actorOf(Props(new SubscriberActor)))
+
+    // Wait for the system to be terminated (wait a bit more than the test duration)
+    import scala.concurrent.duration._
+    Await.result(system.whenTerminated, 30 seconds)
+
+    // Return the metrics collected
+    metrics
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
+++ b/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
@@ -121,9 +121,8 @@ class SlidingAverageSnapshotTest extends UnitTest {
       // Time range from the metrics should be within the averaging window (10 ms tolerance)
       (metrics.to.millis - metrics.from.millis).toInt should be(490 +- 510)
 
-      // The values in the histogram should contain the last 5 measurements and nothing
-      // from the previous ones
-      metrics.metrics.values.head.counters.head._2.count.toInt should be (10)
+      // The counter takes in account the last 5 values in the window
+      metrics.metrics.values.head.counters.head._2.count.toInt should be (5)
     }
 
   }


### PR DESCRIPTION
This PR introduces the `SlidingAverageSnapshot` class that can be used to compute the average values for the metrics presented in the `/metrics` endpoint.

Related JIRA: [MARATHON-8104](https://jira.mesosphere.com/browse/MARATHON-8104)

## More Details

Kamon publishes the `TickMetricSnapshot` at configurable intervals (with the `kamon.metric.tick-interval ` parameter), containing the current snapshot of all metrics. Marathon implements the `/metrics` endpoint by plugging a custom reporter.

Currently we are merging all these snapshots into a single `TickMetricSnapshot` since the beginning of time. This PR changes this by introducing a `SlidingAverageSnapshot` class that is used by our custom reporter to keep track of only the last X snapshots.

This is implemented using a ring buffer where the snapshots are stored, effectively creating a "Sliding average window" for the last X snapshots. To configure the size of the window the user should tweak the `kamon.metric.tick-interval` parameter and the `metrics_averaging_window` parameter.