### PR TITLE
Remove launch queue querying in favour of instance tracker.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -2,13 +2,15 @@ package mesosphere.marathon
 package api.v2
 
 import java.time.Clock
+
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.{Context, MediaType, Response}
-
 import mesosphere.marathon.api.AuthResource
+import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec}
 import mesosphere.marathon.raml.Raml
 import mesosphere.marathon.state.PathId._
@@ -19,6 +21,8 @@ import scala.concurrent.ExecutionContext
 class QueueResource @Inject() (
     clock: Clock,
     launchQueue: LaunchQueue,
+    instanceTracker: InstanceTracker,
+    groupManager: GroupManager,
     val authenticator: Authenticator,
     val authorizer: Authorizer,
     val config: MarathonConf)(implicit val executionContext: ExecutionContext) extends AuthResource {
@@ -37,9 +41,10 @@ class QueueResource @Inject() (
   def resetDelay(
     @PathParam("appId") id: String,
     @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    //    import scala.concurrent.ExecutionContext.Implicits.global
     val appId = id.toRootPath
-    val maybeApps = result(launchQueue.list)
-    val maybeApp = maybeApps.find(_.runSpec.id == appId).map(_.runSpec)
+    val appScheduled = result(instanceTracker.specInstances(appId)).exists(_.isScheduled)
+    val maybeApp = if (appScheduled) groupManager.runSpec(appId) else None
     withAuthorization(UpdateRunSpec, maybeApp, notFound(s"Application $appId not found in tasks queue.")) { app =>
       launchQueue.resetDelay(app)
       noContent

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -5,7 +5,6 @@ import java.time.Clock
 
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.appinfo.{AppInfo, EnrichedTask, EnrichedTasks, TaskCounts, TaskStatsByVersion}
-import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.deployment.{DeploymentPlan, DeploymentStepInfo}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.{Health, HealthCheckManager}
@@ -173,7 +172,7 @@ class AppInfoBaseData(
       }
     )).toMap
     val instanceStatus = instances
-      .filter(_.state.condition != Condition.Scheduled)
+      .filter(!_.isScheduled)
       .flatMap { inst => podInstanceStatus(inst)(specByVersion.apply) }
     val statusSince = if (instanceStatus.isEmpty) now else instanceStatus.map(_.statusSince).max
     val state = await(podState(podDef.instances, instanceStatus, isPodTerminating(podDef.id)))

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/TaskForStatistics.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/TaskForStatistics.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon
 package core.appinfo.impl
 
-import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
@@ -48,7 +47,7 @@ private[appinfo] object TaskForStatistics {
     }
 
     instances.collect {
-      case instance: Instance if instance.state.condition != Condition.Scheduled =>
+      case instance: Instance if !instance.isScheduled =>
         taskForStatistics(instance)
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -4,7 +4,7 @@ package core.launchqueue
 import akka.Done
 import mesosphere.marathon.core.instance.update.InstanceChange
 import mesosphere.marathon.core.launcher.OfferMatchResult
-import mesosphere.marathon.core.launchqueue.LaunchQueue.{QueuedInstanceInfo, QueuedInstanceInfoWithStatistics}
+import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfoWithStatistics
 import mesosphere.marathon.state.{PathId, RunSpec, Timestamp}
 import mesosphere.mesos.NoOfferMatchReason
 
@@ -52,26 +52,14 @@ object LaunchQueue {
   */
 trait LaunchQueue {
 
-  /** Returns all entries of the queue. */
-  def list: Future[Seq[QueuedInstanceInfo]]
-
   /** Returns all entries of the queue with embedded statistics */
   def listWithStatistics: Future[Seq[QueuedInstanceInfoWithStatistics]]
-
-  /** Returns all runnable specs for which queue entries exist. */
-  def listRunSpecs: Future[Seq[RunSpec]]
 
   /** Request to launch `count` additional instances conforming to the given run spec. */
   def add(spec: RunSpec, count: Int = 1): Future[Done]
 
   /** Update the run spec in a task launcher actor. **/
   def sync(spec: RunSpec) = add(spec, 0)
-
-  /** Get information for the given run spec id. */
-  def get(specId: PathId): Future[Option[QueuedInstanceInfo]]
-
-  /** Return how many instances are still to be launched for this PathId. */
-  def count(specId: PathId): Future[Int]
 
   /** Remove all instance launch requests for the given PathId from this queue. */
   def purge(specId: PathId): Future[Done]

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -28,6 +28,28 @@ trait InstanceTracker extends StrictLogging {
   def specInstancesSync(pathId: PathId): Seq[Instance]
   def specInstances(pathId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]]
 
+  /**
+    * List all instances for a run spec with given id.
+    *
+    * @param pathId The id of the run spec.
+    * @return All instances for the run spec.
+    */
+  def list(pathId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]] = specInstances(pathId)
+
+  /**
+    * Look up a specific instance by id.
+    *
+    * @param instanceId The identifier of the instance.
+    * @return None if the instance does not exist, or the instance otherwise.
+    */
+  def get(instanceId: Instance.Id): Future[Option[Instance]] = instance(instanceId)
+
+  /**
+    * Look up a specific instance by id.
+    *
+    * @param instanceId The identifier of the instance.
+    * @return None if the instance does not exist, or the instance otherwise.
+    */
   def instance(instanceId: Instance.Id): Future[Option[Instance]]
 
   def instancesBySpecSync: InstanceTracker.InstancesBySpec

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -33,83 +33,6 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
   }
 
   "LaunchQueueModule" should {
-    "empty queue returns no results" in fixture { f =>
-      import f._
-      When("querying queue")
-      val apps = launchQueue.list.futureValue
-
-      Then("no apps are returned")
-      apps should be(empty)
-    }
-
-    "An added queue item is returned in list" in fixture { f =>
-      import f._
-      Given("a launch queue with one item")
-      instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(Instance.Scheduled(app))
-      instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
-      launchQueue.add(app).futureValue
-
-      When("querying its contents")
-      val list = launchQueue.list.futureValue
-
-      Then("we get back the added app")
-      list should have size 1
-      list.head.runSpec should equal(app)
-      list.head.instancesLeftToLaunch should equal(1)
-      list.head.finalInstanceCount should equal(1)
-      list.head.inProgress should equal(true)
-    }
-
-    "An added queue item is reflected via count" in fixture { f =>
-      import f._
-      Given("a launch queue with one item")
-      instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(Instance.Scheduled(app))
-      instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
-      launchQueue.add(app).futureValue
-
-      When("querying its count")
-      val count = launchQueue.count(app.id).futureValue
-
-      Then("we get a count == 1")
-      count should be(1)
-    }
-
-    "A purged queue item has a count of 0" in fixture { f =>
-      import f._
-      Given("a launch queue with one item which is purged")
-      val scheduled = Instance.Scheduled(app)
-      instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(scheduled)
-      instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
-      instanceTracker.specInstances(app.id) returns Future.successful(Seq(scheduled))
-      instanceTracker.forceExpunge(any) returns Future.successful(Done)
-      launchQueue.add(app).futureValue
-      launchQueue.purge(app.id).futureValue
-
-      When("querying its count")
-      val count = launchQueue.count(app.id).futureValue
-
-      Then("we get a count == 0")
-      count should be(0)
-    }
-
-    "A re-added queue item has a count of 1" in fixture { f =>
-      import f._
-      Given("a launch queue with one item which is purged")
-      val scheduled = Instance.Scheduled(app)
-      instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(scheduled)
-      instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
-      instanceTracker.specInstances(app.id) returns Future.successful(Seq(scheduled))
-      instanceTracker.forceExpunge(any) returns Future.successful(Done)
-      launchQueue.add(app).futureValue
-      launchQueue.purge(app.id).futureValue
-      launchQueue.add(app).futureValue
-
-      When("querying its count")
-      val count = launchQueue.count(app.id).futureValue
-
-      Then("we get a count == 1")
-      count should be(1)
-    }
 
     "adding a queue item registers new offer matcher" in fixture { f =>
       import f._
@@ -187,34 +110,6 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       verify(instanceOpFactory).matchOfferRequest(request)
       matchedTasks.offerId should equal(offer.getId)
       launchedTaskInfos(matchedTasks) should equal(Seq(mesosTask))
-    }
-
-    "TaskChanged updates are answered immediately for suspended queue entries" in fixture { f =>
-      // otherwise we get a deadlock in some cases, see comment in LaunchQueueActor
-      import f._
-      Given("An app in the queue")
-      val scheduledInstance = Instance.Scheduled(app)
-      instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(scheduledInstance)
-      instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
-      launchQueue.add(app, 3).futureValue
-      WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
-        offerMatcherManager.offerMatchers.size == 1
-      }
-
-      And("a task gets launched but not confirmed")
-      instanceOpFactory.matchOfferRequest(Matchers.any()) returns launchResult
-      val matchFuture = offerMatcherManager.offerMatchers.head.matchOffer(offer)
-      matchFuture.futureValue
-
-      And("test app gets purged (but not stopped yet because of in-flight tasks)")
-      launchQueue.purge(app.id)
-      WaitTestSupport.waitUntil("purge gets executed", 1.second) {
-        !launchQueue.list.futureValue.exists(_.runSpec.id == app.id)
-      }
-      reset(instanceTracker, instanceOpFactory)
-
-      When("we send a related task change")
-      launchQueue.notifyOfInstanceUpdate(instanceChange).futureValue
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -15,7 +15,6 @@ import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.history.impl.HistoryActor
 import mesosphere.marathon.core.instance.update.InstanceChangedEventsGenerator
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
-import mesosphere.marathon.core.launcher.impl.LaunchQueueTestHelper
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.KillServiceMock
@@ -173,7 +172,6 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
       val instances = Seq(TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance())
 
-      queue.get(app.id) returns Future.successful(Some(LaunchQueueTestHelper.zeroCounts))
       instanceTracker.specInstances(mockito.Matchers.eq("nope".toPath))(mockito.Matchers.any[ExecutionContext]) returns Future.successful(instances)
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
@@ -189,7 +187,6 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       import f._
       val app = AppDefinition(id = "/test-app-scale".toPath, instances = 1, cmd = Some("sleep"))
 
-      queue.get(app.id) returns Future.successful(Some(LaunchQueueTestHelper.zeroCounts))
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
       schedulerActor ! LeadershipTransition.ElectedAsLeaderAndReady
@@ -212,7 +209,6 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
       killService.customStatusUpdates.put(instance.instanceId, events)
 
-      queue.get(app.id) returns Future.successful(Some(LaunchQueueTestHelper.zeroCounts))
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
       schedulerActor ! LeadershipTransition.ElectedAsLeaderAndReady
@@ -239,7 +235,6 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       val app = AppDefinition(id = "/test-app".toPath, instances = 1, cmd = Some("sleep"))
       val instanceA = TestInstanceBuilder.newBuilderWithLaunchedTask(app.id).getInstance()
 
-      queue.get(app.id) returns Future.successful(Some(LaunchQueueTestHelper.zeroCounts))
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
       schedulerActor ! LeadershipTransition.ElectedAsLeaderAndReady
@@ -460,7 +455,6 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
     val killService = new KillServiceMock(system)
 
     val queue: LaunchQueue = mock[LaunchQueue]
-    queue.get(any[PathId]) returns Future.successful(None)
     queue.add(any, any) returns Future.successful(Done)
 
     val frameworkIdRepo: FrameworkIdRepository = mock[FrameworkIdRepository]

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/AppStartActorTest.scala
@@ -96,7 +96,6 @@ class AppStartActorTest extends AkkaUnitTest {
       val readinessCheckExecutor: ReadinessCheckExecutor = mock[ReadinessCheckExecutor]
       val appId = PathId("/app")
 
-      launchQueue.get(appId) returns Future.successful(None)
       scheduler.startRunSpec(any) returns Future.successful(Done)
 
       def instanceChanged(app: AppDefinition, condition: Condition): InstanceChanged = {

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -170,7 +170,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
       val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
-      queue.count(appNew.id) returns Future.successful(appNew.instances)
+      tracker.list(appNew.id) returns Future.successful(Seq(instance1_1, instance1_2))
 
       queue.sync(appNew) returns Future.successful(Done)
       when(queue.add(same(appNew), any[Int])).thenAnswer(new Answer[Future[Done]] {

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
@@ -218,7 +218,6 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     deploymentRepo.store(any[DeploymentPlan]) returns Future.successful(Done)
     deploymentRepo.delete(any[String]) returns Future.successful(Done)
     deploymentRepo.all() returns Source.empty
-    launchQueue.get(any) returns Future.successful(None)
     launchQueue.add(any, any) returns Future.successful(Done)
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
@@ -10,8 +10,7 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition.{Failed, Running}
 import mesosphere.marathon.core.event.{DeploymentStatus, _}
 import mesosphere.marathon.core.health.MesosCommandHealthCheck
-import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.launcher.impl.LaunchQueueTestHelper
+import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.InstanceTracker
@@ -24,40 +23,33 @@ import scala.util.control.NonFatal
 
 class TaskStartActorTest extends AkkaUnitTest with Eventually {
   "TaskStartActor" should {
-    for (
-      (counts, description) <- Seq(
-        None -> "with no item in queue",
-        Some(LaunchQueueTestHelper.zeroCounts) -> "with zero count queue item"
-      )
-    ) {
-      s"Start success $description" in {
-        val f = new Fixture
-        val promise = Promise[Unit]()
-        val app = AppDefinition("/myApp".toPath, instances = 5)
 
-        f.launchQueue.get(app.id) returns Future.successful(counts)
-        f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
-        val ref = f.startActor(app, app.instances, promise)
-        watch(ref)
+    "Start success no items in the queue" in {
+      val f = new Fixture
+      val promise = Promise[Unit]()
+      val app = AppDefinition("/myApp".toPath, instances = 5)
 
-        eventually { verify(f.launchQueue, atLeastOnce).add(app, app.instances) }
+      f.taskTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
+      val ref = f.startActor(app, app.instances, promise)
+      watch(ref)
 
-        for (i <- 0 until app.instances)
-          system.eventStream.publish(f.instanceChange(app, Instance.Id.forRunSpec(app.id), Running))
+      eventually { verify(f.launchQueue, atLeastOnce).add(app, app.instances) }
 
-        promise.future.futureValue should be(())
+      for (i <- 0 until app.instances)
+        system.eventStream.publish(f.instanceChange(app, Instance.Id.forRunSpec(app.id), Running))
 
-        expectTerminated(ref)
-      }
+      promise.future.futureValue should be(())
+
+      expectTerminated(ref)
     }
 
     "Start success with one task left to launch" in {
       val f = new Fixture
-      val counts = Some(LaunchQueueTestHelper.zeroCounts.copy(instancesLeftToLaunch = 1, finalInstanceCount = 1))
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 5)
 
-      f.launchQueue.get(app.id) returns Future.successful(counts)
+      val instances: Seq[Instance] = Seq(Instance.Scheduled(app))
+      f.taskTracker.specInstances(eq(app.id))(any) returns Future.successful(instances)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -77,8 +69,8 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 5)
 
-      f.launchQueue.get(app.id) returns Future.successful(None)
-      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(1)
+      val instances: Seq[Instance] = Seq(TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance())
+      f.taskTracker.specInstances(eq(app.id))(any) returns Future.successful(instances)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -97,8 +89,8 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val f = new Fixture
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 0)
-      f.launchQueue.get(app.id) returns Future.successful(None)
-      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
+
+      f.taskTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -116,8 +108,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
         instances = 5,
         healthChecks = Set(MesosCommandHealthCheck(command = Command("true")))
       )
-      f.launchQueue.get(app.id) returns Future.successful(None)
-      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -140,8 +131,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
         instances = 0,
         healthChecks = Set(MesosCommandHealthCheck(command = Command("true")))
       )
-      f.launchQueue.get(app.id) returns Future.successful(None)
-      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -156,8 +146,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 1)
 
-      f.launchQueue.get(app.id) returns Future.successful(None)
-      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)


### PR DESCRIPTION
Summary:
Since the instance tracker has the ground truth for scheudled instance
the launch queue should not be queried any more but only the tracker. It
is a single point.

The launch queue still has `listWithStatistics` which should be replace
as well.