### PR TITLE
Fix for flaky SI `test_unhealthy_app_can_be_rolled_back`

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -216,7 +216,7 @@ def ensure_mom():
         except Exception:
             pass
 
-        if not wait_for_service_endpoint('marathon-user'):
+        if not wait_for_service_endpoint('marathon-user', path="ping"):
             print('ERROR: Timeout waiting for endpoint')
 
 
@@ -357,7 +357,7 @@ def get_marathon_leader_not_on_master_leader_node():
 
     if marathon_leader == master_leader:
         delete_marathon_path('v2/leader')
-        wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds())
+        wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds(), path="ping")
         marathon_leader = assert_marathon_leadership_changed(marathon_leader)
         print('switched leader to: {}'.format(marathon_leader))
 
@@ -846,7 +846,7 @@ def dcos_masters_public_ips():
     return master_public_ips
 
 
-def wait_for_service_endpoint(service_name, timeout_sec=120):
+def wait_for_service_endpoint(service_name, timeout_sec=120, path=""):
     """
     Checks the service url. Waits for exhibitor to start up (up to 20 minutes) and then checks the url on all masters.
 
@@ -866,7 +866,7 @@ def wait_for_service_endpoint(service_name, timeout_sec=120):
             stop_max_attempt_number=timeout_sec/5,  # underlying http.get has 5 seconds timeout, so we have to scale it
             retry_on_exception=ignore_provided_exception(DCOSException))
     def check_service_availability_on_master(master_ip, service):
-        url = "https://{}/service/{}/".format(master_ip, service)
+        url = "https://{}/service/{}/{}".format(master_ip, service, path)
 
         auth = DCOSAcsAuth(shakedown.dcos_acs_token())
         response = requests.get(

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -11,7 +11,7 @@ import retrying
 import requests
 
 from datetime import timedelta
-from dcos import http, mesos, config
+from dcos import http, mesos
 from dcos.errors import DCOSException, DCOSHTTPException
 from distutils.version import LooseVersion
 from json.decoder import JSONDecodeError
@@ -846,7 +846,6 @@ def dcos_masters_public_ips():
     return master_public_ips
 
 
-# since exhibitor might take ~ 20 minutes to start up, we need to wait for it
 def wait_for_service_endpoint(service_name, timeout_sec=120):
     """
     Checks the service url. Waits for exhibitor to start up (up to 20 minutes) and then checks the url on all masters.
@@ -870,8 +869,7 @@ def wait_for_service_endpoint(service_name, timeout_sec=120):
         url = "https://{}/service/{}/".format(master_ip, service)
 
         auth = DCOSAcsAuth(shakedown.dcos_acs_token())
-        response = requests.request(
-            method='get',
+        response = requests.get(
             url=url,
             timeout=5,
             auth=auth,

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -20,6 +20,7 @@ from urllib.parse import urljoin
 from shakedown.dcos.master import get_all_master_ips
 from dcos.http import DCOSAcsAuth
 from functools import lru_cache
+from fixtures import get_ssl_context, get_ca_file
 
 
 marathon_1_3 = pytest.mark.skipif('marthon_version_less_than("1.3")')
@@ -857,7 +858,6 @@ def wait_for_service_endpoint(service_name, timeout_sec=120):
     def check_service_availability_on_master(master_ip, service):
         url = "https://{}/service/{}/".format(master_ip, service)
 
-        # dcos.http doesn't correctly handle certs when we use ip as url, so we need a workaround:
         toml_config = config.get_config()
         auth_token = config.get_config_val("core.dcos_acs_token", toml_config)
         auth = DCOSAcsAuth(auth_token)
@@ -866,7 +866,7 @@ def wait_for_service_endpoint(service_name, timeout_sec=120):
             url=url,
             timeout=5,
             auth=auth,
-            verify=False)
+            verify=str(get_ca_file()))
         if response.status_code == 200:
             return True
         else:

--- a/tests/system/dcos_service_marathon_tests.py
+++ b/tests/system/dcos_service_marathon_tests.py
@@ -20,7 +20,7 @@ def test_deploy_custom_framework():
     client.add_app(apps.fake_framework())
     shakedown.deployment_wait(timeout=timedelta(minutes=5).total_seconds())
 
-    assert shakedown.wait_for_service_endpoint('pyfw', timedelta(minutes=5).total_seconds()), \
+    assert common.wait_for_service_endpoint('pyfw', timedelta(minutes=5).total_seconds()), \
         "The framework has not showed up"
 
 

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -35,8 +35,10 @@ def wait_for_marathon_user_and_cleanup():
         common.clean_up_marathon()
     print("exiting wait_for_marathon_user_and_cleanup fixture")
 
