### PR TITLE
Switched to python `logging` instead of `print` in SI tests

### DIFF
--- a/tests/shakedown/shakedown/cli/helpers.py
+++ b/tests/shakedown/shakedown/cli/helpers.py
@@ -32,28 +32,6 @@ def read_config(args):
     return args
 
 
-def set_config_defaults(args):
-    """ Set configuration defaults
-
-        :param args: a dict of arguments
-        :type args: dict
-
-        :return: a dict of arguments
-        :rtype: dict
-    """
-
-    defaults = {
-        'fail': 'fast',
-        'stdout': 'fail'
-    }
-
-    for key in defaults:
-        if not args[key]:
-            args[key] = defaults[key]
-
-    return args
-
-
 def fchr(char):
     """ Print a fancy character
 
@@ -159,9 +137,6 @@ def echo(text, **kwargs):
         :return: a string
         :rtype: str
     """
-
-    if shakedown.cli.quiet:
-        return
 
     if not 'n' in kwargs:
         kwargs['n'] = True

--- a/tests/shakedown/shakedown/dcos/marathon.py
+++ b/tests/shakedown/shakedown/dcos/marathon.py
@@ -7,7 +7,9 @@ from shakedown.dcos.service import service_available_predicate
 from six.moves import urllib
 
 import pytest
+import logging
 
+logger = logging.getLogger(__name__)
 
 marathon_1_3 = pytest.mark.skipif('marthon_version_less_than("1.3")')
 marathon_1_4 = pytest.mark.skipif('marthon_version_less_than("1.4")')
@@ -40,7 +42,7 @@ def mom_version(name='marathon-user'):
     else:
         # We can either skip the corresponding test by returning False
         # or raise an exception.
-        print('WARN: {} MoM not found. Version is None'.format(name))
+        logger.warning('{} MoM not found. Version is None'.format(name))
         return None
 
 
@@ -60,7 +62,7 @@ def mom_version_less_than(version, name='marathon-user'):
     else:
         # We can either skip the corresponding test by returning False
         # or raise an exception.
-        print('WARN: {} MoM not found. mom_version_less_than({}) is False'.format(name, version))
+        logger.warning('{} MoM not found. mom_version_less_than({}) is False'.format(name, version))
         return False
 
 

--- a/tests/shakedown/tests/acceptance/test_dcos_docker.py
+++ b/tests/shakedown/tests/acceptance/test_dcos_docker.py
@@ -1,6 +1,10 @@
+import logging
+
 from shakedown import *
+
+logger = logging.getLogger(__name__)
 
 def test_docker_version():
     master_docker_version = docker_version()
-    print("DC/OS master is running Docker Server {}".format(master_docker_version))
+    logger.info("DC/OS master is running Docker Server {}".format(master_docker_version))
     assert master_docker_version != 'unknown'

--- a/tests/system/Makefile
+++ b/tests/system/Makefile
@@ -21,12 +21,9 @@ build:
 
 test:
 	pipenv run shakedown \
-      --stdout all \
-      --stdout-inline \
       --ssl-no-verify \
-      --timeout 360000 \
       --pytest-option "--junitxml=../../shakedown.xml" \
-      --pytest-option --verbose \
+      --pytest-option -v \
       --pytest-option --full-trace \
       --ssh-key-file "$(CLI_TEST_SSH_KEY)" \
       --ssh-user "centos" \

--- a/tests/system/apps/__init__.py
+++ b/tests/system/apps/__init__.py
@@ -1,7 +1,10 @@
 import os.path
+import logging
 
 from utils import make_id, get_resource
 from os.path import join
+
+logger = logging.getLogger(__name__)
 
 
 def apps_dir():
@@ -18,7 +21,7 @@ def load_app(app_def_file, app_id=None, parent_group="/"):
     else:
         app['id'] = join(parent_group, app_id)
 
-    print('Loaded an app definition with id={}'.format(app['id']))
+    logger.info('Loaded an app definition with id={}'.format(app['id']))
     return app
 
 

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -6,9 +6,9 @@ import shakedown
 import shlex
 import time
 import uuid
-import sys
 import retrying
 import requests
