### PR TITLE
Remove fpm-docker provision file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ ci.tar.gz
 tools/packager/*.deb
 tools/packager/*.rpm
 tools/packager/toor
+tools/packager/fpm-docker/.provisioned


### PR DESCRIPTION
Summary:
Master fails because the build thinks that fpm is available when it's
not.