### PR TITLE
Fix native package tests

### DIFF
--- a/tests/package/Makefile
+++ b/tests/package/Makefile
@@ -20,6 +20,9 @@ debian-systemv/mesos-version: target/mesos-version
 debian-systemd/mesos-version: target/mesos-version
 	if [ $$(cat target/mesos-version) = "1.5.0-2.0.1" ]; then echo "1.5.0-2.0.2" > $@; else echo "Package version patch should not be needed; remove this step from the Makefile"; exit 1; fi
 
+ubuntu-upstart/mesos-version: target/mesos-version
+	if [ $$(cat target/mesos-version) = "1.5.0-2.0.1" ]; then echo "1.5.0-2.0.2" > $@; else echo "Package version patch should not be needed; remove this step from the Makefile"; exit 1; fi
+
 target/mesos-version: ../../project/Dependencies.scala
 	mkdir -p target
 	cat ../../project/Dependencies.scala | grep MesosDebian | cut -f 2 -d '"' > $@.tmp
@@ -47,9 +50,9 @@ target/centos-systemd.built: centos-systemd/Dockerfile centos-systemd/mesos-vers
 	cd centos-systemd && docker build . -t marathon-package-test:centos-systemd
 	touch $@
 
-# target/ubuntu-upstart.built: ubuntu-upstart/Dockerfile ubuntu-upstart/mesos-version
-# 	cd ubuntu-upstart && docker build . -t marathon-package-test:ubuntu-upstart
-# 	touch $@
+target/ubuntu-upstart.built: ubuntu-upstart/Dockerfile ubuntu-upstart/mesos-version
+	cd ubuntu-upstart && docker build . -t marathon-package-test:ubuntu-upstart
+	touch $@
 
 test: | all
 	amm test.sc all

--- a/tests/package/Makefile
+++ b/tests/package/Makefile
@@ -57,4 +57,4 @@ target/ubuntu-upstart.built: ubuntu-upstart/Dockerfile ubuntu-upstart/mesos-vers
 test: | all
 	amm test.sc all
 
-all: target/mesos.built target/debian-systemv.built target/debian-systemd.built target/centos-systemd.built target/centos-systemv.built # target/ubuntu-upstart.built
+all: target/mesos.built target/debian-systemv.built target/debian-systemd.built target/centos-systemd.built target/centos-systemv.built target/ubuntu-upstart.built

--- a/tests/package/Makefile
+++ b/tests/package/Makefile
@@ -12,6 +12,14 @@ clean:
 %/mesos-version: target/mesos-version
 	cp target/mesos-version $@
 
+# 1.5.0-2.0.1 package has issues for Debian, and 1.5.0-2.0.2 isn't released for all distros. When we move past this,
+# remove these build steps
+debian-systemv/mesos-version: target/mesos-version
+	if [ $$(cat target/mesos-version) = "1.5.0-2.0.1" ]; then echo "1.5.0-2.0.2" > $@; else echo "Package version patch should not be needed; remove this step from the Makefile"; exit 1; fi
+
+debian-systemd/mesos-version: target/mesos-version
+	if [ $$(cat target/mesos-version) = "1.5.0-2.0.1" ]; then echo "1.5.0-2.0.2" > $@; else echo "Package version patch should not be needed; remove this step from the Makefile"; exit 1; fi
+
 target/mesos-version: ../../project/Dependencies.scala
 	mkdir -p target
 	cat ../../project/Dependencies.scala | grep MesosDebian | cut -f 2 -d '"' > $@.tmp
@@ -39,11 +47,11 @@ target/centos-systemd.built: centos-systemd/Dockerfile centos-systemd/mesos-vers
 	cd centos-systemd && docker build . -t marathon-package-test:centos-systemd
 	touch $@
 
-target/ubuntu-upstart.built: ubuntu-upstart/Dockerfile ubuntu-upstart/mesos-version
-	cd ubuntu-upstart && docker build . -t marathon-package-test:ubuntu-upstart
-	touch $@
+# target/ubuntu-upstart.built: ubuntu-upstart/Dockerfile ubuntu-upstart/mesos-version
+# 	cd ubuntu-upstart && docker build . -t marathon-package-test:ubuntu-upstart
+# 	touch $@
 
 test: | all
 	amm test.sc all
 
-all: target/mesos.built target/debian-systemv.built target/debian-systemd.built target/centos-systemd.built target/centos-systemv.built target/ubuntu-upstart.built
+all: target/mesos.built target/debian-systemv.built target/debian-systemd.built target/centos-systemd.built target/centos-systemv.built # target/ubuntu-upstart.built

--- a/tests/package/test.sc
+++ b/tests/package/test.sc
@@ -456,7 +456,7 @@ def main(args: String*): Unit = {
     new DebianSystemvTest,
     new CentosSystemdTest,
     new CentosSystemvTest,
-    // new UbuntuUpstartTest, Mesos 1.5.0-2.0.1 package does not work for Ubuntu Trusty, the last Upstart distro. So we cannot test it.
+    new UbuntuUpstartTest,
     new DockerImageTest
   )
   val predicate: (String => Boolean) = args match {

--- a/tests/package/test.sc
+++ b/tests/package/test.sc
@@ -444,7 +444,7 @@ def main(args: String*): Unit = {
     new DebianSystemvTest,
     new CentosSystemdTest,
     new CentosSystemvTest,
-    new UbuntuUpstartTest,
+    // new UbuntuUpstartTest, Mesos 1.5.0-2.0.1 package does not work for Ubuntu Trusty, the last Upstart distro. So we cannot test it.
     new DockerImageTest
   )
   val predicate: (String => Boolean) = args match {

--- a/tests/package/test.sc
+++ b/tests/package/test.sc
@@ -17,11 +17,11 @@ abstract class UnitTest extends WordSpec with GivenWhenThen with Matchers with E
 case class Container(containerId: String, ipAddress: String)
 
 trait FailureWatcher extends Suite {
-  var _result = Promise[Boolean]
-  def result = _result.future
+  private var _resultPromise = Promise[Boolean]
+  def result = _resultPromise.future
   override def run(testName: Option[String], args: Args): Status = {
     val status = super.run(testName, args)
-    status.whenCompleted { r => _result.tryComplete(r) }
+    status.whenCompleted { r => _resultPromise.tryComplete(r) }
     status
   }
 }


### PR DESCRIPTION
* For the moment, target Mesos 1.5.0-2.0.2 for Debian tests
* Disable Ubuntu upstart package tests
* Also, return nonzero exit status of any of the tests fail

JIRA issues: MARATHON-8129