### PR TITLE
HTTPS readiness checks do not check certificates

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
@@ -189,15 +189,6 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
       .withUri(httpRequest.uri.toHttpRequestTargetOriginForm)
       .withDefaultHeaders(hostHeader)
     // This is only a health check, so we are going to allow _very_ bad SSL configuration.
-    val disabledSslConfig = AkkaSSLConfig().mapSettings(s => s.withLoose {
-      s.loose.withAcceptAnyCertificate(true)
-        .withAllowLegacyHelloMessages(Some(true))
-        .withAllowUnsafeRenegotiation(Some(true))
-        .withAllowWeakCiphers(true)
-        .withAllowWeakProtocols(true)
-        .withDisableHostnameVerification(true)
-        .withDisableSNI(true)
-    })
     val connectionFlow = Http().outgoingConnectionHttps(
       host,
       port,
@@ -227,4 +218,14 @@ object HealthCheckWorker {
     context.init(Array[KeyManager](), Array(BlindFaithX509TrustManager), null)
     context
   }
+
+  val disabledSslConfig = AkkaSSLConfig().mapSettings(s => s.withLoose {
+    s.loose.withAcceptAnyCertificate(true)
+      .withAllowLegacyHelloMessages(Some(true))
+      .withAllowUnsafeRenegotiation(Some(true))
+      .withAllowWeakCiphers(true)
+      .withAllowWeakProtocols(true)
+      .withDisableHostnameVerification(true)
+      .withDisableSNI(true)
+  })
 }

--- a/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
@@ -102,7 +102,7 @@ private[readiness] class ReadinessCheckExecutorImpl(implicit actorSystem: ActorS
   private[impl] def akkaHttpGet(check: ReadinessCheckSpec): Future[AkkaHttpResponse] = {
     Timeout(check.timeout)(Http().singleRequest(
       request = RequestBuilding.Get(check.url),
-      connectionContext = ConnectionContext.https(HealthCheckWorker.disabledSslContext, sslConfig = Some(HealthCheckWorker.disabledSslConfig))
+      connectionContext = ConnectionContext.https(HealthCheckWorker.disabledSslContext, sslConfig = Some(HealthCheckWorker.disabledSslConfig()))
     ))
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
@@ -1,20 +1,15 @@
 package mesosphere.marathon
 package core.readiness.impl
 
-import java.security.cert.X509Certificate
-import javax.net.ssl.{KeyManager, SSLContext, X509TrustManager}
-
 import akka.actor.{ActorSystem, Cancellable}
-import akka.pattern.after
-import akka.http.scaladsl.{ConnectionContext, Http}
-import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.client.RequestBuilding
+import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.model.{MediaTypes, StatusCodes, HttpResponse => AkkaHttpResponse}
-import akka.stream.scaladsl.Keep
+import akka.http.scaladsl.{ConnectionContext, Http}
+import akka.pattern.after
+import akka.stream.scaladsl.{Keep, Source}
 import akka.stream.{KillSwitches, Materializer}
-import akka.stream.scaladsl.Source
 import com.typesafe.scalalogging.StrictLogging
-import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import mesosphere.marathon.core.health.impl.HealthCheckWorker
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
 import mesosphere.marathon.core.readiness.{HttpResponse, ReadinessCheckExecutor, ReadinessCheckResult}


### PR DESCRIPTION
This is re-implementation of https://github.com/mesosphere/marathon/commit/17d27b6acf3e202f5113a401ab39e176135efb46 for readiness checks.

This allows HTTPS readiness checks with e.g. self-signed certs.

JIRA issues: MARATHON-8430
