### PR TITLE
Annotate logger output for Marathon test instances.

### DIFF
--- a/src/test/scala/mesosphere/marathon/integration/setup/ProcessOutputToLogStream.scala
+++ b/src/test/scala/mesosphere/marathon/integration/setup/ProcessOutputToLogStream.scala
@@ -1,11 +1,12 @@
 package mesosphere.marathon
 package integration.setup
 
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.{Logger, StrictLogging}
 
 import scala.sys.process.ProcessLogger
 
 case class ProcessOutputToLogStream(process: String) extends ProcessLogger with StrictLogging {
+  override val logger = Logger(s"mesosphere.marathon.integration.process.$process")
   override def out(msg: => String): Unit = logger.debug(msg)
   override def err(msg: => String): Unit = logger.warn(msg)
   override def buffer[T](f: => T): T = f


### PR DESCRIPTION
Summary:
Our integration test spawn Mesos and Marathon processes and pipe their
stdout and stderr to the test's logger. To ease debugging we called the
logger after the test suites and the Marathon port. The naming was lost
with the switch to `StrictLogging`.