### PR TITLE
Report successful and failed loop builds.

### DIFF
--- a/ci/dataDogClient.sc
+++ b/ci/dataDogClient.sc
@@ -1,0 +1,46 @@
+#!/usr/bin/env amm
+
+import java.time.Instant
+import scalaj.http._
+import upickle._
+
+/**
+ * Makes a POST request to DataDog's API with provided path and body.
+ *
+ * @param path The API path, e.g. 'series'.
+ * @param body The body of the post request.
+ */
+def execute(path:String, body: String): Unit = {
+
+  val DATADOG_API_KEY = sys.env.getOrElse(
+    "DATADOG_API_KEY",
+    throw new IllegalArgumentException("DATADOG_API_KEY enviroment variable was not set.")
+  )
+
+  val response = Http(s"https://api.datadoghq.com/api/v1/$path")
+    .header("Content-type", "application/json")
+    .param("api_key", DATADOG_API_KEY)
+    .timeout(connTimeoutMs = 5000, readTimeoutMs = 100000)
+    .postData(body)
+    .asString
+    .throwError
+}
+
+/**
+ * Report a metric count to DataDog.
+ *
+ * @param name The name of the metric, e.g. "marathon.build.loop.master.successes".
+ * @param count The count of the metric.
+ */
+@main
+def reportCount(name: String, count: Int): Unit = {
+
+  val now = Instant.now.getEpochSecond
+  val metric = Js.Obj(
+    "metric" -> Js.Str(name),
+    "points" -> Js.Arr(Js.Arr(Js.Num(now), Js.Num(count))),
+    "type" -> Js.Str("count")
+    )
+  val request = Js.Obj("series"  -> Js.Arr(metric))
+  execute("series", request.toString)
+}

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -11,6 +11,7 @@ import scala.util.control.NonFatal
 import scala.util.Try
 
 import $file.awsClient
+import $file.dataDogClient
 import $file.fileUtil
 import $file.githubClient
 import $file.provision
@@ -252,8 +253,13 @@ def pr(pullId: String): Unit = asPullRequest(pullId) {
  */
 @main
 def loop(): Unit = {
-  provisionHost()
-  build(buildName = utils.loopBuildName())
+  try {
+    provisionHost()
+    build(buildName = utils.loopBuildName())
+    dataDogClient.reportCount(s"marathon.build.${utils.loopName}.success", 1)
+  } finally {
+    dataDogClient.reportCount(s"marathon.build.${utils.loopName}.failure", 1)
+  }
 }
 
 /**

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -120,14 +120,18 @@ def isPullRequest(): Option[String] = {
   sys.env.get("JOB_NAME").collect { case pr(pullId) => pullId }
 }
 
+// The name of the build loop.
+lazy val loopName: String = {
+  val loopNamePattern = """marathon-sandbox/(.*)""".r
+  sys.env.get("JOB_NAME")
+    .collect { case loopNamePattern(name) => name }
+    .getOrElse("loop")
+}
+
 /**
  * @return Name for build loops.
  */
 def loopBuildName(): String = {
-  val loopNamePattern = """marathon-sandbox/(.*)""".r
-  val loopName = sys.env.get("JOB_NAME")
-    .collect { case loopNamePattern(name) => name }
-    .getOrElse("loop")
   val buildNumber = sys.env.get("BUILD_NUMBER").getOrElse("0")
   s"$loopName-$buildNumber"
 }


### PR DESCRIPTION
Summary:
We missed a commit that caused flaky tests because the Marathon loop
itself was not working. This change introduces a count metric in
DataDog. We will set up a monitor that alarms if the number of
successful builds is below a certain threashold in the last 24hrs. In
the future we might want to add commit events so that we can triage the
problematic commits faster.

JIRA issues: MARATHON-8199