### PR TITLE
Use `eventually` instead of `shakedown.deployment_wait()`.

### DIFF
--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -26,7 +26,7 @@ def test_launch_mesos_container():
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait()
+    assert_that(lambda: client.get_deployments(app_def['id']), eventually(has_len(0), max_attempts=120))
 
     tasks = client.get_tasks(app_def["id"])
     app = client.get_app(app_def["id"])
@@ -43,7 +43,7 @@ def test_launch_docker_container():
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    assert_that(lambda: client.get_deployments(app_id), eventually(has_len(0), max_attempts=120))
 
     tasks = client.get_tasks(app_id)
     app = client.get_app(app_id)
@@ -60,7 +60,7 @@ def test_launch_mesos_container_with_docker_image():
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    assert_that(lambda: client.get_deployments(app_id), eventually(has_len(0), max_attempts=120))
 
     assert_that(lambda: client.get_tasks(app_id),
                 eventually(has_len(equal_to(1)), max_attempts=30))

--- a/tests/system/matcher/eventually.py
+++ b/tests/system/matcher/eventually.py
@@ -33,7 +33,7 @@ class Eventually(Matcher):
         return "eventually {}".format(self.matcher.describe())
 
 
-def eventually(matcher, wait_fixed=1000, max_attempts=3):
+def eventually(matcher, wait_fixed=1000, max_attempts=30):
     """Retry match if it failed.
 
     This matcher will retry the inner match after `wait_fixed` milliseconds but


### PR DESCRIPTION
Summary:
The `deployment_wait` method of Shakedown uses a busy, noisy spinner.
The `assert_that(..., eventually(...))` pattern on the other hand gives
more insight into errors.