### PR TITLE
Limit max number of concurrently running deployments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## Change from 1.6.352 to 1.6.xxx
+
+## Limit maximum number of running deployments
+New command line flag `--max_running_deployments` was added to limit the max number of concurrently running deployments. The default value is set to 100. Should the user try to submit more updates than set by this flag a HTTP 403 Error is returned with an explanatory error message. We introduced this flag because having lots of running deployments can lead to a significant performance decrease in the failover scenario during marathon initialization phase. 
+
 ## Change from 1.6.322 to 1.6.352
 
 ### GPU Scheduling

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -184,7 +184,8 @@ When using Debian packages, these environment variables should be defined in `/e
 * <span class="label label-default">v1.6.0</span>`--draining_seconds` (Optional. Default: 0):
     Time (in seconds) when marathon will start declining offers before a [maintenance window](http://mesos.apache.org/documentation/latest/maintenance/) start time.
     **Note:** In order to activate the `--draining_seconds` configuration, you must add `maintenance_mode` to the set of `--enable_features`.
-
+* <span class="label label-default">> v1.6.352</span>`--max_running_deployments` (Optional. Default: 100):
+    Maximum number of concurrently running deployments. Should the user try to submit more updates than set by this flag a HTTP 403 Error is returned with an explanatory error message.
 
 ## Tuning Flags for Offer Matching/Launching Tasks
 

--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -32,7 +32,7 @@ case class AppLockedException(deploymentIds: Seq[String] = Nil)
   )
 
 case class TooManyRunningDeploymentsException(maxNum: Int) extends Exception(
-  s"Max number ($maxNum) of running deployment is achieved. Wait for existing deployments to complete or cancel one." +
+  s"Max number ($maxNum) of running deployments is achieved. Wait for existing deployments to complete or cancel one." +
     "You can increase max deployment number by using --max_running_deployments parameter but be " +
     "advised that this can have negative effects on the performance."
 )

--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -31,7 +31,7 @@ case class AppLockedException(deploymentIds: Seq[String] = Nil)
       "View details at '/v2/deployments/<DEPLOYMENT_ID>'."
   )
 
-case class TooManyRunningDeployments(maxNum: Int) extends Exception(
+case class TooManyRunningDeploymentsException(maxNum: Int) extends Exception(
   s"Max number ($maxNum) of running deployment is achieved. Wait for existing deployments to complete or cancel one." +
     "You can increase max deployment number by using --max_running_deployments parameter but be " +
     "advised that this can have negative effects on the performance."

--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -31,6 +31,12 @@ case class AppLockedException(deploymentIds: Seq[String] = Nil)
       "View details at '/v2/deployments/<DEPLOYMENT_ID>'."
   )
 
+case class TooManyRunningDeployments(maxNum: Int) extends Exception(
+  s"Max number ($maxNum) of running deployment is achieved. Wait for existing deployments to complete or cancel one." +
+    "You can increase max deployment number by using --max_running_deployments parameter but be " +
+    "advised that this can have negative effects on the performance."
+)
+
 class PortRangeExhaustedException(
     val minPort: Int,
     val maxPort: Int) extends Exception(s"All ports in the range [$minPort-$maxPort) are already in use")

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -9,6 +9,7 @@ import akka.actor.{ ActorRef, ActorSystem }
 import akka.stream.Materializer
 import akka.util.Timeout
 import com.google.common.util.concurrent.AbstractExecutionThreadService
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.core.deployment.{ DeploymentManager, DeploymentPlan, DeploymentStepInfo }
 import mesosphere.marathon.core.election.{ ElectionCandidate, ElectionService }
@@ -22,7 +23,6 @@ import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.stream.Sink
 import mesosphere.util.PromiseActor
 import org.apache.mesos.SchedulerDriver
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
@@ -77,7 +77,7 @@ class MarathonSchedulerService @Inject() (
     deploymentManager: DeploymentManager,
     @Named("schedulerActor") schedulerActor: ActorRef,
     @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) mesosHeartbeatActor: ActorRef)(implicit mat: Materializer)
-  extends AbstractExecutionThreadService with ElectionCandidate with DeploymentService {
+  extends AbstractExecutionThreadService with ElectionCandidate with DeploymentService with StrictLogging {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -103,8 +103,6 @@ class MarathonSchedulerService @Inject() (
 
   private[mesosphere] var timer = newTimer()
 
-  val log = LoggerFactory.getLogger(getClass.getName)
-
   // This is a little ugly as we are using a mutable variable. But drivers can't
   // be reused (i.e. once stopped they can't be started again. Thus,
   // we have to allocate a new driver before each run or after each stop.
@@ -115,7 +113,7 @@ class MarathonSchedulerService @Inject() (
   protected def newTimer() = new Timer("marathonSchedulerTimer")
 
   def deploy(plan: DeploymentPlan, force: Boolean = false): Future[Done] = {
-    log.info(s"Deploy plan with force=$force:\n$plan ")
+    logger.info(s"Deploy plan with force=$force:\n$plan ")
     val future: Future[Any] = PromiseActor.askWithoutTimeout(system, schedulerActor, Deploy(plan, force))
     future.map {
       case DeploymentStarted(_) => Done
@@ -145,12 +143,12 @@ class MarathonSchedulerService @Inject() (
   //Begin Service interface
 
   override def startUp(): Unit = {
-    log.info("Starting up")
+    logger.info("Starting up")
     super.startUp()
   }
 
   override def run(): Unit = {
-    log.info("Beginning run")
+    logger.info("Beginning run")
 
     // The first thing we do is offer our leadership.
     electionService.offerLeadership(this)
@@ -162,20 +160,20 @@ class MarathonSchedulerService @Inject() (
       isRunningLatch.await()
     }
 
-    log.info("Completed run")
+    logger.info("Completed run")
   }
 
   override def triggerShutdown(): Unit = synchronized {
-    log.info("Shutdown triggered")
+    logger.info("Shutdown triggered")
 
     electionService.abdicateLeadership()
     stopDriver()
 
-    log.info("Cancelling timer")
+    logger.info("Cancelling timer")
     timer.cancel()
 
     // The countdown latch blocks run() from exiting. Counting down the latch removes the block.
-    log.info("Removing the blocking of run()")
+    logger.info("Removing the blocking of run()")
     isRunningLatch.countDown()
 
     super.triggerShutdown()
@@ -184,7 +182,7 @@ class MarathonSchedulerService @Inject() (
   private[this] def stopDriver(): Unit = synchronized {
     // many are the assumptions concerning when this is invoked. see startLeadership, stopLeadership,
     // triggerShutdown.
-    log.info("Stopping driver")
+    logger.info("Stopping driver")
 
     // Stopping the driver will cause the driver run() method to return.
     driver.foreach(_.stop(true)) // failover = true
@@ -198,7 +196,7 @@ class MarathonSchedulerService @Inject() (
   //Begin ElectionCandidate interface
 
   override def startLeadership(): Unit = synchronized {
-    log.info("As new leader running the driver")
+    logger.info("As new leader running the driver")
 
     // allow interactions with the persistence store
     persistenceStore.markOpen()
@@ -212,12 +210,12 @@ class MarathonSchedulerService @Inject() (
     refreshCachesAndDoMigration()
 
     // run all pre-driver callbacks
-    log.info(s"""Call preDriverStarts callbacks on ${prePostDriverCallbacks.mkString(", ")}""")
+    logger.info(s"""Call preDriverStarts callbacks on ${prePostDriverCallbacks.mkString(", ")}""")
     Await.result(
       Future.sequence(prePostDriverCallbacks.map(_.preDriverStarts)),
       config.onElectedPrepareTimeout().millis
     )
-    log.info("Finished preDriverStarts callbacks")
+    logger.info("Finished preDriverStarts callbacks")
 
     // start all leadership coordination actors
     Await.result(leadershipCoordinator.prepareForStart(), config.maxActorStartupTime().milliseconds)
@@ -237,9 +235,9 @@ class MarathonSchedulerService @Inject() (
     } onComplete { result =>
       synchronized {
 
-        log.info(s"Driver future completed with result=$result.")
+        logger.info(s"Driver future completed with result=$result.")
         result match {
-          case Failure(t) => log.error("Exception while running driver", t)
+          case Failure(t) => logger.error("Exception while running driver", t)
           case _ =>
         }
 
@@ -253,9 +251,9 @@ class MarathonSchedulerService @Inject() (
 
         driver = None
 
-        log.info(s"Call postDriverRuns callbacks on ${prePostDriverCallbacks.mkString(", ")}")
+        logger.info(s"Call postDriverRuns callbacks on ${prePostDriverCallbacks.mkString(", ")}")
         Await.result(Future.sequence(prePostDriverCallbacks.map(_.postDriverTerminates)), config.zkTimeoutDuration)
-        log.info("Finished postDriverRuns callbacks")
+        logger.info("Finished postDriverRuns callbacks")
       }
     }
   }
@@ -283,7 +281,7 @@ class MarathonSchedulerService @Inject() (
 
   override def stopLeadership(): Unit = synchronized {
     // invoked by election service upon loss of leadership (state transitioned to Idle)
-    log.info("Lost leadership")
+    logger.info("Lost leadership")
 
     // disallow any interaction with the persistence storage
     persistenceStore.markClosed()
@@ -309,7 +307,7 @@ class MarathonSchedulerService @Inject() (
         def run(): Unit = {
           if (electionService.isLeader) {
             schedulerActor ! ScaleRunSpecs
-          } else log.info("Not leader therefore not scaling apps")
+          } else logger.info("Not leader therefore not scaling apps")
         }
       },
       scaleAppsInitialDelay.toMillis,
@@ -322,7 +320,7 @@ class MarathonSchedulerService @Inject() (
           if (electionService.isLeader) {
             schedulerActor ! ReconcileTasks
             schedulerActor ! ReconcileHealthChecks
-          } else log.info("Not leader therefore not reconciling tasks")
+          } else logger.info("Not leader therefore not reconciling tasks")
         }
       },
       reconciliationInitialDelay.toMillis,

--- a/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
@@ -67,7 +67,7 @@ class MarathonExceptionMapper extends ExceptionMapper[JavaException] {
     case _: IllegalArgumentException => UnprocessableEntity.intValue
     case _: ValidationFailedException => UnprocessableEntity.intValue
     case e: WebApplicationException => e.getResponse.getStatus
-    case _: TooManyRunningDeployments => Forbidden.intValue
+    case _: TooManyRunningDeploymentsException => Forbidden.intValue
     case _ => InternalServerError.intValue
   }
 

--- a/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
@@ -67,6 +67,7 @@ class MarathonExceptionMapper extends ExceptionMapper[JavaException] {
     case _: IllegalArgumentException => UnprocessableEntity.intValue
     case _: ValidationFailedException => UnprocessableEntity.intValue
     case e: WebApplicationException => e.getResponse.getStatus
+    case _: TooManyRunningDeployments => Forbidden.intValue
     case _ => InternalServerError.intValue
   }
 

--- a/src/main/scala/mesosphere/marathon/core/group/GroupManagerConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/GroupManagerConfig.scala
@@ -29,6 +29,13 @@ trait GroupManagerConfig extends ScallopConf {
     descr = "INTERNAL TUNING PARAMETER: Group manager module's execution context thread pool size"
   )
 
+  lazy val maxRunningDeployments = opt[Int](
+    "max_running_deployments",
+    descr = "Max number of concurrently running deployments. Over the limit deployments will be dismissed.",
+    noshort = true,
+    default = Some(100)
+  )
+
   def availableFeatures: Set[String]
   def localPortMin: ScallopOption[Int]
   def localPortMax: ScallopOption[Int]

--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
@@ -163,12 +163,13 @@ class GroupManagerImpl(
     case NonFatal(ex) => Future.failed(ex)
   }
 
+  @SuppressWarnings(Array("all")) // async/await
   def checkMaxRunningDeployments(): Future[Done] = async {
     val max = config.maxRunningDeployments()
     val num = await(deploymentService.get().listRunningDeployments()).size
     if (num >= max) {
       dismissedDeploymentsMetric.increment()
-      throw new TooManyRunningDeployments(max)
+      throw new TooManyRunningDeploymentsException(max)
     }
     Done
   }

--- a/src/test/scala/mesosphere/marathon/api/TestGroupManagerFixture.scala
+++ b/src/test/scala/mesosphere/marathon/api/TestGroupManagerFixture.scala
@@ -37,6 +37,7 @@ class TestGroupManagerFixture(
     override def get() = service
   }
 
+  schedulerProvider.get().listRunningDeployments() returns Future.successful(Seq.empty)
   groupRepository.root() returns Future.successful(initialRoot)
 
   private[this] val groupManagerModule = new GroupManagerModule(

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -45,6 +45,8 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation {
     val groupRepository: GroupRepository = f.groupRepository
     val groupManager: GroupManager = f.groupManager
 
+    f.schedulerProvider.get().listRunningDeployments() returns Future.successful(Seq.empty)
+
     implicit val authorizer = auth.auth
 
     val groupsResource: GroupsResource = new GroupsResource(groupManager, groupInfo, config, new GroupApiService(groupManager))(auth.auth, auth.auth, mat)

--- a/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
@@ -13,7 +13,7 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.GroupRepository
 import mesosphere.marathon.test.GroupCreation
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 
 class GroupManagerTest extends AkkaUnitTest with GroupCreation {
   class Fixture(

--- a/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
@@ -136,7 +136,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       val running = (1.to(maxRunningDeployments).map(_ => mock[DeploymentStepInfo]))
       deploymentService.listRunningDeployments() returns Future.successful(running)
 
-      intercept[TooManyRunningDeployments] {
+      intercept[TooManyRunningDeploymentsException] {
         throw groupManager.updateRoot(PathId.empty, _.putGroup(rootGroup, rootGroup.version), rootGroup.version, force = false).failed.futureValue
       }
 


### PR DESCRIPTION
Summary:

Added a new command parameter `--max_running_deployments` limiting the max number of concurrently running deployments in the system. By default `max_running_deployments` is set to 100. Over the limit, deployments are dismissed with an HTTP 403 Error and a helpful error message. Added a new metric to help monitor the number of dismissed deployments.

JIRA: MARATHON-8172, MARATHON_EE-1955
