### PR TITLE
Rolling back deployments allows duplicate service ports

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogic.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogic.scala
@@ -15,7 +15,9 @@ object AssignDynamicServiceLogic extends StrictLogging {
     * @return true if app is new or an updated, false otherwise.
     */
   private def changedOrNew(original: RootGroup, newApp: AppDefinition): Boolean = {
-    original.app(newApp.id).forall { _.isUpgrade(newApp) }
+    original
+      .app(newApp.id)
+      .forall { originalApp => originalApp.isUpgrade(newApp) || originalApp.isRevert(newApp) }
   }
 
   private def mergeServicePortsAndPortDefinitions(

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -375,6 +375,11 @@ case class AppDefinition(
       throw new IllegalStateException("Can't change app to pod")
   }
 
+  def isRevert(to: RunSpec) = {
+    id == to.id &&
+      version > to.version
+  }
+
   /**
     * Returns the changed app definition that is marked for restarting.
     */


### PR DESCRIPTION
Summary: now we check apps for assigning ports if we're doing a rollback

JIRA issues: MARATHON-8160

