### PR TITLE
Default to application/json when Accept */* provided

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -105,6 +105,13 @@ trait RestResource extends JaxResource {
 }
 
 object RestResource {
+
+  /**
+    * By default, if an endpoint accepts both text/plain and application/json, when Accept: * / * is provided then the
+    * server will default to text/plain. This media type will cause text/plain to be a lower priority, so other
+    * mediatypes will be preferred by default.
+    */
+  final val TEXT_PLAIN_LOW = "text/plain;qs=0.1"
   val DeploymentHeader = "Marathon-Deployment-Id"
 
   def entity(err: scala.collection.Seq[(JsPath, scala.collection.Seq[JsonValidationError])]): JsValue = {

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -77,7 +77,7 @@ class AppTasksResource @Inject() (
   }
 
   @GET
-  @Produces(Array(MediaType.TEXT_PLAIN))
+  @Produces(Array(RestResource.TEXT_PLAIN_LOW))
   @SuppressWarnings(Array("all")) /* async/await */
   def indexTxt(
     @PathParam("appId") appId: String,

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -88,7 +88,7 @@ class TasksResource @Inject() (
   }
 
   @GET
-  @Produces(Array(MediaType.TEXT_PLAIN))
+  @Produces(Array(RestResource.TEXT_PLAIN_LOW))
   @SuppressWarnings(Array("all")) /* async/await */
   def indexTxt(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
     result(async {


### PR DESCRIPTION
This matches previous behavior, pre-Jersey 2.27 behavior. The solution that existed before violated the HTTP spec.

JIRA Issues: MARATHON-8200
