### PR TITLE
Remove sandboxes folder.

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -89,6 +89,7 @@ def checkSystemIntegrationTests(logFileName: String): Unit = {
 @main
 def zipLogs(logFileName: String = "ci.log", sandboxFileName: String = "sandboxes"): Unit = {
   Try(%("tar", "--exclude=provisioner", "-zcf", s"$sandboxFileName.tar.gz", "sandboxes"))
+  Try%('sudo, "rm", "-rf", "sandboxes")
   Try(%("tar", "-zcf", s"$logFileName.tar.gz", "--remove-files", logFileName))
 }
 

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -89,7 +89,7 @@ def checkSystemIntegrationTests(logFileName: String): Unit = {
 @main
 def zipLogs(logFileName: String = "ci.log", sandboxFileName: String = "sandboxes"): Unit = {
   Try(%("tar", "--exclude=provisioner", "-zcf", s"$sandboxFileName.tar.gz", "sandboxes"))
-  Try%('sudo, "rm", "-rf", "sandboxes")
+  Try(%('sudo, "rm", "-rf", "sandboxes"))
   Try(%("tar", "-zcf", s"$logFileName.tar.gz", "--remove-files", logFileName))
 }
 


### PR DESCRIPTION
Summary:
If a build runs on a Jenkins node that already saw a build the sandboxes will be
merged. To avoid this issue we remove the sandbox before.
