### PR TITLE
Ensure that replace actor is intialized.

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.deployment.impl
 
 import akka.Done
-import akka.actor.{Actor, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.testkit.TestActorRef
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.condition.Condition
@@ -17,7 +17,6 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.{KillServiceMock, Task}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
-import org.mockito.{Mockito}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
@@ -52,7 +51,6 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
         ref ! f.instanceChanged(newApp, Running)
 
       promise.future.futureValue
-      verify(f.queue).resetDelay(newApp)
       f.killService.killed should contain(instanceA.instanceId)
       f.killService.killed should contain(instanceB.instanceId)
 
@@ -72,7 +70,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
       f.queue.sync(eq(newApp)) returns Future.successful(Done)
-      f.queue.add(eq(newApp), any) returns Future.successful(Done)
+      f.queue.add(newApp, 4) returns Future.successful(Done)
 
       val instanceC = f.runningInstance(newApp)
 
@@ -81,11 +79,11 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val ref = f.replaceActor(newApp, promise)
       watch(ref)
 
-      for (_ <- 0 until newApp.instances)
+      // Report all remaining instances as running.
+      for (_ <- 0 until (newApp.instances - 1))
         ref ! f.instanceChanged(newApp, Running)
 
       promise.future.futureValue
-      verify(f.queue).resetDelay(newApp)
       f.killService.killed should contain(instanceA.instanceId)
       f.killService.killed should not contain instanceC.instanceId
 
@@ -458,7 +456,8 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
       // the kill is confirmed (see answer above) and the first new task is queued
       eventually {
-        verify(f.queue, times(1)).add(newApp, 1)
+        verify(f.queue, times(1)).sync(newApp)
+        verify(f.queue, times(1)).resetDelay(newApp)
       }
 
       eventually {
@@ -508,6 +507,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
       f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB)
+      f.queue.sync(app) returns Future.successful(Done)
       val promise = Promise[Unit]()
 
       When("The replace actor is started")
@@ -527,17 +527,16 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition(id = "/myApp".toPath, instances = 1, portDefinitions = Seq(port), readinessChecks = Seq(check))
       val instance = f.runningInstance(app)
       f.tracker.specInstancesSync(app.id) returns Seq(instance)
+      f.queue.sync(app) returns Future.successful(Done)
       val readyCheck = Observable.from(instance.tasksMap.values.map(task => ReadinessCheckResult(check.name, task.taskId, ready = true, None)))
       f.readinessCheckExecutor.execute(any[ReadinessCheckExecutor.ReadinessCheckSpec]) returns readyCheck
       val promise = Promise[Unit]()
 
       When("The replace actor is started")
       val ref = f.replaceActor(app, promise)
-      watch(ref)
 
       Then("It needs to wait for the readiness checks to pass")
-      expectTerminated(ref)
-      promise.isCompleted should be(true)
+      promise.future.futureValue
     }
 
     "If all tasks are replaced already, we will wait for the readiness checks and health checks" in {
@@ -555,6 +554,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       )
       val instance = f.runningInstance(app)
       f.tracker.specInstancesSync(app.id) returns Seq(instance)
+      f.queue.sync(app) returns Future.successful(Done)
       val readyCheck = Observable.from(instance.tasksMap.values.map(task => ReadinessCheckResult(ready.name, task.taskId, ready = true, None)))
       f.readinessCheckExecutor.execute(any[ReadinessCheckExecutor.ReadinessCheckSpec]) returns readyCheck
       val promise = Promise[Unit]()
@@ -590,9 +590,9 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       watch(ref)
 
       for (_ <- 0 until newApp.instances)
-        ref.receive(f.instanceChanged(newApp, Running))
+        ref ! f.instanceChanged(newApp, Running)
 
-      verify(f.queue, Mockito.timeout(1000)).resetDelay(newApp)
+      verify(f.queue, timeout(1000)).resetDelay(newApp)
       f.killService.killed should contain(instanceA.instanceId)
       f.killService.killed should contain(instanceB.instanceId)
 
@@ -685,7 +685,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
     def healthChanged(app: AppDefinition, healthy: Boolean): InstanceHealthChanged = {
       InstanceHealthChanged(Instance.Id.forRunSpec(app.id), app.version, app.id, healthy = Some(healthy))
     }
-    def replaceActor(app: AppDefinition, promise: Promise[Unit]): TestActorRef[TaskReplaceActor] = TestActorRef(
+    def replaceActor(app: AppDefinition, promise: Promise[Unit]): ActorRef = system.actorOf(
       TaskReplaceActor.props(deploymentsManager, deploymentStatus, killService, queue,
         tracker, system.eventStream, readinessCheckExecutor, app, promise)
     )

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -19,11 +19,9 @@ import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import rx.lang.scala.Observable
 
 import scala.concurrent.{Future, Promise}
-import scala.concurrent.duration._
 
 class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
   "TaskReplaceActor" should {
@@ -516,7 +514,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
       Then("The replace actor finishes immediately")
       expectTerminated(ref)
-      promise.isCompleted should be(true)
+      promise.future.futureValue
     }
 
     "If all tasks are replaced already, we will wait for the readiness checks" in {
@@ -566,7 +564,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
       Then("It needs to wait for the readiness checks to pass")
       expectTerminated(ref)
-      promise.isCompleted should be(true)
+      promise.future.futureValue
     }
 
     "Wait until the tasks are killed" in {
@@ -596,8 +594,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       f.killService.killed should contain(instanceA.instanceId)
       f.killService.killed should contain(instanceB.instanceId)
 
-      promise.future.futureValue(Timeout(0.second))
-      promise.isCompleted should be(true)
+      promise.future.futureValue
     }
 
     "Tasks to replace need to wait for health and readiness checks" in {


### PR DESCRIPTION
Summary:
There was a race condition between the pre-start phase of the
`TaskReplaceActor` and instance status change updates.