### PR TITLE
Fix broken offer rejection statistics when maintenance mode is enabled

### DIFF
--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -238,12 +238,12 @@ object ResourceMatcher extends StrictLogging {
     val checkAvailability: Boolean = {
       if (conf.availableFeatures.contains(Features.MAINTENANCE_MODE)) {
         val result = Availability.offerAvailable(offer, conf.drainingTime)
-        noOfferMatchReasons += NoOfferMatchReason.UnfulfilledConstraint
-        // Add unavailability to noOfferMatchReasons
-        noOfferMatchReasons += NoOfferMatchReason.AgentMaintenance
-        logger.info(
-          s"Offer [${offer.getId.getValue}]. Agent [${offer.getSlaveId}] on host [${offer.getHostname}] unavailable.\n"
-        )
+        if (!result) {
+          noOfferMatchReasons += NoOfferMatchReason.UnfulfilledConstraint
+          // Add unavailability to noOfferMatchReasons
+          noOfferMatchReasons += NoOfferMatchReason.AgentMaintenance
+          logger.info(s"Offer [${offer.getId.getValue}]. Agent [${offer.getSlaveId}] on host [${offer.getHostname}] unavailable.\n")
+        }
         result
       } else true
     }

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -914,6 +914,19 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       resourceMatchResponse shouldBe ResourceMatchResponse.NoMatch(Seq(InsufficientCpus, UnfulfilledConstraint, AgentMaintenance))
     }
 
+    "match offers with maintenance mode and enabled feature but no maintenance scheduled should not match because of *only* insufficient cpus" in {
+      val maintenanceEnabledConf = AllConf.withTestConfig( "--draining_seconds", "300", "--enable_features", Features.MAINTENANCE_MODE)
+      val offer = MarathonTestHelper.makeBasicOffer().build
+      val app = AppDefinition(
+        id = "/test".toRootPath,
+        resources = Resources(cpus = 1000, mem = 128.0, disk = 0.0)
+      )
+
+      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, maintenanceEnabledConf, Seq.empty)
+
+      resourceMatchResponse shouldBe ResourceMatchResponse.NoMatch(Seq(InsufficientCpus))
+    }
+
     "match offers with empty region if localRegion is not available" in {
       val offer = MarathonTestHelper.makeBasicOffer().build()
       val app = AppDefinition(

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -17,7 +17,7 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.tasks.PortsMatcher
 import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
-import mesosphere.mesos.NoOfferMatchReason.DeclinedScarceResources
+import mesosphere.mesos.NoOfferMatchReason.{AgentMaintenance, DeclinedScarceResources, InsufficientCpus, UnfulfilledConstraint}
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
 import mesosphere.mesos.protos.Implicits._
 import mesosphere.mesos.protos.{Resource, ResourceProviderID, TextAttribute}
@@ -25,7 +25,6 @@ import mesosphere.util.state.FrameworkId
 import org.apache.mesos.Protos.Attribute
 import org.scalatest.Inside
 import org.scalatest.prop.TableDrivenPropertyChecks
-
 import java.util.UUID
 
 import scala.collection.immutable.Seq
@@ -889,7 +888,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       res.scalarMatch(Resource.DISK) should be(empty)
     }
 
-    "match offers with maintenance mode and enabled feature should match" in {
+    "match offers with maintenance mode and enabled feature should not match" in {
       val maintenanceEnabledConf = AllConf.withTestConfig("--draining_seconds", "300", "--enable_features", Features.MAINTENANCE_MODE)
       val offer = MarathonTestHelper.makeBasicOfferWithUnavailability(clock.now).build
       val app = AppDefinition(
@@ -899,7 +898,20 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
 
       val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, maintenanceEnabledConf, Seq.empty)
 
-      resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
+      resourceMatchResponse shouldBe ResourceMatchResponse.NoMatch(Seq(UnfulfilledConstraint, AgentMaintenance))
+    }
+
+    "match offers with maintenance mode, too many required cpus and enabled feature should not match" in {
+      val maintenanceEnabledConf = AllConf.withTestConfig("--draining_seconds", "300", "--enable_features", Features.MAINTENANCE_MODE)
+      val offer = MarathonTestHelper.makeBasicOfferWithUnavailability(clock.now).build
+      val app = AppDefinition(
+        id = "/test".toRootPath,
+        resources = Resources(cpus = 1000, mem = 128.0, disk = 0.0)
+      )
+
+      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, maintenanceEnabledConf, Seq.empty)
+
+      resourceMatchResponse shouldBe ResourceMatchResponse.NoMatch(Seq(InsufficientCpus, UnfulfilledConstraint, AgentMaintenance))
     }
 
     "match offers with empty region if localRegion is not available" in {


### PR DESCRIPTION
Summary:
We were adding `UnfulfilledConstraint` and `AgentMaintenance` to the list of offer rejection reasons if maintenance mode was enabled. Fixed and added a test to prevent this in the future.