+
 def get_ca_file():
     return Path(fixtures_dir(), 'dcos-ca.crt')
+
 
 def get_ssl_context():
     """Looks for the DC/OS certificate in the fixtures folder.

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -18,9 +18,9 @@ def fixtures_dir():
 @pytest.fixture(scope="function")
 def wait_for_marathon_and_cleanup():
     print("entering wait_for_marathon_and_cleanup fixture")
-    common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds(), path="ping")
     yield
-    common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds(), path="ping")
     common.clean_up_marathon()
     print("exiting wait_for_marathon_and_cleanup fixture")
 
@@ -28,10 +28,10 @@ def wait_for_marathon_and_cleanup():
 @pytest.fixture(scope="function")
 def wait_for_marathon_user_and_cleanup():
     print("entering wait_for_marathon_user_and_cleanup fixture")
-    common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds(), path="ping")
     with shakedown.marathon_on_marathon():
         yield
-        common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds())
+        common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds(), path="ping")
         common.clean_up_marathon()
     print("exiting wait_for_marathon_user_and_cleanup fixture")
 

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -35,6 +35,8 @@ def wait_for_marathon_user_and_cleanup():
         common.clean_up_marathon()
     print("exiting wait_for_marathon_user_and_cleanup fixture")
 
+def get_ca_file():
+    return Path(fixtures_dir(), 'dcos-ca.crt')
 
 def get_ssl_context():
     """Looks for the DC/OS certificate in the fixtures folder.
