### PR TITLE
Replace LoggingFactory with StrictLogging pt. 2

### DIFF
--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SchedulerActor.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SchedulerActor.scala
@@ -1,16 +1,15 @@
 package mesosphere.mesos.simulation
 
-import akka.actor.{ Actor, Stash }
+import akka.actor.{Actor, Stash}
 import akka.event.LoggingReceive
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.stream.Implicits._
-import org.apache.mesos.Protos.{ FrameworkID, MasterInfo, Offer, TaskStatus }
-import org.apache.mesos.{ Scheduler, SchedulerDriver }
-import org.slf4j.LoggerFactory
+import org.apache.mesos.Protos.{FrameworkID, MasterInfo, Offer, TaskStatus}
+import org.apache.mesos.{Scheduler, SchedulerDriver}
 
 import scala.collection.immutable.Seq
 
-object SchedulerActor {
-  private val log = LoggerFactory.getLogger(getClass)
+object SchedulerActor extends StrictLogging {
 
   case class Registered(
       frameworkId: FrameworkID,
@@ -28,7 +27,7 @@ class SchedulerActor(scheduler: Scheduler) extends Actor with Stash {
 
   def waitForDriver: Receive = LoggingReceive.withLabel("waitForDriver") {
     case driver: SchedulerDriver =>
-      log.info("received driver")
+      logger.info("received driver")
       driverOpt = Some(driver)
       context.become(handleCmds(driver))
       unstashAll()

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SchedulerActor.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SchedulerActor.scala
@@ -9,7 +9,7 @@ import org.apache.mesos.{Scheduler, SchedulerDriver}
 
 import scala.collection.immutable.Seq
 
-object SchedulerActor extends StrictLogging {
+object SchedulerActor {
 
   case class Registered(
       frameworkId: FrameworkID,
@@ -18,7 +18,7 @@ object SchedulerActor extends StrictLogging {
   case class ResourceOffers(offers: Seq[Offer])
 }
 
-class SchedulerActor(scheduler: Scheduler) extends Actor with Stash {
+class SchedulerActor(scheduler: Scheduler) extends Actor with Stash with StrictLogging {
   import SchedulerActor._
 
   var driverOpt: Option[SchedulerDriver] = None

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
@@ -3,12 +3,12 @@ package mesosphere.mesos.simulation
 import java.util
 import java.util.Collections
 
-import akka.actor.{ ActorRef, ActorSystem, Props }
-import com.typesafe.config.{ Config, ConfigFactory }
+import akka.actor.{ActorRef, ActorSystem, Props}
+import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.stream.Implicits._
 import org.apache.mesos.Protos._
 import org.apache.mesos.SchedulerDriver
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -23,17 +23,15 @@ import scala.concurrent.duration.Duration
   * [[mesosphere.mesos.simulation.DriverActor]].
   * Unimplemented methods throw [[scala.NotImplementedError]]s.
   */
-class SimulatedDriver(driverProps: Props) extends SchedulerDriver {
-
-  private[this] val log = LoggerFactory.getLogger(getClass)
+class SimulatedDriver(driverProps: Props) extends SchedulerDriver with StrictLogging {
 
   private[this] def driverCmd(cmd: AnyRef): Status = {
     driverActorRefOpt match {
       case Some(driverActor) =>
-        log.debug(s"send driver cmd $cmd")
+        logger.debug(s"send driver cmd $cmd")
         driverActor ! cmd
       case None =>
-        log.debug("no driver actor configured")
+        logger.debug("no driver actor configured")
     }
     status
   }
@@ -83,7 +81,7 @@ class SimulatedDriver(driverProps: Props) extends SchedulerDriver {
   }
 
   override def start(): Status = {
-    log.info("Starting simulated Mesos")
+    logger.info("Starting simulated Mesos")
     val config: Config = ConfigFactory.load(getClass.getClassLoader, "mesos-simulation.conf")
     val sys: ActorSystem = ActorSystem("mesos-simulation", config)
     system = Some(sys)
@@ -116,7 +114,7 @@ class SimulatedDriver(driverProps: Props) extends SchedulerDriver {
         Await.result(sys.whenTerminated, Duration.Inf)
         driverActorRefOpt = None
         system = None
-        log.info("Stopped simulated Mesos")
+        logger.info("Stopped simulated Mesos")
         Status.DRIVER_STOPPED
     }
   }

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
@@ -8,7 +8,6 @@ import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.raml.{App, AppUpdate}
 import mesosphere.marathon.state.PathId
 import org.scalatest.concurrent.Eventually
-import org.slf4j.LoggerFactory
 import play.api.libs.json._
 
 import scala.collection.immutable.Seq
@@ -46,8 +45,6 @@ class SingleAppScalingTest extends AkkaIntegrationTest with ZookeeperServerTest 
   override lazy val marathonUrl: String = s"http://localhost:${marathonServer.httpPort}"
   override lazy val testBasePath: PathId = PathId.empty
   override lazy val marathon: MarathonFacade = new MarathonFacade(marathonUrl, testBasePath)
-
-  private[this] val log = LoggerFactory.getLogger(getClass)
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -105,7 +102,7 @@ class SingleAppScalingTest extends AkkaIntegrationTest with ZookeeperServerTest 
       val appIdPath = testBasePath / "/test/app"
       val appWithManyInstances = appProxy(appIdPath, "v1", instances = 100000, healthCheck = None)
       val response = marathon.createAppV2(appWithManyInstances)
-      log.info(s"XXX ${response.originalResponse.status}: ${response.originalResponse.entity}")
+      logger.info(s"XXX ${response.originalResponse.status}: ${response.originalResponse.entity}")
 
       val startTime = System.currentTimeMillis()
       var metrics = Seq.newBuilder[JsValue]
@@ -127,7 +124,7 @@ class SingleAppScalingTest extends AkkaIntegrationTest with ZookeeperServerTest 
         val tasksRunning = (appJson \ "tasksRunning").as[Int]
         val tasksStaged = (appJson \ "tasksStaged").as[Int]
 
-        log.info(s"XXX (starting) Current instance count: staged $tasksStaged, running $tasksRunning / $instances")
+        logger.info(s"XXX (starting) Current instance count: staged $tasksStaged, running $tasksRunning / $instances")
 
         appInfos += ScalingTestResultFiles.addTimestamp(startTime)(appJson)
         metrics += ScalingTestResultFiles.addTimestamp(startTime)(marathon.metrics().entityJson)
@@ -136,9 +133,9 @@ class SingleAppScalingTest extends AkkaIntegrationTest with ZookeeperServerTest 
       ScalingTestResultFiles.writeJson(SingleAppScalingTest.appInfosFile, appInfos.result())
       ScalingTestResultFiles.writeJson(SingleAppScalingTest.metricsFile, metrics.result())
 
-      log.info("XXX suspend")
+      logger.info("XXX suspend")
       val result = marathon.updateApp(appWithManyInstances.id.toPath, AppUpdate(instances = Some(0)), force = true).originalResponse
-      log.info(s"XXX ${result.status}: ${result.entity}")
+      logger.info(s"XXX ${result.status}: ${result.entity}")
 
       eventually {
         val currentApp = marathon.app(appIdPath)
@@ -146,13 +143,13 @@ class SingleAppScalingTest extends AkkaIntegrationTest with ZookeeperServerTest 
         val instances = (currentApp.entityJson \ "app" \ "instances").as[Int]
         val tasksRunning = (currentApp.entityJson \ "app" \ "tasksRunning").as[Int]
         val tasksStaged = (currentApp.entityJson \ "app" \ "tasksStaged").as[Int]
-        log.info(s"XXX (suspendSuccessfully) Current instance count: staged $tasksStaged, running $tasksRunning / $instances")
+        logger.info(s"XXX (suspendSuccessfully) Current instance count: staged $tasksStaged, running $tasksRunning / $instances")
 
         require(instances == 0)
       }
 
       eventually {
-        log.info("XXX deleting")
+        logger.info("XXX deleting")
         val deleteResult: RestResult[ITDeploymentResult] = marathon.deleteApp(appWithManyInstances.id.toPath, force = true)
         waitForDeployment(deleteResult)
       }

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -1,8 +1,8 @@
 package mesosphere.marathon
 
 import java.util.concurrent.TimeUnit
-import javax.inject.Named
 
+import javax.inject.Named
 import akka.actor.SupervisorStrategy.Restart
 import akka.actor._
 import akka.event.EventStream
@@ -10,6 +10,7 @@ import akka.routing.RoundRobinPool
 import akka.stream.Materializer
 import com.google.inject._
 import com.google.inject.name.Names
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.deployment.DeploymentManager
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.health.HealthCheckManager
@@ -18,7 +19,6 @@ import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.storage.repository.{ DeploymentRepository, GroupRepository }
 import mesosphere.util.state._
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
@@ -33,9 +33,7 @@ object ModuleNames {
 }
 
 class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSystem)
-  extends AbstractModule {
-
-  val log = LoggerFactory.getLogger(getClass.getName)
+  extends AbstractModule with StrictLogging {
 
   def configure(): Unit = {
     bind(classOf[MarathonConf]).toInstance(conf)

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 
 import akka.event.EventStream
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.base._
 import mesosphere.marathon.core.event.{ SchedulerRegisteredEvent, _ }
 import mesosphere.marathon.core.launcher.OfferProcessor
@@ -13,7 +14,6 @@ import mesosphere.mesos.LibMesos
 import mesosphere.util.state.{ FrameworkId, MesosLeaderInfo }
 import org.apache.mesos.Protos._
 import org.apache.mesos.{ Scheduler, SchedulerDriver }
-import org.slf4j.LoggerFactory
 
 import scala.concurrent._
 import scala.util.control.NonFatal
@@ -24,9 +24,7 @@ class MarathonScheduler(
     taskStatusProcessor: TaskStatusUpdateProcessor,
     frameworkIdRepository: FrameworkIdRepository,
     mesosLeaderInfo: MesosLeaderInfo,
-    config: MarathonConf) extends Scheduler {
-
-  private[this] val log = LoggerFactory.getLogger(getClass.getName)
+    config: MarathonConf) extends Scheduler with StrictLogging {
 
   private var lastMesosMasterVersion: Option[SemanticVersion] = Option.empty
   @volatile private[this] var localFaultDomain: Option[FaultDomain] = Option.empty
@@ -39,7 +37,7 @@ class MarathonScheduler(
     driver: SchedulerDriver,
     frameworkId: FrameworkID,
     master: MasterInfo): Unit = {
-    log.info(s"Registered as ${frameworkId.getValue} to master '${master.getId}'")
+    logger.info(s"Registered as ${frameworkId.getValue} to master '${master.getId}'")
     masterVersionCheck(master)
     updateLocalFaultDomain(master)
     Await.result(frameworkIdRepository.store(FrameworkId.fromProto(frameworkId)), zkTimeout)
@@ -48,7 +46,7 @@ class MarathonScheduler(
   }
 
   override def reregistered(driver: SchedulerDriver, master: MasterInfo): Unit = {
-    log.info("Re-registered to %s".format(master))
+    logger.info("Re-registered to %s".format(master))
     masterVersionCheck(master)
     updateLocalFaultDomain(master)
     mesosLeaderInfo.onNewMasterInfo(master)
@@ -59,23 +57,23 @@ class MarathonScheduler(
     offers.foreach { offer =>
       val processFuture = offerProcessor.processOffer(offer)
       processFuture.onComplete {
-        case scala.util.Success(_) => log.debug(s"Finished processing offer '${offer.getId.getValue}'")
-        case scala.util.Failure(NonFatal(e)) => log.error(s"while processing offer '${offer.getId.getValue}'", e)
+        case scala.util.Success(_) => logger.debug(s"Finished processing offer '${offer.getId.getValue}'")
+        case scala.util.Failure(NonFatal(e)) => logger.error(s"while processing offer '${offer.getId.getValue}'", e)
       }
     }
   }
 
   override def offerRescinded(driver: SchedulerDriver, offer: OfferID): Unit = {
-    log.info("Offer %s rescinded".format(offer))
+    logger.info("Offer %s rescinded".format(offer))
   }
 
   override def statusUpdate(driver: SchedulerDriver, status: TaskStatus): Unit = {
-    log.info("Received status update for task %s: %s (%s)"
+    logger.info("Received status update for task %s: %s (%s)"
       .format(status.getTaskId.getValue, status.getState, status.getMessage))
 
     taskStatusProcessor.publish(status).failed.foreach {
       case NonFatal(e) =>
-        log.error(s"while processing task status update $status", e)
+        logger.error(s"while processing task status update $status", e)
     }
   }
 
@@ -84,12 +82,12 @@ class MarathonScheduler(
     executor: ExecutorID,
     slave: SlaveID,
     message: Array[Byte]): Unit = {
-    log.info(s"Received framework message $executor $slave $message")
+    logger.info(s"Received framework message $executor $slave $message")
     eventBus.publish(MesosFrameworkMessageEvent(executor.getValue, slave.getValue, message))
   }
 
   override def disconnected(driver: SchedulerDriver): Unit = {
-    log.warn("Disconnected")
+    logger.warn("Disconnected")
 
     eventBus.publish(SchedulerDisconnectedEvent())
 
@@ -101,7 +99,7 @@ class MarathonScheduler(
   }
 
   override def slaveLost(driver: SchedulerDriver, slave: SlaveID): Unit = {
-    log.info(s"Lost slave $slave")
+    logger.info(s"Lost slave $slave")
   }
 
   override def executorLost(
@@ -109,11 +107,11 @@ class MarathonScheduler(
     executor: ExecutorID,
     slave: SlaveID,
     p4: Int): Unit = {
-    log.info(s"Lost executor $executor slave $p4")
+    logger.info(s"Lost executor $executor slave $p4")
   }
 
   override def error(driver: SchedulerDriver, message: String): Unit = {
-    log.warn(s"Error: $message\n" +
+    logger.warn(s"Error: $message\n" +
       "In case Mesos does not allow registration with the current frameworkId, " +
       s"delete the ZooKeeper Node: ${config.zkPath}/state/framework:id\n" +
       "CAUTION: if you remove this node, all tasks started with the current frameworkId will be orphaned!")
@@ -139,10 +137,10 @@ class MarathonScheduler(
     */
   protected def masterVersionCheck(masterInfo: MasterInfo): Unit = {
     val masterVersion = masterInfo.getVersion
-    log.info(s"Mesos Master version $masterVersion")
+    logger.info(s"Mesos Master version $masterVersion")
     lastMesosMasterVersion = SemanticVersion(masterVersion)
     if (!LibMesos.masterCompatible(masterVersion)) {
-      log.error(s"Mesos Master version $masterVersion does not meet minimum required version ${LibMesos.MesosMasterMinimumVersion}")
+      logger.error(s"Mesos Master version $masterVersion does not meet minimum required version ${LibMesos.MesosMasterMinimumVersion}")
       suicide(removeFrameworkId = false)
     }
   }
@@ -179,7 +177,7 @@ class MarathonScheduler(
     * the leading Mesos master process is killed.
     */
   protected def suicide(removeFrameworkId: Boolean): Unit = {
-    log.error("Committing suicide!")
+    logger.error("Committing suicide!")
 
     if (removeFrameworkId) Await.ready(frameworkIdRepository.delete(), config.zkTimeoutDuration)
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -2,8 +2,8 @@ package mesosphere.marathon
 
 import java.util.concurrent.CountDownLatch
 import java.util.{ Timer, TimerTask }
-import javax.inject.{ Inject, Named }
 
+import javax.inject.{ Inject, Named }
 import akka.Done
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.stream.Materializer

--- a/src/main/scala/mesosphere/marathon/SchedulerDriverFactory.scala
+++ b/src/main/scala/mesosphere/marathon/SchedulerDriverFactory.scala
@@ -1,10 +1,10 @@
 package mesosphere.marathon
 
+import com.typesafe.scalalogging.StrictLogging
 import javax.inject.Inject
 
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
 import org.apache.mesos.{ Scheduler, SchedulerDriver }
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.Await
 
@@ -19,11 +19,9 @@ class MesosSchedulerDriverFactory @Inject() (
     frameworkIdRepository: FrameworkIdRepository,
     scheduler: Scheduler)
 
-  extends SchedulerDriverFactory {
+  extends SchedulerDriverFactory with StrictLogging {
 
-  private[this] val log = LoggerFactory.getLogger(getClass.getName)
-
-  log.debug("using scheduler " + scheduler)
+  logger.debug("using scheduler " + scheduler)
 
   /**
     * As a side effect, the corresponding driver is set in the [[MarathonSchedulerDriverHolder]].

--- a/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
@@ -2,38 +2,36 @@ package mesosphere.marathon
 package api
 
 import java.lang.{ Exception => JavaException }
+
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.Response.Status
 import javax.ws.rs.core.{ MediaType, Response }
 import javax.ws.rs.ext.{ ExceptionMapper, Provider }
-
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.google.inject.Singleton
 import com.sun.jersey.api.NotFoundException
 import mesosphere.marathon.api.v2.Validation._
 import akka.http.scaladsl.model.StatusCodes._
-import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.StrictLogging
 import play.api.libs.json.{ JsResultException, JsValue, Json }
 
 import scala.concurrent.TimeoutException
 
 @Provider
 @Singleton
-class MarathonExceptionMapper extends ExceptionMapper[JavaException] {
-
-  private[this] val log = LoggerFactory.getLogger(getClass.getName)
+class MarathonExceptionMapper extends ExceptionMapper[JavaException] with StrictLogging {
 
   def toResponse(exception: JavaException): Response = {
     exception match {
       case e: NotFoundException =>
         // route is not found
-        log.debug("No Route Found", e)
+        logger.debug("No Route Found", e)
       case e: WebApplicationException =>
         // things like invalid requests etc
-        log.warn("Invalid Request", e)
+        logger.warn("Invalid Request", e)
       case _ =>
-        log.error("Exception while processing request", exception)
+        logger.error("Exception while processing request", exception)
     }
 
     Response

--- a/src/main/scala/mesosphere/marathon/api/WebJarServlet.scala
+++ b/src/main/scala/mesosphere/marathon/api/WebJarServlet.scala
@@ -3,8 +3,8 @@ package api
 
 import com.typesafe.scalalogging.StrictLogging
 import java.net.URI
-import javax.servlet.http.{ HttpServlet, HttpServletRequest, HttpServletResponse }
 
+import javax.servlet.http.{ HttpServlet, HttpServletRequest, HttpServletResponse }
 import mesosphere.marathon.io.IO
 import com.google.common.io.{ ByteStreams, Closeables }
 
@@ -52,9 +52,8 @@ class WebJarServlet extends HttpServlet with StrictLogging {
     val mime = Option(getServletContext.getMimeType(file)).getOrElse(mimeType(mediaType)) //e.g plain/text
     val resourceURI = s"/META-INF/resources/webjars$jar$resource"
     //log request data, since the names are not very intuitive
-
     logger.debug(
-      s"""
+        s"""
          |pathinfo: ${req.getPathInfo}
          |context: ${req.getContextPath}
          |servlet: ${req.getServletPath}
@@ -66,6 +65,7 @@ class WebJarServlet extends HttpServlet with StrictLogging {
          |mime: $mime
          |resourceURI: $resourceURI
        """.stripMargin)
+
 
     //special rule for accessing root -> redirect to ui main page
     if (req.getRequestURI == "/") sendRedirect(resp, "ui/")

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -1,14 +1,15 @@
 package mesosphere.marathon
 package api.v2
 
+import com.typesafe.scalalogging.StrictLogging
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.{ Context, MediaType, Response }
-
 import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api._
 import mesosphere.marathon.core.appinfo.EnrichedTask
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
@@ -22,7 +23,6 @@ import mesosphere.marathon.raml.Task._
 import mesosphere.marathon.raml.TaskConversion._
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.state.PathId._
-import org.slf4j.LoggerFactory
 
 import scala.async.Async._
 import scala.concurrent.Future
@@ -36,9 +36,8 @@ class AppTasksResource @Inject() (
     val config: MarathonConf,
     groupManager: GroupManager,
     val authorizer: Authorizer,
-    val authenticator: Authenticator) extends AuthResource {
+    val authenticator: Authenticator) extends AuthResource with StrictLogging {
 
-  val log = LoggerFactory.getLogger(getClass.getName)
   val GroupTasks = """^((?:.+/)|)\*$""".r
 
   @GET

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -11,7 +11,6 @@ import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, ViewRunSpec }
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.Timestamp
-import org.slf4j.LoggerFactory
 
 @Produces(Array(MarathonMediaType.PREFERRED_APPLICATION_JSON))
 @Consumes(Array(MediaType.APPLICATION_JSON))
@@ -21,8 +20,6 @@ class AppVersionsResource(
     val authenticator: Authenticator,
     val authorizer: Authorizer,
     val config: MarathonConf) extends AuthResource {
-
-  val log = LoggerFactory.getLogger(getClass.getName)
 
   @GET
   def index(

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoEmbedResolver.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoEmbedResolver.scala
@@ -1,14 +1,13 @@
 package mesosphere.marathon
 package api.v2
 
-import mesosphere.marathon.core.appinfo.{ GroupInfo, AppInfo }
-import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.appinfo.{ AppInfo, GroupInfo }
 
 /**
   * Resolves AppInfo.Embed and GroupInfo.Embed from query parameters.
   */
-private[api] object InfoEmbedResolver {
-  private[this] val log = LoggerFactory.getLogger(getClass)
+private[api] object InfoEmbedResolver extends StrictLogging {
 
   private[this] val EmbedAppsPrefixes = Set("group.apps.", "apps.", "app.")
 
@@ -36,7 +35,7 @@ private[api] object InfoEmbedResolver {
     def mapEmbedStrings(prefix: String, withoutPrefix: String): Set[AppInfo.Embed] = withoutPrefix match {
       case EmbedTasks => Set(AppInfo.Embed.Tasks, /* deprecated */ AppInfo.Embed.Deployments)
       case EmbedTasksAndFailures =>
-        log.warn(s"Using deprecated embed=s$prefix$withoutPrefix. " +
+        logger.warn(s"Using deprecated embed=s$prefix$withoutPrefix. " +
           s"Use ${prefix}tasks, ${prefix}lastTaskFailure, ${prefix}deployments instead.")
         Set(AppInfo.Embed.Tasks, AppInfo.Embed.LastTaskFailure, AppInfo.Embed.Deployments)
       case EmbedDeployments => Set(AppInfo.Embed.Deployments)
@@ -45,7 +44,7 @@ private[api] object InfoEmbedResolver {
       case EmbedCounts => Set(AppInfo.Embed.Counts)
       case EmbedTaskStats => Set(AppInfo.Embed.TaskStats)
       case unknown: String =>
-        log.warn(s"unknown app embed argument: $prefix$unknown")
+        logger.warn(s"unknown app embed argument: $prefix$unknown")
         Set.empty
     }
 
@@ -65,7 +64,7 @@ private[api] object InfoEmbedResolver {
       case EmbedApps => Some(GroupInfo.Embed.Apps)
       case EmbedPods => Some(GroupInfo.Embed.Pods)
       case unknown: String =>
-        log.warn(s"unknown group embed argument: $unknown")
+        logger.warn(s"unknown group embed argument: $unknown")
         None
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/LabelSelector.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LabelSelector.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon
 package api.v2
 
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.appinfo.AppSelector
 import mesosphere.marathon.state.AppDefinition
-import org.slf4j.LoggerFactory
 
 import scala.util.control.NonFatal
 import scala.util.parsing.combinator.RegexParsers
@@ -38,9 +38,7 @@ case class LabelSelectors(selectors: Seq[LabelSelector]) extends AppSelector {
   * a in (t1, t2, t3), b notin (t1), c, d
   *
   */
-class LabelSelectorParsers extends RegexParsers {
-
-  private[this] val log = LoggerFactory.getLogger(getClass.getName)
+class LabelSelectorParsers extends RegexParsers with StrictLogging {
 
   //Allowed characters are A-Za-z0-9._- All other characters can be used, but need to be escaped.
   def term: Parser[String] = """(\\.|[-A-Za-z0-9_.])+""".r ^^ { _.replaceAll("""\\(.)""", "$1") }
@@ -73,7 +71,7 @@ class LabelSelectorParsers extends RegexParsers {
       }
     } catch {
       case NonFatal(ex) =>
-        log.warn(s"Could not parse $in", ex)
+        logger.warn(s"Could not parse $in", ex)
         Left(ex.getMessage)
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -23,7 +23,6 @@ import mesosphere.marathon.raml.Task._
 import mesosphere.marathon.raml.TaskConversion._
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.stream.Implicits._
-import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 
 import scala.async.Async._
@@ -39,7 +38,6 @@ class TasksResource @Inject() (
     val authenticator: Authenticator,
     val authorizer: Authorizer) extends AuthResource {
 
-  val log = LoggerFactory.getLogger(getClass.getName)
   implicit val ec = ExecutionContext.Implicits.global
 
   @GET

--- a/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
@@ -10,7 +10,6 @@ import com.wix.accord.ViolationBuilder._
 import mesosphere.marathon.api.v2.Validation.ConstraintViolation
 import mesosphere.marathon.state.FetchUri
 import mesosphere.marathon.stream.Implicits._
-import org.slf4j.LoggerFactory
 import play.api.libs.json._
 
 import scala.collection.GenTraversableOnce
@@ -273,18 +272,6 @@ trait Validation {
   }
 
   def group(violations: Iterable[Violation]): Result = if (violations.nonEmpty) Failure(violations.to[Set]) else Success
-
-  /**
-    * For debugging purposes only.
-    * Since the macro removes all logging statements in the validator itself.
-    * Usage: info("message") { yourValidator }
-    */
-  def info[T](message: String)(implicit validator: Validator[T]): Validator[T] = new Validator[T] {
-    override def apply(t: T): Result = {
-      LoggerFactory.getLogger(Validation.getClass).info(s"Validate: $message on $t")
-      validator(t)
-    }
-  }
 
   def matchRegexWithFailureMessage(regex: Regex, failureMessage: String): Validator[String] =
     new NullSafeValidator[String](

--- a/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
@@ -8,7 +8,6 @@ import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.event.impl.stream._
 import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer }
 import org.eclipse.jetty.servlets.EventSourceServlet
-import org.slf4j.LoggerFactory
 
 /**
   * Exposes everything necessary to provide an internal event stream, an HTTP events stream and HTTP event callbacks.
@@ -20,7 +19,6 @@ class EventModule(
     electionService: ElectionService,
     authenticator: Authenticator,
     authorizer: Authorizer)(implicit val materializer: Materializer) {
-  val log = LoggerFactory.getLogger(getClass.getName)
 
   lazy val httpEventStreamActor: ActorRef = {
     val outstanding = conf.eventStreamMaxOutstandingMessages()

--- a/src/main/scala/mesosphere/marathon/core/flow/FlowModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/FlowModule.scala
@@ -4,18 +4,16 @@ package core.flow
 import java.time.Clock
 
 import akka.event.EventStream
-import mesosphere.marathon.MarathonSchedulerDriverHolder
-import mesosphere.marathon.core.flow.impl.{ OfferReviverDelegate, OfferMatcherLaunchTokensActor, ReviveOffersActor }
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.flow.impl.{ OfferMatcherLaunchTokensActor, OfferReviverDelegate, ReviveOffersActor }
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
-import org.slf4j.LoggerFactory
 import rx.lang.scala.Observable
 
 /**
   * This module contains code for managing the flow/backpressure of the application.
   */
-class FlowModule(leadershipModule: LeadershipModule) {
-  private[this] val log = LoggerFactory.getLogger(getClass)
+class FlowModule(leadershipModule: LeadershipModule) extends StrictLogging {
 
   /**
     * Call `reviveOffers` of the `SchedulerDriver` interface whenever there is new interest
@@ -40,10 +38,10 @@ class FlowModule(leadershipModule: LeadershipModule) {
         offersWanted, driverHolder
       )
       val actorRef = leadershipModule.startWhenLeader(reviveOffersActor, "reviveOffersWhenWanted")
-      log.info("Calling reviveOffers is enabled. Use --disable_revive_offers_for_new_apps to disable.")
+      logger.info("Calling reviveOffers is enabled. Use --disable_revive_offers_for_new_apps to disable.")
       Some(new OfferReviverDelegate(actorRef))
     } else {
-      log.info("Calling reviveOffers is disabled. Use --revive_offers_for_new_apps to enable.")
+      logger.info("Calling reviveOffers is disabled. Use --revive_offers_for_new_apps to enable.")
       None
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheckManager.scala
@@ -5,14 +5,11 @@ import akka.Done
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
 import org.apache.mesos.Protos.TaskStatus
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 import scala.collection.immutable.{ Map, Seq }
 
 trait HealthCheckManager {
-
-  protected[this] val log = LoggerFactory.getLogger(getClass.getName)
 
   /**
     * Returns the active health checks for the app with the supplied id.

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, headers }
 import akka.http.scaladsl.{ ConnectionContext, Http }
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings, Materializer }
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ Sink, Source }
 import com.typesafe.scalalogging.StrictLogging
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
@@ -29,9 +29,7 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
   import HealthCheckWorker._
 
   private implicit val system = context.system
-  private implicit val scheduler = system.scheduler
   import context.dispatcher // execution context for futures
-  private implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system))
 
   def receive: Receive = {
     case HealthCheckJob(app, instance, check) =>
@@ -167,7 +165,7 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
       }
   }
 
-  def singleRequest(httpRequest: HttpRequest, timeout: FiniteDuration)(implicit mat: Materializer): Future[HttpResponse] = {
+  def singleRequest(httpRequest: HttpRequest, timeout: FiniteDuration): Future[HttpResponse] = {
     val host = httpRequest.uri.authority.host.toString()
     val port = httpRequest.uri.effectivePort
     val hostHeader = headers.Host(host, port)
@@ -183,7 +181,7 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     Source.single(effectiveRequest).via(connectionFlow).runWith(Sink.head)
   }
 
-  def singleRequestHttps(httpRequest: HttpRequest, timeout: FiniteDuration)(implicit mat: Materializer): Future[HttpResponse] = {
+  def singleRequestHttps(httpRequest: HttpRequest, timeout: FiniteDuration): Future[HttpResponse] = {
     val host = httpRequest.uri.authority.host.toString()
     val port = httpRequest.uri.effectivePort
     val hostHeader = headers.Host(host, port)

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -7,6 +7,8 @@ import akka.event.EventStream
 import akka.pattern.ask
 import akka.stream.Materializer
 import akka.util.Timeout
+import com.typesafe.scalalogging.StrictLogging
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.marathon.core.event.{ AddHealthCheck, RemoveHealthCheck }
 import mesosphere.marathon.core.group.GroupManager
@@ -32,7 +34,7 @@ class MarathonHealthCheckManager(
     killService: KillService,
     eventBus: EventStream,
     instanceTracker: InstanceTracker,
-    groupManager: GroupManager)(implicit mat: Materializer) extends HealthCheckManager {
+    groupManager: GroupManager)(implicit mat: Materializer) extends HealthCheckManager with StrictLogging {
 
   protected[this] case class ActiveHealthCheck(
       healthCheck: HealthCheck,
@@ -61,9 +63,9 @@ class MarathonHealthCheckManager(
       val healthChecksForApp = listActive(app.id, app.version)
 
       if (healthChecksForApp.exists(_.healthCheck == healthCheck)) {
-        log.debug(s"Not adding duplicated health check for app [$app.id] and version [${app.version}]: [$healthCheck]")
+        logger.debug(s"Not adding duplicated health check for app [$app.id] and version [${app.version}]: [$healthCheck]")
       } else {
-        log.info(s"Adding health check for app [${app.id}] and version [${app.version}]: [$healthCheck]")
+        logger.info(s"Adding health check for app [${app.id}] and version [${app.version}]: [$healthCheck]")
 
         val ref = actorRefFactory.actorOf(
           HealthCheckActor.props(app, appHealthChecksActor, killService, healthCheck, instanceTracker, eventBus))
@@ -104,7 +106,7 @@ class MarathonHealthCheckManager(
       val healthChecksForVersion: Set[ActiveHealthCheck] = listActive(appId, appVersion)
       val toRemove: Set[ActiveHealthCheck] = healthChecksForVersion.filter(_.healthCheck == healthCheck)
       for (ahc <- toRemove) {
-        log.info(s"Removing health check for app [$appId] and version [$appVersion]: [$healthCheck]")
+        logger.info(s"Removing health check for app [$appId] and version [$appVersion]: [$healthCheck]")
         deactivate(ahc)
         eventBus.publish(RemoveHealthCheck(appId))
       }
@@ -151,7 +153,7 @@ class MarathonHealthCheckManager(
 
     def reconcileApp(app: AppDefinition, instances: Seq[Instance]): Future[Done] = {
       val appId = app.id
-      log.info(s"reconcile [$appId] with latest version [${app.version}]")
+      logger.info(s"reconcile [$appId] with latest version [${app.version}]")
 
       val instancesByVersion = instances.groupBy(_.version)
 
@@ -181,12 +183,12 @@ class MarathonHealthCheckManager(
             // FIXME: If the app version of the task is not available anymore, no health check is started.
             // We generated a new app version for every scale change. If maxVersions is configured, we
             // throw away old versions such that we may not have the app configuration of all tasks available anymore.
-            log.warn(
+            logger.warn(
               s"Cannot find health check configuration for [$appId] and version [$version], " +
                 "using most recent one.")
 
           case Some(appVersion) =>
-            log.info(s"addAllFor [$appId] version [$version]")
+            logger.info(s"addAllFor [$appId] version [$version]")
             addAllFor(appVersion, instancesByVersion.getOrElse(version, Seq.empty))
         }
       }
@@ -207,10 +209,10 @@ class MarathonHealthCheckManager(
       val maybeResult: Option[HealthResult] =
         if (taskStatus.hasHealthy) {
           val healthy = taskStatus.getHealthy
-          log.info(s"Received status for $instanceId with version [$version] and healthy [$healthy]")
+          logger.info(s"Received status for $instanceId with version [$version] and healthy [$healthy]")
           Some(if (healthy) Healthy(instanceId, version) else Unhealthy(instanceId, version, ""))
         } else {
-          log.debug(s"Ignoring status for $instanceId with no health information")
+          logger.debug(s"Ignoring status for $instanceId with no health information")
           None
         }
 
@@ -224,7 +226,7 @@ class MarathonHealthCheckManager(
         result <- maybeResult
         ref <- healthCheckActors
       } {
-        log.info(s"Forwarding health result [$result] to health check actor [$ref]")
+        logger.info(s"Forwarding health result [$result] to health check actor [$ref]")
         ref ! result
       }
     }

--- a/src/main/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitor.scala
+++ b/src/main/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitor.scala
@@ -2,12 +2,12 @@ package mesosphere.marathon
 package core.heartbeat
 
 import java.util.{ Collections, UUID }
-import javax.inject.Named
 
+import javax.inject.Named
 import akka.actor.ActorRef
+import com.typesafe.scalalogging.StrictLogging
 import org.apache.mesos.Protos._
 import org.apache.mesos.{ Scheduler, SchedulerDriver }
-import org.slf4j.LoggerFactory
 
 /**
   * @constructor create a mesos Scheduler decorator that intercepts callbacks from a mesos SchedulerDriver,
@@ -22,13 +22,11 @@ import org.slf4j.LoggerFactory
   * @see org.apache.mesos.Scheduler
   * @see org.apache.mesos.SchedulerDriver
   */
-class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) heartbeatActor: ActorRef) extends Scheduler {
+class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) heartbeatActor: ActorRef) extends Scheduler with StrictLogging {
 
   import MesosHeartbeatMonitor._
 
-  private[this] val log = LoggerFactory.getLogger(getClass.getName)
-
-  log.debug(s"created mesos heartbeat monitor for scheduler $scheduler")
+  logger.debug(s"created mesos heartbeat monitor for scheduler $scheduler")
 
   protected[marathon] def heartbeatReactor(driver: SchedulerDriver): Heartbeat.Reactor = new Heartbeat.Reactor {
     // virtualHeartbeatTasks is sent in a reconciliation message to mesos in order to force a
@@ -44,14 +42,14 @@ class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEART
       // because that means that we've prompted mesos via task reconciliation and it still hasn't responded in a
       // timely manner.
       if (skipped > 1) {
-        log.info(s"missed ${skipped - 1} expected heartbeat(s) from mesos master; possibly disconnected")
+        logger.info(s"missed ${skipped - 1} expected heartbeat(s) from mesos master; possibly disconnected")
       }
-      log.debug("Prompting mesos for a heartbeat via explicit task reconciliation")
+      logger.debug("Prompting mesos for a heartbeat via explicit task reconciliation")
       driver.reconcileTasks(virtualHeartbeatTasks)
     }
 
     override def onFailure(): Unit = {
-      log.warn("Too many subsequent heartbeats missed; inferring disconnected from mesos master")
+      logger.warn("Too many subsequent heartbeats missed; inferring disconnected from mesos master")
       disconnected(driver)
     }
   }
@@ -60,13 +58,13 @@ class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEART
     driver: SchedulerDriver,
     frameworkId: FrameworkID,
     master: MasterInfo): Unit = {
-    log.debug("registered heartbeat monitor")
+    logger.debug("registered heartbeat monitor")
     heartbeatActor ! Heartbeat.MessageActivate(heartbeatReactor(driver), sessionOf(driver))
     scheduler.registered(driver, frameworkId, master)
   }
 
   override def reregistered(driver: SchedulerDriver, master: MasterInfo): Unit = {
-    log.debug("reregistered heartbeat monitor")
+    logger.debug("reregistered heartbeat monitor")
     heartbeatActor ! Heartbeat.MessageActivate(heartbeatReactor(driver), sessionOf(driver))
     scheduler.reregistered(driver, master)
   }
@@ -88,7 +86,7 @@ class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEART
     if (!isFakeHeartbeatUpdate(status)) {
       scheduler.statusUpdate(driver, status)
     } else {
-      log.debug("received fake heartbeat task-status update")
+      logger.debug("received fake heartbeat task-status update")
     }
   }
 
@@ -111,7 +109,7 @@ class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEART
   override def disconnected(driver: SchedulerDriver): Unit = {
     // heartbeatReactor may have triggered this, but that's ok because if it did then
     // it's already "inactive", so this becomes a no-op
-    log.debug("disconnected heartbeat monitor")
+    logger.debug("disconnected heartbeat monitor")
     heartbeatActor ! Heartbeat.MessageDeactivate(sessionOf(driver))
     scheduler.disconnected(driver)
   }
@@ -133,7 +131,7 @@ class MesosHeartbeatMonitor(scheduler: Scheduler, @Named(ModuleNames.MESOS_HEART
   override def error(driver: SchedulerDriver, message: String): Unit = {
     // errors from the driver are fatal (to the driver) so it should be safe to deactivate here because
     // the marathon scheduler **should** either exit or else create a new driver instance and reregister.
-    log.debug("errored heartbeat monitor")
+    logger.debug("errored heartbeat monitor")
     heartbeatActor ! Heartbeat.MessageDeactivate(sessionOf(driver))
     scheduler.error(driver, message)
   }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -273,11 +273,9 @@ class InstanceOpFactoryImpl(
           taskId -> Task.Id.forResidentTask(taskId)
         }(collection.breakOut)
 
-        val containerNameToTaskId: Map[String, Task.Id] = oldToNewTaskIds.values.map { taskId =>
-          taskId match {
-            case Task.ResidentTaskId(_, Some(containerName), _) => containerName -> taskId
-            case _ => throw new IllegalStateException(s"failed to extract a container name from the task id $taskId")
-          }
+        val containerNameToTaskId: Map[String, Task.Id] = oldToNewTaskIds.values.map {
+          case taskId @ Task.ResidentTaskId(_, Some(containerName), _) => containerName -> taskId
+          case taskId => throw new IllegalStateException(s"failed to extract a container name from the task id $taskId")
         }(collection.breakOut)
         val podContainerTaskIds: Seq[Task.Id] = pod.containers.map { container =>
           containerNameToTaskId.getOrElse(container.name, throw new IllegalStateException(

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
@@ -3,16 +3,15 @@ package core.launcher.impl
 
 import java.util.Collections
 
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.launcher.{ InstanceOp, TaskLauncher }
 import mesosphere.marathon.metrics.{ Metrics, ServiceMetric }
 import mesosphere.marathon.stream.Implicits._
 import org.apache.mesos.Protos.{ OfferID, Status }
 import org.apache.mesos.{ Protos, SchedulerDriver }
-import org.slf4j.LoggerFactory
 
 private[launcher] class TaskLauncherImpl(
-    marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder) extends TaskLauncher {
-  private[this] val log = LoggerFactory.getLogger(getClass)
+    marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder) extends TaskLauncher with StrictLogging {
 
   private[this] val usedOffersMeter = Metrics.minMaxCounter(ServiceMetric, getClass, "usedOffers")
   private[this] val launchedTasksMeter = Metrics.minMaxCounter(ServiceMetric, getClass, "launchedTasks")
@@ -25,9 +24,8 @@ private[launcher] class TaskLauncherImpl(
       //The filter duration is set to 0, so we get the same offer in the next allocator cycle.
       val noFilter = Protos.Filters.newBuilder().setRefuseSeconds(0).build()
       val operations = taskOps.flatMap(_.offerOperations)
-      if (log.isDebugEnabled) {
-        log.debug(s"Operations on $offerID:\n${operations.mkString("\n")}")
-      }
+      logger.debug(s"Operations on $offerID:\n${operations.mkString("\n")}")
+
       driver.acceptOffers(Collections.singleton(offerID), operations.asJava, noFilter)
     }
     if (accepted) {
@@ -58,13 +56,12 @@ private[launcher] class TaskLauncherImpl(
     marathonSchedulerDriverHolder.driver match {
       case Some(driver) =>
         val status = block(driver)
-        if (log.isDebugEnabled) {
-          log.debug(s"$description returned status = $status")
-        }
+        logger.debug(s"$description returned status = $status")
+
         status == Status.DRIVER_RUNNING
 
       case None =>
-        log.warn(s"Cannot execute '$description', no driver available")
+        logger.warn(s"Cannot execute '$description', no driver available")
         false
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiter.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiter.scala
@@ -4,9 +4,9 @@ package core.launchqueue.impl
 import java.time.Clock
 import java.util.concurrent.TimeUnit
 
-import mesosphere.marathon.state.{ RunSpec, PathId, Timestamp }
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.state.{ PathId, RunSpec, Timestamp }
 import mesosphere.util.DurationToHumanReadable
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
   *
   * We do not keep the delays for every version because that would include scaling changes or manual restarts.
   */
-private[launchqueue] class RateLimiter(clock: Clock) {
+private[launchqueue] class RateLimiter(clock: Clock) extends StrictLogging {
   import RateLimiter._
 
   /** The task launch delays per run spec and their last config change. */
@@ -47,7 +47,7 @@ private[launchqueue] class RateLimiter(clock: Clock) {
     val now: Timestamp = clock.now()
     val timeLeft = (now until newDelay.deadline).toHumanReadable
 
-    log.info(
+    logger.info(
       s"$message. Task launch delay for [${spec.id} - ${spec.versionInfo.lastConfigChangeVersion}] is set to $timeLeft")
     taskLaunchDelays += ((spec.id -> spec.versionInfo.lastConfigChangeVersion) -> newDelay)
     newDelay.deadline
@@ -56,7 +56,7 @@ private[launchqueue] class RateLimiter(clock: Clock) {
   def resetDelay(runSpec: RunSpec): Unit = {
     val key = runSpec.id -> runSpec.versionInfo.lastConfigChangeVersion
     taskLaunchDelays.get(key).foreach { _ =>
-      log.info(s"Task launch delay for [${runSpec.id} - ${runSpec.versionInfo.lastConfigChangeVersion}}] reset to zero")
+      logger.info(s"Task launch delay for [${runSpec.id} - ${runSpec.versionInfo.lastConfigChangeVersion}}] reset to zero")
       taskLaunchDelays -= key
     }
   }
@@ -64,14 +64,13 @@ private[launchqueue] class RateLimiter(clock: Clock) {
   def advanceDelay(runSpec: RunSpec): Unit = {
     val key = runSpec.id -> runSpec.versionInfo.lastConfigChangeVersion
     taskLaunchDelays.get(key).foreach { delay =>
-      log.info(s"Task launch delay for [${runSpec.id} - ${runSpec.versionInfo.lastConfigChangeVersion}}] got advanced")
+      logger.info(s"Task launch delay for [${runSpec.id} - ${runSpec.versionInfo.lastConfigChangeVersion}}] got advanced")
       taskLaunchDelays += key -> Delay(clock, delay.currentDelay, delay.maxLaunchDelay)
     }
   }
 }
 
 private object RateLimiter {
-  private val log = LoggerFactory.getLogger(getClass.getName)
 
   private object Delay {
     def apply(clock: Clock, runSpec: RunSpec): Delay = {

--- a/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
@@ -7,10 +7,10 @@ import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.{ MediaTypes, StatusCodes, HttpResponse => AkkaHttpResponse }
 import akka.stream.Materializer
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
 import mesosphere.marathon.core.readiness.{ HttpResponse, ReadinessCheckExecutor, ReadinessCheckResult }
 import mesosphere.marathon.util.Timeout
-import org.slf4j.LoggerFactory
 import rx.lang.scala.Observable
 
 import scala.concurrent.Future
@@ -22,10 +22,9 @@ import scala.util.control.NonFatal
   * A Akka-HTTP-based implementation of a ReadinessCheckExecutor.
   */
 private[readiness] class ReadinessCheckExecutorImpl(implicit actorSystem: ActorSystem, materializer: Materializer)
-  extends ReadinessCheckExecutor {
+  extends ReadinessCheckExecutor with StrictLogging {
 
   import scala.concurrent.ExecutionContext.Implicits.global
-  private[this] val log = LoggerFactory.getLogger(getClass)
   private implicit val scheduler = actorSystem.scheduler
 
   override def execute(readinessCheckSpec: ReadinessCheckSpec): Observable[ReadinessCheckResult] = {
@@ -46,13 +45,13 @@ private[readiness] class ReadinessCheckExecutorImpl(implicit actorSystem: ActorS
     Observable.interval(interval)
 
   private[impl] def executeSingleCheck(check: ReadinessCheckSpec): Future[ReadinessCheckResult] = {
-    log.info(s"Querying ${check.taskId} readiness check '${check.checkName}' at '${check.url}'")
+    logger.info(s"Querying ${check.taskId} readiness check '${check.checkName}' at '${check.url}'")
 
     akkaHttpGet(check)
       .flatMap(akkaResponseToCheckResponse(_, check))
       .map(ReadinessCheckResult.forSpecAndResponse(check, _))
       .recover(exceptionToErrorResponse(check))
-      .andThen { case Success(result) => log.info(result.summary) }
+      .andThen { case Success(result) => logger.info(result.summary) }
   }
 
   private[impl] def akkaResponseToCheckResponse(akkaResponse: AkkaHttpResponse, check: ReadinessCheckSpec): Future[HttpResponse] = {

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -116,21 +116,22 @@ case class Task(taskId: Task.Id, runSpecVersion: Timestamp, status: Task.Status)
           TaskUpdateEffect.Noop
         }
 
-      // case 4: health or state updated
-      case _ =>
-        // TODO(PODS): strange to use Condition here
-        updatedHealthOrState(status.mesosStatus, newMesosStatus).map { newTaskStatus =>
-          val updatedNetworkInfo = status.networkInfo.update(newMesosStatus)
-          val updatedStatus = status.copy(
-            mesosStatus = Some(newTaskStatus), condition = newStatus, networkInfo = updatedNetworkInfo)
-          val updatedTask = copy(status = updatedStatus)
-          // TODO(PODS): The instance needs to handle a terminal task via an Update here
-          // Or should we use Expunge in case of a terminal update for resident tasks?
-          TaskUpdateEffect.Update(newState = updatedTask)
-        } getOrElse {
-          logger.debug(s"Ignoring status update for $taskId. Status did not change.")
-          TaskUpdateEffect.Noop
-        }
+    // case 4: health or state updated
+    case  _ =>
+      // TODO(PODS): strange to use Condition here
+      updatedHealthOrState(status.mesosStatus, newMesosStatus).map { newTaskStatus =>
+        val updatedNetworkInfo = status.networkInfo.update(newMesosStatus)
+        val updatedStatus = status.copy(
+          mesosStatus = Some(newTaskStatus), condition = newStatus, networkInfo = updatedNetworkInfo)
+        val updatedTask = copy(status = updatedStatus)
+        // TODO(PODS): The instance needs to handle a terminal task via an Update here
+        // Or should we use Expunge in case of a terminal update for resident tasks?
+        TaskUpdateEffect.Update(newState = updatedTask)
+      } getOrElse {
+        logger.debug(s"Ignoring status update for $taskId. Status did not change.")
+        TaskUpdateEffect.Noop
+      }
+
     }
   }
 
@@ -324,7 +325,6 @@ object Task {
     // Regular expression for matching taskIds since instance-era
     private val TaskIdWithInstanceIdRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)[\._]([^_\.]+)$""".r
     private val ResidentTaskIdWithInstanceIdRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)[\._]([^_\.]+)\.(\d+)$""".r
-    private val ReservationIdWithInstanceIdRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)$""".r
 
     private val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
 
@@ -377,7 +377,7 @@ object Task {
       *
       * Use @forResidentTask when you want to launch a task on an existing reservation.
       */
-    @deprecated("Task ids should be created from instance ids and not run spec ids")
+    @deprecated("Task ids should be created from instance ids and not run spec ids", "1.6.322")
     def forRunSpec(id: PathId): Id = LegacyId(id, ".", uuidGenerator.generate())
 
     /**

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
@@ -11,7 +11,6 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.Timestamp
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -100,9 +99,8 @@ private[jobs] object OverdueTasksActor {
   private[jobs] case class Check(maybeAck: Option[ActorRef])
 }
 
-private class OverdueTasksActor(support: OverdueTasksActor.Support) extends Actor {
+private class OverdueTasksActor(support: OverdueTasksActor.Support) extends Actor with StrictLogging {
   var checkTicker: Cancellable = _
-  private[this] val log = LoggerFactory.getLogger(getClass)
 
   override def preStart(): Unit = {
     import context.dispatcher
@@ -127,7 +125,7 @@ private class OverdueTasksActor(support: OverdueTasksActor.Support) extends Acto
 
         case None =>
           import context.dispatcher
-          resultFuture.failed.foreach { case NonFatal(e) => log.warn("error while checking for overdue tasks", e) }
+          resultFuture.failed.foreach { case NonFatal(e) => logger.warn("error while checking for overdue tasks", e) }
       }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceUpdateActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceUpdateActor.scala
@@ -2,16 +2,15 @@ package mesosphere.marathon
 package core.task.tracker.impl
 
 import java.time.Clock
-
 import java.util.concurrent.TimeoutException
 
 import akka.actor.{ Actor, Props, Status }
 import akka.event.LoggingReceive
 import akka.pattern.pipe
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.tracker.impl.InstanceUpdateActor.{ ActorMetrics, FinishedInstanceOp, ProcessInstanceOp }
 import mesosphere.marathon.metrics._
-import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.Queue
 import scala.concurrent.Future
@@ -56,8 +55,7 @@ object InstanceUpdateActor {
 private[impl] class InstanceUpdateActor(
     clock: Clock,
     metrics: ActorMetrics,
-    processor: InstanceOpProcessor) extends Actor {
-  private[this] val log = LoggerFactory.getLogger(getClass)
+    processor: InstanceOpProcessor) extends Actor with StrictLogging {
 
   // this has to be a mutable field because we need to access it in postStop()
   private[impl] var operationsByInstanceId =
@@ -105,11 +103,9 @@ private[impl] class InstanceUpdateActor(
         operationsByInstanceId += op.instanceId -> newQueue
 
       val activeCount = metrics.numberOfActiveOps.decrement()
-      if (log.isDebugEnabled) {
-        val queuedCount = metrics.numberOfQueuedOps.value()
-        log.debug(s"Finished processing ${op.op} for app [${op.appId}] and ${op.instanceId} "
-          + s"$activeCount active, $queuedCount queued.")
-      }
+      val queuedCount = metrics.numberOfQueuedOps.value()
+      logger.debug(s"Finished processing ${op.op} for app [${op.appId}] and ${op.instanceId} "
+        + s"$activeCount active, $queuedCount queued.")
 
       processNextOpIfExists(op.instanceId)
 
@@ -122,7 +118,7 @@ private[impl] class InstanceUpdateActor(
     operationsByInstanceId(instanceId).headOption foreach { op =>
       val queuedCount = metrics.numberOfQueuedOps.decrement()
       val activeCount = metrics.numberOfActiveOps.increment()
-      log.debug(s"Start processing ${op.op} for app [${op.appId}] and ${op.instanceId}. "
+      logger.debug(s"Start processing ${op.op} for app [${op.appId}] and ${op.instanceId}. "
         + s"$activeCount active, $queuedCount queued.")
 
       import context.dispatcher
@@ -136,7 +132,7 @@ private[impl] class InstanceUpdateActor(
         } else
           metrics.processOpTimer(processor.process(op))
       }.map { _ =>
-        log.debug(s"Finished processing ${op.op} for app [${op.appId}] and ${op.instanceId}")
+        logger.debug(s"Finished processing ${op.op} for app [${op.appId}] and ${op.instanceId}")
         FinishedInstanceOp(op)
       }
       future.pipeTo(self)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstancesLoaderImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstancesLoaderImpl.scala
@@ -2,10 +2,10 @@ package mesosphere.marathon
 package core.task.tracker.impl
 
 import akka.stream.Materializer
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.storage.repository.InstanceRepository
 import mesosphere.marathon.stream.Sink
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 
@@ -13,18 +13,16 @@ import scala.concurrent.Future
   * Loads all task data into an [[InstanceTracker.InstancesBySpec]] from an [[InstanceRepository]].
   */
 private[tracker] class InstancesLoaderImpl(repo: InstanceRepository)(implicit val mat: Materializer)
-  extends InstancesLoader {
+  extends InstancesLoader with StrictLogging {
   import scala.concurrent.ExecutionContext.Implicits.global
-
-  private[this] val log = LoggerFactory.getLogger(getClass.getName)
 
   override def load(): Future[InstanceTracker.InstancesBySpec] = {
     for {
       names <- repo.ids().runWith(Sink.seq)
-      _ = log.info(s"About to load ${names.size} tasks")
+      _ = logger.info(s"About to load ${names.size} tasks")
       instances <- Future.sequence(names.map(repo.get)).map(_.flatten)
     } yield {
-      log.info(s"Loaded ${instances.size} tasks")
+      logger.info(s"Loaded ${instances.size} tasks")
       InstanceTracker.InstancesBySpec.forInstances(instances)
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -4,23 +4,21 @@ package core.task.update.impl.steps
 import akka.Done
 import akka.event.EventStream
 import com.google.inject.Inject
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.InstanceHealthChanged
 import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 
 /**
   * Post this update to the internal event stream.
   */
-class PostToEventStreamStepImpl @Inject() (eventBus: EventStream) extends InstanceChangeHandler {
-
-  private[this] val log = LoggerFactory.getLogger(getClass)
+class PostToEventStreamStepImpl @Inject() (eventBus: EventStream) extends InstanceChangeHandler with StrictLogging {
 
   override def name: String = "postTaskStatusEvent"
 
   override def process(update: InstanceChange): Future[Done] = {
-    log.debug("Publishing events for {} of runSpec [{}]: {}", update.id, update.runSpecId, update.condition)
+    logger.debug("Publishing events for {} of runSpec [{}]: {}", update.id, update.runSpecId, update.condition)
     update.events.foreach(eventBus.publish)
 
     // TODO(PODS): this can be generated in InstanceChangedEventsGenerator as well

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
@@ -2,14 +2,13 @@ package mesosphere.marathon
 package core.task.update.impl.steps
 //scalastyle:off
 import javax.inject.Named
-
 import akka.Done
 import akka.actor.ActorRef
 import com.google.inject.{ Inject, Provider }
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.MarathonSchedulerActor.ScaleRunSpec
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 //scalastyle:on
@@ -17,9 +16,8 @@ import scala.concurrent.Future
   * Trigger rescale of affected app if a task died or a reserved task timed out.
   */
 class ScaleAppUpdateStepImpl @Inject() (
-    @Named("schedulerActor") schedulerActorProvider: Provider[ActorRef]) extends InstanceChangeHandler {
+    @Named("schedulerActor") schedulerActorProvider: Provider[ActorRef]) extends InstanceChangeHandler with StrictLogging {
 
-  private[this] val log = LoggerFactory.getLogger(getClass)
   private[this] lazy val schedulerActor = schedulerActorProvider.get()
 
   private[this] def scalingWorthy: Condition => Boolean = {
@@ -40,7 +38,7 @@ class ScaleAppUpdateStepImpl @Inject() (
       val runSpecId = update.runSpecId
       val instanceId = update.id
       val state = update.condition
-      log.info(s"initiating a scale check for runSpec [$runSpecId] due to [$instanceId] $state")
+      logger.info(s"initiating a scale check for runSpec [$runSpecId] due to [$instanceId] $state")
       // TODO(PODS): we should rename the Message and make the SchedulerActor generic
       Some(ScaleRunSpec(runSpecId))
     } else {

--- a/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
@@ -26,7 +26,7 @@ class SlidingAverageSnapshot(val averagingWindow: Duration) extends StrictLoggin
   /**
     * A ring buffer that collects the snapshots
     */
-  private var averageRing: Array[TickMetricSnapshot] = ringFactory(Kamon.config)
+  private val averageRing: Array[TickMetricSnapshot] = ringFactory(Kamon.config)
 
   /**
     * The current index to the average ring buffer

--- a/src/main/scala/mesosphere/marathon/tasks/ResourceUtil.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/ResourceUtil.scala
@@ -1,17 +1,17 @@
 package mesosphere.marathon
 package tasks
 
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.state.DiskSource
 import mesosphere.mesos.protos
 import org.apache.mesos.Protos.Resource.DiskInfo.Source
 import org.apache.mesos.Protos.Resource.{ DiskInfo, ReservationInfo }
 import org.apache.mesos.{ Protos => MesosProtos }
-import org.slf4j.LoggerFactory
 
 import scala.util.control.NonFatal
 
-object ResourceUtil {
+object ResourceUtil extends StrictLogging {
   implicit class RichResource(resource: MesosProtos.Resource) {
     def getDiskSourceOption: Option[Source] =
       if (resource.hasDisk && resource.getDisk.hasSource)
@@ -30,8 +30,6 @@ object ResourceUtil {
         diskSource.path).mkString(":")
     }
   }
-
-  private[this] val log = LoggerFactory.getLogger(getClass)
 
   /**
     * The resources in launched tasks, should
@@ -152,7 +150,7 @@ object ResourceUtil {
       case MesosProtos.Value.Type.SET => consumeSetResource
 
       case unexpectedResourceType: MesosProtos.Value.Type =>
-        log.warn("unexpected resourceType {} for resource {}", Seq(unexpectedResourceType, resource.getName): _*)
+        logger.warn("unexpected resourceType {} for resource {}", Seq(unexpectedResourceType, resource.getName): _*)
         // we don't know the resource, thus we consume it completely
         None
     }
@@ -173,7 +171,7 @@ object ResourceUtil {
           usedResources.foldLeft(Some(resource): Option[MesosProtos.Resource]) {
             case (Some(resource), usedResource) =>
               if (resource.getType != usedResource.getType) {
-                log.warn(
+                logger.warn(
                   "Different resource types for resource {}: {} and {}",
                   resource.getName, resource.getType, usedResource.getType)
                 None
@@ -181,7 +179,7 @@ object ResourceUtil {
                 try ResourceUtil.consumeResource(resource, usedResource)
                 catch {
                   case NonFatal(e) =>
-                    log.warn("while consuming {} of type {}", resource.getName, resource.getType, e)
+                    logger.warn("while consuming {} of type {}", resource.getName, resource.getType, e)
                     None
                 }
 

--- a/src/main/scala/mesosphere/marathon/upgrade/GroupVersioningUtil.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/GroupVersioningUtil.scala
@@ -1,15 +1,14 @@
 package mesosphere.marathon
 package upgrade
 
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.state.{ AppDefinition, RootGroup, Timestamp, VersionInfo }
-import org.slf4j.LoggerFactory
 
 /**
   * Tools related to app/group versioning.
   */
-object GroupVersioningUtil {
-  private[this] val log = LoggerFactory.getLogger(getClass)
+object GroupVersioningUtil extends StrictLogging {
 
   /**
     * Calculate a new group from the given `to` parameter that sets the version of all changed apps
@@ -29,17 +28,17 @@ object GroupVersioningUtil {
     def updateAppVersionInfo(maybeOldApp: Option[AppDefinition], newApp: AppDefinition): AppDefinition = {
       val newVersionInfo = maybeOldApp match {
         case None =>
-          log.info(s"${newApp.id}: new app detected")
+          logger.info(s"${newApp.id}: new app detected")
           VersionInfo.forNewConfig(newVersion = version)
         case Some(oldApp) =>
           if (oldApp.isUpgrade(newApp)) {
-            log.info(s"${newApp.id}: upgrade detected for app (oldVersion ${oldApp.versionInfo})")
+            logger.info(s"${newApp.id}: upgrade detected for app (oldVersion ${oldApp.versionInfo})")
             oldApp.versionInfo.withConfigChange(newVersion = version)
           } else if (oldApp.isOnlyScaleChange(newApp)) {
-            log.info(s"${newApp.id}: scaling op detected for app (oldVersion ${oldApp.versionInfo})")
+            logger.info(s"${newApp.id}: scaling op detected for app (oldVersion ${oldApp.versionInfo})")
             oldApp.versionInfo.withScaleOrRestartChange(newVersion = version)
           } else if (oldApp.versionInfo != newApp.versionInfo && newApp.versionInfo == VersionInfo.NoVersion) {
-            log.info(s"${newApp.id}: restart detected for app (oldVersion ${oldApp.versionInfo})")
+            logger.info(s"${newApp.id}: restart detected for app (oldVersion ${oldApp.versionInfo})")
             oldApp.versionInfo.withScaleOrRestartChange(newVersion = version)
           } else {
             oldApp.versionInfo
@@ -77,17 +76,17 @@ object GroupVersioningUtil {
     def updatePodVersionInfo(maybeOldPod: Option[PodDefinition], newPod: PodDefinition): PodDefinition = {
       val newVersionInfo = maybeOldPod match {
         case None =>
-          log.info(s"${newPod.id}: new pod detected")
+          logger.info(s"${newPod.id}: new pod detected")
           VersionInfo.forNewConfig(newVersion = version)
         case Some(oldPod) =>
           if (oldPod.isUpgrade(newPod)) {
-            log.info(s"${newPod.id}: upgrade detected for Pod (oldVersion ${oldPod.versionInfo})")
+            logger.info(s"${newPod.id}: upgrade detected for Pod (oldVersion ${oldPod.versionInfo})")
             oldPod.versionInfo.withConfigChange(newVersion = version)
           } else if (oldPod.isOnlyScaleChange(newPod)) {
-            log.info(s"${newPod.id}: scaling op detected for Pod (oldVersion ${oldPod.versionInfo})")
+            logger.info(s"${newPod.id}: scaling op detected for Pod (oldVersion ${oldPod.versionInfo})")
             oldPod.versionInfo.withScaleOrRestartChange(newVersion = version)
           } else if (oldPod.versionInfo != newPod.versionInfo && newPod.versionInfo == VersionInfo.NoVersion) {
-            log.info(s"${newPod.id}: restart detected for Pod (oldVersion ${oldPod.versionInfo})")
+            logger.info(s"${newPod.id}: restart detected for Pod (oldVersion ${oldPod.versionInfo})")
             oldPod.versionInfo.withScaleOrRestartChange(newVersion = version)
           } else {
             oldPod.versionInfo

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package core.instance
 
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
@@ -10,7 +11,6 @@ import mesosphere.marathon.state.{ PathId, Timestamp }
 import mesosphere.marathon.test.MarathonTestHelper
 import mesosphere.marathon.test.MarathonTestHelper.Implicits._
 import org.apache.mesos
-import org.slf4j.LoggerFactory
 
 case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuilder) {
 
@@ -211,9 +211,7 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
   }
 }
 
-object TestTaskBuilder {
-
-  private[this] val log = LoggerFactory.getLogger(getClass)
+object TestTaskBuilder extends StrictLogging {
 
   def newBuilder(instanceBuilder: TestInstanceBuilder) = TestTaskBuilder(None, instanceBuilder)
 
@@ -224,7 +222,7 @@ object TestTaskBuilder {
       version: Timestamp = Timestamp(10), now: Timestamp = Timestamp(10),
       taskCondition: Condition = Condition.Staging): Task = {
 
-      log.debug(s"offer: $offer")
+      logger.debug(s"offer: $offer")
       Task(
         taskId = Task.Id(taskInfo.getTaskId),
         runSpecVersion = version,

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -11,7 +11,6 @@ import mesosphere.marathon.core.task.{ Task, TaskCondition }
 import mesosphere.marathon.state.{ PathId, Timestamp }
 import org.apache.mesos.Protos.TaskStatus.Reason
 import org.apache.mesos.Protos.{ TaskState, TaskStatus }
-import org.slf4j.LoggerFactory
 
 class TaskStatusUpdateTestHelper(val operation: InstanceUpdateOperation, val effect: InstanceUpdateEffect) {
   def simpleName = operation match {
@@ -43,7 +42,6 @@ class TaskStatusUpdateTestHelper(val operation: InstanceUpdateOperation, val eff
 }
 
 object TaskStatusUpdateTestHelper {
-  val log = LoggerFactory.getLogger(getClass)
   def apply(operation: InstanceUpdateOperation, effect: InstanceUpdateEffect): TaskStatusUpdateTestHelper =
     new TaskStatusUpdateTestHelper(operation, effect)
 

--- a/src/test/scala/mesosphere/marathon/integration/setup/ProcessOutputToLogStream.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ProcessOutputToLogStream.scala
@@ -1,13 +1,12 @@
 package mesosphere.marathon
 package integration.setup
 
-import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.StrictLogging
 
 import scala.sys.process.ProcessLogger
 
-case class ProcessOutputToLogStream(process: String) extends ProcessLogger {
-  val log = LoggerFactory.getLogger(s"mesosphere.marathon.integration.process.$process")
-  override def out(msg: => String): Unit = log.debug(msg)
-  override def err(msg: => String): Unit = log.warn(msg)
+case class ProcessOutputToLogStream(process: String) extends ProcessLogger with StrictLogging {
+  override def out(msg: => String): Unit = logger.debug(msg)
+  override def err(msg: => String): Unit = logger.warn(msg)
   override def buffer[T](f: => T): T = f
 }


### PR DESCRIPTION
Summary:
In a few cases, we still used `LoggingFactory` instead of `StrictLogging`. Additionally got rid of a couple of compiler warnings.
