### PR TITLE
When proxying events, flush after each element received

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/forwarder/ServletOutputStreamSink.scala
+++ b/src/main/scala/mesosphere/marathon/api/forwarder/ServletOutputStreamSink.scala
@@ -117,7 +117,7 @@ object ServletOutputStreamSink {
   def apply(outputStream: ServletOutputStream, autoFlushing: Boolean = false): Sink[ByteString, Future[Done]] = {
     val sink = Sink.fromGraph(new ServletOutputStreamSink(outputStream))
     if (autoFlushing)
-      Flow[ByteString].intersperse(ByteString.empty).toMat(sink)(Keep.right)
+      Flow[ByteString].mapConcat { bs => List(bs, ByteString.empty) }.toMat(sink)(Keep.right)
     else
       sink
   }


### PR DESCRIPTION
Previously, we used intersperse, which would (understandably) prefix elements
with the flush sequence. This was not the desired behavior.

JIRA Issues: MARATHON-8256