@@ -44,7 +46,7 @@ def get_ssl_context():
         SSLContext with file.
 
     """
-    cafile = Path(fixtures_dir(), 'dcos-ca.crt')
+    cafile = get_ca_file()
     if cafile.is_file():
         print(f'Provide certificate {cafile}') # NOQA E999
         ssl_context = ssl.create_default_context(cafile=cafile)

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -18,9 +18,9 @@ def fixtures_dir():
 @pytest.fixture(scope="function")
 def wait_for_marathon_and_cleanup():
     print("entering wait_for_marathon_and_cleanup fixture")
-    shakedown.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds())
     yield
-    shakedown.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds())
     common.clean_up_marathon()
     print("exiting wait_for_marathon_and_cleanup fixture")
 
@@ -28,10 +28,10 @@ def wait_for_marathon_and_cleanup():
 @pytest.fixture(scope="function")
 def wait_for_marathon_user_and_cleanup():
     print("entering wait_for_marathon_user_and_cleanup fixture")
-    shakedown.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds())
     with shakedown.marathon_on_marathon():
         yield
-        shakedown.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds())
+        common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds())
         common.clean_up_marathon()
     print("exiting wait_for_marathon_user_and_cleanup fixture")
 

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -903,7 +903,7 @@ def test_marathon_with_master_process_failure(marathon_service_name):
     original_task_id = tasks[0]['id']
 
     common.systemctl_master('restart')
-    common.wait_for_service_endpoint(marathon_service_name)
+    common.wait_for_service_endpoint(marathon_service_name, path="ping")
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_task_recovery():

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -903,7 +903,7 @@ def test_marathon_with_master_process_failure(marathon_service_name):
     original_task_id = tasks[0]['id']
 
     common.systemctl_master('restart')
-    shakedown.wait_for_service_endpoint(marathon_service_name)
+    common.wait_for_service_endpoint(marathon_service_name)
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_task_recovery():

--- a/tests/system/test_marathon_on_marathon.py
+++ b/tests/system/test_marathon_on_marathon.py
@@ -121,7 +121,7 @@ def test_mom_when_mom_process_killed():
 
         common.kill_process_on_host(common.ip_of_mom(), 'marathon-assembly')
         shakedown.wait_for_task('marathon', 'marathon-user', 300)
-        common.wait_for_service_endpoint('marathon-user')
+        common.wait_for_service_endpoint('marathon-user', path="ping")
 
         @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
         def check_task_is_back():
@@ -162,7 +162,7 @@ def test_mom_with_network_failure():
     reconnect_agent(task_ip)
 
     time.sleep(timedelta(minutes=1).total_seconds())
-    common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds(), path="ping")
     shakedown.wait_for_task("marathon-user", app_id.lstrip('/'))
 
     with shakedown.marathon_on_marathon():
@@ -214,7 +214,7 @@ def test_mom_with_network_failure_bounce_master():
     reconnect_agent(task_ip)
 
     time.sleep(timedelta(minutes=1).total_seconds())
-    common.wait_for_service_endpoint('marathon-user', timedelta(minutes=10).total_seconds())
+    common.wait_for_service_endpoint('marathon-user', timedelta(minutes=10).total_seconds(), path="ping")
 
     with shakedown.marathon_on_marathon():
         client = marathon.create_client()

--- a/tests/system/test_marathon_on_marathon.py
+++ b/tests/system/test_marathon_on_marathon.py
@@ -121,7 +121,7 @@ def test_mom_when_mom_process_killed():
 
         common.kill_process_on_host(common.ip_of_mom(), 'marathon-assembly')
         shakedown.wait_for_task('marathon', 'marathon-user', 300)
-        shakedown.wait_for_service_endpoint('marathon-user')
+        common.wait_for_service_endpoint('marathon-user')
 
         @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
         def check_task_is_back():
@@ -162,7 +162,7 @@ def test_mom_with_network_failure():
     reconnect_agent(task_ip)
 
     time.sleep(timedelta(minutes=1).total_seconds())
-    shakedown.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds())
     shakedown.wait_for_task("marathon-user", app_id.lstrip('/'))
 
     with shakedown.marathon_on_marathon():
@@ -214,7 +214,7 @@ def test_mom_with_network_failure_bounce_master():
     reconnect_agent(task_ip)
 
     time.sleep(timedelta(minutes=1).total_seconds())
-    shakedown.wait_for_service_endpoint('marathon-user', timedelta(minutes=10).total_seconds())
+    common.wait_for_service_endpoint('marathon-user', timedelta(minutes=10).total_seconds())
 
     with shakedown.marathon_on_marathon():
         client = marathon.create_client()
@@ -242,7 +242,7 @@ def test_framework_unavailable_on_mom():
         shakedown.deployment_wait()
 
     try:
-        shakedown.wait_for_service_endpoint('pyfw', 15)
+        common.wait_for_service_endpoint('pyfw', 15)
     except Exception:
         pass
     else:

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -106,7 +106,7 @@ def assert_mom_ee(version, security_mode='permissive'):
     client = marathon.create_client()
     client.add_app(app_def)
     shakedown.deployment_wait()
-    shakedown.wait_for_service_endpoint(mom_ee_endpoint(version, security_mode))
+    common.wait_for_service_endpoint(mom_ee_endpoint(version, security_mode))
 
 
 # strict security mode

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -106,7 +106,7 @@ def assert_mom_ee(version, security_mode='permissive'):
     client = marathon.create_client()
     client.add_app(app_def)
     shakedown.deployment_wait()
-    common.wait_for_service_endpoint(mom_ee_endpoint(version, security_mode))
+    common.wait_for_service_endpoint(mom_ee_endpoint(version, security_mode), path="ping")
 
 
 # strict security mode

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -63,7 +63,7 @@ def setup_module(module):
     # - marathon leader registration with mesos
     # - admin router refreshing cache (every 30s)
     # We should not start our tests before marathon is accessible through service endpoint.
-    shakedown.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds())
 
     common.cluster_info()
     common.clean_up_marathon()
@@ -84,7 +84,7 @@ def test_marathon_delete_leader(marathon_service_name):
     print('leader: {}'.format(original_leader))
     common.delete_marathon_path('v2/leader')
 
-    shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
 
     common.assert_marathon_leadership_changed(original_leader)
 
@@ -107,7 +107,7 @@ def test_marathon_delete_leader_and_check_apps(marathon_service_name):
     # abdicate leader after app was started successfully
     common.delete_marathon_path('v2/leader')
 
-    shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
 
     # wait until leader changed
     common.assert_marathon_leadership_changed(original_leader)
@@ -140,7 +140,7 @@ def test_marathon_delete_leader_and_check_apps(marathon_service_name):
     # abdicate leader after app was started successfully
     common.delete_marathon_path('v2/leader')
 
-    shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
 
     # wait until leader changed
     common.assert_marathon_leadership_changed(original_leader)
@@ -309,7 +309,7 @@ def test_marathon_backup_and_restore_leader(marathon_service_name):
     common.delete_marathon_path(url)
 
     # Wait for new leader (but same master server) to be up and ready
-    shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
     app = client.get_app(app_id)
     assert app['tasksRunning'] == 1, "The number of running tasks is {}, but 1 was expected".format(app["tasksRunning"])
     assert task_id == app['tasks'][0]['id'], "Task has a different ID after restore"
@@ -355,7 +355,7 @@ def test_marathon_backup_and_check_apps(marathon_service_name):
     url = 'v2/leader?backup={}'.format(backup_url1)
     common.delete_marathon_path(url)
 
-    shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
 
     # wait until leader changed
     common.assert_marathon_leadership_changed(original_leader)
@@ -394,7 +394,7 @@ def test_marathon_backup_and_check_apps(marathon_service_name):
     print('DELETE {}'.format(url))
     common.delete_marathon_path(url)
 
-    shakedown.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
 
     # wait until leader changed
     # if leader changed, this means that marathon was able to start again, which is great :-).

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -63,7 +63,7 @@ def setup_module(module):
     # - marathon leader registration with mesos
     # - admin router refreshing cache (every 30s)
     # We should not start our tests before marathon is accessible through service endpoint.
-    common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds(), path="ping")
 
     common.cluster_info()
     common.clean_up_marathon()
@@ -84,7 +84,7 @@ def test_marathon_delete_leader(marathon_service_name):
     print('leader: {}'.format(original_leader))
     common.delete_marathon_path('v2/leader')
 
-    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds(), path="ping")
 
     common.assert_marathon_leadership_changed(original_leader)
 
@@ -107,7 +107,7 @@ def test_marathon_delete_leader_and_check_apps(marathon_service_name):
     # abdicate leader after app was started successfully
     common.delete_marathon_path('v2/leader')
 
-    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds(), path="ping")
 
     # wait until leader changed
     common.assert_marathon_leadership_changed(original_leader)
@@ -140,7 +140,7 @@ def test_marathon_delete_leader_and_check_apps(marathon_service_name):
     # abdicate leader after app was started successfully
     common.delete_marathon_path('v2/leader')
 
-    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds(), path="ping")
 
     # wait until leader changed
     common.assert_marathon_leadership_changed(original_leader)
@@ -309,7 +309,7 @@ def test_marathon_backup_and_restore_leader(marathon_service_name):
     common.delete_marathon_path(url)
 
     # Wait for new leader (but same master server) to be up and ready
-    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds(), path="ping")
     app = client.get_app(app_id)
     assert app['tasksRunning'] == 1, "The number of running tasks is {}, but 1 was expected".format(app["tasksRunning"])
     assert task_id == app['tasks'][0]['id'], "Task has a different ID after restore"
@@ -355,7 +355,7 @@ def test_marathon_backup_and_check_apps(marathon_service_name):
     url = 'v2/leader?backup={}'.format(backup_url1)
     common.delete_marathon_path(url)
 
-    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds(), path="ping")
 
     # wait until leader changed
     common.assert_marathon_leadership_changed(original_leader)
@@ -394,7 +394,7 @@ def test_marathon_backup_and_check_apps(marathon_service_name):
     print('DELETE {}'.format(url))
     common.delete_marathon_path(url)
 
-    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds())
+    common.wait_for_service_endpoint(marathon_service_name, timedelta(minutes=5).total_seconds(), path="ping")
 
     # wait until leader changed
     # if leader changed, this means that marathon was able to start again, which is great :-).

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -71,7 +71,7 @@ def test_custom_service_name():
     shakedown.install_package('marathon', options_json=options)
     shakedown.deployment_wait()
 
-    assert shakedown.wait_for_service_endpoint('test-marathon')
+    assert common.wait_for_service_endpoint('test-marathon')
 
 
 @pytest.fixture(
@@ -110,7 +110,7 @@ def uninstall(service, package=PACKAGE_NAME):
             cosmos_pm = packagemanager.PackageManager(cosmos.get_cosmos_url())
             cosmos_pm.uninstall_app(package, True, service)
             shakedown.deployment_wait()
-            assert shakedown.wait_for_service_endpoint_removal('test-marathon')
+            assert common.wait_for_service_endpoint_removal('test-marathon')
             shakedown.delete_zk_node('/universe/{}'.format(service))
 
     except Exception:

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -71,7 +71,7 @@ def test_custom_service_name():
     shakedown.install_package('marathon', options_json=options)
     shakedown.deployment_wait()
 
-    assert common.wait_for_service_endpoint('test-marathon')
+    assert common.wait_for_service_endpoint('test-marathon', path="ping")
 
 
 @pytest.fixture(


### PR DESCRIPTION
Summary: wait_for_service_endpoint was ported from shakedown and rewritten in order to reduce flakiness.

JIRA issues: MARATHON-8155
