### PR TITLE
Unify `deployment_wait` in the SI tests

### DIFF
--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -17,6 +17,7 @@ def load_app(app_def_file, app_id=None):
     else:
         app['id'] = app_id
 
+    print('Loaded an app definition with id={}'.format(app['id']))
     return app
 
 

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -293,7 +293,7 @@ def clear_pods():
         pods = client.list_pod()
         for pod in pods:
             client.remove_pod(pod["id"], True)
-        shakedown.deployment_wait()
+            deployment_wait(service_id=pod["id"])
     except Exception:
         pass
 

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -723,7 +723,7 @@ def deployment_wait(service_id=None, wait_fixed=2000, max_attempts=60, ):
     if (service_id is None):
         print('Waiting for all current deployments to finish')
     else:
-        print('Waiting for for {} to deploy successfully'.format(service_id))
+        print('Waiting for {} to deploy successfully'.format(service_id))
 
     assert_that(lambda: deployments_for(service_id),
                 eventually(has_len(0), wait_fixed=wait_fixed, max_attempts=max_attempts))

--- a/tests/system/dcos_service_marathon_tests.py
+++ b/tests/system/dcos_service_marathon_tests.py
@@ -3,7 +3,6 @@
 import apps
 import common
 import retrying
-import shakedown
 import time
 
 from datetime import timedelta
