### PR TITLE
Don't use https to ping marathon if we run SI tests on a disabled cluster

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -888,10 +888,8 @@ def wait_for_service_endpoint(service_name, timeout_sec=120, path=""):
             stop_max_attempt_number=timeout_sec/5,  # underlying http.get has 5 seconds timeout, so we have to scale it
             retry_on_exception=ignore_provided_exception(DCOSException))
     def check_service_availability_on_master(master_ip, service):
-        schema = "https"
 
-        if ee_version() == 'disabled':
-            schema = "http"
+        schema = 'https' if ee_version() == 'strict' or ee_version() == 'permissive' else 'http'
 
         url = "{}://{}/service/{}/{}".format(schema, master_ip, service, path)
 

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -22,7 +22,7 @@ from dcos.http import DCOSAcsAuth
 from functools import lru_cache
 from fixtures import get_ca_file
 from requests.exceptions import ReadTimeout
-
+from shakedown.dcos.cluster import ee_version
 
 marathon_1_3 = pytest.mark.skipif('marthon_version_less_than("1.3")')
 marathon_1_4 = pytest.mark.skipif('marthon_version_less_than("1.4")')
@@ -888,7 +888,12 @@ def wait_for_service_endpoint(service_name, timeout_sec=120, path=""):
             stop_max_attempt_number=timeout_sec/5,  # underlying http.get has 5 seconds timeout, so we have to scale it
             retry_on_exception=ignore_provided_exception(DCOSException))
     def check_service_availability_on_master(master_ip, service):
-        url = "https://{}/service/{}/{}".format(master_ip, service, path)
+        schema = "https"
+
+        if ee_version() == 'disabled':
+            schema = "http"
+
+        url = "{}://{}/service/{}/{}".format(schema, master_ip, service, path)
 
         auth = DCOSAcsAuth(shakedown.dcos_acs_token())
         try:


### PR DESCRIPTION
if we run tests on a disabled cluster, http is being used instead of https.