### PR TITLE
Fix an error in changelog messaging for MoM

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,7 +30,7 @@ Additionally, we have added support for Debian Stretch.
 
 Previously, the Marathon Docker container would only run as user root. The packaging has been updated so that the container is now run, by default, as the user `nobody`.
 
-**NOTE** This is a breaking change! If you did not specify `MARATHON_MESOS_USER` before, and did not specify the container user of `nobody` when launching Marathon in a container before, then add the environment value `MARATHON_MESOS_USER=root` to the containerized Marathon.
+When launching new Marathon-on-Marathon instances, note that this means that the default framework user will be `nobody`, rather than `root`, unless it is specified. When installing via the DC/OS Universe, the value is explicitly set. Note that it is not possible to change the framework user after the initial framework registration.
 
 ### Non-leader/standby Marathon instances respond to /v2/events with a redirect, rather than proxy
 

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -98,7 +98,9 @@ When using Debian packages, the ideal way to customize Marathon is to specify co
     use this value for launching new tasks. Examples: `*`, `production,*`, `production`
 * `--mesos_user` (Optional. Default: current user): Mesos user for
     this framework. _Note: Default is determined by
-    [`SystemProperties.get("user.name")`](http://www.scala-lang.org/api/current/index.html#scala.sys.SystemProperties@get\(key:String\):Option[String])._
+    [`SystemProperties.get("user.name")`](http://www.scala-lang.org/api/current/index.html#scala.sys.SystemProperties@get\(key:String\):Option[String]),
+    which defaults to the system user as which Marathon is running. The value of this field is only used during initial
+    registration, changing it later has no affect.
 * `--reconciliation_initial_delay` (Optional. Default: 15000 (15 seconds)): The
     delay, in milliseconds, before Marathon begins to periodically perform task
     reconciliation operations.


### PR DESCRIPTION
When upgrading Marathon it is not necessary to set MARATHON_MESOS_USER
as this value has no effect after initial registration.

Clarify this fact in the command-line-flags docs.