@@ -25,8 +24,10 @@ def test_deploy_custom_framework():
     """
 
     client = marathon.create_client()
-    client.add_app(apps.fake_framework())
-    shakedown.deployment_wait(timeout=timedelta(minutes=5).total_seconds())
+    app_def = apps.fake_framework()
+    app_id = app_def["id"]
+    client.add_app(app_def)
+    common.deployment_wait(timeout=timedelta(minutes=5).total_seconds(), service_id=app_id)
 
     assert common.wait_for_service_endpoint('pyfw', timedelta(minutes=5).total_seconds()), \
         "The framework has not showed up"

--- a/tests/system/dcos_service_marathon_tests.py
+++ b/tests/system/dcos_service_marathon_tests.py
@@ -27,7 +27,7 @@ def test_deploy_custom_framework():
     app_def = apps.fake_framework()
     app_id = app_def["id"]
     client.add_app(app_def)
-    common.deployment_wait(timeout=timedelta(minutes=5).total_seconds(), service_id=app_id)
+    common.deployment_wait(service_id=app_id, max_attempts=300)
 
     assert common.wait_for_service_endpoint('pyfw', timedelta(minutes=5).total_seconds()), \
         "The framework has not showed up"

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -17,23 +17,19 @@ def fixtures_dir():
 
 @pytest.fixture(scope="function")
 def wait_for_marathon_and_cleanup():
-    print("entering wait_for_marathon_and_cleanup fixture")
     common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds(), path="ping")
     yield
     common.wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds(), path="ping")
     common.clean_up_marathon()
-    print("exiting wait_for_marathon_and_cleanup fixture")
 
 
 @pytest.fixture(scope="function")
 def wait_for_marathon_user_and_cleanup():
-    print("entering wait_for_marathon_user_and_cleanup fixture")
     common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds(), path="ping")
     with shakedown.marathon_on_marathon():
         yield
         common.wait_for_service_endpoint('marathon-user', timedelta(minutes=5).total_seconds(), path="ping")
         common.clean_up_marathon()
-    print("exiting wait_for_marathon_user_and_cleanup fixture")
 
 
 def get_ca_file():

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -23,13 +23,14 @@ def test_launch_mesos_container():
     """Launches a Mesos container with a simple command."""
 
     app_def = apps.mesos_app(app_id='mesos-container-app')
+    app_id = app_def["id"]
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
-    tasks = client.get_tasks(app_def["id"])
-    app = client.get_app(app_def["id"])
+    tasks = client.get_tasks(app_id)
+    app = client.get_app(app_id)
 
     assert len(tasks) == 1, "The number of tasks is {} after deployment, but only 1 was expected".format(len(tasks))
     assert app['container']['type'] == 'MESOS', "The container type is not MESOS"
@@ -43,7 +44,7 @@ def test_launch_docker_container():
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     tasks = client.get_tasks(app_id)
     app = client.get_app(app_id)
@@ -60,7 +61,7 @@ def test_launch_mesos_container_with_docker_image():
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     assert_that(lambda: client.get_tasks(app_id),
                 eventually(has_len(equal_to(1)), max_attempts=30))
@@ -88,7 +89,7 @@ def test_launch_mesos_grace_period(marathon_service_name):
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     tasks = shakedown.get_service_task(marathon_service_name, app_id)
     assert tasks is not None
@@ -124,7 +125,7 @@ def test_launch_docker_grace_period(marathon_service_name):
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     tasks = shakedown.get_service_task(marathon_service_name, app_id)
     assert tasks is not None
@@ -148,12 +149,13 @@ def test_docker_port_mappings():
     """Tests that Docker ports are mapped and are accessible from the host."""
 
     app_def = apps.docker_http_server(app_id='docker-port-mapping-app')
+    app_id = app_def["id"]
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_def["id"])
+    common.deployment_wait(app_id)
 
-    tasks = client.get_tasks(app_def["id"])
+    tasks = client.get_tasks(app_id)
     host = tasks[0]['host']
     port = tasks[0]['ports'][0]
     cmd = r'curl -s -w "%{http_code}"'
@@ -167,10 +169,11 @@ def test_docker_dns_mapping(marathon_service_name):
     """Tests that a running Docker task is accessible via DNS."""
 
     app_def = apps.docker_http_server(app_id='docker-dns-mapping-app')
+    app_id = app_def["id"]
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_def["id"])
+    common.deployment_wait(app_id)
 
     bad_cmd = 'ping -c 1 docker-test.marathon-user.mesos-bad'
     status, output = shakedown.run_command_on_master(bad_cmd)
@@ -178,7 +181,7 @@ def test_docker_dns_mapping(marathon_service_name):
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_dns():
-        dnsname = '{}.{}.mesos'.format(app_def["id"].lstrip('/'), marathon_service_name)
+        dnsname = '{}.{}.mesos'.format(app_id.lstrip('/'), marathon_service_name)
         cmd = 'ping -c 1 {}'.format(dnsname)
         shakedown.wait_for_dns(dnsname)
         status, output = shakedown.run_command_on_master(cmd)
@@ -216,19 +219,19 @@ def test_task_failure_recovers():
 
     app_def = apps.sleep_app()
     app_def['cmd'] = 'sleep 1000'
+    app_id = app_def["id"]
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_def["id"])
+    common.deployment_wait(service_id=app_id)
 
-    tasks = client.get_tasks(app_def["id"])
+    tasks = client.get_tasks(app_id)
     old_task_id = tasks[0]['id']
     host = tasks[0]['host']
 
     common.kill_process_on_host(host, '[s]leep 1000')
-    shakedown.deployment_wait()
 
-    assert_that(lambda: client.get_tasks(app_def["id"])[0],
+    assert_that(lambda: client.get_tasks(app_id)[0],
                 eventually(has_value('id', not_(equal_to(old_task_id))), max_attempts=30))
 
 
@@ -242,13 +245,13 @@ def test_run_app_with_specified_user():
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     tasks = client.get_tasks(app_id)
     task = tasks[0]
     assert task['state'] == 'TASK_RUNNING', "The task is not running: {}".format(task['state'])
 
-    app = client.get_app(app_def["id"])
+    app = client.get_app(app_id)
     assert app['user'] == 'centos', "The app's user is not centos: {}".format(app['user'])
 
 
@@ -284,11 +287,12 @@ def test_launch_group():
 
     group_def = groups.sleep_group()
     groups_id = group_def["groups"][0]["id"]
+    app_id = group_def["groups"][0]["apps"][0]["id"]
 
     client = marathon.create_client()
     client.create_group(group_def)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
     group_apps = client.get_group(groups_id)
     apps = group_apps['apps']
@@ -301,18 +305,18 @@ def test_launch_and_scale_group():
 
     group_def = groups.sleep_group()
     groups_id = group_def["groups"][0]["id"]
+    app1_id = group_def["groups"][0]["apps"][0]["id"]
+    app2_id = group_def["groups"][0]["apps"][1]["id"]
 
     client = marathon.create_client()
     client.create_group(group_def)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app1_id)
 
     group_apps = client.get_group(groups_id)
     apps = group_apps['apps']
     assert len(apps) == 2, "The number of apps is {}, but 2 was expected".format(len(apps))
 
-    app1_id = group_def["groups"][0]["apps"][0]["id"]
-    app2_id = group_def["groups"][0]["apps"][1]["id"]
     tasks1 = client.get_tasks(app1_id)
     tasks2 = client.get_tasks(app2_id)
     assert len(tasks1) == 1, "The number of tasks #1 is {} after deployment, but 1 was expected".format(len(tasks1))
@@ -320,7 +324,7 @@ def test_launch_and_scale_group():
 
     # scale by 2 for the entire group
     client.scale_group(groups_id, 2)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app1_id)
 
     tasks1 = client.get_tasks(app1_id)
     tasks2 = client.get_tasks(app2_id)
@@ -334,18 +338,18 @@ def test_scale_app_in_group():
 
     group_def = groups.sleep_group()
     groups_id = group_def["groups"][0]["id"]
+    app1_id = group_def["groups"][0]["apps"][0]["id"]
+    app2_id = group_def["groups"][0]["apps"][1]["id"]
 
     client = marathon.create_client()
     client.create_group(group_def)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app1_id)
 
     group_apps = client.get_group(groups_id)
     apps = group_apps['apps']
     assert len(apps) == 2, "The number of apps is {}, but 2 was expected".format(len(apps))
 
-    app1_id = group_def["groups"][0]["apps"][0]["id"]
-    app2_id = group_def["groups"][0]["apps"][1]["id"]
     tasks1 = client.get_tasks(app1_id)
     tasks2 = client.get_tasks(app2_id)
     assert len(tasks1) == 1, "The number of tasks #1 is {} after deployment, but 1 was expected".format(len(tasks1))
@@ -353,7 +357,7 @@ def test_scale_app_in_group():
 
     # scaling just one app in the group
     client.scale_app(app1_id, 2)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app1_id)
 
     tasks1 = client.get_tasks(app1_id)
     tasks2 = client.get_tasks(app2_id)
@@ -367,18 +371,18 @@ def test_scale_app_in_group_then_group():
 
     group_def = groups.sleep_group()
     groups_id = group_def["groups"][0]["id"]
+    app1_id = group_def["groups"][0]["apps"][0]["id"]
+    app2_id = group_def["groups"][0]["apps"][1]["id"]
 
     client = marathon.create_client()
     client.create_group(group_def)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app1_id)
 
     group_apps = client.get_group(groups_id)
     apps = group_apps['apps']
     assert len(apps) == 2, "The number of apps is {}, but 2 was expected".format(len(apps))
 
-    app1_id = group_def["groups"][0]["apps"][0]["id"]
-    app2_id = group_def["groups"][0]["apps"][1]["id"]
     tasks1 = client.get_tasks(app1_id)
     tasks2 = client.get_tasks(app2_id)
     assert len(tasks1) == 1, "The number of tasks #1 is {} after deployment, but 1 was expected".format(len(tasks1))
@@ -386,17 +390,17 @@ def test_scale_app_in_group_then_group():
 
     # scaling just one app in the group
     client.scale_app(app1_id, 2)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app1_id)
 
     tasks1 = client.get_tasks(app1_id)
     tasks2 = client.get_tasks(app2_id)
     assert len(tasks1) == 2, "The number of tasks #1 is {} after scale, but 2 was expected".format(len(tasks1))
     assert len(tasks2) == 1, "The number of tasks #2 is {} after scale, but 1 was expected".format(len(tasks2))
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app1_id)
 
     # scaling the group after one app in the group was scaled
     client.scale_group(groups_id, 2)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app1_id)
 
     tasks1 = client.get_tasks(app1_id)
     tasks2 = client.get_tasks(app2_id)
@@ -407,13 +411,14 @@ def test_scale_app_in_group_then_group():
 def assert_app_healthy(client, app_def, health_check):
     app_def['healthChecks'] = [health_check]
     instances = app_def['instances']
+    app_id = app_def["id"]
 
     print('Testing {} health check protocol.'.format(health_check['protocol']))
     client.add_app(app_def)
 
-    shakedown.deployment_wait(timeout=timedelta(minutes=5).total_seconds())
+    common.deployment_wait(timeout=timedelta(minutes=5).total_seconds(), service_id=app_id)
 
-    app = client.get_app(app_def["id"])
+    app = client.get_app(app_id)
     assert app['tasksRunning'] == instances, \
         "The number of running tasks is {}, but {} was expected".format(app['tasksRunning'], instances)
     assert app['tasksHealthy'] == instances, \
@@ -438,7 +443,7 @@ def test_app_with_no_health_check_not_healthy():
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     app = client.get_app(app_id)
 
@@ -488,21 +493,22 @@ def test_task_gets_restarted_due_to_network_split():
     """Verifies that a health check fails in presence of a network partition."""
 
     app_def = apps.http_server()
+    app_id = app_def["id"]
     app_def['healthChecks'] = [common.health_check()]
     common.pin_to_host(app_def, common.ip_other_than_mom())
 
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
-    app = client.get_app(app_def["id"])
+    app = client.get_app(app_id)
     assert app['tasksRunning'] == 1, \
         "The number of running tasks is {}, but 1 was expected".format(app['tasksRunning'])
     assert app['tasksHealthy'] == 1, \
         "The number of healthy tasks is {}, but 1 was expected".format(app['tasksHealthy'])
 
-    tasks = client.get_tasks(app_def["id"])
+    tasks = client.get_tasks(app_id)
     task_id = tasks[0]['id']
     host = tasks[0]['host']
     port = tasks[0]['ports'][0]
@@ -510,10 +516,10 @@ def test_task_gets_restarted_due_to_network_split():
     # introduce a network partition
     common.block_iptable_rules_for_seconds(host, port, sleep_seconds=10, block_input=True, block_output=False)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
-    app = client.get_app(app_def["id"])
-    tasks = client.get_tasks(app_def["id"])
+    app = client.get_app(app_id)
+    tasks = client.get_tasks(app_id)
     new_task_id = tasks[0]['id']
     assert task_id != new_task_id, "The task didn't get killed because of a failed health check"
 
@@ -525,11 +531,11 @@ def test_task_gets_restarted_due_to_network_split():
     # network partition should cause a task restart
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_health_message():
-        tasks = client.get_tasks(app_def["id"])
+        tasks = client.get_tasks(app_id)
         new_task_id = tasks[0]['id']
         assert task_id != new_task_id, "The task has not been restarted: {}".format(task_id)
 
-        app = client.get_app(app_def["id"])
+        app = client.get_app(app_id)
         assert app['tasksRunning'] == 1, \
             "The number of running tasks is {}, but 1 was expected".format(app['tasksRunning'])
         assert app['tasksHealthy'] == 1, \
@@ -544,11 +550,12 @@ def test_health_check_works_with_resident_task():
     """
 
     app_def = apps.resident_docker_app()
