### PR TITLE
Crash if ZK DNS is not resolvable

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreBenchmark.scala
@@ -8,7 +8,7 @@ import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.{ActorMaterializer, Materializer}
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import mesosphere.marathon.core.base.LifecycleState
+import mesosphere.marathon.core.base.{JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.storage.{CuratorZk, StorageConf}
 import mesosphere.marathon.storage.repository.StoredGroup
@@ -32,7 +32,7 @@ object ZkPersistenceStoreBenchmark {
   }
   Conf.verify()
   val lifecycleState = LifecycleState.WatchingJVM
-  val curator = CuratorZk(Conf, lifecycleState)
+  val curator = CuratorZk(Conf, lifecycleState, JvmExitsCrashStrategy)
   val metrics = DummyMetrics
   val zkStore = curator.leafStore(metrics)
 

--- a/benchmark/src/main/scala/mesosphere/marathon/core/storage/zookeeper/ZooKeeperPersistenceStoreBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/core/storage/zookeeper/ZooKeeperPersistenceStoreBenchmark.scala
@@ -128,6 +128,8 @@ class ZooKeeperPersistenceStoreBenchmark {
         .map(_ => Node(randomPath("/tests"), ByteString(Random.alphanumeric.take(size).mkString)))
         .via(store.createFlow)
         .runWith(Sink.ignore), Duration.Inf)
+
+    hole.consume(res)
   }
 
   @Benchmark

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -153,7 +153,8 @@ class CoreModuleImpl @Inject() (
   override lazy val storageModule = StorageModule(
     metricsModule.metrics,
     marathonConf,
-    lifecycleState)(
+    lifecycleState,
+    crashStrategy)(
       actorsModule.materializer,
       storageExecutionContext,
       actorSystem.scheduler,

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -46,7 +46,7 @@ private[marathon] class InstanceUpdateOpResolver(
       case op: GoalChange =>
         updateExistingInstance(op.instanceId)(i => {
           val updatedInstance = i.copy(state = i.state.copy(goal = op.goal))
-          val events = InstanceChangedEventsGenerator.events(updatedInstance, task = None, clock.now(), previousCondition = Some(i.state.condition))
+          val _ = InstanceChangedEventsGenerator.events(updatedInstance, task = None, clock.now(), previousCondition = Some(i.state.condition))
 
           logger.debug(s"Updating goal of instance ${i.instanceId} to ${op.goal}")
           InstanceUpdateEffect.Update(updatedInstance, oldState = Some(i), events = Nil)

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -46,7 +46,7 @@ private[marathon] class InstanceUpdateOpResolver(
       case op: GoalChange =>
         updateExistingInstance(op.instanceId)(i => {
           val updatedInstance = i.copy(state = i.state.copy(goal = op.goal))
-          val _ = InstanceChangedEventsGenerator.events(updatedInstance, task = None, clock.now(), previousCondition = Some(i.state.condition))
+          val events = InstanceChangedEventsGenerator.events(updatedInstance, task = None, clock.now(), previousCondition = Some(i.state.condition))
 
           logger.debug(s"Updating goal of instance ${i.instanceId} to ${op.goal}")
           InstanceUpdateEffect.Update(updatedInstance, oldState = Some(i), events = Nil)

--- a/src/main/scala/mesosphere/marathon/core/storage/backup/Backup.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/backup/Backup.scala
@@ -8,7 +8,7 @@ import akka.stream.ActorMaterializer
 import ch.qos.logback.classic.{Level, Logger}
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
-import mesosphere.marathon.core.base.LifecycleState
+import mesosphere.marathon.core.base.{JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.metrics.MetricsConf
 import mesosphere.marathon.storage.{StorageConf, StorageModule}
 import org.rogach.scallop.ScallopConf
@@ -43,7 +43,7 @@ abstract class BackupRestoreAction extends StrictLogging {
     metricsModule.start(system)
 
     try {
-      val storageModule = StorageModule(metricsModule.metrics, conf, LifecycleState.WatchingJVM)
+      val storageModule = StorageModule(metricsModule.metrics, conf, LifecycleState.WatchingJVM, JvmExitsCrashStrategy)
       storageModule.persistenceStore.markOpen()
       val backup = storageModule.persistentStoreBackup
       Await.result(fn(backup), Duration.Inf)

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -7,7 +7,7 @@ import java.util.Collections
 
 import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.Materializer
-import mesosphere.marathon.core.base.LifecycleState
+import mesosphere.marathon.core.base.{CrashStrategy, LifecycleState}
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
 import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
@@ -110,6 +110,7 @@ case class CuratorZk(
     versionCacheConfig: Option[VersionCacheConfig],
     availableFeatures: Set[String],
     lifecycleState: LifecycleState,
+    crashStrategy: CrashStrategy,
     defaultNetworkName: Option[String],
     backupLocation: Option[URI]
 ) extends PersistenceStorageConfig[ZkId, String, ZkSerialized] {
@@ -131,8 +132,9 @@ case class CuratorZk(
     builder.retryPolicy(retryPolicy)
     builder.namespace(zkUrl.path.stripPrefix("/"))
     val client = RichCuratorFramework(builder.build())
+
     client.start()
-    client.blockUntilConnected(lifecycleState)
+    client.blockUntilConnected(lifecycleState, crashStrategy)
 
     // make sure that we read up-to-date values from ZooKeeper
     Await.ready(client.sync("/"), Duration.Inf)
@@ -155,7 +157,7 @@ case class CuratorZk(
 
 object CuratorZk {
   val StoreName = "zk"
-  def apply(conf: StorageConf, lifecycleState: LifecycleState): CuratorZk =
+  def apply(conf: StorageConf, lifecycleState: LifecycleState, crashStrategy: CrashStrategy): CuratorZk =
     CuratorZk(
       cacheType = if (conf.storeCache()) LazyCaching else NoCaching,
       sessionTimeout = Some(conf.zkSessionTimeoutDuration),
@@ -175,6 +177,7 @@ object CuratorZk {
       availableFeatures = conf.availableFeatures,
       backupLocation = conf.backupLocation.toOption,
       lifecycleState = lifecycleState,
+      crashStrategy = crashStrategy,
       defaultNetworkName = conf.defaultNetworkName.toOption
     )
 }
@@ -207,10 +210,10 @@ object InMem {
 object StorageConfig {
   val DefaultVersionCacheConfig = Option(VersionCacheConfig.Default)
 
-  def apply(conf: StorageConf, lifecycleState: LifecycleState): StorageConfig = {
+  def apply(conf: StorageConf, lifecycleState: LifecycleState, crashStrategy: CrashStrategy): StorageConfig = {
     conf.internalStoreBackend() match {
       case InMem.StoreName => InMem(conf)
-      case CuratorZk.StoreName => CuratorZk(conf, lifecycleState)
+      case CuratorZk.StoreName => CuratorZk(conf, lifecycleState, crashStrategy)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -3,7 +3,7 @@ package storage
 
 import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.Materializer
-import mesosphere.marathon.core.base.LifecycleState
+import mesosphere.marathon.core.base.{CrashStrategy, LifecycleState}
 import mesosphere.marathon.core.storage.backup.PersistentStoreBackup
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.cache.LoadTimeCachingPersistenceStore
@@ -13,7 +13,6 @@ import mesosphere.marathon.storage.repository._
 
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
-//import scala.language.existentials
 
 /**
   * Provides the repositories for all persistable entities.
@@ -32,11 +31,11 @@ trait StorageModule {
 }
 
 object StorageModule {
-  def apply(metrics: Metrics, conf: StorageConf with NetworkConf, lifecycleState: LifecycleState)(
+  def apply(metrics: Metrics, conf: StorageConf with NetworkConf, lifecycleState: LifecycleState, crashStrategy: CrashStrategy)(
     implicit
     mat: Materializer, ctx: ExecutionContext,
     scheduler: Scheduler, actorSystem: ActorSystem): StorageModule = {
-    val currentConfig = StorageConfig(conf, lifecycleState)
+    val currentConfig = StorageConfig(conf, lifecycleState, crashStrategy)
     apply(metrics, currentConfig, conf.mesosBridgeName())
   }
 

--- a/src/test/scala/mesosphere/marathon/util/ZookeeperServer.scala
+++ b/src/test/scala/mesosphere/marathon/util/ZookeeperServer.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package util
 
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.base.LifecycleState
+import mesosphere.marathon.core.base.{JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.core.storage.store.impl.zk.{NoRetryPolicy, RichCuratorFramework}
 import mesosphere.util.PortAllocator
 import org.apache.curator.RetryPolicy
@@ -95,7 +95,7 @@ trait ZookeeperServerTest extends BeforeAndAfterAll { this: Suite with ScalaFutu
     val client: CuratorFramework = CuratorFrameworkFactory.newClient(zkServer.connectUri, retryPolicy)
     client.start()
     val richClient: RichCuratorFramework = RichCuratorFramework(client)
-    richClient.blockUntilConnected(LifecycleState.WatchingJVM)
+    richClient.blockUntilConnected(LifecycleState.WatchingJVM, JvmExitsCrashStrategy)
     val namespacedClient = namespace.fold(client) { ns =>
       richClient.create(s"/$namespace").futureValue(PatienceConfiguration.Timeout(10.seconds))
       client.usingNamespace(ns)


### PR DESCRIPTION
Summary:
Currently, if Marathon can't connect to ZK because its name is resolvable, Guice will reinstantiate `StorageModule` N times, effectively retrying to connect to ZK N times. Marathon will eventually exit with exitCode=137 but it takes ~5min with default settings. With this change, we crash on the first error.

Related JIRA: DCOS-39846, COPS-3593, MARATHON-7390