### PR TITLE
Enable Maintenance Mode decline-offers behavior by default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,14 @@ Event-proxying has the following deprecation schedule:
 
 In some clusters with heavy standby-proxy usage, a limit of 32 max-open-connections was too small. This default has been increased to 64. In addition, the flag `--leader_proxy_max_open_connections` has been introduced to tune the value further, if needed.
 
+### Maintenance Mode Support Production Ready, Now Default
+
+Support for declining offers for agents undergoing a maintenance window is now enabled by default, and the feature is now recommended for production use.
+
+Previously, this support was enabled by `--enable_features maintenance_mode`. Operators should remove `maintenance_mode` from the `--enable_features` value list, as it now has no effect. In Marathon 1.8.x, including the term `maintenance_mode` in the `--enable_features` list will be considered an error.
+
+The flag `--maintenance_behavior` has been introduced. To revert back to the default maintenance mode behavior in Marathon 1.6.x and earlier, operators can specify `--maintenance_behavior disabled`.
+
 ### Fixed Issues
 
 - [MARATHON-8409](https://jira.mesosphere.com/browse/MARATHON-8409) - You can now launch marathon in Docker as non-root user.

--- a/changelog.md
+++ b/changelog.md
@@ -37,7 +37,7 @@ Support for declining offers for agents undergoing a maintenance window is now e
 
 Previously, this support was enabled by `--enable_features maintenance_mode`. Operators should remove `maintenance_mode` from the `--enable_features` value list, as it now has no effect. In Marathon 1.8.x, including the term `maintenance_mode` in the `--enable_features` list will be considered an error.
 
-The flag `--maintenance_behavior` has been introduced. To revert back to the default maintenance mode behavior in Marathon 1.6.x and earlier, operators can specify `--maintenance_behavior disabled`.
+The flag `--disable_maintenance_mode` has been introduced. To revert back to the default maintenance mode behavior in Marathon 1.6.x and earlier (ignore), operators can specify `--disable_maintenance_mode`.
 
 ### Fixed Issues
 

--- a/changelog.md
+++ b/changelog.md
@@ -33,9 +33,9 @@ In some clusters with heavy standby-proxy usage, a limit of 32 max-open-connecti
 
 ### Maintenance Mode Support Production Ready, Now Default
 
-Support for declining offers for agents undergoing a maintenance window is now enabled by default, and the feature is now recommended for production use.
+Marathon now declines offers for agents with scheduled maintenance.
 
-Previously, this support was enabled by `--enable_features maintenance_mode`. Operators should remove `maintenance_mode` from the `--enable_features` value list, as it now has no effect. In Marathon 1.8.x, including the term `maintenance_mode` in the `--enable_features` list will be considered an error.
+Previously, this behavior was enabled by `--enable_features maintenance_mode`. Operators should remove `maintenance_mode` from the `--enable_features` value list, as it now has no effect. In Marathon 1.8.x, including the term `maintenance_mode` in the `--enable_features` list will be considered an error.
 
 The flag `--disable_maintenance_mode` has been introduced. To revert back to the default maintenance mode behavior in Marathon 1.6.x and earlier (ignore), operators can specify `--disable_maintenance_mode`.
 

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -187,15 +187,15 @@ When using Debian packages, the ideal way to customize Marathon is to specify co
       If not provided, the [AWS default credentials provider chain](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) is used to look up aws credentials.
 * <span class="label label-default">v1.6.0</span>`--draining_seconds` (Optional. Default: 0):
     Time (in seconds) when Marathon will start declining offers before a [maintenance window](http://mesos.apache.org/documentation/latest/maintenance/) start time.
-    **Note:** This flag has no effect if `--disable_maintenance_mode` is set to `disabled`.
+    **Note:** This flag has no effect if `--disable_maintenance_mode` is specified.
 * <span class="label label-default">> v1.6.352</span>`--max_running_deployments` (Optional. Default: 100):
     Maximum number of concurrently running deployments. Should the user try to submit more updates than set by this flag a HTTP 403 Error is returned with an explanatory error message.
 * `--[disable_]suppress_offers` (Optional. Default: disabled)
     Controls whether or not Marathon will suppress offers if there is nothing to launch. Enabling helps the performance
     of Mesos in larger clusters, but enabling this flag will cause Marathon to more slowly release reservations.
-* <span class="label label-default">v1.6.0</span>`--[disable]_maintenance_mode` (Optional. Default: enabled)
-    Specifies if Marathon should enable the current level of maintenance mode support. See the [maintenance mode
-    docs](./maintenance-mode.html) for more information.
+* <span class="label label-default">v1.6.0</span>`--[disable]_maintenance_mode` (Optional. Default: enabled) Specifies
+    if Marathon should enable maintenance mode support. See the [maintenance mode docs](./maintenance-mode.html) for
+    more information.
 
 ## Tuning Flags for Offer Matching/Launching Tasks
 

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -187,15 +187,15 @@ When using Debian packages, the ideal way to customize Marathon is to specify co
       If not provided, the [AWS default credentials provider chain](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) is used to look up aws credentials.
 * <span class="label label-default">v1.6.0</span>`--draining_seconds` (Optional. Default: 0):
     Time (in seconds) when Marathon will start declining offers before a [maintenance window](http://mesos.apache.org/documentation/latest/maintenance/) start time.
-    **Note:** This flag has no effect if `--maintenance_behavior` is set to `disabled`.
+    **Note:** This flag has no effect if `--disable_maintenance_mode` is set to `disabled`.
 * <span class="label label-default">> v1.6.352</span>`--max_running_deployments` (Optional. Default: 100):
     Maximum number of concurrently running deployments. Should the user try to submit more updates than set by this flag a HTTP 403 Error is returned with an explanatory error message.
 * `--[disable_]suppress_offers` (Optional. Default: disabled)
     Controls whether or not Marathon will suppress offers if there is nothing to launch. Enabling helps the performance
     of Mesos in larger clusters, but enabling this flag will cause Marathon to more slowly release reservations.
-* <span class="label label-default">v1.6.0</span>`--maintenance_behavior` (Optional. Default: decline_offers)
-    Specifies how Marathon should behave agents undergoing a maintenance window. Valid options are `decline_offers` and
-    `disabled`. See the [maintenance mode docs](./maintenance-mode.html) for more information.
+* <span class="label label-default">v1.6.0</span>`--[disable]_maintenance_mode` (Optional. Default: enabled)
+    Specifies if Marathon should enable the current level of maintenance mode support. See the [maintenance mode
+    docs](./maintenance-mode.html) for more information.
 
 ## Tuning Flags for Offer Matching/Launching Tasks
 

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -186,13 +186,16 @@ When using Debian packages, the ideal way to customize Marathon is to specify co
       Please note: access_key and secret_key are optional.
       If not provided, the [AWS default credentials provider chain](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) is used to look up aws credentials.
 * <span class="label label-default">v1.6.0</span>`--draining_seconds` (Optional. Default: 0):
-    Time (in seconds) when marathon will start declining offers before a [maintenance window](http://mesos.apache.org/documentation/latest/maintenance/) start time.
-    **Note:** In order to activate the `--draining_seconds` configuration, you must add `maintenance_mode` to the set of `--enable_features`.
+    Time (in seconds) when Marathon will start declining offers before a [maintenance window](http://mesos.apache.org/documentation/latest/maintenance/) start time.
+    **Note:** This flag has no effect if `--maintenance_behavior` is set to `disabled`.
 * <span class="label label-default">> v1.6.352</span>`--max_running_deployments` (Optional. Default: 100):
     Maximum number of concurrently running deployments. Should the user try to submit more updates than set by this flag a HTTP 403 Error is returned with an explanatory error message.
 * `--[disable_]suppress_offers` (Optional. Default: disabled)
     Controls whether or not Marathon will suppress offers if there is nothing to launch. Enabling helps the performance
     of Mesos in larger clusters, but enabling this flag will cause Marathon to more slowly release reservations.
+* <span class="label label-default">v1.6.0</span>`--maintenance_behavior` (Optional. Default: decline_offers)
+    Specifies how Marathon should behave agents undergoing a maintenance window. Valid options are `decline_offers` and
+    `disabled`. See the [maintenance mode docs](./maintenance-mode.html) for more information.
 
 ## Tuning Flags for Offer Matching/Launching Tasks
 

--- a/docs/docs/maintenance-mode.md
+++ b/docs/docs/maintenance-mode.md
@@ -4,21 +4,17 @@ title: Maintenance Mode
 
 # Maintenance Mode
 
-As of version 1.6, Marathon has simple built-in support for [Mesos Maintenance Primitives](http://mesos.apache.org/documentation/latest/maintenance/).
+As of version 1.6, Marathon has simple built-in support for [Mesos Maintenance Primitives](http://mesos.apache.org/documentation/latest/maintenance/) by declining offers for agents undergoing a maintenance window. As of Marathon 1.7, this behavior is enabled by default, and can be controlled via the `maintenance_behavior` [command-line flag](./command-line-flags.html).
 
-Operators regularly need to perform maintenance tasks on machines that comprise a Mesos cluster. Most Mesos upgrades can be done without affecting running tasks, but there are situations where maintenance may affect running tasks. In order to meet Service Level Agreements or to ensure uninterrupted services for their end users, Marathon is respecting configured maintenance windows. 
-If this feature is enabled, Marathon is not scheduling tasks to agents currently within a maintenance window. Furthermore Marathon can decline offers before a maintenance window, if the according parameter is configured via command line argument.
+Maintenance Behavior has the following modes:
 
-## How it works
-The current implementation is respecting configured maintenance windows from Mesos agents. If Marathon receives an offer with an included [maintenance window](http://mesos.apache.org/documentation/latest/maintenance/), Marathon will check this agent is currently within this period or if the configured time before the window is reached. If one of this checks is true, Marathon will not use this offer to start a new task.
+- `decline_offers` (default) - Marathon will decline offers for agents currently undergoing a maintenance window. Furthermore, the flag `draining_seconds` can be specified to cause Marathon to begin declining offers for an agent before its maintenance window begins.
+- `disabled` - Marathon ignores agent maintenance windows, accepting offers and launching tasks on agents regardless of their maintenance window state.
 
 ## Limitations
-As described, Marathon will not start tasks on certain offers. But Marathon will also not migrate tasks from agents close to a maintenance window to other agents. In case an agent goes down for a planned maintenance, Marathon would detect the unreachable agent after receiving the according Mesos task status updates. Marathon would then restart these unreachable tasks on other agents. If your application is not allowed to have downtime, you need to manually migrate the tasks.
 
-The efforts to enhance the current implementation are tracked in [this JIRA issue](https://jira.mesosphere.com/browse/MARATHON-3216).
+Automatic draining is not yet implemented. If an agent (marked under maintenance or not) is shut down, Marathon will not receive terminal task statuses for the tasks that were running on the agent. As such, the tasks will be seen as unreachable and relaunched per the configured [unreachable strategy](./unreachable.html). To avoid this, you can manually kill tasks on the agents currently under a maintenance window before the agent is fully shut down.
 
-## How to configure
-By default, this feature is deactivated. It needs to be activated via command line argument. You need to add `maintenance_mode` to the set of `--enable_features` in your marathon startup arguments.
-If you want to configure a duration before the maintenance window, in which offers are also declined, you need to add the `draining_seconds` command line argument. The configured duration is in seconds.
+If you'd prefer to overscale rather than underscale during the transition, you can scale the application up by N instances, and then kill-and-scale back down to the original instance count.
 
-Please see [command-line-flags.html] for further informations.
+The efforts to implement richer Maintenance Mode behavior are tracked in [this JIRA issue](https://jira.mesosphere.com/browse/MARATHON-3216).

--- a/docs/docs/maintenance-mode.md
+++ b/docs/docs/maintenance-mode.md
@@ -4,7 +4,7 @@ title: Maintenance Mode
 
 # Maintenance Mode
 
-As of version 1.6, Marathon has primitive support for [Mesos Maintenance Primitives](http://mesos.apache.org/documentation/latest/maintenance/) by declining offers for agents undergoing a maintenance window. As of Marathon 1.7, this behavior is enabled by default, and can be disabled via the `--disable_maintenance_mode` [command-line flag](./command-line-flags.html).
+As of version 1.6, Marathon has primitive support for [Mesos Maintenance Primitives](http://mesos.apache.org/documentation/latest/maintenance/) by declining offers for agents with scheduled maintenance under [DRAIN mode](http://mesos.apache.org/documentation/latest/maintenance/#how-does-it-work). As of Marathon 1.7, this behavior is enabled by default, and can be disabled via the `--disable_maintenance_mode` [command-line flag](./command-line-flags.html).
 
 For clarity,
 
@@ -13,7 +13,7 @@ For clarity,
 
 ## Limitations
 
-Automatic draining is not yet implemented. If an agent (marked under maintenance or not) is shut down, Marathon will not receive terminal task statuses for the tasks that were running on the agent. As such, the tasks will be seen as unreachable and relaunched per the configured [unreachable strategy](./unreachable.html). To avoid this, you can manually kill tasks on the agents currently under a maintenance window before the agent is fully shut down.
+Automatic draining is not yet implemented. If an agent (with scheduled maintenance or not) is shut down, Marathon will not receive terminal task statuses for the tasks that were running on the agent. As such, the tasks will be seen as unreachable and relaunched per the configured [unreachable strategy](./unreachable.html). To avoid this, you can manually kill tasks on the agents currently under a maintenance window before the agent is fully shut down.
 
 If you'd prefer to overscale rather than underscale during the transition, you can scale the application up by N instances, and then kill-and-scale back down to the original instance count.
 

--- a/docs/docs/maintenance-mode.md
+++ b/docs/docs/maintenance-mode.md
@@ -4,12 +4,12 @@ title: Maintenance Mode
 
 # Maintenance Mode
 
-As of version 1.6, Marathon has simple built-in support for [Mesos Maintenance Primitives](http://mesos.apache.org/documentation/latest/maintenance/) by declining offers for agents undergoing a maintenance window. As of Marathon 1.7, this behavior is enabled by default, and can be controlled via the `maintenance_behavior` [command-line flag](./command-line-flags.html).
+As of version 1.6, Marathon has primitive support for [Mesos Maintenance Primitives](http://mesos.apache.org/documentation/latest/maintenance/) by declining offers for agents undergoing a maintenance window. As of Marathon 1.7, this behavior is enabled by default, and can be disabled via the `--disable_maintenance_mode` [command-line flag](./command-line-flags.html).
 
-Maintenance Behavior has the following modes:
+For clarity,
 
-- `decline_offers` (default) - Marathon will decline offers for agents currently undergoing a maintenance window. Furthermore, the flag `draining_seconds` can be specified to cause Marathon to begin declining offers for an agent before its maintenance window begins.
-- `disabled` - Marathon ignores agent maintenance windows, accepting offers and launching tasks on agents regardless of their maintenance window state.
+- `--maintenance_mode` (default) - Marathon will decline offers for agents currently undergoing a maintenance window. Furthermore, the flag `draining_seconds` can be specified to cause Marathon to begin declining offers for an agent before its maintenance window begins.
+- `--disable_maintenance_mode` - Marathon ignores agent maintenance windows, accepting offers and launching tasks on agents regardless of their maintenance window state.
 
 ## Limitations
 
@@ -17,4 +17,4 @@ Automatic draining is not yet implemented. If an agent (marked under maintenance
 
 If you'd prefer to overscale rather than underscale during the transition, you can scale the application up by N instances, and then kill-and-scale back down to the original instance count.
 
-The efforts to implement richer Maintenance Mode behavior are tracked in [this JIRA issue](https://jira.mesosphere.com/browse/MARATHON-3216).
+The efforts to implement richer maintenance mode behavior are tracked in [MARATHON-3216](https://jira.mesosphere.com/browse/MARATHON-3216).

--- a/src/main/scala/mesosphere/marathon/Features.scala
+++ b/src/main/scala/mesosphere/marathon/Features.scala
@@ -20,14 +20,20 @@ object Features {
   //enable maintenance mode
   lazy val MAINTENANCE_MODE = "maintenance_mode"
 
-  lazy val availableFeatures = Map(
-    VIPS -> "Enable networking VIPs UI",
-    TASK_KILLING -> "Enable the optional TASK_KILLING state, available in Mesos 0.28 and later",
-    EXTERNAL_VOLUMES -> "Enable external volumes support in Marathon",
-    SECRETS -> "Enable support for secrets in Marathon (experimental)",
-    GPU_RESOURCES -> "Enable support for GPU in Marathon (experimental)",
-    MAINTENANCE_MODE -> "Enable support for maintenance mode  in Marathon (experimental)"
-  )
+  lazy val availableFeatures = {
+    val b = Map.newBuilder[String, String]
+
+    b += VIPS -> "Enable networking VIPs UI"
+    b += TASK_KILLING -> "Enable the optional TASK_KILLING state, available in Mesos 0.28 and later"
+    b += EXTERNAL_VOLUMES -> "Enable external volumes support in Marathon"
+    b += SECRETS -> "Enable support for secrets in Marathon (experimental)"
+    b += GPU_RESOURCES -> "Enable support for GPU in Marathon (experimental)"
+
+    if (BuildInfo.version < SemVer(1, 8, 0))
+      b += MAINTENANCE_MODE -> "(on by default, has no effect) Decline offers from agents undergoing a maintenance window"
+
+    b.result()
+  }
 
   def description: String = {
     availableFeatures.map { case (name, description) => s"$name - $description" }.mkString(", ")

--- a/src/main/scala/mesosphere/marathon/MaintenanceBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/MaintenanceBehavior.scala
@@ -1,0 +1,7 @@
+package mesosphere.marathon
+
+sealed trait MaintenanceBehavior
+object MaintenanceBehavior {
+  case object DeclineOffers extends MaintenanceBehavior
+  case object Disabled extends MaintenanceBehavior
+}

--- a/src/main/scala/mesosphere/marathon/MaintenanceBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/MaintenanceBehavior.scala
@@ -1,7 +1,0 @@
-package mesosphere.marathon
-
-sealed trait MaintenanceBehavior
-object MaintenanceBehavior {
-  case object DeclineOffers extends MaintenanceBehavior
-  case object Disabled extends MaintenanceBehavior
-}

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -290,14 +290,17 @@ trait MarathonConf
   lazy val drainingSeconds = opt[Long](
     "draining_seconds",
     descr = "(Default: 0 seconds) the seconds when marathon will start declining offers before a maintenance " +
-      "window start time. This has no effect if '--maintenance_behavior' is set to 'disabled'!",
+      "window start time. This has no effect if '--disable_maintenance_mode' is specified!",
     default = Some(0)
   )
 
-  lazy val maintenanceBehavior = opt[MaintenanceBehavior](
-    "maintenance_behavior",
-    descr = "(default: decline_offers) how Marathon should react to agents undergoing Maintenance mode. Possible values: 'decline_offers', 'disabled'",
-    default = Some(MaintenanceBehavior.DeclineOffers))(maintenanceBehaviorReader)
+  lazy val maintenanceMode = toggle(
+    "maintenance_mode",
+    descrYes = "(Default) Marathon will decline offers from agents undergoing an active maintenance window",
+    descrNo = "(Default) Marathon will ignore maintenance windows, accepting offers from agents undergoing an active maintenance window",
+    prefix = "disable_",
+    noshort = true,
+    default = Some(true))
 
   private[this] def validateGpuSchedulingBehavior(setting: String): Boolean = {
     val allowedSettings = Set(GpuSchedulingBehavior.Undefined, GpuSchedulingBehavior.Restricted, GpuSchedulingBehavior.Unrestricted)
@@ -398,11 +401,5 @@ object MarathonConf extends StrictLogging {
       case _ =>
         Left("Expected exactly one connection string")
     }
-  }
-
-  val maintenanceBehaviorReader: ValueConverter[MaintenanceBehavior] = implicitly[ValueConverter[String]].flatMap {
-    case "decline_offers" => Right(Some(MaintenanceBehavior.DeclineOffers))
-    case "disabled" => Right(Some(MaintenanceBehavior.Disabled))
-    case o => Left(s"${o} is not a valid value for maintenance_behavior; valid values are: 'decline_offers', 'disabled'")
   }
 }

--- a/src/main/scala/mesosphere/mesos/MatcherConf.scala
+++ b/src/main/scala/mesosphere/mesos/MatcherConf.scala
@@ -1,6 +1,7 @@
 package mesosphere.mesos
 
 import org.rogach.scallop.ScallopOption
+import mesosphere.marathon.MaintenanceBehavior
 
 import scala.concurrent.duration._
 
@@ -13,4 +14,6 @@ trait MatcherConf {
   def drainingTime: FiniteDuration = FiniteDuration(drainingSeconds(), SECONDS)
 
   def gpuSchedulingBehavior: ScallopOption[String]
+
+  def maintenanceBehavior: ScallopOption[MaintenanceBehavior]
 }

--- a/src/main/scala/mesosphere/mesos/MatcherConf.scala
+++ b/src/main/scala/mesosphere/mesos/MatcherConf.scala
@@ -1,7 +1,6 @@
 package mesosphere.mesos
 
 import org.rogach.scallop.ScallopOption
-import mesosphere.marathon.MaintenanceBehavior
 
 import scala.concurrent.duration._
 
@@ -15,5 +14,5 @@ trait MatcherConf {
 
   def gpuSchedulingBehavior: ScallopOption[String]
 
-  def maintenanceBehavior: ScallopOption[MaintenanceBehavior]
+  def maintenanceMode: ScallopOption[Boolean]
 }

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -3,7 +3,7 @@ package mesosphere.mesos
 import java.time.Clock
 
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.{Features, GpuSchedulingBehavior}
+import mesosphere.marathon.{GpuSchedulingBehavior, MaintenanceBehavior}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.pod.PodDefinition
@@ -236,7 +236,7 @@ object ResourceMatcher extends StrictLogging {
     }
 
     val checkAvailability: Boolean = {
-      if (conf.availableFeatures.contains(Features.MAINTENANCE_MODE)) {
+      if (conf.maintenanceBehavior() == MaintenanceBehavior.DeclineOffers) {
         val result = Availability.offerAvailable(offer, conf.drainingTime)
         if (!result) {
           noOfferMatchReasons += NoOfferMatchReason.UnfulfilledConstraint

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -3,7 +3,7 @@ package mesosphere.mesos
 import java.time.Clock
 
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.{GpuSchedulingBehavior, MaintenanceBehavior}
+import mesosphere.marathon.GpuSchedulingBehavior
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.pod.PodDefinition
@@ -236,7 +236,7 @@ object ResourceMatcher extends StrictLogging {
     }
 
     val checkAvailability: Boolean = {
-      if (conf.maintenanceBehavior() == MaintenanceBehavior.DeclineOffers) {
+      if (conf.maintenanceMode()) {
         val result = Availability.offerAvailable(offer, conf.drainingTime)
         if (!result) {
           noOfferMatchReasons += NoOfferMatchReason.UnfulfilledConstraint

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -872,7 +872,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     }
 
     "when ignore maintenance mode is configured, offers with an active maintenance window should match" in {
-      val maintenanceDisabledConf = AllConf.withTestConfig("--maintenance_behavior", "disabled")
+      val maintenanceDisabledConf = AllConf.withTestConfig("--disable_maintenance_mode")
       val offer = MarathonTestHelper.makeBasicOfferWithUnavailability(clock.now).build
       val app = AppDefinition(
         id = "/test".toRootPath,

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -871,14 +871,15 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       response shouldBe a[ResourceMatchResponse.Match]
     }
 
-    "match offers with maintenance mode and not enabled feature should not match" in {
+    "when ignore maintenance mode is configured, offers with an active maintenance window should match" in {
+      val maintenanceDisabledConf = AllConf.withTestConfig("--maintenance_behavior", "disabled")
       val offer = MarathonTestHelper.makeBasicOfferWithUnavailability(clock.now).build
       val app = AppDefinition(
         id = "/test".toRootPath,
         resources = Resources(cpus = 0.1, mem = 128.0, disk = 0.0)
       )
 
-      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, config, Seq.empty)
+      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, maintenanceDisabledConf, Seq.empty)
 
       resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
       val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
@@ -889,27 +890,25 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     }
 
     "match offers with maintenance mode and enabled feature should not match" in {
-      val maintenanceEnabledConf = AllConf.withTestConfig("--draining_seconds", "300", "--enable_features", Features.MAINTENANCE_MODE)
       val offer = MarathonTestHelper.makeBasicOfferWithUnavailability(clock.now).build
       val app = AppDefinition(
         id = "/test".toRootPath,
         resources = Resources(cpus = 0.1, mem = 128.0, disk = 0.0)
       )
 
-      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, maintenanceEnabledConf, Seq.empty)
+      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, config, Seq.empty)
 
       resourceMatchResponse shouldBe ResourceMatchResponse.NoMatch(Seq(UnfulfilledConstraint, AgentMaintenance))
     }
 
     "match offers with maintenance mode, too many required cpus and enabled feature should not match" in {
-      val maintenanceEnabledConf = AllConf.withTestConfig("--draining_seconds", "300", "--enable_features", Features.MAINTENANCE_MODE)
       val offer = MarathonTestHelper.makeBasicOfferWithUnavailability(clock.now).build
       val app = AppDefinition(
         id = "/test".toRootPath,
         resources = Resources(cpus = 1000, mem = 128.0, disk = 0.0)
       )
 
-      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, maintenanceEnabledConf, Seq.empty)
+      val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, config, Seq.empty)
 
       resourceMatchResponse shouldBe ResourceMatchResponse.NoMatch(Seq(InsufficientCpus, UnfulfilledConstraint, AgentMaintenance))
     }


### PR DESCRIPTION
We deprecate the `maintenance_mode` specification mechanism via `--enable_features`.

To allow a user to disable the feature going forward, we introduce a `--disable_maintenance_mode` toggle flag. We also clarify the documentation surrounding the feature.

JIRA Issues: MARATHON-8315