### PR TITLE
HTTPS readiness checks do not check certificates

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerActor.scala
@@ -3,9 +3,9 @@ package core.health.impl
 
 import java.net.{InetSocketAddress, Socket}
 import java.security.cert.X509Certificate
-
 import javax.net.ssl.{KeyManager, SSLContext, X509TrustManager}
-import akka.actor.{Actor, PoisonPill}
+
+import akka.actor.{Actor, ActorSystem, PoisonPill}
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, headers}
@@ -189,19 +189,10 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
       .withUri(httpRequest.uri.toHttpRequestTargetOriginForm)
       .withDefaultHeaders(hostHeader)
     // This is only a health check, so we are going to allow _very_ bad SSL configuration.
-    val disabledSslConfig = AkkaSSLConfig().mapSettings(s => s.withLoose {
-      s.loose.withAcceptAnyCertificate(true)
-        .withAllowLegacyHelloMessages(Some(true))
-        .withAllowUnsafeRenegotiation(Some(true))
-        .withAllowWeakCiphers(true)
-        .withAllowWeakProtocols(true)
-        .withDisableHostnameVerification(true)
-        .withDisableSNI(true)
-    })
     val connectionFlow = Http().outgoingConnectionHttps(
       host,
       port,
-      ConnectionContext.https(disabledSslContext, sslConfig = Some(disabledSslConfig)),
+      ConnectionContext.https(disabledSslContext, sslConfig = Some(disabledSslConfig())),
       settings = ClientConnectionSettings(system).withIdleTimeout(timeout)
     )
     Source.single(effectiveRequest).via(connectionFlow).runWith(Sink.head)
@@ -230,4 +221,14 @@ object HealthCheckWorker {
     context.init(Array[KeyManager](), Array(BlindFaithX509TrustManager), null)
     context
   }
+
+  def disabledSslConfig()(implicit as: ActorSystem) = AkkaSSLConfig().mapSettings(s => s.withLoose {
+    s.loose.withAcceptAnyCertificate(true)
+      .withAllowLegacyHelloMessages(Some(true))
+      .withAllowUnsafeRenegotiation(Some(true))
+      .withAllowWeakCiphers(true)
+      .withAllowWeakProtocols(true)
+      .withDisableHostnameVerification(true)
+      .withDisableSNI(true)
+  })
 }

--- a/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
@@ -2,12 +2,13 @@ package mesosphere.marathon
 package core.readiness.impl
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.client.RequestBuilding
+import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.model.{MediaTypes, StatusCodes, HttpResponse => AkkaHttpResponse}
+import akka.http.scaladsl.{ConnectionContext, Http}
 import akka.stream.Materializer
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.health.impl.HealthCheckWorker
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
 import mesosphere.marathon.core.readiness.{HttpResponse, ReadinessCheckExecutor, ReadinessCheckResult}
 import mesosphere.marathon.util.Timeout
@@ -79,7 +80,8 @@ private[readiness] class ReadinessCheckExecutorImpl(implicit actorSystem: ActorS
 
   private[impl] def akkaHttpGet(check: ReadinessCheckSpec): Future[AkkaHttpResponse] = {
     Timeout(check.timeout)(Http().singleRequest(
-      request = RequestBuilding.Get(check.url)
+      request = RequestBuilding.Get(check.url),
+      connectionContext = ConnectionContext.https(HealthCheckWorker.disabledSslContext, sslConfig = Some(HealthCheckWorker.disabledSslConfig()))
     ))
   }
 }


### PR DESCRIPTION
This is re-implementation of 17d27b6 for readiness checks.

This allows HTTPS readiness checks with e.g. self-signed certs.

JIRA issues: MARATHON-8430