### PR TITLE
Fix waiting for service endpoints in SI tests

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -21,7 +21,6 @@ from shakedown.dcos.master import get_all_master_ips
 from dcos.http import DCOSAcsAuth
 from functools import lru_cache
 from fixtures import get_ca_file
-from requests.exceptions import ReadTimeout
 from shakedown.dcos.cluster import ee_version
 from matcher import assert_that, eventually, has_len
 from precisely import equal_to

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -868,6 +868,7 @@ def wait_for_service_endpoint(service_name, timeout_sec=120, path=""):
         return response.status_code
 
     schema = 'https' if ee_version() == 'strict' or ee_version() == 'permissive' else 'http'
+    print('Waiting for service /service/{}/{} to become available on all masters'.format(service_name, path))
 
     for ip in dcos_masters_public_ips():
         url = "{}://{}/service/{}/{}".format(schema, ip, service_name, path)

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -24,6 +24,7 @@ from fixtures import get_ca_file
 from requests.exceptions import ReadTimeout
 from shakedown.dcos.cluster import ee_version
 from matcher import assert_that, eventually, has_len
+from precisely import equal_to
 
 marathon_1_3 = pytest.mark.skipif('marthon_version_less_than("1.3")')
 marathon_1_4 = pytest.mark.skipif('marthon_version_less_than("1.4")')
@@ -856,30 +857,20 @@ def wait_for_service_endpoint(service_name, timeout_sec=120, path=""):
         else:
             return False
 
-    @retrying.retry(
-            wait_fixed=1000,
-            stop_max_attempt_number=timeout_sec/5,  # underlying http.get has 5 seconds timeout, so we have to scale it
-            retry_on_exception=ignore_provided_exception(DCOSException))
-    def check_service_availability_on_master(master_ip, service):
-
-        schema = 'https' if ee_version() == 'strict' or ee_version() == 'permissive' else 'http'
-
-        url = "{}://{}/service/{}/{}".format(schema, master_ip, service, path)
-
+    def master_service_status_code(url):
         auth = DCOSAcsAuth(shakedown.dcos_acs_token())
-        try:
-            response = requests.get(
-                url=url,
-                timeout=5,
-                auth=auth,
-                verify=verify_ssl())
-        except ReadTimeout as e:
-            raise DCOSException("service " + service_name + " is unavailable at " + master_ip)
 
-        if response.status_code == 200:
-            return True
-        else:
-            print(response)
-            raise DCOSException("service " + service_name + " is unavailable at " + master_ip)
+        response = requests.get(
+            url=url,
+            timeout=5,
+            auth=auth,
+            verify=verify_ssl())
 
-    return all(check_service_availability_on_master(ip, service_name) for ip in dcos_masters_public_ips())
+        return response.status_code
+
+    schema = 'https' if ee_version() == 'strict' or ee_version() == 'permissive' else 'http'
+
+    for ip in dcos_masters_public_ips():
+        url = "{}://{}/service/{}/{}".format(schema, ip, service_name, path)
+        print('\nWaiting for {} to become available...'.format(url))
+        assert_that(lambda: master_service_status_code(url), eventually(equal_to(200), max_attempts=timeout_sec/5))

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -871,5 +871,4 @@ def wait_for_service_endpoint(service_name, timeout_sec=120, path=""):
 
     for ip in dcos_masters_public_ips():
         url = "{}://{}/service/{}/{}".format(schema, ip, service_name, path)
-        print('\nWaiting for {} to become available...'.format(url))
         assert_that(lambda: master_service_status_code(url), eventually(equal_to(200), max_attempts=timeout_sec/5))

--- a/tests/system/dcos_service_marathon_tests.py
+++ b/tests/system/dcos_service_marathon_tests.py
@@ -29,8 +29,7 @@ def test_deploy_custom_framework():
     client.add_app(app_def)
     common.deployment_wait(service_id=app_id, max_attempts=300)
 
-    assert common.wait_for_service_endpoint('pyfw', timedelta(minutes=5).total_seconds()), \
-        "The framework has not showed up"
+    common.wait_for_service_endpoint('pyfw', timedelta(minutes=5).total_seconds())
 
 
 def test_framework_readiness_time_check():

--- a/tests/system/matcher/eventually.py
+++ b/tests/system/matcher/eventually.py
@@ -30,7 +30,7 @@ class Eventually(Matcher):
             return unmatched(explanation)
 
     def describe(self):
-        return "eventually {}".format(self.matcher.describe())
+        return "eventually {}".format(self._matcher.describe())
 
 
 def eventually(matcher, wait_fixed=1000, max_attempts=3):

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -50,9 +50,6 @@ for attribute in dir(marathon_pods_tests):
         exec("from marathon_pods_tests import {}".format(attribute))
 
 
-pytestmark = [pytest.mark.usefixtures('wait_for_marathon_and_cleanup')]
-
-
 @pytest.fixture(scope="function")
 def marathon_service_name():
     return "marathon"

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -50,6 +50,9 @@ for attribute in dir(marathon_pods_tests):
         exec("from marathon_pods_tests import {}".format(attribute))
 
 
+pytestmark = [pytest.mark.usefixtures('wait_for_marathon_and_cleanup')]
+
+
 @pytest.fixture(scope="function")
 def marathon_service_name():
     return "marathon"

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -70,7 +70,7 @@ def test_custom_service_name():
     shakedown.install_package('marathon', options_json=options)
     common.deployment_wait(service_id=options["service"]["name"], max_attempts=300)
 
-    assert common.wait_for_service_endpoint('test-marathon', path="ping", timeout_sec=300)
+    common.wait_for_service_endpoint('test-marathon', timeout_sec=300, path="ping")
 
 
 @pytest.fixture(


### PR DESCRIPTION
Summary:
Turns out, we weren't really waiting for the service in some cases e.g. in case of a `ConnectionError`. I fixed that problem and reworked the code be reader-friendly and use our new `eventually` matcher.