### PR TITLE
Default for unreachable strategy on PUT /apps (#6556)

### DIFF
--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -309,6 +309,46 @@ class AppUpdateTest extends UnitTest with ValidationTestLike {
       )))
     }
 
+    "empty app unreachableStrategy on resident app" in {
+      val json =
+        """
+      {
+        "cmd": "sleep 1000",
+        "container": {
+          "type": "MESOS",
+          "volumes": [
+            {
+              "containerPath": "home",
+              "mode": "RW",
+              "persistent": {
+                "size": 100
+                }
+              }]
+        }
+      }
+      """
+
+      val update = fromJsonString(json)
+      val strategy = AppHelpers.withoutPriorAppDefinition(update, "foo".toPath).unreachableStrategy
+      strategy.get should be (raml.UnreachableDisabled.DefaultValue)
+    }
+
+    "empty app unreachableStrategy on non-resident app" in {
+      val json =
+        """
+      {
+        "cmd": "sleep 1000",
+        "container": {
+          "type": "MESOS"
+        }
+      }
+      """
+
+      val update = fromJsonString(json)
+      val strategy = AppHelpers.withoutPriorAppDefinition(update, "foo".toPath).unreachableStrategy
+      strategy.get should be (raml.UnreachableEnabled.Default)
+    }
+
     "empty app updateStrategy" in {
       val json =
         """


### PR DESCRIPTION
When creating app through HTTP POST we provide the defaults, but not on PUT. This unifies this behavior.

JIRA issues: MARATHON-7941