### PR TITLE
Use NGinx Alpine Docker image to reduce size.

### DIFF
--- a/tests/system/apps/resident-docker-app.json
+++ b/tests/system/apps/resident-docker-app.json
@@ -18,7 +18,7 @@
       }
     ],
     "docker": {
-      "image": "nginx",
+      "image": "nginx:alpine",
       "network": "USER",
       "privileged": false,
       "forcePullImage": false


### PR DESCRIPTION
Summary:
The current Docker image in our tests is above 50MB. This reduces the
size to 8MB and thus the test runtime.