### PR TITLE
SystemConfig is the Correct Security Constraint

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/SystemResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/SystemResource.scala
@@ -12,7 +12,7 @@ import com.typesafe.config.{ Config, ConfigRenderOptions }
 import com.typesafe.scalalogging.StrictLogging
 import com.wix.accord.Validator
 import mesosphere.marathon.metrics.Metrics
-import mesosphere.marathon.plugin.auth.AuthorizedResource.{ SystemConfig, SystemMetrics }
+import mesosphere.marathon.plugin.auth.AuthorizedResource.SystemConfig
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, UpdateResource, ViewResource }
 import mesosphere.marathon.raml.{ LoggerChange, Raml }
 import mesosphere.marathon.raml.MetricsConversion._
@@ -79,7 +79,7 @@ class SystemResource @Inject() (val config: MarathonConf, cfg: Config)(implicit
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MarathonMediaType.PREFERRED_APPLICATION_JSON))
   def metrics(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    withAuthorization(ViewResource, SystemMetrics){
+    withAuthorization(ViewResource, SystemConfig){
       ok(jsonString(Raml.toRaml(Metrics.snapshot())))
     }
   }


### PR DESCRIPTION
SystemConfig is the Correct Security Constraint

Summary:
Removing use of SystemMetrics.  SystemMetrics is not a configurable security constraint.
Switching back to SystemConfig which is.  https://jira.mesosphere.com/browse/MARATHON_EE-1884

JIRA issues:  MARATHON_EE-1884
