### PR TITLE
Disable Connection Pooling for HTTP Health Checks

### DIFF
--- a/docs/docs/event-bus.md
+++ b/docs/docs/event-bus.md
@@ -8,7 +8,7 @@ Marathon has an internal event bus that captures all API requests and scaling ev
 By subscribing to the event bus, you can be informed about every event instantly, without pulling.
 The event bus is useful for integrating with any entity that acts based on the state of Marathon, like load balancers, or to compile statistics.
 
-For more information, see the `/v2/events` entry in the [Marathon REST API Reference](https://mesosphere.github.io/marathon/docs/generated/api.html).
+For more information, see the `/v2/events` entry in the [Marathon REST API Reference](https://mesosphere.github.io/marathon/api-console/index.html).
 
 ## Subscription to Events via The Event Stream
 

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
@@ -6,9 +6,12 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.{ KeyManager, SSLContext, X509TrustManager }
 
 import akka.actor.{ Actor, PoisonPill }
+import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.client.RequestBuilding
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.{ ConnectionContext, Http }
-import akka.stream.Materializer
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings, Materializer }
+import akka.stream.scaladsl.{ Sink, Source }
 import com.typesafe.scalalogging.StrictLogging
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import mesosphere.marathon.core.health._
@@ -18,6 +21,8 @@ import mesosphere.marathon.util.Timeout
 import mesosphere.util.ThreadPoolContext
 
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NonFatal
 import scala.util.{ Failure, Success }
 
 class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with StrictLogging {
@@ -27,6 +32,7 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
   private implicit val system = context.system
   private implicit val scheduler = system.scheduler
   import context.dispatcher // execution context for futures
+  private implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system))
 
   def receive: Receive = {
     case HealthCheckJob(app, instance, check) =>
@@ -92,20 +98,25 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     val url = s"http://$host:$port$absolutePath"
     logger.debug(s"Checking the health of [$url] for instance=${instance.instanceId} via HTTP")
 
-    Timeout(check.timeout)(Http().singleRequest(
-      RequestBuilding.Get(url)
-    )).map { response =>
-      response.discardEntityBytes() //forget about the body
-      if (acceptableResponses.contains(response.status.intValue())) {
-        Some(Healthy(instance.instanceId, instance.runSpecVersion))
-      } else if (check.ignoreHttp1xx && (toIgnoreResponses.contains(response.status.intValue))) {
-        logger.debug(s"Ignoring health check HTTP response ${response.status.intValue} for instance=${instance.instanceId}")
-        None
-      } else {
-        logger.debug(s"Health check for instance=${instance.instanceId} responded with ${response.status}")
-        Some(Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString()))
+    singleRequest(
+      RequestBuilding.Get(url),
+      check.timeout
+    ).map { response =>
+        response.discardEntityBytes() //forget about the body
+        if (acceptableResponses.contains(response.status.intValue())) {
+          Some(Healthy(instance.instanceId, instance.runSpecVersion))
+        } else if (check.ignoreHttp1xx && (toIgnoreResponses.contains(response.status.intValue))) {
+          logger.debug(s"Ignoring health check HTTP response ${response.status.intValue} for instance=${instance.instanceId}")
+          None
+        } else {
+          logger.debug(s"Health check for instance=${instance.instanceId} responded with ${response.status}")
+          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString()))
+        }
+      }.recover {
+        case NonFatal(e) =>
+          logger.debug(s"Health check for instance=${instance.instanceId} did not respond due to ${e.getMessage}.")
+          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage))
       }
-    }
   }
 
   def tcp(
@@ -139,28 +150,52 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     val url = s"https://$host:$port$absolutePath"
     logger.debug(s"Checking the health of [$url] for instance=${instance.instanceId} via HTTPS")
 
-    // This is only a health check, so we are going to allow _very_ bad SSL configuration.
-    val disabledSslConfig = AkkaSSLConfig().mapSettings(s => s.withLoose {
-      s.loose.withAcceptAnyCertificate(true)
-        .withAllowLegacyHelloMessages(Some(true))
-        .withAllowUnsafeRenegotiation(Some(true))
-        .withAllowWeakCiphers(true)
-        .withAllowWeakProtocols(true)
-        .withDisableHostnameVerification(true)
-        .withDisableSNI(true)
-    })
-
-    Timeout(check.timeout)(Http().singleRequest(
+    singleRequest(
       RequestBuilding.Get(url),
-      connectionContext = ConnectionContext.https(disabledSslContext, sslConfig = Some(disabledSslConfig))
-    )).map { response =>
-      response.discardEntityBytes() // forget about the body
-      if (acceptableResponses.contains(response.status.intValue())) {
-        Some(Healthy(instance.instanceId, instance.runSpecVersion))
-      } else {
-        logger.debug(s"Health check for ${instance.instanceId} responded with ${response.status}")
-        Some(Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString()))
-      }
+      check.timeout
+    ).map { response =>
+        response.discardEntityBytes() // forget about the body
+        if (acceptableResponses.contains(response.status.intValue())) {
+          Some(Healthy(instance.instanceId, instance.runSpecVersion))
+        } else {
+          logger.debug(s"Health check for ${instance.instanceId} responded with ${response.status}")
+          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString()))
+        }
+    }.recover {
+      case NonFatal(e) =>
+        logger.debug(s"Health check for instance=${instance.instanceId} did not respond due to ${e.getMessage}.")
+        Some(Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage))
+    }
+  }
+
+  def singleRequest(httpRequest: HttpRequest, timeout: FiniteDuration)(implicit mat: Materializer): Future[HttpResponse] = {
+    if (httpRequest.uri.scheme.equalsIgnoreCase("https")) {
+      // This is only a health check, so we are going to allow _very_ bad SSL configuration.
+      val disabledSslConfig = AkkaSSLConfig().mapSettings(s => s.withLoose {
+        s.loose.withAcceptAnyCertificate(true)
+          .withAllowLegacyHelloMessages(Some(true))
+          .withAllowUnsafeRenegotiation(Some(true))
+          .withAllowWeakCiphers(true)
+          .withAllowWeakProtocols(true)
+          .withDisableHostnameVerification(true)
+          .withDisableSNI(true)
+      })
+      val authority = httpRequest.uri.authority
+      val connectionFlow = Http().outgoingConnectionHttps(
+        authority.host.toString(),
+        authority.port,
+        ConnectionContext.https(disabledSslContext, sslConfig = Some(disabledSslConfig)),
+        settings = ClientConnectionSettings(system).withIdleTimeout(timeout)
+      )
+      Source.single(httpRequest).via(connectionFlow).runWith(Sink.head)
+    } else {
+      val authority = httpRequest.uri.authority
+      val connectionFlow = Http().outgoingConnection(
+        authority.host.toString(),
+        authority.port,
+        settings = ClientConnectionSettings(system).withIdleTimeout(timeout)
+      )
+      Source.single(httpRequest).via(connectionFlow).runWith(Sink.head)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
@@ -161,11 +161,11 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
           logger.debug(s"Health check for ${instance.instanceId} responded with ${response.status}")
           Some(Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString()))
         }
