### PR TITLE
Drop the state_directory field

### DIFF
--- a/ci/upgrade.sc
+++ b/ci/upgrade.sc
@@ -17,14 +17,12 @@ case class Source(kind:String, url: String, sha1: String)
 case class BuildInfo(
   requires: List[String],
   single_source: Source,
-  username: String,
-  state_directory: Boolean
+  username: String
 )
 case class EeBuildInfo(
   requires: List[String],
   sources: Map[String, Source],
-  username: String,
-  state_directory: Boolean
+  username: String
 )
 implicit val singleSourceFormat = Json.format[Source]
 implicit val buildInfoFormat = Json.format[BuildInfo]


### PR DESCRIPTION
This field is not used and is optional. So we have to make it optional or drop it. Since it's not used, I am droping it.

(e.g. Metronome ee.buildinfo.json does not contain this https://github.com/mesosphere/dcos-enterprise/blob/master/packages/metronome/ee.buildinfo.json)
