### PR TITLE
Add meter() to Metrics API

### DIFF
--- a/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/Metrics.scala
@@ -36,6 +36,10 @@ trait MinMaxCounter extends Metric {
   def decrement(times: Long): Unit
 }
 
+trait Meter extends Metric {
+  def mark(): Unit
+}
+
 trait TimerAdapter extends Metric {
   def update(value: Long): Unit
 }
@@ -69,5 +73,6 @@ trait Metrics {
   def closureGauge[N](name: String, currentValue: () => N,
     unit: DropwizardUnitOfMeasurement = DropwizardUnitOfMeasurement.None): ClosureGauge
   def settableGauge(name: String, unit: DropwizardUnitOfMeasurement = DropwizardUnitOfMeasurement.None): SettableGauge
+  def meter(name: String): Meter
   def timer(name: String): Timer
 }

--- a/src/main/scala/mesosphere/marathon/metrics/current/DropwizardMetrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/current/DropwizardMetrics.scala
@@ -12,7 +12,7 @@ import com.github.rollingmetrics.histogram.{HdrBuilder, OverflowResolver}
 import kamon.metric.instrument.{Time, UnitOfMeasurement => KamonUnitOfMeasurement}
 import mesosphere.marathon.metrics.deprecated.MetricPrefix
 import mesosphere.marathon.metrics.dummy.DummyMetrics
-import mesosphere.marathon.metrics.{ClosureGauge, Counter, Gauge, HistogramTimer, Metrics, MetricsConf, MinMaxCounter, SettableGauge, Timer, TimerAdapter}
+import mesosphere.marathon.metrics.{ClosureGauge, Counter, Gauge, HistogramTimer, Meter, Metrics, MetricsConf, MinMaxCounter, SettableGauge, Timer, TimerAdapter}
 import mesosphere.marathon.metrics.current.{UnitOfMeasurement => DropwizardUnitOfMeasurement}
 
 class DropwizardMetrics(metricsConf: MetricsConf, registry: MetricRegistry) extends Metrics {
@@ -82,6 +82,13 @@ class DropwizardMetrics(metricsConf: MetricsConf, registry: MetricRegistry) exte
     name: String,
     unit: DropwizardUnitOfMeasurement = DropwizardUnitOfMeasurement.None): SettableGauge = {
     new DropwizardSettableGauge(constructName(name, "gauge", unit))
+  }
+
+  implicit class DropwizardMeter(val meter: codahale.metrics.Meter) extends Meter {
+    override def mark(): Unit = meter.mark()
+  }
+  override def meter(name: String): Meter = {
+    registry.meter(constructName(name, "meter", DropwizardUnitOfMeasurement.None))
   }
 
   implicit class DropwizardTimerAdapter(val timer: metrics.Timer) extends TimerAdapter {

--- a/src/main/scala/mesosphere/marathon/metrics/deprecated/KamonMetrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/deprecated/KamonMetrics.scala
@@ -5,7 +5,7 @@ import kamon.Kamon
 import kamon.metric.instrument
 import kamon.metric.instrument.{Time, UnitOfMeasurement}
 import mesosphere.marathon.metrics.dummy.DummyMetrics
-import mesosphere.marathon.metrics.{ClosureGauge, Counter, Gauge, HistogramTimer, Metrics, MinMaxCounter, SettableGauge, Timer, TimerAdapter}
+import mesosphere.marathon.metrics.{ClosureGauge, Counter, Gauge, HistogramTimer, Meter, Metrics, MinMaxCounter, SettableGauge, Timer, TimerAdapter}
 import mesosphere.marathon.metrics.current.{UnitOfMeasurement => DropwizardUnitOfMeasurement}
 
 object KamonMetrics extends Metrics {
@@ -85,5 +85,6 @@ object KamonMetrics extends Metrics {
     name: String,
     unit: DropwizardUnitOfMeasurement = DropwizardUnitOfMeasurement.None): SettableGauge =
     DummyMetrics.settableGauge(name, unit)
+  override def meter(name: String): Meter = DummyMetrics.meter(name)
   override def timer(name: String): Timer = DummyMetrics.timer(name)
 }

--- a/src/main/scala/mesosphere/marathon/metrics/dummy/DummyMetrics.scala
+++ b/src/main/scala/mesosphere/marathon/metrics/dummy/DummyMetrics.scala
@@ -5,7 +5,7 @@ import java.time.Clock
 
 import akka.stream.scaladsl.Source
 import kamon.metric.instrument.{Time, UnitOfMeasurement => KamonUnitOfMeasurement}
-import mesosphere.marathon.metrics.{ClosureGauge, Counter, Gauge, Metrics, MinMaxCounter, SettableGauge, Timer}
+import mesosphere.marathon.metrics.{ClosureGauge, Counter, Gauge, Meter, Metrics, MinMaxCounter, SettableGauge, Timer}
 import mesosphere.marathon.metrics.current.{UnitOfMeasurement => DropwizardUnitOfMeasurement}
 import mesosphere.marathon.metrics.deprecated.MetricPrefix
 
@@ -28,6 +28,9 @@ object DummyMetrics extends Metrics {
     override def increment(times: Long): Unit = ()
     override def decrement(): Unit = ()
     override def decrement(times: Long): Unit = ()
+  }
+  class DummyMeter extends Meter {
+    override def mark(): Unit = ()
   }
   class DummyTimer extends Timer {
     override def apply[T](f: => Future[T]): Future[T] = f
@@ -63,5 +66,7 @@ object DummyMetrics extends Metrics {
     name: String,
     unit: DropwizardUnitOfMeasurement = DropwizardUnitOfMeasurement.None): SettableGauge =
     new DummyGauge
+
+  override def meter(name: String): Meter = new DummyMeter
   override def timer(name: String): Timer = new DummyTimer
 }


### PR DESCRIPTION
This method is of no use in Marathon currently, but it will be used
in Metronome soon.