### PR TITLE
Use unique names for system test apps.

### DIFF
--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -1,5 +1,4 @@
 import os.path
-import uuid
 
 from utils import make_id, get_resource
 
@@ -8,20 +7,21 @@ def apps_dir():
     return os.path.dirname(os.path.abspath(__file__))
 
 
-def load_app(app_name):
-    app_path = os.path.join(apps_dir(), "{}.json".format(app_name))
+def load_app(app_def_file, app_id=None):
+    """Loads an app definition from a json file and sets the app id."""
+    app_path = os.path.join(apps_dir(), "{}.json".format(app_def_file))
     app = get_resource(app_path)
-    app['id'] = make_id(app_name)
+
+    if app_id is None:
+        app['id'] = make_id(app_def_file)
+    else:
+        app['id'] = app_id
+
     return app
 
 
 def mesos_app(app_id=None):
-    if app_id is None:
-        app_id = '/mesos-app-{}'.format(uuid.uuid4().hex)
-
-    app_def = load_app('mesos-app')
-    app_def['id'] = app_id
-    return app_def
+    return load_app('mesos-app', app_id)
 
 
 def http_server():
@@ -29,12 +29,7 @@ def http_server():
 
 
 def docker_http_server(app_id=None):
-    if app_id is None:
-        app_id = '/docker-http-server-{}'.format(uuid.uuid4().hex)
-
-    app_def = load_app('docker-http-server')
-    app_def['id'] = app_id
-    return app_def
+    return load_app('docker-http-server', app_id)
 
 
 def healthcheck_and_volume():
@@ -42,19 +37,11 @@ def healthcheck_and_volume():
 
 
 def ucr_docker_http_server(app_id=None):
-    if app_id is None:
-        app_id = '/ucr-docker-http-server-{}'.format(uuid.uuid4().hex)
-
-    app_def = load_app('ucr-docker-http-server')
-    app_def['id'] = app_id
-    return app_def
+    return load_app('ucr-docker-http-server', app_id)
 
 
 def sleep_app(app_id=None):
-    if app_id is None:
-        app_id = '/sleep-{}'.format(uuid.uuid4().hex)
-    app = load_app('sleep-app')
-    app['id'] = app_id
+    app = load_app('sleep-app', app_id)
     return app
 
 

--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -15,24 +15,39 @@ def load_app(app_name):
     return app
 
 
-def mesos_app():
-    return load_app('mesos-app')
+def mesos_app(app_id=None):
+    if app_id is None:
+        app_id = '/mesos-app-{}'.format(uuid.uuid4().hex)
+
+    app_def = load_app('mesos-app')
+    app_def['id'] = app_id
+    return app_def
 
 
 def http_server():
     return load_app('http-server')
 
 
-def docker_http_server():
-    return load_app('docker-http-server')
+def docker_http_server(app_id=None):
+    if app_id is None:
+        app_id = '/docker-http-server-{}'.format(uuid.uuid4().hex)
+
+    app_def = load_app('docker-http-server')
+    app_def['id'] = app_id
+    return app_def
 
 
 def healthcheck_and_volume():
     return load_app('healthcheck-and-volume')
 
 
-def ucr_docker_http_server():
-    return load_app('ucr-docker-http-server')
+def ucr_docker_http_server(app_id=None):
+    if app_id is None:
+        app_id = '/ucr-docker-http-server-{}'.format(uuid.uuid4().hex)
+
+    app_def = load_app('ucr-docker-http-server')
+    app_def['id'] = app_id
+    return app_def
 
 
 def sleep_app(app_id=None):

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -20,7 +20,7 @@ from shakedown import dcos_version_less_than, marthon_version_less_than, require
 def test_launch_mesos_container():
     """Launches a Mesos container with a simple command."""
 
-    app_def = apps.mesos_app()
+    app_def = apps.mesos_app(app_id='mesos-container-app')
 
     client = marathon.create_client()
     client.add_app(app_def)
