### PR TITLE
Name sandboxes archive after Jenkins job.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ ansiColor('xterm') {
             reportName: 'Scapegoat Report', reportTitles: ''
         ])
         archive includes: "*-sandboxes.tar.gz"
-        archive includes: "*-log.tar.gz"
+        archive includes: "*log.tar.gz"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ ansiColor('xterm') {
             reportDir: 'target/scala-2.12/scapegoat-report', reportFiles: 'scapegoat.html',
             reportName: 'Scapegoat Report', reportTitles: ''
         ])
-        archive includes: "sandboxes.tar.gz"
+        archive includes: "ci-${env.BUILD_TAG}-sandboxes.tar.gz"
         archive includes: "ci-${env.BUILD_TAG}.log.tar.gz"
         archive includes: "ci-${env.BUILD_TAG}.log"  // Only in case the build was  aborted and the logs weren't zipped
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,8 @@ ansiColor('xterm') {
             reportDir: 'target/scala-2.12/scapegoat-report', reportFiles: 'scapegoat.html',
             reportName: 'Scapegoat Report', reportTitles: ''
         ])
-        archive includes: "c*.tar.gz"
+        archive includes: "*-sandboxes.tar.gz"
+        archive includes: "*-log.tar.gz"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,9 +29,7 @@ ansiColor('xterm') {
             reportDir: 'target/scala-2.12/scapegoat-report', reportFiles: 'scapegoat.html',
             reportName: 'Scapegoat Report', reportTitles: ''
         ])
-        archive includes: "ci-${env.BUILD_TAG}-sandboxes.tar.gz"
-        archive includes: "ci-${env.BUILD_TAG}.log.tar.gz"
-        archive includes: "ci-${env.BUILD_TAG}.log"  // Only in case the build was  aborted and the logs weren't zipped
+        archive includes: "c*.tar.gz"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ ansiColor('xterm') {
             reportDir: 'target/scala-2.12/scapegoat-report', reportFiles: 'scapegoat.html',
             reportName: 'Scapegoat Report', reportTitles: ''
         ])
