### PR TITLE
Rename metrics for the performance CI

### DIFF
--- a/tests/performance/config/perf-driver/measure/measure-metric-currentDeploymentCount.yml
+++ b/tests/performance/config/perf-driver/measure/measure-metric-currentDeploymentCount.yml
@@ -53,4 +53,4 @@ trackers:
   # Extract the currentDeploymentCount metric from the metric observer
   - class: tracker.DumpMetricTracker
     map:
-      min-max-counters.service.mesosphere.marathon.core.deployment.impl.DeploymentManagerActor.currentDeploymentCount.mean: currentDeploymentCount
+      gauges.marathon.deployments.active.gauge.value: currentDeploymentCount

--- a/tests/performance/config/perf-driver/measure/measure-metric-queueSize.yml
+++ b/tests/performance/config/perf-driver/measure/measure-metric-queueSize.yml
@@ -53,4 +53,4 @@ trackers:
   # Extract the queueSize metric from the metric observer
   - class: tracker.DumpMetricTracker
     map:
-      min-max-counters.service.mesosphere.marathon.core.group.impl.GroupManagerImpl.queueSize.mean: queueSize
+      gauges.marathon.debug.root-group.updates.active.gauge.value: queueSize


### PR DESCRIPTION
Summary:
This commit fixes the performance CI by renaming the old metric names to new metric names

JIRA issues: DCOS-40466
