### PR TITLE
Backport: Implement gpu_scheduling_behavior parameter and basic functionality

### DIFF
--- a/docs/docs/rest-api/public/api/v2/examples/queue.json
+++ b/docs/docs/rest-api/public/api/v2/examples/queue.json
@@ -145,9 +145,9 @@
             "processed": 23
           },
           {
-            "reason": "InsufficientGpus",
+            "reason": "DeclinedScarceResources",
             "declined": 0,
-            "processed": 23
+            "processed": 11
           }
         ],
         "rejectSummaryLaunchAttempt": [
@@ -187,9 +187,9 @@
             "processed": 46
           },
           {
-            "reason": "InsufficientGpus",
+            "reason": "DeclinedScarceResources",
             "declined": 0,
-            "processed": 46
+            "processed": 31
           }
         ]
       },

--- a/src/main/scala/mesosphere/marathon/GpuSchedulingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/GpuSchedulingBehavior.scala
@@ -1,0 +1,7 @@
+package mesosphere.marathon
+
+object GpuSchedulingBehavior {
+  final val Undefined: String = "undefined"
+  final val Restricted: String = "restricted"
+  final val Unrestricted: String = "unrestricted"
+}

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -309,5 +309,34 @@ trait MarathonConf
     noshort = true,
     hidden = true,
     default = Some(MesosHeartbeatMonitor.DEFAULT_HEARTBEAT_FAILURE_THRESHOLD))
+
+  lazy val drainingSeconds = opt[Long](
+    "draining_seconds",
+    descr = "(Default: 0 seconds) the seconds when marathon will start declining offers before a maintenance " +
+      "window start time. This is only evaluated if `maintenance_mode` is in the set of `enable_features`!",
+    default = Some(0)
+  )
+
+  private[this] def validateGpuSchedulingBehavior(setting: String): Boolean = {
+    val allowedSettings = Set(GpuSchedulingBehavior.Undefined, GpuSchedulingBehavior.Restricted, GpuSchedulingBehavior.Unrestricted)
+    require(
+      isFeatureSet(Features.GPU_RESOURCES) || setting == GpuSchedulingBehavior.Undefined,
+      "gpu_resources must be set in order to use gpu_scheduling_behavior"
+    )
+    require(
+      allowedSettings.contains(setting),
+      s"Setting $setting is invalid. Valid settings are ${allowedSettings.mkString(", ")}"
+    )
+    true
+  }
+
+  lazy val gpuSchedulingBehavior = opt[String](
+    name = "gpu_scheduling_behavior",
+    descr = "Defines how offered GPU resources should be treated. Possible settings are `undefined`, `restricted` and " +
+    "`unrestricted`",
+    noshort = true,
+    default = Some(GpuSchedulingBehavior.Undefined),
+    validate = validateGpuSchedulingBehavior
+  )
 }
 

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -69,7 +69,7 @@ class InstanceOpFactoryImpl(
       config.mesosBridgeName())
 
     val matchedOffer =
