### PR TITLE
Deprecate /v2/events heavy event format

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,11 +40,10 @@ The default response format of the `/v2/events` is marked as deprecated and will
 
 #### Deprecation Details
 
-The "lightweight" plan format can be already seen using the `?plan-format=light` argument. In summary, this format drops the following fields from the HTTP response, since they are considered redundant:
+The "lightweight" plan format can be already seen using the `?plan-format=light` argument. In summary, this format drops the following fields from the deployment-related events in the event stream accessed via /v2/events:
 
 * `plan.original` - The current state of the root group
 * `plan.target` - The target state of the root group
-
 
 ## Change from 1.6.322 to 1.6.352
 

--- a/changelog.md
+++ b/changelog.md
@@ -32,7 +32,7 @@ The route `/v2/schemas` has the following deprecation schedule:
 
 ### /v2/events
 
-The default response format of the `/v2/events` is marked as deprecated and will be permanently switched to the `/v2/events?plan-format=light` in the next release. The following deprecation schedule is planned for this endpoint:
+The default response format of the `/v2/events` is marked as deprecated and will be switched to the `/v2/events?plan-format=light` in the first 1.7.x release. The following deprecation schedule is planned for this endpoint:
 
 * 1.6.x - `/v2/events`  will continue to function as normal
 * 1.7.x - The default `/v2/events` format will be switched to "light". You will still have the ability to use the command-line argument `--deprecated_features=api_heavy_events` to re-enable the heavy event response.

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,22 @@ The route `/v2/schemas` has the following deprecation schedule:
 - 1.8.x - `/v2/schemas` is scheduled to be completely removed. If `--deprecated_features=json_schemas_resource` is
   still specified, Marathon will refuse to launch, with an error.
 
+### /v2/events
+
+The default response format of the `/v2/events` is marked as deprecated and will be permanently switched to the `/v2/events?plan-format=light` in the next release. The following deprecation schedule is planned for this endpoint:
+
+* 1.6.x - `/v2/events`  will continue to function as normal
+* 1.7.x - The default `/v2/events` format will be switched to "light". You will still have the ability to use the command-line argument `--deprecated_features=api_heavy_events` to re-enable the heavy event response.
+* 1.8.x - The `/v2/events` format will be permanently switched to "light". If the `--deprecated_features=api_heavy_events` is still specified, Marathon will refuse to launch, with an error.
+
+#### Deprecation Details
+
+The "lightweight" plan format can be already seen using the `?plan-format=light` argument. In summary, this format drops the following fields from the HTTP response, since they are considered redundant:
+
+* `plan.original` - The current state of the root group
+* `plan.target` - The target state of the root group
+
+
 ## Change from 1.6.322 to 1.6.352
 
 ### GPU Scheduling

--- a/changelog.md
+++ b/changelog.md
@@ -36,7 +36,7 @@ The default response format of the `/v2/events` is marked as deprecated and will
 
 * 1.6.x - `/v2/events`  will continue to function as normal
 * 1.7.x - The default `/v2/events` format will be switched to "light". You will still have the ability to use the command-line argument `--deprecated_features=api_heavy_events` to re-enable the heavy event response.
-* 1.8.x - The `/v2/events` format will be permanently switched to "light". If the `--deprecated_features=api_heavy_events` is still specified, Marathon will refuse to launch, with an error.
+* 1.8.x - The `/v2/events` format will be permanently switched to "light". If `--deprecated_features=api_heavy_events` is still specified, Marathon will refuse to launch, with an error.
 
 #### Deprecation Details
 

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -21,5 +21,17 @@ object DeprecatedFeatures {
     softRemoveVersion = SemVer(1, 7, 0),
     hardRemoveVersion = SemVer(1, 8, 0))
 
