### PR TITLE
Collect and archive Mesos sandboxes after failed SI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ ci.log
 ci.tar.gz
 *.jfr
 .python-version
+.pytest_cache

--- a/Jenkinsfile.disabled.si
+++ b/Jenkinsfile.disabled.si
@@ -36,7 +36,7 @@ node('py36') {
         } finally {
             junit allowEmptyResults: true, testResults: 'shakedown.xml'
             archive includes: "**/diagnostics.zip"
-            archive includes: "**/sandbox_.tar.gz"
+            archive includes: "**/sandbox_*.tar.gz"
         }
     }
   }

--- a/Jenkinsfile.disabled.si
+++ b/Jenkinsfile.disabled.si
@@ -36,6 +36,7 @@ node('py36') {
         } finally {
             junit allowEmptyResults: true, testResults: 'shakedown.xml'
             archive includes: "**/diagnostics.zip"
+            archive includes: "**/sandbox_.tar.gz"
         }
     }
   }

--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -35,7 +35,7 @@ node('py36') {
         } finally {
             junit allowEmptyResults: true, testResults: 'shakedown.xml'
             archive includes: "**/diagnostics.zip"
-            archive includes: "**/sandbox_.tar.gz"
+            archive includes: "**/sandbox_*.tar.gz"
         }
     }
   }

--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -35,6 +35,7 @@ node('py36') {
         } finally {
             junit allowEmptyResults: true, testResults: 'shakedown.xml'
             archive includes: "**/diagnostics.zip"
+            archive includes: "**/sandbox_.tar.gz"
         }
     }
   }

--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -36,7 +36,7 @@ node('py36') {
         } finally {
             junit allowEmptyResults: true, testResults: 'shakedown.xml'
             archive includes: "**/diagnostics.zip"
-            archive includes: "**/sandbox_.tar.gz"
+            archive includes: "**/sandbox_*.tar.gz"
         }
     }
   }

--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -36,6 +36,7 @@ node('py36') {
         } finally {
             junit allowEmptyResults: true, testResults: 'shakedown.xml'
             archive includes: "**/diagnostics.zip"
+            archive includes: "**/sandbox_.tar.gz"
         }
     }
   }

--- a/Jenkinsfile.pr.si
+++ b/Jenkinsfile.pr.si
@@ -29,7 +29,7 @@ node('py36') {
         } finally {
             junit allowEmptyResults: true, testResults: 'shakedown.xml'
             archive includes: "**/diagnostics.zip"
-            archive includes: "**/sandbox_.tar.gz"
+            archive includes: "**/sandbox_*.tar.gz"
 
             withCredentials([usernamePassword(credentialsId:'a7ac7f84-64ea-4483-8e66-bb204484e58f',passwordVariable:'GIT_PASSWORD', usernameVariable: 'GIT_USER')]) {
                 sh """python3 ./ci/github_status.py "$JOB_NAME/${params.Variant}" "$BUILD_URL" \$(git rev-parse HEAD) $currentBuild.result"""

--- a/Jenkinsfile.pr.si
+++ b/Jenkinsfile.pr.si
@@ -29,6 +29,7 @@ node('py36') {
         } finally {
             junit allowEmptyResults: true, testResults: 'shakedown.xml'
             archive includes: "**/diagnostics.zip"
+            archive includes: "**/sandbox_.tar.gz"
 
             withCredentials([usernamePassword(credentialsId:'a7ac7f84-64ea-4483-8e66-bb204484e58f',passwordVariable:'GIT_PASSWORD', usernameVariable: 'GIT_USER')]) {
                 sh """python3 ./ci/github_status.py "$JOB_NAME/${params.Variant}" "$BUILD_URL" \$(git rev-parse HEAD) $currentBuild.result"""

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -36,7 +36,7 @@ node('py36') {
         } finally {
             junit allowEmptyResults: true, testResults: 'shakedown.xml'
             archive includes: "**/diagnostics.zip"
-            archive includes: "**/sandbox_.tar.gz"
+            archive includes: "**/sandbox_*.tar.gz"
         }
     }
   }

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -36,6 +36,7 @@ node('py36') {
         } finally {
             junit allowEmptyResults: true, testResults: 'shakedown.xml'
             archive includes: "**/diagnostics.zip"
+            archive includes: "**/sandbox_.tar.gz"
         }
     }
   }

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -99,6 +99,7 @@ def docker_ipv6_network_fixture():
 def archive_sandboxes():
     # Nothing to setup
     yield
+    print('>>> Archiving Mesos sandboxes')
     # We tarball the sandboxes from all the agents first and download them afterwards
     for agent in shakedown.get_private_agents():
         file_name = 'sandbox_{}.tar.gz'.format(agent.replace(".", "_"))

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -103,7 +103,7 @@ def archive_sandboxes():
     # We tarball the sandboxes from all the agents first and download them afterwards
     for agent in shakedown.get_private_agents():
         file_name = 'sandbox_{}.tar.gz'.format(agent.replace(".", "_"))
-        cmd = 'sudo tar -zcvf {} /var/lib/mesos/slave'.format(file_name)
+        cmd = 'sudo tar --exclude=provisioner -zcf {} /var/lib/mesos/slave'.format(file_name)
         status, output = shakedown.run_command_on_agent(agent, cmd)  # NOQA
 
         if status:

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -93,3 +93,19 @@ def docker_ipv6_network_fixture():
     yield
     for agent in agents:
         shakedown.run_command_on_agent(agent, f"sudo docker network rm mesos-docker-ipv6-test")
+
+
+@pytest.fixture(autouse=True, scope='session')
+def archive_sandboxes():
+    # Nothing to setup
+    yield
+    # We tarball the sandboxes from all the agents first and download them afterwards
+    for agent in shakedown.get_private_agents():
+        file_name = 'sandbox_{}.tar.gz'.format(agent.replace(".", "_"))
+        cmd = 'sudo tar -zcvf {} /var/lib/mesos/slave'.format(file_name)
+        status, output = shakedown.run_command_on_agent(agent, cmd)  # NOQA
+
+        if status:
+            shakedown.copy_file_from_agent(agent, file_name)
+        else:
+            print('DEBUG: Failed to tarball the sandbox from the agent={}, output={}'.format(agent, output))

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -23,7 +23,7 @@ import marathon_common_tests
 import marathon_pods_tests
 
 from shakedown import dcos_version_less_than, marthon_version_less_than, required_masters, required_public_agents # NOQA F401
-from fixtures import sse_events, wait_for_marathon_and_cleanup, user_billy, docker_ipv6_network_fixture # NOQA F401
+from fixtures import sse_events, wait_for_marathon_and_cleanup, user_billy, docker_ipv6_network_fixture, archive_sandboxes # NOQA F401
 
 # the following lines essentially do:
 #     from dcos_service_marathon_tests import test_*


### PR DESCRIPTION
Summary:
To ease debugging of flaky SI tests we tarball and download Mesos sandboxes after failed SI runs and archive them with the Jenkins build.