### PR TITLE
Assert that subscription keys are removed eventually.

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehaviorTest.scala
@@ -181,7 +181,7 @@ class ReadinessBehaviorTest extends AkkaUnitTest with Eventually with GroupCreat
       Then("Task should be removed from healthy, ready and subscriptions.")
       actor.underlyingActor.healthyInstances should be(empty)
       actor.underlyingActor.readyInstances should be(empty)
-      actor.underlyingActor.subscriptionKeys should be(empty)
+      eventually(actor.underlyingActor.subscriptionKeys should be(empty))
       actor.stop()
     }
   }


### PR DESCRIPTION
Summary:
This should stabilize the `ReadinessBehaviorTest`. In 1.6 we would
remove the subscription key immediately. This was changed on master to
be asyncronous. So we have to wait a little until the key is removed.