### PR TITLE
Introduce factory method for provisioning instances

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon
 package core.instance
 
-import java.time.Clock
 import java.util.{Base64, UUID}
 
 import com.fasterxml.uuid.{EthernetAddress, Generators}
@@ -126,7 +125,7 @@ object Instance {
       * @return new instance in a provisioned state
       */
     def apply(scheduledInstance: Instance, agentInfo: AgentInfo, networkInfo: core.task.state.NetworkInfo, app: AppDefinition, now: Timestamp): Instance = {
-      require(scheduledInstance.isScheduled, s"Instance '${scheduledInstance.instanceId}' cannot be in state '${scheduledInstance.state.condition}'. Scheduled instance is required to create provisioned instance.")
+      require(scheduledInstance.isScheduled, s"Instance '${scheduledInstance.instanceId}' must not be in state '${scheduledInstance.state.condition}'. Scheduled instance is required to create provisioned instance.")
 
       val task = Task(
         taskId = Task.Id.forInstanceId(scheduledInstance.instanceId, None),

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -125,14 +125,14 @@ object Instance {
       * @param scheduledInstance instance in a Scheduled state
       * @return new instance in a provisioned state
       */
-    def apply(scheduledInstance: Instance, agentInfo: AgentInfo, networkInfo: core.task.state.NetworkInfo, app: AppDefinition)(implicit clock: Clock): Instance = {
-      require(scheduledInstance.isScheduled, "Scheduled instance is required to create provisioned instance.")
+    def apply(scheduledInstance: Instance, agentInfo: AgentInfo, networkInfo: core.task.state.NetworkInfo, app: AppDefinition, now: Timestamp): Instance = {
+      require(scheduledInstance.isScheduled, s"Instance '${scheduledInstance.instanceId}' cannot be in state '${scheduledInstance.state.condition}'. Scheduled instance is required to create provisioned instance.")
 
       val task = Task(
         taskId = Task.Id.forInstanceId(scheduledInstance.instanceId, None),
         runSpecVersion = app.version,
         status = Task.Status(
-          stagedAt = clock.now(),
+          stagedAt = now,
           condition = Condition.Created,
           networkInfo = networkInfo
         )
@@ -142,9 +142,9 @@ object Instance {
 
       scheduledInstance.copy(
         agentInfo = Some(agentInfo),
-        state = Instance.InstanceState(Condition.Provisioned, clock.now(), None, None),
+        state = Instance.InstanceState(Condition.Provisioned, now, None, None),
         tasksMap = tasksMap,
-        runSpecVersion = app.version // Note: The app version might change.
+        runSpecVersion = app.version
       )
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -7,18 +7,17 @@ import java.util.{Base64, UUID}
 import com.fasterxml.uuid.{EthernetAddress, Generators}
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance.{AgentInfo, InstanceState}
-import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state._
-import mesosphere.marathon.tasks.OfferUtil
-import mesosphere.marathon.stream.Implicits._
-import mesosphere.mesos.Placed
 import mesosphere.marathon.raml.Raml
+import mesosphere.marathon.state._
+import mesosphere.marathon.stream.Implicits._
+import mesosphere.marathon.tasks.OfferUtil
+import mesosphere.mesos.Placed
 import org.apache._
-import org.apache.mesos.Protos.{Attribute, NetworkInfo}
-import play.api.libs.json._
-import play.api.libs.json.Reads._
+import org.apache.mesos.Protos.Attribute
 import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -1,11 +1,13 @@
 package mesosphere.marathon
 package core.instance
 
+import java.time.Clock
 import java.util.{Base64, UUID}
 
 import com.fasterxml.uuid.{EthernetAddress, Generators}
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance.{AgentInfo, InstanceState}
+import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state._
 import mesosphere.marathon.tasks.OfferUtil
@@ -13,7 +15,7 @@ import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.Placed
 import mesosphere.marathon.raml.Raml
 import org.apache._
-import org.apache.mesos.Protos.Attribute
+import org.apache.mesos.Protos.{Attribute, NetworkInfo}
 import play.api.libs.json._
 import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
@@ -116,6 +118,36 @@ object Instance {
      * @return An instance in the scheduled state.
      */
     def apply(runSpec: RunSpec): Instance = Scheduled(runSpec, Id.forRunSpec(runSpec.id))
+  }
+
+  object Provisioned {
+    /**
+      * Factory method for creating provisioned instance from Scheduled instance for apps
+      * @param scheduledInstance instance in a Scheduled state
+      * @return new instance in a provisioned state
+      */
+    def apply(scheduledInstance: Instance, agentInfo: AgentInfo, networkInfo: core.task.state.NetworkInfo, app: AppDefinition)(implicit clock: Clock): Instance = {
+      require(scheduledInstance.isScheduled, "Scheduled instance is required to create provisioned instance.")
+
+      val task = Task(
+        taskId = Task.Id.forInstanceId(scheduledInstance.instanceId, None),
+        runSpecVersion = app.version,
+        status = Task.Status(
+          stagedAt = clock.now(),
+          condition = Condition.Created,
+          networkInfo = networkInfo
+        )
+      )
+
+      val tasksMap = Map(task.taskId -> task)
+
+      scheduledInstance.copy(
+        agentInfo = Some(agentInfo),
+        state = Instance.InstanceState(Condition.Provisioned, clock.now(), None, None),
+        tasksMap = tasksMap,
+        runSpecVersion = app.version // Note: The app version might change.
+      )
+    }
   }
 
   /**

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -134,7 +134,7 @@ class InstanceOpFactoryImpl(
 
         val agentInfo = AgentInfo(offer)
 
-        val provisionedInstance = Instance.Provisioned(scheduledInstance, agentInfo, networkInfo, app)(clock)
+        val provisionedInstance = Instance.Provisioned(scheduledInstance, agentInfo, networkInfo, app, clock.now())
         val instanceOp = taskOperationFactory.provision(taskInfo, provisionedInstance.appTask, provisionedInstance)
 
         OfferMatchResult.Match(app, offer, instanceOp, clock.now())

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -131,27 +131,11 @@ class InstanceOpFactoryImpl(
         val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId, None)
         val taskBuilder = new TaskBuilder(app, taskId, config, runSpecTaskProc)
         val (taskInfo, networkInfo) = taskBuilder.build(offer, matches.resourceMatch, None)
-        val task = Task(
-          taskId = taskId,
-          runSpecVersion = app.version,
-          status = Task.Status(
-            stagedAt = now,
-            condition = Condition.Created,
-            networkInfo = networkInfo
-          )
-        )
 
         val agentInfo = AgentInfo(offer)
 
-        val tasksMap = Map(task.taskId -> task)
-        val state = Instance.InstanceState(Condition.Provisioned, now, None, None)
-        val provisionedInstance = scheduledInstance.copy(
-          agentInfo = Some(agentInfo),
-          state = state,
-          tasksMap = tasksMap,
-          runSpecVersion = app.version // Note: The app version might change.
-        )
-        val instanceOp = taskOperationFactory.provision(taskInfo, task, provisionedInstance)
+        val provisionedInstance = Instance.Provisioned(scheduledInstance, agentInfo, networkInfo, app)(clock)
+        val instanceOp = taskOperationFactory.provision(taskInfo, provisionedInstance.appTask, provisionedInstance)
 
         OfferMatchResult.Match(app, offer, instanceOp, clock.now())
       case matchesNot: ResourceMatchResponse.NoMatch => OfferMatchResult.NoMatch(app, offer, matchesNot.reasons, clock.now())


### PR DESCRIPTION
I need this as a foundation to introduce provisioning to resident apps because otherwise I would need to copy-paste the same creation logic to other places. Also I think that the `Instance` object is a nice place for such factory method.

JIRA issues: MARATHON-8167
