### PR TITLE
Using SSE endpoint for performance tests

### DIFF
--- a/tests/performance/config/perf-driver/observers/observer-marathon-sse.yml
+++ b/tests/performance/config/perf-driver/observers/observer-marathon-sse.yml
@@ -11,5 +11,5 @@
 observers:
 
   # The events observer is subscribing to the
-  - class: observer.MarathonPollerObserver
-    url: "{{marathon_url}}/v2/events"
+  - class: observer.MarathonEventsObserver
+    url: "{{marathon_url}}/v2/events?plan-format=light"

--- a/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
+++ b/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
@@ -21,7 +21,7 @@ include:
 
   # Use marathon's SSE endpoint to measure our metrics
   - observers/observer-marathon-http-timing.yml
-  - observers/observer-marathon-poller.yml
+  - observers/observer-marathon-sse.yml
 
   # Measure the given metrics
   - measure/measure-deploymentTime.yml

--- a/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
+++ b/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
@@ -21,7 +21,7 @@ include:
 
   # Use marathon's SSE endpoint to measure our metrics
   - observers/observer-marathon-http-timing.yml
-  - observers/observer-marathon-poller.yml
+  - observers/observer-marathon-sse.yml
 
   # Measure the given metrics
   - measure/measure-deploymentTime.yml


### PR DESCRIPTION
Now that we have lightweight events in place this commit switches the perf
driver configuration to use the SSE endpoint for receiving deployment
completion events.