### PR TITLE
Documentation page for native packages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 ## Change from 1.6.352 to 1.6.xxx
 
+### Native Packages
+
+We have stopped publishing native packages for operating system versions that are past their end-of-life:
+
+- Ubuntu Yakkety
+- Ubuntu Wily
+- Ubuntu Vivid
+
+Additionally, we have added support for Debian Stretch.
+
 ### Limit maximum number of running deployments
 New command line flag `--max_running_deployments` was added to limit the max number of concurrently running deployments. The default value is set to 100. Should the user try to submit more updates than set by this flag a HTTP 403 Error is returned with an explanatory error message. We introduced this flag because having lots of running deployments can lead to a significant performance decrease in the failover scenario during marathon initialization phase. Note that if you reach the maximum deployment number, you will have to use `?force=true` parameter to cancel an existing deployment.
 

--- a/ci/releases.sc
+++ b/ci/releases.sc
@@ -112,12 +112,9 @@ def uploadLinuxPackagesToRepos(tagName: String): Unit = {
 
   val mappings = Seq(
     "systemd" -> s"debian/jessie${pkgType}",
-    "systemd" -> s"ubuntu/yakkety${pkgType}",
+    "systemd" -> s"debian/stretch${pkgType}",
     "systemd" -> s"ubuntu/xenial${pkgType}",
-    "systemd" -> s"ubuntu/wily${pkgType}",
-    "systemd" -> s"ubuntu/vivid${pkgType}",
     "upstart" -> s"ubuntu/trusty${pkgType}",
-    "upstart" -> s"ubuntu/precise${pkgType}",
     "systemv" -> s"el${pkgType}/6",
     "systemd" -> s"el${pkgType}/7")
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -28,7 +28,7 @@ for details. Running `make install` will install Mesos in `/usr/local`.
 
 #### Through your Package Manager
 
-Marathon packages are available from Mesosphere's [repositories](http://mesosphere.com/2014/07/17/mesosphere-package-repositories/).
+Please see the documentation on [Marathon native package repositories](native-packages.html).
 
 #### From a Tarball
 

--- a/docs/docs/native-packages.md
+++ b/docs/docs/native-packages.md
@@ -1,0 +1,65 @@
+# Native Packages
+
+(since Marathon 1.5.0)
+
+Native packages are built alongside with each Marathon release and are available for the following distributions:
+
+- Debian Jessie
+- Debian Stretch
+- Ubuntu Xenial
+- Ubuntu Trusty
+- Centos 6
+- Centos 7
+
+# Installing Marathon
+
+## Ubuntu and Debian
+
+```
+# Setup
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+CODENAME=$(lsb_release -cs)
+
+# Add the repository
+echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" | \
+  sudo tee /etc/apt/sources.list.d/mesosphere.list
+sudo apt-get -y update
+
+# Install packages
+sudo apt-get -y install mesos marathon
+```
+
+# RedHat and CentOS 6
+
+```
+# Add the repository
+sudo rpm -Uvh http://repos.mesosphere.com/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm
+
+# Install packages
+sudo yum -y install mesos marathon
+```
+
+# RedHat and CentOS 7
+
+```
+# Add the repository
+sudo rpm -Uvh http://repos.mesosphere.com/el/7/noarch/RPMS/mesosphere-el-repo-7-2.noarch.rpm
+
+# Install packages
+sudo yum -y install mesos marathon
+```
+
+# Configuring Marathon
+
+After installation, you can configure Marathon command-line arguments by specifying environment variables in `/etc/default/marathon`. For information about how environment variables map to command-line arguments, see "Specifying Command-Line Flags with Environment Variables" in the [command line flags](command-line-flags.html) documentation.
+
+**IMPORTANT** Marathon is configured to launch as the system user `marathon`, and this causes the default value for `--mesos_user` to be `marathon`. It is unlikely that your agents will have this user. You will want to either add the `marathon` user to all agents, or specify a system user that is present on all agents by setting `MARATHON_MESOS_USER`.
+
+# Logging Location
+
+For systemd based distros, logs go to the system journal and can be viewed by running `journalctl -xefu marathon`.
+
+For SystemV distros (Centos / RedHat 6), logs are written to /var/log/marathon.
+
+For Upstart distros (Ubuntu Trusty), logs are sent to the upstart logging mechanism.


### PR DESCRIPTION
Backport of f07d534 (#6385)

Add page explaining how to configure native packages. Also, include a
caveat for the --mesos-user default.

JIRA Issues: MARATHON-8331