### PR TITLE
Added a `parent_group` fixture to the SI tests

### DIFF
--- a/tests/shakedown/shakedown/clients/marathon.py
+++ b/tests/shakedown/shakedown/clients/marathon.py
@@ -376,7 +376,8 @@ class Client(object):
         params = self._force_params(force)
         path = 'v2/groups{}'.format(group_id)
 
-        self._rpc.http_req(http.delete, path, params=params)
+        response = self._rpc.http_req(http.delete, path, params=params)
+        return response.json()
 
     def kill_tasks(self, app_id, scale=None, host=None):
         """Kills the tasks for a given application,

--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -7,13 +7,13 @@ def apps_dir():
     return os.path.dirname(os.path.abspath(__file__))
 
 
-def load_app(app_def_file, app_id=None):
+def load_app(app_def_file, app_id=None, parent_group=None):
     """Loads an app definition from a json file and sets the app id."""
     app_path = os.path.join(apps_dir(), "{}.json".format(app_def_file))
     app = get_resource(app_path)
 
     if app_id is None:
-        app['id'] = make_id(app_def_file)
+        app['id'] = make_id(app_def_file, parent_group)
     else:
         app['id'] = app_id
 
@@ -21,78 +21,77 @@ def load_app(app_def_file, app_id=None):
     return app
 
 
-def mesos_app(app_id=None):
-    return load_app('mesos-app', app_id)
+def mesos_app(app_id=None, parent_group=None):
+    return load_app('mesos-app', app_id, parent_group)
 
 
-def http_server():
-    return load_app('http-server')
+def http_server(app_id=None, parent_group=None):
+    return load_app('http-server', app_id, parent_group)
 
 
-def docker_http_server(app_id=None):
-    return load_app('docker-http-server', app_id)
+def docker_http_server(app_id=None, parent_group=None):
+    return load_app('docker-http-server', app_id, parent_group)
 
 
-def healthcheck_and_volume():
-    return load_app('healthcheck-and-volume')
+def healthcheck_and_volume(app_id=None, parent_group=None):
+    return load_app('healthcheck-and-volume', app_id, parent_group)
 
 
-def ucr_docker_http_server(app_id=None):
-    return load_app('ucr-docker-http-server', app_id)
+def ucr_docker_http_server(app_id=None, parent_group=None):
+    return load_app('ucr-docker-http-server', parent_group=None)
 
 
-def sleep_app(app_id=None):
-    app = load_app('sleep-app', app_id)
-    return app
+def sleep_app(app_id=None, parent_group=None):
+    return load_app('sleep-app', app_id, parent_group)
 
 
-def docker_nginx_ssl():
-    return load_app('docker-nginx-ssl')
+def docker_nginx_ssl(app_id=None, parent_group=None):
+    return load_app('docker-nginx-ssl', app_id, parent_group)
 
 
-def resident_docker_app():
-    return load_app('resident-docker-app')
+def resident_docker_app(app_id=None, parent_group=None):
+    return load_app('resident-docker-app', app_id, parent_group)
 
 
-def persistent_volume_app():
-    return load_app('persistent-volume-app')
+def persistent_volume_app(app_id=None, parent_group=None):
+    return load_app('persistent-volume-app', app_id, parent_group)
 
 
-def readiness_and_health_app():
-    return load_app('readiness-and-health-app')
+def readiness_and_health_app(app_id=None, parent_group=None):
+    return load_app('readiness-and-health-app', app_id, parent_group)
 
 
-def private_docker_app():
-    return load_app('private-docker-app')
+def private_docker_app(app_id=None, parent_group=None):
+    return load_app('private-docker-app', app_id, parent_group)
 
 
-def private_ucr_docker_app():
-    return load_app('private-ucr-docker-app')
+def private_ucr_docker_app(app_id=None, parent_group=None):
+    return load_app('private-ucr-docker-app', app_id, parent_group)
 
 
-def pinger_localhost_app():
-    return load_app('pinger-localhost-app')
+def pinger_localhost_app(app_id=None, parent_group=None):
+    return load_app('pinger-localhost-app', app_id, parent_group)
 
 
-def pinger_bridge_app():
-    return load_app('pinger-bridge-app')
+def pinger_bridge_app(app_id=None, parent_group=None):
+    return load_app('pinger-bridge-app', app_id, parent_group)
 
 
-def pinger_container_app():
-    return load_app('pinger-container-app')
+def pinger_container_app(app_id=None, parent_group=None):
+    return load_app('pinger-container-app', app_id, parent_group)
 
 
-def fake_framework():
-    return load_app('fake-framework')
+def fake_framework(app_id=None, parent_group=None):
+    return load_app('fake-framework', app_id, parent_group)
 
 
-def external_volume_mesos_app():
-    return load_app('external-volume-mesos-app')
+def external_volume_mesos_app(app_id=None, parent_group=None):
+    return load_app('external-volume-mesos-app', app_id, parent_group)
 
 
-def ipv6_healthcheck():
+def ipv6_healthcheck(app_id=None, parent_group=None):
     """ The app uses netcat to listen on port. It uses alpine image which has netcat with ipv6 support by default.
         It uses command nc (shortcut for netcat) that runs for every new connection an echo command in shell.
         For more information about the nc options just run `docker run alpine nc --help`
     """
-    return load_app('ipv6-healthcheck')
+    return load_app('ipv6-healthcheck', app_id, parent_group)

--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -1,6 +1,7 @@
 import os.path
 
 from utils import make_id, get_resource
+from os.path import join
 
 
 def apps_dir():
@@ -15,7 +16,7 @@ def load_app(app_def_file, app_id=None, parent_group="/"):
     if app_id is None:
         app['id'] = make_id(app_def_file, parent_group)
     else:
-        app['id'] = app_id
+        app['id'] = join(parent_group, app_id)
 
     print('Loaded an app definition with id={}'.format(app['id']))
     return app

--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -7,7 +7,7 @@ def apps_dir():
     return os.path.dirname(os.path.abspath(__file__))
 
 
-def load_app(app_def_file, app_id=None, parent_group=None):
+def load_app(app_def_file, app_id=None, parent_group="/"):
     """Loads an app definition from a json file and sets the app id."""
     app_path = os.path.join(apps_dir(), "{}.json".format(app_def_file))
     app = get_resource(app_path)
@@ -21,75 +21,75 @@ def load_app(app_def_file, app_id=None, parent_group=None):
     return app
 
 
-def mesos_app(app_id=None, parent_group=None):
+def mesos_app(app_id=None, parent_group="/"):
     return load_app('mesos-app', app_id, parent_group)
 
 
-def http_server(app_id=None, parent_group=None):
+def http_server(app_id=None, parent_group="/"):
     return load_app('http-server', app_id, parent_group)
 
 
-def docker_http_server(app_id=None, parent_group=None):
+def docker_http_server(app_id=None, parent_group="/"):
     return load_app('docker-http-server', app_id, parent_group)
 
 
-def healthcheck_and_volume(app_id=None, parent_group=None):
+def healthcheck_and_volume(app_id=None, parent_group="/"):
     return load_app('healthcheck-and-volume', app_id, parent_group)
 
 
-def ucr_docker_http_server(app_id=None, parent_group=None):
-    return load_app('ucr-docker-http-server', parent_group=None)
+def ucr_docker_http_server(app_id=None, parent_group="/"):
+    return load_app('ucr-docker-http-server', parent_group="/")
 
 
-def sleep_app(app_id=None, parent_group=None):
+def sleep_app(app_id=None, parent_group="/"):
     return load_app('sleep-app', app_id, parent_group)
 
 
-def docker_nginx_ssl(app_id=None, parent_group=None):
+def docker_nginx_ssl(app_id=None, parent_group="/"):
     return load_app('docker-nginx-ssl', app_id, parent_group)
 
 
-def resident_docker_app(app_id=None, parent_group=None):
+def resident_docker_app(app_id=None, parent_group="/"):
     return load_app('resident-docker-app', app_id, parent_group)
 
 
-def persistent_volume_app(app_id=None, parent_group=None):
+def persistent_volume_app(app_id=None, parent_group="/"):
     return load_app('persistent-volume-app', app_id, parent_group)
 
 
-def readiness_and_health_app(app_id=None, parent_group=None):
+def readiness_and_health_app(app_id=None, parent_group="/"):
     return load_app('readiness-and-health-app', app_id, parent_group)
 
 
-def private_docker_app(app_id=None, parent_group=None):
+def private_docker_app(app_id=None, parent_group="/"):
     return load_app('private-docker-app', app_id, parent_group)
 
 
-def private_ucr_docker_app(app_id=None, parent_group=None):
+def private_ucr_docker_app(app_id=None, parent_group="/"):
     return load_app('private-ucr-docker-app', app_id, parent_group)
 
 
-def pinger_localhost_app(app_id=None, parent_group=None):
+def pinger_localhost_app(app_id=None, parent_group="/"):
     return load_app('pinger-localhost-app', app_id, parent_group)
 
 
-def pinger_bridge_app(app_id=None, parent_group=None):
+def pinger_bridge_app(app_id=None, parent_group="/"):
     return load_app('pinger-bridge-app', app_id, parent_group)
 
 
-def pinger_container_app(app_id=None, parent_group=None):
+def pinger_container_app(app_id=None, parent_group="/"):
     return load_app('pinger-container-app', app_id, parent_group)
 
 
-def fake_framework(app_id=None, parent_group=None):
+def fake_framework(app_id=None, parent_group="/"):
     return load_app('fake-framework', app_id, parent_group)
 
 
-def external_volume_mesos_app(app_id=None, parent_group=None):
+def external_volume_mesos_app(app_id=None, parent_group="/"):
     return load_app('external-volume-mesos-app', app_id, parent_group)
 
 
-def ipv6_healthcheck(app_id=None, parent_group=None):
+def ipv6_healthcheck(app_id=None, parent_group="/"):
     """ The app uses netcat to listen on port. It uses alpine image which has netcat with ipv6 support by default.
         It uses command nc (shortcut for netcat) that runs for every new connection an echo command in shell.
         For more information about the nc options just run `docker run alpine nc --help`

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -145,12 +145,11 @@ def cluster_info(mom_name='marathon-user'):
         print("Marathon MoM not present")
 
 
