### PR TITLE
Log incoming offers at info level

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -10,8 +10,6 @@ import mesosphere.marathon.core.matcher.base.OfferMatcher.{InstanceOpWithSource,
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.metrics.{Metrics, ServiceMetric}
 import org.apache.mesos.Protos.{Offer, OfferID}
-import mesosphere.marathon.raml.RamlConversions.offerWrites
-import play.api.libs.json.Json
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
@@ -81,10 +79,9 @@ private[launcher] class OfferProcessorImpl(
   }
 
   private def logOffer(offer: Offer): Unit = {
-    val raml = offerWrites(offer)
-    val json = Json.toJson(raml)
-    val compact = json.toString()
-    logger.info(s"Processing offer: $compact")
+    val offerId = offer.getId.getValue
+    val agentId = offer.getSlaveId.getValue
+    logger.info(s"Processing offer: offerId $offerId, agentId $agentId")
   }
 
   override def processOffer(offer: Offer): Future[Done] = {

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -86,9 +86,9 @@ private[launcher] class OfferProcessorImpl(
 
   override def processOffer(offer: Offer): Future[Done] = {
     incomingOffersMeter.increment()
+    logOffer(offer)
     offerStreamInput.offer(offer)
     warnOnZeroResource(offer)
-    logOffer(offer)
 
     val matchFuture: Future[MatchedInstanceOps] = matchTimeMeter {
       offerMatcher.matchOffer(offer)


### PR DESCRIPTION
Summary:
It should be done in order to ease troubleshooting when Mesos and Marathon are under load, and it takes noticeable time to receive offers.

JIRA issues: MARATHON-8282