-  def all = Seq(syncProxy, jsonSchemasResource)
+  val apiHeavyEvents = DeprecatedFeature(
+    "api_heavy_events",
+    description = "Enables the legacy heavy events format returned via /v2/events which makes /v2/events unusable in larger cluster. Light events are returned with /v2/events?plan-format=light and include a subset of the fields.",
+    softRemoveVersion = SemVer(1, 7, 0),
+    hardRemoveVersion = SemVer(1, 8, 0))
+
+  def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents)
+
+  def description: String = {
+    "  - " + all.map { df =>
+      s"${df.key}: ${df.description} (soft-remove: ${df.softRemoveVersion}; hard-remove: ${df.hardRemoveVersion})"
+    }.mkString("\n  - ")
+  }
 }

--- a/src/main/scala/mesosphere/marathon/FeaturesConf.scala
+++ b/src/main/scala/mesosphere/marathon/FeaturesConf.scala
@@ -13,7 +13,7 @@ trait FeaturesConf extends ScallopConf {
     val unknown = parsed.collect { case (key, None) => key }
     require(
       unknown.isEmpty,
-      s"Unknown deprecated features specified: ${unknown.mkString(", ")}. Available deprecated features are: ${Features.description}" +
+      s"Unknown deprecated features specified: ${unknown.mkString(", ")}. Available deprecated features are:\n\n${DeprecatedFeatures.description}" +
         "\n\n" +
         "If you recently upgraded, you should downgrade to the old Marathon version and remove the deprecated " +
         "feature(s) in question, ensuring that your cluster continues to function without it."

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -183,7 +183,7 @@ class CoreModuleImpl @Inject() (
   // EVENT
 
   override lazy val eventModule: EventModule = new EventModule(
-    eventStream, actorSystem, marathonConf,
+    eventStream, actorSystem, marathonConf, marathonConf.deprecatedFeatures(),
     electionModule.service, authModule.authenticator, authModule.authorizer)(actorsModule.materializer)
 
   // HISTORY

--- a/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
@@ -16,6 +16,7 @@ class EventModule(
     eventBus: EventStream,
     actorSystem: ActorSystem,
     conf: EventConf,
+    deprecatedFeatureSet: DeprecatedFeatureSet,
     electionService: ElectionService,
     authenticator: Authenticator,
     authorizer: Authorizer)(implicit val materializer: Materializer) {
@@ -38,6 +39,11 @@ class EventModule(
   }
 
   lazy val httpEventStreamServlet: EventSourceServlet = {
-    new HttpEventStreamServlet(httpEventStreamActor, conf, authenticator, authorizer)
+    new HttpEventStreamServlet(
+      httpEventStreamActor,
+      conf,
+      deprecatedFeatureSet.isEnabled(DeprecatedFeatures.apiHeavyEvents),
+      authenticator,
+      authorizer)
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventSSEHandleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventSSEHandleTest.scala
@@ -19,7 +19,7 @@ class HttpEventSSEHandleTest extends UnitTest {
       req.getParameterMap returns Map("event_type" -> Array(unsubscribe.eventType)).asJava
 
       Given("handler for request is created")
-      val handle = new HttpEventSSEHandle(req, emitter)
+      val handle = new HttpEventSSEHandle(req, emitter, true)
 
       When("Want to sent unwanted event")
       handle.sendEvent(subscribed)
@@ -43,7 +43,7 @@ class HttpEventSSEHandleTest extends UnitTest {
       req.getParameterMap returns Collections.emptyMap()
 
       Given("handler for request is created")
-      val handle = new HttpEventSSEHandle(req, emitter)
+      val handle = new HttpEventSSEHandle(req, emitter, true)
 
       When("Want to sent event")
       handle.sendEvent(subscribed)

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServletTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamServletTest.scala
@@ -58,7 +58,7 @@ class HttpEventStreamServletTest extends UnitTest {
     val actor = mock[ActorRef]
     val auth = new TestAuthFixture
     val config = AllConf.withTestConfig()
-    def streamServlet() = new HttpEventStreamServlet(actor, config, auth.auth, auth.auth)
+    def streamServlet() = new HttpEventStreamServlet(actor, config, true, auth.auth, auth.auth)
   }
 }
 


### PR DESCRIPTION
- Also, the deprecated features description was showing the wrong
  text; fix this, also.

JIRA Issues: MARATHON-8259
