### PR TITLE
Consider resident condition as terminal

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/condition/Condition.scala
+++ b/src/main/scala/mesosphere/marathon/core/condition/Condition.scala
@@ -56,7 +56,7 @@ object Condition {
   case object Provisioned extends Active
 
   /** Reserved: Task with persistent volume has reservation, but is not launched or scheduled to be launched */
-  case object Reserved extends Condition
+  case object Reserved extends Terminal
 
   /** Created: Task is known in marathon and sent to Mesos, but not staged yet */
   case object Created extends Active

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/StartingBehavior.scala
@@ -44,7 +44,7 @@ trait StartingBehavior extends ReadinessBehavior with StrictLogging { this: Acto
   final override def receive: Receive = readinessBehavior orElse commonBehavior
 
   def commonBehavior: Receive = {
-    case InstanceChanged(id, `version`, `pathId`, condition: Condition, instance) if condition.isTerminal || instance.isReservedTerminal =>
+    case InstanceChanged(id, `version`, `pathId`, condition: Condition, instance) if condition.isTerminal =>
       logger.warn(s"New instance [$id] failed during app ${runSpec.id.toString} scaling, queueing another instance")
       instanceTerminated(id)
       launchQueue.add(runSpec, 1).pipeTo(self)

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -40,8 +40,6 @@ case class Instance(
 
   lazy val isReserved: Boolean = state.condition == Condition.Reserved
 
-  def isReservedTerminal: Boolean = isReserved
-
   /**
     * An instance is scheduled for launching when its goal is to be running but it's not active.
     *

--- a/src/main/scala/mesosphere/marathon/core/task/termination/InstanceChangedPredicates.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/InstanceChangedPredicates.scala
@@ -8,7 +8,6 @@ object InstanceChangedPredicates {
 
   val considerTerminal: Condition => Boolean = Set(
     // Note - these statuses are NOT terminal statuses, but a list of statuses such that if a task is seen to transition to it, consider the old task gone
-    Condition.Reserved,
     Condition.Unreachable,
     Condition.UnreachableInactive,
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -53,7 +53,7 @@ private[tracker] class InstanceTrackerDelegate(
   // TODO(jdef) support pods when counting launched instances
   override def countActiveSpecInstances(appId: PathId): Future[Int] = {
     import scala.concurrent.ExecutionContext.Implicits.global
-    instancesBySpec().map(_.specInstances(appId).count(instance => instance.isActive || (instance.isReserved && !instance.isReservedTerminal)))
+    instancesBySpec().map(_.specInstances(appId).count(instance => instance.isActive))
   }
 
   override def hasSpecInstancesSync(appId: PathId): Boolean = instancesBySpecSync.hasSpecInstances(appId)

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo17.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo17.scala
@@ -122,7 +122,7 @@ object MigrationTo17 extends MaybeStore with StrictLogging {
     val updatedInstanceState = if (!instance.hasReservation) {
       instance.state.copy(goal = Goal.Running)
     } else {
-      if (instance.isReservedTerminal) {
+      if (instance.isReserved) {
         instance.state.copy(goal = Goal.Stopped)
       } else {
         instance.state.copy(goal = Goal.Running)

--- a/src/test/scala/mesosphere/marathon/core/task/TaskStatusComparisonTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskStatusComparisonTest.scala
@@ -3,7 +3,6 @@ package core.task
 
 import mesosphere.UnitTest
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.condition.Condition.Reserved
 import mesosphere.marathon.core.task.state.NetworkInfoPlaceholder
 import mesosphere.marathon.state.Timestamp
 import org.scalatest.prop.TableDrivenPropertyChecks

--- a/src/test/scala/mesosphere/marathon/core/task/TaskStatusComparisonTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskStatusComparisonTest.scala
@@ -3,6 +3,7 @@ package core.task
 
 import mesosphere.UnitTest
 import mesosphere.marathon.core.condition.Condition
+import mesosphere.marathon.core.condition.Condition.Reserved
 import mesosphere.marathon.core.task.state.NetworkInfoPlaceholder
 import mesosphere.marathon.state.Timestamp
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -60,6 +61,14 @@ class TaskStatusComparisonTest extends UnitTest with TableDrivenPropertyChecks {
         s"${if (!isActive) "not" else ""} be active" in { task.isActive should be(isActive) }
         s"${if (!isTerminal) "not" else ""} be terminated" in { task.isTerminal should be(isTerminal) }
       }
+    }
+
+    "should say it's reserved when in reserved state" in {
+      val status = Task.Status(Timestamp.now, None, None, Reserved, NetworkInfoPlaceholder())
+      val task = mock[Task]
+      task.status returns status
+
+      task.
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/TaskStatusComparisonTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskStatusComparisonTest.scala
@@ -17,7 +17,7 @@ class TaskStatusComparisonTest extends UnitTest with TableDrivenPropertyChecks {
     // and isCreated to be false.
     val conditions = Table (
       ("condition",                   "isCreated", "isError", "isFailed", "isFinished", "isKilled", "isKilling", "isRunning", "isStaging", "isStarting", "isUnreachable", "isUnreachableInactive", "isGone", "isUnknown", "isDropped", "isActive", "isTerminal"),
-      (Condition.Reserved,            false,       false,     false,      false,        false,      false,       false,       false,       false,        false,           false,                   false,    false,       false,       false,      false       ),
+      (Condition.Reserved,            false,       false,     false,      false,        false,      false,       false,       false,       false,        false,           false,                   false,    false,       false,       false,      true       ),
       (Condition.Created,             true,        false,     false,      false,        false,      false,       false,       false,       false,        false,           false,                   false,    false,       false,       true,       false       ),
       (Condition.Error,               false,       true,      false,      false,        false,      false,       false,       false,       false,        false,           false,                   false,    false,       false,       false,      true        ),
       (Condition.Failed,              false,       false,     true,       false,        false,      false,       false,       false,       false,        false,           false,                   false,    false,       false,       false,      true        ),
@@ -61,14 +61,6 @@ class TaskStatusComparisonTest extends UnitTest with TableDrivenPropertyChecks {
         s"${if (!isActive) "not" else ""} be active" in { task.isActive should be(isActive) }
         s"${if (!isTerminal) "not" else ""} be terminated" in { task.isTerminal should be(isTerminal) }
       }
-    }
-
-    "should say it's reserved when in reserved state" in {
-      val status = Task.Status(Timestamp.now, None, None, Reserved, NetworkInfoPlaceholder())
-      val task = mock[Task]
-      task.status returns status
-
-      task.
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
@@ -156,23 +156,6 @@ class TaskTest extends UnitTest with Inside {
       task.isUnreachableExpired(f.clock.now, 10.minutes) should be(false)
     }
 
-    "a reserved task transitions to launched on running MesosUpdate" in {
-      val f = new Fixture
-      val condition = Condition.Reserved
-      val taskId = Task.Id.forRunSpec(f.appWithIpAddress.id)
-      val status = Task.Status(f.clock.now, None, None, condition, NetworkInfoPlaceholder())
-      val task = Task(taskId, f.clock.now, status)
-      val instance = mock[Instance]
-      instance.hasReservation returns true
-      val mesosStatus = MesosTaskStatusTestHelper.running(taskId)
-      inside(task.update(instance, Condition.Running, mesosStatus, f.clock.now)) {
-        case effect: TaskUpdateEffect.Update =>
-          effect.newState shouldBe a[Task]
-          effect.newState.status.condition shouldBe Condition.Running
-          effect.newState.status.mesosStatus shouldBe Some(mesosStatus)
-      }
-    }
-
     "a reserved task updates network info on MesosUpdate" in {
       val f = new Fixture
 


### PR DESCRIPTION
We don't use reserved state for nothing else as terminal instances, that are stopped or are waiting to be rescheduled.
