### PR TITLE
[Performance] Track mesos offer requests

### DIFF
--- a/tests/performance/config/perf-driver/measure/measure-mesosOffers.yml
+++ b/tests/performance/config/perf-driver/measure/measure-mesosOffers.yml
@@ -1,0 +1,43 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Measure Marathon Offers            #
+# ----------------------------------------------------------- #
+# This fragment installs a command-line observer to extract   #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # Define the metrics we are measuring
+  metrics:
+    - name: mesosOffers
+      uuid: e721b47324ae4536ab8f8c94040c0eb2
+      desc: The number of offers sent to marathon by mesos
+      summarize: [mean_err]
+      units: count
+
+  # Define the indicators that can summarise our values
+  indicators:
+
+    # Calculate `meanMesosOffers` by calculating the normalizing average
+    # of all the `mesosOffers` mean values, normalized against each test's
+    # normalization expression
+    - name: meanMesosOffers
+      class: indicator.NormalizedMeanMetricIndicator
+      metric: mesosOffers.mean_err
+      normalizeto: "{{normalize_to}}"
+
+# Tracker configuration
+# ===========================
+trackers:
+
+  # Collect the accumulative number of mesos offers
+  - class: tracker.CountTracker
+    metric: mesosOffers
+
+    # Locate all the LogStax events that contains "offers_sent" in the tags
+    events: LogStaxMessageEvent[tags<~offers_sent]
+
+    # Use the number of offers found as the value
+    step: "int(event.fields['offer_count'])"
+

--- a/tests/performance/config/perf-driver/observers/observer-dcluster-mesos-logs.yml
+++ b/tests/performance/config/perf-driver/observers/observer-dcluster-mesos-logs.yml
@@ -1,0 +1,55 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Mesos-Master logs receiver         #
+# ----------------------------------------------------------- #
+# This fragment installs a command-line observer that uses    #
+#
+# ----------------------------------------------------------- #
+
+# Channel configuration
+# ===========================
+channels:
+
+  #
+  # Launch docker logs, using a CmdlineChannel without parameters that will
+  # be started with the tests.
+  #
+  - class: channel.CmdlineChannel
+
+    # Follow the logs of a container named "mesos_master"
+    cmdline: "docker logs --tail 0 -f $(docker ps -q --filter 'name=mesos_master')"
+
+    # Start when tests are started
+    shell: yes
+    atstart: yes
+    restart: yes
+
+    # Tag the log line events as of "mesos" kind
+    kind:
+      stdout: mesos
+      stderr: mesos
+
+# Observer configuration
+# ===========================
+observers:
+
+  #
+  # Register a logstax observer that will detect offer dispatching from mesos
+  #
+  - class: observer.LogStaxObserver
+
+    # Track all log lines of "mesos" kind
+    events:
+      - name: LogLineEvent
+        kind: [mesos]
+        field: line
+
+    # Apply filters on the log lines
+    filters:
+
+      # Use a grok filter to tokenize the offer sending
+      - type: grok
+        match:
+          message: ".*Sending %{NUMBER:offer_count} offers to framework.*"
+        add_tag:
+          - offers_sent
+

--- a/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
+++ b/tests/performance/config/perf-driver/test-1-apps-n-instances.yml
@@ -22,6 +22,7 @@ include:
   # Use marathon's SSE endpoint to measure our metrics
   - observers/observer-marathon-http-timing.yml
   - observers/observer-marathon-sse.yml
+  - observers/observer-dcluster-mesos-logs.yml
 
   # Measure the given metrics
   - measure/measure-deploymentTime.yml
@@ -29,3 +30,4 @@ include:
   - measure/measure-httpRequestTime.yml
   - measure/measure-failedDeployments.yml
   - measure/measure-groupsResponseTime.yml
+  - measure/measure-mesosOffers.yml

--- a/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
+++ b/tests/performance/config/perf-driver/test-n-apps-1-instances.yml
@@ -22,6 +22,7 @@ include:
   # Use marathon's SSE endpoint to measure our metrics
   - observers/observer-marathon-http-timing.yml
   - observers/observer-marathon-sse.yml
+  - observers/observer-dcluster-mesos-logs.yml
 
   # Measure the given metrics
   - measure/measure-deploymentTime.yml
@@ -29,3 +30,4 @@ include:
   - measure/measure-httpRequestTime.yml
   - measure/measure-failedDeployments.yml
   - measure/measure-groupsResponseTime.yml
+  - measure/measure-mesosOffers.yml


### PR DESCRIPTION
Adding a log-line parser for the marathon-dcluster environment that is
crawling the mesos logs, looking for offer requests and increasing the
mesosOffers counter accordingly.

JIRA issues: MARATHON-8151