### PR TITLE
Synchronize python dependencies before running SI tests

### DIFF
--- a/tests/system/Makefile
+++ b/tests/system/Makefile
@@ -14,7 +14,7 @@ help:
 
 init:
 	pip3 install pipenv
-	pipenv install --dev --skip-lock
+	pipenv sync
 
 build:
 	pipenv run flake8 --count --max-line-length=120


### PR DESCRIPTION
Summary:
we use `pipenv sync` to synchronize python dependencies defined in the Pipfile during `make init` prior to running SI tests.