-        archive includes: "*-sandboxes.tar.gz"
+        archive includes: "*sandboxes.tar.gz"
         archive includes: "*log.tar.gz"
       }
     }

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -84,11 +84,11 @@ def checkSystemIntegrationTests(logFileName: String): Unit = {
  * Compresses sandboxes and logs.
  *
  * @param logFileName Name of log file.
- * @param sandboxFilePrefix The start of the file name for the sandboxes archive.
+ * @param sandboxFile The start of the file name for the sandboxes archive.
  */
 @main
-def zipLogs(logFileName: String = "ci.log", sandboxFilePrefix: String = "sandboxes"): Unit = {
-  Try(%("tar", "--exclude=provisioner", "-zcf", s"$sandboxFilePrefix.tar.gz", "sandboxes"))
+def zipLogs(logFileName: String = "ci.log", sandboxFile: String = "sandboxes"): Unit = {
+  Try(%("tar", "--exclude=provisioner", "-zcf", s"$sandboxFile.tar.gz", "sandboxes"))
   Try(%("tar", "-zcf", s"$logFileName.tar.gz", "--remove-files", logFileName))
 }
 
@@ -131,17 +131,17 @@ def createTarballPackages(): SemVer = utils.stage("Package Tarballs") {
  * The pipeline target for GitHub pull request builds. It wraps other targets
  * and does some additional reporting to GitHub.
  */
-def asPullRequest(pullNumber: String)(run: => (SemVer, Option[awsClient.Artifact])): Unit = {
+def asPullRequest(pullId: String)(run: => (SemVer, Option[awsClient.Artifact])): Unit = {
   val buildUrl: String = sys.env.getOrElse("BUILD_URL", throw new IllegalArgumentException("No BUILD_URL was defined."))
   val buildTag: String = sys.env.getOrElse("BUILD_TAG", "here")
 
   try {
-    githubClient.reject(pullNumber, buildUrl, buildTag)
+    githubClient.reject(pullId, buildUrl, buildTag)
     val (_, maybeArtifact) = run
-    githubClient.reportSuccess(pullNumber, buildUrl, buildTag, maybeArtifact)
+    githubClient.reportSuccess(pullId, buildUrl, buildTag, maybeArtifact)
   } catch {
     case NonFatal(e) =>
-      githubClient.reportFailure(pullNumber, buildUrl, buildTag, e.getMessage())
+      githubClient.reportFailure(pullId, buildUrl, buildTag, e.getMessage())
       throw e
   }
 }
@@ -168,11 +168,11 @@ def provisionHost(): Unit = utils.stage("Provision") {
 def build(runTests: Boolean = true, buildName: String = "run"): SemVer = {
   if (runTests) {
     val logFileName = s"$buildName.log"
-    val sandboxFilePrefix = s"$buildName-sandboxes"
+    val sandboxFile = s"$buildName.sandboxes"
     try {
       compileAndTest(logFileName)
     } finally {
-      zipLogs(logFileName, sandboxFilePrefix)    // Try to archive ci and sandbox logs in any case
+      zipLogs(logFileName, sandboxFile)    // Try to archive ci and sandbox logs in any case
     }
   }
 
@@ -220,7 +220,8 @@ def updateDcosImage(version: SemVer, artifactUrl: String, sha1: String): Unit = 
 def master(): Unit = {
   provisionHost()
 
-  val version = build(buildName = "master")
+  val buildNumber = sys.env.get("BUILD_NUMBER").getOrElse("0")
+  val version = build(buildName = s"master-$buildNumber")
   buildDockerAndLinuxPackages()
   testDockerAndLinuxPackages()
 
@@ -235,10 +236,10 @@ def master(): Unit = {
  * Build target for pull request builds.
  */
 @main
-def pr(pullNumber: String): Unit = asPullRequest(pullNumber) {
+def pr(pullId: String): Unit = asPullRequest(pullId) {
   provisionHost()
   val buildNumber = sys.env.get("BUILD_NUMBER").getOrElse("0")
-  val version = build(buildName = s"PR-$pullNumber-$buildNumber")
+  val version = build(buildName = s"PR-$pullId-$buildNumber")
 
   // Uploads
   val artifact = uploadTarballPackagesToS3(version, s"builds/$version")
@@ -251,13 +252,7 @@ def pr(pullNumber: String): Unit = asPullRequest(pullNumber) {
 @main
 def loop(): Unit = {
   provisionHost()
-
-  val loopNamePattern = """marathon-sandbox/(.*)""".r
-  val loopName = sys.env.get("JOB_NAME")
-    .collect { case loopNamePattern(name) => name }
-    .getOrElse("loop")
-  val buildNumber = sys.env.get("BUILD_NUMBER").getOrElse("0")
-  build(buildName = s"$loopName-buildNumber")
+  build(buildName = utils.loopBuildName())
 }
 
 /**
@@ -268,7 +263,7 @@ def loop(): Unit = {
 @main
 def jenkins(): Unit = {
   utils.isPullRequest() match {
-    case Some(pullNumber) => pr(pullNumber)
+    case Some(pullId) => pr(pullId)
     case None => master()
   }
 }

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -84,11 +84,11 @@ def checkSystemIntegrationTests(logFileName: String): Unit = {
  * Compresses sandboxes and logs.
  *
  * @param logFileName Name of log file.
- * @param sandboxFile The start of the file name for the sandboxes archive.
+ * @param sandboxFileName The start of the file name for the sandboxes archive.
  */
 @main
-def zipLogs(logFileName: String = "ci.log", sandboxFile: String = "sandboxes"): Unit = {
-  Try(%("tar", "--exclude=provisioner", "-zcf", s"$sandboxFile.tar.gz", "sandboxes"))
+def zipLogs(logFileName: String = "ci.log", sandboxFileName: String = "sandboxes"): Unit = {
+  Try(%("tar", "--exclude=provisioner", "-zcf", s"$sandboxFileName.tar.gz", "sandboxes"))
   Try(%("tar", "-zcf", s"$logFileName.tar.gz", "--remove-files", logFileName))
 }
 

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -131,8 +131,7 @@ def createTarballPackages(): SemVer = utils.stage("Package Tarballs") {
  * The pipeline target for GitHub pull request builds. It wraps other targets
  * and does some additional reporting to GitHub.
  */
-def asPullRequest(run: => (SemVer, Option[awsClient.Artifact])): Unit = {
-  val pullNumber: String = sys.env.getOrElse("CHANGE_ID", throw new IllegalArgumentException("No CHANGE_ID was defined."))
+def asPullRequest(pullNumber: String)(run: => (SemVer, Option[awsClient.Artifact])): Unit = {
   val buildUrl: String = sys.env.getOrElse("BUILD_URL", throw new IllegalArgumentException("No BUILD_URL was defined."))
   val buildTag: String = sys.env.getOrElse("BUILD_TAG", "here")
 
@@ -166,11 +165,10 @@ def provisionHost(): Unit = utils.stage("Provision") {
  * @return Version of Marathon build
  */
 @main
-def build(runTests: Boolean = true): SemVer = {
+def build(runTests: Boolean = true, buildName: String = "run"): SemVer = {
   if (runTests) {
-    val buildName = sys.env.getOrElse("BUILD_TAG", "run")
-    val logFileName = s"ci-$buildName.log"
-    val sandboxFilePrefix = s"ci-$buildName-sandboxes"
+    val logFileName = s"$buildName.log"
+    val sandboxFilePrefix = s"$buildName-sandboxes"
     try {
       compileAndTest(logFileName)
     } finally {
@@ -222,7 +220,7 @@ def updateDcosImage(version: SemVer, artifactUrl: String, sha1: String): Unit = 
 def master(): Unit = {
   provisionHost()
 
-  val version = build()
+  val version = build(buildName = "master")
   buildDockerAndLinuxPackages()
   testDockerAndLinuxPackages()
 
@@ -237,9 +235,10 @@ def master(): Unit = {
  * Build target for pull request builds.
  */
 @main
-def pr(): Unit = asPullRequest {
+def pr(pullNumber: String): Unit = asPullRequest(pullNumber) {
   provisionHost()
-  val version = build()
+  val buildNumber = sys.env.get("BUILD_NUMBER").getOrElse("0")
+  val version = build(buildName = s"PR-$pullNumber-$buildNumber")
 
   // Uploads
   val artifact = uploadTarballPackagesToS3(version, s"builds/$version")
@@ -252,7 +251,13 @@ def pr(): Unit = asPullRequest {
 @main
 def loop(): Unit = {
   provisionHost()
-  build()
+
+  val loopNamePattern = """marathon-sandbox/(.*)""".r
+  val loopName = sys.env.get("JOB_NAME")
+    .collect { case loopNamePattern(name) => name }
+    .getOrElse("loop")
+  val buildNumber = sys.env.get("BUILD_NUMBER").getOrElse("0")
+  build(buildName = s"$loopName-buildNumber")
 }
 
 /**
@@ -262,8 +267,10 @@ def loop(): Unit = {
  */
 @main
 def jenkins(): Unit = {
-  if(utils.isPullRequest) pr()
-  else master()
+  utils.isPullRequest() match {
+    case Some(pullNumber) => pr(pullNumber)
+    case None => master()
+  }
 }
 
 /**

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -84,10 +84,11 @@ def checkSystemIntegrationTests(logFileName: String): Unit = {
  * Compresses sandboxes and logs.
  *
  * @param logFileName Name of log file.
+ * @param sandboxFilePrefix The start of the file name for the sandboxes archive.
  */
 @main
-def zipLogs(logFileName: String = "ci.log"): Unit = {
-  Try(%("tar", "--exclude=provisioner", "-zcf", "sandboxes.tar.gz", "sandboxes"))
+def zipLogs(logFileName: String = "ci.log", sandboxFilePrefix: String = "sandboxes"): Unit = {
+  Try(%("tar", "--exclude=provisioner", "-zcf", s"$sandboxFilePrefix.tar.gz", "sandboxes"))
   Try(%("tar", "-zcf", s"$logFileName.tar.gz", "--remove-files", logFileName))
 }
 
@@ -167,11 +168,13 @@ def provisionHost(): Unit = utils.stage("Provision") {
 @main
 def build(runTests: Boolean = true): SemVer = {
   if (runTests) {
-    val logFileName = s"ci-${sys.env.getOrElse("BUILD_TAG", "run")}.log"
+    val buildName = sys.env.getOrElse("BUILD_TAG", "run")
+    val logFileName = s"ci-$buildName.log"
+    val sandboxFilePrefix = s"ci-$buildName-sandboxes"
     try {
       compileAndTest(logFileName)
     } finally {
-      zipLogs(logFileName)    // Try to archive ci and sandbox logs in any case
+      zipLogs(logFileName, sandboxFilePrefix)    // Try to archive ci and sandbox logs in any case
     }
   }
 

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -117,7 +117,19 @@ def isMasterBuild(): Boolean = {
  */
 def isPullRequest(): Option[String] = {
   val pr = """marathon-pipelines/PR-(\d+)""".r
-  sys.env.get("JOB_NAME").collect { case pr(pullNumber) => pullNumber }
+  sys.env.get("JOB_NAME").collect { case pr(pullId) => pullId }
+}
+
+/**
+ * @return Name for build loops.
+ */
+def loopBuildName(): String = {
+  val loopNamePattern = """marathon-sandbox/(.*)""".r
+  val loopName = sys.env.get("JOB_NAME")
+    .collect { case loopNamePattern(name) => name }
+    .getOrElse("loop")
+  val buildNumber = sys.env.get("BUILD_NUMBER").getOrElse("0")
+  s"$loopName-$buildNumber"
 }
 
 def priorPatchVersion(tag: String): Option[String] = {

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -113,11 +113,11 @@ def isMasterBuild(): Boolean = {
 }
 
 /**
- * @return True if build is for pull request.
+ * @return Pull request number if build is for pull request or None if not.
  */
-def isPullRequest(): Boolean = {
+def isPullRequest(): Option[String] = {
   val pr = """marathon-pipelines/PR-(\d+)""".r
-  sys.env.get("JOB_NAME").collect { case pr(_) => true }.getOrElse(false)
+  sys.env.get("JOB_NAME").collect { case pr(pullNumber) => pullNumber }
 }
 
 def priorPatchVersion(tag: String): Option[String] = {


### PR DESCRIPTION
Summary:
Currently the sandboxes archive is called `sandboxes.tar.gz`. To make
debugging a little easier this patch will rename it to `ci-<Jenkins job>-sandboxes.tar.gz`.