### PR TITLE
 Construct task ids from instance ids. 

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -127,7 +127,7 @@ class InstanceOpFactoryImpl(
       case matches: ResourceMatchResponse.Match =>
         val now = clock.now()
 
-        val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId, None)
+        val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId)
         val taskBuilder = new TaskBuilder(app, taskId, config, runSpecTaskProc)
         val (taskInfo, networkInfo) = taskBuilder.build(offer, matches.resourceMatch, None)
 
@@ -172,7 +172,7 @@ class InstanceOpFactoryImpl(
 
       // resources are reserved for this role, so we only consider those resources
       val rolesToConsider = config.mesosRole.get.toSet
-      val taskId = Task.Id.forInstanceId(volumeMatch.instance.instanceId, None)
+      val taskId = Task.Id.forInstanceId(volumeMatch.instance.instanceId)
       val reservationLabels = TaskLabels.labelsForTask(request.frameworkId, taskId).labels
       val resourceMatchResponse =
         ResourceMatcher.matchResources(
@@ -260,7 +260,7 @@ class InstanceOpFactoryImpl(
           val originalIds = if (reservedInstance.tasksMap.nonEmpty) {
             reservedInstance.tasksMap.keys
           } else {
-            Seq(Task.Id.forInstanceId(reservedInstance.instanceId, None))
+            Seq(Task.Id.forInstanceId(reservedInstance.instanceId))
           }
           originalIds.map(ti => Task.Id.forResidentTask(ti)).to[Seq]
         }
@@ -341,7 +341,7 @@ class InstanceOpFactoryImpl(
         // will be replaced with a new task once we launch on an existing reservation this way, the reservation will be
         // labeled with a taskId that does not relate to a task existing in Mesos (previously, Marathon reused taskIds so
         // there was always a 1:1 correlation from reservation to taskId)
-        val reservationLabels = TaskLabels.labelsForTask(frameworkId, Task.Id.forInstanceId(scheduledInstance.instanceId, None))
+        val reservationLabels = TaskLabels.labelsForTask(frameworkId, Task.Id.forInstanceId(scheduledInstance.instanceId))
         val stateOp = InstanceUpdateOperation.Reserve(Instance.scheduled(scheduledInstance, reservation, agentInfo))
         (reservationLabels, stateOp)
 

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -367,17 +367,6 @@ object Task {
     def apply(mesosTaskId: MesosProtos.TaskID): Id = apply(mesosTaskId.getValue)
 
     /**
-      * Create a taskId according to the old schema (no instance designator, no Mesos container name).
-      * Use this when needing to create an ID for a normal App task or a task for initial reservation handling.
-      *
-      * Use @forResidentTask when you want to launch a task on an existing reservation.
-      */
-    //    def forRunSpec(id: PathId): Id = {
-    //      val taskId = id.safePath + "." + uuidGenerator.generate()
-    //      Task.Id(taskId)
-    //    }
-
-    /**
       * Create a taskId for a pod instance's task. This will create a taskId designating the instance and each
       * task container's name. It may be used for reservations for persitent pods as well.
       *

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -17,6 +17,7 @@ import org.apache.mesos.Protos.{TaskState, TaskStatus}
 import org.apache.mesos.{Protos => MesosProtos}
 
 import scala.concurrent.duration.FiniteDuration
+import mesosphere.marathon.api.v2.json.Formats._
 import play.api.libs.json._
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -374,8 +374,10 @@ object Task {
       *
       * Use @forResidentTask when you want to launch a task on an existing reservation.
       */
-    @deprecated("Task ids should be created from instance ids and not run spec ids", "1.6.322")
-    def forRunSpec(id: PathId): Id = LegacyId(id, ".", uuidGenerator.generate())
+    //    def forRunSpec(id: PathId): Id = {
+    //      val taskId = id.safePath + "." + uuidGenerator.generate()
+    //      Task.Id(taskId)
+    //    }
 
     /**
       * Create a taskId for a pod instance's task. This will create a taskId designating the instance and each

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -3,7 +3,6 @@ package core.task
 
 import java.util.{Base64, UUID}
 
-import com.fasterxml.uuid.{EthernetAddress, Generators}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition.Terminal
@@ -18,7 +17,6 @@ import org.apache.mesos.Protos.{TaskState, TaskStatus}
 import org.apache.mesos.{Protos => MesosProtos}
 
 import scala.concurrent.duration.FiniteDuration
-import mesosphere.marathon.api.v2.json.Formats._
 import play.api.libs.json._
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -323,8 +323,6 @@ object Task {
     private val TaskIdWithInstanceIdRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)[\._]([^_\.]+)$""".r
     private val ResidentTaskIdWithInstanceIdRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)[\._]([^_\.]+)\.(\d+)$""".r
 
-    private val uuidGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
-
     /**
       * Parse instance and task id from idString.
       *

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -372,7 +372,7 @@ object Task {
       * @param instanceId the ID of the instance that this task is contained in
       * @param container the name of the task as per the pod container config.
       */
-    def forInstanceId(instanceId: Instance.Id, container: Option[MesosContainer]): Id = EphemeralOrReservedTaskId(instanceId, container.map(_.name))
+    def forInstanceId(instanceId: Instance.Id, container: Option[MesosContainer] = None): Id = EphemeralOrReservedTaskId(instanceId, container.map(_.name))
 
     /**
       * Create a taskId for a resident task launch. This will append or increment a launch attempt count that might

--- a/src/test/scala/mesosphere/marathon/api/EndpointsHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/EndpointsHelperTest.scala
@@ -35,7 +35,7 @@ class EndpointsHelperTest extends UnitTest {
             case (Some(_), i) if !app.requirePorts => Option(1000 + (taskIndex * 10) + i)
             case (portOption, _) => portOption
           }
-          val taskId = Task.Id.forInstanceId(instanceId, None)
+          val taskId = Task.Id.forInstanceId(instanceId)
           val task = Task(taskId, runSpecVersion = Timestamp.zero, status = Task.Status(
             stagedAt = Timestamp.zero, startedAt = None, mesosStatus = None, condition = Condition.Running,
             networkInfo = NetworkInfo(hostname, hostPorts = hostPorts, ipAddresses = ipAddresses)

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -190,7 +190,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
     "deleteOne with scale and wipe fails" in new Fixture {
       val appId = PathId("/my/app")
       val instanceId = Instance.Id.forRunSpec(appId)
-      val id = Task.Id.forInstanceId(instanceId, None)
+      val id = Task.Id.forInstanceId(instanceId)
 
       healthCheckManager.statuses(appId) returns Future.successful(collection.immutable.Map.empty)
 
@@ -428,7 +428,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val req = auth.request
       val appId = PathId("/app")
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
 
       Given("The app exists")
       groupManager.runSpec("/app".toRootPath) returns Some(AppDefinition(appId))
@@ -447,7 +447,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val req = auth.request
       val appId = PathId("/app")
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
 
       Given("The app not exists")
       groupManager.runSpec("/app".toRootPath) returns None

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -189,7 +189,8 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
 
     "deleteOne with scale and wipe fails" in new Fixture {
       val appId = PathId("/my/app")
-      val id = Task.Id.forRunSpec(appId)
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val id = Task.Id.forInstanceId(instanceId, None)
 
       healthCheckManager.statuses(appId) returns Future.successful(collection.immutable.Map.empty)
 
@@ -425,10 +426,12 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       auth.authenticated = true
       auth.authorized = false
       val req = auth.request
-      val taskId = Task.Id.forRunSpec(PathId("/app"))
+      val appId = PathId("/app")
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
 
       Given("The app exists")
-      groupManager.runSpec("/app".toRootPath) returns Some(AppDefinition("/app".toRootPath))
+      groupManager.runSpec("/app".toRootPath) returns Some(AppDefinition(appId))
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("deleteOne is called")
@@ -442,7 +445,9 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       auth.authenticated = true
       auth.authorized = false
       val req = auth.request
-      val taskId = Task.Id.forRunSpec(PathId("/app"))
+      val appId = PathId("/app")
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
 
       Given("The app not exists")
       groupManager.runSpec("/app".toRootPath) returns None

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -191,7 +191,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       Given("a request")
       val app1 = "/my/app-1".toRootPath
       val instance1 = Instance.Id.forRunSpec(app1)
-      val taskId1 = Task.Id.forInstanceId(instance1, None).idString
+      val taskId1 = Task.Id.forInstanceId(instance1).idString
       val body = s"""{"ids": ["$taskId1"]}"""
       val bodyBytes = body.toCharArray.map(_.toByte)
 
@@ -240,9 +240,9 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       val instance1 = Instance.Id.forRunSpec(appId)
       val instance2 = Instance.Id.forRunSpec(appId)
       val instance3 = Instance.Id.forRunSpec(appId)
-      val taskId1 = Task.Id.forInstanceId(instance1, None).idString
-      val taskId2 = Task.Id.forInstanceId(instance2, None).idString
-      val taskId3 = Task.Id.forInstanceId(instance3, None).idString
+      val taskId1 = Task.Id.forInstanceId(instance1).idString
+      val taskId2 = Task.Id.forInstanceId(instance2).idString
+      val taskId3 = Task.Id.forInstanceId(instance3).idString
       val body = s"""{"ids": ["$taskId1", "$taskId2", "$taskId3"]}""".getBytes
 
       Given("the app exists")
@@ -262,9 +262,9 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       val instance1 = Instance.Id.forRunSpec(appId)
       val instance2 = Instance.Id.forRunSpec(appId)
       val instance3 = Instance.Id.forRunSpec(appId)
-      val taskId1 = Task.Id.forInstanceId(instance1, None).idString
-      val taskId2 = Task.Id.forInstanceId(instance2, None).idString
-      val taskId3 = Task.Id.forInstanceId(instance3, None).idString
+      val taskId1 = Task.Id.forInstanceId(instance1).idString
+      val taskId2 = Task.Id.forInstanceId(instance2).idString
+      val taskId3 = Task.Id.forInstanceId(instance3).idString
       val body = s"""{"ids": ["$taskId1", "$taskId2", "$taskId3"]}""".getBytes
 
       Given("the app does not exist")
@@ -301,9 +301,9 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       val instance1 = Instance.Id.forRunSpec(appId)
       val instance2 = Instance.Id.forRunSpec(appId)
       val instance3 = Instance.Id.forRunSpec(appId)
-      val taskId1 = Task.Id.forInstanceId(instance1, None).idString
-      val taskId2 = Task.Id.forInstanceId(instance2, None).idString
-      val taskId3 = Task.Id.forInstanceId(instance3, None).idString
+      val taskId1 = Task.Id.forInstanceId(instance1).idString
+      val taskId2 = Task.Id.forInstanceId(instance2).idString
+      val taskId3 = Task.Id.forInstanceId(instance3).idString
       val body = s"""{"ids": ["$taskId1", "$taskId2", "$taskId3"]}""".getBytes
 
       override val taskKiller = new TaskKiller(
@@ -333,7 +333,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       Given("a valid and an invalid taskId")
       val app1 = "/my/app-1".toRootPath
       val instance1 = Instance.Id.forRunSpec(app1)
-      val taskId1 = Task.Id.forInstanceId(instance1, None).idString
+      val taskId1 = Task.Id.forInstanceId(instance1).idString
       val body = s"""{"ids": ["$taskId1", "invalidTaskId"]}"""
       val bodyBytes = body.toCharArray.map(_.toByte)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -190,7 +190,8 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
     "killTasks with scale and wipe fails" in new Fixture {
       Given("a request")
       val app1 = "/my/app-1".toRootPath
-      val taskId1 = Task.Id.forRunSpec(app1).idString
+      val instance1 = Instance.Id.forRunSpec(app1)
+      val taskId1 = Task.Id.forInstanceId(instance1, None).idString
       val body = s"""{"ids": ["$taskId1"]}"""
       val bodyBytes = body.toCharArray.map(_.toByte)
 
@@ -236,9 +237,12 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       auth.authenticated = false
       val req = auth.request
       val appId = "/my/app".toRootPath
-      val taskId1 = Task.Id.forRunSpec(appId).idString
-      val taskId2 = Task.Id.forRunSpec(appId).idString
-      val taskId3 = Task.Id.forRunSpec(appId).idString
+      val instance1 = Instance.Id.forRunSpec(appId)
+      val instance2 = Instance.Id.forRunSpec(appId)
+      val instance3 = Instance.Id.forRunSpec(appId)
+      val taskId1 = Task.Id.forInstanceId(instance1, None).idString
+      val taskId2 = Task.Id.forInstanceId(instance2, None).idString
+      val taskId3 = Task.Id.forInstanceId(instance3, None).idString
       val body = s"""{"ids": ["$taskId1", "$taskId2", "$taskId3"]}""".getBytes
 
       Given("the app exists")
@@ -255,9 +259,12 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       auth.authenticated = false
       val req = auth.request
       val appId = "/my/app".toRootPath
-      val taskId1 = Task.Id.forRunSpec(appId).idString
-      val taskId2 = Task.Id.forRunSpec(appId).idString
-      val taskId3 = Task.Id.forRunSpec(appId).idString
+      val instance1 = Instance.Id.forRunSpec(appId)
+      val instance2 = Instance.Id.forRunSpec(appId)
+      val instance3 = Instance.Id.forRunSpec(appId)
+      val taskId1 = Task.Id.forInstanceId(instance1, None).idString
+      val taskId2 = Task.Id.forInstanceId(instance2, None).idString
+      val taskId3 = Task.Id.forInstanceId(instance3, None).idString
       val body = s"""{"ids": ["$taskId1", "$taskId2", "$taskId3"]}""".getBytes
 
       Given("the app does not exist")
@@ -291,9 +298,12 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       auth.authorized = false
       val req = auth.request
       val appId = "/my/app".toRootPath
-      val taskId1 = Task.Id.forRunSpec(appId).idString
-      val taskId2 = Task.Id.forRunSpec(appId).idString
-      val taskId3 = Task.Id.forRunSpec(appId).idString
+      val instance1 = Instance.Id.forRunSpec(appId)
+      val instance2 = Instance.Id.forRunSpec(appId)
+      val instance3 = Instance.Id.forRunSpec(appId)
+      val taskId1 = Task.Id.forInstanceId(instance1, None).idString
+      val taskId2 = Task.Id.forInstanceId(instance2, None).idString
+      val taskId3 = Task.Id.forInstanceId(instance3, None).idString
       val body = s"""{"ids": ["$taskId1", "$taskId2", "$taskId3"]}""".getBytes
 
       override val taskKiller = new TaskKiller(
@@ -322,7 +332,8 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
     "killTasks fails for invalid taskId" in new Fixture {
       Given("a valid and an invalid taskId")
       val app1 = "/my/app-1".toRootPath
-      val taskId1 = Task.Id.forRunSpec(app1).idString
+      val instance1 = Instance.Id.forRunSpec(app1)
+      val taskId1 = Task.Id.forInstanceId(instance1, None).idString
       val body = s"""{"ids": ["$taskId1", "invalidTaskId"]}"""
       val bodyBytes = body.toCharArray.map(_.toByte)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
@@ -49,7 +49,8 @@ class EnrichedTaskWritesTest extends UnitTest {
     }
 
     val taskWithMultipleIPs = {
-      val taskStatus = mesosStatus(Task.Id.forRunSpec(PathId("/foo/bar")))
+      val instanceId = Instance.Id.forRunSpec(PathId("/foo/bar"))
+      val taskStatus = mesosStatus(Task.Id.forInstanceId(instanceId, None))
       val networkInfo = NetworkInfo(hostName, hostPorts = Nil, ipAddresses = Nil).update(taskStatus)
       val instance = TestInstanceBuilder.newBuilder(runSpecId = runSpecId, version = time)
         .withAgentInfo(agentInfo)

--- a/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/EnrichedTaskWritesTest.scala
@@ -50,7 +50,7 @@ class EnrichedTaskWritesTest extends UnitTest {
 
     val taskWithMultipleIPs = {
       val instanceId = Instance.Id.forRunSpec(PathId("/foo/bar"))
-      val taskStatus = mesosStatus(Task.Id.forInstanceId(instanceId, None))
+      val taskStatus = mesosStatus(Task.Id.forInstanceId(instanceId))
       val networkInfo = NetworkInfo(hostName, hostPorts = Nil, ipAddresses = Nil).update(taskStatus)
       val instance = TestInstanceBuilder.newBuilder(runSpecId = runSpecId, version = time)
         .withAgentInfo(agentInfo)

--- a/src/test/scala/mesosphere/marathon/api/v2/json/ReadinessCheckResultFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/ReadinessCheckResultFormatTest.scala
@@ -3,6 +3,7 @@ package api.v2.json
 
 import mesosphere.UnitTest
 import mesosphere.marathon.api.JsonTestHelper
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.readiness.{HttpResponse, ReadinessCheckResult}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.PathId
@@ -26,7 +27,8 @@ class ReadinessCheckResultFormatTest extends UnitTest {
 
   object Fixture {
     val httpResponse = HttpResponse(200, "application/json", "{}")
-    val taskId = Task.Id.forRunSpec(PathId("/foo/bar"))
+    val instanceId = Instance.Id.forRunSpec(PathId("/foo/bar"))
+    val taskId = Task.Id.forInstanceId(instanceId, None)
     val readinessCheckResult = ReadinessCheckResult(
       "readinessCheck",
       taskId,

--- a/src/test/scala/mesosphere/marathon/api/v2/json/ReadinessCheckResultFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/ReadinessCheckResultFormatTest.scala
@@ -28,7 +28,7 @@ class ReadinessCheckResultFormatTest extends UnitTest {
   object Fixture {
     val httpResponse = HttpResponse(200, "application/json", "{}")
     val instanceId = Instance.Id.forRunSpec(PathId("/foo/bar"))
-    val taskId = Task.Id.forInstanceId(instanceId, None)
+    val taskId = Task.Id.forInstanceId(instanceId)
     val readinessCheckResult = ReadinessCheckResult(
       "readinessCheck",
       taskId,

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
@@ -206,7 +206,8 @@ object Fixture {
 
 class Fixture {
   val runSpecId = PathId("/test")
-  val taskId = Task.Id.forRunSpec(runSpecId)
+  val instanceId = Instance.Id.forRunSpec(runSpecId)
+  val taskId = Task.Id.forInstanceId(instanceId, None)
   val taskWithoutState = Task(
     taskId = taskId,
     runSpecVersion = Timestamp(0),

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
@@ -207,7 +207,7 @@ object Fixture {
 class Fixture {
   val runSpecId = PathId("/test")
   val instanceId = Instance.Id.forRunSpec(runSpecId)
-  val taskId = Task.Id.forInstanceId(instanceId, None)
+  val taskId = Task.Id.forInstanceId(instanceId)
   val taskWithoutState = Task(
     taskId = taskId,
     runSpecVersion = Timestamp(0),

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskLifeTimeTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskLifeTimeTest.scala
@@ -6,24 +6,21 @@ import java.time.{OffsetDateTime, ZoneOffset}
 import mesosphere.UnitTest
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder, TestTaskBuilder}
-import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{PathId, Timestamp, UnreachableStrategy}
 
 class TaskLifeTimeTest extends UnitTest {
   private[this] val now: Timestamp = Timestamp(OffsetDateTime.of(2015, 4, 9, 12, 30, 0, 0, ZoneOffset.UTC))
   private[this] val runSpecId = PathId("/test")
   private[this] val agentInfo = AgentInfo(host = "host", agentId = Some("agent"), region = None, zone = None, attributes = Nil)
-  private[this] def newTaskId(): Task.Id = {
-    Task.Id.forRunSpec(runSpecId)
-  }
+  private[this] def newInstanceId(): Instance.Id = Instance.Id.forRunSpec(runSpecId)
 
   private[this] def stagedInstance(): Instance = {
-    TestInstanceBuilder.fromTask(TestTaskBuilder.Helper.stagedTask(newTaskId()), agentInfo, UnreachableStrategy.default())
+    TestInstanceBuilder.fromTask(TestTaskBuilder.Helper.stagedTask(newInstanceId()), agentInfo, UnreachableStrategy.default())
   }
 
   private[this] def runningInstanceWithLifeTime(lifeTimeSeconds: Double): Instance = {
     TestInstanceBuilder.fromTask(
-      TestTaskBuilder.Helper.runningTask(newTaskId(), startedAt = (now.millis - lifeTimeSeconds * 1000.0).round),
+      TestTaskBuilder.Helper.runningTask(newInstanceId(), startedAt = (now.millis - lifeTimeSeconds * 1000.0).round),
       agentInfo,
       UnreachableStrategy.default()
     )

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskStatsByVersionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskStatsByVersionTest.scala
@@ -7,7 +7,6 @@ import mesosphere.UnitTest
 import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder, TestTaskBuilder}
-import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{PathId, Timestamp, UnreachableStrategy, VersionInfo}
 import play.api.libs.json.Json
 
@@ -97,15 +96,13 @@ class TaskStatsByVersionTest extends UnitTest {
     lastConfigChangeAt = lastConfigChangeAt
   )
   val appId = PathId("/test")
-  private[this] def newTaskId(): Task.Id = {
-    // TODO(PODS): this relied on incremental taskIds before and might be broken
-    Task.Id.forRunSpec(appId)
-  }
+  private[this] def newInstanceId(): Instance.Id = Instance.Id.forRunSpec(appId)
+
   private[this] def runningInstanceStartedAt(version: Timestamp, startingDelay: FiniteDuration): Instance = {
     val startedAt = (version + startingDelay).millis
     val agentInfo = AgentInfo(host = "host", agentId = Some("agent"), region = None, zone = None, attributes = Nil)
     TestInstanceBuilder.fromTask(
-      TestTaskBuilder.Helper.runningTask(newTaskId(), appVersion = version, startedAt = startedAt),
+      TestTaskBuilder.Helper.runningTask(newInstanceId(), appVersion = version, startedAt = startedAt),
       agentInfo,
       unreachableStrategy = UnreachableStrategy.default()
     )

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -287,7 +287,7 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
       val emptyRootGroup = createRootGroup()
       val deployment = DeploymentPlan(emptyRootGroup, emptyRootGroup.updateApps(PathId.empty, _ => Map(app.id -> app), emptyRootGroup.version))
       val instanceId = Instance.Id.forRunSpec(app.id)
-      val taskId: Task.Id = Task.Id.forInstanceId(instanceId, None)
+      val taskId: Task.Id = Task.Id.forInstanceId(instanceId)
       val result = ReadinessCheckResult("foo", taskId, ready = false, None)
       f.marathonSchedulerService.listRunningDeployments() returns Future.successful(Seq[DeploymentStepInfo](
         DeploymentStepInfo(deployment, DeploymentStep(Seq.empty), 1, Map(taskId -> result))

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -286,7 +286,8 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
       Given("One related and one unrelated deployment")
       val emptyRootGroup = createRootGroup()
       val deployment = DeploymentPlan(emptyRootGroup, emptyRootGroup.updateApps(PathId.empty, _ => Map(app.id -> app), emptyRootGroup.version))
-      val taskId: Task.Id = Task.Id.forRunSpec(app.id)
+      val instanceId = Instance.Id.forRunSpec(app.id)
+      val taskId: Task.Id = Task.Id.forInstanceId(instanceId, None)
       val result = ReadinessCheckResult("foo", taskId, ready = false, None)
       f.marathonSchedulerService.listRunningDeployments() returns Future.successful(Seq[DeploymentStepInfo](
         DeploymentStepInfo(deployment, DeploymentStep(Seq.empty), 1, Map(taskId -> result))

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehaviorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehaviorTest.scala
@@ -196,7 +196,7 @@ class ReadinessBehaviorTest extends AkkaUnitTest with Eventually with GroupCreat
     val tracker = mock[InstanceTracker]
     val appId = PathId("/test")
     val instanceId = Instance.Id.forRunSpec(appId)
-    val taskId = Task.Id.forInstanceId(instanceId, container = None)
+    val taskId = Task.Id.forInstanceId(instanceId)
     val hostName = "some.host"
     val agentInfo = mock[Instance.AgentInfo]
     agentInfo.host returns hostName

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -559,7 +559,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
 
       When("The replace actor is started")
-      val ref = f.replaceActor(app, promise)
+      f.replaceActor(app, promise)
 
       Then("It needs to wait for the readiness checks to pass")
       promise.future.futureValue

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -659,8 +659,8 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       }
       assert(f.killService.numKilled == 0)
 
-      val newTaskId = Task.Id.forRunSpec(newApp.id)
-      val newInstanceId = newTaskId.instanceId
+      val newInstanceId = Instance.Id.forRunSpec(newApp.id)
+      val newTaskId = Task.Id.forInstanceId(newInstanceId, None)
 
       //unhealthy
       ref ! InstanceHealthChanged(newInstanceId, newApp.version, newApp.id, healthy = Some(false))

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -660,7 +660,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       assert(f.killService.numKilled == 0)
 
       val newInstanceId = Instance.Id.forRunSpec(newApp.id)
-      val newTaskId = Task.Id.forInstanceId(newInstanceId, None)
+      val newTaskId = Task.Id.forInstanceId(newInstanceId)
 
       //unhealthy
       ref ! InstanceHealthChanged(newInstanceId, newApp.version, newApp.id, healthy = Some(false))

--- a/src/test/scala/mesosphere/marathon/core/health/HealthTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/HealthTest.scala
@@ -68,7 +68,7 @@ class HealthTest extends UnitTest with Formats {
     val version = Timestamp(1)
     val now = Timestamp(2)
     val instanceId = Instance.Id.forRunSpec(appId)
-    val taskId = Task.Id.forInstanceId(instanceId, container = None)
+    val taskId = Task.Id.forInstanceId(instanceId)
     val h1 = Health(instanceId)
 
     val h2 = Health(

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -877,7 +877,7 @@ class MesosHealthCheckTest extends UnitTest {
 
     val config = MarathonTestHelper.defaultConfig()
     val instanceId = Instance.Id.forRunSpec(app.id)
-    val taskId = Task.Id.forInstanceId(instanceId, None)
+    val taskId = Task.Id.forInstanceId(instanceId)
     val builder = new TaskBuilder(app, taskId, config)
     val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, Seq.empty,
       config.defaultAcceptedResourceRolesSet, config, Seq.empty)

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -11,6 +11,7 @@ import mesosphere.marathon.api.v2.ValidationHelper
 import mesosphere.marathon.core.pod.{BridgeNetwork, ContainerNetwork, HostNetwork}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.raml.{AppHealthCheck, Raml}
 import mesosphere.marathon.state.Container.PortMapping
 import mesosphere.marathon.state._
@@ -875,7 +876,8 @@ class MesosHealthCheckTest extends UnitTest {
       cpus = 1.0, mem = 128.0, disk = 1000.0, beginPort = 31000, endPort = 32000, role = ResourceRole.Unreserved).build
 
     val config = MarathonTestHelper.defaultConfig()
-    val taskId = Task.Id.forRunSpec(app.id)
+    val instanceId = Instance.Id.forRunSpec(app.id)
+    val taskId = Task.Id.forInstanceId(instanceId, None)
     val builder = new TaskBuilder(app, taskId, config)
     val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, Seq.empty,
       config.defaultAcceptedResourceRolesSet, config, Seq.empty)

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -49,7 +49,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
   def makeRunningTask(appId: PathId, version: Timestamp)(implicit instanceTracker: InstanceTracker): (Instance.Id, Task.Id) = {
     val instance = TestInstanceBuilder.newBuilder(appId, version = version).addTaskStaged().getInstance()
     val (taskId, _) = instance.tasksMap.head
-    val taskStatus = TestTaskBuilder.Helper.runningTask(taskId).status.mesosStatus.get
+    val taskStatus = TestTaskBuilder.Helper.runningTask(instance.instanceId).status.mesosStatus.get
 
     instanceTracker.launchEphemeral(instance).futureValue
     instanceTracker.updateStatus(instance, taskStatus, clock.now()).futureValue
@@ -90,7 +90,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
       val instance = TestInstanceBuilder.newBuilder(appId).addTaskStaged().getInstance()
       val instanceId = instance.instanceId
       val (taskId, _) = instance.tasksMap.head
-      val taskStatus = TestTaskBuilder.Helper.unhealthyTask(taskId).status.mesosStatus.get
+      val taskStatus = TestTaskBuilder.Helper.unhealthyTask(instanceId).status.mesosStatus.get
 
       val healthCheck = MesosCommandHealthCheck(gracePeriod = 0.seconds, command = Command("true"))
 
@@ -301,7 +301,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
       instanceTracker.launchEphemeral(instance).futureValue
 
       // Send an unhealthy update
-      val taskStatus = TestTaskBuilder.Helper.unhealthyTask(taskId).status.mesosStatus.get
+      val taskStatus = TestTaskBuilder.Helper.unhealthyTask(instanceId).status.mesosStatus.get
       instanceTracker.updateStatus(instance, taskStatus, clock.now()).futureValue
 
       assert(hcManager.status(app.id, instanceId).futureValue.isEmpty)

--- a/src/test/scala/mesosphere/marathon/core/history/impl/HistoryActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/history/impl/HistoryActorTest.scala
@@ -34,7 +34,7 @@ class HistoryActorTest extends AkkaUnitTest with ImplicitSender {
 
     MesosStatusUpdateEvent(
       slaveId = "slaveId",
-      taskId = Task.Id.forInstanceId(instanceId, None),
+      taskId = Task.Id.forInstanceId(instanceId),
       taskStatus = state,
       message = "message",
       appId = runSpecId,
@@ -47,7 +47,7 @@ class HistoryActorTest extends AkkaUnitTest with ImplicitSender {
 
   private def unhealthyInstanceKilled() = {
     val instanceId = Instance.Id.forRunSpec(runSpecId)
-    val taskId = Task.Id.forInstanceId(instanceId, None)
+    val taskId = Task.Id.forInstanceId(instanceId)
     UnhealthyInstanceKillEvent(
       appId = runSpecId,
       taskId = taskId,

--- a/src/test/scala/mesosphere/marathon/core/history/impl/HistoryActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/history/impl/HistoryActorTest.scala
@@ -5,6 +5,7 @@ import akka.actor.Props
 import akka.testkit.{ImplicitSender, TestActorRef}
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.event.{MesosStatusUpdateEvent, UnhealthyInstanceKillEvent}
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{PathId, TaskFailure, Timestamp}
 import mesosphere.marathon.storage.repository.TaskFailureRepository
@@ -29,9 +30,11 @@ class HistoryActorTest extends AkkaUnitTest with ImplicitSender {
         .setProtocol(NetworkInfo.Protocol.IPv4)
         .build()
 
+    val instanceId = Instance.Id.forRunSpec(runSpecId)
+
     MesosStatusUpdateEvent(
       slaveId = "slaveId",
-      taskId = Task.Id.forRunSpec(runSpecId),
+      taskId = Task.Id.forInstanceId(instanceId, None),
       taskStatus = state,
       message = "message",
       appId = runSpecId,
@@ -43,11 +46,12 @@ class HistoryActorTest extends AkkaUnitTest with ImplicitSender {
   }
 
   private def unhealthyInstanceKilled() = {
-    val taskId = Task.Id.forRunSpec(runSpecId)
+    val instanceId = Instance.Id.forRunSpec(runSpecId)
+    val taskId = Task.Id.forInstanceId(instanceId, None)
     UnhealthyInstanceKillEvent(
       appId = runSpecId,
       taskId = taskId,
-      instanceId = taskId.instanceId,
+      instanceId = instanceId,
       version = Timestamp(1024),
       reason = "unknown",
       host = "localhost",

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
@@ -148,9 +148,8 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
     def tasks(statuses: Condition*): Map[Task.Id, Task] = tasks(statuses.to[Seq])
 
     def tasks(statuses: Seq[Condition]): Map[Task.Id, Task] = {
-      val instanceId = Instance.Id.forRunSpec(id)
-
       statuses.map { status =>
+        val instanceId = Instance.Id.forRunSpec(id)
         val taskId = Task.Id.forInstanceId(instanceId, None)
         val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(status, taskId, Timestamp.now)
         val task = TestTaskBuilder.Helper.minimalTask(taskId, Timestamp.now(), mesosStatus, status)

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
@@ -147,12 +147,15 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
 
     def tasks(statuses: Condition*): Map[Task.Id, Task] = tasks(statuses.to[Seq])
 
-    def tasks(statuses: Seq[Condition]): Map[Task.Id, Task] =
+    def tasks(statuses: Seq[Condition]): Map[Task.Id, Task] = {
+      val instanceId = Instance.Id.forRunSpec(id)
+
       statuses.map { status =>
-        val taskId = Task.Id.forRunSpec(id)
+        val taskId = Task.Id.forInstanceId(instanceId, None)
         val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(status, taskId, Timestamp.now)
         val task = TestTaskBuilder.Helper.minimalTask(taskId, Timestamp.now(), mesosStatus, status)
         task.taskId -> task
       }(collection.breakOut)
+    }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
@@ -150,7 +150,7 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
     def tasks(statuses: Seq[Condition]): Map[Task.Id, Task] = {
       statuses.map { status =>
         val instanceId = Instance.Id.forRunSpec(id)
-        val taskId = Task.Id.forInstanceId(instanceId, None)
+        val taskId = Task.Id.forInstanceId(instanceId)
         val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(status, taskId, Timestamp.now)
         val task = TestTaskBuilder.Helper.minimalTask(taskId, Timestamp.now(), mesosStatus, status)
         task.taskId -> task

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
@@ -134,7 +134,8 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
     def tasks(statuses: Condition*): Map[Task.Id, Task] = tasks(statuses.to[Seq])
     def tasks(statuses: Seq[Condition]): Map[Task.Id, Task] =
       statuses.map { status =>
-        val taskId = Task.Id.forRunSpec(id)
+        val instanceId = Instance.Id.forRunSpec(id)
+        val taskId = Task.Id.forInstanceId(instanceId, None)
         val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(status, taskId, clock.now())
         val task = TestTaskBuilder.Helper.minimalTask(taskId, clock.now(), mesosStatus, status)
         task.taskId -> task

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
@@ -135,7 +135,7 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
     def tasks(statuses: Seq[Condition]): Map[Task.Id, Task] =
       statuses.map { status =>
         val instanceId = Instance.Id.forRunSpec(id)
-        val taskId = Task.Id.forInstanceId(instanceId, None)
+        val taskId = Task.Id.forInstanceId(instanceId)
         val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(status, taskId, clock.now())
         val task = TestTaskBuilder.Helper.minimalTask(taskId, clock.now(), mesosStatus, status)
         task.taskId -> task

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -70,9 +70,8 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
   def taskRunning(containerName: Option[String] = None, stagedAt: Timestamp = now,
     startedAt: Timestamp = now): TestTaskBuilder = {
     val instance = instanceBuilder.getInstance()
-    this.copy(task = Some(TestTaskBuilder.Helper.runningTask(
-      Task.Id.forInstanceId(instance.instanceId, maybeMesosContainerByName(containerName)),
-      instance.runSpecVersion, stagedAt = stagedAt.millis, startedAt = startedAt.millis)))
+    this.copy(task = Some(TestTaskBuilder.Helper.runningTask(instance.instanceId, instance.runSpecVersion,
+      stagedAt = stagedAt.millis, startedAt = startedAt.millis, maybeMesosContainerByName(containerName))))
   }
 
   /**
@@ -168,9 +167,8 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
   def taskStaged(containerName: Option[String] = None, stagedAt: Timestamp = now,
     version: Option[Timestamp] = None): TestTaskBuilder = {
     val instance = instanceBuilder.getInstance()
-    this.copy(task = Some(TestTaskBuilder.Helper.stagedTask(
-      Task.Id.forInstanceId(instance.instanceId, maybeMesosContainerByName(containerName)),
-      version.getOrElse(instance.runSpecVersion), stagedAt = stagedAt.millis)))
+    this.copy(task = Some(TestTaskBuilder.Helper.stagedTask(instance.instanceId, version.getOrElse(instance.runSpecVersion),
+      stagedAt = stagedAt.millis, maybeMesosContainerByName(containerName))))
   }
 
   def taskStarting(stagedAt: Timestamp = now, containerName: Option[String] = None): TestTaskBuilder = {
@@ -231,7 +229,7 @@ object TestTaskBuilder extends StrictLogging {
           networkInfo = NetworkInfo(hostName = "host.some", hostPorts = Seq(1, 2, 3), ipAddresses = Nil)))
     }
 
-    def minimalTask(appId: PathId): Task = minimalTask(Task.Id.forRunSpec(appId))
+    def minimalTask(appId: PathId): Task = minimalTask(Instance.Id.forRunSpec(appId), None, Timestamp.now())
 
     def minimalTask(instanceId: Instance.Id, container: Option[MesosContainer], now: Timestamp): Task =
       minimalTask(Task.Id.forInstanceId(instanceId, container), now)
@@ -257,7 +255,8 @@ object TestTaskBuilder extends StrictLogging {
 
     def minimalLostTask(appId: PathId, taskCondition: Condition = Condition.Gone,
       since: Timestamp = Timestamp.now()): Task = {
-      val taskId = Task.Id.forRunSpec(appId)
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val status = MesosTaskStatusTestHelper.lost(
         mesos.Protos.TaskStatus.Reason.REASON_RECONCILIATION, taskId, since)
       minimalTask(
@@ -278,7 +277,8 @@ object TestTaskBuilder extends StrictLogging {
 
     def minimalRunning(appId: PathId, taskCondition: Condition = Condition.Running,
       since: Timestamp = Timestamp.now()): Task = {
-      val taskId = Task.Id.forRunSpec(appId)
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val status = MesosTaskStatusTestHelper.mesosStatus(
         state = mesos.Protos.TaskState.TASK_RUNNING, maybeHealthy = Option(true), taskId = taskId)
       minimalTask(
@@ -290,7 +290,8 @@ object TestTaskBuilder extends StrictLogging {
     }
 
     def residentReservedTask(appId: PathId, maybeTaskId: Option[Task.Id] = None): Task = {
-      val taskId = maybeTaskId.getOrElse(Task.Id.forRunSpec(appId))
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = maybeTaskId.getOrElse(Task.Id.forInstanceId(instanceId, None))
       Task(
         taskId = taskId,
         status = Task.Status(Timestamp.now(), condition = Condition.Reserved, networkInfo = NetworkInfoPlaceholder()),
@@ -299,7 +300,8 @@ object TestTaskBuilder extends StrictLogging {
 
     def residentLaunchedTask(appId: PathId, maybeTaskId: Option[Task.Id] = None): Task = {
       val now = Timestamp.now()
-      val taskId = maybeTaskId.getOrElse(Task.Id.forRunSpec(appId))
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = maybeTaskId.getOrElse(Task.Id.forInstanceId(instanceId, None))
       Task(
         taskId = taskId,
         runSpecVersion = now,
@@ -313,7 +315,8 @@ object TestTaskBuilder extends StrictLogging {
 
     def unreachableTask(appId: PathId, maybeTaskId: Option[Task.Id] = None): Task = {
       val now = Timestamp.now()
-      val taskId = maybeTaskId.getOrElse(Task.Id.forRunSpec(appId))
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = maybeTaskId.getOrElse(Task.Id.forInstanceId(instanceId, None))
       Task(
         taskId = taskId,
         runSpecVersion = now,
@@ -344,10 +347,14 @@ object TestTaskBuilder extends StrictLogging {
           networkInfo = NetworkInfoPlaceholder()))
 
     def stagedTaskForApp(
-      appId: PathId = PathId("/test"), appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task =
-      stagedTask(Task.Id.forRunSpec(appId), appVersion = appVersion, stagedAt = stagedAt)
+      appId: PathId = PathId("/test"), appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task = {
+      val instanceId = Instance.Id.forRunSpec(appId)
+      stagedTask(instanceId, appVersion = appVersion, stagedAt = stagedAt)
+    }
 
-    def stagedTask(taskId: Task.Id, appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2): Task =
+    def stagedTask(instanceId: Instance.Id, appVersion: Timestamp = Timestamp(1), stagedAt: Long = 2, container: Option[MesosContainer] = None): Task = {
+      val taskId = Task.Id.forInstanceId(instanceId, container)
+
       Task(
         taskId = taskId,
         runSpecVersion = appVersion,
@@ -357,6 +364,7 @@ object TestTaskBuilder extends StrictLogging {
           mesosStatus = Some(statusForState(taskId.idString, mesos.Protos.TaskState.TASK_STAGING)),
           condition = Condition.Staging,
           networkInfo = NetworkInfoPlaceholder()))
+    }
 
     def statusForState(taskId: String, state: mesos.Protos.TaskState,
       maybeReason: Option[mesos.Protos.TaskStatus.Reason] = None): mesos.Protos.TaskStatus = {
@@ -375,19 +383,21 @@ object TestTaskBuilder extends StrictLogging {
       stagedAt: Long = 2,
       startedAt: Long = 3): Task =
       runningTask(
-        Task.Id.forRunSpec(appId),
+        Instance.Id.forRunSpec(appId),
         appVersion = appVersion,
         stagedAt = stagedAt,
         startedAt = startedAt
       )
 
     def runningTask(
-      taskId: Task.Id,
+      instanceId: Instance.Id,
       appVersion: Timestamp = Timestamp(1),
       stagedAt: Long = 2,
-      startedAt: Long = 3): Task = {
+      startedAt: Long = 3,
+      container: Option[MesosContainer] = None): Task = {
       import mesosphere.marathon.test.MarathonTestHelper.Implicits._
 
+      val taskId = Task.Id.forInstanceId(instanceId, container)
       startingTask(taskId, appVersion, stagedAt)
         .withStatus((status: Task.Status) =>
           status.copy(
@@ -410,22 +420,20 @@ object TestTaskBuilder extends StrictLogging {
             mesosStatus = Some(statusForState(taskId.idString, mesos.Protos.TaskState.TASK_KILLED))))
     }
 
-    def healthyTask(appId: PathId): Task = healthyTask(Task.Id.forRunSpec(appId))
-
-    def healthyTask(taskId: Task.Id): Task = {
+    def healthyTask(instanceId: Instance.Id): Task = {
       import mesosphere.marathon.test.MarathonTestHelper.Implicits._
 
-      runningTask(taskId).withStatus { status =>
+      runningTask(instanceId).withStatus { status =>
         status.copy(mesosStatus = status.mesosStatus.map(_.toBuilder.setHealthy(true).build()))
       }
     }
 
-    def unhealthyTask(appId: PathId): Task = unhealthyTask(Task.Id.forRunSpec(appId))
+    def unhealthyTask(appId: PathId): Task = unhealthyTask(Instance.Id.forRunSpec(appId))
 
-    def unhealthyTask(taskId: Task.Id): Task = {
+    def unhealthyTask(instanceId: Instance.Id): Task = {
       import mesosphere.marathon.test.MarathonTestHelper.Implicits._
 
-      runningTask(taskId).withStatus { status =>
+      runningTask(instanceId).withStatus { status =>
         status.copy(mesosStatus = status.mesosStatus.map(_.toBuilder.setHealthy(false).build()))
       }
     }

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -24,7 +24,7 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
     val instance = instanceBuilder.getInstance()
     this.copy(task = Some(TestTaskBuilder.Helper.makeTaskFromTaskInfo(
       taskInfo, offer, version, now, taskCondition).copy(
-      taskId = Task.Id.forInstanceId(instance.instanceId, None))))
+      taskId = Task.Id.forInstanceId(instance.instanceId))))
   }
 
   def taskForStatus(mesosState: mesos.Protos.TaskState, stagedAt: Timestamp = now,
@@ -41,11 +41,11 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
   def taskLaunched(container: Option[MesosContainer] = None): TestTaskBuilder =
     this.copy(task = Some(TestTaskBuilder.Helper.minimalTask(
       instanceBuilder.getInstance().instanceId, container, now).copy(
-        taskId = Task.Id.forInstanceId(instanceBuilder.getInstance().instanceId, None))))
+        taskId = Task.Id.forInstanceId(instanceBuilder.getInstance().instanceId))))
 
   def taskResidentLaunched(): TestTaskBuilder = {
     val instance = instanceBuilder.getInstance()
-    val taskId = Task.Id.forInstanceId(instance.instanceId, None)
+    val taskId = Task.Id.forInstanceId(instance.instanceId)
     this.copy(task = Some(TestTaskBuilder.Helper.residentLaunchedTask(instance.instanceId.runSpecId, Some(taskId))))
   }
 
@@ -57,13 +57,13 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
 
   def taskResidentReserved(): TestTaskBuilder = {
     val instance = instanceBuilder.getInstance()
-    val taskId = Task.Id.forInstanceId(instance.instanceId, container = None)
+    val taskId = Task.Id.forInstanceId(instance.instanceId)
     this.copy(task = Some(TestTaskBuilder.Helper.residentReservedTask(instance.instanceId.runSpecId, Some(taskId))))
   }
 
   def taskUnreachable(): TestTaskBuilder = {
     val instance = instanceBuilder.getInstance()
-    val taskId = Task.Id.forInstanceId(instance.instanceId, None)
+    val taskId = Task.Id.forInstanceId(instance.instanceId)
     this.copy(task = Some(TestTaskBuilder.Helper.unreachableTask(instance.instanceId.runSpecId, Some(taskId))))
   }
 
@@ -256,7 +256,7 @@ object TestTaskBuilder extends StrictLogging {
     def minimalLostTask(appId: PathId, taskCondition: Condition = Condition.Gone,
       since: Timestamp = Timestamp.now()): Task = {
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val status = MesosTaskStatusTestHelper.lost(
         mesos.Protos.TaskStatus.Reason.REASON_RECONCILIATION, taskId, since)
       minimalTask(
@@ -278,7 +278,7 @@ object TestTaskBuilder extends StrictLogging {
     def minimalRunning(appId: PathId, taskCondition: Condition = Condition.Running,
       since: Timestamp = Timestamp.now()): Task = {
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val status = MesosTaskStatusTestHelper.mesosStatus(
         state = mesos.Protos.TaskState.TASK_RUNNING, maybeHealthy = Option(true), taskId = taskId)
       minimalTask(
@@ -291,7 +291,7 @@ object TestTaskBuilder extends StrictLogging {
 
     def residentReservedTask(appId: PathId, maybeTaskId: Option[Task.Id] = None): Task = {
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = maybeTaskId.getOrElse(Task.Id.forInstanceId(instanceId, None))
+      val taskId = maybeTaskId.getOrElse(Task.Id.forInstanceId(instanceId))
       Task(
         taskId = taskId,
         status = Task.Status(Timestamp.now(), condition = Condition.Reserved, networkInfo = NetworkInfoPlaceholder()),
@@ -301,7 +301,7 @@ object TestTaskBuilder extends StrictLogging {
     def residentLaunchedTask(appId: PathId, maybeTaskId: Option[Task.Id] = None): Task = {
       val now = Timestamp.now()
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = maybeTaskId.getOrElse(Task.Id.forInstanceId(instanceId, None))
+      val taskId = maybeTaskId.getOrElse(Task.Id.forInstanceId(instanceId))
       Task(
         taskId = taskId,
         runSpecVersion = now,
@@ -316,7 +316,7 @@ object TestTaskBuilder extends StrictLogging {
     def unreachableTask(appId: PathId, maybeTaskId: Option[Task.Id] = None): Task = {
       val now = Timestamp.now()
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = maybeTaskId.getOrElse(Task.Id.forInstanceId(instanceId, None))
+      val taskId = maybeTaskId.getOrElse(Task.Id.forInstanceId(instanceId))
       Task(
         taskId = taskId,
         runSpecVersion = now,

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -143,7 +143,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       val lostInstance = TestInstanceBuilder.newBuilder(appId).addTaskLost().getInstance()
       instanceTracker.instance(lostInstance.instanceId) returns Future.successful(Some(lostInstance))
       val reason = mesos.Protos.TaskStatus.Reason.REASON_SLAVE_DISCONNECTED
-      val taskId = Task.Id.forInstanceId(lostInstance.instanceId, None)
+      val taskId = Task.Id.forInstanceId(lostInstance.instanceId)
       val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(
         state = mesos.Protos.TaskState.TASK_LOST,
         maybeReason = Some(reason),

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
@@ -246,7 +246,7 @@ class InstanceUpdaterTest extends UnitTest {
     // Setup staged instance with a staged task
     val app = new AppDefinition(PathId("/test"))
     val scheduledInstance = Instance.scheduled(app)
-    val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId, None)
+    val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId)
     val provisionedInstance = scheduledInstance.provisioned(AgentInfoPlaceholder(), NetworkInfoPlaceholder(), app, Timestamp.now(f.clock), taskId)
     val withStoppedGoal = provisionedInstance.copy(state = provisionedInstance.state.copy(goal = Goal.Stopped))
 

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -28,8 +28,8 @@ class OfferProcessorImplTest extends UnitTest {
   private val appId: PathId = PathId("/testapp")
   private[this] val instanceId1 = Instance.Id.forRunSpec(appId)
   private[this] val instanceId2 = Instance.Id.forRunSpec(appId)
-  private[this] val taskInfo1 = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId1, None)).build()
-  private[this] val taskInfo2 = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId2, None)).build()
+  private[this] val taskInfo1 = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId1)).build()
+  private[this] val taskInfo2 = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId2)).build()
   private[this] val instance1 = TestInstanceBuilder.newBuilderWithInstanceId(instanceId1).addTaskWithBuilder().taskFromTaskInfo(taskInfo1).build().getInstance()
   private[this] val instance2 = TestInstanceBuilder.newBuilderWithInstanceId(instanceId2).addTaskWithBuilder().taskFromTaskInfo(taskInfo2).build().getInstance()
   private[this] val task1: Task = instance1.appTask

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLabelsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLabelsTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package core.launcher.impl
 
 import mesosphere.UnitTest
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.stream.Implicits._
@@ -46,7 +47,8 @@ class TaskLabelsTest extends UnitTest {
   }
   class Fixture {
     val appId = PathId("/test")
-    val taskId = Task.Id.forRunSpec(appId)
+    val instanceId = Instance.Id.forRunSpec(appId)
+    val taskId = Task.Id.forInstanceId(instanceId, None)
     val frameworkId = MarathonTestHelper.frameworkId
     val otherFrameworkId = FrameworkId("very other different framework id")
 

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLabelsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLabelsTest.scala
@@ -48,7 +48,7 @@ class TaskLabelsTest extends UnitTest {
   class Fixture {
     val appId = PathId("/test")
     val instanceId = Instance.Id.forRunSpec(appId)
-    val taskId = Task.Id.forInstanceId(instanceId, None)
+    val taskId = Task.Id.forInstanceId(instanceId)
     val frameworkId = MarathonTestHelper.frameworkId
     val otherFrameworkId = FrameworkId("very other different framework id")
 

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
@@ -33,8 +33,8 @@ class TaskLauncherImplTest extends UnitTest {
   }
   private[this] val appId = PathId("/test")
   private[this] val instanceId = Instance.Id.forRunSpec(appId)
-  private[this] val launch1 = launch(MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId, None)))
-  private[this] val launch2 = launch(MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId, None)))
+  private[this] val launch1 = launch(MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId)))
+  private[this] val launch2 = launch(MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId)))
   private[this] val ops = Seq(launch1, launch2)
   private[this] val opsAsJava = ops.flatMap(_.offerOperations).asJava
   private[this] val filter = Protos.Filters.newBuilder().setRefuseSeconds(0).build()

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -57,7 +57,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
     val marathonInstance = TestInstanceBuilder.newBuilderWithLaunchedTask(app.id, version = app.version, now = Timestamp.now()).getInstance()
     val marathonTask: Task = marathonInstance.appTask
     val instanceId = marathonInstance.instanceId
-    val task = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId, None)).build()
+    val task = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId)).build()
     val metrics: Metrics = DummyMetrics
     val opFactory = new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role")).launchEphemeral(
       _: Mesos.TaskInfo, _: Task, _: Instance)
@@ -207,7 +207,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       promise.future.futureValue
 
       When("the launcher receives the update for the provisioned instance")
-      val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId, None)
+      val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId)
       val provisionedInstance = scheduledInstance.provisioned(TestInstanceBuilder.defaultAgentInfo, NetworkInfoPlaceholder(), f.app, clock.now(), taskId)
       val update = InstanceUpdated(provisionedInstance, Some(scheduledInstance.state), Seq.empty)
       Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.marathonInstance, provisionedInstance))
@@ -485,7 +485,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       val scheduledInstance = Instance.scheduled(f.app)
 
       val scheduledInstanceB = Instance.scheduled(f.app)
-      val taskId = Task.Id.forInstanceId(scheduledInstanceB.instanceId, None)
+      val taskId = Task.Id.forInstanceId(scheduledInstanceB.instanceId)
       val provisionedInstance = scheduledInstanceB.provisioned(TestInstanceBuilder.defaultAgentInfo, NetworkInfoPlaceholder(), f.app, clock.now(), taskId)
       Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(scheduledInstance, provisionedInstance))
 

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
@@ -139,7 +139,7 @@ class OfferOperationFactoryTest extends UnitTest {
   class Fixture {
     val runSpecId = PathId("/my-app")
     val instanceId = Instance.Id.forRunSpec(runSpecId)
-    val taskId = Task.Id.forInstanceId(instanceId, None)
+    val taskId = Task.Id.forInstanceId(instanceId)
     val frameworkId = MarathonTestHelper.frameworkId
     val reservationLabels = TaskLabels.labelsForTask(frameworkId, taskId)
     val principal = Some("principal")

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.matcher.base.util
 
 import mesosphere.UnitTest
-import mesosphere.marathon.core.instance.{LocalVolume, LocalVolumeId}
+import mesosphere.marathon.core.instance.{Instance, LocalVolume, LocalVolumeId}
 import mesosphere.marathon.core.launcher.InstanceOpFactory
 import mesosphere.marathon.core.launcher.impl.TaskLabels
 import mesosphere.marathon.core.task.Task
@@ -138,7 +138,8 @@ class OfferOperationFactoryTest extends UnitTest {
   }
   class Fixture {
     val runSpecId = PathId("/my-app")
-    val taskId = Task.Id.forRunSpec(runSpecId)
+    val instanceId = Instance.Id.forRunSpec(runSpecId)
+    val taskId = Task.Id.forInstanceId(instanceId, None)
     val frameworkId = MarathonTestHelper.frameworkId
     val reservationLabels = TaskLabels.labelsForTask(frameworkId, taskId)
     val principal = Some("principal")

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -153,7 +153,7 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     "deregistering only matcher works" in new Fixture {
       val offer: Offer = MarathonTestHelper.makeBasicOffer(cpus = 1.0).build()
 
-      val task = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId, None)).build()
+      val task = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId)).build()
       val matcher: CPUOfferMatcher = new CPUOfferMatcher(Seq(task))
       module.subOfferMatcherManager.setLaunchTokens(10)
       module.subOfferMatcherManager.addSubscription(matcher)
@@ -170,9 +170,9 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
 
       module.subOfferMatcherManager.setLaunchTokens(10)
 
-      val task1: TaskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId, None)).build()
+      val task1: TaskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId)).build()
       module.subOfferMatcherManager.addSubscription(new CPUOfferMatcher(Seq(task1)))
-      val task2: TaskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId, None)).build()
+      val task2: TaskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId)).build()
       module.subOfferMatcherManager.addSubscription(new CPUOfferMatcher(Seq(task2)))
 
       val matchedTasksFuture: Future[MatchedInstanceOps] =
@@ -190,7 +190,7 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
 
         module.subOfferMatcherManager.setLaunchTokens(launchTokens)
 
-        val task1: TaskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId, None)).build()
+        val task1: TaskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId)).build()
         module.subOfferMatcherManager.addSubscription(new ConstantOfferMatcher(Seq(task1)))
 
         val matchedTasksFuture: Future[MatchedInstanceOps] =
@@ -205,9 +205,9 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
 
       module.subOfferMatcherManager.setLaunchTokens(10)
 
-      val task1: TaskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId, None)).build()
+      val task1: TaskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId)).build()
       module.subOfferMatcherManager.addSubscription(new CPUOfferMatcher(Seq(task1)))
-      val task2: TaskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId, None)).build()
+      val task2: TaskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(F.instanceId)).build()
       module.subOfferMatcherManager.addSubscription(new CPUOfferMatcher(Seq(task2)))
 
       val matchedTasksFuture: Future[MatchedInstanceOps] =

--- a/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
@@ -33,7 +33,7 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       Given("an offer with volume")
       val appId = PathId("/test")
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
       val offer = MarathonTestHelper.offerWithVolumes(taskId, localVolumeIdLaunched)
 
@@ -63,7 +63,7 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       Given("an offer with volume")
       val appId = PathId("/test")
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
       val offer = MarathonTestHelper.offerWithVolumes(taskId, localVolumeIdLaunched)
 
@@ -93,7 +93,7 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       Given("an offer with volume")
       val appId = PathId("/test")
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
       val offer = MarathonTestHelper.offerWithVolumes(taskId, localVolumeIdLaunched)
 
@@ -123,7 +123,7 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       Given("an offer with volume")
       val appId = PathId("/test")
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
       val offer = MarathonTestHelper.offerWithVolumes(taskId, localVolumeIdLaunched)
 

--- a/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.matcher.reconcile.impl
 
 import mesosphere.UnitTest
-import mesosphere.marathon.core.instance.{LocalVolumeId, TestInstanceBuilder}
+import mesosphere.marathon.core.instance.{Instance, LocalVolumeId, TestInstanceBuilder}
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.launcher.InstanceOp
 import mesosphere.marathon.core.task.Task
@@ -32,7 +32,8 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       val f = new Fixture
       Given("an offer with volume")
       val appId = PathId("/test")
-      val taskId = Task.Id.forRunSpec(appId)
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
       val offer = MarathonTestHelper.offerWithVolumes(taskId, localVolumeIdLaunched)
 
@@ -61,7 +62,8 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       val f = new Fixture
       Given("an offer with volume")
       val appId = PathId("/test")
-      val taskId = Task.Id.forRunSpec(appId)
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
       val offer = MarathonTestHelper.offerWithVolumes(taskId, localVolumeIdLaunched)
 
@@ -90,7 +92,8 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       val f = new Fixture
       Given("an offer with volume")
       val appId = PathId("/test")
-      val taskId = Task.Id.forRunSpec(appId)
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
       val offer = MarathonTestHelper.offerWithVolumes(taskId, localVolumeIdLaunched)
 
@@ -119,7 +122,8 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       val f = new Fixture
       Given("an offer with volume")
       val appId = PathId("/test")
-      val taskId = Task.Id.forRunSpec(appId)
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
       val offer = MarathonTestHelper.offerWithVolumes(taskId, localVolumeIdLaunched)
 

--- a/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckResultTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckResultTest.scala
@@ -3,6 +3,7 @@ package core.readiness
 
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import mesosphere.UnitTest
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.PathId
@@ -72,8 +73,9 @@ class ReadinessCheckResultTest extends UnitTest {
     }
   }
   class Fixture {
+    val instanceId = Instance.Id.forRunSpec(PathId("/test"))
     val check = ReadinessCheckSpec(
-      taskId = Task.Id.forRunSpec(PathId("/test")),
+      taskId = Task.Id.forInstanceId(instanceId, None),
       checkName = "testCheck",
       url = "http://sample.url:123",
       interval = 3.seconds,

--- a/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckResultTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/readiness/ReadinessCheckResultTest.scala
@@ -75,7 +75,7 @@ class ReadinessCheckResultTest extends UnitTest {
   class Fixture {
     val instanceId = Instance.Id.forRunSpec(PathId("/test"))
     val check = ReadinessCheckSpec(
-      taskId = Task.Id.forInstanceId(instanceId, None),
+      taskId = Task.Id.forInstanceId(instanceId),
       checkName = "testCheck",
       url = "http://sample.url:123",
       interval = 3.seconds,

--- a/src/test/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImplTest.scala
@@ -3,6 +3,7 @@ package core.readiness.impl
 
 import akka.stream.scaladsl.Sink
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor.ReadinessCheckSpec
 import mesosphere.marathon.core.readiness.{HttpResponse, ReadinessCheckResult}
 import mesosphere.marathon.core.task.Task
@@ -108,8 +109,9 @@ class ReadinessCheckExecutorImplTest extends AkkaUnitTest {
   }
 
   class Fixture {
+    val instanceId = Instance.Id.forRunSpec(PathId("/test"))
     lazy val check = ReadinessCheckSpec(
-      taskId = Task.Id.forRunSpec(PathId("/test")),
+      taskId = Task.Id.forInstanceId(instanceId, None),
       checkName = "testCheck",
       url = "http://sample.url:123",
       interval = 1.milliseconds, // we're testing!

--- a/src/test/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/readiness/impl/ReadinessCheckExecutorImplTest.scala
@@ -111,7 +111,7 @@ class ReadinessCheckExecutorImplTest extends AkkaUnitTest {
   class Fixture {
     val instanceId = Instance.Id.forRunSpec(PathId("/test"))
     lazy val check = ReadinessCheckSpec(
-      taskId = Task.Id.forInstanceId(instanceId, None),
+      taskId = Task.Id.forInstanceId(instanceId),
       checkName = "testCheck",
       url = "http://sample.url:123",
       interval = 1.milliseconds, // we're testing!

--- a/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
@@ -148,7 +148,8 @@ class TaskTest extends UnitTest with Inside {
       val f = new Fixture
 
       val condition = Condition.Unreachable
-      val taskId = Task.Id.forRunSpec(f.appWithIpAddress.id)
+      val instanceId = Instance.Id.forRunSpec(f.appWithIpAddress.id)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(condition, taskId, f.clock.now - 5.minutes)
       val task = TestTaskBuilder.Helper.minimalTask(taskId, f.clock.now - 5.minutes, mesosStatus, condition)
 
@@ -159,7 +160,8 @@ class TaskTest extends UnitTest with Inside {
     "a reserved task transitions to launched on running MesosUpdate" in {
       val f = new Fixture
       val condition = Condition.Reserved
-      val taskId = Task.Id.forRunSpec(f.appWithIpAddress.id)
+      val instanceId = Instance.Id.forRunSpec(f.appWithIpAddress.id)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val status = Task.Status(f.clock.now, None, None, condition, NetworkInfoPlaceholder())
       val task = Task(taskId, f.clock.now, status)
       val instance = mock[Instance]
@@ -177,7 +179,8 @@ class TaskTest extends UnitTest with Inside {
       val f = new Fixture
 
       val condition = Condition.Running
-      val taskId = Task.Id.forRunSpec(f.appWithIpAddress.id)
+      val instanceId = Instance.Id.forRunSpec(f.appWithIpAddress.id)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val status = Task.Status(
         stagedAt = f.clock.now,
         startedAt = Some(f.clock.now),
@@ -209,7 +212,8 @@ class TaskTest extends UnitTest with Inside {
       val f = new Fixture
 
       val condition = Condition.Staging
-      val taskId = Task.Id.forRunSpec(f.appWithIpAddress.id)
+      val instanceId = Instance.Id.forRunSpec(f.appWithIpAddress.id)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val status = Task.Status(
         stagedAt = f.clock.now,
         startedAt = None,

--- a/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskTest.scala
@@ -149,7 +149,7 @@ class TaskTest extends UnitTest with Inside {
 
       val condition = Condition.Unreachable
       val instanceId = Instance.Id.forRunSpec(f.appWithIpAddress.id)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(condition, taskId, f.clock.now - 5.minutes)
       val task = TestTaskBuilder.Helper.minimalTask(taskId, f.clock.now - 5.minutes, mesosStatus, condition)
 
@@ -161,7 +161,7 @@ class TaskTest extends UnitTest with Inside {
       val f = new Fixture
       val condition = Condition.Reserved
       val instanceId = Instance.Id.forRunSpec(f.appWithIpAddress.id)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val status = Task.Status(f.clock.now, None, None, condition, NetworkInfoPlaceholder())
       val task = Task(taskId, f.clock.now, status)
       val instance = mock[Instance]
@@ -180,7 +180,7 @@ class TaskTest extends UnitTest with Inside {
 
       val condition = Condition.Running
       val instanceId = Instance.Id.forRunSpec(f.appWithIpAddress.id)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val status = Task.Status(
         stagedAt = f.clock.now,
         startedAt = Some(f.clock.now),
@@ -213,7 +213,7 @@ class TaskTest extends UnitTest with Inside {
 
       val condition = Condition.Staging
       val instanceId = Instance.Id.forRunSpec(f.appWithIpAddress.id)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val status = Task.Status(
         stagedAt = f.clock.now,
         startedAt = None,

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -93,7 +93,7 @@ object TaskStatusUpdateTestHelper {
   }
 
   def staging(instance: Instance = defaultInstance) = {
-    val taskId = Task.Id.forInstanceId(instance.instanceId, None)
+    val taskId = Task.Id.forInstanceId(instance.instanceId)
     val status = MesosTaskStatusTestHelper.staging(taskId)
     taskUpdateFor(instance, Condition.Staging, status)
   }
@@ -124,7 +124,7 @@ object TaskStatusUpdateTestHelper {
   }
 
   def unreachable(instance: Instance = defaultInstance) = {
-    val mesosStatus = MesosTaskStatusTestHelper.unreachable(Task.Id.forInstanceId(instance.instanceId, None))
+    val mesosStatus = MesosTaskStatusTestHelper.unreachable(Task.Id.forInstanceId(instance.instanceId))
     val marathonTaskStatus = TaskCondition(mesosStatus)
 
     marathonTaskStatus match {
@@ -144,12 +144,12 @@ object TaskStatusUpdateTestHelper {
   }
 
   def killing(instance: Instance = defaultInstance) = {
-    val status = MesosTaskStatusTestHelper.killing(Task.Id.forInstanceId(instance.instanceId, None))
+    val status = MesosTaskStatusTestHelper.killing(Task.Id.forInstanceId(instance.instanceId))
     taskUpdateFor(instance, Condition.Killing, status)
   }
 
   def error(instance: Instance = defaultInstance) = {
-    val status = MesosTaskStatusTestHelper.error(Task.Id.forInstanceId(instance.instanceId, None))
+    val status = MesosTaskStatusTestHelper.error(Task.Id.forInstanceId(instance.instanceId))
     taskExpungeFor(instance, Condition.Error, status)
   }
   def failed(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
@@ -60,9 +60,10 @@ class KillServiceActorTest extends AkkaUnitTest with StrictLogging {
     "asked to kill an unknown instance" should {
       "issue a kill to the driver" in withActor(defaultConfig) { (f, actor) =>
 
-        val taskId = Task.Id.forRunSpec(PathId("/unknown"))
+        val instanceId = Instance.Id.forRunSpec(PathId("/unknown"))
+        val taskId = Task.Id.forInstanceId(instanceId, None)
         actor ! KillServiceActor.KillUnknownTaskById(taskId)
-        f.publishUnknownInstanceTerminated(taskId.instanceId)
+        f.publishUnknownInstanceTerminated(instanceId)
 
         verify(f.driver, timeout(f.killConfig.killRetryTimeout.toMillis.toInt * 2)).killTask(taskId.mesosTaskId)
         noMoreInteractions(f.driver)

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
@@ -61,7 +61,7 @@ class KillServiceActorTest extends AkkaUnitTest with StrictLogging {
       "issue a kill to the driver" in withActor(defaultConfig) { (f, actor) =>
 
         val instanceId = Instance.Id.forRunSpec(PathId("/unknown"))
-        val taskId = Task.Id.forInstanceId(instanceId, None)
+        val taskId = Task.Id.forInstanceId(instanceId)
         actor ! KillServiceActor.KillUnknownTaskById(taskId)
         f.publishUnknownInstanceTerminated(instanceId)
 

--- a/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
@@ -24,7 +24,7 @@ class InstanceIdTest extends UnitTest with Inside {
     "be converted to TaskIds without container name" in {
       val appId = "/test/foo/bla/rest".toPath
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = Task.Id.forInstanceId(instanceId, container = None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       taskId.idString should be(instanceId.idString + ".$anon")
     }
 

--- a/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
@@ -4,7 +4,7 @@ package raml
 import mesosphere.UnitTest
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.health.{MesosCommandHealthCheck, MesosHttpHealthCheck, PortReference}
-import mesosphere.marathon.core.instance.{Goal, Reservation}
+import mesosphere.marathon.core.instance.{Goal, Instance, Reservation}
 import mesosphere.marathon.core.pod.{ContainerNetwork, MesosContainer, PodDefinition}
 import mesosphere.marathon.core.task.state.NetworkInfoPlaceholder
 import mesosphere.marathon.state.{PathId, Timestamp}
@@ -534,7 +534,8 @@ object PodStatusConversionTest {
   } // fakeInstance
 
   def fakeTask(networks: Seq[Protos.NetworkInfo]) = {
-    val taskId = core.task.Task.Id.forRunSpec(PathId.empty)
+    val instanceId = Instance.Id.forRunSpec(PathId.empty)
+    val taskId = core.task.Task.Id.forInstanceId(instanceId, None)
     core.task.Task(
       taskId = taskId,
       status = core.task.Task.Status(

--- a/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
@@ -535,7 +535,7 @@ object PodStatusConversionTest {
 
   def fakeTask(networks: Seq[Protos.NetworkInfo]) = {
     val instanceId = Instance.Id.forRunSpec(PathId.empty)
-    val taskId = core.task.Task.Id.forInstanceId(instanceId, None)
+    val taskId = core.task.Task.Id.forInstanceId(instanceId)
     core.task.Task(
       taskId = taskId,
       status = core.task.Task.Status(

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo160Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo160Test.scala
@@ -85,7 +85,7 @@ class MigrationTo160Test extends AkkaUnitTest with GroupCreation with StrictLogg
 
     val taskMap = List(
       Task(
-        Task.Id.forInstanceId(instanceId1, None),
+        Task.Id.forInstanceId(instanceId1),
         Timestamp.now(),
         Task.Status(
           stagedAt = Timestamp.now(),

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo17Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo17Test.scala
@@ -99,13 +99,13 @@ class MigrationTo17Test extends AkkaUnitTest with StrictLogging with Inspectors 
 
     /**
       * Construct a 1.6.0 version JSON for a terminal resident instance.
-      * @param i The id of the instance.
+      * @param id The id of the instance.
       * @return The JSON of the instance.
       */
-    def legacyResidentInstanceJson(i: Instance.Id): JsValue = {
-      val taskId = Task.Id.forInstanceId(i, None)
+    def legacyResidentInstanceJson(id: Instance.Id): JsValue = {
+      val taskId = Task.Id.forInstanceId(id)
 
-      legacyInstanceJson(i) ++
+      legacyInstanceJson(id) ++
         Json.obj("state" -> Json.obj("since" -> "2015-01-01T12:00:00.000Z", "condition" -> Json.obj("str" -> "Reserved"), "goal" -> "running")) ++
         Json.obj("reservation" -> Json.obj("volumeIds" -> Json.arr(), "state" -> Json.obj("name" -> "suspended"))) ++
         Json.obj("tasksMap" -> Json.obj(taskId.idString -> terminalTask(taskId)))

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package tasks
 
+import com.fasterxml.uuid.Generators
 import mesosphere.UnitTest
 import mesosphere.marathon.core.instance.TestInstanceBuilder
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
@@ -18,6 +19,8 @@ class InstanceOpFactoryHelperTest extends UnitTest {
     val runSpecId = PathId("/test")
     val metrics = DummyMetrics
     val helper = new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role"))
+
+    val uuidGenerator = Generators.timeBasedGenerator()
   }
 
   "InstanceOpFactoryHelper" should {
@@ -27,7 +30,8 @@ class InstanceOpFactoryHelperTest extends UnitTest {
       Given("A non-matching task and taskInfo")
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(f.runSpecId).getInstance()
       val task: Task = instance.appTask
-      val taskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id("no-match")).build()
+      val otherTaskId = Task.LegacyId(f.runSpecId, "-", f.uuidGenerator.generate())
+      val taskInfo = MarathonTestHelper.makeOneCPUTask(otherTaskId).build()
 
       When("We create a launch operation")
       val error = intercept[AssertionError] {

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
@@ -27,7 +27,7 @@ class InstanceOpFactoryHelperTest extends UnitTest {
       Given("A non-matching task and taskInfo")
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(f.runSpecId).getInstance()
       val task: Task = instance.appTask
-      val taskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forRunSpec(f.runSpecId)).build()
+      val taskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instance.instanceId, None)).build()
 
       When("We create a launch operation")
       val error = intercept[AssertionError] {

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
@@ -27,7 +27,7 @@ class InstanceOpFactoryHelperTest extends UnitTest {
       Given("A non-matching task and taskInfo")
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(f.runSpecId).getInstance()
       val task: Task = instance.appTask
-      val taskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instance.instanceId, None)).build()
+      val taskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id("no-match")).build()
 
       When("We create a launch operation")
       val error = intercept[AssertionError] {

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
@@ -44,7 +44,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
         case matched: OfferMatchResult.Match => matched
       }
 
-      val expectedTaskId = Task.Id.forInstanceId(matched.instanceOp.stateOp.instanceId, None)
+      val expectedTaskId = Task.Id.forInstanceId(matched.instanceOp.stateOp.instanceId)
       val expectedTask = Task(
         taskId = expectedTaskId,
         runSpecVersion = app.version,
@@ -157,7 +157,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       val localVolumeIdUnwanted = LocalVolumeId(app.id, "persistent-volume-unwanted", "uuidUnwanted")
       val localVolumeIdMatch = LocalVolumeId(app.id, "persistent-volume", "uuidMatch")
       val reservedInstance = f.scheduledReservedInstance(app.id, localVolumeIdMatch)
-      val reservedTaskId = Task.Id.forInstanceId(reservedInstance.instanceId, None)
+      val reservedTaskId = Task.Id.forInstanceId(reservedInstance.instanceId)
       val offer = f.offerWithVolumes(
         reservedTaskId, localVolumeIdLaunched, localVolumeIdUnwanted, localVolumeIdMatch
       )
@@ -213,7 +213,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       val volumeId = LocalVolumeId(app.id, "/path", "uuid1")
       val existingReservedInstance = f.scheduledReservedInstance(app.id, volumeId)
 
-      val taskId = Task.Id.forInstanceId(existingReservedInstance.instanceId, None)
+      val taskId = Task.Id.forInstanceId(existingReservedInstance.instanceId)
       val updatedHostName = "updatedHostName"
       val updatedAgentId = "updatedAgentId"
       val offer = f.offerWithVolumes(taskId, updatedHostName, updatedAgentId, volumeId)

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -353,7 +353,7 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
       val status = Protos.TaskStatus
         .newBuilder
         .setState(Protos.TaskState.TASK_RUNNING)
-        .setTaskId(Task.Id.forInstanceId(sampleInstance.instanceId, None).mesosTaskId)
+        .setTaskId(Task.Id.forInstanceId(sampleInstance.instanceId).mesosTaskId)
         .setHealthy(true)
         .build()
 
@@ -379,7 +379,7 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
       val status = Protos.TaskStatus
         .newBuilder
         .setState(Protos.TaskState.TASK_RUNNING)
-        .setTaskId(Task.Id.forInstanceId(sampleInstance.instanceId, None).mesosTaskId)
+        .setTaskId(Task.Id.forInstanceId(sampleInstance.instanceId).mesosTaskId)
         .build()
 
       instanceTracker.launchEphemeral(sampleInstance).futureValue
@@ -403,7 +403,7 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
       val status = Protos.TaskStatus
         .newBuilder
         .setState(Protos.TaskState.TASK_RUNNING)
-        .setTaskId(Task.Id.forInstanceId(sampleInstance.instanceId, None).mesosTaskId)
+        .setTaskId(Task.Id.forInstanceId(sampleInstance.instanceId).mesosTaskId)
         .build()
 
       instanceTracker.launchEphemeral(sampleInstance).futureValue
@@ -435,7 +435,7 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
 
   def makeTaskStatus(instance: Instance, state: TaskState = TaskState.TASK_RUNNING) = {
     TaskStatus.newBuilder
-      .setTaskId(Task.Id.forInstanceId(instance.instanceId, None).mesosTaskId)
+      .setTaskId(Task.Id.forInstanceId(instance.instanceId).mesosTaskId)
       .setState(state)
       .build
   }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -54,7 +54,6 @@ class TaskIdTest extends UnitTest with Inside {
     "TaskIds for resident tasks can be created from legacy taskIds" in {
       val instanceId = Instance.Id.forRunSpec(PathId("/app"))
       val originalId = Task.Id.forInstanceId(instanceId, None)
-      originalId.attempt shouldBe None
 
       val newTaskId = Task.Id.forResidentTask(originalId)
       // this is considered the first attempt
@@ -99,11 +98,12 @@ class TaskIdTest extends UnitTest with Inside {
     "TaskId.reservationId removes attempt from app task id" in {
       val instanceId = Instance.Id.forRunSpec(PathId("/app/test/23"))
       val originalId = Task.Id.forInstanceId(instanceId, None)
-      val reservationIdFromOriginal = Task.Id.reservationId(originalId.idString)
+      //      val reservationIdFromOriginal = Task.Id.reservationId(originalId.idString)
 
       val residentTaskId = Task.Id.forResidentTask(originalId)
       residentTaskId.instanceId shouldEqual originalId.instanceId
-      residentTaskId.reservationId shouldEqual originalId.reservationId
+      // TODO(karsten): Test reservation id.
+      //residentTaskId.reservationId shouldEqual originalId.reservationId
 
       val anotherResidentTaskId = Task.Id.forResidentTask(residentTaskId)
       anotherResidentTaskId.instanceId shouldEqual originalId.instanceId

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -15,7 +15,7 @@ class TaskIdTest extends UnitTest with Inside {
     "AppIds can be converted to TaskIds and back to AppIds" in {
       val appId = "/test/foo/bla/rest".toPath
       val instanceId = Instance.Id.forRunSpec(appId)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       taskId.runSpecId should equal(appId)
     }
 
@@ -99,7 +99,7 @@ class TaskIdTest extends UnitTest with Inside {
 
     "TaskId.reservationId removes attempt from app task id" in {
       val instanceId = Instance.Id.forRunSpec(PathId("/app/test/23"))
-      val originalId = Task.Id.forInstanceId(instanceId, None)
+      val originalId = Task.Id.forInstanceId(instanceId)
 
       val residentTaskId = Task.Id.forResidentTask(originalId)
       residentTaskId.instanceId shouldEqual originalId.instanceId
@@ -111,7 +111,7 @@ class TaskIdTest extends UnitTest with Inside {
     }
 
     "TaskId.reservationId removes attempt and container name from pod task id" in {
-      val originalId = Task.Id.forInstanceId(Instance.Id.forRunSpec(PathId("/app/test/23")), None)
+      val originalId = Task.Id.forInstanceId(Instance.Id.forRunSpec(PathId("/app/test/23")))
 
       val residentTaskId = Task.Id.forResidentTask(originalId)
       residentTaskId.instanceId shouldEqual originalId.instanceId

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -13,7 +13,8 @@ class TaskIdTest extends UnitTest with Inside {
   "TaskIds" should {
     "AppIds can be converted to TaskIds and back to AppIds" in {
       val appId = "/test/foo/bla/rest".toPath
-      val taskId = Task.Id.forRunSpec(appId)
+      val instanceId = Instance.Id.forRunSpec(appId)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       taskId.runSpecId should equal(appId)
     }
 
@@ -51,8 +52,9 @@ class TaskIdTest extends UnitTest with Inside {
     }
 
     "TaskIds for resident tasks can be created from legacy taskIds" in {
-      val originalId = Task.Id.forRunSpec(PathId("/app"))
-      originalId shouldBe a[Task.LegacyId]
+      val instanceId = Instance.Id.forRunSpec(PathId("/app"))
+      val originalId = Task.Id.forInstanceId(instanceId, None)
+      originalId.attempt shouldBe None
 
       val newTaskId = Task.Id.forResidentTask(originalId)
       // this is considered the first attempt
@@ -87,14 +89,17 @@ class TaskIdTest extends UnitTest with Inside {
     }
 
     "TaskId.reservationId is the same as task id when task id is without attempt counter" in {
-      val originalId = Task.Id.forRunSpec(PathId("/app/test/23"))
+      val instanceId = Instance.Id.forRunSpec(PathId("/app/test/23"))
+      val originalId = Task.Id.forInstanceId(instanceId, None)
       val reservationId = originalId.reservationId
 
       reservationId shouldEqual originalId.idString
     }
 
     "TaskId.reservationId removes attempt from app task id" in {
-      val originalId = Task.Id.forRunSpec(PathId("/app/test/23"))
+      val instanceId = Instance.Id.forRunSpec(PathId("/app/test/23"))
+      val originalId = Task.Id.forInstanceId(instanceId, None)
+      val reservationIdFromOriginal = Task.Id.reservationId(originalId.idString)
 
       val residentTaskId = Task.Id.forResidentTask(originalId)
       residentTaskId.instanceId shouldEqual originalId.instanceId

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -383,7 +383,7 @@ object MarathonTestHelper {
   }
 
   def emptyInstance(): Instance = Instance(
-    instanceId = Task.Id.forRunSpec(PathId("/test")).instanceId,
+    instanceId = Instance.Id.forRunSpec(PathId("/test")),
     agentInfo = Some(Instance.AgentInfo("", None, None, None, Nil)),
     state = InstanceState(Condition.Created, since = clock.now(), None, healthy = None, goal = Goal.Running),
     tasksMap = Map.empty[Task.Id, Task],

--- a/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
@@ -64,8 +64,8 @@ class PersistentVolumeMatcherTest extends UnitTest {
       val offer =
         f.offerWithVolumes(unknownInstance, localVolumeId1)
           .toBuilder
-          .addAllResources(MarathonTestHelper.persistentVolumeResources(Task.Id.forInstanceId(instances.head.instanceId, None), localVolumeId2).asJava)
-          .addAllResources(MarathonTestHelper.persistentVolumeResources(Task.Id.forInstanceId(instances(1).instanceId, None), localVolumeId3).asJava)
+          .addAllResources(MarathonTestHelper.persistentVolumeResources(Task.Id.forInstanceId(instances.head.instanceId), localVolumeId2).asJava)
+          .addAllResources(MarathonTestHelper.persistentVolumeResources(Task.Id.forInstanceId(instances(1).instanceId), localVolumeId3).asJava)
           .build()
 
       When("We ask for a volume match")
@@ -96,7 +96,7 @@ class PersistentVolumeMatcherTest extends UnitTest {
   }
   class Fixture {
     def offerWithVolumes(instance: Instance, localVolumeIds: LocalVolumeId*) = {
-      val taskId = Task.Id.forInstanceId(instance.instanceId, None)
+      val taskId = Task.Id.forInstanceId(instance.instanceId)
       MarathonTestHelper.offerWithVolumesOnly(taskId, localVolumeIds: _*)
     }
     def appWithPersistentVolume(): AppDefinition = MarathonTestHelper.appWithPersistentVolume()

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -1159,7 +1159,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
 
       val basicOffer = MarathonTestHelper.makeBasicOffer(gpus = 4)
 
-      val offer = MarathonTestHelper.addVolumesToOffer(basicOffer, Task.Id.forInstanceId(instance.instanceId, None), localVolumeId).build()
+      val offer = MarathonTestHelper.addVolumesToOffer(basicOffer, Task.Id.forInstanceId(instance.instanceId), localVolumeId).build()
 
       val resourceMatchResponse = ResourceMatcher.matchResources(
         offer,
@@ -1184,7 +1184,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val localVolumeId = LocalVolumeId(app.id, "persistent-volume", "uuid")
       val instance = TestInstanceBuilder.scheduledWithReservation(app, Seq(localVolumeId))
 
-      val taskId = Task.Id.forInstanceId(instance.instanceId, None)
+      val taskId = Task.Id.forInstanceId(instance.instanceId)
 
       val basicOffer = MarathonTestHelper.makeBasicOffer(gpus = 4)
 

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1293,7 +1293,7 @@ class TaskBuilderTest extends UnitTest {
       val config = MarathonTestHelper.defaultConfig()
 
       val instanceId = Instance.Id.forRunSpec(app.id)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val builder = new TaskBuilder(app, taskId, config)
       def shouldBuildTask(message: String, offer: Offer): Unit = {
         val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq,
@@ -1361,7 +1361,7 @@ class TaskBuilderTest extends UnitTest {
       var runningInstances = Set.empty[Instance]
 
       val instanceId = Instance.Id.forRunSpec(app.id)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val config = MarathonTestHelper.defaultConfig()
       val builder = new TaskBuilder(app, taskId, config)
       def shouldBuildTask(offer: Offer): Unit = {
@@ -1455,7 +1455,7 @@ class TaskBuilderTest extends UnitTest {
         )
       )
       val instanceId = Instance.Id.forRunSpec(runSpecId)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val env3 = TaskBuilder.taskContextEnv(runSpec = runSpec, Some(taskId))
 
       assert(
@@ -1880,7 +1880,7 @@ class TaskBuilderTest extends UnitTest {
       val offer = MarathonTestHelper.makeBasicOffer(1.0, 128.0, 31000, 32000).build
       val config = MarathonTestHelper.defaultConfig()
       val instanceId = Instance.Id.forRunSpec(app.id)
-      val taskId = Task.Id.forInstanceId(instanceId, None)
+      val taskId = Task.Id.forInstanceId(instanceId)
       val builder = new TaskBuilder(app, taskId, config)
       val runningInstances = Set.empty[Instance]
 
@@ -1902,9 +1902,9 @@ class TaskBuilderTest extends UnitTest {
     "tty defined in an app will render ContainerInfo correctly" in {
       val appWithTTY = AppDefinition(id = PathId("/tty"), container = Some(Docker()), tty = Some(true))
       val instanceId = Instance.Id.forRunSpec(appWithTTY.id)
-      val taskId = Task.Id.forInstanceId(instanceId, None) // What about container?
+      val taskId = Task.Id.forInstanceId(instanceId) // What about container?
       val builder = new TaskBuilder(appWithTTY, taskId, MarathonTestHelper.defaultConfig())
-      val containerInfo = builder.computeContainerInfo(Seq(Some(123)), Task.Id.forInstanceId(instanceId, None)) // TODO: What about container?
+      val containerInfo = builder.computeContainerInfo(Seq(Some(123)), Task.Id.forInstanceId(instanceId)) // TODO: What about container?
       containerInfo should be(defined)
       containerInfo.get.hasTtyInfo should be(true)
       containerInfo.get.getTtyInfo.hasWindowSize should be(false)
@@ -1913,9 +1913,9 @@ class TaskBuilderTest extends UnitTest {
     "no tty defined in an app will render ContainerInfo without tty" in {
       val appNoTTY = MarathonTestHelper.makeBasicApp().copy(tty = Some(false))
       val instanceId = Instance.Id.forRunSpec(appNoTTY.id)
-      val taskId = Task.Id.forInstanceId(instanceId, None) // What about container?
+      val taskId = Task.Id.forInstanceId(instanceId) // What about container?
       val builder = new TaskBuilder(appNoTTY, taskId, MarathonTestHelper.defaultConfig())
-      val containerInfo = builder.computeContainerInfo(Seq(Some(123)), Task.Id.forInstanceId(instanceId, None)) // TODO: What about container?
+      val containerInfo = builder.computeContainerInfo(Seq(Some(123)), Task.Id.forInstanceId(instanceId)) // TODO: What about container?
       containerInfo should be(empty)
     }
   }
@@ -1927,7 +1927,7 @@ class TaskBuilderTest extends UnitTest {
     acceptedResourceRoles: Option[Set[String]] = None,
     envVarsPrefix: Option[String] = None): Option[(MesosProtos.TaskInfo, NetworkInfo)] = {
     val instanceId = Instance.Id.forRunSpec(app.id)
-    val taskId = Task.Id.forInstanceId(instanceId, None)
+    val taskId = Task.Id.forInstanceId(instanceId)
     val builder = new TaskBuilder(
       app,
       taskId,

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1292,7 +1292,8 @@ class TaskBuilderTest extends UnitTest {
       var runningInstances = Set.empty[Instance]
       val config = MarathonTestHelper.defaultConfig()
 
-      val taskId = Task.Id.forRunSpec(app.id)
+      val instanceId = Instance.Id.forRunSpec(app.id)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val builder = new TaskBuilder(app, taskId, config)
       def shouldBuildTask(message: String, offer: Offer): Unit = {
         val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq,
@@ -1359,7 +1360,8 @@ class TaskBuilderTest extends UnitTest {
 
       var runningInstances = Set.empty[Instance]
 
-      val taskId = Task.Id.forRunSpec(app.id)
+      val instanceId = Instance.Id.forRunSpec(app.id)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val config = MarathonTestHelper.defaultConfig()
       val builder = new TaskBuilder(app, taskId, config)
       def shouldBuildTask(offer: Offer): Unit = {
@@ -1452,7 +1454,8 @@ class TaskBuilderTest extends UnitTest {
           "LABEL2" -> "VALUE2"
         )
       )
-      val taskId = Task.Id.forRunSpec(runSpecId)
+      val instanceId = Instance.Id.forRunSpec(runSpecId)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val env3 = TaskBuilder.taskContextEnv(runSpec = runSpec, Some(taskId))
 
       assert(
@@ -1876,7 +1879,8 @@ class TaskBuilderTest extends UnitTest {
 
       val offer = MarathonTestHelper.makeBasicOffer(1.0, 128.0, 31000, 32000).build
       val config = MarathonTestHelper.defaultConfig()
-      val taskId = Task.Id.forRunSpec(app.id)
+      val instanceId = Instance.Id.forRunSpec(app.id)
+      val taskId = Task.Id.forInstanceId(instanceId, None)
       val builder = new TaskBuilder(app, taskId, config)
       val runningInstances = Set.empty[Instance]
 
@@ -1897,9 +1901,10 @@ class TaskBuilderTest extends UnitTest {
 
     "tty defined in an app will render ContainerInfo correctly" in {
       val appWithTTY = AppDefinition(id = PathId("/tty"), container = Some(Docker()), tty = Some(true))
-      val taskId = Task.Id.forRunSpec(appWithTTY.id)
+      val instanceId = Instance.Id.forRunSpec(appWithTTY.id)
+      val taskId = Task.Id.forInstanceId(instanceId, None) // What about container?
       val builder = new TaskBuilder(appWithTTY, taskId, MarathonTestHelper.defaultConfig())
-      val containerInfo = builder.computeContainerInfo(Seq(Some(123)), Task.Id.forRunSpec(appWithTTY.id))
+      val containerInfo = builder.computeContainerInfo(Seq(Some(123)), Task.Id.forInstanceId(instanceId, None)) // TODO: What about container?
       containerInfo should be(defined)
       containerInfo.get.hasTtyInfo should be(true)
       containerInfo.get.getTtyInfo.hasWindowSize should be(false)
@@ -1907,9 +1912,10 @@ class TaskBuilderTest extends UnitTest {
 
     "no tty defined in an app will render ContainerInfo without tty" in {
       val appNoTTY = MarathonTestHelper.makeBasicApp().copy(tty = Some(false))
-      val taskId = Task.Id.forRunSpec(appNoTTY.id)
+      val instanceId = Instance.Id.forRunSpec(appNoTTY.id)
+      val taskId = Task.Id.forInstanceId(instanceId, None) // What about container?
       val builder = new TaskBuilder(appNoTTY, taskId, MarathonTestHelper.defaultConfig())
-      val containerInfo = builder.computeContainerInfo(Seq(Some(123)), Task.Id.forRunSpec(appNoTTY.id))
+      val containerInfo = builder.computeContainerInfo(Seq(Some(123)), Task.Id.forInstanceId(instanceId, None)) // TODO: What about container?
       containerInfo should be(empty)
     }
   }
@@ -1920,7 +1926,8 @@ class TaskBuilderTest extends UnitTest {
     mesosRole: Option[String] = None,
     acceptedResourceRoles: Option[Set[String]] = None,
     envVarsPrefix: Option[String] = None): Option[(MesosProtos.TaskInfo, NetworkInfo)] = {
-    val taskId = Task.Id.forRunSpec(app.id)
+    val instanceId = Instance.Id.forRunSpec(app.id)
+    val taskId = Task.Id.forInstanceId(instanceId, None)
     val builder = new TaskBuilder(
       app,
       taskId,


### PR DESCRIPTION
Summary:
`Task.Id.forRunSpec` has been deprecated and was only used in test code but not
production code. This removed the method and should avoid all the deprecation
warnings.

Co-authored-by: Aleksey Dukhovniy <adukhovniy@mesosphere.io>