+    app_id = app_def["id"]
 
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait(timeout=timedelta(minutes=10).total_seconds())
+    common.deployment_wait(timeout=timedelta(minutes=10).total_seconds(), service_id=app_id)
     tasks = client.get_tasks(app_def["id"])
     assert len(tasks) == 1, "The number of tasks is {}, but 1 was expected".format(len(tasks))
 
@@ -560,23 +567,24 @@ def test_pinned_task_scales_on_host_only():
     """Tests that a pinned app scales only on the pinned node."""
 
     app_def = apps.sleep_app()
+    app_id = app_def["id"]
     host = common.ip_other_than_mom()
     common.pin_to_host(app_def, host)
 
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
-    tasks = client.get_tasks(app_def["id"])
+    tasks = client.get_tasks(app_id)
     assert len(tasks) == 1, "The number of tasks is {} after deployment, but 1 was expected".format(len(tasks))
     assert tasks[0]['host'] == host, \
         "The task is on {}, but it is supposed to be on {}".format(tasks[0]['host'], host)
 
-    client.scale_app(app_def["id"], 10)
-    shakedown.deployment_wait()
+    client.scale_app(app_id, 10)
+    common.deployment_wait(service_id=app_id)
 
-    tasks = client.get_tasks(app_def["id"])
+    tasks = client.get_tasks(app_id)
     assert len(tasks) == 10, "The number of tasks is {} after scale, but 10 was expected".format(len(tasks))
     for task in tasks:
         assert task['host'] == host, "The task is on {}, but it is supposed to be on {}".format(task['host'], host)
