### PR TITLE
Proper task kill in `UpgradeIntegrationTest`

### DIFF
--- a/tests/integration/src/test/resources/python/app_mock.py
+++ b/tests/integration/src/test/resources/python/app_mock.py
@@ -90,6 +90,16 @@ def make_handler(app_id, version, task_id, base_url):
             logging.debug("Done processing health request.")
             return
 
+        def handle_suicide(self):
+
+            logging.info("Received a suicide request. Sending a SIGTER to myself.")
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+
+            os.kill(os.getpid(), signal.SIGTERM)
+            return
+
         def do_GET(self):
             try:
                 logging.debug("Got GET request")
@@ -97,6 +107,8 @@ def make_handler(app_id, version, task_id, base_url):
                     return self.handle_ping()
                 elif self.path == '/ready':
                     return self.check_readiness()
+                elif self.path == '/suicide':
+                    return self.handle_suicide()
                 else:
                     return self.check_health()
             except Exception:

--- a/tests/integration/src/test/resources/python/app_mock.py
+++ b/tests/integration/src/test/resources/python/app_mock.py
@@ -102,24 +102,30 @@ def make_handler(app_id, version, task_id, base_url):
 
         def do_GET(self):
             try:
-                logging.debug("Got GET request")
+                logging.debug("Got GET request for path {}".format(self.path))
                 if self.path == '/ping':
                     return self.handle_ping()
                 elif self.path == '/ready':
                     return self.check_readiness()
-                elif self.path == '/suicide':
-                    return self.handle_suicide()
                 else:
                     return self.check_health()
             except Exception:
-                logging.exception('Could not handle GET request')
+                logging.exception("Could not handle GET request for path {}".format(self.path))
 
         def do_POST(self):
             try:
-                logging.debug("Got POST request")
+                logging.debug("Got POST request for path {}".format(self.path))
                 return self.check_health()
             except Exception:
-                logging.exception('Could not handle POST request')
+                logging.exception("Could not handle POST request for path {}".format(self.path))
+
+        def do_DELETE(self):
+            try:
+                logging.debug("Got DELETE request for path {}".format(self.path))
+                if self.path == '/suicide':
+                    return self.handle_suicide()
+            except Exception:
+                logging.exception("Could not handle DELETE request for path {}".format(self.path))
 
     return Handler
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
@@ -7,7 +7,7 @@ import java.nio.file.Files
 
 import akka.actor.{ActorSystem, Scheduler}
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.client.RequestBuilding.Get
+import akka.http.scaladsl.client.RequestBuilding.{Delete, Get}
 import akka.http.scaladsl.model.Uri
 import akka.stream.Materializer
 import mesosphere.marathon.core.pod.{HostNetwork, MesosContainer, PodDefinition}
@@ -285,7 +285,7 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
       val port = ports.headOption.value
 
       val url = Uri.from(scheme = "http", host = host, port = port, path = "/suicide")
-      Http().singleRequest(Get(url)).map { result =>
+      Http().singleRequest(Delete(url)).map { result =>
         result.discardEntityBytes() // forget about the body
         if (result.status.isFailure())
           fail(s"Task suicide failed with status ${result.status} for task $task")

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
@@ -6,6 +6,7 @@ import java.net.URL
 import java.nio.file.Files
 
 import akka.actor.{ActorSystem, Scheduler}
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.stream.Materializer
 import mesosphere.marathon.core.pod.{HostNetwork, MesosContainer, PodDefinition}
@@ -134,7 +135,7 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
       marathon149.stop().futureValue
 
       And(s"App ${app_149_fail.id} fails")
-      killTask("app-149-fail")
+      suicideTasks(originalApp149FailedTasks)
 
       // Pass upgrade to 1.5.6
       And("Marathon is upgraded to 1.5.6")
@@ -163,7 +164,7 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
       marathon156.stop().futureValue
 
       And(s"App ${app_156_fail.id} fails")
-      killTask("app-156-fail")
+      suicideTasks(originalApp156FailedTasks)
 
       // Pass upgrade to 1.6.322
       And("Marathon is upgraded to 1.6.322")
@@ -273,16 +274,19 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
     marathonCurrent.close()
   }
 
-  def killTask(appName: String): Unit = {
-    val pidPattern = """([^\s]+)\s+([^\s]+)\s+.*""".r
-    val pids = Process("ps aux").!!.split("\n").filter { process =>
-      process.contains("src/test/resources/python/app_mock.py") && process.contains(appName)
-    }.collect {
-      case pidPattern(_, pid) => pid
-    }
+  def suicideTasks(tasks: List[ITEnrichedTask]): Unit = {
+    logger.info(s"Sending suicide requests to the tasks of the ${tasks.head.appId}: ${tasks.map(_.id)}")
+    tasks.foreach{ task =>
+      val host = task.host
+      val ports = task.ports.headOption.value
+      val port = ports.headOption.value
 
-    Process(s"kill -9 ${pids.mkString(" ")}").!
-    logger.info(s"Killed tasks of app $appName with PIDs ${pids.mkString(" ")}")
+      Http().singleRequest(Get(akka.http.scaladsl.model.Uri(s"$host:$port/suicide"))).map { result =>
+        result.discardEntityBytes() // forget about the body
+        if (result.status.isFailure())
+          fail(s"Task suicide failed with status ${result.status} for task $task")
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Summary:
The current version of `UpgradeIntegrationTest` goes wild over the whole machine killing every PID which matched a (rather short) app name. This PR introduces a suicide command that can be sent to the `app_mock` which will terminate it.
