### PR TITLE
Treat non-absolute paths POSTed to /v2/groups as children of /root

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -131,7 +131,7 @@ class GroupsResource @Inject() (
     @DefaultValue("false")@QueryParam("force") force: Boolean,
     body: Array[Byte],
     @Context req: HttpServletRequest,
-    @Suspended asyncResponse: AsyncResponse): Unit = createWithPath("", force, body, req, asyncResponse)
+    @Suspended asyncResponse: AsyncResponse): Unit = createWithPath("/", force, body, req, asyncResponse)
 
   /**
     * Create a group.
@@ -177,7 +177,7 @@ class GroupsResource @Inject() (
         rootGroup.app(effectivePath),
         s"An app with the path $effectivePath already exists.")
 
-      val (deployment, path) = await(updateOrCreate(effectivePath, groupUpdate, force))
+      val (deployment, path) = await(updateOrCreate(PathId("/"), groupUpdate, force))
       deploymentResult(deployment, Response.created(new URI(path.toString)))
     }
   }


### PR DESCRIPTION
When POSTing the following payload to /v2/groups:

  {"id": "testing"}

Marathon would create the group "testing" under "testing". This is because it
was incorrectly passing the normalized top-level group path as the parent path
for the group update function.

JIRA Issues: MARATHON-8017
