### PR TITLE
Indicate suicide reason with exit code. (#6469)

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -243,6 +243,11 @@ layout: default
                     Slow Docker apps and deployments
                 </a>
             </li>
+            <li>
+                <a href="{{ site.baseurl }}/docs/exit-codes.html">
+                   Exit Codes
+                </a>
+            </li>
         </ul>
 
         <h5>Development</h5>

--- a/docs/docs/exit-codes.md
+++ b/docs/docs/exit-codes.md
@@ -1,0 +1,21 @@
+---
+title: Exit Codes 
+---
+
+# Exit Codes 
+
+Marathon follows the [Let-it-crash](https://www.reactivedesignpatterns.com/patterns/let-it-crash.html) pattern. Instead
+of trying to fix an illegal state it will stop itself to be restarted by its supervisor. The following exit codes should
+help you figure out why the Marathon process stopped.
+
+| Exit Code | Reason                                                               |
+|-----------|----------------------------------------------------------------------|
+|100        | `ZookeeperConnectionFailure` - Could not connect to Zookeeper        |
+|101        | `ZookeeperConnectionLost` - Lost connect to Zookeeper                |
+|102        | `PluginInitializationFailure` - Could not load plugin                |
+|103        | `LeadershipLoss` - Lost leadership                                   |
+|104        | `LeadershipEndedFaulty` - Leadership ended with an error             |
+|105        | `LeadershipEndedGracefully` - Leadership ended without an error      |
+|106        | `MesosSchedulerError` - The Mesos scheduler driver had an error       |
+|107        | `UncaughtException` - An internal unknown error could not be handled |
+|137        | Killed by an external process or uncaught exception                  |

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -8,12 +8,13 @@ import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.api.LeaderProxyFilterModule
 import org.eclipse.jetty.servlets.EventSourceServlet
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import kamon.Kamon
 import mesosphere.marathon.api.HttpModule
 import mesosphere.marathon.api.MarathonRestModule
 import mesosphere.marathon.core.CoreGuiceModule
-import mesosphere.marathon.core.base.toRichRuntime
+import mesosphere.marathon.core.base.{CrashStrategy, toRichRuntime}
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.LibMesos
@@ -29,7 +30,7 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
   SLF4JBridgeHandler.install()
   Thread.setDefaultUncaughtExceptionHandler((thread: Thread, throwable: Throwable) => {
     logger.error(s"Terminating due to uncaught exception in thread ${thread.getName}:${thread.getId}", throwable)
-    Runtime.getRuntime.asyncExit()
+    Runtime.getRuntime.asyncExit(CrashStrategy.UncaughtException.code)
   })
 
   val cliConf = new AllConf(args)

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -24,7 +24,8 @@ class MarathonScheduler(
     taskStatusProcessor: TaskStatusUpdateProcessor,
     frameworkIdRepository: FrameworkIdRepository,
     mesosLeaderInfo: MesosLeaderInfo,
-    config: MarathonConf) extends Scheduler with StrictLogging {
+    config: MarathonConf,
+    crashStrategy: CrashStrategy) extends Scheduler with StrictLogging {
 
   private var lastMesosMasterVersion: Option[SemanticVersion] = Option.empty
   @volatile private[this] var localFaultDomain: Option[FaultDomain] = Option.empty
@@ -181,7 +182,6 @@ class MarathonScheduler(
 
     if (removeFrameworkId) Await.ready(frameworkIdRepository.delete(), config.zkTimeoutDuration)
 
-    // Asynchronously call asyncExit to avoid deadlock due to the JVM shutdown hooks
-    Runtime.getRuntime.asyncExit()
+    crashStrategy.crash(CrashStrategy.MesosSchedulerError)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -270,7 +270,7 @@ class CoreModuleImpl @Inject() (
     eventStream,
     taskTerminationModule.taskKillService)(schedulerActionsExecutionContext)
 
-  override lazy val marathonScheduler: MarathonScheduler = new MarathonScheduler(eventStream, launcherModule.offerProcessor, taskStatusUpdateProcessor, storageModule.frameworkIdRepository, mesosLeaderInfo, marathonConf)
+  override lazy val marathonScheduler: MarathonScheduler = new MarathonScheduler(eventStream, launcherModule.offerProcessor, taskStatusUpdateProcessor, storageModule.frameworkIdRepository, mesosLeaderInfo, marathonConf, crashStrategy)
 
   // MesosHeartbeatMonitor decorates MarathonScheduler
   override def mesosHeartbeatMonitor = new MesosHeartbeatMonitor(marathonScheduler, heartbeatActor)

--- a/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
@@ -6,11 +6,25 @@ import akka.Done
 import scala.concurrent.{ExecutionContext, Future}
 
 trait CrashStrategy {
-  def crash(): Future[Done]
+  def crash(reason: CrashStrategy.Reason): Future[Done]
+}
+
+object CrashStrategy {
+  sealed trait Reason {
+    val code: Int
+  }
+  case object ZookeeperConnectionFailure extends Reason { override val code: Int = 100 }
+  case object ZookeeperConnectionLoss extends Reason { override val code: Int = 101 }
+  case object PluginInitializationFailure extends Reason { override val code: Int = 102 }
+  case object LeadershipLoss extends Reason { override val code: Int = 103 }
+  case object LeadershipEndedFaulty extends Reason { override val code: Int = 104 }
+  case object LeadershipEndedGracefully extends Reason { override val code: Int = 105 }
+  case object MesosSchedulerError extends Reason { override val code: Int = 106 }
+  case object UncaughtException extends Reason { override val code: Int = 107 }
 }
 
 case object JvmExitsCrashStrategy extends CrashStrategy {
-  override def crash(): Future[Done] = {
-    Runtime.getRuntime.asyncExit()(ExecutionContext.Implicits.global)
+  override def crash(reason: CrashStrategy.Reason): Future[Done] = {
+    Runtime.getRuntime.asyncExit(reason.code)(ExecutionContext.Implicits.global)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/base/RichRuntime.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/RichRuntime.scala
@@ -23,7 +23,7 @@ case class RichRuntime(runtime: Runtime) extends StrictLogging {
     * @return the Future of this operation.
     */
   def asyncExit(
-    exitCode: Int = RichRuntime.FatalErrorSignal,
+    exitCode: Int,
     waitForExit: FiniteDuration = RichRuntime.DefaultExitDelay)(implicit ec: ExecutionContext): Future[Done] = {
     val timer = new Timer()
     val promise = Promise[Done]()
@@ -50,6 +50,5 @@ case class RichRuntime(runtime: Runtime) extends StrictLogging {
 }
 
 object RichRuntime {
-  val FatalErrorSignal = 137
   val DefaultExitDelay = 10.seconds
 }

--- a/src/main/scala/mesosphere/marathon/core/election/ElectionService.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/ElectionService.scala
@@ -197,7 +197,7 @@ class ElectionServiceImpl(
       case LeadershipTransition.Standby =>
         _leaderAndReady = false
         logger.error("Lost leadership; crashing")
-        crashStrategy.crash()
+        crashStrategy.crash(CrashStrategy.LeadershipLoss)
     }
   }
 
@@ -270,10 +270,10 @@ class ElectionServiceImpl(
     leaderStreamDone.onComplete {
       case Failure(ex) =>
         logger.info("Leadership ended with failure; exiting", ex)
-        crashStrategy.crash()
+        crashStrategy.crash(CrashStrategy.LeadershipEndedFaulty)
       case Success(_) =>
         logger.info("Leadership ended gracefully; exiting")
-        crashStrategy.crash()
+        crashStrategy.crash(CrashStrategy.LeadershipEndedGracefully)
     }(ExecutionContexts.callerThread)
 
     leaderStream

--- a/src/main/scala/mesosphere/marathon/core/plugin/impl/PluginManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/plugin/impl/PluginManagerImpl.scala
@@ -46,7 +46,7 @@ private[plugin] class PluginManagerImpl(
         } catch {
           case NonFatal(ex) => {
             logger.error(s"Plugin Initialization Failure: ${ex.getMessage}.", ex)
-            crashStrategy.crash()
+            crashStrategy.crash(CrashStrategy.PluginInitializationFailure)
           }
         }
 

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/RichCuratorFramework.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/RichCuratorFramework.scala
@@ -13,7 +13,7 @@ import org.apache.curator.framework.CuratorFramework
 import org.apache.zookeeper.CreateMode
 import org.apache.zookeeper.data.{ACL, Stat}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.control.NonFatal
 
 /**
@@ -153,7 +153,7 @@ class RichCuratorFramework(val client: CuratorFramework) extends StrictLogging {
 
     if (!client.blockUntilConnected(client.getZookeeperClient.getConnectionTimeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS)) {
       logger.error("Failed to connect to ZK. Marathon will exit now.")
-      crashStrategy.crash()
+      crashStrategy.crash(CrashStrategy.ZookeeperConnectionFailure)
     }
   }
 }
@@ -163,17 +163,17 @@ object RichCuratorFramework {
   /**
     * Listen to connection state changes and suicide if the connection to ZooKeeper is lost.
     */
-  object ConnectionLostListener extends ConnectionStateListener {
+  class ConnectionLostListener(crashStrategy: CrashStrategy) extends ConnectionStateListener {
     override def stateChanged(client: CuratorFramework, newState: ConnectionState): Unit = {
       if (!newState.isConnected) {
         client.close()
-        Runtime.getRuntime.asyncExit()(ExecutionContext.Implicits.global)
+        crashStrategy.crash(CrashStrategy.ZookeeperConnectionLoss)
       }
     }
   }
 
-  def apply(client: CuratorFramework): RichCuratorFramework = {
-    client.getConnectionStateListenable().addListener(ConnectionLostListener)
+  def apply(client: CuratorFramework, crashStrategy: CrashStrategy): RichCuratorFramework = {
+    client.getConnectionStateListenable().addListener(new ConnectionLostListener(crashStrategy))
     new RichCuratorFramework(client)
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -125,7 +125,7 @@ case class CuratorZk(
     })
     builder.retryPolicy(retryPolicy)
     builder.namespace(zkUrl.path.stripPrefix("/"))
-    val client = RichCuratorFramework(builder.build())
+    val client = RichCuratorFramework(builder.build(), crashStrategy)
 
     client.start()
     client.blockUntilConnected(lifecycleState, crashStrategy)

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -4,6 +4,7 @@ import akka.Done
 import akka.event.EventStream
 import akka.testkit.TestProbe
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.base.CrashStrategy
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.launchqueue.LaunchQueue
@@ -33,13 +34,15 @@ class MarathonSchedulerTest extends AkkaUnitTest {
     val eventBus: EventStream = system.eventStream
     val taskStatusProcessor: TaskStatusUpdateProcessor = mock[TaskStatusUpdateProcessor]
     val offerProcessor: OfferProcessor = mock[OfferProcessor]
+    val crashStrategy: CrashStrategy = mock[CrashStrategy]
     val marathonScheduler: MarathonScheduler = new MarathonScheduler(
       eventBus,
       offerProcessor = offerProcessor,
       taskStatusProcessor = taskStatusProcessor,
       frameworkIdRepository,
       mesosLeaderInfo,
-      config) {
+      config,
+      crashStrategy) {
       override protected def suicide(removeFrameworkId: Boolean): Unit = {
         suicideCalled = Some(removeFrameworkId)
       }

--- a/src/test/scala/mesosphere/marathon/test/TestCrashStrategy.scala
+++ b/src/test/scala/mesosphere/marathon/test/TestCrashStrategy.scala
@@ -7,7 +7,7 @@ import scala.concurrent.Future
 
 class TestCrashStrategy extends CrashStrategy {
   @volatile var crashed: Boolean = false
-  override def crash(): Future[Done] = {
+  override def crash(reason: CrashStrategy.Reason): Future[Done] = {
     crashed = true
     Future.successful(Done)
   }

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -915,7 +915,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     }
 
     "match offers with maintenance mode and enabled feature but no maintenance scheduled should not match because of *only* insufficient cpus" in {
-      val maintenanceEnabledConf = AllConf.withTestConfig( "--draining_seconds", "300", "--enable_features", Features.MAINTENANCE_MODE)
+      val maintenanceEnabledConf = AllConf.withTestConfig("--draining_seconds", "300", "--enable_features", Features.MAINTENANCE_MODE)
       val offer = MarathonTestHelper.makeBasicOffer().build
       val app = AppDefinition(
         id = "/test".toRootPath,


### PR DESCRIPTION
Summary:
The current exit code `137` is confusing since it can indicate an
external `SIGKILL` or a Marathon suicide. This change introduces
different exit codes to indicate why Marathon stopped itself.

JIRA issues: MARATHON-8381