### PR TITLE
Start development of 1.7.

### DIFF
--- a/version
+++ b/version
@@ -5,8 +5,8 @@
 # Change MINOR to x+1 and BRANCH_POINT to commit hash of common ancestor of master and releases/1.x
 # after a releases/1.x was cut
 MAJOR=1
-MINOR=6
-BRANCH_POINT=aa89e89
+MINOR=7
+BRANCH_POINT=2af52d9
 
 # Infer version
 # Number of commits since branch point


### PR DESCRIPTION
Summary:
We have a few 1.7 related pull requests. Let's land them on master and
cut the `releases/1.6` branch at 2af52d9.

JIRA issues: MARATHON-8300