### PR TITLE
Adding `revivedOffers` metric

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActor.scala
@@ -3,16 +3,15 @@ package core.flow.impl
 
 import java.time.Clock
 
-import akka.actor.{Actor, Cancellable, Props}
-import akka.event.{EventStream, LoggingReceive}
+import akka.actor.{ Actor, Cancellable, Props }
+import akka.event.{ EventStream, LoggingReceive }
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.MarathonSchedulerDriverHolder
 import mesosphere.marathon.core.flow.ReviveOffersConfig
 import mesosphere.marathon.core.flow.impl.ReviveOffersActor.OffersWanted
 import mesosphere.marathon.core.event.{SchedulerRegisteredEvent, SchedulerReregisteredEvent}
-import mesosphere.marathon.metrics.{Metrics, ServiceMetric}
+import mesosphere.marathon.metrics.{ Metrics, ServiceMetric }
 import mesosphere.marathon.state.Timestamp
-import rx.lang.scala.{Observable, Subscription}
+import rx.lang.scala.{ Observable, Subscription }
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._
@@ -38,7 +37,7 @@ private[impl] class ReviveOffersActor(
     offersWanted: Observable[Boolean],
     driverHolder: MarathonSchedulerDriverHolder) extends Actor with StrictLogging {
 
-  private[this] val revivedOffersMetric = Metrics.minMaxCounter(ServiceMetric, getClass, "revivedOffers")
+  private[this] val reviveCountMetric = Metrics.minMaxCounter(ServiceMetric, getClass, "reviveCount")
 
   private[impl] var subscription: Subscription = _
   private[impl] var offersCurrentlyWanted: Boolean = false
@@ -69,7 +68,7 @@ private[impl] class ReviveOffersActor(
       nextReviveCancellableOpt.foreach(_.cancel())
       nextReviveCancellableOpt = None
 
-      revivedOffersMetric.increment()
+      reviveCountMetric.increment()
       driverHolder.driver.foreach(_.reviveOffers())
       lastRevive = now
 


### PR DESCRIPTION
This PR introduces the `mesosphere.marathon.core.flow.impl.ReviveOffersActor.revivedOffers`
metric that counts the times the ReviveOffersActor sends a revive request to mesos.

Related JIRA: MARATHON-8161