### PR TITLE
Async deployment responses

### DIFF
--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -52,7 +52,7 @@ case class ConflictingChangeException(msg: String) extends Exception(msg)
 /**
   * Is thrown if an object validation is not successful.
   *
-  * TODO - convert to Rejection
+  * TODO(MARATHON-8202) - convert to Rejection
   *
   * @param obj object which is not valid
   * @param failure validation information kept in a Failure object

--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -5,27 +5,27 @@ import mesosphere.marathon.state.{PathId, Timestamp}
 @SuppressWarnings(Array("NullAssignment"))
 class Exception(msg: String, cause: Throwable = null) extends scala.RuntimeException(msg, cause)
 
-// TODO - convert to Rejection
+// TODO(MARATHON-8202) - convert to Rejection
 case class PathNotFoundException(id: PathId, version: Option[Timestamp] = None) extends Exception(
   s"Path '$id' does not exist" + version.fold("")(v => s" in version $v")
 )
 
-// TODO - convert to Rejection
+// TODO(MARATHON-8202) - convert to Rejection
 case class AppNotFoundException(id: PathId, version: Option[Timestamp] = None) extends Exception(
   s"App '$id' does not exist" + version.fold("")(v => s" in version $v")
 )
 
-// TODO - convert to Rejection
+// TODO(MARATHON-8202) - convert to Rejection
 case class PodNotFoundException(id: PathId, version: Option[Timestamp] = None) extends Exception(
   s"Pod '$id' does not exist" + version.fold("")(v => s" in version $v")
 )
 
-// TODO - convert to Rejection
+// TODO(MARATHON-8202) - convert to Rejection
 case class UnknownGroupException(id: PathId) extends Exception(s"Group '$id' does not exist")
 
 case class WrongConfigurationException(message: String) extends Exception(message)
 
-// TODO - convert to Rejection
+// TODO(MARATHON-8202) - convert to Rejection
 case class AppLockedException(deploymentIds: Seq[String] = Nil)
   extends Exception(
     "App is locked by one or more deployments. " +
@@ -33,14 +33,14 @@ case class AppLockedException(deploymentIds: Seq[String] = Nil)
       "View details at '/v2/deployments/<DEPLOYMENT_ID>'."
   )
 
-// TODO - convert to Rejection
+// TODO(MARATHON-8202) - convert to Rejection
 case class TooManyRunningDeploymentsException(maxNum: Int) extends Exception(
   s"Max number ($maxNum) of running deployments is achieved. Wait for existing deployments to complete or cancel one." +
     "You can increase max deployment number by using --max_running_deployments parameter but be " +
     "advised that this can have negative effects on the performance."
 )
 
-// TODO - convert to Rejection
+// TODO(MARATHON-8202) - convert to Rejection
 class PortRangeExhaustedException(
     val minPort: Int,
     val maxPort: Int) extends Exception(s"All ports in the range [$minPort-$maxPort) are already in use")

--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -1,27 +1,31 @@
 package mesosphere.marathon
-
 import com.wix.accord.Failure
 import mesosphere.marathon.state.{PathId, Timestamp}
 
 @SuppressWarnings(Array("NullAssignment"))
 class Exception(msg: String, cause: Throwable = null) extends scala.RuntimeException(msg, cause)
 
+// TODO - convert to Rejection
 case class PathNotFoundException(id: PathId, version: Option[Timestamp] = None) extends Exception(
   s"Path '$id' does not exist" + version.fold("")(v => s" in version $v")
 )
 
+// TODO - convert to Rejection
 case class AppNotFoundException(id: PathId, version: Option[Timestamp] = None) extends Exception(
   s"App '$id' does not exist" + version.fold("")(v => s" in version $v")
 )
 
+// TODO - convert to Rejection
 case class PodNotFoundException(id: PathId, version: Option[Timestamp] = None) extends Exception(
   s"Pod '$id' does not exist" + version.fold("")(v => s" in version $v")
 )
 
+// TODO - convert to Rejection
 case class UnknownGroupException(id: PathId) extends Exception(s"Group '$id' does not exist")
 
 case class WrongConfigurationException(message: String) extends Exception(message)
 
+// TODO - convert to Rejection
 case class AppLockedException(deploymentIds: Seq[String] = Nil)
   extends Exception(
     "App is locked by one or more deployments. " +
@@ -29,17 +33,17 @@ case class AppLockedException(deploymentIds: Seq[String] = Nil)
       "View details at '/v2/deployments/<DEPLOYMENT_ID>'."
   )
 
+// TODO - convert to Rejection
 case class TooManyRunningDeploymentsException(maxNum: Int) extends Exception(
   s"Max number ($maxNum) of running deployments is achieved. Wait for existing deployments to complete or cancel one." +
     "You can increase max deployment number by using --max_running_deployments parameter but be " +
     "advised that this can have negative effects on the performance."
 )
 
+// TODO - convert to Rejection
 class PortRangeExhaustedException(
     val minPort: Int,
     val maxPort: Int) extends Exception(s"All ports in the range [$minPort-$maxPort) are already in use")
-
-case class UpgradeInProgressException(msg: String) extends Exception(msg)
 
 case class CanceledActionException(msg: String) extends Exception(msg)
 
@@ -47,6 +51,9 @@ case class ConflictingChangeException(msg: String) extends Exception(msg)
 
 /**
   * Is thrown if an object validation is not successful.
+  *
+  * TODO - convert to Rejection
+  *
   * @param obj object which is not valid
   * @param failure validation information kept in a Failure object
   */
@@ -80,9 +87,6 @@ class KillingInstancesFailedException(msg: String) extends Exception(msg)
 abstract class DeploymentFailedException(msg: String) extends Exception(msg)
 
 class DeploymentCanceledException(msg: String) extends DeploymentFailedException(msg)
-class AppStartCanceledException(msg: String) extends DeploymentFailedException(msg)
-class AppStopCanceledException(msg: String) extends DeploymentFailedException(msg)
-class ResolveArtifactsCanceledException(msg: String) extends DeploymentFailedException(msg)
 
 /*
  * Store specific exceptions

--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -45,8 +45,6 @@ case class CanceledActionException(msg: String) extends Exception(msg)
 
 case class ConflictingChangeException(msg: String) extends Exception(msg)
 
-case class AccessDeniedException(msg: String = "Authorization Denied") extends Exception(msg)
-
 /**
   * Is thrown if an object validation is not successful.
   * @param obj object which is not valid

--- a/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
+++ b/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
@@ -62,7 +62,7 @@ class GroupApiService(groupManager: GroupManager)(implicit authorizer: Authorize
 
   private def checkAuthorizationOrThrow[Resource](action: AuthorizedAction[Resource], resource: Resource)(implicit identity: Identity, authorizer: Authorizer): Boolean = {
     if (!authorizer.isAuthorized(identity, action, resource))
-      throw AccessDeniedException()
+      throw RejectionException(Rejection.AccessDeniedRejection(authorizer, identity))
     else
       true
   }

--- a/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
@@ -18,6 +18,12 @@ import play.api.libs.json.{JsResultException, JsValue, Json}
 
 import scala.concurrent.TimeoutException
 
+/**
+  * Class used to map exceptions thrown in Jersey controller methods. It is configured by providing it to
+  * [[RootApplication]].
+  *
+  * Handles a few exceptions, plus all [[Rejection]]s via RejectionException
+  */
 @Provider
 @Singleton
 class MarathonExceptionMapper extends ExceptionMapper[JavaException] with StrictLogging {

--- a/src/main/scala/mesosphere/marathon/api/Rejection.scala
+++ b/src/main/scala/mesosphere/marathon/api/Rejection.scala
@@ -11,10 +11,23 @@ import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, Identity}
   */
 case class RejectionException(rejection: Rejection) extends Exception(s"Unhandled rejection: ${rejection}")
 
+/**
+  * Models known reasons why an API request could be confused.
+  */
 sealed trait Rejection {}
 object Rejection {
+  /**
+    * The request was authenticated, but access was not allowed to the resource.
+    */
   case class AccessDeniedRejection(authorizer: Authorizer, identity: Identity) extends Rejection
-  case class NotAuthenticatedRejection(authenticator: Authenticator, request: HttpServletRequest) extends Rejection
-  case object ServiceUnavailableRejection extends Rejection
 
+  /**
+    * Authentication was required, but failed.
+    */
+  case class NotAuthenticatedRejection(authenticator: Authenticator, request: HttpServletRequest) extends Rejection
+
+  /**
+    * A dependent service (IE authentication) was not available, and therefore the request could not be processed.
+    */
+  case object ServiceUnavailableRejection extends Rejection
 }

--- a/src/main/scala/mesosphere/marathon/api/Rejection.scala
+++ b/src/main/scala/mesosphere/marathon/api/Rejection.scala
@@ -1,0 +1,20 @@
+package mesosphere.marathon
+package api
+
+import javax.servlet.http.HttpServletRequest
+import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, Identity}
+
+/**
+  * Exception which, when thrown, will cause the corresponding rejection type to be mapped to an API response.
+  *
+  * Mapping is done in [[MarathonExceptionMapper]]
+  */
+case class RejectionException(rejection: Rejection) extends Exception(s"Unhandled rejection: ${rejection}")
+
+sealed trait Rejection {}
+object Rejection {
+  case class AccessDeniedRejection(authorizer: Authorizer, identity: Identity) extends Rejection
+  case class NotAuthenticatedRejection(authenticator: Authenticator, request: HttpServletRequest) extends Rejection
+  case object ServiceUnavailableRejection extends Rejection
+
+}

--- a/src/main/scala/mesosphere/marathon/api/ResponseFacade.scala
+++ b/src/main/scala/mesosphere/marathon/api/ResponseFacade.scala
@@ -7,6 +7,9 @@ import javax.ws.rs.core.{NewCookie, Response}
 
 import mesosphere.marathon.plugin.http.HttpResponse
 
