### PR TITLE
Introduce and use Subject to fix race-condition when sending last leadership transition

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -105,7 +105,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
         killService,
         launchQueue,
         driverHolder,
-        electionService,
+        electionService.leadershipTransitionEvents,
         eventBus
       )(mat).withRouter(RoundRobinPool(nrOfInstances = 1, supervisorStrategy = supervision)),
       "MarathonScheduler")

--- a/src/main/scala/mesosphere/marathon/core/election/ElectionService.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/ElectionService.scala
@@ -2,19 +2,19 @@ package mesosphere.marathon
 package core.election
 
 import akka.{Done, NotUsed}
-import akka.actor.{ActorRef, ActorSystem, Cancellable, PoisonPill}
+import akka.actor.{ActorRef, ActorSystem, Cancellable}
 import akka.event.EventStream
 import akka.stream.ClosedShape
 import akka.stream.scaladsl.{Broadcast, GraphDSL, RunnableGraph, Flow, Sink, Source, Keep}
 import akka.stream.OverflowStrategy
 import akka.stream.ActorMaterializer
 import com.typesafe.scalalogging.StrictLogging
+import java.util.concurrent.atomic.AtomicBoolean
 import kamon.Kamon
 import kamon.metric.instrument.Time
 import mesosphere.marathon.core.async.ExecutionContexts
 import mesosphere.marathon.core.base.CrashStrategy
