### PR TITLE
Define second level scheduler interface.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -12,6 +12,7 @@ import mesosphere.marathon.core.election.LeadershipTransition
 import mesosphere.marathon.core.event.DeploymentSuccess
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.{Goal, Instance}
+import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.RescheduleReserved
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.{KillReason, KillService}
@@ -420,7 +421,7 @@ class SchedulerActions(
     */
   // FIXME: extract computation into a function that can be easily tested
   def scale(runSpec: RunSpec): Future[Done] = async {
-    logger.debug("Scale for run spec {}", runSpec)
+    logger.info("Scale for run spec {}", runSpec)
 
     val instances = await(instanceTracker.specInstances(runSpec.id))
     val runningInstances = instances.filter(_.isActive)
@@ -470,7 +471,22 @@ class SchedulerActions(
 
       if (toAdd > 0) {
         logger.info(s"Queueing $toAdd new instances for ${runSpec.id} to the already $leftToLaunch queued ones")
-        await(launchQueue.add(runSpec, toAdd))
+        // TODO(karsten): Use scheduler interface or instance tracker instead or get rid of the scale checks.
+
+        // Reschedule stopped resident instances first.
+        val existingReservedStoppedInstances = instances
+          .filter(i => i.isReserved && i.state.goal == Goal.Stopped) // resident to relaunch
+          .take(toAdd)
+          .map(RescheduleReserved(_, runSpec.version))
+        await(Future.sequence(existingReservedStoppedInstances.map(instanceTracker.process)).map(_ => Done))
+
+        // Schedule remaining instances
+        val leftToAdd = math.max(0, toAdd - existingReservedStoppedInstances.length)
+        val instancesToSchedule = 0.until(leftToAdd).map { _ => Instance.scheduled(runSpec, Instance.Id.forRunSpec(runSpec.id)) }
+        await(instanceTracker.schedule(instancesToSchedule))
+
+        // Let launch queue manage task launcher actor.
+        await(launchQueue.sync(runSpec))
       } else {
         logger.info(s"Already queued or started ${runningInstances.size} instances for ${runSpec.id}. Not scaling.")
       }

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -9,18 +9,20 @@ import javax.ws.rs._
 import javax.ws.rs.core.{Context, MediaType, Response}
 import mesosphere.marathon.api.AuthResource
 import mesosphere.marathon.core.group.GroupManager
-import mesosphere.marathon.core.launchqueue.{LaunchQueue, LaunchStats}
+import mesosphere.marathon.core.launchqueue.LaunchStats
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec}
 import mesosphere.marathon.raml.Raml
+import mesosphere.marathon.scheduling.Scheduler
 import mesosphere.marathon.state.PathId._
+
 import scala.concurrent.ExecutionContext
 
 @Path("v2/queue")
 @Consumes(Array(MediaType.APPLICATION_JSON))
 class QueueResource @Inject() (
     clock: Clock,
-    launchQueue: LaunchQueue,
+    internalScheduler: Scheduler,
     instanceTracker: InstanceTracker,
     groupManager: GroupManager,
     val authenticator: Authenticator,
@@ -48,7 +50,7 @@ class QueueResource @Inject() (
     val appScheduled = result(instanceTracker.specInstances(appId)).exists(_.isScheduled)
     val maybeApp = if (appScheduled) groupManager.runSpec(appId) else None
     withAuthorization(UpdateRunSpec, maybeApp, notFound(s"Application $appId not found in tasks queue.")) { app =>
-      launchQueue.resetDelay(app)
+      internalScheduler.resetDelay(app)
       noContent
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -91,6 +91,9 @@ class CoreGuiceModule(cliConf: MarathonConf) extends AbstractModule {
   final def launchStats(coreModule: CoreModule): LaunchStats = coreModule.launchQueueModule.launchStats
 
   @Provides @Singleton
+  final def internalScheduler(coreModule: CoreModule): scheduling.Scheduler = coreModule.schedulingModule.scheduler
+
+  @Provides @Singleton
   final def podStatusService(appInfoModule: AppInfoModule): PodStatusService = appInfoModule.podStatusService
 
   @Provides @Singleton

--- a/src/main/scala/mesosphere/marathon/core/CoreModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModule.scala
@@ -20,6 +20,7 @@ import mesosphere.marathon.core.readiness.ReadinessModule
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
 import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
+import mesosphere.marathon.scheduling.SchedulingModule
 import mesosphere.marathon.storage.StorageModule
 
 /**
@@ -52,4 +53,5 @@ trait CoreModule {
   def storageModule: StorageModule
   def taskJobsModule: TaskJobsModule
   def taskTerminationModule: TaskTerminationModule
+  def schedulingModule: SchedulingModule
 }

--- a/src/main/scala/mesosphere/marathon/core/deployment/DeploymentModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/DeploymentModule.scala
@@ -6,12 +6,10 @@ import akka.event.EventStream
 import akka.stream.Materializer
 import mesosphere.marathon.core.deployment.impl.{DeploymentActor, DeploymentManagerActor, DeploymentManagerDelegate}
 import mesosphere.marathon.core.health.HealthCheckManager
-import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
-import mesosphere.marathon.core.task.termination.KillService
-import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.scheduling.SchedulingModule
 import mesosphere.marathon.storage.repository.DeploymentRepository
 
 /**
@@ -22,23 +20,19 @@ class DeploymentModule(
     metrics: Metrics,
     config: DeploymentConfig,
     leadershipModule: LeadershipModule,
-    taskTracker: InstanceTracker,
-    killService: KillService,
-    launchQueue: LaunchQueue,
-    scheduler: SchedulerActions,
+    schedulingModule: SchedulingModule,
+    schedulerActions: SchedulerActions,
     healthCheckManager: HealthCheckManager,
     eventBus: EventStream,
     readinessCheckExecutor: ReadinessCheckExecutor,
     deploymentRepository: DeploymentRepository,
-    deploymentActorProps: (ActorRef, KillService, SchedulerActions, DeploymentPlan, InstanceTracker, LaunchQueue, HealthCheckManager, EventStream, ReadinessCheckExecutor) => Props = DeploymentActor.props)(implicit val mat: Materializer) {
+    deploymentActorProps: (ActorRef, SchedulerActions, scheduling.Scheduler, DeploymentPlan, HealthCheckManager, EventStream, ReadinessCheckExecutor) => Props = DeploymentActor.props)(implicit val mat: Materializer) {
 
   private[this] val deploymentManagerActorRef: ActorRef = {
     val props = DeploymentManagerActor.props(
       metrics,
-      taskTracker: InstanceTracker,
-      killService,
-      launchQueue,
-      scheduler,
+      schedulerActions,
+      schedulingModule.scheduler,
       healthCheckManager,
       eventBus,
       readinessCheckExecutor,

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehavior.scala
@@ -12,7 +12,6 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.readiness.{ReadinessCheckExecutor, ReadinessCheckResult}
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.{AppDefinition, PathId, RunSpec, Timestamp}
 
 /**
@@ -32,7 +31,6 @@ trait ReadinessBehavior extends StrictLogging { this: Actor =>
   def runSpec: RunSpec
   def readinessCheckExecutor: ReadinessCheckExecutor
   def deploymentManagerActor: ActorRef
-  def instanceTracker: InstanceTracker
   def status: DeploymentStatus
 
   //computed values to have stable identifier in pattern matcher
@@ -124,7 +122,7 @@ trait ReadinessBehavior extends StrictLogging { this: Actor =>
 
     def instanceRunBehavior: Receive = {
       def markAsHealthyAndReady(instance: Instance): Unit = {
-        logger.debug(s"Started instance is ready: ${instance.instanceId}")
+        logger.info(s"Started instance is ready: ${instance.instanceId}")
         healthy += instance.instanceId
         ready += instance.instanceId
         instanceConditionChanged(instance.instanceId)

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -5,28 +5,28 @@ import akka.Done
 import akka.actor._
 import akka.event.EventStream
 import akka.pattern._
+import akka.stream.{ActorMaterializer, OverflowStrategy}
+import akka.stream.scaladsl.Sink
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event._
-import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.instance.{Goal, Instance}
-import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.termination.InstanceChangedPredicates.considerTerminal
-import mesosphere.marathon.core.task.termination.{KillReason, KillService}
-import mesosphere.marathon.core.task.tracker.InstanceTracker
+import mesosphere.marathon.core.task.termination.KillReason
 import mesosphere.marathon.state.RunSpec
+import mesosphere.marathon.stream.EnrichedSource
 
 import scala.async.Async.{async, await}
 import scala.collection.{SortedSet, mutable}
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.duration._
 
 class TaskReplaceActor(
     val deploymentManagerActor: ActorRef,
     val status: DeploymentStatus,
-    val killService: KillService,
-    val launchQueue: LaunchQueue,
-    val instanceTracker: InstanceTracker,
+    val scheduler: scheduling.Scheduler,
     val eventBus: EventStream,
     val readinessCheckExecutor: ReadinessCheckExecutor,
     val runSpec: RunSpec,
@@ -40,7 +40,10 @@ class TaskReplaceActor(
   // Killed resident tasks are not expunged from the instances list. Ignore
   // them. LaunchQueue takes care of launching instances against reservations
   // first
-  val currentInstances = instanceTracker.specInstancesSync(runSpec.id).filter(_.state.goal == Goal.Running)
+  val currentInstances = {
+    // TODO(karsten): Use InstanceTrackerConfig.internalTaskTrackerRequestTimeout or rather be async.
+    Await.result(scheduler.getInstances(runSpec.id), 1000.millis).filter(_.state.goal == Goal.Running)
+  }
 
   // In case previous master was abdicated while the deployment was still running we might have
   // already started some new tasks.
@@ -63,6 +66,18 @@ class TaskReplaceActor(
   // The number of started instances. Defaults to the number of already started instances.
   var instancesStarted: Int = instancesAlreadyStarted.size
 
+  // We instantiate the materializer here so that all materialized streams end up as children of this actor
+  implicit val materializer = ActorMaterializer()
+
+  val bufferSize = Int.MaxValue
+  val overflowStrategy = OverflowStrategy.fail
+  val frames = EnrichedSource.eventBusSource(classOf[InstanceChanged], eventBus, bufferSize, overflowStrategy).mapAsync(1) { event =>
+    async {
+      val instances = await(scheduler.getInstances(runSpec.id))
+      Frame(instances, event)
+    }
+  }
+
   @SuppressWarnings(Array("all")) // async/await
   override def preStart(): Unit = {
     super.preStart()
@@ -73,6 +88,8 @@ class TaskReplaceActor(
     // reconcile the state from a possible previous run
     reconcileAlreadyStartedInstances()
 
+    frames.runWith(Sink.actorRef(self, NoMoreFrames))
+
     async {
       // Update run spec in task launcher actor.
       // Currently the [[TaskLauncherActor]] always starts instances with the latest run spec. Let's say there are 2
@@ -80,17 +97,18 @@ class TaskReplaceActor(
       // kill the 2 running instances and only tell the [[TaskLauncherActor]] to start the 3 scheduled v1 instances with
       // the v2 run spec. We then schedule 2 more v2 instances. In the future we probably want to bind instances to a
       // certain run spec. Until then we have to update the run spec in a [[TaskLauncherActor]]
-      await(launchQueue.sync(runSpec))
+      await(scheduler.sync(runSpec))
 
       // kill old instances to free some capacity
       for (_ <- 0 until ignitionStrategy.nrToKillImmediately) killNextOldInstance()
 
       // start new instances, if possible
-      await(launchInstances())
+      val instances = await(scheduler.getInstances(runSpec.id))
+      val launched = await(launchInstances(instances))
 
       // reset the launch queue delay
       logger.info("Resetting the backoff delay before restarting the runSpec")
-      launchQueue.resetDelay(runSpec)
+      scheduler.resetDelay(runSpec)
 
       // it might be possible, that we come here, but nothing is left to do
       checkFinished()
@@ -123,23 +141,22 @@ class TaskReplaceActor(
 
   def replaceBehavior: Receive = {
     // New instance failed to start, restart it
-    case InstanceChanged(id, `version`, `pathId`, condition, Instance(_, Some(agentInfo), _, _, _, _, reservation)) if !oldInstanceIds(id) && considerTerminal(condition) =>
+    case Frame(instances, InstanceChanged(id, `version`, `pathId`, condition, Instance(_, Some(agentInfo), _, _, _, _, reservation))) if !oldInstanceIds(id) && considerTerminal(condition) =>
       logger.warn(s"New instance $id is terminal on agent ${agentInfo.agentId} during app $pathId restart: $condition reservation: $reservation")
       instanceTerminated(id)
       instancesStarted -= 1
-      launchInstances().pipeTo(self)
+      launchInstances(instances).pipeTo(self)
 
     // Old instance successfully killed
-    case InstanceChanged(id, _, `pathId`, condition, _) if oldInstanceIds(id) && considerTerminal(condition) =>
+    case Frame(instances, InstanceChanged(id, _, `pathId`, condition, _)) if oldInstanceIds(id) && considerTerminal(condition) =>
       logger.info(s"Instance $id became $condition. Launching more instances.")
       oldInstanceIds -= id
       instanceTerminated(id)
-      launchInstances()
-        .map(_ => CheckFinished)
-        .pipeTo(self)
+      launchInstances(instances).map(_ => CheckFinished).pipeTo(self)
 
     // Ignore change events, that are not handled in parent receives
-    case _: InstanceChanged =>
+    case Frame(_, event) =>
+      self ! event
 
     case Status.Failure(e) =>
       // This is the result of failed launchQueue.addAsync(...) call. Log the message and
@@ -166,14 +183,24 @@ class TaskReplaceActor(
 
   // Careful not to make this method completely asynchronous - it changes local actor's state `instancesStarted`.
   // Only launching new instances needs to be asynchronous.
-  def launchInstances(): Future[Done] = {
+  def launchInstances(instances: Seq[Instance]): Future[Done] = {
     val leftCapacity = math.max(0, ignitionStrategy.maxCapacity - oldInstanceIds.size - instancesStarted)
     val instancesNotStartedYet = math.max(0, runSpec.instances - instancesStarted)
     val instancesToStartNow = math.min(instancesNotStartedYet, leftCapacity)
     if (instancesToStartNow > 0) {
       logger.info(s"Reconciling instances during app $pathId restart: queuing $instancesToStartNow new instances")
       instancesStarted += instancesToStartNow
-      launchQueue.add(runSpec, instancesToStartNow)
+      async {
+        // Reschedule stopped resident instances first.
+        val existingReservedStoppedInstances = instances
+          .filter(i => i.isReserved && i.state.goal == Goal.Stopped) // resident to relaunch
+          .take(instancesToStartNow)
+        await(scheduler.reschedule(existingReservedStoppedInstances, runSpec))
+
+        // Schedule remaining instances
+        val instancesToSchedule = math.max(0, instancesToStartNow - existingReservedStoppedInstances.length)
+        await(scheduler.schedule(runSpec, instancesToSchedule))
+      }
     } else {
       Future.successful(Done)
     }
@@ -184,23 +211,22 @@ class TaskReplaceActor(
     if (toKill.nonEmpty) {
       val dequeued = toKill.dequeue()
       async {
-        await(instanceTracker.get(dequeued)) match {
+        await(scheduler.getInstance(dequeued)) match {
           case None =>
             logger.warn(s"Was about to kill instance ${dequeued} but it did not exist in the instance tracker anymore.")
           case Some(nextOldInstance) =>
             maybeNewInstanceId match {
               case Some(newInstanceId: Instance.Id) =>
-                logger.info(s"Killing old ${nextOldInstance.instanceId} because $newInstanceId became reachable")
+                logger.info(s"Killing old ${nextOldInstance} because $newInstanceId became reachable")
               case _ =>
-                logger.info(s"Killing old ${nextOldInstance.instanceId}")
+                logger.info(s"Killing old ${nextOldInstance}")
             }
 
             if (runSpec.isResident) {
-              await(instanceTracker.setGoal(nextOldInstance.instanceId, Goal.Stopped))
+              await(scheduler.stop(nextOldInstance, KillReason.Upgrading))
             } else {
-              await(instanceTracker.setGoal(nextOldInstance.instanceId, Goal.Decommissioned))
+              await(scheduler.decommission(nextOldInstance, KillReason.Upgrading))
             }
-            await(killService.killInstance(nextOldInstance, KillReason.Upgrading))
         }
       }
     }
@@ -223,19 +249,19 @@ object TaskReplaceActor extends StrictLogging {
 
   object CheckFinished
 
+  case class Frame(instances: Seq[Instance], event: InstanceChanged)
+  case object NoMoreFrames
+
   //scalastyle:off
   def props(
     deploymentManagerActor: ActorRef,
     status: DeploymentStatus,
-    killService: KillService,
-    launchQueue: LaunchQueue,
-    instanceTracker: InstanceTracker,
+    scheduler: scheduling.Scheduler,
     eventBus: EventStream,
     readinessCheckExecutor: ReadinessCheckExecutor,
     app: RunSpec,
     promise: Promise[Unit]): Props = Props(
-    new TaskReplaceActor(deploymentManagerActor, status, killService, launchQueue, instanceTracker, eventBus,
-      readinessCheckExecutor, app, promise)
+    new TaskReplaceActor(deploymentManagerActor, status, scheduler, eventBus, readinessCheckExecutor, app, promise)
   )
 
   /** Encapsulates the logic how to get a Restart going */

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -7,9 +7,7 @@ import akka.actor.{Actor, ActorRef, Props}
 import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.DeploymentStatus
-import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
-import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.RunSpec
 
 import scala.async.Async.{async, await}
@@ -19,9 +17,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class TaskStartActor(
     val deploymentManagerActor: ActorRef,
     val status: DeploymentStatus,
-    val scheduler: SchedulerActions,
-    val launchQueue: LaunchQueue,
-    val instanceTracker: InstanceTracker,
+    val scheduler: scheduling.Scheduler,
     val eventBus: EventStream,
     val readinessCheckExecutor: ReadinessCheckExecutor,
     val runSpec: RunSpec,
@@ -29,7 +25,7 @@ class TaskStartActor(
     promise: Promise[Unit]) extends Actor with StrictLogging with StartingBehavior {
 
   override val nrToStart: Future[Int] = async {
-    val instances = await(instanceTracker.specInstances(runSpec.id))
+    val instances = await(scheduler.getInstances(runSpec.id))
     val alreadyLaunched = instances.count { i => i.isActive || i.isScheduled }
     val target = Math.max(0, scaleTo - alreadyLaunched)
     logger.info(s"TaskStartActor about to start $target instances. $alreadyLaunched already launched, $scaleTo is target count")
@@ -39,8 +35,10 @@ class TaskStartActor(
   override def initializeStart(): Future[Done] = async {
     val toStart = await(nrToStart)
     logger.info(s"TaskStartActor: initializing for ${runSpec.id} and toStart: $toStart")
-    if (toStart > 0) await(launchQueue.add(runSpec, toStart))
-    else Done
+    if (toStart > 0) {
+      await(scheduler.schedule(runSpec, toStart))
+      Done
+    } else Done
   }.pipeTo(self)
 
   override def postStop(): Unit = {
@@ -61,16 +59,13 @@ object TaskStartActor {
   def props(
     deploymentManager: ActorRef,
     status: DeploymentStatus,
-    scheduler: SchedulerActions,
-    launchQueue: LaunchQueue,
-    instanceTracker: InstanceTracker,
+    scheduler: scheduling.Scheduler,
     eventBus: EventStream,
     readinessCheckExecutor: ReadinessCheckExecutor,
     runSpec: RunSpec,
     scaleTo: Int,
     promise: Promise[Unit]): Props = {
-    Props(new TaskStartActor(deploymentManager, status, scheduler, launchQueue, instanceTracker,
-      eventBus, readinessCheckExecutor, runSpec, scaleTo, promise)
+    Props(new TaskStartActor(deploymentManager, status, scheduler, eventBus, readinessCheckExecutor, runSpec, scaleTo, promise)
     )
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -14,11 +14,8 @@ import scala.concurrent.Future
   */
 trait LaunchQueue {
 
-  /** Request to launch `count` additional instances conforming to the given run spec. */
-  def add(spec: RunSpec, count: Int = 1): Future[Done]
-
   /** Update the run spec in a task launcher actor. **/
-  def sync(spec: RunSpec) = add(spec, 0)
+  def sync(spec: RunSpec): Future[Done]
 
   /** Remove all instance launch requests for the given PathId from this queue. */
   def purge(specId: PathId): Future[Done]

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -32,8 +32,8 @@ private[launchqueue] class LaunchQueueDelegate(
   override def purge(runSpecId: PathId): Future[Done] =
     askQueueActorFuture[LaunchQueueDelegate.Request, Done]("asyncPurge", timeout = purgeTimeout)(LaunchQueueDelegate.Purge(runSpecId))
 
-  override def add(runSpec: RunSpec, count: Int): Future[Done] =
-    askQueueActorFuture[LaunchQueueDelegate.Request, Done]("add")(LaunchQueueDelegate.Add(runSpec, count))
+  override def sync(spec: RunSpec): Future[Done] =
+    askQueueActorFuture[LaunchQueueDelegate.Request, Done]("add")(LaunchQueueDelegate.Sync(spec))
 
   private[this] def askQueueActorFuture[T, R: ClassTag](
     method: String,
@@ -58,6 +58,6 @@ private[launchqueue] class LaunchQueueDelegate(
 private[impl] object LaunchQueueDelegate {
   sealed trait Request
   case class Purge(runSpecId: PathId) extends Request
+  case class Sync(runSpec: RunSpec) extends Request
   case class ConfirmPurge(runSpecId: PathId) extends Request
-  case class Add(spec: RunSpec, count: Int) extends Request
 }

--- a/src/main/scala/mesosphere/marathon/scheduling/LegacyScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/scheduling/LegacyScheduler.scala
@@ -1,0 +1,104 @@
+package mesosphere.marathon
+package scheduling
+
+import akka.Done
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.RescheduleReserved
+import mesosphere.marathon.core.instance.{Goal, Instance}
+import mesosphere.marathon.core.launcher.OfferProcessor
+import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.task.termination.{KillReason, KillService}
+import mesosphere.marathon.core.task.tracker.InstanceTracker
+import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
+import mesosphere.marathon.state.{PathId, RunSpec}
+import org.apache.mesos.Protos
+
+import scala.async.Async.{async, await}
+import scala.concurrent.{ExecutionContext, Future}
+
+case class LegacyScheduler(
+    offerProcessor: OfferProcessor,
+    instanceTracker: InstanceTracker,
+    statusUpdateProcessor: TaskStatusUpdateProcessor,
+    killService: KillService,
+    launchQueue: LaunchQueue) extends Scheduler with StrictLogging {
+
+  override def schedule(runSpec: RunSpec, count: Int)(implicit ec: ExecutionContext): Future[Done] = async {
+    // Let launch queue manage task launcher actor.
+    await(launchQueue.sync(runSpec))
+
+    val instancesToSchedule = 0.until(count).map { _ => Instance.scheduled(runSpec, Instance.Id.forRunSpec(runSpec.id)) }
+    await(instanceTracker.schedule(instancesToSchedule))
+
+    logger.info(s"Scheduled ${instancesToSchedule.map(_.instanceId)}")
+    Done
+  }
+
+  override def reschedule(instance: Instance, runSpec: RunSpec)(implicit ec: ExecutionContext): Future[Done] =
+    async {
+      // Let launch queue manage task launcher actor.
+      await(launchQueue.sync(runSpec))
+
+      /* This method is actually and update from Goal.Stopped to Goal.Running. However, only instances with reservations
+         support such an update. MARATHON-8373 will introduce incarnations for ephemeral instances and enable rescheduling
+         support for all instances.
+       */
+      assert(instance.isReserved && instance.state.goal == Goal.Stopped)
+      await(instanceTracker.process(RescheduleReserved(instance, runSpec.version)))
+
+      logger.info(s"Rescheduled ${instance.instanceId}")
+      Done
+    }
+
+  // TODO(karsten): Investigate how we can drop this method as it leaks implementation details of the scheduler.
+  override def resetDelay(spec: RunSpec): Unit = launchQueue.resetDelay(spec)
+
+  /* The sync is responsible for two things:
+     1. Tell the [[LaunchQueueActor]] to start a [[TaskLauncherActor]].
+     2. Tell the [[TaskLauncherActor]] about the new run spec version to start.
+
+     Once we attach the run spec to an instance we can drop 2. This is addressed in MARATHON-8325.
+     Once the [[TaskLauncherActor]] is just a pure function called un [[OfferMatcherManagerActor]] we can drop 1. and
+     thus this method altogether. See MARATHON-8444 for that.
+
+     Overall this method should not be part of the future interface as it leaks implementation details of the scheduler
+     internals.
+   */
+  override def sync(spec: RunSpec)(implicit ec: ExecutionContext): Future[Done] = launchQueue.sync(spec)
+
+  override def getInstances(runSpecId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]] =
+    instanceTracker.specInstances(runSpecId)
+
+  override def getInstance(instanceId: Instance.Id)(implicit ec: ExecutionContext): Future[Option[Instance]] =
+    instanceTracker.get(instanceId)
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def run(instances: Seq[Instance])(implicit ec: ExecutionContext): Future[Done] =
+    async {
+      val work = Future.sequence(instances.map { i => instanceTracker.setGoal(i.instanceId, Goal.Running) })
+      await(work)
+      Done
+    }
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def decommission(instances: Seq[Instance], killReason: KillReason)(implicit ec: ExecutionContext): Future[Done] =
+    async {
+      val work = Future.sequence(instances.map { i => instanceTracker.setGoal(i.instanceId, Goal.Decommissioned) })
+      await(work)
+
+      await(killService.killInstances(instances, killReason))
+    }
+
+  @SuppressWarnings(Array("all")) // async/await
+  override def stop(instances: Seq[Instance], killReason: KillReason)(implicit ec: ExecutionContext): Future[Done] =
+    async {
+      val work = Future.sequence(instances.map { i => instanceTracker.setGoal(i.instanceId, Goal.Stopped) })
+      await(work)
+
+      await(killService.killInstances(instances, killReason))
+    }
+
+  override def processOffer(offer: Protos.Offer): Future[Done] = offerProcessor.processOffer(offer)
+
+  override def processMesosUpdate(status: Protos.TaskStatus)(implicit ec: ExecutionContext): Future[Done] = statusUpdateProcessor.publish(status).map(_ => Done)
+}

--- a/src/main/scala/mesosphere/marathon/scheduling/Scheduler.scala
+++ b/src/main/scala/mesosphere/marathon/scheduling/Scheduler.scala
@@ -1,0 +1,102 @@
+package mesosphere.marathon
+package scheduling
+
+import akka.Done
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.launcher.OfferProcessor
+import mesosphere.marathon.core.task.termination.KillReason
+import mesosphere.marathon.state.{PathId, RunSpec}
+import org.apache.mesos.Protos
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait Scheduler extends OfferProcessor {
+
+  /**
+    * Creates a new instance based on the provided run spec and schedules it.
+    *
+    * @param runSpec The run spec for the new instances
+    * @param count Number of new instance to schedule
+    * @return The scheduled instance.
+    */
+  def schedule(runSpec: RunSpec, count: Int)(implicit ec: ExecutionContext): Future[Done]
+
+  /**
+    * Reschedules a persistent instance with a new run spec.
+    *
+    * @param instance
+    * @param runSpec
+    * @return
+    */
+  def reschedule(instance: Instance, runSpec: RunSpec)(implicit ec: ExecutionContext): Future[Done]
+
+  def reschedule(instances: Seq[Instance], runSpec: RunSpec)(implicit ec: ExecutionContext): Future[Done] = {
+    Future.sequence(instances.map(reschedule(_, runSpec))).map(_ => Done)
+  }
+
+  def resetDelay(spec: RunSpec): Unit
+  def sync(spec: RunSpec)(implicit ec: ExecutionContext): Future[Done]
+
+  /**
+    * Retrieve all instances for a specific run spec.
+    *
+    * @param runSpecId The path id of the run spec.
+    * @param ec The execution context for the future.
+    * @return A future list of all instances of the run spec.
+    */
+  def getInstances(runSpecId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]]
+
+  /**
+    * Retrieve instance for instance id.
+    *
+    * @param instanceId id of the instance to retreive.
+    * @param ec The execution context for the future.
+    * @return A future optional instance.
+    */
+  def getInstance(instanceId: Instance.Id)(implicit ec: ExecutionContext): Future[Option[Instance]]
+
+  /**
+    * Run all instances with given ids.
+    *
+    * This method is idempotent.
+    *
+    * @param instances
+    * @param ec
+    * @return
+    */
+  def run(instances: Seq[Instance])(implicit ec: ExecutionContext): Future[Done]
+
+  /**
+    * Stop instances with give ids but keep them in store.
+    *
+    * This method is idempotent.
+    *
+    * @param instances The instances that should be stopped.
+    * @param ec
+    * @return Done when successful.
+    */
+  def stop(instances: Seq[Instance], killReason: KillReason)(implicit ec: ExecutionContext): Future[Done]
+  def stop(instance: Instance, killReason: KillReason)(implicit ec: ExecutionContext): Future[Done] = stop(Seq(instance), killReason)
+
+  /**
+    * Stop and remove instances with given ids. This will also free all reservations.
+    *
+    * This method is idempotent.
+    *
+    * @param instances The instances that should be decommissioned.
+    * @param ec
+    * @return Done when successful.
+    */
+  def decommission(instances: Seq[Instance], killReason: KillReason)(implicit ec: ExecutionContext): Future[Done]
+  def decommission(instance: Instance, killReason: KillReason)(implicit ec: ExecutionContext): Future[Done] = decommission(Seq(instance), killReason)
+
+  /**
+    * Handle a Mesos offer, e.g. free reservations or match an offer to launch instances.
+    *
+    * @param offer the offer to match
+    * @return the future indicating when the processing of the offer has finished and if there were any errors
+    */
+  def processOffer(offer: Protos.Offer): Future[Done]
+
+  def processMesosUpdate(status: Protos.TaskStatus)(implicit ec: ExecutionContext): Future[Done]
+}

--- a/src/main/scala/mesosphere/marathon/scheduling/SchedulingModule.scala
+++ b/src/main/scala/mesosphere/marathon/scheduling/SchedulingModule.scala
@@ -1,0 +1,18 @@
+package mesosphere.marathon
+package scheduling
+
+import mesosphere.marathon.core.launcher.OfferProcessor
+import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.task.termination.KillService
+import mesosphere.marathon.core.task.tracker.InstanceTracker
+import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
+
+class SchedulingModule(
+    offerProcessor: OfferProcessor,
+    instanceTracker: InstanceTracker,
+    statusUpdateProcessor: TaskStatusUpdateProcessor,
+    killService: KillService,
+    launchQueue: LaunchQueue) {
+
+  lazy val scheduler: Scheduler = LegacyScheduler(offerProcessor, instanceTracker, statusUpdateProcessor, killService, launchQueue)
+}

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -44,8 +44,8 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
       instanceTracker.process(any[InstanceUpdateOperation]) returns Future.successful[InstanceUpdateEffect](InstanceUpdateEffect.Noop(null))
 
-      When("Adding an app to the launchQueue")
-      launchQueue.add(app).futureValue
+      When("Syncing an app to the launchQueue")
+      launchQueue.sync(app).futureValue
 
       Then("A new offer matcher gets registered")
       WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
@@ -60,7 +60,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
       instanceTracker.specInstances(app.id) returns Future.successful(Seq.empty)
       instanceTracker.forceExpunge(any) returns Future.successful(Done)
-      launchQueue.add(app).futureValue
+      launchQueue.sync(app).futureValue
 
       When("The app is purged")
       launchQueue.purge(app.id).futureValue
@@ -78,7 +78,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(scheduledInstance)
       instanceTracker.process(any[InstanceUpdateOperation]) returns Future.successful[InstanceUpdateEffect](InstanceUpdateEffect.Noop(null))
       instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
-      launchQueue.add(app).futureValue
+      launchQueue.sync(app).futureValue
       WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
         offerMatcherManager.offerMatchers.size == 1
       }
@@ -103,7 +103,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(scheduledInstance)
       instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
       instanceTracker.process(any[InstanceUpdateOperation]) returns Future.successful[InstanceUpdateEffect](InstanceUpdateEffect.Noop(null))
-      launchQueue.add(app).futureValue
+      launchQueue.sync(app).futureValue
       WaitTestSupport.waitUntil("registered as offer matcher", 1.second) {
         offerMatcherManager.offerMatchers.size == 1
       }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -5,9 +5,7 @@ import akka.event.EventStream
 import akka.testkit.TestProbe
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.event._
-import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.state.Region
 import mesosphere.marathon.storage.repository.{AppRepository, FrameworkIdRepository}
 import mesosphere.marathon.test.{MarathonTestHelper, TestCrashStrategy}
@@ -30,13 +28,11 @@ class MarathonSchedulerTest extends AkkaUnitTest {
     val config: AllConf = MarathonTestHelper.defaultConfig(maxInstancesPerOffer = 10)
     val probe: TestProbe = TestProbe()
     val eventBus: EventStream = system.eventStream
-    val taskStatusProcessor: TaskStatusUpdateProcessor = mock[TaskStatusUpdateProcessor]
-    val offerProcessor: OfferProcessor = mock[OfferProcessor]
-    val crashStrategy = new TestCrashStrategy
+    val scheduler: scheduling.Scheduler = mock[scheduling.Scheduler]
+    val crashStrategy: TestCrashStrategy = new TestCrashStrategy
     val marathonScheduler: MarathonScheduler = new MarathonScheduler(
       eventBus,
-      offerProcessor = offerProcessor,
-      taskStatusProcessor = taskStatusProcessor,
+      scheduler,
       frameworkIdRepository,
       mesosLeaderInfo,
       config,

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -6,10 +6,10 @@ import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launcher.OfferMatchResult
-import mesosphere.marathon.core.launchqueue.{LaunchQueue, LaunchStats}
-import mesosphere.marathon.core.launchqueue.LaunchStats.QueuedInstanceInfoWithStatistics
+import mesosphere.marathon.core.launchqueue.LaunchStats
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.raml.{App, Raml}
+import mesosphere.marathon.scheduling.Scheduler
 import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.stream.Implicits._
@@ -23,17 +23,18 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class QueueResourceTest extends UnitTest with JerseyTest {
+  import LaunchStats.QueuedInstanceInfoWithStatistics
   case class Fixture(
       clock: SettableClock = new SettableClock(),
       config: MarathonConf = mock[MarathonConf],
       auth: TestAuthFixture = new TestAuthFixture,
-      queue: LaunchQueue = mock[LaunchQueue],
+      scheduler: Scheduler = mock[Scheduler],
       stats: LaunchStats = mock[LaunchStats],
       instanceTracker: InstanceTracker = mock[InstanceTracker],
       groupManager: GroupManager = mock[GroupManager]) {
     val queueResource: QueueResource = new QueueResource(
       clock,
-      queue,
+      scheduler,
       instanceTracker,
       groupManager,
       auth.auth,
@@ -148,7 +149,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
 
       //then
       response.getStatus should be(204)
-      verify(queue, times(1)).resetDelay(app)
+      verify(scheduler, times(1)).resetDelay(app)
     }
 
     "access without authentication is denied" in new Fixture {

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/AppStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/AppStartActorTest.scala
@@ -8,12 +8,8 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.event.{DeploymentStatus, InstanceChanged, InstanceHealthChanged}
 import mesosphere.marathon.core.health.{MarathonHttpHealthCheck, PortReference}
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
-import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.{AppDefinition, PathId}
-import mesosphere.marathon.test.MarathonTestHelper
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 import scala.concurrent.duration._
@@ -33,7 +29,7 @@ class AppStartActorTest extends AkkaUnitTest {
 
       promise.future.futureValue(Timeout(5.seconds))
 
-      verify(f.scheduler).startRunSpec(app.copy(instances = 2))
+      verify(f.schedulerActions).startRunSpec(app.copy(instances = 2))
       expectTerminated(ref)
     }
 
@@ -52,7 +48,7 @@ class AppStartActorTest extends AkkaUnitTest {
 
       promise.future.futureValue(Timeout(5.seconds))
 
-      verify(f.scheduler).startRunSpec(app.copy(instances = 2))
+      verify(f.schedulerActions).startRunSpec(app.copy(instances = 2))
       expectTerminated(ref)
     }
 
@@ -65,7 +61,7 @@ class AppStartActorTest extends AkkaUnitTest {
 
       promise.future.futureValue(Timeout(5.seconds))
 
-      verify(f.scheduler).startRunSpec(app.copy(instances = 0))
+      verify(f.schedulerActions).startRunSpec(app.copy(instances = 0))
       expectTerminated(ref)
     }
 
@@ -81,22 +77,21 @@ class AppStartActorTest extends AkkaUnitTest {
 
       promise.future.futureValue(Timeout(5.seconds))
 
-      verify(f.scheduler).startRunSpec(app.copy(instances = 0))
+      verify(f.schedulerActions).startRunSpec(app.copy(instances = 0))
       expectTerminated(ref)
     }
 
     class Fixture {
 
-      val scheduler: SchedulerActions = mock[SchedulerActions]
-      val launchQueue: LaunchQueue = mock[LaunchQueue]
-      val instanceTracker: InstanceTracker = MarathonTestHelper.createTaskTracker(
-        AlwaysElectedLeadershipModule.forRefFactory(system))
+      val schedulerActions: SchedulerActions = mock[SchedulerActions]
       val deploymentManager: TestProbe = TestProbe()
       val deploymentStatus: DeploymentStatus = mock[DeploymentStatus]
       val readinessCheckExecutor: ReadinessCheckExecutor = mock[ReadinessCheckExecutor]
       val appId = PathId("/app")
 
-      scheduler.startRunSpec(any) returns Future.successful(Done)
+      val scheduler = mock[scheduling.Scheduler]
+
+      schedulerActions.startRunSpec(any) returns Future.successful(Done)
 
       def instanceChanged(app: AppDefinition, condition: Condition): InstanceChanged = {
         val instanceId = Instance.Id.forRunSpec(app.id)
@@ -110,8 +105,8 @@ class AppStartActorTest extends AkkaUnitTest {
       }
 
       def startActor(app: AppDefinition, scaleTo: Int, promise: Promise[Unit]): TestActorRef[AppStartActor] =
-        TestActorRef(AppStartActor.props(deploymentManager.ref, deploymentStatus, scheduler,
-          launchQueue, instanceTracker, system.eventStream, readinessCheckExecutor, app, scaleTo, Seq.empty, promise)
+        TestActorRef(AppStartActor.props(deploymentManager.ref, deploymentStatus, schedulerActions, scheduler,
+          system.eventStream, readinessCheckExecutor, app, scaleTo, Seq.empty, promise)
         )
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -12,16 +12,15 @@ import mesosphere.marathon.core.deployment.impl.DeploymentManagerActor.Deploymen
 import mesosphere.marathon.core.event.InstanceChanged
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
-import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
-import mesosphere.marathon.core.task.KillServiceMock
-import mesosphere.marathon.core.task.tracker.InstanceTracker
+import mesosphere.marathon.core.task.termination.KillReason
 import mesosphere.marathon.state._
 import mesosphere.marathon.test.GroupCreation
 import org.mockito.Matchers
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
+import org.scalatest.concurrent.Eventually
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -31,17 +30,17 @@ import scala.util.Success
 // setup which makes the test overly complicated because events etc have to be mocked for these.
 // The way forward should be to provide factories that create the child actors with a given context, or
 // to use delegates that hide the implementation behind a mockable function call.
-class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
+class DeploymentActorTest extends AkkaUnitTest with GroupCreation with Eventually {
 
   implicit val defaultTimeout: Timeout = 5.seconds
 
   class Fixture {
-    val tracker: InstanceTracker = mock[InstanceTracker]
-    tracker.setGoal(any, any).returns(Future.successful(Done))
+    val scheduler: scheduling.Scheduler = mock[scheduling.Scheduler]
+    scheduler.stop(any[Seq[Instance]], any)(any) returns Future.successful(Done)
+    scheduler.decommission(any[Seq[Instance]], any)(any) returns Future.successful(Done)
+    scheduler.decommission(any[Instance], any)(any) returns Future.successful(Done)
 
-    val queue: LaunchQueue = mock[LaunchQueue]
-    val killService = new KillServiceMock(system)
-    val scheduler: SchedulerActions = mock[SchedulerActions]
+    val schedulerActions: SchedulerActions = mock[SchedulerActions]
     val hcManager: HealthCheckManager = mock[HealthCheckManager]
     val config: DeploymentConfig = mock[DeploymentConfig]
     val readinessCheckExecutor: ReadinessCheckExecutor = mock[ReadinessCheckExecutor]
@@ -55,14 +54,17 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       InstanceChanged(instanceId, app.version, app.id, condition, instance)
     }
 
+    def instanceKilled(instance: Instance): InstanceChanged = {
+      val updatedInstance = instance.copy(state = instance.state.copy(condition = Condition.Killed))
+      InstanceChanged(instance.instanceId, instance.runSpecVersion, instance.runSpecId, Condition.Killed, instance)
+    }
+
     def deploymentActor(manager: ActorRef, plan: DeploymentPlan) = system.actorOf(
       DeploymentActor.props(
         manager,
-        killService,
+        schedulerActions,
         scheduler,
         plan,
-        tracker,
-        queue,
         hcManager,
         system.eventStream,
         readinessCheckExecutor
@@ -121,22 +123,21 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
       val plan = DeploymentPlan(origGroup, targetGroup)
 
-      queue.purge(any) returns Future.successful(Done)
-      scheduler.startRunSpec(any) returns Future.successful(Done)
-      tracker.setGoal(any, any).returns(Future.successful(Done))
-      tracker.specInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2))
-      tracker.specInstancesSync(app2.id) returns Seq(instance2_1)
-      tracker.specInstances(Matchers.eq(app2.id))(any[ExecutionContext]) returns Future.successful(Seq(instance2_1))
-      tracker.specInstances(Matchers.eq(app3.id))(any[ExecutionContext]) returns Future.successful(Seq(instance3_1))
-      tracker.specInstances(Matchers.eq(app4.id))(any[ExecutionContext]) returns Future.successful(Seq(instance4_1))
-      tracker.get(instance1_1.instanceId) returns Future.successful(Some(instance1_1))
-      tracker.get(instance1_2.instanceId) returns Future.successful(Some(instance1_2))
-      tracker.get(instance2_1.instanceId) returns Future.successful(Some(instance2_1))
-      tracker.get(instance3_1.instanceId) returns Future.successful(Some(instance3_1))
-      tracker.get(instance4_1.instanceId) returns Future.successful(Some(instance4_1))
+      //queue.purge(any) returns Future.successful(Done)
+      schedulerActions.startRunSpec(any) returns Future.successful(Done)
+      scheduler.getInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2))
+      scheduler.getInstances(Matchers.eq(app2.id))(any) returns Future.successful(Seq(instance2_1))
+      scheduler.getInstances(Matchers.eq(app3.id))(any) returns Future.successful(Seq(instance3_1))
+      scheduler.getInstances(Matchers.eq(app4.id))(any) returns Future.successful(Seq(instance4_1))
+      scheduler.getInstance(Matchers.eq(instance1_1.instanceId))(any) returns Future.successful(Some(instance1_1))
+      scheduler.getInstance(Matchers.eq(instance1_2.instanceId))(any) returns Future.successful(Some(instance1_2))
+      scheduler.getInstance(Matchers.eq(instance2_1.instanceId))(any) returns Future.successful(Some(instance2_1))
+      scheduler.getInstance(Matchers.eq(instance3_1.instanceId))(any) returns Future.successful(Some(instance3_1))
+      scheduler.getInstance(Matchers.eq(instance4_1.instanceId))(any) returns Future.successful(Some(instance4_1))
 
-      queue.sync(app2New) returns Future.successful(Done)
-      when(queue.add(same(app2New), any[Int])).thenAnswer(new Answer[Future[Done]] {
+      scheduler.sync(Matchers.eq(app2New))(any) returns Future.successful(Done)
+      scheduler.reschedule(any[Seq[Instance]], same(app2New))(any) returns Future.successful(Done)
+      when(scheduler.schedule(same(app2New), any[Int])(any)).thenAnswer(new Answer[Future[Done]] {
         def answer(invocation: InvocationOnMock): Future[Done] = {
           for (i <- 0 until invocation.getArguments()(1).asInstanceOf[Int])
             system.eventStream.publish(instanceChanged(app2New, Condition.Running))
@@ -149,15 +150,24 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
         case (step, num) => managerProbe.expectMsg(7.seconds, DeploymentStepInfo(plan, step, num + 1))
       }
 
+      eventually {
+        verify(scheduler).decommission(Matchers.eq(instance1_2), any[KillReason])(any)
+      }
+      system.eventStream.publish(instanceKilled(instance1_2))
+
+      eventually {
+        verify(scheduler).decommission(Matchers.eq(instance2_1), any[KillReason])(any)
+      }
+      system.eventStream.publish(instanceKilled(instance2_1))
+
+      eventually {
+        verify(scheduler).decommission(Matchers.eq(instance4_1), any[KillReason])(any)
+      }
+      system.eventStream.publish(instanceKilled(instance4_1))
+
       managerProbe.expectMsg(5.seconds, DeploymentFinished(plan, Success(Done)))
 
-      withClue(killService.killed.mkString(",")) {
-        killService.killed should contain(instance1_2.instanceId) // killed due to scale down
-        killService.killed should contain(instance2_1.instanceId) // killed due to config change
-        killService.killed should contain(instance4_1.instanceId) // killed because app4 does not exist anymore
-        killService.numKilled should be(3)
-        verify(queue).resetDelay(app4.copy(instances = 0))
-      }
+      verify(scheduler).resetDelay(app4.copy(instances = 0))
     }
 
     "Restart app" in new Fixture {
@@ -173,17 +183,15 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val instance1_1 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp.zero).getInstance()
       val instance1_2 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp(1000)).getInstance()
 
-      tracker.specInstancesSync(app.id) returns Seq(instance1_1, instance1_2)
-      tracker.get(instance1_1.instanceId) returns Future.successful(Some(instance1_1))
-      tracker.get(instance1_2.instanceId) returns Future.successful(Some(instance1_2))
-      tracker.specInstances(app.id) returns Future.successful(Seq(instance1_1, instance1_2))
+      scheduler.getInstances(Matchers.eq(app.id))(any) returns Future.successful(Seq(instance1_1, instance1_2))
+      scheduler.getInstance(Matchers.eq(instance1_1.instanceId))(any) returns Future.successful(Some(instance1_1))
+      scheduler.getInstance(Matchers.eq(instance1_2.instanceId))(any) returns Future.successful(Some(instance1_2))
 
       val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
-      tracker.list(appNew.id) returns Future.successful(Seq(instance1_1, instance1_2))
-
-      queue.sync(appNew) returns Future.successful(Done)
-      when(queue.add(same(appNew), any[Int])).thenAnswer(new Answer[Future[Done]] {
+      scheduler.sync(Matchers.eq(appNew))(any) returns Future.successful(Done)
+      scheduler.reschedule(any[Seq[Instance]], same(appNew))(any) returns Future.successful(Done)
+      when(scheduler.schedule(same(appNew), any[Int])(any)).thenAnswer(new Answer[Future[Done]] {
         def answer(invocation: InvocationOnMock): Future[Done] = {
           for (i <- 0 until invocation.getArguments()(1).asInstanceOf[Int])
             system.eventStream.publish(instanceChanged(appNew, Condition.Running))
@@ -195,11 +203,20 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       plan.steps.zipWithIndex.foreach {
         case (step, num) => managerProbe.expectMsg(5.seconds, DeploymentStepInfo(plan, step, num + 1))
       }
+
+      eventually {
+        verify(scheduler).decommission(Matchers.eq(instance1_1), any[KillReason])(any)
+      }
+      system.eventStream.publish(instanceKilled(instance1_1))
+
+      eventually {
+        verify(scheduler).decommission(Matchers.eq(instance1_2), any[KillReason])(any)
+      }
+      system.eventStream.publish(instanceKilled(instance1_2))
+
       managerProbe.expectMsg(5.seconds, DeploymentFinished(plan, Success(Done)))
 
-      killService.killed should contain(instance1_1.instanceId)
-      killService.killed should contain(instance1_2.instanceId)
-      verify(queue).add(appNew, 2)
+      verify(scheduler).schedule(Matchers.eq(appNew), Matchers.eq(2))(any)
     }
 
     "Restart suspended app" in new Fixture {
@@ -213,9 +230,6 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(appNew.id -> appNew))))
 
       val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
-
-      tracker.specInstancesSync(app.id) returns Seq.empty[Instance]
-      queue.add(app, 2) returns Future.successful(Done)
 
       deploymentActor(managerProbe.ref, plan)
       plan.steps.zipWithIndex.foreach {
@@ -240,19 +254,20 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
       val plan = DeploymentPlan(original = origGroup, target = targetGroup, toKill = Map(app1.id -> Seq(instance1_2)))
 
-      tracker.setGoal(any, any).returns(Future.successful(Done))
-      tracker.specInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2, instance1_3))
+      scheduler.getInstances(Matchers.eq(app1.id))(any) returns Future.successful(Seq(instance1_1, instance1_2, instance1_3))
 
       deploymentActor(managerProbe.ref, plan)
+
+      eventually {
+        verify(scheduler).decommission(Matchers.eq(instance1_2), any[KillReason])(any)
+      }
+      system.eventStream.publish(instanceKilled(instance1_2))
 
       plan.steps.zipWithIndex.foreach {
         case (step, num) => managerProbe.expectMsg(5.seconds, DeploymentStepInfo(plan, step, num + 1))
       }
 
       managerProbe.expectMsg(5.seconds, DeploymentFinished(plan, Success(Done)))
-
-      killService.numKilled should be(1)
-      killService.killed should contain(instance1_2.instanceId)
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehaviorTest.scala
@@ -247,7 +247,6 @@ class ReadinessBehaviorTest extends AkkaUnitTest with Eventually with GroupCreat
         override def deploymentManagerActor: ActorRef = deploymentManagerProbe.ref
         override def status: DeploymentStatus = deploymentStatus
         override def readinessCheckExecutor: ReadinessCheckExecutor = executor
-        override def instanceTracker: InstanceTracker = tracker
         override def receive: Receive = readinessBehavior orElse {
           case notHandled => throw new RuntimeException(notHandled.toString)
         }

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActorTest.scala
@@ -40,7 +40,7 @@ class LaunchQueueActorTest extends AkkaUnitTest with ImplicitSender {
       instanceTracker.process(any[InstanceUpdateOperation]) returns Future.successful[InstanceUpdateEffect](InstanceUpdateEffect.Noop(null))
       instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
       instanceTracker.specInstances(any[PathId])(any) returns Future.successful(Seq.empty)
-      launchQueue.ask(LaunchQueueDelegate.Add(app, 3)).futureValue
+      launchQueue.ask(LaunchQueueDelegate.Sync(app)).futureValue
 
       When("An InstanceChange is send to the task launcher actor")
       launchQueue ! instanceUpdate

--- a/src/test/scala/mesosphere/marathon/test/JerseyTest.scala
+++ b/src/test/scala/mesosphere/marathon/test/JerseyTest.scala
@@ -6,7 +6,7 @@ import java.lang.{Exception => JavaException}
 import java.util.concurrent.TimeUnit
 import javax.ws.rs.container.AsyncResponse
 import javax.ws.rs.core.Response
-import mesosphere.marathon.api.{ MarathonExceptionMapper, RejectionException }
+import mesosphere.marathon.api.{MarathonExceptionMapper, RejectionException}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.exceptions.TestFailedException
 import scala.concurrent.{ExecutionContext, Future, Promise}

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -19,7 +19,7 @@ import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.pod.Network
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerModule}
+import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
 import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.raml.{Raml, Resources}
 import mesosphere.marathon.state.Container.Docker
@@ -365,6 +365,7 @@ object MarathonTestHelper {
     assert(validationResult.isSuccess == valid, s"validation errors $validationResult for json:\n$pretty")
   }
 
+  // TODO(karsten): Remove and replace with mock.
   def createTaskTrackerModule(
     leadershipModule: LeadershipModule,
     store: Option[InstanceRepository] = None)(implicit mat: Materializer): InstanceTrackerModule = {
@@ -408,12 +409,6 @@ object MarathonTestHelper {
       unreachableStrategy,
       None
     )
-  }
-
-  def createTaskTracker(
-    leadershipModule: LeadershipModule,
-    store: Option[InstanceRepository] = None)(implicit mat: Materializer): InstanceTracker = {
-    createTaskTrackerModule(leadershipModule, store).instanceTracker
   }
 
   def persistentVolumeResources(taskId: Task.Id, localVolumeIds: LocalVolumeId*) = localVolumeIds.map { id =>


### PR DESCRIPTION
Summary:
The orchestration layer should only communicate via the scheduler
interface. The instance tracker, launch queue and kill service will be
hidden behind that. This diff defines said interface and implements a
legacy scheduler that just forwards all requests to the underlying
modules.

JIRA issues: MARATHON-8224

# Outstanding

- [ ] Handle purging.
- [x] Reschedule stopped reserved instances.
- [x] Sequentialize updates in scheduler.