### PR TITLE
Write out correct version in ZkId.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -3,6 +3,7 @@ package core.storage.store.impl.zk
 
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 import akka.stream.Materializer
@@ -31,7 +32,8 @@ case class ZkId(category: String, id: String, version: Option[OffsetDateTime]) {
 
   // BUG: id = "" for the root group this results in "Path must not end with / character" in curator
   def path: String = version.fold(f"/$category/$bucket%x/$id") { v =>
-    f"/$category/$bucket%x/$id/${ZkId.DateFormat.format(v)}"
+    val truncatedVersion = v.truncatedTo(ChronoUnit.MILLIS)
+    f"/$category/$bucket%x/$id/${ZkId.DateFormat.format(truncatedVersion)}"
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package core.storage.store.impl.zk
 
 import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 import akka.stream.Materializer
@@ -14,7 +15,6 @@ import mesosphere.marathon.core.storage.backup.BackupItem
 import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.core.storage.store.impl.{BasePersistenceStore, CategorizedKey}
 import mesosphere.marathon.metrics.Metrics
-import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.storage.migration.{Migration, StorageVersions}
 import mesosphere.marathon.util.{WorkQueue, toRichFuture}
 import org.apache.zookeeper.KeeperException
@@ -31,13 +31,12 @@ case class ZkId(category: String, id: String, version: Option[OffsetDateTime]) {
 
   // BUG: id = "" for the root group this results in "Path must not end with / character" in curator
   def path: String = version.fold(f"/$category/$bucket%x/$id") { v =>
-    f"/$category/$bucket%x/$id/${ZkId.WriteDateFormat.format(v)}"
+    f"/$category/$bucket%x/$id/${ZkId.DateFormat.format(v)}"
   }
 }
 
 object ZkId {
-  val WriteDateFormat = Timestamp.WriteFormatter // WriteDateFormat is following our formatting style
-  val ReadDateFormat = Timestamp.ReadFormatter // ReadDateFormat is compatible with every possible ISO-8601 string
+  val DateFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME
   val HashBucketSize = 16
 }
 
@@ -136,7 +135,7 @@ class ZkPersistenceStore(
         await(client.children(path).asTry) match {
           case Success(Children(_, _, nodes)) =>
             nodes.map { path =>
-              OffsetDateTime.parse(path, ZkId.ReadDateFormat)
+              OffsetDateTime.parse(path, ZkId.DateFormat)
             }
           case Failure(_: NoNodeException) =>
             Seq.empty

--- a/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
@@ -65,7 +65,7 @@ trait DefaultConversions {
   }
 
   implicit object OffsetDateTimeWrite extends play.api.libs.json.Writes[OffsetDateTime] {
-    def writes(o: OffsetDateTime) = JsString(o.format(Timestamp.WriteFormatter))
+    def writes(o: OffsetDateTime) = JsString(o.format(Timestamp.formatter))
   }
 
 }

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -28,7 +28,7 @@ abstract case class Timestamp private (private val instant: Instant) extends Ord
   def youngerThan(that: Timestamp): Boolean = this.after(that)
   def olderThan(that: Timestamp): Boolean = this.before(that)
 
-  override def toString: String = Timestamp.WriteFormatter.format(instant)
+  override def toString: String = Timestamp.formatter.format(instant)
 
   def toInstant: Instant = instant
 
@@ -70,7 +70,7 @@ object Timestamp {
   /**
     * Returns a new Timestamp representing the supplied time.
     */
-  def apply(time: String): Timestamp = Timestamp(Try(OffsetDateTime.parse(time, ReadFormatter)) match {
+  def apply(time: String): Timestamp = Timestamp(Try(OffsetDateTime.parse(time)) match {
     case Success(parsed) => parsed
     case Failure(e: DateTimeParseException) => throw new IllegalArgumentException(s"Invalid timestamp provided '$time'. Expecting ISO-8601 datetime string.", e)
     case Failure(e) => throw e
@@ -105,6 +105,5 @@ object Timestamp {
   /*
    * .toString in java.time is truncating zeros in millis part, so we use custom formatter to keep them
    */
-  val WriteFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
-  val ReadFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
 }

--- a/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
@@ -48,16 +48,15 @@ case class StoredPlan(
   def toProto: Protos.DeploymentPlanDefinition = {
     Protos.DeploymentPlanDefinition.newBuilder
       .setId(id)
-      .setOriginalRootVersion(StoredPlan.WriteDateFormat.format(originalVersion))
-      .setTargetRootVersion(StoredPlan.WriteDateFormat.format(targetVersion))
-      .setTimestamp(StoredPlan.WriteDateFormat.format(version))
+      .setOriginalRootVersion(StoredPlan.DateFormat.format(originalVersion))
+      .setTargetRootVersion(StoredPlan.DateFormat.format(targetVersion))
+      .setTimestamp(StoredPlan.DateFormat.format(version))
       .build()
   }
 }
 
 object StoredPlan {
-  val ReadDateFormat = Timestamp.ReadFormatter
-  val WriteDateFormat = Timestamp.WriteFormatter
+  val DateFormat = StoredGroup.DateFormat
 
   def apply(deploymentPlan: DeploymentPlan): StoredPlan = {
     StoredPlan(deploymentPlan.id, deploymentPlan.original.version.toOffsetDateTime,
@@ -66,14 +65,14 @@ object StoredPlan {
 
   def apply(proto: Protos.DeploymentPlanDefinition): StoredPlan = {
     val version = if (proto.hasTimestamp) {
-      OffsetDateTime.parse(proto.getTimestamp, ReadDateFormat)
+      OffsetDateTime.parse(proto.getTimestamp, DateFormat)
     } else {
       OffsetDateTime.MIN
     }
     StoredPlan(
       proto.getId,
-      OffsetDateTime.parse(proto.getOriginalRootVersion, ReadDateFormat),
-      OffsetDateTime.parse(proto.getTargetRootVersion, ReadDateFormat),
+      OffsetDateTime.parse(proto.getOriginalRootVersion, DateFormat),
+      OffsetDateTime.parse(proto.getTargetRootVersion, DateFormat),
       version)
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -44,6 +44,8 @@ case class StoredGroup(
         case NonFatal(ex) =>
           logger.error(s"Failed to load $appId:$appVersion for group $id ($version)", ex)
           throw ex
+      }.map { maybeAppDef =>
+        (appId, maybeAppDef)
       }
     }
     val podFutures = podIds.map {
@@ -51,28 +53,34 @@ case class StoredGroup(
         case NonFatal(ex) =>
           logger.error(s"Failed to load $podId:$podVersion for group $id ($version)", ex)
           throw ex
+      }.map { maybePodDef =>
+        (podId, maybePodDef)
       }
     }
 
     val groupFutures = storedGroups.map(_.resolve(appRepository, podRepository))
 
     val allApps = await(Future.sequence(appFutures))
-    if (allApps.exists(_.isEmpty)) {
-      logger.warn(s"Group $id $version is missing ${allApps.count(_.isEmpty)} apps")
+    if (allApps.exists { case (_, maybeAppDef) => maybeAppDef.isEmpty }) {
+      val missingApps = allApps.filter { case (_, maybeAppDef) => maybeAppDef.isEmpty }
+      val summarizedMissingApps = summarize(missingApps.toIterator.map(_._1))
+      logger.warn(s"Group $id $version is missing apps: $summarizedMissingApps")
     }
 
     val allPods = await(Future.sequence(podFutures))
-    if (allPods.exists(_.isEmpty)) {
-      logger.warn(s"Group $id $version is missing ${allPods.count(_.isEmpty)} pods")
+    if (allPods.exists { case (_, maybePodDef) => maybePodDef.isEmpty }) {
+      val missingPods = allPods.filter { case (_, maybePodDef) => maybePodDef.isEmpty }
+      val summarizedMissingPods = summarize(missingPods.toIterator.map(_._1))
+      logger.warn(s"Group $id $version is missing pods: $summarizedMissingPods")
     }
 
-    val apps: Map[PathId, AppDefinition] = await(Future.sequence(appFutures)).collect {
-      case Some(app: AppDefinition) =>
+    val apps: Map[PathId, AppDefinition] = allApps.collect {
+      case (_, Some(app: AppDefinition)) =>
         app.id -> app
     }(collection.breakOut)
 
-    val pods: Map[PathId, PodDefinition] = await(Future.sequence(podFutures)).collect {
-      case Some(pod: PodDefinition) =>
+    val pods: Map[PathId, PodDefinition] = allPods.collect {
+      case (_, Some(pod: PodDefinition)) =>
         pod.id -> pod
     }(collection.breakOut)
 

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -14,7 +14,6 @@ import akka.util.ByteString
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStoreTest, TestClass1}
 import mesosphere.marathon.metrics.dummy.DummyMetrics
-import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.util.ZookeeperServerTest
 
@@ -78,8 +77,8 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
     val store = defaultStore
     implicit val clock = new SettableClock()
 
-    val offsetDateTimeOnlyMillisStr = offsetDateTime.format(Timestamp.WriteFormatter)
-    val offsetDateTimeOnlyMillis = OffsetDateTime.parse(offsetDateTimeOnlyMillisStr, Timestamp.ReadFormatter)
+    val offsetDateTimeOnlyMillisStr = offsetDateTime.format(ZkId.DateFormat)
+    val offsetDateTimeOnlyMillis = OffsetDateTime.parse(offsetDateTimeOnlyMillisStr, ZkId.DateFormat)
 
     val tc = TestClass1("abc", 1, offsetDateTime)
 

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -72,30 +72,5 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
 
   behave like basicPersistenceStore("ZookeeperPersistenceStore", defaultStore)
   behave like backupRestoreStore("ZookeeperPersistenceStore", defaultStore)
-
-  def trimmingTest(offsetDateTime: OffsetDateTime): Unit = {
-    val store = defaultStore
-    implicit val clock = new SettableClock()
-
-    val offsetDateTimeOnlyMillisStr = offsetDateTime.format(ZkId.DateFormat)
-    val offsetDateTimeOnlyMillis = OffsetDateTime.parse(offsetDateTimeOnlyMillisStr, ZkId.DateFormat)
-
-    val tc = TestClass1("abc", 1, offsetDateTime)
-
-    store.store("test", tc).futureValue shouldEqual Done
-    store.versions("test").runWith(Sink.seq).futureValue shouldEqual Seq(offsetDateTimeOnlyMillis)
-  }
-
-  "handle nanoseconds when providing versions" in {
-    val offsetDateTime = OffsetDateTime.of(2015, 2, 3, 12, 30, 15, 123456789, ZoneOffset.UTC)
-
-    trimmingTest(offsetDateTime)
-  }
-
-  "handle milliseconds when providing versions" in {
-    val offsetDateTime = OffsetDateTime.of(2015, 2, 3, 12, 30, 15, 123000000, ZoneOffset.UTC)
-
-    trimmingTest(offsetDateTime)
-  }
 }
 

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -6,12 +6,16 @@ import java.nio.charset.StandardCharsets
 import java.time.{Instant, OffsetDateTime, ZoneOffset}
 import java.util.UUID
 
+import akka.Done
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStoreTest, TestClass1}
 import mesosphere.marathon.metrics.dummy.DummyMetrics
+import mesosphere.marathon.state.Timestamp
+import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.util.ZookeeperServerTest
 
 trait ZkTestClass1Serialization {
@@ -69,5 +73,32 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
 
   behave like basicPersistenceStore("ZookeeperPersistenceStore", defaultStore)
   behave like backupRestoreStore("ZookeeperPersistenceStore", defaultStore)
+
+  "ZkId should trim anything but millis after serialization" in {
+    val dateTime = OffsetDateTime.of(2015, 5, 14, 15, 43, 21, 0, ZoneOffset.UTC)
+    val withNanos = dateTime.withNano(123456789)
+    val zkId = ZkId("cat", "path", Some(withNanos))
+    val zkIdVersion = zkId.path.reverse.takeWhile(_ != '/').reverse
+    zkIdVersion shouldEqual "2015-05-14T15:43:21.123Z"
+    ZkId("cat", "path", Some(OffsetDateTime.parse(zkIdVersion))).path shouldEqual zkId.path
+  }
+
+  def trimmingTest(offsetDateTime: OffsetDateTime): Unit = {
+    val store = defaultStore
+    implicit val clock = new SettableClock()
+    val offsetDateTimeOnlyMillisStr = offsetDateTime.format(Timestamp.formatter)
+    val offsetDateTimeOnlyMillis = OffsetDateTime.parse(offsetDateTimeOnlyMillisStr)
+    val tc = TestClass1("abc", 1, offsetDateTime)
+    store.store("test", tc).futureValue shouldEqual Done
+    store.versions("test").runWith(Sink.seq).futureValue shouldEqual Seq(offsetDateTimeOnlyMillis)
+  }
+  "handle nanoseconds when providing versions" in {
+    val offsetDateTime = OffsetDateTime.of(2015, 2, 3, 12, 30, 15, 123456789, ZoneOffset.UTC)
+    trimmingTest(offsetDateTime)
+  }
+  "handle milliseconds when providing versions" in {
+    val offsetDateTime = OffsetDateTime.of(2015, 2, 3, 12, 30, 15, 123000000, ZoneOffset.UTC)
+    trimmingTest(offsetDateTime)
+  }
 }
 

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -6,15 +6,12 @@ import java.nio.charset.StandardCharsets
 import java.time.{Instant, OffsetDateTime, ZoneOffset}
 import java.util.UUID
 
-import akka.Done
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
-import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStoreTest, TestClass1}
 import mesosphere.marathon.metrics.dummy.DummyMetrics
-import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.util.ZookeeperServerTest
 
 trait ZkTestClass1Serialization {

--- a/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package state
 
+import java.time.format.DateTimeFormatter
 import java.time.{Instant, OffsetDateTime, ZoneOffset}
 import java.time.temporal.ChronoUnit
 

--- a/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
@@ -71,24 +71,5 @@ class TimestampTest extends UnitTest {
         timestamp.millis shouldEqual instant.truncatedTo(ChronoUnit.SECONDS).toEpochMilli
       }
     }
-    "converting to/from OffsetDateTime" should {
-      "be compatible" in {
-
-        val dateTimeStr = "2018-09-26T12:46:13.587Z"
-
-        val timestamp = Timestamp(dateTimeStr)
-        val timestampString = timestamp.toString
-
-        val offsetDateTime = OffsetDateTime.parse(timestampString)
-
-        val formatted = Timestamp.WriteFormatter.format(offsetDateTime)
-
-        Timestamp(offsetDateTime) shouldEqual timestamp
-        Timestamp(timestampString) shouldEqual timestamp
-        Timestamp(formatted) shouldEqual timestamp
-
-        OffsetDateTime.parse(dateTimeStr, Timestamp.ReadFormatter).format(Timestamp.WriteFormatter) shouldEqual timestamp.toString
-      }
-    }
   }
 }

--- a/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon
 package state
 
-import java.time.format.DateTimeFormatter
 import java.time.{Instant, OffsetDateTime, ZoneOffset}
 import java.time.temporal.ChronoUnit
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -55,8 +55,8 @@ case class ITEnrichedTask(
     host: String,
     ports: Option[Seq[Int]],
     slaveId: Option[String],
-    startedAt: Option[Date],
-    stagedAt: Option[Date],
+    startedAt: Option[Timestamp],
+    stagedAt: Option[Timestamp],
     state: String,
     version: Option[String],
     region: Option[String],
@@ -125,8 +125,8 @@ class MarathonFacade(
     (__ \ "host").format[String] ~
     (__ \ "ports").formatNullable[Seq[Int]] ~
     (__ \ "slaveId").formatNullable[String] ~
-    (__ \ "startedAt").formatNullable[Date] ~
-    (__ \ "stagedAt").formatNullable[Date] ~
+    (__ \ "startedAt").formatNullable[Timestamp] ~
+    (__ \ "stagedAt").formatNullable[Timestamp] ~
     (__ \ "state").format[String] ~
     (__ \ "version").formatNullable[String] ~
     (__ \ "region").formatNullable[String] ~


### PR DESCRIPTION
Summary:
With #6558 we started to include the micro seconds in app versions even
when they were zero. Older Marathon versions would drop the zeros. We
would not find apps from previous versions though since the string representation is different. 

Commit that introduced storing timestamps with trailing zeros was reverted (since it generated a lot of flakes), and now we truncate microsecond instead of changing the formatter. 

JIRA issues: MARATHON-8461