### PR TITLE
Ignore MARATHON_APP_{...}

### DIFF
--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -238,6 +238,11 @@ object Main {
     */
   def envToArgs(env: Map[String, String]): Seq[String] = {
     env.flatMap {
+      case (k, v) if k.startsWith("MARATHON_APP_") =>
+        /* Marathon sets passes several environment variables, prefixed with MARATHON_APP_, to Marathon instances. We
+         * need to explicitly ignore these and not treat them as parameters in the case of Marathon launching other
+         * instances of Marathon */
+        Nil
       case (k, v) if k.startsWith("MARATHON_") =>
         val argName = s"--${k.drop(9).toLowerCase}"
         if (v.isEmpty)

--- a/src/test/scala/mesosphere/marathon/MainTest.scala
+++ b/src/test/scala/mesosphere/marathon/MainTest.scala
@@ -16,5 +16,9 @@ class MainTest extends UnitTest {
       Main.envToArgs(Map("CMD_MARATHON_HTTP_PORT" -> "8080")) shouldBe Seq()
       Main.envToArgs(Map("marathon_http_port" -> "8080")) shouldBe Seq()
     }
+
+    "ignores strings beginning with MARATHON_APP_" in {
+      Main.envToArgs(Map("MARATHON_APP_VERSION" -> "1.5")) shouldBe Seq()
+    }
   }
 }


### PR DESCRIPTION
This was ignored previously, but due to poor test coverage there was
an oversight while porting this behavior to Scala due to fix a
different issue.

JIRA Issues: MARATHON-8310
