### PR TITLE
Properly return Content-Type header when using async proxy

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/forwarder/AsyncUrlConnectionRequestForwarder.scala
+++ b/src/main/scala/mesosphere/marathon/api/forwarder/AsyncUrlConnectionRequestForwarder.scala
@@ -74,6 +74,7 @@ class AsyncUrlConnectionRequestForwarder(
           response.addHeader(name, value)
     }
     response.addHeader(HEADER_VIA, viaValue)
+    response.addHeader(CONTENT_TYPE, remote.entity.contentType.toString)
     Done
   }
 

--- a/src/main/scala/mesosphere/marathon/api/forwarder/RequestForwarder.scala
+++ b/src/main/scala/mesosphere/marathon/api/forwarder/RequestForwarder.scala
@@ -15,6 +15,7 @@ object RequestForwarder {
 
   /** Header for proxy loop detection. Simply "Via" is ignored by the URL connection.*/
   val HEADER_VIA: String = "X-Marathon-Via"
+  val CONTENT_TYPE: String = "Content-Type"
   val ERROR_STATUS_LOOP: String = "Detected proxying loop."
   val ERROR_STATUS_CONNECTION_REFUSED: String = "Connection to leader refused."
   val ERROR_STATUS_GATEWAY_TIMEOUT: String = "Connection to leader timed out."

--- a/tests/integration/src/test/scala/mesosphere/IntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/IntegrationTest.scala
@@ -2,7 +2,6 @@ package mesosphere
 
 import com.typesafe.config.{Config, ConfigFactory}
 import mesosphere.marathon.integration.setup.RestResult
-import mesosphere.marathon.integration.setup.RestResult
 import mesosphere.marathon.raml.{PodState, PodStatus}
 import org.scalatest._
 import org.scalatest.matchers.{BeMatcher, MatchResult}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
@@ -4,7 +4,8 @@ package integration.setup
 import java.util.concurrent.{ConcurrentLinkedQueue, Executor}
 
 import javax.servlet.DispatcherType
-import javax.ws.rs.core.Response
+import javax.ws.rs.Produces
+import javax.ws.rs.core.{MediaType, Response}
 import javax.ws.rs.{GET, Path}
 import akka.Done
 import akka.actor.ActorSystem
@@ -126,6 +127,13 @@ object ForwarderService extends StrictLogging {
     @Path("/hello")
     def index(): Response = {
       Response.ok().entity("Hi").build()
+    }
+
+    @GET
+    @Path("/json")
+    @Produces(Array(MediaType.APPLICATION_JSON))
+    def json(): Response = {
+      Response.ok.entity("{}").build()
     }
 
     @GET


### PR DESCRIPTION
Akka HTTP lifts this header out to the entity. We have to explicitly set it when returning the response.

JIRA-Issues: MARATHON-8251