### PR TITLE
Enable marathon to run as non-root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -201,7 +201,8 @@ lazy val packagingSettings = Seq(
       restCommands ++
       Seq(
         Cmd("ENV", "JAVA_HOME /docker-java-home"),
-        Cmd("RUN", "ln -sf /marathon/bin/marathon /marathon/bin/start"))
+        Cmd("RUN", s"""ln -sf /marathon/bin/marathon /marathon/bin/start && \\
+          | chown nobody:nogroup -R /marathon""".stripMargin))
   },
 
   /* Linux packaging settings (http://sbt-native-packager.readthedocs.io/en/latest/formats/linux.html)

--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@ Event-proxying has the following deprecation schedule:
 
 ### Fixed Issues
 
+- [MARATHON-8409](https://jira.mesosphere.com/browse/MARATHON-8409) - You can now launch marathon in Docker as non-root user.
 - [MARATHON-8017](https://jira.mesosphere.com/browse/MARATHON-8017) - Fixed various issues when posting groups with relative ids.
 - [MARATHON-7568](https://jira.mesosphere.com/browse/MARATHON-7568) - We now redact any Zookeeper credentials from the /v2/info response endpoint.
 - [MARATHON-8326](https://jira.mesosphere.com/browse/MARATHON-8326) - Pods can be deleted together with persistent volumes, using a new wipe=true query parameter.


### PR DESCRIPTION
Summary:
Currently, Marathon is built as a root user in docker, and therefore makes it impossible for non-root users to be able to run it. This commit make sure that everybody can read and execute the files in the /marathon directory, by changing the default owner to nouser:nogoup

JIRA issues: MARATHON-8409