### PR TITLE
Stabilize and cleanup system tests with `eventually`.

### DIFF
--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -14,8 +14,8 @@ import time
 from datetime import timedelta
 from dcos import http, marathon
 from dcos.errors import DCOSException
-from matcher import assert_that, eventually, has_len, prop
-from precisely import contains_string, equal_to, has_attrs, not_
+from matcher import assert_that, eventually, has_len, has_value, has_values, prop
+from precisely import contains_string, equal_to, not_
 from shakedown import dcos_version_less_than, marthon_version_less_than, required_private_agents # NOQA
 
 
@@ -229,7 +229,7 @@ def test_task_failure_recovers():
     shakedown.deployment_wait()
 
     assert_that(lambda: client.get_tasks(app_def["id"])[0],
-                eventually(not_(has_attrs(id=old_task_id)), max_attempts=30))
+                eventually(has_value('id', not_(equal_to(old_task_id))), max_attempts=30))
 
 
 @pytest.mark.skipif("shakedown.ee_version() == 'strict'")
@@ -480,7 +480,7 @@ def test_failing_health_check_results_in_unhealthy_app():
     client.add_app(app_def)
 
     assert_that(lambda: client.get_app(app_def["id"]), eventually(
-        has_attrs(tasksRunning=1, tasksHealthy=0, tasksUnhealthy=1), max_attempts=30))
+        has_values(tasksRunning=1, tasksHealthy=0, tasksUnhealthy=1), max_attempts=30))
 
 
 @shakedown.private_agents(2)
@@ -552,7 +552,7 @@ def test_health_check_works_with_resident_task():
     tasks = client.get_tasks(app_def["id"])
     assert len(tasks) == 1, "The number of tasks is {}, but 1 was expected".format(len(tasks))
 
-    assert_that(lambda: client.get_app(app_def['id']), eventually(has_attrs(tasksHealthy=1), max_attempts=30))
+    assert_that(lambda: client.get_app(app_def['id']), eventually(has_value('tasksHealthy', 1), max_attempts=30))
 
 
 @shakedown.private_agents(2)
@@ -1058,7 +1058,7 @@ def test_healtchcheck_and_volume():
     assert len(app['container']['volumes']) == 2, "The container does not have the correct amount of volumes"
 
     # check if app becomes healthy
-    assert_that(lambda: client.get_app(app_id), eventually(has_attrs(tasksHealthy=1), max_attempts=30))
+    assert_that(lambda: client.get_app(app_id), eventually(has_value('tasksHealthy', 1), max_attempts=30))
 
 
 @shakedown.dcos_1_9

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -14,8 +14,8 @@ import time
 from datetime import timedelta
 from dcos import http, marathon
 from dcos.errors import DCOSException
-from matcher import assert_that, eventually, prop
-from precisely import contains_string
+from matcher import assert_that, eventually, has_len, prop
+from precisely import contains_string, equal_to, has_attrs, not_
 from shakedown import dcos_version_less_than, marthon_version_less_than, required_private_agents # NOQA
 
 
@@ -62,10 +62,10 @@ def test_launch_mesos_container_with_docker_image():
     client.add_app(app_def)
     shakedown.deployment_wait(app_id=app_id)
 
-    tasks = client.get_tasks(app_id)
-    app = client.get_app(app_id)
+    assert_that(lambda: client.get_tasks(app_id),
+                eventually(has_len(equal_to(1)), max_attempts=30))
 
-    assert len(tasks) == 1, "The number of tasks is {} after deployment, but only 1 was expected".format(len(tasks))
+    app = client.get_app(app_id)
     assert app['container']['type'] == 'MESOS', "The container type is not MESOS"
 
 
@@ -228,13 +228,8 @@ def test_task_failure_recovers():
     common.kill_process_on_host(host, '[s]leep 1000')
     shakedown.deployment_wait()
 
-    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
-    def check_new_task_id():
-        tasks = client.get_tasks(app_def["id"])
-        new_task_id = tasks[0]['id']
-        assert old_task_id != new_task_id, "The task ID has not changed: {}".format(old_task_id)
-
-    check_new_task_id()
+    assert_that(lambda: client.get_tasks(app_def["id"])[0],
+                eventually(not_(has_attrs(id=old_task_id)), max_attempts=30))
 
 
 @pytest.mark.skipif("shakedown.ee_version() == 'strict'")
@@ -267,9 +262,8 @@ def test_run_app_with_non_existing_user():
     client = marathon.create_client()
     client.add_app(app_def)
 
-    assert_that(lambda: client.get_app(app_def["id"]),
-                eventually(prop(['lastTaskFailure', 'message'], contains_string("No such user 'bad'")), max_attempts=30)
-                )
+    assert_that(lambda: client.get_app(app_def["id"]), eventually(
+        prop(['lastTaskFailure', 'message'], contains_string("No such user 'bad'")), max_attempts=30))
 
 
 def test_run_app_with_non_downloadable_artifact():
@@ -281,14 +275,8 @@ def test_run_app_with_non_downloadable_artifact():
     client = marathon.create_client()
     client.add_app(app_def)
 
