### PR TITLE
Move Docker pull config factory to Shakedown.

### DIFF
--- a/tests/shakedown/shakedown/dcos/docker.py
+++ b/tests/shakedown/shakedown/dcos/docker.py
@@ -166,3 +166,24 @@ def prefetch_docker_image_on_private_agents(
 
     shakedown.delete_all_apps()
     shakedown.deployment_wait(timeout)
+
+
+def create_docker_pull_config_json(username, password):
+    """Create a Docker config.json represented using Python data structures.
+
+       :param username: username for a private Docker registry
+       :param password: password for a private Docker registry
+       :return: Docker config.json
+    """
+    print('Creating a config.json content for dockerhub username {}'.format(username))
+
+    import base64
+    auth_hash = base64.b64encode('{}:{}'.format(username, password).encode()).decode()
+
+    return {
+        "auths": {
+            "https://index.docker.io/v1/": {
+                "auth": auth_hash
+            }
+        }
+    }

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -14,7 +14,7 @@ from dcos import http, mesos
 from dcos.errors import DCOSException, DCOSHTTPException
 from distutils.version import LooseVersion
 from json.decoder import JSONDecodeError
-from shakedown import marathon
+from shakedown import docker, marathon
 from urllib.parse import urljoin
 
 
@@ -388,27 +388,6 @@ def is_enterprise_cli_package_installed():
     return any(cmd['name'] == 'dcos-enterprise-cli' for cmd in result_json)
 
 
-def create_docker_pull_config_json(username, password):
-    """Create a Docker config.json represented using Python data structures.
-
-       :param username: username for a private Docker registry
-       :param password: password for a private Docker registry
-       :return: Docker config.json
-    """
-    print('Creating a config.json content for dockerhub username {}'.format(username))
-
-    import base64
-    auth_hash = base64.b64encode('{}:{}'.format(username, password).encode()).decode()
-
-    return {
-        "auths": {
-            "https://index.docker.io/v1/": {
-                "auth": auth_hash
-            }
-        }
-    }
-
-
 def create_docker_credentials_file(username, password, file_name='docker.tar.gz'):
     """Create a docker credentials file. Docker username and password are used to create
        a `{file_name}` with `.docker/config.json` containing the credentials.
@@ -420,7 +399,7 @@ def create_docker_credentials_file(username, password, file_name='docker.tar.gz'
     print('Creating a tarball {} with json credentials for dockerhub username {}'.format(file_name, username))
     config_json_filename = 'config.json'
 
-    config_json = create_docker_pull_config_json(username, password)
+    config_json = docker.create_docker_pull_config_json(username, password)
 
     # Write config.json to file
     with open(config_json_filename, 'w') as f:

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -11,7 +11,7 @@ import time
 
 from datetime import timedelta
 from dcos import marathon, http
-from shakedown import dcos_version_less_than, marthon_version_less_than, required_private_agents # NOQA
+from shakedown import dcos_version_less_than, docker, marthon_version_less_than, required_private_agents # NOQA
 from urllib.parse import urljoin
 
 from fixtures import sse_events, wait_for_marathon_and_cleanup # NOQA
@@ -85,7 +85,7 @@ def test_create_pod_with_private_image():
     password = os.environ['DOCKER_HUB_PASSWORD']
 
     secret_name = "pullconfig"
-    secret_value_json = common.create_docker_pull_config_json(username, password)
+    secret_value_json = docker.create_docker_pull_config_json(username, password)
     secret_value = json.dumps(secret_value_json)
 
     pod_def = pods.private_docker_pod()

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -12,7 +12,7 @@ import shakedown
 import json
 
 from dcos import http
-from shakedown import marathon
+from shakedown import docker, marathon
 from urllib.parse import urljoin
 from utils import get_resource
 
@@ -205,7 +205,7 @@ def ensure_docker_config_secret():
 
     username = os.environ['DOCKER_HUB_USERNAME']
     password = os.environ['DOCKER_HUB_PASSWORD']
-    config_json = common.create_docker_pull_config_json(username, password)
+    config_json = docker.create_docker_pull_config_json(username, password)
     common.create_secret(MOM_EE_DOCKER_CONFIG_SECRET_NAME, value=json.dumps(config_json))
     assert common.has_secret(MOM_EE_DOCKER_CONFIG_SECRET_NAME)
 

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -22,7 +22,7 @@ import marathon_auth_common_tests
 import marathon_common_tests
 import marathon_pods_tests
 
-from shakedown import dcos_version_less_than, marthon_version_less_than, required_masters, required_public_agents # NOQA F401
+from shakedown import dcos_version_less_than, docker, marthon_version_less_than, required_masters, required_public_agents # NOQA F401
 from fixtures import sse_events, wait_for_marathon_and_cleanup, user_billy, docker_ipv6_network_fixture # NOQA F401
 
 # the following lines essentially do:
@@ -417,7 +417,7 @@ def test_private_repository_mesos_app():
     password = os.environ['DOCKER_HUB_PASSWORD']
 
     secret_name = "pullconfig"
-    secret_value_json = common.create_docker_pull_config_json(username, password)
+    secret_value_json = docker.create_docker_pull_config_json(username, password)
     secret_value = json.dumps(secret_value_json)
 
     app_def = apps.private_ucr_docker_app()


### PR DESCRIPTION
Summary:
This is the start of moving helper mehtods from `tests/system/common.py`
to Shakedown.