### PR TITLE
Fix leaked process assertion in the pipeline script

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -36,7 +36,7 @@ val PACKAGE_DOCS_DIR: Path = pwd / 'target / "universal-docs"
 @main
 def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") {
 
-  def run(cmd: String *) = utils.withCleanUp {utils.runWithTimeout(30.minutes, logFileName)(cmd)}
+  def run(cmd: String *) = utils.runWithTimeout(30.minutes, logFileName)(cmd)
 
   run("sbt", "clean", "compile", "test:compile")
 
@@ -44,7 +44,7 @@ def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") 
 
   run("sbt", "test", "integration:test", "scapegoat")
 
-  // Check leaked processes
+  // Check leaked processes after integration tests
   checkLeakedProcesses()
 
   // Compile other projects.

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -105,11 +105,6 @@ def runWithTimeout(timeout: FiniteDuration, logFileName: String)(commands: Seq[S
     }
 }
 
-def withCleanUp[T](block: => T): T = {
-  try { block }
-  finally { provision.killStaleTestProcesses() }
-}
-
 /**
  * @return True if build is on master build.
  */


### PR DESCRIPTION
Summary:
`utils.withCleanUp` block would go and kill leaked processes so that later `checkLeakedProcesses()` call wouldn't make much sense. No we only kill leaked process at the very beginning of the pipeline during the `provisionHost()` call.
