### PR TITLE
Tune HdrHistogram reservoir parameters

### DIFF
--- a/src/main/scala/mesosphere/marathon/metrics/MetricsConf.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/MetricsConf.scala
@@ -31,10 +31,19 @@ trait MetricsConf extends ScallopConf {
     noshort = true
   )
 
+  lazy val metricsHistogramReservoirHighestTrackableValue = opt[Long](
+    name = "metrics_histogram_reservoir_highest_trackable_value",
+    descr = "The highest trackable value of histograms and timers.",
+    default = Some(3600000000000L),
+    argName = "value",
+    validate = _ > 1L,
+    noshort = true
+  )
+
   lazy val metricsHistogramReservoirSignificantDigits = opt[Int](
     name = "metrics_histogram_reservoir_significant_digits",
     descr = "The number of significant decimal digits to which histograms and timers will maintain value resolution and separation.",
-    default = Some(2),
+    default = Some(3),
     argName = "digits",
     validate = v => v >= 0 && v <= 5,
     noshort = true

--- a/src/main/scala/mesosphere/marathon/metrics/current/DropwizardMetrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/current/DropwizardMetrics.scala
@@ -44,6 +44,7 @@ class DropwizardMetrics(metricsConf: MetricsConf, registry: MetricRegistry) exte
   override def deprecatedTimer(metricName: String): Timer = DummyMetrics.deprecatedTimer(metricName)
 
   private val namePrefix = metricsConf.metricsNamePrefix()
+  private val histogramReservoirHighestTrackableValue = metricsConf.metricsHistogramReservoirHighestTrackableValue()
   private val histogramReservoirSignificantDigits = metricsConf.metricsHistogramReservoirSignificantDigits()
   private val histogramReservoirResetPeriodically = metricsConf.metricsHistogramReservoirResetPeriodically()
   private val histogramReservoirResettingIntervalMs = metricsConf.metricsHistogramReservoirResettingIntervalMs()
@@ -94,7 +95,7 @@ class DropwizardMetrics(metricsConf: MetricsConf, registry: MetricRegistry) exte
       val reservoirBuilder = new HdrBuilder()
         .withSignificantDigits(histogramReservoirSignificantDigits)
         .withLowestDiscernibleValue(1)
-        .withHighestTrackableValue(Long.MaxValue, OverflowResolver.REDUCE_TO_HIGHEST_TRACKABLE)
+        .withHighestTrackableValue(histogramReservoirHighestTrackableValue, OverflowResolver.REDUCE_TO_HIGHEST_TRACKABLE)
       if (histogramReservoirResetPeriodically) {
         if (histogramReservoirResettingChunks == 0)
           reservoirBuilder.resetReservoirPeriodically(Duration.ofMillis(histogramReservoirResettingIntervalMs))


### PR DESCRIPTION
With these new values, timers are able to track values anywhere
from 1 microsecond to 1 hour. The memory footprint of all the timers,
backed by HdrHistograms, is currently about 40 MB.

JIRA issues: MARATHON-8371