-      RunSpecOfferMatcher.matchOffer(pod, request.offer, request.instances, builderConfig.acceptedResourceRoles)
+      RunSpecOfferMatcher.matchOffer(pod, request.offer, request.instances, builderConfig.acceptedResourceRoles, config)
 
     matchedOffer match {
       case matches: ResourceMatchResponse.Match =>
@@ -91,7 +91,7 @@ class InstanceOpFactoryImpl(
     val InstanceOpFactory.Request(runSpec, offer, instances, _) = request
 
     val matchResponse =
-      RunSpecOfferMatcher.matchOffer(app, offer, instances.values.toIndexedSeq, config.defaultAcceptedResourceRolesSet)
+      RunSpecOfferMatcher.matchOffer(app, offer, instances.values.toIndexedSeq, config.defaultAcceptedResourceRolesSet, config)
     matchResponse match {
       case matches: ResourceMatchResponse.Match =>
         val taskId = Task.Id.forRunSpec(app.id)
@@ -134,7 +134,7 @@ class InstanceOpFactoryImpl(
      *  - if we don't: skip for now
      *
      * Scenario 2:
-     *  We ned to reserve resources and receive an offer that has matching resources
+     *  We need to reserve resources and receive an offer that has matching resources
      *  - schedule a ReserveAndCreate TaskOp
      */
 
@@ -157,7 +157,9 @@ class InstanceOpFactoryImpl(
           ResourceMatcher.matchResources(
             offer, runSpec, instancesToConsiderForConstraints,
             ResourceSelector.reservedWithLabels(rolesToConsider, reservationLabels),
-            schedulerPlugins
+            config,
+            schedulerPlugins,
+            request.reserved
           )
 
         resourceMatchResponse match {
@@ -184,6 +186,7 @@ class InstanceOpFactoryImpl(
 
       val resourceMatchResponse =
         ResourceMatcher.matchResources(offer, runSpec, instances.valuesIterator.toStream, ResourceSelector.reservable,
+          config,
           schedulerPlugins)
       resourceMatchResponse match {
         case matches: ResourceMatchResponse.Match =>

--- a/src/main/scala/mesosphere/mesos/NoOfferMatchReason.scala
+++ b/src/main/scala/mesosphere/mesos/NoOfferMatchReason.scala
@@ -13,6 +13,7 @@ object NoOfferMatchReason {
   case object UnfulfilledRole extends NoOfferMatchReason
   case object UnfulfilledConstraint extends NoOfferMatchReason
   case object NoCorrespondingReservationFound extends NoOfferMatchReason
+  case object DeclinedScarceResources extends NoOfferMatchReason
 
   /**
     * This sequence is used to funnel reasons for not matching an offer.
@@ -27,7 +28,8 @@ object NoOfferMatchReason {
     InsufficientMemory,
     InsufficientDisk,
     InsufficientGpus,
-    InsufficientPorts
+    InsufficientPorts,
+    DeclinedScarceResources
   )
 
   def fromResourceType(name: String): NoOfferMatchReason = name match {

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -1,6 +1,7 @@
 package mesosphere.mesos
 
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.{ Features, GpuSchedulingBehavior, MarathonConf }
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.plugin.scheduler.SchedulerPlugin
@@ -129,8 +130,14 @@ object ResourceMatcher extends StrictLogging {
     * resources, the disk resources for the local volumes are included since they must become part of
     * the reservation.
     */
-  def matchResources(offer: Offer, runSpec: RunSpec, knownInstances: => Seq[Instance],
-    selector: ResourceSelector, schedulerPlugins: Seq[SchedulerPlugin] = Seq.empty): ResourceMatchResponse = {
+  def matchResources(
+    offer: Offer,
+    runSpec: RunSpec,
+    knownInstances: => Seq[Instance],
+    selector: ResourceSelector,
+    conf: MarathonConf,
+    schedulerPlugins: Seq[SchedulerPlugin] = Seq.empty,
+    reservedInstances: Seq[Instance] = Seq.empty): ResourceMatchResponse = {
 
     val groupedResources: Map[Role, Seq[Protos.Resource]] = offer.getResourcesList.groupBy(_.getName).map { case (k, v) => k -> v.to[Seq] }
 
@@ -161,6 +168,11 @@ object ResourceMatcher extends StrictLogging {
     val noOfferMatchReasons = scalarMatchResults
       .filter(scalar => !scalar.matches)
       .map(scalar => NoOfferMatchReason.fromResourceType(scalar.resourceName)).toBuffer
+
+    var onMatchActions: Vector[() => Unit] = Vector.empty
+    def addOnMatch(action: () => Unit) = {
+      onMatchActions :+= action
+    }
 
     // Current mesos implementation will only send resources with one distinct role assigned.
     // If not a single resource (matching the resource selector) was found, a NoOfferMatchReason.UnmatchedRole
@@ -195,11 +207,40 @@ object ResourceMatcher extends StrictLogging {
       badConstraints.isEmpty
     }
 
+    val checkGpuSchedulingBehaviour: Boolean = {
+      val availableGPUs = groupedResources.getOrElse(Resource.GPUS, Nil).foldLeft(0.0)(_ + _.getScalar.getValue)
+      val gpuResourcesAreWasted = availableGPUs > 0 && runSpec.resources.gpus == 0
+      conf.gpuSchedulingBehavior() match {
+        case GpuSchedulingBehavior.Undefined =>
+          if (gpuResourcesAreWasted) {
+            addOnMatch(() => logger.warn(s"Runspec [${runSpec.id}] doesn't require any GPU resources but " +
+              "will be launched on an agent with GPU resources."))
+          }
+          true
+
+        case GpuSchedulingBehavior.Restricted =>
+          val noPersistentVolumeToMatch = PersistentVolumeMatcher.matchVolumes(offer, reservedInstances).isEmpty
+          if (gpuResourcesAreWasted && noPersistentVolumeToMatch) {
+            noOfferMatchReasons += NoOfferMatchReason.DeclinedScarceResources
+            false
+          } else {
+            addOnMatch(() => logger.warn(s"Runspec [${runSpec.id}] doesn't require any GPU resources but " +
+              "will be launched on an agent with GPU resources due to required persistent volume."))
+            true
+          }
+
+        case GpuSchedulingBehavior.Unrestricted =>
+          true
+      }
+    }
+
     val resourceMatchOpt = if (scalarMatchResults.forall(_.matches)
       && meetsAllConstraints
+      && checkGpuSchedulingBehaviour
       && schedulerPlugins.forall(_.isMatch(offer, runSpec))) {
       portsMatchOpt match {
         case Some(portsMatch) =>
+          onMatchActions.foreach(action => action.apply())
           Some(ResourceMatch(scalarMatchResults.collect { case m: ScalarMatch => m }, portsMatch))
         case None =>
           // Add ports to noOfferMatchReasons

--- a/src/main/scala/mesosphere/mesos/RunSpecOfferMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/RunSpecOfferMatcher.scala
@@ -2,6 +2,7 @@ package mesosphere.mesos
 
 import com.google.protobuf.TextFormat
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.state.{ AppDefinition, RunSpec }
@@ -18,7 +19,12 @@ object RunSpecOfferMatcher extends StrictLogging {
     * @param knownInstances All instances associated with the given runSpec, needed to validate constraints
     * @param givenAcceptedResourceRoles The resource roles for which to look.
     */
-  def matchOffer(runSpec: RunSpec, offer: Offer, knownInstances: => Seq[Instance], givenAcceptedResourceRoles: Set[String]): ResourceMatchResponse = {
+  def matchOffer(
+    runSpec: RunSpec,
+    offer: Offer,
+    knownInstances: => Seq[Instance],
+    givenAcceptedResourceRoles: Set[String],
+    conf: MarathonConf): ResourceMatchResponse = {
     val acceptedResourceRoles: Set[String] = {
       val roles = if (runSpec.acceptedResourceRoles.isEmpty) {
         givenAcceptedResourceRoles
@@ -30,7 +36,7 @@ object RunSpecOfferMatcher extends StrictLogging {
     }
 
     val resourceMatchResponse =
-      ResourceMatcher.matchResources(offer, runSpec, knownInstances, ResourceSelector.any(acceptedResourceRoles))
+      ResourceMatcher.matchResources(offer, runSpec, knownInstances, ResourceSelector.any(acceptedResourceRoles), conf)
 
     def logInsufficientResources(): Unit = {
       val runSpecHostPorts = runSpec match {

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -825,7 +825,7 @@ class MesosHealthCheckTest extends UnitTest {
     val config = MarathonTestHelper.defaultConfig()
     val taskId = Task.Id.forRunSpec(app.id)
     val builder = new TaskBuilder(app, taskId, config)
-    val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, Seq.empty, config.defaultAcceptedResourceRolesSet)
+    val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, Seq.empty, config.defaultAcceptedResourceRolesSet, config)
     resourceMatch match {
       case matches: ResourceMatchResponse.Match => Some(builder.build(offer, matches.resourceMatch, None))
       case _ => None

--- a/src/test/scala/mesosphere/marathon/raml/QueueInfoConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/QueueInfoConversionTest.scala
@@ -50,8 +50,15 @@ class QueueInfoConversionTest extends UnitTest {
         OfferMatchResult.NoMatch(app, offer, Seq(NoOfferMatchReason.InsufficientCpus), now),
         OfferMatchResult.NoMatch(app, offer, Seq(NoOfferMatchReason.InsufficientMemory), now)
       )
-      val summary: Map[NoOfferMatchReason, Int] = Map(NoOfferMatchReason.InsufficientCpus -> 75, NoOfferMatchReason.InsufficientMemory -> 15, NoOfferMatchReason.InsufficientDisk -> 10)
-      val lastSummary: Map[NoOfferMatchReason, Int] = Map(NoOfferMatchReason.InsufficientCpus -> 3, NoOfferMatchReason.InsufficientMemory -> 1)
+      val summary: Map[NoOfferMatchReason, Int] = Map(
+        NoOfferMatchReason.InsufficientCpus -> 75,
+        NoOfferMatchReason.InsufficientMemory -> 15,
+        NoOfferMatchReason.InsufficientDisk -> 10
+      )
+      val lastSummary: Map[NoOfferMatchReason, Int] = Map(
+        NoOfferMatchReason.InsufficientCpus -> 3,
+        NoOfferMatchReason.InsufficientMemory -> 1
+      )
       val offersSummary: Seq[DeclinedOfferStep] = List(
         DeclinedOfferStep("UnfulfilledRole", 0, 123),
         DeclinedOfferStep("UnfulfilledConstraint", 0, 123),
@@ -60,7 +67,8 @@ class QueueInfoConversionTest extends UnitTest {
         DeclinedOfferStep("InsufficientMemory", 15, 48), // 48 - 15 = 33
         DeclinedOfferStep("InsufficientDisk", 10, 33), // 33 - 10 = 23
         DeclinedOfferStep("InsufficientGpus", 0, 23),
-        DeclinedOfferStep("InsufficientPorts", 0, 23)
+        DeclinedOfferStep("InsufficientPorts", 0, 23),
+        DeclinedOfferStep("DeclinedScarceResources", 0, 23)
       )
       val lastOffersSummary: Seq[DeclinedOfferStep] = List(
         DeclinedOfferStep("UnfulfilledRole", 0, 4),
@@ -70,7 +78,8 @@ class QueueInfoConversionTest extends UnitTest {
         DeclinedOfferStep("InsufficientMemory", 1, 1), // 1 - 1 = 0
         DeclinedOfferStep("InsufficientDisk", 0, 0),
         DeclinedOfferStep("InsufficientGpus", 0, 0),
-        DeclinedOfferStep("InsufficientPorts", 0, 0)
+        DeclinedOfferStep("InsufficientPorts", 0, 0),
+        DeclinedOfferStep("DeclinedScarceResources", 0, 0)
       )
 
       val info = QueuedInstanceInfoWithStatistics(app, inProgress = true,

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -406,6 +406,11 @@ object MarathonTestHelper {
       .build()
   }
 
+  def addVolumesToOffer(offer: Offer.Builder, taskId: Task.Id, localVolumeIds: Task.LocalVolumeId*): Offer.Builder = {
+    offer
+      .addAllResources(persistentVolumeResources(taskId, localVolumeIds: _*).asJava)
+  }
+
   def appWithPersistentVolume(): AppDefinition = {
     MarathonTestHelper.makeBasicApp().copy(
       container = Some(mesosContainerWithPersistentVolume),

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1249,7 +1249,7 @@ class TaskBuilderTest extends UnitTest {
       val s = Seq(t1, t2)
 
       val config = MarathonTestHelper.defaultConfig()
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, s, config.defaultAcceptedResourceRolesSet)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, s, config.defaultAcceptedResourceRolesSet, config)
       assert(resourceMatch.isInstanceOf[ResourceMatchResponse.Match])
       // TODO test for resources etc.
     }
@@ -1272,7 +1272,7 @@ class TaskBuilderTest extends UnitTest {
       val taskId = Task.Id.forRunSpec(app.id)
       val builder = new TaskBuilder(app, taskId, config)
       def shouldBuildTask(message: String, offer: Offer): Unit = {
-        val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq, config.defaultAcceptedResourceRolesSet)
+        val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq, config.defaultAcceptedResourceRolesSet, config)
         withClue(message) {
           assert(resourceMatch.isInstanceOf[ResourceMatchResponse.Match])
         }
@@ -1291,7 +1291,7 @@ class TaskBuilderTest extends UnitTest {
       }
 
       def shouldNotBuildTask(message: String, offer: Offer): Unit = {
-        val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq, config.defaultAcceptedResourceRolesSet)
+        val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq, config.defaultAcceptedResourceRolesSet, config)
         assert(resourceMatch.isInstanceOf[ResourceMatchResponse.NoMatch], message)
       }
 
@@ -1336,7 +1336,7 @@ class TaskBuilderTest extends UnitTest {
       val config = MarathonTestHelper.defaultConfig()
       val builder = new TaskBuilder(app, taskId, config)
       def shouldBuildTask(offer: Offer): Unit = {
-        val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq, config.defaultAcceptedResourceRolesSet)
+        val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq, config.defaultAcceptedResourceRolesSet, config)
         assert(resourceMatch.isInstanceOf[ResourceMatchResponse.Match])
         val matches = resourceMatch.asInstanceOf[ResourceMatchResponse.Match]
         val (taskInfo, networkInfo) = builder.build(offer, matches.resourceMatch, None)
@@ -1354,7 +1354,7 @@ class TaskBuilderTest extends UnitTest {
       }
 
       def shouldNotBuildTask(message: String, offer: Offer): Unit = {
-        val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq, config.defaultAcceptedResourceRolesSet)
+        val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq, config.defaultAcceptedResourceRolesSet, config)
         assert(resourceMatch.isInstanceOf[ResourceMatchResponse.NoMatch], message)
       }
 
@@ -1838,7 +1838,7 @@ class TaskBuilderTest extends UnitTest {
       val builder = new TaskBuilder(app, taskId, config)
       val runningInstances = Set.empty[Instance]
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq, config.defaultAcceptedResourceRolesSet)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq, config.defaultAcceptedResourceRolesSet, config)
       assert(resourceMatch.isInstanceOf[ResourceMatchResponse.Match])
       val matches = resourceMatch.asInstanceOf[ResourceMatchResponse.Match]
       val (taskInfo, _) = builder.build(offer, matches.resourceMatch, None)
@@ -1886,7 +1886,7 @@ class TaskBuilderTest extends UnitTest {
         envVarsPrefix = envVarsPrefix))
 
     val config = MarathonTestHelper.defaultConfig()
-    val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, Seq.empty, acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet))
+    val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, Seq.empty, acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet), config)
 
     resourceMatch match {
       case matches: ResourceMatchResponse.Match => Some(builder.build(offer, matches.resourceMatch, None))

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration._
 class TaskGroupBuilderTest extends UnitTest with Inside {
 
   implicit val clock = new SettableClock()
-  val config = AllConf.withTestConfig()
+  implicit val config = AllConf.withTestConfig()
 
   val defaultBuilderConfig = TaskGroupBuilder.BuilderConfig(
     acceptedResourceRoles = Set(ResourceRole.Unreserved),
@@ -74,7 +74,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
           )
         )
       )
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
         offer,
@@ -107,7 +107,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
           )
         )
       )
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
         offer,
@@ -144,7 +144,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         )
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -201,7 +201,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         user = Some("user")
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -238,7 +238,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         labels = Map("a" -> "a", "b" -> "b")
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (executorInfo, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -292,7 +292,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         )
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, instanceId) = TaskGroupBuilder.build(
         podSpec,
@@ -341,7 +341,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         labels = Map("a" -> "a")
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -431,7 +431,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         )
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -494,7 +494,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
           )
         )
       )
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -548,7 +548,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
               ))
           )))
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -609,7 +609,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         )
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -678,7 +678,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         )
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -739,7 +739,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         )
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (executorInfo, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -783,7 +783,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         )
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -819,7 +819,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         executorResources = Resources(cpus = 20.0)
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (executorInfo, _, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -879,7 +879,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         )
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (executorInfo, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -972,7 +972,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         )
       )
 
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -1013,7 +1013,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 4.1, mem = 1056.0, disk = 10.0).build
       val container = MesosContainer(name = "foo", resources = raml.Resources(cpus = 1.0f, mem = 128.0f))
       val podSpec = PodDefinition(id = "/product/frontend".toPath, containers = Seq(container))
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
 
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
@@ -1050,7 +1050,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
         lifecycle = Some(Lifecycle(Some(killDuration.toSeconds))))
 
       val podSpec = PodDefinition(id = PathId("/tty"), containers = Seq(container))
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles)
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Seq.empty, defaultBuilderConfig.acceptedResourceRoles, config)
       val (_, taskGroupInfo, _, _) = TaskGroupBuilder.build(
         podSpec,
         offer,


### PR DESCRIPTION
Summary: Implemented a new GPU-aware offer matching logic, command line flags, RAML examples and unit test

JIRA issues: MARATHON-8088

(cherry picked from commit faa801c)

