### PR TITLE
Bumping mesos version on perf ci to 1.5.1

### DIFF
--- a/tests/performance/config/dcluster/large-cluster.conf
+++ b/tests/performance/config/dcluster/large-cluster.conf
@@ -2,7 +2,7 @@
 # to deploy a cluster with overcommitted resources for performance checks
 
 # Docker image versions
-mesos = 1.4.0-rc2
+mesos = 1.5.1-rc1
 zookeeper = 3.4
 
 # Overcommit the resources, allocing deployment of at least 10,000 apps


### PR DESCRIPTION
This commit fixes the (currently broken) continuous CI by bumping mesos version to 1.5.x