### PR TITLE
Limit max number of concurrently running deployments (#6178)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+## Changes from 1.5.8 to 1.5.9
+
+### Backports from 1.6
+
+- [MARATHON-8172](https://jira.mesosphere.com/browse/MARATHON-8172) New command line flag `--max_running_deployments` was added to limit the max number of concurrently running deployments (#6178) 
+
+
 ## Changes from 1.5.7 to 1.5.8
 Bugfix release
 
@@ -123,7 +130,7 @@ This plugin allows to reject offers. Possible use-cases are:
   * Binding to agents. For example, agents can be marked as included into primary or secondary group. Task can be marked with group name.  Plugin can schedule task deployment to primary agents. If all primary agents are busy, task can be scheduled to secondary agents
 
 
-## Changes from 1.4.x to 1.5.0 (unreleased)
+## Changes from 1.4.x to 1.5.0
 
 ### Recommended Mesos version is 1.3.0
 

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -174,7 +174,8 @@ The core functionality flags can be also set by environment variable `MARATHON_O
     - S3 provider (experimental): s3://bucket-name/key-in-bucket?access_key=xxx&secret_key=xxx&region=eu-central-1
       Please note: access_key and secret_key are optional.
       If not provided, the [AWS default credentials provider chain](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) is used to look up aws credentials.
-
+* <span class="label label-default">v1.5.9</span>`--max_running_deployments` (Optional. Default: 100):
+    Maximum number of concurrently running deployments. Should the user try to submit more updates than set by this flag a HTTP 403 Error is returned with an explanatory error message.
 
 ## Tuning Flags for Offer Matching/Launching Tasks
 

--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -31,6 +31,12 @@ case class AppLockedException(deploymentIds: Seq[String] = Nil)
       "View details at '/v2/deployments/<DEPLOYMENT_ID>'."
   )
 
+case class TooManyRunningDeploymentsException(maxNum: Int) extends Exception(
+  s"Max number ($maxNum) of running deployments is achieved. Wait for existing deployments to complete or cancel one." +
+    "You can increase max deployment number by using --max_running_deployments parameter but be " +
+    "advised that this can have negative effects on the performance."
+)
+
 class PortRangeExhaustedException(
   val minPort: Int,
   val maxPort: Int) extends Exception(s"All ports in the range [$minPort-$maxPort) are already in use")

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -9,6 +9,7 @@ import akka.actor.{ ActorRef, ActorSystem }
 import akka.stream.Materializer
 import akka.util.Timeout
 import com.google.common.util.concurrent.AbstractExecutionThreadService
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.core.deployment.{ DeploymentManager, DeploymentPlan, DeploymentStepInfo }
 import mesosphere.marathon.core.election.{ ElectionCandidate, ElectionService }
@@ -22,7 +23,6 @@ import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.stream.Sink
 import mesosphere.util.PromiseActor
 import org.apache.mesos.SchedulerDriver
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
@@ -77,7 +77,7 @@ class MarathonSchedulerService @Inject() (
   deploymentManager: DeploymentManager,
   @Named("schedulerActor") schedulerActor: ActorRef,
   @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) mesosHeartbeatActor: ActorRef)(implicit mat: Materializer)
-    extends AbstractExecutionThreadService with ElectionCandidate with DeploymentService {
+    extends AbstractExecutionThreadService with ElectionCandidate with DeploymentService with StrictLogging {
 
   import mesosphere.marathon.core.async.ExecutionContexts.global
 
@@ -103,8 +103,6 @@ class MarathonSchedulerService @Inject() (
 
   private[mesosphere] var timer = newTimer()
 
-  val log = LoggerFactory.getLogger(getClass.getName)
-
   // This is a little ugly as we are using a mutable variable. But drivers can't
   // be reused (i.e. once stopped they can't be started again. Thus,
   // we have to allocate a new driver before each run or after each stop.
@@ -115,7 +113,7 @@ class MarathonSchedulerService @Inject() (
   protected def newTimer() = new Timer("marathonSchedulerTimer")
 
   def deploy(plan: DeploymentPlan, force: Boolean = false): Future[Done] = {
-    log.info(s"Deploy plan with force=$force:\n$plan ")
+    logger.info(s"Deploy plan with force=$force:\n$plan ")
     val future: Future[Any] = PromiseActor.askWithoutTimeout(system, schedulerActor, Deploy(plan, force))
     future.map {
       case DeploymentStarted(_) => Done
@@ -145,12 +143,12 @@ class MarathonSchedulerService @Inject() (
   //Begin Service interface
 
   override def startUp(): Unit = {
-    log.info("Starting up")
+    logger.info("Starting up")
     super.startUp()
   }
 
   override def run(): Unit = {
-    log.info("Beginning run")
+    logger.info("Beginning run")
 
     // The first thing we do is offer our leadership.
     electionService.offerLeadership(this)
@@ -162,20 +160,20 @@ class MarathonSchedulerService @Inject() (
       isRunningLatch.await()
     }
 
-    log.info("Completed run")
+    logger.info("Completed run")
   }
 
   override def triggerShutdown(): Unit = synchronized {
-    log.info("Shutdown triggered")
+    logger.info("Shutdown triggered")
 
     electionService.abdicateLeadership()
     stopDriver()
 
-    log.info("Cancelling timer")
+    logger.info("Cancelling timer")
     timer.cancel()
 
     // The countdown latch blocks run() from exiting. Counting down the latch removes the block.
-    log.info("Removing the blocking of run()")
+    logger.info("Removing the blocking of run()")
     isRunningLatch.countDown()
 
     super.triggerShutdown()
@@ -184,7 +182,7 @@ class MarathonSchedulerService @Inject() (
   private[this] def stopDriver(): Unit = synchronized {
     // many are the assumptions concerning when this is invoked. see startLeadership, stopLeadership,
     // triggerShutdown.
-    log.info("Stopping driver")
+    logger.info("Stopping driver")
 
     // Stopping the driver will cause the driver run() method to return.
     driver.foreach(_.stop(true)) // failover = true
@@ -198,7 +196,7 @@ class MarathonSchedulerService @Inject() (
   //Begin ElectionCandidate interface
 
   override def startLeadership(): Unit = synchronized {
-    log.info("As new leader running the driver")
+    logger.info("As new leader running the driver")
 
     // allow interactions with the persistence store
     persistenceStore.markOpen()
@@ -212,12 +210,12 @@ class MarathonSchedulerService @Inject() (
     refreshCachesAndDoMigration()
 
     // run all pre-driver callbacks
-    log.info(s"""Call preDriverStarts callbacks on ${prePostDriverCallbacks.mkString(", ")}""")
+    logger.info(s"""Call preDriverStarts callbacks on ${prePostDriverCallbacks.mkString(", ")}""")
     Await.result(
       Future.sequence(prePostDriverCallbacks.map(_.preDriverStarts)),
       config.onElectedPrepareTimeout().millis
     )
-    log.info("Finished preDriverStarts callbacks")
+    logger.info("Finished preDriverStarts callbacks")
 
     // start all leadership coordination actors
     Await.result(leadershipCoordinator.prepareForStart(), config.maxActorStartupTime().milliseconds)
@@ -237,9 +235,9 @@ class MarathonSchedulerService @Inject() (
     } onComplete { result =>
       synchronized {
 
-        log.info(s"Driver future completed with result=$result.")
+        logger.info(s"Driver future completed with result=$result.")
         result match {
-          case Failure(t) => log.error("Exception while running driver", t)
+          case Failure(t) => logger.error("Exception while running driver", t)
           case _ =>
         }
 
@@ -253,9 +251,9 @@ class MarathonSchedulerService @Inject() (
 
         driver = None
 
-        log.info(s"Call postDriverRuns callbacks on ${prePostDriverCallbacks.mkString(", ")}")
+        logger.info(s"Call postDriverRuns callbacks on ${prePostDriverCallbacks.mkString(", ")}")
         Await.result(Future.sequence(prePostDriverCallbacks.map(_.postDriverTerminates)), config.zkTimeoutDuration)
-        log.info("Finished postDriverRuns callbacks")
+        logger.info("Finished postDriverRuns callbacks")
       }
     }
   }
@@ -283,7 +281,7 @@ class MarathonSchedulerService @Inject() (
 
   override def stopLeadership(): Unit = synchronized {
     // invoked by election service upon loss of leadership (state transitioned to Idle)
-    log.info("Lost leadership")
+    logger.info("Lost leadership")
 
     // disallow any interaction with the persistence storage
     persistenceStore.markClosed()
@@ -309,7 +307,7 @@ class MarathonSchedulerService @Inject() (
         def run(): Unit = {
           if (electionService.isLeader) {
             schedulerActor ! ScaleRunSpecs
-          } else log.info("Not leader therefore not scaling apps")
+          } else logger.info("Not leader therefore not scaling apps")
         }
       },
       scaleAppsInitialDelay.toMillis,
@@ -322,7 +320,7 @@ class MarathonSchedulerService @Inject() (
           if (electionService.isLeader) {
             schedulerActor ! ReconcileTasks
             schedulerActor ! ReconcileHealthChecks
-          } else log.info("Not leader therefore not reconciling tasks")
+          } else logger.info("Not leader therefore not reconciling tasks")
         }
       },
       reconciliationInitialDelay.toMillis,

--- a/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
@@ -67,6 +67,7 @@ class MarathonExceptionMapper extends ExceptionMapper[JavaException] {
     case _: IllegalArgumentException => UnprocessableEntity.intValue
     case _: ValidationFailedException => UnprocessableEntity.intValue
     case e: WebApplicationException => e.getResponse.getStatus
+    case _: TooManyRunningDeploymentsException => Forbidden.intValue
     case _ => InternalServerError.intValue
   }
 

--- a/src/main/scala/mesosphere/marathon/core/group/GroupManagerConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/GroupManagerConfig.scala
@@ -29,6 +29,13 @@ trait GroupManagerConfig extends ScallopConf {
     descr = "INTERNAL TUNING PARAMETER: Group manager module's execution context thread pool size"
   )
 
+  lazy val maxRunningDeployments = opt[Int](
+    "max_running_deployments",
+    descr = "Max number of concurrently running deployments. Over the limit deployments will be dismissed.",
+    noshort = true,
+    default = Some(100)
+  )
+
   def availableFeatures: Set[String]
   def localPortMin: ScallopOption[Int]
   def localPortMax: ScallopOption[Int]

--- a/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
@@ -66,8 +66,8 @@ object AppHealthCheckActor {
     * @param healthState The new state of the health check
     */
   case class HealthCheckStatusChanged(
-      appKey: ApplicationKey,
-      healthCheck: HealthCheck, healthState: Health)
+    appKey: ApplicationKey,
+    healthCheck: HealthCheck, healthState: Health)
 
   /**
     * This proxy class is the implementation of the actor. It has been created to be used in performance benchmarks.

--- a/src/test/scala/mesosphere/marathon/api/TestGroupManagerFixture.scala
+++ b/src/test/scala/mesosphere/marathon/api/TestGroupManagerFixture.scala
@@ -28,6 +28,7 @@ class TestGroupManagerFixture(initialRoot: RootGroup = RootGroup.empty) extends 
     override def get() = service
   }
 
+  schedulerProvider.get().listRunningDeployments() returns Future.successful(Seq.empty)
   groupRepository.root() returns Future.successful(initialRoot)
 
   private[this] val groupManagerModule = new GroupManagerModule(

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -43,6 +43,9 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation {
     val config: AllConf = f.config
     val groupRepository: GroupRepository = f.groupRepository
     val groupManager: GroupManager = f.groupManager
+
+    f.schedulerProvider.get().listRunningDeployments() returns Future.successful(Seq.empty)
+
     val groupsResource: GroupsResource = new GroupsResource(groupManager, groupInfo, config)(auth.auth, auth.auth, mat)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
@@ -2,9 +2,9 @@ package mesosphere.marathon
 package core.group
 
 import javax.inject.Provider
-
 import akka.Done
 import akka.event.EventStream
+import mesosphere.marathon.core.deployment.DeploymentStepInfo
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.async.ExecutionContexts
 import mesosphere.marathon.core.event.GroupChangeSuccess
@@ -19,11 +19,17 @@ import scala.concurrent.{ Future, Promise }
 class GroupManagerTest extends AkkaUnitTest with GroupCreation {
   class Fixture(
       val servicePortsRange: Range = 1000.to(20000),
-      val initialRoot: Option[RootGroup] = Some(RootGroup.empty)) {
-    val config = AllConf.withTestConfig("--local_port_min", servicePortsRange.min.toString,
-      "--local_port_max", (servicePortsRange.max).toString)
+      val initialRoot: Option[RootGroup] = Some(RootGroup.empty),
+      val maxRunningDeployments: Int = 100) {
+    val config = AllConf.withTestConfig(
+      "--local_port_min", servicePortsRange.min.toString,
+      "--local_port_max", (servicePortsRange.max).toString,
+      "--max_running_deployments", maxRunningDeployments.toString
+    )
     val groupRepository = mock[GroupRepository]
     val deploymentService = mock[DeploymentService]
+    deploymentService.listRunningDeployments() returns Future.successful(Seq.empty)
+
     val eventStream = mock[EventStream]
     val groupManager = new GroupManagerImpl(config, initialRoot, groupRepository, new Provider[DeploymentService] {
       override def get(): DeploymentService = deploymentService
@@ -35,8 +41,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       groupManager.rootGroupOption() shouldBe None
     }
 
-    "Don't store invalid groups" in new Fixture {
-
+    "not store invalid groups" in new Fixture {
       val app1 = AppDefinition("/app1".toPath)
       val rootGroup = createRootGroup(Map(app1.id -> app1), groups = Set(createGroup("/app1".toPath)))
 
@@ -81,7 +86,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
         groupId shouldBe PathId.empty
     }
 
-    "Store new apps with correct version infos in groupRepo and appRepo" in new Fixture {
+    "store new apps with correct version infos in groupRepo and appRepo" in new Fixture {
 
       val app: AppDefinition = AppDefinition("/app1".toPath, cmd = Some("sleep 3"), portDefinitions = Seq.empty)
       val rootGroup = createRootGroup(Map(app.id -> app), version = Timestamp(1))
@@ -100,7 +105,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       verify(groupRepository).storeRootVersion(groupWithVersionInfo, Seq(appWithVersionInfo), Nil)
     }
 
-    "Expunge removed apps from appRepo" in new Fixture(initialRoot = Option({
+    "expunge removed apps from appRepo" in new Fixture(initialRoot = Option({
       val app: AppDefinition = AppDefinition("/app1".toPath, cmd = Some("sleep 3"), portDefinitions = Seq.empty)
       createRootGroup(Map(app.id -> app), version = Timestamp(1))
     })) {
@@ -113,6 +118,20 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       groupManager.updateRoot(PathId.empty, _.putGroup(groupEmpty, version = Timestamp(1)), Timestamp(1), force = false).futureValue
       verify(groupRepository).storeRootVersion(groupEmpty, Nil, Nil)
       verify(groupRepository).storeRoot(groupEmpty, Nil, Seq("/app1".toPath), Nil, Nil)
+    }
+
+    "dismiss deployments when max_running_deployments limit is achieved" in new Fixture(maxRunningDeployments = 5) {
+      val app1 = AppDefinition("/app1".toPath)
+      val rootGroup = createRootGroup(Map(app1.id -> app1), groups = Set(createGroup("/app1".toPath)))
+      groupRepository.root() returns Future.successful(createRootGroup())
+
+      val running = (1.to(maxRunningDeployments).map(_ => mock[DeploymentStepInfo]))
+      deploymentService.listRunningDeployments() returns Future.successful(running)
+
+      intercept[TooManyRunningDeploymentsException] {
+        throw groupManager.updateRoot(PathId.empty, _.putGroup(rootGroup, rootGroup.version), rootGroup.version, force = false).failed.futureValue
+      }
+
     }
   }
 }


### PR DESCRIPTION
Summary:
Added a new command parameter `--max_running_deployments` limiting the max number of concurrently running deployments in the system. Over the limit deployments are dismissed with a HTTP 403 Error and a helpful error message. Added a new metric to help monitor the number of dismissed deployments.

JIRA: MARATHON-8172, MARATHON_EE-1955
(cherry picked from commit 3e49e3fe0ceda056e788da50bc989d00b6b78f03)