-    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
-    def check_failure_message():
-        app = client.get_app(app_def["id"])
-        message = app['lastTaskFailure']['message']
-        error = "Failed to fetch all URIs for container"
-        assert error in message, "Launched an app with a non-downloadable artifact"
-
-    check_failure_message()
+    assert_that(lambda: client.get_app(app_def["id"]), eventually(
+        prop(['lastTaskFailure', 'message'], contains_string("Failed to fetch all URIs for container")), max_attempts=30)) # NOQA E501
 
 
 def test_launch_group():
@@ -491,18 +479,8 @@ def test_failing_health_check_results_in_unhealthy_app():
     client = marathon.create_client()
     client.add_app(app_def)
 
-    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
-    def check_failure_message():
-        app = client.get_app(app_def["id"])
-        print("{}, {}, {}".format(app['tasksRunning'], app['tasksHealthy'], app['tasksUnhealthy']))
-        assert app['tasksRunning'] == 1, \
-            "The number of running tasks is {}, but 1 was expected".format(app['tasksRunning'])
-        assert app['tasksHealthy'] == 0, \
-            "The number of healthy tasks is {}, but 0 was expected".format(app['tasksHealthy'])
-        assert app['tasksUnhealthy'] == 1, \
-            "The number of unhealthy tasks is {}, but 1 was expected".format(app['tasksUnhealthy'])
-
-    check_failure_message()
+    assert_that(lambda: client.get_app(app_def["id"]), eventually(
+        has_attrs(tasksRunning=1, tasksHealthy=0, tasksUnhealthy=1), max_attempts=30))
 
 
 @shakedown.private_agents(2)
@@ -574,13 +552,7 @@ def test_health_check_works_with_resident_task():
     tasks = client.get_tasks(app_def["id"])
     assert len(tasks) == 1, "The number of tasks is {}, but 1 was expected".format(len(tasks))
 
-    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
-    def assert_healthy_app(app_id):
-        app = client.get_app(app_id)
-        assert app['tasksHealthy'] == 1, \
-            "The number of healthy tasks is {}, but 1 was expected".format(app['tasksHealthy'])
-
-    assert_healthy_app(app_def["id"])
+    assert_that(lambda: client.get_app(app_def['id']), eventually(has_attrs(tasksHealthy=1), max_attempts=30))
 
 
 @shakedown.private_agents(2)
@@ -722,12 +694,7 @@ def test_restart_container_with_persistent_volume():
     client.restart_app(app_id)
     common.deployment_wait(service_id=app_id)
 
-    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
-    def check_task_recovery():
-        tasks = client.get_tasks(app_id)
-        assert len(tasks) == 1, "The number of tasks is {} after recovery, but 1 was expected".format(len(tasks))
-
-    check_task_recovery()
+    assert_that(lambda: client.get_tasks(app_id), eventually(has_len(equal_to(1)), max_attempts=30))
 
     host = tasks[0]['host']
     port = tasks[0]['ports'][0]
@@ -1091,12 +1058,7 @@ def test_healtchcheck_and_volume():
     assert len(app['container']['volumes']) == 2, "The container does not have the correct amount of volumes"
 
     # check if app becomes healthy
-    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
-    def check_health():
-        app = client.get_app(app_id)
-        assert app['tasksHealthy'] == 1, "The app is not healthy"
-
-    check_health()
+    assert_that(lambda: client.get_app(app_id), eventually(has_attrs(tasksHealthy=1), max_attempts=30))
 
 
 @shakedown.dcos_1_9

--- a/tests/system/matcher/__init__.py
+++ b/tests/system/matcher/__init__.py
@@ -1,5 +1,5 @@
 from .eventually import eventually
-from .property import prop
+from .property import has_value, has_values, prop
 from precisely import has_feature
 
 # py.test integration; hide these frames from tracebacks
@@ -14,6 +14,8 @@ __all__ = [
     "assert_that",
     "eventually",
     "has_len",
+    "has_value",
+    "has_values",
     "prop"
 ]
 

--- a/tests/system/matcher/__init__.py
+++ b/tests/system/matcher/__init__.py
@@ -1,12 +1,19 @@
 from .eventually import eventually
 from .property import prop
+from precisely import has_feature
 
 # py.test integration; hide these frames from tracebacks
 __tracebackhide__ = True
 
+
+def has_len(matcher):
+    return has_feature("len", len, matcher)
+
+
 __all__ = [
     "assert_that",
     "eventually",
+    "has_len",
     "prop"
 ]
 

--- a/tests/system/matcher/property.py
+++ b/tests/system/matcher/property.py
@@ -71,7 +71,7 @@ class HasValue(Matcher):
 
 
 def has_values(**kwargs):
-    return HasValues(kwargs)
+    return HasValues(kwargs.items())
 
 
 class HasValues(Matcher):


### PR DESCRIPTION
Summary:
This is a small follow up that replaces a few retrying blocks with the
new `eventually` matcher. It also introduces `has_len` to match the
length of a sequence.