### PR TITLE
Activate `HeartbeatMonitor` even before Marathon is connected to Mesos (#6347)

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -57,9 +57,8 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
   @Singleton
   def provideMesosHeartbeatActor(system: ActorSystem): ActorRef = {
     system.actorOf(Heartbeat.props(Heartbeat.Config(
-      FiniteDuration(conf.mesosHeartbeatInterval.getOrElse(
-        MesosHeartbeatMonitor.DEFAULT_HEARTBEAT_INTERVAL_MS), TimeUnit.MILLISECONDS),
-      conf.mesosHeartbeatFailureThreshold.getOrElse(MesosHeartbeatMonitor.DEFAULT_HEARTBEAT_FAILURE_THRESHOLD)
+      FiniteDuration(conf.mesosHeartbeatInterval(), TimeUnit.MILLISECONDS),
+      conf.mesosHeartbeatFailureThreshold()
     )), ModuleNames.MESOS_HEARTBEAT_ACTOR)
   }
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -3,13 +3,13 @@ package mesosphere.marathon
 import java.util.concurrent.CountDownLatch
 import java.util.{Timer, TimerTask}
 
-import javax.inject.{Inject, Named}
 import akka.Done
 import akka.actor.{ActorRef, ActorSystem}
 import akka.stream.Materializer
 import akka.util.Timeout
 import com.google.common.util.concurrent.AbstractExecutionThreadService
 import com.typesafe.scalalogging.StrictLogging
+import javax.inject.{Inject, Named}
 import mesosphere.marathon.MarathonSchedulerActor._
 import mesosphere.marathon.core.deployment.{DeploymentManager, DeploymentPlan, DeploymentStepInfo}
 import mesosphere.marathon.core.election.{ElectionCandidate, ElectionService}
@@ -76,7 +76,7 @@ class MarathonSchedulerService @Inject() (
     migration: Migration,
     deploymentManager: DeploymentManager,
     @Named("schedulerActor") schedulerActor: ActorRef,
-    @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) mesosHeartbeatActor: ActorRef)(implicit mat: Materializer)
+    heartbeatMonitor: MesosHeartbeatMonitor)(implicit mat: Materializer)
   extends AbstractExecutionThreadService with ElectionCandidate with DeploymentService with StrictLogging {
 
   import scala.concurrent.ExecutionContext.Implicits.global
@@ -226,6 +226,11 @@ class MarathonSchedulerService @Inject() (
     // start timers
     schedulePeriodicOperations()
 
+    // We have to start the Heartbeat monitor even before we're successfully registered, since in rare occasions driver
+    // can hang forever trying to connect to Mesos (or doing some other driver work). In this case we also want
+    // to suicide after not receiving any messages for a while.
+    driver.foreach(heartbeatMonitor.activate(_))
+
     // The following block asynchronously runs the driver. Note that driver.run()
     // blocks until the driver has been stopped (or aborted).
     Future {
@@ -293,7 +298,7 @@ class MarathonSchedulerService @Inject() (
     oldTimer.cancel()
 
     driver.foreach { driverInstance =>
-      mesosHeartbeatActor ! Heartbeat.MessageDeactivate(MesosHeartbeatMonitor.sessionOf(driverInstance))
+      heartbeatMonitor.deactivate(driverInstance)
       // Our leadership has been defeated. Thus, stop the driver.
       stopDriver()
     }

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -2,8 +2,8 @@ package mesosphere.marathon
 package core
 
 import java.time.Clock
-import javax.inject.Named
 
+import javax.inject.Named
 import akka.actor.{ActorRef, Props}
 import akka.stream.Materializer
 import com.google.inject._
@@ -15,6 +15,7 @@ import mesosphere.marathon.core.deployment.DeploymentManager
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
+import mesosphere.marathon.core.heartbeat.MesosHeartbeatMonitor
 import mesosphere.marathon.core.instance.update.InstanceChangeHandler
 import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.launchqueue.LaunchQueue
@@ -238,4 +239,7 @@ class CoreGuiceModule(config: Config) extends AbstractModule {
 
   @Provides @Singleton
   def scheduler(coreModule: CoreModule): Scheduler = coreModule.mesosHeartbeatMonitor
+
+  @Provides @Singleton
+  def heartbeatMonitor(coreModule: CoreModule): MesosHeartbeatMonitor = coreModule.mesosHeartbeatMonitor
 }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerServiceTest.scala
@@ -72,6 +72,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
     val migration: Migration = mock[Migration]
     val schedulerActor: ActorRef = probe.ref
     val heartbeatActor: ActorRef = heartbeatProbe.ref
+    val heartbeatMonitor: MesosHeartbeatMonitor = new MesosHeartbeatMonitor(marathonScheduler, heartbeatActor)
     val prePostDriverCallbacks: Seq[PrePostDriverCallback] = Seq.empty
     val mockTimer: Timer = mock[Timer]
     val deploymentManager: DeploymentManager = mock[DeploymentManager]
@@ -100,7 +101,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
         migration,
         deploymentManager,
         schedulerActor,
-        heartbeatActor
+        heartbeatMonitor
       )
       schedulerService.timer = mockTimer
 
@@ -124,7 +125,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
         migration,
         deploymentManager,
         schedulerActor,
-        heartbeatActor
+        heartbeatMonitor
       ) {
         override def startLeadership(): Unit = ()
       }
@@ -153,7 +154,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
         migration,
         deploymentManager,
         schedulerActor,
-        heartbeatActor
+        heartbeatMonitor
       )
       schedulerService.timer = mockTimer
 
@@ -190,7 +191,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
         migration,
         deploymentManager,
         schedulerActor,
-        heartbeatActor
+        heartbeatMonitor
       )
 
       schedulerService.timer = mockTimer
@@ -214,7 +215,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
         migration,
         deploymentManager,
         schedulerActor,
-        heartbeatActor
+        heartbeatMonitor
       )
 
       schedulerService.timer = mockTimer
@@ -243,7 +244,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
         migration,
         deploymentManager,
         schedulerActor,
-        heartbeatActor
+        heartbeatMonitor
       )
       schedulerService.timer = mockTimer
 
@@ -276,7 +277,7 @@ class MarathonSchedulerServiceTest extends AkkaUnitTest {
         migration,
         deploymentManager,
         schedulerActor,
-        heartbeatActor
+        heartbeatMonitor
       )
       schedulerService.timer = mockTimer
 

--- a/src/test/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/heartbeat/MesosHeartbeatMonitorTest.scala
@@ -66,7 +66,7 @@ class MesosHeartbeatMonitorTest extends AkkaUnitTest {
 
       // activation messages
       val registeredDriver = mock[SchedulerDriver]
-      monitor.registered(registeredDriver, null, null)
+      monitor.activate(registeredDriver)
       factory.heartbeatActor.expectMsgType[Heartbeat.Message] should be(
         Heartbeat.MessageActivate(factory.reactor, MesosHeartbeatMonitor.sessionOf(registeredDriver)))
 


### PR DESCRIPTION
Summary:
Fixes a rare bug where Mesos scheduler driver is hanging while connecting to Mesos. This change
will make sure that the `HeartbeatMonitor` is active and has a chance to kill Marathon.

Additionally, some unused code was removed from the `HeartbeatMonitor` specifically the `Reactor.Decorator`.

JIRA: MARATHON-8304, COPS-3413
(cherry picked from commit 3fb760f9c17267b67b50718e95400e0123a808eb)