### PR TITLE
Use rescheduleReserved - we need it to change the condition

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -49,6 +49,17 @@ private[marathon] class InstanceUpdateOpResolver(
           InstanceUpdateEffect.Update(op.instance, oldState = Some(oldInstance), Seq.empty)
         }
 
+      case op: RescheduleReserved =>
+        // TODO(alena): Create events
+        updateExistingInstance(op.instanceId) { i =>
+          InstanceUpdateEffect.Update(
+            i.copy(
+              state = InstanceState(Condition.Scheduled, Timestamp.now(), None, None, Goal.Running),
+              runSpecVersion = op.reservedInstance.version,
+              unreachableStrategy = op.reservedInstance.unreachableStrategy),
+            oldState = Some(i), Seq.empty)
+        }
+
       case op: Provision =>
         updateExistingInstance(op.instanceId) { oldInstance =>
           // TODO(karsten): Create events

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -23,6 +23,15 @@ object InstanceUpdateOperation {
     override def instanceId: Instance.Id = instance.instanceId
   }
 
+  /**
+    * * Reschedules resident instance that already has a reservation but became terminal (reserved).
+    *
+    * @param reservedInstance already existing reserved instance that is now in scheduled state.
+    */
+  case class RescheduleReserved(reservedInstance: Instance) extends InstanceUpdateOperation {
+    override def instanceId: Instance.Id = reservedInstance.instanceId
+  }
+
   case class Reserve(instance: Instance) extends InstanceUpdateOperation {
     override def instanceId: Instance.Id = instance.instanceId
   }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
@@ -9,6 +9,7 @@ import akka.pattern.{ask, pipe}
 import akka.util.Timeout
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.update.InstanceChange
+import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.RescheduleReserved
 import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfo
 import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
@@ -206,8 +207,7 @@ private[impl] class LaunchQueueActor(
         val existingReservedStoppedInstances = await(instanceTracker.specInstances(runSpec.id))
           .filter(residentInstanceToRelaunch)
           .take(count)
-          .map(_.instanceId)
-        val relaunched = await(Future.sequence(existingReservedStoppedInstances.map { instanceId => instanceTracker.setGoal(instanceId, Goal.Running) }))
+        val relaunched = await(Future.sequence(existingReservedStoppedInstances.map { instance => instanceTracker.process(RescheduleReserved(instance)) }))
 
         // Schedule additional resident instances or all ephemeral instances
         val instancesToSchedule = existingReservedStoppedInstances.length.until(count).map { _ => Instance.Scheduled(runSpec, Instance.Id.forRunSpec(runSpec.id)) }


### PR DESCRIPTION
I know I approved this change but I am afraid we can't just set goals.

We don't want to use the `Reserved` condition for scheduled state of the instance, just terminal.

If we remove Scheduled state altogether and use `Instance.isScheduled` only, we don't need to do this.
