### PR TITLE
Clean sbt integration test project.

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -39,7 +39,7 @@ def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") 
 
   def run(cmd: String *) = utils.runWithTimeout(30.minutes, logFileName)(cmd)
 
-  run("sbt", "clean", "compile", "test:compile")
+  run("sbt", "clean", "integration/clean", "compile", "test:compile")
 
   checkUnusedImports(logFileName)
 


### PR DESCRIPTION
Summary:
If there are changes on the integration tests we have to clean the
project as well since Jenkins reuses nodes.