### PR TITLE
Fix a `StackOverflowError` when GETin `v2/info` when running locally

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -354,7 +354,7 @@ object MarathonConf extends StrictLogging {
       /**
         * Credentials are not provided via the URL
         */
-      override def redactedConnectionString = toString
+      override def redactedConnectionString = string
     }
   }
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/SystemResourceIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/SystemResourceIntegrationTest.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
 class SystemResourceIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
   "Marathon" should {
-    "responses to a ping" in {
+    "respond to a ping" in {
 
       When("The system is pinged")
       val result = marathon.ping()


### PR DESCRIPTION
Summary:
When previously started locally with a Mesos connection string like `127.0.0.1:5050` Marathon would throw a `StackOverflowError` when GETing the `v2/info` which was caused by a recursive method call.