### PR TITLE
Deprecation schedule for /v2/schemas

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,20 @@ Previously, when under substantial load, Marathon would time out a deployment in
 
 To handle the potential increase in concurrent connections, deployment operations and leader request proxying now use nonblocking I/O. The nonblocking I/O proxying logic may have some subtle differences in how responses are handled, including more aggressive rejection of malformed HTTP requests. In the off-chance that this causes an issue in your cluster, the old behavior can be restored with the command line flag `--deprecated_features=sync_proxy`. `sync_proxy` is scheduled to be removed in Marathon `1.8.0`.
 
+### Deprecated Features
+
+#### /v2/schemas
+
+The route `/v2/schemas` has been deprecated in favor of the RAML specifications. Clients that need to perform local validation of requests can access the RAML specifications with the prefix the `/public/api`. For example, to get the RAML definition for the apps resource, `GET http://marathon:8080/public/api/v2/apps.raml`.
+
+The route `/v2/schemas` has the following deprecation schedule:
+
+- 1.6.x - `/v2/schemas` will continue to function as normal.
+- 1.7.x - The API will stop responding to `/v2/schemas`; requests to it will be met with a 404 response. The route can
+  be re-enabled with the command-line argument `--deprecated_features=json_schemas_resource`.
+- 1.7.x - `/v2/schemas` is scheduled to be completely removed. If `--deprecated_features=json_schemas_resource` is
+  still specified, Marathon will refuse to launch, with an error.
+
 ## Change from 1.6.322 to 1.6.352
 
 ### GPU Scheduling

--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,7 @@ The route `/v2/schemas` has the following deprecation schedule:
 - 1.6.x - `/v2/schemas` will continue to function as normal.
 - 1.7.x - The API will stop responding to `/v2/schemas`; requests to it will be met with a 404 response. The route can
   be re-enabled with the command-line argument `--deprecated_features=json_schemas_resource`.
-- 1.7.x - `/v2/schemas` is scheduled to be completely removed. If `--deprecated_features=json_schemas_resource` is
+- 1.8.x - `/v2/schemas` is scheduled to be completely removed. If `--deprecated_features=json_schemas_resource` is
   still specified, Marathon will refuse to launch, with an error.
 
 ## Change from 1.6.322 to 1.6.352

--- a/docs/docs/deprecation.md
+++ b/docs/docs/deprecation.md
@@ -22,13 +22,13 @@ Hypothetical release notes:
 >
 > ### /v2/oldroute
 >
-> `/v2/oldroute` has been marked as deprecated and clients should be updated to use `/newroute`. `/v2/route` has the
+> The route `/v2/oldroute` has been marked as deprecated and clients should be updated to use `/newroute`. `/v2/route` has the
 > following deprecation schedule:
 >
 > - 1.5.x - `/v2/oldroute` will continue to function as normal.
 > - 1.6.x - The API will stop responding to `/v2/oldroute`; requests to it will be met with a 404 response. The route
->   can be re-enabled by the command-line argument `--deprecated_features=api_oldroute`.
-> - 1.7.x - `/v2/oldroute` is scheduled to be completely removed. If the `--deprecated_features=api_oldroute` is still
+>   can be re-enabled with the command-line argument `--deprecated_features=api_oldroute`.
+> - 1.7.x - `/v2/oldroute` is scheduled to be completely removed. If `--deprecated_features=api_oldroute` is still
 >   specified, Marathon will refuse to launch, with an error.
 
 As mentioned in the schedule, if Marathon is upgraded to `1.7.x` and `--deprecated_features=api_oldroute` is still

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -1,7 +1,5 @@
 package mesosphere.marathon
 
