### PR TITLE
Decrease runtime of ForwardToLeaderIntegrationTest

### DIFF
--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/ForwardToLeaderIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/ForwardToLeaderIntegrationTest.scala
@@ -34,142 +34,160 @@ class ForwardToLeaderIntegrationTest extends AkkaIntegrationTest with TableDrive
 
     s"ForwardingToLeader (async = ${async})" should {
       "direct ping" in withForwarder { forwarder =>
-        val helloPort = forwarder.startHelloApp().futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
+        val helloApp = forwarder.startHelloApp()
+        helloApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
         val appFacade = new AppMockFacade()
-        val result = appFacade.ping("localhost", port = helloPort).futureValue
+        val result = appFacade.ping("localhost", port = helloApp.port).futureValue
         result should be(OK)
         result.entityString should be("pong\n")
         result.value.headers.exists(_.name == RequestForwarder.HEADER_VIA) should be(false)
         result.value.headers.count(_.name == LeaderProxyFilter.HEADER_MARATHON_LEADER) should be(1)
-        result.value.headers.find(_.name == LeaderProxyFilter.HEADER_MARATHON_LEADER).get.value should be(s"http://localhost:$helloPort")
+        result.value.headers.find(_.name == LeaderProxyFilter.HEADER_MARATHON_LEADER).get.value should be(s"http://localhost:${helloApp.port}")
       }
 
       "forward ping" in withForwarder { forwarder =>
-        val helloPort = forwarder.startHelloApp().futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
-        val forwardPort = forwarder.startForwarder(helloPort).futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
+        val helloApp = forwarder.startHelloApp()
+        helloApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
+        val forwardApp = forwarder.startForwarder(helloApp.port)
+        forwardApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
 
         val appFacade = new AppMockFacade()
-        val result = appFacade.ping("localhost", port = forwardPort).futureValue
+        val result = appFacade.ping("localhost", port = forwardApp.port).futureValue
         result should be(OK)
         result.entityString should be("pong\n")
         result.value.headers.count(_.name == RequestForwarder.HEADER_VIA) should be(1)
-        result.value.headers.find(_.name == RequestForwarder.HEADER_VIA).get.value should be(s"1.1 localhost:$forwardPort")
+        result.value.headers.find(_.name == RequestForwarder.HEADER_VIA).get.value should be(s"1.1 localhost:${forwardApp.port}")
         result.value.headers.count(_.name == LeaderProxyFilter.HEADER_MARATHON_LEADER) should be(1)
-        result.value.headers.find(_.name == LeaderProxyFilter.HEADER_MARATHON_LEADER).get.value should be(s"http://localhost:$helloPort")
+        result.value.headers.find(_.name == LeaderProxyFilter.HEADER_MARATHON_LEADER).get.value should be(s"http://localhost:${helloApp.port}")
       }
 
       "direct HTTPS ping" in withForwarder { forwarder =>
-        val helloPort = forwarder.startHelloApp("--https_port", Seq(
+        val helloApp = forwarder.startHelloApp("--https_port", Seq(
           "--disable_http",
           "--ssl_keystore_path", SSLContextTestUtil.selfSignedKeyStorePath,
           "--ssl_keystore_password", SSLContextTestUtil.keyStorePassword,
-          "--https_address", "localhost")).futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
+          "--https_address", "localhost"))
+        helloApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
 
-        val pingURL = new URL(s"https://localhost:$helloPort/ping")
+        val pingURL = new URL(s"https://localhost:${helloApp.port}/ping")
         val connection = SSLContextTestUtil.sslConnection(pingURL, SSLContextTestUtil.selfSignedSSLContext)
         val via = connection.getHeaderField(RequestForwarder.HEADER_VIA)
         val leader = connection.getHeaderField(LeaderProxyFilter.HEADER_MARATHON_LEADER)
         val response = IOUtils.toString(connection.getInputStream, "UTF-8")
         response should be("pong\n")
         via should be(null)
-        leader should be(s"https://localhost:$helloPort")
+        leader should be(s"https://localhost:${helloApp.port}")
       }
 
       "forwarding HTTPS ping with a self-signed cert" in withForwarder { forwarder =>
-        val helloPort = forwarder.startHelloApp("--https_port", Seq(
+        val helloApp = forwarder.startHelloApp("--https_port", Seq(
           "--disable_http",
           "--ssl_keystore_path", SSLContextTestUtil.selfSignedKeyStorePath,
           "--ssl_keystore_password", SSLContextTestUtil.keyStorePassword,
-          "--https_address", "localhost")).futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
+          "--https_address", "localhost"))
+        helloApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
 
-        val forwardPort = forwarder.startForwarder(helloPort, "--https_port", args = Seq(
+        val forwardApp = forwarder.startForwarder(helloApp.port, "--https_port", args = Seq(
           "--disable_http",
           "--ssl_keystore_path", SSLContextTestUtil.selfSignedKeyStorePath,
           "--ssl_keystore_password", SSLContextTestUtil.keyStorePassword,
-          "--https_address", "localhost")).futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
+          "--https_address", "localhost"))
+        forwardApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
 
-        val pingURL = new URL(s"https://localhost:$forwardPort/ping")
+        val pingURL = new URL(s"https://localhost:${forwardApp.port}/ping")
         val connection = SSLContextTestUtil.sslConnection(pingURL, SSLContextTestUtil.selfSignedSSLContext)
         val via = connection.getHeaderField(RequestForwarder.HEADER_VIA)
         val leader = connection.getHeaderField(LeaderProxyFilter.HEADER_MARATHON_LEADER)
         val response = IOUtils.toString(connection.getInputStream, "UTF-8")
         response should be("pong\n")
-        via should be(s"1.1 localhost:$forwardPort")
-        leader should be(s"https://localhost:$helloPort")
+        via should be(s"1.1 localhost:${forwardApp.port}")
+        leader should be(s"https://localhost:${helloApp.port}")
       }
 
       "forwarding HTTPS ping with a ca signed cert" in withForwarder { forwarder =>
-        val helloPort = forwarder.startHelloApp("--https_port", Seq(
+        val helloApp = forwarder.startHelloApp("--https_port", Seq(
           "--disable_http",
           "--ssl_keystore_path", SSLContextTestUtil.caKeyStorePath,
           "--ssl_keystore_password", SSLContextTestUtil.keyStorePassword,
-          "--https_address", "localhost")).futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
+          "--https_address", "localhost"))
+        helloApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
 
-        val forwardPort = forwarder.startForwarder(
-          helloPort,
+        val forwardApp = forwarder.startForwarder(
+          helloApp.port,
           "--https_port",
-          trustStorePath = Some(SSLContextTestUtil.caTrustStorePath),
           args = Seq(
             "--disable_http",
             "--ssl_keystore_path", SSLContextTestUtil.caKeyStorePath,
             "--ssl_keystore_password", SSLContextTestUtil.keyStorePassword,
-            "--https_address", "localhost")).futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
+            "--https_address", "localhost"))
 
-        val pingURL = new URL(s"https://localhost:$forwardPort/ping")
+        forwardApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
+        val forwardPort = forwardApp.port
+
+        val pingURL = new URL(s"https://localhost:${forwardPort}/ping")
         val connection = SSLContextTestUtil.sslConnection(pingURL, SSLContextTestUtil.caSignedSSLContext)
         val via = connection.getHeaderField(RequestForwarder.HEADER_VIA)
         val leader = connection.getHeaderField(LeaderProxyFilter.HEADER_MARATHON_LEADER)
         val response = IOUtils.toString(connection.getInputStream, "UTF-8")
         response should be("pong\n")
         via should be(s"1.1 localhost:$forwardPort")
-        leader should be(s"https://localhost:$helloPort")
+        leader should be(s"https://localhost:${helloApp.port}")
       }
 
       "direct 404" in withForwarder { forwarder =>
-        val helloPort = forwarder.startHelloApp().futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
+        val helloApp = forwarder.startHelloApp()
+        helloApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
         val appFacade = new AppMockFacade()
-        val result = appFacade.custom("/notfound")("localhost", port = helloPort).futureValue
+        val result = appFacade.custom("/notfound")("localhost", port = helloApp.port).futureValue
         result should be(NotFound)
       }
 
       "forwarding 404" in withForwarder { forwarder =>
-        val helloPort = forwarder.startHelloApp().futureValue
-        val forwardPort = forwarder.startForwarder(helloPort).futureValue
+        val helloApp = forwarder.startHelloApp()
+        helloApp.launched.futureValue
+        val forwardApp = forwarder.startForwarder(helloApp.port)
+        forwardApp.launched.futureValue
         val appFacade = new AppMockFacade()
-        val result = appFacade.custom("/notfound")("localhost", port = forwardPort).futureValue
+        val result = appFacade.custom("/notfound")("localhost", port = forwardApp.port).futureValue
         result should be(NotFound)
       }
 
       "direct internal server error" in withForwarder { forwarder =>
-        val helloPort = forwarder.startHelloApp().futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
+        val helloApp = forwarder.startHelloApp()
+        helloApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
         val appFacade = new AppMockFacade()
-        val result = appFacade.custom("/hello/crash")("localhost", port = helloPort).futureValue
+        val result = appFacade.custom("/hello/crash")("localhost", port = helloApp.port).futureValue
         result should be(ServerError)
         result.entityString should be("Error")
       }
 
       "forwarding internal server error" in withForwarder { forwarder =>
-        val helloPort = forwarder.startHelloApp().futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
-        val forwardPort = forwarder.startForwarder(helloPort).futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
+        val helloApp = forwarder.startHelloApp()
+        helloApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The hello app did not start in time"
+        val forwardApp = forwarder.startForwarder(helloApp.port)
+        forwardApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
         val appFacade = new AppMockFacade()
-        val result = appFacade.custom("/hello/crash")("localhost", port = forwardPort).futureValue
+        val result = appFacade.custom("/hello/crash")("localhost", port = forwardApp.port).futureValue
         result should be(ServerError)
         result.entityString should be("Error")
       }
 
       "forwarding connection failed" in withForwarder { forwarder =>
-        val forwardPort = forwarder.startForwarder(PortAllocator.ephemeralPort()).futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
+        val forwardApp = forwarder.startForwarder(PortAllocator.ephemeralPort())
+        forwardApp.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
         val appFacade = new AppMockFacade()
-        val result = appFacade.ping("localhost", port = forwardPort).futureValue
+        val result = appFacade.ping("localhost", port = forwardApp.port).futureValue
         result should be(BadGateway)
       }
 
       "forwarding loop" in withForwarder { forwarder =>
-        val forwardPort1 = forwarder.startForwarder(PortAllocator.ephemeralPort()).futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
-        forwarder.startForwarder(PortAllocator.ephemeralPort()).futureValue
+        val forwardApp1 = forwarder.startForwarder(PortAllocator.ephemeralPort())
+        forwardApp1.launched.futureValue(forwarderStartTimeout, forwarderStartInterval) withClue "The forwarder service did not start in time"
+        val forwardApp2 = forwarder.startForwarder(PortAllocator.ephemeralPort())
+        forwardApp2.launched.futureValue
 
         val appFacade = new AppMockFacade()
-        val result = appFacade.ping("localhost", port = forwardPort1).futureValue
+        val result = appFacade.ping("localhost", port = forwardApp1.port).futureValue
         result should be(BadGateway)
       }
 


### PR DESCRIPTION
Previously, we would launch the forwarder tests in a separate JVM for every test. This is no longer necessary with the removal of our jersey-guice dependency.

Now, we launch the forwarders in the same JVM, and this reduces the runtime by almost 2 orders of magnitude (332 seconds to 9 seconds).