### PR TITLE
Send Instance health changed event when the overall status Backport

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckBenchmark.scala
@@ -1,0 +1,105 @@
+package mesosphere.marathon
+package core.health.impl
+
+import java.util.concurrent.TimeUnit
+
+import mesosphere.marathon.core.health.{Health, MarathonHttpHealthCheck, PortReference, impl}
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{ApplicationKey, InstanceKey}
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.state.PathId
+import org.openjdk.jmh.annotations.{Mode, OutputTimeUnit, Scope, State, BenchmarkMode, Fork, Benchmark}
+import org.openjdk.jmh.infra.Blackhole
+import mesosphere.marathon.state.Timestamp
+
+object AppHealthCheckBenchmark {
+  private final val NB_APPLICATIONS = 1000
+  private final val NB_VERSIONS_PER_APPLICATION = 3
+
+  // this number is used for head revision of the app only
+  private final val NB_INSTANCES_PER_APPLICATION = 10
+  private final val NB_INSTANCES = NB_APPLICATIONS * NB_INSTANCES_PER_APPLICATION
+
+  private final val NB_STATUS_UPDATES = 10000
+
+  val randomGenerator = scala.util.Random
+
+  val healthChecks = Seq(
+    MarathonHttpHealthCheck(portIndex = Some(PortReference(80))),
+    MarathonHttpHealthCheck(portIndex = Some(PortReference(443))),
+    MarathonHttpHealthCheck(portIndex = Some(PortReference(8080)))
+  )
+  val applicationKeys = 0.to(NB_APPLICATIONS).flatMap(appId => {
+    0.to(NB_VERSIONS_PER_APPLICATION).map(version => Timestamp(version.toLong))
+      .map(version => ApplicationKey(PathId(s"$appId"), version))
+  })
+
+  val shuffledApplicationKeys = scala.util.Random.shuffle(applicationKeys)
+
+  val instanceKeys = applicationKeys.flatMap(appKey => {
+    0.to(NB_INSTANCES_PER_APPLICATION).map(instanceId => InstanceKey(appKey, Instance.Id(s"$instanceId")))
+  })
+
+  val randomlySelectedInstanceKeysWithStatus = 0.to(NB_STATUS_UPDATES).map(idx => {
+    val instanceIdx = randomGenerator.nextInt(NB_INSTANCES)
+    val hcIdx = instanceIdx % 3
+    val healthSelector = instanceIdx % 2
+    val instanceKey = instanceKeys(instanceIdx)
+    val failingHealth = Health(instanceKey.instanceId, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(10)))
+    val successHealth = Health(instanceKey.instanceId, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0)))
+    val health = healthSelector match {
+      case 0 => successHealth
+      case _ => failingHealth
+    }
+    (instanceKey.applicationKey, healthChecks(hcIdx), health)
+  })
+  val doNothingNotifier = (h: Option[Boolean]) => {}
+
+  val appHealthCheckProxy = new impl.AppHealthCheckActor.AppHealthCheckProxy
+  val appHealthCheckProxyWithAlreadyRegisteredHealthChecks = {
+    val proxy = new impl.AppHealthCheckActor.AppHealthCheckProxy
+    for(
+      applicationKey <- applicationKeys;
+      healthCheck <- healthChecks
+    ) {
+      proxy.addHealthCheck(applicationKey, healthCheck)
+    }
+    proxy
+  }
+}
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
+@Fork(1)
+class AppHealthCheckBenchmark {
+  import AppHealthCheckBenchmark._
+
+  /**
+    * Simulate Marathon starting and registering all health checks
+    * @param hole
+    */
+  @Benchmark
+  def addHealthChecks(hole: Blackhole): Unit = {
+    for(
+      applicationKey <- shuffledApplicationKeys;
+      healthCheck <- healthChecks
+    ) {
+      appHealthCheckProxy.addHealthCheck(applicationKey, healthCheck)
+    }
+  }
+
+  /**
+    * Simulate all health checks reporting at the same time, which is unlickely
+    * to happen but give an idea on the performance of this method.
+    * @param hole
+    */
+  @Benchmark
+  def updateHealthCheckStatuses(hole: Blackhole): Unit = {
+    for(
+      update <- randomlySelectedInstanceKeysWithStatus
+    ) {
+      appHealthCheckProxyWithAlreadyRegisteredHealthChecks
+        .updateHealthCheckStatus(update._1, update._2, update._3, doNothingNotifier)
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
@@ -1,0 +1,243 @@
+package mesosphere.marathon
+package core.health.impl
+
+import akka.actor.{ Actor, Props }
+import akka.event.EventStream
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.event.InstanceHealthChanged
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{
+  AddHealthCheck,
+  RemoveHealthCheck,
+  PurgeHealthCheckStatuses,
+  HealthCheckStatusChanged,
+  AppHealthCheckProxy,
+  ApplicationKey
+}
+import mesosphere.marathon.core.health.{ Health, HealthCheck }
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.state.{ PathId, Timestamp }
+
+import scala.collection.generic.Subtractable
+import scala.collection.mutable
+
+/**
+  * Actor computing instance healthiness of all instances of each application
+  * in order to send `InstanceHealthChanged` events to the event bus when the healthiness
+  * of a given instance changes. It basically aggregates all statuses of a given instance.
+  *
+  * There are 3 possible healthiness states:
+  * - `Unknown` if at least one health check status of the instance is unknown
+  * - `Unhealthy` if all statuses of the instance are known but at least one is failing
+  * - `Healthy` if all statuses of the instance are known and all are healthy
+  */
+object AppHealthCheckActor {
+  case class ApplicationKey(appId: PathId, version: Timestamp)
+  case class InstanceKey(applicationKey: ApplicationKey, instanceId: Instance.Id)
+
+  def props(eventBus: EventStream): Props = Props(new AppHealthCheckActor(eventBus))
+
+  /**
+    * Actor command adding an health check definition for a given application so that the actor knows which health check
+    * statuses are know and which are not for a given instance.
+    * @param appKey The application key of the application for which the health check is defined
+    * @param healthCheck The definition of the health check to add
+    */
+  case class AddHealthCheck(appKey: ApplicationKey, healthCheck: HealthCheck)
+
+  /**
+    * Actor command removing a health check definition for a given application.
+    * This method also purges the statuses of health checks of all instances that ran it.
+    * @param appKey The application key of the application for which the health check is removed
+    * @param healthCheck The definition of the health check to remove
+    */
+  case class RemoveHealthCheck(appKey: ApplicationKey, healthCheck: HealthCheck)
+
+  /**
+    * Actor command purging several health check statuses.
+    * @param toPurge The list of health check statuses to purge.
+    */
+  case class PurgeHealthCheckStatuses(toPurge: Seq[(InstanceKey, HealthCheck)])
+
+  /**
+    * Actor command updating the status of an health check of a given instance of an application. If the instance status
+    * has changed, it sends a `InstanceHealthChanged` event to the event bus.
+    * @param appKey The application key for which the health check status is updated
+    * @param healthCheck The health check for which the status is updated
+    * @param healthState The new state of the health check
+    */
+  case class HealthCheckStatusChanged(
+      appKey: ApplicationKey,
+      healthCheck: HealthCheck, healthState: Health)
+
+  /**
+    * This proxy class is the implementation of the actor. It has been created to be used in performance benchmarks.
+    * Beware this class is NOT thread safe.
+    */
+  class AppHealthCheckProxy extends StrictLogging {
+    /**
+      * Map of health check definitions of all applications
+      */
+    private[impl] val healthChecks: mutable.Map[ApplicationKey, Set[HealthCheck]] = mutable.Map.empty
+
+    /**
+      *  Map of statuses of all health checks for all instances of all applications.
+      *  Statuses are optional, therefore the global health status of an instance
+      *  is either:
+      *    unknown (if some results are still missing)
+      *    healthy (if all results are known and healthy)
+      *    not healthy (if all results are known and at least one is unhealthy)
+      */
+    private[impl] val healthCheckStates: mutable.Map[InstanceKey, Map[HealthCheck, Option[Health]]] =
+      mutable.Map.empty
+
+    /**
+      * This method derives the instance healthiness from a list of health check statuses
+      * @param instanceHealthResults The map of health checks statuses per health check definition
+      * @return The instance global healthiness
+      */
+    private def computeGlobalHealth(instanceHealthResults: Map[HealthCheck, Option[Health]]): Option[Boolean] = {
+      val isHealthAlive = (health: Option[Health]) => health.fold(false)(_.alive)
+      val isHealthUnknown = (health: Option[Health]) => health.isEmpty
+
+      if (instanceHealthResults.values.forall(isHealthAlive))
+        Some(true)
+      else if (instanceHealthResults.values.exists(isHealthUnknown))
+        Option.empty[Boolean]
+      else
+        Some(false)
+    }
+
+    /**
+      * Add an health check definition for a given application so that the actor knows which health check
+      * statuses are know and which are not for a given instance.
+      * @param applicationKey The application key of the application for which the health check is defined
+      * @param healthCheck The definition of the health check to add
+      */
+    def addHealthCheck(applicationKey: ApplicationKey, healthCheck: HealthCheck): Unit = {
+      logger.debug(s"Add health check $healthCheck to instance appId:${applicationKey.appId} version:${applicationKey.version}")
+      healthChecks.update(applicationKey, healthChecks.getOrElse(applicationKey, Set.empty) + healthCheck)
+    }
+
+    /**
+      * Remove a health check definition for a given application.
+      * This method also purges the statuses of health checks of all instances that ran it.
+      * @param applicationKey The application key of the application for which the health check is removed
+      * @param healthCheck The definition of the health check to remove
+      */
+    def removeHealthCheck(applicationKey: ApplicationKey, healthCheck: HealthCheck): Unit = {
+      logger.debug(s"Remove health check $healthCheck from instance appId:${applicationKey.appId} version:${applicationKey.version}")
+      purgeHealthCheckDefinition(applicationKey, healthCheck)
+      healthCheckStates retain { (_, value) => value.exists(x => x._1 != healthCheck) }
+    }
+
+    /**
+      * Generic purge method removing health check definitions or statuses from the actor containers
+      * @param healthChecksContainers The container to purge
+      * @param toPurge the health checks to purge from the container
+      */
+    private def purgeHealthChecks[K, A, V <: Traversable[A] with Subtractable[HealthCheck, V]](
+      healthChecksContainers: mutable.Map[K, V], toPurge: Seq[(K, HealthCheck)]): Unit = {
+      toPurge.foreach({
+        case (key, healthCheck) =>
+          healthChecksContainers.get(key) match {
+            case Some(hcContainer) =>
+              val newHcContainer = hcContainer - healthCheck
+
+              if (newHcContainer.isEmpty)
+                healthChecksContainers.remove(key)
+              else
+                healthChecksContainers.update(key, newHcContainer)
+            case _ =>
+          }
+      })
+    }
+
+    /**
+      * Purge one health check definition
+      * @param applicationKey The application key of the application to purge the health check definition from
+      * @param healthCheck The health check definition to purge
+      */
+    private def purgeHealthCheckDefinition(applicationKey: ApplicationKey, healthCheck: HealthCheck): Unit = {
+      purgeHealthChecks[ApplicationKey, HealthCheck, Set[HealthCheck]](healthChecks, Seq(applicationKey -> healthCheck))
+    }
+
+    /**
+      * Purge several health check statuses.
+      * @param toPurge The list of health check statuses to purge.
+      */
+    private[impl] def purgeHealthChecksStatuses(toPurge: Seq[(InstanceKey, HealthCheck)]): Unit = {
+      purgeHealthChecks[InstanceKey, (HealthCheck, Option[Health]), Map[HealthCheck, Option[Health]]](healthCheckStates, toPurge)
+    }
+
+    /**
+      * Update the status of an health check of a given instance of an application. If the instance status
+      * has changed, notifier callback is called.
+      * @param appKey The application key for which the health check status is updated
+      * @param healthCheck The health check for which the status is updated
+      * @param healthState The new state of the health check
+      * @param notifier The notifier callback called when the instance healthiness has changed.
+      */
+    def updateHealthCheckStatus(appKey: ApplicationKey, healthCheck: HealthCheck, healthState: Health,
+      notifier: (Option[Boolean] => Unit)): Unit = {
+      healthChecks.get(appKey) match {
+        case Some(hcDefinitions) if hcDefinitions.contains(healthCheck) =>
+          logger.debug(s"Status changed to $healthState for health check $healthCheck of " +
+            s"instance appId:${appKey.appId} version:${appKey.version} instanceId:${healthState.instanceId}")
+
+          val instanceKey = InstanceKey(appKey, healthState.instanceId)
+          val currentInstanceHealthResults = healthCheckStates.getOrElse(instanceKey, {
+            hcDefinitions.map(x => (x, Option.empty[Health])).toMap
+          })
+
+          val newInstanceHealthResults = currentInstanceHealthResults + (healthCheck -> Some(healthState))
+
+          val currentInstanceGlobalHealth = computeGlobalHealth(currentInstanceHealthResults)
+          val newInstanceGlobalHealth = computeGlobalHealth(newInstanceHealthResults)
+
+          // only notifies on transitions between statuses
+          if (currentInstanceGlobalHealth != newInstanceGlobalHealth)
+            notifier(newInstanceGlobalHealth)
+
+          healthCheckStates.update(instanceKey, newInstanceHealthResults)
+        case _ =>
+          logger.warn(s"Status of $healthCheck health check changed but it does not exist in inventory")
+      }
+    }
+  }
+}
+
+/**
+  * This actor aggregates the statuses of health checks at the application level
+  * in order to maintain a global healthiness status for each instance.
+  *
+  * @param eventBus The eventStream to publish status changed events to
+  */
+class AppHealthCheckActor(eventBus: EventStream) extends Actor with StrictLogging {
+  // A proxy class has been created in order to be tested in performance benchmarks.
+  val proxy = new AppHealthCheckProxy
+
+  private def notifyHealthChanged(applicationKey: ApplicationKey, instanceId: Instance.Id,
+    healthiness: Option[Boolean]): Unit = {
+    logger.debug(s"Instance global health status changed to healthiness=$healthiness " +
+      s"for instance appId:$applicationKey instanceId:$instanceId")
+    eventBus.publish(InstanceHealthChanged(
+      instanceId, applicationKey.version, applicationKey.appId, healthiness))
+  }
+
+  override def receive: Receive = {
+    case AddHealthCheck(appKey, healthCheck) =>
+      proxy.addHealthCheck(appKey, healthCheck)
+
+    case RemoveHealthCheck(appKey, healthCheck) =>
+      proxy.removeHealthCheck(appKey, healthCheck)
+
+    case PurgeHealthCheckStatuses(toPurge) =>
+      proxy.purgeHealthChecksStatuses(toPurge)
+
+    case HealthCheckStatusChanged(appKey, healthCheck, health) =>
+      val notifier = (newHealthiness: Option[Boolean]) => {
+        notifyHealthChanged(appKey, health.instanceId, newHealthiness)
+      }
+      proxy.updateHealthCheckStatus(appKey, healthCheck, health, notifier)
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -8,6 +8,7 @@ import akka.stream.Materializer
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health._
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{ ApplicationKey, HealthCheckStatusChanged, InstanceKey, PurgeHealthCheckStatuses }
 import mesosphere.marathon.core.health.impl.HealthCheckActor._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
@@ -20,6 +21,7 @@ import scala.util.{ Failure, Success }
 
 private[health] class HealthCheckActor(
     app: AppDefinition,
+    appHealthCheckActor: ActorRef,
     killService: KillService,
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
@@ -85,6 +87,12 @@ private[health] class HealthCheckActor(
     // The Map built with filterKeys wraps the original map and contains a reference to activeInstanceIds.
     // Therefore we materialize it into a new map.
     healthByInstanceId = healthByInstanceId.filterKeys(activeInstanceIds).iterator.toMap
+
+    val hcToPurge = instances.withFilter(!_.isActive).map(instance => {
+      val instanceKey = InstanceKey(ApplicationKey(instance.runSpecId, instance.runSpecVersion), instance.instanceId)
+      (instanceKey, healthCheck)
+    })
+    appHealthCheckActor ! PurgeHealthCheckStatuses(hcToPurge)
   }
 
   def scheduleNextHealthCheck(interval: Option[FiniteDuration] = None): Unit = healthCheck match {
@@ -201,13 +209,10 @@ private[health] class HealthCheckActor(
 
     logger.info("Received health result for app [{}] version [{}]: [{}]", app.id, app.version, result)
     healthByInstanceId += (instanceId -> instanceHealth.newHealth)
+    appHealthCheckActor ! HealthCheckStatusChanged(ApplicationKey(app.id, app.version), healthCheck, newHealth)
 
     if (health.alive != newHealth.alive && result.publishEvent) {
       eventBus.publish(HealthStatusChanged(app.id, instanceId, result.version, alive = newHealth.alive))
-      // We moved to InstanceHealthChanged Events everywhere
-      // Since we perform marathon based health checks only for apps, (every task is an instance)
-      // every health result is translated to an instance health changed event
-      eventBus.publish(InstanceHealthChanged(instanceId, result.version, app.id, Some(newHealth.alive)))
     }
   }
 
@@ -242,6 +247,7 @@ private[health] class HealthCheckActor(
 object HealthCheckActor {
   def props(
     app: AppDefinition,
+    appHealthCheckActor: ActorRef,
     killService: KillService,
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
@@ -249,6 +255,7 @@ object HealthCheckActor {
 
     Props(new HealthCheckActor(
       app,
+      appHealthCheckActor,
       killService,
       healthCheck,
       instanceTracker,

--- a/src/test/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActorTest.scala
@@ -1,0 +1,230 @@
+package mesosphere.marathon
+package core.health.impl
+
+import akka.testkit.{ TestActorRef, TestProbe }
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.event.InstanceHealthChanged
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{
+  AddHealthCheck,
+  ApplicationKey,
+  HealthCheckStatusChanged,
+  RemoveHealthCheck,
+  InstanceKey,
+  PurgeHealthCheckStatuses
+}
+import mesosphere.marathon.core.health.{ Health, MarathonHttpHealthCheck, PortReference }
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.state.PathId.StringPathId
+import mesosphere.marathon.state.Timestamp
+
+class AppHealthCheckActorTest extends AkkaUnitTest {
+  class Fixture {
+    val appId = "/test".toPath
+    val appVersion = Timestamp(1)
+    val appKey = ApplicationKey(appId, appVersion)
+    val hcPort80 = MarathonHttpHealthCheck(portIndex = Some(PortReference(80)))
+    val hcPort443 = MarathonHttpHealthCheck(portIndex = Some(PortReference(443)))
+    val instances = List(
+      Instance.Id("instance1"),
+      Instance.Id("instance2"),
+      Instance.Id("instance3")
+    )
+  }
+
+  "AppHealthCheckActor" should {
+    "send status changed event when all instances are healthy" in {
+      val f = new Fixture
+      val systemLog = TestProbe()
+
+      val actor = system.actorOf(AppHealthCheckActor.props(system.eventStream))
+      system.eventStream.subscribe(systemLog.ref, classOf[InstanceHealthChanged])
+
+      actor ! AddHealthCheck(f.appKey, f.hcPort80)
+      actor ! AddHealthCheck(f.appKey, f.hcPort443)
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort80)
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort443)
+
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances.head, f.appKey.version, f.appKey.appId, Some(true)))
+    }
+
+    "send status changed event when one instance becomes unhealthy" in {
+      val f = new Fixture
+      val systemLog = TestProbe()
+
+      val actor = system.actorOf(AppHealthCheckActor.props(system.eventStream))
+      system.eventStream.subscribe(systemLog.ref, classOf[InstanceHealthChanged])
+
+      actor ! AddHealthCheck(f.appKey, f.hcPort80)
+      actor ! AddHealthCheck(f.appKey, f.hcPort443)
+
+      // all health checks pass once
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      // and suddenly one fails
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(8))))
+
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort80)
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort443)
+
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances.head, f.appKey.version, f.appKey.appId, Some(true)))
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances.head, f.appKey.version, f.appKey.appId, Some(false)))
+    }
+
+    "not send status changed even when health check is not registered" in {
+      val f = new Fixture
+      val systemLog = TestProbe()
+
+      val actor = system.actorOf(AppHealthCheckActor.props(system.eventStream))
+      system.eventStream.subscribe(systemLog.ref, classOf[InstanceHealthChanged])
+
+      // all health checks pass once
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      systemLog.expectNoMsg()
+    }
+
+    "send status changed event when several instances become healthy" in {
+      val f = new Fixture
+      val systemLog = TestProbe()
+
+      val actor = system.actorOf(AppHealthCheckActor.props(system.eventStream))
+      system.eventStream.subscribe(systemLog.ref, classOf[InstanceHealthChanged])
+
+      actor ! AddHealthCheck(f.appKey, f.hcPort80)
+      actor ! AddHealthCheck(f.appKey, f.hcPort443)
+
+      // all health checks pass once
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances(1), lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances.head, f.appKey.version, f.appKey.appId, Some(true)))
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances(1), lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances(1), f.appKey.version, f.appKey.appId, Some(true)))
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances(2), lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances(2), lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      systemLog.expectMsg(InstanceHealthChanged(
+        f.instances(2), f.appKey.version, f.appKey.appId, Some(true)))
+
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort80)
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort443)
+    }
+
+    "health checks inventories is cleaned when health checks of a given version are removed" in {
+      val f = new Fixture
+      val actor = TestActorRef[AppHealthCheckActor](AppHealthCheckActor.props(system.eventStream))
+
+      assert(!actor.underlyingActor.proxy.healthChecks.contains(f.appKey))
+      actor ! AddHealthCheck(f.appKey, f.hcPort80)
+      awaitAssert(actor.underlyingActor.proxy.healthChecks.contains(f.appKey))
+      actor ! AddHealthCheck(f.appKey, f.hcPort443)
+      awaitAssert(actor.underlyingActor.proxy.healthChecks.contains(f.appKey))
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort80)
+      awaitAssert(actor.underlyingActor.proxy.healthChecks.contains(f.appKey))
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort443)
+      awaitAssert(!actor.underlyingActor.proxy.healthChecks.contains(f.appKey))
+    }
+
+    "health checks results are cleaned when health checks of a given version are removed" in {
+      val f = new Fixture
+      val actor = TestActorRef[AppHealthCheckActor](AppHealthCheckActor.props(system.eventStream))
+
+      val instanceKey = InstanceKey(f.appKey, f.instances.head)
+      assert(!actor.underlyingActor.proxy.healthCheckStates.contains(instanceKey))
+      actor ! AddHealthCheck(f.appKey, f.hcPort80)
+      actor ! AddHealthCheck(f.appKey, f.hcPort443)
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      awaitAssert(actor.underlyingActor.proxy.healthCheckStates.contains(instanceKey))
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort80)
+      actor ! RemoveHealthCheck(f.appKey, f.hcPort443)
+      awaitAssert(!actor.underlyingActor.proxy.healthCheckStates.contains(instanceKey))
+    }
+
+    "health checks results are purged one by one" in {
+      val f = new Fixture
+      val actor = TestActorRef[AppHealthCheckActor](AppHealthCheckActor.props(system.eventStream))
+
+      val instanceKey = InstanceKey(f.appKey, f.instances.head)
+      assert(!actor.underlyingActor.proxy.healthCheckStates.contains(instanceKey))
+      actor ! AddHealthCheck(f.appKey, f.hcPort80)
+      actor ! AddHealthCheck(f.appKey, f.hcPort443)
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      awaitAssert(actor.underlyingActor.proxy.healthCheckStates(instanceKey).contains(f.hcPort80))
+      awaitAssert(actor.underlyingActor.proxy.healthCheckStates(instanceKey).contains(f.hcPort443))
+
+      actor ! PurgeHealthCheckStatuses(Seq(
+        (InstanceKey(f.appKey, f.instances.head), f.hcPort80)
+      ))
+      awaitAssert(!actor.underlyingActor.proxy.healthCheckStates(instanceKey).contains(f.hcPort80))
+      awaitAssert(actor.underlyingActor.proxy.healthCheckStates(instanceKey).contains(f.hcPort443))
+
+      actor ! PurgeHealthCheckStatuses(Seq(
+        (InstanceKey(f.appKey, f.instances.head), f.hcPort443)
+      ))
+
+      awaitAssert(!actor.underlyingActor.proxy.healthCheckStates.contains(instanceKey))
+    }
+
+    "health checks results are purged all at once" in {
+      val f = new Fixture
+      val actor = TestActorRef[AppHealthCheckActor](AppHealthCheckActor.props(system.eventStream))
+
+      val instanceKey = InstanceKey(f.appKey, f.instances.head)
+      assert(!actor.underlyingActor.proxy.healthCheckStates.contains(instanceKey))
+      actor ! AddHealthCheck(f.appKey, f.hcPort80)
+      actor ! AddHealthCheck(f.appKey, f.hcPort443)
+
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort80,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+      actor ! HealthCheckStatusChanged(f.appKey, f.hcPort443,
+        Health(f.instances.head, lastSuccess = Some(Timestamp(5)), lastFailure = Some(Timestamp(0))))
+
+      awaitAssert(actor.underlyingActor.proxy.healthCheckStates(instanceKey).contains(f.hcPort80))
+      awaitAssert(actor.underlyingActor.proxy.healthCheckStates(instanceKey).contains(f.hcPort443))
+
+      actor ! PurgeHealthCheckStatuses(Seq(
+        (InstanceKey(f.appKey, f.instances.head), f.hcPort80),
+        (InstanceKey(f.appKey, f.instances.head), f.hcPort443)
+      ))
+
+      awaitAssert(!actor.underlyingActor.proxy.healthCheckStates.contains(instanceKey))
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
@@ -36,6 +36,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
 
     val instanceBuilder = TestInstanceBuilder.newBuilder(appId, version = appVersion).addTaskRunning()
     val instance = instanceBuilder.getInstance()
+    val appHealthCheckActor = TestProbe()
 
     val task: Task = instance.appTask
 
@@ -44,7 +45,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
 
     def actor(healthCheck: HealthCheck) = TestActorRef[HealthCheckActor](
       Props(
-        new HealthCheckActor(app, killService, healthCheck, tracker, system.eventStream)
+        new HealthCheckActor(app, appHealthCheckActor.ref, killService, healthCheck, tracker, system.eventStream)
       )
     )
 
@@ -52,6 +53,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
       Props(
         new HealthCheckActor(
           app,
+          appHealthCheckActor.ref,
           killService,
           MarathonHttpHealthCheck(portIndex = Some(PortReference(0))),
           tracker,

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -250,12 +250,12 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
 
       // reconcile starts health checks of task 1
       val captured1 = captureEvents.forBlock {
-        assert(hcManager.list(appId) == Set.empty[HealthCheck])
         currentAppVersion = startTask_i(1)
+        assert(hcManager.list(appId) == Set.empty[HealthCheck])
         groupManager.appVersion(currentAppVersion.id, currentAppVersion.version.toOffsetDateTime) returns Future.successful(Some(currentAppVersion))
         hcManager.reconcile(Seq(currentAppVersion)).futureValue
       }
-      assert(captured1.map(_.eventType) == Vector("add_health_check_event"))
+      assert(captured1.map(_.eventType).count(_ == "add_health_check_event") == 1)
       assert(hcManager.list(appId) == healthChecks(1)) // linter:ignore:UnlikelyEquality
 
       // reconcile leaves health check running
@@ -271,7 +271,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
         groupManager.appVersion(currentAppVersion.id, currentAppVersion.version.toOffsetDateTime) returns Future.successful(Some(currentAppVersion))
         hcManager.reconcile(Seq(currentAppVersion)).futureValue
       }
-      assert(captured3.map(_.eventType) == Vector("add_health_check_event", "add_health_check_event"))
+      assert(captured3.map(_.eventType).count(_ == "add_health_check_event") == 2)
       assert(hcManager.list(appId) == healthChecks(1) ++ healthChecks(2)) // linter:ignore:UnlikelyEquality
 
       // reconcile stops health checks which are not current and which are without tasks


### PR DESCRIPTION
Back port of #6046 

* Send Instance health changed event when the overall status changed

Before this fix, during a deployment triggered by a restart, the old
instances of an app were killed before the new ones were healthy. This
was due to the "instance_health_changed_event" event sent too early to
the ReadinessBehavior instance (when the first health check reported to be
healthy instead of ALL health checks).

The aim of this fix is to aggregate the results of health checks and
maintain a global instance health state which is Some(true) if all health
checks of a given instances report healthy, Some(false) if all health checks
report unhealthy and Option.empty if there is at least one unreported result.
The "instance_health_changed_event" event is now sent only when there is a
transition between those 3 states.

This commit relates to those tickets: MARATHON-7609, MARATHON-2683.

* Purge health checks statuses of done tasks

Also make some improvements to AppHealthCheckActor.

* Create a benchmark for AppHealthCheckActor

* Optimize the update of new health check results in AppHealthCheckActor

Two optimization have been done here:

* Don't browse the healthChecks map several times in updateHealthCheck method
* Use mutable maps instead of immutable ones

* Simplify the AppHealthCheckActor and factorize the code

* Use genericity for health check purges
* Use pattern matching for readability when possible

* Add more documentation to AppHealthCheckActor

* Fix formatting of MarathonHealthCheckManager and remove _ imports

* isLaunched -> isActive

Making this change compatible with change introduced by 4d20e105d72f5b690e09d206dccc4c595f0b68ec
