### PR TITLE
Do not leak ZK credentials in /v2/info

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ We have stopped publishing native packages for operating system versions that ar
 
 Additionally, we have added support for Debian Stretch.
 
+### Fixed Issues
+
+- [MARATHON-7568](https://jira.mesosphere.com/browse/MARATHON-7568) - We now redact any Zookeeper credentials from the /v2/info response endpoint.
+
 ## Changes from 1.5.10 to 1.5.11
 
 ### Fixed issues

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -1,5 +1,7 @@
 package mesosphere.marathon
 
+import com.typesafe.scalalogging.StrictLogging
+import java.net.URL
 import mesosphere.marathon.core.appinfo.AppInfoConfig
 import mesosphere.marathon.core.deployment.DeploymentConfig
 import mesosphere.marathon.core.event.EventConf
@@ -16,7 +18,8 @@ import mesosphere.marathon.core.task.tracker.InstanceTrackerConfig
 import mesosphere.marathon.core.task.update.TaskStatusUpdateConfig
 import mesosphere.marathon.state.ResourceRole
 import mesosphere.marathon.storage.StorageConf
-import org.rogach.scallop.{ ScallopConf, ScallopOption }
+import org.rogach.scallop.{ ScallopConf, ScallopOption, ValueConverter }
+import reflect.runtime.universe.TypeTag
 
 import scala.sys.SystemProperties
 
@@ -38,11 +41,12 @@ trait MarathonConf
     with TaskJobsConfig with TaskStatusUpdateConfig with InstanceTrackerConfig with DeploymentConfig with ZookeeperConf
     with AppInfoConfig {
 
-  lazy val mesosMaster = opt[String](
+  import MarathonConf._
+  lazy val mesosMaster = opt[MesosMasterConnection](
     "master",
-    descr = "The URL of the Mesos master",
+    descr = "The URL of the Mesos master. Either http://host:port, or zk://host1:port1,host2:port2,.../path",
     required = true,
-    noshort = true)
+    noshort = true)(mesosMasterValueConverter)
 
   lazy val mesosLeaderUiUrl = opt[String](
     "mesos_leader_ui_url",
@@ -340,3 +344,74 @@ trait MarathonConf
   )
 }
 
+object MarathonConf extends StrictLogging {
+  sealed trait MesosMasterConnection {
+    def unredactedConnectionString: String
+    def redactedConnectionString: String
+    override def toString() = redactedConnectionString
+  }
+
+  object MesosMasterConnection {
+    case class Zk(zkUrl: ZookeeperConf.ZkUrl) extends MesosMasterConnection {
+      override def unredactedConnectionString = zkUrl.unredactedConnectionString
+      override def redactedConnectionString = zkUrl.toString()
+    }
+    case class Http(url: URL) extends MesosMasterConnection {
+      override def unredactedConnectionString = url.toString
+      /**
+        * Credentials are not provided via the URL
+        */
+      override def redactedConnectionString = url.toString
+    }
+    /**
+      * Describes a protocol-less connection string. Unfortunately, we did not strictly validate the Mesos master string
+      * in the past.
+      */
+    case class Unspecified(string: String) extends MesosMasterConnection {
+      override def unredactedConnectionString = string
+      /**
+        * Credentials are not provided via the URL
+        */
+      override def redactedConnectionString = toString
+    }
+  }
+
+  val httpUrlValueConverter = new ValueConverter[URL] {
+    val argType = org.rogach.scallop.ArgType.SINGLE
+    override val tag = implicitly[TypeTag[URL]]
+
+    def parse(s: List[(String, List[String])]): Either[String, Option[URL]] = s match {
+      case (_, urlString :: Nil) :: Nil =>
+        try Right(Some(new java.net.URL(urlString)))
+        catch {
+          case ex: IllegalArgumentException =>
+            return Left(s"${urlString} is not a valid URL")
+        }
+      case Nil =>
+        Right(None)
+      case other =>
+        Left("Expected exactly one url")
+    }
+  }
+
+  val mesosMasterValueConverter = new ValueConverter[MesosMasterConnection] {
+    val argType = org.rogach.scallop.ArgType.SINGLE
+    override val tag = implicitly[TypeTag[MesosMasterConnection]]
+
+    private val httpLike = "(?i)(^https?://.+)$".r
+    def parse(s: List[(String, List[String])]): Either[String, Option[MesosMasterConnection]] = s match {
+      case (_, zkUrlString :: Nil) :: Nil if zkUrlString.take(5).equalsIgnoreCase("zk://") =>
+        ZookeeperConf.ZkUrl.parse(zkUrlString).right.map { zkUrl => Some(MesosMasterConnection.Zk(zkUrl)) }
+      case (_, httpLike(httpUrlString) :: Nil) :: Nil =>
+        httpUrlValueConverter.parse(s).right.map { url => url.map(MesosMasterConnection.Http(_)) }
+      case (_, addressPort :: Nil) :: Nil =>
+        // localhost:5050 or 127.0.0.1:5050 or leader.mesos:5050
+        logger.warn(s"Specifying a Mesos Master connection without a protocol is deprecated and will likely be prohibited in the future. Please specify a protocol (http://, zk://, https://)")
+        Right(Some(MesosMasterConnection.Unspecified(addressPort)))
+      case Nil =>
+        Right(None)
+      case _ =>
+        Left("Expected exactly one connection string")
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -406,7 +406,7 @@ object MarathonConf extends StrictLogging {
         httpUrlValueConverter.parse(s).right.map { url => url.map(MesosMasterConnection.Http(_)) }
       case (_, addressPort :: Nil) :: Nil =>
         // localhost:5050 or 127.0.0.1:5050 or leader.mesos:5050
-        logger.warn(s"Specifying a Mesos Master connection without a protocol is deprecated and will likely be prohibited in the future. Please specify a protocol (http://, zk://, https://)")
+        logger.warn("Specifying a Mesos Master connection without a protocol is deprecated and will likely be prohibited in the future. Please specify a protocol (http://, zk://, https://)")
         Right(Some(MesosMasterConnection.Unspecified(addressPort)))
       case Nil =>
         Right(None)

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -28,7 +28,6 @@ import scala.util.control.NonFatal
 object ModuleNames {
   final val HOST_PORT = "HOST_PORT"
 
-  final val SERVER_SET_PATH = "SERVER_SET_PATH"
   final val HISTORY_ACTOR_PROPS = "HISTORY_ACTOR_PROPS"
 
   final val MESOS_HEARTBEAT_ACTOR = "MesosHeartbeatActor"
@@ -54,10 +53,6 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
     bind(classOf[SchedulerDriverFactory]).to(classOf[MesosSchedulerDriverFactory]).in(Scopes.SINGLETON)
     bind(classOf[MarathonSchedulerService]).in(Scopes.SINGLETON)
     bind(classOf[DeploymentService]).to(classOf[MarathonSchedulerService])
-
-    bind(classOf[String])
-      .annotatedWith(Names.named(ModuleNames.SERVER_SET_PATH))
-      .toInstance(conf.zooKeeperServerSetPath)
   }
 
   @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR)

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -112,7 +112,7 @@ class MarathonScheduler @Inject() (
   override def error(driver: SchedulerDriver, message: String): Unit = {
     log.warn(s"Error: $message\n" +
       "In case Mesos does not allow registration with the current frameworkId, " +
-      s"delete the ZooKeeper Node: ${config.zkPath}/state/framework:id\n" +
+      s"delete the ZooKeeper Node: ${config.zooKeeperUrl().path}/state/framework:id\n" +
       "CAUTION: if you remove this node, all tasks started with the current frameworkId will be orphaned!")
 
     // Currently, it's pretty hard to disambiguate this error from other causes of framework errors.

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerDriver.scala
@@ -89,10 +89,10 @@ object MarathonSchedulerDriver {
     val implicitAcknowledgements = false
     val newDriver: MesosSchedulerDriver = credential match {
       case Some(cred) =>
-        new MesosSchedulerDriver(newScheduler, frameworkInfo, config.mesosMaster(), implicitAcknowledgements, cred)
+        new MesosSchedulerDriver(newScheduler, frameworkInfo, config.mesosMaster().unredactedConnectionString, implicitAcknowledgements, cred)
 
       case None =>
-        new MesosSchedulerDriver(newScheduler, frameworkInfo, config.mesosMaster(), implicitAcknowledgements)
+        new MesosSchedulerDriver(newScheduler, frameworkInfo, config.mesosMaster().unredactedConnectionString, implicitAcknowledgements)
     }
 
     log.debug("Finished creating new driver", newDriver)

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -44,7 +44,7 @@ class InfoResource @Inject() (
     "leader_proxy_read_timeout_ms" -> config.leaderProxyReadTimeout.get,
     "local_port_max" -> config.localPortMax.get,
     "local_port_min" -> config.localPortMin.get,
-    "master" -> config.mesosMaster.get,
+    "master" -> config.mesosMaster().redactedConnectionString,
     "max_instances_per_offer" -> config.maxInstancesPerOffer.get,
     "mesos_bridge_name" -> config.mesosBridgeName.get,
     "mesos_heartbeat_failure_threshold" -> config.mesosHeartbeatFailureThreshold.get,
@@ -72,7 +72,7 @@ class InfoResource @Inject() (
 
   // ZooKeeper congiurations
   private[this] lazy val zookeeperConfigValues = Json.obj(
-    "zk" -> s"zk://${config.zkHosts}${config.zkPath}",
+    "zk" -> config.zooKeeperUrl().redactedConnectionString,
     "zk_compression" -> config.zooKeeperCompressionEnabled.get,
     "zk_compression_threshold" -> config.zooKeeperCompressionThreshold.get,
     "zk_connection_timeout" -> config.zooKeeperConnectionTimeout(),

--- a/src/test/scala/mesosphere/marathon/ZookeeperConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/ZookeeperConfTest.scala
@@ -11,26 +11,25 @@ class ZookeeperConfTest extends UnitTest {
     "urlParameterGetParsed" in {
       val url = "zk://host1:123,host2,host3:312/path"
       val opts = conf("--zk", url)
-      assert(opts.zkURL == url)
-      assert(opts.zkHosts == "host1:123,host2,host3:312")
-      assert(opts.zkPath == "/path")
-      assert(opts.zkUsername.isEmpty)
-      assert(opts.zkPassword.isEmpty)
+      assert(opts.zooKeeperUrl().unredactedConnectionString == url)
+      assert(opts.zooKeeperUrl().hostsString == "host1:123,host2,host3:312")
+      assert(opts.zooKeeperUrl().path == "/path")
+      assert(opts.zooKeeperUrl().credentials.isEmpty)
       assert(opts.zkDefaultCreationACL == ZooDefs.Ids.OPEN_ACL_UNSAFE)
     }
 
     "urlParameterWithAuthGetParsed" in {
       val url = "zk://user1:pass1@host1:123,host2,host3:312/path"
       val opts = conf("--zk", url)
-      assert(opts.zkURL == url)
-      assert(opts.zkHosts == "host1:123,host2,host3:312")
-      assert(opts.zkPath == "/path")
-      assert(opts.zkUsername == Some("user1"))
-      assert(opts.zkPassword == Some("pass1"))
+      assert(opts.zooKeeperUrl().unredactedConnectionString == url)
+      assert(opts.zooKeeperUrl().hostsString == "host1:123,host2,host3:312")
+      assert(opts.zooKeeperUrl().path == "/path")
+      assert(opts.zooKeeperUrl().credentials == Some(ZookeeperConf.ZkCreds("user1", "pass1")))
       assert(opts.zkDefaultCreationACL == ZooDefs.Ids.CREATOR_ALL_ACL)
     }
 
     "wrongURLIsNotParsed" in {
+      assert(Try(conf("--zk", "zk://host1:2181/path")).isSuccess, "Valid")
       assert(Try(conf("--zk", "zk://host1:foo/path")).isFailure, "No port number")
       assert(Try(conf("--zk", "zk://host1")).isFailure, "No path")
       assert(Try(conf("--zk", "zk://user@host1:2181/path")).isFailure, "No password")

--- a/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
@@ -6,7 +6,11 @@ import mesosphere.chaos.http.HttpConf
 import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.storage.repository.FrameworkIdRepository
-import mesosphere.util.state.MesosLeaderInfo
+import mesosphere.marathon.test.MarathonTestHelper
+import mesosphere.util.state.{ FrameworkId, MesosLeaderInfo }
+import play.api.libs.json.{ JsObject, JsString, Json }
+
+import scala.concurrent.Future
 
 class InfoResourceTest extends UnitTest {
 
@@ -37,12 +41,40 @@ class InfoResourceTest extends UnitTest {
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(f.auth.UnauthorizedStatus)
     }
+
+    "zk credentials are redacted" in {
+      Given("A request")
+      val f = new Fixture
+      f.leaderInfo.currentLeaderUrl returns Some("http://127.0.0.1:5050")
+      f.frameworkIdRepository.get returns Future.successful(Some(FrameworkId("dummy-uuid")))
+      f.electionService.isLeader returns true
+      f.electionService.leaderHostPort returns Some("127.0.0.1:8080")
+      f.auth.authenticated = true
+      f.auth.authorized = true
+      f.config = MarathonTestHelper.makeConfig(
+        "--master", "zk://root:password@127.0.0.1:2181/mesos",
+        "--zk", "zk://root:password@127.0.0.1:2181/marathon")
+      val resource = f.infoResource()
+
+      When("the info is fetched")
+      val response = resource.index(f.auth.request)
+
+      Then("there must not be the credentials in the Mesos ZK connection string")
+      response.getStatus should be(200)
+
+      val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+      parsedResponse should be (defined)
+      val responseObject = parsedResponse.get.asInstanceOf[JsObject]
+      (responseObject \ "marathon_config" \ "master").get.asInstanceOf[JsString].value shouldEqual "zk://xxxxxxxx:xxxxxxxx@127.0.0.1:2181/mesos"
+      (responseObject \ "zookeeper_config" \ "zk").get.asInstanceOf[JsString].value shouldEqual "zk://xxxxxxxx:xxxxxxxx@127.0.0.1:2181/marathon"
+    }
   }
+
   class Fixture {
     val leaderInfo = mock[MesosLeaderInfo]
     val electionService = mock[ElectionService]
     val auth = new TestAuthFixture
-    val config = mock[MarathonConf with HttpConf]
+    var config = mock[MarathonConf with HttpConf]
     val frameworkIdRepository = mock[FrameworkIdRepository]
 
     def infoResource() = new InfoResource(leaderInfo, frameworkIdRepository, electionService, auth.auth, auth.auth, config)

--- a/src/test/scala/mesosphere/marathon/core/election/impl/CuratorElectionServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/election/impl/CuratorElectionServiceTest.scala
@@ -24,11 +24,11 @@ class CuratorElectionServiceTest extends AkkaUnitTest with Eventually {
 
     "given an unresolvable hostname" should {
 
-      conf.zkHosts returns "unresolvable:8080"
+      conf.zooKeeperUrl returns ScallopStub(
+        Some(ZookeeperConf.ZkUrl(None, hosts = Seq("unresolvable:8080"), path = "/marathon")))
       conf.zooKeeperSessionTimeout returns ScallopStub(Some(10))
       conf.zooKeeperConnectionTimeout returns ScallopStub(Some(10))
       conf.zooKeeperTimeout returns ScallopStub(Some(10))
-      conf.zkPath returns "/marathon"
       conf.zkSessionTimeoutDuration returns 10000.milliseconds
       conf.zkConnectionTimeoutDuration returns 10000.milliseconds
       conf.zkTimeoutDuration returns 250.milliseconds


### PR DESCRIPTION
Backport of 19f147a (#6208)

- Add a test
- Introduce ZKUrl class and MasterConnectionInfo for more sanity and safer redaction
- We validate and parse arguments in to structured data classes whose
  toString method by default renders a redacted connection string.
- Remove extraneous methods
- Introduce ZkCredentials object

JIRA issues: MARATHON-7568
