### PR TITLE
Rework Mesos client

### DIFF
--- a/mesos-client/src/main/scala/mesosphere/mesos/client/MesosCallFactory.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/client/MesosCallFactory.scala
@@ -1,0 +1,235 @@
+package mesosphere.mesos.client
+
+import akka.util.ByteString
+import com.google.protobuf
+import org.apache.mesos.v1.mesos.{ AgentID, ExecutorID, FrameworkID, Filters, KillPolicy, OfferID, Request, TaskID }
+import org.apache.mesos.v1.scheduler.scheduler.Call.{ Accept, Acknowledge, Decline, Kill, Message, Reconcile, Revive }
+import org.apache.mesos.v1.scheduler.scheduler.{ Call, Event }
+
+class MesosCallFactory(frameworkId: FrameworkID) {
+  private val someFrameworkId = Some(frameworkId)
+  /**
+    * ***************************************************************************
+    * Helper methods to create mesos `Call`s
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#calls
+    * ***************************************************************************
+    */
+
+  /**
+    * Factory method to construct a TEARDOWN Mesos Call event. Calling this method has no side effects.
+    *
+    * This event is sent by the scheduler when it wants to tear itself down. When Mesos receives this request it will
+    * shut down all executors (and consequently kill tasks). It then removes the framework and closes all open
+    * connections from this scheduler to the Master.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#teardown
+    */
+  def teardown(): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.TEARDOWN)
+    )
+  }
+
+  /**
+    * Factory method to construct a ACCEPT Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler when it accepts offer(s) sent by the master. The ACCEPT request includes the type
+    * of operations (e.g., launch task, launch task group, reserve resources, create volumes) that the scheduler
+    * wants to perform on the offers. Note that until the scheduler replies (accepts or declines) to an offer,
+    * the offer’s resources are considered allocated to the offer’s role and to the framework.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#accept
+    */
+  def accept(accepts: Accept): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.ACCEPT),
+      accept = Some(accepts))
+  }
+
+  /**
+    * Factory method to construct a DECLINE Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to explicitly decline offer(s) received. Note that this is same as sending an ACCEPT
+    * call with no operations.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#decline
+    */
+  def decline(offerIds: Seq[OfferID], filters: Option[Filters] = None): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.DECLINE),
+      decline = Some(Decline(offerIds = offerIds, filters = filters))
+    )
+  }
+
+  /**
+    * Factory method to construct a REVIVE Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to remove any/all filters that it has previously set via ACCEPT or DECLINE calls.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#revive
+    */
+  def revive(role: Option[String] = None): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.REVIVE),
+      revive = Some(Revive(role = role))
+    )
+  }
+
+  /**
+    * Factory method to construct a SUPPRESS Mesos Call event. Calling this method has no side effects.
+    *
+    * Suppress offers for the specified roles. If `roles` is empty the `SUPPRESS` call will suppress offers for all
+    * of the roles the framework is currently subscribed to.
+    *
+    * http://mesos.apache.org/documentation/latest/upgrades/#1-2-x-revive-suppress
+    */
+  def suppress(roles: Option[String] = None): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.SUPPRESS),
+      suppress = Some(Call.Suppress(roles))
+    )
+  }
+
+  /**
+    * Factory method to construct a KILL Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to kill a specific task. If the scheduler has a custom executor, the kill is forwarded
+    * to the executor; it is up to the executor to kill the task and send a TASK_KILLED (or TASK_FAILED) update.
+    * If the task hasn’t yet been delivered to the executor when Mesos master or agent receives the kill request,
+    * a TASK_KILLED is generated and the task launch is not forwarded to the executor. Note that if the task belongs
+    * to a task group, killing of one task results in all tasks in the task group being killed. Mesos releases the
+    * resources for a task once it receives a terminal update for the task. If the task is unknown to the master,
+    * a TASK_LOST will be generated.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#kill
+    */
+  def kill(taskId: TaskID, agentId: Option[AgentID] = None, killPolicy: Option[KillPolicy]): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.KILL),
+      kill = Some(Kill(taskId = taskId, agentId = agentId, killPolicy = killPolicy))
+    )
+  }
+
+  /**
+    * Factory method to construct a SHUTDOWN Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to shutdown a specific custom executor. When an executor gets a shutdown event, it is
+    * expected to kill all its tasks (and send TASK_KILLED updates) and terminate.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#shutdown
+    */
+  def shutdown(executorId: ExecutorID, agentId: AgentID): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.SHUTDOWN),
+      shutdown = Some(Call.Shutdown(executorId = executorId, agentId = agentId))
+    )
+  }
+
+  /**
+    * Factory method to construct a ACKNOWLEDGE Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to acknowledge a status update. Note that with the new API, schedulers are responsible
+    * for explicitly acknowledging the receipt of status updates that have status.uuid set. These status updates
+    * are retried until they are acknowledged by the scheduler. The scheduler must not acknowledge status updates
+    * that do not have `status.uuid` set, as they are not retried. The `uuid` field contains raw bytes encoded in Base64.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#acknowledge
+    */
+  def acknowledge(agentId: AgentID, taskId: TaskID, uuid: protobuf.ByteString): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.ACKNOWLEDGE),
+      acknowledge = Some(Acknowledge(agentId, taskId, uuid))
+    )
+  }
+
+  /**
+    * Factory method to construct a RECONCILE Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to query the status of non-terminal tasks. This causes the master to send back UPDATE
+    * events for each task in the list. Tasks that are no longer known to Mesos will result in TASK_LOST updates.
+    * If the list of tasks is empty, master will send UPDATE events for all currently known tasks of the framework.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#reconcile
+    */
+  def reconcile(tasks: Seq[Reconcile.Task]): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.RECONCILE),
+      reconcile = Some(Reconcile(tasks))
+    )
+  }
+
+  /**
+    * Factory method to construct a MESSAGE Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to send arbitrary binary data to the executor. Mesos neither interprets this data nor
+    * makes any guarantees about the delivery of this message to the executor. data is raw bytes encoded in Base64
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#message
+    */
+  def message(agentId: AgentID, executorId: ExecutorID, message: ByteString): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.MESSAGE),
+      message = Some(Message(agentId, executorId, protobuf.ByteString.copyFrom(message.toByteBuffer)))
+    )
+  }
+
+  /**
+    * Factory method to construct a REQUEST Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to request resources from the master/allocator. The built-in hierarchical allocator
+    * simply ignores this request but other allocators (modules) can interpret this in a customizable fashion.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#request
+    */
+  def request(requests: Seq[Request]): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.REQUEST),
+      request = Some(Call.Request(requests = requests))
+    )
+  }
+
+  /**
+    * Factory method to construct a ACCEPT_INVERSE_OFFERS Mesos Call event. Calling this method has no side effects.
+    *
+    * Accepts an inverse offer. Inverse offers should only be accepted if the resources in the offer can be safely
+    * evacuated before the provided unavailability.
+    *
+    * https://mesosphere.com/blog/mesos-inverse-offers/
+    */
+  def acceptInverseOffers(offers: Seq[OfferID], filters: Option[Filters] = None): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.ACCEPT_INVERSE_OFFERS),
+      acceptInverseOffers = Some(Call.AcceptInverseOffers(inverseOfferIds = offers, filters = filters))
+    )
+  }
+
+  /**
+    * Factory method to construct a DECLINE_INVERSE_OFFERS Mesos Call event. Calling this method has no side effects.
+    *
+    * Declines an inverse offer. Inverse offers should be declined if
+    * the resources in the offer might not be safely evacuated before
+    * the provided unavailability.
+    *
+    * https://mesosphere.com/blog/mesos-inverse-offers/
+    */
+  def declineInverseOffers(offers: Seq[OfferID], filters: Option[Filters] = None): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.DECLINE_INVERSE_OFFERS),
+      declineInverseOffers = Some(Call.DeclineInverseOffers(inverseOfferIds = offers, filters = filters))
+    )
+  }
+}

--- a/mesos-client/src/main/scala/mesosphere/mesos/client/MesosCallFactory.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/client/MesosCallFactory.scala
@@ -83,16 +83,16 @@ class MesosCallFactory(frameworkId: FrameworkID) {
   /**
     * Factory method to construct a SUPPRESS Mesos Call event. Calling this method has no side effects.
     *
-    * Suppress offers for the specified roles. If `roles` is empty the `SUPPRESS` call will suppress offers for all
-    * of the roles the framework is currently subscribed to.
+    * Suppress offers for the specified role. If `role` is empty the `SUPPRESS` call will suppress offers for all
+    * of the role the framework is currently subscribed to.
     *
     * http://mesos.apache.org/documentation/latest/upgrades/#1-2-x-revive-suppress
     */
-  def suppress(roles: Option[String] = None): Call = {
+  def suppress(role: Option[String] = None): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.SUPPRESS),
-      suppress = Some(Call.Suppress(roles))
+      suppress = Some(Call.Suppress(role))
     )
   }
 

