### PR TITLE
Detect and better handle zk connection turbulence with CuratorElectionStream

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/election/CuratorElectionStream.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/CuratorElectionStream.scala
@@ -295,6 +295,10 @@ object CuratorElectionStream extends StrictLogging {
       override def getAclForPath(path: String): util.List[ACL] = defaultAcl
     }
 
+    /**
+      * Note - this retryPolicy is about retrying operations, such as getChildren or adding a watch. After initially
+      * connected, the reconnection policy is eternal and is not configurable.
+      */
     val retryPolicy = new ExponentialBackoffRetry(1.second.toMillis.toInt, 3)
     val builder = CuratorFrameworkFactory.builder().
       connectString(zkUrl.hostsString).


### PR DESCRIPTION
In this commit, we improve various aspects of the leader election
code:

- Standby instances no longer crash during zookeeper connection
  turbulence (leaders continue to crash immediately)
- We now create a new Zookeeper watch and spawn off a new watch loop
  when the connection has been restored.
- We fixed a bug where connection turbulence would cause the number of
  watch loops to increase exponentially (potentially x3 per
  turbulence)
- Improved logging to help debug future leader election issues

JIRA Issues: MARATHON-8412