+import logging
 
 from datetime import timedelta
 from distutils.version import LooseVersion
@@ -24,6 +24,8 @@ from shakedown.errors import DCOSException, DCOSHTTPException
 from shakedown.http import DCOSAcsAuth
 from matcher import assert_that, eventually, has_len
 from precisely import equal_to
+
+logger = logging.getLogger(__name__)
 
 marathon_1_3 = pytest.mark.skipif('marthon_version_less_than("1.3")')
 marathon_1_4 = pytest.mark.skipif('marthon_version_less_than("1.4")')
@@ -126,23 +128,23 @@ def command_health_check(command='true', failures=1, timeout=2):
 
 
 def cluster_info(mom_name='marathon-user'):
-    print("DC/OS: {}, in {} mode".format(shakedown.dcos_version(), shakedown.ee_version()))
+    logger.info("DC/OS: {}, in {} mode".format(shakedown.dcos_version(), shakedown.ee_version()))
     agents = shakedown.get_private_agents()
-    print("Agents: {}".format(len(agents)))
+    logger.info("Agents: {}".format(len(agents)))
     client = marathon.create_client()
     about = client.get_about()
-    print("Marathon version: {}".format(about.get("version")))
+    logger.info("Marathon version: {}".format(about.get("version")))
 
     if shakedown.service_available_predicate(mom_name):
         with shakedown.marathon_on_marathon(mom_name):
             try:
                 client = marathon.create_client()
                 about = client.get_about()
-                print("Marathon MoM version: {}".format(about.get("version")))
+                logger.info("Marathon MoM version: {}".format(about.get("version")))
             except Exception:
-                print("Marathon MoM not present")
+                logger.info("Marathon MoM not present")
     else:
-        print("Marathon MoM not present")
+        logger.info("Marathon MoM not present")
 
 
 def clean_up_marathon(parent_group="/"):
@@ -179,12 +181,13 @@ def ensure_mom():
 
         try:
             shakedown.install_package_and_wait('marathon')
-            deployment_wait()
+            deployment_wait(service_id='/marathon-user')
         except Exception:
+            logger.exception('Error while waiting for MoM to deploy')
             pass
 
         if not wait_for_service_endpoint('marathon-user', path="ping"):
-            print('ERROR: Timeout waiting for endpoint')
+            logger.error('Timeout waiting for endpoint')
 
 
 def is_mom_installed():
@@ -321,14 +324,14 @@ def assert_app_tasks_healthy(client, app_def):
 def get_marathon_leader_not_on_master_leader_node():
     marathon_leader = shakedown.marathon_leader_ip()
     master_leader = shakedown.master_leader_ip()
-    print('marathon leader: {}'.format(marathon_leader))
-    print('mesos leader: {}'.format(master_leader))
+    logger.info('marathon leader: {}'.format(marathon_leader))
+    logger.info('mesos leader: {}'.format(master_leader))
 
     if marathon_leader == master_leader:
         delete_marathon_path('v2/leader')
         wait_for_service_endpoint('marathon', timedelta(minutes=5).total_seconds(), path="ping")
         marathon_leader = assert_marathon_leadership_changed(marathon_leader)
-        print('switched leader to: {}'.format(marathon_leader))
+        logger.info('switched leader to: {}'.format(marathon_leader))
 
     return marathon_leader
 
@@ -346,7 +349,7 @@ def install_enterprise_cli_package():
     """Install `dcos-enterprise-cli` package. It is required by the `dcos security`
        command to create secrets, manage service accounts etc.
     """
-    print('Installing dcos-enterprise-cli package')
+    logger.info('Installing dcos-enterprise-cli package')
     cmd = 'package install dcos-enterprise-cli --cli --yes'
     stdout, stderr, return_code = shakedown.run_dcos_command(cmd, raise_on_error=True)
 
@@ -354,7 +357,7 @@ def install_enterprise_cli_package():
 def is_enterprise_cli_package_installed():
     """Returns `True` if `dcos-enterprise-cli` package is installed."""
     stdout, stderr, return_code = shakedown.run_dcos_command('package list --json')
