### PR TITLE
Fix the behaviour of the GcActor in marathon

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -61,3 +61,5 @@ kamon {
     value-check-interval-ms: 1000
   }
 }
+
+gc-actor-scan-batch-size = 32

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -61,5 +61,3 @@ kamon {
     value-check-interval-ms: 1000
   }
 }
-
-gc-actor-scan-batch-size = 32

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -69,12 +69,12 @@ class Group(
     */
   def group(gid: PathId): Option[Group] = transitiveGroupsById.get(gid)
 
-  private def transitiveAppsIterator(): Iterator[AppDefinition] = apps.valuesIterator ++ groupsById.valuesIterator.flatMap(_.transitiveAppsIterator())
+  def transitiveAppsIterator(): Iterator[AppDefinition] = apps.valuesIterator ++ groupsById.valuesIterator.flatMap(_.transitiveAppsIterator())
   private def transitiveAppIdsIterator(): Iterator[PathId] = apps.keysIterator ++ groupsById.valuesIterator.flatMap(_.transitiveAppIdsIterator())
   lazy val transitiveApps: Iterable[AppDefinition] = transitiveAppsIterator().toVector
   lazy val transitiveAppIds: Iterable[PathId] = transitiveAppIdsIterator().toVector
 
-  private def transitivePodsIterator(): Iterator[PodDefinition] = pods.valuesIterator ++ groupsById.valuesIterator.flatMap(_.transitivePodsIterator())
+  def transitivePodsIterator(): Iterator[PodDefinition] = pods.valuesIterator ++ groupsById.valuesIterator.flatMap(_.transitivePodsIterator())
   private def transitivePodIdsIterator(): Iterator[PathId] = pods.keysIterator ++ groupsById.valuesIterator.flatMap(_.transitivePodIdsIterator())
   lazy val transitivePods: Iterable[PodDefinition] = transitivePodsIterator().toVector
   lazy val transitivePodIds: Iterable[PathId] = transitivePodIdsIterator().toVector

--- a/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
@@ -28,8 +28,8 @@ trait StorageConf extends ZookeeperConf with BackupConf {
     default = Some(50)
   )
 
-  lazy val scanBatchSize = opt[Int](
-    "gc_scan_batch_size", // while called Zk, applies to every store but the name is kept
+  lazy val gcActorScanBatchSize = opt[Int](
+    "gc_actor_scan_batch_size",
     descr = "Size of GC actor scan batches.",
     default = Some(32)
   )

--- a/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
@@ -28,6 +28,12 @@ trait StorageConf extends ZookeeperConf with BackupConf {
     default = Some(50)
   )
 
+  lazy val scanBatchSize = opt[Int](
+    "gc_scan_batch_size", // while called Zk, applies to every store but the name is kept
+    descr = "Size of GC actor scan batches.",
+    default = Some(32)
+  )
+
   lazy val zkMaxConcurrency = opt[Int](
     "zk_max_concurrency",
     default = Some(32),

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -103,7 +103,7 @@ case class CuratorZk(
     maxConcurrent: Int,
     maxOutstanding: Int,
     maxVersions: Int,
-    scanBatchSize: Int,
+    gcActorScanBatchSize: Int,
     versionCacheConfig: Option[VersionCacheConfig],
     availableFeatures: Set[String],
     lifecycleState: LifecycleState,
@@ -168,7 +168,7 @@ object CuratorZk {
       maxConcurrent = conf.zkMaxConcurrency(),
       maxOutstanding = Int.MaxValue,
       maxVersions = conf.maxVersions(),
-      scanBatchSize = conf.scanBatchSize(),
+      gcActorScanBatchSize = conf.gcActorScanBatchSize(),
       versionCacheConfig = if (conf.versionCacheEnabled()) StorageConfig.DefaultVersionCacheConfig else None,
       availableFeatures = conf.availableFeatures,
       backupLocation = conf.backupLocation.get,
@@ -198,7 +198,7 @@ object CuratorZk {
       maxConcurrent = config.int("max-concurrent-requests", 32),
       maxOutstanding = config.int("max-concurrent-outstanding", Int.MaxValue),
       maxVersions = config.int("max-versions", StorageConfig.DefaultMaxVersions),
-      scanBatchSize = config.int("scan-batch-size", StorageConfig.DefaultScanBatchSize),
+      gcActorScanBatchSize = config.int("gc-actor-scan-batch-size", StorageConfig.DefaultScanBatchSize),
       versionCacheConfig =
         if (config.bool("version-cache-enabled", true)) StorageConfig.DefaultVersionCacheConfig else None,
       availableFeatures = config.stringList("available-features", Seq.empty).to[Set],
@@ -211,7 +211,7 @@ object CuratorZk {
 
 case class InMem(
     maxVersions: Int,
-    scanBatchSize: Int,
+    gcActorScanBatchSize: Int,
     availableFeatures: Set[String],
     defaultNetworkName: Option[String],
     backupLocation: Option[URI]
@@ -228,12 +228,12 @@ object InMem {
   val StoreName = "mem"
 
   def apply(conf: StorageConf): InMem =
-    InMem(conf.maxVersions(), conf.scanBatchSize(), conf.availableFeatures, conf.defaultNetworkName.get, conf.backupLocation.get)
+    InMem(conf.maxVersions(), conf.gcActorScanBatchSize(), conf.availableFeatures, conf.defaultNetworkName.get, conf.backupLocation.get)
 
   def apply(conf: Config): InMem =
     InMem(
       conf.int("max-versions", StorageConfig.DefaultMaxVersions),
-      conf.int("scan-batch-size", StorageConfig.DefaultScanBatchSize),
+      conf.int("gc-actor-scan-batch-size", StorageConfig.DefaultScanBatchSize),
       availableFeatures = conf.stringList("available-features", Seq.empty).to[Set],
       defaultNetworkName = conf.optionalString("default-network-name"),
       backupLocation = conf.optionalString("backup-location").map(new URI(_))

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -50,7 +50,7 @@ object StorageModule {
 
         val instanceRepository = InstanceRepository.zkRepository(store)
         val deploymentRepository = DeploymentRepository.zkRepository(store, groupRepository,
-          appRepository, podRepository, zk.maxVersions)
+          appRepository, podRepository, zk.maxVersions, zk.scanBatchSize)
         val taskFailureRepository = TaskFailureRepository.zkRepository(store)
         val frameworkIdRepository = FrameworkIdRepository.zkRepository(store)
         val runtimeConfigurationRepository = RuntimeConfigurationRepository.zkRepository(store)
@@ -86,7 +86,7 @@ object StorageModule {
         val instanceRepository = InstanceRepository.inMemRepository(store)
         val groupRepository = GroupRepository.inMemRepository(store, appRepository, podRepository)
         val deploymentRepository = DeploymentRepository.inMemRepository(store, groupRepository,
-          appRepository, podRepository, mem.maxVersions)
+          appRepository, podRepository, mem.maxVersions, mem.scanBatchSize)
         val taskFailureRepository = TaskFailureRepository.inMemRepository(store)
         val frameworkIdRepository = FrameworkIdRepository.inMemRepository(store)
         val runtimeConfigurationRepository = RuntimeConfigurationRepository.inMemRepository(store)

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -50,7 +50,7 @@ object StorageModule {
 
         val instanceRepository = InstanceRepository.zkRepository(store)
         val deploymentRepository = DeploymentRepository.zkRepository(store, groupRepository,
-          appRepository, podRepository, zk.maxVersions, zk.scanBatchSize)
+          appRepository, podRepository, zk.maxVersions, zk.gcActorScanBatchSize)
         val taskFailureRepository = TaskFailureRepository.zkRepository(store)
         val frameworkIdRepository = FrameworkIdRepository.zkRepository(store)
         val runtimeConfigurationRepository = RuntimeConfigurationRepository.zkRepository(store)
@@ -86,7 +86,7 @@ object StorageModule {
         val instanceRepository = InstanceRepository.inMemRepository(store)
         val groupRepository = GroupRepository.inMemRepository(store, appRepository, podRepository)
         val deploymentRepository = DeploymentRepository.inMemRepository(store, groupRepository,
-          appRepository, podRepository, mem.maxVersions, mem.scanBatchSize)
+          appRepository, podRepository, mem.maxVersions, mem.gcActorScanBatchSize)
         val taskFailureRepository = TaskFailureRepository.inMemRepository(store)
         val frameworkIdRepository = FrameworkIdRepository.inMemRepository(store)
         val runtimeConfigurationRepository = RuntimeConfigurationRepository.inMemRepository(store)

--- a/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
@@ -82,7 +82,8 @@ class DeploymentRepositoryImpl[K, C, S](
     groupRepository: StoredGroupRepositoryImpl[K, C, S],
     appRepository: AppRepositoryImpl[K, C, S],
     podRepository: PodRepositoryImpl[K, C, S],
-    maxVersions: Int)(implicit
+    maxVersions: Int,
+    scanBatchSize: Int)(implicit
     ir: IdResolver[String, StoredPlan, C, K],
     marshaller: Marshaller[StoredPlan, S],
     unmarshaller: Unmarshaller[S, StoredPlan],
@@ -92,7 +93,7 @@ class DeploymentRepositoryImpl[K, C, S](
 
   private val gcActor = GcActor(
     s"PersistenceGarbageCollector-$hashCode",
-    this, groupRepository, appRepository, podRepository, maxVersions)
+    this, groupRepository, appRepository, podRepository, maxVersions, scanBatchSize)
 
   appRepository.beforeStore = Some((id, version) => {
     val promise = Promise[Done]()

--- a/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
@@ -83,7 +83,7 @@ class DeploymentRepositoryImpl[K, C, S](
     appRepository: AppRepositoryImpl[K, C, S],
     podRepository: PodRepositoryImpl[K, C, S],
     maxVersions: Int,
-    scanBatchSize: Int)(implicit
+    gcActorScanBatchSize: Int)(implicit
     ir: IdResolver[String, StoredPlan, C, K],
     marshaller: Marshaller[StoredPlan, S],
     unmarshaller: Unmarshaller[S, StoredPlan],
@@ -93,7 +93,7 @@ class DeploymentRepositoryImpl[K, C, S](
 
   private val gcActor = GcActor(
     s"PersistenceGarbageCollector-$hashCode",
-    this, groupRepository, appRepository, podRepository, maxVersions, scanBatchSize)
+    this, groupRepository, appRepository, podRepository, maxVersions, gcActorScanBatchSize)
 
   appRepository.beforeStore = Some((id, version) => {
     val promise = Promise[Done]()

--- a/src/main/scala/mesosphere/marathon/storage/repository/GcActor.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GcActor.scala
@@ -320,7 +320,7 @@ private[storage] trait ScanBehavior[K, C, S] extends StrictLogging { this: FSM[S
 
     rootsInUse()
       .grouped(scanBatchSize)
-      .mapAsync(1) { inUseRoots =>
+      .mapAsync(1) { inUseRoots => //inUseRoots has size of scanBatchSize
         async { // linter:ignore UnnecessaryElseBranch
           val allAppIds = await(allAppIdsFuture)
           val allPodIds = await(allPodIdsFuture)

--- a/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
@@ -121,12 +121,12 @@ object DeploymentRepository {
     appRepository: AppRepositoryImpl[ZkId, String, ZkSerialized],
     podRepository: PodRepositoryImpl[ZkId, String, ZkSerialized],
     maxVersions: Int,
-    scanBatchSize: Int)(implicit
+    gcActorScanBatchSize: Int)(implicit
     ctx: ExecutionContext,
     actorRefFactory: ActorRefFactory,
     mat: Materializer): DeploymentRepositoryImpl[ZkId, String, ZkSerialized] = {
     import mesosphere.marathon.storage.store.ZkStoreSerialization._
-    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions, scanBatchSize)
+    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions, gcActorScanBatchSize)
   }
 
   def inMemRepository(
@@ -135,12 +135,12 @@ object DeploymentRepository {
     appRepository: AppRepositoryImpl[RamId, String, Identity],
     podRepository: PodRepositoryImpl[RamId, String, Identity],
     maxVersions: Int,
-    scanBatchSize: Int)(implicit
+    gcActorScanBatchSize: Int)(implicit
     ctx: ExecutionContext,
     actorRefFactory: ActorRefFactory,
     mat: Materializer): DeploymentRepositoryImpl[RamId, String, Identity] = {
     import mesosphere.marathon.storage.store.InMemoryStoreSerialization._
-    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions, scanBatchSize)
+    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions, gcActorScanBatchSize)
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
@@ -120,12 +120,13 @@ object DeploymentRepository {
     groupRepository: StoredGroupRepositoryImpl[ZkId, String, ZkSerialized],
     appRepository: AppRepositoryImpl[ZkId, String, ZkSerialized],
     podRepository: PodRepositoryImpl[ZkId, String, ZkSerialized],
-    maxVersions: Int)(implicit
+    maxVersions: Int,
+    scanBatchSize: Int)(implicit
     ctx: ExecutionContext,
     actorRefFactory: ActorRefFactory,
     mat: Materializer): DeploymentRepositoryImpl[ZkId, String, ZkSerialized] = {
     import mesosphere.marathon.storage.store.ZkStoreSerialization._
-    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions)
+    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions, scanBatchSize)
   }
 
   def inMemRepository(
@@ -133,12 +134,13 @@ object DeploymentRepository {
     groupRepository: StoredGroupRepositoryImpl[RamId, String, Identity],
     appRepository: AppRepositoryImpl[RamId, String, Identity],
     podRepository: PodRepositoryImpl[RamId, String, Identity],
-    maxVersions: Int)(implicit
+    maxVersions: Int,
+    scanBatchSize: Int)(implicit
     ctx: ExecutionContext,
     actorRefFactory: ActorRefFactory,
     mat: Materializer): DeploymentRepositoryImpl[RamId, String, Identity] = {
     import mesosphere.marathon.storage.store.InMemoryStoreSerialization._
-    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions)
+    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions, scanBatchSize)
   }
 }
 

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
@@ -41,7 +41,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
     private val configurationRepository: RuntimeConfigurationRepository = mock[RuntimeConfigurationRepository]
     private val backup: PersistentStoreBackup = mock[PersistentStoreBackup]
     private val serviceDefinitionRepository: ServiceDefinitionRepository = mock[ServiceDefinitionRepository]
-    private val config: StorageConfig = InMem(1, Set.empty, None, None)
+    private val config: StorageConfig = InMem(1, 32, Set.empty, None, None)
 
     // assume no runtime config is stored in repository
     configurationRepository.get() returns Future.successful(None)

--- a/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
@@ -70,7 +70,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
     val appRepo = AppRepository.inMemRepository(store)
     val podRepo = PodRepository.inMemRepository(store)
     val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
-    val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, maxVersions)
+    val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, maxVersions, 32)
     val actor = TestFSMRef(new GcActor(deployRepo, groupRepo, appRepo, podRepo, maxVersions)(mat, ExecutionContexts.callerThread) {
       override def scan(): Future[ScanDone] = {
         testScan.fold(super.scan())(_())
@@ -431,7 +431,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = mock[StoredGroupRepositoryImpl[RamId, String, Identity]]
-        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 1)
+        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 1, 32)
         val actor = TestFSMRef(new GcActor(deployRepo, groupRepo, appRepo, podRepo, 1))
         groupRepo.rootVersions() returns Source(Seq(OffsetDateTime.now(), OffsetDateTime.MIN, OffsetDateTime.MAX))
         groupRepo.root() returns Future.failed(new Exception(""))
@@ -444,7 +444,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
-        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2)
+        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2, 32)
         val actor = TestFSMRef(new GcActor(deployRepo, groupRepo, appRepo, podRepo, 2))
         val root1 = createRootGroup()
         val root2 = createRootGroup()
@@ -460,7 +460,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = mock[PodRepositoryImpl[RamId, String, Identity]]
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
-        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2)
+        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2, 32)
         val actor = TestFSMRef(new GcActor(deployRepo, groupRepo, appRepo, podRepo, 2))
         val root1 = createRootGroup()
         val root2 = createRootGroup()
@@ -476,7 +476,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
-        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2)
+        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2, 32)
         val actor = TestFSMRef(new GcActor(deployRepo, groupRepo, appRepo, podRepo, 2))
         actor.setState(Scanning, UpdatedEntities())
         appRepo.delete(any) returns Future.failed(new Exception(""))


### PR DESCRIPTION
Summary: implemented backpressured batched GC scans, so we don't consume too much memory at once. It stabilize marathon behaviour with lots of deployments.

JIRA issues: MARATHON-8195