-def clean_up_marathon():
+def clean_up_marathon(parent_group="/"):
     client = marathon.create_client()
-    response = client.remove_group("/", force=True)
-    print("DEBUG: response = {}".format(response.json()))
-    deployment_id = response.json()["deploymentId"]
-    deployment_wait(deployment_id=deployment_id)
+
+    response = client.remove_group(parent_group, force=True)
+    deployment_wait(deployment_id=response["deploymentId"])
 
 
 def ip_other_than_mom():
@@ -712,7 +711,7 @@ def deployments_for(service_id=None, deployment_id=None):
             deployment for deployment in deployments
             if (deployment_id == deployment["id"])
         ]
-        return  filtered
+        return filtered
     elif (service_id):
         filtered = [
             deployment for deployment in deployments
@@ -736,7 +735,6 @@ def deployment_wait(service_id=None, deployment_id=None, wait_fixed=2000, max_at
         print('Waiting for {} to deploy successfully'.format(service_id))
     else:
         print('Waiting for all current deployments to finish')
-
 
     assert_that(lambda: deployments_for(service_id, deployment_id),
                 eventually(has_len(0), wait_fixed=wait_fixed, max_attempts=max_attempts))

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -706,16 +706,16 @@ def agent_hostname_by_id(agent_id):
 
 def deployments_for(service_id=None, deployment_id=None):
     deployments = marathon.create_client().get_deployments()
-    if (deployment_id):
+    if deployment_id:
         filtered = [
             deployment for deployment in deployments
-            if (deployment_id == deployment["id"])
+            if deployment_id == deployment["id"]
         ]
         return filtered
-    elif (service_id):
+    elif service_id:
         filtered = [
             deployment for deployment in deployments
-            if (service_id in deployment['affectedApps'] or service_id in deployment['affectedPods'])
+            if service_id in deployment['affectedApps'] or service_id in deployment['affectedPods']
         ]
         return filtered
     else:
@@ -729,9 +729,9 @@ def deployment_wait(service_id=None, deployment_id=None, wait_fixed=2000, max_at
     """
     assert not all([service_id, deployment_id]), "Use either deployment_id or service_id, but not both."
 
-    if (deployment_id):
+    if deployment_id:
         print("Waiting for the deployment_id {} to finish".format(deployment_id))
-    elif (service_id):
+    elif service_id:
         print('Waiting for {} to deploy successfully'.format(service_id))
     else:
         print('Waiting for all current deployments to finish')

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -32,6 +32,17 @@ def wait_for_marathon_user_and_cleanup():
         common.clean_up_marathon()
 
 
+@pytest.fixture(scope="function")
+def parent_group(request):
+    """ Fixture which yields a temporary marathon parent group can be used to place apps/pods within the test
+    function. Parent group will be removed after the test. Group name is equal to the test function name with
+    underscores replaced by dashes.
+    """
+    group = '/{}'.format(request.function.__name__).replace('_', '-')
+    yield group
+    common.clean_up_marathon(parent_group=group)
+
+
 def get_ca_file():
     return Path(fixtures_dir(), 'dcos-ca.crt')
 

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -777,13 +777,14 @@ def test_pod_file_based_secret(secret_fixture):
 
 
 # Uncomment to run a quick and sure-to-pass SI test on any cluster. Useful for running SI tests locally
-# def test_foo():
+# from fixtures import parent_group
+# def test_foo(parent_group):
 #     client = marathon.create_client()
-#     app_def = apps.sleep_app()
+#     app_def = apps.sleep_app(parent_group=parent_group)
 #     app_id = app_def['id']
 #     client.add_app(app_def)
 #     common.deployment_wait(service_id=app_id)
-
+#
 #     tasks = client.get_tasks(app_id)
 #     assert len(tasks) == 1, 'Failed to start a simple sleep app'
 

--- a/tests/system/utils.py
+++ b/tests/system/utils.py
@@ -4,13 +4,12 @@ import uuid
 from dcos import util
 from shakedown import http
 from shakedown.errors import DCOSException
+from os.path import join
 
 
-def make_id(prefix=None):
-    random_part = uuid.uuid4().hex
-    if prefix is None:
-        return '/{}'.format(random_part)
-    return '/{}-{}'.format(prefix, random_part)
+def make_id(app_id_prefix=None, parent_group="/"):
+    app_id = f'{app_id_prefix}-{uuid.uuid4().hex}' if app_id_prefix else str(uuid.uuid4().hex)
+    return join(parent_group, app_id)
 
 
 # should be in shakedown


### PR DESCRIPTION
Summary:
Added a `parent_group` fixture that can be used by the individual SI tests to deploy apps/pods in separate groups. The group will be removed after the test. This can be used to further make individual tests independent (clean up failure in one test should not affect the other). See `test_foo` method as an example.

Additionally:
 - `marathon.py::remove_group()` method now returns response json, similar to other client methods
 - `common.py::clean_up_marathon()` can take a parent group which will be removed which is `/` by default
 - `common.py::deployment_wait()` can now also directly wait for the `deployment_id`
