### PR TITLE
Reschedule resident task during a deployment

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
@@ -7,7 +7,6 @@ import akka.actor.{Actor, Status}
 import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.condition.Condition.Terminal
 import mesosphere.marathon.core.deployment.impl.StartingBehavior.{PostStart, Sync}
 import mesosphere.marathon.core.event.{InstanceChanged, InstanceHealthChanged}
 import mesosphere.marathon.core.instance.Instance

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
@@ -6,6 +6,7 @@ import akka.pattern._
 import akka.actor.{Actor, Status}
 import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition.Terminal
 import mesosphere.marathon.core.deployment.impl.StartingBehavior.{PostStart, Sync}
 import mesosphere.marathon.core.event.{InstanceChanged, InstanceHealthChanged}
@@ -46,7 +47,7 @@ trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Acto
 
   @SuppressWarnings(Array("all")) // async/await
   def commonBehavior: Receive = {
-    case InstanceChanged(id, `version`, `pathId`, _: Terminal, _) =>
+    case InstanceChanged(id, `version`, `pathId`, condition: Condition, instance) if condition.isTerminal || instance.isReservedTerminal =>
       logger.warn(s"New instance [$id] failed during app ${runSpec.id.toString} scaling, queueing another instance")
       instanceTerminated(id)
       launchQueue.add(runSpec, 1).pipeTo(self)

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -37,6 +37,8 @@ case class Instance(
   // An instance has to be considered as Reserved if at least one of its tasks is Reserved.
   def isReserved: Boolean = tasksMap.values.exists(_.status.condition == Condition.Reserved)
 
+  def isReservedTerminal: Boolean = tasksMap.values.exists(_.isReservedTerminal)
+
   def isCreated: Boolean = state.condition == Condition.Created
   def isError: Boolean = state.condition == Condition.Error
   def isFailed: Boolean = state.condition == Condition.Failed

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -48,7 +48,7 @@ private[tracker] class InstanceTrackerDelegate(
   // TODO(jdef) support pods when counting launched instances
   override def countActiveSpecInstances(appId: PathId): Future[Int] = {
     import scala.concurrent.ExecutionContext.Implicits.global
-    instancesBySpec().map(_.specInstances(appId).count(instance => instance.isActive || instance.isReserved))
+    instancesBySpec().map(_.specInstances(appId).count(instance => instance.isActive || (instance.isReserved && !instance.isReservedTerminal)))
   }
 
   override def hasSpecInstancesSync(appId: PathId): Boolean = instancesBySpecSync.hasSpecInstances(appId)

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
@@ -10,11 +10,15 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition.{Failed, Running}
 import mesosphere.marathon.core.event.{DeploymentStatus, _}
 import mesosphere.marathon.core.health.MesosCommandHealthCheck
-import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.launcher.impl.LaunchQueueTestHelper
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
 import mesosphere.marathon.core.task.tracker.InstanceTracker
+import mesosphere.marathon.core.task.tracker.InstanceTracker.{InstancesBySpec, SpecInstances}
+import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{AppDefinition, Command}
 import org.scalatest.concurrent.Eventually
@@ -212,6 +216,31 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       expectTerminated(ref)
     }
   }
+
+  "relaunch when resident task gets terminal" in {
+    val f = new Fixture
+    val promise = Promise[Unit]()
+    val app = AppDefinition("/myApp".toPath)
+
+    f.launchQueue.get(app.id) returns Future.successful(None)
+    f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(0)
+
+    val ref = f.startActor(app, app.instances, promise)
+    watch(ref)
+
+    eventually { verify(f.launchQueue, times(1)).add(eq(app), any) }
+
+    // let existing task die
+    var instance = TestInstanceBuilder.newBuilder(app.id).addTaskReserved(None).getInstance()
+    val reservedTask: Task = instance.appTask
+    instance = instance.copy(tasksMap = Map(reservedTask.taskId -> reservedTask.copy(status = reservedTask.status.copy(mesosStatus = Some(MesosTaskStatusTestHelper.failed(reservedTask.taskId))))))
+    // we need this because otherwise the timer for Sync could fire up and that is not what we are trying to test
+    f.taskTracker.countActiveSpecInstances(app.id) returns Future.successful(1)
+    system.eventStream.publish(InstanceChanged(instance.instanceId, app.version, app.id, instance.state.condition, instance))
+
+    eventually { verify(f.launchQueue, times(2)).add(eq(app), any) }
+  }
+
   class Fixture {
 
     val scheduler: SchedulerActions = mock[SchedulerActions]

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
@@ -17,8 +17,6 @@ import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.core.task.tracker.InstanceTracker.{InstancesBySpec, SpecInstances}
-import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{AppDefinition, Command}
 import org.scalatest.concurrent.Eventually

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
@@ -1,17 +1,20 @@
 package mesosphere.marathon
 package core.task.tracker.impl
 
-import akka.actor.Status
-import akka.testkit.TestProbe
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.instance.TestInstanceBuilder
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
+import mesosphere.marathon.core.task.tracker.InstanceTracker.{InstancesBySpec, SpecInstances}
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.MarathonTestHelper
+import mesosphere.mesos.protos.TextAttribute
 import org.apache.mesos.Protos.{TaskID, TaskStatus}
+import akka.actor.Status
+import akka.testkit.TestProbe
 
 class InstanceTrackerDelegateTest extends AkkaUnitTest {
   class Fixture {
@@ -170,6 +173,52 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       updateValue.getMessage should include(taskId.toString)
       updateValue.getMessage should include("MesosUpdate")
       updateValue.getCause should be(cause)
+    }
+
+    "not consider terminal resident instances as active" in {
+      val f = new Fixture
+      val appId: PathId = PathId("/test")
+
+      val activeCountFuture = f.delegate.countActiveSpecInstances(appId)
+
+      var instance = TestInstanceBuilder.newBuilder(appId).addTaskReserved(None).getInstance()
+      val reservedTask: Task = instance.appTask
+      instance = instance.copy(tasksMap = Map(reservedTask.taskId -> reservedTask.copy(status = reservedTask.status.copy(mesosStatus = Some(MesosTaskStatusTestHelper.failed(reservedTask.taskId))))))
+      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.List)
+      f.taskTrackerProbe.reply(InstancesBySpec(Map(appId -> SpecInstances(Map(instance.instanceId -> instance)))))
+
+      val activeCount = activeCountFuture.futureValue
+      activeCount should be(0)
+    }
+
+    "consider non terminal resident instances as active" in {
+      val f = new Fixture
+      val appId: PathId = PathId("/test")
+
+      val activeCountFuture = f.delegate.countActiveSpecInstances(appId)
+
+      var instance = TestInstanceBuilder.newBuilder(appId).addTaskReserved(None).getInstance()
+      val reservedTask: Task = instance.appTask
+      instance = instance.copy(tasksMap = Map(reservedTask.taskId -> reservedTask.copy(status = reservedTask.status.copy(mesosStatus = Some(MesosTaskStatusTestHelper.running(reservedTask.taskId))))))
+      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.List)
+      f.taskTrackerProbe.reply(InstancesBySpec(Map(appId -> SpecInstances(Map(instance.instanceId -> instance)))))
+
+      val activeCount = activeCountFuture.futureValue
+      activeCount should be(1)
+    }
+
+    "consider resident instances with no mesos status as active" in {
+      val f = new Fixture
+      val appId: PathId = PathId("/test")
+
+      val activeCountFuture = f.delegate.countActiveSpecInstances(appId)
+
+      val instance = TestInstanceBuilder.newBuilder(appId).addTaskReserved(None).getInstance()
+      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.List)
+      f.taskTrackerProbe.reply(InstancesBySpec(Map(appId -> SpecInstances(Map(instance.instanceId -> instance)))))
+
+      val activeCount = activeCountFuture.futureValue
+      activeCount should be(1)
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
@@ -11,7 +11,6 @@ import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
 import mesosphere.marathon.core.task.tracker.InstanceTracker.{InstancesBySpec, SpecInstances}
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.MarathonTestHelper
-import mesosphere.mesos.protos.TextAttribute
 import org.apache.mesos.Protos.{TaskID, TaskStatus}
 import akka.actor.Status
 import akka.testkit.TestProbe


### PR DESCRIPTION
Summary:
Current buggy flow:
- start deployment
- launch new resident task
- resident task have failing health check
- resident task is killed because of failing health check
- scale check is triggered but is ignored because we are in the middle of deployment
- `TaskStartActor` handles only `InstanceChanged` of terminal instances so not the reserved-terminal (note: right now we use Reserved for both Terminal and "Scheduled" cases)

Current change means:
- `TaskStartActor` will get `InstanceChanged` event for resident terminal tasks
- if `Sync` kicks in, it will also not consider terminal Reserved instances as active anymore

JIRA issues: DCOS-38317
