### PR TITLE
Move the instance update to the update method

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -28,7 +28,7 @@ case class TestInstanceBuilder(instance: Instance, now: Timestamp = Timestamp.no
     withReservation(volumeIds).addTaskWithBuilder().taskResidentReserved().build()
 
   def addTaskResidentReserved(state: Reservation.State): TestInstanceBuilder =
-    withReservation(state).addTaskWithBuilder().taskResidentReserved().build()
+    addTaskWithBuilder().taskResidentReserved().build().withReservation(state)
 
   def addTaskResidentLaunched(volumeIds: Seq[LocalVolumeId]): TestInstanceBuilder =
     withReservation(volumeIds).addTaskWithBuilder().taskResidentLaunched().build()


### PR DESCRIPTION
Summary:
I think the reservation update should happen in the instance update method. Someone in a different PR commented on this piece of code in a way that it seemed like it might be misleading so I refactored it. It is supposed to work the same as it worked before :)
