### PR TITLE
Switch to Scalatest JUnitXMLReporter to regain the timestamp field

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ ansiColor('xterm') {
         }
       } finally {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')
+        junit(allowEmptyResults: true, testResults: 'target/test-reports/integration/*.xml')
         publishHTML([
             allowMissing: true, alwaysLinkToLastBuild: false, keepAll: true,
             reportDir: 'target/scala-2.12/scapegoat-report', reportFiles: 'scapegoat.html',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ ansiColor('xterm') {
         }
       } finally {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')
-        junit(allowEmptyResults: true, testResults: 'target/test-reports/integration/*.xml') // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
+        junit(allowEmptyResults: true, testResults: 'target/test-reports/integration/*.xml') // TODO(MARATHON-8215): Remove this line
         publishHTML([
             allowMissing: true, alwaysLinkToLastBuild: false, keepAll: true,
             reportDir: 'target/scala-2.12/scapegoat-report', reportFiles: 'scapegoat.html',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ ansiColor('xterm') {
         }
       } finally {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')
-        junit(allowEmptyResults: true, testResults: 'target/test-reports/integration/*.xml')
+        junit(allowEmptyResults: true, testResults: 'target/test-reports/integration/*.xml') // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
         publishHTML([
             allowMissing: true, alwaysLinkToLastBuild: false, keepAll: true,
             reportDir: 'target/scala-2.12/scapegoat-report', reportFiles: 'scapegoat.html',

--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,10 @@ lazy val testSettings =
 
   parallelExecution in Test := true,
   testForkedParallel in Test := true,
+  testListeners := Nil, // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
   testOptions in Test := Seq(
     Tests.Argument(
+      "-u", "target/test-reports", // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
       "-o", "-eDFG",
       "-l", "mesosphere.marathon.IntegrationTest",
       "-y", "org.scalatest.WordSpec")),
@@ -51,6 +53,7 @@ lazy val testSettings =
   fork in IntegrationTest := true,
   testOptions in IntegrationTest := Seq(
     Tests.Argument(
+      "-u", "target/test-reports", // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
       "-o", "-eDFG",
       "-n", "mesosphere.marathon.IntegrationTest",
       "-y", "org.scalatest.WordSpec")),

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val testSettings =
   testListeners := Nil, // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
   testOptions in Test := Seq(
     Tests.Argument(
-      "-u", "target/test-reports", // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
+      "-u", "target/test-reports/unit", // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
       "-o", "-eDFG",
       "-l", "mesosphere.marathon.IntegrationTest",
       "-y", "org.scalatest.WordSpec")),
@@ -53,7 +53,7 @@ lazy val testSettings =
   fork in IntegrationTest := true,
   testOptions in IntegrationTest := Seq(
     Tests.Argument(
-      "-u", "target/test-reports", // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
+      "-u", "target/test-reports/integration", // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
       "-o", "-eDFG",
       "-n", "mesosphere.marathon.IntegrationTest",
       "-y", "org.scalatest.WordSpec")),

--- a/build.sbt
+++ b/build.sbt
@@ -41,10 +41,10 @@ lazy val testSettings =
 
   parallelExecution in Test := true,
   testForkedParallel in Test := true,
-  testListeners := Nil, // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
+  testListeners := Nil, // TODO(MARATHON-8215): Remove this line
   testOptions in Test := Seq(
     Tests.Argument(
-      "-u", "target/test-reports", // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
+      "-u", "target/test-reports", // TODO(MARATHON-8215): Remove this line
       "-o", "-eDFG",
       "-l", "mesosphere.marathon.IntegrationTest",
       "-y", "org.scalatest.WordSpec")),
@@ -53,7 +53,7 @@ lazy val testSettings =
   fork in IntegrationTest := true,
   testOptions in IntegrationTest := Seq(
     Tests.Argument(
-      "-u", "target/test-reports/integration", // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
+      "-u", "target/test-reports/integration", // TODO(MARATHON-8215): Remove this line
       "-o", "-eDFG",
       "-n", "mesosphere.marathon.IntegrationTest",
       "-y", "org.scalatest.WordSpec")),

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val testSettings =
   testListeners := Nil, // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
   testOptions in Test := Seq(
     Tests.Argument(
-      "-u", "target/test-reports/unit", // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
+      "-u", "target/test-reports", // Remove when https://github.com/sbt/sbt/issues/4153 is resolved
       "-o", "-eDFG",
       "-l", "mesosphere.marathon.IntegrationTest",
       "-y", "org.scalatest.WordSpec")),


### PR DESCRIPTION
SBT 1.x ships with a JUnit XML reporter which is enabled, by
default. Unfortunately, this reporter is missing a field which is
expected by Jenkins: timestamp. We use this field in our test analysis
tool to reason about which tests ran in parallel.

Switching to the Scalatest JUnitXML reporter brings the field back for
the time being.

See https://github.com/sbt/sbt/issues/4153
