### PR TITLE
Prevent XSS and clickjacking

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
@@ -87,6 +87,8 @@ class LeaderProxyFilter(
 
         if (electionService.isLeader) {
           response.addHeader(LeaderProxyFilter.HEADER_MARATHON_LEADER, buildUrl(myHostPort).toString)
+          response.addHeader(LeaderProxyFilter.HEADER_FRAME_OPTIONS, LeaderProxyFilter.VALUE_FRAME_OPTIONS)
+          response.addHeader(LeaderProxyFilter.HEADER_XXS_PROTECTION, LeaderProxyFilter.VALUE_XXS_PROTECTION)
           chain.doFilter(request, response)
         } else if (leaderDataOpt.forall(_ == myHostPort)) { // either not leader or ourselves
           logger.info(
@@ -131,5 +133,10 @@ class LeaderProxyFilter(
 
 object LeaderProxyFilter {
   val HEADER_MARATHON_LEADER: String = "X-Marathon-Leader"
+  val HEADER_FRAME_OPTIONS: String = "X-Frame-Options"
+  val VALUE_FRAME_OPTIONS: String = "DENY"
+  val HEADER_XXS_PROTECTION: String = "X-XSS-Protection"
+  val VALUE_XXS_PROTECTION: String = "1; mode=block"
+
   val ERROR_STATUS_NO_CURRENT_LEADER: String = "Could not determine the current leader"
 }

--- a/src/test/scala/mesosphere/marathon/api/LeaderProxyFilterTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/LeaderProxyFilterTest.scala
@@ -56,6 +56,9 @@ class LeaderProxyFilterTest extends AkkaUnitTest {
 
       // we pass that request down the chain
       verify(response, times(1)).addHeader(LeaderProxyFilter.HEADER_MARATHON_LEADER, "http://host:10000")
+      verify(response, times(1)).addHeader(LeaderProxyFilter.HEADER_FRAME_OPTIONS, LeaderProxyFilter.VALUE_FRAME_OPTIONS)
+      verify(response, times(1)).addHeader(LeaderProxyFilter.HEADER_XXS_PROTECTION, LeaderProxyFilter.VALUE_XXS_PROTECTION)
+
       verify(electionService, times(1)).isLeader
       verify(chain, times(1)).doFilter(request, response)
       verifyClean()
@@ -166,6 +169,8 @@ class LeaderProxyFilterTest extends AkkaUnitTest {
       verify(electionService, times(4)).isLeader
       verify(electionService, times(3)).leaderHostPort
       verify(response, times(1)).addHeader(LeaderProxyFilter.HEADER_MARATHON_LEADER, "http://host:10000")
+      verify(response, times(1)).addHeader(LeaderProxyFilter.HEADER_FRAME_OPTIONS, LeaderProxyFilter.VALUE_FRAME_OPTIONS)
+      verify(response, times(1)).addHeader(LeaderProxyFilter.HEADER_XXS_PROTECTION, LeaderProxyFilter.VALUE_XXS_PROTECTION)
       verify(chain, times(1)).doFilter(request, response)
       verifyClean()
     }


### PR DESCRIPTION
Prevent XSS and clickjacking

Summary:
Adding headers to responses to prevent xss and clickjacking
https://jira.mesosphere.com/browse/MARATHON-8405


JIRA issues:  MARATHON-8405
