### PR TITLE
Script for finding out which version of Marathon/Metronome is in DCOS

### DIFF
--- a/tools/dcos-versions.sc
+++ b/tools/dcos-versions.sc
@@ -22,12 +22,11 @@ case class PackageUrl(url: String, packageName: String) {
   }
 }
 
-@main
-
 /***
   * Find out which version of a package (Marathon/Metronome) is in which version of DC/OS
   * example usage: ./dcos-versions.sh marathon
   */
+@main
 def getDcosVersions(packageName: String): Unit = {
   minorVersions.foreach(minorVersion => {
     var patchVersion = 0

--- a/tools/dcos-versions.sc
+++ b/tools/dcos-versions.sc
@@ -23,6 +23,11 @@ case class PackageUrl(url: String, packageName: String) {
 }
 
 @main
+
+/***
+  * Find out which version of a package (Marathon/Metronome) is in which version of DC/OS
+  * example usage: ./dcos-versions.sh marathon
+  */
 def getDcosVersions(packageName: String): Unit = {
   minorVersions.foreach(minorVersion => {
     var patchVersion = 0

--- a/tools/dcos-versions.sc
+++ b/tools/dcos-versions.sc
@@ -1,0 +1,67 @@
+#!/usr/bin/env amm
+
+import $ivy.`com.typesafe.play::play-json:2.6.0`
+
+import scalaj.http._
+import play.api.libs.json.Json
+
+val minorVersions = Seq(9, 10, 11)
+
+case class ContentResponse(download_url: String)
+implicit val contentResponseFormat = Json.format[ContentResponse]
+
+case class PackageJson(single_source: SourceDefinition)
+case class SourceDefinition(url: String)
+implicit val sourceDefinitionFormat = Json.format[SourceDefinition]
+implicit val packageJsonFormat = Json.format[PackageJson]
+
+case class PackageUrl(url: String, packageName: String) {
+  lazy val packageVersion = {
+    // e.g. metronome-0.5.0.tgz
+    url.split('/').last.replace(".tgz", "").replace(s"$packageName-", "")
+  }
+}
+
+@main
+def getDcosVersions(packageName: String): Unit = {
+  minorVersions.foreach(minorVersion => {
+    var patchVersion = 0
+    var dcosVersionExists = true
+    while (dcosVersionExists) {
+      val dcosVersion = s"1.$minorVersion.$patchVersion"
+      try {
+        val packageVersion = getPackageVersion(dcosVersion, packageName)
+        println(s"$dcosVersion - $packageVersion")
+      } catch {
+        case _: VersionDoesNotExistException =>
+          dcosVersionExists = false
+      }
+
+      patchVersion += 1
+    }
+
+    val dcosVersion = s"1.$minorVersion"
+    val vNextVersion = getPackageVersion(dcosVersion, packageName)
+    println(s"$dcosVersion.next - $vNextVersion")
+  })
+
+  val masterVersion = getPackageVersion("master", packageName)
+  println(s"master - $masterVersion")
+}
+
+class VersionDoesNotExistException() extends Exception
+
+def getPackageVersion(dcosVersion: String, packageName: String): String = {
+  val response = Http(s"https://raw.githubusercontent.com/dcos/dcos/$dcosVersion/packages/$packageName/buildinfo.json")
+    .timeout(connTimeoutMs = 5000, readTimeoutMs = 100000)
+    .asString
+  if (response.code == 404) {
+    throw new VersionDoesNotExistException
+  }
+  if (response.code != 200) {
+    throw new Exception(s"HTTP code ${response.code} from github with response ${response.body}")
+  }
+  // e.g. https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.5.0/metronome-0.5.0.tgz
+  val packageUrl = PackageUrl(Json.parse(response.body).as[PackageJson].single_source.url, packageName)
+  packageUrl.packageVersion
+}


### PR DESCRIPTION
I had to do this manually many times for Metronome, now I don't have to. And you don't have to as well! :)

```
Alenas-MacBook-Pro:tools alenavarkockova$ ./dcos-versions.sc marathon
1.9.0 - 1.4.2
1.9.1 - 1.4.5
1.9.2 - 1.4.5
1.9.3 - 1.4.7
1.9.4 - 1.4.7
1.9.5 - 1.4.8
1.9.6 - 1.4.9
1.9.7 - 1.4.11
1.9.8 - 1.4.11
1.9.next - 1.4.11
1.10.0 - 1.5.0-SNAPSHOT-713-g14280a6
1.10.1 - 1.5.1.2
1.10.2 - 1.5.2
1.10.3 - 1.5.2
1.10.4 - 1.5.5
1.10.5 - 1.5.6
1.10.6 - 1.5.7
1.10.next - 1.5.8
1.11.0 - 1.6.322-2bf46b341
1.11.1 - 1.6.352-044939181
1.11.next - 1.6.392-f9d087d2f
master - 1.6.352-044939181
```
