### PR TITLE
Disable Docker image test and packaging.

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -236,7 +236,7 @@ def buildMaster(): Unit = {
   val version = build(buildName = s"master-$buildNumber")
   buildDockerAndLinuxPackages()
   testDockerAndLinuxPackages()
-  dcos.buildRegistry(version)
+  // dcos.buildRegistry(version) The packaging is broken on master https://jira.mesosphere.com/browse/MARATHON-8442.
 
   // Uploads
   val maybeArtifact = uploadTarballPackagesToS3(version, s"builds/$version")

--- a/tests/package/test.sc
+++ b/tests/package/test.sc
@@ -438,8 +438,8 @@ def main(args: String*): Unit = {
     new Centos6Test,
     new Ubuntu1404Test,
     new Ubuntu1604Test,
-    new Ubuntu1804Test,
-    new DockerImageTest
+    new Ubuntu1804Test
+    //new DockerImageTest Tracking failing DockerImageTest in https://jira.mesosphere.com/browse/MARATHON-8441.
   )
   val predicate: (String => Boolean) = args match {
     case Seq("all") =>


### PR DESCRIPTION
Summary:
The Docker image tests are failing on master even though they pass on
macOS. WE disable the test and start tracking the issue as a blocker.

Also, the packaging fails on master but passed on macOS.