@@ -587,21 +595,22 @@ def test_pinned_task_recovers_on_host():
     """Tests that when a pinned task gets killed, it recovers on the node it was pinned to."""
 
     app_def = apps.sleep_app()
+    app_id = app_def["id"]
     host = common.ip_other_than_mom()
     common.pin_to_host(app_def, host)
 
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait()
-    tasks = client.get_tasks(app_def["id"])
+    common.deployment_wait(service_id=app_id)
+    tasks = client.get_tasks(app_id)
 
     common.kill_process_on_host(host, '[s]leep')
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_for_new_task():
-        new_tasks = client.get_tasks(app_def["id"])
+        new_tasks = client.get_tasks(app_id)
         assert tasks[0]['id'] != new_tasks[0]['id'], "The task did not get killed: {}".format(tasks[0]['id'])
         assert new_tasks[0]['host'] == host, \
             "The task got restarted on {}, but it was supposed to stay on {}".format(new_tasks[0]['host'], host)
@@ -629,7 +638,7 @@ def test_pinned_task_does_not_scale_to_unpinned_host():
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
     client.scale_app(app_id, 2)
 
     time.sleep(5)
@@ -762,22 +771,23 @@ def test_app_update():
     """Tests that an app gets successfully updated."""
 
     app_def = apps.mesos_app(app_id='update-app')
+    app_id = app_def["id"]
 
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
-    tasks = client.get_tasks(app_def["id"])
+    tasks = client.get_tasks(app_id)
     assert len(tasks) == 1, "The number of tasks is {} after deployment, but 1 was expected".format(len(tasks))
 
     app_def['cpus'] = 1
     app_def['instances'] = 2
 
-    client.update_app(app_def["id"], app_def)
-    shakedown.deployment_wait()
+    client.update_app(app_id, app_def)
+    common.deployment_wait(service_id=app_id)
 
-    tasks = client.get_tasks(app_def["id"])
+    tasks = client.get_tasks(app_id)
     assert len(tasks) == 2, "The number of tasks is {} after deployment, but 2 was expected".format(len(tasks))
 
 
@@ -789,14 +799,14 @@ def test_app_update_rollback():
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     tasks = client.get_tasks(app_id)
     assert len(tasks) == 1, "The number of tasks is {} after deployment, but 1 was expected".format(len(tasks))
 
     app_def['instances'] = 2
     client.update_app(app_id, app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     tasks = client.get_tasks(app_id)
     assert len(tasks) == 2, "The number of tasks is {} after update, but 2 was expected".format(len(tasks))
@@ -806,7 +816,7 @@ def test_app_update_rollback():
     app_def['instances'] = 1
     deployment_id = client.update_app(app_id, app_def)
     client.rollback_deployment(deployment_id)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     # update to 1 instance is rollback to 2
     tasks = client.get_tasks(app_id)
@@ -825,7 +835,7 @@ def test_unhealthy_app_can_be_rolled_back():
         retry_on_exception=common.ignore_provided_exception(DCOSException)
     )
     def wait_for_deployment():
-        shakedown.deployment_wait()
+        common.deployment_wait(service_id=app_id)
 
     client = marathon.create_client()
     client.add_app(app_def)
@@ -855,14 +865,16 @@ def test_marathon_with_master_process_failure(marathon_service_name):
     """
 
     app_def = apps.sleep_app()
+    app_id = app_def["id"]
+
     host = common.ip_other_than_mom()
     common.pin_to_host(app_def, host)
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
-    tasks = client.get_tasks(app_def["id"])
+    tasks = client.get_tasks(app_id)
     original_task_id = tasks[0]['id']
 
     common.systemctl_master('restart')
@@ -870,7 +882,7 @@ def test_marathon_with_master_process_failure(marathon_service_name):
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_task_recovery():
-        tasks = client.get_tasks(app_def["id"])
+        tasks = client.get_tasks(app_id)
         assert len(tasks) == 1, "The number of tasks is {} after master restart, but 1 was expected".format(len(tasks))
         assert tasks[0]['id'] == original_task_id, \
             "Task {} has not recovered, it got replaced with another one: {}".format(original_task_id, tasks[0]['id'])
@@ -885,21 +897,23 @@ def test_marathon_when_disconnected_from_zk():
     """
 
     app_def = apps.sleep_app()
+    app_id = app_def["id"]
+
     host = common.ip_other_than_mom()
     common.pin_to_host(app_def, host)
 
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait()
-    tasks = client.get_tasks(app_def["id"])
+    common.deployment_wait(service_id=app_id)
+    tasks = client.get_tasks(app_id)
     original_task_id = tasks[0]['id']
 
     common.block_iptable_rules_for_seconds(host, 2181, sleep_seconds=10, block_input=True, block_output=False)
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_task_is_back():
-        tasks = client.get_tasks(app_def["id"])
+        tasks = client.get_tasks(app_id)
         assert tasks[0]['id'] == original_task_id, \
             "The task {} got replaced with {}".format(original_task_id, tasks[0]['id'])
 