+/**
+  * Implementation of plugin-interface HttpResponse; a response builder with some extra helper methods.
+  */
 class ResponseFacade extends HttpResponse {
   private[this] var builder = Response.status(Status.UNAUTHORIZED)
   override def header(name: String, value: String): Unit = builder.header(name, value)
@@ -25,6 +28,9 @@ class ResponseFacade extends HttpResponse {
 }
 
 object ResponseFacade {
+  /**
+    * Factory method for building a response using [[ResponseFacade]]
+    */
   def apply(fn: HttpResponse => Unit): Response = {
     val responseFacade = new ResponseFacade
     fn(responseFacade)

--- a/src/main/scala/mesosphere/marathon/api/ResponseFacade.scala
+++ b/src/main/scala/mesosphere/marathon/api/ResponseFacade.scala
@@ -23,3 +23,11 @@ class ResponseFacade extends HttpResponse {
   }
   def response: Response = builder.build()
 }
+
+object ResponseFacade {
+  def apply(fn: HttpResponse => Unit): Response = {
+    val responseFacade = new ResponseFacade
+    fn(responseFacade)
+    responseFacade.response
+  }
+}

--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -71,7 +71,7 @@ trait RestResource extends JaxResource {
 
   /**
     * Checks if the implicit validator yields a valid result.
-    * See [[assumeValid]], which is preferred to this.
+    * See [[validateOrThrow]], which is preferred to this.
     *
     * @param t object to validate
     * @param fn function to execute after successful validation
@@ -80,6 +80,7 @@ trait RestResource extends JaxResource {
     * @return returns a 422 response if there is a failure due to validation. Executes fn function if successful.
     */
   protected def withValid[T](t: T)(fn: T => Response)(implicit validator: Validator[T]): Response = {
+    // TODO - replace with Validation.validateOrThrow
     validator(t) match {
       case f: ValidationFailure =>
         val entity = Json.toJson(f).toString

--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 import akka.Done
 import com.typesafe.scalalogging.StrictLogging
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.instance.Instance
@@ -25,7 +25,7 @@ class TaskKiller @Inject() (
     val config: MarathonConf,
     val authenticator: Authenticator,
     val authorizer: Authorizer,
-    killService: KillService) extends AuthResource with StrictLogging {
+    killService: KillService)(implicit val executionContext: ExecutionContext) extends AuthResource with StrictLogging {
 
   @SuppressWarnings(Array("all")) // async/await
   def kill(

--- a/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package api.v2
 
 import com.wix.accord.Validator
+import mesosphere.marathon.api.{Rejection, RejectionException}
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.core.appinfo.{AppSelector, Selector}
@@ -52,7 +53,7 @@ object AppHelpers {
 
   private def checkAuthorization[A, B >: A](action: AuthorizedAction[B], resource: A)(implicit identity: Identity, authorizer: Authorizer): A = {
     if (authorizer.isAuthorized(identity, action, resource)) resource
-    else throw AccessDeniedException()
+    else throw RejectionException(Rejection.AccessDeniedRejection(authorizer, identity))
   }
 
   /**
@@ -60,7 +61,7 @@ object AppHelpers {
     *
     * - [[mesosphere.marathon.ValidationFailedException]]
     * - [[mesosphere.marathon.AppNotFoundException]]
-    * - [[mesosphere.marathon.AccessDeniedException]]
+    * - [[mesosphere.marathon.api.RejectionException]] - AccessDeniedRejection(...)
     *
     * TODO - move async concern out
     */

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon
 package api.v2
 
-import com.typesafe.scalalogging.StrictLogging
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
@@ -9,8 +8,7 @@ import javax.ws.rs.core.{Context, MediaType, Response}
 import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api._
 import mesosphere.marathon.core.appinfo.EnrichedTask
-
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.Instance
@@ -36,7 +34,7 @@ class AppTasksResource @Inject() (
     val config: MarathonConf,
     groupManager: GroupManager,
     val authorizer: Authorizer,
-    val authenticator: Authenticator) extends AuthResource with StrictLogging {
+    val authenticator: Authenticator)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
   val GroupTasks = """^((?:.+/)|)\*$""".r
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -11,6 +11,7 @@ import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, ViewRunSpec}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.Timestamp
+import scala.concurrent.ExecutionContext
 
 @Produces(Array(MediaType.APPLICATION_JSON))
 @Consumes(Array(MediaType.APPLICATION_JSON))
@@ -19,7 +20,7 @@ class AppVersionsResource(
     groupManager: GroupManager,
     val authenticator: Authenticator,
     val authorizer: Authorizer,
-    val config: MarathonConf) extends AuthResource {
+    val config: MarathonConf)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
   @GET
   def index(

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -7,6 +7,7 @@ import java.net.URI
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
+import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.{Context, MediaType, Response}
 
 import akka.event.EventStream
@@ -22,7 +23,10 @@ import mesosphere.marathon.raml.Raml
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
+import org.glassfish.jersey.server.ManagedAsync
 import play.api.libs.json.{JsObject, Json}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.async.Async._
 
 @Path("v2/apps")
 @Consumes(Array(MediaType.APPLICATION_JSON))
@@ -37,7 +41,8 @@ class AppsResource @Inject() (
     groupManager: GroupManager,
     pluginManager: PluginManager)(implicit
     val authenticator: Authenticator,
-    val authorizer: Authorizer) extends RestResource with AuthResource {
+    val authorizer: Authorizer,
+    val executionContext: ExecutionContext) extends RestResource with AuthResource {
 
   import AppHelpers._
   import Normalization._
@@ -70,13 +75,17 @@ class AppsResource @Inject() (
     Response.ok(jsonObjString("apps" -> mapped)).build()
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @POST
+  @ManagedAsync
   def create(
     body: Array[Byte],
     @DefaultValue("false")@QueryParam("force") force: Boolean,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    assumeValid {
       val rawApp = Raml.fromRaml(Json.parse(body).as[raml.App].normalize)
       val now = clock.now()
       val app = validateOrThrow(rawApp).copy(versionInfo = VersionInfo.OnlyVersion(now))
@@ -87,21 +96,24 @@ class AppsResource @Inject() (
         .map(_ => throw ConflictingChangeException(s"An app with id [${app.id}] already exists."))
         .getOrElse(app)
 
-      val plan = result(groupManager.updateApp(app.id, createOrThrow, app.version, force))
+      val groupUpdateResult = groupManager.updateApp(app.id, createOrThrow, app.version, force).map { plan =>
+        val appWithDeployments = AppInfo(
+          app,
+          maybeCounts = Some(TaskCounts.zero),
+          maybeTasks = Some(Seq.empty),
+          maybeDeployments = Some(Seq(Identifiable(plan.id)))
+        )
 
-      val appWithDeployments = AppInfo(
-        app,
-        maybeCounts = Some(TaskCounts.zero),
-        maybeTasks = Some(Seq.empty),
-        maybeDeployments = Some(Seq(Identifiable(plan.id)))
-      )
+        maybePostEvent(req, appWithDeployments.app)
 
-      maybePostEvent(req, appWithDeployments.app)
-      Response
-        .created(new URI(app.id.toString))
-        .header(RestResource.DeploymentHeader, plan.id)
-        .entity(jsonString(appWithDeployments))
-        .build()
+        // servletRequest.getAsyncContext
+        Response
+          .created(new URI(app.id.toString))
+          .header(RestResource.DeploymentHeader, plan.id)
+          .entity(jsonString(appWithDeployments))
+          .build()
+      }
+      await(groupUpdateResult)
     }
   }
 
@@ -186,6 +198,7 @@ class AppsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @PUT
   @Path("""{id:.+}""")
   def replace(
@@ -193,56 +206,79 @@ class AppsResource @Inject() (
     body: Array[Byte],
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @DefaultValue("true")@QueryParam("partialUpdate") partialUpdate: Boolean,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    update(id, body, force, partialUpdate, req, allowCreation = true)
+      await(update(id, body, force, partialUpdate, req, allowCreation = true))
+    }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @PATCH
   @Path("""{id:.+}""")
   def patch(
     @PathParam("id") id: String,
     body: Array[Byte],
     @DefaultValue("false")@QueryParam("force") force: Boolean,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    update(id, body, force, partialUpdate = true, req, allowCreation = false)
+      await(update(id, body, force, partialUpdate = true, req, allowCreation = false))
+    }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @PUT
   def replaceMultiple(
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @DefaultValue("true")@QueryParam("partialUpdate") partialUpdate: Boolean,
     body: Array[Byte],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-
-    updateMultiple(force, partialUpdate, body, allowCreation = true)
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      await(updateMultiple(force, partialUpdate, body, allowCreation = true))
+    }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @PATCH
   def patchMultiple(
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     body: Array[Byte],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    updateMultiple(force, partialUpdate = true, body, allowCreation = false)
+      await(updateMultiple(force, partialUpdate = true, body, allowCreation = false))
+    }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @DELETE
   @Path("""{id:.+}""")
   def delete(
     @DefaultValue("true")@QueryParam("force") force: Boolean,
     @PathParam("id") id: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val appId = id.toRootPath
-    val version = Timestamp.now()
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val appId = id.toRootPath
+      val version = Timestamp.now()
 
-    def deleteApp(rootGroup: RootGroup) = {
-      checkAuthorization(DeleteRunSpec, rootGroup.app(appId), AppNotFoundException(appId))
-      rootGroup.removeApp(appId, version)
+      def deleteApp(rootGroup: RootGroup) = {
+        checkAuthorization(DeleteRunSpec, rootGroup.app(appId), AppNotFoundException(appId))
+        rootGroup.removeApp(appId, version)
+      }
+
+      deploymentResult(await(groupManager.updateRoot(appId.parent, deleteApp, version = version, force = force)))
     }
-
-    deploymentResult(result(groupManager.updateRoot(appId.parent, deleteApp, version = version, force = force)))
   }
 
   @Path("{appId:.+}/tasks")
@@ -252,27 +288,32 @@ class AppsResource @Inject() (
   def appVersionsResource(): AppVersionsResource = new AppVersionsResource(service, groupManager, authenticator,
     authorizer, config)
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @POST
   @Path("{id:.+}/restart")
   def restart(
     @PathParam("id") id: String,
     @DefaultValue("false")@QueryParam("force") force: Boolean,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val appId = id.toRootPath
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val appId = id.toRootPath
 
-    def markForRestartingOrThrow(opt: Option[AppDefinition]) = {
-      opt
-        .map(checkAuthorization(UpdateRunSpec, _))
-        .map(_.markedForRestarting)
-        .getOrElse(throw AppNotFoundException(appId))
+      def markForRestartingOrThrow(opt: Option[AppDefinition]) = {
+        opt
+          .map(checkAuthorization(UpdateRunSpec, _))
+          .map(_.markedForRestarting)
+          .getOrElse(throw AppNotFoundException(appId))
+      }
+
+      val newVersion = clock.now()
+      val restartDeployment = await(
+        groupManager.updateApp(id.toRootPath, markForRestartingOrThrow, newVersion, force)
+      )
+
+      deploymentResult(restartDeployment)
     }
-
-    val newVersion = clock.now()
-    val restartDeployment = result(
-      groupManager.updateApp(id.toRootPath, markForRestartingOrThrow, newVersion, force)
-    )
-
-    deploymentResult(restartDeployment)
   }
 
   /**
@@ -287,22 +328,21 @@ class AppsResource @Inject() (
     * @param identity implicit identity
     * @return http servlet response
     */
+  @SuppressWarnings(Array("all")) /* async/await */
   private[this] def update(id: String, body: Array[Byte], force: Boolean, partialUpdate: Boolean,
-    req: HttpServletRequest, allowCreation: Boolean)(implicit identity: Identity): Response = {
+    req: HttpServletRequest, allowCreation: Boolean)(implicit identity: Identity): Future[Response] = async {
     val appId = id.toRootPath
 
-    assumeValid {
-      val appUpdate = canonicalAppUpdateFromJson(appId, body, partialUpdate)
-      val version = clock.now()
-      val plan = result(groupManager.updateApp(appId, AppHelpers.updateOrCreate(appId, _, appUpdate, partialUpdate, allowCreation, clock.now(), service), version, force))
-      val response = plan.original.app(appId)
-        .map(_ => Response.ok())
-        .getOrElse(Response.created(new URI(appId.toString)))
-      plan.target.app(appId).foreach { appDef =>
-        maybePostEvent(req, appDef)
-      }
-      deploymentResult(plan, response)
+    val appUpdate = canonicalAppUpdateFromJson(appId, body, partialUpdate)
+    val version = clock.now()
+    val plan = await(groupManager.updateApp(appId, AppHelpers.updateOrCreate(appId, _, appUpdate, partialUpdate, allowCreation, clock.now(), service), version, force))
+    val response = plan.original.app(appId)
+      .map(_ => Response.ok())
+      .getOrElse(Response.created(new URI(appId.toString)))
+    plan.target.app(appId).foreach { appDef =>
+      maybePostEvent(req, appDef)
     }
+    deploymentResult(plan, response)
   }
 
   /**
@@ -315,22 +355,21 @@ class AppsResource @Inject() (
     * @param identity implicit identity
     * @return http servlet response
     */
+  @SuppressWarnings(Array("all")) /* async/await */
   private[this] def updateMultiple(force: Boolean, partialUpdate: Boolean,
-    body: Array[Byte], allowCreation: Boolean)(implicit identity: Identity): Response = {
+    body: Array[Byte], allowCreation: Boolean)(implicit identity: Identity): Future[Response] = async {
 
-    assumeValid {
-      val version = clock.now()
-      val updates = canonicalAppUpdatesFromJson(body, partialUpdate)
+    val version = clock.now()
+    val updates = canonicalAppUpdatesFromJson(body, partialUpdate)
 
-      def updateGroup(rootGroup: RootGroup): RootGroup = updates.foldLeft(rootGroup) { (group, update) =>
-        update.id.map(PathId(_)) match {
-          case Some(id) => group.updateApp(id, AppHelpers.updateOrCreate(id, _, update, partialUpdate, allowCreation = allowCreation, clock.now(), service), version)
-          case None => group
-        }
+    def updateGroup(rootGroup: RootGroup): RootGroup = updates.foldLeft(rootGroup) { (group, update) =>
+      update.id.map(PathId(_)) match {
+        case Some(id) => group.updateApp(id, AppHelpers.updateOrCreate(id, _, update, partialUpdate, allowCreation = allowCreation, clock.now(), service), version)
+        case None => group
       }
-
-      deploymentResult(result(groupManager.updateRoot(PathId.empty, updateGroup, version, force)))
     }
+
+    deploymentResult(await(groupManager.updateRoot(PathId.empty, updateGroup, version, force)))
   }
 
   private def maybePostEvent(req: HttpServletRequest, app: AppDefinition) =

--- a/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
@@ -14,6 +14,7 @@ import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.{MarathonConf, MarathonSchedulerService}
+import scala.concurrent.ExecutionContext
 
 @Path("v2/deployments")
 @Consumes(Array(MediaType.APPLICATION_JSON))
@@ -23,7 +24,7 @@ class DeploymentsResource @Inject() (
     groupManager: GroupManager,
     val authenticator: Authenticator,
     val authorizer: Authorizer,
-    val config: MarathonConf)
+    val config: MarathonConf)(implicit val executionContext: ExecutionContext)
   extends AuthResource
   with StrictLogging {
 

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -5,6 +5,7 @@ import java.net.URI
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
+import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.{Context, MediaType, Response}
 
 import akka.stream.Materializer
@@ -23,6 +24,7 @@ import mesosphere.marathon.stream.Sink
 import play.api.libs.json.Json
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.matching.Regex
+import scala.async.Async._
 
 @Path("v2/groups")
 @Produces(Array(MediaType.APPLICATION_JSON))
@@ -128,7 +130,8 @@ class GroupsResource @Inject() (
   def create(
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     body: Array[Byte],
-    @Context req: HttpServletRequest): Response = createWithPath("", force, body, req)
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = createWithPath("", force, body, req, asyncResponse)
 
   /**
     * Create a group.
@@ -137,42 +140,46 @@ class GroupsResource @Inject() (
     * @param force if the change has to be forced. A running upgrade process will be halted and the new one is started.
     * @param body the request body as array byte buffer
     */
+  @SuppressWarnings(Array("all")) /* async/await */
   @POST
   @Path("""{id:.+}""")
   def createWithPath(
     @PathParam("id") id: String,
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     body: Array[Byte],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    val validatedId = validateOrThrow(id.toRootPath)
-    val raw = Json.parse(body).as[raml.GroupUpdate]
-    val effectivePath = raw.id.map(id => validateOrThrow(PathId(id)).canonicalPath(validatedId)).getOrElse(validatedId)
+      val validatedId = validateOrThrow(id.toRootPath)
+      val raw = Json.parse(body).as[raml.GroupUpdate]
+      val effectivePath = raw.id.map(id => validateOrThrow(PathId(id)).canonicalPath(validatedId)).getOrElse(validatedId)
 
-    val groupValidator = Group.validNestedGroupUpdateWithBase(effectivePath)
-    val groupUpdate = validateOrThrow(
-      normalizeApps(
-        effectivePath,
-        raw
-      ))(groupValidator)
+      val groupValidator = Group.validNestedGroupUpdateWithBase(effectivePath)
+      val groupUpdate = validateOrThrow(
+        normalizeApps(
+          effectivePath,
+          raw
+        ))(groupValidator)
 
-    val rootGroup = groupManager.rootGroup()
+      val rootGroup = groupManager.rootGroup()
 
-    def throwIfConflicting[A](conflict: Option[Any], msg: String) = {
-      conflict.map(_ => throw ConflictingChangeException(msg))
+      def throwIfConflicting[A](conflict: Option[Any], msg: String) = {
+        conflict.map(_ => throw ConflictingChangeException(msg))
+      }
+
+      throwIfConflicting(
+        rootGroup.group(effectivePath),
+        s"Group $effectivePath is already created. Use PUT to change this group.")
+
+      throwIfConflicting(
+        rootGroup.app(effectivePath),
+        s"An app with the path $effectivePath already exists.")
+
+      val (deployment, path) = await(updateOrCreate(effectivePath, groupUpdate, force))
+      deploymentResult(deployment, Response.created(new URI(path.toString)))
     }
-
-    throwIfConflicting(
-      rootGroup.group(effectivePath),
-      s"Group $effectivePath is already created. Use PUT to change this group.")
-
-    throwIfConflicting(
-      rootGroup.app(effectivePath),
-      s"An app with the path $effectivePath already exists.")
-
-    val (deployment, path) = updateOrCreate(effectivePath, groupUpdate, force)
-    deploymentResult(deployment, Response.created(new URI(path.toString)))
-
   }
 
   @PUT
@@ -180,8 +187,9 @@ class GroupsResource @Inject() (
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @DefaultValue("false")@QueryParam("dryRun") dryRun: Boolean,
     body: Array[Byte],
-    @Context req: HttpServletRequest): Response = {
-    update("", force, dryRun, body, req)
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = {
+    update("", force, dryRun, body, req, asyncResponse)
   }
 
   /**
@@ -191,6 +199,7 @@ class GroupsResource @Inject() (
     * @param force if the change has to be forced. A running upgrade process will be halted and the new one is started.
     * @param dryRun only create the deployment without executing it.
     */
+  @SuppressWarnings(Array("all")) /* async/await */
   @PUT
   @Path("""{id:.+}""")
   def update(
@@ -198,49 +207,57 @@ class GroupsResource @Inject() (
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     @DefaultValue("false")@QueryParam("dryRun") dryRun: Boolean,
     body: Array[Byte],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    val validatedId = validateOrThrow(id.toRootPath)
-    val raw = Json.parse(body).as[raml.GroupUpdate]
-    val effectivePath = raw.id.map(id => validateOrThrow(PathId(id)).canonicalPath(validatedId)).getOrElse(validatedId)
+      val validatedId = validateOrThrow(id.toRootPath)
+      val raw = Json.parse(body).as[raml.GroupUpdate]
+      val effectivePath = raw.id.map(id => validateOrThrow(PathId(id)).canonicalPath(validatedId)).getOrElse(validatedId)
 
-    val groupValidator = Group.validNestedGroupUpdateWithBase(effectivePath)
-    val groupUpdate = validateOrThrow(
-      normalizeApps(
-        effectivePath,
-        raw
-      ))(groupValidator)
+      val groupValidator = Group.validNestedGroupUpdateWithBase(effectivePath)
+      val groupUpdate = validateOrThrow(
+        normalizeApps(
+          effectivePath,
+          raw
+        ))(groupValidator)
 
-    if (dryRun) {
-      val newVersion = Timestamp.now()
-      val originalGroup = groupManager.rootGroup()
-      val updatedGroup = result(groupsService.updateGroup(originalGroup, effectivePath, groupUpdate, newVersion))
+      if (dryRun) {
+        val newVersion = Timestamp.now()
+        val originalGroup = groupManager.rootGroup()
+        val updatedGroup = await(groupsService.updateGroup(originalGroup, effectivePath, groupUpdate, newVersion))
 
-      ok(
-        Json.obj(
-          "steps".->(DeploymentPlan(originalGroup, updatedGroup).steps)
-        ).toString()
-      )
-    } else {
-      val (deployment, _) = updateOrCreate(effectivePath, groupUpdate, force)
-      deploymentResult(deployment)
+        ok(
+          Json.obj(
+            "steps".->(DeploymentPlan(originalGroup, updatedGroup).steps)
+          ).toString()
+        )
+      } else {
+        val (deployment, _) = await(updateOrCreate(effectivePath, groupUpdate, force))
+        deploymentResult(deployment)
+      }
     }
-
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @DELETE
   def delete(
     @DefaultValue("false")@QueryParam("force") force: Boolean,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val version = Timestamp.now()
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val version = Timestamp.now()
 
-    def clearRootGroup(rootGroup: RootGroup): RootGroup = {
-      checkAuthorization(DeleteGroup, rootGroup)
-      RootGroup(version = version)
+      def clearRootGroup(rootGroup: RootGroup): RootGroup = {
+        checkAuthorization(DeleteGroup, rootGroup)
+        RootGroup(version = version)
+      }
+
+      val deployment = await(groupManager.updateRoot(PathId.empty, clearRootGroup, version, force))
+      deploymentResult(deployment)
     }
-
-    val deployment = result(groupManager.updateRoot(PathId.empty, clearRootGroup, version, force))
-    deploymentResult(deployment)
   }
 
   /**
@@ -249,36 +266,42 @@ class GroupsResource @Inject() (
     * @param force if the change has to be forced. A running upgrade process will be halted and the new one is started.
     * @return A version response, which defines the resulting change.
     */
+  @SuppressWarnings(Array("all")) /* async/await */
   @DELETE
   @Path("""{id:.+}""")
   def delete(
     @PathParam("id") id: String,
     @DefaultValue("false")@QueryParam("force") force: Boolean,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val groupId = id.toRootPath
-    val version = Timestamp.now()
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val groupId = id.toRootPath
+      val version = Timestamp.now()
 
-    def deleteGroup(rootGroup: RootGroup) = {
-      rootGroup.group(groupId) match {
-        case Some(group) => checkAuthorization(DeleteGroup, group)
-        case None => throw UnknownGroupException(groupId)
+      def deleteGroup(rootGroup: RootGroup) = {
+        rootGroup.group(groupId) match {
+          case Some(group) => checkAuthorization(DeleteGroup, group)
+          case None => throw UnknownGroupException(groupId)
+        }
+        rootGroup.removeGroup(groupId, version)
       }
-      rootGroup.removeGroup(groupId, version)
-    }
 
-    val deployment = result(groupManager.updateRoot(groupId.parent, deleteGroup, version, force))
-    deploymentResult(deployment)
+      val deployment = await(groupManager.updateRoot(groupId.parent, deleteGroup, version, force))
+      deploymentResult(deployment)
+    }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   private def updateOrCreate(
     id: PathId,
     update: raml.GroupUpdate,
-    force: Boolean)(implicit identity: Identity): (DeploymentPlan, PathId) = {
+    force: Boolean)(implicit identity: Identity): Future[(DeploymentPlan, PathId)] = async {
     val version = Timestamp.now()
 
     val effectivePath = update.id.map(PathId(_).canonicalPath(id)).getOrElse(id)
-    val deployment = result(groupManager.updateRoot(
-      id.parent, group => result(groupsService.updateGroup(group, effectivePath, update, version)), version, force))
+    val deployment = await(groupManager.updateRootAsync(
+      id.parent, group => groupsService.updateGroup(group, effectivePath, update, version), version, force))
     (deployment, effectivePath)
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -13,6 +13,7 @@ import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
 import mesosphere.util.state.MesosLeaderInfo
 import play.api.libs.json.Json
+import scala.concurrent.ExecutionContext
 
 @Path("v2/info")
 @Consumes(Array(MediaType.APPLICATION_JSON))
@@ -23,7 +24,7 @@ class InfoResource @Inject() (
     val authenticator: Authenticator,
     val authorizer: Authorizer,
     protected val config: MarathonConf with HttpConf
-) extends AuthResource {
+)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
   // Marathon configurations
   private[this] lazy val marathonConfigValues = Json.obj(

--- a/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
@@ -13,13 +13,18 @@ import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.plugin.auth.AuthorizedResource.Plugins
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.plugin.http.HttpRequestHandler
+import scala.concurrent.ExecutionContext
 
 @Path("v2/plugins")
 class PluginsResource @Inject() (
     val config: MarathonConf,
     requestHandlers: Seq[HttpRequestHandler],
     definitions: PluginDefinitions
-)(implicit val authenticator: Authenticator, val authorizer: Authorizer) extends RestResource with AuthResource {
+)(
+    implicit
+    val authenticator: Authenticator,
+    val authorizer: Authorizer,
+    val executionContext: ExecutionContext) extends RestResource with AuthResource {
 
   val pluginIdToHandler: Map[String, HttpRequestHandler] = definitions.plugins
     .withFilter(_.plugin == classOf[HttpRequestHandler].getName)

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -6,6 +6,7 @@ import java.net.URI
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
+import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.Response.Status
 import javax.ws.rs.core.{Context, MediaType, Response}
 
@@ -14,6 +15,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.wix.accord.Validator
 import mesosphere.marathon.api.v2.validation.PodsValidation
+import mesosphere.marathon.api.v2.Validation.validateOrThrow
 import mesosphere.marathon.api.{AuthResource, RestResource, TaskKiller}
 import mesosphere.marathon.core.appinfo.{PodSelector, PodStatusService, Selector}
 import mesosphere.marathon.core.event._
@@ -28,6 +30,7 @@ import Normalization._
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.api.v2.Validation._
 import scala.concurrent.ExecutionContext
+import scala.async.Async._
 
 @Path("v2/pods")
 @Consumes(Array(MediaType.APPLICATION_JSON))
@@ -84,40 +87,46 @@ class PodsResource @Inject() (
     ok()
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @POST
   def create(
     body: Array[Byte],
     @DefaultValue("false")@QueryParam("force") force: Boolean,
-    @Context req: HttpServletRequest): Response = {
-    authenticated(req) { implicit identity =>
-      withValid(unmarshal(body)) { podDef =>
-        val pod = normalize(Raml.fromRaml(podDef.normalize))
-        validateOrThrow(pod)(PodsValidation.pluginValidators)
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val podDef = unmarshal(body)
+      validateOrThrow(podDef)
+      val pod = normalize(Raml.fromRaml(podDef.normalize))
+      validateOrThrow(pod)(PodsValidation.pluginValidators)
 
-        withAuthorization(CreateRunSpec, pod) {
-          val deployment = result(podSystem.create(pod, force))
-          eventBus.publish(PodEvent(req.getRemoteAddr, req.getRequestURI, PodEvent.Created))
+      checkAuthorization(CreateRunSpec, pod)
+      val deployment = await(podSystem.create(pod, force))
+      eventBus.publish(PodEvent(req.getRemoteAddr, req.getRequestURI, PodEvent.Created))
 
-          Response.created(new URI(pod.id.toString))
-            .header(RestResource.DeploymentHeader, deployment.id)
-            .entity(marshal(pod))
-            .build()
-        }
-      }
+      Response.created(new URI(pod.id.toString))
+        .header(RestResource.DeploymentHeader, deployment.id)
+        .entity(marshal(pod))
+        .build()
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @PUT @Path("""{id:.+}""")
   def update(
     @PathParam("id") id: String,
     body: Array[Byte],
     @DefaultValue("false")@QueryParam("force") force: Boolean,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      import PathId._
 
-    import PathId._
-
-    val podId = id.toRootPath
-    withValid(unmarshal(body)) { podDef =>
+      val podId = id.toRootPath
+      val podDef = unmarshal(body)
+      validateOrThrow(podDef)
       if (podId != podDef.id.toRootPath) {
         Response.status(Status.BAD_REQUEST).entity(
           s"""
@@ -128,16 +137,15 @@ class PodsResource @Inject() (
         val pod = normalize(Raml.fromRaml(podDef.normalize))
         validateOrThrow(pod)(PodsValidation.pluginValidators)
 
-        withAuthorization(UpdateRunSpec, pod) {
-          val deployment = result(podSystem.update(pod, force))
-          eventBus.publish(PodEvent(req.getRemoteAddr, req.getRequestURI, PodEvent.Updated))
+        checkAuthorization(UpdateRunSpec, pod)
+        val deployment = await(podSystem.update(pod, force))
+        eventBus.publish(PodEvent(req.getRemoteAddr, req.getRequestURI, PodEvent.Updated))
 
-          val builder = Response
-            .ok(new URI(pod.id.toString))
-            .entity(marshal(pod))
-            .header(RestResource.DeploymentHeader, deployment.id)
-          builder.build()
-        }
+        val builder = Response
+          .ok(new URI(pod.id.toString))
+          .entity(marshal(pod))
+          .header(RestResource.DeploymentHeader, deployment.id)
+        builder.build()
       }
     }
   }
@@ -164,24 +172,32 @@ class PodsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @DELETE @Path("""{id:.+}""")
   def remove(
-    @PathParam("id") id: String,
+    @PathParam("id") idOrig: String,
     @DefaultValue("false")@QueryParam("force") force: Boolean,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    import PathId._
+      import PathId._
 
-    withValid(id.toRootPath) { id =>
-      withAuthorization(DeleteRunSpec, podSystem.find(id), unknownPod(id)) { pod =>
+      val id = idOrig.toRootPath
+      validateOrThrow(id)
+      podSystem.find(id) match {
+        case Some(pod) =>
+          checkAuthorization(DeleteRunSpec, pod)
+          val deployment = await(podSystem.delete(id, force))
 
-        val deployment = result(podSystem.delete(id, force))
-
-        eventBus.publish(PodEvent(req.getRemoteAddr, req.getRequestURI, PodEvent.Deleted))
-        Response.status(Status.ACCEPTED)
-          .location(new URI(deployment.id)) // TODO(jdef) probably want a different header here since deployment != pod
-          .header(RestResource.DeploymentHeader, deployment.id)
-          .build()
+          eventBus.publish(PodEvent(req.getRemoteAddr, req.getRequestURI, PodEvent.Deleted))
+          Response.status(Status.ACCEPTED)
+            .location(new URI(deployment.id)) // TODO(jdef) probably want a different header here since deployment != pod
+            .header(RestResource.DeploymentHeader, deployment.id)
+            .build()
+        case None =>
+          unknownPod(id)
       }
     }
   }
@@ -245,32 +261,42 @@ class PodsResource @Inject() (
     ok(Json.stringify(Json.toJson(result(future))))
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @DELETE
   @Path("""{id:.+}::instances/{instanceId}""")
   def killInstance(
-    @PathParam("id") id: String,
+    @PathParam("id") idOrig: String,
     @PathParam("instanceId") instanceId: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    import PathId._
-    import com.wix.accord.dsl._
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      import PathId._
+      import com.wix.accord.dsl._
 
-    implicit val validId: Validator[String] = validator[String] { ids =>
-      ids should matchRegexFully(Instance.Id.InstanceIdRegex)
-    }
-    // don't need to authorize as taskKiller will do so.
-    withValid(id.toRootPath) { id =>
-      withValid(instanceId) { instanceId =>
-        val parsedInstanceId = Instance.Id.fromIdString(instanceId)
-        val instances = result(taskKiller.kill(id, _.filter(_.instanceId == parsedInstanceId)))
-        instances.headOption.fold(unknownTask(instanceId))(instance => ok(jsonString(instance)))
+      implicit val validId: Validator[String] = validator[String] { ids =>
+        ids should matchRegexFully(Instance.Id.InstanceIdRegex)
       }
+      // don't need to authorize as taskKiller will do so.
+      val id = idOrig.toRootPath
+      validateOrThrow(id)
+      validateOrThrow(instanceId)
+      val parsedInstanceId = Instance.Id.fromIdString(instanceId)
+      val instances = await(taskKiller.kill(id, _.filter(_.instanceId == parsedInstanceId)))
+      instances.headOption.fold(unknownTask(instanceId))(instance => ok(jsonString(instance)))
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @DELETE
   @Path("""{id:.+}::instances""")
-  def killInstances(@PathParam("id") id: String, body: Array[Byte], @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+  def killInstances(
+    @PathParam("id") idOrig: String,
+    body: Array[Byte],
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       import PathId._
       import Validation._
       import com.wix.accord.dsl._
@@ -280,17 +306,18 @@ class PodsResource @Inject() (
       }
 
       // don't need to authorize as taskKiller will do so.
-      withValid(id.toRootPath) { id =>
-        withValid(Json.parse(body).as[Set[String]]) { instancesToKill =>
-          val instancesDesired = instancesToKill.map(Instance.Id.fromIdString(_))
-          def toKill(instances: Seq[Instance]): Seq[Instance] = {
-            instances.filter(instance => instancesDesired.contains(instance.instanceId))
-          }
-          val instances = result(taskKiller.kill(id, toKill))
-          ok(Json.toJson(instances))
-        }
+      val id = idOrig.toRootPath
+      validateOrThrow(id)
+      val instancesToKill = Json.parse(body).as[Set[String]]
+      validateOrThrow(instancesToKill)
+      val instancesDesired = instancesToKill.map(Instance.Id.fromIdString(_))
+      def toKill(instances: Seq[Instance]): Seq[Instance] = {
+        instances.filter(instance => instancesDesired.contains(instance.instanceId))
       }
+      val instances = await(taskKiller.kill(id, toKill))
+      ok(Json.toJson(instances))
     }
+  }
 
   private def notFound(id: PathId): Response = unknownPod(id)
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -27,6 +27,7 @@ import play.api.libs.json.Json
 import Normalization._
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.api.v2.Validation._
+import scala.concurrent.ExecutionContext
 
 @Path("v2/pods")
 @Consumes(Array(MediaType.APPLICATION_JSON))
@@ -43,7 +44,8 @@ class PodsResource @Inject() (
     mat: Materializer,
     clock: Clock,
     scheduler: MarathonScheduler,
-    pluginManager: PluginManager) extends RestResource with AuthResource {
+    pluginManager: PluginManager,
+    val executionContext: ExecutionContext) extends RestResource with AuthResource {
 
   import PodsResource._
   implicit def podDefValidator: Validator[Pod] =

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -12,6 +12,7 @@ import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec}
 import mesosphere.marathon.raml.Raml
 import mesosphere.marathon.state.PathId._
+import scala.concurrent.ExecutionContext
 
 @Path("v2/queue")
 @Consumes(Array(MediaType.APPLICATION_JSON))
@@ -20,7 +21,7 @@ class QueueResource @Inject() (
     launchQueue: LaunchQueue,
     val authenticator: Authenticator,
     val authorizer: Authorizer,
-    val config: MarathonConf) extends AuthResource {
+    val config: MarathonConf)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))

--- a/src/main/scala/mesosphere/marathon/api/v2/SchemaResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/SchemaResource.scala
@@ -7,12 +7,13 @@ import javax.ws.rs._
 import javax.ws.rs.core.MediaType
 
 import mesosphere.marathon.api.RestResource
+import scala.concurrent.ExecutionContext
 
 @Path("v2/schemas")
 @Consumes(Array(MediaType.APPLICATION_JSON))
 @Produces(Array(MediaType.APPLICATION_JSON))
 class SchemaResource @Inject() (
-    val config: MarathonConf) extends RestResource {
+    val config: MarathonConf)(implicit val executionContext: ExecutionContext) extends RestResource {
 
   //TODO: schemas are available via /public/api/v2/schema/* anyway
   @GET

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -36,9 +36,7 @@ class TasksResource @Inject() (
     groupManager: GroupManager,
     healthCheckManager: HealthCheckManager,
     val authenticator: Authenticator,
-    val authorizer: Authorizer) extends AuthResource {
-
-  implicit val ec = ExecutionContext.Implicits.global
+    val authorizer: Authorizer)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))

--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
@@ -10,6 +10,7 @@ import akka.stream.scaladsl.Source
 import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
+import mesosphere.marathon.api.{Rejection, RejectionException}
 import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.event.{GroupChangeFailed, GroupChangeSuccess}
@@ -151,9 +152,9 @@ class GroupManagerImpl(
         eventStream.publish(GroupChangeSuccess(id, version.toString))
       case Success(Left(_)) =>
         ()
-      case Failure(ex: AccessDeniedException) =>
+      case Failure(RejectionException(_: Rejection.AccessDeniedRejection)) =>
         // If the request was not authorized, we should not publish an event
-        logger.warn(s"Deployment failed for change: $version", ex)
+        logger.warn(s"Deployment failed for change: $version; Access denied.")
       case Failure(NonFatal(ex)) =>
         logger.warn(s"Deployment failed for change: $version", ex)
         eventStream.publish(GroupChangeFailed(id, version.toString, ex.getMessage))

--- a/src/test/scala/mesosphere/marathon/api/AuthResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/AuthResourceTest.scala
@@ -52,6 +52,7 @@ class AuthResourceTest extends UnitTest {
 
     class TestResource(val authenticator: Authenticator, val authorizer: Authorizer, val config: MarathonConf)
       extends AuthResource {
+      val executionContext = scala.concurrent.ExecutionContext.global
       def foo(request: HttpServletRequest): Response = authenticated(request) { identity =>
         Response.ok("foo").build()
       }

--- a/src/test/scala/mesosphere/marathon/api/AuthResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/AuthResourceTest.scala
@@ -7,10 +7,11 @@ import javax.ws.rs.core.Response
 import mesosphere.UnitTest
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, Identity}
 import mesosphere.marathon.plugin.http.{HttpRequest, HttpResponse}
+import mesosphere.marathon.test.JerseyTest
 
 import scala.concurrent.Future
 
-class AuthResourceTest extends UnitTest {
+class AuthResourceTest extends UnitTest with JerseyTest {
   "AuthResource" should {
     "authenticated returns service unavailable if the authenticator returns an exception" in {
       Given("An authenticator that always throws an exception")
@@ -18,7 +19,7 @@ class AuthResourceTest extends UnitTest {
       val resource = new TestResource(f.brokenAuthenticator, f.auth.auth, f.config)
 
       When("we try to authenticate a request")
-      val response = resource.foo(f.auth.request)
+      val response = syncRequest { resource.foo(f.auth.request) }
 
       Then("we receive a service unavailable response")
       response.getStatus should be(Response.Status.SERVICE_UNAVAILABLE.getStatusCode)
@@ -30,7 +31,7 @@ class AuthResourceTest extends UnitTest {
       val resource = new TestResource(f.auth.auth, f.auth.auth, f.config)
 
       When("we try to authenticate a request")
-      val response = resource.foo(f.auth.request)
+      val response = syncRequest { resource.foo(f.auth.request) }
 
       Then("we receive an ok response")
       response.getStatus should be(Response.Status.OK.getStatusCode)
@@ -44,7 +45,7 @@ class AuthResourceTest extends UnitTest {
       val resource = new TestResource(f.auth.auth, f.auth.auth, f.config)
 
       When("we try to authenticate a request")
-      val response = resource.foo(f.auth.request)
+      val response = syncRequest { resource.foo(f.auth.request) }
 
       Then("we receive a forbidden response")
       response.getStatus should be (Response.Status.FORBIDDEN.getStatusCode)

--- a/src/test/scala/mesosphere/marathon/api/SystemResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/SystemResourceTest.scala
@@ -5,12 +5,13 @@ import akka.actor.ActorSystem
 import ch.qos.logback.classic.{Level, Logger}
 import javax.ws.rs.core.{MediaType, Request, Variant}
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.test.JerseyTest
 import org.slf4j.LoggerFactory
 import org.mockito.Matchers
 import org.mockito.Mockito.when
 import play.api.libs.json.{JsDefined, JsObject, JsString, Json}
 
-class SystemResourceTest extends AkkaUnitTest {
+class SystemResourceTest extends AkkaUnitTest with JerseyTest {
   class Fixture {
     val auth = new TestAuthFixture
     val conf = mock[MarathonConf]
@@ -110,17 +111,17 @@ class SystemResourceTest extends AkkaUnitTest {
       auth.authenticated = false
 
       When("we try to fetch metrics")
-      val fetchedMetrics = resource.metrics(auth.request)
+      val fetchedMetrics = syncRequest { resource.metrics(auth.request) }
       Then("we receive a NotAuthenticated response")
       fetchedMetrics.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("we try to get logging")
-      val showLoggers = resource.showLoggers(auth.request)
+      val showLoggers = syncRequest { resource.showLoggers(auth.request) }
       Then("we receive a NotAuthenticated response")
       showLoggers.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("we try to change loggers")
-      val changeLogger = resource.changeLogger("""{ "level": "debug", "logger": "org" }""".getBytes, auth.request)
+      val changeLogger = syncRequest { resource.changeLogger("""{ "level": "debug", "logger": "org" }""".getBytes, auth.request) }
       Then("we receive a NotAuthenticated response")
       changeLogger.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -130,17 +131,17 @@ class SystemResourceTest extends AkkaUnitTest {
       auth.authorized = false
 
       When("we try to fetch metrics")
-      val fetchedMetrics = resource.metrics(auth.request)
+      val fetchedMetrics = syncRequest { resource.metrics(auth.request) }
       Then("we receive a Unauthorized response")
       fetchedMetrics.getStatus should be(auth.UnauthorizedStatus)
 
       When("we try to get logging")
-      val showLoggers = resource.showLoggers(auth.request)
+      val showLoggers = syncRequest { resource.showLoggers(auth.request) }
       Then("we receive a Unauthorized response")
       showLoggers.getStatus should be(auth.UnauthorizedStatus)
 
       When("we try to change loggers")
-      val changeLogger = resource.changeLogger("""{ "level": "debug", "logger": "org" }""".getBytes, auth.request)
+      val changeLogger = syncRequest { resource.changeLogger("""{ "level": "debug", "logger": "org" }""".getBytes, auth.request) }
       Then("we receive a Unauthorized response")
       changeLogger.getStatus should be(auth.UnauthorizedStatus)
     }

--- a/src/test/scala/mesosphere/marathon/api/SystemResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/SystemResourceTest.scala
@@ -15,7 +15,7 @@ class SystemResourceTest extends AkkaUnitTest {
     val auth = new TestAuthFixture
     val conf = mock[MarathonConf]
     val actorSystem = mock[ActorSystem]
-    val resource = new SystemResource(conf, system.settings.config)(auth.auth, auth.auth, actorSystem)
+    val resource = new SystemResource(conf, system.settings.config)(auth.auth, auth.auth, actorSystem, ctx)
   }
 
   "SystemResource" should {

--- a/src/test/scala/mesosphere/marathon/api/v2/AppVersionsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppVersionsResourceTest.scala
@@ -6,6 +6,7 @@ import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{AppDefinition, Timestamp}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class AppVersionsResourceTest extends UnitTest {
 

--- a/src/test/scala/mesosphere/marathon/api/v2/AppVersionsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppVersionsResourceTest.scala
@@ -6,9 +6,10 @@ import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{AppDefinition, Timestamp}
+import mesosphere.marathon.test.JerseyTest
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class AppVersionsResourceTest extends UnitTest {
+class AppVersionsResourceTest extends UnitTest with JerseyTest {
 
   case class Fixture(
       auth: TestAuthFixture = new TestAuthFixture,
@@ -25,12 +26,12 @@ class AppVersionsResourceTest extends UnitTest {
       val req = auth.request
 
       When("the index is fetched")
-      val index = appsVersionsResource.index("appId", req)
+      val index = syncRequest { appsVersionsResource.index("appId", req) }
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one app version is fetched")
-      val show = appsVersionsResource.show("appId", "version", req)
+      val show = syncRequest { appsVersionsResource.show("appId", "version", req) }
       Then("we receive a NotAuthenticated response")
       show.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -43,7 +44,7 @@ class AppVersionsResourceTest extends UnitTest {
 
       groupManager.app("appId".toRootPath) returns Some(AppDefinition("appId".toRootPath))
       When("the index is fetched")
-      val index = appsVersionsResource.index("appId", req)
+      val index = syncRequest { appsVersionsResource.index("appId", req) }
       Then("we receive a not authorized response")
       index.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -56,7 +57,7 @@ class AppVersionsResourceTest extends UnitTest {
 
       groupManager.app("appId".toRootPath) returns None
       When("the index is fetched")
-      val index = appsVersionsResource.index("appId", req)
+      val index = syncRequest { appsVersionsResource.index("appId", req) }
       Then("we receive a 404")
       index.getStatus should be(404)
     }
@@ -70,7 +71,7 @@ class AppVersionsResourceTest extends UnitTest {
       val version = Timestamp.now()
       service.getApp("appId".toRootPath, version) returns Some(AppDefinition("appId".toRootPath))
       When("one app version is fetched")
-      val show = appsVersionsResource.show("appId", version.toString, req)
+      val show = syncRequest { appsVersionsResource.show("appId", version.toString, req) }
       Then("we receive a not authorized response")
       show.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -84,7 +85,7 @@ class AppVersionsResourceTest extends UnitTest {
       val version = Timestamp.now()
       service.getApp("appId".toRootPath, version) returns None
       When("one app version is fetched")
-      val show = appsVersionsResource.show("appId", version.toString, req)
+      val show = syncRequest { appsVersionsResource.show("appId", version.toString, req) }
       Then("we receive a not authorized response")
       show.getStatus should be(404)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/DeploymentsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/DeploymentsResourceTest.scala
@@ -9,6 +9,7 @@ import mesosphere.marathon.state.{AppDefinition, PathId}
 import mesosphere.marathon.test.GroupCreation
 
 import scala.collection.immutable.Seq
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class DeploymentsResourceTest extends UnitTest with GroupCreation {

--- a/src/test/scala/mesosphere/marathon/api/v2/DeploymentsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/DeploymentsResourceTest.scala
@@ -6,13 +6,13 @@ import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.deployment.{DeploymentPlan, DeploymentStep, DeploymentStepInfo}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.state.{AppDefinition, PathId}
-import mesosphere.marathon.test.GroupCreation
+import mesosphere.marathon.test.{GroupCreation, JerseyTest}
 
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class DeploymentsResourceTest extends UnitTest with GroupCreation {
+class DeploymentsResourceTest extends UnitTest with GroupCreation with JerseyTest {
 
   case class Fixture(
       service: MarathonSchedulerService = mock[MarathonSchedulerService],
@@ -33,12 +33,12 @@ class DeploymentsResourceTest extends UnitTest with GroupCreation {
       service.listRunningDeployments() returns Future.successful(Seq(deployment))
 
       When("the index is fetched")
-      val running = deploymentsResource.running(req)
+      val running = syncRequest { deploymentsResource.running(req) }
       Then("we receive a NotAuthenticated response")
       running.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one app version is fetched")
-      val cancel = deploymentsResource.cancel(deployment.plan.id, false, req)
+      val cancel = syncRequest { deploymentsResource.cancel(deployment.plan.id, false, req) }
       Then("we receive a NotAuthenticated response")
       cancel.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -54,7 +54,7 @@ class DeploymentsResourceTest extends UnitTest with GroupCreation {
       service.listRunningDeployments() returns Future.successful(Seq(deployment))
 
       When("one app version is fetched")
-      val cancel = deploymentsResource.cancel(deployment.plan.id, false, req)
+      val cancel = syncRequest { deploymentsResource.cancel(deployment.plan.id, false, req) }
       Then("we receive a not authorized response")
       cancel.getStatus should be(auth.UnauthorizedStatus)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -33,7 +33,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation {
     config.availableFeatures returns Set.empty
     config.defaultNetworkName returns ScallopStub(None)
     config.mesosBridgeName returns ScallopStub(Some("default-mesos-bridge-name"))
-    val groupsResource: GroupsResource = new GroupsResource(groupManager, groupInfo, config, groupApiService)(auth.auth, auth.auth, mat)
+    val groupsResource: GroupsResource = new GroupsResource(groupManager, groupInfo, config, groupApiService)(auth.auth, auth.auth, mat, ctx)
   }
 
   case class FixtureWithRealGroupManager(
@@ -49,7 +49,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation {
 
     implicit val authorizer = auth.auth
 
-    val groupsResource: GroupsResource = new GroupsResource(groupManager, groupInfo, config, new GroupApiService(groupManager))(auth.auth, auth.auth, mat)
+    val groupsResource: GroupsResource = new GroupsResource(groupManager, groupInfo, config, new GroupApiService(groupManager))(auth.auth, auth.auth, mat, ctx)
   }
 
   "GroupsResource" should {

--- a/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
 import mesosphere.util.state.MesosLeaderInfo
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class InfoResourceTest extends UnitTest {
 

--- a/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
@@ -6,10 +6,11 @@ import mesosphere.marathon.HttpConf
 import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
+import mesosphere.marathon.test.JerseyTest
 import mesosphere.util.state.MesosLeaderInfo
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class InfoResourceTest extends UnitTest {
+class InfoResourceTest extends UnitTest with JerseyTest {
 
   "InfoResource" should {
     "access without authentication is denied" in {
@@ -19,7 +20,7 @@ class InfoResourceTest extends UnitTest {
       f.auth.authenticated = false
 
       When("we try to fetch the info")
-      val index = resource.index(f.auth.request)
+      val index = syncRequest { resource.index(f.auth.request) }
 
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(f.auth.NotAuthenticatedStatus)
@@ -33,7 +34,7 @@ class InfoResourceTest extends UnitTest {
       f.auth.authorized = false
 
       When("we try to fetch the info")
-      val index = resource.index(f.auth.request)
+      val index = syncRequest { resource.index(f.auth.request) }
 
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(f.auth.UnauthorizedStatus)

--- a/src/test/scala/mesosphere/marathon/api/v2/LeaderResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/LeaderResourceTest.scala
@@ -8,11 +8,11 @@ import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.async.ExecutionContexts
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.storage.repository.RuntimeConfigurationRepository
-import mesosphere.marathon.test.{SettableClock, SimulatedScheduler}
+import mesosphere.marathon.test.{JerseyTest, SettableClock, SimulatedScheduler}
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class LeaderResourceTest extends UnitTest {
+class LeaderResourceTest extends UnitTest with JerseyTest {
 
   "LeaderResource" should {
     "access without authentication is denied" in {
@@ -22,12 +22,12 @@ class LeaderResourceTest extends UnitTest {
       f.auth.authenticated = false
 
       When("we try to get the leader info")
-      val index = resource.index(f.auth.request)
+      val index = syncRequest { resource.index(f.auth.request) }
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(f.auth.NotAuthenticatedStatus)
 
       When("we try to delete the current leader")
-      val delete = resource.delete(null, null, f.auth.request)
+      val delete = syncRequest { resource.delete(null, null, f.auth.request) }
       Then("we receive a NotAuthenticated response")
       delete.getStatus should be(f.auth.NotAuthenticatedStatus)
     }
@@ -40,12 +40,12 @@ class LeaderResourceTest extends UnitTest {
       f.auth.authorized = false
 
       When("we try to get the leader info")
-      val index = resource.index(f.auth.request)
+      val index = syncRequest { resource.index(f.auth.request) }
       Then("we receive a Unauthorized response")
       index.getStatus should be(f.auth.UnauthorizedStatus)
 
       When("we try to delete the current leader")
-      val delete = resource.delete(null, null, f.auth.request)
+      val delete = syncRequest { resource.delete(null, null, f.auth.request) }
       Then("we receive a Unauthorized response")
       delete.getStatus should be(f.auth.UnauthorizedStatus)
     }
@@ -60,7 +60,7 @@ class LeaderResourceTest extends UnitTest {
       f.runtimeRepo.store(any).returns(Future.successful(Done))
 
       When("we try to delete the current leader")
-      val delete = resource.delete(null, null, f.auth.request)
+      val delete = syncRequest { resource.delete(null, null, f.auth.request) }
       Then("we receive a authorized response")
       delete.getStatus should be(200)
       verify(f.electionService, times(0)).abdicateLeadership()

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -24,7 +24,7 @@ import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer}
 import mesosphere.marathon.raml.{EnvVarSecret, ExecutorResources, FixedPodScalingPolicy, NetworkMode, PersistentVolumeInfo, PersistentVolumeType, Pod, PodPersistentVolume, PodSecretVolume, PodState, PodStatus, Raml, Resources, VolumeMount}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{PathId, Timestamp, UnreachableStrategy, VersionInfo}
-import mesosphere.marathon.test.{Mockito, SettableClock}
+import mesosphere.marathon.test.{JerseyTest, Mockito, SettableClock}
 import mesosphere.marathon.util.SemanticVersion
 import play.api.libs.json._
 
@@ -32,7 +32,7 @@ import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class PodsResourceTest extends AkkaUnitTest with Mockito {
+class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
 
   // TODO(jdef) incorporate checks for firing pod events on C, U, D operations
 
@@ -128,7 +128,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
 
-      val response = f.podsResource.create(podSpecJson.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podSpecJson.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_CREATED)
@@ -153,7 +155,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
 
-      val response = f.podsResource.create(podSpecJsonWithBridgeNetwork.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podSpecJsonWithBridgeNetwork.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_CREATED)
@@ -178,7 +182,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
 
-      val response = f.podsResource.create(podSpecJsonWithFileBasedSecret.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podSpecJsonWithFileBasedSecret.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(422)
@@ -192,7 +198,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
 
-      val response = f.podsResource.create(podSpecJsonWithEnvRefSecret.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podSpecJsonWithEnvRefSecret.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(422)
@@ -206,7 +214,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
 
-      val response = f.podsResource.create(podSpecJsonWithEnvRefSecretOnContainerLevel.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podSpecJsonWithEnvRefSecretOnContainerLevel.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(422)
@@ -220,7 +230,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
 
-      val response = f.podsResource.create(podSpecJsonWithEnvRefSecretOnContainerLevel.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podSpecJsonWithEnvRefSecretOnContainerLevel.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(201)
@@ -239,7 +251,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
 
-      val response = f.podsResource.create(podSpecJsonWithFileBasedSecret.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podSpecJsonWithFileBasedSecret.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(201)
@@ -258,7 +272,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
 
-      val response = f.podsResource.create(podSpecJsonWithContainerNetworking.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podSpecJsonWithContainerNetworking.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_CREATED)
@@ -283,7 +299,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
 
-      val response = f.podsResource.create(podSpecJsonWithContainerNetworking.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podSpecJsonWithContainerNetworking.getBytes(), force = false, f.auth.request, r)
+      }
       response.getStatus shouldBe 422
       response.getEntity.toString should include(NetworkValidationMessages.NetworkNameMustBeSpecified)
     }
@@ -294,7 +312,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.create(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
 
-      val response = f.podsResource.create(podSpecJsonWithExecutorResources.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podSpecJsonWithExecutorResources.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_CREATED)
@@ -327,7 +347,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
                        |     "image": { "kind": "DOCKER", "id": "busybox" },
                        |     "exec": { "command": { "shell": "sleep 1" } } } ] }
                      """.stripMargin
-      val response = f.podsResource.update("/mypod", postJson.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.update("/mypod", postJson.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_OK)
@@ -353,7 +375,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
                        |     "resources": { "cpus": 0.03, "mem": 64 },
                        |     "exec": { "command": { "shell": "sleep 1" } } } ] }
                      """.stripMargin
-      val response = f.podsResource.update("/mypod", postJson.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.update("/mypod", postJson.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_OK)
@@ -392,7 +416,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           |   } ] }
         """.stripMargin
 
-      val response = f.podsResource.update("/mypod", podSpecJsonWithPersistentVolume.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.update("/mypod", podSpecJsonWithPersistentVolume.getBytes(), force = false, f.auth.request, r)
+      }
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_OK)
 
@@ -429,7 +455,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           |   } ] }
         """.stripMargin
 
-      val response = f.podsResource.update("/mypod", podSpecJsonWithPersistentVolume.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.update("/mypod", podSpecJsonWithPersistentVolume.getBytes(), force = false, f.auth.request, r)
+      }
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(422)
         response.getEntity.toString should include("unreachableStrategy must be disabled for pods with persistent volumes")
@@ -459,7 +487,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           |   } ] }
         """.stripMargin
 
-      val response = f.podsResource.update("/mypod", podSpecJsonWithPersistentVolume.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.update("/mypod", podSpecJsonWithPersistentVolume.getBytes(), force = false, f.auth.request, r)
+      }
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(422)
         response.getEntity.toString should include("/upgrade/maximumOverCapacity")
@@ -490,7 +520,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           |   } ] }
         """.stripMargin
 
-      val response = f.podsResource.update("/mypod", podSpecJsonWithPersistentVolume.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.update("/mypod", podSpecJsonWithPersistentVolume.getBytes(), force = false, f.auth.request, r)
+      }
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(422)
         response.getEntity.toString should include("/acceptedResourceRoles")
@@ -504,7 +536,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
 
       podSystem.find(any).returns(Some(PodDefinition()))
       podSystem.delete(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
-      val response = f.podsResource.remove("/mypod", force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.remove("/mypod", force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_ACCEPTED)
@@ -617,7 +651,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           |}
         """.stripMargin
 
-      val response = f.podsResource.create(podJson.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podJson.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_CREATED)
@@ -676,7 +712,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           |}
         """.stripMargin
 
-      val response = f.podsResource.create(podJson.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podJson.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(422)
@@ -721,7 +759,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           |}
         """.stripMargin
 
-      val response = f.podsResource.create(podJson.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podJson.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(422)
@@ -761,7 +801,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           |}
         """.stripMargin
 
-      val response = f.podsResource.create(podJson.getBytes(), force = false, f.auth.request)
+      val response = asyncRequest { r =>
+        f.podsResource.create(podJson.getBytes(), force = false, f.auth.request, r)
+      }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(422)
@@ -849,7 +891,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
             None
           )
           killer.kill(any, any, any)(any) returns Future.successful(Seq(instance))
-          val response = f.podsResource.killInstance("/id", instance.instanceId.idString, f.auth.request)
+          val response = asyncRequest { r =>
+            f.podsResource.killInstance("/id", instance.instanceId.idString, f.auth.request, r)
+          }
           withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_OK)
             val killed = Json.fromJson[Instance](Json.parse(response.getEntity.asInstanceOf[String]))
@@ -874,9 +918,10 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           val f = Fixture()
 
           killer.kill(any, any, any)(any) returns Future.successful(instances)
-          val response = f.podsResource.killInstances(
-            "/id",
-            Json.stringify(Json.toJson(instances.map(_.instanceId.idString))).getBytes, f.auth.request)
+          val response = asyncRequest { r =>
+            f.podsResource.killInstances(
+              "/id", Json.stringify(Json.toJson(instances.map(_.instanceId.idString))).getBytes, f.auth.request, r)
+          }
           withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_OK)
             val killed = Json.fromJson[Seq[Instance]](Json.parse(response.getEntity.asInstanceOf[String]))
@@ -894,7 +939,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
           podSystem.find(any).returns(Some(PodDefinition()))
           podSystem.delete(any, eq(false)).returns(Future.successful(DeploymentPlan.empty))
           f.auth.authorized = false
-          val response = f.podsResource.remove("/mypod", force = false, f.auth.request)
+          val response = asyncRequest { r =>
+            f.podsResource.remove("/mypod", force = false, f.auth.request, r)
+          }
           response.getStatus should be(HttpServletResponse.SC_UNAUTHORIZED)
         }
 
@@ -919,32 +966,38 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
         val f = new UnAuthorizedFixture(authorized = false, authenticated = true).fixture
 
         "create a pod" in {
-          val response = f.podsResource.create(podSpecJson.getBytes, force = false, f.auth.request)
+          val response = asyncRequest { r =>
+            f.podsResource.create(podSpecJson.getBytes, force = false, f.auth.request, r)
+          }
           response.getStatus should be(HttpServletResponse.SC_UNAUTHORIZED)
         }
 
         "update a pod" in {
-          val response = f.podsResource.update("mypod", podSpecJson.getBytes, force = false, f.auth.request)
+          val response = asyncRequest { r =>
+            f.podsResource.update("mypod", podSpecJson.getBytes, force = false, f.auth.request, r)
+          }
           response.getStatus should be(HttpServletResponse.SC_UNAUTHORIZED)
         }
 
         "find a pod" in {
-          val response = f.podsResource.find("mypod", f.auth.request)
+          val response = syncRequest { f.podsResource.find("mypod", f.auth.request) }
           response.getStatus should be(HttpServletResponse.SC_UNAUTHORIZED)
         }
 
         "remove a pod" in {
-          val response = f.podsResource.remove("mypod", force = false, f.auth.request)
+          val response = asyncRequest { r =>
+            f.podsResource.remove("mypod", force = false, f.auth.request, r)
+          }
           response.getStatus should be(HttpServletResponse.SC_UNAUTHORIZED)
         }
 
         "versions of a pod" in {
-          val response = f.podsResource.versions("mypod", f.auth.request)
+          val response = syncRequest { f.podsResource.versions("mypod", f.auth.request) }
           response.getStatus should be(HttpServletResponse.SC_UNAUTHORIZED)
         }
 
         "version of a pod" in {
-          val response = f.podsResource.version("mypod", Timestamp.now().toString, f.auth.request)
+          val response = syncRequest { f.podsResource.version("mypod", Timestamp.now().toString, f.auth.request) }
           response.getStatus should be(HttpServletResponse.SC_UNAUTHORIZED)
         }
       }
@@ -953,37 +1006,43 @@ class PodsResourceTest extends AkkaUnitTest with Mockito {
         val f = new UnAuthorizedFixture(authorized = false, authenticated = false).fixture
 
         "create a pod" in {
-          val response = f.podsResource.create(podSpecJson.getBytes, force = false, f.auth.request)
+          val response = asyncRequest { r =>
+            f.podsResource.create(podSpecJson.getBytes, force = false, f.auth.request, r)
+          }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
 
         "update a pod" in {
-          val response = f.podsResource.update("mypod", podSpecJson.getBytes, force = false, f.auth.request)
+          val response = asyncRequest { r =>
+            f.podsResource.update("mypod", podSpecJson.getBytes, force = false, f.auth.request, r)
+          }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
 
         "find a pod" in {
-          val response = f.podsResource.find("mypod", f.auth.request)
+          val response = syncRequest { f.podsResource.find("mypod", f.auth.request) }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
 
         "remove a pod" in {
-          val response = f.podsResource.remove("mypod", force = false, f.auth.request)
+          val response = asyncRequest { r =>
+            f.podsResource.remove("mypod", force = false, f.auth.request, r)
+          }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
 
         "status of a pod" in {
-          val response = f.podsResource.status("mypod", f.auth.request)
+          val response = syncRequest { f.podsResource.status("mypod", f.auth.request) }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
 
         "versions of a pod" in {
-          val response = f.podsResource.versions("mypod", f.auth.request)
+          val response = syncRequest { f.podsResource.versions("mypod", f.auth.request) }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
 
         "version of a pod" in {
-          val response = f.podsResource.version("mypod", Timestamp.now().toString, f.auth.request)
+          val response = syncRequest { f.podsResource.version("mypod", Timestamp.now().toString, f.auth.request) }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
       }

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -15,6 +15,7 @@ import mesosphere.mesos.NoOfferMatchReason
 import play.api.libs.json._
 
 import scala.collection.immutable.Seq
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 

--- a/src/test/scala/mesosphere/marathon/test/JerseyTest.scala
+++ b/src/test/scala/mesosphere/marathon/test/JerseyTest.scala
@@ -1,0 +1,75 @@
+package mesosphere.marathon
+package test
+
+import java.lang.{Exception => JavaException}
+import java.util.concurrent.TimeUnit
+import javax.ws.rs.container.AsyncResponse
+import javax.ws.rs.core.Response
+import mesosphere.marathon.api.MarathonExceptionMapper
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.exceptions.TestFailedException
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Try, Success, Failure}
+
+trait JerseyTest extends ScalaFutures {
+  def mapException(e: JavaException): Response = {
+    val exceptionMapper = new MarathonExceptionMapper()
+    exceptionMapper.toResponse(e)
+  }
+
+  def syncRequest(fn: => Response): Response = {
+    try fn
+    catch {
+      case e: JavaException => mapException(e)
+    }
+  }
+
+  def asyncRequest(fn: AsyncResponse => Unit)(implicit ec: ExecutionContext): Response = {
+    val ar = new JerseyTest.TestAsyncResponse()
+    Try(fn(ar)).
+      flatMap { _ =>
+        ar.response.transform({ t => Success(t) }).futureValue
+      } match {
+        case Success(r) => r
+        case Failure(e: JavaException) => mapException(e)
+        case Failure(e) => throw new TestFailedException(e, 1)
+      }
+  }
+}
+
+object JerseyTest {
+  class TestAsyncResponse(implicit ec: ExecutionContext) extends AsyncResponse {
+    import java.util.{Map, Collection, Date}
+    import javax.ws.rs.container.TimeoutHandler
+
+    private val _result = Promise[Object]
+
+    def response: Future[Response] = _result.future.transform {
+      case Success(r: Response) => Success(r)
+      case Success(o) => Failure(new RuntimeException("did not complete with a response"))
+      case Failure(ex) => Failure(ex)
+    }
+
+    override def resume(response: Object): Boolean = {
+      _result.success(response)
+      true
+    }
+    override def resume(response: Throwable): Boolean = {
+      _result.failure(response)
+      true
+    }
+
+    override def cancel(): Boolean = ???
+    override def cancel(retryAfter: Int): Boolean = ???
+    override def cancel(retryAfter: Date): Boolean = ???
+    override def isSuspended(): Boolean = ???
+    override def isCancelled(): Boolean = ???
+    override def isDone(): Boolean = _result.isCompleted
+    override def setTimeout(time: Long, unit: TimeUnit): Boolean = ???
+    override def setTimeoutHandler(handler: TimeoutHandler): Unit = ???
+    override def register(callback: Class[_]): Collection[Class[_]] = ???
+    override def register(callback: Class[_], callbacks: Class[_]*): Map[Class[_], Collection[Class[_]]] = ???
+    override def register(callback: Object): Collection[Class[_]] = ???
+    override def register(callback: Any, callbacks: Object*): java.util.Map[Class[_], Collection[Class[_]]] = ???
+  }
+}

--- a/src/test/scala/mesosphere/marathon/test/JerseyTest.scala
+++ b/src/test/scala/mesosphere/marathon/test/JerseyTest.scala
@@ -17,6 +17,9 @@ trait JerseyTest extends ScalaFutures {
     exceptionMapper.toResponse(e)
   }
 
+  /**
+    * Call a synchronous Jersey controller method. Maps any thrown exceptions to responses using MarathonExceptionMapper
+    */
   def syncRequest(fn: => Response): Response = {
     try fn
     catch {
@@ -24,6 +27,10 @@ trait JerseyTest extends ScalaFutures {
     }
   }
 
+  /**
+    * Instantiate an AsyncResponse for calling an asynchronous Jersey controller method. Maps any thrown exceptions /
+    * asyncResponse failures to responses using MarathonExceptionMapper.
+    */
   def asyncRequest(fn: AsyncResponse => Unit)(implicit ec: ExecutionContext): Response = {
     val ar = new JerseyTest.TestAsyncResponse()
     Try(fn(ar)).
@@ -38,6 +45,9 @@ trait JerseyTest extends ScalaFutures {
 }
 
 object JerseyTest {
+  /**
+    * Stub AsyncResource used for testing asynchronous Jersey controller methods.
+    */
   class TestAsyncResponse(implicit ec: ExecutionContext) extends AsyncResponse {
     import java.util.{Map, Collection, Date}
     import javax.ws.rs.container.TimeoutHandler


### PR DESCRIPTION
In this change we convert deployment creating API methods to use Jersey 2 AsyncResponse. By doing this, we no longer timeout ("Futures timed out"); if a deployment takes 2 minutes to schedule, and the HTTP client does not have a shorter receive timeout configured, then the response will be delivered after 2 minutes.

Also, we consolidate some response logic, converging places where there were multiple response generators to just simply prefer the MarathonExceptionMapper instead.

JIRA Issues: MARATHON-8174