### PR TITLE
Count instances to schedule inside instanceTracker

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
@@ -52,9 +52,7 @@ trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Acto
       launchQueue.add(runSpec, 1).pipeTo(self)
 
     case Sync => async {
-      val instances = await(instanceTracker.specInstances(runSpec.id))
-      val actualSize = instances.count { i => i.isActive || i.isReserved || i.isScheduled || i.isProvisioned }
-      val instancesToStartNow = Math.max(scaleTo - actualSize, 0)
+      val instancesToStartNow = await(instanceTracker.instancesToScheduleCount(runSpec.id, scaleTo))
       logger.debug(s"Sync start instancesToStartNow=$instancesToStartNow appId=${runSpec.id}")
       if (instancesToStartNow > 0) {
         logger.info(s"Reconciling app ${runSpec.id} scaling: queuing $instancesToStartNow new instances")

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -29,14 +29,7 @@ class TaskStartActor(
     val scaleTo: Int,
     promise: Promise[Unit]) extends Actor with StrictLogging with StartingBehavior {
 
-  // TODO(karsten): We probably want to remove the queue.get method since all information is part of the instance tracker.
-  override val nrToStart: Future[Int] = async {
-    val alreadyLaunched = await(launchQueue.get(runSpec.id)) match {
-      case Some(info) => info.finalInstanceCount
-      case None => await(instanceTracker.countActiveSpecInstances(runSpec.id))
-    }
-    Math.max(0, scaleTo - alreadyLaunched)
-  }.pipeTo(self)
+  override val nrToStart: Future[Int] = instanceTracker.instancesToScheduleCount(runSpec.id, scaleTo).pipeTo(self)
 
   @SuppressWarnings(Array("all")) // async/await
   override def initializeStart(): Future[Done] = async {

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -30,10 +30,10 @@ trait InstanceTracker extends StrictLogging {
 
   def instance(instanceId: Instance.Id): Future[Option[Instance]]
 
+  def instancesToScheduleCount(appId: PathId, targetCount: Int): Future[Int]
+
   def instancesBySpecSync: InstanceTracker.InstancesBySpec
   def instancesBySpec()(implicit ec: ExecutionContext): Future[InstanceTracker.InstancesBySpec]
-
-  def countActiveSpecInstances(appId: PathId): Future[Int]
 
   def hasSpecInstancesSync(appId: PathId): Boolean
   def hasSpecInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Boolean]

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
@@ -36,7 +36,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
         val app = AppDefinition("/myApp".toPath, instances = 5)
 
         f.launchQueue.get(app.id) returns Future.successful(counts)
-        f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
+        f.taskTracker.instancesToScheduleCount(app.id, 5) returns Future.successful(5)
         val ref = f.startActor(app, app.instances, promise)
         watch(ref)
 
@@ -53,11 +53,10 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
 
     "Start success with one task left to launch" in {
       val f = new Fixture
-      val counts = Some(LaunchQueueTestHelper.zeroCounts.copy(instancesLeftToLaunch = 1, finalInstanceCount = 1))
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 5)
 
-      f.launchQueue.get(app.id) returns Future.successful(counts)
+      f.taskTracker.instancesToScheduleCount(app.id, 5) returns Future.successful(4)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -78,7 +77,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition("/myApp".toPath, instances = 5)
 
       f.launchQueue.get(app.id) returns Future.successful(None)
-      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(1)
+      f.taskTracker.instancesToScheduleCount(app.id, 5) returns Future.successful(4)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -98,7 +97,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 0)
       f.launchQueue.get(app.id) returns Future.successful(None)
-      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.instancesToScheduleCount(app.id, 0) returns Future.successful(0)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -117,7 +116,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
         healthChecks = Set(MesosCommandHealthCheck(command = Command("true")))
       )
       f.launchQueue.get(app.id) returns Future.successful(None)
-      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.instancesToScheduleCount(app.id, 5) returns Future.successful(5)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -141,7 +140,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
         healthChecks = Set(MesosCommandHealthCheck(command = Command("true")))
       )
       f.launchQueue.get(app.id) returns Future.successful(None)
-      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.instancesToScheduleCount(app.id, 0) returns Future.successful(0)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -157,7 +156,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition("/myApp".toPath, instances = 1)
 
       f.launchQueue.get(app.id) returns Future.successful(None)
-      f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
+      f.taskTracker.instancesToScheduleCount(app.id, 1) returns Future.successful(1)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)


### PR DESCRIPTION
In the future, InstanceTracker will have all the state to make this decision, this just moves this logic in there instead of having it spread in between StartActor and StartingBehavior.

Actually what happens then is that those classes call LaunchQueue that again calls InstanceTracker so in the ideal world in the future, we should just say InstanceTracker to schedule (instead of asking it for the count).

JIRA issues: MARATHON-8167
