### PR TITLE
Run performance tests using local Marathon

### DIFF
--- a/tests/performance/config/perf-driver/environments/target-standalone.yml
+++ b/tests/performance/config/perf-driver/environments/target-standalone.yml
@@ -1,0 +1,24 @@
+# ----------------------------------------------------------- #
+# Configuration Fragment : Stand-Alone Marathon Target        #
+# ----------------------------------------------------------- #
+# This fragment instructs the driver to use the marathon      #
+# instance specified by it's URL. No authentication will be   #
+# used.                                                       #
+# ----------------------------------------------------------- #
+
+# Global test configuration
+# ===========================
+config:
+
+  # We require the following definitions to be present (might be defined by
+  # other fragments, or must be given by the user)
+  definitions:
+    - name: marathon_url
+      desc: The URL where to find marathon
+      required: yes
+
+# Test Metadata
+# ===========================
+meta:
+  env: standalone
+

--- a/tests/performance/manual_run.sh
+++ b/tests/performance/manual_run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This script runs the scale tests on a DC/OS cluster specified by the user
+
+# Require a cluster URL
+[ -z "$1" ] && echo -e "Usage: $0 <marathon> [<test file> ...]" && exit 1
+MARATHON_URL=$1
+shift
+
+# We need the CLI, so ask the user
+if ! which dcos >/dev/null; then
+  echo "ERROR: Please install the DC/OS CLI before using this tool"
+  exit 1
+fi
+if ! which dcos-perf-test-driver >/dev/null; then
+  echo "ERROR: Please install the DC/OS Performance Test Driver before using this tool"
+  exit 1
+fi
+
+# Collect some useful metadata
+DCOS_VERSION=$(dcos --version | grep dcos.version | awk -F'=' '{print $2}')
+MARATHON_VERSION=$(dcos marathon --version | awk '{print $3}')
+
+# If the user hasn't specified any test files, run them all
+TESTS=$*
+[ -z "$TESTS" ] && TESTS=$(ls config/perf-driver/test-*.yml)
+for TEST in $TESTS; do
+  dcos-perf-test-driver \
+    ./config/perf-driver/environments/target-standalone.yml \
+    ./config/perf-driver/environments/env-local.yml \
+    "./$TEST" \
+    -M "version=${DCOS_VERSION}" \
+    -M "marathon=${MARATHON_VERSION}" \
+    -D "dcos_auth_token=${DCOS_AUTH_TOKEN}" \
+    -D "marathon_url=${MARATHON_URL}"
+done


### PR DESCRIPTION
Summary:
This commit introduces the `manual_run.sh` script that can be used to launch
the scale tests targeting a Marathon instance solely by it's URL.
