### PR TITLE
Use parallel requests on the continuous-n-apps test

### DIFF
--- a/tests/performance/config/perf-driver/policies/test-continuous-n-apps.yml
+++ b/tests/performance/config/perf-driver/policies/test-continuous-n-apps.yml
@@ -49,7 +49,7 @@ policies:
     # Complete the policy when 10000 deployment completion events are received
     events:
       start: MarathonStartedEvent
-      end: MarathonDeploymentSuccessEvent:nth(10000,all) MarathonDeploymentFailedEvent:nth(10000,all)
+      end: MarathonDeploymentSuccessEvent:nth(10000,all) MarathonDeploymentFailedEvent:nth(10000,all) MarathonDeploymentRequestFailedEvent(10000,all)
 
     # Don't let the tests run for more than 1 hour.
     timeout: 60m
@@ -66,6 +66,7 @@ channels:
     deploy:
       - type: app
         repeat: "{{apps}}"
+        parallel: 500
         spec: |
           {
             "cmd": "sleep infinity",

--- a/tests/performance/config/perf-driver/policies/test-continuous-n-apps.yml
+++ b/tests/performance/config/perf-driver/policies/test-continuous-n-apps.yml
@@ -66,7 +66,7 @@ channels:
     deploy:
       - type: app
         repeat: "{{apps}}"
-        parallel: 500
+        parallel: 100
         spec: |
           {
             "cmd": "sleep infinity",


### PR DESCRIPTION
In order to speed-up the deployment of 10k apps, this PR changes the number of parallel requests to `100`