### PR TITLE
Remove synchronous instance tracker calls.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -44,8 +44,8 @@ class TaskReplaceActor(
   // In case previous master was abdicated while the deployment was still running we might have
   // already started some new tasks.
   // All already started and active tasks are filtered while the rest is considered
-  private[this] var instancesAlreadyStarted: Seq[Instance] = _
-  private[this] var instancesToKill: Seq[Instance] = _
+  private[this] var instancesAlreadyStarted: Seq[Instance] = Seq.empty
+  private[this] var instancesToKill: Seq[Instance] = Seq.empty
 
   // The ignition strategy for this run specification
   private[this] lazy val ignitionStrategy: RestartStrategy = computeRestartStrategy(runSpec, currentRunningInstances.size)
@@ -56,7 +56,7 @@ class TaskReplaceActor(
   private[this] lazy val toKill: mutable.Queue[Instance] = instancesToKill.to[mutable.Queue]
 
   // All instances to kill as set for quick lookup
-  private[this] var oldInstanceIds: SortedSet[Id] = _
+  private[this] var oldInstanceIds: SortedSet[Id] = SortedSet.empty
 
   // The number of started instances. Defaults to the number of already started instances.
   var instancesStarted: Int = _

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -5,6 +5,7 @@ import java.time.Clock
 
 import akka.Done
 import akka.actor._
+import akka.pattern.pipe
 import akka.event.LoggingReceive
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.flow.OfferReviver
@@ -91,6 +92,8 @@ private class TaskLauncherActor(
     localRegion: () => Option[Region]) extends Actor with StrictLogging with Stash {
   // scalastyle:on parameter.number
 
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   private[this] var inFlightInstanceOperations = Map.empty[Instance.Id, Cancellable]
 
   private[this] var recheckBackOff: Option[Cancellable] = None
@@ -109,7 +112,8 @@ private class TaskLauncherActor(
 
     logger.info(s"Started instanceLaunchActor for ${runSpec.id} version ${runSpec.version} with initial count $instancesToLaunch")
 
-    instanceMap = instanceTracker.instancesBySpecSync.instancesMap(runSpec.id).instanceMap
+    val t = instanceTracker.instancesBySpec()
+    t.pipeTo(self)
     rateLimiterActor ! RateLimiterActor.GetDelay(runSpec)
   }
 
@@ -129,7 +133,23 @@ private class TaskLauncherActor(
     logger.info(s"Stopped InstanceLauncherActor for ${runSpec.id} version ${runSpec.version}")
   }
 
-  override def receive: Receive = waitForInitialDelay
+  override def receive: Receive = initializing
+
+  private[this] def initializing: Receive = {
+    case initialInstances: InstanceTracker.InstancesBySpec =>
+
+      instanceMap = initialInstances.instancesMap(runSpec.id).instanceMap
+
+      context.become(waitForInitialDelay)
+      unstashAll()
+
+    case Status.Failure(cause) =>
+      // escalate this failure
+      throw new IllegalStateException("while loading instances", cause)
+
+    case stashMe: AnyRef =>
+      stash()
+  }
 
   private[this] def waitForInitialDelay: Receive = LoggingReceive.withLabel("waitingForInitialDelay") {
     case RateLimiterActor.DelayUpdate(spec, delayUntil) if spec == runSpec =>

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -112,8 +112,7 @@ private class TaskLauncherActor(
 
     logger.info(s"Started instanceLaunchActor for ${runSpec.id} version ${runSpec.version} with initial count $instancesToLaunch")
 
-    val t = instanceTracker.instancesBySpec()
-    t.pipeTo(self)
+    instanceTracker.instancesBySpec().pipeTo(self)
     rateLimiterActor ! RateLimiterActor.GetDelay(runSpec)
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -17,25 +17,17 @@ import scala.concurrent.{ ExecutionContext, Future }
   * * Creating an instance
   * * Updating an instance (due to a state change, a timeout, a Mesos update)
   * * Expunging an instance
-  *
-  *
-  * FIXME: To allow introducing the new asynchronous [[InstanceTracker]] without needing to
-  * refactor a lot of code at once, synchronous methods are still available but should be
-  * avoided in new code.
   */
 trait InstanceTracker {
 
-  def specInstancesSync(pathId: PathId): Seq[Instance]
   def specInstances(pathId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]]
 
   def instance(instanceId: Instance.Id): Future[Option[Instance]]
 
-  def instancesBySpecSync: InstanceTracker.InstancesBySpec
   def instancesBySpec()(implicit ec: ExecutionContext): Future[InstanceTracker.InstancesBySpec]
 
   def countActiveSpecInstances(appId: PathId): Future[Int]
 
-  def hasSpecInstancesSync(appId: PathId): Boolean
   def hasSpecInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Boolean]
 
   /** Process an InstanceUpdateOperation and propagate its result. */

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -455,7 +455,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
     val instanceTracker: InstanceTracker = mock[InstanceTracker]
     instanceTracker.specInstances(any)(any) returns Future.successful(Seq.empty[Instance])
-    instanceTracker.specInstancesSync(any) returns Seq.empty[Instance]
+    //    instanceTracker.specInstances(any) returns Future.successful(Seq.empty[Instance])
 
     val killService = new KillServiceMock(system)
 

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -455,7 +455,6 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
     val instanceTracker: InstanceTracker = mock[InstanceTracker]
     instanceTracker.specInstances(any)(any) returns Future.successful(Seq.empty[Instance])
-    //    instanceTracker.specInstances(any) returns Future.successful(Seq.empty[Instance])
 
     val killService = new KillServiceMock(system)
 

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -122,7 +122,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       queue.asyncPurge(any) returns Future.successful(Done)
       scheduler.startRunSpec(any) returns Future.successful(Done)
       tracker.specInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2))
-      tracker.specInstancesSync(app2.id) returns Seq(instance2_1)
+      tracker.specInstances(Matchers.eq(app2.id))(any[ExecutionContext]) returns Future.successful(Seq(instance2_1))
       tracker.specInstances(Matchers.eq(app2.id))(any[ExecutionContext]) returns Future.successful(Seq(instance2_1))
       tracker.specInstances(Matchers.eq(app3.id))(any[ExecutionContext]) returns Future.successful(Seq(instance3_1))
       tracker.specInstances(Matchers.eq(app4.id))(any[ExecutionContext]) returns Future.successful(Seq(instance4_1))
@@ -164,8 +164,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val instance1_1 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp.zero).getInstance()
       val instance1_2 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp(1000)).getInstance()
 
