### PR TITLE
Reschedule instance with provision timeout.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -80,7 +80,7 @@ class TaskReplaceActor(
       // kill the 2 running instances and only tell the [[TaskLauncherActor]] to start the 3 scheduled v1 instances with
       // the v2 run spec. We then schedule 2 more v2 instances. In the future we probably want to bind instances to a
       // certain run spec. Until then we have to update the run spec in a [[TaskLauncherActor]]
-      val synced = await(launchQueue.sync(runSpec))
+      await(launchQueue.sync(runSpec))
 
       // kill old instances to free some capacity
       for (_ <- 0 until ignitionStrategy.nrToKillImmediately) killNextOldInstance()

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -78,6 +78,16 @@ case class Instance(
   override def region: Option[String] = agentInfo.flatMap(_.region)
 
   /**
+    * Factory method for creating a scheduled instance from this instance.
+    *
+    * @return new instance with same id in scheduled state.
+    */
+  def rescheduled(): Instance = {
+    val state = InstanceState(Condition.Scheduled, Timestamp.now(), None, None, Goal.Running)
+    Instance(instanceId, None, state, Map.empty, version, unreachableStrategy, None)
+  }
+
+  /**
     * Factory method for creating provisioned instance from Scheduled instance for apps
     * @return new instance in a provisioned state
     */

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -78,16 +78,6 @@ case class Instance(
   override def region: Option[String] = agentInfo.flatMap(_.region)
 
   /**
-    * Factory method for creating a scheduled instance from this instance.
-    *
-    * @return new instance with same id in scheduled state.
-    */
-  def rescheduled(): Instance = {
-    val state = InstanceState(Condition.Scheduled, Timestamp.now(), None, None, Goal.Running)
-    Instance(instanceId, None, state, Map.empty, version, unreachableStrategy, None)
-  }
-
-  /**
     * Factory method for creating provisioned instance from Scheduled instance for apps
     * @return new instance in a provisioned state
     */

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -64,7 +64,7 @@ private[launchqueue] object TaskLauncherActor {
 
   case object Stop extends Requests
 
-  private val OfferOperationRejectedTimeoutReason: String =
+  val OfferOperationRejectedTimeoutReason: String =
     "InstanceLauncherActor: no accept received within timeout. " +
       "You can reconfigure the timeout with --task_operation_notification_timeout."
 }
@@ -217,6 +217,7 @@ private class TaskLauncherActor(
             * The rescheduled instance forgets about all tasks. If these tasks do come back in an update they a killed.
             * See [[mesosphere.marathon.core.task.update.impl.TaskStatusUpdateProcessorImpl.publish()]] for the logic.
             */
+          logger.info(s"Reschedule ${instance.instanceId} because of provision timeout.")
           instanceTracker.schedule(instance.rescheduled())
         }
       }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -206,6 +206,7 @@ private class TaskLauncherActor(
     case RecheckIfBackOffUntilReached => OfferMatcherRegistration.manageOfferMatcherStatus()
   }
 
+  @SuppressWarnings(Array("all")) // async/await
   private[this] def receiveTaskLaunchNotification: Receive = {
     case InstanceOpSourceDelegate.InstanceOpRejected(op, TaskLauncherActor.OfferOperationRejectedTimeoutReason) =>
       import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -208,7 +208,6 @@ private class TaskLauncherActor(
   @SuppressWarnings(Array("all")) // async/await
   private[this] def receiveTaskLaunchNotification: Receive = {
     case InstanceOpSourceDelegate.InstanceOpRejected(op, TaskLauncherActor.OfferOperationRejectedTimeoutReason) =>
-      import scala.concurrent.ExecutionContext.Implicits.global
       // Reschedule instance if provisioning timed out and the instance is not running yet.
       if (inFlightInstanceOperations.exists(_.instanceId == op.instanceId)) {
         instanceMap.get(op.instanceId).foreach { instance =>

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -25,7 +25,6 @@ import org.apache.mesos.{Protos => Mesos}
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._
-import scala.async.Async.{await, async}
 
 private[launchqueue] object TaskLauncherActor {
   def props(

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -7,7 +7,6 @@ import akka.Done
 import akka.actor._
 import akka.event.LoggingReceive
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceDeleted, InstanceUpdateOperation}

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -218,7 +218,7 @@ private class TaskLauncherActor(
             * See [[mesosphere.marathon.core.task.update.impl.TaskStatusUpdateProcessorImpl.publish()]] for the logic.
             */
           logger.info(s"Reschedule ${instance.instanceId} because of provision timeout.")
-          instanceTracker.schedule(instance.rescheduled())
+          instanceTracker.forceExpunge(instance.instanceId)
         }
       }
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -211,12 +211,7 @@ private class TaskLauncherActor(
       if (inFlightInstanceOperations.exists(_.instanceId == op.instanceId)) {
         instanceMap.get(op.instanceId).foreach { instance =>
 
-          /**
-            * We don't await the future. It will trigger an instance update event.
-            *
-            * The rescheduled instance forgets about all tasks. If these tasks do come back in an update they a killed.
-            * See [[mesosphere.marathon.core.task.update.impl.TaskStatusUpdateProcessorImpl.publish()]] for the logic.
-            */
+          // We don't await the future. It will trigger an instance update event.
           logger.info(s"Reschedule ${instance.instanceId} because of provision timeout.")
           instanceTracker.forceExpunge(instance.instanceId)
         }

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -33,6 +33,7 @@ abstract case class Timestamp private (private val instant: Instant) extends Ord
   def toInstant: Instant = instant
 
   def millis: Long = toInstant.toEpochMilli
+  def seconds: Long = TimeUnit.MILLISECONDS.toSeconds(millis)
   def micros: Long = TimeUnit.MILLISECONDS.toMicros(millis)
   def nanos: Long = TimeUnit.MILLISECONDS.toNanos(millis)
 

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -500,10 +500,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
 
       Then("the instance is rescheduled")
       eventually {
-        val captor = ArgumentCaptor.forClass(classOf[Instance])
-        verify(instanceTracker).schedule(captor.capture())
-        captor.getValue.instanceId should be(provisionedInstance.instanceId)
-        captor.getValue.state.condition should be(Condition.Scheduled)
+        verify(instanceTracker).forceExpunge(provisionedInstance.instanceId)
       }
     }
 
@@ -525,7 +522,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       Then("the instance is not rescheduled")
       // Wait for all messages being handled.
       (launcherRef ? TaskLauncherActor.GetCount).futureValue.asInstanceOf[QueuedInstanceInfo]
-      verify(instanceTracker, never).schedule(any[Instance])
+      verify(instanceTracker, never).forceExpunge(any[Instance.Id])
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -5,12 +5,11 @@ import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.testkit.TestProbe
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceUpdated}
-import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder, TestTaskBuilder}
+import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.launcher.impl.InstanceOpFactoryHelper
 import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfo

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -12,11 +12,11 @@ import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceUpdated}
 import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.launcher.impl.InstanceOpFactoryHelper
-import mesosphere.marathon.core.launcher.{InstanceOpFactory, OfferMatchResult}
+import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfo
 import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
 import mesosphere.marathon.core.matcher.base.OfferMatcher.MatchedInstanceOps
-import mesosphere.marathon.core.matcher.base.util.ActorOfferMatcher
+import mesosphere.marathon.core.matcher.base.util.{ActorOfferMatcher, InstanceOpSourceDelegate}
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
@@ -28,6 +28,7 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.test.MarathonTestHelper
 import org.mockito
 import org.mockito.{ArgumentCaptor, Mockito}
+import org.scalatest.concurrent.Eventually
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Promise
@@ -42,7 +43,7 @@ import scala.concurrent.duration._
   * * tracking task status
   * * timeout for task launching feedback
   */
-class TaskLauncherActorTest extends AkkaUnitTest {
+class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
 
   import org.mockito.{Matchers => m}
 
@@ -477,6 +478,54 @@ class TaskLauncherActorTest extends AkkaUnitTest {
 
         verifyClean()
       }
+    }
+
+    "reschedule instance on provision timeout" in new Fixture {
+      Given("a provisioned instance")
+      val scheduledInstance = Instance.scheduled(f.app)
+      val provisionedInstance = Instance.scheduled(f.app)
+        .copy(state = Instance.InstanceState(Condition.Provisioned, clock.now(), None, None, Goal.Running))
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(scheduledInstance, provisionedInstance))
+
+      val launcherRef = createLauncherRef()
+      launcherRef ! RateLimiterActor.DelayUpdate(f.app, clock.now())
+
+      // wait for startup
+      (launcherRef ? TaskLauncherActor.GetCount).futureValue.asInstanceOf[QueuedInstanceInfo]
+
+      When("the provision times out")
+      val op = mock[InstanceOp]
+      op.instanceId returns provisionedInstance.instanceId
+      launcherRef ! InstanceOpSourceDelegate.InstanceOpRejected(op, TaskLauncherActor.OfferOperationRejectedTimeoutReason)
+
+      Then("the instance is rescheduled")
+      eventually {
+        val captor = ArgumentCaptor.forClass(classOf[Instance])
+        verify(instanceTracker).schedule(captor.capture())
+        captor.getValue.instanceId should be(provisionedInstance.instanceId)
+        captor.getValue.state.condition should be(Condition.Scheduled)
+      }
+    }
+
+    "not reschedule instance on provision time out for a running instance" in new Fixture {
+      Given("a running instance")
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.marathonInstance))
+
+      val launcherRef = createLauncherRef()
+      launcherRef ! RateLimiterActor.DelayUpdate(f.app, clock.now())
+
+      // wait for startup
+      (launcherRef ? TaskLauncherActor.GetCount).futureValue.asInstanceOf[QueuedInstanceInfo]
+
+      When("the provision times out")
+      val op = mock[InstanceOp]
+      op.instanceId returns f.marathonInstance.instanceId
+      launcherRef ! InstanceOpSourceDelegate.InstanceOpRejected(op, TaskLauncherActor.OfferOperationRejectedTimeoutReason)
+
+      Then("the instance is not rescheduled")
+      // Wait for all messages being handled.
+      (launcherRef ? TaskLauncherActor.GetCount).futureValue.asInstanceOf[QueuedInstanceInfo]
+      verify(instanceTracker, never).schedule(any[Instance])
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/bus/MesosTaskStatusTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/MesosTaskStatusTestHelper.scala
@@ -20,11 +20,10 @@ object MesosTaskStatusTestHelper {
     timestamp: Timestamp = Timestamp.zero,
     taskId: Task.Id = Task.EphemeralOrReservedTaskId(newInstanceId(), None)): TaskStatus = {
 
-    val seconds = timestamp.millis / 1000
     val mesosStatus = TaskStatus.newBuilder
       .setTaskId(taskId.mesosTaskId)
       .setState(state)
-      .setTimestamp(seconds.toDouble)
+      .setTimestamp(timestamp.seconds.toDouble)
     maybeHealthy.foreach(mesosStatus.setHealthy)
     maybeReason.foreach(mesosStatus.setReason)
     maybeMessage.foreach(mesosStatus.setMessage)


### PR DESCRIPTION
Summary:
This reintroduced launch operation timeouts. If Mesos does not confirm a
task launch in time we reschedule the instance and forget about its old tasks.

JIRA issues: MARATHON-8351