### PR TITLE
Back-port SlidingAverageSnapshot fix for metrics

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -325,6 +325,9 @@ The Web Site flags control the behavior of Marathon's web site, including the us
     Expose the execution time per method via the metrics endpoint (/metrics) using code instrumentation.
     Enabling this might noticeably degrade performance but it helps finding performance problems.
     These measurements can be disabled with --disable_metrics. Other metrics are not affected.
+* <span class="label label-default">v1.6.0</span> `--metrics_averaging_window` (Optional. Default: 30 seconds):
+    Configure the size of the sliding average window that is used to compute the values for the `/metrics` endpoint. Note that this value
+    should be at least double the value of the `kamon.metric.tick-interval` parameter, that is 1 second by default.
 * <span class="label label-default">v0.13.0</span> `--reporter_graphite` (Optional. Default: disabled):
     Report metrics to [Graphite](http://graphite.wikidot.com) (StatsD) as defined by the given URL.
     Example: `udp://localhost:2003?prefix=marathon-test&interval=10`

--- a/docs/docs/metrics.md
+++ b/docs/docs/metrics.md
@@ -4,7 +4,7 @@ title: Metrics
 
 # Metrics
 
-Marathon currently uses [Codahale/Dropwizard Metrics](https://github.com/dropwizard/metrics). You can query
+Marathon currently uses [Kamon.io](http://kamon.io/) for it's metrics. You can query
 the current metrics via the `/metrics` HTTP endpoint or configure the metrics to report periodically to:
 
 * graphite via `--reporter_graphite`.
@@ -122,8 +122,10 @@ expect the names of these metrics to change if the affected code changes.
 
 ### Derived metrics (mean, p99, ...)
 
-Our metrics library calculates derived metrics like "mean" and "p99." However, Marathon provides these metrics for the entire life of of the app and applies an exponential weighting algorithm as a heuristic. For more precise metrics, build your dashboard around "counts" rather than "rates" where possible.
+Our metrics library calculates derived metrics like "mean" and "p99" using a sliding average window algorithm. This means that every time you fetch the `/metrics` endpoint you are looking at the average of the last N seconds. By default the length of the window is 30 seconds, but this can be configured with the `--metrics_averaging_window` flag.
+
+For getting the most accurate results it is recommended to configure your polling interval to the size of the sliding average window.
 
 ### Statsd and derived statistics
 
-Statsd typically creates derived statistics (mean, p99) from mean values Marathon reports. Our codahale metrics package also reports derived statistics. To avoid accidentally aggregating statistics multiple times, be sure you know where you are reporting and computing mean values.
+Statsd typically creates derived statistics (mean, p99) from mean values Marathon reports. Our metrics package also reports derived statistics. To avoid accidentally aggregating statistics multiple times, be sure you know where you are reporting and computing mean values.

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 
 import java.lang.Thread.UncaughtExceptionHandler
+import java.time
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
 import com.google.common.util.concurrent.ServiceManager
@@ -145,7 +146,7 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
     }
 
     val injector = Guice.createInjector(modules.asJava)
-    Metrics.start(injector.getInstance(classOf[ActorSystem]))
+    Metrics.start(injector.getInstance(classOf[ActorSystem]), cliConf)
     val services = Seq(
       injector.getInstance(classOf[MarathonHttpService]),
       injector.getInstance(classOf[MarathonSchedulerService]))

--- a/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
@@ -4,7 +4,8 @@ package metrics
 import akka.Done
 import akka.actor.{ Actor, ActorRef, ActorRefFactory, Props }
 import akka.stream.scaladsl.Source
-import java.time.Clock
+import java.time.{ Clock, Duration }
+
 import kamon.Kamon
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import kamon.metric.instrument.Histogram.DynamicRange
@@ -174,16 +175,17 @@ object Metrics {
   def snapshot(): TickMetricSnapshot = metrics
 
   // Starts collecting snapshots.
-  def start(actorRefFactory: ActorRefFactory): Done = {
+  def start(actorRefFactory: ActorRefFactory, config: MetricsReporterConf): Done = {
     class SubscriberActor() extends Actor {
-      val collectionContext: CollectionContext = Kamon.metrics.buildDefaultCollectionContext
+      val slidingAverageSnapshot: SlidingAverageSnapshot = new SlidingAverageSnapshot(
+        Duration.ofSeconds(config.averagingWindow.get.getOrElse(30L))
+      )
+
       override def receive: Actor.Receive = {
-        case TickMetricSnapshot(_, to, tickMetrics) =>
-          val combined = MapMerge.Syntax(metrics.metrics).merge(tickMetrics, (l, r) => l.merge(r, collectionContext))
-          val combinedSnapshot = TickMetricSnapshot(metrics.from, to, combined)
-          metrics = combinedSnapshot
+        case snapshot: TickMetricSnapshot =>
+          metrics = slidingAverageSnapshot.updateWithTick(snapshot)
       }
     }
-    subscribe(actorRefFactory.actorOf(Props(classOf[SubscriberActor])))
+    subscribe(actorRefFactory.actorOf(Props(new SubscriberActor)))
   }
 }

--- a/src/main/scala/mesosphere/marathon/metrics/MetricsReporterConf.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/MetricsReporterConf.scala
@@ -16,5 +16,12 @@ trait MetricsReporterConf extends ScallopConf {
     descr = "URL to dogstatsd agent. e.g. udp://localhost:8125?prefix=marathon-test&tags=marathon&interval=10",
     noshort = true
   )
+
+  lazy val averagingWindow = opt[Long](
+    "metrics_averaging_window",
+    descr = "The length of the average window on metrics (in seconds)",
+    noshort = true
+  )
+
 }
 

--- a/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
@@ -1,0 +1,163 @@
+package mesosphere.marathon
+package metrics
+
+import java.time.Duration
+
+import kamon.Kamon
+import kamon.metric.{ Entity, EntitySnapshot }
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.instrument.CollectionContext
+import kamon.util.{ MapMerge, MilliTimestamp }
+
+/**
+  * Calculates sliding average entity snapshot
+  */
+class SlidingAverageSnapshot(val averagingWindow: Duration) extends StrictLogging {
+
+  val collectionContext: CollectionContext = Kamon.metrics.buildDefaultCollectionContext
+
+  /**
+    * The current summarised snapshot
+    */
+  private var currentSnapshot: TickMetricSnapshot = TickMetricSnapshot(MilliTimestamp.now, MilliTimestamp.now, Map.empty)
+
+  /**
+    * A ring buffer that collects the snapshots
+    */
+  private var averageRing: Array[TickMetricSnapshot] = ringFactory(Kamon.config)
+
+  /**
+    * The current index to the average ring buffer
+    */
+  private var averageIndex: Int = 0
+
+  /**
+    * Rebuilds the average ring, based on the current configuration
+    */
+  private def ringFactory(config: Config): Array[TickMetricSnapshot] = {
+    val tickInterval: Long = config.getDuration("kamon.metric.tick-interval").toMillis
+    val fullFrames: Int = (averagingWindow.toMillis.toFloat / tickInterval).ceil.toInt
+
+    // It does not make sense having a sliding average window with less than
+    // two frames. Let the user know just in case this happened by a misconfiguration.
+    if (fullFrames < 2) {
+      logger.warn(s"SlidingAverageReporter applied over a very small window (${fullFrames} frames), consider" +
+        " increasing averageWindow or decreasing `kamon.metric.tick-interval`!")
+    }
+
+    // Create an array with that many free slots, as the full ticks that fit within the duration requested
+    logger.info(s"Initialized sliding average reporter with ${fullFrames} frames")
+    Array.fill(fullFrames){ null }
+  }
+
+  /**
+    * Combine all the metrics in the ring buffer and return an
+    * @return
+    */
+  private def combineRingMetrics: TickMetricSnapshot = {
+    var rangeFrom: MilliTimestamp = MilliTimestamp.now
+    var rangeTo: MilliTimestamp = MilliTimestamp.now
+    var combined: Option[Map[Entity, EntitySnapshot]] = None
+
+    // To combine the metrics we need to iterate over the ring buffer, performing
+    // the following operations:
+    //
+    // - Find the oldest and the newest timestamp, that will be used as the snapshot
+    //   range for our combined metrics.
+    // - For every snapshot, merge every metric with the current
+    //
+    // Since we are putting items in the ring buffer in order, we can exploit the indices
+    // to quickly identify the oldest and the newest entry:
+    //
+    // - Since we post-increment when adding items on the ring buffer, the item with
+    //   index `averageIndex - 1` is the newest one.
+    // - Consequently, the item with index `averageIndex` is the oldest one.
+    //
+    // In the following loop we are starting from the oldest item and walk our way to the
+    // newest item. That's why we start with `idx = averageIndex` and we advance it
+    // as many times as the items in the ring buffer, effectively reaching to the
+    // newest item on `idx = averageIndex - 1`
+    //
+
+    val maxItems: Int = averageRing.length
+    var i: Int = 0
+    while (i < maxItems) {
+      val idx = (averageIndex + i) % maxItems
+      val inst = averageRing(idx)
+
+      //
+      // The `null` items are items not yet initialized and we
+      // therefore consider them transparent.
+      //
+      combined = inst match {
+        case null => combined
+        case _ => {
+          combined match {
+
+            //
+            // The first record we find is the oldest one. So we are using it's
+            // timestamp as the `rangeFrom` and we initialize the `combined`
+            // snapshot with it's metrics.
+            //
+            // Just in case this is the last item we ever find, we are also
+            // populating `rangeTo` with the correct time bounds.
+            //
+            case None => {
+              rangeFrom = inst.from
+              rangeTo = inst.to
+              Some(inst.metrics)
+            }
+
+            //
+            // Otherwise combine the current metrics and advance `rangeTo`
+            //
+            case Some(current) => {
+              rangeTo = inst.to
+              Some(MapMerge.Syntax(current).merge(inst.metrics, (l, r) => l.merge(r, collectionContext)))
+            }
+          }
+        }
+      }
+
+      // Advance index of while loop
+      i += 1
+    }
+
+    // Compose the snapshot from the combined data
+    TickMetricSnapshot(
+      rangeFrom,
+      rangeTo,
+      combined getOrElse Map()
+    )
+  }
+
+  /**
+    * Update the sliding average window with a new frame that should come at fixed intervals,
+    * as configured in `kamon.metric.tick-interval`
+    *
+    * @param snapshot The snaphot received from Kamon
+    * @return Returns the averaged values of the metrics
+    */
+  def updateWithTick(snapshot: TickMetricSnapshot): TickMetricSnapshot = {
+    // Put the tick metrics on the ring buffer
+    averageRing.update(averageIndex, snapshot)
+    averageIndex = (averageIndex + 1) % averageRing.length
+
+    // Update current snapshot and return it
+    currentSnapshot = combineRingMetrics
+    currentSnapshot
+  }
+
+  /**
+    * Return the computed snapshot
+    * @return
+    */
+  def snapshot(): TickMetricSnapshot = currentSnapshot
+
+  /**
+    * Get the size of the ring
+    */
+  def ringSize(): Int = averageRing.length
+}

--- a/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
+++ b/src/test/scala/mesosphere/marathon/metrics/SlidingAverageSnapshotTest.scala
@@ -1,0 +1,110 @@
+package mesosphere.marathon
+package metrics
+
+import java.time.Duration
+
+import com.typesafe.config.ConfigFactory
+import kamon.Kamon
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.util.MilliTimestamp
+import mesosphere.UnitTest
+
+class SlidingAverageSnapshotTest extends UnitTest {
+
+  "Sliding Average Snapshot" should {
+
+    "should correctly be configured using the `kamon.metric.tick-interval` parameter" in {
+      // Start Kamon with custom parameters
+      Kamon.start(ConfigFactory.parseString(
+        "kamon.metric.tick-interval = 123"
+      ).withFallback(ConfigFactory.load()))
+
+      // Check if the custom configuration had any effect
+      val win: SlidingAverageSnapshot = new SlidingAverageSnapshot(Duration.ofMillis(123 * 4))
+      win.ringSize shouldBe 4
+    }
+
+    "should correctly operate on empty ring buffer" in {
+      val win: SlidingAverageSnapshot = SlidingAverageSnapshotTest.ringFactory(4)
+      val s: TickMetricSnapshot = win.snapshot()
+
+      // The time span should be zero
+      s.from shouldBe s.to
+    }
+
+    "should correctly operate on half-full ring buffer" in {
+      val win: SlidingAverageSnapshot = SlidingAverageSnapshotTest.ringFactory(4)
+      val ts0: MilliTimestamp = MilliTimestamp.now
+      val ts1: MilliTimestamp = MilliTimestamp(ts0.millis + 100)
+      val s1: TickMetricSnapshot = TickMetricSnapshot(ts0, ts1, Map())
+
+      // Insert snapshot
+      win.updateWithTick(TickMetricSnapshot(ts0, ts1, Map()))
+
+      // The time span should be of the first snapshot
+      val s: TickMetricSnapshot = win.snapshot()
+      s.from shouldBe ts0
+      s.to shouldBe ts1
+    }
+
+    "should correctly operate on a full ring buffer" in {
+      val win: SlidingAverageSnapshot = SlidingAverageSnapshotTest.ringFactory(4)
+      val ts0: MilliTimestamp = MilliTimestamp.now
+      val ts1: MilliTimestamp = MilliTimestamp(ts0.millis + 100)
+      val ts2: MilliTimestamp = MilliTimestamp(ts1.millis + 100)
+      val ts3: MilliTimestamp = MilliTimestamp(ts2.millis + 100)
+      val ts4: MilliTimestamp = MilliTimestamp(ts3.millis + 100)
+
+      // Insert snapshots
+      win.updateWithTick(TickMetricSnapshot(ts0, ts1, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts1, ts2, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts2, ts3, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts3, ts4, Map()))
+
+      // The time span should at the bounds of the first and last snapshot
+      val s: TickMetricSnapshot = win.snapshot()
+      s.from shouldBe ts0
+      s.to shouldBe ts4
+    }
+
+    "should correctly operate on an overflown ring buffer" in {
+      val win: SlidingAverageSnapshot = SlidingAverageSnapshotTest.ringFactory(4)
+      val ts0: MilliTimestamp = MilliTimestamp.now
+      val ts1: MilliTimestamp = MilliTimestamp(ts0.millis + 100)
+      val ts2: MilliTimestamp = MilliTimestamp(ts1.millis + 100)
+      val ts3: MilliTimestamp = MilliTimestamp(ts2.millis + 100)
+      val ts4: MilliTimestamp = MilliTimestamp(ts3.millis + 100)
+      val ts5: MilliTimestamp = MilliTimestamp(ts4.millis + 100)
+
+      // Insert snapshots
+      win.updateWithTick(TickMetricSnapshot(ts0, ts1, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts1, ts2, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts2, ts3, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts3, ts4, Map()))
+      win.updateWithTick(TickMetricSnapshot(ts4, ts5, Map()))
+
+      // The time span should at the bounds of the last four snapshots
+      val s: TickMetricSnapshot = win.snapshot()
+      s.from shouldBe ts1
+      s.to shouldBe ts5
+    }
+
+  }
+
+}
+
+object SlidingAverageSnapshotTest {
+
+  /**
+    * Utility function to instantiate a `SlidingAverageSnapshot` class, having the correct
+    * number of frames in it's buffer.
+    *
+    * @param frameCount The number of frames desired in the average ring buffer
+    * @return Returns a new instance of `SlidingAverageSnapshot`
+    */
+  def ringFactory(frameCount: Int): SlidingAverageSnapshot = {
+    val tickInterval: Long = Kamon.config.getDuration("kamon.metric.tick-interval").toMillis
+    new SlidingAverageSnapshot(Duration.ofMillis(tickInterval * frameCount))
+  }
+
+}


### PR DESCRIPTION
This commit contains all the commits from the PR #6065 squashed. In detail, this
commit contains cherry-picked the following commits:

* 604dfef (Use sliding average window on /metrics endpoint)
* f78390c (Adjust tests to use the window for counters)
* 1ae95a0 (Shutting down Kamon between tests)
* bda17fc (Adding more tests for the Averagesnapshot)
* f6bd9c5 (Fixing scapegoat issues)
* 9a07a74 (Slight fixes on the documentation)
* eb2f220 (Using double package notation on test)
* ce557a2 (Passing down `MetricsReporterConf` to the Metrics on start)
* 25ea8f4 (Using `StringLogger` on SlidingAverageSnapshot)
* 8fee8ca (Fixing a few comments)
* fe8c71a (Removing Kamon-dependent tests & updating documentation)
* 0a6a8e9 (Updating the documentation for the `--metrics_averaging_window` flag)
* f76fc18 (Updating metrics documentation)
