### PR TITLE
Add `DCOS_PACKAGE_NAME` to our custom framework definition in SI tests

### DIFF
--- a/tests/system/apps/fake-framework.json
+++ b/tests/system/apps/fake-framework.json
@@ -31,6 +31,7 @@
   ],
   "labels": {
     "DCOS_PACKAGE_FRAMEWORK_NAME": "pyfw",
+    "DCOS_PACKAGE_NAME": "pyfw",
     "DCOS_MIGRATION_API_VERSION": "v1",
     "DCOS_MIGRATION_API_PATH": "/v1/plan",
     "MARATHON_SINGLE_INSTANCE_APP": "true",


### PR DESCRIPTION
Summary:
otherwise, it's not possible to delete the framework from the UI (not that it matters for the SI test, but potentially in the future)