### PR TITLE
Better debugging for the `test_network_pinger` SI test

### DIFF
--- a/tests/system/apps/pinger-container-app.json
+++ b/tests/system/apps/pinger-container-app.json
@@ -1,5 +1,5 @@
 {
-  "id": "/pinger-localhost-app",
+  "id": "/pinger-container-app",
   "instances": 1,
   "cpus": 0.1,
   "mem": 128,

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -1221,7 +1221,7 @@ def test_network_pinger(test_type, get_pinger_app, dns_format, marathon_service_
 
     relay_url = 'http://{}:7777/relay-ping?url={}:7777'.format(relay_dns, pinger_dns)
 
-    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=60, retry_on_exception=common.ignore_exception)
+    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=300, retry_on_exception=common.ignore_exception)
     def http_output_check():
         status, output = shakedown.run_command_on_master('curl {}'.format(relay_url))
         assert status


### PR DESCRIPTION
- Gave container-pinger test case it's own app name
- Increased the waiting duration to 5min just in case
