### PR TITLE
Fail loop builds on error.

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -259,7 +259,9 @@ def loop(): Unit = {
     build(buildName = utils.loopBuildName())
     dataDogClient.reportCount(s"marathon.build.${utils.loopName}.success", 1)
   } catch {
-    case _ => dataDogClient.reportCount(s"marathon.build.${utils.loopName}.failure", 1)
+    case ex =>
+      dataDogClient.reportCount(s"marathon.build.${utils.loopName}.failure", 1)
+      throw ex
   } finally {
     dataDogClient.reportCount(s"marathon.build.${utils.loopName}.duration", ((System.currentTimeMillis - start) / 1000).toInt)
   }


### PR DESCRIPTION
Summary:
We used to swollow every exception. This change will through it so that
`./ci/pipeline loop` will exit with 0 on an error.