### PR TITLE
Report flake8 output as GitHub check.

### DIFF
--- a/tests/system/test_marathon_on_marathon.py
+++ b/tests/system/test_marathon_on_marathon.py
@@ -23,7 +23,7 @@ for attribute in dir(marathon_common_tests):
     if attribute.startswith('test_'):
         exec("from marathon_common_tests import {}".format(attribute))
 
-from shakedown import dcos_version_less_than, required_private_agents # NOQA
+from shakedown import dcos_version_less_than, required_private_agents
 from fixtures import wait_for_marathon_user_and_cleanup # NOQA
 
 


### PR DESCRIPTION
Summary:
GitHub introduced a new API that allows to report checks with source
code annotations. This should ease finding the root cause of CI
failures.