@@ -911,20 +925,22 @@ def test_marathon_when_task_agent_bounced():
     """Launch an app and restart the node the task is running on."""
 
     app_def = apps.sleep_app()
+    app_id = app_def["id"]
+
     host = common.ip_other_than_mom()
     common.pin_to_host(app_def, host)
 
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait()
-    tasks = client.get_tasks(app_def["id"])
+    common.deployment_wait(service_id=app_id)
+    tasks = client.get_tasks(app_id)
     original_task_id = tasks[0]['id']
     shakedown.restart_agent(host)
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_task_is_back():
-        tasks = client.get_tasks(app_def["id"])
+        tasks = client.get_tasks(app_id)
         assert tasks[0]['id'] == original_task_id, \
             "The task {} got replaced with {}".format(original_task_id, tasks[0]['id'])
 
@@ -935,16 +951,18 @@ def test_default_user():
     """Ensures a task is started as root by default."""
 
     app_def = apps.sleep_app()
+    app_id = app_def["id"]
+
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
-    app = client.get_app(app_def["id"])
+    app = client.get_app(app_id)
     user = app.get('user')
     assert user is None, "User is {}, but it should not have been set".format(user)
 
-    tasks = client.get_tasks(app_def["id"])
+    tasks = client.get_tasks(app_id)
     host = tasks[0]['host']
 
     success = shakedown.run_command_on_agent(host, "ps aux | grep '[s]leep ' | awk '{if ($1 !=\"root\") exit 1;}'")
@@ -1015,6 +1033,7 @@ def test_private_repository_docker_app():
     common.copy_docker_credentials_file(agents)
 
     app_def = apps.private_docker_app()
+    app_id = app_def["id"]
 
     if shakedown.ee_version() == 'strict':
         app_def['user'] = 'root'
@@ -1022,7 +1041,7 @@ def test_private_repository_docker_app():
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
     common.assert_app_tasks_running(client, app_def)
 
@@ -1058,7 +1077,7 @@ def test_healtchcheck_and_volume():
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     tasks = client.get_tasks(app_id)
     app = client.get_app(app_id)
@@ -1075,8 +1094,9 @@ def test_vip_mesos_cmd(marathon_service_name):
     """Validates the creation of an app with a VIP label and the accessibility of the service via the VIP."""
 
     app_def = apps.http_server()
+    app_id = app_def["id"]
 
