### PR TITLE
Be conservative when creating new framework IDs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 ## Changes from 1.5.11 to 1.5.12 (unreleased)
 
+### Marathon framework ID generation is now very conservative
+
+Previously, Marathon would automatically request a new framework ID from Mesos if the old one was marked as torn down in Mesos, or if the framework ID record was removed from Zookeeper. This has led to more trouble than it has helped. The new behavior is:
+
+* If Marathon's framework ID has been torn down in Mesos, or if the failover timeout has been exceeded, Marathon will crash, on launch, with a clear message.
+
+* If Marathon's framework ID record was deleted from Zookeeper or is otherwise inaccessible, and there are instances defined, Marathon will refuse to create a new Framework ID and crash.
+
+For more information, refer to the [framework id docs page](https://mesosphere.github.io/marathon/docs/framework-id.html).
+
+
 ### Docker image now allows user `nobody`
 
 Previously, the Marathon Docker container would only run as user root. The packaging has been updated so that the container can be run as the user `nobody`. The default user for running the container (and, subsequently, the default value for `--mesos_user`) has not been changed.

--- a/docs/docs/framework-id.md
+++ b/docs/docs/framework-id.md
@@ -1,0 +1,40 @@
+# Framework ID registration
+Marathon registers as a framework with Mesos. During the first attempt to connect with Mesos, Marathon requests a new framework ID. This framework ID is used to associate the instance of Marathon with the tasks launched by that instance of Marathon.
+
+It is very important to consistently use the same framework ID. If Marathon changes framework IDs while existing tasks are running, then the old tasks will become effectively orphaned, while a new set of tasks will be launched. Because of this, Marathon will refuse to generate a new framework ID if there are any instances specified. This means that Marathon may not be able to launch under the following cases:
+
+* The Zookeeper record containing the Marathon framework ID was removed, is inaccessible, or was corrupted.
+* The framework ID associated with the Marathon instance was marked as "torn down" in Mesos, or the framework failover timeout has been exceeded; as a result Marathon cannot reuse its framework ID.
+
+## Recovering from Framework ID issues
+
+To recover from this, you can use the [Marathon Storage Tool](https://github.com/mesosphere/marathon-storage-tool) to repair / update Marathon's state. Follow the instructions in the README to launch the appropriate version for your Marathon instance, and to provide the appropriate configuration flags.
+
+# Zookeeper record containing the Marathon framework ID was removed/inaccessible/corrupted
+
+To repair the Marathon's framework ID record in Zookeeper, you will need the framework ID as which Marathon should connect. You can get this by accessing the frameworks section of the Mesos UI, or by requesting the framework information JSON state from `{mesos_url}/frameworks`.
+
+Launch the Marathon Storage Tool and update the framework ID using the following commands (where `00000000-0000-0000-0000-000000000000-0000` is your framework ID):
+
+```
+import mesosphere.util.state.FrameworkId
+
+module.frameworkIdRepository.store(
+  FrameworkId("00000000-0000-0000-0000-000000000000-0000"))
+```
+
+It is critical that you specify the framework ID exactly as it is registered in Mesos. Be sure that there are no spaces in the ID.
+
+# Marathon Framework was torn down in Mesos
+
+In this case, Mesos is marked a framework as gone, and a new framework ID will need to be generated. Since Marathon will refuse to generate a new framework ID if instances are defined, you will need to delete all instances, in addition to deleting the framework ID record. All service state (apps, pods, groups, etc.) will be preserved.
+
+```
+purge(listInstances())
+
+module.frameworkIdRepository.delete()
+```
+
+Quit the Marathon Storage Tool, and restart Marathon. Marathon will generate a new framework ID on launch.
+
+Note that old reservations for persistent tasks launched by the old framework ID will not be reused, nor will they be cleaned up. You'll need to manually destroy these reservations using the Mesos API.

--- a/src/main/scala/mesosphere/marathon/MarathonModule.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonModule.scala
@@ -11,6 +11,7 @@ import akka.stream.Materializer
 import com.google.inject._
 import com.google.inject.name.Names
 import mesosphere.chaos.http.HttpConf
+import mesosphere.marathon.core.base.{ CrashStrategy, JvmExitsCrashStrategy }
 import mesosphere.marathon.core.deployment.DeploymentManager
 import mesosphere.marathon.core.election.ElectionService
 import mesosphere.marathon.core.health.HealthCheckManager
@@ -39,6 +40,7 @@ class MarathonModule(conf: MarathonConf, http: HttpConf, actorSystem: ActorSyste
   val log = LoggerFactory.getLogger(getClass.getName)
 
   def configure(): Unit = {
+    bind(classOf[CrashStrategy]).toInstance(JvmExitsCrashStrategy)
     bind(classOf[MarathonConf]).toInstance(conf)
     bind(classOf[HttpConf]).toInstance(http)
     bind(classOf[LeaderProxyConf]).toInstance(conf)

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -25,7 +25,8 @@ class MarathonScheduler @Inject() (
     taskStatusProcessor: TaskStatusUpdateProcessor,
     frameworkIdRepository: FrameworkIdRepository,
     mesosLeaderInfo: MesosLeaderInfo,
-    config: MarathonConf) extends Scheduler {
+    config: MarathonConf,
+    crashStrategy: CrashStrategy) extends Scheduler {
 
   private[this] val log = LoggerFactory.getLogger(getClass.getName)
 
@@ -112,17 +113,9 @@ class MarathonScheduler @Inject() (
   override def error(driver: SchedulerDriver, message: String): Unit = {
     log.warn(s"Error: $message\n" +
       "In case Mesos does not allow registration with the current frameworkId, " +
-      s"delete the ZooKeeper Node: ${config.zooKeeperUrl().path}/state/framework:id\n" +
-      "CAUTION: if you remove this node, all tasks started with the current frameworkId will be orphaned!")
+      "follow the instructions for recovery here: https://mesosphere.github.io/marathon/docs/framework-id.html")
 
-    // Currently, it's pretty hard to disambiguate this error from other causes of framework errors.
-    // Watch MESOS-2522 which will add a reason field for framework errors to help with this.
-    // For now the frameworkId is removed based on the error message.
-    val removeFrameworkId = message match {
-      case "Framework has been removed" => true
-      case _: String => false
-    }
-    suicide(removeFrameworkId)
+    crashStrategy.crash()
   }
 
   /**
@@ -140,30 +133,10 @@ class MarathonScheduler @Inject() (
     lastMesosMasterVersion = SemanticVersion(masterVersion)
     if (!LibMesos.masterCompatible(masterVersion)) {
       log.error(s"Mesos Master version $masterVersion does not meet minimum required version ${LibMesos.MesosMasterMinimumVersion}")
-      suicide(removeFrameworkId = false)
+      crashStrategy.crash()
     }
   }
 
   /** The last version of the mesos master */
   def mesosMasterVersion(): Option[SemanticVersion] = lastMesosMasterVersion
-
-  /**
-    * Exits the JVM process, optionally deleting Marathon's FrameworkID
-    * from the backing persistence store.
-    *
-    * If `removeFrameworkId` is set, the next Marathon process elected
-    * leader will fail to find a stored FrameworkID and invoke `register`
-    * instead of `reregister`.  This is important because on certain kinds
-    * of framework errors (such as exceeding the framework failover timeout),
-    * the scheduler may never re-register with the saved FrameworkID until
-    * the leading Mesos master process is killed.
-    */
-  protected def suicide(removeFrameworkId: Boolean): Unit = {
-    log.error("Committing suicide!")
-
-    if (removeFrameworkId) Await.ready(frameworkIdRepository.delete(), config.zkTimeoutDuration)
-
-    // Asynchronously call asyncExit to avoid deadlock due to the JVM shutdown hooks
-    Runtime.getRuntime.asyncExit()
-  }
 }

--- a/src/main/scala/mesosphere/marathon/SchedulerDriverFactory.scala
+++ b/src/main/scala/mesosphere/marathon/SchedulerDriverFactory.scala
@@ -2,12 +2,18 @@ package mesosphere.marathon
 
 import javax.inject.Inject
 
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.chaos.http.HttpConf
-import mesosphere.marathon.storage.repository.FrameworkIdRepository
+import mesosphere.marathon.core.base.CrashStrategy
+import mesosphere.marathon.storage.repository.{ FrameworkIdRepository, InstanceRepository }
+import org.apache.mesos.Protos.FrameworkID
 import org.apache.mesos.{ Scheduler, SchedulerDriver }
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Await
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 trait SchedulerDriverFactory {
   def createDriver(): SchedulerDriver
@@ -18,7 +24,9 @@ class MesosSchedulerDriverFactory @Inject() (
   config: MarathonConf,
   httpConfig: HttpConf,
   frameworkIdRepository: FrameworkIdRepository,
-  scheduler: Scheduler)
+  instanceRepository: InstanceRepository,
+  crashStrategy: CrashStrategy,
+  scheduler: Scheduler)(implicit materializer: Materializer)
 
     extends SchedulerDriverFactory {
 
@@ -30,10 +38,34 @@ class MesosSchedulerDriverFactory @Inject() (
     * As a side effect, the corresponding driver is set in the [[MarathonSchedulerDriverHolder]].
     */
   override def createDriver(): SchedulerDriver = {
-    implicit val zkTimeout = config.zkTimeoutDuration
-    val frameworkId = Await.result(frameworkIdRepository.get(), zkTimeout).map(_.toProto)
+    val frameworkId: Option[FrameworkID] = MesosSchedulerDriverFactory.getFrameworkId(
+      crashStrategy, config.zkTimeoutDuration, frameworkIdRepository, instanceRepository)
     val driver = MarathonSchedulerDriver.newDriver(config, httpConfig, scheduler, frameworkId)
     holder.driver = Some(driver)
     driver
+  }
+}
+
+object MesosSchedulerDriverFactory extends StrictLogging {
+  def getFrameworkId(
+    crashStrategy: CrashStrategy,
+    zkTimeout: FiniteDuration,
+    frameworkIdRepository: FrameworkIdRepository,
+    instanceRepository: InstanceRepository)(implicit mat: Materializer): Option[FrameworkID] = {
+
+    def instancesAreDefined: Boolean = Await.result(instanceRepository.ids().runWith(Sink.headOption), zkTimeout).nonEmpty
+
+    Await.result(frameworkIdRepository.get(), zkTimeout).map(_.toProto) match {
+      case frameworkId @ Some(_) =>
+        frameworkId
+      case None if instancesAreDefined =>
+        logger.error("Refusing to create a new Framework ID while there are existing instances.\n" +
+          "Please see for an explanation of the issue, and how to recover: https://mesosphere.github.io/marathon/docs/framework-id.html")
+        Await.result(crashStrategy.crash(), Duration.Inf)
+        throw new RuntimeException("Refusing to allow creation of a new Framework ID")
+      case None =>
+        logger.warn("No frameworkId could be read and no instances are defined. This will result in a new frameworkId")
+        None
+    }
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreGuiceModule.scala
@@ -141,6 +141,10 @@ class CoreGuiceModule(config: Config) extends AbstractModule {
     coreModule.storageModule.groupRepository
 
   @Provides @Singleton
+  def instanceRepository(coreModule: CoreModule): InstanceRepository =
+    coreModule.storageModule.instanceRepository
+
+  @Provides @Singleton
   def frameworkIdRepository(coreModule: CoreModule): FrameworkIdRepository =
     coreModule.storageModule.frameworkIdRepository
 

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import akka.event.EventStream
 import com.google.inject.{ Inject, Provider }
 import mesosphere.marathon.core.auth.AuthModule
-import mesosphere.marathon.core.base.{ ActorsModule, JvmExitsCrashStrategy, LifecycleState }
+import mesosphere.marathon.core.base.{ ActorsModule, CrashStrategy, LifecycleState }
 import mesosphere.marathon.core.deployment.DeploymentModule
 import mesosphere.marathon.core.election._
 import mesosphere.marathon.core.event.EventModule
@@ -52,7 +52,8 @@ class CoreModuleImpl @Inject() (
   clock: Clock,
   scheduler: Provider[DeploymentService],
   instanceUpdateSteps: Seq[InstanceChangeHandler],
-  taskStatusUpdateProcessor: TaskStatusUpdateProcessor
+  taskStatusUpdateProcessor: TaskStatusUpdateProcessor,
+  crashStrategy: CrashStrategy
 )
     extends CoreModule {
 
@@ -61,7 +62,6 @@ class CoreModuleImpl @Inject() (
   private[this] lazy val random = Random
   private[this] lazy val lifecycleState = LifecycleState.WatchingJVM
   override lazy val actorsModule = new ActorsModule(actorSystem)
-  private[this] lazy val crashStrategy = JvmExitsCrashStrategy
 
   override lazy val leadershipModule = LeadershipModule(actorsModule.actorRefFactory)
   override lazy val electionModule = new ElectionModule(

--- a/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.core.async.ExecutionContexts
 
 import scala.concurrent.Future
 
-sealed trait CrashStrategy {
+trait CrashStrategy {
   def crash(): Future[Done]
 }
 

--- a/src/test/scala/mesosphere/marathon/SchedulerDriverFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerDriverFactoryTest.scala
@@ -1,0 +1,49 @@
+package mesosphere.marathon
+
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
+import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
+import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.storage.repository.{ FrameworkIdRepository, InstanceRepository }
+import mesosphere.marathon.test.TestCrashStrategy
+
+import org.scalatest.Inside
+import scala.util.{ Try, Failure }
+
+class SchedulerDriverFactoryTest extends AkkaUnitTest with Inside {
+  val appId = "/test/foo/bla/rest".toPath
+  val instanceId = Instance.Id.forRunSpec(appId)
+
+  class Fixture {
+    val store = new InMemoryPersistenceStore
+    val zkTimeout = implicitly[PatienceConfig].timeout
+    val frameworkIdRepository = FrameworkIdRepository.inMemRepository(store)
+    val instanceRepository = InstanceRepository.inMemRepository(store)
+    val crashStrategy = new TestCrashStrategy()
+    store.markOpen()
+  }
+
+  "getFrameworkId throws an exception and crashes if frameworkId is undefined but there are instances defined" in new Fixture {
+    instanceRepository.store(TestInstanceBuilder.emptyInstance(instanceId = instanceId)).futureValue
+
+    inside(Try(
+      MesosSchedulerDriverFactory.getFrameworkId(
+        crashStrategy,
+        zkTimeout,
+        frameworkIdRepository,
+        instanceRepository))) {
+      case Failure(ex: RuntimeException) =>
+        ex.getMessage.should(include("Refusing"))
+    }
+
+    crashStrategy.crashed shouldBe true
+  }
+
+  "getFrameworkId returns None if frameworkId is undefined and instance repository is empty" in new Fixture {
+    MesosSchedulerDriverFactory.getFrameworkId(
+      crashStrategy,
+      zkTimeout,
+      frameworkIdRepository,
+      instanceRepository) shouldBe None
+  }
+}

--- a/src/test/scala/mesosphere/marathon/test/TestCrashStrategy.scala
+++ b/src/test/scala/mesosphere/marathon/test/TestCrashStrategy.scala
@@ -1,0 +1,14 @@
+package mesosphere.marathon
+package test
+
+import akka.Done
+import mesosphere.marathon.core.base.CrashStrategy
+import scala.concurrent.Future
+
+class TestCrashStrategy extends CrashStrategy {
+  @volatile var crashed: Boolean = false
+  override def crash(): Future[Done] = {
+    crashed = true
+    Future.successful(Done)
+  }
+}


### PR DESCRIPTION
Backport of c77c5ef / #6574

Previously, Marathon would automatically request a new framework ID
from Mesos if the old one was marked as torn down in Mesos, or if the
framework ID record was removed from Zookeeper. This has led to more
trouble than it has helped.

If Marathon's framework ID has been torn down in Mesos, Marathon will
crash on launch, with a clear message.

If Marathon's framework ID was removed / is missing, Marathon will
refuse to create a new Framework ID if there are any defined
instances.

JIRA Issues: MARATHON-8420
