### PR TITLE
Fix for broken versioning of Apps and Pods (#6558)

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -2,7 +2,6 @@ package mesosphere.marathon
 package core.storage.store.impl.zk
 
 import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 import akka.stream.Materializer
@@ -15,6 +14,7 @@ import mesosphere.marathon.core.storage.backup.BackupItem
 import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.core.storage.store.impl.{BasePersistenceStore, CategorizedKey}
 import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.storage.migration.{Migration, StorageVersions}
 import mesosphere.marathon.util.{WorkQueue, toRichFuture}
 import org.apache.zookeeper.KeeperException
@@ -31,12 +31,13 @@ case class ZkId(category: String, id: String, version: Option[OffsetDateTime]) {
 
   // BUG: id = "" for the root group this results in "Path must not end with / character" in curator
   def path: String = version.fold(f"/$category/$bucket%x/$id") { v =>
-    f"/$category/$bucket%x/$id/${ZkId.DateFormat.format(v)}"
+    f"/$category/$bucket%x/$id/${ZkId.WriteDateFormat.format(v)}"
   }
 }
 
 object ZkId {
-  val DateFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+  val WriteDateFormat = Timestamp.WriteFormatter // WriteDateFormat is following our formatting style
+  val ReadDateFormat = Timestamp.ReadFormatter // ReadDateFormat is compatible with every possible ISO-8601 string
   val HashBucketSize = 16
 }
 
@@ -135,7 +136,7 @@ class ZkPersistenceStore(
         await(client.children(path).asTry) match {
           case Success(Children(_, _, nodes)) =>
             nodes.map { path =>
-              OffsetDateTime.parse(path, ZkId.DateFormat)
+              OffsetDateTime.parse(path, ZkId.ReadDateFormat)
             }
           case Failure(_: NoNodeException) =>
             Seq.empty

--- a/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
@@ -65,7 +65,7 @@ trait DefaultConversions {
   }
 
   implicit object OffsetDateTimeWrite extends play.api.libs.json.Writes[OffsetDateTime] {
-    def writes(o: OffsetDateTime) = JsString(o.format(Timestamp.formatter))
+    def writes(o: OffsetDateTime) = JsString(o.format(Timestamp.WriteFormatter))
   }
 
 }

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -28,7 +28,7 @@ abstract case class Timestamp private (private val instant: Instant) extends Ord
   def youngerThan(that: Timestamp): Boolean = this.after(that)
   def olderThan(that: Timestamp): Boolean = this.before(that)
 
-  override def toString: String = Timestamp.formatter.format(instant)
+  override def toString: String = Timestamp.WriteFormatter.format(instant)
 
   def toInstant: Instant = instant
 
@@ -69,7 +69,7 @@ object Timestamp {
   /**
     * Returns a new Timestamp representing the supplied time.
     */
-  def apply(time: String): Timestamp = Timestamp(Try(OffsetDateTime.parse(time)) match {
+  def apply(time: String): Timestamp = Timestamp(Try(OffsetDateTime.parse(time, ReadFormatter)) match {
     case Success(parsed) => parsed
     case Failure(e: DateTimeParseException) => throw new IllegalArgumentException(s"Invalid timestamp provided '$time'. Expecting ISO-8601 datetime string.", e)
     case Failure(e) => throw e
@@ -104,5 +104,6 @@ object Timestamp {
   /*
    * .toString in java.time is truncating zeros in millis part, so we use custom formatter to keep them
    */
-  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
+  val WriteFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
+  val ReadFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 }

--- a/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
@@ -48,15 +48,16 @@ case class StoredPlan(
   def toProto: Protos.DeploymentPlanDefinition = {
     Protos.DeploymentPlanDefinition.newBuilder
       .setId(id)
-      .setOriginalRootVersion(StoredPlan.DateFormat.format(originalVersion))
-      .setTargetRootVersion(StoredPlan.DateFormat.format(targetVersion))
-      .setTimestamp(StoredPlan.DateFormat.format(version))
+      .setOriginalRootVersion(StoredPlan.WriteDateFormat.format(originalVersion))
+      .setTargetRootVersion(StoredPlan.WriteDateFormat.format(targetVersion))
+      .setTimestamp(StoredPlan.WriteDateFormat.format(version))
       .build()
   }
 }
 
 object StoredPlan {
-  val DateFormat = StoredGroup.DateFormat
+  val ReadDateFormat = Timestamp.ReadFormatter
+  val WriteDateFormat = Timestamp.WriteFormatter
 
   def apply(deploymentPlan: DeploymentPlan): StoredPlan = {
     StoredPlan(deploymentPlan.id, deploymentPlan.original.version.toOffsetDateTime,
@@ -65,14 +66,14 @@ object StoredPlan {
 
   def apply(proto: Protos.DeploymentPlanDefinition): StoredPlan = {
     val version = if (proto.hasTimestamp) {
-      OffsetDateTime.parse(proto.getTimestamp, DateFormat)
+      OffsetDateTime.parse(proto.getTimestamp, ReadDateFormat)
     } else {
       OffsetDateTime.MIN
     }
     StoredPlan(
       proto.getId,
-      OffsetDateTime.parse(proto.getOriginalRootVersion, DateFormat),
-      OffsetDateTime.parse(proto.getTargetRootVersion, DateFormat),
+      OffsetDateTime.parse(proto.getOriginalRootVersion, ReadDateFormat),
+      OffsetDateTime.parse(proto.getTargetRootVersion, ReadDateFormat),
       version)
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -2,8 +2,6 @@ package mesosphere.marathon
 package storage.repository
 
 import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
@@ -93,18 +91,18 @@ case class StoredGroup(
   }
 
   def toProto: Protos.GroupDefinition = {
-    import StoredGroup.DateFormat
+    import StoredGroup.WriteDateFormat
 
     val b = Protos.GroupDefinition.newBuilder
       .setId(id.safePath)
-      .setVersion(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(version))
+      .setVersion(WriteDateFormat.format(version))
 
     appIds.foreach {
       case (app, appVersion) =>
         b.addApps(
           Protos.GroupDefinition.AppReference.newBuilder()
             .setId(app.safePath)
-            .setVersion(DateFormat.format(appVersion)))
+            .setVersion(WriteDateFormat.format(appVersion)))
     }
 
     podIds.foreach {
@@ -112,7 +110,7 @@ case class StoredGroup(
         b.addPods(
           Protos.GroupDefinition.AppReference.newBuilder()
             .setId(pod.safePath)
-            .setVersion(DateFormat.format(podVersion)))
+            .setVersion(WriteDateFormat.format(podVersion)))
     }
 
     storedGroups.foreach { storedGroup => b.addGroups(storedGroup.toProto) }
@@ -123,7 +121,8 @@ case class StoredGroup(
 }
 
 object StoredGroup {
-  val DateFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+  val ReadDateFormat = Timestamp.ReadFormatter
+  val WriteDateFormat = Timestamp.WriteFormatter
 
   def apply(group: Group): StoredGroup =
     StoredGroup(
@@ -136,11 +135,11 @@ object StoredGroup {
 
   def apply(proto: Protos.GroupDefinition): StoredGroup = {
     val apps: Map[PathId, OffsetDateTime] = proto.getAppsList.map { appId =>
-      PathId.fromSafePath(appId.getId) -> OffsetDateTime.parse(appId.getVersion, DateFormat)
+      PathId.fromSafePath(appId.getId) -> OffsetDateTime.parse(appId.getVersion, ReadDateFormat)
     }(collection.breakOut)
 
     val pods: Map[PathId, OffsetDateTime] = proto.getPodsList.map { podId =>
-      PathId.fromSafePath(podId.getId) -> OffsetDateTime.parse(podId.getVersion, DateFormat)
+      PathId.fromSafePath(podId.getId) -> OffsetDateTime.parse(podId.getVersion, ReadDateFormat)
     }(collection.breakOut)
 
     val groups = proto.getGroupsList.map(StoredGroup(_))
@@ -151,7 +150,7 @@ object StoredGroup {
       podIds = pods,
       storedGroups = groups.toIndexedSeq,
       dependencies = proto.getDependenciesList.map(PathId.fromSafePath)(collection.breakOut),
-      version = OffsetDateTime.parse(proto.getVersion, DateFormat)
+      version = OffsetDateTime.parse(proto.getVersion, ReadDateFormat)
     )
   }
 }

--- a/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
@@ -71,5 +71,24 @@ class TimestampTest extends UnitTest {
         timestamp.millis shouldEqual instant.truncatedTo(ChronoUnit.SECONDS).toEpochMilli
       }
     }
+    "converting to/from OffsetDateTime" should {
+      "be compatible" in {
+
+        val dateTimeStr = "2018-09-26T12:46:13.587Z"
+
+        val timestamp = Timestamp(dateTimeStr)
+        val timestampString = timestamp.toString
+
+        val offsetDateTime = OffsetDateTime.parse(timestampString)
+
+        val formatted = Timestamp.WriteFormatter.format(offsetDateTime)
+
+        Timestamp(offsetDateTime) shouldEqual timestamp
+        Timestamp(timestampString) shouldEqual timestamp
+        Timestamp(formatted) shouldEqual timestamp
+
+        OffsetDateTime.parse(dateTimeStr, Timestamp.ReadFormatter).format(Timestamp.WriteFormatter) shouldEqual timestamp.toString
+      }
+    }
   }
 }


### PR DESCRIPTION
ISO_OFFSET_DATE_TIME and Timestamp.formatter were rendered the same if called .toString in the past. JDK9 started capturing nanoseconds when Instant.now() (underlying in Timestamp) is called . Our API serializes timestamps without keeping nanoseconds. Therefore, any version string stored using the Java 9 definition of ISO_OFFSET_DATE_TIME could not be retrieved anymore using a version string provided by our API. This change will make sure we always store without nanos, using Timestamp.formatter, but are able to deserialize a version string that contains nanos.
(backport from 0d5d791)

Jira Issues: MARATHON-8413