### PR TITLE
Log app being locked as info

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -157,7 +157,7 @@ class MarathonSchedulerActor private (
       } match {
         case None =>
           // ScaleRunSpec is not a user initiated command
-          logger.debug(s"Did not try to scale run spec ${runSpecId}; it is locked")
+          logger.info(s"Did not try to scale run spec ${runSpecId}; it is locked")
         case _ =>
       }
 


### PR DESCRIPTION
I believe this can improve debug-ability while adding just few lines of logs.

The situation I see several times - you are trying to figure out from logs why some instance was not restarted, you see that scale check was initiated but no further messages and it's not apparent if it was because of the lock or not.

The lock might be held e.g. because someone initiated kill for an instance and that kill takes a long time to succeed (e.g. unkillable task). Then the app is locked and new instances are not coming up.

This does not solve that situation but helps it surface in logs.