### PR TITLE
Fix master loop failure metric

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -253,12 +253,15 @@ def pr(pullId: String): Unit = asPullRequest(pullId) {
  */
 @main
 def loop(): Unit = {
+  val start = System.currentTimeMillis
   try {
     provisionHost()
     build(buildName = utils.loopBuildName())
     dataDogClient.reportCount(s"marathon.build.${utils.loopName}.success", 1)
+  } catch {
+    case _ => dataDogClient.reportCount(s"marathon.build.${utils.loopName}.failure", 1)
   } finally {
-    dataDogClient.reportCount(s"marathon.build.${utils.loopName}.failure", 1)
+    dataDogClient.reportCount(s"marathon.build.${utils.loopName}.duration", ((System.currentTimeMillis - start) / 1000).toInt)
   }
 }
 


### PR DESCRIPTION
Summary:
- fixed `marathon_loop_master.failure` metric which was previously sent in any case (instead of failure case)
- added `marathon_loop_master.duration` to the metrics
