### PR TITLE
Introduce task metrics

### DIFF
--- a/src/main/scala/mesosphere/marathon/metrics/AtomicGauge.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/AtomicGauge.scala
@@ -3,6 +3,7 @@ package metrics
 
 import java.util.concurrent.atomic.AtomicLong
 
+import kamon.Kamon
 import kamon.metric.instrument.UnitOfMeasurement
 
 /**
@@ -10,7 +11,12 @@ import kamon.metric.instrument.UnitOfMeasurement
   */
 case class AtomicGauge(name: String, unitOfMeasurement: UnitOfMeasurement = UnitOfMeasurement.Unknown,
     tags: Map[String, String] = Map.empty) extends SettableGauge {
+
   private[this] val counter = new AtomicLong()
+
+  // The current value of the `counter` will be pulled by Kamon when needed
+  // using the following gauge definition
+  Kamon.metrics.gauge(name, unitOfMeasurement) { counter.get() }
 
   def value(): Long = counter.get()
 


### PR DESCRIPTION
This commit fixes the `AtomicGauge` instance that is used explicitly by the
InstaceTrackerActor to track the `running` and `staged` number of instances.

A follow-up commit will introduce the `healthy` and` unhealthy` stats

_Related JIRAs: MARATHON-8212_