### PR TITLE
feat: add Erasys GmbH to list of companies using Marathon

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Across all installations Marathon is managing applications on more than 100,000 
 * [Disqus](https://disqus.com/)
 * [DueDil](https://www.duedil.com/)
 * [eBay](http://www.ebay.com/)
+* [Erasys](http://www.erasys.de/)
 * [The Factory](https://github.com/thefactory/)
 * [Football Radar](http://www.footballradar.com)
 * [Guidewire](https://www.guidewire.com/)


### PR DESCRIPTION
Erasys GmbH has been using Marathon for a while internally. This PR adds the company to the list in the main README.md
