### PR TITLE
Default for unreachable strategy on PUT /apps

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -441,8 +441,12 @@ object AppsResource {
       hasPersistentVolumes = update.container.exists(_.volumes.existsAn[AppPersistentVolume]),
       hasExternalVolumes = update.container.exists(_.volumes.existsAn[AppExternalVolume])
     )
+    val hasPersistentVols = update.container.exists(_.volumes.existsAn[AppPersistentVolume])
+    val unreachableStrategy = update
+      .unreachableStrategy.map(Raml.fromRaml(_))
+      .getOrElse(UnreachableStrategy.default(hasPersistentVols))
     val template = AppDefinition(
-      appId, residency = selectedStrategy.residency, upgradeStrategy = selectedStrategy.upgradeStrategy)
+      appId, residency = selectedStrategy.residency, upgradeStrategy = selectedStrategy.upgradeStrategy, unreachableStrategy = unreachableStrategy)
     Raml.fromRaml(update -> template)
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -397,6 +397,44 @@ class AppUpdateTest extends UnitTest {
       )))
     }
 
+    "empty app unreachableStrategy on resident app" in {
+      val json =
+        """
+      {
+        "cmd": "sleep 1000",
+        "container": {
+          "type": "MESOS",
+          "volumes": [
+            {
+              "containerPath": "home",
+              "mode": "RW",
+              "persistent": {
+                "size": 100
+                }
+              }]
+        }
+      }
+      """
+      val update = fromJsonString(json)
+      val strategy = AppsResource.withoutPriorAppDefinition(update, "foo".toPath).unreachableStrategy
+      strategy.get should be (raml.UnreachableDisabled.DefaultValue)
+    }
+
+    "empty app unreachableStrategy on non-resident app" in {
+      val json =
+        """
+      {
+        "cmd": "sleep 1000",
+        "container": {
+          "type": "MESOS"
+        }
+      }
+      """
+      val update = fromJsonString(json)
+      val strategy = AppsResource.withoutPriorAppDefinition(update, "foo".toPath).unreachableStrategy
+      strategy.get should be (raml.UnreachableEnabled.Default)
+    }
+
     "empty app persists container" in {
       val json =
         """


### PR DESCRIPTION
When creating app through HTTP POST we provide the defaults, but not on PUT. This unifies this behavior.

JIRA issues: MARATHON-7941