@@ -36,7 +36,7 @@ def test_launch_mesos_container():
 def test_launch_docker_container():
     """Launches a Docker container on Marathon."""
 
-    app_def = apps.docker_http_server()
+    app_def = apps.docker_http_server(app_id='launch-docker-container-app')
     app_id = app_def["id"]
 
     client = marathon.create_client()
@@ -53,7 +53,7 @@ def test_launch_docker_container():
 def test_launch_mesos_container_with_docker_image():
     """Launches a Mesos container with a Docker image."""
 
-    app_def = apps.ucr_docker_http_server()
+    app_def = apps.ucr_docker_http_server(app_id='launch-mesos-container-with-docker-image-app')
     app_id = app_def["id"]
 
     client = marathon.create_client()
@@ -74,7 +74,7 @@ def test_launch_mesos_grace_period(marathon_service_name):
        Read more details about this test in `test_root_marathon.py::test_launch_mesos_root_marathon_grace_period`
     """
 
-    app_def = apps.mesos_app()
+    app_def = apps.mesos_app(app_id='mesos-grace-period-app')
 
     default_grace_period = 3
     grace_period = 20
@@ -111,7 +111,7 @@ def test_launch_docker_grace_period(marathon_service_name):
        Read more details about this test in `test_root_marathon.py::test_launch_mesos_root_marathon_grace_period`
     """
 
-    app_def = apps.docker_http_server()
+    app_def = apps.docker_http_server(app_id='launch-docker-grace-period-app')
     app_def['container']['docker']['image'] = 'kensipe/python-test'
 
     default_grace_period = 3
@@ -145,7 +145,7 @@ def test_launch_docker_grace_period(marathon_service_name):
 def test_docker_port_mappings():
     """Tests that Docker ports are mapped and are accessible from the host."""
 
-    app_def = apps.docker_http_server()
+    app_def = apps.docker_http_server(app_id='docker-port-mapping-app')
 
     client = marathon.create_client()
     client.add_app(app_def)
@@ -158,14 +158,13 @@ def test_docker_port_mappings():
     cmd = cmd + ' {}:{}/.dockerenv'.format(host, port)
     status, output = shakedown.run_command_on_agent(host, cmd)
 
-    assert status
-    assert output == "200", "HTTP status code is {}, but 200 was expected".format(output)
+    assert status and output == "200", "HTTP status code is {}, but 200 was expected".format(output)
 
 
 def test_docker_dns_mapping(marathon_service_name):
     """Tests that a running Docker task is accessible via DNS."""
 
-    app_def = apps.docker_http_server()
+    app_def = apps.docker_http_server(app_id='docker-dns-mapping-app')
 
     client = marathon.create_client()
     client.add_app(app_def)
@@ -191,7 +190,7 @@ def test_launch_app_timed():
        This test verifies that if a app is launched on marathon that within 3 secs there is a task spawned.
     """
 
-    app_def = apps.mesos_app()
+    app_def = apps.mesos_app(app_id='timed-launch-app')
 
     client = marathon.create_client()
     client.add_app(app_def)
@@ -798,7 +797,7 @@ def test_app_with_persistent_volume_recovers():
 def test_app_update():
     """Tests that an app gets successfully updated."""
 
-    app_def = apps.mesos_app()
+    app_def = apps.mesos_app(app_id='update-app')
 
     client = marathon.create_client()
     client.add_app(app_def)
@@ -1141,7 +1140,7 @@ def test_vip_docker_bridge_mode(marathon_service_name):
        of the service via the VIP.
     """
 
-    app_def = apps.docker_http_server()
+    app_def = apps.docker_http_server(app_id='vip-docker-bridge-mode-app')
 
     vip_name = app_def["id"].lstrip("/")
     fqn = '{}.{}.l4lb.thisdcos.directory'.format(vip_name, marathon_service_name)


### PR DESCRIPTION
Summary:
This should ease debugging test failures as we can identify the apps on
the Mesos agents. The same approach helped tackle flaky integration
tests. See 92a81025745a43e2883231cd2ff50b4ac27ff6da for details.