### PR TITLE
Back-port lightweight SSE flag

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -272,11 +272,18 @@ trait EventFormats {
   }
 
   implicit lazy val DeploymentPlanWrites: Writes[DeploymentPlan] = Writes { plan =>
-
     Json.obj(
       "id" -> plan.id,
       "original" -> Raml.toRaml[Group, raml.Group](plan.original),
       "target" -> Raml.toRaml[Group, raml.Group](plan.target),
+      "steps" -> plan.steps,
+      "version" -> plan.version
+    )
+  }
+
+  lazy val LightDeploymentPlanWrites: Writes[DeploymentPlan] = Writes { plan =>
+    Json.obj(
+      "id" -> plan.id,
       "steps" -> plan.steps,
       "version" -> plan.version
     )
@@ -313,11 +320,54 @@ trait EventFormats {
   implicit lazy val HealthStatusChangedWrites: Writes[HealthStatusChanged] = Json.writes[HealthStatusChanged]
   implicit lazy val GroupChangeSuccessWrites: Writes[GroupChangeSuccess] = Json.writes[GroupChangeSuccess]
   implicit lazy val GroupChangeFailedWrites: Writes[GroupChangeFailed] = Json.writes[GroupChangeFailed]
+
   implicit lazy val DeploymentSuccessWrites: Writes[DeploymentSuccess] = Json.writes[DeploymentSuccess]
   implicit lazy val DeploymentFailedWrites: Writes[DeploymentFailed] = Json.writes[DeploymentFailed]
   implicit lazy val DeploymentStatusWrites: Writes[DeploymentStatus] = Json.writes[DeploymentStatus]
   implicit lazy val DeploymentStepSuccessWrites: Writes[DeploymentStepSuccess] = Json.writes[DeploymentStepSuccess]
   implicit lazy val DeploymentStepFailureWrites: Writes[DeploymentStepFailure] = Json.writes[DeploymentStepFailure]
+
+  implicit lazy val LightDeploymentSuccessWrites: Writes[DeploymentSuccess] = Writes { event =>
+    Json.obj(
+      "id" -> event.id,
+      "plan" -> LightDeploymentPlanWrites.writes(event.plan),
+      "eventType" -> "deployment_success",
+      "timestamp" -> Timestamp.now().toString
+    )
+  }
+  implicit lazy val LightDeploymentFailedWrites: Writes[DeploymentFailed] = Writes { event =>
+    Json.obj(
+      "id" -> event.id,
+      "plan" -> LightDeploymentPlanWrites.writes(event.plan),
+      "eventType" -> "deployment_failed",
+      "timestamp" -> Timestamp.now().toString
+    )
+  }
+  implicit lazy val LightDeploymentStatusWrites: Writes[DeploymentStatus] = Writes { event =>
+    Json.obj(
+      "plan" -> LightDeploymentPlanWrites.writes(event.plan),
+      "currentStep" -> DeploymentStepWrites.writes(event.currentStep),
+      "eventType" -> "deployment_info",
+      "timestamp" -> Timestamp.now().toString
+    )
+  }
+  implicit lazy val LightDeploymentStepSuccessWrites: Writes[DeploymentStepSuccess] = Writes { event =>
+    Json.obj(
+      "plan" -> LightDeploymentPlanWrites.writes(event.plan),
+      "currentStep" -> DeploymentStepWrites.writes(event.currentStep),
+      "eventType" -> "deployment_step_success",
+      "timestamp" -> Timestamp.now().toString
+    )
+  }
+  implicit lazy val LightDeploymentStepFailureWrites: Writes[DeploymentStepFailure] = Writes { event =>
+    Json.obj(
+      "plan" -> LightDeploymentPlanWrites.writes(event.plan),
+      "currentStep" -> DeploymentStepWrites.writes(event.currentStep),
+      "eventType" -> "deployment_step_failure",
+      "timestamp" -> Timestamp.now().toString
+    )
+  }
+
   implicit lazy val MesosStatusUpdateEventWrites: Writes[MesosStatusUpdateEvent] = Json.writes[MesosStatusUpdateEvent]
   implicit lazy val MesosFrameworkMessageEventWrites: Writes[MesosFrameworkMessageEvent] =
     Json.writes[MesosFrameworkMessageEvent]
@@ -359,7 +409,7 @@ trait EventFormats {
     )
   }
 
-  def eventToJson(event: MarathonEvent): JsValue = event match {
+  def eventToJson(event: MarathonEvent, lightweightPlan: Boolean): JsValue = event match {
     case event: AppTerminatedEvent => Json.toJson(event)
     case event: ApiPostEvent => Json.toJson(event)
     case event: Subscribe => Json.toJson(event)
@@ -373,11 +423,6 @@ trait EventFormats {
     case event: UnhealthyInstanceKillEvent => Json.toJson(event)
     case event: GroupChangeSuccess => Json.toJson(event)
     case event: GroupChangeFailed => Json.toJson(event)
-    case event: DeploymentSuccess => Json.toJson(event)
-    case event: DeploymentFailed => Json.toJson(event)
-    case event: DeploymentStatus => Json.toJson(event)
-    case event: DeploymentStepSuccess => Json.toJson(event)
-    case event: DeploymentStepFailure => Json.toJson(event)
     case event: MesosStatusUpdateEvent => Json.toJson(event)
     case event: MesosFrameworkMessageEvent => Json.toJson(event)
     case event: SchedulerDisconnectedEvent => Json.toJson(event)
@@ -387,6 +432,23 @@ trait EventFormats {
     case event: InstanceHealthChanged => Json.toJson(event)
     case event: UnknownInstanceTerminated => Json.toJson(event)
     case event: PodEvent => Json.toJson(event)
+
+    // Select lightweight plans if requested
+    case event: DeploymentSuccess => Json.toJson(event)(
+      if (lightweightPlan) LightDeploymentSuccessWrites
+      else DeploymentSuccessWrites)
+    case event: DeploymentFailed => Json.toJson(event)(
+      if (lightweightPlan) LightDeploymentFailedWrites
+      else DeploymentFailedWrites)
+    case event: DeploymentStatus => Json.toJson(event)(
+      if (lightweightPlan) LightDeploymentStatusWrites
+      else DeploymentStatusWrites)
+    case event: DeploymentStepSuccess => Json.toJson(event)(
+      if (lightweightPlan) LightDeploymentStepSuccessWrites
+      else DeploymentStepSuccessWrites)
+    case event: DeploymentStepFailure => Json.toJson(event)(
+      if (lightweightPlan) LightDeploymentStepFailureWrites
+      else DeploymentStepFailureWrites)
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/event/EventConf.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/EventConf.scala
@@ -13,6 +13,5 @@ trait EventConf extends ScallopConf {
     noshort = true,
     default = Some(1024)
   )
-
   def zkTimeoutDuration: FiniteDuration
 }

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -12,15 +12,12 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import mesosphere.marathon.core.deployment.{ DeploymentPlan, DeploymentStep }
 import org.apache.mesos.{ Protos => Mesos }
-import play.api.libs.json.Json
 
 import scala.collection.immutable.Seq
 
 sealed trait MarathonEvent {
   val eventType: String
   val timestamp: String
-  @JsonIgnore
-  lazy val jsonString: String = Json.stringify(eventToJson(this))
 }
 
 // api


### PR DESCRIPTION
Summary:
This change adds support for the URL argument `/v2/events?plan-format=light` that subscribes to a "lighter" version of the SSE events, where some of the deployment plan fields are excluded.

Back-ported commits:
* 58fbba21f5b55b3def57a2a20aac3e726fe4d875 (Introduce lightweight SSE flag #5531)

JIRA issues: MARATHON_EE-1673