--- a/mesos-client/src/main/scala/mesosphere/mesos/client/MesosCalls.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/client/MesosCalls.scala
@@ -6,7 +6,7 @@ import org.apache.mesos.v1.mesos.{ AgentID, ExecutorID, FrameworkID, Filters, Ki
 import org.apache.mesos.v1.scheduler.scheduler.Call.{ Accept, Acknowledge, Decline, Kill, Message, Reconcile, Revive }
 import org.apache.mesos.v1.scheduler.scheduler.{ Call, Event }
 
-class MesosCallFactory(frameworkId: FrameworkID) {
+class MesosCalls(frameworkId: FrameworkID) {
   private val someFrameworkId = Some(frameworkId)
   /**
     * ***************************************************************************
@@ -25,7 +25,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#teardown
     */
-  def teardown(): Call = {
+  def newTeardown(): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.TEARDOWN)
@@ -42,7 +42,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#accept
     */
-  def accept(accepts: Accept): Call = {
+  def newAccept(accepts: Accept): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.ACCEPT),
@@ -57,7 +57,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#decline
     */
-  def decline(offerIds: Seq[OfferID], filters: Option[Filters] = None): Call = {
+  def newDecline(offerIds: Seq[OfferID], filters: Option[Filters] = None): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.DECLINE),
@@ -72,7 +72,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#revive
     */
-  def revive(role: Option[String] = None): Call = {
+  def newRevive(role: Option[String] = None): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.REVIVE),
@@ -88,7 +88,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/upgrades/#1-2-x-revive-suppress
     */
-  def suppress(role: Option[String] = None): Call = {
+  def newSuppress(role: Option[String] = None): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.SUPPRESS),
@@ -109,7 +109,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#kill
     */
-  def kill(taskId: TaskID, agentId: Option[AgentID] = None, killPolicy: Option[KillPolicy]): Call = {
+  def newKill(taskId: TaskID, agentId: Option[AgentID] = None, killPolicy: Option[KillPolicy]): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.KILL),
@@ -125,7 +125,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#shutdown
     */
-  def shutdown(executorId: ExecutorID, agentId: AgentID): Call = {
+  def newShutdown(executorId: ExecutorID, agentId: AgentID): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.SHUTDOWN),
@@ -143,7 +143,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#acknowledge
     */
-  def acknowledge(agentId: AgentID, taskId: TaskID, uuid: protobuf.ByteString): Call = {
+  def newAcknowledge(agentId: AgentID, taskId: TaskID, uuid: protobuf.ByteString): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.ACKNOWLEDGE),
@@ -160,7 +160,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#reconcile
     */
-  def reconcile(tasks: Seq[Reconcile.Task]): Call = {
+  def newReconcile(tasks: Seq[Reconcile.Task]): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.RECONCILE),
@@ -176,7 +176,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#message
     */
-  def message(agentId: AgentID, executorId: ExecutorID, message: ByteString): Call = {
+  def newMessage(agentId: AgentID, executorId: ExecutorID, message: ByteString): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.MESSAGE),
@@ -192,7 +192,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#request
     */
-  def request(requests: Seq[Request]): Call = {
+  def newRequest(requests: Seq[Request]): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.REQUEST),
@@ -208,7 +208,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * https://mesosphere.com/blog/mesos-inverse-offers/
     */
-  def acceptInverseOffers(offers: Seq[OfferID], filters: Option[Filters] = None): Call = {
+  def newAcceptInverseOffers(offers: Seq[OfferID], filters: Option[Filters] = None): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.ACCEPT_INVERSE_OFFERS),
@@ -225,7 +225,7 @@ class MesosCallFactory(frameworkId: FrameworkID) {
     *
     * https://mesosphere.com/blog/mesos-inverse-offers/
     */
-  def declineInverseOffers(offers: Seq[OfferID], filters: Option[Filters] = None): Call = {
+  def newDeclineInverseOffers(offers: Seq[OfferID], filters: Option[Filters] = None): Call = {
     Call(
       frameworkId = someFrameworkId,
       `type` = Some(Call.Type.DECLINE_INVERSE_OFFERS),

--- a/mesos-client/src/main/scala/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/client/MesosClient.scala
@@ -1,7 +1,7 @@
 package mesosphere.mesos.client
 
+import akka.stream.{ Materializer, OverflowStrategy }
 import java.net.URI
-import java.util.concurrent.atomic.AtomicReference
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -14,326 +14,174 @@ import akka.util.ByteString
 import akka.{ Done, NotUsed }
 import com.google.protobuf
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.mesos.client.MesosClient.{ MesosRedirectException, ProtobufMediaType, MesosStreamIdHeaderName }
 import mesosphere.mesos.conf.MesosClientConf
 import org.apache.mesos.v1.mesos._
 import org.apache.mesos.v1.scheduler.scheduler.Call.{ Accept, Acknowledge, Decline, Kill, Message, Reconcile, Revive }
 import org.apache.mesos.v1.scheduler.scheduler.{ Call, Event }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 
-class MesosClient(
-    conf: MesosClientConf,
-    frameworkInfo: FrameworkInfo)(
-    implicit
-    val system: ActorSystem,
-    implicit val materializer: ActorMaterializer,
-    implicit val executionContext: ExecutionContext
-) extends MesosApi with StrictLogging {
-
-  private val overflowStrategy = akka.stream.OverflowStrategy.backpressure
-
-  val context = new AtomicReference[MesosConnectionContext](MesosConnectionContext(conf))
-  val contextPromise = Promise[MesosConnectionContext]()
-
-  // format: OFF
-  /**
-    Mesos source is an akka-stream `Source[Event, UniqueKillSwitch]` that frameworks can attach to, to receive mesos event.
-    Basic flow visualized looks like following
-
-     ------------
-    | Http       | (1)
-    | Connection |
-     ------------
-          |
-          v
-     ------------
-    | Connection | (2)
-    | Handler    |     -> updates connection context with mesos streamId
-     ------------
-          |
-          v
-     ------------
-    | Data Bytes | (3)
-    | Extractor  |
-     ------------
-          |
-          v
-     ------------
-    | RecordIO   | (4)
-    | Scanner    |
-     ------------
-          |
-          v
-     --------------
-    | Event        | (5)
-    | Deserializer |
-     --------------
-          |
-          v
-     --------------
-    | Subscribed   | (6)  -> updates connection context with frameworkId
-    | Handler      |
-     --------------
-          |
-          v
-
-
-    1. Http Connection mesos-v1-client uses akka-http low-level `Http.outgoingConnection()` to `POST` a
-       [SUBSCRIBE](http://mesos.apache.org/documentation/latest/scheduler-http-api/#subscribe-1) request to mesos `api/v1/scheduler`
-       endpoint providing framework info. The HTTP response is a stream in RecordIO format which is handled by the later stages.
-    2. Connection Handler handles connection HTTP response, saving `Mesos-Stream-Id`(see the description of the
-       [SUBSCRIBE](http://mesos.apache.org/documentation/latest/scheduler-http-api/#subscribe-1) call) in client's _connection context_
-       object to later use it in mesos sink. Schedulers are expected to make HTTP requests to the leading master. If requests are made
-       to a non-leading master a `HTTP 307 Temporary Redirect` will be received with the `Location` header pointing to the leading master.
-       We update connection context with the new leader address and throw a `MesosRedicrectException` which is handled it in the `recover`
-       stage by building a new flow that reconnects to the new leader.
-    3. Data Byte Extractor simply extracts byte data from the response body
-    4. RecordIO Scanner Each stream message is encoded in RecordIO format, which essentially prepends to a single record (either JSON or
-       serialized protobuf) its length in bytes: `[<length>\n<json string|protobuf bytes>]`. More about the format
-       [here](http://mesos.apache.org/documentation/latest/scheduler-http-api/#recordio-response-format-1). RecordIO Scanner uses
-       `RecordIOFraming.Scanner` from the [alpakka-library](https://github.com/akka/alpakka) to parse the extracted bytes into a complete
-       message frame.
-    5. Event Deserializer Currently mesos-v1-client only supports protobuf encoded events/calls. Event deserializer uses
-       [scalapb](https://scalapb.github.io/) library to parse the extracted RecordIO frame from the previous stage into a mesos
-       [Event](https://github.com/apache/mesos/blob/master/include/mesos/scheduler/scheduler.proto#L36)
-    6. Subscribed Handler parses the `SUBSCRIBED` event and updates the connection context with the returned `frameworkId`.
-
-    Note: _Connection Handler_ updates the _connection context_ object with current mesos leader `host` and `port` along with `Mesos-Stream-Id`
-    header value. These settings are used by mesos sink when sending calls to mesos. The same applies to _Subscribed Handler_ which saves
-    `frameworkId` from the `SUBSCRIBED` event in the connection context.
-
-    It is declared lazy to decouple instantiation of the MesosClient instance from connection initialization.
-    */
-  // format: ON
-  def log[T](prefix: String): Flow[T, T, NotUsed] = Flow[T].map{ e => logger.info(s"$prefix$e"); e }
-
-  val mesosSource: Source[Event, UniqueKillSwitch] = {
-
-    val body = subscribe(frameworkInfo).toByteArray
-
-    val request = HttpRequest(
-      HttpMethods.POST,
-      uri = Uri("/api/v1/scheduler"),
-      entity = HttpEntity(ProtobufMediaType, body),
-      headers = List(headers.Accept(ProtobufMediaType)))
-
-    def httpConnection(host: String, port: Int): Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] =
-      Http().outgoingConnection(host, port)
-
-    val recordIoScanner: Flow[ByteString, ByteString, NotUsed] = RecordIOFraming.scanner()
-
-    val connectionHandler: Flow[HttpResponse, HttpResponse, NotUsed] = Flow[HttpResponse].map { response =>
-      response.status match {
-        case StatusCodes.OK =>
-          logger.info(s"Connected successfully to ${context.get().url}");
-          val streamId = response.headers
-            .find(h => h.is(MesosStreamIdHeaderName.toLowerCase))
-            .getOrElse(throw new IllegalStateException(s"Missing MesosStreamId header in ${response.headers}"))
-
-          // At this point we successfully connected to mesos leader so context should have correct leader's host
-          // and port either from the config or set on the redirect.
-          context.updateAndGet(c => c.copy(streamId = Some(streamId.value())))
-          response
-        case StatusCodes.TemporaryRedirect =>
-          val leader = new URI(response.header[headers.Location].get.value())
-          logger.warn(s"New mesos leader available at $leader")
-          // Update the context with the new leader's host and port and throw an exception that is handled in the
-          // next `recoverWith` stage.
-          context.updateAndGet(c => c.copy(url = leader))
-          response.discardEntityBytes()
-          throw new MesosRedirectException(leader)
-        case _ =>
-          response.discardEntityBytes()
-          throw new IllegalArgumentException(s"Mesos server error: $response")
-      }
-    }
-
-    val dataBytesExtractor: Flow[HttpResponse, ByteString, NotUsed] = Flow[HttpResponse].flatMapConcat(resp => resp.entity.dataBytes)
-
-    val eventDeserializer: Flow[ByteString, Event, NotUsed] = Flow[ByteString].map(bytes => Event.parseFrom(bytes.toArray))
-
-    val subscribedHandler: Flow[Event, Event, NotUsed] = Flow[Event].map { event =>
-      if (event.subscribed.isDefined) {
-        val ctx = context.updateAndGet(c => c.copy(frameworkId = Some(event.subscribed.get.frameworkId)))
-        // We save `frameworkId` in the context and successfully complete the promise, meaning the calls in sink can now be sent
-        contextPromise.success(ctx)
-      }
-      event
-    }
-
-    def connectionSource(host: String, port: Int) =
-      Source.single(request)
-        .via(log(s"Connecting to the new leader: $host:$port"))
-        .via(httpConnection(host, port))
-        .via(log("HttpResponse: "))
-        .via(connectionHandler)
-
-    val source = connectionSource(context.get().host, context.get().port)
-      .recoverWithRetries(conf.redirectRetires, {
-        case MesosRedirectException(_) => connectionSource(context.get().host, context.get().port)
-      })
-      .buffer(conf.sourceBufferSize, overflowStrategy)
-      .via(dataBytesExtractor)
-      .via(recordIoScanner)
-      .via(eventDeserializer)
-      .via(subscribedHandler)
-      .via(log("Received mesos Event: "))
-      .idleTimeout(conf.idleTimeout)
-      .viaMat(KillSwitches.single)(Keep.right)
-
-    source
-  }
-
-  // format: OFF
-  /**
-  Mesos sink is an akka-stream `Sink[Call, Notused]` that sends calls to mesos. Every call is sent via the same long-living
-  connection to mesos. This way we save resources and guarantee message order delivery. The flow visualized:
-
-       |  |  |
-       v  v  v
-      ----------
-     | MergeHub | (1)
-      ----------
-          |
-          v
-     ------------
-    | Call       |
-    | Enhancer   | (2)  <-- reads frameworkId from connection context
-     ------------
-          |
-          v
-     ------------
-    | Event      |
-    | Serializer | (3)
-     ------------
-          |
-          v
-     ------------
-    | Request    |
-    | Builder    | (4)  <-- reads mesosStreamId and from connection context
-     ------------
-          |
-          v
-     ------------
-    | Http       |
-    | Connection | (5)  <-- reads mesos url from connection context
-     ------------
-          |
-          v
-     ------------
-    | Response   |
-    | Handler    | (6)
-     ------------
-
-    1. MergeHub allows dynamic "fan-in" junction point for mesos calls from multiple producers.
-    2. Call Enhancer updates the call with the framework Id from the connection context
-    3. Event Serializer serializes calls to byte array
-    4. Build a HTTP request from the data using `mesosStreamId` header from the context
-    5. Http connection uses akka's `Http().outgoingConnection` to sends the data to mesos. Note that all calls are sent
-       through one long-living connection.
-    6. Response handler will discard response entity or throw an exception on non-2xx response code
-
-    Note: Merge hub will wait for the _connection context_ object to be fully initialized first meaning that we have current leader's
-    `host`, `port` and `Mesos-Stream-Id` to send the events to.
-    */
-  // format: ON
-
-  // Initially `Http().singleRequest` was used to send calls. However when calls are fired at a high-speed rate,
-  // it might quickly overflow small http pool (the pool is shared for the entire actor system). Backpressure is not
-  // applied here.
-  //
-  // `Http().superPool()` or `Http.cachedHostConnectionPool()` are an alternative. However it may happen there that the requests
-  // sent could arrive at mesos out of sent order! The native scheduler driver guarantees that the events will be received by
-  // mesos in the same order they were sent.
-  //
-  // `Http().outgoingConnection` will create one long-living connection and use it to send events to mesos. Backpressure is applied
-  // automatically when mesos is slow and events are in order.
-  private val httpConnection: Flow[HttpRequest, HttpResponse, NotUsed] = Flow[HttpRequest]
-    .via(Http().outgoingConnection(context.get().host, context.get().port))
-
-  private val responseHandler: Sink[HttpResponse, Future[Done]] = Sink.foreach[HttpResponse] { response =>
-    response status match {
-      case status if status.isFailure() =>
-        logger.info(s"A request to mesos failed with response: ${response}")
-        response.discardEntityBytes()
-        throw new IllegalStateException(s"Failed to send a call to mesos")
-      case _ =>
-        logger.debug(s"Mesos call response: $response")
-        response.discardEntityBytes()
-    }
-  }
-
-  private val eventSerializer: Flow[Call, Array[Byte], NotUsed] = Flow[Call]
-    .map(call => call.toByteArray)
-
-  private val requestBuilder: Flow[Array[Byte], HttpRequest, NotUsed] = Flow[Array[Byte]]
-    .map(bytes => HttpRequest(
-      HttpMethods.POST,
-      uri = Uri(s"${context.get().url}/api/v1/scheduler"),
-      entity = HttpEntity(ProtobufMediaType, bytes),
-      headers = List(MesosClient.MesosStreamIdHeader(context.get().streamId.getOrElse(throw new IllegalStateException("MesosStreamId not set.")))))
-    )
-
-  private val callEnhancer: Flow[Call, Call, NotUsed] = Flow[Call]
-    .map { call =>
-      call.update(
-        _.optionalFrameworkId := Some(context.get().frameworkId.getOrElse(throw new IllegalStateException("FrameworkID not set")))
-      )
-    }
-
-  private val sinkHub: RunnableGraph[Sink[Call, NotUsed]] =
-    MergeHub.source[Call](perProducerBufferSize = 16)
-      .mapAsync(1)(event => contextPromise.future.map(_ => event))
-      .via(callEnhancer)
-      .via(log("Sending "))
-      .via(eventSerializer)
-      .via(requestBuilder)
-      .via(httpConnection)
-      .to(responseHandler)
-
-  // By running/materializing the consumer we get back a Sink, and hence now have access to feed elements into it.
-  // This Sink can be materialized any number of times, and every element that enters the Sink will be consumed by
-  // our consumer.
-  override val mesosSink: Sink[Call, NotUsed] = sinkHub.run()
+// TODO - move somewhere shared
+trait StrictLoggingFlow extends StrictLogging {
+  protected def log[T](prefix: String): Flow[T, T, NotUsed] = Flow[T].map{ e => logger.info(s"$prefix$e"); e }
 }
 
 trait MesosApi {
-
   /**
-    * First call to this method will initialize the connection to mesos and return a `Source[String, NotUsed]` with
-    * mesos `Event`s. All subsequent calls will return the previously created event source.
-    * The connection is initialized with a `POST /api/v1/scheduler` with the framework info in the body. The request
-    * is answered by a `SUBSCRIBED` event which contains `MesosStreamId` header. This is reused by all later calls to
-    * `/api/v1/scheduler`.
-    * Multiple subscribers can attach to returned `Source[String, NotUsed]` to receive mesos events. The stream will
-    * be closed either on connection error or connection shutdown e.g.:
+    * Calling shutdown()` or `abort()` on this will close the connection to Mesos.
+    *
+    * Note that depending on `failoverTimeout` provided with SUBSCRIBED call, Mesos could start killing tasks and
+    * executors started by the framework. Make sure to set `failoverTimeout` appropriately.
+    *
+    *  See `teardown()` Call factory method for another way to shutdown a framework.
+    */
+  def killSwitch: KillSwitch
+
+  // format: OFF
+  /**
+    * Source which exposes a live, suspended Mesos event stream (after the first Subscribed event). Can only be
+    * materialized once. If you need to fan-out to multiple, look at BroadcastHub, FlowOps.alsoTo, or the GraphDSL
+    * Broadcast node.
+    *
+    * The original connection is initialized with a `POST /api/v1/scheduler` with the framework info in the body. The
+    * request is answered by a `SUBSCRIBED` event which contains `MesosStreamId` header. This is reused by all later
+    * calls to `/api/v1/scheduler`.
+    *
+    * This source will be closed either on connection error or connection shutdown e.g.:
     * ```
-    * client.source.runWith(Sink.ignore).onComplete{
+    * client.mesosSource.runWith(Sink.ignore).onComplete{
     *  case Success(res) => logger.info(s"Stream completed: $res")
     *  case Failure(e) => logger.error(s"Error in stream: $e")
     * }
     * ```
-    *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#subscribe-1
     *
-    * A materialized value of the source is a kill switch. Calling shutdown()` or `abort()` on it will close the connection to mesos.
-    * Note that depending on `failoverTimeout` provided with SUBSCRIBED call mesos could start killing tasks and
-    * executors started by the framework. Make sure to set `failoverTimeout` appropriately. See `teardown()` method
-    * for another way to shutdown a framework.
+    * The topology for the Mesos Source looks some like this:
+    *
+    * +------------+           +----------------+
+    * | Http       | (1)  -->  | ConnectionInfo | (2)
+    * | Connection |           | Handler        |
+    * +------------+           +----------------+
+    * |
+    * v
+    * +------------+
+    * | Data Bytes | (3)
+    * | Extractor  |
+    * +------------+
+    * |
+    * v
+    * +------------+
+    * | RecordIO   | (4)
+    * | Scanner    |
+    * +------------+
+    * |
+    * v
+    * +--------------+
+    * | Event        | (5)
+    * | Deserializer |
+    * +--------------+
+    * |
+    * v
+    * +------------+      +------------+
+    * + Broadcast  + -->  | Subscribed | (6)
+    * +------------+      | Watcher    |
+    * |                   +------------+
+    * v
+    * +--------------+
+    * | Event        | (7)
+    * | Publisher    |
+    * +--------------+
+    * |
+    * v
+    * +-----------------+
+    * | Your logic here |
+    * +-----------------+
+    *
+    *
+    *
+    * 1. Http Connection mesos-v1-client uses akka-http low-level `Http.outgoingConnection()` to `POST` a
+    * [SUBSCRIBE](http://mesos.apache.org/documentation/latest/scheduler-http-api/#subscribe-1) request to mesos `api/v1/scheduler`
+    * endpoint providing framework info. The HTTP response is a stream in RecordIO format which is handled by the later stages.
+    *
+    * 2. Connection Handler handles connection HTTP response, saving `Mesos-Stream-Id`(see the description of the
+    * [SUBSCRIBE](http://mesos.apache.org/documentation/latest/scheduler-http-api/#subscribe-1) call) in client's _connection context_
+    * object to later use it in Mesos sink. Schedulers are expected to make HTTP requests to the leading master. If requests are made
+    * to a non-leading master a `HTTP 307 Temporary Redirect` will be received with the `Location` header pointing to the leading master.
+    * We update connection context with the new leader address and throw a `MesosRedirectException` which is handled it in the `recover`
+    * stage by building a new flow that reconnects to the new leader.
+    *
+    * 3. Data Byte Extractor simply extracts byte data from the response body
+    *
+    * 4. RecordIO Scanner Each stream message is encoded in RecordIO format, which essentially prepends to a single record (either JSON or
+    * serialized protobuf) its length in bytes: `[<length>\n<json string|protobuf bytes>]`. More about the format
+    * [here](http://mesos.apache.org/documentation/latest/scheduler-http-api/#recordio-response-format-1). RecordIO Scanner uses
+    * `RecordIOFraming.Scanner` from the [alpakka-library](https://github.com/akka/alpakka) to parse the extracted bytes into a complete
+    * message frame.
+    *
+    * 5. Event Deserializer Currently mesos-v1-client only supports protobuf encoded events/calls. Event deserializer uses
+    * [scalapb](https://scalapb.github.io/) library to parse the extracted RecordIO frame from the previous stage into a mesos
+    * [Event](https://github.com/apache/mesos/blob/master/include/mesos/scheduler/scheduler.proto#L36)
+    *
+    * 6. Subscribed Handler parses the `SUBSCRIBED` event and provides it to the constructed MesosClient for later reference.
+    *
+    * 7. Event Publisher is a single-use materializable source and does not include the initial SUBSCRIBED event. The
+    * entire Mesos event stream is backpressured until this source is materialized.
     */
-  def mesosSource: Source[Event, UniqueKillSwitch]
+  def mesosSource: Source[Event, NotUsed]
 
   /**
-    * Sink for mesos calls. Multiple publishers can materialize this sink to send mesos `Call`s. Every `Call` Every call is
-    * sent via one long-living connection to mesos.
-    * Note: a scheduler can't send calls to mesos without subscribing first (see [MesosClient.source] method). Calls
-    * published to sink without a successful subscription will be buffered and will have to wait for subscription
-    * connection. Always call `source()` first.
+    * mesosSink is an akka-stream `Sink[Call, Notused]` that sends Mesos `Call`s events to Mesos. Every call is sent via
+    * the same long-living connection to Mesos. This way we save resources and guarantee message order delivery.
+    *
+    * It is expected that Calls are constructed using the MesosCalls methods exposed via the MesosClient instance. These
+    * methods return Calls with the frameworkId field populated.
+    *
+    * Each materialization results in a new HTTP connection. If you need multiple producers to reuse a single
+    * connection, see MergeHub, FlowOps.merge, or GraphDSL Merge node.
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#calls
+    *
+    * The flow visualized:
+    *
+    * |  |  |
+    * v  v  v
+    * +------------+
+    * | Event      |
+    * | Serializer | (1)
+    * +------------+
+    * |
+    * v
+    * +------------+
+    * | Request    |
+    * | Builder    | (2)  <-- reads mesosStreamId and from connection context
+    * +------------+
+    * |
+    * v
+    * +------------+
+    * | Http       |
+    * | Connection | (3)  <-- reads mesos url from connection context
+    * +------------+
+    * |
+    * v
+    * +------------+
+    * | Response   |
+    * | Handler    | (4)
+    * +------------+
+    *
+    * 1. Event Serializer serializes calls to byte array
+    * 2. Build a HTTP request from the data using `mesosStreamId` header from the context
+    * 3. Http connection uses akka's `Http().outgoingConnection` to sends the data to mesos. Note that all calls are sent
+    * through one long-living connection.
+    * 4. Response handler will discard response entity or throw an exception on non-2xx response code
+    *
+    * Note: the materialized Future[Done] will be completed successfully if your upstream completes, or, will be
+    * completed with an error if the HTTP connection is terminated, or an upstream error is propagated.
     */
-  def mesosSink: Sink[Call, NotUsed]
+  def mesosSink: Sink[Call, Future[Done]]
+}
 
+trait MesosCalls {
+  val frameworkId: FrameworkID
+  private val someFrameworkId = Some(frameworkId)
   /**
     * ***************************************************************************
     * Helper methods to create mesos `Call`s
@@ -341,6 +189,235 @@ trait MesosApi {
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#calls
     * ***************************************************************************
     */
+
+  /**
+    * Factory method to construct a TEARDOWN Mesos Call event. Calling this method has no side effects.
+    *
+    * This event is sent by the scheduler when it wants to tear itself down. When Mesos receives this request it will
+    * shut down all executors (and consequently kill tasks). It then removes the framework and closes all open
+    * connections from this scheduler to the Master.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#teardown
+    */
+  def teardown(): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.TEARDOWN)
+    )
+  }
+
+  /**
+    * Factory method to construct a ACCEPT Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler when it accepts offer(s) sent by the master. The ACCEPT request includes the type
+    * of operations (e.g., launch task, launch task group, reserve resources, create volumes) that the scheduler
+    * wants to perform on the offers. Note that until the scheduler replies (accepts or declines) to an offer,
+    * the offer’s resources are considered allocated to the offer’s role and to the framework.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#accept
+    */
+  def accept(accepts: Accept): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.ACCEPT),
+      accept = Some(accepts))
+  }
+
+  /**
+    * Factory method to construct a DECLINE Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to explicitly decline offer(s) received. Note that this is same as sending an ACCEPT
+    * call with no operations.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#decline
+    */
+  def decline(offerIds: Seq[OfferID], filters: Option[Filters] = None): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.DECLINE),
+      decline = Some(Decline(offerIds = offerIds, filters = filters))
+    )
+  }
+
+  /**
+    * Factory method to construct a REVIVE Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to remove any/all filters that it has previously set via ACCEPT or DECLINE calls.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#revive
+    */
+  def revive(role: Option[String] = None): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.REVIVE),
+      revive = Some(Revive(role = role))
+    )
+  }
+
+  /**
+    * Factory method to construct a SUPPRESS Mesos Call event. Calling this method has no side effects.
+    *
+    * Suppress offers for the specified roles. If `roles` is empty the `SUPPRESS` call will suppress offers for all
+    * of the roles the framework is currently subscribed to.
+    *
+    * http://mesos.apache.org/documentation/latest/upgrades/#1-2-x-revive-suppress
+    */
+  def suppress(roles: Option[String] = None): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.SUPPRESS),
+      suppress = Some(Call.Suppress(roles))
+    )
+  }
+
+  /**
+    * Factory method to construct a KILL Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to kill a specific task. If the scheduler has a custom executor, the kill is forwarded
+    * to the executor; it is up to the executor to kill the task and send a TASK_KILLED (or TASK_FAILED) update.
+    * If the task hasn’t yet been delivered to the executor when Mesos master or agent receives the kill request,
+    * a TASK_KILLED is generated and the task launch is not forwarded to the executor. Note that if the task belongs
+    * to a task group, killing of one task results in all tasks in the task group being killed. Mesos releases the
+    * resources for a task once it receives a terminal update for the task. If the task is unknown to the master,
+    * a TASK_LOST will be generated.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#kill
+    */
+  def kill(taskId: TaskID, agentId: Option[AgentID] = None, killPolicy: Option[KillPolicy]): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.KILL),
+      kill = Some(Kill(taskId = taskId, agentId = agentId, killPolicy = killPolicy))
+    )
+  }
+
+  /**
+    * Factory method to construct a SHUTDOWN Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to shutdown a specific custom executor. When an executor gets a shutdown event, it is
+    * expected to kill all its tasks (and send TASK_KILLED updates) and terminate.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#shutdown
+    */
+  def shutdown(executorId: ExecutorID, agentId: AgentID): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.SHUTDOWN),
+      shutdown = Some(Call.Shutdown(executorId = executorId, agentId = agentId))
+    )
+  }
+
+  /**
+    * Factory method to construct a ACKNOWLEDGE Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to acknowledge a status update. Note that with the new API, schedulers are responsible
+    * for explicitly acknowledging the receipt of status updates that have status.uuid set. These status updates
+    * are retried until they are acknowledged by the scheduler. The scheduler must not acknowledge status updates
+    * that do not have `status.uuid` set, as they are not retried. The `uuid` field contains raw bytes encoded in Base64.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#acknowledge
+    */
+  def acknowledge(agentId: AgentID, taskId: TaskID, uuid: protobuf.ByteString): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.ACKNOWLEDGE),
+      acknowledge = Some(Acknowledge(agentId, taskId, uuid))
+    )
+  }
+
+  /**
+    * Factory method to construct a RECONCILE Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to query the status of non-terminal tasks. This causes the master to send back UPDATE
+    * events for each task in the list. Tasks that are no longer known to Mesos will result in TASK_LOST updates.
+    * If the list of tasks is empty, master will send UPDATE events for all currently known tasks of the framework.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#reconcile
+    */
+  def reconcile(tasks: Seq[Reconcile.Task]): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.RECONCILE),
+      reconcile = Some(Reconcile(tasks))
+    )
+  }
+
+  /**
+    * Factory method to construct a MESSAGE Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to send arbitrary binary data to the executor. Mesos neither interprets this data nor
+    * makes any guarantees about the delivery of this message to the executor. data is raw bytes encoded in Base64
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#message
+    */
+  def message(agentId: AgentID, executorId: ExecutorID, message: ByteString): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.MESSAGE),
+      message = Some(Message(agentId, executorId, protobuf.ByteString.copyFrom(message.toByteBuffer)))
+    )
+  }
+
+  /**
+    * Factory method to construct a REQUEST Mesos Call event. Calling this method has no side effects.
+    *
+    * Sent by the scheduler to request resources from the master/allocator. The built-in hierarchical allocator
+    * simply ignores this request but other allocators (modules) can interpret this in a customizable fashion.
+    *
+    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#request
+    */
+  def request(requests: Seq[Request]): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.REQUEST),
+      request = Some(Call.Request(requests = requests))
+    )
+  }
+
+  /**
+    * Factory method to construct a ACCEPT_INVERSE_OFFERS Mesos Call event. Calling this method has no side effects.
+    *
+    * Accepts an inverse offer. Inverse offers should only be accepted if the resources in the offer can be safely
+    * evacuated before the provided unavailability.
+    *
+    * https://mesosphere.com/blog/mesos-inverse-offers/
+    */
+  def acceptInverseOffers(offers: Seq[OfferID], filters: Option[Filters] = None): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.ACCEPT_INVERSE_OFFERS),
+      acceptInverseOffers = Some(Call.AcceptInverseOffers(inverseOfferIds = offers, filters = filters))
+    )
+  }
+
+  /**
+    * Factory method to construct a DECLINE_INVERSE_OFFERS Mesos Call event. Calling this method has no side effects.
+    *
+    * Declines an inverse offer. Inverse offers should be declined if
+    * the resources in the offer might not be safely evacuated before
+    * the provided unavailability.
+    *
+    * https://mesosphere.com/blog/mesos-inverse-offers/
+    */
+  def declineInverseOffers(offers: Seq[OfferID], filters: Option[Filters] = None): Call = {
+    Call(
+      frameworkId = someFrameworkId,
+      `type` = Some(Call.Type.DECLINE_INVERSE_OFFERS),
+      declineInverseOffers = Some(Call.DeclineInverseOffers(inverseOfferIds = offers, filters = filters))
+    )
+  }
+}
+
+// TODO: Add more integration tests
+
+object MesosClient extends StrictLogging {
+  case class MesosRedirectException(leader: URI) extends Exception(s"New mesos leader available at $leader")
+
+  case class ConnectionInfo(url: URI, streamId: String)
+
+  val MesosStreamIdHeaderName = "Mesos-Stream-Id"
+  def MesosStreamIdHeader(streamId: String) = headers.RawHeader("Mesos-Stream-Id", streamId)
+  val ProtobufMediaType: MediaType.Binary = MediaType.applicationBinary("x-protobuf", Compressible)
 
   /**
     * This is the first step in the communication process between the scheduler and the master. This is also to be
@@ -363,192 +440,166 @@ trait MesosApi {
     )
   }
 
-  /**
-    * Sent by the scheduler when it wants to tear itself down. When Mesos receives this request it will
-    * shut down all executors (and consequently kill tasks). It then removes the framework and closes all
-    * open connections from this scheduler to the Master.
-    *
-    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#teardown
-    */
-  def teardown(): Call = {
-    Call(
-      `type` = Some(Call.Type.TEARDOWN)
-    )
+  private[client] def log[T](prefix: String): Flow[T, T, NotUsed] = Flow[T].map{ e => logger.info(s"$prefix$e"); e }
+
+  private val dataBytesExtractor: Flow[HttpResponse, ByteString, NotUsed] =
+    Flow[HttpResponse].flatMapConcat(resp => resp.entity.dataBytes)
+
+  private val eventDeserializer: Flow[ByteString, Event, NotUsed] =
+    Flow[ByteString].map(bytes => Event.parseFrom(bytes.toArray))
+
+  private def connectionSource(frameworkInfo: FrameworkInfo, url: URI)(implicit mat: Materializer, as: ActorSystem) = {
+    val body = subscribe(frameworkInfo).toByteArray
+
+    val request = HttpRequest(
+      HttpMethods.POST,
+      uri = Uri("/api/v1/scheduler"),
+      entity = HttpEntity(ProtobufMediaType, body),
+      headers = List(headers.Accept(ProtobufMediaType)))
+
+    val httpConnection = Http().outgoingConnection(url.getHost, url.getPort)
+    Source.single(request)
+      .via(log(s"Connecting to the new leader: ${url}"))
+      .via(httpConnection)
+      .via(log("HttpResponse: "))
   }
 
   /**
-    * Sent by the scheduler when it accepts offer(s) sent by the master. The ACCEPT request includes the type
-    * of operations (e.g., launch task, launch task group, reserve resources, create volumes) that the scheduler
-    * wants to perform on the offers. Note that until the scheduler replies (accepts or declines) to an offer,
-    * the offer’s resources are considered allocated to the offer’s role and to the framework.
-    *
-    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#accept
+    * Input events (Call) are sent to the scheduler, serially, with backpressure. Events received from Mesos are
+    * received accordingly.
     */
-  def accept(accepts: Accept): Call = {
-    Call(
-      `type` = Some(Call.Type.ACCEPT),
-      accept = Some(accepts))
-  }
+  def connect(conf: MesosClientConf, frameworkInfo: FrameworkInfo)(
+    implicit
+    system: ActorSystem, materializer: ActorMaterializer, executionContext: ExecutionContext): Future[MesosClient] = {
 
-  /**
-    * Sent by the scheduler to explicitly decline offer(s) received. Note that this is same as sending an ACCEPT
-    * call with no operations.
-    *
-    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#decline
-    */
-  def decline(offerIds: Seq[OfferID], filters: Option[Filters] = None): Call = {
-    Call(
-      `type` = Some(Call.Type.DECLINE),
-      decline = Some(Decline(offerIds = offerIds, filters = filters))
-    )
-  }
+    val subscribedWatcher: Sink[Event, Future[Event.Subscribed]] = Flow[Event].collect {
+      case event if event.subscribed.isDefined =>
+        event.subscribed.get
+    }.toMat(Sink.head)(Keep.right)
 
-  /**
-    * Sent by the scheduler to remove any/all filters that it has previously set via ACCEPT or DECLINE calls.
-    *
-    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#revive
-    */
-  def revive(role: Option[String] = None): Call = {
-    Call(
-      `type` = Some(Call.Type.REVIVE),
-      revive = Some(Revive(role = role))
-    )
-  }
+    def mesosHttpConnection(url: URI, redirectRetries: Int): Source[(HttpResponse, ConnectionInfo), NotUsed] =
+      connectionSource(frameworkInfo, url)
+        .map { response =>
+          response.status match {
+            case StatusCodes.OK =>
+              logger.info(s"Connected successfully to ${url}");
+              val streamId = response.headers
+                .find(h => h.is(MesosStreamIdHeaderName.toLowerCase))
+                .getOrElse(throw new IllegalStateException(s"Missing MesosStreamId header in ${response.headers}"))
 
-  /**
-    * Suppress offers for the specified roles. If `roles` is empty the `SUPPRESS` call will suppress offers for all
-    * of the roles the framework is currently subscribed to.
-    *
-    * http://mesos.apache.org/documentation/latest/upgrades/#1-2-x-revive-suppress
-    */
-  def suppress(roles: Option[String] = None): Call = {
-    Call(
-      `type` = Some(Call.Type.SUPPRESS),
-      suppress = Some(Call.Suppress(roles))
-    )
-  }
+              (response, ConnectionInfo(url, streamId.value()))
+            case StatusCodes.TemporaryRedirect =>
+              val leader = new URI(response.header[headers.Location].get.value())
+              logger.warn(s"New mesos leader available at $leader")
+              // Update the context with the new leader's host and port and throw an exception that is handled in the
+              // next `recoverWith` stage.
+              response.discardEntityBytes()
+              throw new MesosRedirectException(leader)
+            case _ =>
+              response.discardEntityBytes()
+              throw new IllegalArgumentException(s"Mesos server error: $response")
+          }
+        }
+        .recoverWithRetries(conf.redirectRetries, {
+          case MesosRedirectException(leader) => mesosHttpConnection(leader, redirectRetries)
+        })
 
-  /**
-    * Sent by the scheduler to kill a specific task. If the scheduler has a custom executor, the kill is forwarded
-    * to the executor; it is up to the executor to kill the task and send a TASK_KILLED (or TASK_FAILED) update.
-    * If the task hasn’t yet been delivered to the executor when Mesos master or agent receives the kill request,
-    * a TASK_KILLED is generated and the task launch is not forwarded to the executor. Note that if the task belongs
-    * to a task group, killing of one task results in all tasks in the task group being killed. Mesos releases the
-    * resources for a task once it receives a terminal update for the task. If the task is unknown to the master,
-    * a TASK_LOST will be generated.
-    *
-    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#kill
-    */
-  def kill(taskId: TaskID, agentId: Option[AgentID] = None, killPolicy: Option[KillPolicy]): Call = {
-    Call(
-      `type` = Some(Call.Type.KILL),
-      kill = Some(Kill(taskId = taskId, agentId = agentId, killPolicy = killPolicy))
-    )
-  }
+    val initialUrl = new java.net.URI(s"http://${conf.master}")
 
-  /**
-    * Sent by the scheduler to shutdown a specific custom executor. When an executor gets a shutdown event, it is
-    * expected to kill all its tasks (and send TASK_KILLED updates) and terminate.
-    *
-    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#shutdown
-    */
-  def shutdown(executorId: ExecutorID, agentId: AgentID): Call = {
-    Call(
-      `type` = Some(Call.Type.SHUTDOWN),
-      shutdown = Some(Call.Shutdown(executorId = executorId, agentId = agentId))
-    )
-  }
+    val httpConnection = mesosHttpConnection(initialUrl, conf.redirectRetries)
 
-  /**
-    * Sent by the scheduler to acknowledge a status update. Note that with the new API, schedulers are responsible
-    * for explicitly acknowledging the receipt of status updates that have status.uuid set. These status updates
-    * are retried until they are acknowledged by the scheduler. The scheduler must not acknowledge status updates
-    * that do not have `status.uuid` set, as they are not retried. The `uuid` field contains raw bytes encoded in Base64.
-    *
-    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#acknowledge
-    */
-  def acknowledge(agentId: AgentID, taskId: TaskID, uuid: protobuf.ByteString): Call = {
-    Call(
-      `type` = Some(Call.Type.ACKNOWLEDGE),
-      acknowledge = Some(Acknowledge(agentId, taskId, uuid))
-    )
-  }
+    val eventReader = Flow[HttpResponse]
+      .flatMapConcat(_.entity.dataBytes)
+      .via(RecordIOFraming.scanner())
+      .via(eventDeserializer)
+      .via(log("Received mesos Event: "))
+      .idleTimeout(conf.idleTimeout)
+      .buffer(conf.sourceBufferSize, OverflowStrategy.backpressure)
 
-  /**
-    * Sent by the scheduler to query the status of non-terminal tasks. This causes the master to send back UPDATE
-    * events for each task in the list. Tasks that are no longer known to Mesos will result in TASK_LOST updates.
-    * If the list of tasks is empty, master will send UPDATE events for all currently known tasks of the framework.
-    *
-    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#reconcile
-    */
-  def reconcile(tasks: Seq[Reconcile.Task]): Call = {
-    Call(
-      `type` = Some(Call.Type.RECONCILE),
-      reconcile = Some(Reconcile(tasks))
-    )
-  }
+    val eventsOutputSink = Sink.asPublisher[Event](false)
 
-  /**
-    * Sent by the scheduler to send arbitrary binary data to the executor. Mesos neither interprets this data nor
-    * makes any guarantees about the delivery of this message to the executor. data is raw bytes encoded in Base64
-    *
-    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#message
-    */
-  def message(agentId: AgentID, executorId: ExecutorID, message: ByteString): Call = {
-    Call(
-      `type` = Some(Call.Type.MESSAGE),
-      message = Some(Message(agentId, executorId, protobuf.ByteString.copyFrom(message.toByteBuffer)))
-    )
-  }
+    val graph = GraphDSL.create(
+      httpConnection, subscribedWatcher, Sink.head[ConnectionInfo], KillSwitches.single[Event], eventsOutputSink)(
+      { (_, subscribedF, connectionInfoF, killSwitch, eventsOutputPublisher) =>
+        for {
+          subscribed <- subscribedF
+          connectionInfo <- connectionInfoF,
+        } yield {
+          MesosClient(killSwitch, subscribed, connectionInfo, Source.fromPublisher(eventsOutputPublisher))
+        }
+      }
+    ) { implicit b =>
+        { (httpConnectionShape, subscribedWatchedShape, connectionInfoWatcher, killSwitch, eventsOutputSinkShape) =>
+          import GraphDSL.Implicits._
 
-  /**
-    * Sent by the scheduler to request resources from the master/allocator. The built-in hierarchical allocator
-    * simply ignores this request but other allocators (modules) can interpret this in a customizable fashion.
-    *
-    * http://mesos.apache.org/documentation/latest/scheduler-http-api/#request
-    */
-  def request(requests: Seq[Request]): Call = {
-    Call(
-      `type` = Some(Call.Type.REQUEST),
-      request = Some(Call.Request(requests = requests))
-    )
-  }
+          val unzip = b.add(Unzip[HttpResponse, ConnectionInfo])
+          val connectionBroadcast = b.add(Broadcast[(HttpResponse, ConnectionInfo)](2))
+          val eventBroadcast = b.add(Broadcast[Event](2))
 
-  /**
-    * Accepts an inverse offer. Inverse offers should only be accepted if the resources in the offer can be safely
-    * evacuated before the provided unavailability.
-    *
-    * https://mesosphere.com/blog/mesos-inverse-offers/
-    */
-  def acceptInverseOffers(offers: Seq[OfferID], filters: Option[Filters] = None): Call = {
-    Call(
-      `type` = Some(Call.Type.ACCEPT_INVERSE_OFFERS),
-      acceptInverseOffers = Some(Call.AcceptInverseOffers(inverseOfferIds = offers, filters = filters))
-    )
-  }
+          // Wire output events
+          httpConnectionShape ~> unzip.in
+          unzip.out0.via(eventReader) ~> killSwitch ~> eventBroadcast
+          unzip.out1 ~> connectionInfoWatcher
 
-  /**
-    * Declines an inverse offer. Inverse offers should be declined if
-    * the resources in the offer might not be safely evacuated before
-    * the provided unavailability.
-    *
-    * https://mesosphere.com/blog/mesos-inverse-offers/
-    */
-  def declineInverseOffers(offers: Seq[OfferID], filters: Option[Filters] = None): Call = {
-    Call(
-      `type` = Some(Call.Type.DECLINE_INVERSE_OFFERS),
-      declineInverseOffers = Some(Call.DeclineInverseOffers(inverseOfferIds = offers, filters = filters))
-    )
-  }
+          eventBroadcast.out(0).take(1) ~> subscribedWatchedShape
+          /* we drop the subscribed call to prevent a deadlock situation. Reference to events output source isn't
+           available until we get a subscribed call, and backpressure is applied until that occurs. */
+          eventBroadcast.out(1).drop(1) ~> eventsOutputSinkShape
+          ClosedShape
+        }
+      }
 
+    RunnableGraph.fromGraph(graph).run
+  }
 }
 
-// TODO: Add more integration tests
+/**
+  *
+  */
+case class MesosClient(
+  killSwitch: KillSwitch,
+  subscribed: Event.Subscribed,
+  connectionInfo: MesosClient.ConnectionInfo,
+  /**
+    * Events from Mesos scheduler, sans initial Subscribed event.
+    */
+  mesosSource: Source[Event, NotUsed])(
+    implicit
+    as: ActorSystem, m: Materializer) extends MesosApi with MesosCalls with StrictLoggingFlow {
 
-object MesosClient {
-  case class MesosRedirectException(leader: URI) extends Exception(s"New mesos leader available at $leader")
+  val frameworkId = subscribed.frameworkId
 
-  val MesosStreamIdHeaderName = "Mesos-Stream-Id"
-  def MesosStreamIdHeader(streamId: String) = headers.RawHeader("Mesos-Stream-Id", streamId)
-  val ProtobufMediaType: MediaType.Binary = MediaType.applicationBinary("x-protobuf", Compressible)
+  private val responseHandler: Sink[HttpResponse, Future[Done]] = Sink.foreach[HttpResponse] { response =>
+    response status match {
+      case status if status.isFailure() =>
+        logger.info(s"A request to mesos failed with response: ${response}")
+        response.discardEntityBytes()
+        throw new IllegalStateException(s"Failed to send a call to mesos")
+      case _ =>
+        logger.debug(s"Mesos call response: $response")
+        response.discardEntityBytes()
+    }
+  }
+
+  private val eventSerializer: Flow[Call, Array[Byte], NotUsed] = Flow[Call]
+    .map(call => call.toByteArray)
+
+  private val requestBuilder: Flow[Array[Byte], HttpRequest, NotUsed] = Flow[Array[Byte]]
+    .map(bytes => HttpRequest(
+      HttpMethods.POST,
+      uri = Uri(s"${connectionInfo.url}/api/v1/scheduler"),
+      entity = HttpEntity(MesosClient.ProtobufMediaType, bytes),
+      headers = List(MesosClient.MesosStreamIdHeader(connectionInfo.streamId)))
+    )
+
+  def httpConnection: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] =
+    Http().outgoingConnection(connectionInfo.url.getHost, connectionInfo.url.getPort)
+
+  override val mesosSink: Sink[Call, Future[Done]] =
+    Flow[Call]
+      .via(log("Sending "))
+      .via(eventSerializer)
+      .via(requestBuilder)
+      .via(httpConnection)
+      .toMat(responseHandler)(Keep.right)
 }

--- a/mesos-client/src/main/scala/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/client/MesosClient.scala
@@ -114,7 +114,7 @@ trait MesosClient {
 
 // TODO: Add more integration tests
 
-object MesosClient extends StrictLogging {
+object MesosClient extends StrictLogging with StrictLoggingFlow {
   case class MesosRedirectException(leader: URI) extends Exception(s"New mesos leader available at $leader")
 
   case class ConnectionInfo(url: URI, streamId: String)
@@ -142,8 +142,6 @@ object MesosClient extends StrictLogging {
       subscribe = Some(Call.Subscribe(frameworkInfo)),
       `type` = Some(Call.Type.SUBSCRIBE))
   }
-
-  private[client] def log[T](prefix: String): Flow[T, T, NotUsed] = Flow[T].map{ e => logger.info(s"$prefix$e"); e }
 
   private val dataBytesExtractor: Flow[HttpResponse, ByteString, NotUsed] =
     Flow[HttpResponse].flatMapConcat(resp => resp.entity.dataBytes)

--- a/mesos-client/src/main/scala/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/client/MesosClient.scala
@@ -160,6 +160,7 @@ object MesosClient extends StrictLogging {
       headers = List(headers.Accept(ProtobufMediaType)))
 
     val httpConnection = Http().outgoingConnection(url.getHost, url.getPort)
+
     Source.single(request)
       .via(log(s"Connecting to the new leader: ${url}"))
       .via(httpConnection)

--- a/mesos-client/src/main/scala/mesosphere/mesos/client/StrictLoggingFlow.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/client/StrictLoggingFlow.scala
@@ -1,0 +1,10 @@
+package mesosphere.mesos.client
+
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
+import com.typesafe.scalalogging.StrictLogging
+
+// TODO - move somewhere shared
+trait StrictLoggingFlow extends StrictLogging {
+  protected def log[T](prefix: String): Flow[T, T, NotUsed] = Flow[T].map{ e => logger.info(s"$prefix$e"); e }
+}

--- a/mesos-client/src/main/scala/mesosphere/mesos/client/StrictLoggingFlow.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/client/StrictLoggingFlow.scala
@@ -4,7 +4,6 @@ import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import com.typesafe.scalalogging.StrictLogging
 
-// TODO - move somewhere shared
 trait StrictLoggingFlow extends StrictLogging {
   protected def log[T](prefix: String): Flow[T, T, NotUsed] = Flow[T].map{ e => logger.info(s"$prefix$e"); e }
 }

--- a/mesos-client/src/main/scala/mesosphere/mesos/conf/MesosClientConf.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/conf/MesosClientConf.scala
@@ -7,12 +7,12 @@ import scala.concurrent.duration._
   *
   * @param master The URL of the Mesos master
   * @param sourceBufferSize Buffer size of the mesos source im messages
-  * @param redirectRetires Number of retries to follow mesos master redirect
+  * @param redirectRetries Number of retries to follow mesos master redirect
   * @param idleTimeout Time in seconds between two processed elements exceeds the provided timeout then the connection to mesos
   *                    is interrupted. Is usually set to approx. 5 hear beats.
   */
 case class MesosClientConf(
     master: String,
     sourceBufferSize: Int = 10,
-    redirectRetires: Int = 3,
+    redirectRetries: Int = 3,
     idleTimeout: FiniteDuration = 75.seconds)

--- a/mesos-client/src/main/scala/mesosphere/mesos/examples/UselessFramework.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/examples/UselessFramework.scala
@@ -34,7 +34,7 @@ object UselessFramework extends App with StrictLoggingFlow {
   )
 
   val conf = new MesosClientConf(master = s"127.0.0.1:5050")
-  val client = Await.result(MesosClient(conf, frameworkInfo).run, 10.seconds)
+  val client = Await.result(MesosClient(conf, frameworkInfo).runWith(Sink.head), 10.seconds)
 
   client.mesosSource.runWith(Sink.foreach { event =>
 

--- a/mesos-client/src/main/scala/mesosphere/mesos/examples/UselessFramework.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/examples/UselessFramework.scala
@@ -13,52 +13,49 @@ import scala.concurrent.duration._
 
 import scala.util.{ Failure, Success }
 
+/**
+  * Run Foo framework that:
+  *  - successfully subscribes
+  *  - declines all offers.
+  *
+  *  Not much, but shows the basic idea. Good to test against local mesos.
+  *
+  */
 object UselessFramework extends App with StrictLoggingFlow {
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+  implicit val executionContext = system.dispatcher
 
-  /**
-    * Run Foo framework that:
-    *  - successfully subscribes
-    *  - declines all offers.
-    *
-    *  Not much, but shows the basic idea. Good to test against local mesos.
-    *
-    */
-  override def main(args: Array[String]): Unit = {
-    implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
-    implicit val executionContext = system.dispatcher
+  val frameworkInfo = FrameworkInfo(
+    user = "foo",
+    name = "Example FOO Framework",
+    roles = Seq("test"),
+    capabilities = Seq(FrameworkInfo.Capability(`type` = Some(FrameworkInfo.Capability.Type.MULTI_ROLE)))
+  )
 
-    val frameworkInfo = FrameworkInfo(
-      user = "foo",
-      name = "Example FOO Framework",
-      roles = Seq("test"),
-      capabilities = Seq(FrameworkInfo.Capability(`type` = Some(FrameworkInfo.Capability.Type.MULTI_ROLE)))
-    )
+  val conf = new MesosClientConf(master = s"127.0.0.1:5050")
+  val client = Await.result(MesosClient(conf, frameworkInfo).run, 10.seconds)
 
-    val conf = new MesosClientConf(master = s"127.0.0.1:5050")
-    val client = Await.result(MesosClient(conf, frameworkInfo).run, 10.seconds)
+  client.mesosSource.runWith(Sink.foreach { event =>
 
-    client.mesosSource.runWith(Sink.foreach { event =>
+    if (event.`type`.get == Event.Type.SUBSCRIBED) {
+      logger.info("Successfully subscribed to mesos")
+    } else if (event.`type`.get == Event.Type.OFFERS) {
 
-      if (event.`type`.get == Event.Type.SUBSCRIBED) {
-        logger.info("Successfully subscribed to mesos")
-      } else if (event.`type`.get == Event.Type.OFFERS) {
+      val offerIds = event.offers.get.offers.map(_.id).toList
 
-        val offerIds = event.offers.get.offers.map(_.id).toList
-
-        Source(offerIds)
-          .via(log(s"Declining offer with id = ")) // Decline all offers
-          .map(oId => client.callFactory.decline(
-            offerIds = Seq(oId),
-            filters = Some(Filters(Some(5.0f)))
-          ))
-          .runWith(client.mesosSink)
-      }
-
-    }).onComplete{
-      case Success(res) =>
-        logger.info(s"Stream completed: $res"); system.terminate()
-      case Failure(e) => logger.error(s"Error in stream: $e"); system.terminate()
+      Source(offerIds)
+        .via(log(s"Declining offer with id = ")) // Decline all offers
+        .map(oId => client.calls.newDecline(
+          offerIds = Seq(oId),
+          filters = Some(Filters(Some(5.0f)))
+        ))
+        .runWith(client.mesosSink)
     }
+
+  }).onComplete{
+    case Success(res) =>
+      logger.info(s"Stream completed: $res"); system.terminate()
+    case Failure(e) => logger.error(s"Error in stream: $e"); system.terminate()
   }
 }

--- a/mesos-client/src/main/scala/mesosphere/mesos/examples/UselessFramework.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/examples/UselessFramework.scala
@@ -36,7 +36,7 @@ object UselessFramework extends App with StrictLoggingFlow {
     )
 
     val conf = new MesosClientConf(master = s"127.0.0.1:5050")
-    val client = Await.result(MesosClient.connect(conf, frameworkInfo).run, 10.seconds)
+    val client = Await.result(MesosClient(conf, frameworkInfo).run, 10.seconds)
 
     client.mesosSource.runWith(Sink.foreach { event =>
 
@@ -48,7 +48,7 @@ object UselessFramework extends App with StrictLoggingFlow {
 
         Source(offerIds)
           .via(log(s"Declining offer with id = ")) // Decline all offers
-          .map(oId => client.decline(
+          .map(oId => client.callFactory.decline(
             offerIds = Seq(oId),
             filters = Some(Filters(Some(5.0f)))
           ))

--- a/mesos-client/src/main/scala/mesosphere/mesos/examples/UselessFramework.scala
+++ b/mesos-client/src/main/scala/mesosphere/mesos/examples/UselessFramework.scala
@@ -36,7 +36,7 @@ object UselessFramework extends App with StrictLoggingFlow {
     )
 
     val conf = new MesosClientConf(master = s"127.0.0.1:5050")
-    val client = Await.result(MesosClient.connect(conf, frameworkInfo), 10.seconds)
+    val client = Await.result(MesosClient.connect(conf, frameworkInfo).run, 10.seconds)
 
     client.mesosSource.runWith(Sink.foreach { event =>
 

--- a/mesos-client/src/test/scala/mesosphere/mesos/client/MesosClientIntegrationTest.scala
+++ b/mesos-client/src/test/scala/mesosphere/mesos/client/MesosClientIntegrationTest.scala
@@ -3,14 +3,14 @@ package mesosphere.mesos.client
 import java.util.UUID
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, UniqueKillSwitch}
-import akka.stream.scaladsl.{Keep, Sink, SinkQueueWithCancel, Source}
+import akka.stream.{ ActorMaterializer, UniqueKillSwitch }
+import akka.stream.scaladsl.{ Keep, Sink, SinkQueueWithCancel, Source }
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.IntegrationTest
 import mesosphere.marathon.integration.setup.MesosClusterTest
 import mesosphere.mesos.conf.MesosClientConf
-import org.apache.mesos.v1.mesos.{Filters, FrameworkID, FrameworkInfo}
+import org.apache.mesos.v1.mesos.{ Filters, FrameworkID, FrameworkInfo }
 import org.apache.mesos.v1.scheduler.scheduler.Event
 import org.scalatest.Inside
 import org.scalatest.concurrent.Eventually
@@ -30,15 +30,11 @@ class MesosClientIntegrationTest extends AkkaUnitTest
     Then("a framework successfully subscribes without a framework Id")
     event.`type` shouldBe Some(Event.Type.SUBSCRIBED)
 
-
     And("connection context should be initialized")
-    inside(f.client.contextPromise.future.futureValue) {
-      case MesosConnectionContext(url, mesosStreamId, frameworkId) =>
-        url.getHost shouldBe f.mesosHost
-        url.getPort shouldBe f.mesosPort
-        mesosStreamId shouldBe defined
-        frameworkId shouldBe defined
-    }
+    f.client.connectionInfo.url.getHost shouldBe f.mesosHost
+    f.client.connectionInfo.url.getPort shouldBe f.mesosPort
+    f.client.connectionInfo.streamId.length() should be > 1
+    f.client.frameworkId.value.length() should be > 1
   }
 
   "Mesos client should successfully subscribe to mesos with framework Id" in {
@@ -53,13 +49,7 @@ class MesosClientIntegrationTest extends AkkaUnitTest
       event.subscribed.get.frameworkId shouldBe frameworkID
 
       And("connection context should be initialized")
-      inside(f.client.contextPromise.future.futureValue) {
-        case MesosConnectionContext(url, mesosStreamId, frameworkId) =>
-          url.getHost shouldBe f.mesosHost
-          url.getPort shouldBe f.mesosPort
-          mesosStreamId shouldBe defined
-          frameworkId shouldBe Some(frameworkID)
-      }
+      f.client.frameworkId shouldBe (frameworkID)
     }
   }
 
@@ -89,14 +79,13 @@ class MesosClientIntegrationTest extends AkkaUnitTest
     And("an offer event is received")
     val decline = f.client.decline(
       offerIds = Seq(offerId),
-      filters = Some(Filters(Some(0.0f)))
-    )
+      filters = Some(Filters(Some(0.0f))))
 
     And("and an offer is declined")
     Source.single(decline).runWith(f.client.mesosSink)
 
     Then("eventually a new offer event arrives")
-    eventually{
+    eventually {
       events = f.pull(1)
       events.count(_.`type`.contains(Event.Type.OFFERS)) should be > 0
     }
@@ -107,7 +96,7 @@ class MesosClientIntegrationTest extends AkkaUnitTest
   def withFixture(frameworkId: Option[FrameworkID] = None)(fn: Fixture => Unit): Unit = {
     val f = new Fixture(frameworkId)
     try fn(f) finally {
-      f.switch.shutdown()
+      f.client.killSwitch.shutdown()
     }
   }
 
@@ -121,26 +110,25 @@ class MesosClientIntegrationTest extends AkkaUnitTest
       id = frameworkId,
       roles = Seq("foo"),
       failoverTimeout = Some(0.0f),
-      capabilities = Seq(FrameworkInfo.Capability(`type` = Some(FrameworkInfo.Capability.Type.MULTI_ROLE)))
-    )
+      capabilities = Seq(FrameworkInfo.Capability(`type` = Some(FrameworkInfo.Capability.Type.MULTI_ROLE))))
 
     val mesosUrl = new java.net.URI(mesos.url)
     val mesosHost = mesosUrl.getHost
     val mesosPort = mesosUrl.getPort
 
     val conf = new MesosClientConf(master = s"${mesosUrl.getHost}:${mesosUrl.getPort}")
-    val client = new MesosClient(conf, frameworkInfo)
+    val client = MesosClient.connect(conf, frameworkInfo).futureValue
 
-    val (switch: UniqueKillSwitch, queue: SinkQueueWithCancel[Event]) = client.mesosSource.toMat(Sink.queue())(Keep.both).run()
+    val queue = client.mesosSource.runWith(Sink.queue())
 
     /**
-      * Method will pull n elements from the queue effectively awaiting n elements from mesos. Unlike take() e.g.
-      * `f.client.mesosSource.take(1)` it will not cancel the upstream after the number of elements is received. A
-      * TimeoutException is thrown should the element not be available withing `patienceConfig.timeout` milliseconds.
-      *
-      * @param n number of elements to pull
-      * @return a sequence of elements
-      */
+     * Method will pull n elements from the queue effectively awaiting n elements from mesos. Unlike take() e.g.
+     * `f.client.mesosSource.take(1)` it will not cancel the upstream after the number of elements is received. A
+     * TimeoutException is thrown should the element not be available withing `patienceConfig.timeout` milliseconds.
+     *
+     * @param n number of elements to pull
+     * @return a sequence of elements
+     */
     def pull(n: Int): Seq[Event] = {
       (1 to n).map(_ => queue.pull().futureValue.get)
     }

--- a/mesos-client/src/test/scala/mesosphere/mesos/client/MesosClientIntegrationTest.scala
+++ b/mesos-client/src/test/scala/mesosphere/mesos/client/MesosClientIntegrationTest.scala
@@ -115,7 +115,7 @@ class MesosClientIntegrationTest extends AkkaUnitTest
     val mesosPort = mesosUrl.getPort
 
     val conf = new MesosClientConf(master = s"${mesosUrl.getHost}:${mesosUrl.getPort}")
-    val client = MesosClient(conf, frameworkInfo).run.futureValue
+    val client = MesosClient(conf, frameworkInfo).runWith(Sink.head).futureValue
 
     val queue = client.mesosSource.
       runWith(Sink.queue())

--- a/mesos-client/src/test/scala/mesosphere/mesos/client/MesosClientIntegrationTest.scala
+++ b/mesos-client/src/test/scala/mesosphere/mesos/client/MesosClientIntegrationTest.scala
@@ -70,7 +70,7 @@ class MesosClientIntegrationTest extends AkkaUnitTest
     val offerId = offer.offers.get.offers.head.id
 
     And("and an offer is declined")
-    val decline = f.client.callFactory.decline(
+    val decline = f.client.calls.newDecline(
       offerIds = Seq(offerId),
       filters = Some(Filters(Some(0.0f))))
 


### PR DESCRIPTION
We remove the mutable connection info and frameworkId, and instead
return a `Source[MesosClient, NotUsed]`, similar to how Akka HTTP client returns responses with a streamable entity.

The connection logic consumes the initial `Subscribed` event, the data for which is available in the `MesosClient` instance. The further Mesos events are available via a materializable-once source `mesosClient.mesosSource`.