### PR TITLE
Remove marathon.http.responses.event-stream.size.counter.bytes from IT

### DIFF
--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/MetricsIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/MetricsIntegrationTest.scala
@@ -36,7 +36,6 @@ class MetricsIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTe
       counters should contain("marathon.mesos.offers.declined.counter")
       counters should contain("marathon.mesos.offers.incoming.counter")
       counters should contain("marathon.mesos.offers.used.counter")
-      counters should contain("marathon.http.responses.event-stream.size.counter.bytes")
       counters should contain("marathon.http.requests.size.counter.bytes")
       counters should contain("marathon.http.responses.size.counter.bytes")
       counters should contain("marathon.http.responses.size.gzipped.counter.bytes")


### PR DESCRIPTION
It is created only if there is at least one event stream consumer.