### PR TITLE
Update extra-defines.bash

### DIFF
--- a/project/NativePackagerSettings/extra-defines.bash
+++ b/project/NativePackagerSettings/extra-defines.bash
@@ -12,7 +12,7 @@ if [ ! "$1" = "--help" ]; then
     echo "No start hook file found (\$HOOK_MARATHON_START). Proceeding with the start script."
   fi
 
-  for env_op in `env | grep -v ^MARATHON_APP | grep ^MARATHON_ | awk '{gsub(/MARATHON_/,""); gsub(/=/," "); printf("%s%s ", "--", tolower($1)); for(i=2;i<=NF;i++){printf("%s ", $i)}}'`; do
+  for env_op in `env | grep -v ^MARATHON_APP | grep ^MARATHON_ | awk '{gsub(/MARATHON_/,""); sub(/=/," "); printf("%s%s ", "--", tolower($1)); for(i=2;i<=NF;i++){printf("%s ", $i)}}'`; do
     addApp "$env_op"
   done
 fi


### PR DESCRIPTION
only replace the first leftmost `=` sign otherwise we start splitting on equal signs inside the key value. For example trying to use
```
MARATHON_REPORTER_GRAPHITE=tcp://graphite.mycompany.net:2003?prefix=foo&interval=60
```
the above code will return 3 arguments
```
--reporter_graphite
tcp://graphite.mycompany.net:2003?prefix
foo&interval
60
```
And this obviously fails during startup `Error: Bad arguments for option 'reporter_graphite':`

The new code returns 
```
--reporter_graphite
tcp://graphite.mycompany.net:2003?prefix=foo&interval=60
```

<<Replace this line with your Revision Title>>

Summary:
For more details follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html.

JIRA issues:
