### PR TITLE
Define linter for Shakedown and begin cleanup.

### DIFF
--- a/tests/shakedown/.gitignore
+++ b/tests/shakedown/.gitignore
@@ -17,6 +17,7 @@ eggs/
 lib/
 lib64/
 parts/
+Pipfile.lock
 sdist/
 var/
 *.egg-info/

--- a/tests/shakedown/Makefile
+++ b/tests/shakedown/Makefile
@@ -1,0 +1,18 @@
+define USAGE
+Shakedown ⚙️
+
+Commands:
+  init      Install build and test dependencies with pipenv
+  build     Run formatter and linter.
+endef
+
+export USAGE
+help:
+	@echo "$$USAGE"
+
+init:
+	pip3 install pipenv
+	pipenv install --dev
+
+build:
+	pipenv run flake8 --count --max-line-length=120 shakedown dcos

--- a/tests/shakedown/Pipfile
+++ b/tests/shakedown/Pipfile
@@ -1,0 +1,23 @@
+[[source]]
+
+name = "pypi"
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+
+
+[requires]
+
+python_version = "3.6"
+
+
+[dev-packages]
+
+"flake8" = "*"
+"pep8-naming" = "*"
+
+
+[packages]
+
+click = "*"
+retrying = "*"
+toml = "*"

--- a/tests/shakedown/shakedown/dcos/command.py
+++ b/tests/shakedown/shakedown/dcos/command.py
@@ -121,12 +121,12 @@ def run_command(
         :return: Output of command
         :rtype: string
     """
-    
+
     with HostSession(host, username, key_path, noisy) as s:
         if noisy:
             print("\n{}{} $ {}\n".format(shakedown.fchr('>>'), host, command))
         s.run(command)
-    
+
     ec, output = s.get_result()
     return ec == 0, output
 
@@ -209,16 +209,14 @@ def run_dcos_command(command, raise_on_error=False, print_output=True):
         print(stdout, stderr, return_code)
 
     if return_code != 0 and raise_on_error:
-        raise DCOSException(
-            'Got error code {} when running command "dcos {}":\nstdout: "{}"\nstderr: "{}"'.format(
-            return_code, command, stdout, stderr))
+        raise DCOSException('Got error code {} when running command "dcos {}":\nstdout: "{}"\nstderr: "{}"'.format(
+                            return_code, command, stdout, stderr))
 
     return stdout, stderr, return_code
 
 
 class HostSession:
     """Context manager that returns an SSH session, reusing authenticated connections.
-    
     """
     def __init__(self, host, username, key_path, verbose):
         self.host = host
@@ -228,7 +226,7 @@ class HostSession:
         self.exit_code = -1
         self.output = ''
         self.session = None
-    
+
     def __enter__(self):
         """
         :return: this session manager
@@ -237,9 +235,9 @@ class HostSession:
         c = _get_connection(self.host, self.username, self.key_path)
         if c:
             self.session = c.open_session()
-        
+
         return self
-    
+
     def __exit__(self, *args):
         """Executed when the context manager is complete.
 
@@ -260,10 +258,10 @@ class HostSession:
         try_close(self.session)
         # no Exceptions were handled; return False
         return False
-    
+
     def _wait_for_recv(self):
         """After executing a command, wait for results.
-        
+
         Because `recv_ready()` can return False, but still have a
         valid, open connection, it is not enough to ensure output
         from a command execution is properly captured.
@@ -274,17 +272,17 @@ class HostSession:
             time.sleep(0.2)
             if self.session.recv_ready() or self.session.closed:
                 return
-    
+
     def run(self, command):
         """Run `command` on this SSH session. This does not return the
         result, use `get_result` to retrieve command's results.
 
         :param command: SSH command to run
         :type command: str
-        
+
         :return: None
         """
         self.session.exec_command(command)
-    
+
     def get_result(self):
         return self.exit_code, self.output

--- a/tests/shakedown/shakedown/dcos/network.py
+++ b/tests/shakedown/shakedown/dcos/network.py
@@ -2,7 +2,9 @@
     There are a number of common utilies for working with agents and master nodes
     which are provided here.
 """
-from shakedown import *
+import contextlib
+
+from shakedown.dcos.command import run_command_on_agent
 
 
 def restore_iptables(host):
@@ -10,14 +12,16 @@ def restore_iptables(host):
         :param hostname: host or IP of the machine to partition from the cluster
     """
 
-    run_command_on_agent(host, 'if [ -e iptables.rules ]; then sudo iptables-restore < iptables.rules && rm iptables.rules ; fi')
+    cmd = 'if [ -e iptables.rules ]; then sudo iptables-restore < iptables.rules && rm iptables.rules ; fi'
+    run_command_on_agent(host, cmd)
 
 
 def save_iptables(host):
     """ Saves iptables firewall rules such they can be restored
     """
 
-    run_command_on_agent(host, 'if [ ! -e iptables.rules ] ; then sudo iptables -L > /dev/null && sudo iptables-save > iptables.rules ; fi')
+    cmd = 'if [ ! -e iptables.rules ] ; then sudo iptables -L > /dev/null && sudo iptables-save > iptables.rules ; fi'
+    run_command_on_agent(host, cmd)
 
 
 def run_iptables(host, rule):
@@ -37,7 +41,9 @@ def flush_all_rules(host):
 def allow_all_traffic(host):
     """ Opens up iptables on host to allow all traffic
     """
-    run_command_on_agent(host, 'sudo iptables --policy INPUT ACCEPT && sudo iptables --policy OUTPUT ACCEPT && sudo iptables --policy FORWARD ACCEPT')
+
+    cmd = 'sudo iptables --policy INPUT ACCEPT && sudo iptables --policy OUTPUT ACCEPT && sudo iptables --policy FORWARD ACCEPT' # NOQA E501
+    run_command_on_agent(host, cmd)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Summary:
`flake8` shows almost three hundred errors. With this change we define
our dev dependencies with pipenv and run the linter with `make build`.
We also follow the style guide in `network.py`, `command.py` and
`master.py`.

Please note that the tests are not linted.