### PR TITLE
Do not reconcile created tasks

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -2,8 +2,8 @@ package mesosphere.marathon
 
 import akka.Done
 import akka.actor._
-import akka.pattern.pipe
 import akka.event.{EventStream, LoggingReceive}
+import akka.pattern.pipe
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
@@ -12,7 +12,6 @@ import mesosphere.marathon.core.election.LeadershipTransition
 import mesosphere.marathon.core.event.DeploymentSuccess
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.{Goal, Instance}
-import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.{KillReason, KillService}
@@ -22,7 +21,7 @@ import mesosphere.marathon.storage.repository.{DeploymentRepository, GroupReposi
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.Constraints
 import org.apache.mesos
-import org.apache.mesos.Protos.{Status, TaskState}
+import org.apache.mesos.Protos.Status
 import org.apache.mesos.SchedulerDriver
 
 import scala.async.Async.{async, await}

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -505,7 +505,7 @@ object TaskStatusCollector {
   def collectTaskStatusFor(instances: Seq[Instance]): Seq[mesos.Protos.TaskStatus] = {
     instances.flatMap { instance =>
       instance.tasksMap.values.collect {
-        case task @ Task(_, _, Task.Status(_, _, Some(mesosStatus), _, _)) if !task.isTerminal =>
+        case task @ Task(_, _, Task.Status(_, _, Some(mesosStatus), _, _)) if !task.isTerminal && !task.isReserved =>
           mesosStatus
       }
     }(collection.breakOut)

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -505,6 +505,8 @@ object TaskStatusCollector {
   def collectTaskStatusFor(instances: Seq[Instance]): Seq[mesos.Protos.TaskStatus] = {
     instances.flatMap { instance =>
       instance.tasksMap.values.collect {
+        // only tasks not confirmed by mesos does not have mesosStatus (condition Created)
+        // OverdueTasksActor is taking care of those tasks, we don't need to reconcile them
         case task @ Task(_, _, Task.Status(_, _, Some(mesosStatus), _, _)) if !task.isTerminal && !task.isReserved =>
           mesosStatus
       }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -141,7 +141,6 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
         .addTaskDropped(containerName = Some("dropped"))
         .addTaskUnknown(containerName = Some("unknown"))
         .addTaskReserved(containerName = Some("reserved"))
-        .addTaskCreated(containerName = Some("created"))
         .addTaskKilling(containerName = Some("killing"))
         .addTaskRunning(containerName = Some("running"))
         .addTaskStaging(containerName = Some("staging"))
@@ -158,10 +157,10 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       expectMsg(TasksReconciled)
 
       val nonTerminalTasks = instance.tasksMap.values.filter(!_.task.isTerminal)
-      assert(nonTerminalTasks.size == 7, "We should have 7 non-terminal tasks")
+      assert(nonTerminalTasks.size == 6, "We should have 7 non-terminal tasks")
 
       val expectedStatus: java.util.Collection[TaskStatus] = TaskStatusCollector.collectTaskStatusFor(Seq(instance)).asJava
-      assert(expectedStatus.size() == 6, "We should have 6 task status, because Reserved do not have a mesosStatus")
+      assert(expectedStatus.size() == 5, "We should have 6 task status, because Reserved do not have a mesosStatus")
 
       eventually {
         driver.reconcileTasks(expectedStatus)
@@ -169,6 +168,25 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       eventually {
         driver.reconcileTasks(java.util.Arrays.asList())
       }
+    }
+
+    "Created tasks should not be submitted in reconciliation" in withFixture() { f =>
+      import f._
+      val app = AppDefinition(id = "/test-app".toPath, instances = 1, cmd = Some("sleep"))
+      val instance = TestInstanceBuilder.newBuilder(app.id)
+        .addTaskCreated(containerName = Some("created"))
+        .getInstance()
+
+      groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
+      instanceTracker.instancesBySpec()(any[ExecutionContext]) returns Future.successful(InstanceTracker.InstancesBySpec.forInstances(instance))
+
+      leadershipTransitionInput.offer(LeadershipTransition.ElectedAsLeaderAndReady)
+      schedulerActor ! ReconcileTasks
+
+      expectMsg(TasksReconciled)
+
+      val tasksToReconcile: java.util.Collection[TaskStatus] = TaskStatusCollector.collectTaskStatusFor(Seq(instance)).asJava
+      assert(tasksToReconcile.isEmpty, "Created task should not be submited for reconciliation")
     }
 
     "ScaleApps" in withFixture() { f =>

--- a/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import akka.Done
 import akka.stream.scaladsl.Sink
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.storage.repository.{ Repository, RepositoryConstants, VersionedRepository }
+import mesosphere.marathon.core.storage.repository.{Repository, RepositoryConstants, VersionedRepository}
 import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.storage.store.impl.zk.ZkPersistenceStore


### PR DESCRIPTION
Fixes a race condition where created tasks that have not yet been sent to Mesos were included in reconciliation

JIRA issues: MARATHON-8372