-    vip_name = app_def["id"].lstrip("/")
+    vip_name = app_id.lstrip("/")
     fqn = '{}.{}.l4lb.thisdcos.directory'.format(vip_name, marathon_service_name)
 
     app_def['portDefinitions'] = [{
@@ -1091,7 +1111,7 @@ def test_vip_mesos_cmd(marathon_service_name):
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def http_output_check():
@@ -1109,8 +1129,9 @@ def test_vip_docker_bridge_mode(marathon_service_name):
     """
 
     app_def = apps.docker_http_server(app_id='vip-docker-bridge-mode-app')
+    app_id = app_def["id"]
 
-    vip_name = app_def["id"].lstrip("/")
+    vip_name = app_id.lstrip("/")
     fqn = '{}.{}.l4lb.thisdcos.directory'.format(vip_name, marathon_service_name)
 
     app_def['id'] = vip_name
@@ -1127,7 +1148,7 @@ def test_vip_docker_bridge_mode(marathon_service_name):
     client = marathon.create_client()
     client.add_app(app_def)
 
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def http_output_check():
@@ -1183,7 +1204,8 @@ def test_network_pinger(test_type, get_pinger_app, dns_format, marathon_service_
         # need to add app with http service in place or it will fail to fetch
         client.add_app(pinger_app)
         client.add_app(relay_app)
-        shakedown.deployment_wait()
+        common.deployment_wait(service_id=pinger_app["id"])
+        common.deployment_wait(service_id=relay_app["id"])
         shakedown.wait_for_dns(relay_dns)
 
     relay_url = 'http://{}:7777/relay-ping?url={}:7777'.format(relay_dns, pinger_dns)
@@ -1204,13 +1226,14 @@ def test_ipv6_healthcheck(docker_ipv6_network_fixture):
         Marathon. This tests verifies executing such healthcheck.
     """
     app_def = apps.ipv6_healthcheck()
+    app_id = app_def["id"]
     client = marathon.create_client()
     target_instances_count = app_def['instances']
     client.add_app(app_def)
 
-    shakedown.deployment_wait(timeout=timedelta(minutes=1).total_seconds(), app_id=app_def['id'])
+    common.deployment_wait(timeout=timedelta(minutes=1).total_seconds(), service_id=app_id)
 
-    app = client.get_app(app_def["id"])
+    app = client.get_app(app_id)
     assert app['tasksRunning'] == target_instances_count, \
         "The number of running tasks is {}, but {} was expected".format(app['tasksRunning'], target_instances_count)
     assert app['tasksHealthy'] == target_instances_count, \

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -11,7 +11,6 @@ import scripts
 import shakedown
 import time
 
-from datetime import timedelta
 from dcos import http, marathon
 from dcos.errors import DCOSException
 from matcher import assert_that, eventually, has_len, has_value, has_values, prop

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -418,7 +418,7 @@ def assert_app_healthy(client, app_def, health_check):
     print('Testing {} health check protocol.'.format(health_check['protocol']))
     client.add_app(app_def)
 
-    common.deployment_wait(timeout=timedelta(minutes=5).total_seconds(), service_id=app_id)
+    common.deployment_wait(service_id=app_id, max_attempts=300)
 
     app = client.get_app(app_id)
     assert app['tasksRunning'] == instances, \
@@ -557,7 +557,7 @@ def test_health_check_works_with_resident_task():
     client = marathon.create_client()
     client.add_app(app_def)
 
-    common.deployment_wait(timeout=timedelta(minutes=10).total_seconds(), service_id=app_id)
+    common.deployment_wait(service_id=app_id, max_attempts=500)
     tasks = client.get_tasks(app_def["id"])
     assert len(tasks) == 1, "The number of tasks is {}, but 1 was expected".format(len(tasks))
 
@@ -1233,7 +1233,7 @@ def test_ipv6_healthcheck(docker_ipv6_network_fixture):
     target_instances_count = app_def['instances']
     client.add_app(app_def)
 
-    common.deployment_wait(timeout=timedelta(minutes=1).total_seconds(), service_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     app = client.get_app(app_id)
     assert app['tasksRunning'] == target_instances_count, \

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -95,7 +95,7 @@ def test_create_pod_with_private_image():
 
     try:
         client.add_pod(pod_def)
-        common.deployment_wait(timeout=timedelta(minutes=5).total_seconds(), service_id=pod_id)
+        common.deployment_wait(service_id=pod_id, max_attempts=300)
         pod = client.show_pod(pod_id)
         assert pod is not None, "The pod has not been created"
     finally:

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -9,7 +9,6 @@ import retrying
 import shakedown
 import time
 
-from datetime import timedelta
 from dcos import marathon, http
 from shakedown import dcos_version_less_than, marthon_version_less_than, required_private_agents # NOQA
 from urllib.parse import urljoin

--- a/tests/system/test_marathon_on_marathon.py
+++ b/tests/system/test_marathon_on_marathon.py
@@ -89,7 +89,7 @@ def test_mom_when_mom_agent_bounced():
     with shakedown.marathon_on_marathon():
         client = marathon.create_client()
         client.add_app(app_def)
-        shakedown.deployment_wait()
+        common.deployment_wait(service_id=app_id)
         tasks = client.get_tasks(app_id)
         original_task_id = tasks[0]['id']
 
@@ -115,7 +115,7 @@ def test_mom_when_mom_process_killed():
     with shakedown.marathon_on_marathon():
         client = marathon.create_client()
         client.add_app(app_def)
-        shakedown.deployment_wait()
+        common.deployment_wait(service_id=app_id)
         tasks = client.get_tasks(app_id)
         original_task_id = tasks[0]['id']
 
@@ -234,13 +234,13 @@ def test_framework_unavailable_on_mom():
     """
 
     app_def = apps.fake_framework()
+    app_id = app_def["id"]
 
     with shakedown.marathon_on_marathon():
         common.delete_all_apps_wait()
         client = marathon.create_client()
         client.add_app(app_def)
-        shakedown.deployment_wait()
-
+        common.deployment_wait(service_id=app_id)
     try:
         common.wait_for_service_endpoint('pyfw', 15)
     except Exception:

--- a/tests/system/test_marathon_on_marathon.py
+++ b/tests/system/test_marathon_on_marathon.py
@@ -237,7 +237,6 @@ def test_framework_unavailable_on_mom():
     app_id = app_def["id"]
 
     with shakedown.marathon_on_marathon():
-        common.delete_all_apps_wait()
         client = marathon.create_client()
         client.add_app(app_def)
         common.deployment_wait(service_id=app_id)

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -158,7 +158,7 @@ def simple_sleep_app(name):
         app_id = app_def["id"]
 
         client.add_app(app_def)
-        common.deployment_wait(app_id)
+        common.deployment_wait(service_id=app_id)
 
         tasks = shakedown.get_service_task(name, app_id.lstrip("/"))
         print('MoM-EE tasks: {}'.format(tasks))

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -60,7 +60,7 @@ def remove_mom_ee():
 
     client = marathon.create_client()
     client.remove_app(MOM_EE_NAME)
-    shakedown.deployment_wait()
+    common.deployment_wait(MOM_EE_NAME)
     print('Successfully removed {}'.format(MOM_EE_NAME))
 
 
@@ -101,10 +101,11 @@ def assert_mom_ee(version, security_mode='permissive'):
 
     app_def = get_resource(app_def_file)
     app_def['container']['docker']['image'] = 'mesosphere/marathon-dcos-ee:{}'.format(image)
+    app_id = app_def["id"]
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
     common.wait_for_service_endpoint(mom_ee_endpoint(version, security_mode), path="ping")
 
 
@@ -154,10 +155,12 @@ def simple_sleep_app(name):
         client = marathon.create_client()
 
         app_def = apps.sleep_app()
-        client.add_app(app_def)
-        shakedown.deployment_wait()
+        app_id = app_def["id"]
 
-        tasks = shakedown.get_service_task(name, app_def["id"].lstrip("/"))
+        client.add_app(app_def)
+        common.deployment_wait(app_id)
+
+        tasks = shakedown.get_service_task(name, app_id.lstrip("/"))
         print('MoM-EE tasks: {}'.format(tasks))
         return tasks is not None
 

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -238,7 +238,7 @@ def test_external_volume():
         print('INFO: Deploying {} with external volume {}'.format(app_id, volume_name))
         client = marathon.create_client()
         client.add_app(app_def)
-        common.deployment_wait(timeout=300, service_id=app_id)
+        common.deployment_wait(service_id=app_id)
 
         # Create the app: the volume should be successfully created
         common.assert_app_tasks_running(client, app_def)
@@ -252,7 +252,7 @@ def test_external_volume():
         # Scale up again: the volume should be successfully reused
         print('INFO: Scaling {} back to 1 instance'.format(app_id))
         client.scale_app(app_id, 1)
-        common.deployment_wait(timeout=300, service_id=app_id)
+        common.deployment_wait(service_id=app_id)
 
         common.assert_app_tasks_running(client, app_def)
         common.assert_app_tasks_healthy(client, app_def)
@@ -280,6 +280,8 @@ def test_external_volume():
         # and the volume should be cleaned up manually later.
         if not removed:
             print('WARNING: Failed to remove external volume with name={}'.format(volume_name))
+        else:
+            print('DEBUG: External volume with name={} successfully removed'.format(volume_name))
 
 
 @pytest.mark.skipif('common.multi_master() or marthon_version_less_than("1.5")')

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -452,7 +452,7 @@ def test_app_file_based_secret(secret_fixture):
     secret_name, secret_value = secret_fixture
     secret_container_path = 'mysecretpath'
 
-    app_id = uuid.uuid4().hex
+    app_id = '/app-fbs-{}'.format(uuid.uuid4().hex)
     # In case you're wondering about the `cmd`: secrets are mounted via tmpfs inside
     # the container and are not visible outside, hence the intermediate file
     app_def = {
@@ -509,7 +509,7 @@ def test_app_secret_env_var(secret_fixture):
 
     secret_name, secret_value = secret_fixture
 
-    app_id = uuid.uuid4().hex
+    app_id = '/app-secret-env-var-{}'.format(uuid.uuid4().hex)
     app_def = {
         "id": app_id,
         "instances": 1,
@@ -560,7 +560,7 @@ def test_app_inaccessible_secret_env_var():
 
     secret_name = '/some/secret'    # Secret in an inaccessible namespace
 
-    app_id = uuid.uuid4().hex
+    app_id = '/app-inaccessible-secret-env-var-{}'.format(uuid.uuid4().hex)
     app_def = {
         "id": app_id,
         "instances": 1,
@@ -601,7 +601,7 @@ def test_pod_inaccessible_secret_env_var():
 
     secret_name = '/some/secret'    # Secret in an inaccessible namespace
 
-    pod_id = '/{}'.format(uuid.uuid4().hex)
+    pod_id = '/pod-inaccessible-secret-env-var-{}'.format(uuid.uuid4().hex)
     pod_def = {
         "id": pod_id,
         "containers": [{
@@ -647,7 +647,7 @@ def test_pod_secret_env_var(secret_fixture):
 
     secret_name, secret_value = secret_fixture
 
-    pod_id = '/{}'.format(uuid.uuid4().hex)
+    pod_id = '/pod-secret-env-var-{}'.format(uuid.uuid4().hex)
     pod_def = {
         "id": pod_id,
         "containers": [{
@@ -712,7 +712,7 @@ def test_pod_file_based_secret(secret_fixture):
     secret_name, secret_value = secret_fixture
     secret_normalized_name = secret_name.replace('/', '')
 
-    pod_id = '/{}'.format(uuid.uuid4().hex)
+    pod_id = '/pod-fbs-{}'.format(uuid.uuid4().hex)
 
     pod_def = {
         "id": pod_id,

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -99,7 +99,7 @@ def test_marathon_delete_leader_and_check_apps(marathon_service_name):
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     app = client.get_app(app_id)
     assert app['tasksRunning'] == 1, "The number of running tasks is {}, but 1 was expected".format(app["tasksRunning"])
@@ -128,7 +128,7 @@ def test_marathon_delete_leader_and_check_apps(marathon_service_name):
         client.remove_app(app_id)
 
     remove_app(app_id)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
     try:
         client.get_app(app_id)
@@ -187,7 +187,7 @@ def test_launch_app_on_public_agent():
     app_def = common.add_role_constraint_to_app_def(apps.mesos_app(), ['slave_public'])
     app_id = app_def["id"]
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     tasks = client.get_tasks(app_id)
     task_ip = tasks[0]['host']
@@ -212,13 +212,13 @@ async def test_event_channel(sse_events):
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     await common.assert_event('deployment_info', sse_events)
     await common.assert_event('deployment_step_success', sse_events)
 
     client.remove_app(app_id, True)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     await common.assert_event('app_terminated_event', sse_events)
 
@@ -238,7 +238,7 @@ def test_external_volume():
         print('INFO: Deploying {} with external volume {}'.format(app_id, volume_name))
         client = marathon.create_client()
         client.add_app(app_def)
-        shakedown.deployment_wait(timeout=300, app_id=app_id)
+        common.deployment_wait(timeout=300, service_id=app_id)
 
         # Create the app: the volume should be successfully created
         common.assert_app_tasks_running(client, app_def)
@@ -247,12 +247,12 @@ def test_external_volume():
         # Scale down to 0
         print('INFO: Scaling {} to 0 instances'.format(app_id))
         client.stop_app(app_id)
-        shakedown.deployment_wait(app_id=app_id)
+        common.deployment_wait(service_id=app_id)
 
         # Scale up again: the volume should be successfully reused
         print('INFO: Scaling {} back to 1 instance'.format(app_id))
         client.scale_app(app_id, 1)
-        shakedown.deployment_wait(timeout=300, app_id=app_id)
+        common.deployment_wait(timeout=300, service_id=app_id)
 
         common.assert_app_tasks_running(client, app_def)
         common.assert_app_tasks_healthy(client, app_def)
@@ -260,7 +260,7 @@ def test_external_volume():
         # Remove the app to be able to remove the volume
         print('INFO: Finally removing {}'.format(app_id))
         client.remove_app(app_id)
-        shakedown.deployment_wait(app_id=app_id)
+        common.deployment_wait(service_id=app_id)
     except Exception as e:
         print('Fail to test external volumes: {}'.format(e))
         raise e
@@ -299,7 +299,7 @@ def test_marathon_backup_and_restore_leader(marathon_service_name):
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait(app_id=app_id)
+    common.deployment_wait(service_id=app_id)
 
     app = client.get_app(app_id)
     assert app['tasksRunning'] == 1, "The number of running tasks is {}, but 1 was expected".format(app["tasksRunning"])
@@ -349,7 +349,7 @@ def test_marathon_backup_and_check_apps(marathon_service_name):
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
     app = client.get_app(app_id)
     assert app['tasksRunning'] == 1, "The number of running tasks is {}, but 1 was expected".format(app["tasksRunning"])
@@ -384,7 +384,7 @@ def test_marathon_backup_and_check_apps(marathon_service_name):
 
     # then remove
     client.remove_app(app_id)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
     check_app_existence(0)
 
@@ -425,6 +425,7 @@ def test_private_repository_mesos_app():
     secret_value = json.dumps(secret_value_json)
 
     app_def = apps.private_ucr_docker_app()
+    app_id = app_def["id"]
 
     # In strict mode all tasks are started as user `nobody` by default and `nobody`
     # doesn't have permissions to write to /var/log within the container.
@@ -437,7 +438,7 @@ def test_private_repository_mesos_app():
 
     try:
         client.add_app(app_def)
-        shakedown.deployment_wait()
+        common.deployment_wait(service_id=app_id)
 
         common.assert_app_tasks_running(client, app_def)
     finally:
@@ -483,7 +484,7 @@ def test_app_file_based_secret(secret_fixture):
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
     tasks = client.get_tasks(app_id)
     assert len(tasks) == 1, 'Failed to start the file based secret app'
@@ -535,7 +536,7 @@ def test_app_secret_env_var(secret_fixture):
 
     client = marathon.create_client()
     client.add_app(app_def)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=app_id)
 
     tasks = client.get_tasks(app_id)
     assert len(tasks) == 1, 'Failed to start the secret environment variable app'

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -99,7 +99,7 @@ def test_install_universe_package(package):
     shakedown.install_package_and_wait(package)
     assert shakedown.package_installed(package), 'Package failed to install'
 
-    shakedown.deployment_wait(timeout=timedelta(minutes=5).total_seconds())
+    common.deployment_wait(max_attempts=300)
     assert shakedown.service_healthy(package)
 
 
@@ -109,7 +109,7 @@ def uninstall(service, package=PACKAGE_NAME):
         if task is not None:
             cosmos_pm = packagemanager.PackageManager(cosmos.get_cosmos_url())
             cosmos_pm.uninstall_app(package, True, service)
-            shakedown.deployment_wait()
+            common.deployment_wait()
             assert common.wait_for_service_endpoint_removal('test-marathon')
             shakedown.delete_zk_node('/universe/{}'.format(service))
 

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -68,9 +68,9 @@ def test_custom_service_name():
         'service': {'name': "test-marathon"}
     }
     shakedown.install_package('marathon', options_json=options)
-    common.deployment_wait(service_id=options["service"]["name"])
+    common.deployment_wait(service_id=options["service"]["name"], max_attempts=300)
 
-    assert common.wait_for_service_endpoint('test-marathon', path="ping")
+    assert common.wait_for_service_endpoint('test-marathon', path="ping", timeout_sec=300)
 
 
 @pytest.fixture(

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -5,7 +5,6 @@ import pytest
 import retrying
 import shakedown
 
-from datetime import timedelta
 from dcos import packagemanager, cosmos
 
 

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -48,11 +48,11 @@ def test_install_marathon():
         assert found and shakedown.service_healthy(service), f"Service {package} did not register with DCOS" # NOQA E999
 
     assert_service_registration(PACKAGE_NAME, SERVICE_NAME)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=SERVICE_NAME)
 
     # Uninstall
     uninstall('marathon-user')
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=SERVICE_NAME)
 
     # Reinstall
     shakedown.install_package_and_wait(PACKAGE_NAME)
@@ -69,7 +69,7 @@ def test_custom_service_name():
         'service': {'name': "test-marathon"}
     }
     shakedown.install_package('marathon', options_json=options)
-    shakedown.deployment_wait()
+    common.deployment_wait(service_id=options["service"]["name"])
 
     assert common.wait_for_service_endpoint('test-marathon', path="ping")
 

--- a/tests/system/utils.py
+++ b/tests/system/utils.py
@@ -8,7 +8,7 @@ from dcos.errors import DCOSException
 def make_id(prefix=None):
     random_part = uuid.uuid4().hex
     if prefix is None:
-        return random_part
+        return '/{}'.format(random_part)
     return '/{}-{}'.format(prefix, random_part)
 
 


### PR DESCRIPTION
Currently, we're using `deployment_wait` waiting for all existing deployments to finish. This makes our SI tests more brittle and dependent on each other. This change replaces that with waiting for an app/pod id specific to the test in most cases.