### PR TITLE
Retry deployment readiness assertion.

### DIFF
--- a/tests/system/dcos_service_marathon_tests.py
+++ b/tests/system/dcos_service_marathon_tests.py
@@ -11,6 +11,14 @@ from dcos import marathon
 from dcos.errors import DCOSUnprocessableException
 
 
+@retrying.retry(wait_fixed=1000, stop_max_attempt_number=16, retry_on_exception=common.ignore_exception)
+def assert_in_deployment(deployment_id):
+    client = marathon.create_client()
+    deployment = client.get_deployment(deployment_id)
+    assert deployment['currentActions'][0]['readinessCheckResults'][0]['ready'] is False, \
+        "Application's readiness check is green where it should still be red"
+
+
 def test_deploy_custom_framework():
     """Launches an app that has necessary elements to create a service endpoint in DCOS.
        This test confirms that the endpoint is created by the root Marathon.
@@ -34,12 +42,6 @@ def test_framework_readiness_time_check():
     client = marathon.create_client()
     deployment_id = client.add_app(fw)
 
-    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=16, retry_on_exception=common.ignore_exception)
-    def assert_in_deployment(deployment_id):
-        deployment = client.get_deployment(deployment_id)
-        assert deployment['currentActions'][0]['readinessCheckResults'][0]['ready'] is False, \
-            "Application's readiness check is green where it should still be red"
-
     assert_in_deployment(deployment_id)
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
@@ -61,9 +63,7 @@ def test_framework_rollback_before_ready():
 
     # 2 secs later it is still being deployed
     time.sleep(2)
-    deployment = client.get_deployment(deployment_id)
-    assert deployment['currentActions'][0]['readinessCheckResults'][0]['ready'] is False, \
-        "The application is ready, but it should not be"
+    assert_in_deployment(deployment_id)
 
     client.rollback_deployment(deployment_id)
     # normally deployment would take another 28 secs


### PR DESCRIPTION
Summary:
The test case can fail with an index error. I assume that the deployment
did not start at all. So we have to retry the call until we can verify
that the app is not ready yet.