### PR TITLE
Backport fix for flaky `SlidingAverageSnapshotTest`

### DIFF
--- a/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/SlidingAverageSnapshot.scala
@@ -17,11 +17,12 @@ import kamon.util.{MapMerge, MilliTimestamp}
 class SlidingAverageSnapshot(val averagingWindow: Duration) extends StrictLogging {
 
   val collectionContext: CollectionContext = Kamon.metrics.buildDefaultCollectionContext
+  private val creationTime = MilliTimestamp.now
 
   /**
     * The current summarised snapshot
     */
-  private var currentSnapshot: TickMetricSnapshot = TickMetricSnapshot(MilliTimestamp.now, MilliTimestamp.now, Map.empty)
+  private var currentSnapshot: TickMetricSnapshot = TickMetricSnapshot(creationTime, creationTime, Map.empty)
 
   /**
     * A ring buffer that collects the snapshots
@@ -58,7 +59,7 @@ class SlidingAverageSnapshot(val averagingWindow: Duration) extends StrictLoggin
     */
   private def combineRingMetrics: TickMetricSnapshot = {
     var rangeFrom: MilliTimestamp = MilliTimestamp.now
-    var rangeTo: MilliTimestamp = MilliTimestamp.now
+    var rangeTo: MilliTimestamp = rangeFrom
     var combined: Option[Map[Entity, EntitySnapshot]] = None
 
     // To combine the metrics we need to iterate over the ring buffer, performing


### PR DESCRIPTION
This is a back-port for #6341 that consists of the following commits:

- f5c76a0158d8ce0702e880e78dabc78e44eb572a - Fixing flaky sliding average window test
- dd368e3693cc82c8d06bc96d9e0c04634dc37441 - Using the same timestamp on the SlidingAverageSnapshot factory
- 8e40e9304cc2bd068f9a640a7e7b84faee25279e - Rolling back the test assertion

JIRA Issues: MARATHON-8303