### PR TITLE
ElectionServiceTest flakyness fix

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -72,8 +72,9 @@ private[launcher] class OfferProcessorImpl(
   private def warnOnZeroResource(offer: Offer): Unit = {
     val resourcesWithZeroValues = offer
       .getResourcesList.asScala
-      .collect { case resource if resource.getScalar.getValue.ceil.toLong == 0 =>
-        resource.getName
+      .collect {
+        case resource if resource.getScalar.getValue.ceil.toLong == 0 =>
+          resource.getName
       }
     if (resourcesWithZeroValues.nonEmpty) {
       logger.warn(s"Offer ${offer.getId.getValue} has zero-valued resources: ${resourcesWithZeroValues.mkString(", ")}")

--- a/src/test/scala/mesosphere/marathon/core/election/ElectionServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/election/ElectionServiceTest.scala
@@ -90,14 +90,14 @@ class ElectionServiceTest extends AkkaUnitTest with Eventually {
   }
 
   "it provides the last leadershipEvent published for subscribers showing up late" in new Fixture {
-    val transitionEvent = leaderTransitionEvents.take(2).runWith(Sink.seq).futureValue
+    val transitionEvent = leaderTransitionEvents.take(2).runWith(Sink.seq)
     input.offer(LeadershipState.Standby(None)).futureValue
     input.offer(LeadershipState.ElectedAsLeader).futureValue
-    transitionEvent shouldBe List(LeadershipTransition.Standby, LeadershipTransition.ElectedAsLeaderAndReady)
+    transitionEvent.futureValue shouldBe List(LeadershipTransition.Standby, LeadershipTransition.ElectedAsLeaderAndReady)
 
-    val lostEvent = leaderTransitionEvents.take(2).runWith(Sink.seq).futureValue
+    val lostEvent = leaderTransitionEvents.take(2).runWith(Sink.seq)
     input.offer(LeadershipState.Standby(None)).futureValue
-    lostEvent shouldBe Seq(LeadershipTransition.ElectedAsLeaderAndReady, LeadershipTransition.Standby)
+    lostEvent.futureValue shouldBe Seq(LeadershipTransition.ElectedAsLeaderAndReady, LeadershipTransition.Standby)
     leaderTransitionEvents.runWith(Sink.head).futureValue shouldBe (LeadershipTransition.Standby)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/election/ElectionServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/election/ElectionServiceTest.scala
@@ -90,14 +90,14 @@ class ElectionServiceTest extends AkkaUnitTest with Eventually {
   }
 
   "it provides the last leadershipEvent published for subscribers showing up late" in new Fixture {
-    val transitionEvent = leaderTransitionEvents.take(2).runWith(Sink.seq)
-    input.offer(LeadershipState.Standby(None))
-    input.offer(LeadershipState.ElectedAsLeader)
-    transitionEvent.futureValue shouldBe List(LeadershipTransition.Standby, LeadershipTransition.ElectedAsLeaderAndReady)
+    val transitionEvent = leaderTransitionEvents.take(2).runWith(Sink.seq).futureValue
+    input.offer(LeadershipState.Standby(None)).futureValue
+    input.offer(LeadershipState.ElectedAsLeader).futureValue
+    transitionEvent shouldBe List(LeadershipTransition.Standby, LeadershipTransition.ElectedAsLeaderAndReady)
 
-    val lostEvent = leaderTransitionEvents.take(2).runWith(Sink.seq)
-    input.offer(LeadershipState.Standby(None))
-    lostEvent.futureValue shouldBe Seq(LeadershipTransition.ElectedAsLeaderAndReady, LeadershipTransition.Standby)
+    val lostEvent = leaderTransitionEvents.take(2).runWith(Sink.seq).futureValue
+    input.offer(LeadershipState.Standby(None)).futureValue
+    lostEvent shouldBe Seq(LeadershipTransition.ElectedAsLeaderAndReady, LeadershipTransition.Standby)
     leaderTransitionEvents.runWith(Sink.head).futureValue shouldBe (LeadershipTransition.Standby)
   }
 


### PR DESCRIPTION
Summary: made method calls synchronous to remove a race condition

JIRA issues: MARATHON-8302

