### PR TITLE
Populate PodStatus startedAt with instance timestamp

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -191,7 +191,13 @@ class AppInfoBaseData(
       case (instance, task, taskFailure) =>
         raml.TerminationHistory(
           instanceID = instance.instanceId.idString,
-          startedAt = task.status.startedAt.getOrElse(throw new RuntimeException("task startedAt expected to not me empty")).toOffsetDateTime,
+          startedAt = task.status.startedAt.getOrElse {
+            // startedAt will only be set when a task turns running. In order to not break
+            // potential expectations, the property stays mandatory and is populated with the time
+            // when the now terminal task was initially staged instead.
+            logger.warn(s"${task.taskId} has no startedAt. Falling back to stagedAt.")
+            task.status.stagedAt
+          }.toOffsetDateTime,
           terminatedAt = taskFailure.timestamp.toOffsetDateTime,
           message = Some(taskFailure.message),
           containers = List(


### PR DESCRIPTION
Fallback to stagedAt in TerminationHistory when terminal task never started.

Summary:
task.status.startedAt is only populated when a task is reported running. For some reason, the startedAt field was added as a mandatory property to the TerminationHistory API type for PodStatus. This would lead to a hardcoded runtime exception when querying PodStatus for a pod for which an associated terminal task never turned running.
 Ideally, the property would be optional. Anticipating that tooling might expect the field to always be present, this change will populate the field with the time since the instance is in the current state (Created or Staging or Starting) instead.

JIRA issues: MARATHON-8428
