### PR TITLE
Bump buildinfo default version to 1.7

### DIFF
--- a/src/main/scala/mesosphere/marathon/BuildInfo.scala
+++ b/src/main/scala/mesosphere/marathon/BuildInfo.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.io.IO
 
 case object BuildInfo {
   private val marathonJar = "\\bmesosphere\\.marathon\\.marathon-[0-9.]+".r
-  val DefaultBuildVersion = SemVer(1, 6, 0, Some("SNAPSHOT"))
+  val DefaultBuildVersion = SemVer(1, 7, 0, Some("SNAPSHOT"))
 
   /**
     * sbt-native-package provides all of the files as individual JARs. By default, `getResourceAsStream` returns the

--- a/src/test/scala/mesosphere/marathon/BuildInfoTest.scala
+++ b/src/test/scala/mesosphere/marathon/BuildInfoTest.scala
@@ -5,9 +5,9 @@ import mesosphere.UnitTest
 class BuildInfoTest extends UnitTest {
 
   "BuildInfo" should {
-    "return a default versions" in {
+    "return a default version" in {
       BuildInfo.scalaVersion should be("2.x.x")
-      BuildInfo.version should be(SemVer(1, 6, 0, Some("SNAPSHOT")))
+      BuildInfo.version.commit.shouldBe(Some("SNAPSHOT"))
     }
   }
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/EventsIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/EventsIntegrationTest.scala
@@ -11,6 +11,8 @@ import scala.concurrent.Future
 
 class EventsIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
+  override def marathonArgs: Map[String, String] = super.marathonArgs.updated("deprecated_features", "api_heavy_events")
+
   def appId(suffix: String): PathId = testBasePath / s"app-$suffix"
 
   "Filter events" should {

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -190,6 +190,6 @@ class TaskUnreachableIntegrationTest extends AkkaIntegrationTest with EmbeddedMa
   }
 
   private def matchScaleApplication(infoString: String, appId: String): Boolean = {
-    infoString.contains(s"List(Map(actions -> List(Map(action -> ScaleApplication, app -> $appId)))))")
+    infoString.contains(s"List(Map(actions -> List(Map(action -> ScaleApplication, app -> $appId))))")
   }
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
@@ -220,7 +220,7 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
       When("Marathon is upgraded to the current version")
       marathon16322.stop().futureValue
       marathonCurrent.start().futureValue
-      (marathonCurrent.client.info.entityJson \ "version").as[String] should be("1.6.0-SNAPSHOT")
+      (marathonCurrent.client.info.entityJson \ "version").as[String] should be(BuildInfo.version.toString)
 
       Then("All apps from 1.4.9 and 1.5.6 are still running")
       marathonCurrent.client.tasks(app_149.id.toPath).value should contain theSameElementsAs (originalApp149Tasks)


### PR DESCRIPTION
Fix test failures resulting from the deprecated features change as a result of this