-      tracker.specInstancesSync(app.id) returns Seq(instance1_1, instance1_2)
-      tracker.specInstances(app.id) returns Future.successful(Seq(instance1_1, instance1_2))
+      tracker.specInstances(Matchers.eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2))
 
       val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
@@ -202,7 +201,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
       val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
-      tracker.specInstancesSync(app.id) returns Seq.empty[Instance]
+      tracker.specInstances(app.id) returns Future.successful(Seq.empty[Instance])
       queue.addAsync(app, 2) returns Future.successful(Done)
 
       deploymentActor(managerProbe.ref, plan)

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -17,13 +17,13 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.{ KillServiceMock, Task }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
-import org.mockito.{ Mockito }
+import org.mockito.Mockito
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import rx.lang.scala.Observable
 
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
 
 class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
@@ -38,7 +38,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceB))
 
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
@@ -74,7 +74,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
       val instanceC = f.runningInstance(newApp)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceC)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceC))
 
       val ref = f.replaceActor(newApp, promise)
       watch(ref)
@@ -102,7 +102,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
 
-      when(f.tracker.specInstancesSync(app.id)).thenReturn(Seq(instanceA, instanceB))
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceB))
 
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
@@ -133,7 +133,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      when(f.tracker.specInstancesSync(app.id)).thenReturn(Seq(instanceA, instanceB, instanceC))
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceB, instanceC))
 
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
@@ -178,7 +178,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceB, instanceC))
 
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
@@ -232,7 +232,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceB, instanceC))
 
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
@@ -296,7 +296,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceB, instanceC))
 
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
@@ -360,7 +360,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceB, instanceC))
 
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
@@ -426,7 +426,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB, instanceC, instanceD)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceB, instanceC, instanceD))
       f.queue.addAsync(newApp, 1) returns Future.successful(Done)
 
       val ref = f.replaceActor(newApp, promise)
@@ -485,7 +485,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition(id = "/myApp".toPath, instances = 2)
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceB))
       val promise = Promise[Unit]()
 
       When("The replace actor is started")
@@ -504,7 +504,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val port = PortDefinition(0, name = Some(check.portName))
       val app = AppDefinition(id = "/myApp".toPath, instances = 1, portDefinitions = Seq(port), readinessChecks = Seq(check))
       val instance = f.runningInstance(app)
-      f.tracker.specInstancesSync(app.id) returns Seq(instance)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instance))
       val readyCheck = Observable.from(instance.tasksMap.values.map(task => ReadinessCheckResult(check.name, task.taskId, ready = true, None)))
       f.readinessCheckExecutor.execute(any[ReadinessCheckExecutor.ReadinessCheckSpec]) returns readyCheck
       val promise = Promise[Unit]()
@@ -532,7 +532,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
         healthChecks = Set(MarathonHttpHealthCheck())
       )
       val instance = f.runningInstance(app)
-      f.tracker.specInstancesSync(app.id) returns Seq(instance)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instance))
       val readyCheck = Observable.from(instance.tasksMap.values.map(task => ReadinessCheckResult(ready.name, task.taskId, ready = true, None)))
       f.readinessCheckExecutor.execute(any[ReadinessCheckExecutor.ReadinessCheckSpec]) returns readyCheck
       val promise = Promise[Unit]()
@@ -557,7 +557,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instanceA, instanceB))
 
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
@@ -590,7 +590,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
       val instance = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instance)
+      f.tracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instance))
 
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))


### PR DESCRIPTION
Summary:
This change removes all blocking synchronous calls to the instance
tracker. Actors that used to wait for the instance state start in an
initializing state until they receive the result from the instance
tracker. This way we do not block.