### PR TITLE
Remove unprintable characters for swagger conversion

### DIFF
--- a/docs/docs/rest-api/public/api/v2/groups.raml
+++ b/docs/docs/rest-api/public/api/v2/groups.raml
@@ -70,7 +70,7 @@
 
 
       When one of version or scaleBy are set, nothing else than a version change or transitive instance count scaling will be applied.
-      If both version and scaleBy are set, only a version rollback will be performed – the scaleBy value will not be applied.
+      If both version and scaleBy are set, only a version rollback will be performed. The scaleBy value will not be applied.
 
       A deployment can run forever. This is the case, when the new application has a problem and does not become healthy.
       In this case, human interaction is needed with 2 possible choices


### PR DESCRIPTION
Suzanne made this change 7 months ago and it wasn't merged. The hyphen is not an ascii character.