### PR TITLE
Fix Mesos HTTP health check for non-host networking mode with `containerPort=0` (#6235)

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthCheck.scala
@@ -111,10 +111,9 @@ sealed trait MesosHealthCheckWithPorts extends HealthCheckWithPort { this: Healt
   @SuppressWarnings(Array("OptionGet"))
   def effectivePort(portAssignments: Seq[PortAssignment]): Option[Int] = {
     port.orElse {
-      val portAssignment: Option[PortAssignment] = portIndex.flatMap {
-        case intIndex: PortReference.ByIndex => Some(portAssignments(intIndex.value))
-        case nameIndex: PortReference.ByName => portAssignments.find(_.portName.contains(nameIndex.value))
-      }
+      val portAssignment: Option[PortAssignment] = portIndex.map(index => index(portAssignments))
+      // Mesos enters the container's network to probe the port, hence we prefer `containerPort`
+      // to `hostPort` here (as opposed to MarathonHealthCheck which is the opposite)
       portAssignment.flatMap(_.containerPort).orElse(portAssignment.flatMap(_.hostPort))
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/task/state/NetworkInfo.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/state/NetworkInfo.scala
@@ -113,7 +113,8 @@ object NetworkInfo extends StrictLogging {
               effectiveIpAddress = Option(hostName),
               effectivePort = hostPort,
               hostPort = Option(hostPort),
-              containerPort = Option(containerPort)
+              // See [[TaskBuilder.computeContainerInfo.boundPortMappings]] for more info.
+              containerPort = if (containerPort == 0) Option(hostPort) else Option(containerPort)
             )
             gen(xs, rs, assignment :: assignments)
           case (_, mapping :: rs) if mapping.hostPort.isEmpty =>

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -128,28 +128,34 @@ class TaskBuilder(
     } else {
       val builder = ContainerInfo.newBuilder
 
-      def boundPortMappings = runSpec.container.withFilter(_.portMappings.nonEmpty).map { c =>
-        c.portMappings.zip(hostPorts).collect {
-          case (mapping, Some(hport)) =>
-            // Use case: containerPort = 0 and hostPort = 0
-            //
-            // For apps that have their own service registry and require p2p communication,
-            // they will need to advertise
-            // the externally visible ports that their components come up on.
-            // Since they generally know there container port and advertise that, this is
-            // fixed most easily if the container port is the same as the externally visible host
-            // port.
-            if (mapping.containerPort == 0) {
-              mapping.copy(hostPort = Some(hport), containerPort = hport)
-            } else {
-              mapping.copy(hostPort = Some(hport))
-            }
-        }
-      }.getOrElse(Nil)
+      def boundPortMappings(container: Container) = container.portMappings.zip(hostPorts).collect {
+        case (mapping, Some(hport)) =>
+          // Use case: containerPort = 0 and hostPort = 0
+          //
+          // For apps that have their own service registry and require p2p communication, they will need to advertise
+          // the externally visible ports that their components come up on. Since they generally know there container
+          // port and advertise that, this is fixed most easily if the container port is the same as the externally
+          // visible host port.
+          //
+          // *NOTE:*
+          // We have this logic for preferring hostPort to containerPort (if containerPort == 0) in three
+          // different places:
+          // 1. Here, for the generation of the [[ContainerInfo]]
+          // 2. In [[NetworkInfo]] for generation of port assignments [[NetworkInfo.portAssignments]]. The resulting
+          //    effectivePort in the port assignments will affect e.g. [[MesosHealthCheck]]
+          // 3. In [[EnvironmentHelper]] for generating ports environment variables [[EnvironmentHelper.portsEnv]]
+          // I didn't find a way to let them all use the same logic (since all three explicitly or implicitly rely on
+          // RunSpec/Container) hence this comment.
+          if (mapping.containerPort == 0) {
+            mapping.copy(hostPort = Some(hport), containerPort = hport)
+          } else {
+            mapping.copy(hostPort = Some(hport))
+          }
+      }
 
       // Fill in container details if necessary
       runSpec.container.foreach { c =>
-        val containerWithPortMappings = c.copyWith(portMappings = boundPortMappings) match {
+        val containerWithPortMappings = c.copyWith(portMappings = boundPortMappings(c)) match {
           case d: Container.Docker => d.copy(parameters = d.parameters :+
             state.Parameter("label", s"MESOS_TASK_ID=${taskId.mesosTaskId.getValue}")
           )

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -494,6 +494,23 @@ class MesosHealthCheckTest extends UnitTest {
       assertHttpHealthCheckProto(taskInfo, 80, "http")
     }
 
+    "Mesos HTTP HealthCheck toMesos with Docker BRIDGE networking and random container and host ports" in {
+      import MarathonTestHelper.Implicits._
+
+      val app = MarathonTestHelper.makeBasicApp()
+        .withNoPortDefinitions()
+        .withDockerNetworks(ContainerNetwork("whatever"))
+        .withPortMappings(Seq(PortMapping(containerPort = 0, hostPort = Some(0))))
+        .withHealthCheck(mesosHttpHealthCheckWithPortIndex)
+
+      val task: Option[(MesosProtos.TaskInfo, NetworkInfo)] = buildIfMatches(app)
+      assert(task.isDefined)
+
+      val (taskInfo, networkInfo) = task.get
+      val healthCheckPort = networkInfo.hostPorts.head
+      assertHttpHealthCheckProto(taskInfo, port = healthCheckPort, "http")
+    }
+
     "Mesos HTTP HealthCheck toMesos with Docker USER networking and a port mapping NOT requesting a host port, with portIndex" in {
       import MarathonTestHelper.Implicits._
 

--- a/src/test/scala/mesosphere/marathon/core/task/state/NetworkInfoTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/state/NetworkInfoTest.scala
@@ -34,13 +34,20 @@ class NetworkInfoTest extends UnitTest {
               servicePort = 9001,
               protocol = "udp",
               name = Some("admin")
+            ),
+            PortMapping(
+              containerPort = 0,
+              hostPort = Some(0),
+              servicePort = 9002,
+              protocol = "tcp",
+              name = Some("tcp")
             )
           )
         ))
       )
       val networkInfo = NetworkInfo(
         hostName = f.hostName,
-        hostPorts = Seq(20001, 123),
+        hostPorts = Seq(20001, 123, 20002),
         ipAddresses = Nil
       )
       "work without an IP address" in {
@@ -57,7 +64,13 @@ class NetworkInfoTest extends UnitTest {
               effectiveIpAddress = Some(f.hostName),
               effectivePort = 123,
               hostPort = Some(123),
-              containerPort = Some(8081))
+              containerPort = Some(8081)),
+            PortAssignment(
+              portName = Some("tcp"),
+              effectiveIpAddress = Some(f.hostName),
+              effectivePort = 20002,
+              hostPort = Some(20002),
+              containerPort = Some(20002))
           )
         )
       }
@@ -76,7 +89,13 @@ class NetworkInfoTest extends UnitTest {
               effectiveIpAddress = Some(f.hostName),
               effectivePort = 123,
               hostPort = Some(123),
-              containerPort = Some(8081))
+              containerPort = Some(8081)),
+            PortAssignment(
+              portName = Some("tcp"),
+              effectiveIpAddress = Some(f.hostName),
+              effectivePort = 20002,
+              hostPort = Some(20002),
+              containerPort = Some(20002))
           )
         )
       }
