### PR TITLE
Do not start more instances than needed

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -340,9 +340,9 @@ private class TaskLauncherActor(
   }
 
   private[this] def replyWithQueuedInstanceCount(): Unit = {
-    val instancesLaunched = instanceMap.values.count(_.isLaunched)
+    val instancesLaunched = instanceMap.values.count(instance => instance.isLaunched || instance.isReserved)
     val instancesLaunchesInFlight = inFlightInstanceOperations.keys
-      .count(instanceId => instanceMap.get(instanceId).exists(_.isLaunched))
+      .count(instanceId => instanceMap.get(instanceId).exists(instance => instance.isLaunched || instance.isReserved))
     sender() ! QueuedInstanceInfo(
       runSpec,
       inProgress = instancesToLaunch > 0 || inFlightInstanceOperations.nonEmpty,

--- a/src/test/scala/mesosphere/marathon/integration/MarathonStartupIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MarathonStartupIntegrationTest.scala
@@ -1,18 +1,18 @@
 package mesosphere.marathon
 package integration
 
-import akka.stream.scaladsl.{Sink, Source, Tcp}
-import mesosphere.{AkkaIntegrationTest, FutureTestSupport}
+import akka.stream.scaladsl.{ Sink, Source, Tcp }
+import mesosphere.{ AkkaIntegrationTest, FutureTestSupport }
 import mesosphere.marathon.integration.setup._
 import mesosphere.util.PortAllocator
 import org.scalatest.concurrent.Eventually
 
 @IntegrationTest
 class MarathonStartupIntegrationTest extends AkkaIntegrationTest
-  with MesosClusterTest
-  with ZookeeperServerTest
-  with FutureTestSupport
-  with Eventually {
+    with MesosClusterTest
+    with ZookeeperServerTest
+    with FutureTestSupport
+    with Eventually {
 
   def withBoundPort(fn: Int => Unit): Unit = {
     val port = PortAllocator.ephemeralPort()


### PR DESCRIPTION
When determining how many instances to launch during deployments
and scale checks, do account for `isReserved` instances, otherwise
Marathon starts extra instances in case of apps and pods with
persistent volumes.

JIRA issues: MARATHON-7751