### PR TITLE
Only log zero-value offers for scalar resources and ranges

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -81,7 +81,9 @@ private[launcher] class OfferProcessorImpl(
     val resourcesWithZeroValues = offer
       .getResourcesList.asScala
       .collect {
-        case resource if resource.getScalar.getValue.ceil.toLong == 0 =>
+        case resource if resource.hasScalar && resource.getScalar.getValue.ceil.toLong == 0 =>
+          resource.getName
+        case resource if resource.hasRanges && resource.getRanges.getRangeCount == 0 =>
           resource.getName
       }
     if (resourcesWithZeroValues.nonEmpty) {


### PR DESCRIPTION
Only log zero-value offers for scalar resources with value 0 and range resources with empty ranges.

JIRA Issues: MARATHON-8452