### PR TITLE
Backport to 1.5: Loosen constraint validation during migration (#6458)

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo15.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo15.scala
@@ -123,13 +123,19 @@ private[migration] object MigrationTo15 {
       .flatMap(MigratedRoot(root, _).store(groupRepository))
   }
 
+  private def updateUniqueConstraint(constraint: Seq[String]) = constraint match {
+    case Seq(fieldName, "UNIQUE", "") => Seq(fieldName, "UNIQUE")
+    case other => other
+  }
+
   /**
     * migrate service definitions, first by converting from protobuf to RAML and then converting to the model API
     */
   def migrateServiceFlow(implicit appNormalizer: Normalization[raml.App]) = Flow[ServiceDefinition].map { service =>
     import Normalization._
     val rawRaml = Raml.toRaml(service)
-    val normalizedApp = rawRaml.normalize
+    val rawRamlWithMigratedConstraints = rawRaml.copy(constraints = rawRaml.constraints.map(updateUniqueConstraint))
+    val normalizedApp = rawRamlWithMigratedConstraints.normalize
     val appDef = normalizedApp.fromRaml
     // fixup version since it's intentionally lost in the conversion from App to AppDefinition
     appDef.copy(versionInfo = AppDefinition.versionInfoFrom(service))

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo15Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo15Test.scala
@@ -6,6 +6,7 @@ import java.time.OffsetDateTime
 import akka.Done
 import akka.stream.scaladsl.{ Sink, Source }
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.Protos.Constraint
 import mesosphere.marathon.core.pod.{ BridgeNetwork, ContainerNetwork }
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state.VersionInfo.{ FullVersionInfo, OnlyVersion }
@@ -235,6 +236,29 @@ class MigrationTo15Test extends AkkaUnitTest with RecoverMethods with GroupCreat
           container = Some(Container.Docker(image = "image0")),
           networks = Seq(ContainerNetwork("someNetworkName")),
           portDefinitions = Nil
+        )
+        migrateSingleApp(sd) should be(expected)
+      }
+
+      "trim an empty UNIQUE constraint value" in new Fixture {
+        val oldConstraint = Constraint
+          .newBuilder()
+          .setField("hostname")
+          .setOperator(Constraint.Operator.UNIQUE)
+          .setValue("")
+          .build()
+
+        val newConstraint = Constraint
+          .newBuilder()
+          .setField("hostname")
+          .setOperator(Constraint.Operator.UNIQUE)
+          .build()
+
+        val sd = basicCommandService.toBuilder
+          .addConstraints(oldConstraint)
+          .build
+        val expected = basicCommandApp.copy(
+          constraints = Set(newConstraint)
         )
         migrateSingleApp(sd) should be(expected)
       }


### PR DESCRIPTION
Summary: "UNIQUE" constraint value is stripped in case it is empty.

JIRA issues: DCOS-37999

(cherry picked from commit b9b5bc4cd452510f95341196ff378518423562f4)
