### PR TITLE
HTTPS readiness checks do not check certificates

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
+++ b/src/main/scala/mesosphere/marathon/api/LeaderProxyFilter.scala
@@ -356,7 +356,7 @@ object JavaUrlConnectionRequestForwarder extends StrictLogging {
 /**
   * Workaround to overcome Java restrictions; see https://bugs.openjdk.java.net/browse/JDK-7016595
   */
-private [api] object HttpUrlConnectionWorkaround {
+private[api] object HttpUrlConnectionWorkaround {
   private val methodsField = classOf[HttpURLConnection].getDeclaredField("method")
   methodsField.setAccessible(true)
 

--- a/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImpl.scala
@@ -2,11 +2,12 @@ package mesosphere.marathon
 package core.readiness.impl
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.client.RequestBuilding
+import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.model.{ MediaTypes, StatusCodes, HttpResponse => AkkaHttpResponse }
+import akka.http.scaladsl.{ ConnectionContext, Http }
 import akka.stream.Materializer
+import mesosphere.marathon.core.health.impl.HealthCheckWorker
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
 import mesosphere.marathon.core.readiness.{ HttpResponse, ReadinessCheckExecutor, ReadinessCheckResult }
 import mesosphere.marathon.util.Timeout
@@ -80,7 +81,8 @@ private[readiness] class ReadinessCheckExecutorImpl(implicit actorSystem: ActorS
 
   private[impl] def akkaHttpGet(check: ReadinessCheckSpec): Future[AkkaHttpResponse] = {
     Timeout(check.timeout)(Http().singleRequest(
-      request = RequestBuilding.Get(check.url)
+      request = RequestBuilding.Get(check.url),
+      connectionContext = ConnectionContext.https(HealthCheckWorker.disabledSslContext, sslConfig = Some(HealthCheckWorker.disabledSslConfig()))
     ))
   }
 }


### PR DESCRIPTION
This is re-implementation of 17d27b6 for readiness checks.

This allows HTTPS readiness checks with e.g. self-signed certs.

JIRA issues: MARATHON-8430