### PR TITLE
Wait for the cluster to respond before proceeding with SI tests

### DIFF
--- a/tests/shakedown/shakedown/cli/main.py
+++ b/tests/shakedown/shakedown/cli/main.py
@@ -86,13 +86,13 @@ def cli(**args):
     # Making sure that the cluster url is reachable before proceeding
     def cluster_available_predicate(url):
         try:
-            response = http.get(url)
+            response = http.get(url, verify=False)
             return response.status_code == 200
         except Exception as e:
             return False
 
     echo('Waiting for DC/OS cluster to respond...', d='step-min')
-    time_wait(lambda: cluster_available_predicate(args['dcos_url']))
+    time_wait(lambda: cluster_available_predicate(args['dcos_url']), timeout_seconds=300)
 
     if shakedown.attach_cluster(args['dcos_url']):
         echo('Checking DC/OS cluster version...', d='step-min', n=False)

--- a/tests/shakedown/shakedown/cli/main.py
+++ b/tests/shakedown/shakedown/cli/main.py
@@ -6,7 +6,8 @@ import sys
 
 from shakedown.cli.helpers import *
 from shakedown.dcos import dcos_url
-
+from dcos import http
+from shakedown.dcos.spinner import *
 
 @click.command('shakedown')
 @click.argument('tests', nargs=-1)
@@ -63,7 +64,7 @@ def cli(**args):
 
     echo('Running pre-flight checks...', d='step-maj')
 
-    # required modules and their 'version' method
+    # Required modules and their 'version' method
     imported = {}
     requirements = {
         'pytest': '__version__',
@@ -81,6 +82,17 @@ def cli(**args):
             sys.exit(1)
 
         echo(getattr(imported[req], requirements[req]))
+
+    # Making sure that the cluster url is reachable before proceeding
+    def cluster_available_predicate(url):
+        try:
+            response = http.get(url)
+            return response.status_code == 200
+        except Exception as e:
+            return False
+
+    echo('Waiting for DC/OS cluster to respond...', d='step-min')
+    time_wait(lambda: cluster_available_predicate(args['dcos_url']))
 
     if shakedown.attach_cluster(args['dcos_url']):
         echo('Checking DC/OS cluster version...', d='step-min', n=False)

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -773,6 +773,18 @@ def test_pod_file_based_secret(secret_fixture):
     value_check()
 
 
+# Uncomment to run a quick and sure-to-pass SI test on any cluster
+# def test_foo():
+#     client = marathon.create_client()
+#     app_def = apps.sleep_app()
+#     app_id = app_def['id']
+#     client.add_app(app_def)
+#     common.deployment_wait(service_id=app_id)
+
+#     tasks = client.get_tasks(app_id)
+#     assert len(tasks) == 1, 'Failed to start a simple sleep app'
+
+
 @pytest.fixture(scope="function")
 def secret_fixture():
     if not common.is_enterprise_cli_package_installed():

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -773,7 +773,7 @@ def test_pod_file_based_secret(secret_fixture):
     value_check()
 
 
-# Uncomment to run a quick and sure-to-pass SI test on any cluster
+# Uncomment to run a quick and sure-to-pass SI test on any cluster. Useful for running SI tests locally
 # def test_foo():
 #     client = marathon.create_client()
 #     app_def = apps.sleep_app()


### PR DESCRIPTION
this should fix SI failures where the cluster is seemingly not available after being created.

