### PR TITLE
Properly handle ENV args containing "*", " ", or line delimiters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+## Changes since 1.5.9
+
+### Improved environment variable to command line argument mapping
+
+As part of the fix for [MARATHON-8254](https://jira.mesosphere.com/browse/MARATHON-8254), the logic for receiving command-line options from environment variables has been reworked. "*" is properly propagated (previously, the glob-expanded result was getting passed), and spaces and new-lines are now preserved.
+
+There's a small change in behavior for environments in which the launcher script is sourced, rather than executed. Unexported environment variables will not be converted in to parameters.
+
 ## Changes from 1.5.8 to 1.5.9
 Added Metrics, Bug fixes, Backports and performance improvements.
 

--- a/project/NativePackagerSettings/extra-defines.bash
+++ b/project/NativePackagerSettings/extra-defines.bash
@@ -7,12 +7,12 @@ if [ ! "$1" = "--help" ]; then
     starthook_env=${starthook_env##*/}
 
     # In case the hook script needs to add/change environment variables or otherwise access the parent shell
-    [ -f "$starthook_env" ] && source "$starthook_env"
+    if [ -f "$starthook_env" ]; then
+      set -a # export the variables so they can be seen when launching Marathon
+      source "$starthook_env"
+      set +a
+    fi
   else
     echo "No start hook file found (\$HOOK_MARATHON_START). Proceeding with the start script."
   fi
-
-  for env_op in `env | grep -v ^MARATHON_APP | grep ^MARATHON_ | awk '{gsub(/MARATHON_/,""); sub(/=/," "); printf("%s%s ", "--", tolower($1)); for(i=2;i<=NF;i++){printf("%s ", $i)}}'`; do
-    addApp "$env_op"
-  done
 fi

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -230,8 +230,27 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
 }
 
 object Main {
+  /**
+    * Given environment variables starting with MARATHON_, convert to a series of arguments.
+    *
+    * If environment variable specifies an empty string, treat to boolean flag (no argument)
+    *
+    * @returns A list of args intended to be arg-parsed
+    */
+  def envToArgs(env: Map[String, String]): Seq[String] = {
+    env.flatMap {
+      case (k, v) if k.startsWith("MARATHON_") =>
+        val argName = s"--${k.drop(9).toLowerCase}"
+        if (v.isEmpty)
+          Seq(argName)
+        else
+          Seq(argName, v)
+      case _ => Nil
+    }(collection.breakOut)
+  }
+
   def main(args: Array[String]): Unit = {
-    val app = new MarathonApp(args.toVector)
+    val app = new MarathonApp(envToArgs(sys.env) ++ args.toVector)
     app.start()
   }
 }

--- a/src/test/scala/mesosphere/marathon/MainTest.scala
+++ b/src/test/scala/mesosphere/marathon/MainTest.scala
@@ -1,0 +1,20 @@
+package mesosphere.marathon
+
+import mesosphere.UnitTest
+
+class MainTest extends UnitTest {
+  "envToArgs" should {
+    "return boolean flags for empty string values" in {
+      Main.envToArgs(Map("MARATHON_DISABLE_HA" -> "")) shouldBe Seq("--disable_ha")
+    }
+
+    "return downcased parameter flags for non-empty strings" in {
+      Main.envToArgs(Map("MARATHON_HTTP_PORT" -> "8080")) shouldBe Seq("--http_port", "8080")
+    }
+
+    "ignores strings not beginning with MARATHON_" in {
+      Main.envToArgs(Map("CMD_MARATHON_HTTP_PORT" -> "8080")) shouldBe Seq()
+      Main.envToArgs(Map("marathon_http_port" -> "8080")) shouldBe Seq()
+    }
+  }
+}


### PR DESCRIPTION
Backport of 49647f8

Previously, we used a rather difficult-to-grok awk expression with
some bash looping to define the arguments. This proved to be
challenging and was error prone, causing arguments to be passed
incorrectly ("*" would pass an invalid globbed expansion, instead of a
literal "*")

JIRA Issues: MARATHON-8254