### PR TITLE
Limit Akka stream parallelism

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -21,6 +21,7 @@ import mesosphere.marathon.core.appinfo.{PodSelector, PodStatusService, Selector
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.{PodDefinition, PodManager}
+import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.raml.{Pod, Raml}
 import mesosphere.marathon.state.{PathId, Timestamp, VersionInfo}
@@ -250,7 +251,7 @@ class PodsResource @Inject() (
   @GET
   @Path("::status")
   def allStatus(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val future = Source(podSystem.ids()).mapAsync(Int.MaxValue) { id =>
+    val future = Source(podSystem.ids()).mapAsync(RepositoryConstants.maxConcurrency) { id =>
       podStatusService.selectPodStatus(id, authzSelector)
     }.filter(_.isDefined).map(_.get).runWith(Sink.seq)
 

--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
@@ -16,6 +16,7 @@ import mesosphere.marathon.core.event.{GroupChangeFailed, GroupChangeSuccess}
 import mesosphere.marathon.core.group.{GroupManager, GroupManagerConfig}
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.PodDefinition
+import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.metrics.{Counter, Gauge, Metrics, MinMaxCounter}
 import mesosphere.marathon.metrics.deprecated.ServiceMetric
 import mesosphere.marathon.state._
@@ -77,7 +78,7 @@ class GroupManagerImpl(
   override def rootGroupOption(): Option[RootGroup] = root.get()
 
   override def versions(id: PathId): Source[Timestamp, NotUsed] = {
-    groupRepository.rootVersions().mapAsync(Int.MaxValue) { version =>
+    groupRepository.rootVersions().mapAsync(RepositoryConstants.maxConcurrency) { version =>
       groupRepository.rootVersion(version)
     }.collect { case Some(g) if g.group(id).isDefined => g.version }
   }

--- a/src/main/scala/mesosphere/marathon/core/storage/repository/impl/PersistenceStoreRepository.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/repository/impl/PersistenceStoreRepository.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.scaladsl.Source
 import akka.{Done, NotUsed}
-import mesosphere.marathon.core.storage.repository.{Repository, VersionedRepository}
+import mesosphere.marathon.core.storage.repository.{Repository, RepositoryConstants, VersionedRepository}
 import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
 
 import scala.concurrent.Future
@@ -33,7 +33,7 @@ class PersistenceStoreRepository[Id, V, K, C, S](
   override def store(v: V): Future[Done] = persistenceStore.store(extractId(v), v)
 
   // Assume that the underlying store can limit its own concurrency.
-  override def all(): Source[V, NotUsed] = ids().mapAsync(Int.MaxValue)(get).collect { case Some(x) => x }
+  override def all(): Source[V, NotUsed] = ids().mapAsync(RepositoryConstants.maxConcurrency)(get).collect { case Some(x) => x }
 }
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -12,6 +12,7 @@ import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.Protos.{StorageVersion, ZKStoreEntry}
 import mesosphere.marathon.core.storage.backup.BackupItem
+import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.core.storage.store.impl.{BasePersistenceStore, CategorizedKey}
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.storage.migration.{Migration, StorageVersions}
@@ -44,7 +45,7 @@ case class ZkSerialized(bytes: ByteString)
 class ZkPersistenceStore(
     metrics: Metrics,
     val client: RichCuratorFramework,
-    maxConcurrent: Int = 8,
+    maxConcurrent: Int = RepositoryConstants.maxConcurrency,
     maxQueued: Int = 100
 )(
     implicit

--- a/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
@@ -10,6 +10,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.scaladsl.{FileIO, Keep, Sink}
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.storage.backup.impl.TarBackupFlow
+import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
 import mesosphere.marathon.storage.migration.{Migration, StorageVersions}
 import mesosphere.marathon.test.SettableClock
@@ -174,7 +175,7 @@ private[storage] trait PersistenceStoreTest { this: AkkaUnitTest =>
         store.backup().runWith(tarSink).futureValue
 
         Then("the content of the store can be removed completely")
-        store.ids().map(store.deleteAll(_)).mapAsync(Int.MaxValue)(identity).runWith(Sink.ignore).futureValue
+        store.ids().map(store.deleteAll(_)).mapAsync(RepositoryConstants.maxConcurrency)(identity).runWith(Sink.ignore).futureValue
         store.setStorageVersion(StorageVersions(0, 0, 0)).futureValue
 
         When("the state is read from the backup")

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
@@ -42,7 +42,7 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
     val client = zkClient(namespace = Some(root))
     val store = LazyCachingPersistenceStore(
       metrics,
-      new ZkPersistenceStore(metrics, client, 8))
+      new ZkPersistenceStore(metrics, client))
     store.markOpen()
     store
   }

--- a/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
@@ -11,6 +11,7 @@ import akka.testkit.{TestFSMRef, TestKitBase}
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.async.ExecutionContexts
 import mesosphere.marathon.core.pod.PodDefinition
+import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.core.storage.store.impl.memory.{Identity, InMemoryPersistenceStore, RamId}
 import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp, VersionInfo}
 import mesosphere.marathon.test.{GroupCreation, Mockito}
@@ -562,7 +563,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         f.podRepo.ids().runWith(Sink.seq).futureValue should contain theSameElementsAs Seq(dPod1.id, pod3.id)
         f.podRepo.versions(dPod1.id).runWith(Sink.seq).futureValue should contain theSameElementsAs Seq(dPod1V2.version.toOffsetDateTime)
 
-        f.groupRepo.rootVersions().mapAsync(Int.MaxValue)(f.groupRepo.rootVersion).collect {
+        f.groupRepo.rootVersions().mapAsync(RepositoryConstants.maxConcurrency)(f.groupRepo.rootVersion).collect {
           case Some(g) => g
         }.runWith(Sink.seq).futureValue should
           contain theSameElementsAs Seq(root2, root3, root4)

--- a/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
@@ -7,6 +7,7 @@ import java.util.UUID
 import akka.Done
 import akka.stream.scaladsl.Sink
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LoadTimeCachingPersistenceStore}
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.storage.store.impl.zk.ZkPersistenceStore
@@ -141,7 +142,7 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
         repo.rootVersion(firstRoot.version.toOffsetDateTime).futureValue.value should equal(firstRoot)
         repo.rootVersions().runWith(Sink.seq).futureValue should contain theSameElementsAs
           Seq(firstRoot.version.toOffsetDateTime, nextRoot.version.toOffsetDateTime)
-        repo.rootVersions().mapAsync(Int.MaxValue)(repo.rootVersion)
+        repo.rootVersions().mapAsync(RepositoryConstants.maxConcurrency)(repo.rootVersion)
           .collect { case Some(g) => g }.runWith(Sink.seq).futureValue should contain theSameElementsAs
           Seq(firstRoot, nextRoot)
       }

--- a/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import akka.Done
 import akka.stream.scaladsl.Sink
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.storage.repository.{Repository, VersionedRepository}
+import mesosphere.marathon.core.storage.repository.{ Repository, RepositoryConstants, VersionedRepository }
 import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.storage.store.impl.zk.ZkPersistenceStore
@@ -111,7 +111,7 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
         // New Persistence Stores are Garbage collected so they can store extra versions...
         versions.tail.map(_.version.toOffsetDateTime).toSet.diff(
           repo.versions(app.id).runWith(EnrichedSink.set).futureValue) should be ('empty)
-        versions.tail.toSet.diff(repo.versions(app.id).mapAsync(Int.MaxValue)(repo.getVersion(app.id, _))
+        versions.tail.toSet.diff(repo.versions(app.id).mapAsync(RepositoryConstants.maxConcurrency)(repo.getVersion(app.id, _))
           .collect { case Some(g) => g }
           .runWith(EnrichedSink.set).futureValue) should be ('empty)
 
@@ -124,7 +124,7 @@ class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhe
         versions.tail.map(_.version.toOffsetDateTime).toSet.diff(
           repo.versions(app.id).runWith(EnrichedSink.set).futureValue) should be('empty)
         versions.tail.toSet.diff(
-          repo.versions(app.id).mapAsync(Int.MaxValue)(repo.getVersion(app.id, _))
+          repo.versions(app.id).mapAsync(RepositoryConstants.maxConcurrency)(repo.getVersion(app.id, _))
             .collect { case Some(g) => g }
             .runWith(EnrichedSink.set).futureValue
         ) should be ('empty)


### PR DESCRIPTION
Remove all unbounded parallelism in Akka streams. While the downstream
work-queue was processing up to 8 items at a time, we were creating a lot of
futures all at once

JIRA Issues: MARATHON-8398
