### PR TITLE
 Pull in shakedown as an editable dependency. 

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -71,3 +71,26 @@ shakedown test_marathon_root.py::<test name>
 
 For more details checkout the [shakedown site](https://github.com/dcos/shakedown).
 The tests are written under the project [test/system](system/README.md).
+
+### Shakedown Patching
+
+Shakedown is imported as a `[git-subrepo](https://github.com/ingydotnet/git-subrepo#readme)`
+and declared as an editable dependency in the Pipfile. This allows any Marathon
+contributor to also make edits to Shakedown!
+
+If you made an edit simply commit it to the Marathon repository.
+
+```
+git subrepo push tests/shakedown -b foobar
+```
+
+will push all shakedown related commits to the `foobar` branch of the Shakedown
+[repository](https://github.com/dcos/shakedown).
+
+```
+git subrepo pull tests/shakedown -b master
+```
+
+will pull all changes on the Shakedown master as a suqashed commit into the
+Marathon repository. This will keep the Marathon commit history clean.
+

--- a/tests/shakedown/.gitignore
+++ b/tests/shakedown/.gitignore
@@ -1,0 +1,59 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+.python-version
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# OS X
+.DS_Store
+.idea

--- a/tests/shakedown/.gitrepo
+++ b/tests/shakedown/.gitrepo
@@ -1,0 +1,11 @@
+; DO NOT EDIT (unless you know what you are doing)
+;
+; This subdirectory is a git "subrepo", and this file is maintained by the
+; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
+;
+[subrepo]
+	remote = git@github.com:dcos/shakedown.git
+	branch = master
+	commit = b002692ba7d765fad51a7a600775511c44103801
+	parent = 5d43528ac8f572085f1a58e08391a85d04e87a8a
+	cmdver = 0.3.1

--- a/tests/shakedown/.travis.yml
+++ b/tests/shakedown/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+install:
+  - "pip install coveralls"
+  - "pip install -e .[test]"
+script: 
+  - py.test
+  - coverage run --source=flightplan -m py.test
+after_success:
+  - coveralls
+sudo: false

--- a/tests/shakedown/API.md
+++ b/tests/shakedown/API.md
@@ -1,0 +1,3004 @@
+# Using `shakedown` helper methods in your DC/OS tests
+
+
+## Table of contents
+
+  * [Usage](#usage)
+  * [Methods](#methods)
+    * General
+      * [authenticate()](#authenticate)
+      * [dcos_url()](#dcos_url)
+      * [master_url()](#master_url)
+      * [agents_url()](#agents_url)
+      * [dcos_service_url()](#dcos_service_url)
+      * [dcos_state()](#dcos_state)
+      * [dcos_agents_state()](#dcos_agents_state)
+      * [dcos_version()](#dcos_version)
+      * [dcos_acs_token()](#dcos_acs_token)
+      * [dcos_url_path()](#dcos_url_path)
+      * [master_ip()](#master_ip)
+    * Packaging
+      * [install_package()](#install_package)
+      * [install_package_and_wait()](#install_package_and_wait)
+      * [uninstall_package()](#uninstall_package)
+      * [uninstall_package_and_wait()](#uninstall_package_and_wait)
+      * [uninstall_package_and_data()](#uninstall_package_and_data)
+      * [get_package_versions()](#get_package_versions)
+      * [package_installed()](#package_installed)
+      * [get_package_repos()](#get_package_repos)
+      * [add_package_repo()](#add_package_repo)
+      * [remove_package_repo()](#remove_package_repo)
+    * Cluster
+      * [get_resources()](#get_resources)
+      * [resources_needed()](#resources_needed)
+      * [get_used_resources()](#get_used_resources)
+      * [get_unreserved_resources()](#get_unreserved_resources)
+      * [get_reserved_resources()](#get_reserved_resources)
+      * [get_resources_by_role()](#get_resources_by_role)
+      * [available_resources()](#available_resources)
+      * [shakedown_canonical_version()](#shakedown_canonical_version)
+      * [shakedown_version_less_than()](#shakedown_version_less_than)
+      * [dcos_canonical_version()](#dcos_canonical_version)
+      * [dcos_version_less_than()](#dcos_version_less_than)
+      * [required_cpus()](#required_cpus)
+      * [required_mem()](#required_mem)
+      * [bootstrap_metadata()](#bootstrap_metadata)
+      * [ui_config_metadata()](#ui_config_metadata)
+      * [dcos_version_metadata()](#dcos_version_metadata)
+      * [ee_version()](#ee_version)
+      * [mesos_logging_strategy()](#mesos_logging_strategy)
+      * [dcos_1_7](#dcos_1_7)
+      * [dcos_1_8](#dcos_1_8)
+      * [dcos_1_9](#dcos_1_9)
+      * [dcos_1_10](#dcos_1_10)      
+      * [strict](#strict)
+      * [permissive](#permissive)
+      * [disabled](#disabled)
+    * Command execution
+      * [run_command()](#run_command)
+      * [run_command_on_master()](#run_command_on_master)
+      * [run_command_on_agent()](#run_command_on_agent)
+      * [run_command_on_leader()](#run_command_on_leader)
+      * [run_command_on_marathon_leader()](#run_command_on_marathon_leader)
+      * [run_dcos_command()](#run_dcos_command)
+    * Docker
+      * [docker_version()](#docker_version)
+      * [docker_server_version()](#docker_server_version)
+      * [docker_client_version()](#docker_client_version)
+      * [create_docker_credentials_file()](#create_docker_credentials_file)
+      * [distribute_docker_credentials_to_private_agents()](#distribute_docker_credentials_to_private_agents)
+      * [prefetch_docker_image_on_private_agents()](#prefetch_docker_image_on_private_agents)
+    * File operations
+      * [copy_file()](#copy_file)
+      * [copy_file_to_master()](#copy_file_to_master)
+      * [copy_file_to_agent()](#copy_file_to_agent)
+      * [copy_file_from_master()](#copy_file_from_master)
+      * [copy_file_from_agent()](#copy_file_from_agent)
+    * Services
+      * [get_service()](#get_service)
+      * [delete_persistent_data()](#delete_persistent_data)
+      * [destroy_volumes()](#destroy_volumes)
+      * [destroy_volume()](#destroy_volume)
+      * [unreserve_resources()](#unreserve_resources)
+      * [unreserve_resource()](#unreserve_resource)
+      * [get_service_framework_id()](#get_service_framework_id)
+      * [get_service_task()](#get_service_task)
+      * [get_service_tasks()](#get_service_tasks)
+      * [get_service_ips()](#get_service_ips)
+      * [get_marathon_task()](#get_marathon_task)
+      * [get_marathon_tasks()](#get_marathon_tasks)
+      * [service_healthy()](#service_healthy)
+      * [wait_for_service_endpoint()](#wait_for_service_endpoint)
+      * [wait_for_service_endpoint_removal()](#wait_for_service_endpoint_removal)
+    * Spinner
+      * [wait_for()](#wait_for)
+      * [time_wait()](#time_wait)
+      * [wait_while_exceptions()](#wait_while_exceptions)
+      * [elapse_time()](#elapse_time)
+    * Tasks
+      * [get_task()](#get_task)
+      * [get_tasks()](#get_tasks)
+      * [get_active_tasks()](#get_active_tasks)
+      * [task_completed()](#task_completed)
+      * [wait_for_task()](#wait_for_task)
+      * [wait_for_task_property()](#wait_for_task_property)
+      * [wait_for_task_property_value()](#wait_for_task_property_value)
+      * [wait_for_dns()](#wait_for_dns)
+    * ZooKeeper
+      * [get_zk_node_data()](#get_zk_node_data)
+      * [get_zk_node_children()](#get_zk_node_children)
+      * [delete_zk_node()](#delete_zk_node)      
+    * Marathon
+      * [deployment_wait()](#deployment_wait)
+      * [delete_all_apps()](#delete_all_apps)
+      * [delete_all_apps_wait()](#delete_all_apps_wait)
+      * [is_app_healthy()](#is_app_healthy)
+      * [marathon_leader_ip()](#marathon_leader_ip)
+      * [marathon_version()](#marathon_version)
+      * [marthon_version_less_than()](#marthon_version_less_than)
+      * [mom_version()](#mom_version)
+      * [mom_version_less_than()](#mom_version_less_than)
+      * [marathon_on_marathon()](#marathon_on_marathon)
+      * [marathon_1_3](#marathon_1_3)
+      * [marathon_1_4](#marathon_1_4)
+      * [marathon_1_5](#marathon_1_5)
+    * Masters
+      * [partition_master()](#partition_master)
+      * [reconnect_master()](#reconnect_master)
+      * [disconnected_master()](#disconnected_master)
+      * [wait_for_mesos_endpoint()](#wait_for_mesos_endpoint)
+      * [get_all_masters()](#get_all_masters)
+      * [master_leader_ip()](#master_leader_ip)
+      * [get_all_master_ips()](#get_all_master_ips)
+      * [start_master_http_service()](#start_master_http_service)
+      * [kill_process_from_pid_file_on_master()](#kill_process_from_pid_file_on_master)
+      * [master_http_service()](#master_http_service)
+    * Security
+      * [add_user()](#add_user)
+      * [get_user()](#get_user)
+      * [remove_user()](#remove_user)
+      * [ensure_resource()](#ensure_resource)
+      * [set_user_permission()](#set_user_permission)
+      * [remove_user_permission()](#remove_user_permission)
+      * [add_group()](#add_group)
+      * [get_group()](#get_group)
+      * [remove_group()](#remove_group)
+      * [add_user_to_group()](#add_user_to_group)
+      * [remove_user_from_group()](#remove_user_from_group)
+      * [credentials()](#credentials)
+      * [no_user()](#no_user)
+      * [new_dcos_user()](#new_dcos_user)
+      * [dcos_user()](#dcos_user)
+    * Agents
+      * [get_agents()](#get_agents)
+      * [get_private_agents()](#get_private_agents)
+      * [get_public_agents()](#get_public_agents)
+      * [partition_agent()](#partition_agent)
+      * [reconnect_agent()](#reconnect_agent)
+      * [restart_agent()](#restart_agent)
+      * [stop_agent()](#stop_agent)
+      * [start_agent()](#start_agent)
+      * [delete_agent_log()](#delete_agent_log)
+      * [kill_process_on_host()](#kill_process_on_host)
+      * [kill_process_from_pid_file_on_host()](#kill_process_from_pid_file_on_host)      
+      * [disconnected_agent()](#disconnected_agent)
+      * [required_private_agents()](#required_private_agents)
+      * [required_public_agents()](#required_public_agents)
+      * [private_agents](#private_agents)
+      * [public_agents](#public_agents)
+    * Network
+      * [restore_iptables()](#restore_iptables)
+      * [save_iptables()](#save_iptables)
+      * [flush_all_rules()](#flush_all_rules)
+      * [allow_all_traffic()](#allow_all_traffic)
+      * [iptable_rules()](#iptable_rules)
+
+## Usage
+
+`from shakedown import *`
+
+
+## Methods
+
+### authenticate()
+
+Authenticate against an EE DC/OS cluster using a username and password.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**username** | the username used for DC/OS authentication | str
+**password** | the password used for DC/OS authentication | str
+
+##### *example usage*
+
+```python
+# Authenticate against DC/OS, receive an ACS token
+token = authenticate('root', 's3cret')
+```
+
+* [master_url()](#master_url)
+* [agents_url()](#agents_url)
+
+### dcos_url()
+
+The URL to the DC/OS cluster under test.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# Print the DC/OS dashboard URL.
+dcos_url = dcos_url()
+print("Dashboard located at: " + dcos_url)
+```
+
+### master_url()
+
+The URL to the mesos master on the DC/OS cluster under test.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+master_url = master_url()
+print("Master located at: " + master_url)
+```
+
+
+### agents_url()
+
+The URL to the agents end point for the master on the DC/OS cluster under test.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+agents_url = agents_url()
+print("Agent state.json is located at: " + agents_url)
+```
+
+
+### dcos_service_url()
+
+The URI to a named service.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**service** | the name of the service | str
+
+##### *example usage*
+
+```python
+# Print the location of the Jenkins service's dashboard
+jenkins_url = dcos_service_url('jenkins')
+print("Jenkins dashboard located at: " + jenkins_url)
+```
+
+
+### dcos_state()
+
+A JSON hash containing DC/OS state information.
+
+#### *parameters*
+
+None.
+
+#### *example usage*
+
+```python
+# Print state information of DC/OS slaves.
+state_json = json.loads(dcos_json_state())
+print(state_json['slaves'])
+```
+
+
+### dcos_agents_state()
+
+A JSON hash containing DC/OS state information for the agents.
+
+#### *parameters*
+
+None.
+
+#### *example usage*
+
+```python
+# Print state information of DC/OS slaves.
+state_json = dcos_agents_state()
+print(state_json['slaves'])
+```
+
+
+### dcos_version()
+
+The DC/OS version number.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# Print the DC/OS version.
+dcos_version = dcos_version()
+print("Cluster is running DC/OS version " + dcos_version)
+```
+
+
+### dcos_acs_token()
+
+The DC/OS ACS token (if authenticated).
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# Print the DC/OS ACS token.
+token = dcos_acs_token()
+print("Using token " + token)
+```
+
+
+
+### dcos_url_path()
+
+Provides a DC/OS url for the provide path.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**url_path** | the url path | str
+
+##### *example usage*
+
+```python
+url = shakedown.dcos_url_path('marathon/v2/apps')
+response = dcos.http.request('get', url)
+```
+
+
+### master_ip()
+
+The current Mesos master's IP address.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# What's our Mesos master's IP?
+master_ip = master_ip()
+print("Current Mesos master: " + master_ip)
+```
+
+
+### install_package()
+
+Install a package.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**package_name** | the name of the package to install | str
+package_version | the version of the package to install | str | *latest*
+service_name | custom service name | str | `None`
+options_file | a file containing options in JSON format | str | `None`
+options_json | a dict containing options in JSON format | dict | `None`
+wait_for_completion | wait for service to become healthy before completing? | bool | `False`
+timeout_sec | how long in seconds to wait before timing out | int | `600`
+
+##### *example usage*
+
+```python
+# Install the 'jenkins' package; don't wait the service to register
+install_package('jenkins')
+```
+
+
+### install_package_and_wait()
+
+Install a package, and wait for the service to register.
+
+*This method uses the same parameters as [`install_package()`](#install_package)*
+
+
+### uninstall_package()
+
+Uninstall a package.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**package_name** | the name of the package to install | str
+service_name | custom service name | str | `None`
+all_instances | uninstall all instances? | bool | `False`
+wait_for_completion | wait for service to become healthy before completing? | bool | `False`
+timeout_sec | how long in seconds to wait before timing out | int | `600`
+
+##### *example usage*
+
+```python
+# Uninstall the 'jenkins' package; don't wait for the service to unregister
+uninstall_package('jenkins')
+```
+
+
+
+### uninstall_package_and_data()
+
+Uninstall a package, and wait for the service to unregister.  The cleans up the
+reserved resources, the reserved disk and zk entry associated with the service.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**package_name** | the name of the package to install | str
+service_name | custom service name | str | `None`
+role | role for the service if not <service>-role | str | `None`
+principal | principal for the service if not <service>-principal | str | `None`
+zk_node | zk node to delete for the service | str | `None`
+timeout_sec | how long in seconds to wait before timing out | int | `600`
+
+##### *example usage*
+
+```python
+uninstall_package_and_data('confluent-kafka', zk_node='/dcos-service-confluent-kafka')
+```
+
+
+### uninstall_package_and_wait()
+
+Uninstall a package, and wait for the service to unregister.
+
+*This method uses the same parameters as [`uninstall_package()`](#uninstall_package)*
+
+
+### get_package_versions()
+
+Returns the list of versions of a given package.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**package_name** | the name of the package to install | str
+
+##### *example usage*
+
+```python
+versions = get_package_versions('marathon')
+if '1.5.2' not in versions:
+    raise VersionException("version is not in this universe")
+```
+
+
+### package_installed()
+
+Check whether a specified package is currently installed.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**package_name** | the name of the package to install | str
+service_name | custom service name | str | `None`
+
+##### *example usage*
+
+```python
+# Is the 'jenkins' package installed?
+if package_installed('jenkins'):
+    print('Jenkins is installed!')
+```
+
+
+### add_package_repo()
+
+Add a repository to the list of package sources.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**repo_name** | the name of the repository | str
+**repo_url** | the location of the repository | str
+index | the repository index order | int | *-1*
+
+##### *example usage*
+
+```python
+# Search the Multiverse before any other repositories
+add_package_repo('Multiverse', 'https://github.com/mesosphere/multiverse/archive/version-2.x.zip', 0)
+```
+
+
+### remove_package_repo()
+
+Remove a repository from the list of package sources.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**repo_name** | the name of the repository | str
+
+##### *example usage*
+
+```python
+# No longer search the Multiverse
+remove_package_repo('Multiverse')
+```
+
+
+### get_package_repos()
+
+Retrieve a dictionary describing the configured package source repositories.
+
+##### *parameters*
+
+None
+
+##### *example usage*
+
+```python
+# Which repository am I searching through first?
+repos = get_package_repos()
+print("First searching " + repos['repositories'][0]['name'])
+```
+
+
+### get_resources()
+
+Gets a Resource object which includes the current cpu and memory of the cluster
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+
+resources = get_resources()
+
+if resources.cpus > 2:
+  # do stuff
+```
+
+
+### get_used_resources()
+
+Gets a Resource object which includes the amount of cpu and memory being used in the cluster.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+
+resources = get_used_resources()
+
+if resources.cpus > 2:
+  # do stuff
+```
+
+
+### get_unreserved_resources()
+
+Gets a Resource object which includes the amount of cpu and memory that is not currently reserved.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+
+resources = get_unreserved_resources()
+
+if resources.cpus > 2:
+  # do stuff
+```
+
+### get_reserved_resources()
+
+Gets a Resource object which includes the amount of cpu and memory that is currently reserved.
+Role == None is all reserved and 'slave_public' would be the public resources.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+role | role of reservation | str | None
+
+
+##### *example usage*
+
+```python
+
+resources = get_reserved_resources()
+
+if resources.cpus > 2:
+  # do stuff
+```
+
+
+### get_resources_by_role()
+
+Gets a Resource object which includes the amount of cpu and memory that is currently reserved by
+a role.  The default is *
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+role | role of reservation | str | None
+
+
+##### *example usage*
+
+```python
+
+resources = get_resources_by_role()
+
+if resources.cpus > 2:
+  # do stuff
+```
+
+
+### available_resources()
+
+Gets a Resource object which includes the amount of cpu and memory that is  currently available.  This equates to (get_resources() - get_used_resources()).
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+
+resources = available_resources()
+
+if resources.cpus > 2:
+  # do stuff
+```
+
+### resources_needed()
+
+Run a command on a remote host via SSH.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+total_tasks | number of tasks | int | 1
+per_task_cpu | cpu per task requirement | float | 0.01
+per_task_mem | the username used for SSH authentication | float | 1
+
+##### *example usage*
+
+```python
+
+```
+
+
+### shakedown_canonical_version()
+
+Provides a canonical version number of shakedown via distutils.version.LooseVersion.
+Useful for shakedown verison comparisons.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+@pytest.mark.skipif('shakedown_canonical_version() < LooseVersion("1.3")')
+def test_1_3_specific_test():
+```
+
+
+### shakedown_version_less_than()
+
+Returns True if the shakedown version is less than the provided version, otherwise
+returns False.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+version | version string "1.3.3" | str
+
+##### *example usage*
+
+```python
+@pytest.mark.skipif('shakedown_version_less_than("1.3.3")')
+def test_1_3_3_specific_test():
+```
+
+
+### dcos_canonical_version()
+
+Provides a canonical version number.  `dcos_version` returns a version string with a
+few variations such as `1.9-dev`.  `dcos_canonical_version` returns a distutils.version.LooseVersion
+and will strip `-dev` if present.  It can be used to determine if the DC/OS cluster version
+is correct for the test or if it should be skipped.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+@pytest.mark.skipif('dcos_canonical_version() < LooseVersion("1.9")')
+def test_1_9_specific_test():
+```
+
+
+### dcos_version_less_than()
+
+Returns True if the DC/OS version is less than the provided version, otherwise
+returns False.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+version | version string "1.9.0" | str
+
+
+##### *example usage*
+
+```python
+@pytest.mark.skipif('dcos_version_less_than("1.9")')
+def test_1_9_specific_test():
+```
+
+
+### dcos_1_7
+
+Preconfigured annotation which requires DC/OS 1.7+
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# if the DC/OS cluster version 1.6 the test will be skipped
+@dcos_1_7
+def test_1_7_plus_feature():
+```
+
+
+### dcos_1_8
+
+Preconfigured annotation which requires DC/OS 1.8+
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# if the DC/OS cluster version 1.7 the test will be skipped
+@dcos_1_8
+def test_1_8_plus_feature():
+```
+
+
+### dcos_1_9
+
+Preconfigured annotation which requires DC/OS 1.9+
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# if the DC/OS cluster version 1.8 the test will be skipped
+@dcos_1_9
+def test_1_9_plus_feature():
+```
+
+
+### dcos_1_10
+
+Preconfigured annotation which requires DC/OS 1.10+
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# if the DC/OS cluster version 1.9 the test will be skipped
+@dcos_1_10
+def test_1_10_plus_feature():
+```
+
+
+### strict
+
+Preconfigured annotation which requires DC/OS Enterprise in strict mode
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# if the DC/OS enterprise cluster is not in strict mode it will be skipped
+@strict
+def test_strict_only_feature():
+```
+
+
+### permissive
+
+Preconfigured annotation which requires DC/OS Enterprise in permissive mode
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# if the DC/OS enterprise cluster is not in permissive mode it will be skipped
+@permissive
+def test_permissive_only_feature():
+```
+
+
+### disabled
+
+Preconfigured annotation which requires DC/OS Enterprise in disabled mode
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# if the DC/OS enterprise cluster is not in disabled mode it will be skipped
+@disabled
+def test_disabled_only_feature():
+```
+
+
+### required_cpus()
+
+Returns True if the cluster resources are less than the specified number of cores,
+otherwise returns False.  This is based on available resources.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+cpus | number of cpus | int
+role | reservation role | str | *
+
+##### *example usage*
+
+```python
+# skips test if there is only 1 core left in the cluster.
+@pytest.mark.skipif('required_cpus(2)')
+def test_requires_2_cores():
+```
+
+
+### required_mem()
+
+Returns True if the cluster resources are less than the specified amount of memory,
+otherwise returns False.  This is based on available resources.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+mem  | amount of mem    | int
+role | reservation role | str | *
+
+
+##### *example usage*
+
+```python
+
+requires_2_cores = pytest.mark.skipif('required_cpus(2)')
+
+@dcos_1_9
+@requires_2_cores
+@pytest.mark.skipif('required_mem(512)')
+def test_requires_512m_memory():
+# requires DC/OS 1.9, 2 cores and 512M
+```
+
+
+### bootstrap_metadata()
+
+Returns the JSON of the boostrap metadata for DC/OS Enterprise clusters.
+Return None if DC/OS Open or DC/OS Version is < 1.9.
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+metadata = bootstrap_metadata()
+if metadata:
+  print(metadata['security'])
+```
+
+
+### ui_config_metadata()
+
+Returns the JSON of the UI configuration metadata for DC/OS Enterprise clusters.
+Return None if DC/OS Open or DC/OS Version is < 1.9.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+metadata = ui_config_metadata()
+if metadata:
+  print(metadata['uiConfiguration']['plugins']['mesos']['logging-strategy'])
+```
+
+
+### dcos_version_metadata()
+
+Returns the JSON of the DC/OS version metadata for DC/OS Enterprise clusters.
+Returns None if not available.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+metadata = dcos_version_metadata()
+if metadata:
+  print(metadata['dcos-image-commit'])
+```
+
+
+### ee_version()
+
+Returns the DC/OS Enterprise version type which is {strict, permissive, disabled}
+Return None if DC/OS Open or DC/OS Version is < 1.9.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+@pytest.mark.skipif("ee_version() in {'strict', 'disabled'}")
+def test_skips_strict_or_disabled():
+```
+
+
+### mesos_logging_strategy()
+
+Returns the mesos logging strategy if available, otherwise None.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+strategy = mesos_logging_strategy()
+print(strategy)
+```
+
+
+### run_command()
+
+Run a command on a remote host via SSH.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**host** | the hostname or IP to run the command on | str
+**command** | the command to run | str
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+noisy    | Output to stdout if True | bool | True
+
+##### *example usage*
+
+```python
+# I wonder what /etc/motd contains on the Mesos master?
+exit_status, output = run_command(master_ip(), 'cat /etc/motd')
+```
+
+
+### run_command_on_master()
+
+Run a command on the Mesos master via SSH.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**command** | the command to run | str
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+noisy    | Output to stdout if True | bool | True
+
+##### *example usage*
+
+```python
+# What kernel is our Mesos master running?
+exit_status, output = run_command_on_master('uname -a')
+```
+
+
+### run_command_on_agent()
+
+Run a command on a Mesos agent via SSH, proxied via the Mesos master.
+
+*This method uses the same parameters as [`run_command()`](#run_command)*
+
+### run_command_on_leader()
+
+Run a command on the Mesos master leader via SSH.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**command** | the command to run | str
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+noisy    | Output to stdout if True | bool | True
+
+##### *example usage*
+
+```python
+# What kernel is our Mesos leader running?
+exit_status, output = run_command_on_leader('uname -a')
+```
+
+
+### run_command_on_marathon_leader()
+
+Run a command on the Marathon leader via SSH.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**command** | the command to run | str
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+noisy    | Output to stdout if True | bool | True
+
+##### *example usage*
+
+```python
+# What kernel is our Marathon leader running?
+exit_status, output = run_command_on_marathon_leader('uname -a')
+```
+
+
+### run_dcos_command()
+
+Run a command using the `dcos` CLI.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**command** | the command to run | str
+
+##### *example usage*
+
+```python
+# What's the current version of the Jenkins package?
+stdout, stderr, return_code = run_dcos_command('package search jenkins --json')
+result_json = json.loads(stdout)
+print(result_json['packages'][0]['currentVersion'])
+```
+
+
+### docker_version()
+
+Get the version of Docker [Server]
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+host | host or IP of the machine Docker is running on | str | `master_ip()`
+component | which Docker version component to query (`server` or `client`) | str | `server`
+
+##### *example usage*
+
+```python
+master_docker_version = docker_version()
+print("DC/OS master is running Docker version {}".format(master_docker_version))
+```
+
+
+### docker_server_version()
+
+Get the version of Docker Server
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+host | host or IP of the machine Docker is running on | str | `master_ip()`
+
+##### *example usage*
+
+```python
+docker_server = docker_server_version()
+print("DC/OS master is running Docker Server version {}".format(docker_server))
+```
+
+
+### docker_client_version()
+
+Get the version of Docker Client
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+host | host or IP of the machine Docker is running on | str | `master_ip()`
+
+##### *example usage*
+
+```python
+docker_client = docker_client_version()
+print("DC/OS master is running Docker Client version {}".format(docker_client))
+```
+
+
+### create_docker_credentials_file()
+
+Creates a docker credentials file for the provided username and password.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**username** | docker repo username | str
+**password** | docker repo password | str
+file_name | the compressed tar filename | str | docker.tar.gz
+
+##### *example usage*
+
+```python
+create_docker_credentials_file('billy', 'secret')
+```
+
+
+### distribute_docker_credentials_to_private_agents()
+
+Creates a docker credentials file for the provided username and password and
+distributes it to all the private agents.  It deletes the file after distribution.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**username** | docker repo username | str
+**password** | docker repo password | str
+file_name | the compressed tar filename | str | docker.tar.gz
+
+##### *example usage*
+
+```python
+distribute_docker_credentials_to_private_agents('billy', 'secret')
+```
+
+
+### prefetch_docker_image_on_private_agents()
+
+Ensures that the docker image provided is prefetched to all the private agents.
+This can decrease image pull time for subsequent tests.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**image** | docker image name | str
+
+##### *example usage*
+
+```python
+prefetch_docker_image_on_private_agents('nginx')
+```
+
+
+### copy_file()
+
+Copy a file via SCP.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**host** | the hostname or IP to copy the file to/from | str
+**file_path** | the local path to the file to be copied | str
+remote_path | the remote path to copy the file to | str | `.`
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+action | 'put' (default) or 'get' | str | `put`
+
+##### *example usage*
+
+```python
+# Copy a datafile onto the Mesos master
+copy_file(master_ip(), '/var/data/datafile.txt')
+```
+
+
+### copy_file_to_master()
+
+Copy a file to the Mesos master.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**file_path** | the local path to the file to be copied | str
+remote_path | the remote path to copy the file to | str | `.`
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+
+##### *example usage*
+
+```python
+# Copy a datafile onto the Mesos master
+copy_file_to_master('/var/data/datafile.txt')
+```
+
+
+### copy_file_to_agent()
+
+Copy a file to a Mesos agent, proxied through the Mesos master.
+
+*This method uses the same parameters as [`copy_file()`](#copy_file)*
+
+
+### copy_file_from_master()
+
+Copy a file from the Mesos master.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**remote_path** | the remote path of the file to copy | str |
+file_path | the local path to copy the file to | str | `.`
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+
+##### *example usage*
+
+```python
+# Copy a datafile from the Mesos master
+copy_file_from_master('/var/data/datafile.txt')
+```
+
+
+### copy_file_from_agent()
+
+Copy a file from a Mesos agent, proxied through the Mesos master.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**host** | the hostname or IP to copy the file from | str
+**remote_path** | the remote path of the file to copy | str
+file_path | the local path to copy the file to | str | `.`
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+
+##### *example usage*
+
+```python
+# Copy a datafile from an agent running Jenkins
+service_ips = get_service_ips('marathon', 'jenkins')
+for host in service_ips:
+    assert copy_file_from_agent(host, '/home/jenkins/datafile.txt')
+```
+
+
+### get_service()
+
+Retrieve a dictionary describing a named service.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**service_name** | the name of the service | str
+inactive | include inactive services? | bool | `False`
+completed | include completed services? | bool | `False`
+
+##### *example usage*
+
+```python
+# Tell me about the 'jenkins' service
+jenkins = get_service('jenkins')
+```
+
+
+### delete_persistent_data()
+
+Delete the reserved_resources, destroys volumes and deletes the zk node for a given service.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**role** | the role for the service | str
+**zk_node** | the zk node to delete | str
+
+##### *example usage*
+
+```python
+delete_persistent_data('confluent-kafka-role', '/dcos-service-confluent-kafka')
+```
+
+
+### destroy_volumes()
+
+Destroys the volume for the given role (on all slaves in the cluster).  
+It is important to uninstall the service prior to calling this function.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**role** | the role associated with the service | str
+
+##### *example usage*
+
+```python
+destroy_volumes('confluent-kafka-role')
+```
+
+
+### destroy_volume()
+
+Destroys the volume for the given role on a give agent.
+It is important to uninstall the service prior to calling this function.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**agent** | an agent id in the cluster | str
+**role** | the role associated with the service | str
+
+##### *example usage*
+
+```python
+destroy_volumes('a8571994-47f8-4590-8922-47f10886165a-S1', 'confluent-kafka-role')
+```
+
+
+### unreserve_resources()
+
+Unreserve resources for the given role (on all slaves in the cluster).  
+It is important to uninstall the service prior to calling this function.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**role** | the role associated with the service | str
+
+##### *example usage*
+
+```python
+unreserve_resources('confluent-kafka-role')
+```
+
+
+### unreserve_resource()
+
+Unreserve resources for the given role on a give agent.
+It is important to uninstall the service prior to calling this function.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**agent** | an agent id in the cluster | str
+**role** | the role associated with the service | str
+
+##### *example usage*
+
+```python
+unreserve_resource('a8571994-47f8-4590-8922-47f10886165a-S1', 'confluent-kafka-role')
+```
+
+
+### get_service_framework_id()
+
+Get the framework ID of a named service.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**service_name** | the name of the service | str
+inactive | include inactive services? | bool | `False`
+completed | include completed services? | bool | `False`
+
+##### *example usage*
+
+```python
+# What is the framework ID for the 'jenkins' service?
+jenkins_framework_id = get_framework_id('jenkins')
+```
+
+
+### get_service_task()
+
+Get a dictionary describing a named service task.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**service_name** | the name of the service | str
+**task_name** | the name of the task | str
+inactive | include inactive services? | bool | `False`
+completed | include completed services? | bool | `False`
+
+##### *example usage*
+
+```python
+# Tell me about marathon's 'jenkins' task
+jenkins_tasks = get_service_task('marathon', 'jenkins')
+```
+
+
+### get_service_tasks()
+
+Get a list of task IDs associated with a named service.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**service_name** | the name of the service | str
+inactive | include inactive services? | bool | `False`
+completed | include completed services? | bool | `False`
+
+##### *example usage*
+
+```python
+# What's marathon doing right now?
+service_tasks = get_service_tasks('marathon')
+```
+
+
+### get_marathon_task()
+
+Get a dictionary describing a named Marathon task.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**task_name** | the name of the task | str
+inactive | include inactive services? | bool | `False`
+completed | include completed services? | bool | `False`
+
+##### *example usage*
+
+```python
+# Tell me about marathon's 'jenkins' task
+jenkins_tasks = get_marathon_task('jenkins')
+```
+
+
+### get_marathon_tasks()
+
+Get a list of Marathon tasks.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+inactive | include inactive services? | bool | `False`
+completed | include completed services? | bool | `False`
+
+##### *example usage*
+
+```python
+# What's marathon doing right now?
+service_tasks = get_marathon_tasks()
+```
+
+
+### get_service_ips()
+
+Get a set of the IPs associated with a service.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**service_name** | the name of the service | str
+task_name | the name of the task to limit results to | str | `None`
+inactive | include inactive services? | bool | `False`
+completed | include completed services? | bool | `False`
+
+##### *example usage*
+
+```python
+# Get all IPs associated with the 'chronos' task running in the 'marathon' service
+service_ips = get_service_ips('marathon', 'chronos')
+print('service_ips: ' + str(service_ips))
+```
+
+### service_healthy()
+
+Check whether a specified service is currently healthy.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**service_name** | the name of the service | str
+
+##### *example usage*
+
+```python
+# Is the 'jenkins' service healthy?
+if service_healthy('jenkins'):
+    print('Jenkins is healthy!')
+```
+
+### wait_for_service_endpoint()
+
+Checks the service url returns HTTP 200 within a timeout if available it returns true on expiration it returns false.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**service_name** | the name of the service | str
+timeout_sec | how long in seconds to wait before timing out | int | `120`
+
+##### *example usage*
+
+```python
+# will wait
+wait_for_service_endpoint("marathon-user")
+```
+
+### wait_for_service_endpoint_removal()
+
+Checks the service url returns HTTP 500 within a timeout if available it returns true on expiration it returns time to remove.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**service_name** | the name of the service | str
+timeout_sec | how long in seconds to wait before timing out | int | `120`
+
+##### *example usage*
+
+```python
+# will wait
+wait_for_service_endpoint_removal("marathon-user")
+```
+
+### wait_for()
+
+Waits for a function to return true or times out.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**predicate** | the predicate function| fn
+timeout_seconds | how long in seconds to wait before timing out | int | `120`
+sleep_seconds | time to sleep between multiple calls to predicate | int | `1`
+ignore_exceptions | ignore exceptions thrown by predicate | bool | True
+inverse_predicate | if True look for False from predicate | bool | False
+
+##### *example usage*
+
+```python
+# simple predicate
+def deployment_predicate(client=None):
+  ...
+
+wait_for(deployment_predicate, timeout)
+
+# predicate with a parameter
+def service_available_predicate(service_name):
+  ...
+
+wait_for(lambda: service_available_predicate(service_name), timeout_seconds=timeout_sec)
+
+```
+
+### time_wait()
+
+Waits for a function to return true or times out.  Returns the elapsed time of wait.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**predicate** | the predicate function| fn
+timeout_seconds | how long in seconds to wait before timing out | int | `120`
+sleep_seconds | time to sleep between multiple calls to predicate | int | `1`
+ignore_exceptions | ignore exceptions thrown by predicate | bool | True
+inverse_predicate | if True look for False from predicate | bool | False
+noisy | boolean to increase debug output | bool | True
+required_consecutive_success_count | the number of consecutive successes that required | int | 1
+
+
+##### *example usage*
+
+```python
+# simple predicate
+def deployment_predicate(client=None):
+  ...
+
+time_wait(deployment_predicate, timeout)
+
+# predicate with a parameter
+def service_available_predicate(service_name):
+  ...
+
+time_wait(lambda: service_available_predicate(service_name), timeout_seconds=timeout_sec)
+
+```
+
+### wait_while_exceptions()
+
+Waits for a function to return without exception or time out.  Returns the return value of the function.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**predicate** | the predicate function| fn
+timeout_seconds | how long in seconds to wait before timing out | int | `120`
+sleep_seconds | time to sleep between multiple calls to predicate | int | `1`
+noisy | boolean to increase debug output | bool | True
+
+
+##### *example usage*
+
+```python
+# simple predicate
+def deployment_predicate(client=None):
+  ...
+
+wait_while_exceptions(deployment_predicate, timeout)
+
+# predicate with a parameter
+def service_available_predicate(service_name):
+  ...
+
+wait_while_exceptions(lambda: service_available_predicate(service_name), timeout_seconds=timeout_sec)
+
+```
+
+### elapse_time()
+
+returns the time difference with a given precision.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**start** | the start time | time
+end | end time, if not provided current time is used | time | None
+precision | the number decimal places to maintain | int | `3`
+
+##### *example usage*
+
+```python
+# will wait
+elapse_time("marathon-user")
+```
+
+### get_task()
+
+Get information about a task.
+
+*This method uses the same parameters as [`get_tasks()`](#get_tasks)*
+
+
+### get_tasks()
+
+Get a list of tasks, optionally filtered by task ID.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+task_id   | task ID     | str  |
+completed | include completed tasks? | `True`
+
+##### *example usage*
+
+```python
+# What tasks have been run?
+tasks = get_tasks()
+for task in tasks:
+    print("{} has state {}".format(task['id'], task['state']))
+```
+
+
+### get_active_tasks()
+
+Get a list of active tasks, optionally filtered by task name.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+task_id   | task ID     | str
+completed | include completed tasks? | `False`
+
+##### *example usage*
+
+```python
+# What tasks are running?
+tasks = get_active_tasks()
+for task in tasks:
+    print("{} has state {}".format(task['id'], task['state']))
+```
+
+### task_completed()
+
+Check whether a task has completed.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+task_id   | task ID     | str
+
+##### *example usage*
+
+```python
+# Wait for task 'driver-20160517222552-0072' to complete
+while not task_completed('driver-20160517222552-0072'):
+    print('Task not complete; sleeping...')
+    time.sleep(5)
+```
+
+### wait_for_task()
+
+Wait for a task to be reported running by Mesos.  Returns the elapsed time of wait.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+service   | framework service name    | str
+task      | task name | str
+timeout_sec | timeout | int | `120`
+
+
+##### *example usage*
+
+```python
+wait_for_task('marathon', 'marathon-user')
+```
+
+### wait_for_task_property()
+
+Wait for a task to be report having a specific property.   Returns the elapsed time of wait.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+service   | framework service name    | str
+task      | task name | str
+prop      | property name | str
+timeout_sec | timeout | int | `120`
+
+
+##### *example usage*
+
+```python
+wait_for_task_property('marathon', 'chronos', 'resources')
+```
+
+### wait_for_task_property_value()
+
+Wait for a task to be reported having a property with a specific value.  Returns the elapsed time of wait.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+service   | framework service name    | str
+task      | task name | str
+prop      | property name | str
+value      | value of property | str
+timeout_sec | timeout | int | `120`
+
+
+##### *example usage*
+
+```python
+wait_for_task_property_value('marathon', 'marathon-user', 'state', 'TASK_RUNNING')
+```
+
+### wait_for_dns()
+
+Wait for a task dns.  Returns the elapsed time of wait.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+name      | dns name    | str
+timeout_sec | timeout | int | `120`
+
+##### *example usage*
+
+```python
+wait_for_dns('marathon-user.marathon.mesos')
+```
+
+### delete_zk_node()
+
+Delete a named ZooKeeper node.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+node_name | the name of the node | str
+
+##### *example usage*
+
+```python
+# Delete a 'universe/marathon-user' ZooKeeper node
+delete_zk_node('universe/marathon-user')
+```
+
+### get_zk_node_data()
+
+Get data for a Zookeeper node.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+node_name | the name of the node | str
+
+##### *example usage*
+
+```python
+# Get data for a 'universe/marathon-user' ZooKeeper node
+get_zk_node_data('universe/marathon-user')
+```
+
+### get_zk_node_children()
+
+Get child nodes for a Zookeeper node.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+node_name | the name of the node | str
+
+##### *example usage*
+
+```python
+# Get children for a 'universe/marathon-user' ZooKeeper node
+get_zk_node_children('universe/marathon-user')
+```
+
+### deployment_wait()
+
+Waits for Marathon Deployment to complete or times out.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+timeout | max time to wait for deployment | int | 120
+app_id | wait for deployments on this app | string | None
+
+##### *example usage*
+
+```python
+# assuming a client.add_app() or similar
+deployment_wait()
+```
+
+### delete_all_apps()
+
+Deletes all apps running on Marathon.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+delete_all_apps()
+```
+
+### delete_all_apps_wait()
+
+Deletes all apps running on Marathon and waits for deployment to finish.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+delete_all_apps_wait()
+```
+
+
+### is_app_healthy
+
+Returns True if the given app is healthy.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+app_id | marathon app ID | String |
+
+##### *example usage*
+
+```python
+is_app_healthy(app_id)
+```
+
+
+### marathon_leader_ip
+
+Returns the IP address of the marathon leader.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+ip = marathon_leader_ip()
+```
+
+
+### marathon_version
+
+Returns the distutils.version.LooseVersion version of marathon.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+@pytest.mark.skipif('marathon_version() < LooseVersion("1.4")')
+def test_requires_marathon_1_4():
+```
+
+
+### marthon_version_less_than
+
+Returns True if the marathon version is less than the version specified, otherwise
+returns False.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+version | version str "1.4" | String |
+
+##### *example usage*
+
+```python
+@pytest.mark.skipif('marthon_version_less_than("1.4")')
+def test_requires_marathon_1_4():
+```
+
+
+### mom_version
+
+Returns the distutils.version.LooseVersion version of marathon on marathon.  None if not present.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+@pytest.mark.skipif('mom_version() < LooseVersion("1.4")')
+def test_requires_mom_1_4():
+```
+
+
+### mom_version_less_than
+
+Returns True if the marathon on marathon version is less than the version specified, otherwise
+returns False.  Returns False if MoM not present.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+version | version str "1.4" | String |
+
+##### *example usage*
+
+```python
+@pytest.mark.skipif('mom_version_less_than("1.4")')
+def test_requires_mom_1_4():
+```
+
+
+### marathon_on_marathon
+
+Sets the context of the dcos config such that calls to Marathon are against the
+Marathon on Marathon.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+name | name of the MoM service | String | marathon-user
+
+##### *example usage*
+
+```python
+  with marathon_on_marathon():
+    client = marathon.create_client()
+    # this the client is connected to MoM
+    about = client.get_about()
+```
+
+
+### marathon_1_3
+
+Preconfigured annotation which requires marathon 1.3+
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# skips test if marathon 1.2 otherwise runs
+@marathon_1_3
+def test_requires_marathon_1_3():
+```
+
+
+### marathon_1_4
+
+Preconfigured annotation which requires marathon 1.4+
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# skips test if marathon 1.3 otherwise runs
+@marathon_1_4
+def test_requires_marathon_1_4():
+```
+
+
+### marathon_1_5
+
+Preconfigured annotation which requires marathon 1.5+
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# skips test if marathon 1.4 otherwise runs
+@marathon_1_5
+def test_requires_marathon_1_5():
+```
+
+
+### partition_master()
+
+Separates the master from the cluster by disabling inbound and/or outbound traffic.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+incoming | disable incoming traffic? | bool | `True`
+outgoing | disable outgoing traffic? | bool | `True`
+
+##### *example usage*
+
+```python
+# Disable incoming traffic ONLY to the DC/OS master.
+partition_master(True, False)
+```
+
+
+### reconnect_master()
+
+Reconnect a previously partitioned master to the network
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+# Reconnect the master.
+reconnect_master()
+```
+
+### add_user()
+
+Adds user to the DCOS Enterprise.  If not description is provided the uid will
+be used for the description.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**uid** | user id | str
+**password** | password | str
+desc | description for user | str | None
+
+##### *example usage*
+
+```python
+shakedown.add_user('billy', 'billy', 'billy the admin kid')
+```
+
+
+### get_user()
+
+Returns a user from DCOS Enterprise.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**uid** | user id | str
+
+##### *example usage*
+
+```python
+shakedown.get_user('billy')
+```
+
+
+### remove_user()
+
+Removes a user from DCOS Enterprise.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**uid** | user id | str
+
+##### *example usage*
+
+```python
+shakedown.remove_user('billy')
+```
+
+
+### ensure_resource()
+
+Adds resource if not currently in the system.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**rid** | resource id | str
+
+##### *example usage*
+
+```python
+shakedown.ensure_resource('dcos:service:marathon:marathon:services:/example-secure')
+```
+
+
+### set_user_permission()
+
+Assigns access rights to user by uid for a resource by rid
+rid, uid, action='full'
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**rid** | resource id | str
+**uid** | user id | str
+action | access right: read, write, update, delete or full | str | 'full'
+
+##### *example usage*
+
+```python
+# provides full access for billy to resource
+shakedown.set_user_permission('dcos:service:marathon:marathon:services:/example-secure', 'billy')
+```
+
+
+### remove_user_permission()
+
+Removes user permissions for a resource.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**rid** | resource id | str
+**uid** | user id | str
+action | access right: read, write, update, delete or full | str | 'full'
+
+##### *example usage*
+
+```python
+#  removes full access to resource for billy
+shakedown.remove_user_permission('dcos:service:marathon:marathon:services:/example-secure', 'billy')
+```
+
+
+### add_group()
+
+Adds a group to DCOS Enterprise
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**id** | group id | str
+description | description of group | str | None
+
+
+##### *example usage*
+
+```python
+shakedown.add_group('test-group')
+```
+
+
+### get_group()
+
+Returns a group from DCOS Enterprise
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**id** | group id | str
+
+
+##### *example usage*
+
+```python
+shakedown.get_group('test-group')
+```
+
+
+### remove_group()
+
+Removes a group from DCOS Enterprise
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**id** | group id | str
+
+
+##### *example usage*
+
+```python
+#  removes group
+shakedown.remove_group('test-group')
+```
+
+
+### add_user_to_group()
+
+Adds user to group
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**uid** | user id | str
+**gid** | group id | str
+exist_ok | True results in no error if user already belongs to group | bool | True
+
+##### *example usage*
+
+```python
+shakedown.add_user_to_group('billy', 'test-group')
+```
+
+
+### remove_user_from_group()
+
+Removes user from group
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**uid** | user id | str
+**gid** | group id | str
+
+##### *example usage*
+
+```python
+shakedown.remove_user_from_group('billy', 'test-group')
+```
+
+
+### credentials()
+
+Context for credentials such that super user is returned after test
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+@pytest.mark.usefixtures('credentials')
+def test_monkey_with_users():
+```
+
+
+### no_user()
+
+Context with no logged in user.   Return to super user after context.
+
+##### *parameters*
+
+None.
+
+##### *example usage*
+
+```python
+with shakedown.no_user():
+  # do some action requiring no user auth
+```
+
+
+### new_dcos_user()
+
+Context with a newly created and logged in user.   Return to super user after context.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**username** | the username used for DC/OS authentication | str
+**password** | the password used for DC/OS authentication | str
+
+##### *example usage*
+
+```python
+with shakedown.new_dcos_user('kenny', 'kenny'):
+  # do some action for this user
+```
+
+
+### dcos_user()
+
+Context with an existing user logged in.  Return to super user after context.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**username** | the username used for DC/OS authentication | str
+**password** | the password used for DC/OS authentication | str
+
+##### *example usage*
+
+```python
+with shakedown.dcos_user('kenny', 'kenny'):
+  # do some action for this user
+```
+
+
+### get_agents()
+
+Retrieve a list of all agent node IP addresses.
+
+##### *parameters*
+
+None
+
+##### *example usage*
+
+```python
+# What do I look like in IP space?
+nodes = get_agents()
+print("Node IP addresses: " + nodes)
+```
+
+### get_private_agents()
+
+Retrieve a list of all private agent node IP addresses.
+
+##### *parameters*
+
+None
+
+##### *example usage*
+
+```python
+# What do I look like in IP space?
+private_nodes = get_private_agents()
+print("Private IP addresses: " + private_nodes)
+```
+
+
+### get_public_agents()
+
+Retrieve a list of all public agent node IP addresses.
+
+##### *parameters*
+
+None
+
+##### *example usage*
+
+```python
+# What do I look like in IP space?
+public_nodes = get_public_agents()
+print("Public IP addresses: " + public_nodes)
+```
+
+### partition_agent()
+
+Separates the agent from the cluster by adjusting IPTables with the following:
+
+```
+sudo iptables -F INPUT
+sudo iptables -I INPUT -p tcp --dport 22 -j ACCEPT
+sudo iptables -I INPUT -p icmp -j ACCEPT
+sudo iptables -I OUTPUT -p tcp --sport 5051  -j REJECT
+sudo iptables -A INPUT -j REJECT
+```
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+##### *example usage*
+
+```python
+# Partition all the public nodes
+public_nodes = get_public_agents()
+for public_node in public_nodes:
+    partition_agent(public_node)
+```
+
+### reconnect_agent()
+
+Reconnects a previously partitioned agent by reversing the IPTable changes.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+##### *example usage*
+
+```python
+# Reconnect the public agents
+for public_node in public_nodes:
+    reconnect_agent(public_node)
+```
+
+### restart_agent()
+
+Restarts an agent process at the host.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+##### *example usage*
+
+```python
+# Reconnect the public agents
+for public_node in public_nodes:
+    restart_agent(public_node)
+```
+
+### stop_agent()
+
+Stops an agent process at the host.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+##### *example usage*
+
+```python
+# Reconnect the public agents
+for public_node in public_nodes:
+    stop_agent(public_node)
+```
+
+### start_agent()
+
+Start an agent process at the host.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+##### *example usage*
+
+```python
+# Reconnect the public agents
+for public_node in public_nodes:
+    start_agent(public_node)
+```
+
+### delete_agent_log()
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+##### *example usage*
+
+```python
+# Delete agent logs on the public agents
+for public_node in public_nodes:
+    delete_agent_log(public_node)
+```
+
+
+### kill_process_on_host()
+
+Kill the process(es) matching pattern at ip.  This will potentially kill infrastructure processes.
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+pattern  | A regular expression matching the name of the process to
+kill | str
+
+##### *example usage*
+
+```python
+# kill java on the public agents
+for public_node in public_nodes:
+    kill_process_on_host(public_node, "java")
+```
+
+
+### kill_process_from_pid_file_on_host()
+
+Kill the process found in pid file on the host.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+pid_file | name of file holding the PID on master | str | python_http.pid
+
+
+##### *example usage*
+
+```python
+# starts http service on master at port 7777
+pid_file = start_master_http_service()
+
+# kill http service
+kill_process_from_pid_file_on_host(shakedown.master_ip(), pid_file)
+```
+
+
+### disconnected_agent()
+
+Managed context which will disconnect an agent for the duration of the context then restore the agent
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+##### *example usage*
+
+```python
+# disconnects agent
+with disconnected_agent(host):
+        service_delay()
+
+# agent is reconnected
+wait_for_service_url(PACKAGE_APP_ID)
+```
+
+
+### required_private_agents()
+
+Function which returns True if the number of required agents is NOT present, otherwise
+returns False.  The purpose of this function is to be used to determine if a test
+would be skipped or not.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+count | required number of agents | int
+
+##### *example usage*
+
+```python
+# if the DC/OS cluster has less than 2 private agents it will be skipped
+# it will run with 2 or more agents.
+@pytest.mark.skipif('required_private_agents(2)')
+def test_fancy_multi_agent_check():
+```
+
+
+### required_public_agents()
+
+Function which returns True if the number of required agents is NOT present, otherwise
+returns False.  The purpose of this function is to be used to determine if a test
+would be skipped or not.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+count | required number of agents | int
+
+##### *example usage*
+
+```python
+# if the DC/OS cluster has less than 2 public agents it will be skipped
+# it will run with 2 or more agents.
+@pytest.mark.skipif('required_public_agents(2)')
+def test_fancy_multi_agent_check():
+
+```
+
+
+### private_agents
+
+Annotation decorator factory.  It requires the import of required_private_agents
+in order to function.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+count | required number of private agents | int | 1
+
+
+##### *example usage*
+
+```python
+# if the DC/OS cluster has less than 1 private agents it will be skipped
+@private_agents(1)
+def test_fancy_multi_agent_check():
+```
+
+
+### public_agents
+
+Annotation decorator factory.  It requires the import of required_public_agents
+in order to function.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+count | required number of public agents | int | 1
+
+
+##### *example usage*
+
+```python
+# if the DC/OS cluster has less than 1 public agents it will be skipped
+@public_agents(1)
+def test_fancy_multi_agent_check():
+```
+
+
+### disconnected_master()
+
+Managed context which will disconnect the master for the duration of the context then restore the master
+##### *parameters*
+
+None
+
+##### *example usage*
+
+```python
+# disconnects agent
+with disconnected_master(host):
+        service_delay()
+
+# master is reconnected
+wait_for_service_url(PACKAGE_APP_ID)
+```
+
+
+### wait_for_mesos_endpoint()
+
+Checks the mesos url returns HTTP 200 within a timeout if available it returns true on expiration it returns false.
+
+##### *parameters*
+
+None
+
+##### *example usage*
+
+```python
+# disconnect master
+restart_master_node()
+
+# master is reconnected
+wait_for_mesos_endpoint()
+```
+
+### get_all_masters()
+
+Provides a list of all masters in the cluster
+
+##### *parameters*
+
+None
+
+##### *example usage*
+
+```python
+for master in get_all_masters():
+  # do master like things
+```
+
+
+### master_leader_ip()
+
+Provides the IP of the master leader.  This is the internal IP of leader.
+
+##### *parameters*
+
+None
+
+##### *example usage*
+
+```python
+ip = master_leader_ip()
+```
+
+
+### get_all_master_ips()
+
+Provides a list of all the IP address for the masters
+
+##### *parameters*
+
+None
+
+##### *example usage*
+
+```python
+for ip in get_all_master_ips():
+```
+
+### start_master_http_service()
+
+Starts a http service on the master leader.  The main purpose is to serve up artifacts for launched test applications.   This is commonly used in combination with copying tests or artifacts to the leader
+than configuring the messos task to fetch from http://master.mesos:7777/artifact.tar
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+port | the port to use for http | int | 7777
+pid_file | the file to save the pid to | str | python_http.pid
+
+##### *example usage*
+
+```python
+# starts http service on master at port 7777
+start_master_http_service()
+```
+
+### master_http_service()
+
+Managed context which will start the http service and will kill the process when the
+context is over.  It calls `start_master_http_service` before context and
+`kill_process_from_pid_file_on_master` at the end of the context.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+port | the port to use for http | int | 7777
+
+
+##### *example usage*
+
+```python
+copy_file_to_master('foo.tar')
+# create http service
+with master_http_service():
+    # create an app that fetches from http://master.mesos:7777/foo.tar
+    # verify task
+# http is gone
+```
+
+
+### iptable_rules()
+
+Managed context which will save the firewall rules then restore them at the end of the context for the host.
+It calls `save_iptables` before the context and `restore_iptables` and the end of the context.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+
+##### *example usage*
+
+```python
+# disconnects agent
+with iptable_rules(shakedown.master_ip()):
+    block_port(host, port)
+    time.sleep(7)
+
+# firewalls restored
+wait_for_service_url(PACKAGE_APP_ID)
+```
+
+### restore_iptables()
+
+Reverses and restores saved iptable rules.  It works with `save_iptables`.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+
+##### *example usage*
+
+```python
+# disconnects agent
+restore_iptables(host)
+```
+
+### save_iptables()
+
+Saves the current iptables to a file on the host.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+
+##### *example usage*
+
+```python
+# disconnects agent
+save_iptables(host)
+```
+
+
+### flush_all_rules()
+
+Flushes the iptables rules for the host.  `sudo iptables -F INPUT`.   Consider using `save_iptables` prior to use.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+
+##### *example usage*
+
+```python
+# disconnects agent
+flush_all_rules(host)
+```
+
+### allow_all_traffic()
+
+Removes iptable rules allow full access.  Consider using `save_iptables` prior to using.
+sudo iptables --policy INPUT ACCEPT && sudo iptables --policy OUTPUT ACCEPT && sudo iptables --policy FORWARD ACCEPT'
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+hostname | the hostname or IP of the node | str
+
+
+##### *example usage*
+
+```python
+# disconnects agent
+allow_all_traffic(host)
+```

--- a/tests/shakedown/CHANGELOG.md
+++ b/tests/shakedown/CHANGELOG.md
@@ -1,0 +1,466 @@
+## 1.5.0 (2018-03-13)
+
+Fixes:
+
+  - improved SSH session-handling
+
+## 1.4.12 (2017-12-20)
+
+Features:
+
+  - support for DC/OS 1.11 (`@dcos_1_11` PyTest marker)
+
+Fixes:
+
+  - don't flake if a connection error occurs during an install
+
+## 1.4.11 (2017-12-08)
+
+Features:
+
+  - new function to retrieve available versions of packages
+    - `get_package_versions()`
+  - bumped `dcoscli` version to `0.5.7`
+
+Fixes:
+
+  - handle `skip` state when printing output
+
+## 1.4.10 (2017-12-06)
+
+Features:
+
+  - new leader-based run functions
+    - `run_command_on_leader()`
+    - `run_command_on_marathon_leader()`
+  - log the resulting package version when installing from `latest`
+
+## 1.4.9 (2017-10-18)
+
+Features:
+
+  - added API functions to query for Docker version
+    - `docker_version()`
+    - `docker_client_version()`
+    - `docker_server_version()`
+  - added classifiers to the setup to specify the programming langauge to
+    be used with pipenv
+
+Fixes:
+
+  - removed staticly-set assertions in `test_get_reserved_resources()`
+
+## 1.4.8 (2017-09-14)
+
+Features:
+
+  - all CLI options now have the option to be specified as environmental
+    variables, eg. `SHAKEDOWN_DCOS_URL`, `SHAKDOWN_USER`, etc.
+
+Fixes:
+
+  - CLI subcommand (non-app) packages now treated the same as app/service
+    packages
+    - `install_package()` and `uninstall_package()` won't throw exceptions
+    - `package_installed()` returns `True` for non-app packages
+
+## 1.4.7 (2017-09-01)
+
+Features:
+
+  - bumped `dcoscli` version to `0.5.5`
+
+## 1.4.6 (2017-08-23)
+
+Features:
+
+  - bumped `dcoscli` version to `0.5.4`
+  - better attach error handling
+  - move from pip to pip3
+
+## 1.4.5 (2017-07-13)
+
+Features:
+
+  - bumped `dcoscli` version to `0.5.3`
+
+## 1.4.4 (2017-06-19)
+
+Fixes:
+
+  - use `timeout_sec` in `install_package()`
+  - return service name in `_get_service_name()`
+  - `wait_for()` should use `>=`, not `>`
+
+## 1.4.3 (2017-06-05)
+
+Fixes:
+
+  - properly timeout with `time_wait()` in `wait_for_task_completion()`
+  - `time_wait` was not being imported in `dcos/master.py`
+  - use `get_tasks()` in `task_completed()`
+
+## 1.4.2 (2017-05-09)
+
+Features:
+
+  - new methods for deploying Docker credentials
+    - `create_docker_credentials_file()`
+    - `distribute_docker_credentials_to_private_agents()`
+    - `prefetch_docker_image_on_private_agents()`
+  - added ability to query reservations
+    - `get_resources_by_role()`
+
+Fixes:
+
+  - removed redundant filter in `get_task()`
+
+## 1.4.1 (2017-04-26)
+
+Fixes:
+
+  - fix partitioning bug (QUALITY-1432), use new network APIs rather than
+    SSH-based command execution
+
+## 1.4.0 (2017-04-25)
+
+Features:
+
+  - new security methods:
+    - `ensure_resource()`
+    - `add_user()`, `get_user()`, `remove_user()`
+    - `set_user_permission()`
+    - `add_group()`, `get_group()`, and `remove_group()`
+    - `add_user_to_group()`, `remove_user_from_group()`
+  - new security contexts:
+    - `credentials()`
+    - `no_user()`
+    - `new_dcos_user()`
+    - `dcos_user()`
+  - `wait_while_exceptions()` spinner
+  - new contexts available for Marathon-on-Marathon (MoM) deployments
+    - `mom_version()`
+    - `mom_version_less_than()`
+    - `marathon_on_marathon()`
+
+Fixes:
+
+  - Shakedown now functions without authentication options on clusters not
+    requiring authentication
+
+## 1.3.4 (2017-04-20)
+
+Features:
+
+  - `wait_for` waits for service endpoints to be debounced
+    successfully in a specified number of masters in multi-master
+    setups
+  - new PyTest decorators methods for determining Shakedown versions
+    - `shakedown_canonical_version()`
+    - `shakedown_version_less_than()`
+  - new methods for determining leaders in multi-master setups
+    - `marathon_leader_ip()`
+    - `master_leader_ip()`
+
+Fixes:
+
+  - fixed lack zookeeper-related methods failing in methods running
+    commands on masters
+  - fixup for `kill_process_from_pid_file_on_host()` which only killed
+    processes on master
+
+## 1.3.3 (2017-04-13)
+
+Features:
+
+  - ability to start a HTTP server running on the master via
+    `start_master_http_service()` method, along with an associated
+    `master_http_service()` context
+  - new methods for killing processes based on pidfiles
+    - `kill_process_from_pid_file_on_host()`
+    - `kill_process_from_pid_file_on_master()`
+
+## 1.3.2 (2017-04-05)
+
+Fixes:
+
+  - include `partition_cmd` file in package distribution
+  - fixup for `test_install_package_with_subcommand` test
+  - corrected `dcos_agents_state()` example usage docs
+  - `wait_for` now aborts when encountering exception chains
+
+## 1.3.1 (2017-03-09)
+
+Fixes:
+
+  - `@private_agents()` and `@public_agents()` bug in `1.3.0`
+
+## 1.3.0 (2017-03-09)
+
+Features:
+
+  - `--stdout-inline` now passes the `--capture=none` (`-s`) flag to
+    PyTest, enabling streaming inline test output
+  - `@private_agents()` and `@public_agents()` PyTest decorators to
+    replace old explicitly-named (eg. `@private_agent_2`) decorators
+  - `wait_for_mesos_endpoint()` method waits for a specific endpoint
+    to return `HTTP 200`
+  - new ZooKeeper method `get_zk_node_children()`
+  - new master methods `get_all_masters()` and `get_all_master_ips()`
+    for clusters deployed with multiple master nodes
+
+Fixes:
+
+  - updated `test_dcos_command` test to work on new release of CoreOS
+
+## 1.2.2 (2017-03-01)
+
+Features:
+
+  - stringified `wait_for` predicate info for better debugging and
+    understanding of which predicate and which values
+
+Fixes:
+
+  - trailing slash added for `/service/{}/` calls
+  - turn off noisy option in `wait_for`
+  - documented how to use `DCOS_CONFIG_ENV` for parallel execution
+  - `wait_for` log previously ignored exception during waiting when noisy
+    enabled
+
+## 1.2.1 (2017-02-24)
+
+Features:
+
+  - DC/OS Enterprise Edition version-checking
+    - `ee_version()` method, `@strict`, `@permissive`, and `@disabled`
+      PyTest security mode markers
+  - bumped `dcoscli` version to `0.4.16`
+
+## 1.2.0 (2017-02-17)
+
+Features:
+
+  - ability to skip tests based on required resources, DC/OS versioning
+    - eg. `@pytest.mark.skipif('required_cpus(2)')` and `@dcos_1_9`
+  - support for deleting leftover data following persistent service
+    uninstall (ie.a `janitor.py` shim)
+      - `delete_persistent_data()`
+      - `destroy_volume()` / `destroy_volumes()`
+      - `unreserve_resources()` / `unreserve_resources()`
+  - command methods now allow disabling output and/or raising on error
+  - marathon methods add `delete_app`/`delete_app_wait` for a specific app
+  - package install methods support waiting for service tasks to start
+    running, additional logging
+  - package uninstall methods add support for deleting persistent volumes
+    after uninstall
+  - packge repo methods support waiting for add/remove repo to complete,
+    check for a changed package version
+  - service method function for deleting persistent volumes
+  - service method support waiting for task rollout to complete
+  - service method verifying that tasks are not changed
+
+Fixes:
+
+  - marathon methods fix unused `app_id` when checking deployment
+  - `hello-world` package (previously `riak`) now used to test
+    `test_install_package_with_subcommand()`
+  - spinner-related fixes:
+    - while a spinner is polling, print the spin time and any
+      ignored exceptions by default
+    - don't drop the original stack when rethrowing exceptions
+    - return the result of the spin at the end of `wait_for`,
+      allowing passthrough of the predicate return value
+
+## 1.1.15 (2017-02-03)
+
+Features:
+
+  - split `requirements.txt` and `requirements-edge.txt` for
+    building against `dcoscli:master`
+
+Fixes:
+
+  - `_wait()` functions now wait on deployment, not health
+  - uninstalls now wait for Mesos task removal
+  - tests fixed for package installation and waiting
+  - improved error messaging when unable to connect to a host
+
+## 1.1.14 (2017-01-13)
+
+Features:
+
+  - new cluster functions `get_resources`, `resources_needed`,
+    `get_used_resources`, `get_unreserved_resources`,
+    `get_reserved_resources`, and `available_resources`
+
+## 1.1.13 (2017-01-05)
+
+Features:
+
+  - bumped `dcoscli` version to `0.4.15`
+
+Fixes:
+
+  - `timeout_sec` passed through to `time_wait()` method
+
+## 1.1.12 (2016-12-27)
+
+Features:
+
+  - SSH user (default `core`) can be specified on the command line
+    with `--ssh-user`
+  - new ZooKeeper `get_zk_node_data` function`
+
+Fixes:
+
+  - `test_install_package_with_json_options` test is set to `xfail`
+    while it is being diagnosed
+
+## 1.1.11 (2016-12-13)
+
+Features:
+
+  - test timeouts as defined by `--timeout` (or `timeout` in
+    `.shakedown` config) or `@pytest.mark.timeout(n)` for
+    individual tests
+
+Fixes:
+
+  - exit code is now returned for `run_dcos_command` calls
+  - fallbaack to `ssh-agent` if `.ssh/id_rsa` key fails
+  - `wait` predicate fixed from `1.1.9`
+  - use `service_name` rather than former ambiguous `app_id`
+
+## 1.1.10 (2016-11-08)
+
+Fixes:
+
+  - fixing broken PyPI 1.1.9 release
+
+## 1.1.9 (2016-11-08)
+
+Features:
+
+  - 'wait' functions and predicates, including `wait_for_task`,
+    `wait_for_task_property`, `wait_for_dns`, and `deployment_wait`
+  - new marathon methods for `deployment_wait`, `delete_all_apps`,
+    and `delete_all_apps_wait`
+  - support for passing a dict object containing JSON options to
+    `install_package` methods
+  - bumped `dcoscli` version to `0.4.14`
+
+Fixes:
+
+  - pep8-compliance
+
+## 1.1.8 (2016-11-01)
+
+Features:
+
+  - `--dcos-url` now defaults to pre-configured dcos-cli value
+  - `dcos_dns_lookup` method for resolving Mesos-DNS queries
+  - reworked network paritioning methods, including new utility
+    methods for `disconnected_agent`, `disconnected_master`,
+    `save_iptables`, `flush_all_rules`, `allow_all_traffic`, and
+    `iptable_rules`
+  - added `tox.ini` configuration file
+
+Fixes:
+
+  - fixed documentation for `get_private_agents()`
+
+## 1.1.7 (2016-10-20)
+
+Features:
+
+  - `--fail` now defaults to `never`
+  - the `run_command` and associated agent/master methods now return
+    both the exit status and captured output
+
+Fixes:
+
+  - `kill_process_on_host` method now working, better output
+  - improved `--stdout-inline` readability
+  - fixed bug where output from teardown methods did not display if
+    module only had a single test
+
+## 1.1.6 (2016-10-14)
+
+Features:
+
+  - `--username`, `--password`, and `--oauth-token` can now be
+    specified via the command line
+  - updated documentation on installing via PyPI or with virtualenv
+
+Fixes:
+
+  - authentication methods (OAuth, user/pass) are only attempted
+    when the related options are defined
+  - removed `pytest_runtest_makereport` method which was unused and
+    causing pytest warning messages on every run
+
+## 1.1.5 (2016-10-12)
+
+Fixes:
+
+  - cluster authentication attempts are sequenced (existing ACS token ->
+    OAuth token -> username/password combo)
+  - output from module setup and teardown is now printed to stdout
+  - multiple test files (or multiple tests) can be again be specified
+    (broken in `1.1.4`)
+
+
+## 1.1.4 (2016-10-07)
+
+Features:
+
+  - allow a session to be authenticated using a supplied OAuth token
+    in `.shakedown` (`oauth_token = <token>`)
+  - new `delete_agent_log` method to delete logs on agents
+  - pytest-style single-test specification (`test_file.py::test_name`)
+
+Fixes:
+
+  - `dcos-shakedown` command now functions correctly from cmd
+
+
+## 1.1.3 (2016-10-04)
+
+Features:
+
+  - bumped `dcoscli` version to `0.4.13`
+  - modified CLI 'short' flags to match SSH/curl
+
+Fixes:
+
+  - removed superfluous `key not found` error message when SSH
+    key could not be located
+
+
+## 1.1.2 (2016-09-21)
+
+Features:
+
+  - new `--pytest-option` flag to pass CLI options on to pytest
+  - short (single-character) flags for commonly-used CLI options
+
+Fixes:
+
+  - improved `--help` CLI output
+
+
+## 1.1.1 (2016-09-20)
+
+Initial implementation of changelog.
+
+Features:
+
+  - new `partition_master` and `reconnect_master` methods
+
+Fixes:
+
+  - added missing API documentation for `authenticate` method
+  - updated PyPI packaging name to `dcos-shakedown`
+  - renamed `task_name` to `task_id` in task methods
+  - check the exit code of the command in `run_command` method`

--- a/tests/shakedown/CONTRIBUTING.md
+++ b/tests/shakedown/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Shakedown
+Third-party patches are essential for keeping Shakedown great. We want to keep
+it as easy as possible to contribute changes that allow Shakedown to work for
+your needs and in your environment. In order to have a chance of keeping up with
+community contributions, and to ensure a consistent experience for everyone
+involved, we have a few guidelines that we need contributors to follow.
+
+## Submitting Changes to Shakedown
+  * A [GitHub pull request][github-pr] is the preferred way of submitting
+  patches.
+  * Any changes in the public API or behavior must be reflected in the project
+  documentation.
+  * Pull requests should include appropriate additions to the test suite (if
+  applicable).
+  * If the change is a bugfix then the added tests must fail without the patch
+  applied, as a safeguard against future regressions.
+
+## Style Guidelines
+Before submitting your pull request, please consider:
+  * Checking for unnecessary whitespace: this can be accomplished by running
+  the command `git diff --check`. All tabs should be expanded to spaces; hard
+  tabs are not allowed.
+  * Please keep line length to around 79-80 characters. We understand that this
+  isn't always practical; just use your best judgement.
+  * Include comments and documentation where appropriate.
+  * Any changes should follow the guidelines set forth in [PEP-8][pep-8].
+  * Please, no additional copyright statements or licenses in source files.
+
+Additionally, we would prefer the following format for commit messages:
+
+```
+A brief summary, no more than 50 characters
+
+Prior to this patch, there wasn't an example of a commit message in the
+contributing documentation. This had the side effect of the user having
+no idea what an acceptable commit message might look like.
+
+This commit fixes the problem by introducing a real-world example to
+the contributing documentation.
+```
+
+[github-pr]: https://help.github.com/articles/using-pull-requests
+[pep-8]: https://www.python.org/dev/peps/pep-0008/

--- a/tests/shakedown/LICENSE
+++ b/tests/shakedown/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/tests/shakedown/MANIFEST.in
+++ b/tests/shakedown/MANIFEST.in
@@ -1,0 +1,1 @@
+include shakedown/dcos/partition_cmd

--- a/tests/shakedown/README.md
+++ b/tests/shakedown/README.md
@@ -1,0 +1,94 @@
+# Shakedown [![Build Status](http://jenkins.mesosphere.com/service/jenkins/buildStatus/icon?job=public-shakedown-master)](http://jenkins.mesosphere.com/service/jenkins/job/public-shakedown-master/)
+
+DC/OS test harness.
+
+
+## Overview
+
+*A shakedown is a period of testing or a trial journey undergone by a ship, aircraft or other craft and its crew before being declared operational.
+    — https://en.wikipedia.org/wiki/Shakedown_(testing)*
+
+
+## Installation
+
+Shakedown requires Python 3.4+.
+
+### Installing from PyPI
+
+The recommended Shakedown installation method is via the PyPI Python Package Index repository at [https://pypi.python.org/pypi/dcos-shakedown](https://pypi.python.org/pypi/dcos-shakedown).  To install the latest version and all required modules:
+
+`pip3 install dcos-shakedown`
+
+dcos-shakedown has a number of dependencies which need to be available.  One of those dependencies, the cryptography module requires a number of OS level libraries in order to install correctly which include: `build-essential libssl-dev libffi-dev python-dev`.  For environments other than linux please read [Stackoverflow](http://stackoverflow.com/questions/22073516/failed-to-install-python-cryptography-package-with-pip-and-setup-py). On a new ubuntu environment the following should install dcos-shakedown.
+
+* `apt-get update`
+* `apt-get install python3 python3-pip build-essential libssl-dev libffi-dev python-dev`
+* `pip3 install dcos-shakedown`
+
+### Development and bleeding edge
+
+To pull and install from our `master` branch on GitHub:
+
+```
+git clone https://github.com/dcos/shakedown.git
+cd shakedown
+pip3 install -r requirements.txt && pip3 install -e .
+```
+
+Or if you do not wish to pin to a version of `dcos-cli`:
+
+```
+pip3 install -r requirements-edge.txt && pip3 install -e .
+```
+
+### Setting up a new Shakedown virtual environment
+
+If you'd like to isolate your Shakedown Python environment, you can do so using the [virtualenv](https://pypi.python.org/pypi/virtualenv) tool.  To create a new virtual environment in `$HOME/shakedown`:
+
+```
+pip3 install virtualenv
+virtualenv $HOME/shakedown
+source $HOME/shakedown/bin/activate
+pip3 install dcos-shakedown
+```
+
+This virtual environment can then be activated in new terminal sessions with:
+
+`source $HOME/shakedown/bin/activate`
+
+
+## Usage
+
+`shakedown --dcos-url=http://dcos.example.com [options] [path_to_tests]`
+
+- `--dcos-url` is required.
+- tests within the current working directory will be auto-discovered unless specified.
+- arguments can be stored in a `~/.shakedown` [TOML](https://github.com/toml-lang/toml) file (command-line takes precedence)
+- `shakedown --help` is your friend.
+
+
+### Running in parallel
+
+Shakedown can be run against multiple DC/OS clusters in parallel by setting the `DCOS_CONFIG_ENV` environmental variable to a unique file, eg:
+
+`DCOS_CONFIG_ENV='shakedown-custom-01.toml' shakedown --dcos-url=http://dcos.example.com [options] [path_to_tests]`
+
+
+## Helper methods
+
+Shakedown is a testing tool as well as a library.  Many helper functions are available via `from shakedown import *` in your tests.  See the [API documentation](API.md) for more information.
+
+
+## License
+
+Shakedown is licensed under the Apache License, Version 2.0.  For additional information, see the [LICENSE](LICENSE) file included at the root of this repository.
+
+
+## Reporting issues
+
+Please report issues and submit feature requests for Shakedown by [creating an issue in the DC/OS JIRA with the "Shakedown" component](https://jira.mesosphere.com/secure/CreateIssueDetails!init.jspa?pid=14105&components=19807&issuetype=3) (JIRA account required).
+
+
+## Contributing
+
+See the [CONTRIBUTING](CONTRIBUTING.md) file in the root of this repository.

--- a/tests/shakedown/requirements-edge.txt
+++ b/tests/shakedown/requirements-edge.txt
@@ -1,0 +1,6 @@
+click
+dcoscli
+paramiko
+pytest
+pytest-timeout
+scp

--- a/tests/shakedown/requirements.txt
+++ b/tests/shakedown/requirements.txt
@@ -1,0 +1,7 @@
+click
+dcoscli==0.5.7
+paramiko
+pytest
+pytest-timeout
+retrying
+scp

--- a/tests/shakedown/setup.cfg
+++ b/tests/shakedown/setup.cfg
@@ -1,0 +1,5 @@
+[upload]
+dry-run = 1
+
+[metadata]
+description-file = README.md

--- a/tests/shakedown/setup.py
+++ b/tests/shakedown/setup.py
@@ -1,0 +1,49 @@
+from setuptools import find_packages, setup
+
+
+setup(name='dcos-shakedown',
+      version='1.5.0',
+      description=u"DC/OS testing harness and library",
+      long_description=u"A tool and library to abstract common DC/OS-related tasks.",
+      classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 4 - Beta',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Topic :: Software Development :: User Interfaces',
+
+        'License :: OSI Approved :: Apache Software License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+      ],
+      keywords='',
+      author=u"Mesosphere QE",
+      author_email='qe-team@mesosphere.com',
+      url='https://github.com/dcos/shakedown',
+      license='Apache 2',
+      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+      include_package_data=True,
+      zip_safe=False,
+      install_requires=[
+          'click',
+          'dcoscli==0.5.7',
+          'paramiko',
+          'pytest',
+          'pytest-timeout',
+          'retrying',
+          'scp'
+      ],
+      entry_points="""
+      [console_scripts]
+      shakedown=shakedown.cli.main:cli
+      dcos-shakedown=shakedown.cli.main:cli
+      """
+      )

--- a/tests/shakedown/shakedown/__init__.py
+++ b/tests/shakedown/shakedown/__init__.py
@@ -1,0 +1,20 @@
+from shakedown.cli import *
+from shakedown.cli.helpers import *
+from shakedown.dcos import *
+from shakedown.dcos.cluster import *
+from shakedown.dcos.command import *
+from shakedown.dcos.config import *
+from shakedown.dcos.docker import *
+from shakedown.dcos.file import *
+from shakedown.dcos.marathon import *
+from shakedown.dcos.network import *
+from shakedown.dcos.package import *
+from shakedown.dcos.security import *
+from shakedown.dcos.service import *
+from shakedown.dcos.spinner import *
+from shakedown.dcos.task import *
+from shakedown.dcos.zookeeper import *
+from shakedown.dcos.agent import *
+from shakedown.dcos.master import *
+
+VERSION='1.5.0'

--- a/tests/shakedown/shakedown/cli/__init__.py
+++ b/tests/shakedown/shakedown/cli/__init__.py
@@ -1,0 +1,3 @@
+quiet = False
+ssh_key_file = '~/.ssh/id_rsa'
+ssh_user = 'core'

--- a/tests/shakedown/shakedown/cli/helpers.py
+++ b/tests/shakedown/shakedown/cli/helpers.py
@@ -1,0 +1,204 @@
+import click
+import contextlib
+import os
+import re
+import toml
+
+import shakedown
+
+
+def read_config(args):
+    """ Read configuration options from ~/.shakedown (if exists)
+
+        :param args: a dict of arguments
+        :type args: dict
+
+        :return: a dict of arguments
+        :rtype: dict
+    """
+
+    configfile = os.path.expanduser('~/.shakedown')
+
+    if os.path.isfile(configfile):
+        with open(configfile, 'r') as f:
+            config = toml.loads(f.read())
+
+        for key in config:
+            param = key.replace('-', '_')
+
+            if not param in args or args[param] in [False, None]:
+                args[param] = config[key]
+
+    return args
+
+
+def set_config_defaults(args):
+    """ Set configuration defaults
+
+        :param args: a dict of arguments
+        :type args: dict
+
+        :return: a dict of arguments
+        :rtype: dict
+    """
+
+    defaults = {
+        'fail': 'fast',
+        'stdout': 'fail'
+    }
+
+    for key in defaults:
+        if not args[key]:
+            args[key] = defaults[key]
+
+    return args
+
+
+def fchr(char):
+    """ Print a fancy character
+
+        :param char: the shorthand character key
+        :type char: str
+
+        :return: a fancy character
+        :rtype: str
+    """
+
+    return {
+        'PP': chr(10003),
+        'FF': chr(10005),
+        'SK': chr(10073),
+        '>>': chr(12299)
+    }.get(char, '')
+
+
+def banner():
+    """ Display a product banner
+
+        :return: a delightful Mesosphere logo rendered in unicode
+        :rtype: str
+    """
+
+    banner_dict = {
+        'a0': click.style(chr(9601), fg='magenta'),
+        'a1': click.style(chr(9601), fg='magenta', bold=True),
+        'b0': click.style(chr(9616), fg='magenta'),
+        'c0': click.style(chr(9626), fg='magenta'),
+        'c1': click.style(chr(9626), fg='magenta', bold=True),
+        'd0': click.style(chr(9622), fg='magenta'),
+        'd1': click.style(chr(9622), fg='magenta', bold=True),
+        'e0': click.style(chr(9623), fg='magenta'),
+        'e1': click.style(chr(9623), fg='magenta', bold=True),
+        'f0': click.style(chr(9630), fg='magenta'),
+        'f1': click.style(chr(9630), fg='magenta', bold=True),
+        'g1': click.style(chr(9612), fg='magenta', bold=True),
+        'h0': click.style(chr(9624), fg='magenta'),
+        'h1': click.style(chr(9624), fg='magenta', bold=True),
+        'i0': click.style(chr(9629), fg='magenta'),
+        'i1': click.style(chr(9629), fg='magenta', bold=True),
+        'j0': click.style(fchr('>>'), fg='magenta'),
+        'k0': click.style(chr(9473), fg='magenta'),
+        'l0': click.style('_', fg='magenta'),
+        'l1': click.style('_', fg='magenta', bold=True),
+        'v0': click.style('mesosphere', fg='magenta'),
+        'x1': click.style('shakedown', fg='magenta', bold=True),
+        'y0': click.style('v' + shakedown.VERSION, fg='magenta'),
+        'z0': chr(32)
+    }
+
+    banner_map = [
+        " %(z0)s%(z0)s%(l0)s%(l0)s%(l1)s%(l0)s%(l1)s%(l1)s%(l1)s%(l1)s%(l1)s%(l1)s%(l1)s%(l1)s",
+        " %(z0)s%(b0)s%(z0)s%(c0)s%(z0)s%(d0)s%(z0)s%(z0)s%(z0)s%(z0)s%(e1)s%(z0)s%(f1)s%(z0)s%(g1)s",
+        " %(z0)s%(b0)s%(z0)s%(z0)s%(c0)s%(z0)s%(h0)s%(e0)s%(d1)s%(i1)s%(z0)s%(f1)s%(z0)s%(z0)s%(g1)s%(z0)s%(j0)s%(v0)s %(x1)s %(y0)s",
+        " %(z0)s%(b0)s%(z0)s%(z0)s%(f0)s%(c0)s%(i0)s%(z0)s%(z0)s%(h1)s%(f1)s%(c1)s%(z0)s%(z0)s%(g1)s%(z0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(k0)s%(z0)s%(k0)s%(k0)s%(z0)s%(z0)s%(k0)s",
+        " %(z0)s%(i0)s%(f0)s%(h0)s%(z0)s%(z0)s%(c0)s%(z0)s%(z0)s%(f0)s%(z0)s%(z0)s%(i1)s%(c1)s%(h1)s",
+        " %(z0)s%(z0)s%(z0)s%(z0)s%(z0)s%(z0)s%(z0)s%(c0)s%(f0)s",
+    ]
+
+    if 'TERM' in os.environ and os.environ['TERM'] in ('velocity', 'xterm', 'xterm-256color', 'xterm-color'):
+        return echo("\n".join(banner_map) % banner_dict)
+    else:
+        return echo(fchr('>>') + 'mesosphere shakedown v' + shakedown.VERSION, b=True)
+
+
+def decorate(text, style):
+    """ Console decoration style definitions
+
+        :param text: the text string to decorate
+        :type text: str
+        :param style: the style used to decorate the string
+        :type style: str
+
+        :return: a decorated string
+        :rtype: str
+    """
+
+    return {
+        'step-maj': click.style("\n" + '> ' + text, fg='yellow', bold=True),
+        'step-min': click.style('  - ' + text + ' ', bold=True),
+        'item-maj': click.style('    - ' + text + ' '),
+        'item-min': click.style('      - ' + text + ' '),
+        'quote-head-fail': click.style("\n" + chr(9485) + (chr(9480)*2) + ' ' + text, fg='red'),
+        'quote-head-pass': click.style("\n" + chr(9485) + (chr(9480)*2) + ' ' + text, fg='green'),
+        'quote-head-skip': click.style("\n" + chr(9485) + (chr(9480)*2) + ' ' + text, fg='yellow'),
+        'quote-fail': re.sub('^', click.style(chr(9482) + ' ', fg='red'), text, flags=re.M),
+        'quote-pass': re.sub('^', click.style(chr(9482) + ' ', fg='green'), text, flags=re.M),
+        'quote-skip': re.sub('^', click.style(chr(9482) + ' ', fg='yellow'), text, flags=re.M),
+        'fail': click.style(text + ' ', fg='red'),
+        'pass': click.style(text + ' ', fg='green'),
+        'skip': click.style(text + ' ', fg='yellow')
+    }.get(style, '')
+
+
+def echo(text, **kwargs):
+    """ Print results to the console
+
+        :param text: the text string to print
+        :type text: str
+
+        :return: a string
+        :rtype: str
+    """
+
+    if shakedown.cli.quiet:
+        return
+
+    if not 'n' in kwargs:
+        kwargs['n'] = True
+
+    if 'd' in kwargs:
+        text = decorate(text, kwargs['d'])
+
+    if 'TERM' in os.environ and os.environ['TERM'] == 'velocity':
+        if text:
+            print(text, end="", flush=True)
+        if kwargs.get('n'):
+            print()
+    else:
+        click.echo(text, nl=kwargs.get('n'))
+
+
+@contextlib.contextmanager
+def stdchannel_redirected(stdchannel, dest_filename):
+    """ A context manager to temporarily redirect stdout or stderr
+
+        :param stdchannel: the channel to redirect
+        :type stdchannel: sys.std
+        :param dest_filename: the filename to redirect output to
+        :type dest_filename: os.devnull
+
+        :return: nothing
+        :rtype: None
+    """
+
+    try:
+        oldstdchannel = os.dup(stdchannel.fileno())
+        dest_file = open(dest_filename, 'w')
+        os.dup2(dest_file.fileno(), stdchannel.fileno())
+
+        yield
+    finally:
+        if oldstdchannel is not None:
+            os.dup2(oldstdchannel, stdchannel.fileno())
+        if dest_file is not None:
+            dest_file.close()

--- a/tests/shakedown/shakedown/cli/main.py
+++ b/tests/shakedown/shakedown/cli/main.py
@@ -1,0 +1,355 @@
+import click
+import json
+import importlib
+import os
+import sys
+
+from shakedown.cli.helpers import *
+from shakedown.dcos import dcos_url
+
+
+@click.command('shakedown')
+@click.argument('tests', nargs=-1)
+@click.option('-u', '--dcos-url', envvar='SHAKEDOWN_DCOS_URL', help='URL to a running DC/OS cluster.')
+@click.option('-f', '--fail', envvar='SHAKEDOWN_FAIL', type=click.Choice(['fast', 'never']), default='never', help='Sepcify whether to continue testing when encountering failures. (default: never)')
+@click.option('-m', '--timeout', envvar='SHAKEDOWN_TIMEOUT', default=1800, help='Seconds after which to terminate a running test')
+@click.option('--ssh-user', envvar='SHAKEDOWN_SSH_USER', help='Username for cluster ssh authentication')
+@click.option('-i', '--ssh-key-file', envvar='SHAKEDOWN_SSH_KEY_FILE', type=click.Path(), help='Path to the SSH keyfile to use for authentication.')
+@click.option('-q', '--quiet', envvar='SHAKEDOWN_QUIET', is_flag=True, help='Suppress all superfluous output.')
+@click.option('-k', '--ssl-no-verify', envvar='SHAKEDOWN_SSL_NO_VERIFY', is_flag=True, help='Suppress SSL certificate verification.')
+@click.option('-o', '--stdout', envvar='SHAKEDOWN_STDOUT', type=click.Choice(['pass', 'fail', 'skip', 'all', 'none']), help='Print the standard output of tests with the specified result. (default: fail)')
+@click.option('-s', '--stdout-inline', envvar='SHAKEDOWN_STDOUT_INLINE', is_flag=True, help='Display output inline rather than after test phase completion.')
+@click.option('-p', '--pytest-option', envvar='SHAKEDOWN_PYTEST_OPTION', multiple=True, help='Options flags to pass to pytest.')
+@click.option('-t', '--oauth-token', envvar='SHAKEDOWN_OAUTH_TOKEN', help='OAuth token to use for DC/OS authentication.')
+@click.option('-n', '--username', envvar='SHAKEDOWN_USERNAME', help='Username to use for DC/OS authentication.')
+@click.option('-w', '--password', envvar='SHAKEDOWN_PASSWORD', hide_input=True, help='Password to use for DC/OS authentication.')
+@click.option('--no-banner', envvar='SHAKEDOWN_NO_BANNER', is_flag=True, help='Suppress the product banner.')
+@click.version_option(version=shakedown.VERSION)
+
+
+def cli(**args):
+    """ Shakedown is a DC/OS test-harness wrapper for the pytest tool.
+    """
+    import shakedown
+
+    # Read configuration options from ~/.shakedown (if exists)
+    args = read_config(args)
+
+    # Set configuration defaults
+    args = set_config_defaults(args)
+
+    if args['quiet']:
+        shakedown.cli.quiet = True
+
+    if not args['dcos_url']:
+        try:
+            args['dcos_url'] = dcos_url()
+        except:
+            click.secho('error: cluster URL not set, use --dcos-url or see --help for more information.', fg='red', bold=True)
+            sys.exit(1)
+
+    if not args['dcos_url']:
+        click.secho('error: --dcos-url is a required option; see --help for more information.', fg='red', bold=True)
+        sys.exit(1)
+
+    if args['ssh_key_file']:
+        shakedown.cli.ssh_key_file = args['ssh_key_file']
+
+    if args['ssh_user']:
+        shakedown.cli.ssh_user = args['ssh_user']
+
+    if not args['no_banner']:
+        echo(banner(), n=False)
+
+    echo('Running pre-flight checks...', d='step-maj')
+
+    # required modules and their 'version' method
+    imported = {}
+    requirements = {
+        'pytest': '__version__',
+        'dcos': 'version'
+    }
+
+    for req in requirements:
+        ver = requirements[req]
+
+        echo("Checking for {} library...".format(req), d='step-min', n=False)
+        try:
+            imported[req] = importlib.import_module(req, package=None)
+        except ImportError:
+            click.secho("error: {p} is not installed; run 'pip install {p}'.".format(p=req), fg='red', bold=True)
+            sys.exit(1)
+
+        echo(getattr(imported[req], requirements[req]))
+
+    if shakedown.attach_cluster(args['dcos_url']):
+        echo('Checking DC/OS cluster version...', d='step-min', n=False)
+        echo(shakedown.dcos_version())
+    else:
+        with imported['dcos'].cluster.setup_directory() as temp_path:
+            imported['dcos'].cluster.set_attached(temp_path)
+
+            imported['dcos'].config.set_val('core.dcos_url', args['dcos_url'])
+            if args['ssl_no_verify']:
+                imported['dcos'].config.set_val('core.ssl_verify', 'False')
+
+            try:
+                imported['dcos'].cluster.setup_cluster_config(args['dcos_url'], temp_path, False)
+            except:
+                echo('Authenticating with DC/OS cluster...', d='step-min')
+                authenticated = False
+                token = imported['dcos'].config.get_config_val("core.dcos_acs_token")
+                if token is not None:
+                    echo('trying existing ACS token...', d='step-min', n=False)
+                    try:
+                        shakedown.dcos_leader()
+
+                        authenticated = True
+                        echo(fchr('PP'), d='pass')
+                    except imported['dcos'].errors.DCOSException:
+                        echo(fchr('FF'), d='fail')
+                if not authenticated and args['oauth_token']:
+                    try:
+                        echo('trying OAuth token...', d='item-maj', n=False)
+                        token = shakedown.authenticate_oauth(args['oauth_token'])
+
+                        with stdchannel_redirected(sys.stderr, os.devnull):
+                            imported['dcos'].config.set_val('core.dcos_acs_token', token)
+
+                        authenticated = True
+                        echo(fchr('PP'), d='pass')
+                    except:
+                       echo(fchr('FF'), d='fail')
+                if not authenticated and args['username'] and args['password']:
+                    try:
+                        echo('trying username and password...', d='item-maj', n=False)
+                        token = shakedown.authenticate(args['username'], args['password'])
+
+                        with stdchannel_redirected(sys.stderr, os.devnull):
+                            imported['dcos'].config.set_val('core.dcos_acs_token', token)
+
+                        authenticated = True
+                        echo(fchr('PP'), d='pass')
+                    except:
+                        echo(fchr('FF'), d='fail')
+
+                if authenticated:
+                    imported['dcos'].cluster.setup_cluster_config(args['dcos_url'], temp_path, False)
+
+                    echo('Checking DC/OS cluster version...', d='step-min', n=False)
+                    echo(shakedown.dcos_version())
+                else:
+                    click.secho("error: no authentication credentials or token found.", fg='red', bold=True)
+                    sys.exit(1)
+
+    class shakedown:
+        """ This encapsulates a PyTest wrapper plugin
+        """
+
+        state = {}
+
+        stdout = []
+
+        tests = {
+            'file': {},
+            'test': {}
+        }
+
+        report_stats = {
+            'passed':[],
+            'skipped':[],
+            'failed':[],
+            'total_passed':0,
+            'total_skipped':0,
+            'total_failed':0,
+        }
+
+
+        def output(title, state, text, status=True):
+            """ Capture and display stdout/stderr output
+
+                :param title: the title of the output box (eg. test name)
+                :type title: str
+                :param state: state of the result (pass, fail)
+                :type state: str
+                :param text: the stdout/stderr output
+                :type text: str
+                :param status: whether to output a status marker
+                :type status: bool
+            """
+            if state == 'fail':
+                schr = fchr('FF')
+            elif state == 'pass':
+                schr = fchr('PP')
+            elif state == 'skip':
+                schr = fchr('SK')
+            else:
+                schr = ''
+
+            if status:
+                if not args['stdout_inline']:
+                    if state == 'fail':
+                        echo(schr, d='fail')
+                    elif state == 'pass':
+                        echo(schr, d='pass')
+                else:
+                    if not text:
+                        if state == 'fail':
+                            echo(schr, d='fail')
+                        elif state == 'pass':
+                            if '::' in title:
+                                echo(title.split('::')[-1], d='item-min', n=False)
+                            echo(schr, d='pass')
+
+            if text and args['stdout'] in [state, 'all']:
+                o = decorate(schr + ': ', 'quote-head-' + state)
+                o += click.style(decorate(title, style=state), bold=True) + "\n"
+                o += decorate(str(text).strip(), style='quote-' + state)
+
+                if args['stdout_inline']:
+                    echo(o)
+                else:
+                    shakedown.stdout.append(o)
+
+
+        def pytest_collectreport(self, report):
+            """ Collect and validate individual test files
+            """
+
+            if not 'collect' in shakedown.state:
+                shakedown.state['collect'] = 1
+                echo('Collecting and validating test files...', d='step-min')
+
+            if report.nodeid:
+                echo(report.nodeid, d='item-maj', n=False)
+
+                state = None
+
+                if report.failed:
+                    state = 'fail'
+                if report.passed:
+                    state = 'pass'
+                if report.skipped:
+                    state = 'skip'
+
+                if state:
+                    if report.longrepr:
+                        shakedown.output(report.nodeid, state, report.longrepr)
+                    else:
+                        shakedown.output(report.nodeid, state, None)
+
+
+        def pytest_sessionstart(self):
+            """ Tests have been collected, begin running them...
+            """
+
+            echo('Initiating testing phase...', d='step-maj')
+
+
+        def pytest_report_teststatus(self, report):
+            """ Print report results to the console as they are run
+            """
+
+            try:
+                report_file, report_test = report.nodeid.split('::', 1)
+            except ValueError:
+                return
+
+            if not 'test' in shakedown.state:
+                shakedown.state['test'] = 1
+                echo('Running individual tests...', d='step-min')
+
+            if not report_file in shakedown.tests['file']:
+                shakedown.tests['file'][report_file] = 1
+                echo(report_file, d='item-maj')
+            if not report.nodeid in shakedown.tests['test']:
+                shakedown.tests['test'][report.nodeid] = {}
+                if args['stdout_inline']:
+                    echo('')
+                    echo(report_test + ':', d='item-min')
+                else:
+                    echo(report_test, d='item-min', n=False)
+
+            if report.failed:
+                shakedown.tests['test'][report.nodeid]['fail'] = True
+
+            if report.when == 'teardown' and not 'tested' in shakedown.tests['test'][report.nodeid]:
+                shakedown.output(report.nodeid, 'pass', None)
+
+            # Suppress excess terminal output
+            return report.outcome, None, None
+
+
+        def pytest_runtest_logreport(self, report):
+            """ Log the [stdout, stderr] results of tests if desired
+            """
+
+            state = None
+
+            for secname, content in report.sections:
+                if report.failed:
+                    state = 'fail'
+                if report.passed:
+                    state = 'pass'
+                if report.skipped:
+                    state = 'skip'
+
+                if state and secname != 'Captured stdout call':
+                    module = report.nodeid.split('::', 1)[0]
+                    cap_type = secname.split(' ')[-1]
+
+                    if not 'setup' in shakedown.tests['test'][report.nodeid]:
+                        shakedown.tests['test'][report.nodeid]['setup'] = True
+                        shakedown.output(module + ' ' + cap_type, state, content, False)
+                    elif cap_type == 'teardown':
+                        shakedown.output(module + ' ' + cap_type, state, content, False)
+                elif state and report.when == 'call':
+                    if 'tested' in shakedown.tests['test'][report.nodeid]:
+                        shakedown.output(report.nodeid, state, content, False)
+                    else:
+                        shakedown.tests['test'][report.nodeid]['tested'] = True
+                        shakedown.output(report.nodeid, state, content)
+
+            # Capture execution crashes
+            if hasattr(report.longrepr, 'reprcrash'):
+                longreport = report.longrepr
+
+                if 'tested' in shakedown.tests['test'][report.nodeid]:
+                    shakedown.output(report.nodeid, 'fail', 'error: ' + str(longreport.reprcrash), False)
+                else:
+                    shakedown.tests['test'][report.nodeid]['tested'] = True
+                    shakedown.output(report.nodeid, 'fail', 'error: ' + str(longreport.reprcrash))
+
+
+        def pytest_sessionfinish(self, session, exitstatus):
+            """ Testing phase is complete; print extra reports (stdout/stderr, JSON) as requested
+            """
+
+            echo('Test phase completed.', d='step-maj')
+
+            if ('stdout' in args and args['stdout']) and shakedown.stdout:
+                for output in shakedown.stdout:
+                    echo(output)
+
+    opts = ['-q', '--tb=no', "--timeout={}".format(args['timeout'])]
+
+    if args['fail'] == 'fast':
+        opts.append('-x')
+
+    if args['pytest_option']:
+        for opt in args['pytest_option']:
+            opts.append(opt)
+
+    if args['stdout_inline']:
+        opts.append('-s')
+
+    if args['tests']:
+        tests_to_run = []
+        for test in args['tests']:
+            tests_to_run.extend(test.split())
+        for test in tests_to_run:
+            opts.append(test)
+
+    exitstatus = imported['pytest'].main(opts, plugins=[shakedown()])
+
+    sys.exit(exitstatus)

--- a/tests/shakedown/shakedown/dcos/__init__.py
+++ b/tests/shakedown/shakedown/dcos/__init__.py
@@ -1,0 +1,164 @@
+import os
+import dcos
+import dcos.cluster
+import sys
+
+import shakedown
+
+
+def attach_cluster(url):
+    """Attach to an already set-up cluster
+    :return: True if successful, else False
+    """
+    with shakedown.stdchannel_redirected(sys.stderr, os.devnull):
+        clusters = [c.dict() for c in dcos.cluster.get_clusters()]
+    for c in clusters:
+        if url == c['url']:
+            try:
+                dcos.cluster.set_attached(dcos.cluster.get_cluster(c['name']).get_cluster_path())
+                return True
+            except:
+                return False
+
+    return False
+
+
+def dcos_acs_token():
+    """Return the DC/OS ACS token as configured in the DC/OS library.
+    :return: DC/OS ACS token as a string
+    """
+    return dcos.config.get_config().get('core.dcos_acs_token')
+
+
+def dcos_url():
+    """Return the DC/OS URL as configured in the DC/OS library. This is
+    equivalent to the value of '--dcos_url' passed into Shakedown on the
+    command line.
+    :return: DC/OS cluster URL as a string
+    """
+    return dcos.config.get_config().get('core.dcos_url')
+
+
+def dcos_service_url(service):
+    """Return the URL of a service running on DC/OS, based on the value of
+    shakedown.dcos.dcos_url() and the service name.
+    :param service: the name of a registered DC/OS service, as a string
+    :return: the full DC/OS service URL, as a string
+    """
+    return _gen_url("/service/{}/".format(service))
+
+
+def master_url():
+    """Return the URL of a master running on DC/OS, based on the value of
+    shakedown.dcos.dcos_url().
+    :return: the full DC/OS master URL, as a string
+    """
+    return _gen_url("/mesos/")
+
+
+def agents_url():
+    """Return the URL of a master agents running on DC/OS, based on the value of
+    shakedown.dcos.dcos_url().
+    :return: the full DC/OS master URL, as a string
+    """
+    return _gen_url("/mesos/slaves")
+
+
+def dcos_state():
+    client = dcos.mesos.DCOSClient()
+    json_data = client.get_state_summary()
+
+    if json_data:
+        return json_data
+    else:
+        return None
+
+
+def dcos_agents_state():
+    response = dcos.http.get(agents_url())
+
+    if response.status_code == 200:
+        return response.json()
+    else:
+        return None
+
+
+def dcos_leader():
+    return dcos_dns_lookup('leader.mesos.')
+
+
+def dcos_dns_lookup(name):
+    return dcos.mesos.MesosDNSClient().hosts(name)
+
+
+def dcos_version():
+    """Return the version of the running cluster.
+    :return: DC/OS cluster version as a string
+    """
+    url = _gen_url('dcos-metadata/dcos-version.json')
+    response = dcos.http.request('get', url)
+
+    if response.status_code == 200:
+        return response.json()['version']
+    else:
+        return None
+
+
+def master_ip():
+    """Returns the public IP address of the DC/OS master.
+    return: DC/OS IP address as a string
+    """
+    return dcos.mesos.DCOSClient().metadata().get('PUBLIC_IPV4')
+
+
+def authenticate(username, password):
+    """Authenticate with a DC/OS cluster and return an ACS token.
+    return: ACS token
+    """
+    url = _gen_url('acs/api/v1/auth/login')
+
+    creds = {
+        'uid': username,
+        'password': password
+    }
+
+    response = dcos.http.request('post', url, json=creds)
+
+    if response.status_code == 200:
+        return response.json()['token']
+    else:
+        return None
+
+
+def authenticate_oauth(oauth_token):
+    """Authenticate by checking for a valid OAuth token.
+    return: ACS token
+    """
+    url = _gen_url('acs/api/v1/auth/login')
+
+    creds = {
+        'token': oauth_token
+    }
+
+    response = dcos.http.request('post', url, json=creds)
+
+    if response.status_code == 200:
+        return response.json()['token']
+    else:
+        return None
+
+
+def dcos_url_path(url_path):
+    return _gen_url(url_path)
+
+
+def _gen_url(url_path):
+    """Return an absolute URL by combining DC/OS URL and url_path.
+
+    :param url_path: path to append to DC/OS URL
+    :type url_path: str
+    :return: absolute URL
+    :rtype: str
+    """
+    from six.moves import urllib
+    return urllib.parse.urljoin(dcos_url(), url_path)

--- a/tests/shakedown/shakedown/dcos/agent.py
+++ b/tests/shakedown/shakedown/dcos/agent.py
@@ -1,0 +1,227 @@
+"""Utilities for working with agents"""
+
+from shakedown import *
+import os
+import pytest
+from dcos import (marathon, mesos)
+
+from shakedown.dcos import network
+
+
+def get_public_agents():
+    """Provides a list of hostnames / IPs that are public agents in the cluster"""
+    agent_list = []
+    agents = __get_all_agents()
+    for agent in agents:
+        for reservation in agent["reserved_resources"]:
+            if "slave_public" in reservation:
+                agent_list.append(agent["hostname"])
+
+    return agent_list
+
+
+def get_private_agents():
+    """Provides a list of hostnames / IPs that are private agents in the cluster"""
+
+    agent_list = []
+    agents = __get_all_agents()
+    for agent in agents:
+        if(len(agent["reserved_resources"]) == 0):
+            agent_list.append(agent["hostname"])
+        else:
+            private = True
+            for reservation in agent["reserved_resources"]:
+                if("slave_public" in reservation):
+                    private = False
+
+            if(private):
+                agent_list.append(agent["hostname"])
+
+    return agent_list
+
+
+def get_agents():
+    """Provides a list of hostnames / IPs of all agents in the cluster"""
+
+    agent_list = []
+    agents = __get_all_agents()
+    for agent in agents:
+        agent_list.append(agent["hostname"])
+
+    return agent_list
+
+
+def __get_all_agents():
+    """Provides all agent json in the cluster which can be used for filtering"""
+
+    client = mesos.DCOSClient()
+    agents = client.get_state_summary()['slaves']
+    return agents
+
+ALLOW_SSH = '-I INPUT -p tcp --dport 22 -j ACCEPT'
+ALLOW_PING = '-I INPUT -p icmp -j ACCEPT'
+DISALLOW_MESOS = '-I OUTPUT -p tcp --sport 5051  -j REJECT'
+DISALLOW_INPUT = '-A INPUT -j REJECT'
+
+
+def partition_agent(host):
+    """ Partition a node from all network traffic except for SSH and loopback
+
+        :param hostname: host or IP of the machine to partition from the cluster
+    """
+
+    network.save_iptables(host)
+    network.flush_all_rules(host)
+    network.allow_all_traffic(host)
+    network.run_iptables(host, ALLOW_SSH)
+    network.run_iptables(host, ALLOW_PING)
+    network.run_iptables(host, DISALLOW_MESOS)
+    network.run_iptables(host, DISALLOW_INPUT)
+
+
+def reconnect_agent(host):
+    """ Reconnect a previously partitioned node to the network
+
+        :param hostname: host or IP of the machine to partition from the cluster
+    """
+
+    network.restore_iptables(host)
+
+
+@contextlib.contextmanager
+def disconnected_agent(host):
+
+    partition_agent(host)
+    try:
+        yield
+    finally:
+        # return config to previous state
+        reconnect_agent(host)
+
+
+def kill_process_on_host(
+    hostname,
+    pattern
+):
+    """ Kill the process matching pattern at ip
+
+        :param hostname: the hostname or ip address of the host on which the process will be killed
+        :param pattern: a regular expression matching the name of the process to kill
+    """
+
+    status, stdout = run_command_on_agent(hostname, "ps aux | grep -v grep | grep '{}'".format(pattern))
+    pids = [p.strip().split()[1] for p in stdout.splitlines()]
+
+    for pid in pids:
+        status, stdout = run_command_on_agent(hostname, "sudo kill -9 {}".format(pid))
+        if status:
+            print("Killed pid: {}".format(pid))
+        else:
+            print("Unable to killed pid: {}".format(pid))
+
+
+def kill_process_from_pid_file_on_host(hostname, pid_file='app.pid'):
+    """ Retrieves the PID of a process from a pid file on host and kills it.
+
+    :param hostname: the hostname or ip address of the host on which the process will be killed
+    :param pid_file: pid file to use holding the pid number to kill
+    """
+    status, pid = run_command_on_agent(hostname, 'cat {}'.format(pid_file))
+    status, stdout = run_command_on_agent(hostname, "sudo kill -9 {}".format(pid))
+    if status:
+        print("Killed pid: {}".format(pid))
+        run_command_on_agent(hostname, 'rm {}'.format(pid_file))
+    else:
+        print("Unable to killed pid: {}".format(pid))
+
+
+def restart_agent(
+    hostname
+):
+    """ Restarts an agent process at the host
+
+    :param hostname: host or IP of the machine to restart the agent process.
+    """
+
+    run_command_on_agent(hostname, "sudo systemctl restart dcos-mesos-slave")
+
+
+def stop_agent(
+    hostname
+):
+    """ Stops an agent process at the host
+
+    :param hostname: host or IP of the machine to stop the agent process.
+    """
+
+    run_command_on_agent(hostname, "sudo systemctl stop dcos-mesos-slave")
+
+
+def start_agent(
+    hostname
+):
+    """ Starts an agent process at the host
+
+    :param hostname: host or IP of the machine to start the agent process.
+    """
+
+    run_command_on_agent(hostname, "sudo systemctl start dcos-mesos-slave")
+
+
+def restart_agent_node(hostname):
+    """ Restarts the agent node
+    """
+
+    run_command_on_agent(hostname, "sudo /sbin/shutdown -r now")
+
+
+def delete_agent_log(
+    hostname
+):
+    """ Deletes the agent log at the host.  This is necessary if any changes
+    occurred to the agent resources and the agent is restarted.
+
+    :param hostname: host or IP of the machine to delete the agent log.
+    """
+
+    run_command_on_agent(hostname, "sudo rm -f /var/lib/mesos/slave/meta/slaves/latest")
+
+
+def shakedown_dcos_dir():
+    """Gets the path to the shakedown dcos directory"""
+    return os.path.dirname(os.path.realpath(__file__))
+
+
+def required_private_agents(count):
+    """ Returns True if the number of private agents is equal to or greater than
+    the count.  This is useful in using pytest skipif such as:
+    `pytest.mark.skipif('required_private_agents(2)')` which will skip the test if
+    the number of agents is not 2 or more.
+
+    :param count: the number of required private agents.
+    """
+    agent_count = len(get_private_agents())
+    # reverse logic (skip if less than count)
+    # returns True if less than count
+    return agent_count < count
+
+
+def required_public_agents(count):
+    """ Returns True if the number of public agents is equal to or greater than
+    the count.  This is useful in using pytest skipif such as:
+    `pytest.mark.skipif('required_public_agents(2)')` which will skip the test if
+    the number of agents is not 2 or more.
+
+    :param count: the number of required public agents.
+    """
+    agent_count = len(get_public_agents())
+    # reverse logic (skip if less than count)
+    return agent_count < count
+
+
+def private_agents(count=1):
+    return pytest.mark.skipif('required_private_agents({})'.format(count))
+
+
+def public_agents(count=1):
+    return pytest.mark.skipif('required_public_agents({})'.format(count))

--- a/tests/shakedown/shakedown/dcos/cluster.py
+++ b/tests/shakedown/shakedown/dcos/cluster.py
@@ -1,0 +1,271 @@
+from dcos.mesos import DCOSClient
+from distutils.version import LooseVersion
+
+import dcos
+import pytest
+import shakedown
+
+dcos_1_11 = pytest.mark.skipif('dcos_version_less_than("1.11")')
+dcos_1_10 = pytest.mark.skipif('dcos_version_less_than("1.10")')
+dcos_1_9 = pytest.mark.skipif('dcos_version_less_than("1.9")')
+dcos_1_8 = pytest.mark.skipif('dcos_version_less_than("1.8")')
+dcos_1_7 = pytest.mark.skipif('dcos_version_less_than("1.7")')
+
+# runs for strict, ignores if not strict (strict is required)
+strict = pytest.mark.skipif("ee_version() != 'strict'")
+permissive = pytest.mark.skipif("ee_version() != 'permissive'")
+disabled = pytest.mark.skipif("ee_version() != 'disabled'")
+
+PUBLIC_ROLE = 'slave_public'
+
+def shakedown_canonical_version():
+    return __canonical_version(shakedown.VERSION)
+
+
+def shakedown_version_less_than(version):
+    """@pytest.mark.skipif("shakedown_version_less_than('1.3')")
+    skip if shakedown doesn't support it yet.
+    """
+    return shakedown_canonical_version() < LooseVersion(version)
+
+
+def dcos_canonical_version():
+    return __canonical_version(shakedown.dcos_version())
+
+
+def __canonical_version(version):
+    index = version.rfind("-dev")
+    if index != -1:
+        version = version[:index]
+    return LooseVersion(version)
+
+
+def dcos_version_less_than(version):
+    return dcos_canonical_version() < LooseVersion(version)
+
+
+def required_cpus(cpus, role='*'):
+    """ Returns True if the number of available cpus is equal to or greater than
+    the cpus.  This is useful in using pytest skipif such as:
+    `pytest.mark.skipif('required_cpus(2)')` which will skip the test if
+    the number of cpus is not 2 or more.
+
+    :param cpus: the number of required cpus.
+    :param role: the role / reservation (default='*')
+    """
+    resources = get_resources_by_role()
+    # reverse logic (skip if less than count)
+    # returns True if less than count
+    return resources.cpus < cpus
+
+
+def required_mem(mem, role='*'):
+    """ Returns True if the number of available memory is equal to or greater than
+    the mem.  This is useful in using pytest skipif such as:
+    `pytest.mark.skipif('required_mem(2)')` which will skip the test if
+    the number of mem is not 2m or more.
+
+    :param mem: the amount of required mem in meg.
+    :param role: the role / reservation (default='*')
+    """
+    resources = get_resources_by_role()
+    # reverse logic (skip if less than count)
+    # returns True if less than count
+    return resources.mem < mem
+
+
+def bootstrap_metadata():
+    """ Provides cluster metadata which includes security modes
+    """
+    return __metadata_helper('bootstrap-config.json')
+
+
+def ui_config_metadata():
+    """ Provides cluster metadata used by the ui which includes mesos logging strategy
+    """
+    return __metadata_helper('ui-config.json')
+
+
+def dcos_version_metadata():
+    return __metadata_helper('dcos-version.json')
+
+
+def __metadata_helper(json_path):
+    """ Returns json for specific cluster metadata.  Important to realize that
+        this was introduced in dcos-1.9.  Clusters prior to 1.9 and missing metadata
+        will return None
+    """
+    url = shakedown.dcos_url_path('dcos-metadata/{}'.format(json_path))
+    try:
+        response = dcos.http.request('get', url)
+
+        if response.status_code == 200:
+            return response.json()
+    except:
+        pass
+
+    return None
+
+
+def ee_version():
+    """ Provides the type or version of EE if it is Enterprise.
+        Useful for @pytest.mark.skipif("ee_version() in {'strict', 'disabled'}")
+    """
+    metadata = bootstrap_metadata()
+    if metadata:
+        return metadata['security']
+    else:
+        return None
+
+
+def mesos_logging_strategy():
+    metadata = ui_config_metadata()
+
+    if metadata:
+        try:
+            return metadata['uiConfiguration']['plugins']['mesos']['logging-strategy']
+        except:
+            pass
+
+    return None
+
+
+def get_resources():
+    return _get_resources()
+
+
+def resources_needed(total_tasks=1, per_task_cpu=0.01, per_task_mem=1):
+    total_cpu = per_task_cpu * total_tasks
+    total_mem = per_task_mem * total_tasks
+    return Resources(total_cpu, total_mem)
+
+
+def get_used_resources():
+    return _get_resources('used_resources')
+
+
+def get_unreserved_resources():
+    return _get_resources('unreserved_resources')
+
+
+def available_resources():
+    res = get_resources()
+    used = get_used_resources()
+
+    return res - used
+
+
+def get_resources_by_role(role='*'):
+    if '*' in role:
+        return get_resources() - get_reserved_resources()
+    else:
+        return get_reserved_resources(role)
+
+
+def _get_resources(rtype='resources'):
+    """ resource types from state summary include:  resources, used_resources
+    offered_resources, reserved_resources, unreserved_resources
+    The default is resources.
+
+    :param rtype: the type of resources to return
+    :type rtype: str
+    :param role: the name of the role if for reserved and if None all reserved
+    :type rtype: str
+
+    :return: resources(cpu,mem)
+    :rtype: Resources
+    """
+    cpus = 0
+    mem = 0
+    summary = DCOSClient().get_state_summary()
+
+    if 'slaves' in summary:
+        agents = summary.get('slaves')
+        for agent in agents:
+            if agent[rtype].get('cpus') is not None:
+                cpus += agent[rtype].get('cpus')
+            if agent[rtype].get('mem') is not None:
+                mem += agent[rtype].get('mem')
+
+    return Resources(cpus, mem)
+
+
+def get_reserved_resources(role=None):
+    """ resource types from state summary include: reserved_resources
+
+    :param role: the name of the role if for reserved and if None all reserved
+    :type role: str
+
+    :return: resources(cpu,mem)
+    :rtype: Resources
+    """
+    rtype = 'reserved_resources'
+    cpus = 0.0
+    mem = 0.0
+    summary = DCOSClient().get_state_summary()
+
+    if 'slaves' in summary:
+        agents = summary.get('slaves')
+        for agent in agents:
+            resource_reservations = agent.get(rtype)
+            reservations = []
+            if role is None or '*' in role:
+                reservations = resource_reservations.values()
+            elif role in resource_reservations:
+                reservations = [resource_reservations.get(role)]
+            for reservation in reservations:
+                if reservation.get('cpus') is not None:
+                    cpus += reservation.get('cpus')
+                if reservation.get('mem') is not None:
+                    mem += reservation.get('mem')
+
+    return Resources(cpus, mem)
+
+
+class Resources(object):
+
+    cpus = 0
+    mem = 0
+
+    def __init__(self, cpus=0, mem=0):
+        self.cpus = cpus
+        self.mem = mem
+
+    def __str__(self):
+        return "cpus: {}, mem: {}".format(self.cpus, self.mem)
+
+    def __repr__(self):
+        return "cpus: {}, mem: {}".format(self.cpus, self.mem)
+
+    def __sub__(self, other):
+        total_cpu = self.cpus - other.cpus
+        total_mem = self.mem - other.mem
+
+        return Resources(total_cpu, total_mem)
+
+    def __rsub__(self, other):
+        return self.__sub__(other)
+
+    def __gt__(self, other):
+        return self.cpus > other.cpus and self.mem > other.cpus
+
+    def __ge__(self, other):
+        return self.cpus >= other.cpus and self.mem >= other.cpus
+
+    def __lt__(self, other):
+        return self.cpus < other.cpus and self.mem < other.cpus
+
+    def __le__(self, other):
+        return self.cpus <= other.cpus and self.mem <= other.cpus
+
+    def __mul__(self, other):
+        return Resources(self.cpus * other, self.mem * other)
+
+    def __rmul__(self, other):
+        return Resources(self.cpus * other, self.mem * other)
+
+    def __eq__(self, other):
+        """Override the default Equals behavior"""
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False

--- a/tests/shakedown/shakedown/dcos/command.py
+++ b/tests/shakedown/shakedown/dcos/command.py
@@ -1,0 +1,290 @@
+import shlex
+import subprocess
+import time
+from _thread import RLock
+from functools import wraps
+from select import select
+
+import paramiko
+from dcos.errors import DCOSException
+
+import shakedown
+from .helpers import validate_key, try_close, get_transport, start_transport
+
+
+def connection_cache(func: callable):
+    """Connection cache for SSH sessions. This is to prevent opening a
+     new, expensive connection on every command run."""
+    cache = dict()
+    lock = RLock()
+
+    @wraps(func)
+    def func_wrapper(host: str, username: str, *args, **kwargs):
+        key = "{h}-{u}".format(h=host, u=username)
+        if key in cache:
+            # connection exists, check if it is still valid before
+            # returning it.
+            conn = cache[key]
+            if conn and conn.is_active() and conn.is_authenticated():
+                return conn
+            else:
+                # try to close a bad connection and remove it from
+                # the cache.
+                if conn:
+                    try_close(conn)
+                del cache[key]
+
+        # key is not in the cache, so try to recreate it
+        # it may have been removed just above.
+        if key not in cache:
+            conn = func(host, username, *args, **kwargs)
+            if conn is not None:
+                cache[key] = conn
+            return conn
+
+        # not sure how to reach this point, but just in case.
+        return None
+
+    def get_cache() -> dict:
+        return cache
+
+    def purge(key: str=None):
+        with lock:
+            if key is None:
+                conns = [(k, v) for k, v in cache.items()]
+            elif key in cache:
+                conns = ((key, cache[key]), )
+            else:
+                conns = list()
+
+            for k, v in conns:
+                try_close(v)
+                del cache[k]
+
+    func_wrapper.get_cache = get_cache
+    func_wrapper.purge = purge
+    return func_wrapper
+
+
+@connection_cache
+def _get_connection(host, username: str, key_path: str) \
+        -> paramiko.Transport or None:
+    """Return an authenticated SSH connection.
+
+    :param host: host or IP of the machine
+    :type host: str
+    :param username: SSH username
+    :type username: str
+    :param key_path: path to the SSH private key for SSH auth
+    :type key_path: str
+    :return: SSH connection
+    :rtype: paramiko.Transport or None
+    """
+    if not username:
+        username = shakedown.cli.ssh_user
+    if not key_path:
+        key_path = shakedown.cli.ssh_key_file
+    key = validate_key(key_path)
+    transport = get_transport(host, username, key)
+
+    if transport:
+        transport = start_transport(transport, username, key)
+        if transport.is_authenticated():
+            return transport
+        else:
+            print("error: unable to authenticate {}@{} with key {}".format(username, host, key_path))
+    else:
+        print("error: unable to connect to {}".format(host))
+
+    return None
+
+
+def run_command(
+        host,
+        command,
+        username=None,
+        key_path=None,
+        noisy=True
+):
+    """ Run a command via SSH, proxied through the mesos master
+
+        :param host: host or IP of the machine to execute the command on
+        :type host: str
+        :param command: the command to execute
+        :type command: str
+        :param username: SSH username
+        :type username: str
+        :param key_path: path to the SSH private key to use for SSH authentication
+        :type key_path: str
+        :return: True if successful, False otherwise
+        :rtype: bool
+        :return: Output of command
+        :rtype: string
+    """
+    
+    with HostSession(host, username, key_path, noisy) as s:
+        if noisy:
+            print("\n{}{} $ {}\n".format(shakedown.fchr('>>'), host, command))
+        s.run(command)
+    
+    ec, output = s.get_result()
+    return ec == 0, output
+
+
+def run_command_on_master(
+        command,
+        username=None,
+        key_path=None,
+        noisy=True
+):
+    """ Run a command on the Mesos master
+    """
+
+    return run_command(shakedown.master_ip(), command, username, key_path, noisy)
+
+
+def run_command_on_leader(
+        command,
+        username=None,
+        key_path=None,
+        noisy=True
+):
+    """ Run a command on the Mesos leader.  Important for Multi-Master.
+    """
+
+    return run_command(shakedown.master_leader_ip(), command, username, key_path, noisy)
+
+
+def run_command_on_marathon_leader(
+        command,
+        username=None,
+        key_path=None,
+        noisy=True
+):
+    """ Run a command on the Marathon leader
+    """
+
+    return run_command(shakedown.marathon_leader_ip(), command, username, key_path, noisy)
+
+
+def run_command_on_agent(
+        host,
+        command,
+        username=None,
+        key_path=None,
+        noisy=True
+):
+    """ Run a command on a Mesos agent, proxied through the master
+    """
+
+    return run_command(host, command, username, key_path, noisy)
+
+
+def run_dcos_command(command, raise_on_error=False, print_output=True):
+    """ Run `dcos {command}` via DC/OS CLI
+
+        :param command: the command to execute
+        :type command: str
+        :param raise_on_error: whether to raise a DCOSException if the return code is nonzero
+        :type raise_on_error: bool
+        :param print_output: whether to print the resulting stdout/stderr from running the command
+        :type print_output: bool
+
+        :return: (stdout, stderr, return_code)
+        :rtype: tuple
+    """
+
+    call = shlex.split(command)
+    call.insert(0, 'dcos')
+
+    print("\n{}{}\n".format(shakedown.fchr('>>'), ' '.join(call)))
+
+    proc = subprocess.Popen(call, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, error = proc.communicate()
+    return_code = proc.wait()
+    stdout = output.decode('utf-8')
+    stderr = error.decode('utf-8')
+
+    if print_output:
+        print(stdout, stderr, return_code)
+
+    if return_code != 0 and raise_on_error:
+        raise DCOSException(
+            'Got error code {} when running command "dcos {}":\nstdout: "{}"\nstderr: "{}"'.format(
+            return_code, command, stdout, stderr))
+
+    return stdout, stderr, return_code
+
+
+class HostSession:
+    """Context manager that returns an SSH session, reusing authenticated connections.
+    
+    """
+    def __init__(self, host, username, key_path, verbose):
+        self.host = host
+        self.username = username
+        self.key_path = key_path
+        self.verbose = verbose
+        self.exit_code = -1
+        self.output = ''
+        self.session = None
+    
+    def __enter__(self):
+        """
+        :return: this session manager
+        :rtype: HostSession
+        """
+        c = _get_connection(self.host, self.username, self.key_path)
+        if c:
+            self.session = c.open_session()
+        
+        return self
+    
+    def __exit__(self, *args):
+        """Executed when the context manager is complete.
+
+        :return: None
+        """
+        self.exit_code = self.session.recv_exit_status()
+        self._wait_for_recv()
+        # read data that is ready
+        while self.session.recv_ready():
+            # lists of file descriptors that are ready for IO
+            # read, write, "exceptional condition" (?)
+            rl, wl, xl = select([self.session], [], [], 0.0)
+            if len(rl) > 0:
+                recv = str(self.session.recv(1024), "utf-8")
+                if self.verbose:
+                    print(recv, end='', flush=True)
+                self.output += recv
+        try_close(self.session)
+        # no Exceptions were handled; return False
+        return False
+    
+    def _wait_for_recv(self):
+        """After executing a command, wait for results.
+        
+        Because `recv_ready()` can return False, but still have a
+        valid, open connection, it is not enough to ensure output
+        from a command execution is properly captured.
+
+        :return: None
+        """
+        while True:
+            time.sleep(0.2)
+            if self.session.recv_ready() or self.session.closed:
+                return
+    
+    def run(self, command):
+        """Run `command` on this SSH session. This does not return the
+        result, use `get_result` to retrieve command's results.
+
+        :param command: SSH command to run
+        :type command: str
+        
+        :return: None
+        """
+        self.session.exec_command(command)
+    
+    def get_result(self):
+        return self.exit_code, self.output

--- a/tests/shakedown/shakedown/dcos/config.py
+++ b/tests/shakedown/shakedown/dcos/config.py
@@ -1,0 +1,16 @@
+
+import contextlib
+from dcos import config
+
+
+@contextlib.contextmanager
+def dcos_config():
+    """ Context manager for altering the toml
+    """
+
+    toml_config_o = config.get_config()
+    try:
+        yield
+    finally:
+        # return config to previous state
+        config.save(toml_config_o)

--- a/tests/shakedown/shakedown/dcos/docker.py
+++ b/tests/shakedown/shakedown/dcos/docker.py
@@ -1,0 +1,168 @@
+"""Utilities for work with docker commands and images"""
+
+import json
+import os
+
+from datetime import timedelta
+import shakedown
+
+from dcos import marathon
+
+
+def docker_version(host=None, component='server'):
+    """ Return the version of Docker [Server]
+
+        :param host: host or IP of the machine Docker is running on
+        :type host: str
+        :param component: Docker component
+        :type component: str
+        :return: Docker version
+        :rtype: str
+    """
+
+    if component.lower() == 'client':
+        component = 'Client'
+    else:
+        component = 'Server'
+
+    # sudo is required for non-coreOS installs
+    command = 'sudo docker version -f {{.{}.Version}}'.format(component)
+
+    if host is None:
+        success, output = shakedown.run_command_on_master(command, None, None, False)
+    else:
+        success, output = shakedown.run_command_on_host(host, command, None, None, False)
+
+    if success:
+        return output
+    else:
+        return 'unknown'
+
+
+def docker_client_version(host):
+    """ Return the version of Docker Client
+
+        :param host: host or IP of the machine Docker is running on
+        :type host: str
+        :return: Docker Client version
+        :rtype: str
+    """
+    return docker_version('{{.Client.Version}}')
+
+
+def docker_server_version(host):
+    """ Return the version of Docker Server
+
+        :param host: host or IP of the machine Docker is running on
+        :type host: str
+        :return: Docker Server version
+        :rtype: str
+    """
+    return docker_version('{{.Server.Version}}')
+
+
+def create_docker_credentials_file(
+        username,
+        password,
+        file_name='docker.tar.gz'):
+    """ Create a docker credentials file.
+        Docker username and password are used to create a `{file_name}`
+        with `.docker/config.json` containing the credentials.
+
+        :param username: docker username
+        :type username: str
+        :param password: docker password
+        :type password: str
+        :param file_name: credentials file name `docker.tar.gz` by default
+        :type file_name: str
+    """
+
+    import base64
+    auth_hash = base64.b64encode(
+        '{}:{}'.format(username, password).encode()).decode()
+
+    config_json = {
+        "auths": {
+            "https://index.docker.io/v1/": {"auth": auth_hash}
+        }
+    }
+
+    config_json_filename = 'config.json'
+    # Write config.json to file
+    with open(config_json_filename, 'w') as f:
+        json.dump(config_json, f, indent=4)
+
+    try:
+        # Create a docker.tar.gz
+        import tarfile
+        with tarfile.open(file_name, 'w:gz') as tar:
+            tar.add(config_json_filename, arcname='.docker/config.json')
+            tar.close()
+    except Exception as e:
+        print('Failed to create a docker credentils file {}'.format(e))
+        raise e
+    finally:
+        os.remove(config_json_filename)
+
+
+def __distribute_docker_credentials_file(file_name='docker.tar.gz'):
+    """ Create and copy docker credentials file to passed `{agents}`.
+        Used to access private docker repositories in tests.
+    """
+    # Upload docker.tar.gz to all private agents
+    for host in shakedown.get_private_agents():
+        shakedown.copy_file(host, file_name)
+
+
+def distribute_docker_credentials_to_private_agents(
+        username,
+        password,
+        file_name='docker.tar.gz'):
+    """ Create and distributes a docker credentials file to all private agents
+
+        :param username: docker username
+        :type username: str
+        :param password: docker password
+        :type password: str
+        :param file_name: credentials file name `docker.tar.gz` by default
+        :type file_name: str
+    """
+
+    create_docker_credentials_file(username, password, file_name)
+
+    try:
+        __distribute_docker_credentials_file()
+    finally:
+        os.remove(file_name)
+
+
+def prefetch_docker_image_on_private_agents(
+        image,
+        timeout=timedelta(minutes=5).total_seconds()):
+    """ Given a docker image. An app with the image is scale across the private
+        agents to ensure that the image is prefetched to all nodes.
+
+        :param image: docker image name
+        :type image: str
+        :param timeout: timeout for deployment wait in secs (default: 5m)
+        :type password: int
+    """
+    agents = len(shakedown.get_private_agents())
+    app = {
+        "id": "/prefetch",
+        "instances": agents,
+        "container": {
+            "type": "DOCKER",
+            "docker": {"image": image}
+        },
+        "cpus": 0.1,
+        "mem": 128
+    }
+
+    client = marathon.create_client()
+    client.add_app(app)
+
+    shakedown.deployment_wait(timeout)
+
+    shakedown.delete_all_apps()
+    shakedown.deployment_wait(timeout)

--- a/tests/shakedown/shakedown/dcos/file.py
+++ b/tests/shakedown/shakedown/dcos/file.py
@@ -1,0 +1,116 @@
+import os
+import scp
+import time
+
+from shakedown.dcos.helpers import *
+
+import shakedown
+
+
+def copy_file(
+        host,
+        file_path,
+        remote_path='.',
+        username=None,
+        key_path=None,
+        action='put'
+):
+    """ Copy a file via SCP, proxied through the mesos master
+
+        :param host: host or IP of the machine to execute the command on
+        :type host: str
+        :param file_path: the local path to the file to be copied
+        :type file_path: str
+        :param remote_path: the remote path to copy the file to
+        :type remote_path: str
+        :param username: SSH username
+        :type username: str
+        :param key_path: path to the SSH private key to use for SSH authentication
+        :type key_path: str
+
+        :return: True if successful, False otherwise
+        :rtype: bool
+    """
+
+    if not username:
+        username = shakedown.cli.ssh_user
+
+    if not key_path:
+        key_path = shakedown.cli.ssh_key_file
+
+    key = validate_key(key_path)
+
+    transport = get_transport(host, username, key)
+    transport = start_transport(transport, username, key)
+
+    if transport.is_authenticated():
+        start = time.time()
+
+        channel = scp.SCPClient(transport)
+
+        if action == 'get':
+            print("\n{}scp {}:{} {}\n".format(shakedown.cli.helpers.fchr('>>'), host, remote_path, file_path))
+            channel.get(remote_path, file_path)
+        else:
+            print("\n{}scp {} {}:{}\n".format(shakedown.cli.helpers.fchr('>>'), file_path, host, remote_path))
+            channel.put(file_path, remote_path)
+
+        print("{} bytes copied in {} seconds.".format(str(os.path.getsize(file_path)), str(round(time.time() - start, 2))))
+
+        try_close(channel)
+        try_close(transport)
+
+        return True
+    else:
+        print("error: unable to authenticate {}@{} with key {}".format(username, host, key_path))
+        return False
+
+
+def copy_file_to_master(
+        file_path,
+        remote_path='.',
+        username=None,
+        key_path=None
+):
+    """ Copy a file to the Mesos master
+    """
+
+    return copy_file(shakedown.master_ip(), file_path, remote_path, username, key_path)
+
+
+def copy_file_to_agent(
+        host,
+        file_path,
+        remote_path='.',
+        username=None,
+        key_path=None
+):
+    """ Copy a file to a Mesos agent, proxied through the master
+    """
+
+    return copy_file(host, file_path, remote_path, username, key_path)
+
+
+def copy_file_from_master(
+        remote_path,
+        file_path='.',
+        username=None,
+        key_path=None
+):
+    """ Copy a file to the Mesos master
+    """
+
+    return copy_file(shakedown.master_ip(), file_path, remote_path, username, key_path, 'get')
+
+
+def copy_file_from_agent(
+        host,
+        remote_path,
+        file_path='.',
+        username=None,
+        key_path=None
+):
+    """ Copy a file to a Mesos agent, proxied through the master
+    """
+
+    return copy_file(host, file_path, remote_path, username, key_path, 'get')

--- a/tests/shakedown/shakedown/dcos/helpers.py
+++ b/tests/shakedown/shakedown/dcos/helpers.py
@@ -1,0 +1,101 @@
+import os
+import paramiko
+import scp
+
+from dcos import http
+
+import itertools
+import shakedown
+
+
+def get_transport(host, username, key):
+    """ Create a transport object
+
+        :param host: the hostname to connect to
+        :type host: str
+        :param username: SSH username
+        :type username: str
+        :param key: key object used for authentication
+        :type key: paramiko.RSAKey
+
+        :return: a transport object
+        :rtype: paramiko.Transport
+    """
+
+    if host == shakedown.master_ip():
+        transport = paramiko.Transport(host)
+    else:
+        transport_master = paramiko.Transport(shakedown.master_ip())
+        transport_master = start_transport(transport_master, username, key)
+
+        if not transport_master.is_authenticated():
+            print("error: unable to authenticate {}@{} with key {}".format(username, shakedown.master_ip(), key))
+            return False
+
+        try:
+            channel = transport_master.open_channel('direct-tcpip', (host, 22), ('127.0.0.1', 0))
+        except paramiko.SSHException:
+            print("error: unable to connect to {}".format(host))
+            return False
+
+        transport = paramiko.Transport(channel)
+
+    return transport
+
+
+def start_transport(transport, username, key):
+    """ Begin a transport client and authenticate it
+
+        :param transport: the transport object to start
+        :type transport: paramiko.Transport
+        :param username: SSH username
+        :type username: str
+        :param key: key object used for authentication
+        :type key: paramiko.RSAKey
+
+        :return: the transport object passed
+        :rtype: paramiko.Transport
+    """
+
+    transport.start_client()
+
+    agent = paramiko.agent.Agent()
+    keys = itertools.chain((key,) if key else (), agent.get_keys())
+    for test_key in keys:
+        try:
+            transport.auth_publickey(username, test_key)
+            break
+        except paramiko.AuthenticationException as e:
+            pass
+    else:
+        raise ValueError('No valid key supplied')
+
+    return transport
+
+
+# SSH connection will be auto-terminated at the conclusion of this operation, causing
+# a race condition; the try/except block attempts to close the channel and/or transport
+# but does not issue a failure if it has already been closed.
+def try_close(obj):
+    try:
+        obj.close()
+    except:
+        pass
+
+
+def validate_key(key_path):
+    """ Validate a key
+
+        :param key_path: path to a key to use for authentication
+        :type key_path: str
+
+        :return: key object used for authentication
+        :rtype: paramiko.RSAKey
+    """
+
+    key_path = os.path.expanduser(key_path)
+
+    if not os.path.isfile(key_path):
+        return False
+
+    return paramiko.RSAKey.from_private_key_file(key_path)

--- a/tests/shakedown/shakedown/dcos/marathon.py
+++ b/tests/shakedown/shakedown/dcos/marathon.py
@@ -1,0 +1,118 @@
+from distutils.version import LooseVersion
+from dcos import marathon, config
+from shakedown.dcos.spinner import *
+from shakedown.dcos.service import service_available_predicate
+from shakedown import *
+from six.moves import urllib
+
+import pytest
+
+
+marathon_1_3 = pytest.mark.skipif('marthon_version_less_than("1.3")')
+marathon_1_4 = pytest.mark.skipif('marthon_version_less_than("1.4")')
+marathon_1_5 = pytest.mark.skipif('marthon_version_less_than("1.5")')
+
+
+def marathon_leader_ip():
+    """Returns the private IP of the marathon leader.
+    """
+    return dcos_dns_lookup('marathon.mesos')[0]['ip']
+
+
+def marathon_version():
+    client = marathon.create_client()
+    about = client.get_about()
+    # 1.3.9 or 1.4.0-RC8
+    return LooseVersion(about.get("version"))
+
+
+def marthon_version_less_than(version):
+    return marathon_version() < LooseVersion(version)
+
+
+def mom_version(name='marathon-user'):
+    """Returns the version of marathon on marathon.
+    """
+    if service_available_predicate(name):
+        with marathon_on_marathon(name):
+                return marathon_version()
+    else:
+        # We can either skip the corresponding test by returning False
+        # or raise an exception.
+        print('WARN: {} MoM not found. Version is None'.format(name))
+        return None
+
+
+def mom_version_less_than(version, name='marathon-user'):
+    """ Returns True if MoM with the given {name} exists and has a version less
+        than {version}. Note that if MoM does not exist False is returned.
+
+        :param version: required version
+        :type: string
+        :param name: MoM name, default is 'marathon-user'
+        :type: string
+        :return: True if version < MoM version
+        :rtype: bool
+    """
+    if service_available_predicate(name):
+        return mom_version() < LooseVersion(version)
+    else:
+        # We can either skip the corresponding test by returning False
+        # or raise an exception.
+        print('WARN: {} MoM not found. mom_version_less_than({}) is False'.format(name, version))
+        return False
+
+
+def deployment_predicate(app_id=None):
+    return len(marathon.create_client().get_deployments(app_id)) == 0
+
+
+def deployment_wait(timeout=120, app_id=None):
+    time_wait(lambda: deployment_predicate(app_id),
+              timeout)
+
+
+def delete_app(app_id, force=True):
+    marathon.create_client().remove_app(app_id, force=force)
+
+
+def delete_app_wait(app_id, force=True):
+    delete_app(app_id, force)
+    deployment_wait(app_id=app_id)
+
+
+def delete_all_apps(force=True):
+    marathon.create_client().remove_group("/", force=force)
+
+
+def delete_all_apps_wait(force=True):
+    delete_all_apps(force=force)
+    deployment_wait()
+
+
+def is_app_healthy(app_id):
+    app = marathon.create_client().get_app(app_id)
+    if app["healthChecks"]:
+        return app["tasksHealthy"] == app["instances"]
+    else:
+        return app["tasksRunning"] == app["instances"]
+
+
+@contextlib.contextmanager
+def marathon_on_marathon(name='marathon-user'):
+    """ Context manager for altering the marathon client for MoM
+    :param name: service name of MoM to use
+    :type name: str
+    """
+
+    toml_config_o = config.get_config()
+    dcos_url = config.get_config_val('core.dcos_url', toml_config_o)
+    service_name = 'service/{}/'.format(name)
+    marathon_url = urllib.parse.urljoin(dcos_url, service_name)
+    config.set_val('marathon.url', marathon_url)
+
+    try:
+        yield
+    finally:
+        # return config to previous state
+        config.save(toml_config_o)

--- a/tests/shakedown/shakedown/dcos/master.py
+++ b/tests/shakedown/shakedown/dcos/master.py
@@ -1,0 +1,169 @@
+"""Utilities for working with master"""
+import json
+
+from datetime import timedelta
+from shakedown import *
+from shakedown.cli.helpers import *
+from shakedown.dcos.zookeeper import get_zk_node_children, get_zk_node_data
+from shakedown.dcos.agent import kill_process_from_pid_file_on_host
+from shakedown.dcos.spinner import time_wait
+from shakedown.dcos import network
+
+DISABLE_MASTER_INCOMING = "-I INPUT -p tcp --dport 5050 -j REJECT"
+DISABLE_MASTER_OUTGOING = "-I OUTPUT -p tcp --sport 5050 -j REJECT"
+
+
+def partition_master(incoming=True, outgoing=True):
+    """ Partition master's port alone. To keep DC/OS cluster running.
+
+    :param incoming: Partition incoming traffic to master process. Default True.
+    :param outgoing: Partition outgoing traffic from master process. Default True.
+    """
+
+    echo('Partitioning master. Incoming:{} | Outgoing:{}'.format(incoming, outgoing))
+
+    network.save_iptables(shakedown.master_ip())
+    network.flush_all_rules(shakedown.master_ip())
+    network.allow_all_traffic(shakedown.master_ip())
+
+    if incoming and outgoing:
+        network.run_iptables(shakedown.master_ip(), DISABLE_MASTER_INCOMING)
+        network.run_iptables(shakedown.master_ip(), DISABLE_MASTER_OUTGOING)
+    elif incoming:
+        network.run_iptables(shakedown.master_ip(), DISABLE_MASTER_INCOMING)
+    elif outgoing:
+        network.run_iptables(shakedown.master_ip(), DISABLE_MASTER_OUTGOING)
+    else:
+        pass
+
+
+def reconnect_master():
+    """ Reconnect a previously partitioned master to the network
+    """
+    network.restore_iptables(shakedown.master_ip())
+
+
+def restart_master_node():
+    """ Restarts the master node
+    """
+
+    run_command_on_master("sudo /sbin/shutdown -r now")
+
+
+def systemctl_master(command='restart'):
+    """ Used to start, stop or restart the master process
+    """
+    run_command_on_master('sudo systemctl {} dcos-mesos-master'.format(command))
+
+
+def mesos_available_predicate():
+    url = master_url()
+    try:
+        response = http.get(url)
+        return response.status_code == 200
+    except Exception as e:
+        return False
+
+
+def wait_for_mesos_endpoint(timeout_sec=timedelta(minutes=5).total_seconds()):
+    """Checks the service url if available it returns true, on expiration
+    it returns false"""
+
+    return time_wait(lambda: mesos_available_predicate(), timeout_seconds=timeout_sec)
+
+
+def __mesos_zk_nodes():
+    """ Returns all the children nodes under /mesos in zk
+    """
+    return get_zk_node_children('/mesos')
+
+
+def __master_zk_nodes_keys():
+    """ The masters can be registered in zk with arbitrary ids which start with
+        `json.info_`.  This provides a list of all master keys.
+    """
+    master_zk = []
+    for node in __mesos_zk_nodes():
+        if 'json.info' in node['title']:
+            master_zk.append(node['key'])
+
+    return master_zk
+
+
+def get_all_masters():
+    """ Returns the json object that represents each of the masters.
+    """
+    masters = []
+    for master in __master_zk_nodes_keys():
+        master_zk_str = get_zk_node_data(master)['str']
+        masters.append(json.loads(master_zk_str))
+
+    return masters
+
+
+def master_leader_ip():
+    """Returns the private IP of the mesos master leader.
+    In a multi-master cluster this may not map to the public IP of the master_ip.
+    """
+    return dcos_dns_lookup('leader.mesos')[0]['ip']
+
+
+def get_all_master_ips():
+    """ Returns a list of IPs for the masters
+    """
+    ips = []
+    for master in get_all_masters():
+        ips.append(master['hostname'])
+
+    return ips
+
+
+def required_masters(count):
+    """ Returns True if the number of private agents is equal to or greater than
+    the count.  This is useful in using pytest skipif such as:
+    `pytest.mark.skipif('required_masters(3)')` which will skip the test if
+    the number of masters is only 1.
+
+    :param count: the number of required masters.
+    """
+    master_count = len(get_all_masters())
+    # reverse logic (skip if less than count)
+    # returns True if less than count
+    return master_count < count
+
+
+def masters(count=1):
+    return pytest.mark.skipif('required_masters({})'.format(count))
+
+
+def start_master_http_service(port=7777, pid_file='python_http.pid'):
+    """ Starts a http service on the master leader.  The main purpose is to serve
+    up artifacts for launched test applications.   This is commonly used in combination
+    with copying tests or artifacts to the leader than configuring the messos task
+    to fetch from http://master.mesos:7777/artifact.tar (becareful in a multi-master env)
+
+    :param port: port to use for the http service
+    :return: pid_file
+    """
+    shakedown.run_command_on_master(
+        'nohup /opt/mesosphere/bin/python -m http.server {} > http.log 2>&1 & '
+        'echo $! > {}'.format(port, pid_file))
+    return pid_file
+
+
+@contextlib.contextmanager
+def master_http_service(port=7777):
+    pid_file = start_master_http_service(port)
+    yield
+    kill_process_from_pid_file_on_host(shakedown.master_ip(), pid_file)
+
+
+@contextlib.contextmanager
+def disconnected_master(incoming=True, outgoing=True):
+
+    partition_master(incoming, outgoing)
+    try:
+        yield
+    finally:
+        # return config to previous state
+        reconnect_master()

--- a/tests/shakedown/shakedown/dcos/network.py
+++ b/tests/shakedown/shakedown/dcos/network.py
@@ -1,0 +1,50 @@
+"""Utilities for working with nodes
+    There are a number of common utilies for working with agents and master nodes
+    which are provided here.
+"""
+from shakedown import *
+
+
+def restore_iptables(host):
+    """ Reconnect a previously partitioned node to the network
+        :param hostname: host or IP of the machine to partition from the cluster
+    """
+
+    run_command_on_agent(host, 'if [ -e iptables.rules ]; then sudo iptables-restore < iptables.rules && rm iptables.rules ; fi')
+
+
+def save_iptables(host):
+    """ Saves iptables firewall rules such they can be restored
+    """
+
+    run_command_on_agent(host, 'if [ ! -e iptables.rules ] ; then sudo iptables -L > /dev/null && sudo iptables-save > iptables.rules ; fi')
+
+
+def run_iptables(host, rule):
+    """ iptables is challenging to abstract.  This function takes a rule
+        '-I INPUT -p tcp --dport 22 -j ACCEPT' and runs it on the agent.
+    """
+    ip_table_cmd = 'sudo iptables {}'.format(rule)
+    run_command_on_agent(host, ip_table_cmd)
+
+
+def flush_all_rules(host):
+    """ Flushes all the iptables rules
+    """
+    run_command_on_agent(host, 'sudo iptables -F INPUT')
+
+
+def allow_all_traffic(host):
+    """ Opens up iptables on host to allow all traffic
+    """
+    run_command_on_agent(host, 'sudo iptables --policy INPUT ACCEPT && sudo iptables --policy OUTPUT ACCEPT && sudo iptables --policy FORWARD ACCEPT')
+
+
+@contextlib.contextmanager
+def iptable_rules(host):
+    save_iptables(host)
+    try:
+        yield
+    finally:
+        # return config to previous state
+        restore_iptables(host)

--- a/tests/shakedown/shakedown/dcos/package.py
+++ b/tests/shakedown/shakedown/dcos/package.py
@@ -1,0 +1,432 @@
+import json
+import time
+
+from dcos import (cosmos, errors, package, packagemanager, subcommand)
+from shakedown.dcos.service import *
+
+import shakedown
+
+
+def _get_options(options_file=None):
+    """ Read in options_file as JSON.
+
+        :param options_file: filename to return
+        :type options_file: str
+
+        :return: options as dictionary
+        :rtype: dict
+    """
+
+    if options_file is not None:
+        with open(options_file, 'r') as opt_file:
+            options = json.loads(opt_file.read())
+    else:
+        options = {}
+    return options
+
+
+def _get_service_name(package_name, pkg):
+    labels = pkg.marathon_json({}).get('labels')
+    if 'DCOS_SERVICE_NAME' in labels:
+        return labels['DCOS_SERVICE_NAME']
+    else:
+        return package_name
+
+
+def _get_package_manager():
+    """ Get an instance of Cosmos with the correct URL.
+
+        :return: Cosmos instance
+        :rtype: packagemanager.PackageManager
+    """
+
+    return packagemanager.PackageManager(cosmos.get_cosmos_url())
+
+
+def install_package(
+        package_name,
+        package_version=None,
+        service_name=None,
+        options_file=None,
+        options_json=None,
+        wait_for_completion=False,
+        timeout_sec=600,
+        expected_running_tasks=0
+):
+    """ Install a package via the DC/OS library
+
+        :param package_name: name of the package
+        :type package_name: str
+        :param package_version: version of the package (defaults to latest)
+        :type package_version: str
+        :param service_name: unique service name for the package
+        :type service_name: str
+        :param options_file: filename that has options to use and is JSON format
+        :type options_file: str
+        :param options_json: dict that has options to use and is JSON format
+        :type options_json: dict
+        :param wait_for_completion: whether or not to wait for the app's deployment to complete
+        :type wait_for_completion: bool
+        :param timeout_sec: number of seconds to wait for task completion
+        :type timeout_sec: int
+        :param expected_running_tasks: number of service tasks to check for, or zero to disable
+        :type expected_task_count: int
+
+        :return: True if installation was successful, False otherwise
+        :rtype: bool
+    """
+
+    start = time.time()
+
+    if options_file:
+        options = _get_options(options_file)
+    elif options_json:
+        options = options_json
+    else:
+        options = {}
+
+    package_manager = _get_package_manager()
+    pkg = package_manager.get_package_version(package_name, package_version)
+
+    if package_version is None:
+        # Get the resolved version for logging below
+        package_version = 'auto:{}'.format(pkg.version())
+
+    if service_name is None:
+        # Get the service name from the marathon template
+        try:
+            labels = pkg.marathon_json(options).get('labels')
+            if 'DCOS_SERVICE_NAME' in labels:
+                service_name = labels['DCOS_SERVICE_NAME']
+        except errors.DCOSException as e:
+            pass
+
+    print('\n{}installing {} with service={} version={} options={}'.format(
+        shakedown.cli.helpers.fchr('>>'), package_name, service_name, package_version, options))
+
+    try:
+        # Print pre-install notes to console log
+        pre_install_notes = pkg.package_json().get('preInstallNotes')
+        if pre_install_notes:
+            print(pre_install_notes)
+
+        package_manager.install_app(pkg, options, service_name)
+
+        # Print post-install notes to console log
+        post_install_notes = pkg.package_json().get('postInstallNotes')
+        if post_install_notes:
+            print(post_install_notes)
+
+        # Optionally wait for the app's deployment to finish
+        if wait_for_completion:
+            print("\n{}waiting for {} deployment to complete...".format(
+                shakedown.cli.helpers.fchr('>>'), service_name))
+            if expected_running_tasks > 0 and service_name is not None:
+                wait_for_service_tasks_running(service_name, expected_running_tasks, timeout_sec)
+
+            app_id = pkg.marathon_json(options).get('id')
+            shakedown.deployment_wait(timeout_sec, app_id)
+            print('\n{}install completed after {}\n'.format(
+                shakedown.cli.helpers.fchr('>>'), pretty_duration(time.time() - start)))
+        else:
+            print('\n{}install started after {}\n'.format(
+                shakedown.cli.helpers.fchr('>>'), pretty_duration(time.time() - start)))
+    except errors.DCOSException as e:
+        print('\n{}{}'.format(
+            shakedown.cli.helpers.fchr('>>'), e))
+
+    # Install subcommands (if defined)
+    if pkg.cli_definition():
+        print("{}installing CLI commands for package '{}'".format(
+            shakedown.cli.helpers.fchr('>>'), package_name))
+        subcommand.install(pkg)
+
+    return True
+
+
+def install_package_and_wait(
+        package_name,
+        package_version=None,
+        service_name=None,
+        options_file=None,
+        options_json=None,
+        wait_for_completion=True,
+        timeout_sec=600,
+        expected_running_tasks=0
+):
+    """ Install a package via the DC/OS library and wait for completion
+    """
+
+    return install_package(
+        package_name,
+        package_version,
+        service_name,
+        options_file,
+        options_json,
+        wait_for_completion,
+        timeout_sec,
+        expected_running_tasks
+    )
+
+
+def package_installed(package_name, service_name=None):
+    """ Check whether the package package_name is currently installed.
+
+        :param package_name: package name
+        :type package_name: str
+        :param service_name: service_name
+        :type service_name: str
+
+        :return: True if installed, False otherwise
+        :rtype: bool
+    """
+
+    package_manager = _get_package_manager()
+
+    app_installed = len(package_manager.installed_apps(package_name, service_name)) > 0
+
+    subcommand_installed = False
+    for subcmd in package.installed_subcommands():
+        package_json = subcmd.package_json()
+        if package_json['name'] == package_name:
+            subcommand_installed = True
+
+    return (app_installed or subcommand_installed)
+
+
+def uninstall_package(
+        package_name,
+        service_name=None,
+        all_instances=False,
+        wait_for_completion=False,
+        timeout_sec=600
+):
+    """ Uninstall a package using the DC/OS library.
+
+        :param package_name: name of the package
+        :type package_name: str
+        :param service_name: unique service name for the package
+        :type service_name: str
+        :param all_instances: uninstall all instances of package
+        :type all_instances: bool
+        :param wait_for_completion: whether or not to wait for task completion before returning
+        :type wait_for_completion: bool
+        :param timeout_sec: number of seconds to wait for task completion
+        :type timeout_sec: int
+
+        :return: True if uninstall was successful, False otherwise
+        :rtype: bool
+    """
+
+    package_manager = _get_package_manager()
+    pkg = package_manager.get_package_version(package_name, None)
+
+    try:
+        if service_name is None:
+            service_name = _get_service_name(package_name, pkg)
+
+        print("{}uninstalling package '{}' with service name '{}'\n".format(
+            shakedown.cli.helpers.fchr('>>'), package_name, service_name))
+
+        package_manager.uninstall_app(package_name, all_instances, service_name)
+
+        # Optionally wait for the service to unregister as a framework
+        if wait_for_completion:
+            wait_for_mesos_task_removal(service_name, timeout_sec=timeout_sec)
+    except errors.DCOSException as e:
+        print('\n{}{}'.format(
+            shakedown.cli.helpers.fchr('>>'), e))
+
+    # Uninstall subcommands (if defined)
+    if pkg.cli_definition():
+        print("{}uninstalling CLI commands for package '{}'".format(
+            shakedown.cli.helpers.fchr('>>'), package_name))
+        subcommand.uninstall(package_name)
+
+    return True
+
+
+def uninstall_package_and_wait(
+        package_name,
+        service_name=None,
+        all_instances=False,
+        wait_for_completion=True,
+        timeout_sec=600
+):
+    """ Uninstall a package via the DC/OS library and wait for completion
+
+        :param package_name: name of the package
+        :type package_name: str
+        :param service_name: unique service name for the package
+        :type service_name: str
+        :param all_instances: uninstall all instances of package
+        :type all_instances: bool
+        :param wait_for_completion: whether or not to wait for task completion before returning
+        :type wait_for_completion: bool
+        :param timeout_sec: number of seconds to wait for task completion
+        :type timeout_sec: int
+
+        :return: True if uninstall was successful, False otherwise
+        :rtype: bool
+    """
+
+    return uninstall_package(
+        package_name,
+        service_name,
+        all_instances,
+        wait_for_completion,
+        timeout_sec
+    )
+
+
+def uninstall_package_and_data(
+        package_name,
+        service_name=None,
+        role=None,
+        principal=None,
+        zk_node=None,
+        timeout_sec=600):
+    """ Uninstall a package via the DC/OS library, wait for completion, and delete any persistent data
+
+        :param package_name: name of the package
+        :type package_name: str
+        :param service_name: unique service name for the package
+        :type service_name: str
+        :param role: role to use when deleting data, or <service_name>-role if unset
+        :type role: str, or None
+        :param principal: principal to use when deleting data, or <service_name>-principal if unset
+        :type principal: str, or None
+        :param zk_node: zk node to delete, or dcos-service-<service_name> if unset
+        :type zk_node: str, or None
+        :param wait_for_completion: whether or not to wait for task completion before returning
+        :type wait_for_completion: bool
+        :param timeout_sec: number of seconds to wait for task completion
+        :type timeout_sec: int
+    """
+    start = time.time()
+
+    if service_name is None:
+        pkg = _get_package_manager().get_package_version(package_name, None)
+        service_name = _get_service_name(package_name, pkg)
+    print('\n{}uninstalling/deleting {}'.format(shakedown.cli.helpers.fchr('>>'), service_name))
+
+    try:
+        uninstall_package_and_wait(package_name, service_name=service_name, timeout_sec=timeout_sec)
+    except (errors.DCOSException, ValueError) as e:
+        print('Got exception when uninstalling package, ' +
+              'continuing with janitor anyway: {}'.format(e))
+
+    data_start = time.time()
+
+    if (not role or not principal or not zk_node) and service_name is None:
+        raise DCOSException('service_name must be provided when data params are missing AND the package isn\'t installed')
+    if not role:
+        role = '{}-role'.format(service_name)
+    if not zk_node:
+        zk_node = 'dcos-service-{}'.format(service_name)
+    delete_persistent_data(role, zk_node)
+
+    finish = time.time()
+
+    print('\n{}uninstall/delete done after pkg({}) + data({}) = total({})\n'.format(
+        shakedown.cli.helpers.fchr('>>'),
+        pretty_duration(data_start - start),
+        pretty_duration(finish - data_start),
+        pretty_duration(finish - start)))
+
+
+def get_package_repos():
+    """ Return a list of configured package repositories
+    """
+
+    package_manager = _get_package_manager()
+    return package_manager.get_repos()
+
+
+def package_version_changed_predicate(package_manager, package_name, prev_version):
+    """ Returns whether the provided package has a version other than prev_version
+    """
+    return package_manager.get_package_version(package_name, None) != prev_version
+
+
+def add_package_repo(
+        repo_name,
+        repo_url,
+        index=None,
+        wait_for_package=None,
+        expect_prev_version=None):
+    """ Add a repository to the list of package sources
+
+        :param repo_name: name of the repository to add
+        :type repo_name: str
+        :param repo_url: location of the repository to add
+        :type repo_url: str
+        :param index: index (precedence) for this repository
+        :type index: int
+        :param wait_for_package: the package whose version should change after the repo is added
+        :type wait_for_package: str, or None
+
+        :return: True if successful, False otherwise
+        :rtype: bool
+    """
+
+    package_manager = _get_package_manager()
+    if wait_for_package:
+        prev_version = package_manager.get_package_version(wait_for_package, None)
+    if not package_manager.add_repo(repo_name, repo_url, index):
+        return False
+    if wait_for_package:
+        try:
+            spinner.time_wait(lambda: package_version_changed_predicate(package_manager, wait_for_package, prev_version))
+        except TimeoutExpired:
+            return False
+    return True
+
+
+def remove_package_repo(repo_name, wait_for_package=None):
+    """ Remove a repository from the list of package sources
+
+        :param repo_name: name of the repository to remove
+        :type repo_name: str
+        :param wait_for_package: the package whose version should change after the repo is removed
+        :type wait_for_package: str, or None
+
+        :returns: True if successful, False otherwise
+        :rtype: bool
+    """
+
+    package_manager = _get_package_manager()
+    if wait_for_package:
+        prev_version = package_manager.get_package_version(wait_for_package, None)
+    if not package_manager.remove_repo(repo_name):
+        return False
+    if wait_for_package:
+        try:
+            spinner.time_wait(lambda: package_version_changed_predicate(package_manager, wait_for_package, prev_version))
+        except TimeoutExpired:
+            return False
+    return True
+
+
+def remove_package_repo_and_wait(repo_name, wait_for_package):
+    """ Remove a repository from the list of package sources, then wait for the removal to complete
+
+        :param repo_name: name of the repository to remove
+        :type repo_name: str
+        :param wait_for_package: the package whose version should change after the repo is removed
+        :type wait_for_package: str
+
+        :returns: True if successful, False otherwise
+        :rtype: bool
+    """
+    return remove_package_repo(repo_name, wait_for_package)
+
+
+def get_package_versions(package_name):
+    """ Returns the list of versions of a given package
+        :param package_name: name of the package
+        :type package_name: str
+    """
+    package_manager = _get_package_manager()
+    pkg = package_manager.get_package_version(package_name, None)
+    return pkg.package_versions()

--- a/tests/shakedown/shakedown/dcos/security.py
+++ b/tests/shakedown/shakedown/dcos/security.py
@@ -1,0 +1,277 @@
+"""Utilities for working with authenication and authorization
+   Many of the functions here are for DC/OS Enterprise.
+"""
+
+from shakedown import *
+from urllib.parse import urljoin
+from dcos import http
+import pytest
+
+from dcos.errors import DCOSHTTPException
+
+
+def _acl_url():
+    return urljoin(dcos_url(), 'acs/api/v1/')
+
+
+def add_user(uid, password, desc=None):
+    """ Adds user to the DCOS Enterprise.  If not description
+        is provided the uid will be used for the description.
+
+        :param uid: user id
+        :type uid: str
+        :param password: password
+        :type password: str
+        :param desc: description of user
+        :type desc: str
+    """
+    try:
+        desc = uid if desc is None else desc
+        user_object = {"description": desc, "password": password}
+        acl_url = urljoin(_acl_url(), 'users/{}'.format(uid))
+        r = http.put(acl_url, json=user_object)
+        assert r.status_code == 201
+    except DCOSHTTPException as e:
+        # already exists
+        if e.response.status_code != 409:
+            raise
+
+
+def get_user(uid):
+    """ Returns a user from the DCOS Enterprise.  It returns None if none exists.
+
+        :param uid: user id
+        :type uid: str
+        :return: User
+        :rtype: dict
+    """
+    try:
+        acl_url = urljoin(_acl_url(), 'users/{}'.format(uid))
+        r = http.get(acl_url)
+        return r.json()
+        # assert r.status_code == 201
+    except DCOSHTTPException as e:
+        if e.response.status_code == 400:
+            return None
+        else:
+            raise
+
+
+def remove_user(uid):
+    """ Removes a user from the DCOS Enterprise.
+
+        :param uid: user id
+        :type uid: str
+    """
+    try:
+        acl_url = urljoin(_acl_url(), 'users/{}'.format(uid))
+        r = http.delete(acl_url)
+        assert r.status_code == 204
+    except DCOSHTTPException as e:
+        # doesn't exist
+        if e.response.status_code != 400:
+            raise
+
+
+def ensure_resource(rid):
+    """ Creates or confirms that a resource is added into the DCOS Enterprise System.
+        Example:  dcos:service:marathon:marathon:services:/example-secure
+
+        :param rid: resource ID
+        :type rid: str
+    """
+    try:
+        acl_url = urljoin(_acl_url(), 'acls/{}'.format(rid))
+        r = http.put(acl_url, json={'description': 'jope'})
+        assert r.status_code == 201
+    except DCOSHTTPException as e:
+        if e.response.status_code != 409:
+            raise
+
+
+def set_user_permission(rid, uid, action='full'):
+    """ Sets users permission on a given resource.  The resource will be created
+        if it doesn't exist.  Actions are: read, write, update, delete, full.
+
+        :param uid: user id
+        :type uid: str
+        :param rid: resource ID
+        :type rid: str
+        :param action: read, write, update, delete or full
+        :type action: str
+    """
+    rid = rid.replace('/', '%252F')
+    # Create ACL if it does not yet exist.
+    ensure_resource(rid)
+
+    # Set the permission triplet.
+    try:
+        acl_url = urljoin(_acl_url(), 'acls/{}/users/{}/{}'.format(rid, uid, action))
+        r = http.put(acl_url)
+        assert r.status_code == 204
+    except DCOSHTTPException as e:
+        if e.response.status_code != 409:
+            raise
+
+
+def remove_user_permission(rid, uid, action='full'):
+    """ Removes user permission on a given resource.
+
+        :param uid: user id
+        :type uid: str
+        :param rid: resource ID
+        :type rid: str
+        :param action: read, write, update, delete or full
+        :type action: str
+    """
+    rid = rid.replace('/', '%252F')
+
+    try:
+        acl_url = urljoin(_acl_url(), 'acls/{}/users/{}/{}'.format(rid, uid, action))
+        r = http.delete(acl_url)
+        assert r.status_code == 204
+    except DCOSHTTPException as e:
+        if e.response.status_code != 400:
+            raise
+
+
+@contextlib.contextmanager
+def no_user():
+    """ Provides a context with no logged in user.
+    """
+    o_token = dcos_acs_token()
+    dcos.config.set_val('core.dcos_acs_token', '')
+    yield
+    dcos.config.set_val('core.dcos_acs_token', o_token)
+
+
+@contextlib.contextmanager
+def new_dcos_user(user_id, password):
+    """ Provides a context with a newly created user.
+    """
+    o_token = dcos_acs_token()
+    shakedown.add_user(user_id, password, user_id)
+
+    token = shakedown.authenticate(user_id, password)
+    dcos.config.set_val('core.dcos_acs_token', token)
+    yield
+    dcos.config.set_val('core.dcos_acs_token', o_token)
+    shakedown.remove_user(user_id)
+
+
+@contextlib.contextmanager
+def dcos_user(user_id, password):
+    """ Provides a context with user otherthan super
+    """
+
+    o_token = dcos_acs_token()
+
+    token = shakedown.authenticate(user_id, password)
+    dcos.config.set_val('core.dcos_acs_token', token)
+    yield
+    dcos.config.set_val('core.dcos_acs_token', o_token)
+
+
+def add_group(id, description=None):
+    """ Adds group to the DCOS Enterprise.  If not description
+        is provided the id will be used for the description.
+
+        :param id: group id
+        :type id: str
+        :param desc: description of user
+        :type desc: str
+    """
+
+    if not description:
+        description = id
+    data = {
+        'description': description
+    }
+    acl_url = urljoin(_acl_url(), 'groups/{}'.format(id))
+    try:
+        r = http.put(acl_url, json=data)
+        assert r.status_code == 201
+    except DCOSHTTPException as e:
+        if e.response.status_code != 409:
+            raise
+
+
+def get_group(id):
+    """ Returns a group from the DCOS Enterprise.  It returns None if none exists.
+
+        :param id: group id
+        :type id: str
+        :return: Group
+        :rtype: dict
+    """
+    acl_url = urljoin(_acl_url(), 'groups/{}'.format(id))
+    try:
+        r = http.get(acl_url)
+        return r.json()
+    except DCOSHTTPException as e:
+        if e.response.status_code != 400:
+            raise
+
+
+def remove_group(id):
+    """ Removes a group from the DCOS Enterprise.  The group is
+        removed regardless of associated users.
+
+        :param id: group id
+        :type id: str
+    """
+    acl_url = urljoin(_acl_url(), 'groups/{}'.format(id))
+    try:
+        r = http.delete(acl_url)
+        print(r.status_code)
+    except DCOSHTTPException as e:
+        if e.response.status_code != 400:
+            raise
+
+
+def add_user_to_group(uid, gid, exist_ok=True):
+    """ Adds a user to a group within DCOS Enterprise.  The group and
+        user must exist.
+
+        :param uid: user id
+        :type uid: str
+        :param gid: group id
+        :type gid: str
+        :param exist_ok: True if it is ok for the relationship to pre-exist.
+        :type exist_ok: bool
+    """
+    acl_url = urljoin(_acl_url(), 'groups/{}/users/{}'.format(gid, uid))
+    try:
+        r = http.put(acl_url)
+        assert r.status_code == 204
+    except DCOSHTTPException as e:
+        if e.response.status_code == 409 and exist_ok:
+            pass
+        else:
+            raise
+
+
+def remove_user_from_group(uid, gid):
+    """ Removes a user from a group within DCOS Enterprise.
+
+        :param uid: user id
+        :type uid: str
+        :param gid: group id
+        :type gid: str
+    """
+    acl_url = urljoin(_acl_url(), 'groups/{}/users/{}'.format(gid, uid))
+    try:
+        r = http.delete(acl_url)
+        assert r.status_code == 204
+    except dcos.errors.DCOSBadRequest:
+        pass
+
+
+@pytest.fixture(scope="function")
+def credentials():
+    """ Fixture to ensure that SU credentials are restored for auth tests.
+        @pytest.mark.usefixtures('credentials') for a test
+    """
+    o_token = dcos_acs_token()
+    yield
+    dcos.config.set_val('core.dcos_acs_token', o_token)

--- a/tests/shakedown/shakedown/dcos/service.py
+++ b/tests/shakedown/shakedown/dcos/service.py
@@ -1,0 +1,623 @@
+from dcos import (marathon, mesos, http)
+from shakedown.dcos.command import *
+from shakedown.dcos.spinner import *
+from shakedown.dcos import dcos_service_url, dcos_agents_state, master_url
+from shakedown.dcos.master import get_all_masters
+from shakedown.dcos.zookeeper import delete_zk_node
+from dcos.errors import DCOSException, DCOSConnectionError, DCOSHTTPException
+
+from urllib.parse import urljoin
+import json
+
+
+def get_service(
+        service_name,
+        inactive=False,
+        completed=False
+):
+    """ Get a dictionary describing a service
+        :param service_name: the service name
+        :type service_name: str
+        :param inactive: whether to include inactive services
+        :type inactive: bool
+        :param completed: whether to include completed services
+        :type completed: bool
+
+        :return: a dict describing a service
+        :rtype: dict, or None
+    """
+
+    services = mesos.get_master().frameworks(inactive=inactive, completed=completed)
+
+    for service in services:
+        if service['name'] == service_name:
+            return service
+
+    return None
+
+
+def get_service_framework_id(
+        service_name,
+        inactive=False,
+        completed=False
+):
+    """ Get the framework ID for a service
+        :param service_name: the service name
+        :type service_name: str
+        :param inactive: whether to include inactive services
+        :type inactive: bool
+        :param completed: whether to include completed services
+        :type completed: bool
+
+        :return: a framework id
+        :rtype: str, or None
+    """
+
+    service = get_service(service_name, inactive, completed)
+
+    if service is not None and service['id']:
+        return service['id']
+
+    return None
+
+
+def get_service_tasks(
+        service_name,
+        inactive=False,
+        completed=False
+):
+    """ Get a list of tasks associated with a service
+        :param service_name: the service name
+        :type service_name: str
+        :param inactive: whether to include inactive services
+        :type inactive: bool
+        :param completed: whether to include completed services
+        :type completed: bool
+
+        :return: a list of task objects
+        :rtye: [dict], or None
+    """
+
+    service = get_service(service_name, inactive, completed)
+
+    if service is not None and service['tasks']:
+        return service['tasks']
+
+    return []
+
+
+def get_service_task_ids(
+        service_name,
+        task_predicate=None,
+        inactive=False,
+        completed=False
+):
+    """ Get a list of task IDs associated with a service
+        :param service_name: the service name
+        :type service_name: str
+        :param task_predicate: filter function which accepts a task object and returns a boolean
+        :type task_predicate: function, or None
+        :param inactive: whether to include inactive services
+        :type inactive: bool
+        :param completed: whether to include completed services
+        :type completed: bool
+
+        :return: a list of task ids
+        :rtye: [str], or None
+    """
+    tasks = get_service_tasks(service_name, inactive, completed)
+    if task_predicate:
+        return [t['id'] for t in tasks if task_predicate(t)]
+    else:
+        return [t['id'] for t in tasks]
+
+
+def get_marathon_tasks(
+        inactive=False,
+        completed=False
+):
+    """ Get a list of marathon tasks
+    """
+
+    return get_service_tasks('marathon', inactive, completed)
+
+
+def get_mesos_tasks():
+    """ Get a list of mesos tasks
+    """
+    return mesos.get_master().tasks()
+
+
+def get_service_task(
+        service_name,
+        task_name,
+        inactive=False,
+        completed=False
+):
+    """ Get a dictionary describing a service task, or None
+        :param service_name: the service name
+        :type service_name: str
+        :param task_name: the task name
+        :type task_name: str
+        :param inactive: whether to include inactive services
+        :type inactive: bool
+        :param completed: whether to include completed services
+        :type completed: bool
+
+        :return: a dictionary describing the service
+        :rtye: dict, or None
+    """
+
+    service = get_service_tasks(service_name, inactive, completed)
+
+    if service is not None:
+        for task in service:
+            if task['name'] == task_name:
+                return task
+
+    return None
+
+
+def get_marathon_task(
+        task_name,
+        inactive=False,
+        completed=False
+):
+    """ Get a dictionary describing a named marathon task
+    """
+
+    return get_service_task('marathon', task_name, inactive, completed)
+
+
+def get_mesos_task(task_name):
+    """ Get a mesos task with a specific task name
+    """
+    tasks = get_mesos_tasks()
+
+    if tasks is not None:
+        for task in tasks:
+            if task['name'] == task_name:
+                return task
+    return None
+
+
+def get_service_ips(
+        service_name,
+        task_name=None,
+        inactive=False,
+        completed=False
+):
+    """ Get a set of the IPs associated with a service
+        :param service_name: the service name
+        :type service_name: str
+        :param task_name: the task name
+        :type task_name: str
+        :param inactive: wehther to include inactive services
+        :type inactive: bool
+        :param completed: whether to include completed services
+        :type completed: bool
+
+        :return: a list of IP addresses
+        :rtype: [str]
+    """
+
+    service_tasks = get_service_tasks(service_name, inactive, completed)
+
+    ips = set([])
+
+    for task in service_tasks:
+        if task_name is None or task['name'] == task_name:
+            for status in task['statuses']:
+                # Only the TASK_RUNNING status will have correct IP information.
+                if status["state"] != "TASK_RUNNING":
+                    continue
+
+                for ip in status['container_status']['network_infos'][0]['ip_addresses']:
+                    ips.add(ip['ip_address'])
+
+    return ips
+
+
+def service_healthy(service_name, app_id=None):
+    """ Check whether a named service is healthy
+
+        :param service_name: the service name
+        :type service_name: str
+        :param app_id: app_id to filter
+        :type app_id: str
+
+        :return: True if healthy, False otherwise
+        :rtype: bool
+    """
+
+    marathon_client = marathon.create_client()
+    apps = marathon_client.get_apps_for_framework(service_name)
+
+    if apps:
+        for app in apps:
+            if (app_id is not None) and (app['id'] != "/{}".format(str(app_id))):
+                continue
+
+            if (app['tasksHealthy']) \
+            and (app['tasksRunning']) \
+            and (not app['tasksStaged']) \
+            and (not app['tasksUnhealthy']):
+                return True
+
+    return False
+
+
+def mesos_task_present_predicate(task_name):
+    return get_mesos_task(task_name) is not None
+
+
+def mesos_task_not_present_predicate(task_name):
+    return get_mesos_task(task_name) is None
+
+
+def wait_for_mesos_task(task_name, timeout_sec=120):
+    return time_wait(lambda: mesos_task_present_predicate(task_name), timeout_seconds=timeout_sec)
+
+
+def wait_for_mesos_task_removal(task_name, timeout_sec=120):
+    return time_wait(lambda: mesos_task_not_present_predicate(task_name), timeout_seconds=timeout_sec)
+
+
+def delete_persistent_data(role, zk_node):
+    """ Deletes any persistent data associated with the specified role, and zk node.
+
+        :param role: the mesos role to delete, or None to omit this
+        :type role: str
+        :param zk_node: the zookeeper node to be deleted, or None to skip this deletion
+        :type zk_node: str
+    """
+    if role:
+        destroy_volumes(role)
+        unreserve_resources(role)
+
+    if zk_node:
+        delete_zk_node(zk_node)
+
+
+def destroy_volumes(role):
+    """ Destroys all volumes on all the slaves in the cluster for the role.
+    """
+    state = dcos_agents_state()
+    if not state or 'slaves' not in state.keys():
+        return False
+    all_success = True
+    for agent in state['slaves']:
+        if not destroy_volume(agent, role):
+            all_success = False
+    return all_success
+
+
+def destroy_volume(agent, role):
+    """ Deletes the volumes on the specific agent for the role
+    """
+    volumes = []
+    agent_id = agent['id']
+
+    reserved_resources_full = agent.get('reserved_resources_full', None)
+    if not reserved_resources_full:
+        # doesn't exist
+        return True
+
+    reserved_resources = reserved_resources_full.get(role, None)
+    if not reserved_resources:
+        # doesn't exist
+        return True
+
+    for reserved_resource in reserved_resources:
+        name = reserved_resource.get('name', None)
+        disk = reserved_resource.get('disk', None)
+
+        if name == 'disk' and disk is not None and 'persistence' in disk:
+            volumes.append(reserved_resource)
+
+    req_url = urljoin(master_url(), 'destroy-volumes')
+    data = {
+        'slaveId': agent_id,
+        'volumes': json.dumps(volumes)
+    }
+
+    success = False
+    try:
+        response = http.post(req_url, data=data)
+        success = 200 <= response.status_code < 300
+        if response.status_code == 409:
+            # thoughts on what to do here? throw exception
+            # i would rather not print
+            print('''###\nIs a framework using these resources still installed?\n###''')
+    except DCOSHTTPException as e:
+        print("HTTP {}: Unabled to delete volume based on: {}".format(
+            e.response.status_code,
+            e.response.text))
+
+    return success
+
+
+def unreserve_resources(role):
+    """ Unreserves all the resources for all the slaves for the role.
+    """
+    state = dcos_agents_state()
+    if not state or 'slaves' not in state.keys():
+        return False
+    all_success = True
+    for agent in state['slaves']:
+        if not unreserve_resource(agent, role):
+            all_success = False
+    return all_success
+
+
+def unreserve_resource(agent, role):
+    """ Unreserves all the resources for the role on the agent.
+    """
+    resources = []
+    agent_id = agent['id']
+
+    reserved_resources_full = agent.get('reserved_resources_full', None)
+    if not reserved_resources_full:
+        # doesn't exist
+        return True
+
+    reserved_resources = reserved_resources_full.get(role, None)
+    if not reserved_resources:
+        # doesn't exist
+        return True
+
+    for reserved_resource in reserved_resources:
+        resources.append(reserved_resource)
+
+    req_url = urljoin(master_url(), 'unreserve')
+    data = {
+        'slaveId': agent_id,
+        'resources': json.dumps(resources)
+    }
+
+    success = False
+    try:
+        response = http.post(req_url, data=data)
+        success = 200 <= response.status_code < 300
+    except DCOSHTTPException as e:
+        print("HTTP {}: Unabled to unreserve resources based on: {}".format(
+            e.response.status_code,
+            e.response.text))
+
+    return success
+
+
+def service_available_predicate(service_name):
+    url = dcos_service_url(service_name)
+    try:
+        response = http.get(url)
+        return response.status_code == 200
+    except Exception as e:
+        return False
+
+
+def service_unavailable_predicate(service_name):
+    url = dcos_service_url(service_name)
+    try:
+        response = http.get(url)
+    except DCOSHTTPException as e:
+        if e.response.status_code == 500:
+            return True
+    else:
+        return False
+
+
+def wait_for_service_endpoint(service_name, timeout_sec=120):
+    """Checks the service url if available it returns true, on expiration
+    it returns false"""
+
+    master_count = len(get_all_masters())
+    return time_wait(lambda: service_available_predicate(service_name),
+                     timeout_seconds=timeout_sec,
+                     required_consecutive_success_count=master_count)
+
+
+def wait_for_service_endpoint_removal(service_name, timeout_sec=120):
+    """Checks the service url if it is removed it returns true, on expiration
+    it returns false"""
+
+    return time_wait(lambda: service_unavailable_predicate(service_name), timeout_seconds=timeout_sec)
+
+
+def task_states_predicate(service_name, expected_task_count, expected_task_states):
+    """ Returns whether the provided service_names's tasks have expected_task_count tasks
+        in any of expected_task_states. For example, if service 'foo' has 5 tasks which are
+        TASK_STAGING or TASK_RUNNING.
+
+        :param service_name: the service name
+        :type service_name: str
+        :param expected_task_count: the number of tasks which should have an expected state
+        :type expected_task_count: int
+        :param expected_task_states: the list states to search for among the service's tasks
+        :type expected_task_states: [str]
+
+        :return: True if expected_task_count tasks have any of expected_task_states, False otherwise
+        :rtype: bool
+    """
+    try:
+        tasks = get_service_tasks(service_name)
+    except (DCOSConnectionError, DCOSHTTPException):
+        tasks = []
+    matching_tasks = []
+    other_tasks = []
+    for t in tasks:
+        name = t.get('name', 'UNKNOWN_NAME')
+        state = t.get('state', None)
+        if state and state in expected_task_states:
+            matching_tasks.append(name)
+        else:
+            other_tasks.append('{}={}'.format(name, state))
+    print('expected {} tasks in {}:\n- {} in expected {}: {}\n- {} in other states: {}'.format(
+        expected_task_count, ', '.join(expected_task_states),
+        len(matching_tasks), ', '.join(expected_task_states), ', '.join(matching_tasks),
+        len(other_tasks), ', '.join(other_tasks)))
+    return len(matching_tasks) >= expected_task_count
+
+
+def wait_for_service_tasks_state(
+        service_name,
+        expected_task_count,
+        expected_task_states,
+        timeout_sec=120
+):
+    """ Returns once the service has at least N tasks in one of the specified state(s)
+
+        :param service_name: the service name
+        :type service_name: str
+        :param expected_task_count: the expected number of tasks in the specified state(s)
+        :type expected_task_count: int
+        :param expected_task_states: the expected state(s) for tasks to be in, e.g. 'TASK_RUNNING'
+        :type expected_task_states: [str]
+        :param timeout_sec: duration to wait
+        :type timeout_sec: int
+
+        :return: the duration waited in seconds
+        :rtype: int
+    """
+    return time_wait(
+        lambda: task_states_predicate(service_name, expected_task_count, expected_task_states),
+        timeout_seconds=timeout_sec)
+
+
+def wait_for_service_tasks_running(
+        service_name,
+        expected_task_count,
+        timeout_sec=120
+):
+    """ Returns once the service has at least N running tasks
+
+        :param service_name: the service name
+        :type service_name: str
+        :param expected_task_count: the expected number of running tasks
+        :type expected_task_count: int
+        :param timeout_sec: duration to wait
+        :type timeout_sec: int
+
+        :return: the duration waited in seconds
+        :rtype: int
+    """
+    return wait_for_service_tasks_state(service_name, expected_task_count, ['TASK_RUNNING'], timeout_sec)
+
+
+def tasks_all_replaced_predicate(
+        service_name,
+        old_task_ids,
+        task_predicate=None
+):
+    """ Returns whether ALL of old_task_ids have been replaced with new tasks
+
+        :param service_name: the service name
+        :type service_name: str
+        :param old_task_ids: list of original task ids as returned by get_service_task_ids
+        :type old_task_ids: [str]
+        :param task_predicate: filter to use when searching for tasks
+        :type task_predicate: func
+
+        :return: True if none of old_task_ids are still present in the service
+        :rtype: bool
+    """
+    try:
+        task_ids = get_service_task_ids(service_name, task_predicate)
+    except DCOSHTTPException:
+        print('failed to get task ids for service {}'.format(service_name))
+        task_ids = []
+
+    print('waiting for all task ids in "{}" to change:\n- old tasks: {}\n- current tasks: {}'.format(
+        service_name, old_task_ids, task_ids))
+    for id in task_ids:
+        if id in old_task_ids:
+            return False  # old task still present
+    if len(task_ids) < len(old_task_ids):  # new tasks haven't fully replaced old tasks
+        return False
+    return True
+
+
+def tasks_missing_predicate(
+        service_name,
+        old_task_ids,
+        task_predicate=None
+):
+    """ Returns whether any of old_task_ids are no longer present
+
+        :param service_name: the service name
+        :type service_name: str
+        :param old_task_ids: list of original task ids as returned by get_service_task_ids
+        :type old_task_ids: [str]
+        :param task_predicate: filter to use when searching for tasks
+        :type task_predicate: func
+
+        :return: True if any of old_task_ids are no longer present in the service
+        :rtype: bool
+    """
+    try:
+        task_ids = get_service_task_ids(service_name, task_predicate)
+    except DCOSHTTPException:
+        print('failed to get task ids for service {}'.format(service_name))
+        task_ids = []
+
+    print('checking whether old tasks in "{}" are missing:\n- old tasks: {}\n- current tasks: {}'.format(
+        service_name, old_task_ids, task_ids))
+    for id in old_task_ids:
+        if id not in task_ids:
+            return True  # an old task was not present
+    return False
+
+
+def wait_for_service_tasks_all_changed(
+        service_name,
+        old_task_ids,
+        task_predicate=None,
+        timeout_sec=120
+):
+    """ Returns once ALL of old_task_ids have been replaced with new tasks
+
+        :param service_name: the service name
+        :type service_name: str
+        :param old_task_ids: list of original task ids as returned by get_service_task_ids
+        :type old_task_ids: [str]
+        :param task_predicate: filter to use when searching for tasks
+        :type task_predicate: func
+        :param timeout_sec: duration to wait
+        :type timeout_sec: int
+
+        :return: the duration waited in seconds
+        :rtype: int
+    """
+    return time_wait(
+        lambda: tasks_all_replaced_predicate(service_name, old_task_ids, task_predicate),
+        timeout_seconds=timeout_sec)
+
+
+def wait_for_service_tasks_all_unchanged(
+        service_name,
+        old_task_ids,
+        task_predicate=None,
+        timeout_sec=30
+):
+    """ Returns after verifying that NONE of old_task_ids have been removed or replaced from the service
+
+        :param service_name: the service name
+        :type service_name: str
+        :param old_task_ids: list of original task ids as returned by get_service_task_ids
+        :type old_task_ids: [str]
+        :param task_predicate: filter to use when searching for tasks
+        :type task_predicate: func
+        :param timeout_sec: duration to wait until assuming tasks are unchanged
+        :type timeout_sec: int
+
+        :return: the duration waited in seconds (the timeout value)
+        :rtype: int
+    """
+    try:
+        time_wait(
+            lambda: tasks_missing_predicate(service_name, old_task_ids, task_predicate),
+            timeout_seconds=timeout_sec)
+        # shouldn't have exited successfully: raise below
+    except TimeoutExpired:
+        return timeout_sec  # no changes occurred within timeout, as expected
+    raise DCOSException("One or more of the following tasks were no longer found: {}".format(old_task_ids))

--- a/tests/shakedown/shakedown/dcos/spinner.py
+++ b/tests/shakedown/shakedown/dcos/spinner.py
@@ -1,0 +1,201 @@
+from dcos import util
+import time as time_module
+import traceback
+
+import shakedown
+
+from inspect import currentframe, getargvalues, getsource, getouterframes
+
+logger = util.get_logger(__name__)
+
+
+def wait_for(
+        predicate,
+        timeout_seconds=120,
+        sleep_seconds=1,
+        ignore_exceptions=True,
+        inverse_predicate=False,
+        noisy=False,
+        required_consecutive_success_count=1):
+    """ waits or spins for a predicate, returning the result.
+        Predicate is a function that returns a truthy or falsy value.
+        An exception in the function will be returned.
+        A timeout will throw a TimeoutExpired Exception.
+
+    """
+    count = 0
+    start_time = time_module.time()
+    timeout = Deadline.create_deadline(timeout_seconds)
+    while True:
+        try:
+            result = predicate()
+        except Exception as e:
+            if ignore_exceptions:
+                if noisy:
+                    logger.exception("Ignoring error during wait.")
+            else:
+                count = 0
+                raise  # preserve original stack
+        else:
+            if (not inverse_predicate and result) or (inverse_predicate and not result):
+                count = count + 1
+            if count >= required_consecutive_success_count:
+                return result
+
+        if timeout.is_expired():
+            funname = __stringify_predicate(predicate)
+            raise TimeoutExpired(timeout_seconds, funname)
+        if noisy:
+            header = '{}[{}/{}]'.format(
+                shakedown.cli.helpers.fchr('>>'),
+                pretty_duration(time_module.time() - start_time),
+                pretty_duration(timeout_seconds)
+            )
+            if required_consecutive_success_count > 1:
+                header = '{} [{} of {} times]'.format(
+                    header,
+                    count,
+                    required_consecutive_success_count)
+            print('{} spinning...'.format(header))
+        time_module.sleep(sleep_seconds)
+
+
+def __stringify_predicate(predicate):
+    """ Reflection of function name and parameters of the predicate being used.
+    """
+    funname = getsource(predicate).strip().split(' ')[2].rstrip(',')
+    params = 'None'
+
+    # if args dig in the stack
+    if '()' not in funname:
+        stack = getouterframes(currentframe())
+        for frame in range(0, len(stack)):
+            if funname in str(stack[frame]):
+                _, _, _, params = getargvalues(stack[frame][0])
+
+    return "function: {} params: {}".format(funname, params)
+
+
+def time_wait(
+    predicate,
+    timeout_seconds=120,
+    sleep_seconds=1,
+    ignore_exceptions=True,
+    inverse_predicate=False,
+    noisy=True,
+    required_consecutive_success_count=1):
+    """ waits or spins for a predicate and returns the time of the wait.
+        An exception in the function will be returned.
+        A timeout will throw a TimeoutExpired Exception.
+
+    """
+    start = time_module.time()
+    wait_for(predicate, timeout_seconds, sleep_seconds, ignore_exceptions, inverse_predicate, noisy, required_consecutive_success_count)
+    return elapse_time(start)
+
+
+def wait_while_exceptions(
+        predicate,
+        timeout_seconds=120,
+        sleep_seconds=1,
+        noisy=False):
+    """ waits for a predicate, ignoring exceptions, returning the result.
+        Predicate is a function.
+        Exceptions will trigger the sleep and retry; any non-exception result
+        will be returned.
+        A timeout will throw a TimeoutExpired Exception.
+    """
+    start_time = time_module.time()
+    timeout = Deadline.create_deadline(timeout_seconds)
+    while True:
+        try:
+            result = predicate()
+            return result
+        except Exception as e:
+            if noisy:
+                logger.exception("Ignoring error during wait.")
+
+        if timeout.is_expired():
+            funname = __stringify_predicate(predicate)
+            raise TimeoutExpired(timeout_seconds, funname)
+        if noisy:
+            header = '{}[{}/{}]'.format(
+                shakedown.cli.helpers.fchr('>>'),
+                pretty_duration(time_module.time() - start_time),
+                pretty_duration(timeout_seconds)
+            )
+            print('{} spinning...'.format(header))
+        time_module.sleep(sleep_seconds)
+
+
+def elapse_time(start, end=None, precision=3):
+    """ Simple time calculation utility.   Given a start time, it will provide an elapse time.
+    """
+    if end is None:
+        end = time_module.time()
+    return round(end-start, precision)
+
+
+def pretty_duration(seconds):
+    """ Returns a user-friendly representation of the provided duration in seconds.
+    For example: 62.8 => "1m2.8s", or 129837.8 => "2d12h4m57.8s"
+    """
+    if seconds is None:
+        return ''
+    ret = ''
+    if seconds >= 86400:
+        ret += '{:.0f}d'.format(int(seconds / 86400))
+        seconds = seconds % 86400
+    if seconds >= 3600:
+        ret += '{:.0f}h'.format(int(seconds / 3600))
+        seconds = seconds % 3600
+    if seconds >= 60:
+        ret += '{:.0f}m'.format(int(seconds / 60))
+        seconds = seconds % 60
+    if seconds > 0:
+        ret += '{:.1f}s'.format(seconds)
+    return ret
+
+
+class Deadline(object):
+
+    def is_expired(self):
+        raise NotImplementedError()
+
+    @staticmethod
+    def create_deadline(seconds):
+        if seconds is None:
+            return Forever()
+        return Within(seconds)
+
+
+class Within(Deadline):
+
+    def __init__(self, seconds):
+        super(Within, self).__init__()
+        self._deadline = time_module.time() + seconds
+
+    def is_expired(self):
+        return time_module.time() >= self._deadline
+
+
+class Forever(Deadline):
+
+    def is_expired(self):
+        return False
+
+
+class TimeoutExpired(Exception):
+    def __init__(self, timeout_seconds, what):
+        super(TimeoutExpired, self).__init__(timeout_seconds, what)
+        self._timeout_seconds = timeout_seconds
+        self._what = what
+
+    def __str__(self):
+        return "Timeout of {0} expired waiting for {1}".format(pretty_duration(self._timeout_seconds), self._what)
+
+    def __repr__(self):
+        return "{0}: {1}".format(type(self).__name__, self)
+
+    def __unicode__(self):
+        return u"Timeout of {0} expired waiting for {1}".format(pretty_duration(self._timeout_seconds), self._what)

--- a/tests/shakedown/shakedown/dcos/task.py
+++ b/tests/shakedown/shakedown/dcos/task.py
@@ -1,0 +1,138 @@
+from dcos import mesos
+
+from shakedown.dcos.helpers import *
+from shakedown.dcos.service import *
+from shakedown.dcos.spinner import *
+from shakedown.dcos import *
+
+import shakedown
+import time
+
+
+def get_tasks(task_id='', completed=True):
+    """ Get a list of tasks, optionally filtered by task id.
+        The task_id can be the abbrevated.  Example: If a task named 'sleep' is
+        scaled to 3 in marathon, there will be be 3 tasks starting with 'sleep.'
+
+        :param task_id: task ID
+        :type task_id: str
+        :param completed: include completed tasks?
+        :type completed: bool
+
+        :return: a list of tasks
+        :rtype: []
+    """
+
+    client = mesos.DCOSClient()
+    master = mesos.Master(client.get_master_state())
+    mesos_tasks = master.tasks(completed=completed, fltr=task_id)
+    return [task.__dict__['_task'] for task in mesos_tasks]
+
+
+def get_task(task_id, completed=True):
+    """ Get a task by task id where a task_id is required.
+
+        :param task_id: task ID
+        :type task_id: str
+        :param completed: include completed tasks?
+        :type completed: bool
+
+        :return: a task
+        :rtype: obj
+    """
+    tasks = get_tasks(task_id=task_id, completed=completed)
+
+    if len(tasks) == 0:
+        return None
+
+    assert len(tasks) == 1, 'get_task should return at max 1 task for a task id'
+    return tasks[0]
+
+
+def get_active_tasks(task_id=''):
+    """ Get a list of active tasks, optionally filtered by task ID.
+    """
+
+    return get_tasks(task_id=task_id, completed=False)
+
+
+def task_completed(task_id):
+    """ Check whether a task has completed.
+
+        :param task_id: task ID
+        :type task_id: str
+
+        :return: True if completed, False otherwise
+        :rtype: bool
+    """
+
+    tasks = get_tasks(task_id=task_id)
+    completed_states = ('TASK_FINISHED',
+                        'TASK_FAILED',
+                        'TASK_KILLED',
+                        'TASK_LOST',
+                        'TASK_ERROR')
+
+    for task in tasks:
+        if task['state'] in completed_states:
+            return True
+
+    return False
+
+
+def wait_for_task_completion(task_id, timeout_sec=None):
+    """ Block until the task completes
+
+        :param task_id: task ID
+        :type task_id: str
+
+        :rtype: None
+    """
+    return time_wait(lambda: task_completed(task_id), timeout_seconds=timeout_sec)
+
+
+def task_property_value_predicate(service, task, prop, value):
+    try:
+        response = get_service_task(service, task)
+    except Exception as e:
+        pass
+
+    return (response is not None) and (response[prop] == value)
+
+
+def task_predicate(service, task):
+    return task_property_value_predicate(service, task, 'state', 'TASK_RUNNING')
+
+
+def task_property_present_predicate(service, task, prop):
+    """ True if the json_element passed is present for the task specified.
+    """
+    try:
+        response = get_service_task(service, task)
+    except Exception as e:
+        pass
+
+    return (response is not None) and (prop in response)
+
+
+def wait_for_task(service, task, timeout_sec=120):
+    """Waits for a task which was launched to be launched"""
+    return time_wait(lambda: task_predicate(service, task), timeout_seconds=timeout_sec)
+
+
+def wait_for_task_property(service, task, prop, timeout_sec=120):
+    """Waits for a task to have the specified property"""
+    return time_wait(lambda: task_property_present_predicate(service, task, prop), timeout_seconds=timeout_sec)
+
+
+def wait_for_task_property_value(service, task, prop, value, timeout_sec=120):
+    return time_wait(lambda: task_property_value_predicate(service, task, prop, value), timeout_seconds=timeout_sec)
+
+
+def dns_predicate(name):
+    dns = dcos_dns_lookup(name)
+    return dns[0].get('ip') is not None
+
+
+def wait_for_dns(name, timeout_sec=120):
+    return time_wait(lambda: dns_predicate(name), timeout_seconds=timeout_sec)

--- a/tests/shakedown/shakedown/dcos/zookeeper.py
+++ b/tests/shakedown/shakedown/dcos/zookeeper.py
@@ -1,0 +1,24 @@
+from shakedown import *
+
+
+# API found via https://groups.google.com/forum/#!topic/exhibitor-users/HoTXQWmQ1bs
+def get_zk_node_data(node_name):
+    znode_url = "{}/exhibitor/exhibitor/v1/explorer/node-data?key={}".format(dcos_url(), node_name)
+    response = http.get(znode_url)
+    return response.json()
+
+
+def get_zk_node_children(node_name):
+    znode_url = "{}/exhibitor/exhibitor/v1/explorer/node?key={}".format(dcos_url(), node_name)
+    response = http.get(znode_url)
+    return response.json()
+
+
+def delete_zk_node(node_name):
+    znode_url = "{}/exhibitor/exhibitor/v1/explorer/znode/{}".format(dcos_url(), node_name)
+    response = http.delete(znode_url)
+
+    if 200 <= response.status_code < 300:
+        return True
+    else:
+        return False

--- a/tests/shakedown/tests/acceptance/test_00_setup.py
+++ b/tests/shakedown/tests/acceptance/test_00_setup.py
@@ -1,0 +1,6 @@
+from shakedown import *
+
+
+def test_install_package_jenkins():
+    if not package_installed('jenkins'):
+        install_package_and_wait('jenkins')

--- a/tests/shakedown/tests/acceptance/test_dcos_agent.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_agent.py
@@ -1,0 +1,36 @@
+import socket
+
+from shakedown import *
+
+
+def test_get_public_agents():
+    public_agents = get_public_agents()
+
+    assert isinstance(public_agents, list)
+
+    try:
+        assert socket.inet_aton(public_agents[0])
+    except:
+        assert False
+
+
+def test_get_private_agents():
+    private_agents = get_private_agents()
+
+    assert isinstance(private_agents, list)
+
+    try:
+        assert socket.inet_aton(private_agents[0])
+    except:
+        assert False
+
+
+def test_get_agents():
+    agents = get_agents()
+
+    assert isinstance(agents, list)
+
+    try:
+        assert socket.inet_aton(agents[0])
+    except:
+        assert False

--- a/tests/shakedown/tests/acceptance/test_dcos_cluster.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_cluster.py
@@ -1,0 +1,31 @@
+from shakedown import *
+
+
+def test_get_resources():
+    resources = get_resources()
+
+    assert resources.cpus > 0
+    assert resources.mem > 0
+
+
+def test_get_used_resources():
+    unused = get_resources()
+    used = get_used_resources()
+    available = available_resources()
+
+    expected = unused - used
+
+    assert available == expected
+
+
+def test_get_reserved_resources():
+    resources = get_reserved_resources()
+    assert resources.cpus > 0
+    assert resources.mem > 0
+
+
+def test_resources_needed():
+    needed = resources_needed(8, 1, 2)
+
+    assert needed.cpus == 8
+    assert needed.mem == 16

--- a/tests/shakedown/tests/acceptance/test_dcos_command.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_command.py
@@ -1,0 +1,34 @@
+from shakedown import *
+
+
+def test_run_command():
+    exit_status, output = run_command(master_ip(), 'cat /etc/motd')
+    assert exit_status
+
+def test_run_command_on_master():
+    exit_status, output = run_command_on_master('uname -a')
+    assert exit_status
+    assert output.startswith('Linux')
+
+def test_run_command_on_leader():
+    exit_status, output = run_command_on_leader('uname -a')
+    assert exit_status
+    assert output.startswith('Linux')
+
+def test_run_command_on_marathon_leader():
+    exit_status, output = run_command_on_marathon_leader('uname -a')
+    assert exit_status
+    assert output.startswith('Linux')
+
+def test_run_command_on_agent():
+    """Run 'ps' on all agents looking for jenkins."""
+    service_ips = get_private_agents() + get_public_agents()
+    for host in service_ips:
+        exit_status, output = run_command_on_agent(host, 'ps -eaf | grep -i docker | grep -i jenkins')
+        assert exit_status
+        assert len(output) > 0
+
+def test_run_dcos_command():
+    stdout, stderr, return_code = run_dcos_command('package search jenkins --json')
+    result_json = json.loads(stdout)
+    assert result_json['packages'][0]['name'] == 'jenkins'

--- a/tests/shakedown/tests/acceptance/test_dcos_docker.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_docker.py
@@ -1,0 +1,6 @@
+from shakedown import *
+
+def test_docker_version():
+    master_docker_version = docker_version()
+    print("DC/OS master is running Docker Server {}".format(master_docker_version))
+    assert master_docker_version != 'unknown'

--- a/tests/shakedown/tests/acceptance/test_dcos_file.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_file.py
@@ -1,0 +1,67 @@
+import os
+import random
+import string
+
+from shakedown import *
+
+
+def test_copy_file():
+    filename = ''.join(random.choice(string.ascii_uppercase) for i in range(12))
+    f = open('/tmp/' + filename, 'w')
+    f.write('Hello world!')
+    f.close()
+
+    assert copy_file(master_ip(), '/tmp/' + filename)
+    assert run_command(master_ip(), 'cat ' + filename)
+
+    os.remove('/tmp/' + filename)
+
+
+def test_copy_file_to_master():
+    filename = ''.join(random.choice(string.ascii_uppercase) for i in range(12))
+    f = open('/tmp/' + filename, 'w')
+    f.write('Hello world!')
+    f.close()
+
+    assert copy_file_to_master('/tmp/' + filename)
+    assert run_command(master_ip(), 'cat ' + filename)
+
+    os.remove('/tmp/' + filename)
+
+
+def test_copy_file_to_agent():
+    filename = ''.join(random.choice(string.ascii_uppercase) for i in range(12))
+    f = open('/tmp/' + filename, 'w')
+    f.write('Hello world!')
+    f.close()
+
+    # Get all IPs associated with the 'jenkins' task running in the 'marathon' service
+    service_ips = get_service_ips('marathon', 'jenkins')
+    for host in service_ips:
+        assert copy_file_to_agent(host, '/tmp/' + filename)
+        assert run_command_on_agent(host, 'cat ' + filename)
+
+    os.remove('/tmp/' + filename)
+
+
+def test_copy_file_from_master():
+    assert copy_file_from_master('/etc/motd')
+
+    f = open('motd', 'r')
+    print(f.read())
+    f.close()
+
+    os.remove('motd')
+
+
+def test_copy_file_from_agent():
+    # Get all IPs associated with the 'jenkins' task running in the 'marathon' service
+    service_ips = get_service_ips('marathon', 'jenkins')
+    for host in service_ips:
+        assert copy_file_from_agent(host, '/etc/motd')
+
+    f = open('motd', 'r')
+    print(f.read())
+    f.close()
+
+    os.remove('motd')

--- a/tests/shakedown/tests/acceptance/test_dcos_master.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_master.py
@@ -1,0 +1,13 @@
+from shakedown import *
+
+from dcos import http
+
+def test_http_service():
+    with master_http_service():
+
+        # this service is not externally exposed.  the http check must be from inside the cluster
+        cmd = r'curl -s -o /dev/null -w "%{http_code}" http://master.mesos:7777/'
+        status, output = shakedown.run_command_on_master(cmd)
+
+        assert status
+        assert output == '200'

--- a/tests/shakedown/tests/acceptance/test_dcos_package.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_package.py
@@ -1,0 +1,79 @@
+import json
+import pytest
+
+from shakedown import *
+
+@pytest.fixture(scope='function')
+def chronos_cleanup():
+    yield
+    remove_chronos()
+
+
+def test_install_package_and_wait():
+    assert not package_installed('chronos')
+    install_package_and_wait('chronos')
+    assert package_installed('chronos')
+
+
+@pytest.mark.usefixtures("chronos_cleanup")
+def test_uninstall_package_and_wait():
+    if not package_installed('chronos'):
+        install_package_and_wait('chronos')
+
+    assert package_installed('chronos')
+    uninstall_package_and_wait('chronos')
+    delete_zk_node('chronos')
+    assert package_installed('chronos') == False
+    # this should only pass if we can install after the wait
+    install_package_and_wait('chronos')
+
+def task_cpu_predicate(service, task):
+        try:
+            response = get_service_task(service, task)
+        except Exception as e:
+            pass
+
+        return (response is not None) and ('resources' in response) and ('cpus' in response['resources'])
+
+@pytest.mark.usefixtures("chronos_cleanup")
+def test_install_package_with_json_options():
+    install_package_and_wait('chronos', None, 'big-chronos', None, {"chronos": {"cpus": 2}})
+    wait_for(lambda: task_cpu_predicate('marathon', 'big-chronos'))
+    assert get_service_task('marathon', 'big-chronos')['resources']['cpus'] == 2
+    uninstall_package_and_wait('chronos', 'big-chronos')
+
+def test_install_package_with_subcommand():
+    install_package_and_wait('hello-world')
+    stdout, stderr, return_code = run_dcos_command('hello-world --info')
+    assert stdout.startswith('Hello-World')
+
+def test_uninstall_package_with_subcommand():
+    uninstall_package_and_wait('hello-world')
+    stdout, stderr, return_code = run_dcos_command('hello-world --info')
+    assert stderr.endswith("is not a dcos command.\n")
+
+def test_add_package_repo():
+    assert add_package_repo('Multiverse', 'https://github.com/mesosphere/multiverse/archive/version-2.x.zip', 0)
+
+def test_get_package_repo():
+    repos_json = get_package_repos()
+    print(json.dumps(repos_json, sort_keys=True, indent=4, separators=(',', ': ')))
+    assert repos_json['repositories'][0]['name'] == 'Multiverse'
+
+def test_remove_package_repo():
+    assert remove_package_repo('Multiverse')
+
+def test_get_package_versions():
+    versions = get_package_versions('marathon')
+    assert '1.5.2' in versions
+
+def remove_chronos():
+    try:
+        if package_installed('chronos'):
+            uninstall_package_and_wait('chronos')
+        delete_zk_node('chronos')
+    except:
+        pass
+
+def setup_module(module):
+    remove_chronos()

--- a/tests/shakedown/tests/acceptance/test_dcos_package_cli.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_package_cli.py
@@ -1,0 +1,11 @@
+from shakedown import *
+
+def test_install_package_cli():
+    assert not package_installed('dcos-enterprise-cli')
+    install_package_and_wait('dcos-enterprise-cli')
+    assert package_installed('dcos-enterprise-cli')
+
+def test_uninstall_package_cli():
+    assert package_installed('dcos-enterprise-cli')
+    uninstall_package_and_wait('dcos-enterprise-cli')
+    assert not package_installed('dcos-enterprise-cli')

--- a/tests/shakedown/tests/acceptance/test_dcos_service.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_service.py
@@ -1,0 +1,30 @@
+import time
+
+from shakedown import *
+
+
+def test_get_service_framework_id():
+    framework_id = get_service_framework_id('marathon')
+    print('framework_id: ' + framework_id)
+    assert framework_id is not None
+
+
+def test_get_service_tasks():
+    service_tasks = get_service_tasks('marathon')
+    assert service_tasks is not None
+
+
+def test_get_service_task():
+    service_task = get_service_task('marathon', 'jenkins')
+    assert service_task is not None
+
+
+def test_get_service_ips():
+    # Get all IPs associated with the 'jenkins' task running in the 'marathon' service
+    service_ips = get_service_ips('marathon', 'jenkins')
+    assert service_ips is not None
+    print('service_ips: ' + str(service_ips))
+
+
+def test_service_healthy():
+    assert service_healthy('jenkins')

--- a/tests/shakedown/tests/acceptance/test_dcos_task.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_task.py
@@ -1,0 +1,9 @@
+from shakedown import *
+
+
+def test_get_active_tasks():
+    task_names = []
+    for task in get_active_tasks():
+        task_names.append(task['name'])
+
+    assert 'jenkins' in task_names

--- a/tests/shakedown/tests/acceptance/test_dcos_zookeeper.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_zookeeper.py
@@ -1,0 +1,44 @@
+from shakedown import *
+
+
+def test_delete_zk_node():
+    install_package_and_wait('marathon')
+    assert package_installed('marathon'), 'Package failed to install'
+
+    end_time = time.time() + 120
+    found = False
+    while time.time() < end_time:
+        found = get_service('marathon-user') is not None
+        if found and service_healthy('marathon-user'):
+            break
+        time.sleep(1)
+
+    assert found, 'Service did not register with DC/OS'
+
+    task_names = []
+    for task in get_active_tasks():
+        task_names.append(task['name'])
+
+    assert 'marathon-user' in task_names
+
+    uninstall_package_and_wait('marathon')
+
+    assert delete_zk_node('universe/marathon-user')
+
+
+def get_zk_node_data():
+    install_package_and_wait('marathon')
+    get_zk_node_data('universe/marathon-user')
+
+
+def teardown_module(module):
+    clean_marathon()
+
+
+def clean_marathon():
+    try:
+        uninstall_package_and_wait('marathon')
+    except:
+        pass
+
+    delete_zk_node('universe/marathon-user')

--- a/tests/shakedown/tests/test_cli.py
+++ b/tests/shakedown/tests/test_cli.py
@@ -1,0 +1,21 @@
+from click.testing import CliRunner
+
+from shakedown import *
+from dcos import config
+
+
+def test_cli_require_dcos_uri():
+    runner = CliRunner()
+    result = runner.invoke(cli.main.cli, ['tests/test_cli.py'])
+
+    # with preconfigured dcos cli dcos url isn't required
+    assert '--dcos-url' not in result.output
+    print(result.output)
+
+
+def test_cli_version():
+    runner = CliRunner()
+    result = runner.invoke(cli.main.cli, ['--version'])
+    assert result.exit_code == 0
+    assert result.output == "shakedown, version " + shakedown.VERSION + "\n"
+    print(result.output)

--- a/tests/shakedown/tests/unit/dcos/test_dcos_command.py
+++ b/tests/shakedown/tests/unit/dcos/test_dcos_command.py
@@ -1,0 +1,117 @@
+from shakedown import connection_cache
+from shakedown.dcos import command
+
+
+class MockConnection:
+
+    def __init__(self, h, u, k, failure=False):
+        self.h = h
+        self.u = u
+        self.k = k
+        self.failure = failure
+        self.access_count = 0
+
+    def open_session(self):
+        if not self.failure:
+            return self.h, self.u, self.k
+        return None
+
+    def is_active(self):
+        return not self.failure
+
+    def is_authenticated(self):
+        return not self.failure
+
+
+def test_hostsession_enter(monkeypatch):
+    """Test that `get_session` calls `_get_connection` for a 
+    connection and then opens a new session.
+    """
+    def mockreturn(h, u, k):
+        return MockConnection(h, u, k)
+    # replace _get_connection with mockreturn
+    monkeypatch.setattr(command, '_get_connection', mockreturn)
+
+    hs = command.HostSession('local', 'me', 'key', True)
+    v = hs.__enter__()
+    assert v is not None
+    assert hs.host == 'local'
+    assert hs.session[0] == 'local'
+
+
+def test_hostsession_enter_fail(monkeypatch):
+    """Test that `get_session` calls `_get_connection` for a 
+    connection and then opens a new session.
+    """
+    def mockreturn(h, u, k):
+        return MockConnection(h, u, k, True)
+    # replace _get_connection with mockreturn
+    monkeypatch.setattr(command, '_get_connection', mockreturn)
+
+    hs = command.HostSession('local', 'me', 'key', True)
+    v = hs.__enter__()
+    assert v is not None
+    assert hs.host == 'local'
+    assert hs.session is None
+
+
+def test_connection_cache():
+    @connection_cache
+    def f(host, user, key_path):
+        """generic func to emulate _get_connection"""
+        return MockConnection(host, user, key_path)
+
+    # basic tests
+    assert f.get_cache() == {}
+    f('local', 'me', 'key')
+    assert 'local-me' in f.get_cache()
+    cache_obj = f.get_cache()['local-me']
+    f('local', 'me', 'key')
+    assert f.get_cache()['local-me'] == cache_obj
+    assert len(f.get_cache()) == 1
+    f('local2', 'me', 'key')
+    assert len(f.get_cache()) == 2
+    f('local2', 'me2', 'key')
+    assert len(f.get_cache()) == 3
+    f('local2', 'me2', 'key2')
+    assert len(f.get_cache()) == 3
+
+    # set an existing connection to fail
+    # make sure it is recreated and not the same
+    # connection obj as before
+    assert f.get_cache()['local-me'] == cache_obj
+    f.get_cache()['local-me'].failure = True
+    f('local', 'me', 'key2')
+    assert len(f.get_cache()) == 3
+    assert f.get_cache()['local-me'] != cache_obj
+
+    # purge should do things.
+    f.purge('local2-me2')
+    assert len(f.get_cache()) == 2
+    f.purge()
+    assert len(f.get_cache()) == 0
+
+
+def test_connection_cache_none():
+    """Test that a None return from the function is not cached."""
+    return_none = True
+
+    @connection_cache
+    def f(host, user, key_path):
+        """generic func to emulate _get_connection"""
+        nonlocal return_none
+        if return_none:
+            return None
+        return MockConnection(host, user, key_path)
+
+    # basic tests
+    assert f.get_cache() == {}
+    r = f('local', 'me', 'key')
+    assert r is None
+    assert f.get_cache() == dict()
+    return_none = False
+    r = f('local', 'me', 'key')
+    assert r
+    assert 'local-me' in f.get_cache()
+    f('local2', 'me', 'key')
+    assert len(f.get_cache()) == 2

--- a/tests/shakedown/tox.ini
+++ b/tests/shakedown/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+envlist = py34-syntax
+
+[flake8]
+application-import-names=shakedown
+import-order-style=smarkets
+
+[testenv]
+usedevelop = True
+install_command = pip install -U {opts} {packages}
+whitelist_externals = *
+deps =
+  mock
+  pytest
+  pytest-cov
+
+[testenv:py34-syntax]
+deps =
+  flake8
+  flake8-import-order==0.9.2
+  pep8-naming
+
+commands =
+  flake8 --verbose shakedown tests setup.py
+
+[testenv:py34-acceptance]
+commands =
+  py.test -p no:cacheprovider -vv --cov {envsitepackagesdir}/shakedown tests{posargs}

--- a/tests/system/Makefile
+++ b/tests/system/Makefile
@@ -17,7 +17,7 @@ init:
 	pipenv install --dev --skip-lock
 
 build:
-	flake8 --count --max-line-length=120
+	pipenv run flake8 --count --max-line-length=120
 
 test:
 	pipenv run shakedown \

--- a/tests/system/Pipfile
+++ b/tests/system/Pipfile
@@ -12,12 +12,12 @@ python_version = "3.6"
 
 [packages]
 
-shakedown = {git = "https://github.com/dcos/shakedown.git", ref = "1.4.12"}
 aiohttp = "*"
 pytest-asyncio = "*"
 dcos-launch = {git = "https://github.com/dcos/dcos-launch.git", ref = "57d91fb7f582e9687ceca132c1d085e4c144e86c"}
 python-dateutil = "<2.7.0,>=2.1"
 dcos-test-utils = {git = "https://github.com/dcos/dcos-test-utils", ref = "c9a4fc583a4a0bca18040ad4c7772e187e51aa74"}
+"214ae30" = {path = "../shakedown", editable = true}
 
 
 [dev-packages]

--- a/tests/system/Pipfile.lock
+++ b/tests/system/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "89cb8f9f12d8b8ae602e31013491039f7444ac62a26f8deb63942e8a0db2d2da"
+            "sha256": "814f707f477aee9b98a8b4ed1f4f2e5e571e10e0715e72c607882692f97e5658"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -9,9 +9,9 @@
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "17.4.0",
+            "platform_release": "17.5.0",
             "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64",
+            "platform_version": "Darwin Kernel Version 17.5.0: Fri Apr 13 19:32:32 PDT 2018; root:xnu-4570.51.2~1/RELEASE_X86_64",
             "python_full_version": "3.6.3",
             "python_version": "3.6",
             "sys_platform": "darwin"
@@ -29,25 +29,36 @@
         ]
     },
     "default": {
+        "214ae30": {
+            "editable": true,
+            "path": "../shakedown"
+        },
         "aiohttp": {
             "hashes": [
-                "sha256:3da537d4cf64c23b69dafdae0fcfca173eedadac19271ea417e189a629c63258",
-                "sha256:8d65a8033cafc0d0268de5a858465c819475f3467d456aab3fbe3912e298e717",
-                "sha256:42f0237a8314033e7dbb3ac83707bc5e5db28fc300a815d7088f8c52e599f0de",
-                "sha256:1c052bce3eade41f6edf9ff3381051b809a88e65b66dcf2e05d34e9751652ee1",
-                "sha256:c7ce03728c2fe5a47c72b45164f449b027903143ea720ebf379bc7c76b536d2e",
-                "sha256:67c5bf258adba7f57a30949e0a17c4708f98d91263a0c82da27ad37a8f60e3a9",
-                "sha256:d4e6ec8b45ef7aa0bfe0f7f9703b36e62f72f752c286818cf543d44201df559b",
-                "sha256:56c57f1e6e78b30509b8bc451bd24c4a96014fd874f853f9dbe5896287787bec",
-                "sha256:ce6c816ff4ba694f15be0986c12c6200b63f56c3da4c75545cba7c86365e8413",
-                "sha256:389a05544589c0643f0c1ba485c8d5157eb182de4ad35d041f858832a0acb26d",
-                "sha256:9559f4a69132b7aeb116c3ac8029f8bbae48e27292c4ef9c50e94cb872e6d0ce",
-                "sha256:a95add5d4305bf30ed624b171cc91bba61b57b22976b8b30930d511a34d05557",
-                "sha256:a6943101e13106f91d6175dd96bd9097ebbc076799f553e2f8ffc1b811dd190f",
-                "sha256:228ff9359f9dab15f93d9df6623fab495222d96724dca7c5e4852d42b1bac439",
-                "sha256:dc5cab081d4b334d0440b019edf24fe1cb138b8114e0e22d2b0661284bc1775f"
+                "sha256:dd81d85a342edf3d2a388e2f24d9facebc9c04550043888f970ee2f228c93059",
+                "sha256:1a112a1fdf3802b7f2b182e22e51d71e4a8fa7387d0d38e79a268921b869e384",
+                "sha256:601e8e83123b4d423a9dfddf7d6943f4f520651a78ffcd50c99d065136c7ff7b",
+                "sha256:f52e7287eb9286a1e91e4c67c207c2573147fbaddc68f70efb5aeee5d1992f2e",
+                "sha256:7de2c9e445a5d257935011268202338538abef1aaff341a4733eca56419ca6f6",
+                "sha256:ff1447c84a02b9cd5dd3a9332d1fb181a4386c3625765bb5caf1cfbc210ab3f9",
+                "sha256:620f19ba7628b70b177f5c2e6a55a6fd6e7c8591cde38c3f8f52551733d31b66",
+                "sha256:fe7b2972ff7e779e812f974aa5695edc328ecf559ceeea887ac46f06f090ad4c",
+                "sha256:c833aa6f4c9ac3e3eb843e3d999bae51339ad33a937303f43ce78064e61cb4b6",
+                "sha256:550b4a0788500f6d00f41b7fdd9fcce6d78f99706a7b2f6f81d4d331c7ca468e",
+                "sha256:ae7501cc6a6c37b8d4774bf2218c37be47fe42019a2570e8510fc2044e59d573",
+                "sha256:70d56c784da1239c89d39fefa166fd429306dada641178389be4184a9c04e501",
+                "sha256:33aa7c937ebaf063a860cbb0c263a771b33333a84965c6148eeafe64fb4e29ca",
+                "sha256:96bb80b659cc2bafa160f3f0c346ce7fc10de1ffec4908d7f9690797f155f658",
+                "sha256:f20deec7a3fbaec7b5eb7ad99878427ad2ee4cc16a46732b705e8121cbb3cc12"
             ],
-            "version": "==3.1.1"
+            "version": "==3.3.2"
+        },
+        "asn1crypto": {
+            "hashes": [
+                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
+                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
+            ],
+            "version": "==0.24.0"
         },
         "async-generator": {
             "hashes": [
@@ -59,17 +70,97 @@
         },
         "async-timeout": {
             "hashes": [
-                "sha256:9093db5b8ddbe4b8f6885d1a6e0ad84ae3155464cbf6877c387605244c285f3c",
-                "sha256:00cff4d2dce744607335cba84e9929c3165632da2d27970dbc55802a0c7873d0"
+                "sha256:474d4bc64cee20603e225eb1ece15e248962958b45a3648a9f5cc29e827a610c",
+                "sha256:b3c0ddc416736619bd4a95ca31de8da6920c3b9a140c64dbef2b2fa7bf521287"
             ],
-            "version": "==2.0.1"
+            "version": "==3.0.0"
+        },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6",
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585"
+            ],
+            "version": "==1.1.5"
         },
         "attrs": {
             "hashes": [
-                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450",
-                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9"
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
             ],
-            "version": "==17.4.0"
+            "version": "==18.1.0"
+        },
+        "bcrypt": {
+            "hashes": [
+                "sha256:f9210820ee4818d84658ed7df16a7f30c9fba7d8b139959950acef91745cc0f7",
+                "sha256:b1e8491c6740f21b37cca77bc64677696a3fb9f32360794d57fa8477b7329eda",
+                "sha256:9eced8962ce3b7124fe20fd358cf8c7470706437fa064b9874f849ad4c5866fc",
+                "sha256:346d6f84ff0b493dbc90c6b77136df83e81f903f0b95525ee80e5e6d5e4eef84",
+                "sha256:0f317e4ffbdd15c3c0f8ab5fbd86aa9aabc7bea18b5cc5951b456fe39e9f738c",
+                "sha256:f7fd3ed3745fe6e81e28dc3b3d76cce31525a91f32a387e1febd6b982caf8cdb",
+                "sha256:3b4c23300c4eded8895442c003ae9b14328ae69309ac5867e7530de8bdd7875d",
+                "sha256:34dd60b90b0f6de94a89e71fcd19913a30e83091c8468d0923a93a0cccbfbbff",
+                "sha256:2788c32673a2ad0062bea850ab73cffc0dba874db10d7a3682b6f2f280553f20",
+                "sha256:6efd9ca20aefbaf2e7e6817a2c6ed4a50ff6900fafdea1bcb1d0e9471743b144",
+                "sha256:f2fe545d27a619a552396533cddf70d83cecd880a611cdfdbb87ca6aec52f66b",
+                "sha256:e22f0997622e1ceec834fd25947dc2ee2962c2133ea693d61805bc867abaf7ea",
+                "sha256:c906bdb482162e9ef48eea9f8c0d967acceb5c84f2d25574c7d2a58d04861df1",
+                "sha256:43d1960e7db14042319c46925892d5fa99b08ff21d57482e6f5328a1aca03588",
+                "sha256:321d4d48be25b8d77594d8324c0585c80ae91ac214f62db9098734e5e7fb280f",
+                "sha256:ae35dbcb6b011af6c840893b32399252d81ff57d52c13e12422e16b5fea1d0fb",
+                "sha256:09a3b8c258b815eadb611bad04ca15ec77d86aa9ce56070e1af0d5932f17642a",
+                "sha256:988cac675e25133d01a78f2286189c1f01974470817a33eaf4cfee573cfb72a5",
+                "sha256:cb18ffdc861dbb244f14be32c47ab69604d0aca415bee53485fcea4f8e93d5ef",
+                "sha256:8629ea6a8a59f865add1d6a87464c3c676e60101b8d16ef404d0a031424a8491",
+                "sha256:a005ed6163490988711ff732386b08effcbf8df62ae93dd1e5bda0714fad8afb",
+                "sha256:d86da365dda59010ba0d1ac45aa78390f56bf7f992e65f70b3b081d5e5257b09",
+                "sha256:8569844a5d8e1fdde4d7712a05ab2e6061343ac34af6e7e3d7935b2bd1907bfd",
+                "sha256:0872eeecdf9a429c1420158500eedb323a132bc5bf3339475151c52414729e70",
+                "sha256:01477981abf74e306e8ee31629a940a5e9138de000c6b0898f7f850461c4a0a5",
+                "sha256:49e96267cd9be55a349fd74f9852eb9ae2c427cd7f6455d0f1765d7332292832",
+                "sha256:9a6fedda73aba1568962f7543a1f586051c54febbc74e87769bad6a4b8587c39",
+                "sha256:054d6e0acaea429e6da3613fcd12d05ee29a531794d96f6ab959f29a39f33391",
+                "sha256:67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d"
+            ],
+            "version": "==3.1.4"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0",
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7"
+            ],
+            "version": "==2018.4.16"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
+                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
+                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
+                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
+                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
+                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
+                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
+                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
+                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
+                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
+                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
+                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
+                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
+                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb",
+                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
+                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
+                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
+                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
+                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
+                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
+                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
+                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
+                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
+                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
+                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
+                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
+                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4"
+            ],
+            "version": "==1.11.5"
         },
         "chardet": {
             "hashes": [
@@ -77,6 +168,54 @@
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
             ],
             "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
+                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+            ],
+            "version": "==6.7"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:187ae17358436d2c760f28c2aeb02fefa3f37647a9c5b6f7f7c3e83cd1c5a972",
+                "sha256:19e43a13bbf52028dd1e810c803f2ad8880d0692d772f98d42e1eaf34bdee3d6",
+                "sha256:da9291502cbc87dc0284a20c56876e4d2e68deac61cc43df4aec934e44ca97b1",
+                "sha256:2f8ad9580ab4da645cfea52a91d2da99a49a1e76616d8be68441a986fad652b0",
+                "sha256:cc00b4511294f5f6b65c4e77a1a9c62f52490a63d2c120f3872176b40a82351e",
+                "sha256:0954f8813095f581669330e0a2d5e726c33ac7f450c1458fac58bab54595e516",
+                "sha256:d68b0cc40a8432ed3fc84876c519de704d6001800ec22b136e75ae841910c45b",
+                "sha256:cf896020f6a9f095a547b3d672c8db1ef2ed71fca11250731fa1d4a4cb8b1590",
+                "sha256:e0fdb8322206fa02aa38f71519ff75dce2eb481b7e1110e2936795cb376bb6ee",
+                "sha256:277538466657ca5d6637f80be100242f9831d75138b788d718edd3aab34621f8",
+                "sha256:77197a2d525e761cdd4c771180b4bd0d80703654c6385e4311cbbbe2beb56fa1",
+                "sha256:eb8bb79d0ab00c931c8333b745f06fec481a51c52d70acd4ee95d6093ba5c386",
+                "sha256:2c77eb0560f54ce654ab82d6b2a64327a71ee969b29022bf9746ca311c9f5069",
+                "sha256:755a7853b679e79d0a799351c092a9b0271f95ff54c8dd8823d8b527a2926a86",
+                "sha256:131f61de82ef28f3e20beb4bfc24f9692d28cecfd704e20e6c7f070f7793013a",
+                "sha256:ac35435974b2e27cd4520f29c191d7da36f4189aa3264e52c4c6c6d089ab6142",
+                "sha256:04b6ea99daa2a8460728794213d76d45ad58ea247dc7e7ff148d7dd726e87863",
+                "sha256:2b9442f8b4c3d575f6cc3db0e856034e0f5a9d55ecd636f52d8c496795b26952",
+                "sha256:b3d3b3ecba1fe1bdb6f180770a137f877c8f07571f7b2934bb269475bcf0e5e8",
+                "sha256:670a58c0d75cb0e78e73dd003bd96d4440bbb1f2bc041dcf7b81767ca4fb0ce9",
+                "sha256:5af84d23bdb86b5e90aca263df1424b43f1748480bfcde3ac2a3cbe622612468",
+                "sha256:ba22e8eefabdd7aca37d0c0c00d2274000d2cebb5cce9e5a710cb55bf8797b31",
+                "sha256:b798b22fa7e92b439547323b8b719d217f1e1b7677585cfeeedf3b55c70bb7fb",
+                "sha256:59cff28af8cce96cb7e94a459726e1d88f6f5fa75097f9dcbebd99118d64ea4c",
+                "sha256:fe859e445abc9ba9e97950ddafb904e23234c4ecb76b0fae6c86e80592ce464a",
+                "sha256:655f3c474067f1e277430f23cc0549f0b1dc99b82aec6e53f80b9b2db7f76f11",
+                "sha256:0ebc2be053c9a03a2f3e20a466e87bf12a51586b3c79bd2a22171b073a805346",
+                "sha256:01e6e60654df64cca53733cda39446d67100c819c181d403afb120e0d2a71e1b",
+                "sha256:d46f4e5d455cb5563685c52ef212696f0a6cc1ea627603218eabbd8a095291d8",
+                "sha256:3780b2663ee7ebb37cb83263326e3cd7f8b2ea439c448539d4b87de12c8d06ab"
+            ],
+            "version": "==2.0.2"
+        },
+        "dcos": {
+            "hashes": [
+                "sha256:928d6de1277e6a0aa39e521d0033a9da10aa3ec987e8cd05bab40b31a027cc71"
+            ],
+            "version": "==0.5.7"
         },
         "dcos-launch": {
             "git": "https://github.com/dcos/dcos-launch.git",
@@ -86,12 +225,24 @@
             "git": "https://github.com/dcos/dcos-test-utils",
             "ref": "c9a4fc583a4a0bca18040ad4c7772e187e51aa74"
         },
+        "dcoscli": {
+            "hashes": [
+                "sha256:ef43ae67dfef7ba96f73623023acd786a8b96c810019a377afb683b7e5f80443"
+            ],
+            "version": "==0.5.7"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
+        },
         "idna": {
             "hashes": [
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "idna-ssl": {
             "hashes": [
@@ -99,46 +250,73 @@
             ],
             "version": "==1.0.1"
         },
+        "jsonschema": {
+            "hashes": [
+                "sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08",
+                "sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02"
+            ],
+            "version": "==2.6.0"
+        },
         "more-itertools": {
             "hashes": [
-                "sha256:11a625025954c20145b37ff6309cd54e39ca94f72f6bb9576d1195db6fa2442e",
-                "sha256:0dd8f72eeab0d2c3bd489025bb2f6a1b8342f9b198f6fc37b52d15cfa4531fea",
-                "sha256:c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44"
+                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0",
+                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
+                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8"
             ],
-            "version": "==4.1.0"
+            "version": "==4.2.0"
         },
         "multidict": {
             "hashes": [
-                "sha256:0fd4d255adcbab3341d64a2fff5acce23409e57bb94e626485dea3db70ddc35e",
-                "sha256:93f1af99bbe75c854370460a60823d6726f9af2196818a64346000d02e074ed7",
-                "sha256:65546242d0c481c0daf0ef20c1be81c075fb763c5f4346f18f748b422fc40f32",
-                "sha256:0462372fc74e4c061335118a4a5992b9a618d6c584b028ef03cf3e9b88a960e2",
-                "sha256:63663541d395ffe4d51a3c021467d0a7b46c965b63fa1646cb46e2e2f1f36415",
-                "sha256:84a1cb5320f1494cd444ca3bd09ddba2e0af0cb210f9263bcf17357ab22671a1",
-                "sha256:241c11614f64535e213ea143efa8b7e598793256601fc795e77075bdfa54f5d6",
-                "sha256:ea8a18ea02bf84981ec93faded773a866554666f13955c92139127892c4bb45c",
-                "sha256:b46ec31bb7729eaa678a3bb1c999460902df1e295fcc093b9aa5f2c7e68d5803",
-                "sha256:608f7eef60e6558418d7da6551dd3d07ccc1290ecc85755d781bd8100322ea5b",
-                "sha256:068e91060e3e211441b1a31f5e65de88fc346490e1fae583c35a75a5295c8ef7",
-                "sha256:288e8f94fb6f586e7386c1f22c979ce3ec866ab23371fa8fef1dd526cd4dfde1",
-                "sha256:503ae54582601b0ff647731fee5efcdff5db1f4da0350febb31b628236a5f0b5",
-                "sha256:6d5f6f26f9025756035c473167b39c5a72e4e519a2286c9399d21f6682e4e5bc",
-                "sha256:e13265feabb1fa26f9cd49cbafd9b5de70ad768093ddb092af477c9823f44f0e",
-                "sha256:50de6f3786ba868ffb7d78d4bcacf0928321f9892366b2f4a0426bba644e3f25",
-                "sha256:16c78b10e897a512aa34ab1969982e42246e53077ae903c1b334926e1ea832d1",
-                "sha256:e04b5bf8581718cf84c1c60bda40221d926ceb06f942ebabfc3baf467a1e34be",
-                "sha256:d99819e9e15e1295a31a757360cab65bc96162870f90c29432564bd8e8999aca",
-                "sha256:cd172509bfc9144395204dd2c0eb305ae5e89f8ad1714ffd7d793607c53c3244",
-                "sha256:3508bea4974ee30fabcf7c8852fca7d9d54d496eaa068bee8311e0ac4df4ade3",
-                "sha256:fb4412490324705dcd2172baa8a3ea58ae23c5f982476805cad58ae929fe2a52"
+                "sha256:a6e35d28900cf87bcc11e6ca9e474db0099b78f0be0a41d95bef02d49101b5b2",
+                "sha256:a59d58ee85b11f337b54933e8d758b2356fcdcc493248e004c9c5e5d11eedbe4",
+                "sha256:2eb99617c7a0e9f2b90b64bc1fb742611718618572747d6f3d6532b7b78755ab",
+                "sha256:1d6e191965505652f194bc4c40270a842922685918a4f45e6936a6b15cc5816d",
+                "sha256:bbd5a6bffd3ba8bfe75b16b5e28af15265538e8be011b0b9fddc7d86a453fd4a",
+                "sha256:e9404e2e19e901121c3c5c6cffd5a8ae0d1d67919c970e3b3262231175713068",
+                "sha256:d870f399fcd58a1889e93008762a3b9a27cf7ea512818fc6e689f59495648355",
+                "sha256:295961a6a88f1199e19968e15d9b42f3a191c89ec13034dbc212bf9c394c3c82",
+                "sha256:2be5af084de6c3b8e20d6421cb0346378a9c867dcf7c86030d6b0b550f9888e4",
+                "sha256:b4df7ca9c01018a51e43937eaa41f2f5dce17a6382fda0086403bcb1f5c2cf8e",
+                "sha256:4ba654c6b5ad1ae4a4d792abeb695b29ce981bb0f157a41d0fd227b385f2bef0",
+                "sha256:1a1d76374a1e7fe93acef96b354a03c1d7f83e7512e225a527d283da0d7ba5e0",
+                "sha256:5ba766433c30d703f6b2c17eb0b6826c6f898e5f58d89373e235f07764952314"
             ],
-            "version": "==4.1.0"
+            "version": "==4.3.1"
+        },
+        "pager": {
+            "hashes": [
+                "sha256:18aa45ec877dca732e599531c7b3b0b22ed6a4445febdf1bdf7da2761cca340d"
+            ],
+            "version": "==3.3"
+        },
+        "paramiko": {
+            "hashes": [
+                "sha256:24fb31c947de85fbdeca09e222d41206781581fb0bdf118d2ef18f6e414cd388",
+                "sha256:33e36775a6c71790ba7692a73f948b329cf9295a72b0102144b031114bd2a4f3"
+            ],
+            "version": "==2.4.1"
+        },
+        "pkginfo": {
+            "hashes": [
+                "sha256:ad3f6dfe8a831f96a7b56a588ca874137ca102cc6b79fc9b0a1c3b7ab7320f3c"
+            ],
+            "version": "==1.2.1"
         },
         "pluggy": {
             "hashes": [
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5",
                 "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
             ],
             "version": "==0.6.0"
+        },
+        "prettytable": {
+            "hashes": [
+                "sha256:853c116513625c738dc3ce1aee148b5b5757a86727e67eff6502c7ca59d43c36",
+                "sha256:2d5460dc9db74a32bcc8f9f67de68b2c4f4d2f01fa3bd518764c69156d9cacd9",
+                "sha256:a53da3b43d7a5c229b5e3ca2892ef982c46b7923b51e98f0db49956531211c4f"
+            ],
+            "version": "==0.7.2"
         },
         "py": {
             "hashes": [
@@ -147,12 +325,77 @@
             ],
             "version": "==1.5.3"
         },
+        "pyasn1": {
+            "hashes": [
+                "sha256:9a15cc13ff6bf5ed29ac936ca941400be050dff19630d6cd1df3fb978ef4c5ad",
+                "sha256:8fb265066eac1d3bb5015c6988981b009ccefd294008ff7973ed5f64335b0f2d",
+                "sha256:ba77f1e8d7d58abc42bfeddd217b545fdab4c1eeb50fd37c2219810ad56303bf",
+                "sha256:3651774ca1c9726307560792877db747ba5e8a844ea1a41feb7670b319800ab3",
+                "sha256:a66dcda18dbf6e4663bde70eb30af3fc4fe1acb2d14c4867a861681887a5f9a2",
+                "sha256:9334cb427609d2b1e195bb1e251f99636f817d7e3e1dffa150cb3365188fb992",
+                "sha256:d01fbba900c80b42af5c3fe1a999acf61e27bf0e452e0f1ef4619065e57622da",
+                "sha256:2f57960dc7a2820ea5a1782b872d974b639aa3b448ac6628d1ecc5d0fe3986f2",
+                "sha256:602fda674355b4701acd7741b2be5ac188056594bf1eecf690816d944e52905e",
+                "sha256:cdc8eb2eaafb56de66786afa6809cd9db2df1b3b595dcb25aa5b9dc61189d40a",
+                "sha256:f281bf11fe204f05859225ec2e9da7a7c140b65deccd8a4eb0bc75d0bd6949e0",
+                "sha256:fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc"
+            ],
+            "version": "==0.4.3"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
+            ],
+            "version": "==2.18"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d",
+                "sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc"
+            ],
+            "version": "==2.2.0"
+        },
+        "pyjwt": {
+            "hashes": [
+                "sha256:99fe612dbe5f41e07124d9002c118c14f3ee703574ffa9779fee78135b8b94b6",
+                "sha256:87a831b7a3bfa8351511961469ed0462a769724d4da48a501cb8c96d1e17f570"
+            ],
+            "version": "==1.4.2"
+        },
+        "pynacl": {
+            "hashes": [
+                "sha256:0bfa0d94d2be6874e40f896e0a67e290749151e7de767c5aefbad1121cad7512",
+                "sha256:1d33e775fab3f383167afb20b9927aaf4961b953d76eeb271a5703a6d756b65b",
+                "sha256:eb2acabbd487a46b38540a819ef67e477a674481f84a82a7ba2234b9ba46f752",
+                "sha256:14339dc233e7a9dda80a3800e64e7ff89d0878ba23360eea24f1af1b13772cac",
+                "sha256:cf6877124ae6a0698404e169b3ba534542cfbc43f939d46b927d956daf0a373a",
+                "sha256:eeee629828d0eb4f6d98ac41e9a3a6461d114d1d0aa111a8931c049359298da0",
+                "sha256:d0eb5b2795b7ee2cbcfcadacbe95a13afbda048a262bd369da9904fecb568975",
+                "sha256:11aa4e141b2456ce5cecc19c130e970793fa3a2c2e6fbb8ad65b28f35aa9e6b6",
+                "sha256:8ac1167195b32a8755de06efd5b2d2fe76fc864517dab66aaf65662cc59e1988",
+                "sha256:d795f506bcc9463efb5ebb0f65ed77921dcc9e0a50499dedd89f208445de9ecb",
+                "sha256:be71cd5fce04061e1f3d39597f93619c80cdd3558a6c9ba99a546f144a8d8101",
+                "sha256:2a42b2399d0428619e58dac7734838102d35f6dcdee149e0088823629bf99fbb",
+                "sha256:73a5a96fb5fbf2215beee2353a128d382dbca83f5341f0d3c750877a236569ef",
+                "sha256:d8aaf7e5d6b0e0ef7d6dbf7abeb75085713d0100b4eb1a4e4e857de76d77ac45",
+                "sha256:2dce05ac8b3c37b9e2f65eab56c544885607394753e9613fd159d5e2045c2d98",
+                "sha256:f5ce9e26d25eb0b2d96f3ef0ad70e1d3ae89b5d60255c462252a3e456a48c053",
+                "sha256:6453b0dae593163ffc6db6f9c9c1597d35c650598e2c39c0590d1757207a1ac2",
+                "sha256:fabf73d5d0286f9e078774f3435601d2735c94ce9e514ac4fb945701edead7e4",
+                "sha256:13bdc1fe084ff9ac7653ae5a924cae03bf4bb07c6667c9eb5b6eb3c570220776",
+                "sha256:8f505f42f659012794414fa57c498404e64db78f1d98dfd40e318c569f3c783b",
+                "sha256:04e30e5bdeeb2d5b34107f28cd2f5bbfdc6c616f3be88fc6f53582ff1669eeca",
+                "sha256:8abb4ef79161a5f58848b30ab6fb98d8c466da21fdd65558ce1d7afc02c70b5f",
+                "sha256:e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9"
+            ],
+            "version": "==1.2.1"
+        },
         "pytest": {
             "hashes": [
-                "sha256:6266f87ab64692112e5477eba395cfedda53b1933ccd29478e671e73b420c19c",
-                "sha256:fae491d1874f199537fd5872b5e1f0e74a009b979df9d53d1553fd03da1703e1"
+                "sha256:26838b2bc58620e01675485491504c3aa7ee0faf335c37fcd5f8731ca4319591",
+                "sha256:32c49a69566aa7c333188149ad48b58ac11a426d5352ea3d8f6ce843f88199cb"
             ],
-            "version": "==3.5.0"
+            "version": "==3.6.1"
         },
         "pytest-asyncio": {
             "hashes": [
@@ -161,6 +404,13 @@
             ],
             "version": "==0.8.0"
         },
+        "pytest-timeout": {
+            "hashes": [
+                "sha256:cc8808265bcfe81c961f729937591c373dc6a33000456f48c907d401d0f9014d",
+                "sha256:08b550b498b9251901a3747f02aa2624ed53a9c8285ca482551346c85b47d641"
+            ],
+            "version": "==1.3.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:95511bae634d69bc7329ba55e646499a842bc4ec342ad54a8cdb65645a0aad3c",
@@ -168,9 +418,25 @@
             ],
             "version": "==2.6.1"
         },
-        "shakedown": {
-            "git": "https://github.com/dcos/shakedown.git",
-            "ref": "1.4.12"
+        "requests": {
+            "hashes": [
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+            ],
+            "version": "==2.19.1"
+        },
+        "retrying": {
+            "hashes": [
+                "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"
+            ],
+            "version": "==1.3.3"
+        },
+        "scp": {
+            "hashes": [
+                "sha256:5a1b44b3b8d1da27a3592bffebfc717e3c68c9a8bbb87db786b56a3924d2911f",
+                "sha256:ea095dd1d0e131874bc9930c3965bce3d1d70be5adb2a30d811fcaea4708a9ee"
+            ],
+            "version": "==0.11.0"
         },
         "six": {
             "hashes": [
@@ -179,23 +445,45 @@
             ],
             "version": "==1.11.0"
         },
+        "sseclient": {
+            "hashes": [
+                "sha256:fb07aeb662033cc5924d66455cb4aa77e9660eec340eaeb801ddeefa032fbda8"
+            ],
+            "version": "==0.0.14"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:8e86bd6ce8cc11b9620cb637466453d94f5d57ad86f17e98a98d1f73e3baab2d"
+            ],
+            "version": "==0.9.4"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5",
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf"
+            ],
+            "version": "==1.23"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:e8e05d4714a1c51a2f5921e62f547fcb0f713ebbe959e0a7f585cc8bef71d11f",
+                "sha256:1d7e241b431e7afce47e77f8843a276f652699d1fa4f93b9d8ce0076fd7b0b54"
+            ],
+            "version": "==15.2.0"
+        },
         "yarl": {
             "hashes": [
-                "sha256:d9ca55a5a297408f08e5401c23ad22bd9f580dab899212f0d5dc1830f0909404",
-                "sha256:17e57a495efea42bcfca08b49e16c6d89e003acd54c99c903ea1cb3de0ba1248",
-                "sha256:3353fae45d93cc3e7e41bfcb1b633acc37db821d368e660b03068dbfcf68f8c8",
-                "sha256:51a084ff8756811101f8b5031a14d1c2dd26c666976e1b18579c6b1c8761a102",
-                "sha256:045dbba18c9142278113d5dc62622978a6f718ba662392d406141c59b540c514",
-                "sha256:213e8f54b4a942532d6ac32314c69a147d3b82fa1725ca05061b7c1a19a1d9b1",
-                "sha256:7236eba4911a5556b497235828e7a4bc5d90957efa63b7c4b3e744d2d2cf1b94",
-                "sha256:e9a6a319c4bbfb57618f207e86a7c519ab0f637be3d2366e4cdac271577834b8",
-                "sha256:6e75753065c310befab71c5077a59b7cb638d2146b1cfbb1c3b8f08b51362714",
-                "sha256:64727a2593fdba5d6ef69e94eba793a196deeda7152c7bd3a64edda6b1f95f6e",
-                "sha256:5580f22ac1298261cd24e8e584180d83e2cca9a6167113466d2d16cb2aa1f7b1",
-                "sha256:e072edbd1c5628c0b8f97d00cf6c9fcd6a4ee2b5ded10d463fcb6eaa066cf40c",
-                "sha256:a69dd7e262cdb265ac7d5e929d55f2f3d07baaadd158c8f19caebf8dde08dfe8"
+                "sha256:4aec0769f1799a9d4496827292c02a7b1f75c0bab56ab2b60dd94ebb57cbd5ee",
+                "sha256:f17495e6fe3d377e3faac68121caef6f974fcb9e046bc075bcff40d8e5cc69a4",
+                "sha256:6c098b85442c8fe3303e708bbb775afd0f6b29f77612e8892627bcab4b939357",
+                "sha256:f85900b9cca0c67767bb61b2b9bd53208aaa7373dae633dbe25d179b4bf38aa7",
+                "sha256:55369d95afaacf2fa6b49c84d18b51f1704a6560c432a0f9a1aeb23f7b971308",
+                "sha256:db6f70a4b09cde813a4807843abaaa60f3b15fb4a2a06f9ae9c311472662daa1",
+                "sha256:2556b779125621b311844a072e0ed367e8409a18fa12cbd68eb1258d187820f9",
+                "sha256:9182cd6f93412d32e009020a44d6d170d2093646464a88aeec2aef50592f8c78",
+                "sha256:c8cbc21bbfa1dd7d5386d48cc814fe3d35b80f60299cdde9279046f399c3b0d8"
             ],
-            "version": "==1.1.1"
+            "version": "==1.2.6"
         }
     },
     "develop": {

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -826,14 +826,14 @@ def test_app_update_rollback():
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait()
+    shakedown.deployment_wait(app_id=app_id)
 
     tasks = client.get_tasks(app_id)
     assert len(tasks) == 1, "The number of tasks is {} after deployment, but 1 was expected".format(len(tasks))
 
     app_def['instances'] = 2
     client.update_app(app_id, app_def)
-    shakedown.deployment_wait()
+    shakedown.deployment_wait(app_id=app_id)
 
     tasks = client.get_tasks(app_id)
     assert len(tasks) == 2, "The number of tasks is {} after update, but 2 was expected".format(len(tasks))
@@ -843,7 +843,7 @@ def test_app_update_rollback():
     app_def['instances'] = 1
     deployment_id = client.update_app(app_id, app_def)
     client.rollback_deployment(deployment_id)
-    shakedown.deployment_wait()
+    shakedown.deployment_wait(app_id=app_id)
 
     # update to 1 instance is rollback to 2
     tasks = client.get_tasks(app_id)
@@ -1224,7 +1224,7 @@ def test_network_pinger(test_type, get_pinger_app, dns_format, marathon_service_
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=300, retry_on_exception=common.ignore_exception)
     def http_output_check():
         status, output = shakedown.run_command_on_master('curl {}'.format(relay_url))
-        assert status
+        assert status, "curl {} failed on master with {}".format(relay_url, output)
         assert 'Pong {}'.format(pinger_app["id"]) in output
         assert 'Relay from {}'.format(relay_app["id"]) in output
 


### PR DESCRIPTION
Summary:
We have a lot of Shakedown changes pending in `tests/system/common.py`.
So far it takes a few steps to move the changes to Shakedown and then
pull them back again. This patch eases the process by importing
Shakedown as a git-subrepo. It allows making changes to Shakedown in the
Marathon repository *and* push changes upstream to create pull requests
for Shakedown. This way Shakedown in Marathon will be slightly ahead of
the Shakedown master *but* also ensure that the Shakedown master will
stay up-to-date.