### PR TITLE
Add support for symlinks for `--plugin_dir` and `--plugin_conf` parameters

### DIFF
--- a/src/main/scala/mesosphere/marathon/io/IO.scala
+++ b/src/main/scala/mesosphere/marathon/io/IO.scala
@@ -5,13 +5,25 @@ import java.io.{ Closeable, File, FileNotFoundException, InputStream, OutputStre
 
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.commons.io.IOUtils
-import scala.annotation.tailrec
 
+import scala.annotation.tailrec
 import scala.util.{ Failure, Success, Try }
 
 object IO extends StrictLogging {
 
-  def listFiles(file: String): Array[File] = listFiles(new File(file))
+  /**
+    * This method follows symlinks by invoking `getCanonicalFile` method on the File object. A canonical pathname is
+    * both absolute and unique. The precise definition of canonical form is system-dependent. `getCanonicalFile` first
+    * converts this pathname to absolute form if necessary, as if by invoking the getAbsolutePath() method, and then
+    * maps it to its unique form in a system-dependent way. This typically involves removing redundant names such as "."
+    * and ".." from the pathname, resolving symbolic links (on UNIX platforms), and converting drive letters to a
+    * standard case (on Microsoft Windows platforms).
+    *
+    * @param file string path to the directory
+    * @return an array of file objects in the directory
+    */
+  def listFiles(file: String): Array[File] = listFiles(new File(file).getCanonicalFile)
+
   def listFiles(file: File): Array[File] = {
     if (!file.exists()) throw new FileNotFoundException(file.getAbsolutePath)
     if (!file.isDirectory) throw new FileNotFoundException(s"File ${file.getAbsolutePath} is not a directory!")
@@ -42,7 +54,7 @@ object IO extends StrictLogging {
     * each write. Note: This method is blocking!
     *
     * @param maybeFrom Inputstream for copy from.
-    * @param mabyeTo Outputstream to copy to.
+    * @param maybeTo Outputstream to copy to.
     * @return
     */
   def transfer(maybeFrom: Option[InputStream], maybeTo: Option[OutputStream]): Long = {


### PR DESCRIPTION
by internally using `getCanonicalFile` method on the File object. `getCanonicalFile` first converts this pathname to absolute form if necessary, and then maps it to its unique form in a system-dependent way. Among other things this typically involves resolving symbolic links (on UNIX platforms).

(cherry picked from commit 2cbaa0a83b9ed969b19ee09bf01919dadbc0da66)

JIRA issues: MARATHON-8131
