### PR TITLE
Backport #6121 to 1.5.x

### DIFF
--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -1,8 +1,6 @@
 package mesosphere.marathon
 
 import java.lang.Thread.UncaughtExceptionHandler
-import java.net.URI
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
 import com.google.common.util.concurrent.ServiceManager
@@ -16,7 +14,6 @@ import mesosphere.marathon.api.{ MarathonHttpService, MarathonRestModule }
 import mesosphere.marathon.api.akkahttp.AkkaHttpModule
 import mesosphere.marathon.core.CoreGuiceModule
 import mesosphere.marathon.core.async.ExecutionContexts
-
 import mesosphere.marathon.core.base.toRichRuntime
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.stream.Implicits._
@@ -64,26 +61,21 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
         val url = Uri(urlStr)
         val params = url.query()
 
-        s"""
-           |kamon.datadog {
-           |  hostname: ${url.authority.host}
-           |  port: ${if (url.authority.port == 0) 8125 else url.authority.port}
-           |  flush-interval: ${params.collectFirst { case ("interval", iv) => iv.toInt }.getOrElse(10)} seconds
-           |""".stripMargin +
-          params.foldLeft("")(
-            (expr: String, param) => param._1 match {
-              case "prefix" => expr + s"  application-name: ${param._2}\n"
-              case "tags" => expr + s"  global-tags: ${param._2}\n"
-              case "max-packet-size" => expr + s"  max-packet-size: ${param._2}\n"
-              case "api-key" => expr + s"  http.api-key: ${param._2}\n"
-              case "interval" => expr // Already handled; this case used only to account this as 'known' parameter
-              case _ => {
-                logger.warn(s"Datadog reporter parameter `${param._1}` is unknown and ignored")
-                expr
-              }
+        (List(
+          Some("kamon.datadog.hostname" -> url.authority.host),
+          Some("kamon.datadog.port" -> (if (url.authority.port == 0) 8125 else url.authority.port)),
+          Some("kamon.datadog.flush-interval" -> s"${params.collectFirst { case ("interval", iv) => iv.toInt }.getOrElse(10)} seconds")
+        ) ++ params.map {
+            case ("prefix", value) => Some("kamon.datadog.application-name" -> value)
+            case ("tags", value) => Some("kamon.datadog.global-tags" -> value)
+            case ("max-packet-size", value) => Some("kamon.datadog.max-packet-size" -> value)
+            case ("api-key", value) => Some("kamon.datadog.http.api-key" -> value)
+            case ("interval", _) => None // (This case used only to account this as 'known' parameter)
+            case (name, _) => {
+              logger.warn(s"Datadog reporter parameter `${name}` is unknown and ignored")
+              None
             }
-          ) +
-            "}"
+          }).flatten.toMap
       }
 
       //
@@ -91,32 +83,30 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
       //
       val statsd = cliConf.graphite.get.map { urlStr =>
         val url = Uri(urlStr)
+        val params = url.query()
+
         if (url.scheme.toLowerCase() != "udp") {
           logger.warn(s"Graphite reporter protocol ${url.scheme} is not supported; using UDP")
         }
 
-        val params = url.query()
-        s"""
-           |kamon.statsd {
-           |  hostname: ${url.authority.host}
-           |  port: ${if (url.authority.port == 0) 8125 else url.authority.port}
-           |  flush-interval: ${params.collectFirst { case ("interval", iv) => iv.toInt }.getOrElse(10)} seconds
-         """.stripMargin +
-          params.foldLeft("")(
-            (expr: String, param) => param._1 match {
-              case "prefix" => expr + s"  simple-metric-key-generator.application: ${param._2}\n"
-              case "hostname" => expr + s"  simple-metric-key-generator.hostname-override: ${param._2}\n"
-              case "interval" => expr // Already handled; this case used only to account this as 'known' parameter
-              case _ => {
-                logger.warn(s"Statsd reporter parameter `${param._1}` is unknown and ignored")
-                expr
-              }
+        (List(
+          Some("kamon.statsd.hostname" -> url.authority.host),
+          Some("kamon.statsd.port" -> (if (url.authority.port == 0) 8125 else url.authority.port)),
+          Some("kamon.statsd.flush-interval" -> s"${params.collectFirst { case ("interval", iv) => iv.toInt }.getOrElse(10)} seconds")
+        ) ++ params.map {
+            case ("prefix", value) => Some("kamon.statsd.simple-metric-key-generator.application" -> value)
+            case ("hostname", value) => Some("kamon.statsd.simple-metric-key-generator.hostname-override" -> value)
+            case ("interval", _) => None // (This case used only to account this as 'known' parameter)
+            case (name, _) => {
+              logger.warn(s"Statsd reporter parameter `${name}` is unknown and ignored")
+              None
             }
-          ) +
-            "}"
+          }).flatten.toMap
       }
 
-      ConfigFactory.parseString(s"${datadog.getOrElse("")}\n${statsd.getOrElse("")}")
+      // Stringify the map
+      val values = datadog.getOrElse(Map()) ++ statsd.getOrElse(Map())
+      ConfigFactory.parseString(values.map(kv => s"${kv._1}: ${kv._2}").mkString("\n"))
     }
 
     overrides.withFallback(ConfigFactory.load())


### PR DESCRIPTION
This commit back-ports the code fixing the datadog and statsd reporter configuration to 1.5 release.

_Related JIRA: [MARATHON_EE-1916](https://jira.mesosphere.com/browse/MARATHON_EE-1916)_