### PR TITLE
Fix a rare race condition in `MarathonHealthCheckManager`

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -166,7 +166,7 @@ class MarathonHealthCheckManager(
         // since only current version tasks are launched.
         for {
           (version, activeHealthChecks) <- ahcs(appId)
-          if version != app.version && !activeAppVersions.contains(version)
+          if version < app.version && !activeAppVersions.contains(version)
           activeHealthCheck <- activeHealthChecks
         } remove(appId, version, activeHealthCheck.healthCheck)
 


### PR DESCRIPTION
Summary:
which could occur, if a deployment was triggered in the middle of health check reconciliation, creating a new app version (and eventually a health check for it), which reconciliation process didn't know about. In this rare case, a proper health check would've been removed leading to a never-ending deployment. This is also one reason for flaky `test_app_update_rollback` SI test.

Related JIRA: MARATHON-8380