### PR TITLE
Do not allow concurrent performance runs.

### DIFF
--- a/Jenkinsfile.perf
+++ b/Jenkinsfile.perf
@@ -4,7 +4,8 @@ node('hh-nuc-3') {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
   properties([
     // Run pipeline every hour.
-    pipelineTriggers([cron('H * * * *')])
+    pipelineTriggers([cron('H * * * *')]),
+    disableConcurrentBuilds()
   ])
 
   stage("Run Performance Test") {


### PR DESCRIPTION
Summary:
This should avoid the piling of performance benchmarks jobs in case the
NUC is busy.