### PR TITLE
Disable `apt-get` system services

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ ansiColor('xterm') {
       user_is_authorized(master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#marathon-dev')
     }
   }
-  node('JenkinsMarathonCI-Debian9-2018-02-23') {
+  node('JenkinsMarathonCI-Debian9-2018-04-09') {
     stage("Run Pipeline") {
       try {
         checkout scm

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 ansiColor('xterm') {
-  node('JenkinsMarathonCI-Debian9-2018-02-23') {
+  node('JenkinsMarathonCI-Debian9-2018-04-09') {
 
     properties([
       parameters([

--- a/ami/install.bash
+++ b/ami/install.bash
@@ -64,6 +64,8 @@ apt-get install -y nodejs
 # Setup system
 systemctl enable docker
 update-ca-certificates -f
+systemctl stop apt-daily.timer
+systemctl stop apt-daily-upgrade.timer
 
 # Install jq
 curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && sudo chmod +x /usr/local/bin/jq


### PR DESCRIPTION
Summary:
Disable `apt-get` system services since they're likely to interfere with our CI runs (`Could not get lock /var/lib/dpkg/lock` build error). Created a new `JenkinsMarathonCI-Debian9-2018-04-09` AMI with the services stopped und updated the Jenkinsfiles.
