### PR TITLE
Fix for broken versioning of Apps and Pods (#6558)

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -3,6 +3,7 @@ package core.storage.store.impl.zk
 
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 import akka.actor.Scheduler
@@ -31,7 +32,8 @@ case class ZkId(category: String, id: String, version: Option[OffsetDateTime]) {
 
   // BUG: id = "" for the root group this results in "Path must not end with / character" in curator
   def path: String = version.fold(f"/$category/$bucket%x/$id") { v =>
-    f"/$category/$bucket%x/$id/${ZkId.DateFormat.format(v)}"
+    val truncatedVersion = v.truncatedTo(ChronoUnit.MILLIS)
+    f"/$category/$bucket%x/$id/${ZkId.DateFormat.format(truncatedVersion)}"
   }
 }
 

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -6,12 +6,16 @@ import java.nio.charset.StandardCharsets
 import java.time.{ Instant, OffsetDateTime, ZoneOffset }
 import java.util.UUID
 
+import akka.Done
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.storage.store.{ IdResolver, PersistenceStoreTest, TestClass1 }
 import mesosphere.marathon.integration.setup.ZookeeperServerTest
+import mesosphere.marathon.state.Timestamp
+import mesosphere.marathon.test.SettableClock
 
 import scala.concurrent.duration._
 
@@ -68,5 +72,32 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
 
   behave like basicPersistenceStore("ZookeeperPersistenceStore", defaultStore)
   behave like backupRestoreStore("ZookeeperPersistenceStore", defaultStore)
+
+  "ZkId should trim anything but millis after serialization" in {
+    val dateTime = OffsetDateTime.of(2015, 5, 14, 15, 43, 21, 0, ZoneOffset.UTC)
+    val withNanos = dateTime.withNano(123456789)
+    val zkId = ZkId("cat", "path", Some(withNanos))
+    val zkIdVersion = zkId.path.reverse.takeWhile(_ != '/').reverse
+    zkIdVersion shouldEqual "2015-05-14T15:43:21.123Z"
+    ZkId("cat", "path", Some(OffsetDateTime.parse(zkIdVersion))).path shouldEqual zkId.path
+  }
+
+  def trimmingTest(offsetDateTime: OffsetDateTime): Unit = {
+    val store = defaultStore
+    implicit val clock = new SettableClock()
+    val offsetDateTimeOnlyMillisStr = offsetDateTime.format(Timestamp.formatter)
+    val offsetDateTimeOnlyMillis = OffsetDateTime.parse(offsetDateTimeOnlyMillisStr)
+    val tc = TestClass1("abc", 1, offsetDateTime)
+    store.store("test", tc).futureValue shouldEqual Done
+    store.versions("test").runWith(Sink.seq).futureValue shouldEqual Seq(offsetDateTimeOnlyMillis)
+  }
+  "handle nanoseconds when providing versions" in {
+    val offsetDateTime = OffsetDateTime.of(2015, 2, 3, 12, 30, 15, 123456789, ZoneOffset.UTC)
+    trimmingTest(offsetDateTime)
+  }
+  "handle milliseconds when providing versions" in {
+    val offsetDateTime = OffsetDateTime.of(2015, 2, 3, 12, 30, 15, 123000000, ZoneOffset.UTC)
+    trimmingTest(offsetDateTime)
+  }
 }
 


### PR DESCRIPTION
ISO_OFFSET_DATE_TIME and Timestamp.formatter were rendered the same if called .toString in the past. JDK9 started capturing nanoseconds when Instant.now() (underlying in Timestamp) is called . Our API serializes timestamps without keeping nanoseconds. Therefore, any version string stored using the Java 9 definition of ISO_OFFSET_DATE_TIME could not be retrieved anymore using a version string provided by our API. This change will make sure we always store without nanos, using Timestamp.formatter, but are able to deserialize a version string that contains nanos.
(backport of 0d5d791)

Jira Issues: MARATHON-8413