### PR TITLE
Try to reduce conflicts by changing the way we format json

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -275,6 +275,9 @@ def buildPr(pullId: String): Unit = asPullRequest(pullId) {
 
   // Uploads
   val artifact = uploadTarballPackagesToS3(version, s"builds/$version")
+  artifact.foreach { artifact =>
+      updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
+    }
   (version, artifact)
 }
 

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -275,9 +275,6 @@ def buildPr(pullId: String): Unit = asPullRequest(pullId) {
 
   // Uploads
   val artifact = uploadTarballPackagesToS3(version, s"builds/$version")
-  artifact.foreach { artifact =>
-      updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
-    }
   (version, artifact)
 }
 

--- a/ci/upgrade.sc
+++ b/ci/upgrade.sc
@@ -9,6 +9,7 @@ import ammonite.ops._
 import ammonite.ops.ImplicitWd._
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
+import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.{ObjectMapper, ObjectWriter}
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.merge.MergeStrategy
@@ -35,6 +36,10 @@ case class EeBuildInfo(
 implicit val singleSourceFormat = Json.format[Source]
 implicit val buildInfoFormat = Json.format[BuildInfo]
 implicit val eeBuildInfoFormat = Json.format[EeBuildInfo]
+
+class BuildInfoPrettyPrinter extends DefaultPrettyPrinter {
+  override def writeObjectFieldValueSeparator(g: JsonGenerator) = g.writeRaw(": ")
+}
 
 
 /**
@@ -124,7 +129,7 @@ private def prettyPrint(value: JsValue): String = withStringWriter { sw =>
   val jsonFactory = new JsonFactory(mapper)
   def stringJsonGenerator(out: java.io.StringWriter) =
     jsonFactory.createGenerator(out)
-  val prettyPrinter = new DefaultPrettyPrinter().withoutSpacesInObjectEntries()
+  val prettyPrinter = new BuildInfoPrettyPrinter()
   val gen = stringJsonGenerator(sw).setPrettyPrinter(
     prettyPrinter
   )

--- a/ci/upgrade.sc
+++ b/ci/upgrade.sc
@@ -124,10 +124,11 @@ private def prettyPrint(value: JsValue): String = withStringWriter { sw =>
   val jsonFactory = new JsonFactory(mapper)
   def stringJsonGenerator(out: java.io.StringWriter) =
     jsonFactory.createGenerator(out)
+  val prettyPrinter = new DefaultPrettyPrinter().withoutSpacesInObjectEntries()
   val gen = stringJsonGenerator(sw).setPrettyPrinter(
-    new DefaultPrettyPrinter().withoutSpacesInObjectEntries()
+    prettyPrinter
   )
-  val writer: ObjectWriter = mapper.writerWithDefaultPrettyPrinter()
+  val writer: ObjectWriter = mapper.writer(prettyPrinter)
 
   writer.writeValue(gen, value)
   sw.flush()

--- a/ci/upgrade.sc
+++ b/ci/upgrade.sc
@@ -38,7 +38,7 @@ implicit val buildInfoFormat = Json.format[BuildInfo]
 implicit val eeBuildInfoFormat = Json.format[EeBuildInfo]
 
 class BuildInfoPrettyPrinter extends DefaultPrettyPrinter {
-  override def writeObjectFieldValueSeparator(g: JsonGenerator) = g.writeRaw(": ")
+  override def writeObjectFieldValueSeparator(g: JsonGenerator): Unit = g.writeRaw(": ")
 }
 
 

--- a/ci/upgrade.sc
+++ b/ci/upgrade.sc
@@ -124,6 +124,11 @@ def updateBuildInfo(url: String, sha1: String, repoPath: Path, fileName: String,
   write.over(buildInfoPath, s"$prettyJson\n")
 }
 
+/**
+  * The default pretty printer prints spaces in between colons for values and names in json objects
+  * This is not the formatting style we use for buildinfo.json
+  * To avoid unnecessary merge conflicts, implement different formatting strategy
+  */
 private def prettyPrint(value: JsValue): String = withStringWriter { sw =>
   val mapper = (new ObjectMapper).registerModule(PlayJsonModule)
   val jsonFactory = new JsonFactory(mapper)


### PR DESCRIPTION
We bump marathon and metronome in dcos automatically in our PR but the json we submit there has a different formatting than the one we produce by handwriting on master. This attempts to unify the spaces in json formatter to prevent unnecessary merge conflicts.

See this as a example of a bump made from this branch https://github.com/dcos/dcos/pull/1739/commits/f0ab6ecf61dfd78c9944160621a4882a21572df5