### PR TITLE
Add "wipe=true" support for pod's instances endpoint, as it is implemented for app's tasks

### DIFF
--- a/docs/docs/rest-api/public/api/v2/pods.raml
+++ b/docs/docs/rest-api/public/api/v2/pods.raml
@@ -197,6 +197,11 @@
     is: [ secured, objectLocator ]
     description: |
       Kill the given instance of the pod
+    queryParameters:
+      wipe:
+        type: boolean
+        description: If `wipe=true` is specified and the pod uses local persistent volumes, associated dynamic reservations will be unreserved, and persistent volumes will be destroyed.
+        default: false
     responses:
       200:
         body:
@@ -220,6 +225,11 @@
     is: [ secured, objectLocator ]
     description: |
       Kill the given instances of the pod
+    queryParameters:
+      wipe:
+        type: boolean
+        description: If `wipe=true` is specified and the pod uses local persistent volumes, associated dynamic reservations will be unreserved, and persistent volumes will be destroyed.
+        default: false
     responses:
       200:
         body:

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -100,7 +100,7 @@ private[impl] class KillServiceActor(
   def killInstances(instances: Seq[Instance], promise: Promise[Done]): Unit = {
     val instanceIds = instances.map(_.instanceId)
     logger.debug(s"Adding instances $instanceIds to queue; setting up child actor to track progress")
-    promise.completeWith(watchForKilledInstances(instanceIds))
+    promise.completeWith(watchForKilledInstances(instances))
     instances.foreach { instance =>
       // TODO(PODS): do we make sure somewhere that an instance has _at_least_ one task?
       val taskIds: IndexedSeq[Id] = instance.tasksMap.values.withFilter(!_.isTerminal).map(_.taskId)(collection.breakOut)
@@ -115,11 +115,11 @@ private[impl] class KillServiceActor(
   /**
     * Begins watching immediately for terminated instances. Future is completed when all instances are seen.
     */
-  def watchForKilledInstances(instanceIds: Seq[Instance.Id]): Future[Done] = {
+  def watchForKilledInstances(instances: Seq[Instance]): Future[Done] = {
     // Note - we toss the materialized cancellable. We are okay to do this here because KillServiceActor will continue to retry
     // killing the instanceIds in question, forever, until this Future completes.
     KillStreamWatcher.
-      watchForKilledInstances(context.system.eventStream, instanceIds).
+      watchForKilledInstances(context.system.eventStream, instances).
       runWith(Sink.head)
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -892,7 +892,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
           )
           killer.kill(any, any, any)(any) returns Future.successful(Seq(instance))
           val response = asyncRequest { r =>
-            f.podsResource.killInstance("/id", instance.instanceId.idString, f.auth.request, r)
+            f.podsResource.killInstance("/id", instance.instanceId.idString, false, f.auth.request, r)
           }
           withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_OK)
@@ -920,7 +920,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
           killer.kill(any, any, any)(any) returns Future.successful(instances)
           val response = asyncRequest { r =>
             f.podsResource.killInstances(
-              "/id", Json.stringify(Json.toJson(instances.map(_.instanceId.idString))).getBytes, f.auth.request, r)
+              "/id", false, Json.stringify(Json.toJson(instances.map(_.instanceId.idString))).getBytes, f.auth.request, r)
           }
           withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_OK)

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcherTest.scala
@@ -4,12 +4,15 @@ package core.task.termination.impl
 import java.util.UUID
 
 import akka.Done
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Sink, Source}
+import akka.testkit.TestProbe
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.PrefixInstance
 import mesosphere.marathon.state.PathId
-import mesosphere.marathon.stream.Sink
+import mesosphere.marathon.test.MarathonTestHelper
+import scala.concurrent.duration._
 
 class KillStreamWatcherTest extends AkkaUnitTest {
   "killedInstanceFlow yields Done immediately when waiting on empty instance Ids" in {
@@ -41,4 +44,28 @@ class KillStreamWatcherTest extends AkkaUnitTest {
 
     result.futureValue shouldBe Nil
   }
+
+  "KillStreamWatcher emits already terminated instances" in {
+
+    val empty = MarathonTestHelper.emptyInstance()
+    val unreachableInstance = empty.copy(state = empty.state.copy(condition = Condition.Killed))
+
+    val watcher = KillStreamWatcher.watchForKilledInstances(system.eventStream, List(unreachableInstance))
+
+    watcher.runWith(Sink.head).futureValue shouldEqual Done
+  }
+
+  "KillStreamWatcher doesn't emit anything if there are no changes" in {
+
+    val probe = TestProbe("KillStreamWatcher")
+
+    val empty = MarathonTestHelper.emptyInstance()
+    val runnningInstance = empty.copy(state = empty.state.copy(condition = Condition.Running))
+
+    val watcher = KillStreamWatcher.watchForKilledInstances(system.eventStream, List(runnningInstance))
+
+    watcher.runWith(Sink.head).onComplete(_ => probe.ref ! Done)
+    probe.expectNoMessage(100.millis)
+  }
+
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -12,14 +12,13 @@ import mesosphere.marathon.raml.{App, Container, DockerContainer, EngineType}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{HostVolume, VolumeMount}
 import mesosphere.mesos.Constraints.hostnameField
-import mesosphere.{AkkaIntegrationTest, WhenEnvSet, WaitTestSupport}
+import mesosphere.{AkkaIntegrationTest, WaitTestSupport, WhenEnvSet}
 import play.api.libs.json.JsObject
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
-
   // Configure Mesos to provide the Mesos containerizer with Docker image support.
   override lazy val mesosConfig = MesosConfig(
     launcher = "linux",
@@ -381,6 +380,45 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
         val status = marathon.status(pod.id)
         status should be(Stable)
         status.value.instances should have size 2
+      }
+    }
+
+    val pods = List(
+      residentPod("resident-pod-with-one-instance-wipe").copy(instances = 1) -> "persistent",
+      simplePod("simple-pod-with-one-instance-wipe-test").copy(instances = 1) -> "simple"
+    )
+
+    pods.foreach { case (pod, podType) =>
+      s"wipe $podType pod instance" taggedAs WhenEnvSet(envVarRunMesosTests, default = "true") in {
+        Given(s"a $podType pod")
+
+        When(s"The $podType pod is created")
+        val createResult = marathon.createPodV2(pod)
+        createResult should be(Created)
+        waitForDeployment(createResult)
+
+        Then("pod status should be stable")
+        eventually {
+          marathon.status(pod.id) should be(Stable)
+        }
+
+        When("Pods instance is deleted with wipe=true")
+        val status = marathon.status(pod.id)
+        val instanceId = status.value.instances.head.id
+        val deleteResult = marathon.deleteInstance(pod.id, instanceId, wipe = true)
+        deleteResult should be(OK)
+
+        Then("pod instance is erased from marathon's knowledge ")
+        val knownInstanceIds = marathon.status(pod.id).value.instances.map(_.id)
+        knownInstanceIds should not contain instanceId
+
+        And(s"a new pod ${if (podType == "persistent") "with a new persistent volume " else ""}is scheduled")
+        waitForStatusUpdates("TASK_RUNNING")
+        eventually {
+          val status = marathon.status(pod.id)
+          status.value.instances should have size 1
+          status.value.instances.map(_.id) should not contain instanceId
+        }
       }
     }
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -289,9 +289,9 @@ class MarathonFacade(
     result(requestFor[List[PodInstanceStatus]](Delete(s"$url/v2/pods$podId::instances")), waitTime)
   }
 
-  def deleteInstance(podId: PathId, instance: String): RestResult[PodInstanceStatus] = {
+  def deleteInstance(podId: PathId, instance: String, wipe: Boolean = false): RestResult[PodInstanceStatus] = {
     requireInBaseGroup(podId)
-    result(requestFor[PodInstanceStatus](Delete(s"$url/v2/pods$podId::instances/$instance")), waitTime)
+    result(requestFor[PodInstanceStatus](Delete(s"$url/v2/pods$podId::instances/$instance?wipe=$wipe")), waitTime)
   }
 
   //apps tasks resource --------------------------------------


### PR DESCRIPTION
Summary: Implementation of API wipe=true flag, documentation and tests.

JIRA issues: MARATHON-8326

(cherry picked from commit 55527e6d837ca3d29eb5d84b046cfefc3aaa081f)
