### PR TITLE
PATCH call not proxied correctly to active node

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/forwarder/JavaUrlConnectionRequestForwarder.scala
+++ b/src/main/scala/mesosphere/marathon/api/forwarder/JavaUrlConnectionRequestForwarder.scala
@@ -111,7 +111,7 @@ class JavaUrlConnectionRequestForwarder(
   }
 
   private def copyRequestToConnection(leaderConnection: HttpURLConnection, request: HttpServletRequest): Try[Done] = Try {
-    if (request.getMethod == "PATCH") { // workaround to overcome java restrictions, see https://bugs.openjdk.java.net/browse/JDK-7016595
+    if (request.getMethod == "PATCH") { // workaround to overcome java restrictions, see https://bugs.openjdk.java.net/browse/JDK-7016595 and https://stackoverflow.com/a/39641592
       setPatchMethod(leaderConnection)
     } else {
       leaderConnection.setRequestMethod(request.getMethod)

--- a/src/main/scala/mesosphere/marathon/api/forwarder/JavaUrlConnectionRequestForwarder.scala
+++ b/src/main/scala/mesosphere/marathon/api/forwarder/JavaUrlConnectionRequestForwarder.scala
@@ -105,7 +105,7 @@ class JavaUrlConnectionRequestForwarder(
   }
 
   private def copyRequestToConnection(leaderConnection: HttpURLConnection, request: HttpServletRequest): Try[Done] = Try {
-    if (request.getMethod == "PATCH") { //workaround to overcome java restrictions, see https://bugs.openjdk.java.net/browse/JDK-7016595
+    if (request.getMethod == "PATCH") { // workaround to overcome java restrictions, see https://bugs.openjdk.java.net/browse/JDK-7016595
       leaderConnection.setRequestProperty("X-HTTP-Method-Override", "PATCH")
       leaderConnection.setRequestMethod("POST")
     } else {

--- a/src/main/scala/mesosphere/marathon/api/forwarder/JavaUrlConnectionRequestForwarder.scala
+++ b/src/main/scala/mesosphere/marathon/api/forwarder/JavaUrlConnectionRequestForwarder.scala
@@ -105,7 +105,12 @@ class JavaUrlConnectionRequestForwarder(
   }
 
   private def copyRequestToConnection(leaderConnection: HttpURLConnection, request: HttpServletRequest): Try[Done] = Try {
-    leaderConnection.setRequestMethod(request.getMethod)
+    if (request.getMethod == "PATCH") { //workaround to overcome java restrictions, see https://bugs.openjdk.java.net/browse/JDK-7016595
+      leaderConnection.setRequestProperty("X-HTTP-Method-Override", "PATCH")
+      leaderConnection.setRequestMethod("POST")
+    } else {
+      leaderConnection.setRequestMethod(request.getMethod)
+    }
     copyRequestHeadersToConnection(leaderConnection, request)
     copyRequestBodyToConnection(leaderConnection, request)
     Done

--- a/src/main/scala/mesosphere/marathon/api/forwarder/JavaUrlConnectionRequestForwarder.scala
+++ b/src/main/scala/mesosphere/marathon/api/forwarder/JavaUrlConnectionRequestForwarder.scala
@@ -104,10 +104,15 @@ class JavaUrlConnectionRequestForwarder(
     leaderConnection.addRequestProperty(HEADER_FORWARDED_FOR, forwardedFor)
   }
 
+  private def setPatchMethod(connection: HttpURLConnection): Unit = {
+    val methodsField = classOf[HttpURLConnection].getDeclaredField("method")
+    methodsField.setAccessible(true)
+    methodsField.set(connection, "PATCH")
+  }
+
   private def copyRequestToConnection(leaderConnection: HttpURLConnection, request: HttpServletRequest): Try[Done] = Try {
     if (request.getMethod == "PATCH") { // workaround to overcome java restrictions, see https://bugs.openjdk.java.net/browse/JDK-7016595
-      leaderConnection.setRequestProperty("X-HTTP-Method-Override", "PATCH")
-      leaderConnection.setRequestMethod("POST")
+      setPatchMethod(leaderConnection)
     } else {
       leaderConnection.setRequestMethod(request.getMethod)
     }


### PR DESCRIPTION
Summary: added a workaround for http methods unsupported by java

JIRA issues: MARATHON-8095

