### PR TITLE
Adjusting `group_versions_cache_size` on perf tests

### DIFF
--- a/tests/performance/config/dcluster/large-cluster.conf
+++ b/tests/performance/config/dcluster/large-cluster.conf
@@ -21,4 +21,4 @@ mesos_master_port = 5050
 # from /opt/shared (the marathon-perf-testing infrastructure mounts there the
 # contents of the `files` folder from here
 # : https://github.com/mesosphere/marathon-perf-testing/tree/master/files )
-marathon_args = --max_instances_per_offer=500 --max_running_deployments=10000 --plugin_dir=/opt/shared/plugins-1.6 --plugin_conf=/opt/shared/executorid-plugin-config.json
+marathon_args = --group_versions_cache_size=20001 --max_instances_per_offer=500 --max_running_deployments=10000 --plugin_dir=/opt/shared/plugins-1.6 --plugin_conf=/opt/shared/executorid-plugin-config.json


### PR DESCRIPTION
Adjusting `group_versions_cache_size` on perf tests

Summary:
This PR fixes a validation error that was caused by #6226 since we
were modifying the default `max_running_deployments`.

It adjusts `group_versions_cache_size` to `20001`, that is computed
as `2 * max_running_deployments + 1`.
