### PR TITLE
Rename method to reservationTimeout

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActor.scala
@@ -84,7 +84,7 @@ private[jobs] object OverdueTasksActor {
     private[this] def timeoutOverdueReservations(now: Timestamp, instances: Seq[Instance]): Future[Unit] = {
       val taskTimeoutResults = overdueReservations(now, instances).map { instance =>
         logger.warn("Scheduling ReservationTimeout for {}", instance.instanceId)
-        instanceTracker.updateReservationTimeout(instance.instanceId)
+        instanceTracker.reservationTimeout(instance.instanceId)
       }
       Future.sequence(taskTimeoutResults).map(_ => ())
     }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -49,7 +49,7 @@ trait InstanceTracker {
 
   def updateStatus(instance: Instance, mesosStatus: mesos.Protos.TaskStatus, updateTime: Timestamp): Future[Done]
 
-  def updateReservationTimeout(instanceId: Instance.Id): Future[Done]
+  def reservationTimeout(instanceId: Instance.Id): Future[Done]
 }
 
 object InstanceTracker {

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -101,7 +101,7 @@ private[tracker] class InstanceTrackerDelegate(
     process(InstanceUpdateOperation.MesosUpdate(instance, mesosStatus, updateTime)).map(_ => Done)
   }
 
-  override def updateReservationTimeout(instanceId: Instance.Id): Future[Done] = {
+  override def reservationTimeout(instanceId: Instance.Id): Future[Done] = {
     import scala.concurrent.ExecutionContext.Implicits.global
     process(InstanceUpdateOperation.ReservationTimeout(instanceId)).map(_ => Done)
   }

--- a/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/jobs/impl/OverdueTasksActorTest.scala
@@ -139,7 +139,7 @@ class OverdueTasksActorTest extends AkkaUnitTest {
       val recentReserved = reservedWithTimeout(appId, deadline = clock.now() + 1.second)
       val app = InstanceTracker.InstancesBySpec.forInstances(recentReserved, overdueReserved)
       instanceTracker.instancesBySpec()(any[ExecutionContext]) returns Future.successful(app)
-      instanceTracker.updateReservationTimeout(overdueReserved.instanceId) returns Future.successful(Done)
+      instanceTracker.reservationTimeout(overdueReserved.instanceId) returns Future.successful(Done)
 
       When("the check is initiated")
       val testProbe = TestProbe()
@@ -148,7 +148,7 @@ class OverdueTasksActorTest extends AkkaUnitTest {
 
       Then("the reservation gets processed")
       verify(instanceTracker).instancesBySpec()(any[ExecutionContext])
-      verify(instanceTracker).updateReservationTimeout(overdueReserved.instanceId)
+      verify(instanceTracker).reservationTimeout(overdueReserved.instanceId)
       verifyClean()
     }
   }


### PR DESCRIPTION
This is really not doing any update to the timeout, it is assigning the instance as being killed because reservation timeout was reached. We should settle for better name.