### PR TITLE
Decrease archived IT sandbox size by excluding `provisioner` folders from the tarball

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -87,7 +87,7 @@ def checkSystemIntegrationTests(logFileName: String): Unit = {
  */
 @main
 def zipLogs(logFileName: String = "ci.log"): Unit = {
-  Try(%("tar", "--exclude='*/provisioner'", "-zcf", "sandboxes.tar.gz", "sandboxes"))
+  Try(%("tar", "--exclude=provisioner", "-zcf", "sandboxes.tar.gz", "sandboxes"))
   Try(%("tar", "-zcf", s"$logFileName.tar.gz", "--remove-files", logFileName))
 }
 

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -87,7 +87,7 @@ def checkSystemIntegrationTests(logFileName: String): Unit = {
  */
 @main
 def zipLogs(logFileName: String = "ci.log"): Unit = {
-  Try(%("tar", "-zcf", "sandboxes.tar.gz", "sandboxes"))
+  Try(%("tar", "--exclude='*/provisioner'", "-zcf", "sandboxes.tar.gz", "sandboxes"))
   Try(%("tar", "-zcf", s"$logFileName.tar.gz", "--remove-files", logFileName))
 }
 

--- a/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -54,7 +54,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       val app = raml.App(
         id = (testBasePath / "mesos-docker-app-with-entrypoint").toString,
         container = Some(raml.Container(`type` = raml.EngineType.Mesos, docker = Some(raml.DockerContainer(
-          image = "hello-world")))),
+          image = "spaster/alpine-sleep")))),
         cpus = 0.1, mem = 32.0,
         instances = 1
       )
@@ -199,7 +199,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
         containers = Seq(MesosContainer(
           name = "hello",
           resources = raml.Resources(cpus = 0.1, mem = 32.0),
-          image = Some(raml.Image(raml.ImageType.Docker, "hello-world"))
+          image = Some(raml.Image(raml.ImageType.Docker, "spaster/alpine-sleep"))
         ))
       )
 

--- a/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -54,7 +54,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       val app = raml.App(
         id = (testBasePath / "mesos-docker-app-with-entrypoint").toString,
         container = Some(raml.Container(`type` = raml.EngineType.Mesos, docker = Some(raml.DockerContainer(
-          image = "mesosphere/busy-sleep")))),
+          image = "hello-world")))),
         cpus = 0.1, mem = 32.0,
         instances = 1
       )
@@ -199,7 +199,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
         containers = Seq(MesosContainer(
           name = "hello",
           resources = raml.Resources(cpus = 0.1, mem = 32.0),
-          image = Some(raml.Image(raml.ImageType.Docker, "mesosphere/busy-sleep"))
+          image = Some(raml.Image(raml.ImageType.Docker, "hello-world"))
         ))
       )
 

--- a/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -54,7 +54,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       val app = raml.App(
         id = (testBasePath / "mesos-docker-app-with-entrypoint").toString,
         container = Some(raml.Container(`type` = raml.EngineType.Mesos, docker = Some(raml.DockerContainer(
-          image = "hello-world")))),
+          image = "mesosphere/busy-sleep")))),
         cpus = 0.1, mem = 32.0,
         instances = 1
       )
@@ -199,7 +199,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
         containers = Seq(MesosContainer(
           name = "hello",
           resources = raml.Resources(cpus = 0.1, mem = 32.0),
-          image = Some(raml.Image(raml.ImageType.Docker, "hello-world"))
+          image = Some(raml.Image(raml.ImageType.Docker, "mesosphere/busy-sleep"))
         ))
       )
 

--- a/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -54,7 +54,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       val app = raml.App(
         id = (testBasePath / "mesos-docker-app-with-entrypoint").toString,
         container = Some(raml.Container(`type` = raml.EngineType.Mesos, docker = Some(raml.DockerContainer(
-          image = "spaster/alpine-sleep")))),
+          image = "hello-world")))),
         cpus = 0.1, mem = 32.0,
         instances = 1
       )
@@ -199,7 +199,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
         containers = Seq(MesosContainer(
           name = "hello",
           resources = raml.Resources(cpus = 0.1, mem = 32.0),
-          image = Some(raml.Image(raml.ImageType.Docker, "spaster/alpine-sleep"))
+          image = Some(raml.Image(raml.ImageType.Docker, "hello-world"))
         ))
       )
 


### PR DESCRIPTION
Summary:
we exclude `provisioner` folders (containing slave container root file systems) from sandboxes since it is huge (>800Mb) and not useful