### PR TITLE
Do not update DCOS PR for 1.6

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -229,9 +229,6 @@ def master(): Unit = {
 
   // Uploads
   val maybeArtifact = uploadTarballPackagesToS3(version, s"builds/$version")
-  maybeArtifact.foreach { artifact =>
-    updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
-  }
 }
 
 /**


### PR DESCRIPTION
Right now the PR contains both 1.6 and 1.7 versions, which is not correct. It should be just master.