### PR TITLE
Better document `--mesos_role` parameter usage prior to Mesos 1.3

### DIFF
--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -90,10 +90,8 @@ When using Debian packages, the ideal way to customize Marathon is to specify co
     service ports to apps. If you assign your service port statically in your app definition, it does
     not have to be in this range.
 * `--mesos_role` (Optional. Default: None): Mesos role for this framework. If set, Marathon receives resource offers
-    for the specified role in addition to resources with the role designation '*'. This parameter is only applied the 
-    first time the framework registers with Mesos. If you change this parameter to another value later, or leave it out, 
-    this will not have an effect on the role for which Marathon is registered. Please note that Marathon currently 
-    supports only one Mesos role, support for multiple roles will be added in the future releases.
+    for the specified role in addition to resources with the role designation '*'. Marathon currently 
+    supports only one Mesos role. Support for multiple roles will be added in the future. _Note: When using Mesos prior to version 1.3, this parameter is applied when the framework registers with Mesos for the first time, and changing it after that has no effect if the framework is re-registered._
 * <span class="label label-default">v0.9.0</span> `--default_accepted_resource_roles` (Optional. Default: all roles):
     Default for the `"acceptedResourceRoles"`
     attribute as a comma-separated list of strings. All app definitions which do not specify this attribute explicitly


### PR DESCRIPTION
Clarify `--mesos_role` parameter usage prior to Mesos 1.3

JIRA issues:
https://jira.mesosphere.com/browse/MARATHON-8342