### PR TITLE
Increase http proxy max-open-connections values; configure via flag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,10 @@ Event-proxying has the following deprecation schedule:
 - 1.7.x - Standby Marathon instances return redirect responses. The old behavior of proxying event streams can be brought back with the command-line argument `--deprecated_features=proxy_events`.
 - 1.8.x - Event stream proxying logic will be completely removed. If `--deprecated_features=proxy_events` is still specified, Marathon will refuse to launch, with an error.
 
+### Default for "max-open-connections" increased for asynchronous standby proxy, now configurable
+
+In some clusters with heavy standby-proxy usage, a limit of 32 max-open-connections was too small. This default has been increased to 64. In addition, the flag `--leader_proxy_max_open_connections` has been introduced to tune the value further, if needed.
+
 ### Fixed Issues
 
 - [MARATHON-8409](https://jira.mesosphere.com/browse/MARATHON-8409) - You can now launch marathon in Docker as non-root user.

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -330,6 +330,9 @@ The Web Site flags control the behavior of Marathon's web site, including the us
 * `--leader_proxy_ssl_ignore_hostname` (Optional. Default: false): Do not
     verify that the hostname of the Marathon leader matches the one in the SSL
     certificate when proxying API requests to the current leader.
+* <span class="label label-default">v1.7.0</span> `--leader_proxy_max_open_connections` (Optional. Default: 64):
+    Specifies the number of maximum, concurrent open HTTP connections allowed when proxying from the standby to the
+    current leader. Does not apply when using the deprecated sync proxy.
 * `--[disable_]http_compression` (Optional. Default: enabled): Specifies whether Marathon should compress HTTP responses
     for clients that support it. Disabling will reduce the CPU burden on Marathon to service API requests.
 *  <span class="label label-default">v0.10.0</span> `--http_max_concurrent_requests` (Optional.): the maximum number of

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -9,6 +9,9 @@ case class DeprecatedFeature(
 }
 
 object DeprecatedFeatures {
+  /**
+    * Remove in 1.8.x: MARATHON-8431
+    */
   val syncProxy = DeprecatedFeature(
     "sync_proxy",
     description = "Old, blocking IO implementation for leader proxy used by Marathon standby instances.",

--- a/src/main/scala/mesosphere/marathon/LeaderProxyConf.scala
+++ b/src/main/scala/mesosphere/marathon/LeaderProxyConf.scala
@@ -7,6 +7,12 @@ import org.rogach.scallop.ScallopConf
   */
 trait LeaderProxyConf extends ScallopConf {
 
+  lazy val leaderProxyMaxOpenConnections = opt[Int](
+    "leader_proxy_max_open_connections",
+    descr = "Number of maximum open HTTP connections when proxying requests from standby instances to leaders. (does not apply to sync proxy)",
+    default = Some(64),
+    noshort = true)
+
   lazy val leaderProxyConnectionTimeout = opt[Int](
     "leader_proxy_connection_timeout",
     descr = "Maximum time, in milliseconds, to wait for connecting to the current Marathon leader from " +

--- a/src/main/scala/mesosphere/marathon/api/forwarder/AsyncUrlConnectionRequestForwarder.scala
+++ b/src/main/scala/mesosphere/marathon/api/forwarder/AsyncUrlConnectionRequestForwarder.scala
@@ -51,6 +51,7 @@ class AsyncUrlConnectionRequestForwarder(
     withIdleTimeout(leaderProxyConf.leaderProxyReadTimeout().millis).
     withConnectingTimeout(leaderProxyConf.leaderProxyConnectionTimeout().millis)
   private val poolSettings = ConnectionPoolSettings(actorSystem)
+    .withMaxOpenRequests(leaderProxyConf.leaderProxyMaxOpenConnections())
     .withConnectionSettings(connectionSettings)
     .withMaxRetries(0)
 


### PR DESCRIPTION
This increases the default http proxy max-open-connections
configuration value from 32 to 64; additionally, it introduces the
flag `--leader_proxy_max_open_connections`, which can specify a higher value.

Fixes: MARATHON-8323