@@ -91,7 +110,7 @@ class NetworkInfoTest extends UnitTest {
           portMappings = Seq(
             PortMapping(containerPort = 0, hostPort = Some(31000), servicePort = 9000, protocol = "tcp"),
             PortMapping(containerPort = 0, hostPort = None, servicePort = 9001, protocol = "tcp"),
-            PortMapping(containerPort = 0, hostPort = Some(31005), servicePort = 9002, protocol = "tcp")
+            PortMapping(containerPort = 0, hostPort = Some(0), servicePort = 9002, protocol = "tcp")
 
           )
         ))
@@ -111,7 +130,7 @@ class NetworkInfoTest extends UnitTest {
               effectiveIpAddress = Option(f.hostName),
               effectivePort = 31000,
               hostPort = Some(31000),
-              containerPort = Some(0)),
+              containerPort = Some(31000)),
             PortAssignment(
               portName = None,
               effectiveIpAddress = None,
@@ -123,7 +142,7 @@ class NetworkInfoTest extends UnitTest {
               effectiveIpAddress = Option(f.hostName),
               effectivePort = 31005,
               hostPort = Some(31005),
-              containerPort = Some(0))
+              containerPort = Some(31005))
           )
         )
       }
@@ -136,7 +155,7 @@ class NetworkInfoTest extends UnitTest {
               effectiveIpAddress = Some(f.hostName),
               effectivePort = 31000,
               hostPort = Some(31000),
-              containerPort = Some(0)),
+              containerPort = Some(31000)),
             PortAssignment(
               portName = None,
               effectiveIpAddress = Some(f.containerIp),
@@ -148,7 +167,7 @@ class NetworkInfoTest extends UnitTest {
               effectiveIpAddress = Some(f.hostName),
               effectivePort = 31005,
               hostPort = Some(31005),
-              containerPort = Some(0))
+              containerPort = Some(31005))
           )
         )
       }


### PR DESCRIPTION
Summary:
Fixed a bug where for a container in non-host networking mode (`container` and `container/bridged`) with `hostPort=0, containerPort=0` we would set the `containerPort == hostPort` in `ContainerInfo` *and* ports environment variables *but not* in the `NetworkInfo`.
As the result Mesos health checks in this scenario would try to probe `containerPort == 0`. This behavior has now been unified for `NetworkInfo`, `ContainerInfo` and generated ports environment variables resulting in fixed Mesos HTTP health checks.

(cherry picked from commit bbf66a902561452af214e632a79f0db10975762e)

JIRA issues: MARATHON-8216
