### PR TITLE
1.6 - Introduce option to suppress offers

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -192,6 +192,9 @@ When using Debian packages, the ideal way to customize Marathon is to specify co
     **Note:** In order to activate the `--draining_seconds` configuration, you must add `maintenance_mode` to the set of `--enable_features`.
 * <span class="label label-default">> v1.6.352</span>`--max_running_deployments` (Optional. Default: 100):
     Maximum number of concurrently running deployments. Should the user try to submit more updates than set by this flag a HTTP 403 Error is returned with an explanatory error message.
+* `--[disable_]suppress_offers` (Optional. Default: disabled)
+    Controls whether or not Marathon will suppress offers if there is nothing to launch. Enabling helps the performance
+    of Mesos in larger clusters, but enabling this flag will cause Marathon to more slowly release reservations.
 
 ## Tuning Flags for Offer Matching/Launching Tasks
 

--- a/src/main/scala/mesosphere/marathon/core/flow/ReviveOffersConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/ReviveOffersConfig.scala
@@ -22,4 +22,13 @@ trait ReviveOffersConfig extends ScallopConf {
     "revive_offers_repetitions",
     descr = "Repeat every reviveOffer request this many times, delayed by the --min_revive_offers_interval.",
     default = Some(3))
+
+  lazy val suppressOffers = toggle(
+    "suppress_offers",
+    default = Some(false),
+    noshort = true,
+    descrYes = "Suppress Mesos offers if Marathon has nothing to launch.",
+    descrNo = "(Default) Offers will be continually declined for declineOfferDuration.",
+    prefix = "disable_"
+  )
 }

--- a/src/main/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/impl/ReviveOffersActor.scala
@@ -25,7 +25,7 @@ private[flow] object ReviveOffersActor {
   }
 
   private[impl] case object TimedCheck
-  private[impl] case object OffersWanted
+  private[impl] case class OffersWanted(wanted: Boolean)
 }
 
 /**
@@ -46,7 +46,11 @@ private[impl] class ReviveOffersActor(
   private[impl] var nextReviveCancellableOpt: Option[Cancellable] = None
 
   override def preStart(): Unit = {
-    subscription = offersWanted.subscribe(offersWanted => if (offersWanted) self ! OffersWanted)
+    if (conf.suppressOffers())
+      subscription = offersWanted.map(OffersWanted).subscribe(self ! _)
+    else
+      subscription = offersWanted.subscribe(offersWanted => if (offersWanted) self ! OffersWanted(true))
+
     marathonEventStream.subscribe(self, classOf[SchedulerRegisteredEvent])
     marathonEventStream.subscribe(self, classOf[SchedulerReregisteredEvent])
   }
@@ -88,6 +92,11 @@ private[impl] class ReviveOffersActor(
     }
   }
 
+  private[this] def suppressOffers(): Unit = {
+    logger.info("=> Suppress offers NOW")
+    driverHolder.driver.foreach(_.suppressOffers())
+  }
+
   override def receive: Receive = LoggingReceive {
     Seq(
       receiveOffersWantedNotifications,
@@ -96,10 +105,23 @@ private[impl] class ReviveOffersActor(
   }
 
   private[this] def receiveOffersWantedNotifications: Receive = {
-    case OffersWanted =>
+    case OffersWanted(true) =>
       logger.info("Received offers WANTED notification")
       offersCurrentlyWanted = true
       initiateNewSeriesOfRevives()
+
+    case OffersWanted(false) =>
+      logger.info(s"Received offers NOT WANTED notification, canceling $revivesNeeded revives")
+      offersCurrentlyWanted = false
+      revivesNeeded = 0
+      nextReviveCancellableOpt.foreach(_.cancel())
+      nextReviveCancellableOpt = None
+
+      // When we don't want any more offers, we ask mesos to suppress
+      // them. This alleviates load on the allocator, and acts as an
+      // infinite duration filter for all agents until the next time
+      // we call `Revive`.
+      suppressOffers()
   }
 
   def initiateNewSeriesOfRevives(): Unit = {


### PR DESCRIPTION
Backport of 552fd4b / (#6351)

This reverts commit bb6420c4.

- Bring back the logic for offer suppression and introduction a
  command-line option to enable it.
- Documentation.

JIRA Issues: MARATHON-8309
