### PR TITLE
Disable Connection Pooling for HTTP Health Checks

### DIFF
--- a/src/test/scala/mesosphere/ValidationTestLike.scala
+++ b/src/test/scala/mesosphere/ValidationTestLike.scala
@@ -1,14 +1,14 @@
 package mesosphere
 
-import com.wix.accord.Descriptions.{Generic, Path}
+import com.wix.accord.Descriptions.{ Generic, Path }
 import com.wix.accord._
 import mesosphere.marathon.Normalization
 import mesosphere.marathon.ValidationFailedException
 import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.api.v2.Validation.ConstraintViolation
 import org.scalatest._
-import org.scalatest.matchers.{BePropertyMatchResult, BePropertyMatcher, MatchResult, Matcher}
-import play.api.libs.json.{Format, JsError, Json}
+import org.scalatest.matchers.{ BePropertyMatchResult, BePropertyMatcher, MatchResult, Matcher }
+import play.api.libs.json.{ Format, JsError, Json }
 
 import scala.collection.breakOut
 

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
@@ -3,10 +3,13 @@ package core.health.impl
 
 import java.net.{ InetAddress, ServerSocket }
 
+import akka.Done
 import akka.actor.Props
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.StatusCodes
 import akka.testkit.{ ImplicitSender, TestActorRef }
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.health.{ HealthResult, Healthy, MarathonTcpHealthCheck, PortReference }
+import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.instance.{ LegacyAppInstance, TestTaskBuilder }
 import mesosphere.marathon.core.task.Task
@@ -14,7 +17,8 @@ import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{ AppDefinition, PathId, PortDefinition, UnreachableStrategy }
 
 import scala.collection.immutable.Seq
-import scala.concurrent.Future
+import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.duration._
 
 class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
 
@@ -82,6 +86,42 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
 
       watch(ref)
       expectTerminated(ref)
+    }
+
+    "A HTTP health check should work as expected" in {
+
+      import akka.http.scaladsl.server.Directives._
+
+      val promise = Promise[String]()
+
+      val route =
+        path("health") {
+          get {
+            promise.success("success")
+            complete(StatusCodes.OK)
+          }
+        }
+
+      val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+
+      val hostName = "localhost"
+      val appId = PathId("/test_id")
+      val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
+      val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
+      val task = {
+        val t: Task = TestTaskBuilder.Helper.runningTaskForApp(appId)
+        val hostPorts = Seq(8080)
+        t.copy(status = t.status.copy(networkInfo = NetworkInfo(hostName, hostPorts, ipAddresses = Nil)))
+      }
+      val instance = LegacyAppInstance(task, agentInfo, UnreachableStrategy.default())
+
+      val ref = system.actorOf(Props(classOf[HealthCheckWorkerActor], mat))
+      ref ! HealthCheckJob(app, instance, MarathonHttpHealthCheck(port = Some(8080), path = Some("/health")))
+
+      val res = Await.result(promise.future, 10.seconds)
+
+      res shouldEqual "success"
+
     }
   }
 }


### PR DESCRIPTION
Summary: Http().singleRequest is replaced by connection-level api.

JIRA issues: MARATHON-7940
