### PR TITLE
Pod failure reasons are not visible in the UI/API

### DIFF
--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon
 
 import java.lang.Thread.UncaughtExceptionHandler
-import java.time
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
 import com.google.common.util.concurrent.ServiceManager

--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -9,7 +9,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import mesosphere.marathon.api.v2.{ AppNormalization, AppTasksResource, InfoEmbedResolver, LabelSelectorParsers }
-import mesosphere.marathon.api.akkahttp.{ Controller, EntityMarshallers }
 import mesosphere.marathon.api.v2.AppsResource.{ NormalizationConfig, authzSelector }
 import mesosphere.marathon.api.v2.Validation.validateOrThrow
 import mesosphere.marathon.api.v2.validation.AppValidation
@@ -17,7 +16,7 @@ import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager
-import mesosphere.marathon.plugin.auth.{ Authorizer, CreateRunSpec, Identity, ViewResource, ViewRunSpec, Authenticator => MarathonAuthenticator }
+import mesosphere.marathon.plugin.auth.{ Authorizer, CreateRunSpec, Identity, ViewRunSpec, Authenticator => MarathonAuthenticator }
 import mesosphere.marathon.state.{ AppDefinition, Identifiable, PathId }
 import play.api.libs.json.Json
 import PathId._

--- a/src/main/scala/mesosphere/marathon/core/deployment/DeploymentModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/DeploymentModule.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon
 package core.deployment
 
-import akka.Done
 import akka.actor.{ ActorRef, Props }
 import akka.event.EventStream
 import akka.stream.Materializer
@@ -13,8 +12,6 @@ import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.storage.repository.DeploymentRepository
-
-import scala.concurrent.Promise
 
 /**
   * Provides a [[DeploymentManager]] implementation that can be used to start and cancel a deployment and

--- a/src/main/scala/mesosphere/marathon/core/event/Events.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/Events.scala
@@ -2,8 +2,6 @@ package mesosphere.marathon
 package core.event
 
 import akka.event.EventStream
-import com.fasterxml.jackson.annotation.JsonIgnore
-import mesosphere.marathon.api.v2.json.Formats.eventToJson
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.core.instance.update.InstanceChange

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
@@ -17,7 +17,6 @@ import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
-import mesosphere.marathon.util.Timeout
 import mesosphere.util.ThreadPoolContext
 
 import scala.concurrent.Future

--- a/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
@@ -9,9 +9,9 @@ import java.time.{ Clock, Duration }
 import kamon.Kamon
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import kamon.metric.instrument.Histogram.DynamicRange
-import kamon.metric.instrument.{ CollectionContext, Time, UnitOfMeasurement }
+import kamon.metric.instrument.{ Time, UnitOfMeasurement }
 import kamon.metric.{ Entity, SubscriptionFilter, instrument }
-import kamon.util.{ MapMerge, MilliTimestamp }
+import kamon.util.{ MilliTimestamp }
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration

--- a/src/test/scala/mesosphere/marathon/state/TaskFailureTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TaskFailureTest.scala
@@ -8,6 +8,7 @@ import play.api.libs.json.Json
 
 class TaskFailureTest extends UnitTest {
   import TaskFailureTestHelper.taskFailure
+  import TaskFailureTestHelper.taskFailureId
 
   "TaskFailure" should {
     "ToProto" in {
@@ -59,13 +60,13 @@ class TaskFailureTest extends UnitTest {
 
       val json = Json.toJson(taskFailure.copy(slaveId = Some(slaveIDToProto(SlaveID("slave id")))))
       val expectedJson = Json.parse(
-        """
+        s"""
         |{
         |  "appId":"/group/app",
         |  "host":"slave5.mega.co",
         |  "message":"Process exited with status [1]",
         |  "state":"TASK_FAILED",
-        |  "taskId":"group_app-12345",
+        |  "taskId":"$taskFailureId",
         |  "timestamp":"1970-01-01T00:00:02.000Z",
         |  "version":"1970-01-01T00:00:01.000Z",
         |  "slaveId":"slave id"

--- a/src/test/scala/mesosphere/marathon/state/TaskFailureTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/state/TaskFailureTestHelper.scala
@@ -1,12 +1,15 @@
 package mesosphere.marathon
 package state
 
+import java.util.UUID
+
 import org.apache.mesos.{ Protos => mesos }
 
 object TaskFailureTestHelper {
+  val taskFailureId = s"failedtask.${UUID.randomUUID()}"
   lazy val taskFailure = TaskFailure(
     appId = PathId("/group/app"),
-    taskId = mesos.TaskID.newBuilder.setValue("group_app-12345").build,
+    taskId = mesos.TaskID.newBuilder.setValue(taskFailureId).build,
     state = mesos.TaskState.TASK_FAILED,
     message = "Process exited with status [1]",
     host = "slave5.mega.co",


### PR DESCRIPTION
Summary: task termination history is shown in the podStatus

JIRA issues: MARATHON-8148

(cherry picked from commit 48c28a2)

