### PR TITLE
Fix the location of the shakedown.xml for the SI tests builds

### DIFF
--- a/Jenkinsfile.disabled.si
+++ b/Jenkinsfile.disabled.si
@@ -34,7 +34,7 @@ node('py36') {
             sh """./ci/si_pipeline.sh $params.channel disabled"""
           }
         } finally {
-            junit allowEmptyResults: true, testResults: 'shakedown.xml'
+            junit allowEmptyResults: true, testResults: "**/shakedown.xml"
             archive includes: "**/diagnostics.zip"
         }
     }

--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -33,7 +33,7 @@ node('py36') {
             sh """./ci/si_pipeline.sh $params.channel open"""
           }
         } finally {
-            junit allowEmptyResults: true, testResults: 'shakedown.xml'
+            junit allowEmptyResults: true, testResults: "**/shakedown.xml"
             archive includes: "**/diagnostics.zip"
         }
     }

--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -34,7 +34,7 @@ node('py36') {
             sh """./ci/si_pipeline.sh $params.channel permissive"""
           }
         } finally {
-            junit allowEmptyResults: true, testResults: 'shakedown.xml'
+            junit allowEmptyResults: true, testResults: "**/shakedown.xml"
             archive includes: "**/diagnostics.zip"
         }
     }

--- a/Jenkinsfile.pr.si
+++ b/Jenkinsfile.pr.si
@@ -27,7 +27,7 @@ node('py36') {
             sh """./ci/si_pipeline.sh $params.Channel $params.Variant"""
           }
         } finally {
-            junit allowEmptyResults: true, testResults: 'shakedown.xml'
+            junit allowEmptyResults: true, testResults: "**/shakedown.xml"
             archive includes: "**/diagnostics.zip"
 
             withCredentials([usernamePassword(credentialsId:'a7ac7f84-64ea-4483-8e66-bb204484e58f',passwordVariable:'GIT_PASSWORD', usernameVariable: 'GIT_USER')]) {

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -34,7 +34,7 @@ node('py36') {
             sh """./ci/si_pipeline.sh $params.channel strict"""
           }
         } finally {
-            junit allowEmptyResults: true, testResults: 'shakedown.xml'
+            junit allowEmptyResults: true, testResults: "**/shakedown.xml"
             archive includes: "**/diagnostics.zip"
         }
     }

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -24,7 +24,7 @@ function create-junit-xml {
     local testcase_name=$2
     local error_message=$3
 
-	cat > ../shakedown.xml <<-EOF
+	cat > "$ROOT_PATH/shakedown.xml" <<-EOF
 	<testsuites>
 	  <testsuite name="$testsuite_name" errors="0" skipped="0" tests="1" failures="1">
 	      <testcase classname="$testsuite_name" name="$testcase_name">


### PR DESCRIPTION
Jenkins expected this file in the workspace root folder which leads to "green" builds despite cluster launch errors.