### PR TITLE
Do not leak ZK credentials in /v2/info

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/core/storage/zookeeper/ZooKeeperPersistenceStoreBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/core/storage/zookeeper/ZooKeeperPersistenceStoreBenchmark.scala
@@ -52,7 +52,7 @@ object ZooKeeperPersistenceStoreBenchmark extends StrictLogging {
   Conf.verify()
 
   val curator: CuratorFramework = CuratorFrameworkFactory.newClient(
-    Conf.zkHosts,
+    Conf.zooKeeperUrl().hostsString,
     Conf.zooKeeperSessionTimeout().toInt,
     Conf.zooKeeperConnectionTimeout().toInt,
     new BoundedExponentialBackoffRetry(Conf.zooKeeperOperationBaseRetrySleepMs(), Conf.zooKeeperTimeout().toInt, Conf.zooKeeperOperationMaxRetries())

--- a/changelog.md
+++ b/changelog.md
@@ -61,6 +61,10 @@ The "lightweight" plan format can be already seen using the `?plan-format=light`
 * `plan.original` - The current state of the root group
 * `plan.target` - The target state of the root group
 
+### Fixed Issues
+
+- [MARATHON-7568](https://jira.mesosphere.com/browse/MARATHON-7568) - We now redact any Zookeeper credentials from the /v2/info response endpoint.
+
 ## Change from 1.6.322 to 1.6.352
 
 ### GPU Scheduling

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -1,5 +1,7 @@
 package mesosphere.marathon
 
+import com.typesafe.scalalogging.StrictLogging
+import java.net.URL
 import mesosphere.marathon.core.appinfo.AppInfoConfig
 import mesosphere.marathon.core.deployment.DeploymentConfig
 import mesosphere.marathon.core.event.EventConf
@@ -17,7 +19,7 @@ import mesosphere.marathon.core.task.update.TaskStatusUpdateConfig
 import mesosphere.marathon.state.ResourceRole
 import mesosphere.marathon.storage.StorageConf
 import mesosphere.mesos.MatcherConf
-import org.rogach.scallop.{ScallopConf, ScallopOption}
+import org.rogach.scallop.{ScallopConf, ScallopOption, ValueConverter}
 
 import scala.sys.SystemProperties
 
@@ -39,11 +41,12 @@ trait MarathonConf
   with TaskJobsConfig with TaskStatusUpdateConfig with InstanceTrackerConfig with DeploymentConfig with ZookeeperConf
   with MatcherConf with AppInfoConfig {
 
-  lazy val mesosMaster = opt[String](
+  import MarathonConf._
+  lazy val mesosMaster = opt[MesosMasterConnection](
     "master",
-    descr = "The URL of the Mesos master",
+    descr = "The URL of the Mesos master. Either http://host:port, or zk://host1:port1,host2:port2,.../path",
     required = true,
-    noshort = true)
+    noshort = true)(mesosMasterValueConverter)
 
   lazy val mesosLeaderUiUrl = opt[String](
     "mesos_leader_ui_url",
@@ -313,3 +316,72 @@ trait MarathonConf
   )
 }
 
+object MarathonConf extends StrictLogging {
+  sealed trait MesosMasterConnection {
+    def unredactedConnectionString: String
+    def redactedConnectionString: String
+    override def toString() = redactedConnectionString
+  }
+
+  object MesosMasterConnection {
+    case class Zk(zkUrl: ZookeeperConf.ZkUrl) extends MesosMasterConnection {
+      override def unredactedConnectionString = zkUrl.unredactedConnectionString
+      override def redactedConnectionString = zkUrl.toString()
+    }
+    case class Http(url: URL) extends MesosMasterConnection {
+      override def unredactedConnectionString = url.toString
+      /**
+        * Credentials are not provided via the URL
+        */
+      override def redactedConnectionString = url.toString
+    }
+    /**
+      * Describes a protocol-less connection string. Unfortunately, we did not strictly validate the Mesos master string
+      * in the past.
+      */
+    case class Unspecified(string: String) extends MesosMasterConnection {
+      override def unredactedConnectionString = string
+      /**
+        * Credentials are not provided via the URL
+        */
+      override def redactedConnectionString = toString
+    }
+  }
+
+  val httpUrlValueConverter = new ValueConverter[URL] {
+    val argType = org.rogach.scallop.ArgType.SINGLE
+
+    def parse(s: List[(String, List[String])]): Either[String, Option[URL]] = s match {
+      case (_, urlString :: Nil) :: Nil =>
+        try Right(Some(new java.net.URL(urlString)))
+        catch {
+          case ex: IllegalArgumentException =>
+            return Left(s"${urlString} is not a valid URL")
+        }
+      case Nil =>
+        Right(None)
+      case other =>
+        Left("Expected exactly one url")
+    }
+  }
+
+  val mesosMasterValueConverter = new ValueConverter[MesosMasterConnection] {
+    val argType = org.rogach.scallop.ArgType.SINGLE
+
+    private val httpLike = "(?i)(^https?://.+)$".r
+    def parse(s: List[(String, List[String])]): Either[String, Option[MesosMasterConnection]] = s match {
+      case (_, zkUrlString :: Nil) :: Nil if zkUrlString.take(5).equalsIgnoreCase("zk://") =>
+        ZookeeperConf.ZkUrl.parse(zkUrlString).map { zkUrl => Some(MesosMasterConnection.Zk(zkUrl)) }
+      case (_, httpLike(httpUrlString) :: Nil) :: Nil =>
+        httpUrlValueConverter.parse(s).map { url => url.map(MesosMasterConnection.Http(_)) }
+      case (_, addressPort :: Nil) :: Nil =>
+        // localhost:5050 or 127.0.0.1:5050 or leader.mesos:5050
+        logger.warn(s"Specifying a Mesos Master connection without a protocol is deprecated and will likely be prohibited in the future. Please specify a protocol (http://, zk://, https://)")
+        Right(Some(MesosMasterConnection.Unspecified(addressPort)))
+      case Nil =>
+        Right(None)
+      case _ =>
+        Left("Expected exactly one connection string")
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -9,7 +9,6 @@ import akka.event.EventStream
 import akka.routing.RoundRobinPool
 import akka.stream.Materializer
 import com.google.inject._
-import com.google.inject.name.Names
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.deployment.DeploymentManager
 import mesosphere.marathon.core.election.ElectionService
@@ -26,7 +25,6 @@ import scala.util.control.NonFatal
 object ModuleNames {
   final val HOST_PORT = "HOST_PORT"
 
-  final val SERVER_SET_PATH = "SERVER_SET_PATH"
   final val HISTORY_ACTOR_PROPS = "HISTORY_ACTOR_PROPS"
 
   final val MESOS_HEARTBEAT_ACTOR = "MesosHeartbeatActor"
@@ -46,10 +44,6 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
     bind(classOf[SchedulerDriverFactory]).to(classOf[MesosSchedulerDriverFactory]).in(Scopes.SINGLETON)
     bind(classOf[MarathonSchedulerService]).in(Scopes.SINGLETON)
     bind(classOf[DeploymentService]).to(classOf[MarathonSchedulerService])
-
-    bind(classOf[String])
-      .annotatedWith(Names.named(ModuleNames.SERVER_SET_PATH))
-      .toInstance(conf.zooKeeperServerSetPath)
   }
 
   @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR)

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -113,7 +113,7 @@ class MarathonScheduler(
   override def error(driver: SchedulerDriver, message: String): Unit = {
     logger.warn(s"Error: $message\n" +
       "In case Mesos does not allow registration with the current frameworkId, " +
-      s"delete the ZooKeeper Node: ${config.zkPath}/state/framework:id\n" +
+      s"delete the ZooKeeper Node: ${config.zooKeeperUrl().path}/state/framework:id\n" +
       "CAUTION: if you remove this node, all tasks started with the current frameworkId will be orphaned!")
 
     // Currently, it's pretty hard to disambiguate this error from other causes of framework errors.

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
@@ -91,10 +91,10 @@ object MarathonSchedulerDriver extends StrictLogging {
     val implicitAcknowledgements = false
     val newDriver: MesosSchedulerDriver = credential match {
       case Some(cred) =>
-        new MesosSchedulerDriver(newScheduler, frameworkInfo, config.mesosMaster(), implicitAcknowledgements, cred)
+        new MesosSchedulerDriver(newScheduler, frameworkInfo, config.mesosMaster().unredactedConnectionString, implicitAcknowledgements, cred)
 
       case None =>
-        new MesosSchedulerDriver(newScheduler, frameworkInfo, config.mesosMaster(), implicitAcknowledgements)
+        new MesosSchedulerDriver(newScheduler, frameworkInfo, config.mesosMaster().unredactedConnectionString, implicitAcknowledgements)
     }
 
     logger.debug("Finished creating new driver", newDriver)

--- a/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
+++ b/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
@@ -1,9 +1,8 @@
 package mesosphere.marathon
 
-import java.net.InetSocketAddress
-
+import org.apache.curator.framework.AuthInfo
 import org.apache.zookeeper.ZooDefs
-import org.rogach.scallop.ScallopConf
+import org.rogach.scallop.{ScallopConf, ValueConverter}
 
 import scala.concurrent.duration._
 
@@ -27,12 +26,11 @@ trait ZookeeperConf extends ScallopConf {
     default = Some(Duration(10, SECONDS).toMillis)
   )
 
-  lazy val zooKeeperUrl = opt[String](
+  lazy val zooKeeperUrl = opt[ZkUrl](
     "zk",
     descr = "ZooKeeper URL for storing state. Format: zk://host1:port1,host2:port2,.../path",
-    validate = (in) => ZKUrlPattern.pattern.matcher(in).matches(),
-    default = Some("zk://localhost:2181/marathon")
-  )
+    default = Some(ZkUrl.parse("zk://localhost:2181/marathon") match { case Right(u) => u; case _ => ??? /* because scapegoat thought this was better than .right.get */ })
+  )(scallopZkUrlParser)
 
   lazy val zooKeeperCompressionEnabled = toggle(
     "zk_compression",
@@ -79,29 +77,13 @@ trait ZookeeperConf extends ScallopConf {
     default = Some(10)
   )
 
-  def zooKeeperStatePath: String = "%s/state".format(zkPath)
-  def zooKeeperLeaderPath: String = "%s/leader".format(zkPath)
-  def zooKeeperServerSetPath: String = "%s/apps".format(zkPath)
+  def zooKeeperStateUrl: ZkUrl = zooKeeperUrl() / "state"
+  def zooKeeperLeaderUrl: ZkUrl = zooKeeperUrl() / "leader"
 
-  def zooKeeperHostAddresses: Seq[InetSocketAddress] =
-    zkHosts.split(",").map { s =>
-      val splits = s.split(":")
-      require(splits.length == 2, "expected host:port for zk servers")
-      new InetSocketAddress(splits(0), splits(1).toInt)
-    }(collection.breakOut)
-
-  @SuppressWarnings(Array("OptionGet"))
-  def zkURL: String = zooKeeperUrl.toOption.get
-
-  lazy val zkHosts = zkURL match { case ZKUrlPattern(_, _, server, _) => server }
-  lazy val zkPath = zkURL match { case ZKUrlPattern(_, _, _, path) => path }
-  lazy val zkUsername = zkURL match { case ZKUrlPattern(u, _, _, _) => Option(u) }
-  lazy val zkPassword = zkURL match { case ZKUrlPattern(_, p, _, _) => Option(p) }
-
-  lazy val zkDefaultCreationACL = (zkUsername, zkPassword) match {
-    case (Some(_), Some(_)) => ZooDefs.Ids.CREATOR_ALL_ACL
-    case _ => ZooDefs.Ids.OPEN_ACL_UNSAFE
-  }
+  lazy val zkDefaultCreationACL = if (zooKeeperUrl().credentials.nonEmpty)
+    ZooDefs.Ids.CREATOR_ALL_ACL
+  else
+    ZooDefs.Ids.OPEN_ACL_UNSAFE
 
   lazy val zkTimeoutDuration = Duration(zooKeeperTimeout(), MILLISECONDS)
   lazy val zkSessionTimeoutDuration = Duration(zooKeeperSessionTimeout(), MILLISECONDS)
@@ -109,9 +91,83 @@ trait ZookeeperConf extends ScallopConf {
 }
 
 object ZookeeperConf {
-  private val user = """[^/:]+"""
-  private val pass = """[^@]+"""
-  private val hostAndPort = """[A-z0-9-.]+(?::\d+)?"""
-  private val zkNode = """[^/]+"""
-  val ZKUrlPattern = s"""^zk://(?:($user):($pass)@)?($hostAndPort(?:,$hostAndPort)*)(/$zkNode(?:/$zkNode)*)$$""".r
+  val ZkUrlPattern = {
+    val user = """[^/:]+"""
+    val pass = """[^@]+"""
+    val hostAndPort = """[A-z0-9-.]+(?::\d+)?"""
+    val zkNode = """[^/]+"""
+    s"""^zk://(?:($user):($pass)@)?($hostAndPort(?:,$hostAndPort)*)(/$zkNode(?:/$zkNode)*)$$""".r
+  }
+
+  case class ZkCreds(username: String, password: String) {
+    def authInfoDigest: AuthInfo =
+      new AuthInfo("digest", s"${username}:${password}".getBytes("UTF-8"))
+  }
+
+  /**
+    * Class which contains a parse zkUrl
+    */
+  case class ZkUrl(
+      credentials: Option[ZkCreds],
+      hosts: Seq[String],
+      path: String) {
+
+    private def redactedAuthSection = if (credentials.nonEmpty)
+      "xxxxxxxx:xxxxxxxx@"
+    else
+      ""
+
+    private def unredactedAuthSection = credentials match {
+      case Some(ZkCreds(username, password)) =>
+        s"${username}:${password}@"
+      case _ =>
+        ""
+    }
+
+    def /(subpath: String): ZkUrl = copy(path = path + "/" + subpath)
+
+    def hostsString = hosts.mkString(",")
+    /**
+      * Render this zkUrl to a string. In order to prevent accidental logging of sensitive credentials in the log, we
+      * redact user and password from toString.
+      */
+    override def toString(): String =
+      redactedConnectionString
+
+    def redactedConnectionString =
+      s"zk://${redactedAuthSection}${hostsString}${path}"
+
+    def unredactedConnectionString =
+      s"zk://${unredactedAuthSection}${hostsString}${path}"
+
+  }
+
+  val scallopZkUrlParser = new ValueConverter[ZkUrl] {
+    val argType = org.rogach.scallop.ArgType.SINGLE
+
+    def parse(s: List[(String, List[String])]): Either[String, Option[ZkUrl]] = s match {
+      case (_, zkUrlString :: Nil) :: Nil =>
+        ZkUrl.parse(zkUrlString).map(Some(_))
+      case Nil =>
+        Right(None)
+      case other =>
+        Left("Expected exactly one url")
+    }
+  }
+
+  object ZkUrl {
+    /**
+      * Parse a string formatted like zk://user:pass@host1:port,host2:port/path
+      *
+      * Throws if hosts are not all formatted like 'host:port'
+      */
+    def parse(url: String): Either[String, ZkUrl] = url match {
+      case ZkUrlPattern(user, pass, hosts, path) =>
+        // Our regular expression does not match user but no password, or password but no user.
+        val creds = for { u <- Option(user); p <- Option(pass) } yield ZkCreds(u, p)
+        Right(ZkUrl(creds, hosts.split(",").toList, path))
+      case _ =>
+        Left(s"${url} is not a valid zk url; it should formatted like zk://user:pass@host1:port1,host2:port2/path, or zk://host1:port1,host2:port2/marathon")
+    }
+  }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -45,7 +45,7 @@ class InfoResource @Inject() (
     "leader_proxy_read_timeout_ms" -> config.leaderProxyReadTimeout.toOption,
     "local_port_max" -> config.localPortMax.toOption,
     "local_port_min" -> config.localPortMin.toOption,
-    "master" -> config.mesosMaster.toOption,
+    "master" -> config.mesosMaster().redactedConnectionString,
     "max_instances_per_offer" -> config.maxInstancesPerOffer.toOption,
     "mesos_bridge_name" -> config.mesosBridgeName.toOption,
     "mesos_heartbeat_failure_threshold" -> config.mesosHeartbeatFailureThreshold.toOption,
@@ -73,7 +73,7 @@ class InfoResource @Inject() (
 
   // ZooKeeper congiurations
   private[this] lazy val zookeeperConfigValues = Json.obj(
-    "zk" -> s"zk://${config.zkHosts}${config.zkPath}",
+    "zk" -> config.zooKeeperUrl().redactedConnectionString,
     "zk_compression" -> config.zooKeeperCompressionEnabled.toOption,
     "zk_compression_threshold" -> config.zooKeeperCompressionThreshold.toOption,
     "zk_connection_timeout" -> config.zooKeeperConnectionTimeout(),

--- a/src/main/scala/mesosphere/marathon/core/election/CuratorElectionStream.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/CuratorElectionStream.scala
@@ -15,7 +15,7 @@ import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.api.{ACLProvider, CuratorWatcher, UnhandledErrorListener}
 import org.apache.curator.framework.imps.CuratorFrameworkState
 import org.apache.curator.framework.recipes.leader.LeaderLatch
-import org.apache.curator.framework.{AuthInfo, CuratorFrameworkFactory}
+import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.retry.ExponentialBackoffRetry
 import org.apache.zookeeper.{KeeperException, WatchedEvent, ZooDefs}
 import org.apache.zookeeper.data.ACL
@@ -197,12 +197,13 @@ object CuratorElectionStream extends StrictLogging {
     }
   }
 
-  def newCuratorConnection(config: ZookeeperConf) = {
-    logger.info(s"Will do leader election through ${config.zkHosts}")
+  def newCuratorConnection(zkUrl: ZookeeperConf.ZkUrl, sessionTimeoutMs: Int, connectionTimeoutMs: Int,
+    timeoutDurationMs: Int, defaultCreationACL: util.ArrayList[ACL]) = {
+    logger.info(s"Will do leader election through ${zkUrl.redactedConnectionString}")
 
     // let the world read the leadership information as some setups depend on that to find Marathon
     val defaultAcl = new util.ArrayList[ACL]()
-    defaultAcl.addAll(config.zkDefaultCreationACL)
+    defaultAcl.addAll(defaultCreationACL)
     defaultAcl.addAll(ZooDefs.Ids.READ_ACL_UNSAFE)
 
     val aclProvider = new ACLProvider {
@@ -212,26 +213,22 @@ object CuratorElectionStream extends StrictLogging {
 
     val retryPolicy = new ExponentialBackoffRetry(1.second.toMillis.toInt, 10)
     val builder = CuratorFrameworkFactory.builder().
-      connectString(config.zkHosts).
-      sessionTimeoutMs(config.zooKeeperSessionTimeout().toInt).
-      connectionTimeoutMs(config.zooKeeperConnectionTimeout().toInt).
+      connectString(zkUrl.hostsString).
+      sessionTimeoutMs(sessionTimeoutMs).
+      connectionTimeoutMs(connectionTimeoutMs).
       aclProvider(aclProvider).
       retryPolicy(retryPolicy)
 
     // optionally authenticate
-    val client = (config.zkUsername, config.zkPassword) match {
-      case (Some(user), Some(pass)) =>
-        builder.authorization(Collections.singletonList(
-          new AuthInfo("digest", (user + ":" + pass).getBytes("UTF-8"))))
-          .build()
-      case _ =>
-        builder.build()
+    zkUrl.credentials.foreach { credentials =>
+      builder.authorization(Collections.singletonList(credentials.authInfoDigest))
     }
+    val client = builder.build()
 
     val listener = new LastErrorListener
     client.getUnhandledErrorListenable().addListener(listener)
     client.start()
-    if (!client.blockUntilConnected(config.zkTimeoutDuration.toMillis.toInt, TimeUnit.MILLISECONDS)) {
+    if (!client.blockUntilConnected(timeoutDurationMs, TimeUnit.MILLISECONDS)) {
       // If we couldn't connect, throw any errors that were reported
       listener.lastError.foreach { e => throw e }
     }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -72,8 +72,9 @@ private[launcher] class OfferProcessorImpl(
   private def warnOnZeroResource(offer: Offer): Unit = {
     val resourcesWithZeroValues = offer
       .getResourcesList.asScala
-      .collect { case resource if resource.getScalar.getValue.ceil.toLong == 0 =>
-        resource.getName
+      .collect {
+        case resource if resource.getScalar.getValue.ceil.toLong == 0 =>
+          resource.getName
       }
     if (resourcesWithZeroValues.nonEmpty) {
       logger.warn(s"Offer ${offer.getId.getValue} has zero-valued resources: ${resourcesWithZeroValues.mkString(", ")}")

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -16,7 +16,7 @@ import mesosphere.marathon.core.storage.store.impl.zk.{RichCuratorFramework, ZkI
 import org.apache.curator.RetryPolicy
 import org.apache.curator.framework.api.ACLProvider
 import org.apache.curator.framework.imps.GzipCompressionProvider
-import org.apache.curator.framework.{AuthInfo, CuratorFrameworkFactory}
+import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.retry.BoundedExponentialBackoffRetry
 import org.apache.zookeeper.data.ACL
 
@@ -92,11 +92,8 @@ case class CuratorZk(
     sessionTimeout: Option[Duration],
     connectionTimeout: Option[Duration],
     timeout: Duration,
-    zkHosts: String,
-    zkPath: String,
+    zkUrl: ZookeeperConf.ZkUrl,
     zkAcls: util.List[ACL],
-    username: Option[String],
-    password: Option[String],
     enableCompression: Boolean,
     retryPolicy: RetryPolicy,
     maxConcurrent: Int,
@@ -113,14 +110,12 @@ case class CuratorZk(
 
   lazy val client: RichCuratorFramework = {
     val builder = CuratorFrameworkFactory.builder()
-    builder.connectString(zkHosts)
+    builder.connectString(zkUrl.hostsString)
     sessionTimeout.foreach(t => builder.sessionTimeoutMs(t.toMillis.toInt))
     connectionTimeout.foreach(t => builder.connectionTimeoutMs(t.toMillis.toInt))
     if (enableCompression) builder.compressionProvider(new GzipCompressionProvider)
-    (username, password) match {
-      case (Some(user), Some(pass)) =>
-        builder.authorization(Collections.singletonList(new AuthInfo("digest", s"$user:$pass".getBytes("UTF-8"))))
-      case _ =>
+    zkUrl.credentials.foreach { credentials =>
+      builder.authorization(Collections.singletonList(credentials.authInfoDigest))
     }
     builder.aclProvider(new ACLProvider {
       override def getDefaultAcl: util.List[ACL] = zkAcls
@@ -128,7 +123,7 @@ case class CuratorZk(
       override def getAclForPath(path: String): util.List[ACL] = zkAcls
     })
     builder.retryPolicy(retryPolicy)
-    builder.namespace(zkPath.stripPrefix("/"))
+    builder.namespace(zkUrl.path.stripPrefix("/"))
     val client = RichCuratorFramework(builder.build())
     client.start()
     client.blockUntilConnected(lifecycleState)
@@ -158,11 +153,8 @@ object CuratorZk {
       sessionTimeout = Some(conf.zkSessionTimeoutDuration),
       connectionTimeout = Some(conf.zkConnectionTimeoutDuration),
       timeout = conf.zkTimeoutDuration,
-      zkHosts = conf.zkHosts,
-      zkPath = conf.zooKeeperStatePath,
+      zkUrl = conf.zooKeeperStateUrl,
       zkAcls = conf.zkDefaultCreationACL,
-      username = conf.zkUsername,
-      password = conf.zkPassword,
       enableCompression = conf.zooKeeperCompressionEnabled(),
       retryPolicy = new BoundedExponentialBackoffRetry(conf.zooKeeperOperationBaseRetrySleepMs(), conf.zooKeeperTimeout().toInt, conf.zooKeeperOperationMaxRetries()),
       maxConcurrent = conf.zkMaxConcurrency(),

--- a/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
@@ -3,6 +3,7 @@ package mesosphere.marathon
 import mesosphere.UnitTest
 import mesosphere.marathon.state.ResourceRole
 import mesosphere.marathon.test.MarathonTestHelper
+import mesosphere.marathon.ZookeeperConf.ZkUrl
 
 import scala.util.{Failure, Try}
 
@@ -10,7 +11,7 @@ class MarathonConfTest extends UnitTest {
   private[this] val principal = "foo"
   private[this] val secretFile = "/bar/baz"
 
-  "MaratonConf" should {
+  "MarathonConf" should {
     "MesosAuthenticationIsOptional" in {
       val conf = MarathonTestHelper.makeConfig(
         "--master", "127.0.0.1:5050"
@@ -40,6 +41,27 @@ class MarathonConfTest extends UnitTest {
       assert(conf.mesosAuthenticationPrincipal.toOption == Some(principal))
       assert(conf.mesosAuthenticationSecretFile.isDefined)
       assert(conf.mesosAuthenticationSecretFile.toOption == Some(secretFile))
+    }
+
+    "--master" should {
+      "allow a valid zookeeper URL" in {
+        val conf = MarathonTestHelper.makeConfig("--master", "zk://127.0.0.1:2181/mesos")
+        conf.mesosMaster() shouldBe MarathonConf.MesosMasterConnection.Zk(ZkUrl.parse("zk://127.0.0.1:2181/mesos").right.get)
+      }
+
+      "reject an invalid zookeeper URL" in {
+        Try(MarathonTestHelper.makeConfig("--master", "zk://127.0.0.1:lol/mesos")).isFailure shouldBe true
+      }
+
+      "allows an HTTP URL" in {
+        val conf = MarathonTestHelper.makeConfig("--master", "http://127.0.0.1:5050")
+        conf.mesosMaster() shouldBe MarathonConf.MesosMasterConnection.Http(new java.net.URL("http://127.0.0.1:5050"))
+      }
+
+      "allows an unspecified protocol" in {
+        val conf = MarathonTestHelper.makeConfig("--master", "127.0.0.1:5050")
+        conf.mesosMaster() shouldBe MarathonConf.MesosMasterConnection.Unspecified("127.0.0.1:5050")
+      }
     }
 
     "Secret can be specified directly" in {

--- a/src/test/scala/mesosphere/marathon/ZookeeperConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/ZookeeperConfTest.scala
@@ -11,26 +11,25 @@ class ZookeeperConfTest extends UnitTest {
     "urlParameterGetParsed" in {
       val url = "zk://host1:123,host2,host3:312/path"
       val opts = conf("--zk", url)
-      assert(opts.zkURL == url)
-      assert(opts.zkHosts == "host1:123,host2,host3:312")
-      assert(opts.zkPath == "/path")
-      assert(opts.zkUsername.isEmpty)
-      assert(opts.zkPassword.isEmpty)
+      assert(opts.zooKeeperUrl().unredactedConnectionString == url)
+      assert(opts.zooKeeperUrl().hostsString == "host1:123,host2,host3:312")
+      assert(opts.zooKeeperUrl().path == "/path")
+      assert(opts.zooKeeperUrl().credentials.isEmpty)
       assert(opts.zkDefaultCreationACL == ZooDefs.Ids.OPEN_ACL_UNSAFE)
     }
 
     "urlParameterWithAuthGetParsed" in {
       val url = "zk://user1:pass1@host1:123,host2,host3:312/path"
       val opts = conf("--zk", url)
-      assert(opts.zkURL == url)
-      assert(opts.zkHosts == "host1:123,host2,host3:312")
-      assert(opts.zkPath == "/path")
-      assert(opts.zkUsername == Some("user1"))
-      assert(opts.zkPassword == Some("pass1"))
+      assert(opts.zooKeeperUrl().unredactedConnectionString == url)
+      assert(opts.zooKeeperUrl().hostsString == "host1:123,host2,host3:312")
+      assert(opts.zooKeeperUrl().path == "/path")
+      assert(opts.zooKeeperUrl().credentials == Some(ZookeeperConf.ZkCreds("user1", "pass1")))
       assert(opts.zkDefaultCreationACL == ZooDefs.Ids.CREATOR_ALL_ACL)
     }
 
     "wrongURLIsNotParsed" in {
+      assert(Try(conf("--zk", "zk://host1:2181/path")).isSuccess, "Valid")
       assert(Try(conf("--zk", "zk://host1:foo/path")).isFailure, "No port number")
       assert(Try(conf("--zk", "zk://host1")).isFailure, "No path")
       assert(Try(conf("--zk", "zk://user@host1:2181/path")).isFailure, "No password")

--- a/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
@@ -2,13 +2,15 @@ package mesosphere.marathon
 package api.v2
 
 import mesosphere.UnitTest
-import mesosphere.marathon.HttpConf
 import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
-import mesosphere.marathon.test.JerseyTest
-import mesosphere.util.state.MesosLeaderInfo
+import mesosphere.marathon.test.{JerseyTest, MarathonTestHelper}
+import mesosphere.util.state.{FrameworkId, MesosLeaderInfo}
+import play.api.libs.json.{JsObject, JsString, Json}
+
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class InfoResourceTest extends UnitTest with JerseyTest {
 
@@ -39,12 +41,40 @@ class InfoResourceTest extends UnitTest with JerseyTest {
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(f.auth.UnauthorizedStatus)
     }
+
+    "zk credentials are redacted" in {
+      Given("A request")
+      val f = new Fixture
+      f.leaderInfo.currentLeaderUrl returns Some("http://127.0.0.1:5050")
+      f.frameworkIdRepository.get returns Future.successful(Some(FrameworkId("dummy-uuid")))
+      f.electionService.isLeader returns true
+      f.electionService.leaderHostPort returns Some("127.0.0.1:8080")
+      f.auth.authenticated = true
+      f.auth.authorized = true
+      f.config = MarathonTestHelper.makeConfig(
+        "--master", "zk://root:password@127.0.0.1:2181/mesos",
+        "--zk", "zk://root:password@127.0.0.1:2181/marathon")
+      val resource = f.infoResource()
+
+      When("the info is fetched")
+      val response = syncRequest { resource.index(f.auth.request) }
+
+      Then("there must not be the credentials in the Mesos ZK connection string")
+      response.getStatus should be(200)
+
+      val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+      parsedResponse should be (defined)
+      val responseObject = parsedResponse.get.asInstanceOf[JsObject]
+      (responseObject \ "marathon_config" \ "master").get.asInstanceOf[JsString].value shouldEqual "zk://xxxxxxxx:xxxxxxxx@127.0.0.1:2181/mesos"
+      (responseObject \ "zookeeper_config" \ "zk").get.asInstanceOf[JsString].value shouldEqual "zk://xxxxxxxx:xxxxxxxx@127.0.0.1:2181/marathon"
+    }
   }
+
   class Fixture {
     val leaderInfo = mock[MesosLeaderInfo]
     val electionService = mock[ElectionService]
     val auth = new TestAuthFixture
-    val config = mock[MarathonConf with HttpConf]
+    var config = mock[MarathonConf with HttpConf]
     val frameworkIdRepository = mock[FrameworkIdRepository]
 
     def infoResource() = new InfoResource(leaderInfo, frameworkIdRepository, electionService, auth.auth, auth.auth, config)

--- a/tests/integration/src/test/scala/mesosphere/marathon/core/election/CuratorElectionStreamTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/core/election/CuratorElectionStreamTest.scala
@@ -7,8 +7,9 @@ import java.util.concurrent.{Executors}
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.storage.store.impl.zk.NoRetryPolicy
 import mesosphere.marathon.stream.EnrichedFlow
-import mesosphere.marathon.util.{LifeCycledCloseable, ScallopStub, ZookeeperServerTest}
+import mesosphere.marathon.util.{LifeCycledCloseable, ZookeeperServerTest}
 import org.apache.curator.framework.CuratorFrameworkFactory
+import org.apache.zookeeper.ZooDefs
 import org.scalatest.Inside
 import org.scalatest.concurrent.Eventually
 
@@ -45,17 +46,15 @@ class CuratorElectionStreamTest extends AkkaUnitTest with Inside with ZookeeperS
 
   "CuratorElectionStream.newCuratorConnection" should {
     "throw an exception when given an unresolvable hostname" in {
-      val conf = new ZookeeperConf {
-        override lazy val zooKeeperUrl = ScallopStub(Some("zk://unresolvable:8080/marathon"))
-        override lazy val zooKeeperSessionTimeout = ScallopStub(Some(1000L))
-        override lazy val zooKeeperConnectionTimeout = ScallopStub(Some(1000L))
-        override lazy val zkSessionTimeoutDuration = 10000.milliseconds
-        override lazy val zkConnectionTimeoutDuration = 10000.milliseconds
-        override lazy val zkTimeoutDuration = 250.milliseconds
-      }
+      val zkUrl = ZookeeperConf.ZkUrl.parse("zk://unresolvable:8080/marathon/leader").right.get
 
       a[Throwable] shouldBe thrownBy {
-        CuratorElectionStream.newCuratorConnection(conf)
+        new LifeCycledCloseable(CuratorElectionStream.newCuratorConnection(
+          zkUrl = zkUrl,
+          sessionTimeoutMs = 1000,
+          connectionTimeoutMs = 1000,
+          timeoutDurationMs = 250,
+          defaultCreationACL = ZooDefs.Ids.OPEN_ACL_UNSAFE))
       }
     }
   }


### PR DESCRIPTION
Backport of 19f147a (#6208)

- Add a test
- Introduce ZKUrl class and MasterConnectionInfo for more sanity and safer redaction
- We validate and parse arguments in to structured data classes whose
  toString method by default renders a redacted connection string.
- Remove extraneous methods
- Introduce ZkCredentials object

JIRA issues: MARATHON-7568
