### PR TITLE
Stabilize `MesosAppIntegrationTest`

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -67,6 +67,8 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       extractDeploymentIds(result) should have size 1
       waitForDeployment(result)
       waitForTasks(app.id.toPath, 1) // The app has really started
+
+      marathon.deleteApp(app.id.toPath) // Otherwise the container will restart during the test life time since "hello-world' image exits after printing it's message to stdout
     }
 
     "deploy a simple pod" taggedAs WhenEnvSet(envVarRunMesosTests, default = "true") in {
@@ -210,6 +212,8 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       createResult should be(Created)
       waitForDeployment(createResult)
       eventually { marathon.status(pod.id) should be(Stable) }
+
+      marathon.deletePod(pod.id) // Otherwise the container will restart during the test life time since "hello-world' image exits after printing it's message to stdout
     }
 
     "deleting a group deletes pods deployed in the group" taggedAs WhenEnvSet(envVarRunMesosTests, default = "true") in {


### PR DESCRIPTION
Summary:
Docker "hello-world" image ends after printing the hello-world message causing the container restart.
The tests removes the app/pod using it directly after the test.
