### PR TITLE
Removed the redundant Instance.isLaunched value in favor of isActive

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -189,7 +189,7 @@ private class DeploymentActor(
     await(launchQueue.asyncPurge(runSpec.id))
 
     val instances = await(instanceTracker.specInstances(runSpec.id))
-    val launchedInstances = instances.filter(_.isLaunched)
+    val launchedInstances = instances.filter(_.isActive)
 
     logger.info(s"Killing all instances of ${runSpec.id}: ${launchedInstances.map(_.instanceId)}")
     await(killService.killInstances(launchedInstances, KillReason.DeletingApp))

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
@@ -52,8 +52,8 @@ trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Acto
       launchQueue.addAsync(runSpec, 1).pipeTo(self)
 
     case Sync => async {
-      val launchedInstances = await(instanceTracker.countLaunchedSpecInstances(runSpec.id))
-      val actualSize = await(launchQueue.getAsync(runSpec.id)).fold(launchedInstances)(_.finalInstanceCount)
+      val activeInstances = await(instanceTracker.countActiveSpecInstances(runSpec.id))
+      val actualSize = await(launchQueue.getAsync(runSpec.id)).fold(activeInstances)(_.finalInstanceCount)
       val instancesToStartNow = Math.max(scaleTo - actualSize, 0)
       logger.debug(s"Sync start instancesToStartNow=$instancesToStartNow appId=${runSpec.id}")
       if (instancesToStartNow > 0) {

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -32,7 +32,7 @@ class TaskStartActor(
   override val nrToStart: Future[Int] = async {
     val alreadyLaunched = await(launchQueue.getAsync(runSpec.id)) match {
       case Some(info) => info.finalInstanceCount
-      case None => await(instanceTracker.countLaunchedSpecInstances(runSpec.id))
+      case None => await(instanceTracker.countActiveSpecInstances(runSpec.id))
     }
     Math.max(0, scaleTo - alreadyLaunched)
   }.pipeTo(self)

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -81,7 +81,7 @@ private[health] class HealthCheckActor(
       app.version,
       healthCheck
     )
-    val activeInstanceIds: Set[Instance.Id] = instances.withFilter(_.isLaunched).map(_.instanceId)(collection.breakOut)
+    val activeInstanceIds: Set[Instance.Id] = instances.withFilter(_.isActive).map(_.instanceId)(collection.breakOut)
     // The Map built with filterKeys wraps the original map and contains a reference to activeInstanceIds.
     // Therefore we materialize it into a new map.
     healthByInstanceId = healthByInstanceId.filterKeys(activeInstanceIds).iterator.toMap

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -32,7 +32,6 @@ case class Instance(
     reservation: Option[Reservation]) extends MarathonState[Protos.Json, Instance] with Placed {
 
   val runSpecId: PathId = instanceId.runSpecId
-  val isLaunched: Boolean = state.condition.isActive
 
   // An instance has to be considered as Reserved if at least one of its tasks is Reserved.
   def isReserved: Boolean = tasksMap.values.exists(_.status.condition == Condition.Reserved)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -28,8 +28,7 @@ trait InstanceTracker {
   def instancesBySpecSync: InstanceTracker.InstancesBySpec
   def instancesBySpec()(implicit ec: ExecutionContext): Future[InstanceTracker.InstancesBySpec]
 
-  def countLaunchedSpecInstancesSync(appId: PathId): Int
-  def countLaunchedSpecInstances(appId: PathId): Future[Int]
+  def countActiveSpecInstances(appId: PathId): Future[Int]
 
   def hasSpecInstancesSync(appId: PathId): Boolean
   def hasSpecInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Boolean]

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -40,11 +40,9 @@ private[tracker] class InstanceTrackerDelegate(
   }
 
   // TODO(jdef) support pods when counting launched instances
-  override def countLaunchedSpecInstancesSync(appId: PathId): Int =
-    instancesBySpecSync.specInstances(appId).count(instance => instance.isLaunched || instance.isReserved)
-  override def countLaunchedSpecInstances(appId: PathId): Future[Int] = {
+  override def countActiveSpecInstances(appId: PathId): Future[Int] = {
     import scala.concurrent.ExecutionContext.Implicits.global
-    instancesBySpec().map(_.specInstances(appId).count(instance => instance.isLaunched || instance.isReserved))
+    instancesBySpec().map(_.specInstances(appId).count(instance => instance.isActive || instance.isReserved))
   }
 
   override def hasSpecInstancesSync(appId: PathId): Boolean = instancesBySpecSync.hasSpecInstances(appId)

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -454,7 +454,6 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
     val hcManager: HealthCheckManager = mock[HealthCheckManager]
 
     val instanceTracker: InstanceTracker = mock[InstanceTracker]
-    instanceTracker.countLaunchedSpecInstancesSync(any[PathId]) returns 0
     instanceTracker.specInstances(any)(any) returns Future.successful(Seq.empty[Instance])
     instanceTracker.specInstancesSync(any) returns Seq.empty[Instance]
 

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
@@ -36,7 +36,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
         val app = AppDefinition("/myApp".toPath, instances = 5)
 
         f.launchQueue.getAsync(app.id) returns Future.successful(counts)
-        f.taskTracker.countLaunchedSpecInstances(app.id) returns Future.successful(0)
+        f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
         val ref = f.startActor(app, app.instances, promise)
         watch(ref)
 
@@ -78,7 +78,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition("/myApp".toPath, instances = 5)
 
       f.launchQueue.getAsync(app.id) returns Future.successful(None)
-      f.taskTracker.countLaunchedSpecInstances(app.id) returns Future.successful(1)
+      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(1)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -98,7 +98,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 0)
       f.launchQueue.getAsync(app.id) returns Future.successful(None)
-      f.taskTracker.countLaunchedSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -117,7 +117,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
         healthChecks = Set(MesosCommandHealthCheck(command = Command("true")))
       )
       f.launchQueue.getAsync(app.id) returns Future.successful(None)
-      f.taskTracker.countLaunchedSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -141,7 +141,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
         healthChecks = Set(MesosCommandHealthCheck(command = Command("true")))
       )
       f.launchQueue.getAsync(app.id) returns Future.successful(None)
-      f.taskTracker.countLaunchedSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -157,7 +157,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition("/myApp".toPath, instances = 1)
 
       f.launchQueue.getAsync(app.id) returns Future.successful(None)
-      f.taskTracker.countLaunchedSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -184,7 +184,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition("/myApp".toPath, instances = 5)
 
       f.launchQueue.getAsync(app.id) returns Future.successful(None)
-      f.taskTracker.countLaunchedSpecInstances(app.id) returns Future.successful(1)
+      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(1)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -193,7 +193,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       eventually { verify(f.launchQueue, atLeastOnce).addAsync(eq(app), any) }
 
       // let existing task die
-      f.taskTracker.countLaunchedSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
       f.launchQueue.getAsync(app.id) returns Future.successful(Some(LaunchQueueTestHelper.zeroCounts.copy(instancesLeftToLaunch = 4, finalInstanceCount = 4)))
       system.eventStream.publish(f.instanceChange(app, Instance.Id("task-4"), Condition.Error))
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -464,11 +464,11 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
   def shouldNotContainTask(tasks: Seq[Instance], task: Instance) =
     assert(!containsTask(tasks, task), s"Should not contain ${task.instanceId}")
 
-  def shouldHaveTaskStatus(task: Instance, stateOp: InstanceUpdateOperation.MesosUpdate): Unit = {
+  def shouldHaveTaskStatus(instance: Instance, stateOp: InstanceUpdateOperation.MesosUpdate): Unit = {
     assert(Option(stateOp.mesosStatus).isDefined, "mesos status is None")
-    assert(task.isLaunched)
+    assert(instance.isActive)
     assert(
-      task.tasksMap.values.map(_.status.mesosStatus.get).forall(status => status == stateOp.mesosStatus),
+      instance.tasksMap.values.map(_.status.mesosStatus.get).forall(status => status == stateOp.mesosStatus),
       s"Should have task status ${stateOp.mesosStatus}")
   }
 


### PR DESCRIPTION
Removed the redundant Instance.isLaunched value in favor of Instance.isActive (which had the exact same implementation).

Renamed vals like launchedInstances to activeInstances where applicable.

JIRA issues: MARATHON-2547