-import mesosphere.marathon.stream.EnrichedFlow
-import mesosphere.marathon.util.CancellableOnce
+import mesosphere.marathon.stream.{EnrichedFlow, Subject}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -144,6 +144,7 @@ class ElectionServiceImpl(
   @volatile private[this] var _leaderAndReady: Boolean = false
   implicit private lazy val materializer = ActorMaterializer()
   var leaderSubscription: Option[Cancellable] = None
+  private val offerLeadershipCalled = new AtomicBoolean(false)
 
   def subscribe(subscriber: ActorRef): Unit = {
     eventStream.subscribe(subscriber, classOf[LeadershipTransition])
@@ -236,7 +237,6 @@ class ElectionServiceImpl(
     * When the stream ends (exception or not), we report accordingly and crash.
     */
   private def initializeStream(leadershipTransitionsFlow: Flow[LeadershipState, LeadershipTransition, NotUsed]) = {
-
     val graph = GraphDSL.create(leaderEventsSource, localEventListenerSink, localTransitionSink, metricsSink){
       (leaderStream, localEventListenerSinkR, localTransitionSinkR, metricsSinkR) =>
         import system.dispatcher
@@ -253,13 +253,15 @@ class ElectionServiceImpl(
         // we'll help to make it obvious by closing the entire graph (and, by consequence, crashing).
         // Akka will log all stream failures, by default.
         val stateBroadcast = b.add(Broadcast[LeadershipState](2, eagerCancel = true))
-        val transitionBroadcast = b.add(Broadcast[LeadershipTransition](2, eagerCancel = true))
+        val transitionBroadcast = b.add(Broadcast[LeadershipTransition](3, eagerCancel = true))
+        val leadershipTransitionEventsInput = b.add(Sink.fromSubscriber(leadershipTransitionsEventsSubscriber))
         leaderEventsSource ~> stateBroadcast.in
         stateBroadcast ~> localEventListenerSink
         stateBroadcast ~> leadershipTransitionsFlow ~> transitionBroadcast.in
 
         transitionBroadcast ~> metricsSink
         transitionBroadcast ~> localTransitionSink
+        transitionBroadcast ~> leadershipTransitionEventsInput
         ClosedShape
       }
     }
@@ -285,6 +287,8 @@ class ElectionServiceImpl(
     * @param candidate is called back once elected or defeated
     */
   def offerLeadership(candidate: ElectionCandidate): Unit = {
+    if (!offerLeadershipCalled.compareAndSet(false, true))
+      throw new IllegalStateException("You cannot call offerLeadership twice")
 
     /**
       * Deduped event stream with current leader removed. Specified this way to maintain compatibility with the rest of
@@ -315,19 +319,15 @@ class ElectionServiceImpl(
     leaderSubscription = Some(initializeStream(leadershipTransitionsFlow))
   }
 
-  val leadershipTransitionEvents: Source[LeadershipTransition, Cancellable] = {
-    Source.actorRef[LeadershipTransition](16, OverflowStrategy.dropHead) // drop older elements
-      .watchTermination()(Keep.both)
-      .mapMaterializedValue {
-        case (ref, terminated) =>
-          subscribe(ref)
-          // If the stream terminates, for any reason, then unsubscribe from the event stream
-          terminated.onComplete(_ => unsubscribe(ref))(ExecutionContexts.callerThread)
-          // If the stream cancellable gets called, kill the actor created by Source.actorRef; this will gracefully
-          // terminate the stream
-          new CancellableOnce(() => ref ! PoisonPill)
-      }
-  }
+  private[this] val (leadershipTransitionsEventsSubscriber, _leadershipTransitionEvents) =
+    Source.asSubscriber[LeadershipTransition]
+      .prepend(Source.single(LeadershipTransition.Standby))
+      // Subject keeps track of the last item received, and published updates going forward
+      // If they get behind, we can safely drop old updates as the last state matters most here.
+      .toMat(Subject(32, OverflowStrategy.dropHead))(Keep.both)
+      .run
+
+  val leadershipTransitionEvents: Source[LeadershipTransition, Cancellable] = _leadershipTransitionEvents
 }
 
 object ElectionService extends StrictLogging {

--- a/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/event/EventModule.scala
@@ -30,7 +30,7 @@ class EventModule(
     actorSystem.actorOf(
       Props(
         new HttpEventStreamActor(
-          electionService,
+          electionService.leadershipTransitionEvents,
           new HttpEventStreamActorMetrics(),
           handleStreamProps)
       ),

--- a/src/main/scala/mesosphere/marathon/stream/Subject.scala
+++ b/src/main/scala/mesosphere/marathon/stream/Subject.scala
@@ -1,0 +1,117 @@
+package mesosphere.marathon
+package stream
+
+import akka.Done
+import akka.actor.Cancellable
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Sink => AkkaSink, Source, SourceQueueWithComplete}
+import akka.stream.stage.{GraphStageLogic, InHandler, GraphStageWithMaterializedValue}
+import akka.stream.{Attributes, Inlet, SinkShape}
+import mesosphere.marathon.core.async.ExecutionContexts
+import mesosphere.marathon.util.CancellableOnce
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Internal, stream-indepent logic used for managing the subject. The Subject sink needs to continue to function
+  * after the originating stream terminates. This logic is contained in a vanilla class to prevent usage of any akka
+  * stream methods that would stop working once said stream terminates.
+  */
+private class SubjectInternalLogic[T](queueSize: Int, overflowStrategy: OverflowStrategy) {
+  @volatile private[this] var subscribers: Set[SourceQueueWithComplete[T]] = Set.empty
+  @volatile private[this] var lastElement: T = _
+  @volatile private[this] var elementPushed = false
+  @volatile private[this] var completionResult: Option[Try[Done]] = None
+
+  def onElement(t: T): Unit = synchronized {
+    elementPushed = true
+    lastElement = t
+    subscribers.foreach(_.offer(t))
+  }
+
+  private def addSubscriber(sq: SourceQueueWithComplete[T]): Unit = synchronized {
+    completionResult match {
+      case Some(r) =>
+        if (r.isSuccess && elementPushed)
+          sq.offer(lastElement)
+
+        propagateCompletion(sq, r)
+
+      case None =>
+        if (elementPushed) sq.offer(lastElement)
+        subscribers += sq
+    }
+  }
+
+  private[this] def propagateCompletion(sq: SourceQueueWithComplete[T], result: Try[Done]) =
+    result match {
+      case Success(_) => sq.complete()
+      case Failure(ex) => sq.fail(ex)
+    }
+
+  private def removeSubscriber(sq: SourceQueueWithComplete[T]): Unit = synchronized {
+    subscribers -= sq
+  }
+
+  def complete(result: Try[Done]): Unit = synchronized {
+    completionResult = Some(result)
+    subscribers.foreach(propagateCompletion(_, result))
+    subscribers = Set.empty
+  }
+
+  val newSubscriberSource = Source.queue[T](queueSize, overflowStrategy).mapMaterializedValue { sq =>
+    addSubscriber(sq)
+    sq.watchCompletion().onComplete { _ => removeSubscriber(sq) }(ExecutionContexts.callerThread)
+    new CancellableOnce(() => sq.complete())
+  }
+}
+
+/**
+  * See Subject.apply for docs
+  */
+class Subject[T](queueSize: Int, overflowStrategy: OverflowStrategy)
+  extends GraphStageWithMaterializedValue[SinkShape[T], Source[T, Cancellable]] {
+  val input = Inlet[T]("Subject.in")
+
+  override def shape: SinkShape[T] = new SinkShape(input)
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Source[T, Cancellable]) = {
+    class SubjectGraphStageLogic(internalLogic: SubjectInternalLogic[T]) extends GraphStageLogic(shape) {
+      require(overflowStrategy != OverflowStrategy.backpressure, "backpressure not supported")
+
+      override def preStart(): Unit =
+        pull(input)
+
+      setHandler(input, new InHandler {
+        override def onPush(): Unit = {
+          internalLogic.onElement(grab(input))
+          pull(input)
+        }
+
+        override def onUpstreamFinish(): Unit = internalLogic.complete(Success(Done))
+        override def onUpstreamFailure(ex: Throwable): Unit = internalLogic.complete(Failure(ex))
+      })
+    }
+
+    val internalLogic = new SubjectInternalLogic[T](queueSize, overflowStrategy)
+    (new SubjectGraphStageLogic(internalLogic), internalLogic.newSubscriberSource)
+  }
+}
+
+object Subject {
+  /**
+    * Sink which works similar to BroadcastHub, but does not back-pressure and will emit the last element recieved to
+    * any new subscribers. If there are no subscribers, then it behaves similar to Sink.ignore, except it continually
+    * remembers the last element received.
+    *
+    * All messages are relayed asynchronously, the individual consumption rates of each subscriber do not affect
+    * others. Backpressure overflow mechanism not supported.
+    *
+    * Upstream completion or failures are propagated to the subscribers (even to late subscribers)
+    *
+    * In the event of stream failure, subscriber streams may or may not receive the last element before receiving the
+    * error. All bets are off.
+    */
+  def apply[T](queueSize: Int, overflowStrategy: OverflowStrategy): AkkaSink[T, Source[T, Cancellable]] = {
+    require(overflowStrategy != OverflowStrategy.backpressure, "backpressure overflow strategy not supported")
+    AkkaSink.fromGraph(new Subject[T](queueSize, overflowStrategy))
+  }
+}

--- a/src/test/scala/mesosphere/marathon/stream/SubjectTest.scala
+++ b/src/test/scala/mesosphere/marathon/stream/SubjectTest.scala
@@ -1,0 +1,73 @@
+package mesosphere.marathon
+package stream
+
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Keep, Source}
+import java.util.concurrent.Executors
+import mesosphere.{AkkaUnitTest, WhenEnvSet}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.Random
+import scala.concurrent.duration._
+import scala.concurrent.duration.Duration
+
+class SubjectTest extends AkkaUnitTest {
+  "it propagates results to streams that register at any time during the stream" in {
+    val (input, newSubscribers) = Source.queue[Int](32, OverflowStrategy.fail)
+      .toMat(Subject(32, OverflowStrategy.fail))(Keep.both)
+      .run
+
+    val result1 = newSubscribers.runWith(Sink.last)
+    input.offer(1)
+    val result2 = newSubscribers.runWith(Sink.last)
+    input.complete()
+    val result3 = newSubscribers.runWith(Sink.last)
+    result1.futureValue shouldBe 1
+    result2.futureValue shouldBe 1
+    result3.futureValue shouldBe 1
+  }
+
+  /* This test takes a while to run. If you modify Subject's code, you should run this at least once to ensure there
+   * are no races. */
+  "it behaves deterministically called in stochastic, asynchronous contexts" taggedAs WhenEnvSet("ASYNC_STRESS") in {
+    val executor = Executors.newFixedThreadPool(32)
+    val stressTestEc = ExecutionContext.fromExecutor(executor)
+    try {
+      val s = Source(1 to 10000)
+        .mapAsyncUnordered(8) { i =>
+          val (input, newSubscribers) = Source.queue[Int](32, OverflowStrategy.fail)
+            .toMat(Subject(32, OverflowStrategy.fail))(Keep.both)
+            .run
+
+          Future {
+            input.offer(2)
+            Thread.sleep(Random.nextInt(5).toLong)
+            input.offer(1)
+            Thread.sleep(Random.nextInt(5).toLong)
+            input.complete()
+          }(stressTestEc)
+
+          def getSubscriber =
+            Future {
+              /* This checks to make sure there are no data races during the following transitions:
+               * - An element is published
+               * - The last element is published
+               * - The stream is closed */
+              Thread.sleep(Random.nextInt(5).toLong)
+              newSubscribers.runWith(Sink.last)
+            }(stressTestEc)
+
+          // We materialize multiple subscribers in parallel to assert that there are no data races causing subscriptions to drop
+          Future.sequence(List(getSubscriber, getSubscriber, getSubscriber))
+        }
+        .mapConcat(identity)
+        .mapAsync(1)(identity)
+        .idleTimeout(patienceConfig.timeout)
+        .runFold(Set.empty[Int]) { _ + _ }
+
+      Await.result(s, Duration.Inf) shouldBe Set(1)
+    } finally {
+      executor.shutdownNow()
+    }
+  }
+
+}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/ForwarderService.scala
@@ -9,7 +9,6 @@ import javax.ws.rs.core.{MediaType, Response}
 import javax.ws.rs.{GET, Path}
 import akka.Done
 import akka.actor.ActorSystem
-import akka.actor.ActorRef
 import com.google.common.util.concurrent.Service
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.HttpConf
@@ -156,8 +155,6 @@ object ForwarderService extends StrictLogging {
         def offerLeadership(candidate: ElectionCandidate): Unit = ???
         def abdicateLeadership(): Unit = ???
 
-        override def subscribe(self: ActorRef): Unit = ???
-        override def unsubscribe(self: ActorRef): Unit = ???
         override def leadershipTransitionEvents = ???
       }
     }


### PR DESCRIPTION
This commit fixes a race condition that existed in ElectionService.subscribe. The old logic would:

1. Add a subscription to the event stream
2. Send the last known election state value

It was possible that between 1-2, a new value was available, and that this value was published to the subscriber before the last known election state value was updated. This would result in step 2 sending a stale election state value after a newer one was published.

To solve, we introduce a Subject component, which provides the following guarantees:

1) The last received event will be propagated to new subscribers
2) The last received event will not be propagated out of order
3) All events following the initially published last received event will be delivered.

JIRA Issues: MARATHON-8305
