### PR TITLE
Crash if ZK DNS is not resolvable (#6412)

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPresistenceStoreBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPresistenceStoreBenchmark.scala
@@ -7,7 +7,7 @@ import akka.Done
 import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.{ActorMaterializer, Materializer}
 import scala.concurrent.ExecutionContext.Implicits.global
-import mesosphere.marathon.core.base.LifecycleState
+import mesosphere.marathon.core.base.{JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.storage.{CuratorZk, StorageConf}
 import mesosphere.marathon.storage.repository.StoredGroup
 import mesosphere.marathon.storage.store.ZkStoreSerialization
@@ -30,7 +30,7 @@ object ZkPresistenceStoreBenchmark {
   }
   Conf.verify()
   val lifecycleState = LifecycleState.WatchingJVM
-  val curator = CuratorZk(Conf, lifecycleState)
+  val curator = CuratorZk(Conf, lifecycleState, JvmExitsCrashStrategy)
   val zkStore = curator.leafStore
 
   val rootGroup = DependencyGraphBenchmark.rootGroup

--- a/benchmark/src/main/scala/mesosphere/marathon/core/storage/zookeeper/ZooKeeperPersistenceStoreBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/core/storage/zookeeper/ZooKeeperPersistenceStoreBenchmark.scala
@@ -125,6 +125,8 @@ class ZooKeeperPersistenceStoreBenchmark {
         .map(_ => Node(randomPath("/tests"), ByteString(Random.alphanumeric.take(size).mkString)))
         .via(store.createFlow)
         .runWith(Sink.ignore), Duration.Inf)
+
+    hole.consume(res)
   }
 
   @Benchmark

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -3,11 +3,11 @@ package core
 
 import java.time.Clock
 import java.util.concurrent.Executors
-import javax.inject.Named
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.event.EventStream
 import com.google.inject.{Inject, Provider}
+import javax.inject.Named
 import mesosphere.marathon.core.auth.AuthModule
 import mesosphere.marathon.core.base.{ActorsModule, JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.core.deployment.DeploymentModule
@@ -88,7 +88,8 @@ class CoreModuleImpl @Inject() (
   override lazy val taskJobsModule = new TaskJobsModule(marathonConf, leadershipModule, clock)
   override lazy val storageModule = StorageModule(
     marathonConf,
-    lifecycleState)(
+    lifecycleState,
+    crashStrategy)(
     actorsModule.materializer,
     storageExecutionContext,
     actorSystem.scheduler,

--- a/src/main/scala/mesosphere/marathon/core/storage/backup/Backup.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/backup/Backup.scala
@@ -8,7 +8,7 @@ import akka.stream.ActorMaterializer
 import ch.qos.logback.classic.{Level, Logger}
 import com.typesafe.scalalogging.StrictLogging
 import kamon.Kamon
-import mesosphere.marathon.core.base.LifecycleState
+import mesosphere.marathon.core.base.{JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.storage.{StorageConf, StorageModule}
 import org.rogach.scallop.ScallopConf
 import org.slf4j.LoggerFactory
@@ -39,7 +39,7 @@ abstract class BackupRestoreAction extends StrictLogging {
     implicit val scheduler = system.scheduler
     import scala.concurrent.ExecutionContext.Implicits.global
     try {
-      val storageModule = StorageModule(conf, LifecycleState.WatchingJVM)
+      val storageModule = StorageModule(conf, LifecycleState.WatchingJVM, JvmExitsCrashStrategy)
       storageModule.persistenceStore.markOpen()
       val backup = storageModule.persistentStoreBackup
       Await.result(fn(backup), Duration.Inf)

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/RichCuratorFramework.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/RichCuratorFramework.scala
@@ -3,13 +3,13 @@ package core.storage.store.impl.zk
 
 import akka.Done
 import akka.util.ByteString
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.base.{LifecycleState, _}
 import mesosphere.marathon.stream.Implicits._
-import org.apache.curator.RetryPolicy
 import org.apache.curator.framework.api.{BackgroundPathable, Backgroundable, Pathable}
 import org.apache.curator.framework.imps.CuratorFrameworkState
 import org.apache.curator.framework.state.{ConnectionState, ConnectionStateListener}
-import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
+import org.apache.curator.framework.CuratorFramework
 import org.apache.zookeeper.CreateMode
 import org.apache.zookeeper.data.{ACL, Stat}
 
@@ -25,7 +25,7 @@ import scala.util.control.NonFatal
   *
   * @param client The underlying Curator client.
   */
-class RichCuratorFramework(val client: CuratorFramework) {
+class RichCuratorFramework(val client: CuratorFramework) extends StrictLogging {
 
   def close(): Unit = synchronized {
     client.close()
@@ -147,12 +147,14 @@ class RichCuratorFramework(val client: CuratorFramework) {
     * @param lifecycleState reference to interface to query Marathon's lifecycle state
     */
   @SuppressWarnings(Array("CatchFatal"))
-  def blockUntilConnected(lifecycleState: LifecycleState): Unit = {
+  def blockUntilConnected(lifecycleState: LifecycleState, crashStrategy: CrashStrategy): Unit = {
     if (!lifecycleState.isRunning)
       throw new InterruptedException("Not waiting for connection to zookeeper; Marathon is shutting down")
 
-    if (!client.blockUntilConnected(client.getZookeeperClient.getConnectionTimeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS))
-      throw new InterruptedException("Timed out while waiting for zookeeper connection")
+    if (!client.blockUntilConnected(client.getZookeeperClient.getConnectionTimeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+      logger.error("Failed to connect to ZK. Marathon will exit now.")
+      crashStrategy.crash()
+    }
   }
 }
 
@@ -173,12 +175,5 @@ object RichCuratorFramework {
   def apply(client: CuratorFramework): RichCuratorFramework = {
     client.getConnectionStateListenable().addListener(ConnectionLostListener)
     new RichCuratorFramework(client)
-  }
-  def apply(uri: String, retryPolicy: RetryPolicy): RichCuratorFramework = {
-    val c = CuratorFrameworkFactory.newClient(uri, retryPolicy)
-    c.getConnectionStateListenable().addListener(ConnectionLostListener)
-    c.start()
-
-    new RichCuratorFramework(c)
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -7,7 +7,7 @@ import java.util.Collections
 
 import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.Materializer
-import mesosphere.marathon.core.base.LifecycleState
+import mesosphere.marathon.core.base.{CrashStrategy, LifecycleState}
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
 import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
@@ -104,6 +104,7 @@ case class CuratorZk(
     versionCacheConfig: Option[VersionCacheConfig],
     availableFeatures: Set[String],
     lifecycleState: LifecycleState,
+    crashStrategy: CrashStrategy,
     defaultNetworkName: Option[String],
     backupLocation: Option[URI]
 ) extends PersistenceStorageConfig[ZkId, String, ZkSerialized] {
@@ -125,8 +126,9 @@ case class CuratorZk(
     builder.retryPolicy(retryPolicy)
     builder.namespace(zkUrl.path.stripPrefix("/"))
     val client = RichCuratorFramework(builder.build())
+
     client.start()
-    client.blockUntilConnected(lifecycleState)
+    client.blockUntilConnected(lifecycleState, crashStrategy)
 
     // make sure that we read up-to-date values from ZooKeeper
     Await.ready(client.sync("/"), Duration.Inf)
@@ -147,7 +149,7 @@ case class CuratorZk(
 
 object CuratorZk {
   val StoreName = "zk"
-  def apply(conf: StorageConf, lifecycleState: LifecycleState): CuratorZk =
+  def apply(conf: StorageConf, lifecycleState: LifecycleState, crashStrategy: CrashStrategy): CuratorZk =
     CuratorZk(
       cacheType = if (conf.storeCache()) LazyCaching else NoCaching,
       sessionTimeout = Some(conf.zkSessionTimeoutDuration),
@@ -166,6 +168,7 @@ object CuratorZk {
       availableFeatures = conf.availableFeatures,
       backupLocation = conf.backupLocation.toOption,
       lifecycleState = lifecycleState,
+      crashStrategy = crashStrategy,
       defaultNetworkName = conf.defaultNetworkName.toOption
     )
 }
@@ -195,10 +198,10 @@ object InMem {
 object StorageConfig {
   val DefaultVersionCacheConfig = Option(VersionCacheConfig.Default)
 
-  def apply(conf: StorageConf, lifecycleState: LifecycleState): StorageConfig = {
+  def apply(conf: StorageConf, lifecycleState: LifecycleState, crashStrategy: CrashStrategy): StorageConfig = {
     conf.internalStoreBackend() match {
       case InMem.StoreName => InMem(conf)
-      case CuratorZk.StoreName => CuratorZk(conf, lifecycleState)
+      case CuratorZk.StoreName => CuratorZk(conf, lifecycleState, crashStrategy)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -3,7 +3,7 @@ package storage
 
 import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.Materializer
-import mesosphere.marathon.core.base.LifecycleState
+import mesosphere.marathon.core.base.{CrashStrategy, LifecycleState}
 import mesosphere.marathon.core.storage.backup.PersistentStoreBackup
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.cache.LoadTimeCachingPersistenceStore
@@ -12,7 +12,6 @@ import mesosphere.marathon.storage.repository._
 
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
-//import scala.language.existentials
 
 /**
   * Provides the repositories for all persistable entities.
@@ -31,9 +30,9 @@ trait StorageModule {
 }
 
 object StorageModule {
-  def apply(conf: StorageConf with NetworkConf, lifecycleState: LifecycleState)(implicit mat: Materializer, ctx: ExecutionContext,
+  def apply(conf: StorageConf with NetworkConf, lifecycleState: LifecycleState, crashStrategy: CrashStrategy)(implicit mat: Materializer, ctx: ExecutionContext,
     scheduler: Scheduler, actorSystem: ActorSystem): StorageModule = {
-    val currentConfig = StorageConfig(conf, lifecycleState)
+    val currentConfig = StorageConfig(conf, lifecycleState, crashStrategy)
     apply(currentConfig, conf.mesosBridgeName())
   }
 

--- a/src/test/scala/mesosphere/marathon/util/ZookeeperServer.scala
+++ b/src/test/scala/mesosphere/marathon/util/ZookeeperServer.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package util
 
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.base.LifecycleState
+import mesosphere.marathon.core.base.{JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.core.storage.store.impl.zk.{NoRetryPolicy, RichCuratorFramework}
 import mesosphere.util.PortAllocator
 import org.apache.curator.RetryPolicy
@@ -95,7 +95,7 @@ trait ZookeeperServerTest extends BeforeAndAfterAll { this: Suite with ScalaFutu
     val client: CuratorFramework = CuratorFrameworkFactory.newClient(zkServer.connectUri, retryPolicy)
     client.start()
     val richClient: RichCuratorFramework = RichCuratorFramework(client)
-    richClient.blockUntilConnected(LifecycleState.WatchingJVM)
+    richClient.blockUntilConnected(LifecycleState.WatchingJVM, JvmExitsCrashStrategy)
     val namespacedClient = namespace.fold(client) { ns =>
       richClient.create(s"/$namespace").futureValue(PatienceConfiguration.Timeout(10.seconds))
       client.usingNamespace(ns)


### PR DESCRIPTION
Currently, if Marathon can't connect to ZK because its name is resolvable, Guice will reinstantiate `StorageModule` N times, effectively retrying to connect to ZK N times. Marathon will eventually exit with exitCode=137 but it takes ~5min with default settings. With this change, we crash on the first error.

JIRA Issues: MARATHON-7390

(cherry picked from commit ffc7764f162db2e8e2982541b8708881480a9919)