### PR TITLE
Introduced a sclariform rule for multi-import formatting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val formatSettings = Seq(
     .setPreference(DoubleIndentConstructorArguments, true)
     .setPreference(PlaceScaladocAsterisksBeneathSecondAsterisk, true)
     .setPreference(PreserveSpaceBeforeArguments, true)
+    .setPreference(SpacesAroundMultiImports, false)
 )
 
 // Pass arguments to Scalatest runner:

--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/Authenticator.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/Authenticator.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package plugin.auth
 
-import mesosphere.marathon.plugin.http.{ HttpRequest, HttpResponse }
+import mesosphere.marathon.plugin.http.{HttpRequest, HttpResponse}
 import mesosphere.marathon.plugin.plugin.Plugin
 
 import scala.concurrent.Future

--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/AuthorizedAction.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/auth/AuthorizedAction.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package plugin.auth
 
-import mesosphere.marathon.plugin.{ Group, RunSpec }
+import mesosphere.marathon.plugin.{Group, RunSpec}
 
 /**
   * Base trait for all actions in the system.

--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/http/HttpRequestHandlerBase.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/http/HttpRequestHandlerBase.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package plugin.http
 
-import java.net.{ URL, URLConnection }
+import java.net.{URL, URLConnection}
 import com.google.common.io.Resources
 
 /**

--- a/plugin-interface/src/main/scala/mesosphere/marathon/plugin/task/RunSpecTaskProcessor.scala
+++ b/plugin-interface/src/main/scala/mesosphere/marathon/plugin/task/RunSpecTaskProcessor.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon
 package plugin.task
 
-import mesosphere.marathon.plugin.{ ApplicationSpec, PodSpec }
+import mesosphere.marathon.plugin.{ApplicationSpec, PodSpec}
 import mesosphere.marathon.plugin.plugin.Plugin
-import org.apache.mesos.Protos.{ ExecutorInfo, TaskGroupInfo, TaskInfo }
+import org.apache.mesos.Protos.{ExecutorInfo, TaskGroupInfo, TaskInfo}
 
 /**
   * RunSpecTaskProcessor mutates a Mesos task info given some app specification.

--- a/src/main/scala/mesosphere/marathon/BuildInfo.scala
+++ b/src/main/scala/mesosphere/marathon/BuildInfo.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon
 
-import java.util.jar.{ Attributes, Manifest }
+import java.util.jar.{Attributes, Manifest}
 import scala.Predef._
 import scala.util.control.NonFatal
 import mesosphere.marathon.stream.Implicits._

--- a/src/main/scala/mesosphere/marathon/DebugConf.scala
+++ b/src/main/scala/mesosphere/marathon/DebugConf.scala
@@ -2,14 +2,14 @@ package mesosphere.marathon
 
 import java.net.URI
 
-import ch.qos.logback.classic.{ AsyncAppender, Level, LoggerContext }
+import ch.qos.logback.classic.{AsyncAppender, Level, LoggerContext}
 import ch.qos.logback.core.net.ssl.SSLConfiguration
 import com.getsentry.raven.logback.SentryAppender
 import com.google.inject.AbstractModule
 import net.logstash.logback.appender._
 import net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider
 import org.rogach.scallop.ScallopConf
-import org.slf4j.{ Logger, LoggerFactory }
+import org.slf4j.{Logger, LoggerFactory}
 
 /**
   * Options related to debugging marathon.

--- a/src/main/scala/mesosphere/marathon/Exception.scala
+++ b/src/main/scala/mesosphere/marathon/Exception.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 
 import com.wix.accord.Failure
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 
 @SuppressWarnings(Array("NullAssignment"))
 class Exception(msg: String, cause: Throwable = null) extends scala.RuntimeException(msg, cause)

--- a/src/main/scala/mesosphere/marathon/FeaturesConf.scala
+++ b/src/main/scala/mesosphere/marathon/FeaturesConf.scala
@@ -1,6 +1,6 @@
 package mesosphere.marathon
 
-import org.rogach.scallop.{ ScallopConf, ScallopOption }
+import org.rogach.scallop.{ScallopConf, ScallopOption}
 
 trait FeaturesConf extends ScallopConf {
 

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -3,8 +3,8 @@ package mesosphere.marathon
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
 import com.google.common.util.concurrent.ServiceManager
-import com.google.inject.{ Guice, Module }
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.google.inject.{Guice, Module}
+import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.api.LeaderProxyFilterModule
 import org.eclipse.jetty.servlets.EventSourceServlet

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -3,7 +3,7 @@ package mesosphere.marathon
 import mesosphere.marathon.core.appinfo.AppInfoConfig
 import mesosphere.marathon.core.deployment.DeploymentConfig
 import mesosphere.marathon.core.event.EventConf
-import mesosphere.marathon.core.flow.{ LaunchTokenConfig, ReviveOffersConfig }
+import mesosphere.marathon.core.flow.{LaunchTokenConfig, ReviveOffersConfig}
 import mesosphere.marathon.core.group.GroupManagerConfig
 import mesosphere.marathon.core.heartbeat.MesosHeartbeatMonitor
 import mesosphere.marathon.core.launcher.OfferProcessorConfig
@@ -17,7 +17,7 @@ import mesosphere.marathon.core.task.update.TaskStatusUpdateConfig
 import mesosphere.marathon.state.ResourceRole
 import mesosphere.marathon.storage.StorageConf
 import mesosphere.mesos.MatcherConf
-import org.rogach.scallop.{ ScallopConf, ScallopOption }
+import org.rogach.scallop.{ScallopConf, ScallopOption}
 
 import scala.sys.SystemProperties
 

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -17,7 +17,7 @@ import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.heartbeat._
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.termination.KillService
-import mesosphere.marathon.storage.repository.{ DeploymentRepository, GroupRepository }
+import mesosphere.marathon.storage.repository.{DeploymentRepository, GroupRepository}
 import mesosphere.util.state._
 
 import scala.concurrent.duration.FiniteDuration

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -3,17 +3,17 @@ package mesosphere.marathon
 import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.base._
-import mesosphere.marathon.core.event.{ SchedulerRegisteredEvent, _ }
+import mesosphere.marathon.core.event.{SchedulerRegisteredEvent, _}
 import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
-import mesosphere.marathon.state.{ FaultDomain, Region, Zone }
+import mesosphere.marathon.state.{FaultDomain, Region, Zone}
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.util.SemanticVersion
 import mesosphere.mesos.LibMesos
-import mesosphere.util.state.{ FrameworkId, MesosLeaderInfo }
+import mesosphere.util.state.{FrameworkId, MesosLeaderInfo}
 import org.apache.mesos.Protos._
-import org.apache.mesos.{ Scheduler, SchedulerDriver }
+import org.apache.mesos.{Scheduler, SchedulerDriver}
 
 import scala.concurrent._
 import scala.util.control.NonFatal

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -3,32 +3,32 @@ package mesosphere.marathon
 import akka.Done
 import akka.actor._
 import akka.pattern.pipe
-import akka.event.{ EventStream, LoggingReceive }
+import akka.event.{EventStream, LoggingReceive}
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.deployment.{ DeploymentManager, DeploymentPlan, ScalingProposition }
-import mesosphere.marathon.core.election.{ ElectionService, LeadershipTransition }
+import mesosphere.marathon.core.deployment.{DeploymentManager, DeploymentPlan, ScalingProposition}
+import mesosphere.marathon.core.election.{ElectionService, LeadershipTransition}
 import mesosphere.marathon.core.event.DeploymentSuccess
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
+import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{ PathId, RunSpec }
-import mesosphere.marathon.storage.repository.{ DeploymentRepository, GroupRepository }
+import mesosphere.marathon.state.{PathId, RunSpec}
+import mesosphere.marathon.storage.repository.{DeploymentRepository, GroupRepository}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.Constraints
 import org.apache.mesos
-import org.apache.mesos.Protos.{ Status, TaskState }
+import org.apache.mesos.Protos.{Status, TaskState}
 import org.apache.mesos.SchedulerDriver
 
-import scala.async.Async.{ async, await }
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.async.Async.{async, await}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 class MarathonSchedulerActor private (
     groupRepository: GroupRepository,

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
@@ -3,8 +3,8 @@ package mesosphere.marathon
 import java.io.FileInputStream
 
 import com.google.protobuf.ByteString
-import org.apache.mesos.Protos.{ Credential, FrameworkID, FrameworkInfo }
-import org.apache.mesos.{ MesosSchedulerDriver, Scheduler, SchedulerDriver }
+import org.apache.mesos.Protos.{Credential, FrameworkID, FrameworkInfo}
+import org.apache.mesos.{MesosSchedulerDriver, Scheduler, SchedulerDriver}
 import FrameworkInfo.Capability
 import com.typesafe.scalalogging.StrictLogging
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -1,31 +1,31 @@
 package mesosphere.marathon
 
 import java.util.concurrent.CountDownLatch
-import java.util.{ Timer, TimerTask }
+import java.util.{Timer, TimerTask}
 
-import javax.inject.{ Inject, Named }
+import javax.inject.{Inject, Named}
 import akka.Done
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.actor.{ActorRef, ActorSystem}
 import akka.stream.Materializer
 import akka.util.Timeout
 import com.google.common.util.concurrent.AbstractExecutionThreadService
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.MarathonSchedulerActor._
-import mesosphere.marathon.core.deployment.{ DeploymentManager, DeploymentPlan, DeploymentStepInfo }
-import mesosphere.marathon.core.election.{ ElectionCandidate, ElectionService }
+import mesosphere.marathon.core.deployment.{DeploymentManager, DeploymentPlan, DeploymentStepInfo}
+import mesosphere.marathon.core.election.{ElectionCandidate, ElectionService}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.heartbeat._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.leadership.LeadershipCoordinator
 import mesosphere.marathon.core.storage.store.PersistenceStore
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
+import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
 import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.stream.Sink
 import mesosphere.util.PromiseActor
 import org.apache.mesos.SchedulerDriver
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{Await, Future}
 import scala.util.Failure
 
 /**

--- a/src/main/scala/mesosphere/marathon/MetricsModule.scala
+++ b/src/main/scala/mesosphere/marathon/MetricsModule.scala
@@ -5,9 +5,9 @@ import java.lang.management.ManagementFactory
 
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.jetty9.InstrumentedHandler
-import com.codahale.metrics.jvm.{ BufferPoolMetricSet, GarbageCollectorMetricSet, MemoryUsageGaugeSet, ThreadStatesGaugeSet }
-import javax.servlet.{ ServletContextEvent, ServletContextListener }
-import org.eclipse.jetty.server.handler.{ HandlerCollection, RequestLogHandler }
+import com.codahale.metrics.jvm.{BufferPoolMetricSet, GarbageCollectorMetricSet, MemoryUsageGaugeSet, ThreadStatesGaugeSet}
+import javax.servlet.{ServletContextEvent, ServletContextListener}
+import org.eclipse.jetty.server.handler.{HandlerCollection, RequestLogHandler}
 import org.eclipse.jetty.servlet.ServletContextHandler
 
 class MetricsModule() {

--- a/src/main/scala/mesosphere/marathon/SchedulerDriverFactory.scala
+++ b/src/main/scala/mesosphere/marathon/SchedulerDriverFactory.scala
@@ -4,7 +4,7 @@ import com.typesafe.scalalogging.StrictLogging
 import javax.inject.Inject
 
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
-import org.apache.mesos.{ Scheduler, SchedulerDriver }
+import org.apache.mesos.{Scheduler, SchedulerDriver}
 
 import scala.concurrent.Await
 

--- a/src/main/scala/mesosphere/marathon/api/AuthResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/AuthResource.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.AccessDeniedException
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.plugin.http.HttpResponse
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 /**
   * Base trait for authentication and authorization in http resource endpoints.

--- a/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/CORSFilter.scala
@@ -3,7 +3,7 @@ package api
 
 import javax.inject.Inject
 import javax.servlet._
-import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import mesosphere.marathon.stream.Implicits._
 

--- a/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
+++ b/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
@@ -3,11 +3,11 @@ package api
 
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.raml.{ GroupConversion, Raml }
+import mesosphere.marathon.raml.{GroupConversion, Raml}
 import mesosphere.marathon.state._
 
 import scala.async.Async._
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 class GroupApiService(groupManager: GroupManager)(implicit authorizer: Authorizer, executionContext: ExecutionContext) {
 

--- a/src/main/scala/mesosphere/marathon/api/HttpBindings.scala
+++ b/src/main/scala/mesosphere/marathon/api/HttpBindings.scala
@@ -3,8 +3,8 @@ package api
 
 import com.sun.jersey.spi.container.servlet.ServletContainer
 import java.util.EnumSet
-import javax.servlet.{ DispatcherType, Filter, Servlet }
-import org.eclipse.jetty.servlet.{ FilterHolder, ServletContextHandler, ServletHolder }
+import javax.servlet.{DispatcherType, Filter, Servlet}
+import org.eclipse.jetty.servlet.{FilterHolder, ServletContextHandler, ServletHolder}
 import org.eclipse.jetty.servlets.EventSourceServlet
 
 /**

--- a/src/main/scala/mesosphere/marathon/api/HttpModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/HttpModule.scala
@@ -9,9 +9,9 @@ import org.eclipse.jetty.security._
 import org.eclipse.jetty.security.authentication.BasicAuthenticator
 import org.eclipse.jetty.server._
 import org.eclipse.jetty.server.handler.gzip.GzipHandler
-import org.eclipse.jetty.server.handler.{ HandlerCollection, RequestLogHandler }
-import org.eclipse.jetty.servlet.{ ServletContextHandler }
-import org.eclipse.jetty.util.security.{ Constraint, Password }
+import org.eclipse.jetty.server.handler.{HandlerCollection, RequestLogHandler}
+import org.eclipse.jetty.servlet.{ServletContextHandler}
+import org.eclipse.jetty.util.security.{Constraint, Password}
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.rogach.scallop.ScallopOption
 

--- a/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
@@ -1,12 +1,12 @@
 package mesosphere.marathon
 package api
 
-import java.io.{ IOException, InputStream, OutputStream }
+import java.io.{IOException, InputStream, OutputStream}
 import java.net._
 import javax.inject.Named
 import javax.net.ssl._
 import javax.servlet._
-import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import akka.Done
 import akka.http.scaladsl.model.StatusCodes._
@@ -20,7 +20,7 @@ import mesosphere.marathon.stream.Implicits._
 
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 /**
   * Servlet filter that proxies requests to the leader if we are not the leader.

--- a/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala
@@ -1,12 +1,11 @@
 package mesosphere.marathon
 package api
 
-import java.lang.{ Exception => JavaException }
-
+import java.lang.{Exception => JavaException}
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.Response.Status
-import javax.ws.rs.core.{ MediaType, Response }
-import javax.ws.rs.ext.{ ExceptionMapper, Provider }
+import javax.ws.rs.core.{MediaType, Response}
+import javax.ws.rs.ext.{ExceptionMapper, Provider}
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.google.inject.Singleton
@@ -14,7 +13,7 @@ import com.sun.jersey.api.NotFoundException
 import mesosphere.marathon.api.v2.Validation._
 import akka.http.scaladsl.model.StatusCodes._
 import com.typesafe.scalalogging.StrictLogging
-import play.api.libs.json.{ JsResultException, JsValue, Json }
+import play.api.libs.json.{JsResultException, JsValue, Json}
 
 import scala.concurrent.TimeoutException
 

--- a/src/main/scala/mesosphere/marathon/api/MarathonHttpService.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonHttpService.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package api
 
-import com.google.common.util.concurrent.{ AbstractIdleService, Service }
+import com.google.common.util.concurrent.{AbstractIdleService, Service}
 import com.typesafe.scalalogging.StrictLogging
 import org.eclipse.jetty.server.Server
 

--- a/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
+++ b/src/main/scala/mesosphere/marathon/api/MarathonRestModule.scala
@@ -4,7 +4,7 @@ package api
 import com.google.inject.AbstractModule
 import javax.inject.Named
 
-import com.google.inject.{ Provides, Scopes, Singleton }
+import com.google.inject.{Provides, Scopes, Singleton}
 import mesosphere.marathon.io.SSLContextUtil
 
 /**

--- a/src/main/scala/mesosphere/marathon/api/ResponseFacade.scala
+++ b/src/main/scala/mesosphere/marathon/api/ResponseFacade.scala
@@ -3,7 +3,7 @@ package api
 
 import java.net.URI
 import javax.ws.rs.core.Response.Status
-import javax.ws.rs.core.{ NewCookie, Response }
+import javax.ws.rs.core.{NewCookie, Response}
 
 import mesosphere.marathon.plugin.http.HttpResponse
 

--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -3,19 +3,19 @@ package api
 
 import java.net.URI
 import javax.ws.rs.core.Response
-import javax.ws.rs.core.Response.{ ResponseBuilder, Status }
+import javax.ws.rs.core.Response.{ResponseBuilder, Status}
 
 import akka.http.scaladsl.model.StatusCodes
 import com.wix.accord._
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.core.deployment.DeploymentPlan
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json._
 
-import scala.concurrent.{ Await, Awaitable }
+import scala.concurrent.{Await, Awaitable}
 
 trait RestResource extends JaxResource {
 

--- a/src/main/scala/mesosphere/marathon/api/SystemResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/SystemResource.scala
@@ -3,18 +3,18 @@ package api
 
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{ Context, MediaType, Request, Response, Variant }
+import javax.ws.rs.core.{Context, MediaType, Request, Response, Variant}
 
 import akka.actor.ActorSystem
-import ch.qos.logback.classic.{ Level, Logger, LoggerContext }
+import ch.qos.logback.classic.{Level, Logger, LoggerContext}
 import com.google.inject.Inject
-import com.typesafe.config.{ Config, ConfigRenderOptions }
+import com.typesafe.config.{Config, ConfigRenderOptions}
 import com.typesafe.scalalogging.StrictLogging
 import com.wix.accord.Validator
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.plugin.auth.AuthorizedResource.SystemConfig
-import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, UpdateResource, ViewResource }
-import mesosphere.marathon.raml.{ LoggerChange, Raml }
+import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, UpdateResource, ViewResource}
+import mesosphere.marathon.raml.{LoggerChange, Raml}
 import mesosphere.marathon.raml.MetricsConversion._
 import org.slf4j.LoggerFactory
 import play.api.libs.json.Json

--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -9,12 +9,12 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
+import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, Identity, UpdateRunSpec }
+import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, Identity, UpdateRunSpec}
 import mesosphere.marathon.state._
 
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 

--- a/src/main/scala/mesosphere/marathon/api/WebJarServlet.scala
+++ b/src/main/scala/mesosphere/marathon/api/WebJarServlet.scala
@@ -4,9 +4,9 @@ package api
 import com.typesafe.scalalogging.StrictLogging
 import java.net.URI
 
-import javax.servlet.http.{ HttpServlet, HttpServletRequest, HttpServletResponse }
+import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 import mesosphere.marathon.io.IO
-import com.google.common.io.{ ByteStreams, Closeables }
+import com.google.common.io.{ByteStreams, Closeables}
 
 /**
   * This servlet is used to serve static content from JVM webjars resources in the classpath.
@@ -53,7 +53,7 @@ class WebJarServlet extends HttpServlet with StrictLogging {
     val resourceURI = s"/META-INF/resources/webjars$jar$resource"
     //log request data, since the names are not very intuitive
     logger.debug(
-        s"""
+      s"""
          |pathinfo: ${req.getPathInfo}
          |context: ${req.getContextPath}
          |servlet: ${req.getServletPath}
@@ -65,7 +65,6 @@ class WebJarServlet extends HttpServlet with StrictLogging {
          |mime: $mime
          |resourceURI: $resourceURI
        """.stripMargin)
-
 
     //special rule for accessing root -> redirect to ui main page
     if (req.getRequestURI == "/") sendRedirect(resp, "ui/")

--- a/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package api.serialization
 
 import mesosphere.marathon.core.externalvolume.ExternalVolumes
-import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork, HostNetwork, Network }
+import mesosphere.marathon.core.pod.{BridgeNetwork, ContainerNetwork, HostNetwork, Network}
 import mesosphere.marathon.state.Container.PortMapping
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._

--- a/src/main/scala/mesosphere/marathon/api/serialization/EnvVarRefSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/EnvVarRefSerializer.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package api.serialization
 
 import mesosphere.marathon.Protos
-import mesosphere.marathon.state.{ EnvVarValue, EnvVarSecretRef }
+import mesosphere.marathon.state.{EnvVarValue, EnvVarSecretRef}
 
 object EnvVarRefSerializer {
   def toProto(envVar: (String, EnvVarValue)): Option[Protos.EnvVarReference] = envVar match {

--- a/src/main/scala/mesosphere/marathon/api/serialization/SecretSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/SecretSerializer.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package api.serialization
 
-import org.apache.mesos.{ Protos => mesos }
+import org.apache.mesos.{Protos => mesos}
 
 object SecretSerializer {
   def toSecretReference(secret: String): mesos.Secret = {

--- a/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
@@ -4,11 +4,11 @@ package api.v2
 import com.wix.accord.Validator
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.validation.AppValidation
-import mesosphere.marathon.core.appinfo.{ AppSelector, Selector }
-import mesosphere.marathon.plugin.auth.{ AuthorizedAction, Authorizer, CreateRunSpec, Identity, UpdateRunSpec, ViewRunSpec }
+import mesosphere.marathon.core.appinfo.{AppSelector, Selector}
+import mesosphere.marathon.plugin.auth.{AuthorizedAction, Authorizer, CreateRunSpec, Identity, UpdateRunSpec, ViewRunSpec}
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
-import mesosphere.marathon.state.{ AppDefinition, PathId }
-import mesosphere.marathon.raml.{ AppConversion, AppExternalVolume, AppPersistentVolume, Raml }
+import mesosphere.marathon.state.{AppDefinition, PathId}
+import mesosphere.marathon.raml.{AppConversion, AppExternalVolume, AppPersistentVolume, Raml}
 import mesosphere.marathon.state.Timestamp
 import stream.Implicits._
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package api.v2
 
 import mesosphere.marathon.raml._
-import mesosphere.marathon.state.{ FetchUri, PathId }
+import mesosphere.marathon.state.{FetchUri, PathId}
 import mesosphere.marathon.stream.Implicits._
 
 object AppNormalization {

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -5,7 +5,7 @@ import com.typesafe.scalalogging.StrictLogging
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{ Context, MediaType, Response }
+import javax.ws.rs.core.{Context, MediaType, Response}
 import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api._
 import mesosphere.marathon.core.appinfo.EnrichedTask

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -3,12 +3,12 @@ package api.v2
 
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{ Context, MediaType, Response }
+import javax.ws.rs.core.{Context, MediaType, Response}
 
 import mesosphere.marathon.api.v2.json.Formats._
-import mesosphere.marathon.api.{ AuthResource, MarathonMediaType }
+import mesosphere.marathon.api.{AuthResource, MarathonMediaType}
 import mesosphere.marathon.core.group.GroupManager
-import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, ViewRunSpec }
+import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, ViewRunSpec}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.Timestamp
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -7,12 +7,12 @@ import java.net.URI
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{ Context, MediaType, Response }
+import javax.ws.rs.core.{Context, MediaType, Response}
 
 import akka.event.EventStream
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.json.Formats._
-import mesosphere.marathon.api.{ AuthResource, MarathonMediaType, PATCH, RestResource }
+import mesosphere.marathon.api.{AuthResource, MarathonMediaType, PATCH, RestResource}
 import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.event.ApiPostEvent
 import mesosphere.marathon.core.group.GroupManager
@@ -22,7 +22,7 @@ import mesosphere.marathon.raml.Raml
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
-import play.api.libs.json.{ JsObject, Json }
+import play.api.libs.json.{JsObject, Json}
 
 @Path("v2/apps")
 @Consumes(Array(MediaType.APPLICATION_JSON))

--- a/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
@@ -5,15 +5,15 @@ import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.Response.Status._
-import javax.ws.rs.core.{ Context, MediaType, Response }
+import javax.ws.rs.core.{Context, MediaType, Response}
 
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.api.v2.json.Formats._
-import mesosphere.marathon.api.{ AuthResource, MarathonMediaType }
+import mesosphere.marathon.api.{AuthResource, MarathonMediaType}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.state.PathId
-import mesosphere.marathon.{ MarathonConf, MarathonSchedulerService }
+import mesosphere.marathon.{MarathonConf, MarathonSchedulerService}
 
 @Path("v2/deployments")
 @Consumes(Array(MediaType.APPLICATION_JSON))

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -5,14 +5,14 @@ import java.net.URI
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{ Context, Response }
+import javax.ws.rs.core.{Context, Response}
 
 import akka.stream.Materializer
 import mesosphere.marathon.api.v2.InfoEmbedResolver._
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.json.Formats._
-import mesosphere.marathon.api.{ AuthResource, GroupApiService, MarathonMediaType }
-import mesosphere.marathon.core.appinfo.{ GroupInfo, GroupInfoService, Selector }
+import mesosphere.marathon.api.{AuthResource, GroupApiService, MarathonMediaType}
+import mesosphere.marathon.core.appinfo.{GroupInfo, GroupInfoService, Selector}
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.plugin.auth._

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoEmbedResolver.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoEmbedResolver.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package api.v2
 
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.appinfo.{ AppInfo, GroupInfo }
+import mesosphere.marathon.core.appinfo.{AppInfo, GroupInfo}
 
 /**
   * Resolves AppInfo.Embed and GroupInfo.Embed from query parameters.

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -2,12 +2,12 @@ package mesosphere.marathon
 package api.v2
 
 import javax.servlet.http.HttpServletRequest
-import javax.ws.rs.core.{ Context, MediaType, Response }
-import javax.ws.rs.{ Consumes, GET, Path, Produces }
+import javax.ws.rs.core.{Context, MediaType, Response}
+import javax.ws.rs.{Consumes, GET, Path, Produces}
 
 import com.google.inject.Inject
 import mesosphere.marathon.HttpConf
-import mesosphere.marathon.api.{ AuthResource, MarathonMediaType }
+import mesosphere.marathon.api.{AuthResource, MarathonMediaType}
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.storage.repository.FrameworkIdRepository

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -3,12 +3,12 @@ package api.v2
 
 import akka.actor.Scheduler
 import javax.servlet.http.HttpServletRequest
-import javax.ws.rs.core.{ Context, Response }
+import javax.ws.rs.core.{Context, Response}
 import javax.ws.rs._
 
 import com.google.inject.Inject
 import mesosphere.marathon.HttpConf
-import mesosphere.marathon.api.{ AuthResource, MarathonMediaType, RestResource }
+import mesosphere.marathon.api.{AuthResource, MarathonMediaType, RestResource}
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.storage.repository.RuntimeConfigurationRepository

--- a/src/main/scala/mesosphere/marathon/api/v2/NetworkNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/NetworkNormalization.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package api.v2
 
-import mesosphere.marathon.raml.{ Network, NetworkMode }
+import mesosphere.marathon.raml.{Network, NetworkMode}
 
 object NetworkNormalization {
 

--- a/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
@@ -4,7 +4,7 @@ package api.v2
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{ Context, Response }
+import javax.ws.rs.core.{Context, Response}
 
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.api.v2.json.Formats._

--- a/src/main/scala/mesosphere/marathon/api/v2/PodNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodNormalization.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package api.v2
 
-import mesosphere.marathon.raml.{ AnyToRaml, Endpoint, Network, NetworkMode, Pod, PodContainer, PodPersistentVolume, PodSchedulingPolicy, PodUpgradeStrategy }
+import mesosphere.marathon.raml.{AnyToRaml, Endpoint, Network, NetworkMode, Pod, PodContainer, PodPersistentVolume, PodSchedulingPolicy, PodUpgradeStrategy}
 import mesosphere.marathon.stream.Implicits._
 
 object PodNormalization {

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -7,21 +7,21 @@ import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.Response.Status
-import javax.ws.rs.core.{ Context, MediaType, Response }
+import javax.ws.rs.core.{Context, MediaType, Response}
 
 import akka.event.EventStream
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.scaladsl.{Sink, Source}
 import com.wix.accord.Validator
 import mesosphere.marathon.api.v2.validation.PodsValidation
-import mesosphere.marathon.api.{ AuthResource, MarathonMediaType, RestResource, TaskKiller }
-import mesosphere.marathon.core.appinfo.{ PodSelector, PodStatusService, Selector }
+import mesosphere.marathon.api.{AuthResource, MarathonMediaType, RestResource, TaskKiller}
+import mesosphere.marathon.core.appinfo.{PodSelector, PodStatusService, Selector}
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.pod.{ PodDefinition, PodManager }
+import mesosphere.marathon.core.pod.{PodDefinition, PodManager}
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.raml.{ Pod, Raml }
-import mesosphere.marathon.state.{ PathId, Timestamp, VersionInfo }
+import mesosphere.marathon.raml.{Pod, Raml}
+import mesosphere.marathon.state.{PathId, Timestamp, VersionInfo}
 import mesosphere.marathon.util.SemanticVersion
 import play.api.libs.json.Json
 import Normalization._

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -5,11 +5,11 @@ import java.time.Clock
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{ Context, MediaType, Response }
+import javax.ws.rs.core.{Context, MediaType, Response}
 
-import mesosphere.marathon.api.{ AuthResource, MarathonMediaType }
+import mesosphere.marathon.api.{AuthResource, MarathonMediaType}
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec }
+import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec}
 import mesosphere.marathon.raml.Raml
 import mesosphere.marathon.state.PathId._
 

--- a/src/main/scala/mesosphere/marathon/api/v2/SchemaResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/SchemaResource.scala
@@ -6,7 +6,7 @@ import javax.inject.Inject
 import javax.ws.rs._
 import javax.ws.rs.core.MediaType
 
-import mesosphere.marathon.api.{ MarathonMediaType, RestResource }
+import mesosphere.marathon.api.{MarathonMediaType, RestResource}
 
 @Path("v2/schemas")
 @Consumes(Array(MediaType.APPLICATION_JSON))

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -5,19 +5,19 @@ import java.util
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{ Context, MediaType, Response }
+import javax.ws.rs.core.{Context, MediaType, Response}
 
 import mesosphere.marathon.api.EndpointsHelper.ListTasks
-import mesosphere.marathon.api.{ EndpointsHelper, MarathonMediaType, TaskKiller, _ }
+import mesosphere.marathon.api.{EndpointsHelper, MarathonMediaType, TaskKiller, _}
 import mesosphere.marathon.core.appinfo.EnrichedTask
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.group.GroupManager
-import mesosphere.marathon.core.health.{ Health, HealthCheckManager }
+import mesosphere.marathon.core.health.{Health, HealthCheckManager}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec }
+import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec}
 import mesosphere.marathon.raml.AnyToRaml
 import mesosphere.marathon.raml.Task._
 import mesosphere.marathon.raml.TaskConversion._
@@ -26,7 +26,7 @@ import mesosphere.marathon.stream.Implicits._
 import play.api.libs.json.Json
 
 import scala.async.Async._
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 @Path("v2/tasks")
 class TasksResource @Inject() (

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -2,19 +2,19 @@ package mesosphere.marathon
 package api.v2.json
 
 import mesosphere.marathon.core.appinfo._
-import mesosphere.marathon.core.deployment.{ DeploymentAction, DeploymentPlan, DeploymentStep, DeploymentStepInfo }
+import mesosphere.marathon.core.deployment.{DeploymentAction, DeploymentPlan, DeploymentStep, DeploymentStepInfo}
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.plugin.{ PluginDefinition, PluginDefinitions }
+import mesosphere.marathon.core.plugin.{PluginDefinition, PluginDefinitions}
 import mesosphere.marathon.core.pod.PodDefinition
-import mesosphere.marathon.core.readiness.{ HttpResponse, ReadinessCheckResult }
+import mesosphere.marathon.core.readiness.{HttpResponse, ReadinessCheckResult}
 import mesosphere.marathon.core.task.state.NetworkInfo
-import mesosphere.marathon.raml.{ Raml }
+import mesosphere.marathon.raml.{Raml}
 import mesosphere.marathon.raml.Task._
 import mesosphere.marathon.raml.TaskConversion._
 import mesosphere.marathon.state._
-import org.apache.mesos.{ Protos => mesos }
+import org.apache.mesos.{Protos => mesos}
 import play.api.libs.json.JsonValidationError
 import play.api.libs.functional.syntax._
 import play.api.libs.json._

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -3,13 +3,13 @@ package api.v2.validation
 
 import java.util.regex.Pattern
 
-import com.wix.accord.Descriptions.{ Generic, Path }
+import com.wix.accord.Descriptions.{Generic, Path}
 import com.wix.accord._
 import com.wix.accord.dsl._
-import mesosphere.marathon.api.v2.Validation.{ featureEnabled, _ }
+import mesosphere.marathon.api.v2.Validation.{featureEnabled, _}
 import mesosphere.marathon.core.externalvolume.ExternalVolumes
 import mesosphere.marathon.raml._
-import mesosphere.marathon.state.{ AppDefinition, PathId, ResourceRole }
+import mesosphere.marathon.state.{AppDefinition, PathId, ResourceRole}
 import mesosphere.marathon.stream.Implicits._
 
 import scala.util.Try
@@ -18,7 +18,7 @@ trait AppValidation {
   import ArtifactValidation._
   import EnvVarValidation._
   import NetworkValidation._
-  import PathId.{ empty => _, _ }
+  import PathId.{empty => _, _}
   import SchedulingValidation._
   import SecretValidation._
 

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/EnvVarValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/EnvVarValidation.scala
@@ -3,7 +3,7 @@ package api.v2.validation
 
 import com.wix.accord._
 import com.wix.accord.dsl._
-import mesosphere.marathon.raml.{ EnvVarSecret, EnvVarValueOrSecret, SecretDef }
+import mesosphere.marathon.raml.{EnvVarSecret, EnvVarValueOrSecret, SecretDef}
 
 /**
   * RAML-generated validation doesn't cover environment variable names yet

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/NetworkValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/NetworkValidation.scala
@@ -5,7 +5,7 @@ import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.pod
-import mesosphere.marathon.raml.{ Network, NetworkMode }
+import mesosphere.marathon.raml.{Network, NetworkMode}
 
 @SuppressWarnings(Array("all")) // wix breaks stuff
 trait NetworkValidation {

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.plugin.validation.RunSpecValidator
 import mesosphere.marathon.raml._
-import mesosphere.marathon.state.{ PathId, ResourceRole, RootGroup }
+import mesosphere.marathon.state.{PathId, ResourceRole, RootGroup}
 import mesosphere.marathon.util.SemanticVersion
 // scalastyle:on
 

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/SchedulingValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/SchedulingValidation.scala
@@ -6,7 +6,7 @@ import java.util.regex.Pattern
 import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation
-import mesosphere.marathon.raml.{ App, Apps, Constraint, ConstraintOperator, Pod, PodPersistentVolume, PodPlacementPolicy, PodSchedulingBackoffStrategy, PodSchedulingPolicy, PodUpgradeStrategy, UpgradeStrategy }
+import mesosphere.marathon.raml.{App, Apps, Constraint, ConstraintOperator, Pod, PodPersistentVolume, PodPlacementPolicy, PodSchedulingBackoffStrategy, PodSchedulingPolicy, PodUpgradeStrategy, UpgradeStrategy}
 import mesosphere.marathon.state.ResourceRole
 
 import scala.util.Try

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/SecretValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/SecretValidation.scala
@@ -4,7 +4,7 @@ package api.v2.validation
 import com.wix.accord.Validator
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation
-import mesosphere.marathon.raml.{ EnvVarSecret, EnvVarValue, EnvVarValueOrSecret, SecretDef }
+import mesosphere.marathon.raml.{EnvVarSecret, EnvVarValue, EnvVarValueOrSecret, SecretDef}
 
 trait SecretValidation {
   import Validation._

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -4,13 +4,13 @@ package core
 import java.time.Clock
 import javax.inject.Named
 
-import akka.actor.{ ActorRef, Props }
+import akka.actor.{ActorRef, Props}
 import akka.stream.Materializer
 import com.google.inject._
 import com.google.inject.name.Names
 import com.typesafe.config.Config
 import mesosphere.marathon.api.GroupApiService
-import mesosphere.marathon.core.appinfo.{ AppInfoModule, AppInfoService, GroupInfoService, PodStatusService }
+import mesosphere.marathon.core.appinfo.{AppInfoModule, AppInfoService, GroupInfoService, PodStatusService}
 import mesosphere.marathon.core.deployment.DeploymentManager
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
@@ -18,8 +18,8 @@ import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.update.InstanceChangeHandler
 import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.core.leadership.{ LeadershipCoordinator, LeadershipModule }
-import mesosphere.marathon.core.plugin.{ PluginDefinitions, PluginManager }
+import mesosphere.marathon.core.leadership.{LeadershipCoordinator, LeadershipModule}
+import mesosphere.marathon.core.plugin.{PluginDefinitions, PluginManager}
 import mesosphere.marathon.core.pod.PodManager
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.storage.store.PersistenceStore
@@ -28,8 +28,8 @@ import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.core.task.update.impl.steps._
-import mesosphere.marathon.core.task.update.impl.{ TaskStatusUpdateProcessorImpl, ThrottlingTaskStatusUpdateProcessor }
-import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer }
+import mesosphere.marathon.core.task.update.impl.{TaskStatusUpdateProcessorImpl, ThrottlingTaskStatusUpdateProcessor}
+import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer}
 import mesosphere.marathon.plugin.http.HttpRequestHandler
 import mesosphere.marathon.storage.migration.Migration
 import mesosphere.marathon.storage.repository._

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -5,16 +5,16 @@ import java.time.Clock
 import java.util.concurrent.Executors
 import javax.inject.Named
 
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.actor.{ActorRef, ActorSystem}
 import akka.event.EventStream
-import com.google.inject.{ Inject, Provider }
+import com.google.inject.{Inject, Provider}
 import mesosphere.marathon.core.auth.AuthModule
-import mesosphere.marathon.core.base.{ ActorsModule, JvmExitsCrashStrategy, LifecycleState }
+import mesosphere.marathon.core.base.{ActorsModule, JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.core.deployment.DeploymentModule
 import mesosphere.marathon.core.election._
 import mesosphere.marathon.core.event.EventModule
 import mesosphere.marathon.core.flow.FlowModule
-import mesosphere.marathon.core.group.{ GroupManagerConfig, GroupManagerModule }
+import mesosphere.marathon.core.group.{GroupManagerConfig, GroupManagerModule}
 import mesosphere.marathon.core.health.HealthModule
 import mesosphere.marathon.core.heartbeat.MesosHeartbeatMonitor
 import mesosphere.marathon.core.history.HistoryModule
@@ -33,7 +33,7 @@ import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
 import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
-import mesosphere.marathon.storage.{ StorageConf, StorageModule }
+import mesosphere.marathon.storage.{StorageConf, StorageModule}
 import mesosphere.util.NamedExecutionContext
 import mesosphere.util.state.MesosLeaderInfo
 

--- a/src/main/scala/mesosphere/marathon/core/appinfo/AppInfo.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/AppInfo.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.appinfo
 
 import mesosphere.marathon.core.readiness.ReadinessCheckResult
-import mesosphere.marathon.state.{ AppDefinition, Identifiable, TaskFailure }
+import mesosphere.marathon.state.{AppDefinition, Identifiable, TaskFailure}
 
 import scala.collection.immutable.Seq
 

--- a/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/AppInfoModule.scala
@@ -4,7 +4,7 @@ package core.appinfo
 import java.time.Clock
 
 import com.google.inject.Inject
-import mesosphere.marathon.core.appinfo.impl.{ AppInfoBaseData, DefaultInfoService }
+import mesosphere.marathon.core.appinfo.impl.{AppInfoBaseData, DefaultInfoService}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker

--- a/src/main/scala/mesosphere/marathon/core/appinfo/EnrichedTask.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/EnrichedTask.scala
@@ -4,7 +4,7 @@ package core.appinfo
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.Instance.AgentInfo
-import mesosphere.marathon.core.instance.{ Instance, Reservation }
+import mesosphere.marathon.core.instance.{Instance, Reservation}
 import mesosphere.marathon.state.PathId
 
 case class EnrichedTask(

--- a/src/main/scala/mesosphere/marathon/core/appinfo/GroupInfo.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/GroupInfo.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.appinfo
 
 import mesosphere.marathon.raml.PodStatus
-import mesosphere.marathon.state.{ Group, RootGroup }
+import mesosphere.marathon.state.{Group, RootGroup}
 
 case class GroupInfo(
     group: Group,

--- a/src/main/scala/mesosphere/marathon/core/appinfo/GroupInfoService.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/GroupInfoService.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.appinfo
 
-import mesosphere.marathon.state.{ Timestamp, PathId }
+import mesosphere.marathon.state.{Timestamp, PathId}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/mesosphere/marathon/core/appinfo/TaskStatsByVersion.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/TaskStatsByVersion.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.core.appinfo.impl.TaskForStatistics
 import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.VersionInfo._
-import mesosphere.marathon.state.{ Timestamp, VersionInfo }
+import mesosphere.marathon.state.{Timestamp, VersionInfo}
 
 case class TaskStatsByVersion(
     maybeStartedAfterLastScaling: Option[TaskStats],

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -4,22 +4,22 @@ package core.appinfo.impl
 import java.time.Clock
 
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.appinfo.{ AppInfo, EnrichedTask, TaskCounts, TaskStatsByVersion }
-import mesosphere.marathon.core.deployment.{ DeploymentPlan, DeploymentStepInfo }
+import mesosphere.marathon.core.appinfo.{AppInfo, EnrichedTask, TaskCounts, TaskStatsByVersion}
+import mesosphere.marathon.core.deployment.{DeploymentPlan, DeploymentStepInfo}
 import mesosphere.marathon.core.group.GroupManager
-import mesosphere.marathon.core.health.{ Health, HealthCheckManager }
+import mesosphere.marathon.core.health.{Health, HealthCheckManager}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.readiness.ReadinessCheckResult
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.raml.{ ContainerTerminationHistory, PodInstanceState, PodInstanceStatus, PodState, PodStatus, Raml }
+import mesosphere.marathon.raml.{ContainerTerminationHistory, PodInstanceState, PodInstanceStatus, PodState, PodStatus, Raml}
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.TaskFailureRepository
 
-import scala.async.Async.{ async, await }
-import scala.collection.immutable.{ Map, Seq }
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.async.Async.{async, await}
+import scala.collection.immutable.{Map, Seq}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 // TODO(jdef) pods rename this to something like ResourceInfoBaseData

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
@@ -10,10 +10,10 @@ import mesosphere.marathon.raml.PodStatus
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
 
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 import scala.collection.immutable.Seq
 import scala.collection.mutable
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 private[appinfo] class DefaultInfoService(
     groupManager: GroupManager,

--- a/src/main/scala/mesosphere/marathon/core/appinfo/package.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/package.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core
 
 import mesosphere.marathon.core.pod.PodDefinition
-import mesosphere.marathon.state.{ AppDefinition, Group }
+import mesosphere.marathon.state.{AppDefinition, Group}
 
 package object appinfo {
 

--- a/src/main/scala/mesosphere/marathon/core/async/ExecutionContexts.scala
+++ b/src/main/scala/mesosphere/marathon/core/async/ExecutionContexts.scala
@@ -3,7 +3,7 @@ package core.async
 
 import java.util.concurrent.Executor
 
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 object CallerThreadExecutionContext {
   val executor: Executor = (command: Runnable) => command.run()

--- a/src/main/scala/mesosphere/marathon/core/auth/AuthModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/auth/AuthModule.scala
@@ -4,7 +4,7 @@ package core.auth
 import mesosphere.marathon.WrongConfigurationException
 import mesosphere.marathon.core.auth.impl.AuthAllowEverything
 import mesosphere.marathon.core.plugin.PluginManager
-import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer }
+import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer}
 
 import scala.reflect.ClassTag
 

--- a/src/main/scala/mesosphere/marathon/core/auth/impl/AuthAllowEverything.scala
+++ b/src/main/scala/mesosphere/marathon/core/auth/impl/AuthAllowEverything.scala
@@ -1,8 +1,8 @@
 package mesosphere.marathon
 package core.auth.impl
 
-import mesosphere.marathon.plugin.auth.{ Authenticator, AuthorizedAction, Authorizer, Identity }
-import mesosphere.marathon.plugin.http.{ HttpRequest, HttpResponse }
+import mesosphere.marathon.plugin.auth.{Authenticator, AuthorizedAction, Authorizer, Identity}
+import mesosphere.marathon.plugin.http.{HttpRequest, HttpResponse}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
@@ -3,7 +3,7 @@ package core.base
 
 import akka.Done
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 trait CrashStrategy {
   def crash(): Future[Done]

--- a/src/main/scala/mesosphere/marathon/core/base/RichRuntime.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/RichRuntime.scala
@@ -1,13 +1,13 @@
 package mesosphere.marathon
 package core.base
 
-import java.util.{ Timer, TimerTask }
+import java.util.{Timer, TimerTask}
 
 import akka.Done
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContext, Future, _ }
+import scala.concurrent.{ExecutionContext, Future, _}
 
 /**
   * Add asyncExit method to Runtime.

--- a/src/main/scala/mesosphere/marathon/core/condition/Condition.scala
+++ b/src/main/scala/mesosphere/marathon/core/condition/Condition.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.condition
 
 import play.api.libs.json._
-import org.apache.mesos.Protos.{ TaskState => MesosTaskState }
+import org.apache.mesos.Protos.{TaskState => MesosTaskState}
 import scala.collection.breakOut
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/deployment/DeploymentModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/DeploymentModule.scala
@@ -1,10 +1,10 @@
 package mesosphere.marathon
 package core.deployment
 
-import akka.actor.{ ActorRef, Props }
+import akka.actor.{ActorRef, Props}
 import akka.event.EventStream
 import akka.stream.Materializer
-import mesosphere.marathon.core.deployment.impl.{ DeploymentActor, DeploymentManagerActor, DeploymentManagerDelegate }
+import mesosphere.marathon.core.deployment.impl.{DeploymentActor, DeploymentManagerActor, DeploymentManagerDelegate}
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.leadership.LeadershipModule

--- a/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
@@ -9,10 +9,10 @@ import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.validation.PodsValidation
 import mesosphere.marathon.core.deployment.impl.DeploymentPlanReverter
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.pod.{ MesosContainer, PodDefinition }
+import mesosphere.marathon.core.pod.{MesosContainer, PodDefinition}
 import mesosphere.marathon.core.readiness.ReadinessCheckResult
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.raml.{ ArgvCommand, ShellCommand }
+import mesosphere.marathon.raml.{ArgvCommand, ShellCommand}
 import mesosphere.marathon.state._
 
 import scala.collection.SortedMap

--- a/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
@@ -3,7 +3,7 @@ package core.deployment
 
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.state.{ KillSelection, Timestamp }
+import mesosphere.marathon.state.{KillSelection, Timestamp}
 
 case class ScalingProposition(tasksToKill: Option[Seq[Instance]], tasksToStart: Option[Int])
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/AppStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/AppStartActor.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.RunSpec
 
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 
 class AppStartActor(
     val deploymentManagerActor: ActorRef,

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -6,23 +6,23 @@ import akka.actor._
 import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.deployment._
-import mesosphere.marathon.core.deployment.impl.DeploymentActor.{ Cancel, Fail, NextStep }
+import mesosphere.marathon.core.deployment.impl.DeploymentActor.{Cancel, Fail, NextStep}
 import mesosphere.marathon.core.deployment.impl.DeploymentManagerActor.DeploymentFinished
-import mesosphere.marathon.core.event.{ AppTerminatedEvent, DeploymentStatus, DeploymentStepFailure, DeploymentStepSuccess }
+import mesosphere.marathon.core.event.{AppTerminatedEvent, DeploymentStatus, DeploymentStepFailure, DeploymentStepSuccess}
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
-import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
+import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{ AppDefinition, RunSpec }
+import mesosphere.marathon.state.{AppDefinition, RunSpec}
 import mesosphere.mesos.Constraints
 
 import scala.async.Async._
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 private class DeploymentActor(
     deploymentManagerActor: ActorRef,
@@ -48,7 +48,7 @@ private class DeploymentActor(
   // Additionally a BackOffSupervisor is used to make sure child actor failures are not overloading other parts of the system
   // (like LaunchQueue and InstanceTracker) and are not filling the log with exceptions.
   import scala.concurrent.duration._
-  import akka.pattern.{ Backoff, BackoffSupervisor }
+  import akka.pattern.{Backoff, BackoffSupervisor}
 
   def childSupervisor(props: Props, name: String): Props = {
     BackoffSupervisor.props(

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActor.scala
@@ -7,19 +7,19 @@ import akka.actor._
 import akka.event.EventStream
 import akka.stream.Materializer
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.MarathonSchedulerActor.{ DeploymentFailed, DeploymentStarted }
-import mesosphere.marathon.core.deployment.{ DeploymentPlan, DeploymentStepInfo }
+import mesosphere.marathon.MarathonSchedulerActor.{DeploymentFailed, DeploymentStarted}
+import mesosphere.marathon.core.deployment.{DeploymentPlan, DeploymentStepInfo}
 import mesosphere.marathon.core.deployment.impl.DeploymentManagerActor._
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.core.readiness.{ ReadinessCheckExecutor, ReadinessCheckResult }
+import mesosphere.marathon.core.readiness.{ReadinessCheckExecutor, ReadinessCheckResult}
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.storage.repository.DeploymentRepository
 
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 import scala.collection.mutable
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 import scala.util.Try
 import scala.util.control.NonFatal
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerDelegate.scala
@@ -6,8 +6,8 @@ import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.deployment.impl.DeploymentManagerActor.{ CancelDeployment, ListRunningDeployments, StartDeployment }
-import mesosphere.marathon.core.deployment.{ DeploymentConfig, DeploymentManager, DeploymentPlan, DeploymentStepInfo }
+import mesosphere.marathon.core.deployment.impl.DeploymentManagerActor.{CancelDeployment, ListRunningDeployments, StartDeployment}
+import mesosphere.marathon.core.deployment.{DeploymentConfig, DeploymentManager, DeploymentPlan, DeploymentStepInfo}
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehavior.scala
@@ -1,17 +1,17 @@
 package mesosphere.marathon
 package core.deployment.impl
 
-import akka.actor.{ Actor, ActorRef }
+import akka.actor.{Actor, ActorRef}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition.Running
 import mesosphere.marathon.core.deployment.impl.DeploymentManagerActor.ReadinessCheckUpdate
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.PodDefinition
-import mesosphere.marathon.core.readiness.{ ReadinessCheckExecutor, ReadinessCheckResult }
+import mesosphere.marathon.core.readiness.{ReadinessCheckExecutor, ReadinessCheckResult}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{ AppDefinition, PathId, RunSpec, Timestamp }
+import mesosphere.marathon.state.{AppDefinition, PathId, RunSpec, Timestamp}
 import rx.lang.scala.Subscription
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
@@ -3,17 +3,17 @@ package core.deployment.impl
 
 import akka.Done
 import akka.pattern._
-import akka.actor.{ Actor, Status }
+import akka.actor.{Actor, Status}
 import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition.Terminal
-import mesosphere.marathon.core.deployment.impl.StartingBehavior.{ PostStart, Sync }
-import mesosphere.marathon.core.event.{ InstanceChanged, InstanceHealthChanged }
+import mesosphere.marathon.core.deployment.impl.StartingBehavior.{PostStart, Sync}
+import mesosphere.marathon.core.event.{InstanceChanged, InstanceHealthChanged}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 import scala.concurrent.Future
 import scala.concurrent.duration._
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/StopActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/StopActor.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.deployment.impl
 
 import akka.Done
-import akka.actor.{ Actor, ActorRef, Terminated }
+import akka.actor.{Actor, ActorRef, Terminated}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.deployment.impl.DeploymentActor.Cancel
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -13,12 +13,12 @@ import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.termination.InstanceChangedPredicates.considerTerminal
-import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
+import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.RunSpec
 
-import scala.collection.{ SortedSet, mutable }
-import scala.concurrent.{ Future, Promise }
+import scala.collection.{SortedSet, mutable}
+import scala.concurrent.{Future, Promise}
 
 class TaskReplaceActor(
     val deploymentManagerActor: ActorRef,

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -3,7 +3,7 @@ package core.deployment.impl
 
 import akka.Done
 import akka.pattern._
-import akka.actor.{ Actor, ActorRef, Props }
+import akka.actor.{Actor, ActorRef, Props}
 import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.DeploymentStatus
@@ -12,8 +12,8 @@ import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.RunSpec
 
-import scala.async.Async.{ async, await }
-import scala.concurrent.{ Future, Promise }
+import scala.async.Async.{async, await}
+import scala.concurrent.{Future, Promise}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 @SuppressWarnings(Array("all")) // async/await

--- a/src/main/scala/mesosphere/marathon/core/election/CuratorElectionStream.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/CuratorElectionStream.scala
@@ -2,22 +2,22 @@ package mesosphere.marathon
 package core.election
 
 import akka.actor.Cancellable
-import akka.stream.scaladsl.{ Source, SourceQueueWithComplete }
+import akka.stream.scaladsl.{Source, SourceQueueWithComplete}
 import akka.stream.OverflowStrategy
 import com.typesafe.scalalogging.StrictLogging
 import java.util
 import java.util.Collections
 import java.util.concurrent.TimeUnit
-import mesosphere.marathon.metrics.{ Metrics, ServiceMetric, Timer }
+import mesosphere.marathon.metrics.{Metrics, ServiceMetric, Timer}
 import mesosphere.marathon.stream.EnrichedFlow
 import mesosphere.marathon.util.LifeCycledCloseableLike
 import org.apache.curator.framework.CuratorFramework
-import org.apache.curator.framework.api.{ ACLProvider, CuratorWatcher, UnhandledErrorListener }
+import org.apache.curator.framework.api.{ACLProvider, CuratorWatcher, UnhandledErrorListener}
 import org.apache.curator.framework.imps.CuratorFrameworkState
 import org.apache.curator.framework.recipes.leader.LeaderLatch
-import org.apache.curator.framework.{ AuthInfo, CuratorFrameworkFactory }
+import org.apache.curator.framework.{AuthInfo, CuratorFrameworkFactory}
 import org.apache.curator.retry.ExponentialBackoffRetry
-import org.apache.zookeeper.{ KeeperException, WatchedEvent, ZooDefs }
+import org.apache.zookeeper.{KeeperException, WatchedEvent, ZooDefs}
 import org.apache.zookeeper.data.ACL
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/core/election/ElectionModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/ElectionModule.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.election
 
-import akka.actor.{ ActorSystem, Cancellable }
+import akka.actor.{ActorSystem, Cancellable}
 import akka.event.EventStream
 import akka.stream.scaladsl.Source
 import mesosphere.marathon.core.base.CrashStrategy

--- a/src/main/scala/mesosphere/marathon/core/election/ElectionService.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/ElectionService.scala
@@ -2,10 +2,10 @@ package mesosphere.marathon
 package core.election
 
 import akka.NotUsed
-import akka.actor.{ ActorRef, ActorSystem, Cancellable, PoisonPill }
+import akka.actor.{ActorRef, ActorSystem, Cancellable, PoisonPill}
 import akka.event.EventStream
 import akka.stream.ClosedShape
-import akka.stream.scaladsl.{ Broadcast, GraphDSL, RunnableGraph, Flow, Sink, Source, Keep }
+import akka.stream.scaladsl.{Broadcast, GraphDSL, RunnableGraph, Flow, Sink, Source, Keep}
 import akka.stream.OverflowStrategy
 import akka.stream.ActorMaterializer
 import com.typesafe.scalalogging.StrictLogging
@@ -15,8 +15,8 @@ import mesosphere.marathon.core.async.ExecutionContexts
 import mesosphere.marathon.core.base.CrashStrategy
 import mesosphere.marathon.stream.EnrichedFlow
 import mesosphere.marathon.util.CancellableOnce
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success }
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 trait ElectionServiceLeaderInfo {
   /**

--- a/src/main/scala/mesosphere/marathon/core/election/PsuedoElectionStream.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/PsuedoElectionStream.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.election
 
 import akka.actor.Cancellable
-import akka.stream.scaladsl.{ Keep, Source }
+import akka.stream.scaladsl.{Keep, Source}
 import mesosphere.marathon.stream.EnrichedSource
 
 object PsuedoElectionStream {

--- a/src/main/scala/mesosphere/marathon/core/event/EventConf.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/EventConf.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.event
 
-import org.rogach.scallop.{ ScallopConf, ScallopOption }
+import org.rogach.scallop.{ScallopConf, ScallopOption}
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
@@ -1,12 +1,12 @@
 package mesosphere.marathon
 package core.event
 
-import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.event.EventStream
 import akka.stream.Materializer
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.event.impl.stream._
-import mesosphere.marathon.plugin.auth.{ Authenticator, Authorizer }
+import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer}
 import org.eclipse.jetty.servlets.EventSourceServlet
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -8,9 +8,9 @@ import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.core.instance.update.InstanceChange
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
-import mesosphere.marathon.core.deployment.{ DeploymentPlan, DeploymentStep }
-import org.apache.mesos.{ Protos => Mesos }
+import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
+import mesosphere.marathon.core.deployment.{DeploymentPlan, DeploymentStep}
+import org.apache.mesos.{Protos => Mesos}
 import play.api.libs.json.Json
 
 import scala.collection.immutable.Seq

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamActor.scala
@@ -3,10 +3,10 @@ package core.event.impl.stream
 
 import akka.actor._
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.election.{ ElectionService, LeadershipTransition }
+import mesosphere.marathon.core.election.{ElectionService, LeadershipTransition}
 import mesosphere.marathon.core.event.MarathonEvent
 import mesosphere.marathon.core.event.impl.stream.HttpEventStreamActor._
-import mesosphere.marathon.metrics.{ ApiMetric, Metrics, SettableGauge }
+import mesosphere.marathon.metrics.{ApiMetric, Metrics, SettableGauge}
 
 import scala.util.Try
 

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActor.scala
@@ -3,12 +3,12 @@ package core.event.impl.stream
 
 import java.io.EOFException
 
-import akka.actor.{ Actor, Status }
+import akka.actor.{Actor, Status}
 import akka.event.EventStream
 import akka.pattern.pipe
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.impl.stream.HttpEventStreamHandleActor._
-import mesosphere.marathon.core.event.{ EventStreamAttached, EventStreamDetached, MarathonEvent }
+import mesosphere.marathon.core.event.{EventStreamAttached, EventStreamDetached, MarathonEvent}
 import mesosphere.util.ThreadPoolContext
 
 import scala.concurrent.Future

--- a/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServlet.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServlet.scala
@@ -2,18 +2,18 @@ package mesosphere.marathon
 package core.event.impl.stream
 
 import java.util.UUID
-import javax.servlet.http.{ Cookie, HttpServletRequest, HttpServletResponse }
+import javax.servlet.http.{Cookie, HttpServletRequest, HttpServletResponse}
 
 import akka.actor.ActorRef
 import mesosphere.marathon.api.RequestFacade
-import mesosphere.marathon.core.event.{ EventConf, MarathonEvent }
+import mesosphere.marathon.core.event.{EventConf, MarathonEvent}
 import mesosphere.marathon.core.event.impl.stream.HttpEventStreamActor._
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.plugin.http.HttpResponse
 import org.eclipse.jetty.servlets.EventSource.Emitter
-import org.eclipse.jetty.servlets.{ EventSource, EventSourceServlet }
+import org.eclipse.jetty.servlets.{EventSource, EventSourceServlet}
 
-import scala.concurrent.{ Await, blocking }
+import scala.concurrent.{Await, blocking}
 
 /**
   * The Stream handle implementation for SSE.

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/ExternalVolumes.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/ExternalVolumes.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.externalvolume
 
-import com.wix.accord.Descriptions.{ Explicit, Path }
+import com.wix.accord.Descriptions.{Explicit, Path}
 import com.wix.accord._
 import mesosphere.marathon.core.externalvolume.impl._
 import mesosphere.marathon.core.externalvolume.impl.providers.DVDIProvider

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/impl/ExternalVolumeProvider.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/impl/ExternalVolumeProvider.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.externalvolume.impl
 
 import com.wix.accord.Validator
-import mesosphere.marathon.state.{ AppDefinition, ExternalVolume, RootGroup, VolumeMount }
+import mesosphere.marathon.state.{AppDefinition, ExternalVolume, RootGroup, VolumeMount}
 import org.apache.mesos.Protos
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProvider.scala
@@ -5,11 +5,11 @@ import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.validation.SchedulingValidation
 import mesosphere.marathon.core.externalvolume.impl.providers.OptionSupport._
-import mesosphere.marathon.core.externalvolume.impl.{ ExternalVolumeProvider, ExternalVolumeValidations }
-import mesosphere.marathon.raml.{ App, AppExternalVolume, EngineType, ReadMode, Container => AppContainer }
+import mesosphere.marathon.core.externalvolume.impl.{ExternalVolumeProvider, ExternalVolumeValidations}
+import mesosphere.marathon.raml.{App, AppExternalVolume, EngineType, ReadMode, Container => AppContainer}
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
-import org.apache.mesos.Protos.{ Parameter, Parameters, Volume => MesosVolume }
+import org.apache.mesos.Protos.{Parameter, Parameters, Volume => MesosVolume}
 
 /**
   * DVDIProvider (Docker Volume Driver Interface provider) handles external volumes allocated

--- a/src/main/scala/mesosphere/marathon/core/flow/FlowModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/FlowModule.scala
@@ -5,7 +5,7 @@ import java.time.Clock
 
 import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.flow.impl.{ OfferMatcherLaunchTokensActor, OfferReviverDelegate, ReviveOffersActor }
+import mesosphere.marathon.core.flow.impl.{OfferMatcherLaunchTokensActor, OfferReviverDelegate, ReviveOffersActor}
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
 import rx.lang.scala.Observable

--- a/src/main/scala/mesosphere/marathon/core/flow/impl/OfferMatcherLaunchTokensActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/impl/OfferMatcherLaunchTokensActor.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.flow.impl
 
-import akka.actor.{ Actor, Cancellable, Props }
+import akka.actor.{Actor, Cancellable, Props}
 import mesosphere.marathon.core.event.InstanceChanged
 import mesosphere.marathon.core.flow.LaunchTokenConfig
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager

--- a/src/main/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActor.scala
@@ -3,15 +3,15 @@ package core.flow.impl
 
 import java.time.Clock
 
-import akka.actor.{ Actor, Cancellable, Props }
-import akka.event.{ EventStream, LoggingReceive }
+import akka.actor.{Actor, Cancellable, Props}
+import akka.event.{EventStream, LoggingReceive}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.flow.ReviveOffersConfig
 import mesosphere.marathon.core.flow.impl.ReviveOffersActor.OffersWanted
-import mesosphere.marathon.core.event.{ SchedulerRegisteredEvent, SchedulerReregisteredEvent }
-import mesosphere.marathon.metrics.{ Metrics, ServiceMetric }
+import mesosphere.marathon.core.event.{SchedulerRegisteredEvent, SchedulerReregisteredEvent}
+import mesosphere.marathon.metrics.{Metrics, ServiceMetric}
 import mesosphere.marathon.state.Timestamp
-import rx.lang.scala.{ Observable, Subscription }
+import rx.lang.scala.{Observable, Subscription}
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/core/group/GroupManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/GroupManager.scala
@@ -3,12 +3,12 @@ package core.group
 
 import java.time.OffsetDateTime
 
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 import akka.stream.scaladsl.Source
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.async.ExecutionContexts
-import mesosphere.marathon.state.{ AppDefinition, Group, PathId, RootGroup, RunSpec, Timestamp }
+import mesosphere.marathon.state.{AppDefinition, Group, PathId, RootGroup, RunSpec, Timestamp}
 import mesosphere.marathon.core.deployment.DeploymentPlan
 
 import scala.concurrent.Future

--- a/src/main/scala/mesosphere/marathon/core/group/GroupManagerConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/GroupManagerConfig.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.group
 
-import org.rogach.scallop.{ ScallopConf, ScallopOption }
+import org.rogach.scallop.{ScallopConf, ScallopOption}
 
 import scala.concurrent.duration._
 

--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
@@ -7,26 +7,26 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Provider
 import akka.event.EventStream
 import akka.stream.scaladsl.Source
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.deployment.DeploymentPlan
-import mesosphere.marathon.core.event.{ GroupChangeFailed, GroupChangeSuccess }
-import mesosphere.marathon.core.group.{ GroupManager, GroupManagerConfig }
+import mesosphere.marathon.core.event.{GroupChangeFailed, GroupChangeSuccess}
+import mesosphere.marathon.core.group.{GroupManager, GroupManagerConfig}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.PodDefinition
-import mesosphere.marathon.metrics.{ Metrics, ServiceMetric }
+import mesosphere.marathon.metrics.{Metrics, ServiceMetric}
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.GroupRepository
 import mesosphere.marathon.upgrade.GroupVersioningUtil
-import mesosphere.marathon.util.{ LockedVar, WorkQueue }
+import mesosphere.marathon.util.{LockedVar, WorkQueue}
 
 import scala.async.Async._
 import scala.collection.immutable.Seq
-import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 class GroupManagerImpl(
     val config: GroupManagerConfig,

--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state._
 import org.apache.mesos.Protos.NetworkInfo
-import org.apache.mesos.{ Protos => MesosProtos }
+import org.apache.mesos.{Protos => MesosProtos}
 
 import scala.concurrent.duration._
 

--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheckManager.scala
@@ -3,11 +3,11 @@ package core.health
 
 import akka.Done
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
+import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
 import org.apache.mesos.Protos.TaskStatus
 
 import scala.concurrent.Future
-import scala.collection.immutable.{ Map, Seq }
+import scala.collection.immutable.{Map, Seq}
 
 trait HealthCheckManager {
 

--- a/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/AppHealthCheckActor.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.health.impl
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{Actor, Props}
 import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.InstanceHealthChanged
@@ -13,9 +13,9 @@ import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{
   AppHealthCheckProxy,
   ApplicationKey
 }
-import mesosphere.marathon.core.health.{ Health, HealthCheck }
+import mesosphere.marathon.core.health.{Health, HealthCheck}
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 
 import scala.collection.generic.Subtractable
 import scala.collection.mutable

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -2,22 +2,22 @@ package mesosphere.marathon
 package core.health.impl
 
 import akka.Done
-import akka.actor.{ Actor, ActorRef, Cancellable, Props }
+import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import akka.event.EventStream
 import akka.stream.Materializer
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health._
-import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{ ApplicationKey, HealthCheckStatusChanged, InstanceKey, PurgeHealthCheckStatuses }
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor.{ApplicationKey, HealthCheckStatusChanged, InstanceKey, PurgeHealthCheckStatuses}
 import mesosphere.marathon.core.health.impl.HealthCheckActor._
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
+import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{ AppDefinition, Timestamp }
+import mesosphere.marathon.state.{AppDefinition, Timestamp}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 private[health] class HealthCheckActor(
     app: AppDefinition,

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
@@ -1,28 +1,28 @@
 package mesosphere.marathon
 package core.health.impl
 
-import java.net.{ InetSocketAddress, Socket }
+import java.net.{InetSocketAddress, Socket}
 import java.security.cert.X509Certificate
 
-import javax.net.ssl.{ KeyManager, SSLContext, X509TrustManager }
-import akka.actor.{ Actor, PoisonPill }
+import javax.net.ssl.{KeyManager, SSLContext, X509TrustManager}
+import akka.actor.{Actor, PoisonPill}
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.client.RequestBuilding
-import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, headers }
-import akka.http.scaladsl.{ ConnectionContext, Http }
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, headers}
+import akka.http.scaladsl.{ConnectionContext, Http}
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.state.{ AppDefinition, Timestamp }
+import mesosphere.marathon.state.{AppDefinition, Timestamp}
 import mesosphere.util.ThreadPoolContext
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with StrictLogging {
 

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.health.impl
 
 import akka.Done
-import akka.actor.{ ActorRef, ActorRefFactory }
+import akka.actor.{ActorRef, ActorRefFactory}
 import akka.event.EventStream
 import akka.pattern.ask
 import akka.stream.Materializer
@@ -10,21 +10,21 @@ import akka.util.Timeout
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import mesosphere.marathon.core.event.{ AddHealthCheck, RemoveHealthCheck }
+import mesosphere.marathon.core.event.{AddHealthCheck, RemoveHealthCheck}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.health.impl.AppHealthCheckActor.ApplicationKey
-import mesosphere.marathon.core.health.impl.HealthCheckActor.{ AppHealth, GetAppHealth, GetInstanceHealth }
+import mesosphere.marathon.core.health.impl.HealthCheckActor.{AppHealth, GetAppHealth, GetInstanceHealth}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp }
+import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
 import mesosphere.util.RWLock
 import org.apache.mesos.Protos.TaskStatus
 
 import scala.async.Async._
-import scala.collection.immutable.{ Map, Seq }
+import scala.collection.immutable.{Map, Seq}
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitor.scala
+++ b/src/main/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitor.scala
@@ -1,13 +1,12 @@
 package mesosphere.marathon
 package core.heartbeat
 
-import java.util.{ Collections, UUID }
-
+import java.util.{Collections, UUID}
 import javax.inject.Named
 import akka.actor.ActorRef
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.mesos.Protos._
-import org.apache.mesos.{ Scheduler, SchedulerDriver }
+import org.apache.mesos.{Scheduler, SchedulerDriver}
 
 /**
   * @constructor create a mesos Scheduler decorator that intercepts callbacks from a mesos SchedulerDriver,

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -1,13 +1,13 @@
 package mesosphere.marathon
 package core.instance
 
-import java.util.{ Base64, UUID }
+import java.util.{Base64, UUID}
 
-import com.fasterxml.uuid.{ EthernetAddress, Generators }
+import com.fasterxml.uuid.{EthernetAddress, Generators}
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.Instance.{ AgentInfo, InstanceState }
+import mesosphere.marathon.core.instance.Instance.{AgentInfo, InstanceState}
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.{ MarathonState, PathId, Timestamp, UnreachableDisabled, UnreachableEnabled, UnreachableStrategy }
+import mesosphere.marathon.state.{MarathonState, PathId, Timestamp, UnreachableDisabled, UnreachableEnabled, UnreachableStrategy}
 import mesosphere.marathon.tasks.OfferUtil
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.Placed

--- a/src/main/scala/mesosphere/marathon/core/instance/LocalVolume.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/LocalVolume.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon
 package core.instance
 
-import com.fasterxml.uuid.{ EthernetAddress, Generators }
+import com.fasterxml.uuid.{EthernetAddress, Generators}
 import mesosphere.marathon.api.v2.json.Formats._
-import mesosphere.marathon.state.{ PathId, PersistentVolume, VolumeMount }
+import mesosphere.marathon.state.{PathId, PersistentVolume, VolumeMount}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.event.MarathonEvent
 import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangedEventsGenerator.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangedEventsGenerator.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.instance.update
 
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.event.{ InstanceChanged, MarathonEvent, MesosStatusUpdateEvent }
+import mesosphere.marathon.core.event.{InstanceChanged, MarathonEvent, MesosStatusUpdateEvent}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.Timestamp

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation._
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Maps a [[InstanceUpdateOperation]] to the appropriate [[InstanceUpdateEffect]].

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -4,7 +4,7 @@ package core.instance.update
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.AgentInfo
-import mesosphere.marathon.core.task.{ Task, TaskCondition }
+import mesosphere.marathon.core.task.{Task, TaskCondition}
 import mesosphere.marathon.state.Timestamp
 import org.apache.mesos
 

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -3,11 +3,11 @@ package core.instance.update
 
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.{ Instance, Reservation }
-import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.{ LaunchEphemeral, LaunchOnReservation, MesosUpdate, Reserve }
+import mesosphere.marathon.core.instance.{Instance, Reservation}
+import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.{LaunchEphemeral, LaunchOnReservation, MesosUpdate, Reserve}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.update.TaskUpdateEffect
-import mesosphere.marathon.state.{ Timestamp, UnreachableEnabled }
+import mesosphere.marathon.state.{Timestamp, UnreachableEnabled}
 
 /**
   * Provides methods that apply a given [[InstanceUpdateOperation]]

--- a/src/main/scala/mesosphere/marathon/core/launcher/InstanceOp.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/InstanceOp.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.tasks.ResourceUtil
 import mesosphere.marathon.tasks.ResourceUtil.RichResource
 import mesosphere.mesos.protos.ResourceProviderID
-import org.apache.mesos.{ Protos => MesosProtos }
+import org.apache.mesos.{Protos => MesosProtos}
 
 /**
   * An operation which relates to an instance and is send to Mesos for execution in an `acceptOffers` API call.

--- a/src/main/scala/mesosphere/marathon/core/launcher/InstanceOpFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/InstanceOpFactory.scala
@@ -1,11 +1,11 @@
 package mesosphere.marathon
 package core.launcher
 
-import mesosphere.marathon.core.instance.{ Instance, LocalVolume }
-import mesosphere.marathon.state.{ DiskSource, Region, RunSpec }
+import mesosphere.marathon.core.instance.{Instance, LocalVolume}
+import mesosphere.marathon.state.{DiskSource, Region, RunSpec}
 import mesosphere.mesos.protos.ResourceProviderID
 import mesosphere.util.state.FrameworkId
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 /** Infers which TaskOps to create for given run spec and offers. */
 trait InstanceOpFactory {

--- a/src/main/scala/mesosphere/marathon/core/launcher/LauncherModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/LauncherModule.scala
@@ -4,7 +4,7 @@ package core.launcher
 import java.time.Clock
 
 import akka.stream.scaladsl.SourceQueue
-import mesosphere.marathon.core.launcher.impl.{ InstanceOpFactoryImpl, OfferProcessorImpl, TaskLauncherImpl }
+import mesosphere.marathon.core.launcher.impl.{InstanceOpFactoryImpl, OfferProcessorImpl, TaskLauncherImpl}
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker

--- a/src/main/scala/mesosphere/marathon/core/launcher/OfferMatchResult.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/OfferMatchResult.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon
 package core.launcher
 
-import mesosphere.marathon.state.{ RunSpec, Timestamp }
+import mesosphere.marathon.state.{RunSpec, Timestamp}
 import mesosphere.mesos.NoOfferMatchReason
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 /**
   * Defines the offer match result based on the related offer for given runSpec.

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -3,10 +3,10 @@ package core.launcher.impl
 
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
-import mesosphere.marathon.core.launcher.{ InstanceOp, InstanceOpFactory }
+import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory}
 import mesosphere.marathon.core.matcher.base.util.OfferOperationFactory
 import mesosphere.marathon.core.task.Task
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 class InstanceOpFactoryHelper(
     private val principalOpt: Option[String],

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -5,24 +5,24 @@ import java.time.Clock
 
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.Instance.{ AgentInfo, InstanceState }
+import mesosphere.marathon.core.instance.Instance.{AgentInfo, InstanceState}
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
-import mesosphere.marathon.core.instance.{ Instance, LegacyAppInstance, LocalVolume, LocalVolumeId, Reservation }
-import mesosphere.marathon.core.launcher.{ InstanceOp, InstanceOpFactory, OfferMatchResult }
+import mesosphere.marathon.core.instance.{Instance, LegacyAppInstance, LocalVolume, LocalVolumeId, Reservation}
+import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.plugin.scheduler.SchedulerPlugin
 import mesosphere.marathon.plugin.task.RunSpecTaskProcessor
-import mesosphere.marathon.plugin.{ ApplicationSpec, PodSpec }
+import mesosphere.marathon.plugin.{ApplicationSpec, PodSpec}
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
-import mesosphere.mesos.{ DiskResourceMatch, NoOfferMatchReason, PersistentVolumeMatcher, ResourceMatchResponse, ResourceMatcher, RunSpecOfferMatcher, TaskBuilder, TaskGroupBuilder }
+import mesosphere.mesos.{DiskResourceMatch, NoOfferMatchReason, PersistentVolumeMatcher, ResourceMatchResponse, ResourceMatcher, RunSpecOfferMatcher, TaskBuilder, TaskGroupBuilder}
 import mesosphere.util.state.FrameworkId
-import org.apache.mesos.Protos.{ ExecutorInfo, TaskGroupInfo, TaskInfo }
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.Protos.{ExecutorInfo, TaskGroupInfo, TaskInfo}
+import org.apache.mesos.{Protos => Mesos}
 
 import scala.concurrent.duration._
 

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -4,12 +4,12 @@ package core.launcher.impl
 import akka.Done
 import akka.stream.scaladsl.SourceQueue
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.launcher.{ InstanceOp, OfferProcessor, OfferProcessorConfig, TaskLauncher }
+import mesosphere.marathon.core.launcher.{InstanceOp, OfferProcessor, OfferProcessorConfig, TaskLauncher}
 import mesosphere.marathon.core.matcher.base.OfferMatcher
-import mesosphere.marathon.core.matcher.base.OfferMatcher.{ InstanceOpWithSource, MatchedInstanceOps }
+import mesosphere.marathon.core.matcher.base.OfferMatcher.{InstanceOpWithSource, MatchedInstanceOps}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.metrics.{ Metrics, ServiceMetric }
-import org.apache.mesos.Protos.{ Offer, OfferID }
+import mesosphere.marathon.metrics.{Metrics, ServiceMetric}
+import org.apache.mesos.Protos.{Offer, OfferID}
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/ReservationLabels.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/ReservationLabels.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.launcher.impl
 
 import mesosphere.mesos.protos.Implicits._
-import org.apache.mesos.{ Protos => MesosProtos }
+import org.apache.mesos.{Protos => MesosProtos}
 
 /**
   * Encapsulates information about a reserved resource and its (probably empty) list of reservation labels.

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLabels.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLabels.scala
@@ -4,7 +4,7 @@ package core.launcher.impl
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.util.state.FrameworkId
-import org.apache.mesos.{ Protos => MesosProtos }
+import org.apache.mesos.{Protos => MesosProtos}
 
 object TaskLabels {
   private[this] final val FRAMEWORK_ID_LABEL = "marathon_framework_id"

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImpl.scala
@@ -4,11 +4,11 @@ package core.launcher.impl
 import java.util.Collections
 
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.launcher.{ InstanceOp, TaskLauncher }
-import mesosphere.marathon.metrics.{ Metrics, ServiceMetric }
+import mesosphere.marathon.core.launcher.{InstanceOp, TaskLauncher}
+import mesosphere.marathon.metrics.{Metrics, ServiceMetric}
 import mesosphere.marathon.stream.Implicits._
-import org.apache.mesos.Protos.{ OfferID, Status }
-import org.apache.mesos.{ Protos, SchedulerDriver }
+import org.apache.mesos.Protos.{OfferID, Status}
+import org.apache.mesos.{Protos, SchedulerDriver}
 
 private[launcher] class TaskLauncherImpl(
     marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder) extends TaskLauncher with StrictLogging {

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/UnreachableReservedOfferMonitor.scala
@@ -3,18 +3,18 @@ package core.launcher.impl
 
 import akka.event.Logging
 import akka.NotUsed
-import akka.stream.{ Attributes, Materializer }
+import akka.stream.{Attributes, Materializer}
 import mesosphere.marathon.stream.Implicits._
 import scala.collection.breakOut
 import scala.concurrent.Future
 
-import akka.stream.{ ActorAttributes, OverflowStrategy, Supervision }
-import akka.stream.scaladsl.{ Flow, Sink, Source, SourceQueueWithComplete }
+import akka.stream.{ActorAttributes, OverflowStrategy, Supervision}
+import akka.stream.scaladsl.{Flow, Sink, Source, SourceQueueWithComplete}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.util.state.FrameworkId
-import org.apache.mesos.Protos.{ Offer, SlaveID, TaskState, TaskStatus }
+import org.apache.mesos.Protos.{Offer, SlaveID, TaskState, TaskStatus}
 
 /**
   * Until Mesos 1.3.0, resident tasks have no path to become reachable / terminal (see GitHub issue #5284). This module

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -4,8 +4,8 @@ package core.launchqueue
 import akka.Done
 import mesosphere.marathon.core.instance.update.InstanceChange
 import mesosphere.marathon.core.launcher.OfferMatchResult
-import mesosphere.marathon.core.launchqueue.LaunchQueue.{ QueuedInstanceInfo, QueuedInstanceInfoWithStatistics }
-import mesosphere.marathon.state.{ PathId, RunSpec, Timestamp }
+import mesosphere.marathon.core.launchqueue.LaunchQueue.{QueuedInstanceInfo, QueuedInstanceInfoWithStatistics}
+import mesosphere.marathon.state.{PathId, RunSpec, Timestamp}
 import mesosphere.mesos.NoOfferMatchReason
 
 import scala.collection.immutable.Seq

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -3,14 +3,14 @@ package core.launchqueue
 
 import java.time.Clock
 
-import akka.actor.{ ActorRef, Props }
+import akka.actor.{ActorRef, Props}
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.launcher.InstanceOpFactory
 import mesosphere.marathon.core.launchqueue.impl._
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{ Region, RunSpec }
+import mesosphere.marathon.state.{Region, RunSpec}
 
 /**
   * Provides a [[LaunchQueue]] implementation which can be used to launch tasks for a given RunSpec.

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
@@ -3,12 +3,12 @@ package core.launchqueue.impl
 
 import akka.Done
 import akka.actor.SupervisorStrategy.Stop
-import akka.actor.{ Actor, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated }
+import akka.actor.{Actor, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated}
 import akka.event.LoggingReceive
-import akka.pattern.{ ask, pipe }
+import akka.pattern.{ask, pipe}
 import akka.util.Timeout
-import mesosphere.marathon.core.launchqueue.{ LaunchQueue, LaunchQueueConfig }
-import mesosphere.marathon.state.{ PathId, RunSpec }
+import mesosphere.marathon.core.launchqueue.{LaunchQueue, LaunchQueueConfig}
+import mesosphere.marathon.state.{PathId, RunSpec}
 import LaunchQueue.QueuedInstanceInfo
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.update.InstanceChange

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -7,13 +7,13 @@ import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.update.InstanceChange
-import mesosphere.marathon.core.launchqueue.LaunchQueue.{ QueuedInstanceInfo, QueuedInstanceInfoWithStatistics }
-import mesosphere.marathon.core.launchqueue.{ LaunchQueue, LaunchQueueConfig }
-import mesosphere.marathon.state.{ PathId, RunSpec }
+import mesosphere.marathon.core.launchqueue.LaunchQueue.{QueuedInstanceInfo, QueuedInstanceInfoWithStatistics}
+import mesosphere.marathon.core.launchqueue.{LaunchQueue, LaunchQueueConfig}
+import mesosphere.marathon.state.{PathId, RunSpec}
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
-import scala.concurrent.{ Future, ExecutionContext }
+import scala.concurrent.{Future, ExecutionContext}
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/OfferMatchStatisticsActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/OfferMatchStatisticsActor.scala
@@ -1,13 +1,13 @@
 package mesosphere.marathon
 package core.launchqueue.impl
 
-import akka.actor.{ Actor, ActorRef, Props }
+import akka.actor.{Actor, ActorRef, Props}
 import mesosphere.marathon.core.launcher.OfferMatchResult
 import mesosphere.mesos.NoOfferMatchReason
 
 import scala.collection.mutable
 import OfferMatchResult._
-import mesosphere.marathon.core.launchqueue.LaunchQueue.{ QueuedInstanceInfoWithStatistics, QueuedInstanceInfo }
+import mesosphere.marathon.core.launchqueue.LaunchQueue.{QueuedInstanceInfoWithStatistics, QueuedInstanceInfo}
 import mesosphere.marathon.state.PathId
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiter.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiter.scala
@@ -5,7 +5,7 @@ import java.time.Clock
 import java.util.concurrent.TimeUnit
 
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.state.{ PathId, RunSpec, Timestamp }
+import mesosphere.marathon.state.{PathId, RunSpec, Timestamp}
 import mesosphere.util.DurationToHumanReadable
 
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActor.scala
@@ -1,11 +1,11 @@
 package mesosphere.marathon
 package core.launchqueue.impl
 
-import akka.actor.{ Actor, ActorRef, Cancellable, Props }
+import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import akka.event.LoggingReceive
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.launchqueue.impl.RateLimiterActor._
-import mesosphere.marathon.state.{ RunSpec, Timestamp }
+import mesosphere.marathon.state.{RunSpec, Timestamp}
 
 import scala.concurrent.duration._
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -9,19 +9,19 @@ import akka.event.LoggingReceive
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceDeleted, InstanceUpdated }
-import mesosphere.marathon.core.launcher.{ InstanceOp, InstanceOpFactory, OfferMatchResult }
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceDeleted, InstanceUpdated}
+import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfo
 import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
 import mesosphere.marathon.core.launchqueue.impl.TaskLauncherActor.RecheckIfBackOffUntilReached
 import mesosphere.marathon.core.matcher.base.OfferMatcher
-import mesosphere.marathon.core.matcher.base.OfferMatcher.{ InstanceOpWithSource, MatchedInstanceOps }
-import mesosphere.marathon.core.matcher.base.util.{ ActorOfferMatcher, InstanceOpSourceDelegate }
+import mesosphere.marathon.core.matcher.base.OfferMatcher.{InstanceOpWithSource, MatchedInstanceOps}
+import mesosphere.marathon.core.matcher.base.util.{ActorOfferMatcher, InstanceOpSourceDelegate}
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{ Region, RunSpec, Timestamp }
+import mesosphere.marathon.state.{Region, RunSpec, Timestamp}
 import mesosphere.marathon.stream.Implicits._
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/core/leadership/LeadershipModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/leadership/LeadershipModule.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.leadership
 
-import akka.actor.{ ActorRef, ActorRefFactory, Props }
+import akka.actor.{ActorRef, ActorRefFactory, Props}
 import mesosphere.marathon.core.leadership.impl._
 
 trait LeadershipModule {

--- a/src/main/scala/mesosphere/marathon/core/leadership/impl/LeadershipCoordinatorActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/leadership/impl/LeadershipCoordinatorActor.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.leadership.impl
 
-import akka.actor.{ Actor, ActorRef, Props, Stash, Status, Terminated }
+import akka.actor.{Actor, ActorRef, Props, Stash, Status, Terminated}
 import akka.event.LoggingReceive
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.leadership.PreparationMessages

--- a/src/main/scala/mesosphere/marathon/core/leadership/impl/WhenLeaderActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/leadership/impl/WhenLeaderActor.scala
@@ -1,11 +1,11 @@
 package mesosphere.marathon
 package core.leadership.impl
 
-import akka.actor.{ Actor, ActorRef, PoisonPill, Props, Stash, Status, Terminated }
+import akka.actor.{Actor, ActorRef, PoisonPill, Props, Stash, Status, Terminated}
 import akka.event.LoggingReceive
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.leadership.PreparationMessages.{ PrepareForStart, Prepared }
-import mesosphere.marathon.core.leadership.impl.WhenLeaderActor.{ Stop, Stopped }
+import mesosphere.marathon.core.leadership.PreparationMessages.{PrepareForStart, Prepared}
+import mesosphere.marathon.core.leadership.impl.WhenLeaderActor.{Stop, Stopped}
 
 private[leadership] object WhenLeaderActor {
   def props(childProps: Props): Props = {

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/OfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/OfferMatcher.scala
@@ -4,7 +4,7 @@ package core.matcher.base
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launcher.InstanceOp
 import mesosphere.marathon.state.PathId
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/ActorOfferMatcher.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.state.PathId
 import org.apache.mesos.Protos.Offer
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 
 /**
   * Provides a thin wrapper around an OfferMatcher implemented as an actors.

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/InstanceOpSourceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/InstanceOpSourceDelegate.scala
@@ -4,7 +4,7 @@ package core.matcher.base.util
 import akka.actor.ActorRef
 import mesosphere.marathon.core.launcher.InstanceOp
 import mesosphere.marathon.core.matcher.base.OfferMatcher.InstanceOpSource
-import mesosphere.marathon.core.matcher.base.util.InstanceOpSourceDelegate.{ InstanceOpAccepted, InstanceOpRejected }
+import mesosphere.marathon.core.matcher.base.util.InstanceOpSourceDelegate.{InstanceOpAccepted, InstanceOpRejected}
 
 private class InstanceOpSourceDelegate(actorRef: ActorRef) extends InstanceOpSource {
   override def instanceOpAccepted(instanceOp: InstanceOp): Unit = actorRef ! InstanceOpAccepted(instanceOp)

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactory.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactory.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.state.VolumeMount
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.protos.ResourceProviderID
 import org.apache.mesos.Protos.Resource.ReservationInfo
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 class OfferOperationFactory(
     private val principalOpt: Option[String],

--- a/src/main/scala/mesosphere/marathon/core/matcher/base/util/StopOnFirstMatchingOfferMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/base/util/StopOnFirstMatchingOfferMatcher.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.OfferMatcher.MatchedInstanceOps
 import org.apache.mesos.Protos.Offer
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Wraps multiple offer matchers and returns the first non-empty match or (if all are empty) the last empty match.

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManager.scala
@@ -3,7 +3,7 @@ package core.matcher.manager
 
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 trait OfferMatcherManager {
   def addSubscription(offerMatcher: OfferMatcher)(implicit ec: ExecutionContext): Future[Unit]

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -7,10 +7,10 @@ import akka.actor.ActorRef
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.base.util.ActorOfferMatcher
-import mesosphere.marathon.core.matcher.manager.impl.{ OfferMatcherManagerActor, OfferMatcherManagerActorMetrics, OfferMatcherManagerDelegate }
+import mesosphere.marathon.core.matcher.manager.impl.{OfferMatcherManagerActor, OfferMatcherManagerActorMetrics, OfferMatcherManagerDelegate}
 import mesosphere.marathon.state.Region
 import rx.lang.scala.subjects.BehaviorSubject
-import rx.lang.scala.{ Observable, Subject }
+import rx.lang.scala.{Observable, Subject}
 
 import scala.util.Random
 

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
@@ -3,21 +3,21 @@ package core.matcher.manager.impl
 
 import java.time.Clock
 
-import akka.actor.{ Actor, Cancellable, Props }
+import akka.actor.{Actor, Cancellable, Props}
 import akka.event.LoggingReceive
 import akka.pattern.pipe
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.LocalVolumeId
 import mesosphere.marathon.core.matcher.base.OfferMatcher
-import mesosphere.marathon.core.matcher.base.OfferMatcher.{ InstanceOpWithSource, MatchedInstanceOps }
+import mesosphere.marathon.core.matcher.base.OfferMatcher.{InstanceOpWithSource, MatchedInstanceOps}
 import mesosphere.marathon.core.matcher.base.util.ActorOfferMatcher
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManagerConfig
-import mesosphere.marathon.core.matcher.manager.impl.OfferMatcherManagerActor.{ CleanUpOverdueOffers, MatchOfferData, UnprocessedOffer }
-import mesosphere.marathon.metrics.{ Metrics, ServiceMetric, SettableGauge }
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.core.matcher.manager.impl.OfferMatcherManagerActor.{CleanUpOverdueOffers, MatchOfferData, UnprocessedOffer}
+import mesosphere.marathon.metrics.{Metrics, ServiceMetric, SettableGauge}
+import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.tasks.ResourceUtil
-import org.apache.mesos.Protos.{ Offer, OfferID }
+import org.apache.mesos.Protos.{Offer, OfferID}
 import rx.lang.scala.Observer
 
 import scala.collection.immutable.Queue

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerDelegate.scala
@@ -5,7 +5,7 @@ import akka.actor.ActorRef
 import akka.util.Timeout
 import mesosphere.marathon.core.matcher.base.OfferMatcher
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 import akka.pattern.ask

--- a/src/main/scala/mesosphere/marathon/core/matcher/reconcile/OfferMatcherReconciliationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/reconcile/OfferMatcherReconciliationModule.scala
@@ -7,11 +7,11 @@ import akka.event.EventStream
 import mesosphere.marathon.core.flow.ReviveOffersConfig
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.matcher.base.OfferMatcher
-import mesosphere.marathon.core.matcher.reconcile.impl.{ OfferMatcherReconciler, OffersWantedForReconciliationActor }
+import mesosphere.marathon.core.matcher.reconcile.impl.{OfferMatcherReconciler, OffersWantedForReconciliationActor}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.storage.repository.GroupRepository
 import rx.lang.scala.subjects.BehaviorSubject
-import rx.lang.scala.{ Observable, Observer, Subject }
+import rx.lang.scala.{Observable, Observer, Subject}
 
 class OfferMatcherReconciliationModule(
     reviveOffersConfig: ReviveOffersConfig,

--- a/src/main/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconciler.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconciler.scala
@@ -7,14 +7,14 @@ import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.launcher.InstanceOp
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.matcher.base.OfferMatcher
-import mesosphere.marathon.core.matcher.base.OfferMatcher.{ InstanceOpSource, InstanceOpWithSource, MatchedInstanceOps }
+import mesosphere.marathon.core.matcher.base.OfferMatcher.{InstanceOpSource, InstanceOpWithSource, MatchedInstanceOps}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.state.RootGroup
 import mesosphere.marathon.storage.repository.GroupRepository
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.util.state.FrameworkId
-import org.apache.mesos.Protos.{ Offer, OfferID, Resource }
+import org.apache.mesos.Protos.{Offer, OfferID, Resource}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/mesosphere/marathon/core/matcher/reconcile/impl/OffersWantedForReconciliationActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/reconcile/impl/OffersWantedForReconciliationActor.scala
@@ -3,8 +3,8 @@ package core.matcher.reconcile.impl
 
 import java.time.Clock
 
-import akka.actor.{ Actor, Cancellable, Props }
-import akka.event.{ EventStream, LoggingReceive }
+import akka.actor.{Actor, Cancellable, Props}
+import akka.event.{EventStream, LoggingReceive}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.flow.ReviveOffersConfig
 import mesosphere.marathon.core.event.DeploymentStepSuccess

--- a/src/main/scala/mesosphere/marathon/core/plugin/impl/PluginManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/plugin/impl/PluginManagerImpl.scala
@@ -2,18 +2,18 @@ package mesosphere.marathon
 package core.plugin.impl
 
 import java.io.File
-import java.net.{ URL, URLClassLoader }
+import java.net.{URL, URLClassLoader}
 import java.util.ServiceLoader
 
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.base.CrashStrategy
-import mesosphere.marathon.core.plugin.impl.PluginManagerImpl.{ PluginHolder, PluginReference }
-import mesosphere.marathon.core.plugin.{ PluginDefinition, PluginDefinitions, PluginManager }
+import mesosphere.marathon.core.plugin.impl.PluginManagerImpl.{PluginHolder, PluginReference}
+import mesosphere.marathon.core.plugin.{PluginDefinition, PluginDefinitions, PluginManager}
 import mesosphere.marathon.io.IO
 import mesosphere.marathon.plugin.plugin.PluginConfiguration
 import mesosphere.marathon.stream.Implicits._
 import org.apache.commons.io.FileUtils
-import play.api.libs.json.{ JsObject, JsString, Json }
+import play.api.libs.json.{JsObject, JsString, Json}
 
 import scala.util.control.NonFatal
 import scala.reflect.ClassTag

--- a/src/main/scala/mesosphere/marathon/core/pod/MesosContainer.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/MesosContainer.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.pod
 
 import mesosphere.marathon.plugin.ContainerSpec
-import mesosphere.marathon.raml.{ Artifact, Endpoint, Image, Lifecycle, MesosExec, Resources }
+import mesosphere.marathon.raml.{Artifact, Endpoint, Image, Lifecycle, MesosExec, Resources}
 import mesosphere.marathon.state.VolumeMount
 
 import scala.collection.immutable.Map

--- a/src/main/scala/mesosphere/marathon/core/pod/Network.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/Network.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.Protos.NetworkDefinition
 import mesosphere.marathon.plugin.NetworkSpec
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.protos.Implicits._
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 /**
   * Network declared by a [[PodDefinition]].

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -4,7 +4,7 @@ package core.pod
 // scalastyle:off
 import mesosphere.marathon.api.v2.PodNormalization
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.raml.{ Endpoint, ExecutorResources, Pod, Raml, Resources }
+import mesosphere.marathon.raml.{Endpoint, ExecutorResources, Pod, Raml, Resources}
 import mesosphere.marathon.state._
 import play.api.libs.json.Json
 

--- a/src/main/scala/mesosphere/marathon/core/pod/PodManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodManager.scala
@@ -3,7 +3,7 @@ package core.pod
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.core.deployment.DeploymentPlan
 
 import scala.concurrent.Future

--- a/src/main/scala/mesosphere/marathon/core/pod/impl/PodManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/impl/PodManagerImpl.scala
@@ -5,8 +5,8 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.group.GroupManager
-import mesosphere.marathon.core.pod.{ PodDefinition, PodManager }
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.core.pod.{PodDefinition, PodManager}
+import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.stream.Implicits._
 
 import scala.collection.immutable.Seq

--- a/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/ReadinessCheckExecutor.scala
@@ -3,7 +3,7 @@ package core.readiness
 
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.{ AppDefinition, PortAssignment, RunSpec }
+import mesosphere.marathon.state.{AppDefinition, PortAssignment, RunSpec}
 import rx.lang.scala.Observable
 
 import scala.concurrent.duration.FiniteDuration

--- a/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
@@ -5,11 +5,11 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.client.RequestBuilding
-import akka.http.scaladsl.model.{ MediaTypes, StatusCodes, HttpResponse => AkkaHttpResponse }
+import akka.http.scaladsl.model.{MediaTypes, StatusCodes, HttpResponse => AkkaHttpResponse}
 import akka.stream.Materializer
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
-import mesosphere.marathon.core.readiness.{ HttpResponse, ReadinessCheckExecutor, ReadinessCheckResult }
+import mesosphere.marathon.core.readiness.{HttpResponse, ReadinessCheckExecutor, ReadinessCheckResult}
 import mesosphere.marathon.util.Timeout
 import rx.lang.scala.Observable
 

--- a/src/main/scala/mesosphere/marathon/core/storage/backup/Backup.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/backup/Backup.scala
@@ -5,16 +5,16 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
-import ch.qos.logback.classic.{ Level, Logger }
+import ch.qos.logback.classic.{Level, Logger}
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 import mesosphere.marathon.core.base.LifecycleState
-import mesosphere.marathon.storage.{ StorageConf, StorageModule }
+import mesosphere.marathon.storage.{StorageConf, StorageModule}
 import org.rogach.scallop.ScallopConf
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{Await, Future}
 import scala.util.control.NonFatal
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/storage/backup/PersistentStoreBackup.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/backup/PersistentStoreBackup.scala
@@ -10,7 +10,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.storage.backup.impl.PersistentStoreBackupImpl
 import mesosphere.marathon.core.storage.store.PersistenceStore
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Backup & Restore functionality for configured persistent store and backup location.

--- a/src/main/scala/mesosphere/marathon/core/storage/backup/impl/PersistentStoreBackupImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/backup/impl/PersistentStoreBackupImpl.scala
@@ -6,13 +6,13 @@ import java.net.URI
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Flow, Keep }
+import akka.stream.scaladsl.{Flow, Keep}
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.storage.backup.{ BackupItem, PersistentStoreBackup }
+import mesosphere.marathon.core.storage.backup.{BackupItem, PersistentStoreBackup}
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.stream.UriIO
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 class PersistentStoreBackupImpl(store: PersistenceStore[_, _, _])(implicit materializer: Materializer, actorSystem: ActorSystem, ec: ExecutionContext)
   extends PersistentStoreBackup with StrictLogging {

--- a/src/main/scala/mesosphere/marathon/core/storage/repository/Repository.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/repository/Repository.scala
@@ -4,7 +4,7 @@ package core.storage.repository
 import java.time.OffsetDateTime
 
 import akka.stream.scaladsl.Source
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/mesosphere/marathon/core/storage/repository/impl/PersistenceStoreRepository.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/repository/impl/PersistenceStoreRepository.scala
@@ -6,9 +6,9 @@ import java.time.OffsetDateTime
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.scaladsl.Source
-import akka.{ Done, NotUsed }
-import mesosphere.marathon.core.storage.repository.{ Repository, VersionedRepository }
-import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
+import akka.{Done, NotUsed}
+import mesosphere.marathon.core.storage.repository.{Repository, VersionedRepository}
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/PersistenceStore.scala
@@ -5,8 +5,8 @@ import java.time.OffsetDateTime
 
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
-import akka.stream.scaladsl.{ Sink, Source }
-import akka.{ Done, NotUsed }
+import akka.stream.scaladsl.{Sink, Source}
+import akka.{Done, NotUsed}
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.core.storage.backup.BackupItem
 import mesosphere.marathon.util.OpenableOnce

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/BasePersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/BasePersistenceStore.scala
@@ -3,18 +3,18 @@ package core.storage.store.impl
 
 import java.time.OffsetDateTime
 
-import akka.http.scaladsl.marshalling.{ Marshal, Marshaller }
-import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
+import akka.http.scaladsl.marshalling.{Marshal, Marshaller}
+import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
-import mesosphere.marathon.metrics.{ Metrics, ServiceMetric, Timer }
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
+import mesosphere.marathon.metrics.{Metrics, ServiceMetric, Timer}
 import mesosphere.marathon.util.KeyedLock
 
-import scala.async.Async.{ async, await }
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.async.Async.{async, await}
+import scala.concurrent.{ExecutionContext, Future}
 
 case class CategorizedKey[C, K](category: C, key: K)
 

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStore.scala
@@ -6,22 +6,22 @@ import java.time.OffsetDateTime
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Source, Sink => ScalaSink }
-import akka.{ Done, NotUsed }
+import akka.stream.scaladsl.{Source, Sink => ScalaSink}
+import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.core.storage.backup.BackupItem
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
-import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
-import mesosphere.marathon.metrics.{ Counter, Metrics, ServiceMetric }
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
+import mesosphere.marathon.metrics.{Counter, Metrics, ServiceMetric}
 import mesosphere.marathon.storage.VersionCacheConfig
 import mesosphere.marathon.stream.Sink
 import mesosphere.marathon.util.KeyedLock
 
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.Set
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Random
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStore.scala
@@ -5,20 +5,20 @@ import java.io.NotActiveException
 import java.time.OffsetDateTime
 
 import akka.http.scaladsl.marshalling.Marshaller
-import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
+import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Sink, Source }
-import akka.{ Done, NotUsed }
+import akka.stream.scaladsl.{Sink, Source}
+import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.core.storage.backup.BackupItem
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
-import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
 import mesosphere.marathon.util.KeyedLock
 
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
 /**
   * A Write Ahead Cache of another persistence store that preloads the entire persistence store into memory before

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/memory/InMemoryPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/memory/InMemoryPersistenceStore.scala
@@ -1,23 +1,23 @@
 package mesosphere.marathon
 package core.storage.store.impl.memory
 
-import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream }
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 import java.time.OffsetDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.util.ByteString
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.core.storage.backup.BackupItem
-import mesosphere.marathon.core.storage.store.impl.{ BasePersistenceStore, CategorizedKey }
+import mesosphere.marathon.core.storage.store.impl.{BasePersistenceStore, CategorizedKey}
 import mesosphere.marathon.io.IO
-import mesosphere.marathon.storage.migration.{ Migration, StorageVersions }
+import mesosphere.marathon.storage.migration.{Migration, StorageVersions}
 import mesosphere.marathon.util.Lock
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
 case class RamId(category: String, id: String, version: Option[OffsetDateTime])

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/NoRetryPolicy.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/NoRetryPolicy.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.storage.store.impl.zk
 
-import org.apache.curator.{ RetryPolicy, RetrySleeper }
+import org.apache.curator.{RetryPolicy, RetrySleeper}
 
 object NoRetryPolicy extends RetryPolicy {
   override def allowRetry(retryCount: Int, elapsedTimeMs: Long, sleeper: RetrySleeper): Boolean = false

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/RichCuratorFramework.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/RichCuratorFramework.scala
@@ -3,18 +3,18 @@ package core.storage.store.impl.zk
 
 import akka.Done
 import akka.util.ByteString
-import mesosphere.marathon.core.base.{ LifecycleState, _ }
+import mesosphere.marathon.core.base.{LifecycleState, _}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.util.RichLock
 import org.apache.curator.RetryPolicy
-import org.apache.curator.framework.api.{ BackgroundPathable, Backgroundable, Pathable }
+import org.apache.curator.framework.api.{BackgroundPathable, Backgroundable, Pathable}
 import org.apache.curator.framework.imps.CuratorFrameworkState
-import org.apache.curator.framework.state.{ ConnectionState, ConnectionStateListener }
-import org.apache.curator.framework.{ CuratorFramework, CuratorFrameworkFactory }
+import org.apache.curator.framework.state.{ConnectionState, ConnectionStateListener}
+import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
 import org.apache.zookeeper.CreateMode
-import org.apache.zookeeper.data.{ ACL, Stat }
+import org.apache.zookeeper.data.{ACL, Stat}
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkFuture.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkFuture.scala
@@ -6,13 +6,13 @@ import akka.util.ByteString
 import mesosphere.marathon.stream.Implicits._
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.api.CuratorEventType._
-import org.apache.curator.framework.api.{ BackgroundCallback, CuratorEvent }
+import org.apache.curator.framework.api.{BackgroundCallback, CuratorEvent}
 import org.apache.zookeeper.KeeperException
-import org.apache.zookeeper.data.{ ACL, Stat }
+import org.apache.zookeeper.data.{ACL, Stat}
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ CanAwait, ExecutionContext, Future, Promise, TimeoutException }
-import scala.util.{ Failure, Success, Try }
+import scala.concurrent.{CanAwait, ExecutionContext, Future, Promise, TimeoutException}
+import scala.util.{Failure, Success, Try}
 
 private[zk] abstract class ZkFuture[T] extends Future[T] with BackgroundCallback {
   private val promise = Promise[T]()

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -7,25 +7,25 @@ import java.util.UUID
 
 import akka.actor.Scheduler
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Flow, Keep, Merge, Sink, Source }
+import akka.stream.scaladsl.{Flow, Keep, Merge, Sink, Source}
 import akka.util.ByteString
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.Protos.{ StorageVersion, ZKStoreEntry }
+import mesosphere.marathon.Protos.{StorageVersion, ZKStoreEntry}
 import mesosphere.marathon.core.storage.backup.BackupItem
-import mesosphere.marathon.core.storage.store.impl.{ BasePersistenceStore, CategorizedKey }
-import mesosphere.marathon.storage.migration.{ Migration, StorageVersions }
-import mesosphere.marathon.util.{ Retry, WorkQueue, toRichFuture }
+import mesosphere.marathon.core.storage.store.impl.{BasePersistenceStore, CategorizedKey}
+import mesosphere.marathon.storage.migration.{Migration, StorageVersions}
+import mesosphere.marathon.util.{Retry, WorkQueue, toRichFuture}
 import org.apache.zookeeper.KeeperException
-import org.apache.zookeeper.KeeperException.{ NoNodeException, NodeExistsException }
+import org.apache.zookeeper.KeeperException.{NoNodeException, NodeExistsException}
 import org.apache.zookeeper.data.Stat
 
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 import scala.collection.immutable.Seq
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 case class ZkId(category: String, id: String, version: Option[OffsetDateTime]) {
   private val bucket = math.abs(id.hashCode % ZkId.HashBucketSize)

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon
 package core.task
 
-import java.util.{ Base64, UUID }
+import java.util.{Base64, UUID}
 
-import com.fasterxml.uuid.{ EthernetAddress, Generators }
+import com.fasterxml.uuid.{EthernetAddress, Generators}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition.Terminal
@@ -14,8 +14,8 @@ import mesosphere.marathon.core.task.update.TaskUpdateEffect
 import mesosphere.marathon.state._
 import org.apache.mesos
 import org.apache.mesos.Protos.TaskState._
-import org.apache.mesos.Protos.{ TaskState, TaskStatus }
-import org.apache.mesos.{ Protos => MesosProtos }
+import org.apache.mesos.Protos.{TaskState, TaskStatus}
+import org.apache.mesos.{Protos => MesosProtos}
 
 import scala.concurrent.duration.FiniteDuration
 import mesosphere.marathon.api.v2.json.Formats._
@@ -116,21 +116,21 @@ case class Task(taskId: Task.Id, runSpecVersion: Timestamp, status: Task.Status)
           TaskUpdateEffect.Noop
         }
 
-    // case 4: health or state updated
-    case  _ =>
-      // TODO(PODS): strange to use Condition here
-      updatedHealthOrState(status.mesosStatus, newMesosStatus).map { newTaskStatus =>
-        val updatedNetworkInfo = status.networkInfo.update(newMesosStatus)
-        val updatedStatus = status.copy(
-          mesosStatus = Some(newTaskStatus), condition = newStatus, networkInfo = updatedNetworkInfo)
-        val updatedTask = copy(status = updatedStatus)
-        // TODO(PODS): The instance needs to handle a terminal task via an Update here
-        // Or should we use Expunge in case of a terminal update for resident tasks?
-        TaskUpdateEffect.Update(newState = updatedTask)
-      } getOrElse {
-        logger.debug(s"Ignoring status update for $taskId. Status did not change.")
-        TaskUpdateEffect.Noop
-      }
+      // case 4: health or state updated
+      case _ =>
+        // TODO(PODS): strange to use Condition here
+        updatedHealthOrState(status.mesosStatus, newMesosStatus).map { newTaskStatus =>
+          val updatedNetworkInfo = status.networkInfo.update(newMesosStatus)
+          val updatedStatus = status.copy(
+            mesosStatus = Some(newTaskStatus), condition = newStatus, networkInfo = updatedNetworkInfo)
+          val updatedTask = copy(status = updatedStatus)
+          // TODO(PODS): The instance needs to handle a terminal task via an Update here
+          // Or should we use Expunge in case of a terminal update for resident tasks?
+          TaskUpdateEffect.Update(newState = updatedTask)
+        } getOrElse {
+          logger.debug(s"Ignoring status update for $taskId. Status did not change.")
+          TaskUpdateEffect.Noop
+        }
 
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
@@ -4,7 +4,7 @@ package core.task.jobs
 import java.time.Clock
 
 import mesosphere.marathon.core.leadership.LeadershipModule
-import mesosphere.marathon.core.task.jobs.impl.{ ExpungeOverdueLostTasksActor, OverdueTasksActor }
+import mesosphere.marathon.core.task.jobs.impl.{ExpungeOverdueLostTasksActor, OverdueTasksActor}
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.MarathonConf

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
@@ -3,14 +3,14 @@ package core.task.jobs.impl
 
 import java.time.Clock
 
-import akka.actor.{ Actor, Cancellable, Props }
+import akka.actor.{Actor, Cancellable, Props}
 import akka.pattern.pipe
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.jobs.TaskJobsConfig
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.SpecInstances
-import mesosphere.marathon.state.{ PathId, Timestamp, UnreachableDisabled, UnreachableEnabled }
+import mesosphere.marathon.state.{PathId, Timestamp, UnreachableDisabled, UnreachableEnabled}
 
 /**
   * Business logic of overdue tasks actor.

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
@@ -8,7 +8,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
+import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.Timestamp
 

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
@@ -3,10 +3,10 @@ package core.task.termination
 
 import java.time.Clock
 
-import akka.actor.{ ActorRef, Props }
+import akka.actor.{ActorRef, Props}
 import mesosphere.marathon.MarathonSchedulerDriverHolder
 import mesosphere.marathon.core.leadership.LeadershipModule
-import mesosphere.marathon.core.task.termination.impl.{ KillServiceActor, KillServiceDelegate }
+import mesosphere.marathon.core.task.termination.impl.{KillServiceActor, KillServiceDelegate}
 import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
 
 class TaskTerminationModule(

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -4,10 +4,10 @@ package core.task.termination.impl
 import java.time.Clock
 
 import akka.Done
-import akka.actor.{ Actor, Cancellable, Props }
+import akka.actor.{Actor, Cancellable, Props}
 import akka.stream.ActorMaterializer
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.event.{ InstanceChanged, UnknownInstanceTerminated }
+import mesosphere.marathon.core.event.{InstanceChanged, UnknownInstanceTerminated}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.Id
@@ -18,7 +18,7 @@ import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.stream.Sink
 
 import scala.collection.mutable
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 
 /**
   * An actor that handles killing instances in chunks and depending on the instance state.

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
@@ -6,9 +6,9 @@ import akka.actor.ActorRef
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
+import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 import scala.collection.immutable.Seq
 
 private[termination] class KillServiceDelegate(actorRef: ActorRef) extends KillService with StrictLogging {

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
@@ -5,13 +5,13 @@ import akka.NotUsed
 import akka.actor.Cancellable
 import akka.Done
 import akka.stream.OverflowStrategy
-import akka.stream.scaladsl.{ Flow, Source }
+import akka.stream.scaladsl.{Flow, Source}
 import com.typesafe.scalalogging.StrictLogging
 import java.util.UUID
-import mesosphere.marathon.core.event.{ InstanceChanged, UnknownInstanceTerminated }
+import mesosphere.marathon.core.event.{InstanceChanged, UnknownInstanceTerminated}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.termination.InstanceChangedPredicates.considerTerminal
-import mesosphere.marathon.stream.{ EnrichedFlow, EnrichedSource }
+import mesosphere.marathon.stream.{EnrichedFlow, EnrichedSource}
 
 object KillStreamWatcher extends StrictLogging {
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -4,12 +4,12 @@ package core.task.tracker
 import akka.Done
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{ InstanceUpdateEffect, InstanceUpdateOperation }
+import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 import org.apache.mesos
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * The [[InstanceTracker]] exposes the latest known state for every instance and handles the processing of

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTrackerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTrackerModule.scala
@@ -5,7 +5,7 @@ import java.time.Clock
 
 import akka.actor.ActorRef
 import akka.stream.Materializer
-import mesosphere.marathon.core.instance.update.{ InstanceChangeHandler, InstanceUpdateOpResolver }
+import mesosphere.marathon.core.instance.update.{InstanceChangeHandler, InstanceUpdateOpResolver}
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.task.tracker.impl._
 import mesosphere.marathon.storage.repository.InstanceRepository

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTrackerUpdateStepProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTrackerUpdateStepProcessor.scala
@@ -4,7 +4,7 @@ package core.task.tracker
 import akka.Done
 import mesosphere.marathon.core.instance.update.InstanceChange
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Internal processor that handles performing all required steps after a task tracker update.

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessor.scala
@@ -4,9 +4,9 @@ package core.task.tracker.impl
 import akka.actor.ActorRef
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 private[tracker] object InstanceOpProcessor {
   case class Operation(deadline: Timestamp, sender: ActorRef, instanceId: Instance.Id, op: InstanceUpdateOperation) {

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceOpProcessorImpl.scala
@@ -1,17 +1,17 @@
 package mesosphere.marathon
 package core.task.tracker.impl
 
-import akka.actor.{ ActorRef, Status }
+import akka.actor.{ActorRef, Status}
 import akka.util.Timeout
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.MarathonEvent
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{ InstanceUpdateEffect, InstanceUpdateOpResolver }
+import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOpResolver}
 import mesosphere.marathon.core.task.tracker.InstanceTrackerConfig
 import mesosphere.marathon.storage.repository.InstanceRepository
 
 import scala.collection.immutable.Seq
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -8,11 +8,11 @@ import akka.event.LoggingReceive
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.appinfo.TaskCounts
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceDeleted, InstanceUpdateEffect, InstanceUpdateOperation, InstanceUpdated }
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceDeleted, InstanceUpdateEffect, InstanceUpdateOperation, InstanceUpdated}
 import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.ForwardTaskOp
-import mesosphere.marathon.core.task.tracker.{ InstanceTracker, InstanceTrackerUpdateStepProcessor }
+import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerUpdateStepProcessor}
 import mesosphere.marathon.metrics.AtomicGauge
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -6,18 +6,18 @@ import java.util.concurrent.TimeoutException
 
 import akka.Done
 import akka.actor.ActorRef
-import akka.pattern.{ AskTimeoutException, ask }
+import akka.pattern.{AskTimeoutException, ask}
 import akka.util.Timeout
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{ InstanceUpdateEffect, InstanceUpdateOperation }
+import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
 import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.ForwardTaskOp
-import mesosphere.marathon.core.task.tracker.{ InstanceTracker, InstanceTrackerConfig }
-import mesosphere.marathon.metrics.{ Metrics, ServiceMetric }
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerConfig}
+import mesosphere.marathon.metrics.{Metrics, ServiceMetric}
+import mesosphere.marathon.state.{PathId, Timestamp}
 import org.apache.mesos
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerUpdateStepProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerUpdateStepProcessorImpl.scala
@@ -3,11 +3,11 @@ package core.task.tracker.impl
 
 import akka.Done
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceChangeHandler}
 import mesosphere.marathon.core.task.tracker.InstanceTrackerUpdateStepProcessor
-import mesosphere.marathon.metrics.{ Metrics, ServiceMetric, Timer }
+import mesosphere.marathon.metrics.{Metrics, ServiceMetric, Timer}
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Takes care of processing [[InstanceChange]]s and will be called after an instance state

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceUpdateActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceUpdateActor.scala
@@ -4,12 +4,12 @@ package core.task.tracker.impl
 import java.time.Clock
 import java.util.concurrent.TimeoutException
 
-import akka.actor.{ Actor, Props, Status }
+import akka.actor.{Actor, Props, Status}
 import akka.event.LoggingReceive
 import akka.pattern.pipe
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.tracker.impl.InstanceUpdateActor.{ ActorMetrics, FinishedInstanceOp, ProcessInstanceOp }
+import mesosphere.marathon.core.task.tracker.impl.InstanceUpdateActor.{ActorMetrics, FinishedInstanceOp, ProcessInstanceOp}
 import mesosphere.marathon.metrics._
 
 import scala.collection.immutable.Queue

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -10,12 +10,12 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.event.UnknownInstanceTerminated
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
+import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
-import mesosphere.marathon.core.task.{ Task, TaskCondition }
-import mesosphere.marathon.metrics.{ Metrics, ServiceMetric, Timer }
-import org.apache.mesos.{ Protos => MesosProtos }
+import mesosphere.marathon.core.task.{Task, TaskCondition}
+import mesosphere.marathon.metrics.{Metrics, ServiceMetric, Timer}
+import org.apache.mesos.{Protos => MesosProtos}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/ThrottlingTaskStatusUpdateProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/ThrottlingTaskStatusUpdateProcessor.scala
@@ -1,13 +1,13 @@
 package mesosphere.marathon
 package core.task.update.impl
 
-import javax.inject.{ Inject, Named }
+import javax.inject.{Inject, Named}
 
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.util.WorkQueue
 import org.apache.mesos.Protos.TaskStatus
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 object ThrottlingTaskStatusUpdateProcessor {
   /**

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ContinueOnErrorStep.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ContinueOnErrorStep.scala
@@ -3,7 +3,7 @@ package core.task.update.impl.steps
 
 import akka.Done
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceChangeHandler}
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyHealthCheckManagerStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyHealthCheckManagerStepImpl.scala
@@ -2,9 +2,9 @@ package mesosphere.marathon
 package core.task.update.impl.steps
 
 import akka.Done
-import com.google.inject.{ Inject, Provider }
+import com.google.inject.{Inject, Provider}
 import mesosphere.marathon.core.health.HealthCheckManager
-import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceChangeHandler}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyLaunchQueueStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyLaunchQueueStepImpl.scala
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 import akka.Done
 import com.google.inject.Provider
-import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceChangeHandler}
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 
 import scala.concurrent.Future

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
@@ -4,12 +4,12 @@ package core.task.update.impl.steps
 import java.time.OffsetDateTime
 
 import akka.Done
-import com.google.inject.{ Inject, Provider }
+import com.google.inject.{Inject, Provider}
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.group.GroupManager
-import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceChangeHandler}
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.state.{ PathId, RunSpec }
+import mesosphere.marathon.state.{PathId, RunSpec}
 
 import scala.async.Async._
 import scala.concurrent.Future

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/PostToEventStreamStepImpl.scala
@@ -6,7 +6,7 @@ import akka.event.EventStream
 import com.google.inject.Inject
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.InstanceHealthChanged
-import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceChangeHandler}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/ScaleAppUpdateStepImpl.scala
@@ -4,11 +4,11 @@ package core.task.update.impl.steps
 import javax.inject.Named
 import akka.Done
 import akka.actor.ActorRef
-import com.google.inject.{ Inject, Provider }
+import com.google.inject.{Inject, Provider}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.MarathonSchedulerActor.ScaleRunSpec
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceChangeHandler }
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceChangeHandler}
 
 import scala.concurrent.Future
 //scalastyle:on

--- a/src/main/scala/mesosphere/marathon/io/IO.scala
+++ b/src/main/scala/mesosphere/marathon/io/IO.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package io
 
-import java.io.{ BufferedInputStream, Closeable, File, FileInputStream, FileOutputStream, FileNotFoundException, InputStream, OutputStream }
+import java.io.{BufferedInputStream, Closeable, File, FileInputStream, FileOutputStream, FileNotFoundException, InputStream, OutputStream}
 
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.commons.io.IOUtils
@@ -9,7 +9,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 
 import scala.annotation.tailrec
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 object IO extends StrictLogging {
 

--- a/src/main/scala/mesosphere/marathon/io/SSLContextUtil.scala
+++ b/src/main/scala/mesosphere/marathon/io/SSLContextUtil.scala
@@ -3,8 +3,8 @@ package io
 
 import java.io.FileInputStream
 import java.security.KeyStore
-import java.security.cert.{ CertificateException, X509Certificate }
-import javax.net.ssl.{ SSLContext, TrustManager, TrustManagerFactory, X509TrustManager }
+import java.security.cert.{CertificateException, X509Certificate}
+import javax.net.ssl.{SSLContext, TrustManager, TrustManagerFactory, X509TrustManager}
 
 /**
   * Util for create SSLContext objects.

--- a/src/main/scala/mesosphere/marathon/metrics/Aspects.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Aspects.scala
@@ -6,7 +6,7 @@ import javax.ws.rs.core.Response
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 import org.aspectj.lang.ProceedingJoinPoint
-import org.aspectj.lang.annotation.{ Around, Aspect }
+import org.aspectj.lang.annotation.{Around, Aspect}
 
 private object ServletTracing {
   private[metrics] val `1xx` = Kamon.metrics.counter("org.eclipse.jetty.ServletContextHandler.1xx-responses")

--- a/src/main/scala/mesosphere/marathon/metrics/HistogramTimer.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/HistogramTimer.scala
@@ -1,10 +1,10 @@
 package mesosphere.marathon
 package metrics
 
-import akka.stream.scaladsl.{ Flow, Source }
+import akka.stream.scaladsl.{Flow, Source}
 import akka.stream.stage._
-import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
-import java.time.{ Clock, Duration, Instant }
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import java.time.{Clock, Duration, Instant}
 
 import kamon.Kamon
 import kamon.metric.instrument

--- a/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
@@ -2,15 +2,15 @@ package mesosphere.marathon
 package metrics
 
 import akka.Done
-import akka.actor.{ Actor, ActorRef, ActorRefFactory, Props }
+import akka.actor.{Actor, ActorRef, ActorRefFactory, Props}
 import akka.stream.scaladsl.Source
-import java.time.{ Clock, Duration }
+import java.time.{Clock, Duration}
 
 import kamon.Kamon
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import kamon.metric.instrument.Histogram.DynamicRange
-import kamon.metric.instrument.{ Time, UnitOfMeasurement }
-import kamon.metric.{ Entity, SubscriptionFilter, instrument }
+import kamon.metric.instrument.{Time, UnitOfMeasurement}
+import kamon.metric.{Entity, SubscriptionFilter, instrument}
 import kamon.util.MilliTimestamp
 
 import scala.concurrent.Future

--- a/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
@@ -4,12 +4,12 @@ package metrics
 import java.time.Duration
 
 import kamon.Kamon
-import kamon.metric.{ Entity, EntitySnapshot }
+import kamon.metric.{Entity, EntitySnapshot}
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import kamon.metric.instrument.CollectionContext
-import kamon.util.{ MapMerge, MilliTimestamp }
+import kamon.util.{MapMerge, MilliTimestamp}
 
 /**
   * Calculates sliding average entity snapshot

--- a/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
@@ -431,7 +431,7 @@ object AppConversion extends AppConversion {
       hasPersistentVolumes: Boolean,
       hasExternalVolumes: Boolean): state.UpgradeStrategy = {
 
-      import state.UpgradeStrategy.{ empty, forResidentTasks }
+      import state.UpgradeStrategy.{empty, forResidentTasks}
 
       val selectedUpgradeStrategy = upgradeStrategy.getOrElse {
         if (hasPersistentVolumes || hasExternalVolumes) forResidentTasks else empty

--- a/src/main/scala/mesosphere/marathon/raml/ContainerConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/ContainerConversion.scala
@@ -5,7 +5,7 @@ import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.state.Parameter
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.protos.Implicits._
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 trait ContainerConversion extends HealthCheckConversion with VolumeConversion with NetworkConversion {
 

--- a/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
@@ -4,9 +4,9 @@ package raml
 import java.time.OffsetDateTime
 
 import mesosphere.marathon.core.instance
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.stream.Implicits._
-import org.apache.mesos.{ Protos => mesos }
+import org.apache.mesos.{Protos => mesos}
 import play.api.libs.json.JsString
 
 import scala.collection.breakOut

--- a/src/main/scala/mesosphere/marathon/raml/EnvVarConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/EnvVarConversion.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package raml
 
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 import scala.collection.immutable.Map
 

--- a/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package raml
 
-import mesosphere.marathon.state.{ AppDefinition, PathId, Timestamp, Group => CoreGroup, VersionInfo => CoreVersionInfo }
+import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp, Group => CoreGroup, VersionInfo => CoreVersionInfo}
 
 trait GroupConversion {
 

--- a/src/main/scala/mesosphere/marathon/raml/HealthCheckConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/HealthCheckConversion.scala
@@ -2,8 +2,8 @@ package mesosphere.marathon
 package raml
 
 import mesosphere.marathon.Protos.HealthCheckDefinition
-import mesosphere.marathon.core.health.{ HealthCheck => CoreHealthCheck, _ }
-import mesosphere.marathon.state.{ ArgvList, Command, Executable }
+import mesosphere.marathon.core.health.{HealthCheck => CoreHealthCheck, _}
+import mesosphere.marathon.state.{ArgvList, Command, Executable}
 
 import scala.concurrent.duration._
 
@@ -110,7 +110,7 @@ trait HealthCheckConversion {
       case state.ArgvList(args) => throw SerializationFailedException("serialization of ArgvList not supported")
     }
 
-    import Protos.HealthCheckDefinition.{ Protocol => ProtocolProto }
+    import Protos.HealthCheckDefinition.{Protocol => ProtocolProto}
     implicit val protocolWrites: Writes[ProtocolProto, AppHealthCheckProtocol] = Writes {
       case ProtocolProto.COMMAND => AppHealthCheckProtocol.Command
       case ProtocolProto.HTTP => AppHealthCheckProtocol.Http
@@ -147,7 +147,7 @@ trait HealthCheckConversion {
       )
     }
 
-    import raml.{ AppHealthCheckProtocol => AHCP }
+    import raml.{AppHealthCheckProtocol => AHCP}
     health match {
       case hc: MarathonHttpHealthCheck => create(hc.protocol.toRaml[AppHealthCheckProtocol], ipProtocol = None, ignoreHttp1xx = Some(hc.ignoreHttp1xx), path = hc.path, port = hc.port, portReference = hc.portIndex)
       case hc: MarathonTcpHealthCheck => create(AHCP.Tcp, ipProtocol = None, port = hc.port, portReference = hc.portIndex)
@@ -157,7 +157,7 @@ trait HealthCheckConversion {
     }
   }
 
-  import Protos.ResidencyDefinition.{ TaskLostBehavior => TaskLostProto }
+  import Protos.ResidencyDefinition.{TaskLostBehavior => TaskLostProto}
   implicit val taskLostBehaviorWrites: Writes[TaskLostProto, TaskLostBehavior] = Writes {
     case TaskLostProto.WAIT_FOREVER => TaskLostBehavior.WaitForever
     case TaskLostProto.RELAUNCH_AFTER_TIMEOUT => TaskLostBehavior.RelaunchAfterTimeout

--- a/src/main/scala/mesosphere/marathon/raml/MetricsConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/MetricsConversion.scala
@@ -1,11 +1,11 @@
 package mesosphere.marathon
 package raml
 
-import java.time.{ Instant, OffsetDateTime, ZoneId }
+import java.time.{Instant, OffsetDateTime, ZoneId}
 
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
-import kamon.metric.instrument.{ Time, Counter => KCounter, Histogram => KHistogram, UnitOfMeasurement => KUnitOfMeasurement }
-import play.api.libs.json.{ JsObject, Json }
+import kamon.metric.instrument.{Time, Counter => KCounter, Histogram => KHistogram, UnitOfMeasurement => KUnitOfMeasurement}
+import play.api.libs.json.{JsObject, Json}
 
 trait MetricsConversion {
   lazy val zoneId = ZoneId.systemDefault()

--- a/src/main/scala/mesosphere/marathon/raml/NetworkConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/NetworkConversion.scala
@@ -4,7 +4,7 @@ package raml
 import mesosphere.marathon.core.pod
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.protos.Implicits._
-import org.apache.mesos.Protos.ContainerInfo.DockerInfo.{ Network => DockerNetworkMode }
+import org.apache.mesos.Protos.ContainerInfo.DockerInfo.{Network => DockerNetworkMode}
 
 trait NetworkConversion {
 

--- a/src/main/scala/mesosphere/marathon/raml/OfferConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/OfferConversion.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package raml
 
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 import mesosphere.marathon.stream.Implicits._
 
 trait OfferConversion {

--- a/src/main/scala/mesosphere/marathon/raml/PodConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodConversion.scala
@@ -4,7 +4,7 @@ package raml
 import mesosphere.marathon.core.pod
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.pod.PodDefinition._
-import mesosphere.marathon.state.{ PathId, Timestamp }
+import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.state
 
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
@@ -4,9 +4,9 @@ package raml
 import java.time.OffsetDateTime
 
 import mesosphere.marathon.core.condition
-import mesosphere.marathon.core.health.{ MesosCommandHealthCheck, MesosHttpHealthCheck, MesosTcpHealthCheck, PortReference }
+import mesosphere.marathon.core.health.{MesosCommandHealthCheck, MesosHttpHealthCheck, MesosTcpHealthCheck, PortReference}
 import mesosphere.marathon.core.instance
-import mesosphere.marathon.core.pod.{ MesosContainer, PodDefinition }
+import mesosphere.marathon.core.pod.{MesosContainer, PodDefinition}
 import mesosphere.marathon.core.task
 import mesosphere.marathon.raml.LocalVolumeConversion.localVolumeIdWrites
 import mesosphere.marathon.stream.Implicits._

--- a/src/main/scala/mesosphere/marathon/raml/VolumeConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/VolumeConversion.scala
@@ -1,10 +1,10 @@
 package mesosphere.marathon
 package raml
 
-import mesosphere.marathon.state.{ DiskType, Volume }
+import mesosphere.marathon.state.{DiskType, Volume}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.protos.Implicits._
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 trait VolumeConversion extends ConstraintConversion with DefaultConversions {
 

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -11,16 +11,16 @@ import mesosphere.marathon.api.v2.validation.NetworkValidation
 import mesosphere.marathon.core.externalvolume.ExternalVolumes
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.plugin.PluginManager
-import mesosphere.marathon.core.pod.{ HostNetwork, Network }
+import mesosphere.marathon.core.pod.{HostNetwork, Network}
 import mesosphere.marathon.core.readiness.ReadinessCheck
 import mesosphere.marathon.plugin.validation.RunSpecValidator
-import mesosphere.marathon.raml.{ App, Apps, ExecutorResources, Resources }
-import mesosphere.marathon.state.Container.{ Docker, MesosAppC, MesosDocker }
+import mesosphere.marathon.raml.{App, Apps, ExecutorResources, Resources}
+import mesosphere.marathon.state.Container.{Docker, MesosAppC, MesosDocker}
 import mesosphere.marathon.state.VersionInfo._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.TaskBuilder
-import mesosphere.mesos.protos.{ Resource, ScalarResource }
-import org.apache.mesos.{ Protos => mesos }
+import mesosphere.mesos.protos.{Resource, ScalarResource}
+import org.apache.mesos.{Protos => mesos}
 
 import scala.concurrent.duration._
 

--- a/src/main/scala/mesosphere/marathon/state/Container.scala
+++ b/src/main/scala/mesosphere/marathon/state/Container.scala
@@ -10,7 +10,7 @@ import scala.collection.immutable.Seq
 
 sealed trait Container extends Product with Serializable {
 
-  import Container.{ Docker, PortMapping }
+  import Container.{Docker, PortMapping}
 
   def portMappings: Seq[PortMapping]
   val volumes: Seq[VolumeWithMount[Volume]]

--- a/src/main/scala/mesosphere/marathon/state/Executable.scala
+++ b/src/main/scala/mesosphere/marathon/state/Executable.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package state
 
-import org.apache.mesos.{ Protos => MesosProtos }
+import org.apache.mesos.{Protos => MesosProtos}
 import mesosphere.marathon.stream.Implicits._
 
 sealed trait Executable

--- a/src/main/scala/mesosphere/marathon/state/FetchUri.scala
+++ b/src/main/scala/mesosphere/marathon/state/FetchUri.scala
@@ -3,7 +3,7 @@ package state
 
 import java.net.URI
 
-import org.apache.mesos.{ Protos => mesos }
+import org.apache.mesos.{Protos => mesos}
 
 import scala.collection.immutable.Seq
 import scala.util.Try

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -10,9 +10,9 @@ import mesosphere.util.summarize
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.core.pod.PodDefinition
-import mesosphere.marathon.plugin.{ Group => IGroup }
-import mesosphere.marathon.state.Group.{ defaultApps, defaultDependencies, defaultGroups, defaultPods, defaultVersion }
-import mesosphere.marathon.state.PathId.{ StringPathId, validPathWithBase }
+import mesosphere.marathon.plugin.{Group => IGroup}
+import mesosphere.marathon.state.Group.{defaultApps, defaultDependencies, defaultGroups, defaultPods, defaultVersion}
+import mesosphere.marathon.state.PathId.{StringPathId, validPathWithBase}
 
 class Group(
     val id: PathId,

--- a/src/main/scala/mesosphere/marathon/state/Parameter.scala
+++ b/src/main/scala/mesosphere/marathon/state/Parameter.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package state
 
-import org.apache.mesos.{ Protos => mesos }
+import org.apache.mesos.{Protos => mesos}
 
 case class Parameter(
     key: String,

--- a/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
+++ b/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
@@ -3,10 +3,10 @@ package state
 
 import mesosphere.marathon.Protos
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.event.{ InstanceChanged, UnhealthyInstanceKillEvent }
+import mesosphere.marathon.core.event.{InstanceChanged, UnhealthyInstanceKillEvent}
 import mesosphere.mesos.protos.Implicits.slaveIDToProto
 import mesosphere.mesos.protos.SlaveID
-import org.apache.mesos.{ Protos => mesos }
+import org.apache.mesos.{Protos => mesos}
 
 case class TaskFailure(
     appId: PathId,

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -1,8 +1,8 @@
 package mesosphere.marathon
 package state
 
-import java.time.format.{ DateTimeFormatter, DateTimeParseException }
-import java.time.{ Duration, Instant, OffsetDateTime, ZoneOffset }
+import java.time.format.{DateTimeFormatter, DateTimeParseException}
+import java.time.{Duration, Instant, OffsetDateTime, ZoneOffset}
 import java.util.concurrent.TimeUnit
 
 import org.apache.mesos
@@ -10,7 +10,7 @@ import org.apache.mesos
 import scala.concurrent.duration.FiniteDuration
 import scala.language.implicitConversions
 import scala.math.Ordered
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 /**
   * An ordered wrapper for UTC timestamps.

--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package state
 
-import com.wix.accord.Descriptions.{ Generic, Path => WixPath }
+import com.wix.accord.Descriptions.{Generic, Path => WixPath}
 import java.util.regex.Pattern
 
 import com.wix.accord._

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -5,23 +5,23 @@ import java.net.URI
 import java.util
 import java.util.Collections
 
-import akka.actor.{ ActorSystem, Scheduler }
+import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.Materializer
 import com.typesafe.config.Config
 import mesosphere.marathon.core.base.LifecycleState
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
-import mesosphere.marathon.core.storage.store.impl.cache.{ LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore }
-import mesosphere.marathon.core.storage.store.impl.memory.{ Identity, InMemoryPersistenceStore, RamId }
-import mesosphere.marathon.core.storage.store.impl.zk.{ NoRetryPolicy, RichCuratorFramework, ZkId, ZkPersistenceStore, ZkSerialized }
-import mesosphere.marathon.util.{ RetryConfig, toRichConfig }
+import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
+import mesosphere.marathon.core.storage.store.impl.memory.{Identity, InMemoryPersistenceStore, RamId}
+import mesosphere.marathon.core.storage.store.impl.zk.{NoRetryPolicy, RichCuratorFramework, ZkId, ZkPersistenceStore, ZkSerialized}
+import mesosphere.marathon.util.{RetryConfig, toRichConfig}
 import org.apache.curator.framework.api.ACLProvider
 import org.apache.curator.framework.imps.GzipCompressionProvider
-import org.apache.curator.framework.{ AuthInfo, CuratorFrameworkFactory }
+import org.apache.curator.framework.{AuthInfo, CuratorFrameworkFactory}
 import org.apache.zookeeper.ZooDefs
 import org.apache.zookeeper.data.ACL
 
-import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
 sealed trait StorageConfig extends Product with Serializable {

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -1,13 +1,13 @@
 package mesosphere.marathon
 package storage
 
-import akka.actor.{ ActorSystem, Scheduler }
+import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.Materializer
 import mesosphere.marathon.core.base.LifecycleState
 import mesosphere.marathon.core.storage.backup.PersistentStoreBackup
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.cache.LoadTimeCachingPersistenceStore
-import mesosphere.marathon.storage.migration.{ Migration, ServiceDefinitionRepository }
+import mesosphere.marathon.storage.migration.{Migration, ServiceDefinitionRepository}
 import mesosphere.marathon.storage.repository._
 
 import scala.collection.immutable.Seq

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -15,15 +15,15 @@ import mesosphere.marathon.storage.StorageConfig
 import mesosphere.marathon.storage.repository._
 import mesosphere.marathon.util.toRichFuture
 
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{Await, Future}
 import scala.util.control.NonFatal
 import mesosphere.marathon.raml.RuntimeConfiguration
 import mesosphere.marathon.storage.migration.Migration.MigrationAction
 
 import scala.concurrent.ExecutionContext
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 /**
   * Base trait of a migration step.

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo142.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo142.scala
@@ -3,12 +3,12 @@ package storage.migration
 
 import akka.Done
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Flow, Keep, Sink }
+import akka.stream.scaladsl.{Flow, Keep, Sink}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.AppRepository
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 @SuppressWarnings(Array("ClassNames"))
 class MigrationTo142(appRepository: AppRepository) extends MigrationStep with StrictLogging {

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo146.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo146.scala
@@ -3,14 +3,14 @@ package storage.migration
 
 import akka.Done
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Flow, Keep, Sink }
+import akka.stream.scaladsl.{Flow, Keep, Sink}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.state._
-import mesosphere.marathon.storage.repository.{ AppRepository, PodRepository }
+import mesosphere.marathon.storage.repository.{AppRepository, PodRepository}
 
 import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 @SuppressWarnings(Array("ClassNames"))
 class MigrationTo146(appRepository: AppRepository, podRepository: PodRepository) extends MigrationStep with StrictLogging {

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo15.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo15.scala
@@ -5,19 +5,19 @@ import java.time.OffsetDateTime
 
 import akka.Done
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.Protos._
-import mesosphere.marathon.api.v2.{ AppNormalization, AppHelpers }
+import mesosphere.marathon.api.v2.{AppNormalization, AppHelpers}
 import mesosphere.marathon.core.async.ExecutionContexts
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.zk.ZkPersistenceStore
 import mesosphere.marathon.raml.Raml
-import mesosphere.marathon.state.{ AppDefinition, PathId, RootGroup }
+import mesosphere.marathon.state.{AppDefinition, PathId, RootGroup}
 import mesosphere.marathon.storage.repository.GroupRepository
 
-import scala.async.Async.{ async, await }
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.async.Async.{async, await}
+import scala.concurrent.{ExecutionContext, Future}
 
 case class MigrationTo15(migration: Migration) extends MigrationStep with StrictLogging {
 

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo152.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo152.scala
@@ -3,14 +3,14 @@ package storage.migration
 
 import akka.Done
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Flow, Keep, Sink }
+import akka.stream.scaladsl.{Flow, Keep, Sink}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.migration.MigrationTo146.Environment
 import mesosphere.marathon.storage.repository.InstanceRepository
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 @SuppressWarnings(Array("ClassNames"))
 class MigrationTo152(instanceRepository: InstanceRepository) extends MigrationStep with StrictLogging {

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo160.scala
@@ -8,15 +8,15 @@ import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.instance.{ Instance, Reservation }
+import mesosphere.marathon.core.instance.{Instance, Reservation}
 import mesosphere.marathon.core.instance.Instance.Id
-import mesosphere.marathon.core.storage.store.impl.cache.{ LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore }
-import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
-import mesosphere.marathon.core.storage.store.impl.zk.{ ZkId, ZkPersistenceStore, ZkSerialized }
+import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
+import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkPersistenceStore, ZkSerialized}
 import mesosphere.marathon.storage.repository.InstanceRepository
-import play.api.libs.json.{ JsValue, Json }
+import play.api.libs.json.{JsValue, Json}
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 @SuppressWarnings(Array("ClassNames"))
 class MigrationTo160(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _]) extends MigrationStep with StrictLogging {

--- a/src/main/scala/mesosphere/marathon/storage/migration/ServiceDefinitionRepository.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/ServiceDefinitionRepository.scala
@@ -8,11 +8,11 @@ import akka.http.scaladsl.unmarshalling.Unmarshaller
 import mesosphere.marathon.Protos.ServiceDefinition
 import mesosphere.marathon.core.storage.repository.ReadOnlyVersionedRepository
 import mesosphere.marathon.core.storage.repository.impl.PersistenceStoreVersionedRepository
-import mesosphere.marathon.core.storage.store.impl.memory.{ Identity, RamId }
-import mesosphere.marathon.core.storage.store.impl.zk.{ ZkId, ZkSerialized }
-import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
+import mesosphere.marathon.core.storage.store.impl.memory.{Identity, RamId}
+import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkSerialized}
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
 import mesosphere.marathon.state.PathId
-import mesosphere.marathon.storage.store.{ InMemoryStoreSerialization, ZkStoreSerialization }
+import mesosphere.marathon.storage.store.{InMemoryStoreSerialization, ZkStoreSerialization}
 
 trait ServiceDefinitionRepository extends ReadOnlyVersionedRepository[PathId, ServiceDefinition]
 

--- a/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
@@ -8,18 +8,18 @@ import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.Protos
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.core.storage.repository.impl.PersistenceStoreRepository
-import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
-import mesosphere.marathon.state.{ RootGroup, Timestamp }
-import mesosphere.marathon.storage.repository.GcActor.{ StoreApp, StorePlan, StorePod, StoreRoot }
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
+import mesosphere.marathon.state.{RootGroup, Timestamp}
+import mesosphere.marathon.storage.repository.GcActor.{StoreApp, StorePlan, StorePod, StoreRoot}
 
-import scala.async.Async.{ async, await }
-import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.async.Async.{async, await}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
 case class StoredPlan(
     id: String,

--- a/src/main/scala/mesosphere/marathon/storage/repository/GcActor.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GcActor.scala
@@ -1,23 +1,23 @@
 package mesosphere.marathon
 package storage.repository
 
-import java.time.{ Duration, Instant, OffsetDateTime }
+import java.time.{Duration, Instant, OffsetDateTime}
 
 import akka.Done
-import akka.actor.{ ActorRef, ActorRefFactory, FSM, LoggingFSM, Props }
+import akka.actor.{ActorRef, ActorRefFactory, FSM, LoggingFSM, Props}
 import akka.pattern._
 import akka.stream.Materializer
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 import kamon.metric.instrument.Time
 import mesosphere.marathon.core.deployment.DeploymentPlan
-import mesosphere.marathon.state.{ PathId, RootGroup }
-import mesosphere.marathon.storage.repository.GcActor.{ CompactDone, _ }
+import mesosphere.marathon.state.{PathId, RootGroup}
+import mesosphere.marathon.storage.repository.GcActor.{CompactDone, _}
 import mesosphere.marathon.stream.Sink
 
-import scala.async.Async.{ async, await }
-import scala.collection.{ SortedSet, mutable }
-import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.async.Async.{async, await}
+import scala.collection.{SortedSet, mutable}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
 
 /**

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -8,24 +8,24 @@ import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.util.summarize
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.storage.repository.impl.PersistenceStoreVersionedRepository
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
-import mesosphere.marathon.core.storage.store.impl.cache.{ LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore }
-import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
-import mesosphere.marathon.state.{ AppDefinition, Group, RootGroup, PathId, Timestamp }
+import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
+import mesosphere.marathon.state.{AppDefinition, Group, RootGroup, PathId, Timestamp}
 import mesosphere.marathon.stream.Implicits._
-import mesosphere.marathon.util.{ RichLock, toRichFuture }
+import mesosphere.marathon.util.{RichLock, toRichFuture}
 
 import scala.annotation.tailrec
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 case class StoredGroup(
     id: PathId,

--- a/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
@@ -8,22 +8,22 @@ import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.storage.repository._
-import mesosphere.marathon.core.storage.repository.impl.{ PersistenceStoreRepository, PersistenceStoreVersionedRepository }
-import mesosphere.marathon.core.storage.store.impl.memory.{ Identity, RamId }
-import mesosphere.marathon.core.storage.store.impl.zk.{ ZkId, ZkSerialized }
-import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStore }
+import mesosphere.marathon.core.storage.repository.impl.{PersistenceStoreRepository, PersistenceStoreVersionedRepository}
+import mesosphere.marathon.core.storage.store.impl.memory.{Identity, RamId}
+import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkSerialized}
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
 import mesosphere.marathon.state._
 import mesosphere.util.state.FrameworkId
 import mesosphere.marathon.raml.RuntimeConfiguration
 
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 import scala.collection.immutable.Seq
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 trait GroupRepository {
   /** Fetch the root, returns an empty root if the root doesn't yet exist */

--- a/src/main/scala/mesosphere/marathon/storage/store/InMemoryStoreSerialization.scala
+++ b/src/main/scala/mesosphere/marathon/storage/store/InMemoryStoreSerialization.scala
@@ -9,11 +9,11 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.storage.store.IdResolver
-import mesosphere.marathon.core.storage.store.impl.memory.{ Identity, RamId }
+import mesosphere.marathon.core.storage.store.impl.memory.{Identity, RamId}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.raml.RuntimeConfiguration
-import mesosphere.marathon.state.{ AppDefinition, PathId, TaskFailure }
-import mesosphere.marathon.storage.repository.{ StoredGroup, StoredPlan }
+import mesosphere.marathon.state.{AppDefinition, PathId, TaskFailure}
+import mesosphere.marathon.storage.repository.{StoredGroup, StoredPlan}
 import mesosphere.util.state.FrameworkId
 
 trait InMemoryStoreSerialization {

--- a/src/main/scala/mesosphere/marathon/storage/store/ZkStoreSerialization.scala
+++ b/src/main/scala/mesosphere/marathon/storage/store/ZkStoreSerialization.scala
@@ -7,15 +7,15 @@ import java.time.OffsetDateTime
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.util.ByteString
-import mesosphere.marathon.Protos.{ DeploymentPlanDefinition, ServiceDefinition }
+import mesosphere.marathon.Protos.{DeploymentPlanDefinition, ServiceDefinition}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.storage.store.IdResolver
-import mesosphere.marathon.core.storage.store.impl.zk.{ ZkId, ZkSerialized }
-import mesosphere.marathon.raml.{ Pod, Raml }
-import mesosphere.marathon.state.{ AppDefinition, PathId, TaskFailure }
-import mesosphere.marathon.storage.repository.{ StoredGroup, StoredGroupRepositoryImpl, StoredPlan }
+import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkSerialized}
+import mesosphere.marathon.raml.{Pod, Raml}
+import mesosphere.marathon.state.{AppDefinition, PathId, TaskFailure}
+import mesosphere.marathon.storage.repository.{StoredGroup, StoredGroupRepositoryImpl, StoredPlan}
 import mesosphere.util.state.FrameworkId
 import mesosphere.marathon.raml.RuntimeConfiguration
 import play.api.libs.json.Json

--- a/src/main/scala/mesosphere/marathon/stream/CollectionStage.scala
+++ b/src/main/scala/mesosphere/marathon/stream/CollectionStage.scala
@@ -1,11 +1,11 @@
 package mesosphere.marathon
 package stream
 
-import akka.stream.{ Attributes, Inlet, SinkShape }
-import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler }
+import akka.stream.{Attributes, Inlet, SinkShape}
+import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler}
 
 import scala.collection.mutable
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 
 /**
   * Akka Streaming Graph Stage that collects a set of values into the given collection

--- a/src/main/scala/mesosphere/marathon/stream/Collectors.scala
+++ b/src/main/scala/mesosphere/marathon/stream/Collectors.scala
@@ -2,13 +2,13 @@ package mesosphere.marathon
 package stream
 
 import java.util
-import java.util.function.{ BiConsumer, BinaryOperator, Function, Supplier }
+import java.util.function.{BiConsumer, BinaryOperator, Function, Supplier}
 import java.util.stream.Collector
 import java.util.stream.Collector.Characteristics
 
 import mesosphere.marathon.functional._
 
-import scala.collection.immutable.{ IndexedSeq, Seq }
+import scala.collection.immutable.{IndexedSeq, Seq}
 import scala.collection.mutable
 
 private class GenericCollector[T, C <: TraversableOnce[T]](builder: () => mutable.Builder[T, C])

--- a/src/main/scala/mesosphere/marathon/stream/EnrichedFlow.scala
+++ b/src/main/scala/mesosphere/marathon/stream/EnrichedFlow.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package stream
 
 import akka.NotUsed
-import akka.stream.scaladsl.{ Flow, Source }
+import akka.stream.scaladsl.{Flow, Source}
 
 @SuppressWarnings(Array("AsInstanceOf"))
 object EnrichedFlow {

--- a/src/main/scala/mesosphere/marathon/stream/EnrichedSource.scala
+++ b/src/main/scala/mesosphere/marathon/stream/EnrichedSource.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package stream
 
-import akka.actor.{ Cancellable, PoisonPill }
+import akka.actor.{Cancellable, PoisonPill}
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Source
 import mesosphere.marathon.util.CancellableOnce

--- a/src/main/scala/mesosphere/marathon/stream/RichStream.scala
+++ b/src/main/scala/mesosphere/marathon/stream/RichStream.scala
@@ -2,8 +2,8 @@ package mesosphere.marathon
 package stream
 
 import java.util
-import java.util.stream.{ DoubleStream, IntStream, LongStream, Stream, StreamSupport }
-import java.util.{ Spliterator, Spliterators }
+import java.util.stream.{DoubleStream, IntStream, LongStream, Stream, StreamSupport}
+import java.util.{Spliterator, Spliterators}
 
 import mesosphere.marathon.functional._
 import mesosphere.marathon.stream.StreamConversions._

--- a/src/main/scala/mesosphere/marathon/stream/ScalaConversions.scala
+++ b/src/main/scala/mesosphere/marathon/stream/ScalaConversions.scala
@@ -5,7 +5,7 @@ import java.util
 
 import mesosphere.marathon.functional._
 
-import scala.collection.immutable.{ IndexedSeq, Seq, Set }
+import scala.collection.immutable.{IndexedSeq, Seq, Set}
 import scala.collection.mutable
 import scala.language.implicitConversions
 

--- a/src/main/scala/mesosphere/marathon/stream/Sink.scala
+++ b/src/main/scala/mesosphere/marathon/stream/Sink.scala
@@ -1,15 +1,15 @@
 package mesosphere.marathon
 package stream
 
-import akka.actor.{ ActorRef, Props, Status }
-import akka.{ Done, NotUsed }
-import akka.stream.{ Graph, SinkShape, UniformFanOutShape }
-import akka.stream.scaladsl.{ SinkQueueWithCancel, Sink => AkkaSink }
-import org.reactivestreams.{ Publisher, Subscriber }
+import akka.actor.{ActorRef, Props, Status}
+import akka.{Done, NotUsed}
+import akka.stream.{Graph, SinkShape, UniformFanOutShape}
+import akka.stream.scaladsl.{SinkQueueWithCancel, Sink => AkkaSink}
+import org.reactivestreams.{Publisher, Subscriber}
 
 import scala.collection.immutable
 import scala.collection.immutable.Seq
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 /**

--- a/src/main/scala/mesosphere/marathon/stream/TarFlow.scala
+++ b/src/main/scala/mesosphere/marathon/stream/TarFlow.scala
@@ -5,7 +5,7 @@ import akka.NotUsed
 import akka.stream.scaladsl._
 import java.nio.charset.StandardCharsets.UTF_8
 import akka.util.ByteString
-import org.apache.commons.compress.archivers.tar.{ TarArchiveEntry, TarConstants }
+import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarConstants}
 import scala.annotation.tailrec
 
 /**

--- a/src/main/scala/mesosphere/marathon/stream/UriIO.scala
+++ b/src/main/scala/mesosphere/marathon/stream/UriIO.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package stream
 
-import com.amazonaws.auth.{ AWSCredentials, AWSStaticCredentialsProvider, BasicAWSCredentials }
+import com.amazonaws.auth.{AWSCredentials, AWSStaticCredentialsProvider, BasicAWSCredentials}
 import java.net.URI
 import java.nio.file.Paths
 
@@ -12,16 +12,16 @@ import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.acl.CannedAcl
 import akka.stream.alpakka.s3.impl.MetaHeaders
 import akka.stream.alpakka.s3.scaladsl.S3Client
-import akka.stream.scaladsl.{ FileIO, Source, Sink => ScalaSink }
+import akka.stream.scaladsl.{FileIO, Source, Sink => ScalaSink}
 import akka.util.ByteString
 import akka.Done
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.typesafe.scalalogging.StrictLogging
 import com.wix.accord.Validator
 import com.wix.accord.dsl._
-import mesosphere.marathon.api.v2.Validation.{ isTrue, uriIsValid }
+import mesosphere.marathon.api.v2.Validation.{isTrue, uriIsValid}
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 /**

--- a/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/PortsMatcher.scala
@@ -3,13 +3,13 @@ package tasks
 
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.pod.PodDefinition
-import mesosphere.marathon.state.{ AppDefinition, Container, ResourceRole, RunSpec }
+import mesosphere.marathon.state.{AppDefinition, Container, ResourceRole, RunSpec}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.tasks.PortsMatcher.PortWithRole
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
 import mesosphere.mesos.protos
-import mesosphere.mesos.protos.{ RangesResource, Resource }
-import org.apache.mesos.{ Protos => MesosProtos }
+import mesosphere.mesos.protos.{RangesResource, Resource}
+import org.apache.mesos.{Protos => MesosProtos}
 
 import scala.annotation.tailrec
 import scala.util.Random

--- a/src/main/scala/mesosphere/marathon/tasks/ResourceUtil.scala
+++ b/src/main/scala/mesosphere/marathon/tasks/ResourceUtil.scala
@@ -6,8 +6,8 @@ import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.state.DiskSource
 import mesosphere.mesos.protos
 import org.apache.mesos.Protos.Resource.DiskInfo.Source
-import org.apache.mesos.Protos.Resource.{ DiskInfo, ReservationInfo }
-import org.apache.mesos.{ Protos => MesosProtos }
+import org.apache.mesos.Protos.Resource.{DiskInfo, ReservationInfo}
+import org.apache.mesos.{Protos => MesosProtos}
 
 import scala.util.control.NonFatal
 

--- a/src/main/scala/mesosphere/marathon/upgrade/GroupVersioningUtil.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/GroupVersioningUtil.scala
@@ -3,7 +3,7 @@ package upgrade
 
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.pod.PodDefinition
-import mesosphere.marathon.state.{ AppDefinition, RootGroup, Timestamp, VersionInfo }
+import mesosphere.marathon.state.{AppDefinition, RootGroup, Timestamp, VersionInfo}
 
 /**
   * Tools related to app/group versioning.

--- a/src/main/scala/mesosphere/marathon/util/Lock.scala
+++ b/src/main/scala/mesosphere/marathon/util/Lock.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package util
 
 import com.typesafe.scalalogging.StrictLogging
-import java.util.concurrent.locks.{ ReentrantLock, ReentrantReadWriteLock }
+import java.util.concurrent.locks.{ReentrantLock, ReentrantReadWriteLock}
 
 class RichLock(val lock: ReentrantLock) extends AnyVal {
   def apply[T](f: => T): T = {

--- a/src/main/scala/mesosphere/marathon/util/Retry.scala
+++ b/src/main/scala/mesosphere/marathon/util/Retry.scala
@@ -7,8 +7,8 @@ import java.time
 import akka.actor.Scheduler
 import com.typesafe.config.Config
 
-import scala.concurrent.duration.{ FiniteDuration, _ }
-import scala.concurrent.{ ExecutionContext, Future, Promise, blocking => blockingCall }
+import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.{ExecutionContext, Future, Promise, blocking => blockingCall}
 import scala.util.Random
 import scala.util.control.NonFatal
 

--- a/src/main/scala/mesosphere/marathon/util/RichConfig.scala
+++ b/src/main/scala/mesosphere/marathon/util/RichConfig.scala
@@ -2,9 +2,9 @@ package mesosphere.marathon
 package util
 
 import java.util.concurrent.TimeUnit
-import java.{ time, util }
+import java.{time, util}
 
-import com.typesafe.config.{ Config, ConfigMemorySize }
+import com.typesafe.config.{Config, ConfigMemorySize}
 import mesosphere.marathon.stream.Implicits._
 
 import scala.concurrent.duration.Duration

--- a/src/main/scala/mesosphere/marathon/util/RichFuture.scala
+++ b/src/main/scala/mesosphere/marathon/util/RichFuture.scala
@@ -3,7 +3,7 @@ package util
 
 import mesosphere.marathon.core.async.ExecutionContexts
 
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 import scala.util.Try
 
 class RichFuture[T](val future: Future[T]) extends AnyVal {

--- a/src/main/scala/mesosphere/marathon/util/Timeout.scala
+++ b/src/main/scala/mesosphere/marathon/util/Timeout.scala
@@ -5,8 +5,8 @@ import akka.actor.Scheduler
 import mesosphere.util.DurationToHumanReadable
 import akka.pattern.after
 
-import scala.concurrent.duration.{ Duration, FiniteDuration }
-import scala.concurrent.{ ExecutionContext, Future, blocking => blockingCall }
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future, blocking => blockingCall}
 
 /**
   * Function transformations to make a method timeout after a given duration.

--- a/src/main/scala/mesosphere/marathon/util/TimeoutException.scala
+++ b/src/main/scala/mesosphere/marathon/util/TimeoutException.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package util
 
-import java.util.concurrent.{ TimeoutException => JavaTimeoutException }
+import java.util.concurrent.{TimeoutException => JavaTimeoutException}
 
 /**
   * Extension of a TimeoutException that allows a cause

--- a/src/main/scala/mesosphere/marathon/util/WorkQueue.scala
+++ b/src/main/scala/mesosphere/marathon/util/WorkQueue.scala
@@ -4,7 +4,7 @@ package util
 import com.typesafe.scalalogging.StrictLogging
 import scala.collection.concurrent.TrieMap
 
-import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
 import scala.collection.mutable
 

--- a/src/main/scala/mesosphere/mesos/Availability.scala
+++ b/src/main/scala/mesosphere/mesos/Availability.scala
@@ -4,7 +4,7 @@ import java.time.Clock
 
 import mesosphere.marathon.RichClock
 import mesosphere.marathon.state.Timestamp
-import org.apache.mesos.Protos.{ DurationInfo, Offer }
+import org.apache.mesos.Protos.{DurationInfo, Offer}
 
 import scala.concurrent.duration._
 

--- a/src/main/scala/mesosphere/mesos/Constraints.scala
+++ b/src/main/scala/mesosphere/mesos/Constraints.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.RunSpec
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.tasks.OfferUtil
-import org.apache.mesos.Protos.{ Attribute, Offer, Value }
+import org.apache.mesos.Protos.{Attribute, Offer, Value}
 
 import scala.collection.immutable.Seq
 import scala.util.Try

--- a/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/PersistentVolumeMatcher.scala
@@ -1,8 +1,8 @@
 package mesosphere.mesos
 
-import mesosphere.marathon.core.instance.{ Instance, Reservation }
+import mesosphere.marathon.core.instance.{Instance, Reservation}
 import mesosphere.marathon.stream.Implicits._
-import org.apache.mesos.{ Protos => Mesos }
+import org.apache.mesos.{Protos => Mesos}
 
 import scala.collection.immutable.Seq
 

--- a/src/main/scala/mesosphere/mesos/PortDiscovery.scala
+++ b/src/main/scala/mesosphere/mesos/PortDiscovery.scala
@@ -2,7 +2,7 @@ package mesosphere.mesos
 
 import mesosphere.marathon.api.serialization.PortMappingSerializer
 import mesosphere.marathon.raml.Endpoint
-import mesosphere.marathon.state.{ AppDefinition, PortDefinition }
+import mesosphere.marathon.state.{AppDefinition, PortDefinition}
 import mesosphere.marathon.state.Container.PortMapping
 import org.apache.mesos.Protos.Port
 import mesosphere.marathon.core.pod.Network

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -3,15 +3,15 @@ package mesosphere.mesos
 import java.time.Clock
 
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.{ Features, GpuSchedulingBehavior }
+import mesosphere.marathon.{Features, GpuSchedulingBehavior}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.plugin.scheduler.SchedulerPlugin
 import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
-import mesosphere.marathon.tasks.{ OfferUtil, PortsMatch, PortsMatcher, ResourceUtil }
-import mesosphere.mesos.protos.{ Resource, ResourceProviderID }
+import mesosphere.marathon.tasks.{OfferUtil, PortsMatch, PortsMatcher, ResourceUtil}
+import mesosphere.mesos.protos.{Resource, ResourceProviderID}
 import org.apache.mesos.Protos
 import org.apache.mesos.Protos.Offer
 import org.apache.mesos.Protos.Resource.DiskInfo.Source

--- a/src/main/scala/mesosphere/mesos/RunSpecOfferMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/RunSpecOfferMatcher.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.plugin.scheduler.SchedulerPlugin
-import mesosphere.marathon.state.{ AppDefinition, Region, RunSpec }
+import mesosphere.marathon.state.{AppDefinition, Region, RunSpec}
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
 import org.apache.mesos.Protos.Offer
 

--- a/src/main/scala/mesosphere/mesos/ScalarMatchResult.scala
+++ b/src/main/scala/mesosphere/mesos/ScalarMatchResult.scala
@@ -3,9 +3,9 @@ package mesosphere.mesos
 import mesosphere.marathon.raml._
 import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.ResourceUtil
-import mesosphere.mesos.protos.{ Resource, ResourceProviderID, ScalarResource }
+import mesosphere.mesos.protos.{Resource, ResourceProviderID, ScalarResource}
 import org.apache.mesos.Protos
-import org.apache.mesos.Protos.Resource.{ DiskInfo, ReservationInfo }
+import org.apache.mesos.Protos.Resource.{DiskInfo, ReservationInfo}
 
 import scala.collection.immutable.Seq
 

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -2,7 +2,7 @@ package mesosphere.mesos
 
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.api.serialization.SecretSerializer
-import mesosphere.marathon.core.health.{ MesosCommandHealthCheck, MesosHealthCheck }
+import mesosphere.marathon.core.health.{MesosCommandHealthCheck, MesosHealthCheck}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod._
 import mesosphere.marathon.core.task.Task
@@ -13,8 +13,8 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.tasks.PortsMatch
 import mesosphere.mesos.protos.Implicits._
-import org.apache.mesos.Protos.{ DurationInfo, KillPolicy }
-import org.apache.mesos.{ Protos => mesos }
+import org.apache.mesos.Protos.{DurationInfo, KillPolicy}
+import org.apache.mesos.{Protos => mesos}
 
 import java.util.concurrent.TimeUnit.SECONDS
 import scala.collection.immutable.Seq

--- a/src/main/scala/mesosphere/mesos/protos/Implicits.scala
+++ b/src/main/scala/mesosphere/mesos/protos/Implicits.scala
@@ -1,6 +1,6 @@
 package mesosphere.mesos.protos
 
-import com.google.protobuf.{ ByteString, Message }
+import com.google.protobuf.{ByteString, Message}
 import mesosphere.marathon.stream.Implicits._
 import org.apache.mesos.Protos
 

--- a/src/main/scala/mesosphere/util/RWLock.scala
+++ b/src/main/scala/mesosphere/util/RWLock.scala
@@ -1,6 +1,6 @@
 package mesosphere.util
 
-import java.util.concurrent.locks.{ Lock, ReentrantReadWriteLock }
+import java.util.concurrent.locks.{Lock, ReentrantReadWriteLock}
 
 case class RWLock[T](private val value: T) {
 

--- a/src/main/scala/mesosphere/util/ThreadPoolContext.scala
+++ b/src/main/scala/mesosphere/util/ThreadPoolContext.scala
@@ -1,6 +1,6 @@
 package mesosphere.util
 
-import java.util.concurrent.{ ExecutorService, Executors, ThreadFactory }
+import java.util.concurrent.{ExecutorService, Executors, ThreadFactory}
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import scala.concurrent.ExecutionContext
 

--- a/src/main/scala/mesosphere/util/state/FrameworkId.scala
+++ b/src/main/scala/mesosphere/util/state/FrameworkId.scala
@@ -1,6 +1,6 @@
 package mesosphere.util.state
 
-import mesosphere.marathon.state.{ MarathonState, Timestamp }
+import mesosphere.marathon.state.{MarathonState, Timestamp}
 import org.apache.mesos.Protos
 import org.apache.mesos.Protos.FrameworkID
 


### PR DESCRIPTION
Summary:
- No more spaces after and before  curly braces in multi-imports
- No more difference between IntelliJ and Scala import formatting
- No more "stupid" import conflicts