### PR TITLE
Be more lenient about occasional transitional unknown leader states

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/election/CuratorElectionStream.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/CuratorElectionStream.scala
@@ -241,11 +241,11 @@ object CuratorElectionStream extends StrictLogging {
       if (selfParticipantCount > 1) {
         throw new IllegalStateException(s"Multiple election participants have the same id: ${hostPort}. This is not allowed.")
       } else {
-        val element = participants.find(_.isLeader).map(_.getId) match {
+        val nextState = participants.find(_.isLeader).map(_.getId) match {
           case Some(leader) if leader == hostPort => LeadershipState.ElectedAsLeader
           case otherwise => LeadershipState.Standby(otherwise)
         }
-        sq.offer(element)
+        sq.offer(nextState)
       }
     }
 

--- a/src/main/scala/mesosphere/marathon/core/election/CuratorElectionStream.scala
+++ b/src/main/scala/mesosphere/marathon/core/election/CuratorElectionStream.scala
@@ -24,7 +24,6 @@ import org.apache.curator.retry.ExponentialBackoffRetry
 import org.apache.zookeeper.Watcher.Event.EventType
 import org.apache.zookeeper.{KeeperException, WatchedEvent, ZooDefs}
 import org.apache.zookeeper.data.ACL
-import scala.annotation.tailrec
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -221,7 +220,7 @@ object CuratorElectionStream extends StrictLogging {
       * Emit current leader. Does not fail on connection error, but throws if multiple election candidates have the same
       * ID.
       */
-    @tailrec def emitLeader(loopId: Int, retries: Int = 0): Unit = {
+    def emitLeader(loopId: Int): Unit = {
       val participants = oldLeaderHostPortMetric.blocking {
         newLeaderHostPortMetric.blocking {
           try {
@@ -242,15 +241,11 @@ object CuratorElectionStream extends StrictLogging {
       if (selfParticipantCount > 1) {
         throw new IllegalStateException(s"Multiple election participants have the same id: ${hostPort}. This is not allowed.")
       } else {
-        participants.find(_.isLeader).map(_.getId) match {
-          case Some(leader) if leader == hostPort =>
-            sq.offer(LeadershipState.ElectedAsLeader)
-          case None if participants.nonEmpty && retries < 3 =>
-            logger.info(s"Leader record was removed while querying participants; retrying after ${retries} retries")
-            emitLeader(loopId, retries + 1)
-          case otherwise =>
-            sq.offer(LeadershipState.Standby(otherwise))
+        val element = participants.find(_.isLeader).map(_.getId) match {
+          case Some(leader) if leader == hostPort => LeadershipState.ElectedAsLeader
+          case otherwise => LeadershipState.Standby(otherwise)
         }
+        sq.offer(element)
       }
     }
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/core/election/CuratorElectionStreamTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/core/election/CuratorElectionStreamTest.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.election
 
-import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.scaladsl.{Keep, Sink, SinkQueue, Source}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.Executors
 
@@ -47,6 +47,14 @@ class CuratorElectionStreamTest extends AkkaUnitTest with Inside with ZookeeperS
     }
   }
 
+  private def nextKnownState(sinkQueue: SinkQueue[LeadershipState]): Option[LeadershipState] = {
+    val next = sinkQueue.pull().futureValue
+    if (next == Some(LeadershipState.Standby(None)))
+      nextKnownState(sinkQueue)
+    else
+      next
+  }
+
   "CuratorElectionStream.newCuratorConnection" should {
     "throw an exception when given an unresolvable hostname" in {
       val zkUrl = ZookeeperConf.ZkUrl.parse("zk://unresolvable:8080/marathon/leader").right.get
@@ -67,7 +75,7 @@ class CuratorElectionStreamTest extends AkkaUnitTest with Inside with ZookeeperS
       f.metrics, f.client, f.leaderPath, 5000.millis, "host:8080", f.electionEC)
       .toMat(Sink.queue())(Keep.both)
       .run
-    leader.pull().futureValue shouldBe Some(LeadershipState.ElectedAsLeader)
+    nextKnownState(leader) shouldBe Some(LeadershipState.ElectedAsLeader)
     cancellable.cancel()
     leader.pull().futureValue shouldBe Some(LeadershipState.Standby(None))
     leader.pull().futureValue shouldBe None
@@ -81,18 +89,18 @@ class CuratorElectionStreamTest extends AkkaUnitTest with Inside with ZookeeperS
       .toMat(Sink.queue())(Keep.both)
       .run
 
-    leader1.pull().futureValue shouldBe Some(LeadershipState.ElectedAsLeader)
+    nextKnownState(leader1) shouldBe Some(LeadershipState.ElectedAsLeader)
 
     val (cancellable2, leader2) = CuratorElectionStream(
       f.metrics, f.client2, f.leaderPath, 15000.millis, "host:2", f.electionEC)
       .toMat(Sink.queue())(Keep.both)
       .run
 
-    leader2.pull().futureValue shouldBe Some(LeadershipState.Standby(Some("host:1")))
+    nextKnownState(leader2) shouldBe Some(LeadershipState.Standby(Some("host:1")))
 
     f.client.close() // simulate a connection close for the first client
 
-    leader2.pull().futureValue shouldBe Some(LeadershipState.ElectedAsLeader)
+    nextKnownState(leader2) shouldBe Some(LeadershipState.ElectedAsLeader)
 
     cancellable1.cancel()
     cancellable2.cancel()
@@ -104,25 +112,25 @@ class CuratorElectionStreamTest extends AkkaUnitTest with Inside with ZookeeperS
       .toMat(Sink.queue())(Keep.both)
       .run
 
-    leader1.pull().futureValue shouldBe Some(LeadershipState.ElectedAsLeader)
+    nextKnownState(leader1) shouldBe Some(LeadershipState.ElectedAsLeader)
 
     val (cancellable2, leader2) = CuratorElectionStream(
       f.metrics, f.client, f.leaderPath, 15000.millis, "changehost:2", f.electionEC)
       .toMat(Sink.queue())(Keep.both)
       .run
 
-    leader2.pull().futureValue shouldBe Some(LeadershipState.Standby(Some("changehost:1")))
+    nextKnownState(leader2) shouldBe Some(LeadershipState.Standby(Some("changehost:1")))
 
     val (cancellable3, leader3) = CuratorElectionStream(
       f.metrics, f.client, f.leaderPath, 15000.millis, "changehost:3", f.electionEC)
       .toMat(Sink.queue())(Keep.both)
       .run
 
-    leader3.pull().futureValue shouldBe Some(LeadershipState.Standby(Some("changehost:1")))
+    nextKnownState(leader3) shouldBe Some(LeadershipState.Standby(Some("changehost:1")))
 
     cancellable1.cancel()
-    leader2.pull().futureValue shouldBe Some(LeadershipState.ElectedAsLeader)
-    leader3.pull().futureValue shouldBe Some(LeadershipState.Standby(Some("changehost:2")))
+    nextKnownState(leader2) shouldBe Some(LeadershipState.ElectedAsLeader)
+    nextKnownState(leader3) shouldBe Some(LeadershipState.Standby(Some("changehost:2")))
     cancellable2.cancel()
     cancellable3.cancel()
   }
@@ -135,7 +143,7 @@ class CuratorElectionStreamTest extends AkkaUnitTest with Inside with ZookeeperS
       .toMat(Sink.queue())(Keep.both)
       .run
     eventually { f.client.beforeCloseHooksLength shouldBe 1 }
-    events.pull().futureValue shouldBe Some(LeadershipState.ElectedAsLeader)
+    nextKnownState(events) shouldBe Some(LeadershipState.ElectedAsLeader)
     killSwitch.success(())
     events.pull().futureValue shouldBe None
     eventually { f.client.beforeCloseHooksLength shouldBe 0 }
@@ -170,7 +178,7 @@ class CuratorElectionStreamTest extends AkkaUnitTest with Inside with ZookeeperS
       .toMat(Sink.queue())(Keep.both)
       .run
     Given("an elected leader")
-    leader.pull().futureValue shouldBe Some(LeadershipState.ElectedAsLeader)
+    nextKnownState(leader) shouldBe Some(LeadershipState.ElectedAsLeader)
 
     When("we stop the Zookeeper server")
     zkServer.stop()
@@ -185,7 +193,7 @@ class CuratorElectionStreamTest extends AkkaUnitTest with Inside with ZookeeperS
     zkServer.start()
 
     Then("The stream should emit the current leadership state again")
-    leader.pull().futureValue shouldBe Some(LeadershipState.ElectedAsLeader)
+    nextKnownState(leader) shouldBe Some(LeadershipState.ElectedAsLeader)
 
     cancellable.cancel()
     leader.pull().futureValue shouldBe Some(LeadershipState.Standby(None))


### PR DESCRIPTION
Sometimes LeaderLatch will return no leader. This causes CuratorElectionStream to occasionally emit and extra Standby(None) during leadership transition. This isn't an issue as long as the actual leader state is eventually emitted

JIRA Issues: MARATHON-8433