### PR TITLE
Run Docker app as root to grant read permission to credentials.

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -461,10 +461,6 @@ def copy_docker_credentials_file(agents, file_name='docker.tar.gz'):
         for agent in agents:
             print("Copying docker credentials to {}".format(agent))
             shakedown.copy_file_to_agent(agent, file_name)
-
-            cmd = "sudo setfacl -m u:nobody:r /home/centos/{}".format(file_name)
-            status, stdout = shakedown.run_command_on_agent(agent, cmd)
-            assert status, "{} failed: {}".format(cmd, stdout)
     except Exception as e:
         print('Failed to upload {} to agent: {}'.format(file_name, agent))
         raise e

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -462,7 +462,7 @@ def copy_docker_credentials_file(agents, file_name='docker.tar.gz'):
             print("Copying docker credentials to {}".format(agent))
             shakedown.copy_file_to_agent(agent, file_name)
 
-            cmd = "setfacl -m u:nobody:r /home/centos/{}".format(file_name)
+            cmd = "sudo setfacl -m u:nobody:r /home/centos/{}".format(file_name)
             status, stdout = shakedown.run_command_on_agent(agent, cmd)
             assert status, "{} failed: {}".format(cmd, stdout)
     except Exception as e:

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -461,6 +461,10 @@ def copy_docker_credentials_file(agents, file_name='docker.tar.gz'):
         for agent in agents:
             print("Copying docker credentials to {}".format(agent))
             shakedown.copy_file_to_agent(agent, file_name)
+
+            cmd = "setfacl -m u:nobody:r /home/centos/{}".format(pattern)
+            status, stdout = shakedown.run_command_on_agent(agent, cmd)
+            assert status, "{} failed: {}".format(cmd, output)
     except Exception as e:
         print('Failed to upload {} to agent: {}'.format(file_name, agent))
         raise e

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -462,9 +462,9 @@ def copy_docker_credentials_file(agents, file_name='docker.tar.gz'):
             print("Copying docker credentials to {}".format(agent))
             shakedown.copy_file_to_agent(agent, file_name)
 
-            cmd = "setfacl -m u:nobody:r /home/centos/{}".format(pattern)
+            cmd = "setfacl -m u:nobody:r /home/centos/{}".format(file_name)
             status, stdout = shakedown.run_command_on_agent(agent, cmd)
-            assert status, "{} failed: {}".format(cmd, output)
+            assert status, "{} failed: {}".format(cmd, stdout)
     except Exception as e:
         print('Failed to upload {} to agent: {}'.format(file_name, agent))
         raise e

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -1016,6 +1016,10 @@ def test_private_repository_docker_app():
 
     app_def = apps.private_docker_app()
 
+    if shakedown.ee_version() == 'strict':
+        app_def['user'] = 'root'
+        common.add_dcos_marathon_user_acls()
+
     client = marathon.create_client()
     client.add_app(app_def)
     shakedown.deployment_wait()


### PR DESCRIPTION
Summary:
The system tests fail on a strict EE cluster with CentOS because the
user `nobody` has no read access to the Docker credentail tarball in
`/home/centos`. With this change we run the app as `root` which has
read access.

JIRA issues: MARATHON-8324