-import com.typesafe.scalalogging.StrictLogging
-
 case class DeprecatedFeature(
     key: String,
     description: String,
@@ -10,7 +8,7 @@ case class DeprecatedFeature(
   require(hardRemoveVersion > softRemoveVersion)
 }
 
-object DeprecatedFeatures extends StrictLogging {
+object DeprecatedFeatures {
   val syncProxy = DeprecatedFeature(
     "sync_proxy",
     description = "Old, blocking IO implementation for leader proxy used by Marathon standby instances.",
@@ -24,52 +22,4 @@ object DeprecatedFeatures extends StrictLogging {
     hardRemoveVersion = SemVer(1, 8, 0))
 
   def all = Seq(syncProxy, jsonSchemasResource)
-}
-
-/**
-  * Encloses a list of explicitly-enabled deprecated features
-  *
-  * @param currentVersion The current version of Marathon
-  * @param enbaledDeprecatedFeatures The deprecated features specified to be enable
-  */
-case class DeprecatedFeatureSet(
-    currentVersion: SemVer,
-    enabledDeprecatedFeatures: Set[DeprecatedFeature]) extends StrictLogging {
-
-  /**
-    * If a deprecated feature has not been soft-removed (still enabled by default), then return true
-    *
-    * Otherwise, only return true if the feature in question has been explicitly enabled.
-    */
-  def isEnabled(df: DeprecatedFeature) =
-    enabledDeprecatedFeatures.contains(df) || (currentVersion < df.softRemoveVersion)
-
-  private def softRemovedFeatures =
-    enabledDeprecatedFeatures.filter { df => currentVersion >= df.softRemoveVersion && currentVersion < df.hardRemoveVersion }
-
-  private def hardRemovedFeatures =
-    enabledDeprecatedFeatures.filter { df => currentVersion >= df.hardRemoveVersion }
-
-  /**
-    * Log appropriate warnings for soft-removed features, errors for hard-removed.
-    */
-  def logDeprecationWarningsAndErrors(): Unit = {
-    softRemovedFeatures.foreach { df =>
-      logger.warn(s"Deprecated feature ${df.key} is scheduled to be removed in ${df.hardRemoveVersion}. You should " +
-        "remove the deprecated feature flag as soon possible.")
-    }
-
-    hardRemovedFeatures.foreach { df =>
-      logger.error(s"${df.key} has been removed as of ${df.hardRemoveVersion}. It has the following description:\n\n" +
-        df.description + "\n\n" +
-        "You should migrate back to a previous version of Marathon, remove the deprecated feature flag, ensure that " +
-        "your cluster continues to work, and then upgrade again.\n\n" +
-        "If you are confident that you no longer need the deprecated feature flag, you can simply remove it.")
-    }
-  }
-
-  /**
-    * @return Boolean true if all specified deprecatedFeatures are still allowed in the current version of Marathon
-    */
-  def isValid(): Boolean = hardRemovedFeatures.isEmpty
 }

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -2,47 +2,79 @@ package mesosphere.marathon
 
 import com.typesafe.scalalogging.StrictLogging
 
-object DeprecatedFeatures extends StrictLogging {
-  case class DeprecatedFeature(
-      key: String,
-      description: String,
-      warnVersion: SemVer,
-      removeVersion: SemVer
-  )
+case class DeprecatedFeature(
+    key: String,
+    description: String,
+    softRemoveVersion: SemVer,
+    hardRemoveVersion: SemVer) {
+  require(hardRemoveVersion > softRemoveVersion)
+}
 
+object DeprecatedFeatures extends StrictLogging {
   val syncProxy = DeprecatedFeature(
     "sync_proxy",
     description = "Old, blocking IO implementation for leader proxy used by Marathon standby instances.",
-    warnVersion = SemVer(1, 7, 0),
-    removeVersion = SemVer(1, 8, 0))
+    softRemoveVersion = SemVer(1, 6, 0),
+    hardRemoveVersion = SemVer(1, 8, 0))
 
-  def all = Seq(syncProxy)
+  val jsonSchemasResource = DeprecatedFeature(
+    "json_schemas_resource",
+    description = "Enables the /v2/schemas route. JSON Schema has been deprecated in favor of RAML and many of the definitions are not up-to-date with the current API",
+    softRemoveVersion = SemVer(1, 7, 0),
+    hardRemoveVersion = SemVer(1, 8, 0))
+
+  def all = Seq(syncProxy, jsonSchemasResource)
+}
+
+/**
+  * Provided a list of enabled deprecated features, output appropriate log messages based on current version and
+  * deprecation / removal versions.
+  *
+  * @param currentVersion The current version of Marathon
+  * @param enbaledDeprecatedFeatures The deprecated features specified to be enable
+  */
+case class DeprecatedFeatureSet(
+    currentVersion: SemVer,
+    enabledDeprecatedFeatures: Set[DeprecatedFeature]) extends StrictLogging {
 
   /**
-    * Provided a list of enabled deprecated features, output appropriate log messages based on current version and
-    * deprecation / removal versions.
+    * If a deprecated feature has not been soft-removed (still enabled by default), then return true
     *
-    * @param deprecatedfeature The deprecated features specified to enable
-    * @param currentVersion The current version of Marathon
+    * Otherwise, only return true if the feature in question has been explicitly enabled.
+    */
+  def isEnabled(df: DeprecatedFeature) = {
+    enabledDeprecatedFeatures.contains(df) || (currentVersion < df.softRemoveVersion)
+  }
+
+  private def softRemovedFeatures =
+    enabledDeprecatedFeatures.filter { df => currentVersion >= df.softRemoveVersion && currentVersion < df.hardRemoveVersion }
+
+  private def hardRemovedFeatures =
+    enabledDeprecatedFeatures.filter { df => currentVersion >= df.hardRemoveVersion }
+
+  /**
+    * Log warnings for soft-removed features, errors for hard-removed.
+    *
+    */
+  def logDeprecationWarningsAndErrors(): Unit = {
+    softRemovedFeatures.foreach { df =>
+      logger.warn(s"Deprecated feature ${df.key} is scheduled to be removed in ${df.hardRemoveVersion}. You should " +
+        "remove the deprecated feature flag as soon possible.")
+    }
+
+    hardRemovedFeatures.foreach { df =>
+      logger.error(s"${df.key} has been removed as of ${df.hardRemoveVersion}. It has the following description:\n\n" +
+        df.description + "\n\n" +
+        "You should migrate back to a previous version of Marathon, remove the deprecated feature flag, ensure that " +
+        "your cluster continues to work, and then upgrade again.\n\n" +
+        "If you are confident that you no longer need the deprecated feature flag, you can simply remove it.")
+    }
+  }
+
+  /**
+    * Returns if all deprecated features are still allowed to be enabled.
+    *
     * @return Boolean true if all specified deprecatedFeatures are still allowed in the current version of Marathon
     */
-  def allDeprecatedFeaturesActive(
-    deprecatedFeatures: Iterable[DeprecatedFeature],
-    currentVersion: SemVer = BuildInfo.version): Boolean = {
-    var success = true
-
-    deprecatedFeatures.foreach { df =>
-      if (currentVersion >= df.removeVersion) {
-        success = false
-        logger.error(s"${df.key} has been removed as of ${df.removeVersion}. You should migrate back to a previous " +
-          "version of Marathon, remove the deprecated feature flag, ensure that your cluster continues to work, and " +
-          "then upgrade again.\n\n" +
-          "If you are confident that you no longer need the deprecated feature flag, you can simply remove it.")
-      } else if (currentVersion >= df.warnVersion) {
-        logger.warn(s"Deprecated feature ${df.key} is scheduled to be removed in ${df.removeVersion}. You should " +
-          "remove the deprecated feature flag as soon possible.")
-      }
-    }
-    success
-  }
+  def isValid(): Boolean = hardRemovedFeatures.isEmpty
 }

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -27,8 +27,7 @@ object DeprecatedFeatures extends StrictLogging {
 }
 
 /**
-  * Provided a list of enabled deprecated features, output appropriate log messages based on current version and
-  * deprecation / removal versions.
+  * Encloses a list of explicitly-enabled deprecated features
   *
   * @param currentVersion The current version of Marathon
   * @param enbaledDeprecatedFeatures The deprecated features specified to be enable
@@ -42,9 +41,8 @@ case class DeprecatedFeatureSet(
     *
     * Otherwise, only return true if the feature in question has been explicitly enabled.
     */
-  def isEnabled(df: DeprecatedFeature) = {
+  def isEnabled(df: DeprecatedFeature) =
     enabledDeprecatedFeatures.contains(df) || (currentVersion < df.softRemoveVersion)
-  }
 
   private def softRemovedFeatures =
     enabledDeprecatedFeatures.filter { df => currentVersion >= df.softRemoveVersion && currentVersion < df.hardRemoveVersion }
@@ -53,8 +51,7 @@ case class DeprecatedFeatureSet(
     enabledDeprecatedFeatures.filter { df => currentVersion >= df.hardRemoveVersion }
 
   /**
-    * Log warnings for soft-removed features, errors for hard-removed.
-    *
+    * Log appropriate warnings for soft-removed features, errors for hard-removed.
     */
   def logDeprecationWarningsAndErrors(): Unit = {
     softRemovedFeatures.foreach { df =>
@@ -72,8 +69,6 @@ case class DeprecatedFeatureSet(
   }
 
   /**
-    * Returns if all deprecated features are still allowed to be enabled.
-    *
     * @return Boolean true if all specified deprecatedFeatures are still allowed in the current version of Marathon
     */
   def isValid(): Boolean = hardRemovedFeatures.isEmpty

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeaturesSet.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeaturesSet.scala
@@ -1,0 +1,51 @@
+package mesosphere.marathon
+
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Encloses a list of explicitly-enabled deprecated features
+  *
+  * @param currentVersion The current version of Marathon
+  * @param enbaledDeprecatedFeatures The deprecated features specified to be enable
+  */
+case class DeprecatedFeatureSet(
+    currentVersion: SemVer,
+    enabledDeprecatedFeatures: Set[DeprecatedFeature]) extends StrictLogging {
+
+  /**
+    * If a deprecated feature has not been soft-removed (still enabled by default), then return true
+    *
+    * Otherwise, only return true if the feature in question has been explicitly enabled.
+    */
+  def isEnabled(df: DeprecatedFeature) =
+    enabledDeprecatedFeatures.contains(df) || (currentVersion < df.softRemoveVersion)
+
+  private def softRemovedFeatures =
+    enabledDeprecatedFeatures.filter { df => currentVersion >= df.softRemoveVersion && currentVersion < df.hardRemoveVersion }
+
+  private def hardRemovedFeatures =
+    enabledDeprecatedFeatures.filter { df => currentVersion >= df.hardRemoveVersion }
+
+  /**
+    * Log appropriate warnings for soft-removed features, errors for hard-removed.
+    */
+  def logDeprecationWarningsAndErrors(): Unit = {
+    softRemovedFeatures.foreach { df =>
+      logger.warn(s"Deprecated feature ${df.key} is scheduled to be removed in ${df.hardRemoveVersion}. You should " +
+        "remove the deprecated feature flag as soon possible.")
+    }
+
+    hardRemovedFeatures.foreach { df =>
+      logger.error(s"${df.key} has been removed as of ${df.hardRemoveVersion}. It has the following description:\n\n" +
+        df.description + "\n\n" +
+        "You should migrate back to a previous version of Marathon, remove the deprecated feature flag, ensure that " +
+        "your cluster continues to work, and then upgrade again.\n\n" +
+        "If you are confident that you no longer need the deprecated feature flag, you can simply remove it.")
+    }
+  }
+
+  /**
+    * @return Boolean true if all specified deprecatedFeatures are still allowed in the current version of Marathon
+    */
+  def isValid(): Boolean = hardRemovedFeatures.isEmpty
+}

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -37,7 +37,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
 
   def configure(): Unit = {
     bind(classOf[MarathonConf]).toInstance(conf)
-    bind(classOf[FeaturesConf]).toInstance(conf)
+    bind(classOf[DeprecatedFeatureSet]).toInstance(conf.deprecatedFeatures())
     bind(classOf[HttpConf]).toInstance(http)
     bind(classOf[LeaderProxyConf]).toInstance(conf)
     bind(classOf[ZookeeperConf]).toInstance(conf)

--- a/src/test/scala/mesosphere/marathon/DeprecatedFeaturesSetTest.scala
+++ b/src/test/scala/mesosphere/marathon/DeprecatedFeaturesSetTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 
 import mesosphere.UnitTest
 
-class DeprecatedFeaturesTest extends UnitTest {
+class DeprecatedFeaturesSetTest extends UnitTest {
   val currentVersion = SemVer(1, 6, 0)
   val hardRemovedIn170 = DeprecatedFeature("test", description = "", softRemoveVersion = SemVer(1, 6, 0), hardRemoveVersion = SemVer(1, 7, 0))
   val softRemovedIn170 = DeprecatedFeature("test", description = "", softRemoveVersion = SemVer(1, 7, 0), hardRemoveVersion = SemVer(1, 8, 0))

--- a/src/test/scala/mesosphere/marathon/DeprecatedFeaturesTest.scala
+++ b/src/test/scala/mesosphere/marathon/DeprecatedFeaturesTest.scala
@@ -3,15 +3,37 @@ package mesosphere.marathon
 import mesosphere.UnitTest
 
 class DeprecatedFeaturesTest extends UnitTest {
-  import DeprecatedFeatures._
-  val removedIn170 = DeprecatedFeature("test", description = "", warnVersion = SemVer(1, 6, 0), removeVersion = SemVer(1, 7, 0))
-  "allDeprecatedFeaturesActive" should {
-    "return true for warning features" in {
-      allDeprecatedFeaturesActive(Seq(removedIn170), SemVer(1, 6, 0))
+  val currentVersion = SemVer(1, 6, 0)
+  val hardRemovedIn170 = DeprecatedFeature("test", description = "", softRemoveVersion = SemVer(1, 6, 0), hardRemoveVersion = SemVer(1, 7, 0))
+  val softRemovedIn170 = DeprecatedFeature("test", description = "", softRemoveVersion = SemVer(1, 7, 0), hardRemoveVersion = SemVer(1, 8, 0))
+
+  "DeprecatedFeatureSet" should {
+    val fixture = DeprecatedFeatureSet(
+      currentVersion = currentVersion,
+      enabledDeprecatedFeatures = Set(hardRemovedIn170))
+
+    "isValid()" should {
+      "return true when softRemoved features are included" in {
+        fixture.isValid() shouldBe true
+      }
+
+      "return false when hardRemoved features are included" in {
+        fixture.copy(currentVersion = SemVer(1, 7, 0)).isValid() shouldBe false
+      }
     }
 
-    "return false for removed features" in {
-      allDeprecatedFeaturesActive(Seq(removedIn170), SemVer(1, 7, 0))
+    "isEnabled(...)" should {
+      "return true for explicitly enabled features" in {
+        fixture.isEnabled(hardRemovedIn170) shouldBe (true)
+      }
+
+      "return false for soft-removed features not explicitly enabled" in {
+        DeprecatedFeatureSet(currentVersion, Set.empty).isEnabled(hardRemovedIn170) shouldBe false
+      }
+
+      "return true for features not yet soft-removed" in {
+        fixture.isEnabled(softRemovedIn170) shouldBe (true)
+      }
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/FeaturesConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/FeaturesConfTest.scala
@@ -50,7 +50,7 @@ class FeaturesConfTest extends UnitTest with Inside {
       "--master", "127.0.0.1:5050"
     )
 
-    conf.deprecatedFeatures() should be(empty)
+    conf.deprecatedFeatures().enabledDeprecatedFeatures should be(empty)
   }
 
   "deprecatedFeatures should not allow unknown deprecated features" in {


### PR DESCRIPTION
Describe and enforce /v2/schemas deprecation schedule. Also, replace the concept of "warnVersion" with "softRemovalVersion" in the deprecation mechanism. Add additional test coverage.

JIRA Issues: MARATHON-7978
