### PR TITLE
Run SI test builds every 2h

### DIFF
--- a/Jenkinsfile.disabled.si
+++ b/Jenkinsfile.disabled.si
@@ -11,7 +11,7 @@ node('py36') {
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
             // Run pipeline at 1:00, 7:00, 13:00 and 19:00.
-            pipelineTriggers([cron('0 1,7,13,19 * * *')]),
+            pipelineTriggers([cron('H H(0-23)/2 * * *')]),
             parameters([
                     string(name: 'channel',
                             defaultValue: 'testing/pull/1296',

--- a/Jenkinsfile.disabled.si
+++ b/Jenkinsfile.disabled.si
@@ -10,7 +10,7 @@ node('py36') {
     // DC/OS EE: channel="testing/pull/1296", for strict, permissive or disabled clusters
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
-            // Run pipeline at 1:00, 7:00, 13:00 and 19:00.
+            // Run pipeline every 2h.
             pipelineTriggers([cron('H H(0-23)/2 * * *')]),
             parameters([
                     string(name: 'channel',

--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -10,7 +10,7 @@ node('py36') {
     // DC/OS EE: channel="testing/pull/1296", for strict, permissive or disabled clusters
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
-            // Run pipeline at 0:00, 6:00, 12:00 and 18:00.
+            // Run pipeline every 2h.
             pipelineTriggers([cron('H H(0-23)/2 * * *')]),
             parameters([
                     string(name: 'channel',

--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -11,7 +11,7 @@ node('py36') {
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
             // Run pipeline at 0:00, 6:00, 12:00 and 18:00.
-            pipelineTriggers([cron('0 0,6,12,18 * * *')]),
+            pipelineTriggers([cron('H H(0-23)/2 * * *')]),
             parameters([
                     string(name: 'channel',
                             defaultValue: 'testing/pull/1739',

--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -10,7 +10,7 @@ node('py36') {
     // DC/OS EE: channel="testing/pull/1296", for strict, permissive or disabled clusters
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
-            // Run pipeline at 2:00, 8:00, 14:00 and 20:00.
+            // Run pipeline every 2h.
             pipelineTriggers([cron('H H(0-23)/2 * * *')]),
             parameters([
                     string(name: 'channel',

--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -11,7 +11,7 @@ node('py36') {
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
             // Run pipeline at 2:00, 8:00, 14:00 and 20:00.
-            pipelineTriggers([cron('0 2,8,14,20 * * *')]),
+            pipelineTriggers([cron('H H(0-23)/2 * * *')]),
             parameters([
                     string(name: 'channel',
                             defaultValue: 'testing/pull/1296',

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -11,7 +11,7 @@ node('py36') {
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
             // Run pipeline at 3:00, 9:00, 15:00 and 21:00.
-            pipelineTriggers([cron('0 3,9,15,21 * * *')]),
+            pipelineTriggers([cron('H H(0-23)/2 * * *')]),
             parameters([
                     string(name: 'channel',
                             defaultValue: 'testing/pull/1296',

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -10,7 +10,7 @@ node('py36') {
     // DC/OS EE: channel="testing/pull/1296", for strict, permissive or disabled clusters
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
-            // Run pipeline at 3:00, 9:00, 15:00 and 21:00.
+            // Run pipeline every 2h.
             pipelineTriggers([cron('H H(0-23)/2 * * *')]),
             parameters([
                     string(name: 'channel',


### PR DESCRIPTION
Summary:
Updated the SI pipeline triggers to run roughly every 2h. However, we use Jenkins `H` cron job [option](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.jelly#L40) for Jenkins to try to spread the load evenly. Overall we should end up with running approx. two SI jobs at any time which shouldn't be a problem.
