### PR TITLE
Fixing datadog and statsd reporter configuration

### DIFF
--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -14,6 +14,7 @@ import mesosphere.chaos.http.HttpModule
 import mesosphere.chaos.metrics.MetricsModule
 import mesosphere.marathon.api.{ MarathonHttpService, MarathonRestModule }
 import mesosphere.marathon.core.CoreGuiceModule
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.marathon.core.base.toRichRuntime
 import mesosphere.marathon.metrics.Metrics
@@ -52,29 +53,64 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
   val config: Config = {
     // eventually we will need a more robust way of going from Scallop -> Config.
     val overrides = {
+
+      //
+      // Create Kamon configuration spec for the `kamon.datadog` plugin
+      //
       val datadog = cliConf.dataDog.get.map { urlStr =>
-        val url = new URI(urlStr)
+        val url = Uri(urlStr)
+        val params = url.query()
+
         s"""
-      |kamon.datadog {
-      |hostname: ${url.getHost}
-      |port: ${if (url.getPort == -1) 8125 else url.getPort}
-      |}
-        """.stripMargin
+           |kamon.datadog {
+           |  hostname: ${url.authority.host}
+           |  port: ${if (url.authority.port == 0) 8125 else url.authority.port}
+           |  flush-interval: ${params.collectFirst { case ("interval", iv) => iv.toInt }.getOrElse(10)} seconds
+           |""".stripMargin +
+          params.foldLeft("")(
+            (expr: String, param) => param._1 match {
+              case "prefix" => expr + s"  application-name: ${param._2}\n"
+              case "tags" => expr + s"  global-tags: ${param._2}\n"
+              case "max-packet-size" => expr + s"  max-packet-size: ${param._2}\n"
+              case "api-key" => expr + s"  http.api-key: ${param._2}\n"
+              case "interval" => expr // Already handled; this case used only to account this as 'known' parameter
+              case _ => {
+                logger.warn(s"Datadog reporter parameter `${param._1}` is unknown and ignored")
+                expr
+              }
+            }
+          ) +
+            "}"
       }
+
+      //
+      // Create Kamon configuration spec for the `kamon.statsd` plugin
+      //
       val statsd = cliConf.graphite.get.map { urlStr =>
         val url = Uri(urlStr)
-
         if (url.scheme.toLowerCase() != "udp") {
           logger.warn(s"Graphite reporter protocol ${url.scheme} is not supported; using UDP")
         }
+
         val params = url.query()
         s"""
            |kamon.statsd {
            |  hostname: ${url.authority.host}
            |  port: ${if (url.authority.port == 0) 8125 else url.authority.port}
            |  flush-interval: ${params.collectFirst { case ("interval", iv) => iv.toInt }.getOrElse(10)} seconds
-           |}
-         """.stripMargin
+         """.stripMargin +
+          params.foldLeft("")(
+            (expr: String, param) => param._1 match {
+              case "prefix" => expr + s"  simple-metric-key-generator.application: ${param._2}\n"
+              case "hostname" => expr + s"  simple-metric-key-generator.hostname-override: ${param._2}\n"
+              case "interval" => expr // Already handled; this case used only to account this as 'known' parameter
+              case _ => {
+                logger.warn(s"Statsd reporter parameter `${param._1}` is unknown and ignored")
+                expr
+              }
+            }
+          ) +
+            "}"
       }
 
       ConfigFactory.parseString(s"${datadog.getOrElse("")}\n${statsd.getOrElse("")}")


### PR DESCRIPTION
This commit is handling the missing `prefix` URI parameter for the `--reporter_graphite` and `--reporter_datadog` arguments.

It is also adding support for more parameters that the plugins support but we didn't expose already.

Related JIRAs: [MARATHON_EE-1916](https://jira.mesosphere.com/browse/MARATHON_EE-1916) and [MARATHON-8083](https://jira.mesosphere.com/browse/MARATHON-8083)