-    print('package list command returned code:{}, stderr:{}, stdout: {}'.format(return_code, stderr, stdout))
+    logger.info('package list command returned code:{}, stderr:{}, stdout: {}'.format(return_code, stderr, stdout))
     try:
         result_json = json.loads(stdout)
     except JSONDecodeError as error:
@@ -369,7 +372,7 @@ def create_docker_pull_config_json(username, password):
        :param password: password for a private Docker registry
        :return: Docker config.json
     """
-    print('Creating a config.json content for dockerhub username {}'.format(username))
+    logger.info('Creating a config.json content for dockerhub username {}'.format(username))
 
     import base64
     auth_hash = base64.b64encode('{}:{}'.format(username, password).encode()).decode()
@@ -391,7 +394,7 @@ def create_docker_credentials_file(username, password, file_name='docker.tar.gz'
        :type command: str
     """
 
-    print('Creating a tarball {} with json credentials for dockerhub username {}'.format(file_name, username))
+    logger.info('Creating a tarball {} with json credentials for dockerhub username {}'.format(file_name, username))
     config_json_filename = 'config.json'
 
     config_json = create_docker_pull_config_json(username, password)
@@ -407,7 +410,7 @@ def create_docker_credentials_file(username, password, file_name='docker.tar.gz'
             tar.add(config_json_filename, arcname='.docker/config.json')
             tar.close()
     except Exception as e:
-        print('Failed to create a docker credentils file {}'.format(e))
+        logger.info('Failed to create a docker credentils file {}'.format(e))
         raise e
     finally:
         os.remove(config_json_filename)
@@ -425,12 +428,12 @@ def copy_docker_credentials_file(agents, file_name='docker.tar.gz'):
 
     # Upload docker.tar.gz to all private agents
     try:
-        print('Uploading tarball with docker credentials to all private agents...')
+        logger.info('Uploading tarball with docker credentials to all private agents...')
         for agent in agents:
-            print("Copying docker credentials to {}".format(agent))
+            logger.info("Copying docker credentials to {}".format(agent))
             shakedown.copy_file_to_agent(agent, file_name)
     except Exception as e:
-        print('Failed to upload {} to agent: {}'.format(file_name, agent))
+        logger.info('Failed to upload {} to agent: {}'.format(file_name, agent))
         raise e
     finally:
         os.remove(file_name)
@@ -459,7 +462,7 @@ def delete_secret(secret_name):
        :param secret_name: secret name
        :type secret_name: str
     """
-    print('Removing existing secret {}'.format(secret_name))
+    logger.info('Removing existing secret {}'.format(secret_name))
     stdout, stderr, return_code = shakedown.run_dcos_command('security secrets delete {}'.format(secret_name))
     assert return_code == 0, "Failed to remove existing secret"
 
@@ -476,7 +479,7 @@ def create_secret(name, value=None, description=None):
        :param description: option secret description
        :type description: str
     """
-    print('Creating new secret {}:{}'.format(name, value))
+    logger.info('Creating new secret {}:{}'.format(name, value))
 
     value_opt = '-v {}'.format(shlex.quote(value)) if value else ''
     description_opt = '-d "{}"'.format(description) if description else ''
@@ -507,7 +510,7 @@ def create_sa_secret(secret_name, service_account, strict=False, private_key_fil
     """
     assert os.path.isfile(private_key_filename), "Failed to create secret: private key not found"
 
-    print('Creating new sa-secret {} for service-account: {}'.format(secret_name, service_account))
+    logger.info('Creating new sa-secret {} for service-account: {}'.format(secret_name, service_account))
     strict_opt = '--strict' if strict else ''
     stdout, stderr, return_code = shakedown.run_dcos_command('security secrets create-sa-secret {} {} {} {}'.format(
         strict_opt,
@@ -539,7 +542,7 @@ def delete_service_account(service_account):
        :param service_account: service account name
        :type service_account: str
     """
-    print('Removing existing service account {}'.format(service_account))
+    logger.info('Removing existing service account {}'.format(service_account))
     stdout, stderr, return_code = \
         shakedown.run_dcos_command('security org service-accounts delete {}'.format(service_account))
     assert return_code == 0, "Failed to create a service account"
@@ -563,13 +566,13 @@ def create_service_account(service_account, private_key_filename='private-key.pe
        :param account_description: service account description
        :type account_description: str
     """
-    print('Creating a key pair for the service account')
+    logger.info('Creating a key pair for the service account')
     shakedown.run_dcos_command('security org service-accounts keypair {} {}'.format(
         private_key_filename, public_key_filename))
     assert os.path.isfile(private_key_filename), "Private key of the service account key pair not found"
     assert os.path.isfile(public_key_filename), "Public key of the service account key pair not found"
 
-    print('Creating {} service account'.format(service_account))
+    logger.info('Creating {} service account'.format(service_account))
     stdout, stderr, return_code = shakedown.run_dcos_command(
         'security org service-accounts create -p {} -d "{}" {}'.format(
             public_key_filename, account_description, service_account))
@@ -584,19 +587,19 @@ def set_service_account_permissions(service_account, resource='dcos:superuser', 
        https://docs.mesosphere.com/1.9/administration/id-and-access-mgt/permissions/user-service-perms/
     """
     try:
-        print('Granting {} permissions to {}/users/{}'.format(action, resource, service_account))
+        logger.info('Granting {} permissions to {}/users/{}'.format(action, resource, service_account))
         url = urljoin(shakedown.dcos_url(), 'acs/api/v1/acls/{}/users/{}/{}'.format(resource, service_account, action))
         req = http.put(url)
         msg = 'Failed to grant permissions to the service account: {}, {}'.format(req, req.text)
         assert req.status_code == 204, msg
     except DCOSHTTPException as e:
         if (e.response.status_code == 409):
-            print('Service account {} already has {} permissions set'.format(service_account, resource))
+            logger.info('Service account {} already has {} permissions set'.format(service_account, resource))
         else:
-            print("Unexpected HTTP error: {}".format(e.response))
+            logger.error("Unexpected HTTP error: {}".format(e.response))
             raise
     except Exception:
-        print("Unexpected error:", sys.exc_info()[0])
+        logger.exception("Unexpected error when setting service account permissions")
         raise
 
 
@@ -606,19 +609,19 @@ def add_acs_resource(resource):
     """
     import json
     try:
-        print('Adding ACS resource: {}'.format(resource))
+        logger.info('Adding ACS resource: {}'.format(resource))
         url = urljoin(shakedown.dcos_url(), 'acs/api/v1/acls/{}'.format(resource))
         extra_args = {'headers': {'Content-Type': 'application/json'}}
         req = http.put(url, data=json.dumps({'description': resource}), **extra_args)
         assert req.status_code == 201, 'Failed create ACS resource: {}, {}'.format(req, req.text)
     except DCOSHTTPException as e:
         if (e.response.status_code == 409):
-            print('ACS resource {} already exists'.format(resource))
+            logger.info('ACS resource {} already exists'.format(resource))
         else:
-            print("Unexpected HTTP error: {}, {}".format(e.response, e.response.text))
+            logger.error("Unexpected HTTP error: {}, {}".format(e.response, e.response.text))
             raise
     except Exception:
-        print("Unexpected error:", sys.exc_info()[0])
+        logger.exception("Unexpected error while adding ACS resource {}".format(resource))
         raise
 
 
@@ -730,11 +733,11 @@ def deployment_wait(service_id=None, deployment_id=None, wait_fixed=2000, max_at
     assert not all([service_id, deployment_id]), "Use either deployment_id or service_id, but not both."
 
     if deployment_id:
-        print("Waiting for the deployment_id {} to finish".format(deployment_id))
+        logger.info("Waiting for the deployment_id {} to finish".format(deployment_id))
     elif service_id:
-        print('Waiting for {} to deploy successfully'.format(service_id))
+        logger.info('Waiting for {} to deploy successfully'.format(service_id))
     else:
-        print('Waiting for all current deployments to finish')
+        logger.info('Waiting for all current deployments to finish')
 
     assert_that(lambda: deployments_for(service_id, deployment_id),
                 eventually(has_len(0), wait_fixed=wait_fixed, max_attempts=max_attempts))
@@ -746,7 +749,7 @@ def __marathon_leadership_changed_in_mesosDNS(original_leader):
         We have to retry because mesosDNS checks for changes only every 30s.
     """
     current_leader = shakedown.marathon_leader_ip()
-    print(f'leader according to MesosDNS: {current_leader}, original leader: {original_leader}') # NOQA E999
+    logger.info(f'Current leader according to MesosDNS: {current_leader}, original leader: {original_leader}') # NOQA E999
 
     assert current_leader, "MesosDNS returned empty string for Marathon leader ip."
     error = f'Current leader did not change: original={original_leader}, current={current_leader}' # NOQA E999
@@ -762,7 +765,7 @@ def __marathon_leadership_changed_in_marathon_api(original_leader):
     """
     # Leader is returned like this 10.0.6.88:8080 - we want just the IP
     current_leader = marathon.create_client().get_leader().split(':', 1)[0]
-    print('leader according to marathon API: {}'.format(current_leader))
+    logger.info('Current leader according to marathon API: {}'.format(current_leader))
     assert original_leader != current_leader
     return current_leader
 
@@ -805,7 +808,7 @@ def task_by_name(tasks, name):
 
 async def find_event(event_type, event_stream):
     async for event in event_stream:
-        print('Check event: {}'.format(event))
+        logger.info('Check event: {}'.format(event))
         if event['eventType'] == event_type:
             return event
 
@@ -826,9 +829,9 @@ def kill_process_on_host(hostname, pattern):
     status, stdout = shakedown.run_command_on_agent(hostname, cmd)
     pids = [p.strip() for p in stdout.splitlines()]
     if pids:
-        print("Killed pids: {}".format(", ".join(pids)))
+        logger.info("Killed pids: {}".format(", ".join(pids)))
     else:
-        print("Killed no pids")
+        logger.info("Killed no pids")
     return pids
 
 
@@ -879,7 +882,7 @@ def wait_for_service_endpoint(service_name, timeout_sec=120, path=""):
         return response.status_code
 
     schema = 'https' if ee_version() == 'strict' or ee_version() == 'permissive' else 'http'
-    print('Waiting for service /service/{}/{} to become available on all masters'.format(service_name, path))
+    logger.info('Waiting for service /service/{}/{} to become available on all masters'.format(service_name, path))
 
     for ip in dcos_masters_public_ips():
         url = "{}://{}/service/{}/{}".format(schema, ip, service_name, path)

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -5,10 +5,14 @@ import os.path
 import pytest
 import shakedown
 import ssl
+import logging
+
 from datetime import timedelta
 from pathlib import Path
 from sseclient.async import SSEClient
 from urllib.parse import urljoin
+
+logger = logging.getLogger(__name__)
 
 
 def fixtures_dir():
@@ -57,7 +61,7 @@ def get_ssl_context():
     """
     cafile = get_ca_file()
     if cafile.is_file():
-        print(f'Provide certificate {cafile}') # NOQA E999
+        logger.info(f'Provide certificate {cafile}') # NOQA E999
         ssl_context = ssl.create_default_context(cafile=cafile)
         return ssl_context
     else:
@@ -84,7 +88,7 @@ async def sse_events():
 
 @pytest.fixture(scope="function")
 def user_billy():
-    print("entering user_billy fixture")
+    logger.info("entering user_billy fixture")
     shakedown.add_user('billy', 'billy')
     shakedown.set_user_permission(rid='dcos:adminrouter:service:marathon', uid='billy', action='full')
     shakedown.set_user_permission(rid='dcos:service:marathon:marathon:services:/', uid='billy', action='full')
@@ -92,7 +96,7 @@ def user_billy():
     shakedown.remove_user_permission(rid='dcos:adminrouter:service:marathon', uid='billy', action='full')
     shakedown.remove_user_permission(rid='dcos:service:marathon:marathon:services:/', uid='billy', action='full')
     shakedown.remove_user('billy')
-    print("exiting user_billy fixture")
+    logger.info("exiting user_billy fixture")
 
 
 @pytest.fixture(scope="function")
@@ -110,7 +114,7 @@ def docker_ipv6_network_fixture():
 def archive_sandboxes():
     # Nothing to setup
     yield
-    print('>>> Archiving Mesos sandboxes')
+    logger.info('>>> Archiving Mesos sandboxes')
     # We tarball the sandboxes from all the agents first and download them afterwards
     for agent in shakedown.get_private_agents():
         file_name = 'sandbox_{}.tar.gz'.format(agent.replace(".", "_"))
@@ -120,4 +124,4 @@ def archive_sandboxes():
         if status:
             shakedown.copy_file_from_agent(agent, file_name)
         else:
-            print('DEBUG: Failed to tarball the sandbox from the agent={}, output={}'.format(agent, output))
+            logger.warning('Failed to tarball the sandbox from the agent={}, output={}'.format(agent, output))

--- a/tests/system/logging.conf
+++ b/tests/system/logging.conf
@@ -1,0 +1,22 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=defaultFormatter
+
+[logger_root]
+level=INFO
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=INFO
+formatter=defaultFormatter
+args=(sys.stdout,)
+
+[formatter_defaultFormatter]
+format=%(asctime)s - %(name)s:%(lineno)d - %(levelname)s - %(message)s
+datefmt=%d-%m-%Y %H:%M:%S

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -10,12 +10,15 @@ import retrying
 import scripts
 import shakedown
 import time
+import logging
 
 from shakedown import http, dcos_version_less_than, marthon_version_less_than, required_private_agents # NOQA
 from shakedown.clients import marathon
 from shakedown.errors import DCOSException
 from matcher import assert_that, eventually, has_len, has_value, has_values, prop
 from precisely import contains_string, equal_to, not_
+
+logger = logging.getLogger(__name__)
 
 
 def test_launch_mesos_container():
@@ -414,7 +417,7 @@ def assert_app_healthy(client, app_def, health_check):
     instances = app_def['instances']
     app_id = app_def["id"]
 
-    print('Testing {} health check protocol.'.format(health_check['protocol']))
+    logger.info('Testing {} health check protocol.'.format(health_check['protocol']))
     client.add_app(app_def)
 
     common.deployment_wait(service_id=app_id, max_attempts=300)
@@ -629,7 +632,7 @@ def test_pinned_task_does_not_scale_to_unpinned_host():
     app_id = app_def['id']
 
     host = common.ip_other_than_mom()
-    print('Constraint set to host: {}'.format(host))
+    logger.info('Constraint set to host: {}'.format(host))
     # the size of cpus is designed to be greater than 1/2 of a node
     # such that only 1 task can land on the node.
     cores = common.cpus_on_agent(host)
@@ -1065,7 +1068,7 @@ def test_metrics_endpoint(marathon_service_name):
         metric_name = 'marathon.apps.active.gauge'
 
     response_json = response.json()
-    print(response_json['gauges'])
+    logger.info('Found metric gauges: '.format(response_json['gauges']))
     assert response_json['gauges'][metric_name] is not None, \
         "{} is absent".format(metric_name)
 

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -8,6 +8,7 @@ import pytest
 import retrying
 import shakedown
 import time
+import logging
 
 from shakedown import http, dcos_version_less_than, marthon_version_less_than, required_private_agents # NOQA
 from shakedown.clients import marathon
@@ -15,6 +16,7 @@ from urllib.parse import urljoin
 
 from fixtures import sse_events, wait_for_marathon_and_cleanup # NOQA
 
+logger = logging.getLogger(__name__)
 
 PACKAGE_NAME = 'marathon'
 DCOS_SERVICE_URL = shakedown.dcos_service_url(PACKAGE_NAME) + "/"
@@ -511,7 +513,7 @@ def test_pod_with_persistent_volume():
     port2 = tasks[1]['discovery']['ports']['ports'][0]["number"]
     path1 = tasks[0]['container']['volumes'][0]['container_path']
     path2 = tasks[1]['container']['volumes'][0]['container_path']
-    print(host, port1, port2, path1, path2)
+    logger.info('Deployd two containers on {}:{}/{} and {}:{}/{}'.format(host, port1, path1, host, port2, path2))
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=60, retry_on_exception=common.ignore_exception)
     def check_http_endpoint(port, path):
@@ -580,7 +582,7 @@ def test_pod_with_persistent_volume_recovers():
     port2 = tasks[1]['discovery']['ports']['ports'][0]["number"]
     path1 = tasks[0]['container']['volumes'][0]['container_path']
     path2 = tasks[1]['container']['volumes'][0]['container_path']
-    print(host, port1, port2, path1, path2)
+    logger.info('Deployd two containers on {}:{}/{} and {}:{}/{}'.format(host, port1, path1, host, port2, path2))
 
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_data(port, path):

--- a/tests/system/test_marathon_on_marathon.py
+++ b/tests/system/test_marathon_on_marathon.py
@@ -11,6 +11,7 @@ import retrying
 import scripts
 import shakedown
 import time
+import logging
 
 from datetime import timedelta
 from shakedown import marathon
@@ -26,6 +27,8 @@ for attribute in dir(marathon_common_tests):
 from shakedown import dcos_version_less_than, required_private_agents # NOQA
 from fixtures import wait_for_marathon_user_and_cleanup # NOQA
 
+
+logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.usefixtures('wait_for_marathon_user_and_cleanup')]
 
@@ -136,7 +139,7 @@ def test_mom_with_network_failure():
     """Marathon on Marathon (MoM) tests for DC/OS with network failures simulated by knocking out ports."""
 
     mom_ip = common.ip_of_mom()
-    print("MoM IP: {}".format(mom_ip))
+    logger.info("MoM IP: {}".format(mom_ip))
 
     app_def = apps.sleep_app()
     app_id = app_def["id"]
@@ -184,7 +187,7 @@ def test_mom_with_network_failure_bounce_master():
 
     # get MoM ip
     mom_ip = common.ip_of_mom()
-    print("MoM IP: {}".format(mom_ip))
+    logger.info("MoM IP: {}".format(mom_ip))
 
     app_def = apps.sleep_app()
     app_id = app_def["id"]
@@ -196,7 +199,7 @@ def test_mom_with_network_failure_bounce_master():
         tasks = client.get_tasks(app_id)
         original_task_id = tasks[0]["id"]
         task_ip = tasks[0]['host']
-        print("\nTask IP: " + task_ip)
+        logger.info("\nTask IP: " + task_ip)
 
     # PR for network partitioning in shakedown makes this better
     # take out the net
@@ -252,7 +255,7 @@ def partition_agent(hostname):
     """Partition a node from all network traffic except for SSH and loopback"""
 
     shakedown.copy_file_to_agent(hostname, "{}/net-services-agent.sh".format(scripts.scripts_dir()))
-    print("partitioning {}".format(hostname))
+    logger.info("partitioning {}".format(hostname))
     shakedown.run_command_on_agent(hostname, 'sh net-services-agent.sh fail')
 
 

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -4,9 +4,11 @@ import common
 import pytest
 import retrying
 import shakedown
+import logging
 
 from shakedown.clients import packagemanager, cosmos
 
+logger = logging.getLogger(__name__)
 
 PACKAGE_NAME = 'marathon'
 SERVICE_NAME = 'marathon-user'
@@ -87,7 +89,7 @@ def package(request):
             'dcos-service-{}'.format(package_name))
     except Exception as e:
         # cleanup does NOT fail the test
-        print(e)
+        logger.exception('Faild to uninstall {} package'.format(package_name))
 
 
 def test_install_universe_package(package):


### PR DESCRIPTION
Summary:
We removed `shakedown` Pytest plugin which previously captured and enriched test stdout. This was done to consolidate the logging format of different test and library modules. In detail:
- removed `--fail, --timeout, --quite, --stdout, --stdout-inline` shakedown options - we pass what we need directly through `--pytest-option`
- removed default Pytest options from the shakedown `main.py`
- using python `logging` package instead of just `print`ing in all Marathon SI tests and in both marathon clients (`marathon.py`s)
- logging configuration is read from `logging.conf`

JIRA: MARATHON-8390