### PR TITLE
Remove synchronous `LaunchQueue` methods

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -455,9 +455,11 @@ class SchedulerActions(
 
     }
 
-    instancesToStart.foreach { toStart: Int =>
+    if (instancesToStart.isDefined) {
+      val toStart = instancesToStart.get
+
       logger.info(s"Need to scale ${runSpec.id} from ${runningInstances.size} up to $targetCount instances")
-      val leftToLaunch = launchQueue.get(runSpec.id).fold(0)(_.instancesLeftToLaunch)
+      val leftToLaunch = await(launchQueue.getAsync(runSpec.id)).fold(0)(_.instancesLeftToLaunch)
       val toAdd = toStart - leftToLaunch
 
       if (toAdd > 0) {

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -464,7 +464,7 @@ class SchedulerActions(
 
       if (toAdd > 0) {
         logger.info(s"Queueing $toAdd new instances for ${runSpec.id} to the already $leftToLaunch queued ones")
-        launchQueue.add(runSpec, toAdd)
+        await(launchQueue.addAsync(runSpec, toAdd))
       } else {
         logger.info(s"Already queued or started ${runningInstances.size} instances for ${runSpec.id}. Not scaling.")
       }

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -285,7 +285,7 @@ class MarathonSchedulerActor private (
 
   def deploymentFailed(plan: DeploymentPlan, reason: Throwable): Unit = {
     logger.error(s"Deployment ${plan.id}:${plan.version} of ${plan.targetIdsString} failed", reason)
-    Future.sequence(plan.affectedRunSpecIds.map(launchQueue.asyncPurge))
+    Future.sequence(plan.affectedRunSpecIds.map(launchQueue.purgeAsync))
       .recover { case NonFatal(error) => logger.warn(s"Error during async purge: planId=${plan.id} for ${plan.targetIdsString}", error); Done }
       .foreach { _ => eventBus.publish(core.event.DeploymentFailed(plan.id, plan, reason = Some(reason.getMessage()))) }
   }
@@ -443,7 +443,7 @@ class SchedulerActions(
     instancesToKill.foreach { instances: Seq[Instance] =>
       logger.info(s"Scaling ${runSpec.id} from ${runningInstances.size} down to $targetCount instances")
 
-      launchQueue.asyncPurge(runSpec.id)
+      launchQueue.purgeAsync(runSpec.id)
         .recover {
           case NonFatal(e) =>
             logger.warn("Async purge failed: {}", e)

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -36,7 +36,8 @@ class QueueResource @Inject() (
     @PathParam("appId") id: String,
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
     val appId = id.toRootPath
-    val maybeApp = launchQueue.list.find(_.runSpec.id == appId).map(_.runSpec)
+    val maybeApps = result(launchQueue.listAsync)
+    val maybeApp = maybeApps.find(_.runSpec.id == appId).map(_.runSpec)
     withAuthorization(UpdateRunSpec, maybeApp, notFound(s"Application $appId not found in tasks queue.")) { app =>
       launchQueue.resetDelay(app)
       noContent

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -26,8 +26,9 @@ class QueueResource @Inject() (
   @Produces(Array(MarathonMediaType.PREFERRED_APPLICATION_JSON))
   def index(@Context req: HttpServletRequest, @QueryParam("embed") embed: java.util.Set[String]): Response = authenticated(req) { implicit identity =>
     val embedLastUnusedOffers = embed.contains(QueueResource.EmbedLastUnusedOffers)
-    val infos = launchQueue.listWithStatistics.filter(t => t.inProgress && isAuthorized(ViewRunSpec, t.runSpec))
-    ok(Raml.toRaml((infos, embedLastUnusedOffers, clock)))
+    val maybeStats = result(launchQueue.listWithStatisticsAsync)
+    val stats = maybeStats.filter(t => t.inProgress && isAuthorized(ViewRunSpec, t.runSpec))
+    ok(Raml.toRaml((stats, embedLastUnusedOffers, clock)))
   }
 
   @DELETE

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -186,7 +186,7 @@ private class DeploymentActor(
     healthCheckManager.removeAllFor(runSpec.id)
 
     // Purging launch queue
-    await(launchQueue.asyncPurge(runSpec.id))
+    await(launchQueue.purgeAsync(runSpec.id))
 
     val instances = await(instanceTracker.specInstances(runSpec.id))
     val launchedInstances = instances.filter(_.isActive)

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -63,8 +63,6 @@ trait LaunchQueue {
   def listWithStatisticsAsync: Future[Seq[QueuedInstanceInfoWithStatistics]]
 
   /** Returns all runnable specs for which queue entries exist. */
-  def listRunSpecs: Seq[RunSpec]
-
   def listRunSpecsAsync: Future[Seq[RunSpec]]
 
   /** Request to launch `count` additional instances conforming to the given run spec. */

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -83,7 +83,7 @@ trait LaunchQueue {
   def countAsync(specId: PathId): Future[Int]
 
   /** Remove all instance launch requests for the given PathId from this queue. */
-  def asyncPurge(specId: PathId): Future[Done]
+  def purgeAsync(specId: PathId): Future[Done]
 
   /** Add delay to the given RunnableSpec because of a failed instance */
   def addDelay(spec: RunSpec): Unit

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -78,8 +78,6 @@ trait LaunchQueue {
   def getAsync(specId: PathId): Future[Option[QueuedInstanceInfo]]
 
   /** Return how many instances are still to be launched for this PathId. */
-  def count(specId: PathId): Int
-
   def countAsync(specId: PathId): Future[Int]
 
   /** Remove all instance launch requests for the given PathId from this queue. */

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -73,8 +73,6 @@ trait LaunchQueue {
   def addAsync(spec: RunSpec, count: Int = 1): Future[Done]
 
   /** Get information for the given run spec id. */
-  def get(specId: PathId): Option[QueuedInstanceInfo]
-
   def getAsync(specId: PathId): Future[Option[QueuedInstanceInfo]]
 
   /** Return how many instances are still to be launched for this PathId. */

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -56,8 +56,6 @@ trait LaunchQueue {
   def listAsync: Future[Seq[QueuedInstanceInfo]]
 
   /** Returns all entries of the queue with embedded statistics */
-  def listWithStatistics: Seq[QueuedInstanceInfoWithStatistics]
-
   def listWithStatisticsAsync: Future[Seq[QueuedInstanceInfoWithStatistics]]
 
   /** Returns all runnable specs for which queue entries exist. */

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -53,8 +53,6 @@ object LaunchQueue {
 trait LaunchQueue {
 
   /** Returns all entries of the queue. */
-  def list: Seq[QueuedInstanceInfo]
-
   def listAsync: Future[Seq[QueuedInstanceInfo]]
 
   /** Returns all entries of the queue with embedded statistics */

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -68,8 +68,6 @@ trait LaunchQueue {
   def listRunSpecsAsync: Future[Seq[RunSpec]]
 
   /** Request to launch `count` additional instances conforming to the given run spec. */
-  def add(spec: RunSpec, count: Int = 1): Done
-
   def addAsync(spec: RunSpec, count: Int = 1): Future[Done]
 
   /** Get information for the given run spec id. */

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -13,7 +13,7 @@ import mesosphere.marathon.state.{ PathId, RunSpec }
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future, ExecutionContext }
+import scala.concurrent.{ Future, ExecutionContext }
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -54,8 +54,6 @@ private[launchqueue] class LaunchQueueDelegate(
       case None => 0
     }(ExecutionContext.Implicits.global)
 
-  override def listRunSpecs: Seq[RunSpec] = list.map(_.runSpec)
-
   override def listRunSpecsAsync: Future[Seq[RunSpec]] =
     listAsync.map(_.map(_.runSpec))(ExecutionContext.Implicits.global)
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -42,9 +42,6 @@ private[launchqueue] class LaunchQueueDelegate(
   override def listWithStatisticsAsync: Future[Seq[QueuedInstanceInfoWithStatistics]] =
     askQueueActorFuture[LaunchQueueDelegate.Request, Seq[QueuedInstanceInfoWithStatistics]]("listWithStatistics")(LaunchQueueDelegate.ListWithStatistics)
 
-  override def get(runSpecId: PathId): Option[QueuedInstanceInfo] =
-    askQueueActor[LaunchQueueDelegate.Request, Option[QueuedInstanceInfo]]("get")(LaunchQueueDelegate.Count(runSpecId))
-
   override def getAsync(runSpecId: PathId): Future[Option[QueuedInstanceInfo]] =
     askQueueActorFuture[LaunchQueueDelegate.Request, Option[QueuedInstanceInfo]]("get")(LaunchQueueDelegate.Count(runSpecId))
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -31,10 +31,6 @@ private[launchqueue] class LaunchQueueDelegate(
   override def listAsync: Future[Seq[QueuedInstanceInfo]] =
     askQueueActorFuture[LaunchQueueDelegate.Request, Seq[QueuedInstanceInfo]]("list")(LaunchQueueDelegate.List)
 
-  override def listWithStatistics: Seq[QueuedInstanceInfoWithStatistics] = {
-    askQueueActor[LaunchQueueDelegate.Request, Seq[QueuedInstanceInfoWithStatistics]]("listWithStatistics")(LaunchQueueDelegate.ListWithStatistics)
-  }
-
   override def listWithStatisticsAsync: Future[Seq[QueuedInstanceInfoWithStatistics]] =
     askQueueActorFuture[LaunchQueueDelegate.Request, Seq[QueuedInstanceInfoWithStatistics]]("listWithStatistics")(LaunchQueueDelegate.ListWithStatistics)
 
@@ -58,14 +54,6 @@ private[launchqueue] class LaunchQueueDelegate(
 
   override def addAsync(runSpec: RunSpec, count: Int): Future[Done] =
     askQueueActorFuture[LaunchQueueDelegate.Request, Done]("add")(LaunchQueueDelegate.Add(runSpec, count))
-
-  private[this] def askQueueActor[T, R: ClassTag](
-    method: String,
-    timeout: Timeout = launchQueueRequestTimeout)(message: T): R = {
-
-    val answerFuture = askQueueActorFuture[T, R](method, timeout)(message)
-    Await.result(answerFuture, timeout.duration)
-  }
 
   private[this] def askQueueActorFuture[T, R: ClassTag](
     method: String,

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -51,8 +51,6 @@ private[launchqueue] class LaunchQueueDelegate(
   override def notifyOfInstanceUpdate(update: InstanceChange): Future[Done] =
     askQueueActorFuture[InstanceChange, Done]("notifyOfInstanceUpdate")(update)
 
-  override def count(runSpecId: PathId): Int = get(runSpecId).map(_.instancesLeftToLaunch).getOrElse(0)
-
   override def countAsync(runSpecId: PathId): Future[Int] =
     getAsync(runSpecId).map {
       case Some(i) => i.instancesLeftToLaunch

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -64,7 +64,7 @@ private[launchqueue] class LaunchQueueDelegate(
   override def listRunSpecsAsync: Future[Seq[RunSpec]] =
     listAsync.map(_.map(_.runSpec))(ExecutionContext.Implicits.global)
 
-  override def asyncPurge(runSpecId: PathId): Future[Done] =
+  override def purgeAsync(runSpecId: PathId): Future[Done] =
     askQueueActorFuture[LaunchQueueDelegate.Request, Done]("asyncPurge", timeout = purgeTimeout)(LaunchQueueDelegate.Purge(runSpecId))
 
   override def add(runSpec: RunSpec, count: Int): Done =

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -62,9 +62,6 @@ private[launchqueue] class LaunchQueueDelegate(
   override def purgeAsync(runSpecId: PathId): Future[Done] =
     askQueueActorFuture[LaunchQueueDelegate.Request, Done]("asyncPurge", timeout = purgeTimeout)(LaunchQueueDelegate.Purge(runSpecId))
 
-  override def add(runSpec: RunSpec, count: Int): Done =
-    askQueueActor[LaunchQueueDelegate.Request, Done]("add")(LaunchQueueDelegate.Add(runSpec, count))
-
   override def addAsync(runSpec: RunSpec, count: Int): Future[Done] =
     askQueueActorFuture[LaunchQueueDelegate.Request, Done]("add")(LaunchQueueDelegate.Add(runSpec, count))
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -28,10 +28,6 @@ private[launchqueue] class LaunchQueueDelegate(
 
   val launchQueueRequestTimeout: Timeout = config.launchQueueRequestTimeout().milliseconds
 
-  override def list: Seq[QueuedInstanceInfo] = {
-    askQueueActor[LaunchQueueDelegate.Request, Seq[QueuedInstanceInfo]]("list")(LaunchQueueDelegate.List)
-  }
-
   override def listAsync: Future[Seq[QueuedInstanceInfo]] =
     askQueueActorFuture[LaunchQueueDelegate.Request, Seq[QueuedInstanceInfo]]("list")(LaunchQueueDelegate.List)
 

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -87,7 +87,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       Given("a launch queue with one item which is purged")
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
       launchQueue.add(app)
-      launchQueue.asyncPurge(app.id).futureValue
+      launchQueue.purgeAsync(app.id).futureValue
 
       When("querying its count")
       val count = launchQueue.count(app.id)
@@ -105,7 +105,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       Given("a launch queue with one item which is purged")
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
       launchQueue.add(app)
-      launchQueue.asyncPurge(app.id).futureValue
+      launchQueue.purgeAsync(app.id).futureValue
       launchQueue.add(app)
 
       When("querying its count")
@@ -144,7 +144,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       launchQueue.add(app)
 
       When("The app is purged")
-      launchQueue.asyncPurge(app.id).futureValue
+      launchQueue.purgeAsync(app.id).futureValue
 
       Then("No offer matchers remain registered")
       offerMatcherManager.offerMatchers should be(empty)
@@ -223,7 +223,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       matchFuture.futureValue
 
       And("test app gets purged (but not stopped yet because of in-flight tasks)")
-      launchQueue.asyncPurge(app.id)
+      launchQueue.purgeAsync(app.id)
       WaitTestSupport.waitUntil("purge gets executed", 1.second) {
         !launchQueue.list.exists(_.runSpec.id == app.id)
       }

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -34,7 +34,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     "empty queue returns no results" in fixture { f =>
       import f._
       When("querying queue")
-      val apps = launchQueue.list
+      val apps = launchQueue.listAsync.futureValue
 
       Then("no apps are returned")
       apps should be(empty)
@@ -50,7 +50,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       launchQueue.addAsync(app).futureValue
 
       When("querying its contents")
-      val list = launchQueue.list
+      val list = launchQueue.listAsync.futureValue
 
       Then("we get back the added app")
       list should have size 1
@@ -225,7 +225,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       And("test app gets purged (but not stopped yet because of in-flight tasks)")
       launchQueue.purgeAsync(app.id)
       WaitTestSupport.waitUntil("purge gets executed", 1.second) {
-        !launchQueue.list.exists(_.runSpec.id == app.id)
+        !launchQueue.listAsync.futureValue.exists(_.runSpec.id == app.id)
       }
       reset(instanceTracker, instanceOpFactory)
 

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -72,7 +72,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       launchQueue.add(app)
 
       When("querying its count")
-      val count = launchQueue.count(app.id)
+      val count = launchQueue.countAsync(app.id).futureValue
 
       Then("we get a count == 1")
       count should be(1)
@@ -90,7 +90,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       launchQueue.purgeAsync(app.id).futureValue
 
       When("querying its count")
-      val count = launchQueue.count(app.id)
+      val count = launchQueue.countAsync(app.id).futureValue
 
       Then("we get a count == 0")
       count should be(0)
@@ -109,7 +109,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       launchQueue.add(app)
 
       When("querying its count")
-      val count = launchQueue.count(app.id)
+      val count = launchQueue.countAsync(app.id).futureValue
 
       Then("we get a count == 1")
       count should be(1)

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -47,7 +47,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       import f._
       Given("a launch queue with one item")
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
-      launchQueue.add(app)
+      launchQueue.addAsync(app).futureValue
 
       When("querying its contents")
       val list = launchQueue.list
@@ -69,7 +69,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       import f._
       Given("a launch queue with one item")
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
-      launchQueue.add(app)
+      launchQueue.addAsync(app).futureValue
 
       When("querying its count")
       val count = launchQueue.countAsync(app.id).futureValue
@@ -86,7 +86,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       import f._
       Given("a launch queue with one item which is purged")
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
-      launchQueue.add(app)
+      launchQueue.addAsync(app).futureValue
       launchQueue.purgeAsync(app.id).futureValue
 
       When("querying its count")
@@ -104,9 +104,9 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       import f._
       Given("a launch queue with one item which is purged")
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
-      launchQueue.add(app)
+      launchQueue.addAsync(app).futureValue
       launchQueue.purgeAsync(app.id).futureValue
-      launchQueue.add(app)
+      launchQueue.addAsync(app).futureValue
 
       When("querying its count")
       val count = launchQueue.countAsync(app.id).futureValue
@@ -125,7 +125,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
 
       When("Adding an app to the launchQueue")
-      launchQueue.add(app)
+      launchQueue.addAsync(app).futureValue
 
       Then("A new offer matcher gets registered")
       WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
@@ -141,7 +141,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       import f._
       Given("An app in the queue")
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
-      launchQueue.add(app)
+      launchQueue.addAsync(app).futureValue
 
       When("The app is purged")
       launchQueue.purgeAsync(app.id).futureValue
@@ -159,7 +159,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
 
       Given("An app in the queue")
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
-      launchQueue.add(app)
+      launchQueue.addAsync(app).futureValue
       WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
         offerMatcherManager.offerMatchers.size == 1
       }
@@ -185,7 +185,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       import f._
       Given("An app in the queue")
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
-      launchQueue.add(app)
+      launchQueue.addAsync(app).futureValue
       WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
         offerMatcherManager.offerMatchers.size == 1
       }
@@ -212,7 +212,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       import f._
       Given("An app in the queue")
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.empty
-      launchQueue.add(app, 3)
+      launchQueue.addAsync(app, 3).futureValue
       WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
         offerMatcherManager.offerMatchers.size == 1
       }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -302,7 +302,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
       val plan = DeploymentPlan("d2", origGroup, targetGroup, List(DeploymentStep(List(StopApplication(app)))), Timestamp.now())
 
-      f.queue.asyncPurge(app.id) returns Future.successful(Done)
+      f.queue.purgeAsync(app.id) returns Future.successful(Done)
 
       instanceTracker.specInstances(mockito.Matchers.eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instance))
       system.eventStream.subscribe(probe.ref, classOf[UpgradeEvent])
@@ -312,7 +312,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
       expectMsg(DeploymentStarted(plan))
 
-      verify(f.queue, timeout(1000)).asyncPurge(app.id)
+      verify(f.queue, timeout(1000)).purgeAsync(app.id)
       verify(f.queue, timeout(1000)).resetDelay(app.copy(instances = 0))
 
       system.eventStream.unsubscribe(probe.ref)

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -181,7 +181,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       schedulerActor ! ScaleRunSpecs
 
       eventually {
-        verify(queue).add(app, 1)
+        verify(queue).addAsync(app, 1)
       }
     }
 
@@ -196,7 +196,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       schedulerActor ! ScaleRunSpec("/test-app-scale".toPath)
 
       eventually {
-        verify(queue).add(app, 1)
+        verify(queue).addAsync(app, 1)
       }
 
       expectMsg(RunSpecScaled(app.id))
@@ -248,7 +248,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       expectMsg(TasksKilled(app.id, List(instanceA.instanceId)))
 
       eventually {
-        verify(queue).add(app, 1)
+        verify(queue).addAsync(app, 1)
       }
     }
 
@@ -461,6 +461,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
     val queue: LaunchQueue = mock[LaunchQueue]
     queue.getAsync(any[PathId]) returns Future.successful(None)
+    queue.addAsync(any, any) returns Future.successful(Done)
 
     val frameworkIdRepo: FrameworkIdRepository = mock[FrameworkIdRepository]
     val driver: SchedulerDriver = mock[SchedulerDriver]

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -173,7 +173,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
       val instances = Seq(TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance())
 
-      queue.get(app.id) returns Some(LaunchQueueTestHelper.zeroCounts)
+      queue.getAsync(app.id) returns Future.successful(Some(LaunchQueueTestHelper.zeroCounts))
       instanceTracker.specInstances(mockito.Matchers.eq("nope".toPath))(mockito.Matchers.any[ExecutionContext]) returns Future.successful(instances)
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
@@ -189,7 +189,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       import f._
       val app = AppDefinition(id = "/test-app-scale".toPath, instances = 1, cmd = Some("sleep"))
 
-      queue.get(app.id) returns Some(LaunchQueueTestHelper.zeroCounts)
+      queue.getAsync(app.id) returns Future.successful(Some(LaunchQueueTestHelper.zeroCounts))
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
       schedulerActor ! LeadershipTransition.ElectedAsLeaderAndReady
@@ -212,7 +212,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
       killService.customStatusUpdates.put(instance.instanceId, events)
 
-      queue.get(app.id) returns Some(LaunchQueueTestHelper.zeroCounts)
+      queue.getAsync(app.id) returns Future.successful(Some(LaunchQueueTestHelper.zeroCounts))
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
       schedulerActor ! LeadershipTransition.ElectedAsLeaderAndReady
@@ -239,7 +239,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       val app = AppDefinition(id = "/test-app".toPath, instances = 1, cmd = Some("sleep"))
       val instanceA = TestInstanceBuilder.newBuilderWithLaunchedTask(app.id).getInstance()
 
-      queue.get(app.id) returns Some(LaunchQueueTestHelper.zeroCounts)
+      queue.getAsync(app.id) returns Future.successful(Some(LaunchQueueTestHelper.zeroCounts))
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
       schedulerActor ! LeadershipTransition.ElectedAsLeaderAndReady
@@ -460,7 +460,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
     val killService = new KillServiceMock(system)
 
     val queue: LaunchQueue = mock[LaunchQueue]
-    queue.get(any[PathId]) returns None
+    queue.getAsync(any[PathId]) returns Future.successful(None)
 
     val frameworkIdRepo: FrameworkIdRepository = mock[FrameworkIdRepository]
     val driver: SchedulerDriver = mock[SchedulerDriver]

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -90,7 +90,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       val unreachableInstances = Seq.fill(5)(TestInstanceBuilder.newBuilder(app.id).addTaskUnreachableInactive().getInstance())
       val runnningInstances = Seq.fill(10)(TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance())
       f.instanceTracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(unreachableInstances ++ runnningInstances)
-      f.queue.get(eq(app.id)) returns Some(LaunchQueueTestHelper.zeroCounts)
+      f.queue.getAsync(eq(app.id)) returns Future.successful(Some(LaunchQueueTestHelper.zeroCounts))
 
       When("the app is scaled")
       f.scheduler.scale(app).futureValue
@@ -104,7 +104,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
 
       Given("an app with 10 instances and an active queue with 4 tasks")
       val app = MarathonTestHelper.makeBasicApp().copy(instances = 10)
-      f.queue.get(app.id) returns Some(LaunchQueueTestHelper.instanceCounts(instancesLeftToLaunch = 4, finalInstanceCount = 10))
+      f.queue.getAsync(app.id) returns Future.successful(Some(LaunchQueueTestHelper.instanceCounts(instancesLeftToLaunch = 4, finalInstanceCount = 10)))
       f.instanceTracker.specInstances(app.id) returns Future.successful(Seq.empty[Instance])
 
       When("app is scaled")
@@ -119,7 +119,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
 
       Given("an app with 10 instances and an active queue with 10 tasks")
       val app = MarathonTestHelper.makeBasicApp().copy(instances = 10)
-      f.queue.get(app.id) returns Some(LaunchQueueTestHelper.instanceCounts(instancesLeftToLaunch = 10, finalInstanceCount = 10))
+      f.queue.getAsync(app.id) returns Future.successful(Some(LaunchQueueTestHelper.instanceCounts(instancesLeftToLaunch = 10, finalInstanceCount = 10)))
       f.instanceTracker.specInstances(app.id) returns Future.successful(Seq.empty[Instance])
 
       When("app is scaled")
@@ -135,7 +135,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
 
       Given("an app with 10 instances and an active queue with 10 tasks")
       val app = MarathonTestHelper.makeBasicApp().copy(instances = 10)
-      f.queue.get(app.id) returns Some(LaunchQueueTestHelper.instanceCounts(instancesLeftToLaunch = 15, finalInstanceCount = 10))
+      f.queue.getAsync(app.id) returns Future.successful(Some(LaunchQueueTestHelper.instanceCounts(instancesLeftToLaunch = 15, finalInstanceCount = 10)))
       f.instanceTracker.specInstances(app.id) returns Future.successful(Seq.empty[Instance])
 
       When("app is scaled")
@@ -208,7 +208,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
         runningInstance(stagedAt = 2L)
       )
 
-      f.queue.get(app.id) returns None
+      f.queue.getAsync(app.id) returns Future.successful(None)
       f.queue.purgeAsync(app.id) returns Future.successful(Done)
       f.instanceTracker.specInstances(app.id) returns Future.successful(instances)
       When("the app is scaled")

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -96,7 +96,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       f.scheduler.scale(app).futureValue
 
       Then("5 tasks should be placed onto the launchQueue")
-      verify(f.queue, times(1)).add(app, 5)
+      verify(f.queue, times(1)).addAsync(app, 5)
     }
 
     "Scale up with some tasks in launch queue" in {
@@ -111,7 +111,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       f.scheduler.scale(app).futureValue
 
       Then("6 more tasks are added to the queue")
-      verify(f.queue, times(1)).add(app, 6)
+      verify(f.queue, times(1)).addAsync(app, 6)
     }
 
     "Scale up with enough tasks in launch queue" in {
@@ -126,7 +126,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       f.scheduler.scale(app).futureValue
 
       Then("no tasks are added to the queue")
-      verify(f.queue, never).add(eq(app), any[Int])
+      verify(f.queue, never).addAsync(eq(app), any[Int])
     }
 
     // This test was an explicit wish by Matthias E.
@@ -142,7 +142,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       f.scheduler.scale(app).futureValue
 
       Then("no tasks are added to the queue")
-      verify(f.queue, never).add(eq(app), any[Int])
+      verify(f.queue, never).addAsync(eq(app), any[Int])
     }
 
     // This scenario is the following:
@@ -277,6 +277,8 @@ class SchedulerActionsTest extends AkkaUnitTest {
       val driver = mock[SchedulerDriver]
       val killService = mock[KillService]
       val clock = new SettableClock()
+
+      queue.addAsync(any, any) returns Future.successful(Done)
 
       val scheduler = new SchedulerActions(
         groupRepo,

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -171,13 +171,13 @@ class SchedulerActionsTest extends AkkaUnitTest {
         runningInstance()
       )
 
-      f.queue.asyncPurge(app.id) returns Future.successful(Done)
+      f.queue.purgeAsync(app.id) returns Future.successful(Done)
       f.instanceTracker.specInstances(app.id) returns Future.successful(tasks)
       When("the app is scaled")
       f.scheduler.scale(app).futureValue
 
       Then("the queue is purged")
-      verify(f.queue, times(1)).asyncPurge(app.id)
+      verify(f.queue, times(1)).purgeAsync(app.id)
 
       And("the youngest STAGED tasks are killed")
       verify(f.killService, withinTimeout()).killInstances(List(staged_3, staged_2), KillReason.OverCapacity)
@@ -209,13 +209,13 @@ class SchedulerActionsTest extends AkkaUnitTest {
       )
 
       f.queue.get(app.id) returns None
-      f.queue.asyncPurge(app.id) returns Future.successful(Done)
+      f.queue.purgeAsync(app.id) returns Future.successful(Done)
       f.instanceTracker.specInstances(app.id) returns Future.successful(instances)
       When("the app is scaled")
       f.scheduler.scale(app).futureValue
 
       Then("the queue is purged")
-      verify(f.queue, times(1)).asyncPurge(app.id)
+      verify(f.queue, times(1)).purgeAsync(app.id)
 
       And("the youngest RUNNING tasks are killed")
       verify(f.killService, withinTimeout()).killInstances(List(running_7, running_6), KillReason.OverCapacity)
@@ -250,14 +250,14 @@ class SchedulerActionsTest extends AkkaUnitTest {
         runningInstance(stagedAt = 2L)
       )
 
-      f.queue.asyncPurge(app.id) returns Future.successful(Done)
+      f.queue.purgeAsync(app.id) returns Future.successful(Done)
       f.instanceTracker.specInstances(app.id) returns Future.successful(tasks)
 
       When("the app is scaled")
       f.scheduler.scale(app).futureValue
 
       Then("the queue is purged")
-      verify(f.queue, times(1)).asyncPurge(app.id)
+      verify(f.queue, times(1)).purgeAsync(app.id)
 
       And("all STAGED tasks plus the youngest RUNNING tasks are killed")
       verify(f.killService, withinTimeout()).killInstances(List(staged_1, running_4), KillReason.OverCapacity)

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -15,6 +15,7 @@ import mesosphere.mesos.NoOfferMatchReason
 import play.api.libs.json._
 
 import scala.collection.immutable.Seq
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class QueueResourceTest extends UnitTest {
@@ -116,7 +117,7 @@ class QueueResourceTest extends UnitTest {
 
     "unknown application backoff can not be removed from the launch queue" in new Fixture {
       //given
-      queue.list returns Seq.empty
+      queue.listAsync returns Future.successful(Seq.empty)
 
       //when
       val response = queueResource.resetDelay("unknown", auth.request)
@@ -128,12 +129,12 @@ class QueueResourceTest extends UnitTest {
     "application backoff can be removed from the launch queue" in new Fixture {
       //given
       val app = AppDefinition(id = "app".toRootPath)
-      queue.list returns Seq(
+      queue.listAsync returns Future.successful(Seq(
         QueuedInstanceInfo(
           app, inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
           backOffUntil = clock.now() + 100.seconds, startedAt = clock.now()
         )
-      )
+      ))
 
       //when
       val response = queueResource.resetDelay("app", auth.request)
@@ -169,7 +170,7 @@ class QueueResourceTest extends UnitTest {
       val appId = "appId".toRootPath
       val taskCount = LaunchQueue.QueuedInstanceInfo(AppDefinition(appId), inProgress = false, 0, 0,
         backOffUntil = clock.now() + 100.seconds, startedAt = clock.now())
-      queue.list returns Seq(taskCount)
+      queue.listAsync returns Future.successful(Seq(taskCount))
 
       val resetDelay = queueResource.resetDelay("appId", req)
       Then("we receive a not authorized response")
@@ -183,7 +184,7 @@ class QueueResourceTest extends UnitTest {
       val req = auth.request
 
       When("one delay is reset")
-      queue.list returns Seq.empty
+      queue.listAsync returns Future.successful(Seq.empty)
 
       val resetDelay = queueResource.resetDelay("appId", req)
       Then("we receive a not authorized response")

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -48,7 +48,7 @@ class QueueResourceTest extends UnitTest {
         MarathonTestHelper.makeBasicOffer().build(),
         Seq(NoOfferMatchReason.InsufficientCpus, NoOfferMatchReason.DeclinedScarceResources),
         clock.now())
-      queue.listWithStatistics returns Seq(
+      queue.listWithStatisticsAsync returns Future.successful(Seq(
         QueuedInstanceInfoWithStatistics(
           app, inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
           backOffUntil = clock.now() + 100.seconds, startedAt = clock.now(),
@@ -60,7 +60,7 @@ class QueueResourceTest extends UnitTest {
           lastNoMatch = None,
           lastNoMatches = Seq(noMatch)
         )
-      )
+      ))
 
       //when
       val response = queueResource.index(auth.request, Set("lastUnusedOffers").asJava)
@@ -92,14 +92,14 @@ class QueueResourceTest extends UnitTest {
     "the generated info from the queue contains 0 if there is no delay" in new Fixture {
       //given
       val app = AppDefinition(id = "app".toRootPath)
-      queue.listWithStatistics returns Seq(
+      queue.listWithStatisticsAsync returns Future.successful(Seq(
         QueuedInstanceInfoWithStatistics(
           app, inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
           backOffUntil = clock.now() - 100.seconds, startedAt = clock.now(), rejectSummaryLastOffers = Map.empty,
           rejectSummaryLaunchAttempt = Map.empty, processedOffersCount = 3, unusedOffersCount = 1, lastMatch = None,
           lastNoMatch = None, lastNoMatches = Seq.empty
         )
-      )
+      ))
       //when
       val response = queueResource.index(auth.request, Set.empty[String].asJava)
 

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/AppStartActorTest.scala
@@ -96,7 +96,7 @@ class AppStartActorTest extends AkkaUnitTest {
       val readinessCheckExecutor: ReadinessCheckExecutor = mock[ReadinessCheckExecutor]
       val appId = PathId("/app")
 
-      launchQueue.get(appId) returns None
+      launchQueue.getAsync(appId) returns Future.successful(None)
       scheduler.startRunSpec(any) returns Future.successful(Done)
 
       def instanceChanged(app: AppDefinition, condition: Condition): InstanceChanged = {

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -119,7 +119,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
       val plan = DeploymentPlan(origGroup, targetGroup)
 
-      queue.asyncPurge(any) returns Future.successful(Done)
+      queue.purgeAsync(any) returns Future.successful(Done)
       scheduler.startRunSpec(any) returns Future.successful(Done)
       tracker.specInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2))
       tracker.specInstancesSync(app2.id) returns Seq(instance2_1)

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -307,7 +307,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       // only one task is queued directly, all old still running
       val queueOrder = org.mockito.Mockito.inOrder(f.queue)
       eventually {
-        queueOrder.verify(f.queue).add(_: AppDefinition, 1)
+        queueOrder.verify(f.queue).addAsync(_: AppDefinition, 1)
       }
       assert(f.killService.numKilled == 0)
 
@@ -317,7 +317,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
         f.killService.numKilled should be(1)
       }
       eventually {
-        queueOrder.verify(f.queue).add(_: AppDefinition, 1)
+        queueOrder.verify(f.queue).addAsync(_: AppDefinition, 1)
       }
 
       // second new task becomes healthy and another old task is killed
@@ -326,7 +326,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
         f.killService.numKilled should be(2)
       }
       eventually {
-        queueOrder.verify(f.queue).add(_: AppDefinition, 1)
+        queueOrder.verify(f.queue).addAsync(_: AppDefinition, 1)
       }
 
       // third new task becomes healthy and last old task is killed
@@ -334,7 +334,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       eventually {
         f.killService.numKilled should be(3)
       }
-      queueOrder.verify(f.queue, never).add(_: AppDefinition, 1)
+      queueOrder.verify(f.queue, never).addAsync(_: AppDefinition, 1)
 
       promise.future.futureValue
 
@@ -371,7 +371,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       // two tasks are queued directly, all old still running
       val queueOrder = org.mockito.Mockito.inOrder(f.queue)
       eventually {
-        queueOrder.verify(f.queue).add(_: AppDefinition, 2)
+        queueOrder.verify(f.queue).addAsync(_: AppDefinition, 2)
       }
       assert(f.killService.numKilled == 0)
 
@@ -381,7 +381,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
         f.killService.numKilled should be(1)
       }
       eventually {
-        queueOrder.verify(f.queue).add(_: AppDefinition, 1)
+        queueOrder.verify(f.queue).addAsync(_: AppDefinition, 1)
       }
 
       // second new task becomes healthy and another old task is killed
@@ -389,14 +389,14 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       eventually {
         f.killService.numKilled should be(2)
       }
-      queueOrder.verify(f.queue, never).add(_: AppDefinition, 1)
+      queueOrder.verify(f.queue, never).addAsync(_: AppDefinition, 1)
 
       // third new task becomes healthy and last old task is killed
       ref ! f.healthChanged(newApp, healthy = true)
       eventually {
         f.killService.numKilled should be(3)
       }
-      queueOrder.verify(f.queue, never).add(_: AppDefinition, 1)
+      queueOrder.verify(f.queue, never).addAsync(_: AppDefinition, 1)
 
       promise.future.futureValue
 
@@ -601,7 +601,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       // only one task is queued directly
       val queueOrder = org.mockito.Mockito.inOrder(f.queue)
       eventually {
-        queueOrder.verify(f.queue).add(_: AppDefinition, 1)
+        queueOrder.verify(f.queue).addAsync(_: AppDefinition, 1)
       }
       assert(f.killService.numKilled == 0)
 


### PR DESCRIPTION
Summary:
Removed synchronous `LaunchQueue` methods and replaced them with their asynchronous counterparts.