### PR TITLE
Backport of Fix the behaviour of the GcActor in marathon

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConf.scala
@@ -28,6 +28,12 @@ trait StorageConf extends ZookeeperConf with BackupConf {
     default = Some(50)
   )
 
+  lazy val gcActorScanBatchSize = opt[Int](
+    "gc_actor_scan_batch_size",
+    descr = "Size of GC actor scan batches.",
+    default = Some(32)
+  )
+
   lazy val zkMaxConcurrency = opt[Int](
     "zk_max_concurrency",
     default = Some(32),

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -103,6 +103,7 @@ case class CuratorZk(
     maxConcurrent: Int,
     maxOutstanding: Int,
     maxVersions: Int,
+    gcActorScanBatchSize: Int,
     versionCacheConfig: Option[VersionCacheConfig],
     availableFeatures: Set[String],
     lifecycleState: LifecycleState,
@@ -167,6 +168,7 @@ object CuratorZk {
       maxConcurrent = conf.zkMaxConcurrency(),
       maxOutstanding = Int.MaxValue,
       maxVersions = conf.maxVersions(),
+      gcActorScanBatchSize = conf.gcActorScanBatchSize(),
       versionCacheConfig = if (conf.versionCacheEnabled()) StorageConfig.DefaultVersionCacheConfig else None,
       availableFeatures = conf.availableFeatures,
       backupLocation = conf.backupLocation.get,
@@ -196,6 +198,7 @@ object CuratorZk {
       maxConcurrent = config.int("max-concurrent-requests", 32),
       maxOutstanding = config.int("max-concurrent-outstanding", Int.MaxValue),
       maxVersions = config.int("max-versions", StorageConfig.DefaultMaxVersions),
+      gcActorScanBatchSize = config.int("gc-actor-scan-batch-size", StorageConfig.DefaultScanBatchSize),
       versionCacheConfig =
         if (config.bool("version-cache-enabled", true)) StorageConfig.DefaultVersionCacheConfig else None,
       availableFeatures = config.stringList("available-features", Seq.empty).to[Set],
@@ -208,6 +211,7 @@ object CuratorZk {
 
 case class InMem(
     maxVersions: Int,
+    gcActorScanBatchSize: Int,
     availableFeatures: Set[String],
     defaultNetworkName: Option[String],
     backupLocation: Option[URI]
@@ -224,11 +228,12 @@ object InMem {
   val StoreName = "mem"
 
   def apply(conf: StorageConf): InMem =
-    InMem(conf.maxVersions(), conf.availableFeatures, conf.defaultNetworkName.get, conf.backupLocation.get)
+    InMem(conf.maxVersions(), conf.gcActorScanBatchSize(), conf.availableFeatures, conf.defaultNetworkName.get, conf.backupLocation.get)
 
   def apply(conf: Config): InMem =
     InMem(
       conf.int("max-versions", StorageConfig.DefaultMaxVersions),
+      conf.int("gc-actor-scan-batch-size", StorageConfig.DefaultScanBatchSize),
       availableFeatures = conf.stringList("available-features", Seq.empty).to[Set],
       defaultNetworkName = conf.optionalString("default-network-name"),
       backupLocation = conf.optionalString("backup-location").map(new URI(_))
@@ -240,6 +245,7 @@ object StorageConfig {
 
   val DefaultLegacyMaxVersions = 25
   val DefaultMaxVersions = 5000
+  val DefaultScanBatchSize = 32
   def apply(conf: StorageConf, lifecycleState: LifecycleState): StorageConfig = {
     conf.internalStoreBackend() match {
       case InMem.StoreName => InMem(conf)

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -50,7 +50,7 @@ object StorageModule {
 
         val instanceRepository = InstanceRepository.zkRepository(store)
         val deploymentRepository = DeploymentRepository.zkRepository(store, groupRepository,
-          appRepository, podRepository, zk.maxVersions)
+          appRepository, podRepository, zk.maxVersions, zk.gcActorScanBatchSize)
         val taskFailureRepository = TaskFailureRepository.zkRepository(store)
         val frameworkIdRepository = FrameworkIdRepository.zkRepository(store)
         val runtimeConfigurationRepository = RuntimeConfigurationRepository.zkRepository(store)
@@ -86,7 +86,7 @@ object StorageModule {
         val instanceRepository = InstanceRepository.inMemRepository(store)
         val groupRepository = GroupRepository.inMemRepository(store, appRepository, podRepository)
         val deploymentRepository = DeploymentRepository.inMemRepository(store, groupRepository,
-          appRepository, podRepository, mem.maxVersions)
+          appRepository, podRepository, mem.maxVersions, mem.gcActorScanBatchSize)
         val taskFailureRepository = TaskFailureRepository.inMemRepository(store)
         val frameworkIdRepository = FrameworkIdRepository.inMemRepository(store)
         val runtimeConfigurationRepository = RuntimeConfigurationRepository.inMemRepository(store)

--- a/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
@@ -82,7 +82,8 @@ class DeploymentRepositoryImpl[K, C, S](
     groupRepository: StoredGroupRepositoryImpl[K, C, S],
     appRepository: AppRepositoryImpl[K, C, S],
     podRepository: PodRepositoryImpl[K, C, S],
-    maxVersions: Int)(implicit
+    maxVersions: Int,
+    gcActorScanBatchSize: Int)(implicit
   ir: IdResolver[String, StoredPlan, C, K],
     marshaller: Marshaller[StoredPlan, S],
     unmarshaller: Unmarshaller[S, StoredPlan],
@@ -92,7 +93,7 @@ class DeploymentRepositoryImpl[K, C, S](
 
   private val gcActor = GcActor(
     s"PersistenceGarbageCollector-$hashCode",
-    this, groupRepository, appRepository, podRepository, maxVersions)
+    this, groupRepository, appRepository, podRepository, maxVersions, gcActorScanBatchSize)
 
   appRepository.beforeStore = Some((id, version) => {
     val promise = Promise[Done]()

--- a/src/main/scala/mesosphere/marathon/storage/repository/GcActor.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GcActor.scala
@@ -3,10 +3,11 @@ package storage.repository
 
 import java.time.{ Duration, Instant, OffsetDateTime }
 
-import akka.Done
+import akka.{ Done, NotUsed }
 import akka.actor.{ ActorRef, ActorRefFactory, FSM, LoggingFSM, Props }
 import akka.pattern._
 import akka.stream.Materializer
+import akka.stream.scaladsl.Source
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
 import kamon.metric.instrument.Time
@@ -67,7 +68,8 @@ private[storage] class GcActor[K, C, S](
   val groupRepository: StoredGroupRepositoryImpl[K, C, S],
   val appRepository: AppRepositoryImpl[K, C, S],
   val podRepository: PodRepositoryImpl[K, C, S],
-  val maxVersions: Int)(implicit val mat: Materializer, val ctx: ExecutionContext)
+  val maxVersions: Int,
+  val scanBatchSize: Int = 32)(implicit val mat: Materializer, val ctx: ExecutionContext)
     extends FSM[State, Data] with LoggingFSM[State, Data] with ScanBehavior[K, C, S] with CompactBehavior[K, C, S] {
 
   // We already released metrics with these names, so we can't use the Metrics.* methods
@@ -128,6 +130,7 @@ private[storage] trait ScanBehavior[K, C, S] extends StrictLogging { this: FSM[S
   val groupRepository: StoredGroupRepositoryImpl[K, C, S]
   val deploymentRepository: DeploymentRepositoryImpl[K, C, S]
   val self: ActorRef
+  def scanBatchSize: Int
 
   when(Scanning) {
     case Event(RunGC, updates: UpdatedEntities) =>
@@ -265,9 +268,8 @@ private[storage] trait ScanBehavior[K, C, S] extends StrictLogging { this: FSM[S
 
     def appsInUse(roots: Seq[StoredGroup]): Map[PathId, Set[OffsetDateTime]] = {
       val appVersionsInUse = new mutable.HashMap[PathId, mutable.Set[OffsetDateTime]] with mutable.MultiMap[PathId, OffsetDateTime]
-      currentRoot.transitiveAppsById.foreach {
-        case (id, app) =>
-          appVersionsInUse.addBinding(id, app.version.toOffsetDateTime)
+      currentRoot.transitiveApps.foreach { app =>
+        appVersionsInUse.addBinding(app.id, app.version.toOffsetDateTime)
       }
       roots.foreach { root =>
         root.transitiveAppIds.foreach {
@@ -280,9 +282,8 @@ private[storage] trait ScanBehavior[K, C, S] extends StrictLogging { this: FSM[S
 
     def podsInUse(roots: Seq[StoredGroup]): Map[PathId, Set[OffsetDateTime]] = {
       val podVersionsInUse = new mutable.HashMap[PathId, mutable.Set[OffsetDateTime]] with mutable.MultiMap[PathId, OffsetDateTime]
-      currentRoot.transitivePodsById.foreach {
-        case (id, pod) =>
-          podVersionsInUse.addBinding(id, pod.version.toOffsetDateTime)
+      currentRoot.transitivePods.foreach { pod =>
+        podVersionsInUse.addBinding(pod.id, pod.version.toOffsetDateTime)
       }
       roots.foreach { root =>
         root.transitivePodIds.foreach {
@@ -293,65 +294,68 @@ private[storage] trait ScanBehavior[K, C, S] extends StrictLogging { this: FSM[S
       podVersionsInUse.map { case (id, pods) => id -> pods.to[Set] }(collection.breakOut)
     }
 
-    def rootsInUse(): Future[Seq[StoredGroup]] = {
-      Future.sequence {
-        storedPlans.flatMap(plan =>
-          Seq(
-            groupRepository.lazyRootVersion(plan.originalVersion),
-            groupRepository.lazyRootVersion(plan.targetVersion))
-        )
-      }
-    }.map(_.flatten)
+    def rootsInUse(): Source[StoredGroup, NotUsed] = {
+      Source(storedPlans)
+        .mapConcat(plan => Seq(plan.originalVersion, plan.targetVersion))
+        .mapAsync(1)(groupRepository.lazyRootVersion)
+        .mapConcat(_.toList)
+    }
 
     def appsExceedingMaxVersions(usedApps: Set[PathId]): Future[Map[PathId, Set[OffsetDateTime]]] = {
-      Future.sequence {
-        usedApps.map { id =>
-          appRepository.versions(id).runWith(Sink.sortedSet).map(id -> _)
-        }
-      }.map(_.filter(_._2.size > maxVersions).toMap)
+      Source(usedApps)
+        .mapAsync(1)(id => appRepository.versions(id).runWith(Sink.sortedSet).map(id -> _))
+        .filter(_._2.size > maxVersions)
+        .runWith(Sink.map)
     }
 
     def podsExceedingMaxVersions(usedPods: Set[PathId]): Future[Map[PathId, Set[OffsetDateTime]]] = {
-      Future.sequence {
-        usedPods.map { id =>
-          podRepository.versions(id).runWith(Sink.sortedSet).map(id -> _)
+      Source(usedPods)
+        .mapAsync(1)(id => podRepository.versions(id).runWith(Sink.sortedSet).map(id -> _))
+        .filter(_._2.size > maxVersions)
+        .runWith(Sink.map)
+    }
+
+    val allAppIdsFuture = appRepository.ids().runWith(Sink.set)
+    val allPodIdsFuture = podRepository.ids().runWith(Sink.set)
+
+    rootsInUse()
+      .grouped(scanBatchSize)
+      .mapAsync(1) { inUseRoots => //inUseRoots has size of scanBatchSize
+        async { // linter:ignore UnnecessaryElseBranch
+          val allAppIds = await(allAppIdsFuture)
+          val allPodIds = await(allPodIdsFuture)
+          val usedApps = appsInUse(inUseRoots)
+          val usedPods = podsInUse(inUseRoots)
+          val appsWithTooManyVersions = await(appsExceedingMaxVersions(usedApps.keySet))
+          val podsWithTooManyVersions = await(podsExceedingMaxVersions(usedPods.keySet))
+
+          val appVersionsToDelete = appsWithTooManyVersions.map {
+            case (id, versions) =>
+              val candidateVersions = versions.diff(usedApps.getOrElse(id, SortedSet.empty))
+              id -> candidateVersions.take(versions.size - maxVersions)
+          }
+
+          val podVersionsToDelete = podsWithTooManyVersions.map {
+            case (id, versions) =>
+              val candidateVersions = versions.diff(usedPods.getOrElse(id, SortedSet.empty))
+              id -> candidateVersions.take(versions.size - maxVersions)
+          }
+
+          val appsToCompletelyDelete = allAppIds.diff(usedApps.keySet)
+          val podsToCompletelyDelete = allPodIds.diff(usedPods.keySet)
+          ScanDone(appsToCompletelyDelete, appVersionsToDelete,
+            podsToCompletelyDelete, podVersionsToDelete, rootsToDelete)
+        }.recover {
+          case NonFatal(e) =>
+            logger.error(s"Error while scanning for unused apps and pods ${Option(e.getMessage).getOrElse("")}: ", e)
+            ScanDone()
         }
-      }.map(_.filter(_._2.size > maxVersions).toMap)
-    }
-
-    async { // linter:ignore UnnecessaryElseBranch
-      val inUseRootFuture = rootsInUse()
-      val allAppIdsFuture = appRepository.ids().runWith(Sink.set)
-      val allPodIdsFuture = podRepository.ids().runWith(Sink.set)
-      val allAppIds = await(allAppIdsFuture)
-      val allPodIds = await(allPodIdsFuture)
-      val inUseRoots = await(inUseRootFuture)
-      val usedApps = appsInUse(inUseRoots)
-      val usedPods = podsInUse(inUseRoots)
-      val appsWithTooManyVersions = await(appsExceedingMaxVersions(usedApps.keySet))
-      val podsWithTooManyVersions = await(podsExceedingMaxVersions(usedPods.keySet))
-
-      val appVersionsToDelete = appsWithTooManyVersions.map {
-        case (id, versions) =>
-          val candidateVersions = versions.diff(usedApps.getOrElse(id, SortedSet.empty))
-          id -> candidateVersions.take(versions.size - maxVersions)
       }
-
-      val podVersionsToDelete = podsWithTooManyVersions.map {
-        case (id, versions) =>
-          val candidateVersions = versions.diff(usedPods.getOrElse(id, SortedSet.empty))
-          id -> candidateVersions.take(versions.size - maxVersions)
+      .fold(ScanDone()) {
+        case (acc, scan) =>
+          acc ++ scan
       }
-
-      val appsToCompletelyDelete = allAppIds.diff(usedApps.keySet)
-      val podsToCompletelyDelete = allPodIds.diff(usedPods.keySet)
-      ScanDone(appsToCompletelyDelete, appVersionsToDelete,
-        podsToCompletelyDelete, podVersionsToDelete, rootsToDelete)
-    }.recover {
-      case NonFatal(e) =>
-        logger.error(s"Error while scanning for unused apps and pods ${Option(e.getMessage).getOrElse("")}: ", e)
-        ScanDone()
-    }
+      .runWith(Sink.head)
   }
 }
 
@@ -446,22 +450,25 @@ private[storage] trait CompactBehavior[K, C, S] extends StrictLogging { this: FS
           s"(${podVersionsToDelete.map { case (id, v) => id -> v.mkString("[", ", ", "]") }.mkString(", ")} as no roots refer to them" +
           " and they exceed max versions")
       }
-      val appFutures = appsToDelete.map(appRepository.delete)
-      val appVersionFutures = appVersionsToDelete.flatMap {
-        case (id, versions) =>
-          versions.map { version => appRepository.deleteVersion(id, version) }
-      }
-      val podFutures = podsToDelete.map(podRepository.delete)
-      val podVersionFutures = podVersionsToDelete.flatMap {
-        case (id, versions) =>
-          versions.map { version => podRepository.deleteVersion(id, version) }
-      }
-      val rootFutures = rootVersionsToDelete.map(groupRepository.deleteRootVersion)
-      await(Future.sequence(appFutures))
-      await(Future.sequence(appVersionFutures))
-      await(Future.sequence(podFutures))
-      await(Future.sequence(podVersionFutures))
-      await(Future.sequence(rootFutures))
+      val appsDeletion = Source(appsToDelete)
+        .mapAsync(1)(appRepository.delete)
+      val appsVersionsDeletion = Source(appVersionsToDelete)
+        .mapConcat { case (id, versions) => versions.map(v => v -> id) }
+        .mapAsync(1){ case (version, id) => appRepository.deleteVersion(id, version) }
+      val podsDeletion = Source(podsToDelete)
+        .mapAsync(1)(podRepository.delete)
+      val podsVersionsDeletion = Source(podVersionsToDelete)
+        .mapConcat { case (id, versions) => versions.map(v => v -> id) }
+        .mapAsync(1){ case (version, id) => podRepository.deleteVersion(id, version) }
+      val rootVersionsDeletion = Source(rootVersionsToDelete)
+        .mapAsync(1)(groupRepository.deleteRootVersion)
+      val deletionProcess = (appsDeletion ++
+        appsVersionsDeletion ++
+        podsDeletion ++
+        podsVersionsDeletion ++
+        rootVersionsDeletion)
+        .runWith(Sink.ignore)
+      await(deletionProcess)
       CompactDone
     }.recover {
       case NonFatal(e) =>
@@ -500,8 +507,9 @@ object GcActor {
     groupRepository: StoredGroupRepositoryImpl[K, C, S],
     appRepository: AppRepositoryImpl[K, C, S],
     podRepository: PodRepositoryImpl[K, C, S],
-    maxVersions: Int)(implicit mat: Materializer, ctx: ExecutionContext): Props = {
-    Props(new GcActor[K, C, S](deploymentRepository, groupRepository, appRepository, podRepository, maxVersions))
+    maxVersions: Int,
+    scanBatchSize: Int)(implicit mat: Materializer, ctx: ExecutionContext): Props = {
+    Props(new GcActor[K, C, S](deploymentRepository, groupRepository, appRepository, podRepository, maxVersions, scanBatchSize))
   }
 
   def apply[K, C, S](
@@ -510,12 +518,13 @@ object GcActor {
     groupRepository: StoredGroupRepositoryImpl[K, C, S],
     appRepository: AppRepositoryImpl[K, C, S],
     podRepository: PodRepositoryImpl[K, C, S],
-    maxVersions: Int)(implicit
+    maxVersions: Int,
+    scanBatchSize: Int)(implicit
     mat: Materializer,
     ctx: ExecutionContext,
     actorRefFactory: ActorRefFactory): ActorRef = {
     actorRefFactory.actorOf(props(deploymentRepository, groupRepository,
-      appRepository, podRepository, maxVersions), name)
+      appRepository, podRepository, maxVersions, scanBatchSize), name)
   }
 
   sealed trait Message extends Product with Serializable
@@ -526,6 +535,25 @@ object GcActor {
       podVersionsToDelete: Map[PathId, Set[OffsetDateTime]] = Map.empty,
       rootVersionsToDelete: Set[OffsetDateTime] = Set.empty) extends Message {
     def isEmpty = appsToDelete.isEmpty && appVersionsToDelete.isEmpty && rootVersionsToDelete.isEmpty
+    def ++(that: ScanDone): ScanDone = ScanDone(
+      appsToDelete ++ that.appsToDelete,
+      that.appVersionsToDelete.foldLeft(appVersionsToDelete) {
+        case (acc, thatValue @ (thatPathId, thatVersions)) =>
+          acc.get(thatPathId) match {
+            case Some(existingVersions) => acc.updated(thatPathId, existingVersions ++ thatVersions)
+            case None => acc + thatValue
+          }
+      },
+      podsToDelete ++ that.podsToDelete,
+      that.podVersionsToDelete.foldLeft(podVersionsToDelete) {
+        case (acc, thatValue @ (thatPathId, thatVersions)) =>
+          acc.get(thatPathId) match {
+            case Some(existingVersions) => acc.updated(thatPathId, existingVersions ++ thatVersions)
+            case None => acc + thatValue
+          }
+      },
+      rootVersionsToDelete ++ that.rootVersionsToDelete
+    )
   }
   case object RunGC extends Message
   sealed trait CompactDone extends Message

--- a/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/Repositories.scala
@@ -120,12 +120,13 @@ object DeploymentRepository {
     groupRepository: StoredGroupRepositoryImpl[ZkId, String, ZkSerialized],
     appRepository: AppRepositoryImpl[ZkId, String, ZkSerialized],
     podRepository: PodRepositoryImpl[ZkId, String, ZkSerialized],
-    maxVersions: Int)(implicit
+    maxVersions: Int,
+    gcActorScanBatchSize: Int)(implicit
     ctx: ExecutionContext,
     actorRefFactory: ActorRefFactory,
     mat: Materializer): DeploymentRepositoryImpl[ZkId, String, ZkSerialized] = {
     import mesosphere.marathon.storage.store.ZkStoreSerialization._
-    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions)
+    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions, gcActorScanBatchSize)
   }
 
   def inMemRepository(
@@ -133,12 +134,13 @@ object DeploymentRepository {
     groupRepository: StoredGroupRepositoryImpl[RamId, String, Identity],
     appRepository: AppRepositoryImpl[RamId, String, Identity],
     podRepository: PodRepositoryImpl[RamId, String, Identity],
-    maxVersions: Int)(implicit
+    maxVersions: Int,
+    gcActorScanBatchSize: Int)(implicit
     ctx: ExecutionContext,
     actorRefFactory: ActorRefFactory,
     mat: Materializer): DeploymentRepositoryImpl[RamId, String, Identity] = {
     import mesosphere.marathon.storage.store.InMemoryStoreSerialization._
-    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions)
+    new DeploymentRepositoryImpl(persistenceStore, groupRepository, appRepository, podRepository, maxVersions, gcActorScanBatchSize)
   }
 }
 

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
@@ -40,7 +40,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
     private val configurationRepository: RuntimeConfigurationRepository = mock[RuntimeConfigurationRepository]
     private val backup: PersistentStoreBackup = mock[PersistentStoreBackup]
     private val serviceDefinitionRepository: ServiceDefinitionRepository = mock[ServiceDefinitionRepository]
-    private val config: StorageConfig = InMem(1, Set.empty, None, None)
+    private val config: StorageConfig = InMem(1, 32, Set.empty, None, None)
 
     // assume no runtime config is stored in repository
     configurationRepository.get() returns Future.successful(None)

--- a/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
@@ -70,7 +70,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
     val appRepo = AppRepository.inMemRepository(store)
     val podRepo = PodRepository.inMemRepository(store)
     val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
-    val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, maxVersions)
+    val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, maxVersions, 32)
     val actor = TestFSMRef(new GcActor(deployRepo, groupRepo, appRepo, podRepo, maxVersions)(mat, ExecutionContexts.callerThread) {
       override def scan(): Future[ScanDone] = {
         testScan.fold(super.scan())(_())
@@ -431,7 +431,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = mock[StoredGroupRepositoryImpl[RamId, String, Identity]]
-        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 1)
+        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 1, 32)
         val actor = TestFSMRef(new GcActor(deployRepo, groupRepo, appRepo, podRepo, 1))
         groupRepo.rootVersions() returns Source(Seq(OffsetDateTime.now(), OffsetDateTime.MIN, OffsetDateTime.MAX))
         groupRepo.root() returns Future.failed(new Exception(""))
@@ -444,7 +444,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
-        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2)
+        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2, 32)
         val actor = TestFSMRef(new GcActor(deployRepo, groupRepo, appRepo, podRepo, 2))
         val root1 = createRootGroup()
         val root2 = createRootGroup()
@@ -460,7 +460,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val appRepo = AppRepository.inMemRepository(store)
         val podRepo = mock[PodRepositoryImpl[RamId, String, Identity]]
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
-        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2)
+        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2, 32)
         val actor = TestFSMRef(new GcActor(deployRepo, groupRepo, appRepo, podRepo, 2))
         val root1 = createRootGroup()
         val root2 = createRootGroup()
@@ -476,7 +476,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val appRepo = mock[AppRepositoryImpl[RamId, String, Identity]]
         val podRepo = PodRepository.inMemRepository(store)
         val groupRepo = GroupRepository.inMemRepository(store, appRepo, podRepo)
-        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2)
+        val deployRepo = DeploymentRepository.inMemRepository(store, groupRepo, appRepo, podRepo, 2, 32)
         val actor = TestFSMRef(new GcActor(deployRepo, groupRepo, appRepo, podRepo, 2))
         actor.setState(Scanning, UpdatedEntities())
         appRepo.delete(any) returns Future.failed(new Exception(""))


### PR DESCRIPTION
Summary: implemented backpressured batched GC scans, so we don't consume too much memory at once. It stabilize marathon behaviour with lots of deployments.

JIRA issues: MARATHON-8195
