### PR TITLE
Increase the max_instances_per_offer on perf tests

### DIFF
--- a/tests/performance/config/dcluster/large-cluster.conf
+++ b/tests/performance/config/dcluster/large-cluster.conf
@@ -15,3 +15,7 @@ mesos_resources_mem = 8192000
 marathon_port = 8080
 marathon_jmx = 9010
 mesos_master_port = 5050
+
+# Increase the number of instances launched per offer since the performance
+# tests should put pressure on marathon.
+marathon_args = "--max_instances_per_offer=500"


### PR DESCRIPTION
This PR tunes the marathon instances launched in the debugging cluster by setting
the `--max_instances_per_offer` parameter to 500. This will smoothen-out the deploymentTime
plots and reduce the artifacts produced by the small number instances launched, compared to
the number of deployment requests received.
