### PR TITLE
Fix the log line printed when gpu resources are not wasted

### DIFF
--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -266,9 +266,12 @@ object ResourceMatcher extends StrictLogging {
           if (gpuResourcesAreWasted && noPersistentVolumeToMatch) {
             noOfferMatchReasons += NoOfferMatchReason.DeclinedScarceResources
             false
-          } else {
+          } else if (noPersistentVolumeToMatch) {
             addOnMatch(() => logger.info(s"Runspec [${runSpec.id}] doesn't require any GPU resources but " +
               "will be launched on an agent with GPU resources due to required persistent volume."))
+            true
+          } else {
+            // we are ust wasting resources but we don't have any volumes
             true
           }
 

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -263,15 +263,14 @@ object ResourceMatcher extends StrictLogging {
 
         case GpuSchedulingBehavior.Restricted =>
           val noPersistentVolumeToMatch = PersistentVolumeMatcher.matchVolumes(offer, reservedInstances).isEmpty
-          if (gpuResourcesAreWasted && noPersistentVolumeToMatch) {
+          if (!gpuResourcesAreWasted) {
+            true
+          } else if (gpuResourcesAreWasted && noPersistentVolumeToMatch) {
             noOfferMatchReasons += NoOfferMatchReason.DeclinedScarceResources
             false
-          } else if (noPersistentVolumeToMatch) {
+          } else {
             addOnMatch(() => logger.info(s"Runspec [${runSpec.id}] doesn't require any GPU resources but " +
               "will be launched on an agent with GPU resources due to required persistent volume."))
-            true
-          } else {
-            // we are ust wasting resources but we don't have any volumes
             true
           }
 


### PR DESCRIPTION
Right now we print that we are launching on a reservation even if GPU resources are not wasted.

JIRA issues: MARATHON-8183
