### PR TITLE
Stabilize `MesosAppIntegrationTest`

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/DockerAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/DockerAppIntegrationTest.scala
@@ -15,9 +15,17 @@ class DockerAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
   // FIXME (gkleiman): Docker tests don't work under Docker Machine yet. So they can be disabled through an env variable.
   val envVar = "RUN_DOCKER_INTEGRATION_TESTS"
 
-  //clean up state before running the test case
-  after(cleanUp())
+  // This suite would some time time out in `beforeAll` call because mesos agent would crash during docker initialisation
+  // with:
+  // ```
+  // [main.cpp:498] EXIT with status 1: Failed to create a containerizer: Could not create DockerContainerizer:
+  // Failed to create docker: Timed out getting docker version
+  // ```
+  // Currently it is not possible to change the waiting duration:
+  // https://github.com/mesosphere/mesos/blob/master/src/slave/constants.hpp#L144
 
+  // and it's questionable whether it would be the solution - it's is possible that docker client/daemon is simply
+  // hanging. I guess we have to leave with this flake for the time being.
   def healthyDockerApp(testName: String, f: (App) => App = (x) => x) =
     testName taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a new app")

--- a/src/test/scala/mesosphere/marathon/integration/DockerAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/DockerAppIntegrationTest.scala
@@ -15,7 +15,7 @@ class DockerAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
   // FIXME (gkleiman): Docker tests don't work under Docker Machine yet. So they can be disabled through an env variable.
   val envVar = "RUN_DOCKER_INTEGRATION_TESTS"
 
-  // This suite would some time time out in `beforeAll` call because mesos agent would crash during docker initialisation
+  // This suite would sometimes time out in `beforeAll` method because mesos agent would crash during docker initialisation
   // with:
   // ```
   // [main.cpp:498] EXIT with status 1: Failed to create a containerizer: Could not create DockerContainerizer:

--- a/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -4,15 +4,15 @@ package integration
 import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.Protos.Constraint.Operator.UNIQUE
 import mesosphere.marathon.api.RestResource
-import mesosphere.marathon.core.health.{ MesosHttpHealthCheck, PortReference }
+import mesosphere.marathon.core.health.{MesosHttpHealthCheck, PortReference}
 import mesosphere.marathon.core.pod._
 import mesosphere.marathon.integration.facades.MarathonFacade._
-import mesosphere.marathon.integration.setup.{ EmbeddedMarathonTest, MesosConfig, WaitTestSupport }
-import mesosphere.marathon.raml.{ App, Container, DockerContainer, EngineType }
+import mesosphere.marathon.integration.setup.{EmbeddedMarathonTest, MesosConfig, WaitTestSupport}
+import mesosphere.marathon.raml.{App, Container, DockerContainer, EngineType}
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{ HostVolume, VolumeMount }
+import mesosphere.marathon.state.{HostVolume, PathId, VolumeMount}
 import mesosphere.mesos.Constraints.hostnameField
-import mesosphere.{ AkkaIntegrationTest, WhenEnvSet }
+import mesosphere.{AkkaIntegrationTest, WhenEnvSet}
 import play.api.libs.json.JsObject
 
 import scala.collection.immutable.Seq
@@ -215,7 +215,8 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
 
     "deleting a group deletes pods deployed in the group" taggedAs WhenEnvSet(envVar, default = "true") in {
       Given("a deployed pod")
-      val pod = simplePod("simple-pod-is-deleted-with-group")
+      val parentGroup = testBasePath / "foo"
+      val pod = simplePod(parentGroup.toString + "/simple-pod-is-deleted-with-group")
       val createResult = marathon.createPodV2(pod)
       createResult should be(Created)
       waitForDeployment(createResult)
@@ -223,11 +224,11 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       marathon.listPodsInBaseGroupByPodId(pod.id).value should have size 1
 
       Then("The pod should show up as a group")
-      val groupResult = marathon.group(testBasePath)
+      val groupResult = marathon.group(parentGroup)
       groupResult should be(OK)
 
       When("The pod group is deleted")
-      val deleteResult = marathon.deleteGroup(testBasePath)
+      val deleteResult = marathon.deleteGroup(parentGroup)
       deleteResult should be(OK)
       waitForDeployment(deleteResult)
 


### PR DESCRIPTION
One of the tests was removing the whole root group which is not good since the tests
are running in parallel.
