### PR TITLE
Be conservative when creating new framework IDs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,16 @@
 
 Previously, the Marathon Docker container would only run as user root. The packaging has been updated so that the container can be run as the user `nobody`. The default user for running the container (and, subsequently, the default value for `--mesos_user`) has not been changed.
 
+### Marathon framework ID generation is now very conservative
+
+Previously, Marathon would automatically request a new framework ID from Mesos if the old one was marked as torn down in Mesos, or if the framework ID record was removed from Zookeeper. This has led to more trouble than it has helped. The new behavior is:
+
+* If Marathon's framework ID has been torn down in Mesos, or if the failover timeout has been exceeded, Marathon will crash, on launch, with a clear message.
+
+* If Marathon's framework ID record was deleted from Zookeeper or is otherwise inaccessible, and there are instances defined, Marathon will refuse to create a new Framework ID and crash.
+
+For more information, refer to the [framework id docs page](https://mesosphere.github.io/marathon/docs/framework-id.html).
+
 ### New Exit Codes
 
 Marathon will indicate with an exit code why it stopped itself. See the [docs page](https://mesosphere.github.io/marathon/docs/exit-codes.html) for a list of all codes and their meanings.

--- a/docs/docs/exit-codes.md
+++ b/docs/docs/exit-codes.md
@@ -16,6 +16,7 @@ help you figure out why the Marathon process stopped.
 |103        | `LeadershipLoss` - Lost leadership                                   |
 |104        | `LeadershipEndedFaulty` - Leadership ended with an error             |
 |105        | `LeadershipEndedGracefully` - Leadership ended without an error      |
-|106        | `MesosSchedulerError` - The Mesos scheduler driver had an error       |
+|106        | `MesosSchedulerError` - The Mesos scheduler driver had an error      |
 |107        | `UncaughtException` - An internal unknown error could not be handled |
+|108        | The Framework ID could not be read.                                  |
 |137        | Killed by an external process or uncaught exception                  |

--- a/docs/docs/framework-id.md
+++ b/docs/docs/framework-id.md
@@ -1,0 +1,40 @@
+# Framework ID registration
+Marathon registers as a framework with Mesos. During the first attempt to connect with Mesos, Marathon requests a new framework ID. This framework ID is used to associate the instance of Marathon with the tasks launched by that instance of Marathon.
+
+It is very important to consistently use the same framework ID. If Marathon changes framework IDs while existing tasks are running, then the old tasks will become effectively orphaned, while a new set of tasks will be launched. Because of this, Marathon will refuse to generate a new framework ID if there are any instances specified. This means that Marathon may not be able to launch under the following cases:
+
+* The Zookeeper record containing the Marathon framework ID was removed, is inaccessible, or was corrupted.
+* The framework ID associated with the Marathon instance was marked as "torn down" in Mesos, or the framework failover timeout has been exceeded; as a result Marathon cannot reuse its framework ID.
+
+## Recovering from Framework ID issues
+
+To recover from this, you can use the [Marathon Storage Tool](https://github.com/mesosphere/marathon-storage-tool) to repair / update Marathon's state. Follow the instructions in the README to launch the appropriate version for your Marathon instance, and to provide the appropriate configuration flags.
+
+# Zookeeper record containing the Marathon framework ID was removed/inaccessible/corrupted
+
+To repair the Marathon's framework ID record in Zookeeper, you will need the framework ID as which Marathon should connect. You can get this by accessing the frameworks section of the Mesos UI, or by requesting the framework information JSON state from `{mesos_url}/frameworks`.
+
+Launch the Marathon Storage Tool and update the framework ID using the following commands (where `00000000-0000-0000-0000-000000000000-0000` is your framework ID):
+
+```
+import mesosphere.util.state.FrameworkId
+
+module.frameworkIdRepository.store(
+  FrameworkId("00000000-0000-0000-0000-000000000000-0000"))
+```
+
+It is critical that you specify the framework ID exactly as it is registered in Mesos. Be sure that there are no spaces in the ID.
+
+# Marathon Framework was torn down in Mesos
+
+In this case, Mesos is marked a framework as gone, and a new framework ID will need to be generated. Since Marathon will refuse to generate a new framework ID if instances are defined, you will need to delete all instances, in addition to deleting the framework ID record. All service state (apps, pods, groups, etc.) will be preserved.
+
+```
+purge(listInstances())
+
+module.frameworkIdRepository.delete()
+```
+
+Quit the Marathon Storage Tool, and restart Marathon. Marathon will generate a new framework ID on launch.
+
+Note that old reservations for persistent tasks launched by the old framework ID will not be reused, nor will they be cleaned up. You'll need to manually destroy these reservations using the Mesos API.

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -10,6 +10,7 @@ import akka.routing.RoundRobinPool
 import akka.stream.Materializer
 import com.google.inject._
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.base.{CrashStrategy, JvmExitsCrashStrategy}
 import mesosphere.marathon.core.deployment.DeploymentManager
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.health.HealthCheckManager
@@ -34,6 +35,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
   extends AbstractModule with StrictLogging {
 
   def configure(): Unit = {
+    bind(classOf[CrashStrategy]).toInstance(JvmExitsCrashStrategy)
     bind(classOf[MarathonConf]).toInstance(conf)
     bind(classOf[DeprecatedFeatureSet]).toInstance(conf.deprecatedFeatures())
     bind(classOf[HttpConf]).toInstance(http)

--- a/src/main/scala/mesosphere/marathon/SchedulerDriverFactory.scala
+++ b/src/main/scala/mesosphere/marathon/SchedulerDriverFactory.scala
@@ -1,12 +1,16 @@
 package mesosphere.marathon
 
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
 import com.typesafe.scalalogging.StrictLogging
 import javax.inject.Inject
-
-import mesosphere.marathon.storage.repository.FrameworkIdRepository
+import mesosphere.marathon.core.base.CrashStrategy
+import mesosphere.marathon.storage.repository.{FrameworkIdRepository, InstanceRepository}
+import org.apache.mesos.Protos.FrameworkID
 import org.apache.mesos.{Scheduler, SchedulerDriver}
 
 import scala.concurrent.Await
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 trait SchedulerDriverFactory {
   def createDriver(): SchedulerDriver
@@ -17,7 +21,9 @@ class MesosSchedulerDriverFactory @Inject() (
     config: MarathonConf,
     httpConfig: HttpConf,
     frameworkIdRepository: FrameworkIdRepository,
-    scheduler: Scheduler)
+    instanceRepository: InstanceRepository,
+    crashStrategy: CrashStrategy,
+    scheduler: Scheduler)(implicit materializer: Materializer)
 
   extends SchedulerDriverFactory with StrictLogging {
 
@@ -27,10 +33,34 @@ class MesosSchedulerDriverFactory @Inject() (
     * As a side effect, the corresponding driver is set in the [[MarathonSchedulerDriverHolder]].
     */
   override def createDriver(): SchedulerDriver = {
-    implicit val zkTimeout = config.zkTimeoutDuration
-    val frameworkId = Await.result(frameworkIdRepository.get(), zkTimeout).map(_.toProto)
+    val frameworkId: Option[FrameworkID] = MesosSchedulerDriverFactory.getFrameworkId(
+      crashStrategy, config.zkTimeoutDuration, frameworkIdRepository, instanceRepository)
     val driver = MarathonSchedulerDriver.newDriver(config, httpConfig, scheduler, frameworkId)
     holder.driver = Some(driver)
     driver
+  }
+}
+
+object MesosSchedulerDriverFactory extends StrictLogging {
+  def getFrameworkId(
+    crashStrategy: CrashStrategy,
+    zkTimeout: FiniteDuration,
+    frameworkIdRepository: FrameworkIdRepository,
+    instanceRepository: InstanceRepository)(implicit mat: Materializer): Option[FrameworkID] = {
+
+    def instancesAreDefined: Boolean = Await.result(instanceRepository.ids().runWith(Sink.headOption), zkTimeout).nonEmpty
+
+    Await.result(frameworkIdRepository.get(), zkTimeout).map(_.toProto) match {
+      case frameworkId @ Some(_) =>
+        frameworkId
+      case None if instancesAreDefined =>
+        logger.error("Refusing to create a new Framework ID while there are existing instances.\n" +
+          "Please see for an explanation of the issue, and how to recover: https://mesosphere.github.io/marathon/docs/framework-id.html")
+        Await.result(crashStrategy.crash(CrashStrategy.FrameworkIdMissing), Duration.Inf)
+        throw new RuntimeException("Refusing to allow creation of a new Framework ID")
+      case None =>
+        logger.warn("No frameworkId could be read and no instances are defined. This will result in a new frameworkId")
+        None
+    }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -136,6 +136,10 @@ class CoreGuiceModule(config: Config) extends AbstractModule {
     coreModule.storageModule.groupRepository
 
   @Provides @Singleton
+  def instanceRepository(coreModule: CoreModule): InstanceRepository =
+    coreModule.storageModule.instanceRepository
+
+  @Provides @Singleton
   def frameworkIdRepository(coreModule: CoreModule): FrameworkIdRepository =
     coreModule.storageModule.frameworkIdRepository
 

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -9,7 +9,7 @@ import akka.event.EventStream
 import com.google.inject.{Inject, Provider}
 import javax.inject.Named
 import mesosphere.marathon.core.auth.AuthModule
-import mesosphere.marathon.core.base.{ActorsModule, JvmExitsCrashStrategy, LifecycleState}
+import mesosphere.marathon.core.base.{ActorsModule, CrashStrategy, LifecycleState}
 import mesosphere.marathon.core.deployment.DeploymentModule
 import mesosphere.marathon.core.election._
 import mesosphere.marathon.core.event.EventModule
@@ -58,7 +58,8 @@ class CoreModuleImpl @Inject() (
     instanceUpdateSteps: Seq[InstanceChangeHandler],
     taskStatusUpdateProcessor: TaskStatusUpdateProcessor,
     mesosLeaderInfo: MesosLeaderInfo,
-    @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) heartbeatActor: ActorRef
+    @Named(ModuleNames.MESOS_HEARTBEAT_ACTOR) heartbeatActor: ActorRef,
+    crashStrategy: CrashStrategy
 )
   extends CoreModule {
 
@@ -67,7 +68,6 @@ class CoreModuleImpl @Inject() (
   private[this] lazy val random = Random
   private[this] lazy val lifecycleState = LifecycleState.WatchingJVM
   override lazy val actorsModule = new ActorsModule(actorSystem)
-  private[this] lazy val crashStrategy = JvmExitsCrashStrategy
   private[this] val electionExecutor = Executors.newSingleThreadExecutor()
 
   override lazy val leadershipModule = LeadershipModule(actorsModule.actorRefFactory)

--- a/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
@@ -21,6 +21,7 @@ object CrashStrategy {
   case object LeadershipEndedGracefully extends Reason { override val code: Int = 105 }
   case object MesosSchedulerError extends Reason { override val code: Int = 106 }
   case object UncaughtException extends Reason { override val code: Int = 107 }
+  case object FrameworkIdMissing extends Reason { override val code: Int = 108 }
 }
 
 case object JvmExitsCrashStrategy extends CrashStrategy {

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerTest.scala
@@ -4,14 +4,13 @@ import akka.Done
 import akka.event.EventStream
 import akka.testkit.TestProbe
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.base.CrashStrategy
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.launcher.OfferProcessor
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.state.Region
 import mesosphere.marathon.storage.repository.{AppRepository, FrameworkIdRepository}
-import mesosphere.marathon.test.MarathonTestHelper
+import mesosphere.marathon.test.{MarathonTestHelper, TestCrashStrategy}
 import mesosphere.util.state.{FrameworkId, MutableMesosLeaderInfo}
 import org.apache.mesos.Protos.DomainInfo.FaultDomain.{RegionInfo, ZoneInfo}
 import org.apache.mesos.Protos._
@@ -22,8 +21,6 @@ import scala.concurrent.Future
 
 class MarathonSchedulerTest extends AkkaUnitTest {
   class Fixture {
-    var suicideCalled: Option[Boolean] = None
-
     val repo: AppRepository = mock[AppRepository]
     val queue: LaunchQueue = mock[LaunchQueue]
     val frameworkIdRepository: FrameworkIdRepository = mock[FrameworkIdRepository]
@@ -34,7 +31,7 @@ class MarathonSchedulerTest extends AkkaUnitTest {
     val eventBus: EventStream = system.eventStream
     val taskStatusProcessor: TaskStatusUpdateProcessor = mock[TaskStatusUpdateProcessor]
     val offerProcessor: OfferProcessor = mock[OfferProcessor]
-    val crashStrategy: CrashStrategy = mock[CrashStrategy]
+    val crashStrategy = new TestCrashStrategy
     val marathonScheduler: MarathonScheduler = new MarathonScheduler(
       eventBus,
       offerProcessor = offerProcessor,
@@ -43,9 +40,6 @@ class MarathonSchedulerTest extends AkkaUnitTest {
       mesosLeaderInfo,
       config,
       crashStrategy) {
-      override protected def suicide(removeFrameworkId: Boolean): Unit = {
-        suicideCalled = Some(removeFrameworkId)
-      }
     }
   }
 
@@ -137,9 +131,8 @@ class MarathonSchedulerTest extends AkkaUnitTest {
       When("An error is reported")
       marathonScheduler.error(driver, "some weird mesos message")
 
-      Then("Suicide is called without removing the framework id")
-      suicideCalled should be(defined)
-      suicideCalled.get should be (false)
+      Then("Marathon crashes")
+      crashStrategy.crashed shouldBe true
     }
 
     "Suicide with a framework error will remove the framework id" in new Fixture {
@@ -149,9 +142,8 @@ class MarathonSchedulerTest extends AkkaUnitTest {
       When("An error is reported")
       marathonScheduler.error(driver, "Framework has been removed")
 
-      Then("Suicide is called with removing the framework id")
-      suicideCalled should be(defined)
-      suicideCalled.get should be (true)
+      Then("Marathon crashes")
+      crashStrategy.crashed shouldBe true
     }
 
     "Store default region when registered" in new Fixture {

--- a/src/test/scala/mesosphere/marathon/SchedulerDriverFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerDriverFactoryTest.scala
@@ -1,0 +1,50 @@
+package mesosphere.marathon
+
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.base.CrashStrategy
+import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
+import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.storage.repository.{FrameworkIdRepository, InstanceRepository}
+import mesosphere.marathon.test.TestCrashStrategy
+
+import org.scalatest.Inside
+import scala.util.{Try, Failure}
+
+class SchedulerDriverFactoryTest extends AkkaUnitTest with Inside {
+  val appId = "/test/foo/bla/rest".toPath
+  val instanceId = Instance.Id.forRunSpec(appId)
+
+  class Fixture {
+    val store = new InMemoryPersistenceStore
+    val zkTimeout = implicitly[PatienceConfig].timeout
+    val frameworkIdRepository = FrameworkIdRepository.inMemRepository(store)
+    val instanceRepository = InstanceRepository.inMemRepository(store)
+    val crashStrategy = new TestCrashStrategy()
+    store.markOpen()
+  }
+
+  "getFrameworkId throws an exception and crashes if frameworkId is undefined but there are instances defined" in new Fixture {
+    instanceRepository.store(TestInstanceBuilder.emptyInstance(instanceId = instanceId)).futureValue
+
+    inside(Try(
+      MesosSchedulerDriverFactory.getFrameworkId(
+        crashStrategy,
+        zkTimeout,
+        frameworkIdRepository,
+        instanceRepository))) {
+      case Failure(ex: RuntimeException) =>
+        ex.getMessage.should(include("Refusing"))
+    }
+
+    crashStrategy.crashedReason shouldBe Some(CrashStrategy.FrameworkIdMissing)
+  }
+
+  "getFrameworkId returns None if frameworkId is undefined and instance repository is empty" in new Fixture {
+    MesosSchedulerDriverFactory.getFrameworkId(
+      crashStrategy,
+      zkTimeout,
+      frameworkIdRepository,
+      instanceRepository) shouldBe None
+  }
+}

--- a/src/test/scala/mesosphere/marathon/test/TestCrashStrategy.scala
+++ b/src/test/scala/mesosphere/marathon/test/TestCrashStrategy.scala
@@ -6,9 +6,10 @@ import mesosphere.marathon.core.base.CrashStrategy
 import scala.concurrent.Future
 
 class TestCrashStrategy extends CrashStrategy {
-  @volatile var crashed: Boolean = false
+  def crashed = crashedReason.nonEmpty
+  @volatile var crashedReason: Option[CrashStrategy.Reason] = None
   override def crash(reason: CrashStrategy.Reason): Future[Done] = {
-    crashed = true
+    crashedReason = Some(reason)
     Future.successful(Done)
   }
 }


### PR DESCRIPTION
Backport of c77c5ef / #6574

Previously, Marathon would automatically request a new framework ID
from Mesos if the old one was marked as torn down in Mesos, or if the
framework ID record was removed from Zookeeper. This has led to more
trouble than it has helped.

If Marathon's framework ID has been torn down in Mesos, Marathon will
crash on launch, with a clear message.

If Marathon's framework ID was removed / is missing, Marathon will
refuse to create a new Framework ID if there are any defined
instances.

JIRA Issues: MARATHON-8420