-    }.recover {
-      case NonFatal(e) =>
-        logger.debug(s"Health check for instance=${instance.instanceId} did not respond due to ${e.getMessage}.")
-        Some(Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage))
-    }
+      }.recover {
+        case NonFatal(e) =>
+          logger.debug(s"Health check for instance=${instance.instanceId} did not respond due to ${e.getMessage}.")
+          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage))
+      }
   }
 
   def singleRequest(httpRequest: HttpRequest, timeout: FiniteDuration)(implicit mat: Materializer): Future[HttpResponse] = {

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
@@ -109,9 +109,9 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
       val hostName = "localhost"
       val appId = PathId("/test_id")
       val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
-      val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
+      val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), attributes = Nil)
       val task = {
-        val t: Task = TestTaskBuilder.Helper.runningTaskForApp(appId)
+        val t = TestTaskBuilder.Helper.runningTaskForApp(appId)
         val hostPorts = Seq(port)
         t.copy(status = t.status.copy(networkInfo = NetworkInfo(hostName, hostPorts, ipAddresses = Nil)))
       }
@@ -120,7 +120,7 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
       val tasksMap = Map(task.taskId -> task)
       val state = Instance.InstanceState(None, tasksMap, since, unreachableStrategy)
 
-      val instance = Instance(task.taskId.instanceId, agentInfo, state, tasksMap, task.runSpecVersion, unreachableStrategy, None)
+      val instance = Instance(task.taskId.instanceId, agentInfo, state, tasksMap, task.runSpecVersion, unreachableStrategy)
 
       val ref = system.actorOf(Props(classOf[HealthCheckWorkerActor], mat))
       ref ! HealthCheckJob(app, instance, MarathonHttpHealthCheck(port = Some(port), path = Some("/health")))

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActorTest.scala
@@ -3,18 +3,22 @@ package core.health.impl
 
 import java.net.{ InetAddress, ServerSocket }
 
+import akka.Done
 import akka.actor.Props
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.StatusCodes
 import akka.testkit.{ ImplicitSender, TestActorRef }
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.health.{ HealthResult, Healthy, MarathonTcpHealthCheck, PortReference }
+import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance.AgentInfo
-import mesosphere.marathon.core.instance.{ LegacyAppInstance, TestTaskBuilder }
+import mesosphere.marathon.core.instance.{ Instance, LegacyAppInstance, TestTaskBuilder }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{ AppDefinition, PathId, PortDefinition, UnreachableStrategy }
 
 import scala.collection.immutable.Seq
-import scala.concurrent.Future
+import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.duration._
 
 class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
 
@@ -82,6 +86,47 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
 
       watch(ref)
       expectTerminated(ref)
+    }
+
+    "A HTTP health check should work as expected" in {
+
+      import akka.http.scaladsl.server.Directives._
+
+      val promise = Promise[String]()
+
+      val route =
+        path("health") {
+          get {
+            promise.success("success")
+            complete(StatusCodes.OK)
+          }
+        }
+
+      val binding = Http().bindAndHandle(route, "localhost", 0).futureValue
+
+      val port = binding.localAddress.getPort
+
+      val hostName = "localhost"
+      val appId = PathId("/test_id")
+      val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
+      val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
+      val task = {
+        val t: Task = TestTaskBuilder.Helper.runningTaskForApp(appId)
+        val hostPorts = Seq(port)
+        t.copy(status = t.status.copy(networkInfo = NetworkInfo(hostName, hostPorts, ipAddresses = Nil)))
+      }
+      val since = task.status.startedAt.getOrElse(task.status.stagedAt)
+      val unreachableStrategy = UnreachableStrategy.default()
+      val tasksMap = Map(task.taskId -> task)
+      val state = Instance.InstanceState(None, tasksMap, since, unreachableStrategy)
+
+      val instance = Instance(task.taskId.instanceId, agentInfo, state, tasksMap, task.runSpecVersion, unreachableStrategy, None)
+
+      val ref = system.actorOf(Props(classOf[HealthCheckWorkerActor], mat))
+      ref ! HealthCheckJob(app, instance, MarathonHttpHealthCheck(port = Some(port), path = Some("/health")))
+
+      promise.future.futureValue shouldEqual "success"
+
     }
   }
 }


### PR DESCRIPTION
Summary: Http().singleRequest is replaced by connection-level API.

JIRA issues: MARATHON-7940

(cherry picked from commit 72cc1e9)
