### PR TITLE
Fix a `StackOverflowError` when GETin `v2/info` when running locally …

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -372,7 +372,7 @@ object MarathonConf extends StrictLogging {
       /**
         * Credentials are not provided via the URL
         */
-      override def redactedConnectionString = toString
+      override def redactedConnectionString = string
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/integration/SystemResourceIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/SystemResourceIntegrationTest.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
 class SystemResourceIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
   "Marathon" should {
-    "responses to a ping" in {
+    "respond to a ping" in {
 
       When("The system is pinged")
       val result = marathon.ping()


### PR DESCRIPTION
…(#6424)

When previously started locally with a mesos connection string like `127.0.0.1:5050` Marathon would throw an `StackOverflowError` when GETing the `v2/info`.

JIRA issues: