### PR TITLE
Include gzipped data in overall metrics, remove gzipped read data

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/HttpTransferMetricsHandler.scala
+++ b/src/main/scala/mesosphere/marathon/api/HttpTransferMetricsHandler.scala
@@ -86,17 +86,17 @@ class HttpTransferMetricsHandler(httpMetrics: HttpTransferMetrics) extends Abstr
     if (!isExcluded(request)) {
       val bytesRead = request.getContentLengthLong
       val bytesWritten = request.getResponse.getContentCount
-      if (bytesRead > 0) // bytesRead can be -1 if no entity provided
+      if (bytesRead > 0) { // bytesRead can be -1 if no entity provided
+        httpMetrics.bytesReadMetric.increment(bytesRead)
         if (isGzip(request.getHeader(HttpHeaders.CONTENT_ENCODING)))
           httpMetrics.gzippedBytesReadMetric.increment(bytesRead)
-        else
-          httpMetrics.bytesReadMetric.increment(bytesRead)
+      }
 
-      if (bytesWritten > 0) // bytesWritten can be -1 if no entity returned
+      if (bytesWritten > 0) { // bytesWritten can be -1 if no entity returned
+        httpMetrics.bytesWrittenMetric.increment(bytesWritten)
         if (isGzip(request.getResponse.getHeader(HttpHeaders.CONTENT_ENCODING)))
           httpMetrics.gzippedBytesWrittenMetric.increment(bytesWritten)
-        else
-          httpMetrics.bytesWrittenMetric.increment(bytesWritten)
+      }
     }
 }
 

--- a/src/main/scala/mesosphere/marathon/api/HttpTransferMetricsHandler.scala
+++ b/src/main/scala/mesosphere/marathon/api/HttpTransferMetricsHandler.scala
@@ -16,10 +16,7 @@ import HttpTransferMetricsHandler._
 /* Container for HTTP Metrics
  */
 trait HttpTransferMetrics {
-  /**
-    * Metric representing the total HTTP entity gzipped bytes read (does not include HTTP headers)
-    */
-  val gzippedBytesReadMetric: Counter
+  // Our GZIP handler only supports writing gzipped responses, not reading
 
   /**
     * Metric representing the total HTTP entity gzipped bytes written (does not include HTTP headers)
@@ -44,7 +41,6 @@ trait HttpTransferMetrics {
   * currently (and lamentably) tied to classes.
   */
 class HTTPMetricsFilter extends HttpTransferMetrics {
-  val gzippedBytesReadMetric = Metrics.counter(ServiceMetric, getClass, "gzippedBytesRead")
   val gzippedBytesWrittenMetric = Metrics.counter(ServiceMetric, getClass, "gzippedBytesWritten")
   val bytesReadMetric = Metrics.counter(ServiceMetric, getClass, "bytesRead")
   val bytesWrittenMetric = Metrics.counter(ServiceMetric, getClass, "bytesWritten")
@@ -84,13 +80,12 @@ class HttpTransferMetricsHandler(httpMetrics: HttpTransferMetrics) extends Abstr
 
   protected def updateResponse(request: Request) =
     if (!isExcluded(request)) {
-      val bytesRead = request.getContentLengthLong
-      val bytesWritten = request.getResponse.getContentCount
-      if (bytesRead > 0) { // bytesRead can be -1 if no entity provided
+
+      val bytesRead = request.getHttpInput.getContentConsumed
+      val bytesWritten = request.getResponse.getHttpOutput.getWritten
+
+      if (bytesRead > 0) // bytesRead can be -1 if no entity provided
         httpMetrics.bytesReadMetric.increment(bytesRead)
-        if (isGzip(request.getHeader(HttpHeaders.CONTENT_ENCODING)))
-          httpMetrics.gzippedBytesReadMetric.increment(bytesRead)
-      }
 
       if (bytesWritten > 0) { // bytesWritten can be -1 if no entity returned
         httpMetrics.bytesWrittenMetric.increment(bytesWritten)


### PR DESCRIPTION
- Switch from input entity ContentLength header to httpInput getContentConsumed, as the client may not specify the `Content-Length`.
- Also, remove gzippedBytesRead, as we don't even support reading gzipped entities.