### PR TITLE
Initialise `CuratorFramework` explicitly in the `CoreModuleImpl`

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreBenchmark.scala
@@ -10,7 +10,7 @@ import akka.stream.{ActorMaterializer, Materializer}
 import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.marathon.core.base.{JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.metrics.dummy.DummyMetrics
-import mesosphere.marathon.storage.{CuratorZk, StorageConf}
+import mesosphere.marathon.storage.{CuratorZk, StorageConf, StorageConfig}
 import mesosphere.marathon.storage.repository.StoredGroup
 import mesosphere.marathon.storage.store.ZkStoreSerialization
 import mesosphere.marathon.upgrade.DependencyGraphBenchmark
@@ -31,8 +31,9 @@ object ZkPersistenceStoreBenchmark {
     override def availableFeatures: Set[String] = Set.empty
   }
   Conf.verify()
+  val curatorFramework: Option[RichCuratorFramework] = StorageConfig.curatorFramework(Conf, JvmExitsCrashStrategy, LifecycleState.WatchingJVM)
   val lifecycleState = LifecycleState.WatchingJVM
-  val curator = CuratorZk(Conf, lifecycleState, JvmExitsCrashStrategy)
+  val curator = CuratorZk(Conf, curatorFramework.get)
   val metrics = DummyMetrics
   val zkStore = curator.leafStore(metrics)
 

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -16,7 +16,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.auth.AuthModule
 import mesosphere.marathon.core.base.{ActorsModule, JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.core.deployment.DeploymentModule
-import mesosphere.marathon.core.election._
+import mesosphere.marathon.core.election.ElectionModule
 import mesosphere.marathon.core.event.EventModule
 import mesosphere.marathon.core.flow.FlowModule
 import mesosphere.marathon.core.group.{GroupManagerConfig, GroupManagerModule}
@@ -38,7 +38,7 @@ import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
 import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
-import mesosphere.marathon.storage._
+import mesosphere.marathon.storage.{StorageConf, StorageConfig, StorageModule}
 import mesosphere.marathon.stream.EnrichedFlow
 import mesosphere.util.NamedExecutionContext
 import mesosphere.util.state.MesosLeaderInfo

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -153,7 +153,7 @@ class CoreModuleImpl @Inject() (
   override lazy val taskJobsModule = new TaskJobsModule(marathonConf, leadershipModule, clock)
 
   // Initialize Apache Curator Framework (wrapped in [[RichCuratorFramework]] and connect/sync with the storage
-  // for an underlying Zookeeper storage. None is returned for for [[InMem]] storage) since it's not needed.
+  // for an underlying Zookeeper storage. None is returned for [[InMem]] storage) since it's not needed.
   lazy val curatorFramework: Option[RichCuratorFramework] = StorageConfig.curatorFramework(marathonConf, crashStrategy, lifecycleState)
 
   override lazy val storageModule = StorageModule(

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -22,7 +22,6 @@ import org.apache.zookeeper.data.Stat
 
 import scala.async.Async.{async, await}
 import scala.collection.immutable.Seq
-import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -45,7 +45,6 @@ case class ZkSerialized(bytes: ByteString)
 class ZkPersistenceStore(
     metrics: Metrics,
     val client: RichCuratorFramework,
-    timeout: Duration,
     maxConcurrent: Int = 8,
     maxQueued: Int = 100
 )(

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -2,8 +2,6 @@ package mesosphere.marathon
 package storage
 
 import java.net.URI
-import java.util
-import java.util.Collections
 
 import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.Materializer
@@ -14,12 +12,6 @@ import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistence
 import mesosphere.marathon.core.storage.store.impl.memory.{Identity, InMemoryPersistenceStore, RamId}
 import mesosphere.marathon.core.storage.store.impl.zk.{RichCuratorFramework, ZkId, ZkPersistenceStore, ZkSerialized}
 import mesosphere.marathon.metrics.Metrics
-import org.apache.curator.RetryPolicy
-import org.apache.curator.framework.api.ACLProvider
-import org.apache.curator.framework.imps.GzipCompressionProvider
-import org.apache.curator.framework.CuratorFrameworkFactory
-import org.apache.curator.retry.BoundedExponentialBackoffRetry
-import org.apache.zookeeper.data.ACL
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}

--- a/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageConfig.scala
@@ -94,13 +94,7 @@ object VersionCacheConfig {
 
 case class CuratorZk(
     cacheType: CacheType,
-    sessionTimeout: Option[Duration],
-    connectionTimeout: Option[Duration],
-    timeout: Duration,
-    zkUrl: ZookeeperConf.ZkUrl,
-    zkAcls: util.List[ACL],
-    enableCompression: Boolean,
-    retryPolicy: RetryPolicy,
+    client: RichCuratorFramework,
     maxConcurrent: Int,
     maxOutstanding: Int,
     maxVersions: Int,
@@ -109,38 +103,9 @@ case class CuratorZk(
     groupVersionsCacheSize: Int,
     versionCacheConfig: Option[VersionCacheConfig],
     availableFeatures: Set[String],
-    lifecycleState: LifecycleState,
-    crashStrategy: CrashStrategy,
     defaultNetworkName: Option[String],
     backupLocation: Option[URI]
 ) extends PersistenceStorageConfig[ZkId, String, ZkSerialized] {
-
-  lazy val client: RichCuratorFramework = {
-    val builder = CuratorFrameworkFactory.builder()
-    builder.connectString(zkUrl.hostsString)
-    sessionTimeout.foreach(t => builder.sessionTimeoutMs(t.toMillis.toInt))
-    connectionTimeout.foreach(t => builder.connectionTimeoutMs(t.toMillis.toInt))
-    if (enableCompression) builder.compressionProvider(new GzipCompressionProvider)
-    zkUrl.credentials.foreach { credentials =>
-      builder.authorization(Collections.singletonList(credentials.authInfoDigest))
-    }
-    builder.aclProvider(new ACLProvider {
-      override def getDefaultAcl: util.List[ACL] = zkAcls
-
-      override def getAclForPath(path: String): util.List[ACL] = zkAcls
-    })
-    builder.retryPolicy(retryPolicy)
-    builder.namespace(zkUrl.path.stripPrefix("/"))
-    val client = RichCuratorFramework(builder.build(), crashStrategy)
-
-    client.start()
-    client.blockUntilConnected(lifecycleState, crashStrategy)
-
-    // make sure that we read up-to-date values from ZooKeeper
-    Await.ready(client.sync("/"), Duration.Inf)
-
-    client
-  }
 
   def leafStore(metrics: Metrics)(
     implicit
@@ -150,23 +115,17 @@ case class CuratorZk(
     actorSystem.registerOnTermination {
       client.close()
     }
-    new ZkPersistenceStore(metrics, client, timeout, maxConcurrent, maxOutstanding)
+    new ZkPersistenceStore(metrics, client, maxConcurrent, maxOutstanding)
   }
 
 }
 
 object CuratorZk {
   val StoreName = "zk"
-  def apply(conf: StorageConf, lifecycleState: LifecycleState, crashStrategy: CrashStrategy): CuratorZk =
+  def apply(conf: StorageConf, curatorFramework: RichCuratorFramework): CuratorZk =
     CuratorZk(
       cacheType = if (conf.storeCache()) LazyCaching else NoCaching,
-      sessionTimeout = Some(conf.zkSessionTimeoutDuration),
-      connectionTimeout = Some(conf.zkConnectionTimeoutDuration),
-      timeout = conf.zkTimeoutDuration,
-      zkUrl = conf.zooKeeperStateUrl,
-      zkAcls = conf.zkDefaultCreationACL,
-      enableCompression = conf.zooKeeperCompressionEnabled(),
-      retryPolicy = new BoundedExponentialBackoffRetry(conf.zooKeeperOperationBaseRetrySleepMs(), conf.zooKeeperTimeout().toInt, conf.zooKeeperOperationMaxRetries()),
+      curatorFramework,
       maxConcurrent = conf.zkMaxConcurrency(),
       maxOutstanding = Int.MaxValue,
       maxVersions = conf.maxVersions(),
@@ -176,8 +135,6 @@ object CuratorZk {
       versionCacheConfig = if (conf.versionCacheEnabled()) StorageConfig.DefaultVersionCacheConfig else None,
       availableFeatures = conf.availableFeatures,
       backupLocation = conf.backupLocation.toOption,
-      lifecycleState = lifecycleState,
-      crashStrategy = crashStrategy,
       defaultNetworkName = conf.defaultNetworkName.toOption
     )
 }
@@ -210,10 +167,31 @@ object InMem {
 object StorageConfig {
   val DefaultVersionCacheConfig = Option(VersionCacheConfig.Default)
 
-  def apply(conf: StorageConf, lifecycleState: LifecycleState, crashStrategy: CrashStrategy): StorageConfig = {
+  def apply(conf: StorageConf, curatorFramework: Option[RichCuratorFramework]): StorageConfig = {
     conf.internalStoreBackend() match {
       case InMem.StoreName => InMem(conf)
-      case CuratorZk.StoreName => CuratorZk(conf, lifecycleState, crashStrategy)
+      case CuratorZk.StoreName => CuratorZk(conf, curatorFramework.getOrElse(throw new IllegalArgumentException("RichCuratorFramework has to be defined to use the ZK store")))
     }
+  }
+
+  /**
+    * Return an optional curator framework instance, depending on the underlying storage type. For [[InMem]] storage None
+    * is returned. For [[CuratorZk]] [[RichCuratorFramework]] instance is initialized and connection to Zookeeper is established.
+    *
+    * @param conf
+    * @param crashStrategy
+    * @param lifecycleState
+    * @return
+    */
+  def curatorFramework(conf: StorageConf, crashStrategy: CrashStrategy, lifecycleState: LifecycleState) = conf.internalStoreBackend() match {
+    case InMem.StoreName => None
+    case CuratorZk.StoreName =>
+      val client = RichCuratorFramework(conf, crashStrategy)
+      client.start()
+      client.blockUntilConnected(lifecycleState, crashStrategy)
+      // make sure that we read up-to-date values from ZooKeeper
+      Await.ready(client.sync("/"), Duration.Inf)
+
+      Some(client)
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -3,10 +3,10 @@ package storage
 
 import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.Materializer
-import mesosphere.marathon.core.base.{CrashStrategy, LifecycleState}
 import mesosphere.marathon.core.storage.backup.PersistentStoreBackup
 import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.storage.store.impl.cache.LoadTimeCachingPersistenceStore
+import mesosphere.marathon.core.storage.store.impl.zk.RichCuratorFramework
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.storage.migration.{Migration, ServiceDefinitionRepository}
 import mesosphere.marathon.storage.repository._
@@ -31,11 +31,11 @@ trait StorageModule {
 }
 
 object StorageModule {
-  def apply(metrics: Metrics, conf: StorageConf with NetworkConf, lifecycleState: LifecycleState, crashStrategy: CrashStrategy)(
+  def apply(metrics: Metrics, conf: StorageConf with NetworkConf, curatorFramework: Option[RichCuratorFramework])(
     implicit
     mat: Materializer, ctx: ExecutionContext,
     scheduler: Scheduler, actorSystem: ActorSystem): StorageModule = {
-    val currentConfig = StorageConfig(conf, lifecycleState, crashStrategy)
+    val currentConfig = StorageConfig(conf, curatorFramework)
     apply(metrics, currentConfig, conf.mesosBridgeName())
   }
 

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
@@ -42,7 +42,7 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
     val client = zkClient(namespace = Some(root))
     val store = LazyCachingPersistenceStore(
       metrics,
-      new ZkPersistenceStore(metrics, client, Duration.Inf, 8))
+      new ZkPersistenceStore(metrics, client, 8))
     store.markOpen()
     store
   }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
@@ -23,7 +23,7 @@ class LoadTimeCachingPersistenceStoreTest extends AkkaUnitTest
   def zkStore: ZkPersistenceStore = {
     val root = UUID.randomUUID().toString
     val rootZkClient = zkClient(namespace = Some(root))
-    new ZkPersistenceStore(metrics, rootZkClient, Duration.Inf)
+    new ZkPersistenceStore(metrics, rootZkClient)
   }
 
   private def cachedInMemory = {

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LoadTimeCachingPersistenceStoreTest.scala
@@ -12,8 +12,6 @@ import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.util.ZookeeperServerTest
 import mesosphere.marathon.storage.store.InMemoryStoreSerialization
 
-import scala.concurrent.duration.Duration
-
 class LoadTimeCachingPersistenceStoreTest extends AkkaUnitTest
   with PersistenceStoreTest with ZookeeperServerTest with ZkTestClass1Serialization
   with InMemoryStoreSerialization with InMemoryTestClass1Serialization {

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -64,7 +64,7 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
   def defaultStore: ZkPersistenceStore = {
     val root = UUID.randomUUID().toString
     val client = zkClient(namespace = Some(root))
-    val store = new ZkPersistenceStore(metrics, client, Duration.Inf)
+    val store = new ZkPersistenceStore(metrics, client)
     store.markOpen()
     store
   }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -14,8 +14,6 @@ import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStoreTest,
 import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.util.ZookeeperServerTest
 
-import scala.concurrent.duration._
-
 trait ZkTestClass1Serialization {
   implicit object ZkTestClass1Resolver extends IdResolver[String, TestClass1, String, ZkId] {
     override def fromStorageId(path: ZkId): String = path.id.replaceAll("_", "/")

--- a/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
@@ -160,7 +160,7 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
   private def zkStore: ZkPersistenceStore = {
     val root = UUID.randomUUID().toString
     val rootClient = zkClient(namespace = Some(root))
-    new ZkPersistenceStore(metrics, rootClient, Duration.Inf)
+    new ZkPersistenceStore(metrics, rootClient)
   }
 
   def createZkRepos(appRepository: AppRepository, podRepository: PodRepository, maxVersions: Int): GroupRepository = { // linter:ignore:UnusedParameter

--- a/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
@@ -17,7 +17,6 @@ import mesosphere.marathon.test.Mockito
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
 
 class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServerTest {
   import PathId._

--- a/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
@@ -18,8 +18,6 @@ import mesosphere.marathon.stream.EnrichedSink
 import org.scalatest.GivenWhenThen
 import org.scalatest.time.{Seconds, Span}
 
-import scala.concurrent.duration._
-
 class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhenThen {
   import PathId._
 

--- a/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
@@ -169,7 +169,7 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
   def createZKRepo(): AppRepository = {
     val root = UUID.randomUUID().toString
     val rootClient = zkClient(namespace = Some(root))
-    val store = new ZkPersistenceStore(metrics, rootClient, Duration.Inf)
+    val store = new ZkPersistenceStore(metrics, rootClient)
     store.markOpen()
     AppRepository.zkRepository(store)
   }

--- a/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
@@ -13,8 +13,6 @@ import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.util.ZookeeperServerTest
 import mesosphere.util.state.FrameworkId
 
-import scala.concurrent.duration._
-
 class SingletonRepositoryTest extends AkkaUnitTest with ZookeeperServerTest {
   val metrics = DummyMetrics
 

--- a/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/SingletonRepositoryTest.scala
@@ -58,7 +58,7 @@ class SingletonRepositoryTest extends AkkaUnitTest with ZookeeperServerTest {
   }
 
   def createZKRepo(): FrameworkIdRepository = {
-    val store = new ZkPersistenceStore(metrics, zkClient(), 10.seconds)
+    val store = new ZkPersistenceStore(metrics, zkClient())
     store.markOpen()
     FrameworkIdRepository.zkRepository(store)
   }


### PR DESCRIPTION
Summary:
we used to initialize `CuratorFramework` and wait/sync for the connection to ZK in the `StorageConfig` class. However, this made introducing new repositories (specifically new ones, based on the `ZookeeperPersistenceStore` class) too cumbersome. Apache Curator (wrapped into `RichCuratorFramework`) is now being explicitly initialized in the `CoreModuelImpl` and passed down the dependency chain.

Related: DCOS-41405