### PR TITLE
Import performance test Jenkins job definition.

### DIFF
--- a/Jenkinsfile.perf
+++ b/Jenkinsfile.perf
@@ -1,0 +1,25 @@
+#!/usr/bin/env groovy
+
+node('hh-nuc-3') {
+  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
+  properties([
+    // Run pipeline twice a day.
+    pipelineTriggers([cron('H 0,12 * * *')])
+  ])
+
+  stage("Run Performance Test") {
+    try {
+      checkout scm
+      withCredentials(
+        [ string(credentialsId: '66c40969-a46d-470e-b8a2-6f04f2b3f2d5', variable: 'DATADOG_API_KEY'),
+          usernamePassword(credentialsId: 'a7ac7f84-64ea-4483-8e66-bb204484e58f', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PASS')
+        ]) {
+          sh """./tests/performance/live.sh"""
+      }
+    } finally {
+      archive includes: "results/**/*.json"
+      archive includes: "results/*.png"
+    }
+  }
+}
+}

--- a/tests/performance/config/perf-driver/reporters/report-datadog.yml
+++ b/tests/performance/config/perf-driver/reporters/report-datadog.yml
@@ -15,9 +15,6 @@ config:
     - name: datadog_api_key
       desc: The datadog API Key
       required: yes
-    - name: datadog_app_key
-      desc: The datadog App Key
-      required: yes
 
 # Global test configuration
 # ===========================

--- a/tests/performance/live.sh
+++ b/tests/performance/live.sh
@@ -33,8 +33,6 @@ docker run -i --rm \
     -e "PERF_DRIVER_ENVIRONMENT=env-ci-live.yml" \
     -e "DATADOG_API_KEY=$DATADOG_API_KEY" \
     -e "DATADOG_APP_KEY=$DATADOG_APP_KEY" \
-    -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-    -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
     -e DCLUSTER_ARGS="--docker_network='${DOCKER_NETWORK}' --marathon_jmx_host=marathon_1 --share_folder=${MARATHON_PERF_TESTING_DIR}/files" \
     icharalampidis/marathon-perf-testing:latest \
     ./tests/performance/ci_run_dcluster.sh \

--- a/tests/performance/live.sh
+++ b/tests/performance/live.sh
@@ -32,7 +32,6 @@ docker run -i --rm \
     -e "PARTIAL_TESTS=test-5k-apps" \
     -e "PERF_DRIVER_ENVIRONMENT=env-ci-live.yml" \
     -e "DATADOG_API_KEY=$DATADOG_API_KEY" \
-    -e "DATADOG_APP_KEY=$DATADOG_APP_KEY" \
     -e DCLUSTER_ARGS="--docker_network='${DOCKER_NETWORK}' --marathon_jmx_host=marathon_1 --share_folder=${MARATHON_PERF_TESTING_DIR}/files" \
     icharalampidis/marathon-perf-testing:latest \
     ./tests/performance/ci_run_dcluster.sh \

--- a/tests/performance/live.sh
+++ b/tests/performance/live.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+MARATHON_DIR=$(pwd)
+MARATHON_PERF_TESTING_DIR=$(pwd)/marathon-perf-testing
+
+# Bring an up-to-date marathon-perf-testing environment
+[ ! -d marathon-perf-testing ] && git clone "https://${GIT_USER}:${GIT_PASS}@github.com/mesosphere/marathon-perf-testing.git"
+(cd marathon-perf-testing; git pull --rebase)
+
+# Privileged clean-up of the results folder
+docker run -i --rm \
+    --privileged \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$MARATHON_DIR:/marathon" \
+    icharalampidis/marathon-perf-testing:latest \
+    rm -rf /marathon/results
+
+# Configuration
+DOCKER_NETWORK=testing
+
+# Get the git hash
+GIT_HASH=$(cd "$MARATHON_DIR" && git rev-parse HEAD)
+echo "- Running on GIT hash $GIT_HASH..."
+
+# Run the CI job
+docker run -i --rm \
+    --network ${DOCKER_NETWORK} \
+    --privileged \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$MARATHON_DIR:/marathon" \
+    -e "PARTIAL_TESTS=test-5k-apps" \
+    -e "PERF_DRIVER_ENVIRONMENT=env-ci-live.yml" \
+    -e "DATADOG_API_KEY=$DATADOG_API_KEY" \
+    -e "DATADOG_APP_KEY=$DATADOG_APP_KEY" \
+    -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+    -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+    -e DCLUSTER_ARGS="--docker_network='${DOCKER_NETWORK}' --marathon_jmx_host=marathon_1 --share_folder=${MARATHON_PERF_TESTING_DIR}/files" \
+    icharalampidis/marathon-perf-testing:latest \
+    ./tests/performance/ci_run_dcluster.sh \
+    -Djmx_host=marathon_1 -Djmx_port=9010 -Dmarathon_url=http://marathon_1:8080 \
+    -Mgit_hash="${GIT_HASH}"

--- a/tests/performance/scripts/dcluster_run.sh
+++ b/tests/performance/scripts/dcluster_run.sh
@@ -22,10 +22,6 @@ if [ -z "$DATADOG_API_KEY" ]; then
   echo "ERROR: Required 'DATADOG_API_KEY' environment variable"
   exit 253
 fi
-if [ -z "$DATADOG_APP_KEY" ]; then
-  echo "ERROR: Required 'DATADOG_APP_KEY' environment variable"
-  exit 253
-fi
 
 # Get mesos version from the cluster config
 MESOS_VERSION=$(cat $CLUSTER_CONFIG | grep 'mesos\s*=' | awk -F'=' '{print $2}' | tr -d ' ')
@@ -58,7 +54,6 @@ for TEST_CONFIG in $TESTS_DIR/test-*.yml; do
     -M "mesos=${MESOS_VERSION}" \
     -D "jmx_port=9010" \
     -D "datadog_api_key=${DATADOG_API_KEY}" \
-    -D "datadog_app_key=${DATADOG_APP_KEY}" \
     $*
   EXITCODE=$?; [ $EXITCODE -ne 0 ] && break
 


### PR DESCRIPTION
Summary:
The current Jenkins job definition that runs performance tests against master
and reports it to DataDog is not version controlled. This makes
iterating over the tests hard. This diff defines yet another Jenkinfiles
and imports the bash script verbatim. Once `ic/perf/5k-with-timeseries`
is merged into master we can define a Jenkins job or pipeline using the
definition of this diff and start iterating.