### PR TITLE
Switch to Scalatest JUnitXMLReporter to regain the timestamp field

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ ansiColor('gnome-terminal') {
         }
       } finally {
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')
+        junit(allowEmptyResults: true, testResults: 'target/test-reports/integration/*.xml') // TODO(MARATHON-8215): Remove this line
         archive includes: 'sandboxes.tar.gz'
         archive includes: 'ci.tar.gz'
         archive includes: 'ci.log'  // Only in case the build was  aborted and the logs weren't zipped

--- a/build.sbt
+++ b/build.sbt
@@ -54,8 +54,10 @@ lazy val testSettings =
   testListeners := Seq(new PhabricatorTestReportListener(target.value / "phabricator-test-reports")),
   parallelExecution in Test := true,
   testForkedParallel in Test := true,
+  testListeners := Nil, // TODO(MARATHON-8215): Remove this line
   testOptions in Test := Seq(
     Tests.Argument(
+      "-u", "target/test-reports", // TODO(MARATHON-8215): Remove this line
       "-o", "-eDFG",
       "-l", "mesosphere.marathon.IntegrationTest",
       "-y", "org.scalatest.WordSpec")),
@@ -64,6 +66,7 @@ lazy val testSettings =
   fork in IntegrationTest := true,
   testOptions in IntegrationTest := Seq(
     Tests.Argument(
+      "-u", "target/test-reports/integration", // TODO(MARATHON-8215): Remove this line
       "-o", "-eDFG",
       "-n", "mesosphere.marathon.IntegrationTest",
       "-y", "org.scalatest.WordSpec")),


### PR DESCRIPTION
Backport of #6214

Summary:
SBT 1.x ships with a JUnit XML reporter which is enabled, by
default. Unfortunately, this reporter is missing a field which is
expected by Jenkins: timestamp. We use this field in our test analysis
tool to reason about which tests ran in parallel.

Switching to the Scalatest JUnitXML reporter brings the field back for
the time being.

See https://github.com/sbt/sbt/issues/4153
